### PR TITLE
fix(ops): add type=button to BacklogPanel Create Item button (FB-4261943C)

### DIFF
--- a/apps/web/components/ops/BacklogPanel.tsx
+++ b/apps/web/components/ops/BacklogPanel.tsx
@@ -293,6 +293,7 @@ export function BacklogPanel({
             Cancel
           </button>
           <button
+            type="button"
             onClick={handleSubmit}
             disabled={isPending}
             className="flex-1 py-2 rounded bg-[var(--dpf-accent)] text-xs text-white font-semibold hover:opacity-90 disabled:opacity-50"


### PR DESCRIPTION
## Summary

One-attribute fix for `apps/web/components/ops/BacklogPanel.tsx:295`. The Create Item button at the bottom of the /ops "+ Add item" modal lacked an explicit `type` attribute. HTML5's default button type is `"submit"`, which in some browsers tries to bubble up to a parent `<form>`. Because this button lives in a sibling footer div *outside* the modal's `<form>` (form ends at line 270; button is in the footer div starting at line 287), the default submit semantics can race with the `onClick` handler and silently swallow the click — the modal closes as if successful but no row is created.

This is the silent-fail pattern Mark reported on /ops "+ Add item" three times this week. The Cancel button two lines above (line 289) already has `type="button"`. This change mirrors the same pattern.

## Test plan

- [x] One-line change: `type="button"` added.
- [ ] CI typecheck.
- [ ] Manual: open /ops, "+ Add item", fill in fields, click Create Item, verify row appears in the list.

## Closes

- FB-4261943C
- BI-AD60D184

🤖 Generated with [Claude Code](https://claude.com/claude-code)