### PR TITLE
feat(mcp): role-based token templates (Admin / Development / Employee / Observer)

### DIFF
--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -6,8 +6,10 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 vi.mock("@/lib/actions/mcp-tokens", () => ({
   copyMyMcpToken: vi.fn(),
   issueMyMcpToken: vi.fn(),
+  issueMyTemplateMcpToken: vi.fn(),
   issueMyWriteMcpToken: vi.fn(),
   listAvailableMcpScopes: vi.fn(),
+  listMcpTokenTemplates: vi.fn(),
   listMyMcpTokens: vi.fn(),
   revokeMyMcpToken: vi.fn(),
   rotateMyMcpToken: vi.fn(),
@@ -16,7 +18,9 @@ vi.mock("@/lib/actions/mcp-tokens", () => ({
 
 import {
   copyMyMcpToken,
+  issueMyTemplateMcpToken,
   listAvailableMcpScopes,
+  listMcpTokenTemplates,
   listMyMcpTokens,
   rotateMyMcpToken,
 } from "@/lib/actions/mcp-tokens";
@@ -24,6 +28,8 @@ import { McpTokenManager } from "./McpTokenManager";
 
 const copyMock = copyMyMcpToken as unknown as ReturnType<typeof vi.fn>;
 const scopesMock = listAvailableMcpScopes as unknown as ReturnType<typeof vi.fn>;
+const templatesMock = listMcpTokenTemplates as unknown as ReturnType<typeof vi.fn>;
+const templateIssueMock = issueMyTemplateMcpToken as unknown as ReturnType<typeof vi.fn>;
 const tokensMock = listMyMcpTokens as unknown as ReturnType<typeof vi.fn>;
 const rotateMock = rotateMyMcpToken as unknown as ReturnType<typeof vi.fn>;
 
@@ -31,6 +37,50 @@ beforeEach(() => {
   vi.resetAllMocks();
   scopesMock.mockResolvedValue({
     scopes: ["backlog_read", "backlog_write", "spec_plan_read"],
+  });
+  templatesMock.mockResolvedValue({
+    templates: [
+      {
+        id: "admin",
+        label: "Admin",
+        category: "admin",
+        tier: "admin",
+        description: "Full platform admin",
+        grants: ["admin_read", "admin_write", "backlog_read"],
+      },
+      {
+        id: "development",
+        label: "Development",
+        category: "development",
+        tier: "write",
+        description: "Coding agent + sandbox + iac",
+        grants: ["backlog_read", "backlog_write", "sandbox_execute", "iac_execute"],
+      },
+      {
+        id: "employee_finance",
+        label: "Employee — Finance",
+        category: "employee",
+        tier: "write",
+        description: "Finance human or coworker",
+        grants: ["financial_report_create", "backlog_read"],
+      },
+      {
+        id: "observer",
+        label: "Read-only observer",
+        category: "observer",
+        tier: "read",
+        description: "Every *_read grant",
+        grants: ["backlog_read", "spec_plan_read"],
+      },
+      {
+        id: "custom",
+        label: "Custom",
+        category: "custom",
+        tier: "read",
+        description: "Pick scopes manually",
+        grants: [],
+      },
+    ],
   });
   tokensMock.mockResolvedValue({
     ok: true,
@@ -168,5 +218,58 @@ describe("McpTokenManager", () => {
     expect(screen.getByText("dpfmcp_ROTATED")).toBeTruthy();
     expect(screen.getByText(/SetEnvironmentVariable/)).toBeTruthy();
     expect(screen.getByText(/api\/mcp\/token\/refresh/)).toBeTruthy();
+  });
+
+  it("renames the legacy one-click affordance to 'Issue development token'", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByRole("button", { name: /Issue development token/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Issue write token/i })).toBeNull();
+  });
+
+  it("opens the template picker modal and issues a finance-employee token via the template action", async () => {
+    templateIssueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_fin",
+      plaintext: "dpfmcp_FIN",
+      prefix: "dpfmcp_FIN1",
+      tokenSuffix: "FIN1",
+      expiresAt: null,
+      setupSnippets: {
+        claudeCode: "{}",
+        codex: "[mcp_servers.dpf]",
+        vscode: "{}",
+        syncCommand: "",
+        envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_FIN', 'User')",
+        runtimeRefreshPowerShell: "Invoke-RestMethod /api/mcp/token/refresh dpfmcp_FIN",
+      },
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Issue token from template/i }));
+    expect(await screen.findByRole("heading", { name: /Issue MCP token/i })).toBeTruthy();
+
+    // Pick the finance template (template picker is the first combobox in the dialog)
+    const templateSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(templateSelect, { target: { value: "employee_finance" } });
+    // Active template description is visible
+    expect(screen.getByText(/Finance human or coworker/)).toBeTruthy();
+    // Grant chip for financial_report_create renders
+    expect(screen.getByText("financial_report_create")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText(/Employee — Finance/i), {
+      target: { value: "Finance coworker" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Issue token$/i }));
+
+    await waitFor(() => {
+      expect(templateIssueMock).toHaveBeenCalledWith({
+        templateId: "employee_finance",
+        name: "Finance coworker",
+        expiresInDays: 90,
+        baseUrl: "http://localhost:3000",
+      });
+    });
   });
 });

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -16,16 +16,20 @@ import { type ReactNode, useEffect, useMemo, useState, useTransition } from "rea
 import {
   copyMyMcpToken,
   issueMyMcpToken,
+  issueMyTemplateMcpToken,
   issueMyWriteMcpToken,
   listAvailableMcpScopes,
+  listMcpTokenTemplates,
   listMyMcpTokens,
   revokeMyMcpToken,
   rotateMyMcpToken,
   upgradeMyMcpTokenForCodingAgent,
+  type McpTokenTemplateSummary,
 } from "@/lib/actions/mcp-tokens";
 import {
   defaultMcpTokenScopes,
   type McpTokenScopeTier,
+  type McpTokenTemplateId,
 } from "@/lib/mcp-token-scopes";
 
 export interface McpTokenManagerProps {
@@ -110,6 +114,7 @@ async function writeClipboardText(value: string): Promise<boolean> {
 export function McpTokenManager(props: McpTokenManagerProps) {
   const [tokens, setTokens] = useState<TokenRow[]>([]);
   const [scopes, setScopes] = useState<string[]>([]);
+  const [templates, setTemplates] = useState<McpTokenTemplateSummary[]>([]);
   const [view, setView] = useState<View>({ kind: "idle" });
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [notice, setNotice] = useState<Notice>(null);
@@ -117,6 +122,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   const [pending, startTransition] = useTransition();
 
   const [formName, setFormName] = useState("");
+  const [formTemplateId, setFormTemplateId] = useState<McpTokenTemplateId>("development");
   const [formScope, setFormScope] = useState<McpTokenScopeTier>("read");
   const [formScopes, setFormScopes] = useState<Set<string>>(() => new Set());
   const [formExpires, setFormExpires] = useState<string>("90");
@@ -126,14 +132,16 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [tokensResult, scopesResult] = await Promise.all([
+      const [tokensResult, scopesResult, templatesResult] = await Promise.all([
         listMyMcpTokens(),
         listAvailableMcpScopes(),
+        listMcpTokenTemplates(),
       ]);
       if (cancelled) return;
       if (tokensResult.ok) setTokens(tokensResult.tokens);
       const availableScopes = scopesResult.scopes;
       setScopes(availableScopes);
+      setTemplates(templatesResult.templates);
       setFormScopes((current) =>
         current.size > 0 ? current : new Set(defaultMcpTokenScopes(availableScopes)),
       );
@@ -150,18 +158,37 @@ export function McpTokenManager(props: McpTokenManagerProps) {
     });
   }
 
-  function applyScopeDefaults(scope: McpTokenScopeTier) {
-    setFormScope(scope);
-    setFormScopes(new Set(defaultMcpTokenScopes(scopes, scope)));
+  function applyTemplate(templateId: McpTokenTemplateId) {
+    setFormTemplateId(templateId);
+    const template = templates.find((t) => t.id === templateId);
+    if (!template) return;
+    setFormScope(template.tier);
+    if (templateId === "custom") {
+      // Preserve whatever the user had ticked; fall back to read defaults
+      // if they switched to custom from a clean form.
+      setFormScopes((prev) =>
+        prev.size > 0 ? prev : new Set(defaultMcpTokenScopes(scopes)),
+      );
+    } else {
+      setFormScopes(new Set(template.grants));
+    }
   }
 
-  function openForm(scope: McpTokenScopeTier = "read") {
+  function openForm(templateId: McpTokenTemplateId = "development") {
     setInlineError(null);
     setFormName("");
-    setFormScope(scope);
-    setFormScopes(new Set(defaultMcpTokenScopes(scopes, scope)));
     setFormExpires("90");
     setNotice(null);
+    setFormTemplateId(templateId);
+    const template = templates.find((t) => t.id === templateId);
+    if (template && templateId !== "custom") {
+      setFormScope(template.tier);
+      setFormScopes(new Set(template.grants));
+    } else {
+      // Custom or templates-not-yet-loaded → fall back to read defaults.
+      setFormScope("read");
+      setFormScopes(new Set(defaultMcpTokenScopes(scopes)));
+    }
     setView({ kind: "form", error: null });
   }
 
@@ -172,11 +199,29 @@ export function McpTokenManager(props: McpTokenManagerProps) {
       else next.add(scope);
       return next;
     });
+    // Manually toggling a scope means the operator has diverged from the
+    // template — drop them into "custom" so the picker label stays honest.
+    setFormTemplateId("custom");
   }
 
   function submit() {
     startTransition(async () => {
       const expiresInDays = formExpires === "never" ? null : parseInt(formExpires, 10);
+      if (formTemplateId !== "custom") {
+        const result = await issueMyTemplateMcpToken({
+          templateId: formTemplateId,
+          name: formName.trim(),
+          expiresInDays,
+          baseUrl: props.baseUrl,
+        });
+        if (!result.ok) {
+          setView({ kind: "form", error: result.message });
+          return;
+        }
+        setView({ kind: "issued", payload: { ...result, mode: "issued" } });
+        refresh();
+        return;
+      }
       const result = await issueMyMcpToken({
         name: formName.trim(),
         capability: formScope === "read" ? "read" : "write",
@@ -285,7 +330,9 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             <h2 className="text-lg font-semibold text-[var(--dpf-text)]">MCP access tokens</h2>
           </div>
           <p className="mt-1 max-w-2xl text-sm leading-5 text-[var(--dpf-muted)]">
-            External coding-agent access for <code>/api/mcp/v1</code>.
+            External coding-agent access for <code>/api/mcp/v1</code>. Pick a
+            role template (Admin, Development, Employee, Observer) or compose
+            a custom grant set.
           </p>
         </div>
         <div className="flex shrink-0 flex-wrap items-center gap-2">
@@ -294,18 +341,19 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             onClick={issueWriteToken}
             disabled={pending}
             className={buttonClass("primary")}
+            title="One-click: issues a development-template token (read code/specs, write backlog/work-capsules, sandbox + iac_execute) valid for 90 days."
           >
             <ShieldCheck className="h-4 w-4" aria-hidden="true" />
-            Issue write token
+            Issue development token
           </button>
           <button
             type="button"
-            onClick={() => openForm("read")}
+            onClick={() => openForm("development")}
             disabled={pending}
             className={buttonClass()}
           >
             <Plus className={iconClass()} aria-hidden="true" />
-            Generate token
+            Issue token from template
           </button>
         </div>
       </div>
@@ -362,13 +410,15 @@ export function McpTokenManager(props: McpTokenManagerProps) {
           formName={formName}
           formScope={formScope}
           formScopes={formScopes}
+          formTemplateId={formTemplateId}
           pending={pending}
           scopes={scopes}
+          templates={templates}
           onCancel={() => setView({ kind: "idle" })}
           onExpiresChange={setFormExpires}
           onNameChange={setFormName}
-          onScopeChange={applyScopeDefaults}
           onSubmit={submit}
+          onTemplateChange={applyTemplate}
           onToggleScope={toggleScope}
         />
       )}
@@ -520,27 +570,35 @@ function TokenFormDialog(props: {
   formName: string;
   formScope: McpTokenScopeTier;
   formScopes: Set<string>;
+  formTemplateId: McpTokenTemplateId;
   pending: boolean;
   scopes: string[];
+  templates: McpTokenTemplateSummary[];
   onCancel: () => void;
   onExpiresChange: (value: string) => void;
   onNameChange: (value: string) => void;
-  onScopeChange: (value: McpTokenScopeTier) => void;
   onSubmit: () => void;
+  onTemplateChange: (value: McpTokenTemplateId) => void;
   onToggleScope: (scope: string) => void;
 }) {
+  const activeTemplate = props.templates.find((t) => t.id === props.formTemplateId);
+  const showCustomGrants = props.formTemplateId === "custom";
+  const groupedTemplates = useMemo(() => groupTemplatesByCategory(props.templates), [props.templates]);
+
   return (
     <DialogFrame onClose={props.onCancel}>
       <div
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-lg rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5 shadow-xl"
+        className="w-full max-w-xl rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5 shadow-xl"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Generate MCP token</h3>
-            <p className="mt-1 text-xs text-[var(--dpf-muted)]">Choose authority, scopes, and expiry for this client.</p>
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Issue MCP token</h3>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Pick the role this token is for. Grants and audit tier come from the template; switch to Custom to compose them by hand.
+            </p>
           </div>
           <button type="button" onClick={props.onCancel} className={buttonClass()}>
             <X className={iconClass()} aria-hidden="true" />
@@ -550,46 +608,89 @@ function TokenFormDialog(props: {
 
         <div className="mt-4 space-y-3">
           <label className="block text-sm">
+            <span className="font-medium text-[var(--dpf-text)]">Role template</span>
+            <select
+              value={props.formTemplateId}
+              onChange={(event) => props.onTemplateChange(event.target.value as McpTokenTemplateId)}
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
+            >
+              {groupedTemplates.map((group) => (
+                <optgroup
+                  key={group.category}
+                  label={categoryLabel(group.category)}
+                  className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+                >
+                  {group.templates.map((template) => (
+                    <option
+                      key={template.id}
+                      value={template.id}
+                      className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+                    >
+                      {template.label} ({template.tier})
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            {activeTemplate && (
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">{activeTemplate.description}</p>
+            )}
+          </label>
+
+          {!showCustomGrants && activeTemplate && (
+            <fieldset className="text-sm">
+              <legend className="font-medium text-[var(--dpf-text)]">
+                Grants ({activeTemplate.grants.length})
+              </legend>
+              <div className="mt-2 flex max-h-32 flex-wrap gap-1.5 overflow-y-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+                {activeTemplate.grants.length === 0 ? (
+                  <span className="text-xs text-[var(--dpf-muted)]">
+                    No grants from this template are registered on this install.
+                  </span>
+                ) : (
+                  activeTemplate.grants.map((grant) => (
+                    <span
+                      key={grant}
+                      className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 font-mono text-[11px] text-[var(--dpf-text)]"
+                    >
+                      {grant}
+                    </span>
+                  ))
+                )}
+              </div>
+            </fieldset>
+          )}
+
+          {showCustomGrants && (
+            <fieldset className="text-sm">
+              <legend className="font-medium text-[var(--dpf-text)]">
+                Scopes ({props.formScopes.size} selected)
+              </legend>
+              <div className="mt-2 grid max-h-44 grid-cols-1 gap-1 overflow-y-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 sm:grid-cols-2">
+                {props.scopes.map((scope) => (
+                  <label key={scope} className="inline-flex items-center gap-2 text-xs text-[var(--dpf-text)]">
+                    <input
+                      type="checkbox"
+                      checked={props.formScopes.has(scope)}
+                      onChange={() => props.onToggleScope(scope)}
+                    />
+                    <span className="break-all">{scope}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          )}
+
+          <label className="block text-sm">
             <span className="font-medium text-[var(--dpf-text)]">Name</span>
             <input
               type="text"
               value={props.formName}
               onChange={(event) => props.onNameChange(event.target.value)}
-              placeholder="Mark laptop"
+              placeholder={activeTemplate?.label ?? "Mark laptop"}
               className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
             />
           </label>
-
-          <fieldset className="text-sm">
-            <legend className="font-medium text-[var(--dpf-text)]">Scope tier</legend>
-            <div className="mt-2 grid gap-2 sm:grid-cols-3">
-              {(["read", "write", "admin"] as const).map((scope) => (
-                <ScopeTierOption
-                  key={scope}
-                  checked={props.formScope === scope}
-                  label={scope}
-                  value={scope}
-                  onChange={() => props.onScopeChange(scope)}
-                />
-              ))}
-            </div>
-          </fieldset>
-
-          <fieldset className="text-sm">
-            <legend className="font-medium text-[var(--dpf-text)]">Scopes</legend>
-            <div className="mt-2 grid max-h-44 grid-cols-1 gap-1 overflow-y-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 sm:grid-cols-2">
-              {props.scopes.map((scope) => (
-                <label key={scope} className="inline-flex items-center gap-2 text-xs text-[var(--dpf-text)]">
-                  <input
-                    type="checkbox"
-                    checked={props.formScopes.has(scope)}
-                    onChange={() => props.onToggleScope(scope)}
-                  />
-                  <span className="break-all">{scope}</span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
 
           <label className="block text-sm">
             <span className="font-medium text-[var(--dpf-text)]">Expires</span>
@@ -620,11 +721,15 @@ function TokenFormDialog(props: {
           <button
             type="button"
             onClick={props.onSubmit}
-            disabled={props.pending || !props.formName.trim() || props.formScopes.size === 0}
+            disabled={
+              props.pending ||
+              (showCustomGrants && props.formScopes.size === 0) ||
+              (!showCustomGrants && (activeTemplate?.grants.length ?? 0) === 0)
+            }
             className={buttonClass("primary")}
           >
             <KeyRound className="h-4 w-4" aria-hidden="true" />
-            {props.pending ? "Generating..." : "Generate"}
+            {props.pending ? "Generating..." : "Issue token"}
           </button>
         </div>
       </div>
@@ -632,26 +737,37 @@ function TokenFormDialog(props: {
   );
 }
 
-function ScopeTierOption(props: {
-  checked: boolean;
-  label: string;
-  value: McpTokenScopeTier;
-  onChange: () => void;
-}) {
-  return (
-    <label
-      className="flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[var(--dpf-text)]"
-    >
-      <input
-        type="radio"
-        name="scope-tier"
-        value={props.value}
-        checked={props.checked}
-        onChange={props.onChange}
-      />
-      <span className="text-sm">{props.label}</span>
-    </label>
-  );
+function categoryLabel(category: McpTokenTemplateSummary["category"]): string {
+  switch (category) {
+    case "admin":
+      return "Admin";
+    case "development":
+      return "Development";
+    case "employee":
+      return "Employee surfaces";
+    case "observer":
+      return "Observers";
+    case "custom":
+      return "Custom";
+  }
+}
+
+function groupTemplatesByCategory(
+  templates: McpTokenTemplateSummary[],
+): Array<{ category: McpTokenTemplateSummary["category"]; templates: McpTokenTemplateSummary[] }> {
+  const order: McpTokenTemplateSummary["category"][] = [
+    "admin",
+    "development",
+    "employee",
+    "observer",
+    "custom",
+  ];
+  return order
+    .map((category) => ({
+      category,
+      templates: templates.filter((t) => t.category === category),
+    }))
+    .filter((g) => g.templates.length > 0);
 }
 
 function IssuedTokenDialog(props: { payload: Issued; onClose: () => void }) {

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -30,13 +30,66 @@ import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 import {
   copyMyMcpToken,
   issueMyMcpToken,
+  issueMyTemplateMcpToken,
   issueMyWriteMcpToken,
   listAvailableMcpScopes,
+  listMcpTokenTemplates,
   listMyMcpTokens,
   revokeMyMcpToken,
   rotateMyMcpToken,
   upgradeMyMcpTokenForCodingAgent,
 } from "./mcp-tokens";
+
+// Grant map used by the template-resolution path. Lists every grant our
+// templates reference so resolveTemplateGrants() does not silently strip
+// scopes when the test runs against the mocked catalog.
+const FULL_GRANT_MAP: Record<string, string[]> = {
+  t_a: ["architecture_read"],
+  t_b: ["backlog_read"],
+  t_c: ["code_graph_read"],
+  t_d: ["file_read"],
+  t_e: ["spec_plan_read"],
+  t_f: ["work_capsule_read"],
+  t_g: ["registry_read"],
+  t_h: ["ea_graph_read"],
+  t_i: ["thread_read"],
+  t_j: ["deliberation_read"],
+  t_k: ["release_plan_read"],
+  t_l: ["agent_control_read"],
+  t_m: ["telemetry_read"],
+  t_n: ["portfolio_read"],
+  t_o: ["document_read"],
+  t_p: ["admin_read"],
+  t_q: ["marketing_read"],
+  t_r: ["consumer_read"],
+  t_s: ["backlog_write"],
+  t_t: ["backlog_triage"],
+  t_u: ["build_promote"],
+  t_v: ["build_plan_write"],
+  t_w: ["work_capsule_write"],
+  t_x: ["work_capsule_adopt"],
+  t_y: ["sandbox_execute"],
+  t_z: ["iac_execute"],
+  t_aa: ["deployment_plan_create"],
+  t_ab: ["release_gate_create"],
+  t_ac: ["release_plan_create"],
+  t_ad: ["deliberation_create"],
+  t_ae: ["thread_write"],
+  t_af: ["decision_record_create"],
+  t_ag: ["tool_evaluation_create"],
+  t_ah: ["document_write"],
+  t_ai: ["ea_graph_write"],
+  t_aj: ["registry_write"],
+  t_ak: ["document_publish"],
+  t_al: ["consumer_write"],
+  t_am: ["policy_write"],
+  t_an: ["financial_report_create"],
+  t_ao: ["marketing_write"],
+  t_ap: ["web_search"],
+  t_aq: ["external_registry_search"],
+  t_ar: ["data_governance_validate"],
+  t_as: ["admin_write"],
+};
 
 const addScopesMock = addScopesToMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const authMock = auth as unknown as ReturnType<typeof vi.fn>;
@@ -119,8 +172,9 @@ describe("listMyMcpTokens", () => {
 });
 
 describe("issueMyWriteMcpToken", () => {
-  it("one-click issues a write-scoped token with the standard write grant set", async () => {
+  it("one-click issues a development-template token (rotation of the legacy write affordance)", async () => {
     authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue(FULL_GRANT_MAP);
     issueMock.mockResolvedValue({
       ok: true,
       tokenId: "tok_write",
@@ -140,10 +194,203 @@ describe("issueMyWriteMcpToken", () => {
         userId: "u1",
         capability: "write",
         scope: "write",
-        name: "Write MCP token",
-        scopes: expect.arrayContaining(["backlog_read", "work_capsule_write"]),
+        name: "Development MCP token",
+        scopes: expect.arrayContaining([
+          "backlog_read",
+          "work_capsule_write",
+          "sandbox_execute",
+          "iac_execute",
+        ]),
       }),
     );
+  });
+});
+
+describe("listMcpTokenTemplates", () => {
+  it("returns empty for unauthenticated requests", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await listMcpTokenTemplates();
+    expect(result.templates).toEqual([]);
+  });
+
+  it("returns the canonical templates with grants resolved against the install catalog", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue(FULL_GRANT_MAP);
+    const result = await listMcpTokenTemplates();
+    const ids = result.templates.map((t) => t.id);
+    expect(ids).toEqual([
+      "admin",
+      "development",
+      "employee_finance",
+      "employee_hr",
+      "employee_ea",
+      "employee_marketing",
+      "observer",
+      "custom",
+    ]);
+    const dev = result.templates.find((t) => t.id === "development");
+    expect(dev?.tier).toBe("write");
+    expect(dev?.grants).toEqual(expect.arrayContaining(["iac_execute", "sandbox_execute"]));
+    const observer = result.templates.find((t) => t.id === "observer");
+    // Observer must never carry a *_write grant.
+    expect(observer?.grants.some((g) => g.endsWith("_write"))).toBe(false);
+  });
+
+  it("strips template grants that the install does not expose", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    // Bare-bones catalog: only backlog_read is registered.
+    grantMapMock.mockReturnValue({ tool_a: ["backlog_read"] });
+    const result = await listMcpTokenTemplates();
+    const finance = result.templates.find((t) => t.id === "employee_finance");
+    expect(finance?.grants).toEqual(["backlog_read"]);
+  });
+});
+
+describe("issueMyTemplateMcpToken", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await issueMyTemplateMcpToken({
+      templateId: "development",
+      name: "agent",
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("unauthorized");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown templates", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const result = await issueMyTemplateMcpToken({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      templateId: "not_a_real_template" as any,
+      name: "agent",
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("invalid_template");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to issue from the custom template (use issueMyMcpToken instead)", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const result = await issueMyTemplateMcpToken({
+      templateId: "custom",
+      name: "agent",
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("invalid_template");
+  });
+
+  it("fails when the install does not expose any of the template's grants", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue({ tool_a: ["unrelated_grant"] });
+    const result = await issueMyTemplateMcpToken({
+      templateId: "employee_finance",
+      name: "Finance bot",
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("no_resolvable_scopes");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("issues a finance-employee token with only finance-relevant scopes", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue(FULL_GRANT_MAP);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_fin",
+      plaintext: "dpfmcp_FIN",
+      prefix: "dpfmcp_FIN1",
+      tokenSuffix: "FIN1",
+      expiresAt: new Date("2026-08-25T00:00:00Z"),
+    });
+    const result = await issueMyTemplateMcpToken({
+      templateId: "employee_finance",
+      name: "Finance coworker",
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        scope: "write",
+        capability: "write",
+        name: "Finance coworker",
+        scopes: expect.arrayContaining(["financial_report_create", "registry_read"]),
+      }),
+    );
+    const passed = issueMock.mock.calls[0]![0] as { scopes: string[] };
+    // Finance must never carry sandbox_execute or iac_execute.
+    expect(passed.scopes).not.toContain("sandbox_execute");
+    expect(passed.scopes).not.toContain("iac_execute");
+    expect(passed.scopes).not.toContain("admin_write");
+  });
+
+  it("issues an admin token at the admin tier with admin_write included", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue(FULL_GRANT_MAP);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_admin",
+      plaintext: "dpfmcp_ADM",
+      prefix: "dpfmcp_ADM1",
+      tokenSuffix: "ADM1",
+      expiresAt: null,
+    });
+    const result = await issueMyTemplateMcpToken({
+      templateId: "admin",
+      name: "Platform admin",
+      expiresInDays: null,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "admin",
+        capability: "write",
+        scopes: expect.arrayContaining(["admin_write", "iac_execute"]),
+      }),
+    );
+  });
+
+  it("issues an observer token at the read tier with no *_write scopes", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue(FULL_GRANT_MAP);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_obs",
+      plaintext: "dpfmcp_OBS",
+      prefix: "dpfmcp_OBS1",
+      tokenSuffix: "OBS1",
+      expiresAt: null,
+    });
+    const result = await issueMyTemplateMcpToken({
+      templateId: "observer",
+      name: "Read-only dashboard",
+      expiresInDays: null,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "read",
+        capability: "read",
+      }),
+    );
+    const passed = issueMock.mock.calls[0]![0] as { scopes: string[] };
+    expect(passed.scopes.some((g) => g.endsWith("_write"))).toBe(false);
   });
 });
 

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -17,7 +17,11 @@ import { buildSetupSnippets } from "@/lib/auth/mcp-setup-snippets";
 import { writeMcpJsonToHost } from "@/lib/auth/mcp-host-writer";
 import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
-  WRITE_MCP_TOKEN_SCOPES,
+  getMcpTokenTemplate,
+  MCP_TOKEN_TEMPLATES,
+  resolveTemplateGrants,
+  type McpTokenTemplate,
+  type McpTokenTemplateId,
 } from "@/lib/mcp-token-scopes";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 
@@ -130,23 +134,80 @@ export async function issueMyMcpToken(input: {
   };
 }
 
-export async function issueMyWriteMcpToken(input: {
+// Lightweight DTO for the admin UI's template picker. We hand the client a
+// trimmed payload (no closures, no nested helpers) since this is rendered in
+// a client component.
+export type McpTokenTemplateSummary = {
+  id: McpTokenTemplateId;
+  label: string;
+  category: McpTokenTemplate["category"];
+  tier: McpTokenTemplate["tier"];
+  description: string;
+  grants: string[];
+};
+
+export async function listMcpTokenTemplates(): Promise<{
+  templates: McpTokenTemplateSummary[];
+}> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { templates: [] };
+  }
+  const { scopes: availableScopes } = await listAvailableMcpScopes();
+  const templates = MCP_TOKEN_TEMPLATES.map<McpTokenTemplateSummary>((t) => ({
+    id: t.id,
+    label: t.label,
+    category: t.category,
+    tier: t.tier,
+    description: t.description,
+    // Resolve against this install's catalog so the UI cannot pre-select a
+    // grant that the platform would silently strip at issue time. The
+    // `custom` template intentionally exposes no preselected grants.
+    grants: resolveTemplateGrants(t, availableScopes),
+  }));
+  return { templates };
+}
+
+export async function issueMyTemplateMcpToken(input: {
+  templateId: McpTokenTemplateId;
+  name: string;
+  expiresInDays: number | null;
   baseUrl: string;
-  name?: string;
-  expiresInDays?: number | null;
 }): Promise<IssueTokenActionResult> {
   const session = await auth();
   if (!session?.user?.id) {
     return { ok: false, error: "unauthorized", message: "Sign in first" };
   }
+  const template = getMcpTokenTemplate(input.templateId);
+  if (!template || template.id === "custom") {
+    return {
+      ok: false,
+      error: "invalid_template",
+      message:
+        template?.id === "custom"
+          ? "Custom tokens must be issued via issueMyMcpToken with an explicit scope list."
+          : `Unknown MCP token template: ${input.templateId}`,
+    };
+  }
 
+  const { scopes: availableScopes } = await listAvailableMcpScopes();
+  const scopes = resolveTemplateGrants(template, availableScopes);
+  if (scopes.length === 0) {
+    return {
+      ok: false,
+      error: "no_resolvable_scopes",
+      message: `Template "${template.label}" has no grants registered on this install.`,
+    };
+  }
+
+  const capability: McpTokenCapability = template.tier === "read" ? "read" : "write";
   const result: IssueMcpTokenResult = await issueMcpApiToken({
     userId: session.user.id,
-    name: input.name?.trim() || "Write MCP token",
-    capability: "write",
-    scope: "write",
-    scopes: [...WRITE_MCP_TOKEN_SCOPES],
-    expiresInDays: input.expiresInDays === undefined ? 90 : input.expiresInDays,
+    name: input.name.trim() || template.label,
+    capability,
+    scope: template.tier,
+    scopes,
+    expiresInDays: input.expiresInDays,
     agentId: null,
   });
   if (!result.ok) {
@@ -162,6 +223,23 @@ export async function issueMyWriteMcpToken(input: {
     expiresAt: result.expiresAt?.toISOString() ?? null,
     setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
   };
+}
+
+// Back-compat alias: the one-click "Issue write token" / "Issue development
+// token" button on the admin page now goes through the development template
+// so the grant bundle stays in one place (mcp-token-scopes.ts). Callers that
+// passed name / expiresInDays still work.
+export async function issueMyWriteMcpToken(input: {
+  baseUrl: string;
+  name?: string;
+  expiresInDays?: number | null;
+}): Promise<IssueTokenActionResult> {
+  return issueMyTemplateMcpToken({
+    templateId: "development",
+    name: input.name?.trim() || "Development MCP token",
+    expiresInDays: input.expiresInDays === undefined ? 90 : input.expiresInDays,
+    baseUrl: input.baseUrl,
+  });
 }
 
 function isOwnedActiveToken(

--- a/apps/web/lib/mcp-token-scopes.test.ts
+++ b/apps/web/lib/mcp-token-scopes.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
+  MCP_TOKEN_TEMPLATES,
   WRITE_MCP_TOKEN_SCOPES,
   defaultMcpTokenScopes,
+  getMcpTokenTemplate,
+  resolveTemplateGrants,
 } from "./mcp-token-scopes";
 
 describe("defaultMcpTokenScopes", () => {
@@ -48,5 +51,78 @@ describe("defaultMcpTokenScopes", () => {
     expect(defaultMcpTokenScopes([...CODING_AGENT_MCP_TOKEN_SCOPES])).toEqual([
       ...CODING_AGENT_MCP_TOKEN_SCOPES,
     ]);
+  });
+});
+
+describe("MCP_TOKEN_TEMPLATES", () => {
+  it("exposes the canonical role catalog in display order", () => {
+    expect(MCP_TOKEN_TEMPLATES.map((t) => t.id)).toEqual([
+      "admin",
+      "development",
+      "employee_finance",
+      "employee_hr",
+      "employee_ea",
+      "employee_marketing",
+      "observer",
+      "custom",
+    ]);
+  });
+
+  it("tags each template with a coarse tier consistent with its grants", () => {
+    const admin = getMcpTokenTemplate("admin");
+    const development = getMcpTokenTemplate("development");
+    const observer = getMcpTokenTemplate("observer");
+    const custom = getMcpTokenTemplate("custom");
+
+    expect(admin?.tier).toBe("admin");
+    expect(admin?.grants).toContain("admin_write");
+    expect(admin?.grants).toContain("iac_execute");
+
+    expect(development?.tier).toBe("write");
+    expect(development?.grants).toContain("sandbox_execute");
+    expect(development?.grants).toContain("iac_execute");
+    expect(development?.grants).not.toContain("admin_write");
+
+    expect(observer?.tier).toBe("read");
+    // An observer must never have a write or sandbox_execute grant.
+    expect(observer?.grants.some((g) => g.endsWith("_write"))).toBe(false);
+    expect(observer?.grants).not.toContain("sandbox_execute");
+    expect(observer?.grants).not.toContain("iac_execute");
+
+    // Custom is a UI-only sentinel; it must not pre-select any grants.
+    expect(custom?.grants).toEqual([]);
+  });
+
+  it("groups employee surfaces under the employee category", () => {
+    const employees = MCP_TOKEN_TEMPLATES.filter((t) => t.category === "employee");
+    expect(employees.map((t) => t.id).sort()).toEqual([
+      "employee_ea",
+      "employee_finance",
+      "employee_hr",
+      "employee_marketing",
+    ]);
+    // Employee surfaces must not include the platform admin/iac grants.
+    for (const t of employees) {
+      expect(t.grants).not.toContain("admin_write");
+      expect(t.grants).not.toContain("iac_execute");
+      expect(t.grants).not.toContain("sandbox_execute");
+    }
+  });
+
+  it("returns undefined for unknown template ids", () => {
+    expect(getMcpTokenTemplate("does_not_exist")).toBeUndefined();
+  });
+});
+
+describe("resolveTemplateGrants", () => {
+  it("filters template grants down to the install's available scope catalog", () => {
+    const development = getMcpTokenTemplate("development")!;
+    const resolved = resolveTemplateGrants(development, ["backlog_read", "iac_execute"]);
+    expect(resolved.sort()).toEqual(["backlog_read", "iac_execute"]);
+  });
+
+  it("returns empty when no grants overlap (do-not-issue signal)", () => {
+    const finance = getMcpTokenTemplate("employee_finance")!;
+    expect(resolveTemplateGrants(finance, ["unrelated_grant"])).toEqual([]);
   });
 });

--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -40,3 +40,260 @@ export function defaultMcpTokenScopes(
   const available = new Set(availableScopes);
   return requestedScopesForTier(tier).filter((scope) => available.has(scope));
 }
+
+// ---------------------------------------------------------------------------
+// Role-based token templates
+// ---------------------------------------------------------------------------
+//
+// The coarse scope tier (read/write/admin) tells an auditor at a glance how
+// dangerous a token is. The granular `scopes[]` array is what governedExecuteTool
+// actually enforces. The templates below bundle the right grants for the
+// common consumer of an MCP token — a development agent, a finance coworker,
+// an HR coworker, etc — so issuance is a one-click role choice instead of a
+// "tick 30 checkboxes correctly" exercise.
+//
+// Template grants are drawn from the existing TOOL_TO_GRANTS catalog
+// (apps/web/lib/tak/agent-grants.ts). Adding a new grant string anywhere
+// requires updating both that file and the relevant template here in the
+// same commit.
+
+export const MCP_TOKEN_TEMPLATE_CATEGORIES = [
+  "admin",
+  "development",
+  "employee",
+  "observer",
+  "custom",
+] as const;
+
+export type McpTokenTemplateCategory =
+  (typeof MCP_TOKEN_TEMPLATE_CATEGORIES)[number];
+
+export const MCP_TOKEN_TEMPLATE_IDS = [
+  "admin",
+  "development",
+  "employee_finance",
+  "employee_hr",
+  "employee_ea",
+  "employee_marketing",
+  "observer",
+  "custom",
+] as const;
+
+export type McpTokenTemplateId = (typeof MCP_TOKEN_TEMPLATE_IDS)[number];
+
+export type McpTokenTemplate = {
+  id: McpTokenTemplateId;
+  label: string;
+  category: McpTokenTemplateCategory;
+  tier: McpTokenScopeTier;
+  description: string;
+  grants: readonly string[];
+};
+
+const DEVELOPMENT_TEMPLATE_GRANTS = [
+  // Reads needed to navigate the codebase, specs, backlog, and architecture
+  "architecture_read",
+  "backlog_read",
+  "code_graph_read",
+  "file_read",
+  "spec_plan_read",
+  "work_capsule_read",
+  "registry_read",
+  "ea_graph_read",
+  "thread_read",
+  "deliberation_read",
+  "release_plan_read",
+  "agent_control_read",
+  "telemetry_read",
+  "portfolio_read",
+  "document_read",
+  // Writes / actions for the build-studio + ship loop
+  "backlog_write",
+  "backlog_triage",
+  "build_promote",
+  "build_plan_write",
+  "work_capsule_write",
+  "work_capsule_adopt",
+  "sandbox_execute",
+  "iac_execute",
+  "deployment_plan_create",
+  "release_gate_create",
+  "release_plan_create",
+  "deliberation_create",
+  "thread_write",
+  "decision_record_create",
+  "tool_evaluation_create",
+  "document_write",
+] as const;
+
+const EMPLOYEE_FINANCE_TEMPLATE_GRANTS = [
+  "financial_report_create",
+  "registry_read",
+  "document_read",
+  "backlog_read",
+  "thread_read",
+] as const;
+
+const EMPLOYEE_HR_TEMPLATE_GRANTS = [
+  "consumer_read",
+  "consumer_write",
+  "policy_write",
+  "registry_read",
+  "document_read",
+  "backlog_read",
+  "thread_read",
+] as const;
+
+const EMPLOYEE_EA_TEMPLATE_GRANTS = [
+  "ea_graph_read",
+  "ea_graph_write",
+  "architecture_read",
+  "registry_read",
+  "registry_write",
+  "document_read",
+  "document_write",
+  "document_publish",
+  "backlog_read",
+  "thread_read",
+] as const;
+
+const EMPLOYEE_MARKETING_TEMPLATE_GRANTS = [
+  "marketing_read",
+  "marketing_write",
+  "registry_read",
+  "document_read",
+  "web_search",
+  "thread_read",
+] as const;
+
+const OBSERVER_TEMPLATE_GRANTS = [
+  "architecture_read",
+  "backlog_read",
+  "code_graph_read",
+  "file_read",
+  "spec_plan_read",
+  "work_capsule_read",
+  "registry_read",
+  "ea_graph_read",
+  "thread_read",
+  "deliberation_read",
+  "release_plan_read",
+  "agent_control_read",
+  "telemetry_read",
+  "document_read",
+  "admin_read",
+  "marketing_read",
+  "consumer_read",
+  "portfolio_read",
+] as const;
+
+// Admin is the union of every grant a development token plus every
+// employee surface plus admin_*/policy_write/data_governance_validate.
+// Built by combining the smaller templates so we do not maintain two lists.
+const ADMIN_TEMPLATE_GRANTS = Array.from(
+  new Set<string>([
+    ...DEVELOPMENT_TEMPLATE_GRANTS,
+    ...EMPLOYEE_FINANCE_TEMPLATE_GRANTS,
+    ...EMPLOYEE_HR_TEMPLATE_GRANTS,
+    ...EMPLOYEE_EA_TEMPLATE_GRANTS,
+    ...EMPLOYEE_MARKETING_TEMPLATE_GRANTS,
+    "admin_read",
+    "admin_write",
+    "data_governance_validate",
+    "external_registry_search",
+    "web_search",
+    "registry_write",
+    "document_publish",
+  ]),
+);
+
+export const MCP_TOKEN_TEMPLATES: readonly McpTokenTemplate[] = [
+  {
+    id: "admin",
+    label: "Admin",
+    category: "admin",
+    tier: "admin",
+    description:
+      "Full platform admin including admin_write, policy_write, and every employee surface. Use sparingly.",
+    grants: ADMIN_TEMPLATE_GRANTS,
+  },
+  {
+    id: "development",
+    label: "Development",
+    category: "development",
+    tier: "write",
+    description:
+      "Coding agent: read code/specs/backlog, write backlog and work capsules, run sandbox, ship via Build Studio (sandbox_execute + iac_execute).",
+    grants: DEVELOPMENT_TEMPLATE_GRANTS,
+  },
+  {
+    id: "employee_finance",
+    label: "Employee — Finance",
+    category: "employee",
+    tier: "write",
+    description:
+      "Finance human or coworker: period summaries, financial reports, supporting registry/document reads.",
+    grants: EMPLOYEE_FINANCE_TEMPLATE_GRANTS,
+  },
+  {
+    id: "employee_hr",
+    label: "Employee — HR",
+    category: "employee",
+    tier: "write",
+    description:
+      "HR human or coworker: employee records, leave policy, supporting registry/document reads.",
+    grants: EMPLOYEE_HR_TEMPLATE_GRANTS,
+  },
+  {
+    id: "employee_ea",
+    label: "Employee — Enterprise Architecture",
+    category: "employee",
+    tier: "write",
+    description:
+      "EA human or coworker: read/write the EA graph, import/export ArchiMate, publish architecture documents.",
+    grants: EMPLOYEE_EA_TEMPLATE_GRANTS,
+  },
+  {
+    id: "employee_marketing",
+    label: "Employee — Marketing",
+    category: "employee",
+    tier: "write",
+    description:
+      "Marketing human or coworker: campaign briefs, SEO analysis, archetype refinement.",
+    grants: EMPLOYEE_MARKETING_TEMPLATE_GRANTS,
+  },
+  {
+    id: "observer",
+    label: "Read-only observer",
+    category: "observer",
+    tier: "read",
+    description:
+      "Every *_read grant in the catalog. Safe default for analytics dashboards, audit, and external monitoring agents.",
+    grants: OBSERVER_TEMPLATE_GRANTS,
+  },
+  {
+    id: "custom",
+    label: "Custom",
+    category: "custom",
+    tier: "read",
+    description:
+      "Pick individual scopes manually. Use when none of the role templates fit.",
+    grants: [],
+  },
+];
+
+export function getMcpTokenTemplate(id: string): McpTokenTemplate | undefined {
+  return MCP_TOKEN_TEMPLATES.find((t) => t.id === id);
+}
+
+// Filter a template's grants down to what the install actually exposes.
+// Mirrors defaultMcpTokenScopes: installs may not register every grant in
+// every release, and we never want to issue a token that requests a scope
+// the platform cannot honour.
+export function resolveTemplateGrants(
+  template: McpTokenTemplate,
+  availableScopes: readonly string[],
+): string[] {
+  const available = new Set(availableScopes);
+  return template.grants.filter((grant) => available.has(grant));
+}


### PR DESCRIPTION
## Summary

Refs [BI-9866659C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory) — MCP token lifecycle UX. This PR lands AC #2 (named templates) and the renaming concern; idle hygiene, rotate-with-edit, ephemeral ship-phase tokens, and revoked-token hide are deferred to follow-up.

Admin > Platform Development > MCP previously asked operators to compose a token by ticking individual grants against the coarse read/write/admin tier. Operators have to think about ~40 grant strings to issue one token, and the prominent **"Issue write token"** button hides what is functionally a development-agent bundle.

This PR adds a role template catalog so issuance becomes \"pick a role\" instead of \"pick 30 grants correctly\".

### Templates (all grants drawn from the existing TOOL_TO_GRANTS catalog — no new grant strings)

| Template | Tier | Bundle |
|---|---|---|
| **Admin** | admin | every grant including admin_write, policy_write, iac_execute |
| **Development** | write | code/specs/backlog reads, work-capsule writes, sandbox_execute, iac_execute, build_promote, release gates, deliberation |
| **Employee — Finance** | write | financial_report_create + reads |
| **Employee — HR** | write | consumer_read/write, policy_write, reads |
| **Employee — Enterprise Architecture** | write | ea_graph_read/write, document_publish |
| **Employee — Marketing** | write | marketing_read/write, reads |
| **Observer** | read | every *_read grant, no writes anywhere |
| **Custom** | user-picked | flat checkbox picker (legacy UX preserved) |

Each template's grants are filtered against the install's registered scope catalog at issue time, so installs that don't expose a given grant won't be issued a token requesting it.

### Renaming

The misleading **\"Issue write token\"** affordance becomes **\"Issue development token\"** since the bundle is the coding-agent loadout, not a generic write scope. \`issueMyWriteMcpToken\` is preserved as a back-compat alias that delegates through the development template — no callers break.

### UX changes

- Primary button: **\"Issue development token\"** (one-click 90-day dev bundle)
- Secondary button: **\"Issue token from template\"** opens the role picker modal
- Modal puts the role template dropdown above name/expiry; grants render as read-only chips when a template is active, flat checkbox picker only when Custom is selected
- Manually toggling a grant flips the picker to Custom so the label stays honest

## Test plan

- [x] \`pnpm --filter web exec vitest run\` for the three affected files: **45 tests pass**
  - \`apps/web/lib/mcp-token-scopes.test.ts\` — template catalog shape, tier consistency, employee category guard, resolveTemplateGrants
  - \`apps/web/lib/actions/mcp-tokens.test.ts\` — issueMyTemplateMcpToken (auth, unknown template, custom-template refusal, no-resolvable-scopes, finance/admin/observer issuance), listMcpTokenTemplates (unauthed, full catalog, install filtering), issueMyWriteMcpToken rotated through development template
  - \`apps/web/components/admin/McpTokenManager.test.tsx\` — \"Issue development token\" rename guard, template picker modal flow → finance token issuance
- [x] \`pnpm --filter web exec next build\` — succeeds (single pre-existing Turbopack NFT cascade warning on next.config.mjs, unrelated)
- [x] Pre-commit typecheck passes (scoped to apps/web)
- [ ] **Live portal UX verification deferred** — the operator flagged Build Studio is still being worked on, so a docker rebuild against the install needs explicit go before merge. Happy to drive the page via Claude-in-Chrome once the portal is in a state to absorb the rebuild.

## Out of scope (follow-up from BI-9866659C)

- Last-used / idle-days columns, sortable, stale filter, bulk-revoke
- One-click \"Rotate with edit\" (issue new + revoke old + refresh + show plaintext, atomically)
- Per-build ephemeral tokens auto-issued on ship-phase entry
- Show-revoked toggle + 90-day auto-archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)