### PR TITLE
fix(security): correct CodeQL model-pack syntax (was silently ignored)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -17,6 +17,12 @@ queries:
 
 # Load our custom data-extensions model pack so the JS sanitiser
 # declarations apply at scan time.
+#
+# IMPORTANT — path-based packs must be in the flat list form. The
+# per-language map form (`packs: { javascript: [...] }`) is only for
+# *published* registry packs; path entries are silently rejected with
+# "Invalid CodeQL pack specification" and the pack is ignored. The pack
+# itself declares its target language via `extensionTargets:` in
+# `.github/codeql/dpf-sanitizers/qlpack.yml`.
 packs:
-  javascript:
-    - ./.github/codeql/dpf-sanitizers
+  - ./.github/codeql/dpf-sanitizers

--- a/.github/codeql/dpf-sanitizers/qlpack.yml
+++ b/.github/codeql/dpf-sanitizers/qlpack.yml
@@ -10,5 +10,9 @@ library: true
 dataExtensions:
   - "**/*.model.yml"
 
-dependencies:
+# Data-extension packs use `extensionTargets:` to declare which library
+# packs they augment, not `dependencies:` (which is for query-pack imports).
+# This was the first cause of the model pack being silently ignored on
+# the initial scan after activation.
+extensionTargets:
   codeql/javascript-all: "*"


### PR DESCRIPTION
## Summary

First post-activation scan after switching to advanced CodeQL revealed the model pack from PR #998 was silently ignored. Two bugs in the syntax:

1. **`codeql-config.yml`** referenced the path-based pack under a language key (`packs: javascript: [...]`). That nested form is only valid for *published* registry packs; path entries are rejected with "Invalid CodeQL pack specification: './.github/codeql/dpf-sanitizers'. Ignoring." (visible in run 26307052428 init log). The flat list form is required for path-based packs.

2. **`qlpack.yml`** declared the augmented pack under `dependencies:` which is for query-pack imports. Data-extension packs use `extensionTargets:` instead — without that key, even a correctly-referenced pack contributes zero rows.

Both fixed.

## Why we missed it the first time

The init step prints "WARNING: Invalid CodeQL pack specification" as a single line buried in 1000+ lines of pack-resolution log. The analyze step proceeds and the workflow reports green. There's no "model pack contributed 0 rows" assertion. Adding one would be a kernel-principle-worthy regression test (TODO: file BI).

## Test plan

- [ ] Next scan after merge produces no "Invalid CodeQL pack specification" warning in the init log
- [ ] Alerts #36, #37, #73, #83, #88 close on next scan
- [ ] No "extension not loaded" warnings in the analyze log

🤖 Generated with [Claude Code](https://claude.com/claude-code)