### PR TITLE
fix(installer): enable Docker Model Runner before model pull

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1298,7 +1298,43 @@ if (-not (Test-StepDone "mcp_seed")) {
 
 Write-Step 8 10 "Setting up your AI Coworker..."
 if (-not (Test-StepDone "model")) {
-    # Pull model via Docker Model Runner (built into Docker Desktop 4.40+)
+    # Pull model via Docker Model Runner (built into Docker Desktop 4.40+).
+    #
+    # Docker Model Runner is DISABLED by default in fresh Docker Desktop
+    # installs. Without explicitly enabling it first, `docker model pull`
+    # fails with "Docker Model Runner is not running" — but the exit code
+    # behavior is inconsistent across versions, so the user ends up with
+    # .selected-model set, no actual model on disk, and the portal's
+    # AI Coworker silently broken ("AI provider is temporarily unavailable"
+    # on first portal load). Enabling is idempotent — no-op if already on.
+    Write-Action "Enabling Docker Model Runner..."
+    $oldEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    docker desktop enable model-runner 2>&1 | Out-Null
+    $enableExit = $LASTEXITCODE
+    $ErrorActionPreference = $oldEAP
+
+    if ($enableExit -ne 0) {
+        Write-Warn "Could not enable Docker Model Runner automatically."
+        Write-Warn "Requires Docker Desktop 4.40+. Enable manually: Settings -> AI -> Enable Docker Model Runner"
+        Write-Warn "Then re-run this installer."
+    } else {
+        # Wait briefly for Model Runner to come up before pulling.
+        $mrReady = $false
+        for ($i = 0; $i -lt 15; $i++) {
+            $oldEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            docker model list 2>&1 | Out-Null
+            $listExit = $LASTEXITCODE
+            $ErrorActionPreference = $oldEAP
+            if ($listExit -eq 0) { $mrReady = $true; break }
+            Start-Sleep -Seconds 2
+        }
+        if (-not $mrReady) {
+            Write-Warn "Docker Model Runner did not become ready in 30s. The model pull will likely fail."
+        }
+    }
+
     Write-Action "Pulling AI model $selectedModel via Docker Model Runner, these may be big..."
     Write-Action "This may take several minutes depending on your internet speed, and size of your video card."
     $oldEAP = $ErrorActionPreference


### PR DESCRIPTION
## Summary

- `install-dpf.ps1` Step 8 pulls the hardware-matched local LLM via `docker model pull $selectedModel`, but never explicitly enables Docker Model Runner first.
- Docker Model Runner is OFF by default in fresh Docker Desktop installs (verified on Docker Desktop 4.74.0 / Win 11 25H2).
- Without enabling, the pull fails silently or no-ops depending on Docker Desktop version. The user gets `.selected-model` written, hardware detected, but no actual model on disk.
- On first portal load, the AI Coworker setup step fails with "AI provider is temporarily unavailable" — chicken-and-egg, since that coworker is *what's supposed to guide the user* through configuring providers.
- Surfaced 2026-05-23 during a real cold install on an RTX 4090 host.

## Fix

Before the existing `docker model pull`, add:

1. `docker desktop enable model-runner` (idempotent — no-op if already on)
2. Poll `docker model list` for up to 30s until it exits 0 (Model Runner ready)
3. Then the existing pull logic

Both operations are idempotent and gated by the existing `Test-StepDone "model"` so re-runs are safe.

If `docker desktop enable model-runner` exits non-zero (Docker Desktop < 4.40), we emit actionable guidance ("Settings → AI → Enable Docker Model Runner") rather than silently failing.

## Verification

On the same install where this surfaced:
- Before patch: `docker model ls` → "Docker Model Runner is not running"; portal AI Coworker dead.
- After running `docker desktop enable model-runner` manually + `docker model pull ai/qwen2.5:0.5B-F16`: `http://model-runner.docker.internal/v1/models` reachable from inside the `dpf-portal-1` container; chat completion returned a working response.

## Test plan

- [ ] Fresh Docker Desktop install (Model Runner off): run installer, confirm Step 8 emits "Enabling Docker Model Runner..." then pulls the selected model.
- [ ] Already-enabled Docker Desktop: `docker desktop enable model-runner` is a no-op, installer continues cleanly.
- [ ] Docker Desktop < 4.40 (no model-runner subsystem): enable exits non-zero, installer prints the manual GUI guidance, continues, hits the existing pull-failed warning.
- [ ] Re-run installer after Step 8 completed: skipped via `Test-StepDone "model"`.

Continues the 2026-05-23 cold-install dogfooding stream alongside [#1041](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1041), [#1042](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1042), [#1043](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1043).