### PR TITLE
fix(build-studio): guard scoutFindings array fields in ideate dispatch

### DIFF
--- a/apps/web/lib/integrate/ideate-dispatch.test.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { buildResearchPrompt } from "./ideate-dispatch";
+
+describe("buildResearchPrompt", () => {
+  const baseParams = {
+    featureTitle: "Test feature",
+    featureDescription: "Test description",
+    reusabilityScope: "one-off",
+    userContext: "test user",
+  };
+
+  it("includes scout findings when arrays are populated", () => {
+    const prompt = buildResearchPrompt({
+      ...baseParams,
+      scoutFindings: {
+        relatedModels: [
+          { name: "User", file: "schema.prisma", line: 42 },
+          { name: "Org", file: "schema.prisma", line: 78 },
+        ],
+        gaps: [{ entity: "PermissionScope", reason: "no model exists" }],
+        suggestedQuestions: [],
+      },
+    });
+
+    expect(prompt).toContain("Related models found: User at schema.prisma:42, Org at schema.prisma:78");
+    expect(prompt).toContain("Gaps identified: PermissionScope — no model exists");
+  });
+
+  it("does not throw when scoutFindings.relatedModels is undefined", () => {
+    // Regression: type says required, but runtime JSON can omit fields. The
+    // pre-fix path crashed with "Cannot read properties of undefined (reading 'map')"
+    // on the first BS dispatch of a fresh build, before any scout has run.
+    expect(() =>
+      buildResearchPrompt({
+        ...baseParams,
+        scoutFindings: {
+          // @ts-expect-error — intentionally simulating partial JSON shape
+          relatedModels: undefined,
+          gaps: [{ entity: "X", reason: "y" }],
+          suggestedQuestions: [],
+        },
+      }),
+    ).not.toThrow();
+
+    const prompt = buildResearchPrompt({
+      ...baseParams,
+      scoutFindings: {
+        // @ts-expect-error
+        relatedModels: undefined,
+        gaps: [],
+        suggestedQuestions: [],
+      },
+    });
+    expect(prompt).toContain("Related models found: (none reported)");
+  });
+
+  it("does not throw when scoutFindings.gaps is undefined", () => {
+    expect(() =>
+      buildResearchPrompt({
+        ...baseParams,
+        scoutFindings: {
+          relatedModels: [],
+          // @ts-expect-error — intentionally simulating partial JSON shape
+          gaps: undefined,
+          suggestedQuestions: [],
+        },
+      }),
+    ).not.toThrow();
+
+    const prompt = buildResearchPrompt({
+      ...baseParams,
+      scoutFindings: {
+        relatedModels: [],
+        // @ts-expect-error
+        gaps: undefined,
+        suggestedQuestions: [],
+      },
+    });
+    expect(prompt).toContain("Gaps identified: (none reported)");
+  });
+
+  it("omits the SCOUT FINDINGS block entirely when scoutFindings is undefined", () => {
+    const prompt = buildResearchPrompt(baseParams);
+    expect(prompt).not.toContain("SCOUT FINDINGS");
+  });
+});

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -139,8 +139,15 @@ async function ensureClaudeAuth(providerId: string): Promise<{ authEnvFragment: 
  * Build the research prompt for Codex CLI.
  * This is a self-contained prompt — Codex will search the codebase,
  * read files, and output a structured JSON design document.
+ *
+ * Exported for unit testing the defensive guards on `scoutFindings.*` —
+ * the type declares those arrays as required, but `scoutFindings` comes
+ * back from JSON the scout produced, and a hallucinated or partial
+ * response can leave `relatedModels` or `gaps` undefined. Without guards
+ * the first BS dispatch on a fresh build crashes the agent send path
+ * with "Cannot read properties of undefined (reading 'map')".
  */
-function buildResearchPrompt(params: {
+export function buildResearchPrompt(params: {
   featureTitle: string;
   featureDescription: string;
   reusabilityScope: string;
@@ -158,8 +165,8 @@ ${params.businessContext ? `BUSINESS CONTEXT: ${params.businessContext}` : ""}
 ${
   params.scoutFindings
     ? `SCOUT FINDINGS (pre-validated — trust these):
-Related models found: ${params.scoutFindings.relatedModels.map((m) => `${m.name} at ${m.file}:${m.line}`).join(", ")}
-Gaps identified: ${params.scoutFindings.gaps.map((g) => `${g.entity} — ${g.reason}`).join("; ")}
+Related models found: ${(Array.isArray(params.scoutFindings.relatedModels) ? params.scoutFindings.relatedModels : []).map((m) => `${m.name} at ${m.file}:${m.line}`).join(", ") || "(none reported)"}
+Gaps identified: ${(Array.isArray(params.scoutFindings.gaps) ? params.scoutFindings.gaps : []).map((g) => `${g.entity} — ${g.reason}`).join("; ") || "(none reported)"}
 ${params.scoutFindings.externalStructure ? `External URL structure identified` : ""}
 
 Use these as the basis for your existingFunctionalityAudit. The related models above are confirmed to exist — cite them with file and line numbers.`


### PR DESCRIPTION
## Summary

`buildResearchPrompt` in `apps/web/lib/integrate/ideate-dispatch.ts` unconditionally invoked `.map` on `params.scoutFindings.relatedModels` and `.gaps`. The TS types declare both as required arrays, but the scout JSON can omit fields — and frequently does on a fresh build, a partial scout, or a hallucinated response. When that happened the first BS dispatch crashed the background agent send with:

```
TypeError: Cannot read properties of undefined (reading 'map')
```

The crash surfaced via `api/agent/send/route.ts`'s background-failure handler as the toast Mark and I saw on FB-7A21E1F6 and FB-0A1B06B3 this session: *"The AI coworker hit a background error and could not finish this request: Cannot read properties of undefined (reading 'map')"*.

## Fix

Defensive `Array.isArray(...) ? ... : []` at both call sites + a `(none reported)` fallback string so the rendered prompt stays readable when scout data is sparse. `buildResearchPrompt` is now exported so the regression test can exercise the guard directly.

## Test plan

- [x] New `lib/integrate/ideate-dispatch.test.ts` — 4 cases:
  - happy path renders both arrays
  - undefined `relatedModels` does not throw + falls back to "(none reported)"
  - undefined `gaps` same
  - missing `scoutFindings` entirely omits the SCOUT FINDINGS block
- [x] `pnpm exec vitest run lib/integrate/ideate-dispatch.test.ts` → 4/4 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] Pre-commit scoped typecheck passes

## Companion PRs from this session

- [apps#985](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/985) `fix(build-studio): guard undefined fileStructure on /build page` — same defensive-typing family, click-crash fix.
- [apps#990](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/990) `fix(sandbox): add bash to dpf-sandbox image` — root-cause unblock for BS verification.
- [apps#1000](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1000) `doc(triage): session-final-status 2026-05-22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)