### PR TITLE
feat(assurance): auto-trigger pnpm-audit scan after BOM generation

### DIFF
--- a/apps/web/lib/assurance/bom-job.test.ts
+++ b/apps/web/lib/assurance/bom-job.test.ts
@@ -70,6 +70,7 @@ describe("generateAndPersistBuildBom", () => {
       },
     };
 
+    const queueScan = vi.fn(async () => ({ ids: ["evt-scan-1"] }));
     const result = await generateAndPersistBuildBom({
       db,
       buildId: "BUILD-1",
@@ -78,9 +79,11 @@ describe("generateAndPersistBuildBom", () => {
       now: new Date("2026-05-22T00:00:00.000Z"),
       gitRef: "abc123",
       readTextFile: vi.fn(async (path: string) => path.endsWith("package.json") ? packageJson : lockText),
+      queueScan,
     });
 
     expect(result).toMatchObject({ skipped: false, componentCount: 2, occurrenceCount: 2 });
+    expect(queueScan).toHaveBeenCalledWith({ buildId: "BUILD-1", requestedByUserId: "user-1" });
     expect(db.toolExecution.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         toolName: "generate_cyclonedx_bom",
@@ -110,5 +113,56 @@ describe("generateAndPersistBuildBom", () => {
       }),
     }));
     expect(db.buildActivity.create).toHaveBeenCalled();
+  });
+
+  it("still returns success when the auto-scan trigger fails (best-effort)", async () => {
+    const db = {
+      featureBuild: {
+        findUnique: vi.fn(async () => ({
+          buildId: "BUILD-2",
+          title: "Trigger-failure build",
+          threadId: null,
+          createdById: "creator-1",
+          digitalProductId: null,
+        })),
+      },
+      modelProfile: { findMany: vi.fn(async () => []) },
+      toolExecution: { create: vi.fn(async () => ({ id: "tool-2" })) },
+      toolExecutionReceipt: { create: vi.fn(async () => ({ id: "receipt-2" })) },
+      assuranceRun: { create: vi.fn(async () => ({ id: "run-db-2", runId: "run-2" })) },
+      bomComponent: {
+        upsert: vi.fn(async ({ where }: { where: { componentKey: string } }) => ({
+          id: `db-${where.componentKey}`,
+          componentKey: where.componentKey,
+        })),
+      },
+      bomDocument: {
+        upsert: vi.fn(async ({ create }: { create: { documentId: string } }) => ({
+          id: "document-db-2",
+          documentId: create.documentId,
+        })),
+      },
+      bomComponentOccurrence: {
+        createMany: vi.fn(async ({ data }: { data: unknown[] }) => ({ count: data.length })),
+      },
+      buildActivity: { create: vi.fn() },
+    };
+
+    const queueScan = vi.fn(async () => {
+      throw new Error("queue offline");
+    });
+
+    const result = await generateAndPersistBuildBom({
+      db,
+      buildId: "BUILD-2",
+      requestedByUserId: "user-1",
+      projectRoot: "D:/DPF",
+      now: new Date("2026-05-22T00:00:00.000Z"),
+      readTextFile: vi.fn(async (path: string) => path.endsWith("package.json") ? packageJson : lockText),
+      queueScan,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(queueScan).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/lib/assurance/bom-job.ts
+++ b/apps/web/lib/assurance/bom-job.ts
@@ -52,6 +52,9 @@ export interface GenerateAndPersistBuildBomInput {
   now: Date;
   gitRef?: string;
   readTextFile?: (path: string) => Promise<string>;
+  // Injection point so the auto-trigger does not pull the Inngest client
+  // into pure unit tests. Defaults to queueBuildAssuranceScan at runtime.
+  queueScan?: (input: { buildId: string; requestedByUserId: string }) => Promise<unknown>;
 }
 
 async function defaultReadTextFile(path: string): Promise<string> {
@@ -189,6 +192,21 @@ export async function generateAndPersistBuildBom(input: GenerateAndPersistBuildB
       buildId: build.buildId,
       field: "assuranceBom",
     });
+  }
+
+  // Auto-trigger the assurance scan once the BOM is committed. Best-effort:
+  // a queue failure must not roll back BOM persistence — the operator can
+  // still click "Run scan" manually from BuildAssuranceGateCard.
+  try {
+    const enqueue = input.queueScan
+      ?? (await import("./scan-trigger")).queueBuildAssuranceScan;
+    await enqueue({ buildId: build.buildId, requestedByUserId: input.requestedByUserId });
+  } catch (err) {
+    console.error(
+      "[tool-trace] failed to auto-queue assurance scan buildId=%s error=%s",
+      JSON.stringify(build.buildId),
+      JSON.stringify(err instanceof Error ? err.message : String(err)),
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

Phase 2 (PR #1008) shipped the pnpm-audit adapter behind a manual "Run scan" button on `BuildAssuranceGateCard`. This closes the loop by auto-enqueueing `assurance/scan.run` from `generateAndPersistBuildBom` once the BOM is committed.

Refs `BI-39D9FD49` under `EP-ASSURANCE-LEDGER`.

## Changes

- `apps/web/lib/assurance/bom-job.ts`: optional `queueScan` injection point on `GenerateAndPersistBuildBomInput`. After BOM persistence + `agentEventBus` emit, fire the trigger best-effort. Failures are logged via `[tool-trace]` (`JSON.stringify` sanitisation per the PR #1008 pattern) and do **not** roll back BOM persistence — the manual "Run scan" button stays as a recovery affordance.
- `apps/web/lib/assurance/bom-job.test.ts`: assert the trigger fires on the success path; add a regression test that the BOM result still returns `skipped: false` when the trigger throws.

No UI change. No schema migration. No new external dependencies. The manual `Run scan` button stays as a re-scan affordance.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web exec vitest run lib/assurance` — 59 tests pass (incl. the two new bom-job cases)
- [x] `cd apps/web && npx next build` succeeds
- [ ] UX verification via Build Studio sandbox: generate a BOM, observe the scan auto-fires (BuildActivity shows `assurance-scan` row right after `assurance-bom`), findings populate without a manual click.

## Related issues

Refs `BI-39D9FD49`, `EP-ASSURANCE-LEDGER`. Builds on merged PR #1008.

## Notes for the reviewer

- The `queueScan` injection point keeps unit tests independent of `@/lib/queue/inngest-client`; production callers use the runtime default (`queueBuildAssuranceScan`).
- Trigger failures are explicitly swallowed (best-effort). Rationale: BOM persistence is the costly path; a transient queue outage shouldn't redo the BOM run. The operator still sees the scan didn't fire (no `assurance-scan` BuildActivity row) and can hit "Run scan" manually — which preserves the dogfooding signal per the `drive-the-portal-ux` feedback.