### PR TITLE
fix(build-studio): drop phantom businessContext field from Ideate auto-dispatch select

### DIFF
--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -49,7 +49,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: null,
       title: "Untitled",
       description: "",
-      businessContext: null,
     });
 
     const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
@@ -74,7 +73,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: { problemStatement: "Already drafted." },
       title: "T",
       description: "D",
-      businessContext: null,
     });
 
     const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
@@ -90,7 +88,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: null,
       title: "T",
       description: "D",
-      businessContext: null,
     });
     mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "BI body content." });
     mockGetBuildStudioConfig.mockResolvedValue({
@@ -114,7 +111,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: null,
       title: "Fallback Title",
       description: "Fallback description.",
-      businessContext: "biz",
     });
     mockPrisma.backlogItem.findUnique.mockResolvedValue({
       title: "BI Title",
@@ -160,7 +156,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: null,
       title: "T",
       description: "D",
-      businessContext: null,
     });
     mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
     mockDispatchIdeateResearch.mockResolvedValue({
@@ -183,7 +178,6 @@ describe("dispatchIdeateForApprovedBuild", () => {
       designDoc: null,
       title: "T",
       description: "D",
-      businessContext: null,
     });
     mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
     mockDispatchIdeateResearch.mockResolvedValue({

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -64,6 +64,13 @@ export async function dispatchIdeateForApprovedBuild(params: {
 
   try {
     // Fetch the build with the linked BI and current designDoc evidence.
+    // NOTE: businessContext is intentionally NOT selected here — it is not a
+    // field on the FeatureBuild Prisma model. PR #947 originally selected it,
+    // which threw a PrismaClientValidationError on every approve_start and was
+    // silently swallowed by the catch below, leaving every backlog-promoted
+    // build stuck at the post-approval gate with no Ideate work ever firing.
+    // If a future change adds businessContext (or sources it from BacklogItem),
+    // re-introduce it via a separate join rather than as a phantom select field.
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
       select: {
@@ -71,7 +78,6 @@ export async function dispatchIdeateForApprovedBuild(params: {
         designDoc: true,
         title: true,
         description: true,
-        businessContext: true,
       },
     });
 
@@ -148,7 +154,9 @@ export async function dispatchIdeateForApprovedBuild(params: {
       featureDescription,
       reusabilityScope: "parameterizable",
       userContext,
-      businessContext: build.businessContext ?? undefined,
+      // businessContext: see select comment above — field does not exist on
+      // FeatureBuild. Passing undefined preserves the dispatch signature.
+      businessContext: undefined,
       providerId,
       model,
       dispatchEngine: config.provider,


### PR DESCRIPTION
## Summary

- PR #947 (auto-dispatch Ideate research on approve_start) selected `businessContext: true` from `FeatureBuild`, but that field does not exist on the model. Every approve_start on a backlog-promoted draft threw `PrismaClientValidationError` inside the fire-and-forget catch and was logged silently to `BuildActivity`, leaving every backlog-promoted build stuck at "A design document is required before planning" with no Ideate work firing.
- Tests passed only because the mocks fabricated `businessContext: null` — the real Prisma client never accepts it as a select field. Mocks faked the schema and hid the bug.
- Fix removes the phantom select field, passes `undefined` to `dispatchIdeateResearch`, and strips the fabricated field from the six mock literals so future schema drift on the real fields is no longer masked.

## Evidence (live, 2026-05-22)

Three backlog-promoted builds filed and approved during this session — each shows exactly one `approve_start` followed by one `ideate_dispatch` row with the truncated Prisma error, then nothing:

- `FB-DD158A1B` (BI-46216B4C — Tier-0 Backlog Orchestrator sweeper)
- `FB-2E138BE0` (BI-330A89D5 — BS handoff & priority surface)
- `FB-3F5A4D99` (BI-DE9834A8 — Portfolio-rolled spend)

The postmortem-canary verification (BI-F8B05B66) reported "auto-dispatch is live and produces real artifacts" but did so by observing Ideate via the agentic coworker chat path (`buildExecState.ideateResearchRequested`), not via the auto-dispatch on approve_start. Both paths produce Ideate output; only the chat-driven path actually works today.

## Maps to kernel principle

`structural-verification-is-not-functional` — same commandment-tier principle PR #947 explicitly invoked. Approve_start was a structural success; the dispatch path produced no functional truth. Now applied to its own mock-vs-reality drift.

## Follow-on (not in this PR)

Whether `businessContext` *should* be a real field (with a migration, sourced from BI body or operator entry) is a Build Studio design question. A separate BI will be filed to capture that — this PR is purely the urgent hotfix to unstick autonomous flow.

## Test plan

- [x] `vitest run lib/integrate/` — 109 files, 759 passed locally
- [x] `pnpm --filter web typecheck` — green locally
- [ ] CI green
- [ ] Post-merge: re-trigger Record Approve Start on the three stuck builds (FB-DD158A1B, FB-2E138BE0, FB-3F5A4D99) and confirm Ideate dispatch produces a designDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)