### PR TITLE
fix(security): close 6 MEDIUM alerts (5× unpinned-tag + py/log-injection)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -119,11 +119,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # CodeQL actions/unpinned-tag #101-#103: 3rd-party actions pinned to
+      # immutable commit SHAs (with version trailing comment) so a compromised
+      # docker/* maintainer cannot retroactively repoint the v4/v7 tag at
+      # malicious code. Renovate / Dependabot can still bump these in PRs;
+      # the SHA is the cryptographically verifiable handle.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -135,7 +140,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.file }}
@@ -190,11 +195,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # CodeQL actions/unpinned-tag #104-#105: SHA-pin in the merge job too.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/services/browser-use/server.py
+++ b/services/browser-use/server.py
@@ -645,7 +645,13 @@ async def mcp_endpoint(request: Request):
             # trace context to clients. logger.exception() captures the
             # full trace server-side for diagnostics; the client gets a
             # generic message instead.
-            logger.exception("Tool %s failed", tool_name)
+            #
+            # CodeQL #106 (py/log-injection): tool_name comes from the
+            # JSON-RPC request body — an attacker could embed CR/LF to
+            # forge fake log lines. repr() escapes control characters and
+            # is a CodeQL-recognised log-injection sanitiser. The repr()
+            # form also makes clear in logs that this is untrusted input.
+            logger.exception("Tool %s failed", repr(tool_name))
             _ = e  # consumed by logger.exception
             return JSONResponse(content={
                 "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

After switching to advanced CodeQL setup, the `security-extended` query suite surfaced 6 alerts the default suite didn't run:

- **#101–#105** (`actions/unpinned-tag`): `publish-image.yml` referenced `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7` by tag. A compromised docker/* maintainer could retroactively repoint a tag. Pinned all five sites to immutable commit SHAs with a trailing version comment so Renovate/Dependabot can still bump them.

- **#106** (`py/log-injection`): `logger.exception("Tool %s failed", tool_name)` in `services/browser-use/server.py` logged a user-controlled value verbatim — CR/LF could forge fake log lines. Wrapped in `repr()` (a CodeQL-recognised sanitiser that escapes control chars).

## Pinned SHAs

| Action | SHA | Tag |
|---|---|---|
| docker/setup-buildx-action | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` | v4 |
| docker/login-action | `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` | v4 |
| docker/build-push-action | `f9f3042f7e2789586610d6e8b85c8f03e5195baf` | v7 |

Resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` at PR-author time.

## Test plan

- [ ] CI passes (publish-image.yml only fires on release tags so won't run on PR)
- [ ] CodeQL re-scan after merge: alerts #101–#106 close
- [ ] Combined with PR #1006: total open CodeQL alerts → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)