### PR TITLE
fix(security): close js/tainted-format-string #52 in executeTool catch

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -12867,7 +12867,11 @@ export async function executeTool(
   }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[executeTool] Uncaught exception in tool "${toolName}":`, msg);
+    // CodeQL #52 (js/tainted-format-string): keep the format string constant
+    // so a `%s` inside an attacker-controlled toolName cannot consume the
+    // next argument. toolName + msg are passed as additional args; node's
+    // util.format only honours specifiers in the literal first arg.
+    console.error("[executeTool] Uncaught exception in tool %s: %s", toolName, msg);
     return { success: false, error: msg, message: `Tool ${toolName} failed: ${msg}` };
   }
 }


### PR DESCRIPTION
## Summary

CodeQL alert #52 (js/tainted-format-string, HIGH) flagged `console.error` in the `executeTool` catch handler — `toolName` was interpolated INTO the format string via template literal, so an attacker-controlled toolName containing `%s` could consume the next arg (here the error `msg`) when Node's `util.format` parsed the line.

**Fix:** keep the format string constant; pass `toolName` and `msg` as positional substitutions. util.format now sees only the two literal `%s` placeholders we wrote, so no extra arg consumption is possible.

## Test plan

- [ ] Typecheck (pre-commit hook ran clean)
- [ ] Unit tests — no behaviour change beyond log formatting
- [ ] CodeQL re-scan: alert #52 closes

## Related

- Closes alert #52 from the 2026-05-22 security burn-down
- Sibling PR #998 (CodeQL advanced setup + model pack) closes the remaining 4 critical FPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)