### PR TITLE
fix(installer): preserve operator backups across reinstall/uninstall

### DIFF
--- a/docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+++ b/docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
@@ -355,6 +355,21 @@ proven by the promoter. Using the same path means a single tree the
 operator can back up off-host later (Phase 3) by pointing
 restic/rclone/Backblaze at one directory.
 
+> **Known hazard (addendum 2026-05-23).** The Windows-side
+> `dpf-reinstall.ps1` and `uninstall-dpf.ps1` scripts `Remove-Item`
+> the entire `$DPF_DIR` — which, because backups live *inside* it,
+> would silently destroy every dump. Both scripts now preserve
+> `$DPF_DIR\backups\` to a sibling `$DPF_DIR-backups\` before the rm,
+> and `install-dpf.ps1` folds them back in on the next install. This
+> is a defense-in-depth patch; the architecturally correct fix is to
+> relocate the bind-mount source out of the install root entirely
+> (e.g. behind a new `DPF_BACKUPS_HOST_PATH` env var defaulting to
+> a sibling path). That relocation is a follow-up because it touches
+> the host-path-translation logic in `scripts/backup-neo4j.sh`,
+> `scripts/restore-neo4j.sh`, and the Neo4j runner env-forwarding.
+> The bash side (`dpf-reinstall.sh` → `uninstall-dpf.sh --purge`)
+> does not delete the repo dir and is already safe.
+
 ### 5.4 Retention policy (GFS)
 
 7/4/12 GFS is the default in nearly every backup tool that defaults at

--- a/dpf-reinstall.ps1
+++ b/dpf-reinstall.ps1
@@ -12,7 +12,9 @@
 #   4. Removes ALL DPF Docker volumes (including neo4j, qdrant, postgres)
 #   5. Removes DPF Docker images
 #   6. Removes bind-mount data directories
-#   7. Deletes the project directory
+#   7. Preserves $DPF_DIR\backups\ to sibling $DPF_DIR-backups\ (operator
+#      backup history survives the reinstall; install-dpf.ps1 folds them back)
+#   8. Deletes the project directory
 #
 # After this completes, follow the README to install fresh as a new user.
 #
@@ -71,6 +73,10 @@ Write-Host "    - Redis cache"
 Write-Host "    - Sandbox workspace"
 Write-Host "    - All Docker images and volumes"
 Write-Host "    - The entire $DPF_DIR directory"
+Write-Host ""
+Write-Host "  Operator backups under $DPF_DIR\backups\ are PRESERVED" -ForegroundColor Cyan
+Write-Host "  by moving them to $DPF_DIR-backups\ before the rm."
+Write-Host "  install-dpf.ps1 folds them back in on the next install."
 Write-Host ""
 
 # --- Step 1: Check for uncommitted changes ---------------------------------
@@ -192,6 +198,58 @@ if (Test-Path $dockerDataDir) {
     Write-Ok "Removed $dockerDataDir"
 } else {
     Write-Ok "No bind-mount data directory found"
+}
+
+# --- Step 5b: Preserve operator backups before nuking the install dir ------
+#
+# The platform writes daily Postgres/Neo4j/Qdrant dumps to
+# $DPF_DIR\backups\ via a host bind mount (docker-compose.yml). The compose
+# author chose a bind mount precisely so `docker compose down -v` could not
+# destroy backups -- but Step 6 below removes the entire install directory,
+# which would nuke them anyway. Move them to a sibling path this script does
+# NOT touch; install-dpf.ps1 folds them back in on the next install so the
+# admin UX still shows the full history.
+
+Write-Step "Preserving operator backups"
+
+$backupsSrc = Join-Path $DPF_DIR "backups"
+if (Test-Path $backupsSrc) {
+    $hasContent = $false
+    try {
+        $first = Get-ChildItem -LiteralPath $backupsSrc -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+        $hasContent = [bool]$first
+    } catch {
+        $hasContent = $false
+    }
+    if ($hasContent) {
+        $preserveDir = "$DPF_DIR-backups"
+        Write-Host "   Moving $backupsSrc -> $preserveDir" -ForegroundColor Cyan
+        try {
+            if (-not (Test-Path $preserveDir)) {
+                New-Item -ItemType Directory -Path $preserveDir | Out-Null
+            }
+            # Move each top-level entry so we merge with anything already
+            # preserved from a prior reinstall rather than failing on
+            # collision.
+            Get-ChildItem -LiteralPath $backupsSrc -Force | ForEach-Object {
+                $dest = Join-Path $preserveDir $_.Name
+                if (Test-Path $dest) {
+                    Write-Warn "Skipped $($_.Name): already present in $preserveDir"
+                } else {
+                    Move-Item -LiteralPath $_.FullName -Destination $dest -Force
+                }
+            }
+            Write-Ok "Backups preserved at $preserveDir"
+            Write-Host "   install-dpf.ps1 will fold these back into the new install automatically." -ForegroundColor Gray
+        } catch {
+            Write-Warn "Could not preserve backups: $_"
+            Write-Fail "Refusing to delete $DPF_DIR while backups are present. Move $backupsSrc somewhere safe by hand, then re-run."
+        }
+    } else {
+        Write-Ok "No backup files to preserve"
+    }
+} else {
+    Write-Ok "No backups directory found"
 }
 
 # --- Step 6: Remove project directory --------------------------------------

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1168,6 +1168,52 @@ GF_ADMIN_PASSWORD=$adminPass
 "@ | Set-Content "$DPF_DIR\.env"
 }
 
+# --- Restore preserved backups from prior reinstall/uninstall -----------------
+#
+# dpf-reinstall.ps1 and uninstall-dpf.ps1 move $DPF_DIR\backups\ to the
+# sibling $DPF_DIR-backups\ before deleting the install directory, so that
+# operator-owned backup history survives a wipe. Fold them back in here so
+# the admin UX picks them up automatically when the portal first reads the
+# /backups bind mount. Idempotent: only acts if the sibling exists with
+# content, and only moves entries that don't collide with anything fresh.
+
+$preserveDir = "$DPF_DIR-backups"
+if (Test-Path $preserveDir) {
+    $backupsDest = Join-Path $DPF_DIR "backups"
+    try {
+        $entries = Get-ChildItem -LiteralPath $preserveDir -Force -ErrorAction SilentlyContinue
+    } catch {
+        $entries = @()
+    }
+    if ($entries) {
+        Write-Action "Restoring preserved backups from $preserveDir"
+        if (-not (Test-Path $backupsDest)) {
+            New-Item -ItemType Directory -Path $backupsDest | Out-Null
+        }
+        foreach ($entry in $entries) {
+            $dest = Join-Path $backupsDest $entry.Name
+            if (Test-Path $dest) {
+                Write-Warn "  Skipped $($entry.Name): already exists in $backupsDest"
+            } else {
+                try {
+                    Move-Item -LiteralPath $entry.FullName -Destination $dest -Force
+                } catch {
+                    Write-Warn "  Could not move $($entry.Name): $_"
+                }
+            }
+        }
+        # Remove the preserve dir only if it's now empty -- leave it in place
+        # otherwise so the operator can investigate skipped entries.
+        $remaining = Get-ChildItem -LiteralPath $preserveDir -Force -ErrorAction SilentlyContinue
+        if (-not $remaining) {
+            Remove-Item -LiteralPath $preserveDir -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Ok "Backups restored to $backupsDest"
+        } else {
+            Write-Warn "Some entries left in $preserveDir (collisions) -- review by hand."
+        }
+    }
+}
+
 # --- Step 6: Start Platform ---------------------------------------------------
 
 Write-Step 7 10 "Starting the platform..."

--- a/uninstall-dpf.ps1
+++ b/uninstall-dpf.ps1
@@ -67,6 +67,55 @@ Write-Host "========================================================"
 
 Write-Host "Step 3: Removing $DPF_DIR..." -ForegroundColor Cyan
 Set-Location $env:USERPROFILE  # Move out of the directory first
+
+# Operator backup history lives at $DPF_DIR\backups\ (host bind mount).
+# Uninstall implies "remove everything", but operator-owned backups are
+# the one thing the user might still want for a future install -- prompt
+# before destroying them, defaulting to PRESERVE.
+$backupsSrc = Join-Path $DPF_DIR "backups"
+$preserveBackups = $false
+if (Test-Path $backupsSrc) {
+    $hasContent = $false
+    try {
+        $first = Get-ChildItem -LiteralPath $backupsSrc -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+        $hasContent = [bool]$first
+    } catch {
+        $hasContent = $false
+    }
+    if ($hasContent) {
+        Write-Host ""
+        Write-Host "   Found platform backups at $backupsSrc" -ForegroundColor Yellow
+        Write-Host "   These are the only persisted copies of your database dumps."
+        $keep = Read-Host "   Preserve them at $DPF_DIR-backups\ for a future install? (yes/no, default yes)"
+        if ($keep -eq "" -or $keep -eq "yes" -or $keep -eq "y") {
+            $preserveBackups = $true
+        }
+    }
+}
+
+if ($preserveBackups) {
+    $preserveDir = "$DPF_DIR-backups"
+    try {
+        if (-not (Test-Path $preserveDir)) {
+            New-Item -ItemType Directory -Path $preserveDir | Out-Null
+        }
+        Get-ChildItem -LiteralPath $backupsSrc -Force | ForEach-Object {
+            $dest = Join-Path $preserveDir $_.Name
+            if (Test-Path $dest) {
+                Write-Host "   Skipped $($_.Name): already present in $preserveDir" -ForegroundColor Yellow
+            } else {
+                Move-Item -LiteralPath $_.FullName -Destination $dest -Force
+            }
+        }
+        Write-Host "   Backups preserved at $preserveDir" -ForegroundColor Green
+    } catch {
+        Write-Host "   Could not preserve backups: $_" -ForegroundColor Red
+        Write-Host "   Refusing to delete $DPF_DIR while backups are present." -ForegroundColor Red
+        Write-Host "   Move $backupsSrc somewhere safe by hand, then re-run." -ForegroundColor Red
+        exit 1
+    }
+}
+
 if (Test-Path $DPF_DIR) {
     try {
         Remove-Item $DPF_DIR -Recurse -Force
@@ -125,6 +174,8 @@ Write-Host "                                                      " -ForegroundC
 Write-Host "  What was kept:                                      " -ForegroundColor Green
 Write-Host "   Docker Desktop (uninstall separately if needed)   " -ForegroundColor Green
 Write-Host "   WSL2 (Windows feature, safe to keep)              " -ForegroundColor Green
+Write-Host "   Platform backups (if you chose to preserve them)  " -ForegroundColor Green
+Write-Host "     at $DPF_DIR-backups\                            " -ForegroundColor Green
 Write-Host "                                                      " -ForegroundColor Green
 Write-Host "  To reinstall, run install-dpf.ps1 again.            " -ForegroundColor Green
 Write-Host "========================================================" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- `dpf-reinstall.ps1` and `uninstall-dpf.ps1` `Remove-Item $DPF_DIR` — silently destroying every dump under `$DPF_DIR\backups\`, which is the only persisted copy of the daily Postgres / Neo4j / Qdrant backups. `docker-compose.yml` deliberately uses a bind mount so `docker compose down -v` can't kill backups, but the install-dir rm nuked them anyway. Nearly bit us 2026-05-23 (volumes wiped overnight; reinstall was about to take the backups with it).
- Both scripts now preserve `$DPF_DIR\backups\` to a sibling `$DPF_DIR-backups\` before the rm; `install-dpf.ps1` folds them back into the new install transparently. Idempotent + collision-tolerant. Uninstall prompts (default preserve) because its intent is "remove everything."
- Bash side (`dpf-reinstall.sh` → `uninstall-dpf.sh --purge`) does not delete the repo dir and is already safe — no changes needed there.

## Why this is defense in depth, not the architectural fix

The clean answer is to relocate the bind-mount source out of the install root entirely via a new `DPF_BACKUPS_HOST_PATH` env var defaulting to a sibling path. That's a follow-up because it also requires updating the host-path translation in `scripts/backup-neo4j.sh`, `scripts/restore-neo4j.sh`, and the Neo4j runner env-forwarding. This PR is scoped to the immediate safety patch so the next reinstall can't silently destroy operator data.

Spec addendum recording the hazard and the deferred relocation: `docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md` §5.3.

## Test plan

- [ ] Manual: with non-empty `$DPF_DIR\backups\`, run `dpf-reinstall.ps1`, confirm sibling `$DPF_DIR-backups\` is created with the dump tree.
- [ ] Manual: re-run `install-dpf.ps1` after a fresh clone; confirm `$DPF_DIR-backups\` is folded back into `$DPF_DIR\backups\` and the sibling dir is removed.
- [ ] Manual: `uninstall-dpf.ps1` prompts "Preserve them at … (yes/no, default yes)?"; default and "yes" both move backups out; "no" leaves the rm to take them.
- [x] All three scripts parse cleanly under `[System.Management.Automation.Language.Parser]::ParseFile` (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)