### PR TITLE
fix(compose): inngest healthcheck — use bash /dev/tcp not curl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -586,7 +586,10 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8288/health"]
+      # inngest/inngest image ships without curl/wget/nc; use bash's built-in
+      # /dev/tcp probe instead (no external binaries required). Just checks
+      # the API port is listening — the API does its own internal health.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8288"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Inngest healthcheck runs `curl -f http://localhost:8288/health`, but `inngest/inngest` image has no curl/wget/nc.
- Every healthcheck fails with `exec: \"curl\": executable file not found`.
- After 3 retries inngest is marked unhealthy; portal's `depends_on: condition: service_healthy` blocks portal-init and the portal from starting.
- Surfaced 2026-05-23 during a real cold install. Inngest itself starts fine — only the healthcheck command was broken.

## Fix

Replace curl with bash's built-in `/dev/tcp` probe:

```yaml
test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8288"]
```

- `bash` IS present in the inngest image at `/usr/bin/bash` (verified via `docker exec`).
- `/dev/tcp` is a bash pseudo-device — no external binaries required.
- Exit 0 on successful TCP connect, non-zero otherwise.
- Inngest API does its own internal health; this probe just confirms the port is listening.

## Verification

Patched my local `docker-compose.yml` with the new healthcheck and recreated `dpf-inngest-1`:

- Container went from `health=unhealthy` (failingStreak=5) → `health=healthy` on the next check cycle.
- portal-init then ran successfully.
- Portal came up healthy at `localhost:3000/api/health` → HTTP 200.

## Test plan

- [ ] `docker compose up -d inngest` — inngest reaches `healthy` within `start_period + interval` (~70s worst case)
- [ ] `docker inspect dpf-inngest-1 --format '{{.State.Health.Status}}'` returns `healthy`
- [ ] Portal can start (it depends on inngest being healthy)
- [ ] Cold install end-to-end completes through Step 7

Continues the 2026-05-23 cold-install dogfooding stream alongside [#1041](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1041) (README) and [#1042](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1042) (whisper digest).