### PR TITLE
feat(storefront): add primaryActions to capability activation contract

### DIFF
--- a/packages/storefront-templates/src/primary-action-contract.test.ts
+++ b/packages/storefront-templates/src/primary-action-contract.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CapabilityActivation,
+  CapabilityOverride,
+  PrimaryAction,
+  PrimaryActionSurface,
+} from "./types";
+
+describe("PrimaryAction contract", () => {
+  it("typechecks a capability activation with primaryActions", () => {
+    const action: PrimaryAction = {
+      id: "open-customer-detail",
+      label: "Open",
+      surface: "map-pin",
+      isDefault: true,
+    };
+
+    const activation: CapabilityActivation = {
+      capabilityKey: "customer-site-map",
+      applicability: "required",
+      ownershipScopes: ["customer-account", "customer-site"],
+      isolation: "strict-customer-scope",
+      surfaces: ["customers", "map"],
+      primaryActions: [action],
+      sourceRules: ["customer-site-map-rule-1"],
+    };
+
+    expect(activation.primaryActions?.[0]?.id).toBe("open-customer-detail");
+    expect(activation.primaryActions?.[0]?.surface).toBe("map-pin");
+  });
+
+  it("allows activations without primaryActions (backward compat)", () => {
+    const activation: CapabilityActivation = {
+      capabilityKey: "customer-estate",
+      applicability: "required",
+      ownershipScopes: ["customer-account"],
+      isolation: "strict-customer-scope",
+      surfaces: ["customers"],
+      sourceRules: ["customer-estate-rule-1"],
+    };
+
+    expect(activation.primaryActions).toBeUndefined();
+  });
+
+  it("typechecks PrimaryActionSurface as the legal surface union", () => {
+    const surfaces: PrimaryActionSurface[] = [
+      "map-pin",
+      "list-row",
+      "selection",
+      "detail-page",
+    ];
+    expect(surfaces).toHaveLength(4);
+  });
+
+  it("typechecks a capability override that supplies primaryActions", () => {
+    const override: CapabilityOverride = {
+      capabilityKey: "remote-support",
+      applicability: "recommended",
+      primaryActions: [
+        { id: "request-remote-session", label: "Request remote session", surface: "detail-page" },
+      ],
+      reason: "consent gating not yet automated",
+    };
+
+    expect(override.primaryActions?.[0]?.id).toBe("request-remote-session");
+  });
+
+  it("accepts isDefault flag as optional", () => {
+    const a: PrimaryAction = { id: "log-violation", label: "Log violation", surface: "map-pin" };
+    expect(a.isDefault).toBeUndefined();
+
+    const b: PrimaryAction = { id: "open-property", label: "Open", surface: "map-pin", isDefault: true };
+    expect(b.isDefault).toBe(true);
+  });
+});

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -190,6 +190,32 @@ export type PaymentPattern =
 
 export type InvoiceExecutionMode = "none" | "manual" | "prepared-not-prescribed" | "automated";
 
+/**
+ * Where a {@link PrimaryAction} is invoked from in the UI. Drives which actions
+ * the {@link CapabilityActivation} contributes to a given surface (map pin
+ * click, list-row click, multi-select toolbar, detail page).
+ */
+export type PrimaryActionSurface = "map-pin" | "list-row" | "selection" | "detail-page";
+
+/**
+ * Declares an action that a capability contributes to a UI surface, so map-pin
+ * click / list-row click / etc. semantics are capability-driven rather than
+ * hard-coded per archetype. Resolution happens via
+ * `apps/web/lib/customer-surface/pin-actions.ts` (or equivalent host helpers);
+ * see `docs/superpowers/specs/2026-05-22-customer-surface-archetype-activation-design.md`
+ * §11.
+ */
+export interface PrimaryAction {
+  /** Stable id, e.g. "open-customer-detail", "dispatch-tech", "log-violation". */
+  id: string;
+  /** Verb label for the action button, e.g. "Open", "Dispatch", "Log violation". */
+  label: string;
+  /** Which UI scope this action fires from. */
+  surface: PrimaryActionSurface;
+  /** Whether this is the default action (e.g. single-click on map pin). */
+  isDefault?: boolean;
+}
+
 export interface CapabilityActivation {
   capabilityKey: string;
   applicability: CapabilityApplicability;
@@ -197,6 +223,12 @@ export interface CapabilityActivation {
   transactionContexts?: TransactionContext[];
   isolation: CapabilityIsolation;
   surfaces: string[];
+  /**
+   * Actions this capability contributes to UI surfaces. Optional for backward
+   * compatibility — existing capabilities without action declarations behave
+   * exactly as before.
+   */
+  primaryActions?: PrimaryAction[];
   sourceRules: string[];
   reason?: string;
   overrideReason?: string;
@@ -209,6 +241,7 @@ export interface CapabilityOverride {
   transactionContexts?: TransactionContext[];
   isolation?: CapabilityIsolation;
   surfaces?: string[];
+  primaryActions?: PrimaryAction[];
   reason: string;
 }
 


### PR DESCRIPTION
## Summary

Task 0 of the customer-surface implementation plan (`docs/superpowers/plans/2026-05-22-customer-surface-archetype-activation.md`). Extends `CapabilityActivation` and `CapabilityOverride` with an optional `primaryActions?: PrimaryAction[]` field so map-pin / list-row / selection / detail-page action semantics can be declared by capability rules and consumed by UI components — never branched on `archetypeId` in component code.

Why this small slice first: every subsequent customer-surface task (rules engine emissions, pin-action resolver, map view, dispatch view) reads from this contract. Landing it ahead of those tasks gives downstream PRs a stable type surface to build against.

## Changes

- `packages/storefront-templates/src/types.ts`
  - Adds `PrimaryActionSurface` union (`map-pin` | `list-row` | `selection` | `detail-page`).
  - Adds `PrimaryAction` interface (`id`, `label`, `surface`, `isDefault?`).
  - Adds optional `primaryActions?: PrimaryAction[]` field on `CapabilityActivation`.
  - Adds optional `primaryActions?: PrimaryAction[]` field on `CapabilityOverride`.
- `packages/storefront-templates/src/primary-action-contract.test.ts` (NEW, 5 cases)
  - Activations with `primaryActions` typecheck and read correctly.
  - Activations WITHOUT `primaryActions` continue to typecheck (backward compat).
  - `PrimaryActionSurface` accepts the four legal values.
  - Overrides accept `primaryActions`.
  - `isDefault` is optional.

No behavior change. No rule emissions modified (that's Task 3 of the plan). No registry entries added (that's Task 1).

## Verification

- `pnpm --filter @dpf/storefront-templates typecheck` → clean
- `pnpm --filter @dpf/storefront-templates exec vitest run` → 24/24 pass (5 new + 19 pre-existing)

## Spec reference

See `docs/superpowers/specs/2026-05-22-customer-surface-archetype-activation-design.md` §6 (Core Architecture Decision) and §11 (Map Pin Action Model). Spec landed on main as part of PR #1015.

## Plan follow-on

Task 1 (capability registry entries) will land in a follow-on PR off main. Each plan task gets its own PR so review surface stays small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)