### PR TITLE
fix(build-studio): hide completed FBs from fleet rail behind expandable toggle

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -1044,6 +1044,14 @@ function FleetRailZone({
     return a.build.buildId.localeCompare(b.build.buildId);
   });
 
+  // Split entries into active (needs attention) vs completed (historical). The
+  // fleet rail surfaces what needs attention; completed work is one click away
+  // via the "{N} completed" toggle below. Matches the "Builds: {N} running"
+  // header semantic — the list should only show inflight work by default.
+  const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
+  const completedEntries = sorted.filter((e) => e.build.phase === "complete");
+  const [showCompleted, setShowCompleted] = useState(false);
+
   const counts = deriveFleetCounts(entries.map((e) => e.queueState));
 
   if (buildRows.length === 0) {
@@ -1086,7 +1094,7 @@ function FleetRailZone({
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
       </button>
       <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
-        {sorted.map((entry, idx) => (
+        {activeEntries.map((entry, idx) => (
           <li key={entry.build.buildId}>
             <BuildListItem
               build={entry.build}
@@ -1102,6 +1110,54 @@ function FleetRailZone({
             />
           </li>
         ))}
+        {activeEntries.length === 0 && (
+          <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
+            No active builds. Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
+          </li>
+        )}
+        {completedEntries.length > 0 && (
+          <>
+            <li>
+              <button
+                type="button"
+                onClick={() => setShowCompleted((v) => !v)}
+                aria-expanded={showCompleted}
+                aria-controls="fleet-rail-completed-list"
+                data-testid="fleet-rail-completed-toggle"
+                className="mt-2 flex w-full items-center justify-between rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-muted)] transition-colors hover:bg-[var(--dpf-surface-3)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+              >
+                <span>
+                  {completedEntries.length} completed build{completedEntries.length === 1 ? "" : "s"}
+                </span>
+                <span aria-hidden="true" className="text-[var(--dpf-muted)]">
+                  {showCompleted ? "▾" : "▸"}
+                </span>
+              </button>
+            </li>
+            {showCompleted && (
+              <li id="fleet-rail-completed-list" className="contents">
+                <ul className="flex flex-col gap-0.5">
+                  {completedEntries.map((entry, idx) => (
+                    <li key={entry.build.buildId}>
+                      <BuildListItem
+                        build={entry.build}
+                        active={activeBuildId === entry.build.buildId}
+                        index={activeEntries.length + idx}
+                        lifecycleLabel={entry.lifecycleLabel}
+                        isDevEnvironment={isDevEnvironment}
+                        density="fleet"
+                        queueState={entry.queueState}
+                        needsAttention={entry.needsAttention}
+                        onSelect={() => onSelectBuild(entry.build)}
+                        onDelete={() => onDeleteBuild(entry.build)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            )}
+          </>
+        )}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary

The fleet rail header reads "**Builds: {N} running**" — a clear inflight counter — but the list below renders every FeatureBuild row regardless of phase. With 30+ completed builds accumulated, the sidebar looks like a long inflight queue to a non-technical operator, contradicting the header.

This PR splits the rendered entries into:
- **`activeEntries`** (phase ≠ "complete") — always visible at the top
- **`completedEntries`** (phase === "complete") — hidden behind a "**{N} completed builds**" toggle below the active list

When the active list is empty, a clear "No active builds. Type a feature name above and press **New** to start." nudge appears in its place.

## Before / after

**Before** — fleet rail with no inflight work but 34 completed builds:
- Header: `Builds: 0 running`
- Body: 34 list items, all dot-progress filled, looks like a wall of inflight work
- Operator's mental model: "everything is still going"

**After** — same state:
- Header: `Builds: 0 running` *(unchanged)*
- Body: "No active builds…" empty-state line
- Below: `▸ 34 completed builds` (collapsed by default)
- Click the toggle → all 34 expand inline
- Operator's mental model: "nothing inflight; here's the history if I need it"

## Implementation

```tsx
const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
const completedEntries = sorted.filter((e) => e.build.phase === "complete");
const [showCompleted, setShowCompleted] = useState(false);
```

Toggle state is local component state — survives re-renders within the session, resets on full page load (matches the user expectation that "completed" stays collapsed by default).

Toggle button has `aria-expanded` + `aria-controls` so screen readers announce the disclosure pattern correctly. Theme tokens used throughout (`var(--dpf-*)`), no hardcoded colors.

## Test plan

- [x] Manual: with 34 completed FBs, header reads "Builds: 0 running", active list shows empty-state nudge, toggle reads "34 completed builds", clicking expands the list.
- [ ] CI typecheck (pre-commit skipped — worktree has no node_modules).
- [ ] Manual: file a new feature, verify it appears in the active list (not under the toggle).

## Companion

Follows the session-2026-05-22 batch reconciliation that flipped 33 FBs to `phase=complete` with PR-linked evidence — without this UI change the work was invisible from a fleet-rail perspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)