### PR TITLE
feat: add QuickBooks import review queue foundation

### DIFF
--- a/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
+++ b/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
@@ -52,7 +52,9 @@ describe("AccountantWorkLanePanel", () => {
     expect(html).toContain("Vendors");
     expect(html).toContain("Bank transactions");
     expect(html).toContain("QuickBooks reconciliation");
-    expect(html).toContain("BI-07D76D6B");
+    expect(html).toContain("BI-4025EF5F");
+    expect(html).toContain("BI-2DB52EAB");
+    expect(html).toContain("BI-47366954");
     expect(html).toContain("source-attributed");
   });
 });

--- a/apps/web/components/integrations/IntegrationReadinessPanel.test.tsx
+++ b/apps/web/components/integrations/IntegrationReadinessPanel.test.tsx
@@ -28,12 +28,17 @@ describe("IntegrationReadinessPanel", () => {
     expect(screen.getAllByText("Expenses").length).toBeGreaterThan(0);
     expect(screen.getByText(/API coverage: QuickBooks Purchase query/i)).toBeVisible();
     expect(screen.getByRole("heading", { name: "Import staging posture" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Import review queue" })).toBeVisible();
     expect(screen.getByText("Non-editable")).toBeVisible();
+    expect(screen.getByText("BI-4025EF5F")).toBeVisible();
+    expect(screen.getByText("Ready for review")).toBeVisible();
+    expect(screen.getByText(/Review queue records are DPF-held posture only/i)).toBeVisible();
     expect(screen.getAllByText("External-owned")).toHaveLength(9);
     expect(screen.getByText("Invoice")).toBeVisible();
     expect(screen.getAllByText("Not mapped").length).toBeGreaterThan(0);
     expect(screen.getByText("Connected")).toBeVisible();
     expect(screen.queryByText(/clientSecret/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/refreshToken/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /sync|write|update quickbooks/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/integrations/IntegrationReadinessPanel.tsx
+++ b/apps/web/components/integrations/IntegrationReadinessPanel.tsx
@@ -3,6 +3,7 @@ import type {
   IntegrationReadinessState,
 } from "@/lib/integrate/readiness";
 import type { IntegrationImportStagingDescriptor } from "@/lib/integrate/import-staging";
+import type { IntegrationImportReviewPosture } from "@/lib/integrate/import-review";
 
 interface IntegrationReadinessPanelProps {
   descriptor: IntegrationReadinessDescriptor;
@@ -92,6 +93,10 @@ export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPa
         <ImportStagingPosture descriptor={descriptor.importStaging} />
       )}
 
+      {descriptor.importReview && (
+        <ImportReviewPosture posture={descriptor.importReview} />
+      )}
+
       <div className="mt-4">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Next safe actions</h3>
         <ul className="mt-2 flex flex-wrap gap-2">
@@ -104,6 +109,36 @@ export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPa
             </li>
           ))}
         </ul>
+      </div>
+    </section>
+  );
+}
+
+function ImportReviewPosture({ posture }: { posture: IntegrationImportReviewPosture }) {
+  return (
+    <section className="mt-5 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Import review queue</h3>
+          <p className="max-w-3xl text-xs leading-5 text-[var(--dpf-muted)]">
+            {posture.guardrail}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          <MetricPill label="State" value={reviewStatusLabel(posture.status)} />
+          <MetricPill label="Backlog" value={posture.nextBacklogItemId} />
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {posture.families.map((family) => (
+          <span
+            key={family}
+            className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-1 text-xs text-[var(--dpf-text)]"
+          >
+            {family}
+          </span>
+        ))}
       </div>
     </section>
   );
@@ -189,6 +224,18 @@ function ownerSideLabel(ownerSide: string): string {
   }
 
   return "DPF-owned";
+}
+
+function reviewStatusLabel(status: IntegrationImportReviewPosture["status"]): string {
+  if (status === "ready-to-review") {
+    return "Ready for review";
+  }
+
+  if (status === "blocked") {
+    return "Blocked";
+  }
+
+  return "Not started";
 }
 
 function StateChip({ state }: { state: IntegrationReadinessState }) {

--- a/apps/web/lib/finance/accountant-work-lane.test.ts
+++ b/apps/web/lib/finance/accountant-work-lane.test.ts
@@ -67,7 +67,7 @@ describe("bookkeeper accountant work lane", () => {
       ]),
     );
     expect(quickBooks?.writeBoundary).toContain("source-attributed");
-    expect(quickBooks?.nextBacklogItemId).toBe("BI-07D76D6B");
+    expect(quickBooks?.nextBacklogItemId).toBe("BI-4025EF5F");
   });
 
   it("anchors Stripe and bank feeds as reconciliation dependencies, not replacement claims", () => {
@@ -76,8 +76,9 @@ describe("bookkeeper accountant work lane", () => {
     const bankFeeds = lane.providerBoundaries.find((boundary) => boundary.provider === "bank-feed-provider");
 
     expect(stripe?.missingCoverage).toContain("QuickBooks reconciliation");
-    expect(stripe?.nextBacklogItemId).toBe("BI-07D76D6B");
+    expect(stripe?.nextBacklogItemId).toBe("BI-2DB52EAB");
     expect(bankFeeds?.posture).toBe("not-mapped");
+    expect(bankFeeds?.nextBacklogItemId).toBe("BI-47366954");
     expect(lane.promotionGuardrail).toContain("dual-run");
   });
 });

--- a/apps/web/lib/finance/accountant-work-lane.ts
+++ b/apps/web/lib/finance/accountant-work-lane.ts
@@ -162,7 +162,7 @@ export const BOOKKEEPER_ACCOUNTANT_WORK_LANE: AccountantWorkLane = {
       missingCoverage: quickBooksMissingCoverage,
       writeBoundary:
         "QuickBooks staging is source-attributed and non-editable; no write-back or DPF-primary accounting ownership until entity links, reconciliation evidence, rollback/export, and accountant review are proven.",
-      nextBacklogItemId: "BI-07D76D6B",
+      nextBacklogItemId: "BI-4025EF5F",
     },
     {
       provider: "stripe",
@@ -173,7 +173,7 @@ export const BOOKKEEPER_ACCOUNTANT_WORK_LANE: AccountantWorkLane = {
       missingCoverage: ["Fees", "Payout deposits", "Invoice allocation matching", "QuickBooks reconciliation"],
       writeBoundary:
         "Stripe remains the payment processor; DPF should reconcile payment evidence before promoting billing records.",
-      nextBacklogItemId: "BI-07D76D6B",
+      nextBacklogItemId: "BI-2DB52EAB",
     },
     {
       provider: "bank-feed-provider",
@@ -184,17 +184,17 @@ export const BOOKKEEPER_ACCOUNTANT_WORK_LANE: AccountantWorkLane = {
       missingCoverage: ["Direct bank feeds", "Statement source custody", "Automated reconciliation evidence"],
       writeBoundary:
         "Bank feeds stay unmapped until DPF chooses provider ownership and proves rollback/export expectations.",
-      nextBacklogItemId: "BI-07D76D6B",
+      nextBacklogItemId: "BI-47366954",
     },
   ],
   promotionGuardrail:
     "DPF does not become the accounting system of record until read coverage, import staging, reconciliation evidence, rollback/export, and accountant review workflows are proven in dual-run.",
   nextWorkflow: {
-    backlogItemId: "BI-07D76D6B",
-    title: "QuickBooks import staging and ownership posture for core accounting records",
+    backlogItemId: "BI-4025EF5F",
+    title: "QuickBooks import review queue and accounting entity links",
     route: "/platform/tools/integrations/quickbooks",
     reason:
-      "The accountant lane needs source-attributed, non-editable staging before entity links, reconciliation, or write-back gates.",
+      "The accountant lane needs persisted review candidates and explicit entity links before reconciliation or write-back gates.",
   },
 };
 

--- a/apps/web/lib/integrate/import-review-store.test.ts
+++ b/apps/web/lib/integrate/import-review-store.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationImportReviewBatch } from "./import-review";
+import { saveIntegrationImportReviewBatch } from "./import-review-store";
+
+const reviewBatch: IntegrationImportReviewBatch = {
+  batchId: "quickbooks-review-2026-05-22",
+  sourceProvider: "quickbooks",
+  providerEnvironment: "sandbox",
+  sourceTimestamp: "2026-05-22T12:00:00.000Z",
+  status: "reviewing",
+  records: [
+    {
+      entityFamily: "invoices",
+      externalId: "invoice-1",
+      sourceProvider: "quickbooks",
+      sourceTimestamp: "2026-05-22T11:00:00.000Z",
+      ownerSide: "external",
+      reviewStatus: "candidate",
+      proposedLocalEntityType: "Invoice",
+      proposedLocalId: null,
+      proposedLocalStatus: "candidate",
+      proposedLocalConfidence: "low",
+      proposedLocalReason: "Review before linking.",
+      displayFields: [{ label: "Invoice number", value: "INV-1001" }],
+      sourceFingerprint: "a".repeat(64),
+      readOnly: true,
+    },
+  ],
+};
+
+describe("import review persistence", () => {
+  it("upserts a batch by batchRef and replaces read-only review records", async () => {
+    const upsert = vi.fn().mockResolvedValue({ id: "batch-1" });
+    const db = {
+      integrationImportBatch: {
+        upsert,
+      },
+    };
+
+    await saveIntegrationImportReviewBatch(db, reviewBatch);
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { batchRef: "quickbooks-review-2026-05-22" },
+      create: {
+        batchRef: "quickbooks-review-2026-05-22",
+        sourceProvider: "quickbooks",
+        providerEnvironment: "sandbox",
+        sourceTimestamp: new Date("2026-05-22T12:00:00.000Z"),
+        status: "reviewing",
+        records: {
+          create: [
+            {
+              entityFamily: "invoices",
+              externalId: "invoice-1",
+              sourceProvider: "quickbooks",
+              sourceTimestamp: new Date("2026-05-22T11:00:00.000Z"),
+              ownerSide: "external",
+              reviewStatus: "candidate",
+              proposedLocalEntityType: "Invoice",
+              proposedLocalId: null,
+              proposedLocalStatus: "candidate",
+              proposedLocalConfidence: "low",
+              proposedLocalReason: "Review before linking.",
+              displayFields: [{ label: "Invoice number", value: "INV-1001" }],
+              sourceFingerprint: "a".repeat(64),
+              readOnly: true,
+            },
+          ],
+        },
+      },
+      update: {
+        sourceProvider: "quickbooks",
+        providerEnvironment: "sandbox",
+        sourceTimestamp: new Date("2026-05-22T12:00:00.000Z"),
+        status: "reviewing",
+        records: {
+          deleteMany: {},
+          create: [
+            {
+              entityFamily: "invoices",
+              externalId: "invoice-1",
+              sourceProvider: "quickbooks",
+              sourceTimestamp: new Date("2026-05-22T11:00:00.000Z"),
+              ownerSide: "external",
+              reviewStatus: "candidate",
+              proposedLocalEntityType: "Invoice",
+              proposedLocalId: null,
+              proposedLocalStatus: "candidate",
+              proposedLocalConfidence: "low",
+              proposedLocalReason: "Review before linking.",
+              displayFields: [{ label: "Invoice number", value: "INV-1001" }],
+              sourceFingerprint: "a".repeat(64),
+              readOnly: true,
+            },
+          ],
+        },
+      },
+      include: { records: true },
+    });
+  });
+});

--- a/apps/web/lib/integrate/import-review-store.ts
+++ b/apps/web/lib/integrate/import-review-store.ts
@@ -1,0 +1,105 @@
+import type {
+  IntegrationImportReviewBatch,
+  IntegrationImportReviewRecord,
+} from "./import-review";
+
+type IntegrationImportBatchDelegate = {
+  upsert(args: {
+    where: { batchRef: string };
+    create: IntegrationImportBatchMutation;
+    update: Omit<IntegrationImportBatchMutation, "batchRef"> & {
+      records: {
+        deleteMany: Record<string, never>;
+        create: IntegrationImportRecordMutation[];
+      };
+    };
+    include: { records: true };
+  }): Promise<unknown>;
+};
+
+export type IntegrationImportReviewPersistenceClient = {
+  integrationImportBatch: IntegrationImportBatchDelegate;
+};
+
+type IntegrationImportBatchMutation = {
+  batchRef: string;
+  sourceProvider: string;
+  providerEnvironment: string | null;
+  sourceTimestamp: Date | null;
+  status: IntegrationImportReviewBatch["status"];
+  records: {
+    create: IntegrationImportRecordMutation[];
+  };
+};
+
+type IntegrationImportRecordMutation = {
+  entityFamily: string;
+  externalId: string;
+  sourceProvider: string;
+  sourceTimestamp: Date | null;
+  ownerSide: IntegrationImportReviewRecord["ownerSide"];
+  reviewStatus: IntegrationImportReviewRecord["reviewStatus"];
+  proposedLocalEntityType: string;
+  proposedLocalId: string | null;
+  proposedLocalStatus: IntegrationImportReviewRecord["proposedLocalStatus"];
+  proposedLocalConfidence: IntegrationImportReviewRecord["proposedLocalConfidence"];
+  proposedLocalReason: string;
+  displayFields: IntegrationImportReviewRecord["displayFields"];
+  sourceFingerprint: string;
+  readOnly: true;
+};
+
+export async function saveIntegrationImportReviewBatch(
+  db: IntegrationImportReviewPersistenceClient,
+  batch: IntegrationImportReviewBatch,
+): Promise<unknown> {
+  const recordCreates = batch.records.map(toRecordMutation);
+
+  return db.integrationImportBatch.upsert({
+    where: { batchRef: batch.batchId },
+    create: {
+      batchRef: batch.batchId,
+      sourceProvider: batch.sourceProvider,
+      providerEnvironment: batch.providerEnvironment,
+      sourceTimestamp: parseOptionalDate(batch.sourceTimestamp),
+      status: batch.status,
+      records: {
+        create: recordCreates,
+      },
+    },
+    update: {
+      sourceProvider: batch.sourceProvider,
+      providerEnvironment: batch.providerEnvironment,
+      sourceTimestamp: parseOptionalDate(batch.sourceTimestamp),
+      status: batch.status,
+      records: {
+        deleteMany: {},
+        create: recordCreates,
+      },
+    },
+    include: { records: true },
+  });
+}
+
+function toRecordMutation(record: IntegrationImportReviewRecord): IntegrationImportRecordMutation {
+  return {
+    entityFamily: record.entityFamily,
+    externalId: record.externalId,
+    sourceProvider: record.sourceProvider,
+    sourceTimestamp: parseOptionalDate(record.sourceTimestamp),
+    ownerSide: record.ownerSide,
+    reviewStatus: record.reviewStatus,
+    proposedLocalEntityType: record.proposedLocalEntityType,
+    proposedLocalId: record.proposedLocalId,
+    proposedLocalStatus: record.proposedLocalStatus,
+    proposedLocalConfidence: record.proposedLocalConfidence,
+    proposedLocalReason: record.proposedLocalReason,
+    displayFields: record.displayFields,
+    sourceFingerprint: record.sourceFingerprint,
+    readOnly: true,
+  };
+}
+
+function parseOptionalDate(value: string | null): Date | null {
+  return value ? new Date(value) : null;
+}

--- a/apps/web/lib/integrate/import-review.test.ts
+++ b/apps/web/lib/integrate/import-review.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { IntegrationImportStagingRecord } from "./import-staging";
+import {
+  buildIntegrationImportReviewBatch,
+  fingerprintImportStagingRecord,
+} from "./import-review";
+
+const stagedInvoice: IntegrationImportStagingRecord = {
+  entityFamily: "invoices",
+  externalId: "qb-invoice-1001",
+  sourceProvider: "quickbooks",
+  sourceTimestamp: "2026-05-22T12:00:00.000Z",
+  ownerSide: "external",
+  proposedLocalLink: {
+    entityType: "Invoice",
+    localId: null,
+    status: "candidate",
+    confidence: "low",
+    reason: "Review source-attributed QuickBooks record before creating or linking a local DPF record.",
+  },
+  displayFields: [
+    { label: "Invoice number", value: "INV-1001" },
+    { label: "Customer", value: "Acme Services" },
+    { label: "Total", value: "1250.00" },
+  ],
+  readOnly: true,
+};
+
+describe("import review queue contract", () => {
+  it("normalizes staged records into read-only review candidates", () => {
+    const batch = buildIntegrationImportReviewBatch({
+      batchId: "quickbooks-2026-05-22T12-00-00Z",
+      sourceProvider: "quickbooks",
+      providerEnvironment: "sandbox",
+      sourceTimestamp: "2026-05-22T12:00:00.000Z",
+      stagedRecords: [stagedInvoice],
+    });
+
+    expect(batch).toMatchObject({
+      batchId: "quickbooks-2026-05-22T12-00-00Z",
+      sourceProvider: "quickbooks",
+      providerEnvironment: "sandbox",
+      sourceTimestamp: "2026-05-22T12:00:00.000Z",
+      status: "reviewing",
+    });
+    expect(batch.records).toHaveLength(1);
+    expect(batch.records[0]).toMatchObject({
+      entityFamily: "invoices",
+      externalId: "qb-invoice-1001",
+      sourceProvider: "quickbooks",
+      sourceTimestamp: "2026-05-22T12:00:00.000Z",
+      ownerSide: "external",
+      readOnly: true,
+      reviewStatus: "candidate",
+      proposedLocalEntityType: "Invoice",
+      proposedLocalId: null,
+      proposedLocalStatus: "candidate",
+      proposedLocalConfidence: "low",
+    });
+    expect(batch.records[0].sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(batch.records[0].displayFields).toEqual(stagedInvoice.displayFields);
+  });
+
+  it("keeps fingerprints stable for the same source-attributed review fields", () => {
+    const first = fingerprintImportStagingRecord(stagedInvoice);
+    const second = fingerprintImportStagingRecord({
+      ...stagedInvoice,
+      displayFields: [...stagedInvoice.displayFields],
+    });
+
+    expect(first).toBe(second);
+  });
+
+  it("does not preserve raw provider payloads in review records", () => {
+    const batch = buildIntegrationImportReviewBatch({
+      batchId: "quickbooks-2026-05-22T12-00-00Z",
+      sourceProvider: "quickbooks",
+      stagedRecords: [
+        {
+          ...stagedInvoice,
+          displayFields: [
+            ...stagedInvoice.displayFields,
+            { label: "Access token", value: "secret-token" },
+          ],
+        },
+      ],
+    });
+
+    expect(JSON.stringify(batch)).not.toContain("Rows");
+    expect(JSON.stringify(batch)).not.toContain("refreshToken");
+    expect(JSON.stringify(batch)).not.toContain("secret-token");
+  });
+});

--- a/apps/web/lib/integrate/import-review.ts
+++ b/apps/web/lib/integrate/import-review.ts
@@ -1,0 +1,123 @@
+import { createHash } from "crypto";
+import type {
+  IntegrationImportDisplayField,
+  IntegrationImportStagingRecord,
+} from "@/lib/integrate/import-staging";
+
+export const INTEGRATION_IMPORT_REVIEW_STATUSES = [
+  "candidate",
+  "linked",
+  "blocked",
+  "ignored",
+] as const;
+
+export type IntegrationImportReviewStatus =
+  (typeof INTEGRATION_IMPORT_REVIEW_STATUSES)[number];
+
+export interface IntegrationImportReviewRecord {
+  entityFamily: string;
+  externalId: string;
+  sourceProvider: string;
+  sourceTimestamp: string | null;
+  ownerSide: IntegrationImportStagingRecord["ownerSide"];
+  reviewStatus: IntegrationImportReviewStatus;
+  proposedLocalEntityType: string;
+  proposedLocalId: string | null;
+  proposedLocalStatus: IntegrationImportStagingRecord["proposedLocalLink"]["status"];
+  proposedLocalConfidence: IntegrationImportStagingRecord["proposedLocalLink"]["confidence"];
+  proposedLocalReason: string;
+  displayFields: IntegrationImportDisplayField[];
+  sourceFingerprint: string;
+  readOnly: true;
+}
+
+export interface IntegrationImportReviewBatch {
+  batchId: string;
+  sourceProvider: string;
+  providerEnvironment: string | null;
+  sourceTimestamp: string | null;
+  status: "reviewing";
+  records: IntegrationImportReviewRecord[];
+}
+
+export interface IntegrationImportReviewPosture {
+  status: "not-started" | "ready-to-review" | "blocked";
+  sourceProvider: string;
+  readOnly: true;
+  nextBacklogItemId: string;
+  families: string[];
+  guardrail: string;
+}
+
+export function buildIntegrationImportReviewBatch({
+  batchId,
+  sourceProvider,
+  providerEnvironment = null,
+  sourceTimestamp = null,
+  stagedRecords,
+}: {
+  batchId: string;
+  sourceProvider: string;
+  providerEnvironment?: string | null;
+  sourceTimestamp?: string | null;
+  stagedRecords: IntegrationImportStagingRecord[];
+}): IntegrationImportReviewBatch {
+  return {
+    batchId,
+    sourceProvider,
+    providerEnvironment,
+    sourceTimestamp,
+    status: "reviewing",
+    records: stagedRecords
+      .filter((record) => record.sourceProvider === sourceProvider)
+      .map(toReviewRecord),
+  };
+}
+
+export function fingerprintImportStagingRecord(record: IntegrationImportStagingRecord): string {
+  const fingerprintInput = {
+    entityFamily: record.entityFamily,
+    externalId: record.externalId,
+    sourceProvider: record.sourceProvider,
+    sourceTimestamp: record.sourceTimestamp,
+    ownerSide: record.ownerSide,
+    proposedLocalLink: record.proposedLocalLink,
+    displayFields: sanitizeDisplayFields(record.displayFields),
+  };
+
+  return createHash("sha256")
+    .update(JSON.stringify(fingerprintInput))
+    .digest("hex");
+}
+
+function toReviewRecord(record: IntegrationImportStagingRecord): IntegrationImportReviewRecord {
+  return {
+    entityFamily: record.entityFamily,
+    externalId: record.externalId,
+    sourceProvider: record.sourceProvider,
+    sourceTimestamp: record.sourceTimestamp,
+    ownerSide: record.ownerSide,
+    reviewStatus: "candidate",
+    proposedLocalEntityType: record.proposedLocalLink.entityType,
+    proposedLocalId: record.proposedLocalLink.localId,
+    proposedLocalStatus: record.proposedLocalLink.status,
+    proposedLocalConfidence: record.proposedLocalLink.confidence,
+    proposedLocalReason: record.proposedLocalLink.reason,
+    displayFields: sanitizeDisplayFields(record.displayFields),
+    sourceFingerprint: fingerprintImportStagingRecord(record),
+    readOnly: true,
+  };
+}
+
+function sanitizeDisplayFields(
+  displayFields: IntegrationImportDisplayField[],
+): IntegrationImportDisplayField[] {
+  return displayFields.filter((field) => !isSensitiveDisplayField(field));
+}
+
+function isSensitiveDisplayField(field: IntegrationImportDisplayField): boolean {
+  const normalized = `${field.label} ${field.value}`.toLowerCase();
+  return ["access token", "refresh token", "secret", "password", "credential"].some((token) =>
+    normalized.includes(token),
+  );
+}

--- a/apps/web/lib/integrate/quickbooks/import-review.test.ts
+++ b/apps/web/lib/integrate/quickbooks/import-review.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { buildQuickBooksImportReviewBatch } from "./import-review";
+import { QUICKBOOKS_IMPORT_STAGING_ENTITY_FAMILIES } from "./import-staging";
+
+describe("QuickBooks import review mapper", () => {
+  it("turns all staged QuickBooks core accounting families into read-only review candidates", () => {
+    const batch = buildQuickBooksImportReviewBatch({
+      batchId: "quickbooks-review-2026-05-22",
+      providerEnvironment: "sandbox",
+      sourceTimestamp: "2026-05-22T12:00:00.000Z",
+      records: {
+        company: {
+          Id: "company-1",
+          CompanyName: "Acme Services LLC",
+          Country: "US",
+          MetaData: { LastUpdatedTime: "2026-05-22T11:00:00.000Z" },
+        },
+        customers: [
+          {
+            Id: "customer-1",
+            DisplayName: "Acme Managed IT",
+            CompanyName: "Acme Managed IT LLC",
+            MetaData: { LastUpdatedTime: "2026-05-22T10:00:00.000Z" },
+          },
+        ],
+        invoices: [
+          {
+            Id: "invoice-1",
+            DocNumber: "INV-1001",
+            TotalAmt: 1250,
+            Balance: 250,
+            CustomerRef: { value: "customer-1", name: "Acme Managed IT" },
+            MetaData: { LastUpdatedTime: "2026-05-22T10:15:00.000Z" },
+          },
+        ],
+        vendors: [
+          {
+            Id: "vendor-1",
+            DisplayName: "Acme Supplies",
+            PrimaryEmailAddr: { Address: "billing@example.test" },
+            MetaData: { LastUpdatedTime: "2026-05-22T10:20:00.000Z" },
+          },
+        ],
+        bills: [
+          {
+            Id: "bill-1",
+            DocNumber: "BILL-1001",
+            TotalAmt: 300,
+            Balance: 300,
+            VendorRef: { value: "vendor-1", name: "Acme Supplies" },
+            DueDate: "2026-06-01",
+            MetaData: { LastUpdatedTime: "2026-05-22T10:25:00.000Z" },
+          },
+        ],
+        expenses: [
+          {
+            Id: "expense-1",
+            TotalAmt: 42.75,
+            PaymentType: "CreditCard",
+            AccountRef: { value: "account-1", name: "Meals" },
+            EntityRef: { value: "vendor-1", name: "Acme Supplies", type: "Vendor" },
+            MetaData: { LastUpdatedTime: "2026-05-22T10:30:00.000Z" },
+          },
+        ],
+        payments: [
+          {
+            Id: "payment-1",
+            TotalAmt: 1000,
+            CustomerRef: { value: "customer-1", name: "Acme Managed IT" },
+            MetaData: { LastUpdatedTime: "2026-05-22T10:35:00.000Z" },
+          },
+        ],
+        accounts: [
+          {
+            Id: "account-1",
+            Name: "Checking",
+            AccountType: "Bank",
+            AccountSubType: "Checking",
+            CurrentBalance: 4500,
+            MetaData: { LastUpdatedTime: "2026-05-22T10:40:00.000Z" },
+          },
+        ],
+        reports: [
+          {
+            Header: {
+              ReportName: "ProfitAndLoss",
+              Time: "2026-05-22T10:45:00.000Z",
+              StartPeriod: "2026-05-01",
+              EndPeriod: "2026-05-22",
+            },
+            Rows: { Row: [] },
+          },
+        ],
+      },
+    });
+
+    expect(batch.sourceProvider).toBe("quickbooks");
+    expect(batch.providerEnvironment).toBe("sandbox");
+    expect(batch.records.map((record) => record.entityFamily)).toEqual(
+      Array.from(QUICKBOOKS_IMPORT_STAGING_ENTITY_FAMILIES),
+    );
+    expect(batch.records.every((record) => record.ownerSide === "external")).toBe(true);
+    expect(batch.records.every((record) => record.reviewStatus === "candidate")).toBe(true);
+    expect(batch.records.every((record) => record.readOnly === true)).toBe(true);
+    expect(batch.records.every((record) => record.externalId.length > 0)).toBe(true);
+    expect(batch.records.every((record) => /^[a-f0-9]{64}$/.test(record.sourceFingerprint))).toBe(true);
+    expect(JSON.stringify(batch)).not.toContain("Rows");
+    expect(JSON.stringify(batch)).not.toContain("refreshToken");
+  });
+});

--- a/apps/web/lib/integrate/quickbooks/import-review.ts
+++ b/apps/web/lib/integrate/quickbooks/import-review.ts
@@ -1,0 +1,33 @@
+import {
+  buildIntegrationImportReviewBatch,
+  type IntegrationImportReviewBatch,
+} from "@/lib/integrate/import-review";
+import {
+  stageQuickBooksCoreAccountingRecords,
+  type QuickBooksCoreAccountingRecordsInput,
+} from "./import-staging";
+
+export function buildQuickBooksImportReviewBatch({
+  batchId,
+  providerEnvironment = null,
+  sourceTimestamp = null,
+  records,
+}: {
+  batchId: string;
+  providerEnvironment?: string | null;
+  sourceTimestamp?: string | null;
+  records: QuickBooksCoreAccountingRecordsInput;
+}): IntegrationImportReviewBatch {
+  const stagedRecords = stageQuickBooksCoreAccountingRecords({
+    sourceTimestamp,
+    ...records,
+  });
+
+  return buildIntegrationImportReviewBatch({
+    batchId,
+    sourceProvider: "quickbooks",
+    providerEnvironment,
+    sourceTimestamp,
+    stagedRecords,
+  });
+}

--- a/apps/web/lib/integrate/quickbooks/readiness.test.ts
+++ b/apps/web/lib/integrate/quickbooks/readiness.test.ts
@@ -57,6 +57,23 @@ describe("buildQuickBooksReadinessDescriptor", () => {
     expect(
       descriptor.importStaging?.families.every((family) => family.ownerSide === "external"),
     ).toBe(true);
+    expect(descriptor.importReview).toMatchObject({
+      status: "ready-to-review",
+      nextBacklogItemId: "BI-4025EF5F",
+      readOnly: true,
+      sourceProvider: "quickbooks",
+    });
+    expect(descriptor.importReview?.families).toEqual([
+      "company",
+      "customers",
+      "invoices",
+      "vendors",
+      "bills",
+      "expenses",
+      "payments",
+      "accounts",
+      "reports",
+    ]);
     expect(
       descriptor.capabilities.find((capability) => capability.key === "expenses")?.apiCoverageNote,
     ).toContain("Purchase");
@@ -71,6 +88,9 @@ describe("buildQuickBooksReadinessDescriptor", () => {
     );
     expect(descriptor.nextSafeActions).toContain(
       "Review non-editable import staging fields before creating local accounting links",
+    );
+    expect(descriptor.nextSafeActions).toContain(
+      "Persist reviewed import candidates through BI-4025EF5F before reconciliation",
     );
   });
 

--- a/apps/web/lib/integrate/quickbooks/readiness.ts
+++ b/apps/web/lib/integrate/quickbooks/readiness.ts
@@ -154,6 +154,15 @@ export function buildQuickBooksReadinessDescriptor({
   const isError = status === "error";
   const isAuthError = isError && isCredentialError(connection?.lastErrorMsg);
   const importStaging = buildQuickBooksImportStagingDescriptor();
+  const importReview = {
+    status: isConnected ? "ready-to-review" : "not-started",
+    sourceProvider: "quickbooks",
+    readOnly: true,
+    nextBacklogItemId: "BI-4025EF5F",
+    families: Array.from(QUICKBOOKS_IMPORT_STAGING_ENTITY_FAMILIES),
+    guardrail:
+      "Review queue records are DPF-held posture only; staged QuickBooks source records stay non-editable and external-owned until entity links are approved.",
+  } as const;
 
   return {
     schemaVersion: "1.0",
@@ -196,6 +205,7 @@ export function buildQuickBooksReadinessDescriptor({
       }),
     ),
     importStaging,
+    importReview,
     nextSafeActions: resolveNextSafeActions(status),
     updatedAt: connection?.lastTestedAt ?? null,
   };
@@ -237,6 +247,7 @@ function resolveNextSafeActions(status: QuickBooksReadinessConnection["status"])
       "Review mapped read coverage",
       "Use expanded QuickBooks read coverage to plan source-attributed staging before imports or writes",
       "Review non-editable import staging fields before creating local accounting links",
+      "Persist reviewed import candidates through BI-4025EF5F before reconciliation",
       "Keep bank feeds, tax authority, and accountant workflow blocked until their ownership gates are designed",
       "Keep write operations blocked until proposal-mode approval exists",
     ];

--- a/apps/web/lib/integrate/readiness.ts
+++ b/apps/web/lib/integrate/readiness.ts
@@ -1,4 +1,5 @@
 import type { IntegrationImportStagingDescriptor } from "@/lib/integrate/import-staging";
+import type { IntegrationImportReviewPosture } from "@/lib/integrate/import-review";
 
 export const INTEGRATION_READINESS_STATES = [
   "not-connected",
@@ -62,6 +63,7 @@ export interface IntegrationReadinessDescriptor {
   health: IntegrationReadinessHealth;
   capabilities: IntegrationReadinessCapability[];
   importStaging?: IntegrationImportStagingDescriptor;
+  importReview?: IntegrationImportReviewPosture;
   nextSafeActions: string[];
   updatedAt: string | null;
 }

--- a/docs/superpowers/plans/2026-05-17-business-capability-employee-work-taxonomy.md
+++ b/docs/superpowers/plans/2026-05-17-business-capability-employee-work-taxonomy.md
@@ -195,11 +195,13 @@ The duplicate check found adjacent taxonomy nodes, docs refresh work, and `BI-IN
 | --- | --- | --- | --- |
 | `BI-407125DA` Capability taxonomy: establish employee-work backlog capture foundation | `EP-BIZ-CAP` | Done | Standardize the context template and decide whether backlog needs schema or manifest fields later. |
 | `BI-0E6D42B3` Capability taxonomy: audit employee roles against DPF surfaces, coworkers, and integrations | `EP-BIZ-CAP` | Done | Map employee jobs to DPF surfaces, coworkers, queues, and integrations. |
-| `BI-4C166411` Capability taxonomy UX: expose commercial market and product enrichment from taxonomy nodes | `EP-BIZ-CAP` | Open | Render workbook-derived sample services, offering considerations, and commercial market/product guidance in taxonomy node UX instead of silently dropping it. |
-| `BI-C61B5202` QuickBooks parity: expand read-only coverage to vendors, bills, expenses, payments, accounts, and reports | `EP-INT-2E7C1A` | Open | Move QuickBooks entity families from not-mapped to read, still with no writes. |
-| `BI-07D76D6B` QuickBooks parity: define import staging and ownership posture for core accounting records | `EP-INT-2E7C1A` | Open | Stage source-attributed QuickBooks records in DPF without claiming ownership. |
+| `BI-4C166411` Capability taxonomy UX: expose commercial market and product enrichment from taxonomy nodes | `EP-BIZ-CAP` | Done | Render workbook-derived sample services, offering considerations, and commercial market/product guidance in taxonomy node UX instead of silently dropping it. |
+| `BI-C61B5202` QuickBooks parity: expand read-only coverage to vendors, bills, expenses, payments, accounts, and reports | `EP-INT-2E7C1A` | Done | Move QuickBooks entity families from not-mapped to read, still with no writes. |
+| `BI-07D76D6B` QuickBooks parity: define import staging and ownership posture for core accounting records | `EP-INT-2E7C1A` | Done | Stage source-attributed QuickBooks records in DPF without claiming ownership. |
 
 Execution update on 2026-05-17: the batch above was restored and linked through live DPF MCP. The first three items are under `EP-BIZ-CAP`; the QuickBooks items remain under `EP-INT-2E7C1A`. `BI-407125DA` and `BI-0E6D42B3` are done. No DB fallback was used for backlog status updates.
+
+Execution update on 2026-05-22: live MCP shows `BI-C61B5202`, `BI-07D76D6B`, `BI-80A71362`, `BI-861433C0`, and `BI-4C166411` are done. The next QuickBooks bridge is `BI-4025EF5F`, with the focused implementation plan in `docs/superpowers/plans/2026-05-22-quickbooks-parity-import-review-and-entity-link.md`.
 
 ## Second Backlog Batch Created From Role Audit
 
@@ -215,35 +217,34 @@ The role-to-work audit created these additional items through live DPF MCP under
 
 Remaining integration-provider follow-ons stay with `EP-INT-2E7C1A` unless a later epic split is approved:
 
-| Proposed title | Preferred epic | Purpose |
+| Item | Preferred epic | Purpose |
 | --- | --- | --- |
-| Accounting entity link and ownership posture model | `EP-INT-2E7C1A` | Define external/local links and owner-side states for accounting and payment objects. |
-| Stripe and QuickBooks payment reconciliation posture | `EP-INT-2E7C1A` | Define read-first reconciliation across DPF, Stripe, QuickBooks, fees, payouts, and deposits. |
-| Bank feeds and reconciliation source-of-truth decision | `EP-INT-2E7C1A` | Decide whether DPF reads bank facts from QuickBooks, a bank-feed provider, CSV, or direct open-banking later. |
-| Tax/VAT/sales tax mapping posture | `EP-INT-2E7C1A` | Map DPF tax profiles, jurisdictions, liabilities, and reports to QuickBooks tax codes without filing claims. |
-| Reports and close workflow parity | `EP-INT-2E7C1A` | Expand from readiness into P&L, cash flow, aging, close packets, variance notes, and accountant view. |
-| Accountant collaboration and evidence packet | `EP-INT-2E7C1A` plus taxonomy epic | Define accountant principal/access pattern and monthly review evidence. |
+| `BI-4025EF5F` QuickBooks parity: persist import review queue and accounting entity links | `EP-INT-2E7C1A` | Define persisted review queue records, external/local links, and owner-side states for accounting and payment objects. |
+| `BI-2DB52EAB` QuickBooks parity: reconcile QuickBooks, Stripe, payments, fees, payouts, and deposits | `EP-INT-2E7C1A` | Define read-first reconciliation across DPF, Stripe, QuickBooks, fees, payouts, and deposits. |
+| `BI-47366954` QuickBooks parity: decide bank-feed source of truth and reconciliation evidence posture | `EP-INT-2E7C1A` | Decide whether DPF reads bank facts from QuickBooks, a bank-feed provider, CSV, or direct open-banking later. |
+| `BI-47F08F7A` QuickBooks parity: map tax, VAT, and sales-tax posture without filing claims | `EP-INT-2E7C1A` | Map DPF tax profiles, jurisdictions, liabilities, and reports to QuickBooks tax codes without filing claims. |
+| `BI-4291195F` QuickBooks parity: reports, close workflow, and accountant evidence packet | `EP-INT-2E7C1A` | Expand from readiness into P&L, cash flow, aging, close packets, variance notes, and accountant view. |
 | SMB setup readiness for books, payments, payroll, tax, and bank feeds | Business Capability and Employee Work Taxonomy plus `EP-ARCH-8D4F2A` | Add setup routing from business context to finance/integration readiness. |
-| Governed QuickBooks write-back gates | `EP-INT-2E7C1A` | Add proposal-mode writes only after read/stage/ownership gates are proven. |
-| DPF system-of-record promotion criteria for accounting | Future finance/accounting epic | Define dual-run thresholds, rollback/export requirements, and entity-family ownership gates. |
+| `BI-B1F6D8ED` QuickBooks parity: approval-gated write-back and DPF-primary promotion gates | `EP-INT-2E7C1A` | Add proposal-mode writes and DPF-primary promotion only after read/stage/ownership/reconciliation/accountant/export gates are proven. |
 
 ## QuickBooks Long-Tail Sequence (canonical reference)
 
-> **Single source of truth for Chunk 3.** The Chunk 3 tasks below implement steps 1–4 of this sequence. Steps 5–11 become backlog items only after the step 4 gate passes. Do not duplicate this sequence elsewhere.
+> **Single source of truth for Chunk 3.** The Chunk 3 tasks below originally implemented steps 1–4 of this sequence. As of 2026-05-22, steps 1–3 are complete, and `BI-4025EF5F` is the active bridge from staged descriptors into persisted import review and entity links.
 
-The QuickBooks readiness snapshot is the approved starting point, but current `origin/main` does not yet contain the sibling branch's readiness files. Steps 1–4 can proceed immediately. Steps 5–11 unblock after the sibling branch (`DPF-small-business-os-parity`) merges or its equivalent is rebuilt on main.
+The QuickBooks readiness snapshot, read expansion, import staging posture, native integration coverage matrix, taxonomy commercial-market UX, and accountant lane are now merged foundation. The remaining sequence must stay proof-gated: review queue and entity links before reconciliation, reconciliation before write-back, and dual-run/accountant/export evidence before DPF-primary promotion.
 
 1. Read-only company, customer, invoice staging: prove company info, customers, invoices, and invoice lines can be read and displayed with source timestamps.
 2. Vendors, bills, expenses, payments, accounts, and reports: expand read scopes and readiness descriptors before any import or write path.
-3. Import staging and entity ownership: stage company, customer, invoice, vendor, bill, and payment objects with external IDs, source provider, source timestamp, owner side, and proposed local link.
-4. Payments and Stripe/QuickBooks reconciliation: compare invoices, payments, payment intents, fees, payouts, deposits, and DPF payment records with discrepancy reasons.
-5. Bank feeds and reconciliation posture: decide whether bank facts come through QuickBooks, CSV, a bank-feed provider, or a later direct open-banking route; do not imply DPF owns bank rec until source-of-truth is explicit.
-6. Tax, VAT, and sales tax: map DPF tax profiles, jurisdictions, liabilities, tax codes, and reports; preserve external filing boundaries.
-7. Reports and close workflows: produce P&L, cash flow, AR/AP aging, close checklist, variance notes, and accountant packet from read/staged facts.
-8. Accountant collaboration: add accountant principal/access posture, evidence packet, review workflow, and removable access model.
-9. Setup and onboarding: ask once where books, payments, payroll, tax, bank feeds, invoicing, and accountant collaboration live; route the owner to integration readiness and DPF-native defaults.
-10. Governed write-back gates: introduce proposal-mode create/update operations only with idempotency keys, preview, approval, audit receipt, and rollback/export expectations.
-11. DPF system-of-record promotion: promote one entity family at a time only after read coverage, staged import, dual-run comparison, accountant evidence, export completeness, and rollback criteria are met.
+3. Import staging and entity ownership: stage company, customer, invoice, vendor, bill, expense, payment, account, and report objects with external IDs, source provider, source timestamp, owner side, and proposed local link.
+4. Persisted import review and entity links: store reviewed staged records and proposed links without editing source records or claiming local ownership.
+5. Payments and Stripe/QuickBooks reconciliation: compare invoices, payments, payment intents, fees, payouts, deposits, and DPF payment records with discrepancy reasons.
+6. Bank feeds and reconciliation posture: decide whether bank facts come through QuickBooks, CSV, a bank-feed provider, or a later direct open-banking route; do not imply DPF owns bank rec until source-of-truth is explicit.
+7. Tax, VAT, and sales tax: map DPF tax profiles, jurisdictions, liabilities, tax codes, and reports; preserve external filing boundaries.
+8. Reports and close workflows: produce P&L, cash flow, AR/AP aging, close checklist, variance notes, and accountant packet from read/staged facts.
+9. Accountant collaboration: add accountant principal/access posture, evidence packet, review workflow, and removable access model.
+10. Setup and onboarding: ask once where books, payments, payroll, tax, bank feeds, invoicing, and accountant collaboration live; route the owner to integration readiness and DPF-native defaults.
+11. Governed write-back gates: introduce proposal-mode create/update operations only with idempotency keys, preview, approval, audit receipt, and rollback/export expectations.
+12. DPF system-of-record promotion: promote one entity family at a time only after read coverage, staged import, dual-run comparison, accountant evidence, export completeness, and rollback criteria are met.
 
 ## Architecture Posture
 
@@ -365,29 +366,29 @@ Execution result for `BI-407125DA` on 2026-05-17:
 
 ## Chunk 3: QuickBooks Long Tail
 
-**Canonical sequence:** see `§ QuickBooks Long-Tail Sequence` above. This chunk implements sequence steps 1–4 only. Steps 5–11 become backlog items after step 4 passes.
+**Canonical sequence:** see `§ QuickBooks Long-Tail Sequence` above. This chunk shipped sequence steps 1–3 and now hands off to `BI-4025EF5F` for persisted import review and entity links.
 
-**Backlog items:** `BI-C61B5202` (sequence steps 1–2), `BI-07D76D6B` (sequence step 3), plus entity-link, reconciliation, tax, reports/close, accountant collaboration, write-back, and DPF-primary promotion items created after read/import proof.
+**Backlog items:** `BI-C61B5202` (sequence steps 1–2, done), `BI-07D76D6B` (sequence step 3, done), `BI-4025EF5F` (sequence step 4, next), `BI-2DB52EAB`, `BI-47366954`, `BI-47F08F7A`, `BI-4291195F`, and `BI-B1F6D8ED`.
 
-**Dependency:** can start immediately; full sequence (steps 5–11) unblocks after `DPF-small-business-os-parity` branch merges.
+**Dependency:** `BI-4025EF5F` can start immediately from the current merged foundation. Later reconciliation, tax, reporting, write-back, and DPF-primary promotion remain blocked on review queue/entity-link evidence.
 
 ### Task 4: Sequence Replacement Maturity (steps 1–4)
 
-- [ ] **Step 1: Keep the next QuickBooks item read-only** (sequence step 1–2)
+- [x] **Step 1: Keep the next QuickBooks item read-only** (sequence step 1–2)
 
 Implement `BI-C61B5202` before import/write work. The readiness descriptor should move entity families from `not-mapped` to `read` for vendors, bills, expenses, payments, accounts, and reports.
 
-- [ ] **Step 2: Stage before ownership** (sequence step 3)
+- [x] **Step 2: Stage before ownership** (sequence step 3)
 
 Implement `BI-07D76D6B` after read expansion. Imported data remains non-editable and source-attributed. Each staged record carries: `externalId`, `sourceProvider`, `sourceTimestamp`, `ownerSide`, `proposedLocalLink`.
 
-- [ ] **Step 3: Add entity links after staging proves the fields** (sequence step 3 continued)
+- [ ] **Step 3: Persist review queue and entity links after staging proves the fields** (sequence step 4)
 
-Create the proposed accounting entity-link backlog item only after staging shows the exact external/local link structure needed. Do not design the link model speculatively.
+Implement `BI-4025EF5F` using `docs/superpowers/plans/2026-05-22-quickbooks-parity-import-review-and-entity-link.md`. Preserve non-editable staged source records, add durable review/link posture, and keep QuickBooks writes blocked.
 
 - [ ] **Step 4: Gate on read data before reconciliation** (sequence step 4)
 
-Create the proposed Stripe/QuickBooks reconciliation item only after DPF has sufficient QuickBooks and Stripe read data to compare payment facts. Gate: both providers have `read` maturity for payment objects.
+Implement `BI-2DB52EAB` only after `BI-4025EF5F` proves durable entity links. Gate: both providers have `read` maturity for payment objects and review queue records can explain the local/external match candidates.
 
 ## Chunk 4: Employee Work Taxonomy
 
@@ -505,4 +506,4 @@ After applying the body template to 10+ items (Chunk 2, Task 3), review: which f
 
 **Next taxonomy/data slice:** build `BI-861433C0` - publish the native integration coverage matrix for employee work roles. This should consume the same backlog context model and avoid creating a parallel taxonomy system.
 
-**QuickBooks can proceed in parallel:** `BI-C61B5202` and `BI-07D76D6B` remain under `EP-INT-2E7C1A` and do not depend on `EP-BIZ-CAP`.
+**QuickBooks can proceed in parallel:** `BI-4025EF5F` remains under `EP-INT-2E7C1A`, does not depend on `EP-BIZ-CAP`, and is the next manual-work slice while Build Studio capacity is full.

--- a/docs/superpowers/plans/2026-05-22-quickbooks-parity-import-review-and-entity-link.md
+++ b/docs/superpowers/plans/2026-05-22-quickbooks-parity-import-review-and-entity-link.md
@@ -1,0 +1,375 @@
+# QuickBooks Import Review And Entity Link Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `BI-4025EF5F`: a persisted, read-only QuickBooks import review queue with durable accounting entity-link posture.
+
+**Architecture:** Extend the existing source-attributed staging descriptors into a small persisted review substrate. QuickBooks remains read-only and external-owned; DPF stores review metadata, proposed local links, fingerprints, and operator posture without storing raw provider payloads or introducing QuickBooks writes.
+
+**Tech Stack:** Next.js 16 app router, TypeScript, Prisma 7, PostgreSQL, Vitest, existing DPF integration readiness and finance lane components.
+
+---
+
+## Tracking Spine
+
+Live MCP backlog items created on 2026-05-22 under `EP-INT-2E7C1A`:
+
+| Sequence | Item | Scope |
+| --- | --- | --- |
+| Next | `BI-4025EF5F` | Persist QuickBooks import review queue and accounting entity links. |
+| Later | `BI-2DB52EAB` | Reconcile QuickBooks, Stripe, payments, fees, payouts, and deposits. |
+| Later | `BI-47366954` | Decide bank-feed source of truth and reconciliation evidence posture. |
+| Later | `BI-47F08F7A` | Map tax, VAT, and sales-tax posture without filing claims. |
+| Later | `BI-4291195F` | Reports, close workflow, and accountant evidence packet. |
+| Gate | `BI-B1F6D8ED` | Approval-gated write-back and DPF-primary promotion gates. |
+
+`BI-C61B5202` and `BI-07D76D6B` are complete and are prerequisites, not active work.
+
+## Execution Update — 2026-05-22
+
+- `BI-4025EF5F` implemented as a provider-agnostic import review queue plus QuickBooks projection and readiness/accountant-lane posture.
+- Prisma schema validation and client generation pass.
+- Migration SQL was validated against disposable Postgres database `dpf_import_review_verify`; local `prisma migrate dev` was blocked by worktree database context before schema diagnostics, so the durable SQL migration was verified directly.
+- UI verification was run against this branch with `next start` on `http://127.0.0.1:3107`; root Docker was serving a different checkout.
+
+## Scope Guardrails
+
+- Keep QuickBooks read-only. Do not add create, update, delete, sync-write, webhook mutation, or background write-back paths.
+- Persist only review-safe metadata: provider, entity family, external ID, source timestamp, owner side, proposed local link, display fields, source fingerprint, and review state.
+- Do not store raw QuickBooks provider payloads in the review queue.
+- Staged source records remain non-editable. Operator actions may only affect review/link posture in later slices.
+- Do not claim DPF replaces QuickBooks. The visible state is `import-ready` or `review`, not `dpf-primary`.
+- Spend a bounded refactoring budget on existing staging/readiness seams while touching them: remove duplication, clarify naming, and keep descriptors reusable across future providers.
+
+## Proposed Model Shape
+
+Add the smallest durable persistence substrate:
+
+```prisma
+model IntegrationImportBatch {
+  id                  String   @id @default(cuid())
+  batchRef            String   @unique
+  sourceProvider      String
+  providerEnvironment String?
+  sourceTimestamp     DateTime?
+  status              String   @default("reviewing")
+  createdById         String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  records IntegrationImportStagedRecord[]
+
+  @@index([sourceProvider, status])
+  @@index([createdAt])
+}
+
+model IntegrationImportStagedRecord {
+  id                      String   @id @default(cuid())
+  importBatchId           String
+  sourceProvider          String
+  entityFamily            String
+  externalId              String
+  sourceTimestamp         DateTime?
+  ownerSide               String
+  reviewStatus            String   @default("candidate")
+  proposedLocalEntityType String
+  proposedLocalId         String?
+  proposedLocalStatus     String   @default("candidate")
+  proposedLocalConfidence String   @default("low")
+  proposedLocalReason     String
+  displayFields           Json
+  sourceFingerprint       String
+  readOnly                Boolean  @default(true)
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  batch IntegrationImportBatch @relation(fields: [importBatchId], references: [id], onDelete: Cascade)
+
+  @@unique([importBatchId, entityFamily, externalId])
+  @@index([sourceProvider, entityFamily, externalId])
+  @@index([reviewStatus])
+}
+```
+
+If implementation discovers an existing import batch model with the same responsibility, reuse it instead of adding these models.
+
+## File Map
+
+- Modify: `packages/db/prisma/schema.prisma`
+  - Add the two import review models only if no existing model owns this responsibility.
+- Create: `packages/db/prisma/migrations/<timestamp>_quickbooks_import_review_queue/migration.sql`
+  - Add the tables, indexes, and unique constraints.
+- Modify: `apps/web/lib/integrate/import-staging.ts`
+  - Keep descriptor contracts stable; add only shared review-safe types if needed.
+- Create: `apps/web/lib/integrate/import-review.ts`
+  - Own provider-agnostic review queue types, source fingerprinting, validation, and batch normalization.
+- Create: `apps/web/lib/integrate/import-review.test.ts`
+  - Test read-only invariants, fingerprint stability, and raw payload exclusion.
+- Create: `apps/web/lib/integrate/import-review-store.ts`
+  - Own Prisma-compatible persistence for review batches.
+- Create: `apps/web/lib/integrate/import-review-store.test.ts`
+  - Test idempotent batch upsert and read-only record persistence shape.
+- Create: `apps/web/lib/integrate/quickbooks/import-review.ts`
+  - Convert QuickBooks staged records into import review batch entries.
+- Create: `apps/web/lib/integrate/quickbooks/import-review.test.ts`
+  - Test all nine QuickBooks families map to persisted review records with external ownership.
+- Modify: `apps/web/lib/integrate/quickbooks/readiness.ts`
+  - Surface import-review posture in the descriptor without changing write boundaries.
+- Modify: `apps/web/components/integrations/IntegrationReadinessPanel.tsx`
+  - Render review-queue posture in the QuickBooks readiness page.
+- Modify: `apps/web/components/integrations/IntegrationReadinessPanel.test.tsx`
+  - Assert non-editable import review state and no write action copy.
+- Modify: `apps/web/lib/finance/accountant-work-lane.ts`
+  - Point the next QuickBooks/Stripe/bank-feed workflow at `BI-4025EF5F` where appropriate.
+- Modify: `apps/web/components/finance/AccountantWorkLanePanel.test.tsx`
+  - Assert the accountant lane names the new item and preserves the promotion guardrail.
+
+## Chunk 1: Review Contract And Tests
+
+### Task 1: Provider-Agnostic Review Types
+
+**Files:**
+- Create: `apps/web/lib/integrate/import-review.test.ts`
+- Create: `apps/web/lib/integrate/import-review.ts`
+
+- [x] **Step 1: Write failing tests for review-safe normalization**
+
+Test cases:
+- A staged record becomes a review record with `reviewStatus: "candidate"`.
+- `readOnly` remains `true`.
+- The source fingerprint is stable for the same provider/family/external timestamp/display fields.
+- Raw provider payload fields are not accepted or emitted.
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/import-review.test.ts
+```
+
+Expected: fail because `import-review.ts` does not exist.
+
+- [x] **Step 2: Implement minimal provider-agnostic review helpers**
+
+Create types and helpers:
+- `IntegrationImportReviewStatus`
+- `IntegrationImportReviewRecord`
+- `IntegrationImportReviewBatch`
+- `buildIntegrationImportReviewBatch()`
+- `fingerprintImportStagingRecord()`
+
+- [x] **Step 3: Verify tests pass**
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/import-review.test.ts
+```
+
+Expected: pass.
+
+## Chunk 2: QuickBooks Review Projection
+
+### Task 2: QuickBooks Review Mapper
+
+**Files:**
+- Create: `apps/web/lib/integrate/quickbooks/import-review.test.ts`
+- Create: `apps/web/lib/integrate/quickbooks/import-review.ts`
+- Modify: `apps/web/lib/integrate/quickbooks/import-staging.ts`
+
+- [x] **Step 1: Write failing tests for all nine QuickBooks families**
+
+Assert company, customers, invoices, vendors, bills, expenses, payments, accounts, and reports become review records with:
+- `sourceProvider: "quickbooks"`
+- `ownerSide: "external"`
+- `reviewStatus: "candidate"`
+- non-null `externalId`
+- non-null `sourceFingerprint`
+- `readOnly: true`
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/quickbooks/import-review.test.ts
+```
+
+Expected: fail because the mapper does not exist.
+
+- [x] **Step 2: Implement QuickBooks mapper**
+
+Add `buildQuickBooksImportReviewBatch()` and keep it composed from the existing `stageQuickBooksCoreAccountingRecords()` output. Do not duplicate family definitions.
+
+- [x] **Step 3: Apply bounded refactor**
+
+While touching the mapper, extract any duplicated family lookup or display-field formatting only if it makes the staging and review path easier to read. Do not change public descriptor behavior.
+
+- [x] **Step 4: Verify QuickBooks staging and review tests**
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/quickbooks/import-staging.test.ts lib/integrate/quickbooks/import-review.test.ts
+```
+
+Expected: pass.
+
+## Chunk 3: Persistence
+
+### Task 3: Prisma Models, Migration, And Store
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_quickbooks_import_review_queue/migration.sql`
+- Create: `apps/web/lib/integrate/import-review-store.test.ts`
+- Create: `apps/web/lib/integrate/import-review-store.ts`
+
+- [x] **Step 1: Audit existing models one more time**
+
+Run:
+
+```powershell
+rg -n "ImportBatch|ImportStaged|IntegrationImport|sourceProvider|externalId|erpRefId" packages/db/prisma/schema.prisma
+```
+
+Expected: no existing durable model owns import review queue responsibility.
+
+- [x] **Step 2: Add migration SQL and validate it**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+Get-Content -Raw 'packages/db/prisma/migrations/20260522170000_quickbooks_import_review_queue/migration.sql' | docker exec -i dpf-dev-postgres-1 psql -U dpf -d dpf_import_review_verify -v ON_ERROR_STOP=1
+```
+
+Expected: schema validates and migration SQL applies cleanly in a disposable database.
+
+- [x] **Step 3: Validate generated schema**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+```
+
+Expected: pass.
+
+- [x] **Step 4: Add persistence adapter test first**
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/import-review-store.test.ts
+```
+
+Expected: fail until `import-review-store.ts` exists.
+
+- [x] **Step 5: Implement idempotent batch upsert adapter**
+
+Use `IntegrationImportBatch.batchRef` as the stable upsert key. Replace records inside that batch on rerun and preserve `readOnly: true`.
+
+- [x] **Step 6: Verify persistence adapter test passes**
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/import-review-store.test.ts
+```
+
+Expected: pass.
+
+## Chunk 4: UI And Accountant Lane
+
+### Task 4: Readiness Surface And Lane Handoff
+
+**Files:**
+- Modify: `apps/web/lib/integrate/quickbooks/readiness.ts`
+- Modify: `apps/web/components/integrations/IntegrationReadinessPanel.tsx`
+- Modify: `apps/web/components/integrations/IntegrationReadinessPanel.test.tsx`
+- Modify: `apps/web/lib/finance/accountant-work-lane.ts`
+- Modify: `apps/web/components/finance/AccountantWorkLanePanel.test.tsx`
+
+- [x] **Step 1: Write failing UI tests**
+
+Assert the QuickBooks readiness panel shows:
+- import review queue posture
+- non-editable/source-attributed language
+- `BI-4025EF5F` as the next workflow
+- no create/update/write/sync action language
+
+Run:
+
+```powershell
+pnpm --filter web test -- components/integrations/IntegrationReadinessPanel.test.tsx components/finance/AccountantWorkLanePanel.test.tsx
+```
+
+Expected: fail until UI and lane copy are updated.
+
+- [x] **Step 2: Update UI using theme-aware styling**
+
+Use `var(--dpf-*)` tokens only. Keep cards shallow, table layout stable, and labels compact enough for mobile and desktop.
+
+- [x] **Step 3: Verify UI tests**
+
+Run:
+
+```powershell
+pnpm --filter web test -- components/integrations/IntegrationReadinessPanel.test.tsx components/finance/AccountantWorkLanePanel.test.tsx
+```
+
+Expected: pass.
+
+## Chunk 5: Verification And Evidence
+
+### Task 5: Build Gate
+
+**Files:**
+- Modify only as required by fixes found in verification.
+
+- [x] **Step 1: Run affected tests**
+
+Run:
+
+```powershell
+pnpm --filter web test -- lib/integrate/import-review.test.ts lib/integrate/quickbooks/import-staging.test.ts lib/integrate/quickbooks/import-review.test.ts lib/integrate/quickbooks/readiness.test.ts components/integrations/IntegrationReadinessPanel.test.tsx lib/finance/accountant-work-lane.test.ts components/finance/AccountantWorkLanePanel.test.tsx
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run typecheck**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: pass.
+
+- [x] **Step 3: Run production build**
+
+Run:
+
+```powershell
+cd apps/web
+pnpm exec next build
+```
+
+Expected: pass.
+
+- [x] **Step 4: Verify production UI path**
+
+Use the Docker-served portal when it serves this checkout. For this manual worktree, verify a branch-local production server instead. Verify `/platform/tools/integrations/quickbooks` and `/finance` show import-review posture, preserve read-only language, and expose no write-back action.
+
+- [x] **Step 5: Record MCP evidence and update status**
+
+Use `record_execution_evidence` on `BI-4025EF5F`, then mark it done only after tests, typecheck, build, and UX verification pass.
+
+## Out Of Scope
+
+- QuickBooks writes.
+- Payment execution.
+- Bank-feed provider implementation.
+- Tax filing authority.
+- Ledger/journal ownership.
+- DPF-primary promotion.
+- Raw QuickBooks payload storage.

--- a/packages/db/prisma/migrations/20260522170000_quickbooks_import_review_queue/migration.sql
+++ b/packages/db/prisma/migrations/20260522170000_quickbooks_import_review_queue/migration.sql
@@ -1,0 +1,59 @@
+-- CreateTable
+CREATE TABLE "IntegrationImportBatch" (
+    "id" TEXT NOT NULL,
+    "batchRef" TEXT NOT NULL,
+    "sourceProvider" TEXT NOT NULL,
+    "providerEnvironment" TEXT,
+    "sourceTimestamp" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'reviewing',
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IntegrationImportBatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IntegrationImportStagedRecord" (
+    "id" TEXT NOT NULL,
+    "importBatchId" TEXT NOT NULL,
+    "sourceProvider" TEXT NOT NULL,
+    "entityFamily" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "sourceTimestamp" TIMESTAMP(3),
+    "ownerSide" TEXT NOT NULL,
+    "reviewStatus" TEXT NOT NULL DEFAULT 'candidate',
+    "proposedLocalEntityType" TEXT NOT NULL,
+    "proposedLocalId" TEXT,
+    "proposedLocalStatus" TEXT NOT NULL DEFAULT 'candidate',
+    "proposedLocalConfidence" TEXT NOT NULL DEFAULT 'low',
+    "proposedLocalReason" TEXT NOT NULL,
+    "displayFields" JSONB NOT NULL,
+    "sourceFingerprint" TEXT NOT NULL,
+    "readOnly" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IntegrationImportStagedRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationImportBatch_batchRef_key" ON "IntegrationImportBatch"("batchRef");
+
+-- CreateIndex
+CREATE INDEX "IntegrationImportBatch_sourceProvider_status_idx" ON "IntegrationImportBatch"("sourceProvider", "status");
+
+-- CreateIndex
+CREATE INDEX "IntegrationImportBatch_createdAt_idx" ON "IntegrationImportBatch"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "integration_import_record_batch_family_external_key" ON "IntegrationImportStagedRecord"("importBatchId", "entityFamily", "externalId");
+
+-- CreateIndex
+CREATE INDEX "integration_import_record_source_family_external_idx" ON "IntegrationImportStagedRecord"("sourceProvider", "entityFamily", "externalId");
+
+-- CreateIndex
+CREATE INDEX "IntegrationImportStagedRecord_reviewStatus_idx" ON "IntegrationImportStagedRecord"("reviewStatus");
+
+-- AddForeignKey
+ALTER TABLE "IntegrationImportStagedRecord" ADD CONSTRAINT "IntegrationImportStagedRecord_importBatchId_fkey" FOREIGN KEY ("importBatchId") REFERENCES "IntegrationImportBatch"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1348,6 +1348,51 @@ model IntegrationToolCallLog {
   @@index([toolName, calledAt])
 }
 
+// Source-attributed import review queue for external provider records.
+// Stores review/link posture only; raw provider payloads stay outside DPF.
+model IntegrationImportBatch {
+  id                  String   @id @default(cuid())
+  batchRef            String   @unique
+  sourceProvider      String
+  providerEnvironment String?
+  sourceTimestamp     DateTime?
+  status              String   @default("reviewing")
+  createdById         String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  records IntegrationImportStagedRecord[]
+
+  @@index([sourceProvider, status])
+  @@index([createdAt])
+}
+
+model IntegrationImportStagedRecord {
+  id                      String   @id @default(cuid())
+  importBatchId           String
+  sourceProvider          String
+  entityFamily            String
+  externalId              String
+  sourceTimestamp         DateTime?
+  ownerSide               String
+  reviewStatus            String   @default("candidate")
+  proposedLocalEntityType String
+  proposedLocalId         String?
+  proposedLocalStatus     String   @default("candidate")
+  proposedLocalConfidence String   @default("low")
+  proposedLocalReason     String
+  displayFields           Json
+  sourceFingerprint       String
+  readOnly                Boolean  @default(true)
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  batch IntegrationImportBatch @relation(fields: [importBatchId], references: [id], onDelete: Cascade)
+
+  @@unique([importBatchId, entityFamily, externalId], map: "integration_import_record_batch_family_external_key")
+  @@index([sourceProvider, entityFamily, externalId], map: "integration_import_record_source_family_external_idx")
+  @@index([reviewStatus])
+}
 model OAuthPendingFlow {
   id           String   @id @default(cuid())
   state        String   @unique


### PR DESCRIPTION
## Summary
- adds provider-agnostic import review batch/record helpers, a QuickBooks review mapper, and an idempotent persistence adapter
- adds `IntegrationImportBatch` / `IntegrationImportStagedRecord` with a durable migration for source-attributed, read-only accounting import posture
- surfaces QuickBooks import-review posture in integration readiness and the accountant lane, and records the remaining QuickBooks parity backlog sequence

## Guardrails
- no QuickBooks write-back path is introduced
- staged records preserve external ownership, source provider, external ID, source timestamp, proposed local link posture, display fields, and read-only review state
- raw provider payloads are not stored in the import review queue

## Verification
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter @dpf/db exec prisma generate`
- migration SQL applied cleanly to disposable Postgres database `dpf_import_review_verify`
- `pnpm --filter web test -- lib/integrate/import-review.test.ts lib/integrate/import-review-store.test.ts lib/integrate/quickbooks/import-staging.test.ts lib/integrate/quickbooks/import-review.test.ts lib/integrate/quickbooks/readiness.test.ts components/integrations/IntegrationReadinessPanel.test.tsx lib/finance/accountant-work-lane.test.ts components/finance/AccountantWorkLanePanel.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db typecheck`
- `pnpm exec next build` from `apps/web`
- branch-local UX verification on `http://127.0.0.1:3107` after login for `/platform/tools/integrations/quickbooks` and `/finance`

## Notes
- The production build passes with the existing Turbopack/NFT warning on `apps/web/app/api/voice/synthesize/route.ts` via `next.config.mjs`.