### PR TITLE
feat(mcp): rotate-with-edit — atomic issue-new + revoke-old with edited grants

### DIFF
--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 vi.mock("@/lib/actions/mcp-tokens", () => ({
   bulkRevokeMyMcpTokens: vi.fn(),
@@ -14,6 +14,7 @@ vi.mock("@/lib/actions/mcp-tokens", () => ({
   listMyMcpTokens: vi.fn(),
   revokeMyMcpToken: vi.fn(),
   rotateMyMcpToken: vi.fn(),
+  rotateMyMcpTokenWithEdit: vi.fn(),
   upgradeMyMcpTokenForCodingAgent: vi.fn(),
 }));
 
@@ -25,6 +26,7 @@ import {
   listMcpTokenTemplates,
   listMyMcpTokens,
   rotateMyMcpToken,
+  rotateMyMcpTokenWithEdit,
 } from "@/lib/actions/mcp-tokens";
 import { McpTokenManager } from "./McpTokenManager";
 
@@ -35,6 +37,7 @@ const templatesMock = listMcpTokenTemplates as unknown as ReturnType<typeof vi.f
 const templateIssueMock = issueMyTemplateMcpToken as unknown as ReturnType<typeof vi.fn>;
 const tokensMock = listMyMcpTokens as unknown as ReturnType<typeof vi.fn>;
 const rotateMock = rotateMyMcpToken as unknown as ReturnType<typeof vi.fn>;
+const rotateWithEditMock = rotateMyMcpTokenWithEdit as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -401,5 +404,94 @@ describe("McpTokenManager — idle hygiene", () => {
     expect(
       screen.queryByLabelText(/Select token Revoked token for bulk revoke/i),
     ).toBeNull();
+  });
+});
+
+describe("McpTokenManager — rotate with edit", () => {
+  it("opens the form pre-populated from the row and calls rotateMyMcpTokenWithEdit on submit", async () => {
+    rotateWithEditMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_rotated",
+      plaintext: "dpfmcp_ROT",
+      prefix: "dpfmcp_ROT1",
+      tokenSuffix: "ROT1",
+      expiresAt: null,
+      setupSnippets: {
+        claudeCode: "{}",
+        codex: "[mcp_servers.dpf]",
+        vscode: "{}",
+        syncCommand: "",
+        envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_ROT', 'User')",
+        runtimeRefreshPowerShell: "/api/mcp/token/refresh",
+      },
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Mark laptop")).toBeTruthy();
+
+    // The new affordance appears alongside the existing "Rotate token" button.
+    const rotateEditBtn = screen.getByRole("button", { name: /Rotate with edit/i });
+    fireEvent.click(rotateEditBtn);
+
+    // Dialog opens in rotate mode — header copy mentions atomic rotation.
+    expect(
+      await screen.findByRole("heading", { name: /Rotate token with edited grants/i }),
+    ).toBeTruthy();
+
+    // Name field is pre-populated from the row.
+    const nameInput = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(nameInput.value).toBe("Mark laptop");
+
+    // Submit button reads "Rotate with edit" in this mode. The row button
+    // has the same label — scope to the dialog to pick the right one.
+    const dialog = screen.getByRole("dialog");
+    const submitBtn = within(dialog).getByRole("button", { name: /^Rotate with edit$/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(rotateWithEditMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenId: "tok_active",
+          name: "Mark laptop",
+          scope: "write",
+          scopes: ["backlog_read", "backlog_write"],
+          baseUrl: "http://localhost:3000",
+        }),
+      );
+    });
+  });
+
+  it("surfaces the partial revoke warning when the old token revoke fails", async () => {
+    rotateWithEditMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_rotated",
+      plaintext: "dpfmcp_ROT",
+      prefix: "dpfmcp_ROT1",
+      tokenSuffix: "ROT1",
+      expiresAt: null,
+      oldTokenRevokeError: "db_locked",
+      setupSnippets: {
+        claudeCode: "{}",
+        codex: "{}",
+        vscode: "{}",
+        syncCommand: "",
+        envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_ROT', 'User')",
+        runtimeRefreshPowerShell: "/api/mcp/token/refresh",
+      },
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Mark laptop")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Rotate with edit/i }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /^Rotate with edit$/i }),
+    );
+
+    expect(
+      await screen.findByText(/New token issued, but old token revoke failed/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/db_locked/)).toBeTruthy();
   });
 });

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -25,6 +25,7 @@ import {
   listMyMcpTokens,
   revokeMyMcpToken,
   rotateMyMcpToken,
+  rotateMyMcpTokenWithEdit,
   upgradeMyMcpTokenForCodingAgent,
   type McpTokenTemplateSummary,
 } from "@/lib/actions/mcp-tokens";
@@ -62,7 +63,7 @@ type TokenRow = {
 const STALE_THRESHOLD_DAYS = MCP_TOKEN_DEFAULT_STALE_DAYS;
 
 type Issued = {
-  mode: "issued" | "rotated" | "copied";
+  mode: "issued" | "rotated" | "copied" | "rotated-with-edit";
   tokenId: string;
   plaintext: string;
   prefix: string;
@@ -76,6 +77,10 @@ type Issued = {
     envPowerShell: string;
     runtimeRefreshPowerShell: string;
   };
+  // Surfaced from rotateMyMcpTokenWithEdit when the new token issued OK but
+  // the underlying revoke of the old token failed. The operator needs to
+  // manually revoke the old row in this case.
+  oldTokenRevokeError?: string;
 };
 
 type View =
@@ -136,6 +141,11 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   const [formScope, setFormScope] = useState<McpTokenScopeTier>("read");
   const [formScopes, setFormScopes] = useState<Set<string>>(() => new Set());
   const [formExpires, setFormExpires] = useState<string>("90");
+  // null = "issue new token" mode (default). When set to a tokenId, the
+  // form's submit runs rotateMyMcpTokenWithEdit against that token instead
+  // — the modal feels like editing the live row but the security model
+  // stays immutable (new token issued, old revoked atomically).
+  const [formRotateTargetId, setFormRotateTargetId] = useState<string | null>(null);
 
   // Idle hygiene: filter to stale-only and multi-select for bulk revoke.
   const [staleOnly, setStaleOnly] = useState(false);
@@ -194,6 +204,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
     setFormExpires("90");
     setNotice(null);
     setFormTemplateId(templateId);
+    setFormRotateTargetId(null);
     const template = templates.find((t) => t.id === templateId);
     if (template && templateId !== "custom") {
       setFormScope(template.tier);
@@ -203,6 +214,23 @@ export function McpTokenManager(props: McpTokenManagerProps) {
       setFormScope("read");
       setFormScopes(new Set(defaultMcpTokenScopes(scopes)));
     }
+    setView({ kind: "form", error: null });
+  }
+
+  // Open the same form modal pre-populated with the row's current grants
+  // and tier, in Custom mode so the operator sees the flat checkbox picker
+  // and can add/remove grants. Submit branches to rotateMyMcpTokenWithEdit
+  // so the underlying McpToken row stays immutable — new token issued, old
+  // revoked atomically.
+  function openRotateWithEditForm(token: TokenRow) {
+    setInlineError(null);
+    setNotice(null);
+    setFormName(token.name);
+    setFormExpires("90");
+    setFormTemplateId("custom");
+    setFormScope(token.scope);
+    setFormScopes(new Set(token.scopes));
+    setFormRotateTargetId(token.id);
     setView({ kind: "form", error: null });
   }
 
@@ -221,6 +249,35 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   function submit() {
     startTransition(async () => {
       const expiresInDays = formExpires === "never" ? null : parseInt(formExpires, 10);
+
+      // Rotate-with-edit branch: the form was opened against an existing
+      // row. Issue new + revoke old via the dedicated action so the
+      // operator sees a single atomic outcome.
+      if (formRotateTargetId != null) {
+        const result = await rotateMyMcpTokenWithEdit({
+          tokenId: formRotateTargetId,
+          name: formName.trim(),
+          scope: formScope,
+          scopes: [...formScopes],
+          expiresInDays,
+          baseUrl: props.baseUrl,
+        });
+        if (!result.ok) {
+          setView({ kind: "form", error: result.message });
+          return;
+        }
+        setView({
+          kind: "issued",
+          payload: {
+            ...result,
+            mode: "rotated-with-edit",
+            oldTokenRevokeError: result.oldTokenRevokeError,
+          },
+        });
+        refresh();
+        return;
+      }
+
       if (formTemplateId !== "custom") {
         const result = await issueMyTemplateMcpToken({
           templateId: formTemplateId,
@@ -462,6 +519,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             staleOnly={staleOnly}
             onCopy={copyCurrentToken}
             onRotate={rotateToken}
+            onRotateWithEdit={openRotateWithEditForm}
             onRevoke={revoke}
             onUpgrade={upgradeForCodeIntelligence}
             onToggleSelect={toggleSelect}
@@ -482,6 +540,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
           formScope={formScope}
           formScopes={formScopes}
           formTemplateId={formTemplateId}
+          rotateTargetId={formRotateTargetId}
           pending={pending}
           scopes={scopes}
           templates={templates}
@@ -513,6 +572,7 @@ function TokenList(props: {
   staleOnly: boolean;
   onCopy: (token: TokenRow) => void;
   onRotate: (token: TokenRow) => void;
+  onRotateWithEdit: (token: TokenRow) => void;
   onRevoke: (tokenId: string) => void;
   onUpgrade: (tokenId: string) => void;
   onToggleSelect: (tokenId: string) => void;
@@ -592,6 +652,7 @@ function TokenList(props: {
               onToggleSelect={props.onToggleSelect}
               onCopy={props.onCopy}
               onRotate={props.onRotate}
+              onRotateWithEdit={props.onRotateWithEdit}
               onRevoke={props.onRevoke}
               onUpgrade={props.onUpgrade}
             />
@@ -612,6 +673,7 @@ function TokenListItem(props: {
   onToggleSelect: (tokenId: string) => void;
   onCopy: (token: TokenRow) => void;
   onRotate: (token: TokenRow) => void;
+  onRotateWithEdit: (token: TokenRow) => void;
   onRevoke: (tokenId: string) => void;
   onUpgrade: (tokenId: string) => void;
 }) {
@@ -719,10 +781,21 @@ function TokenListItem(props: {
               type="button"
               onClick={() => props.onRotate(token)}
               disabled={disabled}
+              title="Issue a new token with the SAME grants, revoke this one"
               className={buttonClass()}
             >
               <RefreshCw className={iconClass()} aria-hidden="true" />
               Rotate token
+            </button>
+            <button
+              type="button"
+              onClick={() => props.onRotateWithEdit(token)}
+              disabled={disabled}
+              title="Open this token's grants in the form for editing, then issue + revoke atomically"
+              className={buttonClass()}
+            >
+              <RefreshCw className={iconClass()} aria-hidden="true" />
+              Rotate with edit
             </button>
             <button
               type="button"
@@ -780,6 +853,7 @@ function TokenFormDialog(props: {
   formScope: McpTokenScopeTier;
   formScopes: Set<string>;
   formTemplateId: McpTokenTemplateId;
+  rotateTargetId: string | null;
   pending: boolean;
   scopes: string[];
   templates: McpTokenTemplateSummary[];
@@ -793,6 +867,7 @@ function TokenFormDialog(props: {
   const activeTemplate = props.templates.find((t) => t.id === props.formTemplateId);
   const showCustomGrants = props.formTemplateId === "custom";
   const groupedTemplates = useMemo(() => groupTemplatesByCategory(props.templates), [props.templates]);
+  const isRotateMode = props.rotateTargetId != null;
 
   return (
     <DialogFrame onClose={props.onCancel}>
@@ -804,9 +879,13 @@ function TokenFormDialog(props: {
       >
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Issue MCP token</h3>
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">
+              {isRotateMode ? "Rotate token with edited grants" : "Issue MCP token"}
+            </h3>
             <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-              Pick the role this token is for. Grants and audit tier come from the template; switch to Custom to compose them by hand.
+              {isRotateMode
+                ? "Add or remove grants. On submit, a new token is issued with these grants and the original token is revoked — atomically."
+                : "Pick the role this token is for. Grants and audit tier come from the template; switch to Custom to compose them by hand."}
             </p>
           </div>
           <button type="button" onClick={props.onCancel} className={buttonClass()}>
@@ -937,8 +1016,14 @@ function TokenFormDialog(props: {
             }
             className={buttonClass("primary")}
           >
-            <KeyRound className="h-4 w-4" aria-hidden="true" />
-            {props.pending ? "Generating..." : "Issue token"}
+            {isRotateMode ? (
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <KeyRound className="h-4 w-4" aria-hidden="true" />
+            )}
+            {props.pending
+              ? isRotateMode ? "Rotating..." : "Generating..."
+              : isRotateMode ? "Rotate with edit" : "Issue token"}
           </button>
         </div>
       </div>
@@ -983,13 +1068,17 @@ function IssuedTokenDialog(props: { payload: Issued; onClose: () => void }) {
   const title =
     props.payload.mode === "rotated"
       ? "Replacement token issued"
-      : props.payload.mode === "copied"
-        ? "Current token"
-        : "Token issued";
+      : props.payload.mode === "rotated-with-edit"
+        ? "Rotated with edited grants"
+        : props.payload.mode === "copied"
+          ? "Current token"
+          : "Token issued";
   const description =
     props.payload.mode === "copied"
       ? "Clipboard access was blocked. Select the current token or setup command below."
-      : "Copy the token or refresh payload before closing.";
+      : props.payload.mode === "rotated-with-edit"
+        ? "New token is live with the edited grants. The original token has been revoked. Copy the plaintext below before closing — you won't see it again."
+        : "Copy the token or refresh payload before closing.";
 
   return (
     <DialogFrame>
@@ -1008,6 +1097,18 @@ function IssuedTokenDialog(props: { payload: Issued; onClose: () => void }) {
             Close
           </button>
         </div>
+
+        {props.payload.oldTokenRevokeError && (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-[var(--dpf-warning)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-warning)]">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div>
+              <p className="font-medium">New token issued, but old token revoke failed.</p>
+              <p className="mt-1 text-xs">
+                Reason: <code>{props.payload.oldTokenRevokeError}</code>. The new token below is live; manually revoke the original row from the token list to complete the rotation.
+              </p>
+            </div>
+          </div>
+        )}
 
         <div className="mt-4 space-y-3">
           <SnippetBlock

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -38,6 +38,7 @@ import {
   listMyMcpTokens,
   revokeMyMcpToken,
   rotateMyMcpToken,
+  rotateMyMcpTokenWithEdit,
   upgradeMyMcpTokenForCodingAgent,
 } from "./mcp-tokens";
 
@@ -877,3 +878,219 @@ describe("bulkRevokeMyMcpTokens", () => {
     expect(bResult?.error).toBe("db_unavailable");
   });
 });
+
+describe("rotateMyMcpTokenWithEdit", () => {
+  function makeOwnedToken(overrides: Partial<{
+    revokedAt: Date | null;
+    expiresAt: Date | null;
+    name: string;
+  }> = {}) {
+    return {
+      id: "tok_orig",
+      name: overrides.name ?? "Mark laptop",
+      revokedAt: overrides.revokedAt ?? null,
+      expiresAt: overrides.expiresAt ?? null,
+    };
+  }
+
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "x",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("unauthorized");
+    expect(issueMock).not.toHaveBeenCalled();
+    expect(revokeMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty scopes list — a rotation without scopes is operator error", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "x",
+      scope: "read",
+      scopes: [],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("no_scopes");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses tokens not owned by the caller", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([{ id: "tok_other", name: "x", revokedAt: null, expiresAt: null }]);
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "x",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("not_found_or_not_yours");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses revoked tokens — rotate is for active rows only", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken({ revokedAt: new Date("2026-05-21") })]);
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "x",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("revoked");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses expired tokens", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken({ expiresAt: new Date("2020-01-01") })]);
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "x",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("expired");
+  });
+
+  it("issues new + revokes old in order on the happy path", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken()]);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      plaintext: "dpfmcp_NEW",
+      prefix: "dpfmcp_NEW1",
+      tokenSuffix: "NEW1",
+      expiresAt: new Date("2026-08-22T00:00:00Z"),
+    });
+    revokeMock.mockResolvedValue({ ok: true });
+
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "Mark laptop edited",
+      scope: "write",
+      scopes: ["backlog_read", "backlog_write", "sandbox_execute"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.oldTokenRevokeError).toBeUndefined();
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        name: "Mark laptop edited",
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_read", "backlog_write", "sandbox_execute"],
+      }),
+    );
+    expect(revokeMock).toHaveBeenCalledWith("tok_orig", "rotated with edited grants");
+    // Issue must precede revoke — never leave the operator with neither.
+    const issueOrder = issueMock.mock.invocationCallOrder[0]!;
+    const revokeOrder = revokeMock.mock.invocationCallOrder[0]!;
+    expect(issueOrder).toBeLessThan(revokeOrder);
+  });
+
+  it("falls back to the old token's name when operator leaves name blank", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken({ name: "Old name" })]);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      plaintext: "dpfmcp_NEW",
+      prefix: "dpfmcp_NEW1",
+      tokenSuffix: "NEW1",
+      expiresAt: null,
+    });
+    revokeMock.mockResolvedValue({ ok: true });
+
+    await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "   ",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: null,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(issueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Old name" }),
+    );
+  });
+
+  it("returns the new token plus oldTokenRevokeError when revoke of old fails", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken()]);
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      plaintext: "dpfmcp_NEW",
+      prefix: "dpfmcp_NEW1",
+      tokenSuffix: "NEW1",
+      expiresAt: null,
+    });
+    revokeMock.mockResolvedValue({ ok: false, error: "db_locked" });
+
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "edited",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.plaintext).toBe("dpfmcp_NEW");
+    expect(result.oldTokenRevokeError).toBe("db_locked");
+  });
+
+  it("propagates the issue-call failure without touching revoke", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([makeOwnedToken()]);
+    issueMock.mockResolvedValue({
+      ok: false,
+      error: "invalid_scope",
+      message: "scope must be read, write, or admin",
+    });
+
+    const result = await rotateMyMcpTokenWithEdit({
+      tokenId: "tok_orig",
+      name: "edited",
+      scope: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("invalid_scope");
+    // Old token must remain active when new token issuance fails.
+    expect(revokeMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -251,6 +251,100 @@ export async function issueMyWriteMcpToken(input: {
   });
 }
 
+// Functional "edit grants on a live token" without violating immutability.
+// The McpToken row stays untouched audit-wise — we issue a NEW token with
+// the operator-edited grants and revoke the old in one atomic operator
+// action. Order: issue first, then revoke. Doing it the other way around
+// would leave the operator with zero working tokens if the issue call
+// failed.
+//
+// On partial failure (issue ok, revoke fails) we surface the new token
+// plaintext anyway and flag the revoke failure so the operator can
+// manually revoke the old row from the list — never silently drop the new
+// token, never let the operator end up with neither.
+export type RotateWithEditResult = IssueTokenActionResult & {
+  // Present on success when the underlying revoke of the old token row
+  // failed. The new token is already live in this case; the operator must
+  // revoke the old row manually from the list.
+  oldTokenRevokeError?: string;
+};
+
+export async function rotateMyMcpTokenWithEdit(input: {
+  tokenId: string;
+  name: string;
+  scope: McpTokenScope;
+  scopes: string[];
+  expiresInDays: number | null;
+  baseUrl: string;
+}): Promise<RotateWithEditResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false, error: "unauthorized", message: "Sign in first" };
+  }
+  if (input.scopes.length === 0) {
+    return {
+      ok: false,
+      error: "no_scopes",
+      message: "Pick at least one scope before rotating the token.",
+    };
+  }
+
+  // Ownership + active-state check. We refuse to rotate revoked or expired
+  // tokens — that's a re-issue scenario, not a rotation, and the operator
+  // should use the issue flow instead.
+  const tokens = await listMcpApiTokens(session.user.id);
+  const owned = tokens.find((t) => t.id === input.tokenId);
+  if (!owned) {
+    return {
+      ok: false,
+      error: "not_found_or_not_yours",
+      message: "Token was not found for the current user.",
+    };
+  }
+  if (owned.revokedAt != null) {
+    return { ok: false, error: "revoked", message: "Revoked tokens cannot be rotated." };
+  }
+  if (owned.expiresAt != null && owned.expiresAt.getTime() < Date.now()) {
+    return { ok: false, error: "expired", message: "Expired tokens cannot be rotated." };
+  }
+
+  const capability: McpTokenCapability = input.scope === "read" ? "read" : "write";
+  const issueResult: IssueMcpTokenResult = await issueMcpApiToken({
+    userId: session.user.id,
+    // Fall back to the old name so the new row is identifiable in the list.
+    name: input.name.trim() || owned.name,
+    capability,
+    scope: input.scope,
+    scopes: input.scopes,
+    expiresInDays: input.expiresInDays,
+    agentId: null,
+  });
+  if (!issueResult.ok) {
+    return { ok: false, error: issueResult.error, message: issueResult.message };
+  }
+
+  writeMcpJsonToHost(issueResult.plaintext, input.baseUrl);
+
+  const revokeResult = await revokeMcpApiToken(input.tokenId, "rotated with edited grants");
+
+  const base: IssueTokenActionResult = {
+    ok: true,
+    tokenId: issueResult.tokenId,
+    plaintext: issueResult.plaintext,
+    prefix: issueResult.prefix,
+    tokenSuffix: issueResult.tokenSuffix,
+    expiresAt: issueResult.expiresAt?.toISOString() ?? null,
+    setupSnippets: buildSetupSnippets(issueResult.plaintext, input.baseUrl),
+  };
+
+  if (!revokeResult.ok) {
+    // New token IS live — flag the cleanup gap so the UI can prompt for a
+    // manual revoke instead of pretending the old row is gone.
+    return { ...base, oldTokenRevokeError: revokeResult.error };
+  }
+  return base;
+}
+
 function isOwnedActiveToken(
   tokens: Awaited<ReturnType<typeof listMcpApiTokens>>,
   tokenId: string,


### PR DESCRIPTION
## Summary

Continues [BI-9866659C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory) — MCP token lifecycle UX. Lands **AC #3** (rotate-with-edit). #997 shipped templates (#2), #1012 shipped idle hygiene (#1). Remaining: ephemeral ship-phase tokens (#4), revoked-token hide / 90-day archive (#5).

## Why

Today the operator either rotates with the same grants (one-click) or issues a brand-new token from scratch. The common case — \"I need to add \`iac_execute\` to this token without abandoning its name and audit lineage\" — costs a manual issue + manual revoke + manual \`.mcp.json\` copy. Operators reach for \"just mutate the row\" to skip the friction, which is why we keep getting asked for the immutability exception.

Rotate-with-edit closes that gap **without violating immutability**. The McpToken row stays untouched audit-wise — we issue a new token with the edited grants and revoke the old in one atomic operator action.

## What changes

**Server (\`apps/web/lib/actions/mcp-tokens.ts\`)**
- New \`rotateMyMcpTokenWithEdit(tokenId, name, scope, scopes, expiresInDays, baseUrl)\` action.
- Ownership + active-state guard. Refuses revoked or expired rows — those scenarios route through the issue flow instead.
- **Order matters:** issue new token first, then revoke old. Doing it the other way would leave the operator with zero working tokens if issuance failed.
- **Partial-failure handling:** if the new token issues but the old token revoke fails, the new token is still surfaced as live, with \`oldTokenRevokeError\` flagged so the UI can prompt for a manual cleanup revoke. **Never silently drop the new token, never end up with neither.**
- Name falls back to the old token's name when operator leaves it blank, preserving identifiability across rotations.

**UI (\`apps/web/components/admin/McpTokenManager.tsx\`)**
- New **\"Rotate with edit\"** button on each active token row, alongside the existing **\"Rotate token\"** (which still does one-click rotate-with-same).
- Reuses the existing \`TokenFormDialog\`: opens with Custom template, pre-populated with the row's current scope / scopes / name, 90-day expiry default. Operator adds/removes grants like an edit, submits, and sees the new plaintext + setup snippets in the result dialog.
- \`TokenFormDialog\` re-titles to **\"Rotate token with edited grants\"** in rotate mode and the submit CTA reads **\"Rotate with edit\"** / **\"Rotating...\"**.
- \`IssuedTokenDialog\` gains a \`rotated-with-edit\` mode label and renders a **warning banner** with the underlying error when \`oldTokenRevokeError\` is set.

## Test plan

- [x] \`pnpm --filter web exec vitest run\` for the three affected files: **73 tests pass** (+11 for rotate-with-edit)
  - **Action**: auth / empty scopes / not-owned / revoked / expired / happy path with **issue-before-revoke ordering enforced** / name fallback when blank / partial-revoke-failure returns \`oldTokenRevokeError\` / issue-failure short-circuits without touching revoke
  - **Component**: row \"Rotate with edit\" button opens the dialog pre-populated from the row (name + scope + scopes), submit dispatches \`rotateMyMcpTokenWithEdit\` with the right payload, partial-revoke warning banner renders when \`oldTokenRevokeError\` is set
- [x] \`pnpm --filter web exec next build\` — succeeds (only the pre-existing Turbopack NFT cascade warning, unrelated)
- [x] Pre-commit typecheck passes
- [ ] **Live UX verification deferred to post-merge** — same pattern as #997 / #1012. Self-upgrade picks up the new bundle and I drive the new flow on \`localhost:3000/admin/platform-development\` then post screenshots back to this thread.

## Out of scope (remaining BI-9866659C)

- Per-build ephemeral tokens auto-issued on ship-phase entry (#4)
- Show-revoked toggle + 90-day auto-archive (#5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)