### PR TITLE
chore(compose): bump hwdsl2/whisper-server pinned digest (upstream GC)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -615,7 +615,7 @@ services:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest at
     # commit time. Bump deliberately; never reach for `:latest` in shipped
     # compose because it makes the install non-reproducible.
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:b9a90a45e9ef72434862b0aaed5b503da5a03c0b1df650169e261861baf53d75}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:4b4f3747242bc4be9c7a0a6d2160fef0a957813cf08574e0058841aba630dbd7}
     restart: unless-stopped
     environment:
       # `base` (~145 MB) is the smallest model with usable accuracy on English.


### PR DESCRIPTION
## Summary

- The pinned `hwdsl2/whisper-server` sha256 digest in `docker-compose.yml:618` no longer resolves on Docker Hub. Upstream re-pushed `:latest` on 2026-05-21 and the old digest was garbage-collected.
- New installs fail with `Error response from daemon: failed to resolve reference docker.io/hwdsl2/whisper-server@sha256:b9a90a45...: not found`.
- Surfaced 2026-05-23 during a real cold install attempt.

Bumping to the current multi-arch index digest:

```
sha256:4b4f3747242bc4be9c7a0a6d2160fef0a957813cf08574e0058841aba630dbd7
```

Verified via the Docker Hub registry API. The compose file's own comment specifies multi-arch index pinning (preserves amd64 + arm64 support automatically).

## Recurrence concern (followup)

Upstream `hwdsl2/whisper-server` only publishes `:latest` and `:cuda` tags — no versioned tag exists to pin against. Every upstream re-push of `:latest` will GC our pinned digest and break new installs until we bump again. This is the second bump-required-or-installs-break event we've seen with this dependency.

Options to evaluate in a separate PR:
- Mirror to GHCR with a stable tag we control
- Switch STT sidecars to an image that publishes versioned tags
- Add a scheduled CI job that re-resolves the digest and opens a refresh PR

## Test plan

- [ ] Verify the new digest resolves: `docker pull hwdsl2/whisper-server@sha256:4b4f3747242bc4be9c7a0a6d2160fef0a957813cf08574e0058841aba630dbd7`
- [ ] `docker compose up -d dpf-stt` succeeds against the new digest
- [ ] `dpf-stt` container reaches `healthy` within ~60s
- [ ] Cold install end-to-end completes through Compose-up stage

Refs the 2026-05-23 cold-install dogfooding session ([#1041](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1041) was the README defect that surfaced the same day).