### PR TITLE
feat(mcp): hide revoked tokens by default + auto-archive after 90 days

### DIFF
--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -90,6 +90,7 @@ beforeEach(() => {
   });
   tokensMock.mockResolvedValue({
     ok: true,
+    archivedCount: 0,
     tokens: [
       {
         id: "tok_active",
@@ -398,8 +399,11 @@ describe("McpTokenManager — idle hygiene", () => {
     confirmSpy.mockRestore();
   });
 
-  it("does not render a checkbox on revoked rows", async () => {
+  it("does not render a checkbox on revoked rows (once revealed via Show revoked)", async () => {
     render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    // Revoked rows are hidden by default — flip the toggle to reveal.
+    expect(await screen.findByText("Stale agent")).toBeTruthy();
+    fireEvent.click(screen.getByLabelText(/Show revoked tokens/i));
     expect(await screen.findByText("Revoked token")).toBeTruthy();
     expect(
       screen.queryByLabelText(/Select token Revoked token for bulk revoke/i),
@@ -493,5 +497,75 @@ describe("McpTokenManager — rotate with edit", () => {
       await screen.findByText(/New token issued, but old token revoke failed/i),
     ).toBeTruthy();
     expect(screen.getByText(/db_locked/)).toBeTruthy();
+  });
+});
+
+describe("McpTokenManager — revoked hide + archive footer", () => {
+  beforeEach(() => {
+    tokensMock.mockResolvedValue({
+      ok: true,
+      archivedCount: 3, // server reports 3 tokens hidden by the >90d filter
+      tokens: [
+        {
+          id: "tok_active",
+          name: "Active token",
+          prefix: "dpfmcp_AC",
+          tokenSuffix: "AC01",
+          canCopy: true,
+          capability: "write",
+          scope: "write",
+          scopes: ["backlog_write"],
+          lastUsedAt: "2026-05-22T10:00:00.000Z",
+          idleDays: 0,
+          expiresAt: null,
+          revokedAt: null,
+          createdAt: "2026-05-20T00:00:00.000Z",
+        },
+        {
+          id: "tok_recently_revoked",
+          name: "Recently revoked",
+          prefix: "dpfmcp_RV",
+          tokenSuffix: "RV01",
+          canCopy: false,
+          capability: "write",
+          scope: "write",
+          scopes: ["backlog_write"],
+          lastUsedAt: null,
+          idleDays: null,
+          expiresAt: null,
+          revokedAt: "2026-05-15T00:00:00.000Z",
+          createdAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("hides revoked rows by default", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Active token")).toBeTruthy();
+    expect(screen.queryByText("Recently revoked")).toBeNull();
+  });
+
+  it("reveals revoked rows when 'Show revoked' is toggled on", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Active token")).toBeTruthy();
+    const toggle = screen.getByLabelText(/Show revoked tokens/i);
+    fireEvent.click(toggle);
+    expect(screen.getByText("Recently revoked")).toBeTruthy();
+  });
+
+  it("reports the revoked-hidden count next to the toggle", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Active token")).toBeTruthy();
+    expect(screen.getByText(/1 hidden by default/)).toBeTruthy();
+  });
+
+  it("surfaces the archive footer when the server reports archivedCount > 0", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText("Active token")).toBeTruthy();
+    // Footer mentions the count, the 90-day window, and the audit-replay path.
+    expect(screen.getByText(/auto-archived/)).toBeTruthy();
+    expect(screen.getByText(/3/)).toBeTruthy();
+    expect(screen.getByText(/platform\/ai\/authority/)).toBeTruthy();
   });
 });

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -32,6 +32,7 @@ import {
 import {
   defaultMcpTokenScopes,
   MCP_TOKEN_DEFAULT_STALE_DAYS,
+  MCP_TOKEN_REVOKED_ARCHIVE_DAYS,
   type McpTokenScopeTier,
   type McpTokenTemplateId,
 } from "@/lib/mcp-token-scopes";
@@ -58,9 +59,10 @@ type TokenRow = {
   createdAt: string;
 };
 
-// Alias the shared constant from mcp-token-scopes for use inside the JSX —
+// Alias the shared constants from mcp-token-scopes for use inside the JSX —
 // keeps the source of truth out of "use server" modules per Next.js rules.
 const STALE_THRESHOLD_DAYS = MCP_TOKEN_DEFAULT_STALE_DAYS;
+const REVOKED_ARCHIVE_DAYS = MCP_TOKEN_REVOKED_ARCHIVE_DAYS;
 
 type Issued = {
   mode: "issued" | "rotated" | "copied" | "rotated-with-edit";
@@ -150,6 +152,13 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   // Idle hygiene: filter to stale-only and multi-select for bulk revoke.
   const [staleOnly, setStaleOnly] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  // Revoked tokens are hidden by default to keep the active-token list
+  // legible. Operator toggles this on for triage / cleanup work.
+  const [showRevoked, setShowRevoked] = useState(false);
+  // Reported by the server: count of tokens auto-archived (revoked >
+  // REVOKED_ARCHIVE_DAYS ago) and dropped from the response. Surfaced in the
+  // toolbar so the operator knows older revocations aren't gone, just hidden.
+  const [archivedCount, setArchivedCount] = useState(0);
 
   const defaultScopes = useMemo(() => defaultMcpTokenScopes(scopes), [scopes]);
 
@@ -162,7 +171,10 @@ export function McpTokenManager(props: McpTokenManagerProps) {
         listMcpTokenTemplates(),
       ]);
       if (cancelled) return;
-      if (tokensResult.ok) setTokens(tokensResult.tokens);
+      if (tokensResult.ok) {
+        setTokens(tokensResult.tokens);
+        setArchivedCount(tokensResult.archivedCount);
+      }
       const availableScopes = scopesResult.scopes;
       setScopes(availableScopes);
       setTemplates(templatesResult.templates);
@@ -178,7 +190,10 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   function refresh() {
     startTransition(async () => {
       const result = await listMyMcpTokens();
-      if (result.ok) setTokens(result.tokens);
+      if (result.ok) {
+        setTokens(result.tokens);
+        setArchivedCount(result.archivedCount);
+      }
     });
   }
 
@@ -517,6 +532,8 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             defaultScopes={defaultScopes}
             selectedIds={selectedIds}
             staleOnly={staleOnly}
+            showRevoked={showRevoked}
+            archivedCount={archivedCount}
             onCopy={copyCurrentToken}
             onRotate={rotateToken}
             onRotateWithEdit={openRotateWithEditForm}
@@ -524,6 +541,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             onUpgrade={upgradeForCodeIntelligence}
             onToggleSelect={toggleSelect}
             onToggleStaleOnly={() => setStaleOnly((v) => !v)}
+            onToggleShowRevoked={() => setShowRevoked((v) => !v)}
             onBulkRevoke={bulkRevokeSelected}
             onClearSelection={clearSelection}
             isActive={isActive}
@@ -570,6 +588,8 @@ function TokenList(props: {
   defaultScopes: string[];
   selectedIds: Set<string>;
   staleOnly: boolean;
+  showRevoked: boolean;
+  archivedCount: number;
   onCopy: (token: TokenRow) => void;
   onRotate: (token: TokenRow) => void;
   onRotateWithEdit: (token: TokenRow) => void;
@@ -577,35 +597,56 @@ function TokenList(props: {
   onUpgrade: (tokenId: string) => void;
   onToggleSelect: (tokenId: string) => void;
   onToggleStaleOnly: () => void;
+  onToggleShowRevoked: () => void;
   onBulkRevoke: () => void;
   onClearSelection: () => void;
   isActive: (token: TokenRow) => boolean;
   isStale: (token: TokenRow) => boolean;
 }) {
+  const revokedCount = props.tokens.filter((t) => t.revokedAt != null).length;
   const staleCount = props.tokens.filter(props.isStale).length;
-  const visible = props.staleOnly
-    ? props.tokens.filter(props.isStale)
-    : props.tokens;
+  // Filter chain: hide-revoked first (default), then stale-only.
+  let visible = props.showRevoked
+    ? props.tokens
+    : props.tokens.filter((t) => t.revokedAt == null);
+  if (props.staleOnly) visible = visible.filter(props.isStale);
   const selectedCount = props.selectedIds.size;
 
   return (
     <div>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2">
-        <label className="inline-flex items-center gap-2 text-sm text-[var(--dpf-text)]">
-          <input
-            type="checkbox"
-            checked={props.staleOnly}
-            onChange={props.onToggleStaleOnly}
-            aria-label={`Show only tokens idle for at least ${STALE_THRESHOLD_DAYS} days`}
-          />
-          <Clock className="h-3.5 w-3.5 text-[var(--dpf-muted)]" aria-hidden="true" />
-          <span>
-            Show stale only
-            <span className="ml-1 text-xs text-[var(--dpf-muted)]">
-              (≥ {STALE_THRESHOLD_DAYS} days idle — {staleCount} of {props.tokens.length})
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <label className="inline-flex items-center gap-2 text-sm text-[var(--dpf-text)]">
+            <input
+              type="checkbox"
+              checked={props.staleOnly}
+              onChange={props.onToggleStaleOnly}
+              aria-label={`Show only tokens idle for at least ${STALE_THRESHOLD_DAYS} days`}
+            />
+            <Clock className="h-3.5 w-3.5 text-[var(--dpf-muted)]" aria-hidden="true" />
+            <span>
+              Show stale only
+              <span className="ml-1 text-xs text-[var(--dpf-muted)]">
+                (≥ {STALE_THRESHOLD_DAYS} days idle — {staleCount} of {props.tokens.length})
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+          <label className="inline-flex items-center gap-2 text-sm text-[var(--dpf-text)]">
+            <input
+              type="checkbox"
+              checked={props.showRevoked}
+              onChange={props.onToggleShowRevoked}
+              aria-label="Show revoked tokens"
+            />
+            <Ban className="h-3.5 w-3.5 text-[var(--dpf-muted)]" aria-hidden="true" />
+            <span>
+              Show revoked
+              <span className="ml-1 text-xs text-[var(--dpf-muted)]">
+                ({revokedCount} hidden by default)
+              </span>
+            </span>
+          </label>
+        </div>
         {selectedCount > 0 && (
           <div className="flex items-center gap-2">
             <span className="text-xs text-[var(--dpf-muted)]">
@@ -636,7 +677,9 @@ function TokenList(props: {
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-5 text-sm text-[var(--dpf-muted)]">
           {props.staleOnly
             ? `No tokens are idle for ${STALE_THRESHOLD_DAYS}+ days. Uncheck "Show stale only" to see all tokens.`
-            : "No MCP tokens have been issued yet."}
+            : !props.showRevoked && revokedCount > 0
+              ? `All ${revokedCount} of your tokens are revoked. Toggle "Show revoked" above to view them.`
+              : "No MCP tokens have been issued yet."}
         </div>
       ) : (
         <ul className="space-y-2">
@@ -658,6 +701,17 @@ function TokenList(props: {
             />
           ))}
         </ul>
+      )}
+
+      {props.archivedCount > 0 && (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          <strong>{props.archivedCount}</strong>{" "}
+          {props.archivedCount === 1 ? "token" : "tokens"} auto-archived
+          (revoked &gt; {REVOKED_ARCHIVE_DAYS} days). They remain in the
+          database for audit FK integrity and are queryable via{" "}
+          <code>/platform/ai/authority</code>; hidden from this list to keep
+          it legible.
+        </p>
       )}
     </div>
   );

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -1094,3 +1094,109 @@ describe("rotateMyMcpTokenWithEdit", () => {
   });
 });
 
+describe("listMyMcpTokens — revoked archive", () => {
+  it("filters out tokens revoked >90 days and reports archivedCount", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const now = new Date("2026-05-22T12:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    listMock.mockResolvedValue([
+      {
+        // Active token — always visible.
+        id: "tok_active",
+        name: "active",
+        prefix: "dpfmcp_A",
+        tokenSuffix: "AAAA",
+        canCopy: true,
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_write"],
+        lastUsedAt: new Date("2026-05-22T00:00:00Z"),
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date("2026-04-01T00:00:00Z"),
+      },
+      {
+        // Revoked 30 days ago — within window, must remain visible (UI
+        // hides via the "Show revoked" toggle separately).
+        id: "tok_recent_revoke",
+        name: "recent revoke",
+        prefix: "dpfmcp_R",
+        tokenSuffix: "RRRR",
+        canCopy: false,
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_write"],
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: new Date("2026-04-22T12:00:00Z"),
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+      {
+        // Revoked 120 days ago — past archive window, must be hidden.
+        id: "tok_archived_1",
+        name: "archived 1",
+        prefix: "dpfmcp_X",
+        tokenSuffix: "XXXX",
+        canCopy: false,
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_write"],
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: new Date("2026-01-22T12:00:00Z"),
+        createdAt: new Date("2025-10-01T00:00:00Z"),
+      },
+      {
+        // Revoked exactly at threshold (90 days) — must be archived.
+        id: "tok_archived_2",
+        name: "archived 2",
+        prefix: "dpfmcp_Y",
+        tokenSuffix: "YYYY",
+        canCopy: false,
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_write"],
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: new Date("2026-02-21T12:00:00Z"),
+        createdAt: new Date("2025-10-01T00:00:00Z"),
+      },
+    ]);
+
+    const result = await listMyMcpTokens();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+
+    const visibleIds = result.tokens.map((t) => t.id);
+    expect(visibleIds).toEqual(["tok_active", "tok_recent_revoke"]);
+    expect(result.archivedCount).toBe(2);
+
+    vi.useRealTimers();
+  });
+
+  it("reports archivedCount=0 when no tokens are past the window", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([
+      {
+        id: "tok_x",
+        name: "x",
+        prefix: "dpfmcp_X",
+        tokenSuffix: "XXXX",
+        canCopy: true,
+        capability: "read",
+        scope: "read",
+        scopes: ["backlog_read"],
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date(),
+      },
+    ]);
+    const result = await listMyMcpTokens();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.archivedCount).toBe(0);
+  });
+});

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -19,6 +19,7 @@ import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
   deriveIdleDays,
   getMcpTokenTemplate,
+  isMcpTokenArchived,
   MCP_TOKEN_TEMPLATES,
   resolveTemplateGrants,
   type McpTokenTemplate,
@@ -52,13 +53,27 @@ export async function listAvailableMcpScopes(): Promise<{
 export async function listMyMcpTokens() {
   const session = await auth();
   if (!session?.user?.id) {
-    return { ok: false as const, error: "unauthorized", tokens: [] };
+    return {
+      ok: false as const,
+      error: "unauthorized",
+      tokens: [],
+      archivedCount: 0,
+    };
   }
   const tokens = await listMcpApiTokens(session.user.id);
   const now = new Date();
+
+  // Archive filter: revoked tokens older than MCP_TOKEN_REVOKED_ARCHIVE_DAYS
+  // (90 days) fall off the admin UI entirely. They remain in the DB so the
+  // ToolExecution audit FK chain is intact — forensic replay via
+  // /platform/ai/authority continues to surface them via raw queries.
+  const archivedCount = tokens.filter((t) => isMcpTokenArchived(t.revokedAt, now)).length;
+  const visible = tokens.filter((t) => !isMcpTokenArchived(t.revokedAt, now));
+
   return {
     ok: true as const,
-    tokens: tokens.map((t) => ({
+    archivedCount,
+    tokens: visible.map((t) => ({
       id: t.id,
       name: t.name,
       prefix: t.prefix,

--- a/apps/web/lib/mcp-token-scopes.test.ts
+++ b/apps/web/lib/mcp-token-scopes.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
+  MCP_TOKEN_REVOKED_ARCHIVE_DAYS,
   MCP_TOKEN_TEMPLATES,
   WRITE_MCP_TOKEN_SCOPES,
   defaultMcpTokenScopes,
   getMcpTokenTemplate,
+  isMcpTokenArchived,
   resolveTemplateGrants,
 } from "./mcp-token-scopes";
 
@@ -124,5 +126,32 @@ describe("resolveTemplateGrants", () => {
   it("returns empty when no grants overlap (do-not-issue signal)", () => {
     const finance = getMcpTokenTemplate("employee_finance")!;
     expect(resolveTemplateGrants(finance, ["unrelated_grant"])).toEqual([]);
+  });
+});
+
+describe("isMcpTokenArchived", () => {
+  const now = new Date("2026-05-22T12:00:00Z");
+
+  it("returns false for active (non-revoked) tokens", () => {
+    expect(isMcpTokenArchived(null, now)).toBe(false);
+    expect(isMcpTokenArchived(undefined, now)).toBe(false);
+  });
+
+  it("returns false for tokens revoked within the window", () => {
+    // 89 days ago — just inside the window.
+    const recent = new Date(now.getTime() - 89 * 86_400_000);
+    expect(isMcpTokenArchived(recent, now)).toBe(false);
+  });
+
+  it("returns true at exactly the threshold so we never get stuck on a boundary", () => {
+    const atThreshold = new Date(
+      now.getTime() - MCP_TOKEN_REVOKED_ARCHIVE_DAYS * 86_400_000,
+    );
+    expect(isMcpTokenArchived(atThreshold, now)).toBe(true);
+  });
+
+  it("returns true for tokens revoked well past the window", () => {
+    const old = new Date(now.getTime() - 365 * 86_400_000);
+    expect(isMcpTokenArchived(old, now)).toBe(true);
   });
 });

--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -78,6 +78,38 @@ export function deriveIdleDays(
 }
 
 // ---------------------------------------------------------------------------
+// Revoked-token archive window
+// ---------------------------------------------------------------------------
+//
+// Revoked tokens stay in the DB so the ToolExecution audit FK chain isn't
+// broken (per the BI design stance: "We hide them, we don't drop them").
+// After this many days, they fall off the admin UI entirely — operator sees
+// a clean list, but forensic replay via /platform/ai/authority can still
+// surface them via raw queries against the McpApiToken table.
+//
+// 90 days mirrors the typical SOC 2 / similar audit retention window for
+// access-control rotation evidence. Bump consciously — anything shorter
+// risks hiding a token before an incident review uses it.
+export const MCP_TOKEN_REVOKED_ARCHIVE_DAYS = 90;
+
+/**
+ * True when a revoked token is past the archive window and should be hidden
+ * from the admin UI entirely. Returns false for active tokens (no
+ * `revokedAt`) and for revoked tokens still within the window — those stay
+ * visible (toggleable via the UI's "Show revoked" affordance).
+ *
+ * `now` is injectable so callers can hold the clock steady across a batch.
+ */
+export function isMcpTokenArchived(
+  revokedAt: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!revokedAt) return false;
+  const ageMs = now.getTime() - revokedAt.getTime();
+  return ageMs >= MCP_TOKEN_REVOKED_ARCHIVE_DAYS * MS_PER_DAY;
+}
+
+// ---------------------------------------------------------------------------
 // Role-based token templates
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Summary

Closes [BI-9866659C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory) **AC #5**. The MCP token page accumulates revoked rows indefinitely — when an operator revokes a token, that row sticks around forever cluttering the list. We can't hard-delete revoked rows because the \`ToolExecution\` audit FK chain depends on them; the BI design stance is **\"hide them, don't drop them.\"**

## What changes

**Server (\`apps/web/lib/actions/mcp-tokens.ts\` + \`mcp-token-scopes.ts\`)**
- New \`MCP_TOKEN_REVOKED_ARCHIVE_DAYS = 90\` constant + \`isMcpTokenArchived\` helper in \`mcp-token-scopes.ts\` (kept out of the \`\"use server\"\` file because Next.js requires non-async-only exports there — same pattern as the idle hygiene PR).
- **90 days** chosen to align with typical SOC 2 retention windows for access-control rotation evidence. Bump consciously — shorter risks hiding a token before an incident review uses it.
- \`listMyMcpTokens\` now filters out tokens revoked > 90 days ago entirely (audit FK preserved in the DB; forensic replay via \`/platform/ai/authority\` continues to surface them via raw queries) and reports an \`archivedCount\` so the UI can show \"N tokens auto-archived\" context.

**UI (\`apps/web/components/admin/McpTokenManager.tsx\`)**
- New **\"Show revoked\"** toggle in the toolbar, default off. When unchecked, hides revoked-within-90d rows from the list. Counter reads \"(N hidden by default)\" so the operator sees they're not gone.
- New empty-state copy: when all visible tokens are revoked and the toggle is off, points the operator at the toggle instead of saying \"no tokens issued yet\" (which would be misleading).
- New **archive footer** when \`archivedCount > 0\`: *\"N tokens auto-archived (revoked > 90 days). They remain in the database for audit FK integrity and are queryable via /platform/ai/authority; hidden from this list to keep it legible.\"* Spells out the audit-preservation trade-off so an operator never thinks they were hard-deleted.
- The existing \"does not render a checkbox on revoked rows\" test now toggles Show-revoked first to reveal the row before asserting.

## Test plan

- [x] \`pnpm --filter web exec vitest run\` for the three affected files: **83 tests pass** (+11 for the archive)
  - \`mcp-token-scopes.test.ts\`: \`isMcpTokenArchived\` — false for active / non-revoked, false within window, TRUE at exactly 90 days (boundary), TRUE past window
  - \`mcp-tokens.test.ts\`: \`listMyMcpTokens\` filters >90d revoked rows out, reports \`archivedCount\` correctly across a 4-token fixture (active / 30d / 120d / exactly-90d), returns 0 when nothing archived
  - \`McpTokenManager.test.tsx\`: hides revoked by default, reveals on toggle, shows hidden-count next to toggle, renders the archive footer when server reports \`archivedCount > 0\`
- [x] \`pnpm --filter web exec next build\` — succeeds (single pre-existing Turbopack NFT cascade warning, unrelated)
- [x] Rebased onto \`origin/main\` post-#1016 — minor conflicts in the two test files (both PRs appended to the end of the file), resolved cleanly so both describe blocks coexist
- [ ] **Live UX verification deferred to post-merge** — same pattern as #997, #1012, #1016

## BI-9866659C scoreboard

| AC | Description | PR | State |
|---|---|---|---|
| #1 | Idle hygiene (last-used / idle-days, stale filter, bulk-revoke) | #1012 | ✅ merged |
| #2 | Named role templates | #997 | ✅ merged |
| #3 | Rotate-with-edit | #1016 | ✅ merged |
| **#5** | **Revoked hide + 90-day archive** | **this PR** | 🟡 open |
| #4 | Per-build ephemeral ship-phase tokens | — | ⬜ deferred (depends on ship-phase lifecycle hooks) |

AC #4 is the only outstanding piece; it depends on Build Studio surfacing ship-phase enter/exit lifecycle events that the auto-issue / auto-revoke logic can hook into. Filing as a separate effort once those hooks exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)