### PR TITLE
docs(readme): fix Quick install to bootstrap from a cold machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,50 @@ node docs/architecture/generate-agent-standards-white-paper-docx.mjs
 
 ## Quick install
 
-| Platform | Install | Full guide | Status |
-|----------|---------|------------|--------|
-| **Windows 10 / 11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (Windows installer is in-repo) | **GA** |
-| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) | Early access |
-| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) | Early access |
-| **Cloud Single VM** (AWS / GCP / Azure) | `bash install-dpf.sh --headless --release` inside the VM | [docs/install/cloud-single-vm.md](docs/install/cloud-single-vm.md) | Early access — pilots wanted |
+These commands assume a fresh machine with no DPF repo yet. If you've already cloned the repo (contributors), skip to **Step 2** from inside the repo.
+
+### Windows 10 / 11 — **GA**
+
+The Windows installer is a self-contained PowerShell script that clones the repo for you.
+
+```powershell
+# Step 1 — download the installer (run from any directory)
+iwr -UseBasicParsing https://raw.githubusercontent.com/OpenDigitalProductFactory/opendigitalproductfactory/main/install-dpf.ps1 -OutFile install-dpf.ps1
+
+# Step 2 — run it (will prompt for install directory; defaults to C:\DPF)
+powershell -ExecutionPolicy Bypass -File install-dpf.ps1
+```
+
+### macOS Apple Silicon — Early access · [full guide](docs/install/macos.md)
+
+The Unix installer sources helper libraries from inside the repo, so you must clone first.
+
+```bash
+# Step 1 — clone the repo and enter it
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git
+cd opendigitalproductfactory
+
+# Step 2 — run the installer
+bash install-dpf.sh
+```
+
+### Linux (native Docker) — Early access · [full guide](docs/install/linux.md)
+
+```bash
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git
+cd opendigitalproductfactory
+bash install-dpf.sh
+```
+
+### Cloud Single VM (AWS / GCP / Azure) — Early access · pilots wanted · [full guide](docs/install/cloud-single-vm.md)
+
+Inside the VM:
+
+```bash
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git
+cd opendigitalproductfactory
+bash install-dpf.sh --headless --release
+```
 
 Terraform modules for the cloud-VM path live under [`infra/terraform/single-vm/{aws,gcp,azure}/`](infra/terraform/single-vm/).
 


### PR DESCRIPTION
## Summary

- README's Quick install command (`powershell -ExecutionPolicy Bypass -File install-dpf.ps1` and bash equivalents) silently assumes the user already has the installer script in their current directory. On a fresh machine with no DPF repo, PowerShell exits immediately: `The argument 'install-dpf.ps1' to the -File parameter does not exist.`
- Surfaced 2026-05-23 by a real cold install attempt — first time the documented path has been walked end-to-end by a user who didn't already have the repo on disk.
- Fix splits each platform into explicit Step 1 (get the installer) + Step 2 (run it), keeping the contributor-from-inside-repo path via a one-line note at the top of the section.

## What changed

- **Windows**: Step 1 downloads `install-dpf.ps1` via `iwr`; Step 2 runs it. The script is self-contained and clones the repo itself.
- **macOS / Linux / Cloud-VM**: Step 1 is `git clone && cd`, because `install-dpf.sh` sources helper libraries from `scripts/installer/lib/` and cannot run standalone. Step 2 invokes the existing installer command.
- README-only change; no installer behavior change.

## Test plan

- [ ] Walk the Windows Step 1 + Step 2 commands on a fresh PowerShell from a user home dir with no DPF repo present — confirm \`iwr\` succeeds, \`install-dpf.ps1\` is created, and \`powershell -File ...\` runs it without the missing-file error.
- [ ] Walk the macOS / Linux clone + bash commands on a host with no prior clone — confirm \`install-dpf.sh\` finds its lib files relative to the cloned repo.
- [ ] Visual diff of README in GitHub preview — sections render correctly.

Refs the 2026-05-23 volume-wipe + cold-install dogfooding session.