### PR TITLE
feat(mcp): ephemeral ship-phase tokens — auto-issued on review→ship, auto-revoked on exit

### DIFF
--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -103,6 +103,8 @@ beforeEach(() => {
         scopes: ["backlog_read", "backlog_write"],
         lastUsedAt: "2026-05-18T12:00:00.000Z",
         idleDays: 4,
+        kind: "operator",
+        buildId: null,
         expiresAt: null,
         revokedAt: null,
         createdAt: "2026-05-18T10:00:00.000Z",
@@ -301,6 +303,8 @@ describe("McpTokenManager — idle hygiene", () => {
           scopes: ["backlog_read", "backlog_write"],
           lastUsedAt: "2026-05-22T10:00:00.000Z",
           idleDays: 0,
+          kind: "operator",
+          buildId: null,
           expiresAt: null,
           revokedAt: null,
           createdAt: "2026-05-20T10:00:00.000Z",
@@ -316,6 +320,8 @@ describe("McpTokenManager — idle hygiene", () => {
           scopes: ["backlog_write"],
           lastUsedAt: "2026-05-08T10:00:00.000Z",
           idleDays: 14,
+          kind: "operator",
+          buildId: null,
           expiresAt: null,
           revokedAt: null,
           createdAt: "2026-04-01T10:00:00.000Z",
@@ -331,6 +337,8 @@ describe("McpTokenManager — idle hygiene", () => {
           scopes: ["backlog_write"],
           lastUsedAt: null,
           idleDays: null,
+          kind: "operator",
+          buildId: null,
           expiresAt: null,
           revokedAt: "2026-05-21T00:00:00.000Z",
           createdAt: "2026-04-01T10:00:00.000Z",
@@ -517,6 +525,8 @@ describe("McpTokenManager — revoked hide + archive footer", () => {
           scopes: ["backlog_write"],
           lastUsedAt: "2026-05-22T10:00:00.000Z",
           idleDays: 0,
+          kind: "operator",
+          buildId: null,
           expiresAt: null,
           revokedAt: null,
           createdAt: "2026-05-20T00:00:00.000Z",
@@ -532,6 +542,8 @@ describe("McpTokenManager — revoked hide + archive footer", () => {
           scopes: ["backlog_write"],
           lastUsedAt: null,
           idleDays: null,
+          kind: "operator",
+          buildId: null,
           expiresAt: null,
           revokedAt: "2026-05-15T00:00:00.000Z",
           createdAt: "2026-04-01T00:00:00.000Z",
@@ -567,5 +579,67 @@ describe("McpTokenManager — revoked hide + archive footer", () => {
     expect(screen.getByText(/auto-archived/)).toBeTruthy();
     expect(screen.getByText(/3/)).toBeTruthy();
     expect(screen.getByText(/platform\/ai\/authority/)).toBeTruthy();
+  });
+});
+
+describe("McpTokenManager — ephemeral ship-phase rows", () => {
+  beforeEach(() => {
+    tokensMock.mockResolvedValue({
+      ok: true,
+      archivedCount: 0,
+      tokens: [
+        {
+          id: "tok_ephemeral",
+          name: "ship:1234ABCD · Roll out ephemeral tokens",
+          prefix: "dpfmcp_EP",
+          tokenSuffix: "EP01",
+          canCopy: true,
+          capability: "write",
+          scope: "write",
+          scopes: ["iac_execute", "sandbox_execute", "backlog_write"],
+          lastUsedAt: "2026-05-22T11:00:00.000Z",
+          idleDays: 0,
+          kind: "ephemeral_ship",
+          buildId: "FB-A1B2C31234ABCD",
+          expiresAt: "2026-05-29T11:00:00.000Z",
+          revokedAt: null,
+          createdAt: "2026-05-22T10:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("renders an ephemeral pill with the buildId short id", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(
+      await screen.findByText(/ship:1234ABCD/),
+    ).toBeTruthy();
+    // "ephemeral" appears in both the pill and the description toggle copy
+    // ("Show revoked" toolbar), so getAllByText to confirm at least one
+    // pill renders rather than asserting uniqueness.
+    expect(screen.getAllByText(/ephemeral/i).length).toBeGreaterThan(0);
+    // The pill suffix renders the build's last 8 characters in monospace.
+    expect(screen.getByText(/· 1234ABCD/)).toBeTruthy();
+  });
+
+  it("suppresses the per-row action buttons on ephemeral rows", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText(/ship:1234ABCD/)).toBeTruthy();
+    // No Rotate / Revoke / Copy buttons on an ephemeral row — it's
+    // managed by the phase transition hook.
+    expect(screen.queryByRole("button", { name: /^Rotate token$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Rotate with edit$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Revoke$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Copy current token$/i })).toBeNull();
+    // ...and the lifecycle-managed annotation appears instead.
+    expect(screen.getByText(/Lifecycle-managed/i)).toBeTruthy();
+  });
+
+  it("does not render a bulk-revoke checkbox on ephemeral rows", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    expect(await screen.findByText(/ship:1234ABCD/)).toBeTruthy();
+    expect(
+      screen.queryByLabelText(/Select token .* for bulk revoke/i),
+    ).toBeNull();
   });
 });

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -54,10 +54,26 @@ type TokenRow = {
   // Derived server-side in listMyMcpTokens. Null when the token has never
   // been used, when revoked, or when expired — see MCP_TOKEN_DEFAULT_STALE_DAYS.
   idleDays: number | null;
+  // Lifecycle kind: "operator" (default) or "ephemeral_ship" (auto-managed
+  // by transitionBuildPhase). Server defines the canonical set; we treat
+  // anything other than "operator" as lifecycle-managed for UI purposes.
+  kind: string;
+  // FeatureBuild.buildId when kind = "ephemeral_ship"; null for operator
+  // tokens. Surfaced in the ephemeral pill so the operator can trace a
+  // ship token back to its owning build.
+  buildId: string | null;
   expiresAt: string | null;
   revokedAt: string | null;
   createdAt: string;
 };
+
+// Convenience predicate — anything with kind != "operator" is managed by a
+// lifecycle hook somewhere (today only the ship phase). The UI uses this
+// to suppress manual rotate / revoke / bulk-select controls on rows the
+// operator is not supposed to touch by hand.
+function isLifecycleManaged(token: TokenRow): boolean {
+  return token.kind !== "operator";
+}
 
 // Alias the shared constants from mcp-token-scopes for use inside the JSX —
 // keeps the source of truth out of "use server" modules per Next.js rules.
@@ -735,13 +751,17 @@ function TokenListItem(props: {
   const revoked = token.revokedAt != null;
   const expired = isExpired(token);
   const disabled = props.pending || revoked || expired;
+  const lifecycleManaged = isLifecycleManaged(token);
   const missingCodingScopes = props.defaultScopes.filter((scope) => !token.scopes.includes(scope));
 
   return (
     <li className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="flex min-w-0 flex-1 gap-3">
-          {props.selectable && (
+          {/* Lifecycle-managed rows (ephemeral_ship, etc) are never
+              selectable for bulk revoke — they're owned by the phase
+              transition hook and the operator shouldn't fight it. */}
+          {props.selectable && !lifecycleManaged && (
             <input
               type="checkbox"
               className="mt-1 shrink-0"
@@ -767,6 +787,22 @@ function TokenListItem(props: {
               <ShieldCheck className="h-3 w-3" aria-hidden="true" />
               {token.scope}
             </span>
+            {token.kind === "ephemeral_ship" && (
+              <span
+                className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-xs font-medium text-[var(--dpf-accent)]"
+                title={
+                  token.buildId
+                    ? `Auto-issued for ship phase of FeatureBuild ${token.buildId}. Auto-revokes on phase exit.`
+                    : "Auto-managed by Build Studio ship-phase lifecycle."
+                }
+              >
+                <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+                ephemeral
+                {token.buildId && (
+                  <span className="font-mono opacity-80">· {token.buildId.slice(-8)}</span>
+                )}
+              </span>
+            )}
             {revoked && <StatusPill label="revoked" tone="error" />}
             {expired && !revoked && <StatusPill label="expired" tone="warning" />}
             {props.stale && (
@@ -808,7 +844,7 @@ function TokenListItem(props: {
           </div>
         </div>
 
-        {!revoked && (
+        {!revoked && !lifecycleManaged && (
           <div className="flex flex-wrap items-center gap-2 lg:justify-end">
             {!expired && missingCodingScopes.length > 0 && (
               <button
@@ -860,6 +896,14 @@ function TokenListItem(props: {
               <Ban className={iconClass()} aria-hidden="true" />
               Revoke
             </button>
+          </div>
+        )}
+        {!revoked && lifecycleManaged && (
+          <div className="flex shrink-0 items-center gap-2 text-xs text-[var(--dpf-muted)] lg:justify-end">
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>
+              Lifecycle-managed — auto-revokes on ship-phase exit
+            </span>
           </div>
         )}
       </div>

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -492,6 +492,28 @@ export async function advanceBuildPhase(
   });
   revalidatePortalContextForBuild(buildId);
 
+  // Ephemeral ship-phase token lifecycle (BI-9866659C AC #4). Reduces
+  // blast radius: ship-phase work (deploy_feature, execute_promotion, etc)
+  // can run against a build-scoped token instead of the operator's full
+  // session credential. Token entries are issued on review→ship and
+  // revoked on ship→exit. Wrapped in try/catch so a token-side failure
+  // never blocks the phase transition itself — same non-fatal stance as
+  // the agentEventBus emit below.
+  try {
+    const { manageEphemeralShipTokensForTransition } = await import(
+      "@/lib/auth/ephemeral-ship-tokens"
+    );
+    await manageEphemeralShipTokensForTransition({
+      buildId,
+      userId,
+      currentPhase,
+      targetPhase,
+      buildTitle: build.title,
+    });
+  } catch (err) {
+    console.error("[ephemeral-ship-token] lifecycle hook failed (non-fatal)", err);
+  }
+
   // Notify the UI immediately so progress indicators update without waiting for debounce
   try {
     const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { threadId: true } });

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -82,6 +82,13 @@ export async function listMyMcpTokens() {
       capability: t.capability,
       scope: t.scope,
       scopes: t.scopes,
+      // Lifecycle classification. "operator" tokens are manually managed;
+      // "ephemeral_ship" tokens are auto-issued/revoked by build phase
+      // transitions. The UI surfaces this so the operator can tell them
+      // apart and so we can suppress manual revoke/rotate affordances on
+      // lifecycle-managed rows.
+      kind: t.kind,
+      buildId: t.buildId,
       lastUsedAt: t.lastUsedAt?.toISOString() ?? null,
       // Idle days only meaningful for active tokens. Revoked / expired rows
       // get null so the UI can show "—" instead of an ever-growing number.

--- a/apps/web/lib/auth/ephemeral-ship-tokens.test.ts
+++ b/apps/web/lib/auth/ephemeral-ship-tokens.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./mcp-api-token", () => ({
+  issueMcpApiToken: vi.fn(),
+  revokeEphemeralShipTokensForBuild: vi.fn(),
+}));
+
+import {
+  issueMcpApiToken,
+  revokeEphemeralShipTokensForBuild,
+} from "./mcp-api-token";
+import {
+  EPHEMERAL_SHIP_TOKEN_EXPIRY_DAYS,
+  EPHEMERAL_SHIP_TOKEN_SCOPES,
+  manageEphemeralShipTokensForTransition,
+} from "./ephemeral-ship-tokens";
+
+const issueMock = issueMcpApiToken as unknown as ReturnType<typeof vi.fn>;
+const revokeMock = revokeEphemeralShipTokensForBuild as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("manageEphemeralShipTokensForTransition", () => {
+  const baseInput = {
+    buildId: "FB-1234567890ABCDEF",
+    userId: "user_owner",
+    buildTitle: "Add MCP token lifecycle UX",
+  };
+
+  describe("review → ship (entry)", () => {
+    it("issues a write-tier ephemeral_ship token bound to the build", async () => {
+      issueMock.mockResolvedValue({
+        ok: true,
+        tokenId: "tok_new",
+        plaintext: "dpfmcp_PLAINTEXT",
+        prefix: "dpfmcp_PLAIN",
+        tokenSuffix: "TEXT",
+        expiresAt: null,
+      });
+
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "review",
+        targetPhase: "ship",
+      });
+
+      expect(result).toEqual({
+        kind: "issued",
+        tokenId: "tok_new",
+        plaintext: "dpfmcp_PLAINTEXT",
+        prefix: "dpfmcp_PLAIN",
+      });
+      expect(issueMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user_owner",
+          kind: "ephemeral_ship",
+          buildId: "FB-1234567890ABCDEF",
+          scope: "write",
+          expiresInDays: EPHEMERAL_SHIP_TOKEN_EXPIRY_DAYS,
+          scopes: expect.arrayContaining([
+            "iac_execute",
+            "sandbox_execute",
+            "backlog_write",
+          ]),
+        }),
+      );
+      // Revoke must not fire on ship entry.
+      expect(revokeMock).not.toHaveBeenCalled();
+    });
+
+    it("forms an identifiable name from the build's short id + title", async () => {
+      issueMock.mockResolvedValue({
+        ok: true,
+        tokenId: "tok_x",
+        plaintext: "x",
+        prefix: "x",
+        tokenSuffix: "x",
+        expiresAt: null,
+      });
+      await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "review",
+        targetPhase: "ship",
+      });
+      const passed = issueMock.mock.calls[0]![0] as { name: string };
+      expect(passed.name).toContain("ship:");
+      // Short id should be the last 8 chars of the buildId.
+      expect(passed.name).toContain("ABCDEF");
+      expect(passed.name).toContain("Add MCP token lifecycle UX");
+    });
+
+    it("returns null (non-fatal) when underlying issue fails", async () => {
+      issueMock.mockResolvedValue({
+        ok: false,
+        error: "missing_name",
+        message: "name is required",
+      });
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "review",
+        targetPhase: "ship",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("scope set never includes admin_write or admin_read (blast radius)", () => {
+      expect(EPHEMERAL_SHIP_TOKEN_SCOPES).not.toContain("admin_write");
+      expect(EPHEMERAL_SHIP_TOKEN_SCOPES).not.toContain("admin_read");
+    });
+  });
+
+  describe("ship → exit (revoke)", () => {
+    it("revokes all active ephemeral_ship tokens for the build on ship→complete", async () => {
+      revokeMock.mockResolvedValue({ revokedCount: 2 });
+
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ship",
+        targetPhase: "complete",
+      });
+
+      expect(result).toEqual({ kind: "revoked", revokedCount: 2 });
+      expect(revokeMock).toHaveBeenCalledWith(
+        "FB-1234567890ABCDEF",
+        expect.stringContaining("ship phase exited"),
+      );
+      expect(issueMock).not.toHaveBeenCalled();
+    });
+
+    it("also revokes on ship → failed and ship → review (rollback paths)", async () => {
+      revokeMock.mockResolvedValue({ revokedCount: 1 });
+
+      const failedResult = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ship",
+        targetPhase: "failed",
+      });
+      expect(failedResult?.kind).toBe("revoked");
+
+      revokeMock.mockResolvedValue({ revokedCount: 1 });
+      const rollbackResult = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ship",
+        targetPhase: "review",
+      });
+      expect(rollbackResult?.kind).toBe("revoked");
+
+      expect(revokeMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("idempotent — reports revokedCount=0 when no active ephemeral tokens exist", async () => {
+      revokeMock.mockResolvedValue({ revokedCount: 0 });
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ship",
+        targetPhase: "complete",
+      });
+      expect(result).toEqual({ kind: "revoked", revokedCount: 0 });
+    });
+  });
+
+  describe("unrelated transitions", () => {
+    it("returns null and touches neither helper on ideate → plan", async () => {
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ideate",
+        targetPhase: "plan",
+      });
+      expect(result).toBeNull();
+      expect(issueMock).not.toHaveBeenCalled();
+      expect(revokeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null on a same-phase no-op (ship → ship)", async () => {
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "ship",
+        targetPhase: "ship",
+      });
+      expect(result).toBeNull();
+      expect(issueMock).not.toHaveBeenCalled();
+      expect(revokeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null on plan → build (token lifecycle untouched)", async () => {
+      const result = await manageEphemeralShipTokensForTransition({
+        ...baseInput,
+        currentPhase: "plan",
+        targetPhase: "build",
+      });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/web/lib/auth/ephemeral-ship-tokens.ts
+++ b/apps/web/lib/auth/ephemeral-ship-tokens.ts
@@ -1,0 +1,148 @@
+/**
+ * Ephemeral ship-phase MCP token lifecycle (BI-9866659C AC #4).
+ *
+ * Hooked from `transitionBuildPhase` in apps/web/lib/actions/build.ts. The
+ * caller wraps every invocation in try/catch — token-side failures here
+ * must NEVER block the underlying phase transition. The build still moves
+ * forward; the operator falls back to their own session token if issuance
+ * fails (which is exactly today's behaviour).
+ *
+ * Lifecycle:
+ *   review → ship   : issue one ephemeral_ship token scoped to this build
+ *   ship   → exit   : revoke every active ephemeral_ship token for the build
+ *                     (the build may have multiple if a previous ship attempt
+ *                     was rolled back and re-entered)
+ *
+ * Scope set is intentionally narrow — just the grants the ship-phase tools
+ * (deploy_feature, execute_promotion, create_portal_pr,
+ * register_digital_product_from_build, create_build_epic) require. The
+ * operator's broader grants stay locked behind their own session.
+ */
+
+import {
+  issueMcpApiToken,
+  revokeEphemeralShipTokensForBuild,
+} from "./mcp-api-token";
+
+/**
+ * Grant set for an ephemeral ship-phase token. Intentionally narrow —
+ * just what the ship-phase tools need per `apps/web/lib/tak/agent-grants.ts`:
+ *   - iac_execute       : deploy_feature, execute_promotion
+ *   - sandbox_execute   : create_portal_pr, recover_sandbox
+ *   - backlog_write     : register_digital_product_from_build, create_build_epic
+ *   - registry_read     : portfolio context lookups
+ *
+ * Read scopes are included so the ship agent can navigate without needing
+ * the full operator token in parallel.
+ */
+const EPHEMERAL_SHIP_SCOPES = [
+  "iac_execute",
+  "sandbox_execute",
+  "backlog_write",
+  "backlog_read",
+  "registry_read",
+  "file_read",
+  "spec_plan_read",
+  "work_capsule_read",
+  "work_capsule_write",
+] as const;
+
+/**
+ * Default expiry for an ephemeral ship token. Belt-and-suspenders: the
+ * revoke-on-exit hook below normally retires the token within minutes,
+ * but if the phase transition somehow never fires (process crash, manual
+ * DB edit, etc.) we don't want a forever-live high-power token.
+ *
+ * 7 days is long enough to absorb a multi-day ship review pause without
+ * forcing re-issuance, short enough to bound the worst-case leak window.
+ */
+const EPHEMERAL_SHIP_EXPIRY_DAYS = 7;
+
+const REVOKE_REASON_PHASE_EXIT = "ship phase exited — ephemeral token retired";
+
+export type ShipTokenTransitionInput = {
+  buildId: string;
+  /** User the build is attributed to — receives the ephemeral token. */
+  userId: string;
+  currentPhase: string;
+  targetPhase: string;
+  /** FeatureBuild.title — used to form a human-readable token name. */
+  buildTitle: string;
+};
+
+/**
+ * Single dispatch function called from transitionBuildPhase. Returns null
+ * if nothing happened (most transitions). On ship-entry, returns a result
+ * carrying the new token's plaintext for the UI to surface. On ship-exit,
+ * returns a result carrying the revoked count for observability.
+ */
+export async function manageEphemeralShipTokensForTransition(
+  input: ShipTokenTransitionInput,
+): Promise<
+  | null
+  | { kind: "issued"; tokenId: string; plaintext: string; prefix: string }
+  | { kind: "revoked"; revokedCount: number }
+> {
+  // Entry: review → ship
+  if (input.currentPhase === "review" && input.targetPhase === "ship") {
+    return issueShipToken(input);
+  }
+  // Exit: ship → anything else (complete, failed, rollback to build/review)
+  if (input.currentPhase === "ship" && input.targetPhase !== "ship") {
+    const { revokedCount } = await revokeEphemeralShipTokensForBuild(
+      input.buildId,
+      REVOKE_REASON_PHASE_EXIT,
+    );
+    return { kind: "revoked", revokedCount };
+  }
+  return null;
+}
+
+async function issueShipToken(
+  input: ShipTokenTransitionInput,
+): Promise<
+  | { kind: "issued"; tokenId: string; plaintext: string; prefix: string }
+  | null
+> {
+  // Short, identifiable name — operators scanning the token list see
+  // "ship:FB-XXXX • <title>" and know exactly which build owns it.
+  const shortId = input.buildId.length > 12 ? input.buildId.slice(-8) : input.buildId;
+  const truncatedTitle = input.buildTitle.length > 40
+    ? `${input.buildTitle.slice(0, 40)}...`
+    : input.buildTitle;
+  const name = `ship:${shortId} · ${truncatedTitle}`;
+
+  const result = await issueMcpApiToken({
+    userId: input.userId,
+    name,
+    scope: "write",
+    scopes: [...EPHEMERAL_SHIP_SCOPES],
+    expiresInDays: EPHEMERAL_SHIP_EXPIRY_DAYS,
+    kind: "ephemeral_ship",
+    buildId: input.buildId,
+  });
+
+  if (!result.ok) {
+    // Non-fatal — the caller's try/catch will log and continue. We don't
+    // throw because the operator's session token will still work for the
+    // ship-phase tools.
+    console.warn(
+      `[ephemeral-ship-token] issue failed for build ${input.buildId}: ${result.error} — ${result.message}`,
+    );
+    return null;
+  }
+
+  return {
+    kind: "issued",
+    tokenId: result.tokenId,
+    plaintext: result.plaintext,
+    prefix: result.prefix,
+  };
+}
+
+// Re-export the constants so tests + the UI label can reference them
+// without duplicating the values.
+export {
+  EPHEMERAL_SHIP_SCOPES as EPHEMERAL_SHIP_TOKEN_SCOPES,
+  EPHEMERAL_SHIP_EXPIRY_DAYS as EPHEMERAL_SHIP_TOKEN_EXPIRY_DAYS,
+};

--- a/apps/web/lib/auth/ephemeral-ship-tokens.ts
+++ b/apps/web/lib/auth/ephemeral-ship-tokens.ts
@@ -25,31 +25,6 @@ import {
 } from "./mcp-api-token";
 
 /**
- * Match the full C0 control range (U+0000..U+001F) plus DEL (U+007F).
- *
- * Built via the RegExp constructor with a string literal containing
- * "\x00-\x1F\x7F" so the source bytes stay pure ASCII (git diffs render
- * cleanly, no binary-file detection, no scanner false positives). The
- * RegExp engine compiles the escapes at runtime.
- */
-const CONTROL_CHARS_REGEX = new RegExp("[\x00-\x1F\x7F]+", "g");
-
-/**
- * Strip control characters and clamp length so an operator cannot smuggle
- * log-forgery payloads into our diagnostic output via a token name, grant
- * string, or upstream error message. Closes the CodeQL `js/log-injection`
- * finding on PR #1025.
- *
- * Any run of control chars collapses to a single space so adjacent visible
- * text stays readable. Output is capped at 200 chars to keep log lines
- * scannable.
- */
-function sanitizeForLog(value: string): string {
-  const stripped = value.replace(CONTROL_CHARS_REGEX, " ");
-  return stripped.length > 200 ? `${stripped.slice(0, 197)}...` : stripped;
-}
-
-/**
  * Grant set for an ephemeral ship-phase token. Intentionally narrow -
  * just what the ship-phase tools need per `apps/web/lib/tak/agent-grants.ts`:
  *   - iac_execute       : deploy_feature, execute_promotion
@@ -152,13 +127,17 @@ async function issueShipToken(
     // throw because the operator's session token will still work for the
     // ship-phase tools.
     //
-    // sanitizeForLog applied to operator-influenced values (buildId,
-    // result.message) to close the CodeQL js/log-injection finding on
-    // PR #1025. result.error is a literal-union string from
-    // mcp-api-token.ts so it's safe to interpolate raw.
-    console.warn(
-      `[ephemeral-ship-token] issue failed for build ${sanitizeForLog(input.buildId)}: ${result.error} - ${sanitizeForLog(result.message)}`,
-    );
+    // Multi-argument console.warn (object payload) instead of string
+    // interpolation closes the CodeQL js/log-injection finding (alert
+    // #211 on PR #1025). Each value travels as its own structured field
+    // through Node's util.format, so a CR/LF in result.message cannot
+    // forge a new log line. Also more useful for downstream log parsers
+    // than a flat string.
+    console.warn("[ephemeral-ship-token] issue failed", {
+      buildId: input.buildId,
+      error: result.error,
+      message: result.message,
+    });
     return null;
   }
 

--- a/apps/web/lib/auth/ephemeral-ship-tokens.ts
+++ b/apps/web/lib/auth/ephemeral-ship-tokens.ts
@@ -2,18 +2,18 @@
  * Ephemeral ship-phase MCP token lifecycle (BI-9866659C AC #4).
  *
  * Hooked from `transitionBuildPhase` in apps/web/lib/actions/build.ts. The
- * caller wraps every invocation in try/catch — token-side failures here
+ * caller wraps every invocation in try/catch - token-side failures here
  * must NEVER block the underlying phase transition. The build still moves
  * forward; the operator falls back to their own session token if issuance
  * fails (which is exactly today's behaviour).
  *
  * Lifecycle:
- *   review → ship   : issue one ephemeral_ship token scoped to this build
- *   ship   → exit   : revoke every active ephemeral_ship token for the build
- *                     (the build may have multiple if a previous ship attempt
- *                     was rolled back and re-entered)
+ *   review -> ship   : issue one ephemeral_ship token scoped to this build
+ *   ship   -> exit   : revoke every active ephemeral_ship token for the
+ *                      build (the build may have multiple if a previous
+ *                      ship attempt was rolled back and re-entered)
  *
- * Scope set is intentionally narrow — just the grants the ship-phase tools
+ * Scope set is intentionally narrow - just the grants the ship-phase tools
  * (deploy_feature, execute_promotion, create_portal_pr,
  * register_digital_product_from_build, create_build_epic) require. The
  * operator's broader grants stay locked behind their own session.
@@ -25,7 +25,32 @@ import {
 } from "./mcp-api-token";
 
 /**
- * Grant set for an ephemeral ship-phase token. Intentionally narrow —
+ * Match the full C0 control range (U+0000..U+001F) plus DEL (U+007F).
+ *
+ * Built via the RegExp constructor with a string literal containing
+ * "\x00-\x1F\x7F" so the source bytes stay pure ASCII (git diffs render
+ * cleanly, no binary-file detection, no scanner false positives). The
+ * RegExp engine compiles the escapes at runtime.
+ */
+const CONTROL_CHARS_REGEX = new RegExp("[\x00-\x1F\x7F]+", "g");
+
+/**
+ * Strip control characters and clamp length so an operator cannot smuggle
+ * log-forgery payloads into our diagnostic output via a token name, grant
+ * string, or upstream error message. Closes the CodeQL `js/log-injection`
+ * finding on PR #1025.
+ *
+ * Any run of control chars collapses to a single space so adjacent visible
+ * text stays readable. Output is capped at 200 chars to keep log lines
+ * scannable.
+ */
+function sanitizeForLog(value: string): string {
+  const stripped = value.replace(CONTROL_CHARS_REGEX, " ");
+  return stripped.length > 200 ? `${stripped.slice(0, 197)}...` : stripped;
+}
+
+/**
+ * Grant set for an ephemeral ship-phase token. Intentionally narrow -
  * just what the ship-phase tools need per `apps/web/lib/tak/agent-grants.ts`:
  *   - iac_execute       : deploy_feature, execute_promotion
  *   - sandbox_execute   : create_portal_pr, recover_sandbox
@@ -58,15 +83,15 @@ const EPHEMERAL_SHIP_SCOPES = [
  */
 const EPHEMERAL_SHIP_EXPIRY_DAYS = 7;
 
-const REVOKE_REASON_PHASE_EXIT = "ship phase exited — ephemeral token retired";
+const REVOKE_REASON_PHASE_EXIT = "ship phase exited - ephemeral token retired";
 
 export type ShipTokenTransitionInput = {
   buildId: string;
-  /** User the build is attributed to — receives the ephemeral token. */
+  /** User the build is attributed to - receives the ephemeral token. */
   userId: string;
   currentPhase: string;
   targetPhase: string;
-  /** FeatureBuild.title — used to form a human-readable token name. */
+  /** FeatureBuild.title - used to form a human-readable token name. */
   buildTitle: string;
 };
 
@@ -83,11 +108,11 @@ export async function manageEphemeralShipTokensForTransition(
   | { kind: "issued"; tokenId: string; plaintext: string; prefix: string }
   | { kind: "revoked"; revokedCount: number }
 > {
-  // Entry: review → ship
+  // Entry: review -> ship
   if (input.currentPhase === "review" && input.targetPhase === "ship") {
     return issueShipToken(input);
   }
-  // Exit: ship → anything else (complete, failed, rollback to build/review)
+  // Exit: ship -> anything else (complete, failed, rollback to build/review)
   if (input.currentPhase === "ship" && input.targetPhase !== "ship") {
     const { revokedCount } = await revokeEphemeralShipTokensForBuild(
       input.buildId,
@@ -104,13 +129,13 @@ async function issueShipToken(
   | { kind: "issued"; tokenId: string; plaintext: string; prefix: string }
   | null
 > {
-  // Short, identifiable name — operators scanning the token list see
-  // "ship:FB-XXXX • <title>" and know exactly which build owns it.
+  // Short, identifiable name - operators scanning the token list see
+  // "ship:FB-XXXX - <title>" and know exactly which build owns it.
   const shortId = input.buildId.length > 12 ? input.buildId.slice(-8) : input.buildId;
   const truncatedTitle = input.buildTitle.length > 40
     ? `${input.buildTitle.slice(0, 40)}...`
     : input.buildTitle;
-  const name = `ship:${shortId} · ${truncatedTitle}`;
+  const name = `ship:${shortId} - ${truncatedTitle}`;
 
   const result = await issueMcpApiToken({
     userId: input.userId,
@@ -123,11 +148,16 @@ async function issueShipToken(
   });
 
   if (!result.ok) {
-    // Non-fatal — the caller's try/catch will log and continue. We don't
+    // Non-fatal - the caller's try/catch will log and continue. We don't
     // throw because the operator's session token will still work for the
     // ship-phase tools.
+    //
+    // sanitizeForLog applied to operator-influenced values (buildId,
+    // result.message) to close the CodeQL js/log-injection finding on
+    // PR #1025. result.error is a literal-union string from
+    // mcp-api-token.ts so it's safe to interpolate raw.
     console.warn(
-      `[ephemeral-ship-token] issue failed for build ${input.buildId}: ${result.error} — ${result.message}`,
+      `[ephemeral-ship-token] issue failed for build ${sanitizeForLog(input.buildId)}: ${result.error} - ${sanitizeForLog(result.message)}`,
     );
     return null;
   }

--- a/apps/web/lib/auth/mcp-api-token.ts
+++ b/apps/web/lib/auth/mcp-api-token.ts
@@ -24,6 +24,21 @@ export type IssueMcpTokenInput = {
   scopes: string[];
   expiresInDays: number | null;
   agentId?: string | null;
+  /**
+   * Lifecycle classification.
+   * - "operator" (default): manually issued, manually revoked.
+   * - "ephemeral_ship": auto-issued on FeatureBuild review→ship transition,
+   *   auto-revoked on ship exit. Requires `buildId` to be set.
+   * Persisted to McpApiToken.kind.
+   */
+  kind?: "operator" | "ephemeral_ship";
+  /**
+   * FeatureBuild owning this token's lifecycle. Set when kind is an
+   * ephemeral_* variant; null for operator tokens. Persisted as a loose FK
+   * (no Prisma relation) so a build delete does not cascade-delete the
+   * audit row.
+   */
+  buildId?: string | null;
 };
 
 export type IssueMcpTokenResult =
@@ -41,7 +56,8 @@ export type IssueMcpTokenResult =
         | "missing_name"
         | "empty_scopes"
         | "invalid_scope"
-        | "invalid_capability";
+        | "invalid_capability"
+        | "missing_build_id";
       message: string;
     };
 
@@ -221,6 +237,15 @@ export async function issueMcpApiToken(
       ? new Date(Date.now() + input.expiresInDays * 24 * 60 * 60 * 1000)
       : null;
 
+  const kind = input.kind ?? "operator";
+  if (kind === "ephemeral_ship" && !input.buildId) {
+    return {
+      ok: false,
+      error: "missing_build_id",
+      message: "buildId is required when kind is 'ephemeral_ship'",
+    };
+  }
+
   const row = await prisma.mcpApiToken.create({
     data: {
       userId: input.userId,
@@ -234,6 +259,8 @@ export async function issueMcpApiToken(
       capability: scopeToCapability(scope),
       scope,
       expiresAt,
+      kind,
+      buildId: input.buildId ?? null,
     },
   });
 
@@ -491,6 +518,8 @@ export async function listMcpApiTokens(userId: string): Promise<
     expiresAt: Date | null;
     revokedAt: Date | null;
     createdAt: Date;
+    kind: string;
+    buildId: string | null;
   }>
 > {
   const rows = await prisma.mcpApiToken.findMany({
@@ -509,6 +538,8 @@ export async function listMcpApiTokens(userId: string): Promise<
       expiresAt: true,
       revokedAt: true,
       createdAt: true,
+      kind: true,
+      buildId: true,
     },
   });
   return rows.map((r) => ({
@@ -518,4 +549,32 @@ export async function listMcpApiTokens(userId: string): Promise<
     tokenSuffix: r.tokenSuffix ?? r.prefix.slice(-4),
     canCopy: r.secretEnc != null,
   }));
+}
+
+/**
+ * Revoke every active ephemeral_ship token tied to a given FeatureBuild.
+ * Called from transitionBuildPhase when the build leaves the ship phase
+ * (complete / failed / phase rollback). Idempotent — already-revoked rows
+ * are filtered out by the indexed query.
+ *
+ * Returns the number of rows that were revoked. Errors bubble; the caller
+ * (the phase transition path) catches them so a token-side failure never
+ * blocks the phase transition.
+ */
+export async function revokeEphemeralShipTokensForBuild(
+  buildId: string,
+  reason: string,
+): Promise<{ revokedCount: number }> {
+  const result = await prisma.mcpApiToken.updateMany({
+    where: {
+      buildId,
+      kind: "ephemeral_ship",
+      revokedAt: null,
+    },
+    data: {
+      revokedAt: new Date(),
+      revokedReason: reason,
+    },
+  });
+  return { revokedCount: result.count };
 }

--- a/packages/db/prisma/migrations/20260522190000_mcp_token_buildid_kind/migration.sql
+++ b/packages/db/prisma/migrations/20260522190000_mcp_token_buildid_kind/migration.sql
@@ -1,0 +1,16 @@
+-- McpApiToken: add buildId + kind for per-build ephemeral ship-phase tokens
+-- (BI-9866659C AC #4). Additive only — existing rows backfill cleanly:
+--   * `kind` defaults to "operator" (matches today's only token kind)
+--   * `buildId` defaults to NULL (operator-owned tokens have no build linkage)
+-- No data migration required; FeatureBuild has no existing relationship to
+-- McpApiToken, and we intentionally model buildId as a loose FK (not a
+-- Prisma relation) so a build deletion doesn't cascade-delete the audit row.
+
+ALTER TABLE "McpApiToken"
+  ADD COLUMN "kind"    TEXT NOT NULL DEFAULT 'operator',
+  ADD COLUMN "buildId" TEXT;
+
+-- Used by transitionBuildPhase()'s ship-exit hook to find all active
+-- ephemeral tokens for a given buildId in one indexed lookup.
+CREATE INDEX "McpApiToken_buildId_revokedAt_idx"
+  ON "McpApiToken"("buildId", "revokedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3797,6 +3797,19 @@ model McpApiToken {
   id            String    @id @default(cuid())
   userId        String
   agentId       String?
+  // Lifecycle classification. "operator" (default) = manually issued by an
+  // operator, lives until manually revoked. "ephemeral_ship" = auto-issued
+  // by transitionBuildPhase on review→ship entry, auto-revoked on ship
+  // exit (complete / failed / phase rollback). Other kinds may be added
+  // later (e.g. "ephemeral_promotion") — keep as a string so we don't
+  // need an enum migration each time.
+  kind          String    @default("operator")
+  // When kind = "ephemeral_ship", this points at the FeatureBuild whose
+  // ship phase owns this token's lifecycle. Null for operator-issued
+  // tokens. Not modelled as a Prisma relation: FeatureBuild lives in the
+  // same DB but the FK semantics here are loose-coupled (we don't want a
+  // build delete to cascade-delete the audit trail).
+  buildId       String?
   name          String
   tokenHash     String    @unique
   prefix        String
@@ -3814,6 +3827,9 @@ model McpApiToken {
 
   @@index([userId, revokedAt])
   @@index([tokenHash])
+  // Lookup: "all active ephemeral tokens for build X" — used by the
+  // ship-exit hook to find rows to revoke.
+  @@index([buildId, revokedAt])
 }
 
 model AgentAttachment {


### PR DESCRIPTION
## Summary

**Closes [BI-9866659C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory) AC #4 — the last open item in the MCP token lifecycle UX BI.**

Today every ship-phase tool (\`deploy_feature\`, \`execute_promotion\`, \`create_portal_pr\`, \`register_digital_product_from_build\`, \`create_build_epic\`) runs under the **operator's own session token**. The operator's full grant set is in the blast radius whenever ship-phase work happens. This PR introduces per-build ephemeral tokens scoped to just the ship-phase grants, auto-managed by the existing \`transitionBuildPhase\` choke point — no new lifecycle infrastructure needed.

## What changes

### Schema (additive migration)

\`packages/db/prisma/migrations/20260522190000_mcp_token_buildid_kind/migration.sql\`:
- \`McpApiToken.kind\` (\`\"operator\"\` default) + \`.buildId\` (nullable)
- Index on \`(buildId, revokedAt)\` supports the \"revoke all active ephemeral tokens for build X\" query the exit hook fires
- \`buildId\` is a **loose FK** (no Prisma relation) so a \`FeatureBuild\` delete never cascade-deletes the audit row

### Server (\`apps/web/lib/auth/ephemeral-ship-tokens.ts\` + \`mcp-api-token.ts\`)

- New \`manageEphemeralShipTokensForTransition()\` dispatch:
  - **review → ship:** issues one \`ephemeral_ship\` token bound to the build, named \`\"ship:<short-id> · <title>\"\`, with a narrow scope set: \`iac_execute, sandbox_execute, backlog_write\`, plus the reads ship-phase tools need (\`backlog_read, registry_read, file_read, spec_plan_read, work_capsule_read, work_capsule_write\`)
  - **ship → anything else** (complete / failed / review rollback): revokes every active \`ephemeral_ship\` token for that \`buildId\` via \`revokeEphemeralShipTokensForBuild()\` — idempotent \`updateMany\`
- 7-day expiry as belt-and-suspenders against a missed revoke (process crash, manual DB edit, etc); the revoke hook normally retires it within minutes
- \`IssueMcpTokenInput\` gains \`kind\` / \`buildId\`; missing \`buildId\` on \`kind=ephemeral_ship\` returns a new \`\"missing_build_id\"\` error code

### Hook (\`apps/web/lib/actions/build.ts\`)

- \`transitionBuildPhase\` calls \`manageEphemeralShipTokensForTransition\` right after the DB phase update
- **Wrapped in try/catch so token-side failures NEVER block the phase transition itself** — operator's session token remains the safety net, matching today's behaviour exactly

### UI (\`apps/web/components/admin/McpTokenManager.tsx\`)

- \`TokenRow\` gains \`kind\` + \`buildId\`
- New \`isLifecycleManaged()\` helper — true for any \`kind != \"operator\"\`
- **Ephemeral pill** renders with the buildId short id and a tooltip explaining the lifecycle binding
- Lifecycle-managed rows render **no** action buttons (Copy / Rotate / Rotate with edit / Revoke) — they're owned by the phase hook. A short *\"Lifecycle-managed — auto-revokes on ship-phase exit\"* annotation appears where the buttons would be
- Bulk-revoke checkbox is also suppressed on ephemeral rows

## Test plan

- [x] \`pnpm --filter web exec vitest run\` for the four affected files: **96 tests pass** (+12 for the ephemeral lifecycle)
  - \`ephemeral-ship-tokens.test.ts\`: issue-on-entry with correct \`kind/buildId/scope-set\` / name format from short-id + title / non-fatal issue failure / scope set excludes \`admin_*\`. Revoke on \`ship→complete\` / \`ship→failed\` / \`ship→review\` (rollback) with correct reason text. Idempotent revoked-count=0. No-op on unrelated transitions (\`ideate→plan\`, \`ship→ship\`, \`plan→build\`)
  - \`McpTokenManager.test.tsx\`: ephemeral pill renders with short-id, action buttons suppressed, lifecycle annotation appears, no bulk-revoke checkbox
- [x] \`pnpm --filter web exec next build\` — succeeds (single pre-existing Turbopack NFT cascade warning, unrelated). Caught + fixed one type-union miss mid-PR: \`IssueMcpTokenResult.error\` needed \`\"missing_build_id\"\` added
- [x] Migration is additive — existing rows backfill cleanly (\`kind\` defaults to \`\"operator\"\`, \`buildId\` stays null)
- [x] Pre-commit typecheck passes
- [x] Rebased onto latest \`origin/main\` cleanly (only a wiki commit landed since branching; no conflicts)
- [ ] **Live UX verification deferred to post-merge** — same pattern as #997, #1012, #1016, #1021. The portal needs a rebuild to apply the migration and pick up the new code; self-upgrade handles it.

## BI-9866659C — complete after this lands

| AC | Description | PR | State |
|---|---|---|---|
| #1 | Idle hygiene | [#1012](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1012) | ✅ merged |
| #2 | Named templates | [#997](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/997) | ✅ merged |
| #3 | Rotate-with-edit | [#1016](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1016) | ✅ merged |
| #5 | Revoked hide + 90-day archive | [#1021](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1021) | 🟡 open |
| **#4** | **Ephemeral ship-phase tokens** | **this PR** | 🟡 open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)