### PR TITLE
fix(coworker): plain-English messages on agent-stuck and fabrication-stop paths

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -161,24 +161,35 @@ describe("shouldNudge", () => {
 });
 
 describe("buildRepeatedToolStopMessage", () => {
-  it("points non-build repeated tool loops to the activity trail instead of build evidence", () => {
-    expect(buildRepeatedToolStopMessage({
+  it("points non-build repeated tool loops to the activity trail without naming tools", () => {
+    const msg = buildRepeatedToolStopMessage({
       toolName: "suggest_campaign_ideas",
       count: 3,
       routeContext: "/customer/marketing",
       reasonHint: "",
-    })).toBe(
-      "I called suggest_campaign_ideas 3 times with the same arguments and got stuck. I recorded this as a coworker execution issue and stopped before repeating the same tool again. Check the activity trail for what was attempted, then continue from the last saved recommendation.",
-    );
+    });
+
+    // Rule #5: do not leak tool names, call counts, or "reasonHint" architecture
+    // language into the user-facing message.
+    expect(msg).not.toContain("suggest_campaign_ideas");
+    expect(msg).not.toMatch(/\d times with the same arguments/);
+    expect(msg).not.toContain("coworker execution issue");
+    expect(msg).toMatch(/activity panel/i);
+    expect(msg.toLowerCase()).toContain("got stuck");
   });
 
-  it("keeps build evidence guidance only for Build Studio routes", () => {
-    expect(buildRepeatedToolStopMessage({
+  it("points Build Studio routes at the build details panel without naming tools", () => {
+    const msg = buildRepeatedToolStopMessage({
       toolName: "saveBuildEvidence",
       count: 3,
       routeContext: "/build",
       reasonHint: "",
-    })).toContain("Check the build evidence for what was completed.");
+    });
+
+    expect(msg).not.toContain("saveBuildEvidence");
+    expect(msg).not.toMatch(/\d times with the same arguments/);
+    expect(msg).toMatch(/build's details panel|build details/i);
+    expect(msg.toLowerCase()).toContain("got stuck");
   });
 });
 
@@ -443,8 +454,13 @@ describe("runAgenticLoop", () => {
 
     expect(mockRoute).toHaveBeenCalledTimes(1);
     expect(result.providerId).toBe("local");
-    expect(result.content).toContain("routed to Docker Model Runner");
-    expect(result.content).toContain("did not produce the required tool call");
+    // User-facing message must NOT leak infrastructure names / model IDs (rule #5).
+    expect(result.content).not.toContain("Docker Model Runner");
+    expect(result.content).not.toContain("gemma");
+    expect(result.content).not.toContain("tool-capable provider");
+    expect(result.content).not.toMatch(/required tool call/);
+    expect(result.content.toLowerCase()).toContain("couldn't complete");
+    expect(result.content).toMatch(/AI Workforce/);
   });
 
   it("does not surface raw tool_use JSON when a non-build tool loop hits the runtime limit", async () => {
@@ -1028,7 +1044,12 @@ describe("runAgenticLoop", () => {
       ],
     });
 
-    expect(result.content).toContain("I called saveBuildEvidence 3 times with the same arguments and got stuck.");
+    // User-facing message must NOT leak tool names or counts (rule #5).
+    expect(result.content).not.toContain("saveBuildEvidence");
+    expect(result.content).not.toMatch(/\d times with the same arguments/);
+    // It must still tell the user a stop happened and point them at the build details.
+    expect(result.content.toLowerCase()).toContain("got stuck");
+    expect(result.content).toMatch(/build's details panel|build details/i);
     expect(mockExecuteTool).toHaveBeenCalledTimes(6);
   });
 
@@ -1235,7 +1256,13 @@ describe("runAgenticLoop", () => {
     });
 
     expect(result.content).not.toContain("Plan ready");
-    expect(result.content).toContain("Start Implementation cannot unlock until I save buildPlan");
+    // User-facing message must NOT leak tool / schema names (rule #5).
+    expect(result.content).not.toContain("saveBuildEvidence");
+    expect(result.content).not.toContain("reviewBuildPlan");
+    expect(result.content).not.toContain("buildPlan");
+    // It must explain what happened in plain language and offer a next move.
+    expect(result.content.toLowerCase()).toMatch(/caught myself saying the plan is ready/);
+    expect(result.content.toLowerCase()).toContain("send me the same instruction again");
   });
 
   it("nudges build agent to use fallback steps after failed read stalls", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -75,11 +75,24 @@ export function buildRepeatedToolStopMessage(params: {
   routeContext?: string | null;
   reasonHint: string;
 }): string {
-  const base = `I called ${params.toolName} ${params.count} times with the same arguments and got stuck.${params.reasonHint}`;
+  // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose tool
+  // names, file paths, error codes, or internal architecture to the user.
+  // The technical detail (toolName, count, reasonHint) is captured in the
+  // PlatformIssueReport via recordRepeatedToolIssue() at the call site, so
+  // platform engineers still get the full forensic trail. The user just sees
+  // an action they can take.
   if (BUILD_ROUTE_PATTERN.test(params.routeContext ?? "")) {
-    return `${base} Check the build evidence for what was completed.`;
+    return (
+      "I got stuck retrying the same step and stopped before going in circles. "
+      + "Open the build's details panel to see what's been saved, then either "
+      + "send me a new instruction or retry from there."
+    );
   }
-  return `${base} I recorded this as a coworker execution issue and stopped before repeating the same tool again. Check the activity trail for what was attempted, then continue from the last saved recommendation.`;
+  return (
+    "I got stuck retrying the same step and stopped before going in circles. "
+    + "Check the activity panel for what's been recorded, then tell me how "
+    + "you'd like to proceed."
+  );
 }
 
 export function buildRepeatedQuestionNudge(params: {
@@ -283,6 +296,11 @@ function buildFabricationFailureMessage(params: {
   tools: ToolDefinition[];
   executedTools: Array<{ name: string }>;
 }): string {
+  // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose tool
+  // names, schema fields ("buildPlan"), or internal architecture terms like
+  // "authoritative state" / "persisted evidence" to a non-technical user.
+  // The underlying technical context is preserved in the executedTools list
+  // and console logs for engineers.
   const availableToolNames = new Set(params.tools.map((tool) => tool.name));
 
   if (
@@ -290,19 +308,32 @@ function buildFabricationFailureMessage(params: {
     && availableToolNames.has("saveBuildEvidence")
     && availableToolNames.has("reviewBuildPlan")
   ) {
-    return "I still have not persisted the implementation plan evidence. Start Implementation cannot unlock until I save buildPlan and complete reviewBuildPlan, so I am stopping instead of claiming the plan is ready.";
+    return (
+      "I caught myself saying the plan is ready before I'd actually recorded it. "
+      + "I stopped so we don't end up with a half-saved plan. "
+      + "Send me the same instruction again and I'll record it properly this time, "
+      + "or open the build details to see what's saved so far."
+    );
   }
 
-  return "I stopped because I was still describing work without using the required tools. The authoritative state was not updated yet, so the claimed progress would have been misleading.";
+  return (
+    "I caught myself describing work without actually doing it, and stopped so we "
+    + "don't end up with progress that isn't real. "
+    + "Send me the same instruction again, or check the build details to see what's "
+    + "been recorded so far."
+  );
 }
 
-function buildLocalToolCallFailureMessage(result: RoutedInferenceResult): string {
-  const modelLabel = result.modelId || "the selected local model";
-  return [
-    "This turn routed to Docker Model Runner, but the local model did not produce the required tool call for this data-backed request.",
-    `Model: ${modelLabel}.`,
-    "The route is recorded, but there is no tool-backed result to return. Retry with a tool-capable provider or update this coworker's model assignment before asking for current operational totals.",
-  ].join(" ");
+function buildLocalToolCallFailureMessage(_result: RoutedInferenceResult): string {
+  // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose
+  // infrastructure names ("Docker Model Runner"), model IDs, or routing
+  // architecture. The internal route + model details are already recorded
+  // for engineers via RoutedInferenceResult.
+  return (
+    "I couldn't complete this with the model my admin assigned me. "
+    + "Please try the question again — I'll route through a different model. "
+    + "If it keeps failing, an admin can update my model assignment in the AI Workforce settings."
+  );
 }
 
 type ExecutedTool = { name: string; args?: Record<string, unknown>; result: ToolResult };


### PR DESCRIPTION
## Summary

Three user-facing message helpers in `apps/web/lib/tak/agentic-loop.ts` violated `IDENTITY_BLOCK` rule #5 ("NEVER mention internal details: schemas, table names, tool names, file paths, error codes, or system architecture"). Output landed in the AI coworker chat panel and left non-technical users with no idea what to do.

Surfaced by Mark this session auditing the BS coworker dialog. Two real examples from FB-0A1B06B3 / FB-7A21E1F6:

> **Software Engineer**
> I stopped because I was still describing work without using the required tools. The authoritative state was not updated yet, so the claimed progress would have been misleading.

> **Software Engineer**
> I called saveBuildEvidence 5 times with the same arguments and got stuck. Check the build evidence for what was completed.

A non-technical user has no idea what `saveBuildEvidence` is, what "authoritative state" means, or what "Start Implementation cannot unlock until I save buildPlan and complete reviewBuildPlan" implies.

## Fix

| Helper | Was | Now |
|--------|-----|-----|
| `buildRepeatedToolStopMessage` | "I called `<toolName>` `<N>` times with the same arguments and got stuck. Check the build evidence for what was completed." | "I got stuck retrying the same step and stopped before going in circles. Open the build's details panel to see what's been saved, then either send me a new instruction or retry from there." |
| `buildFabricationFailureMessage` (plan branch) | "I still have not persisted the implementation plan evidence. Start Implementation cannot unlock until I save buildPlan and complete reviewBuildPlan, so I am stopping instead of claiming the plan is ready." | "I caught myself saying the plan is ready before I'd actually recorded it. I stopped so we don't end up with a half-saved plan. Send me the same instruction again and I'll record it properly this time, or open the build details to see what's saved so far." |
| `buildFabricationFailureMessage` (general) | "I stopped because I was still describing work without using the required tools. The authoritative state was not updated yet, so the claimed progress would have been misleading." | "I caught myself describing work without actually doing it, and stopped so we don't end up with progress that isn't real. Send me the same instruction again, or check the build details to see what's been recorded so far." |
| `buildLocalToolCallFailureMessage` | "This turn routed to Docker Model Runner, but the local model did not produce the required tool call for this data-backed request. Model: `<modelId>`. The route is recorded, but there is no tool-backed result to return. Retry with a tool-capable provider or update this coworker's model assignment before asking for current operational totals." | "I couldn't complete this with the model my admin assigned me. Please try the question again — I'll route through a different model. If it keeps failing, an admin can update my model assignment in the AI Workforce settings." |

The technical detail (tool names, call counts, model IDs, reasonHint) is still captured for engineers via:
- The existing `recordRepeatedToolIssue` → `PlatformIssueReport` write
- `console.warn("[agentic-loop] stuck: ...")` at the call site
- `RoutedInferenceResult` for the local-tool-call path

Internal LLM-facing nudges (`buildFabricationRecoveryNudge`, `buildRepeatedQuestionNudge`) keep tool names because they're sent back to the model, not the user.

## Test plan

- [x] Updated 4 existing test assertions to verify tool names + architecture language are absent from user-facing strings.
- [x] `pnpm exec vitest run lib/tak/agentic-loop.test.ts` → 66/66 pass.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] Pre-commit scoped typecheck passes.

## Companion PRs from this session series

- [apps#985](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/985) merged — fileStructure crash on /build
- [apps#990](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/990) merged — bash in sandbox image
- [apps#1003](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1003) — scoutFindings .map crash in ideate dispatch
- This PR — user-facing message cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)