### PR TITLE
fix: probe runner calls model directly; retire guard for infra errors

### DIFF
--- a/apps/web/lib/operate/endpoint-test-runner.ts
+++ b/apps/web/lib/operate/endpoint-test-runner.ts
@@ -4,7 +4,6 @@
 
 import { prisma } from "@dpf/db";
 import * as crypto from "crypto";
-import { routeAndCall } from "@/lib/routed-inference";
 import { assembleSystemPrompt, type PromptInput } from "@/lib/prompt-assembler";
 import { evaluateResponseForTest, updatePerformanceProfile } from "@/lib/orchestrator-evaluator";
 import {
@@ -15,7 +14,7 @@ import {
   type CapabilityProbe,
   type TestScenario,
 } from "./endpoint-test-registry";
-import type { ChatMessage } from "@/lib/ai-inference";
+import { callProvider, type ChatMessage } from "@/lib/ai-inference";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -88,16 +87,22 @@ async function runProbe(
     const messages: ChatMessage[] = [{ role: "user", content: probe.userMessage }];
 
     const probeToolsFormatted = probe.tools?.map((t) => ({ type: "function" as const, function: { name: t.name, description: t.description, parameters: t.inputSchema } }));
-    const result = await routeAndCall(messages, systemPrompt, promptInput.sensitivity, {
-      ...(probeToolsFormatted ? { tools: probeToolsFormatted } : {}),
-      preferredProviderId: providerId,
-      ...(modelId !== "default" ? { preferredModelId: modelId } : {}),
-    });
 
-    // Detect failover — if a different endpoint answered, mark as infrastructure failure
-    if (result.downgraded) {
-      return { probeId: probe.id, category: probe.category, name: probe.name, pass: false, reason: "Endpoint unavailable — response came from fallback provider." };
-    }
+    // Resolves BI-INST-007: probes used routeAndCall, which requires
+    // active endpoint manifests in EndpointTaskPerformance. Probes are
+    // SUPPOSED to be the thing that creates those manifests — a
+    // chicken-and-egg that broke every fresh-install probe with
+    // "No eligible endpoints for task 'conversation'" before any model
+    // had ever been profiled. Since the probe runner already knows both
+    // providerId AND modelId (it's testing a SPECIFIC model), there's no
+    // routing decision to make — call the model directly.
+    const result = await callProvider(
+      providerId,
+      modelId,
+      messages,
+      systemPrompt,
+      probeToolsFormatted,
+    );
 
     // Extract tool calls from response
     const toolCalls = result.toolCalls as unknown[] | undefined;
@@ -123,19 +128,16 @@ async function runScenario(
     const messages: ChatMessage[] = [{ role: "user", content: scenario.userMessage }];
 
     const scenarioToolsFormatted = scenario.tools?.map((t) => ({ type: "function" as const, function: { name: t.name, description: t.description, parameters: t.inputSchema } }));
-    const result = await routeAndCall(messages, systemPrompt, promptInput.sensitivity, {
-      ...(scenarioToolsFormatted ? { tools: scenarioToolsFormatted } : {}),
-      preferredProviderId: providerId,
-      ...(modelId !== "default" ? { preferredModelId: modelId } : {}),
-    });
 
-    if (result.downgraded) {
-      return {
-        scenarioId: scenario.id, taskType: scenario.taskType, name: scenario.name,
-        passed: false, assertionResults: [{ description: "Endpoint available", passed: false, detail: "Failover detected" }],
-        orchestratorScore: null, response: result.content,
-      };
-    }
+    // BI-INST-007: same direct-call rationale as runProbe — scenario runner
+    // already targets a specific providerId+modelId, no routing needed.
+    const result = await callProvider(
+      providerId,
+      modelId,
+      messages,
+      systemPrompt,
+      scenarioToolsFormatted,
+    );
 
     const toolCalls = (result as unknown as Record<string, unknown>).toolCalls as unknown[] | undefined;
 

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeNewScore,
   detectDrift,
+  errorLooksLikeInfrastructure,
   type DriftResult,
 } from "./eval-runner";
 
@@ -35,5 +36,75 @@ describe("detectDrift", () => {
   it("returns no drift for improvements", () => {
     const result = detectDrift(90, 70);
     expect(result.severity).toBe("none");
+  });
+});
+
+describe("errorLooksLikeInfrastructure (BI-INST-008 circuit breaker)", () => {
+  // Real error strings observed during the 2026-05-23 cold-install
+  // dogfood. Each of these incorrectly retired every local model
+  // before the circuit breaker landed.
+  it("classifies 'No eligible endpoints for task X' as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Error: No eligible endpoints for task 'conversation': No active endpoint manifests found.",
+    )).toBe(true);
+  });
+  it("classifies 'No active endpoint manifests' as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "No active endpoint manifests found. Configure at least one AI provider with a profiled model.",
+    )).toBe(true);
+  });
+  it("classifies HTTP timeout as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Network error calling local: The operation was aborted due to timeout",
+    )).toBe(true);
+  });
+  it("classifies generic 'network error' as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Network error calling local: fetch failed",
+    )).toBe(true);
+  });
+  it("classifies ECONNREFUSED as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "FetchError: connect ECONNREFUSED 192.168.65.1:11434",
+    )).toBe(true);
+  });
+  it("classifies ENOTFOUND as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "FetchError: getaddrinfo ENOTFOUND model-runner.docker.internal",
+    )).toBe(true);
+  });
+  it("classifies Docker Model Runner not running as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Docker Model Runner is not running. Please start it and try again.",
+    )).toBe(true);
+  });
+
+  // Cases that should NOT match — genuine model-quality failures still retire.
+  it("does NOT classify a JSON parse failure as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Invalid JSON in tool call: unexpected token at position 12",
+    )).toBe(false);
+  });
+  it("does NOT classify a schema validation failure as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Tool call did not match required schema: missing field 'employeeId'",
+    )).toBe(false);
+  });
+  it("does NOT classify model API 4xx as infrastructure (model-side rejection)", () => {
+    // A 4xx from the model API is a model issue — wrong format, exceeded
+    // context limit, content policy violation — model SHOULD be flagged.
+    expect(errorLooksLikeInfrastructure(
+      "Model returned 400: prompt exceeds context window",
+    )).toBe(false);
+  });
+  it("returns false for null (no error)", () => {
+    expect(errorLooksLikeInfrastructure(null)).toBe(false);
+  });
+  it("returns false for empty string", () => {
+    expect(errorLooksLikeInfrastructure("")).toBe(false);
+  });
+  it("is case-insensitive", () => {
+    expect(errorLooksLikeInfrastructure("NETWORK ERROR")).toBe(true);
+    expect(errorLooksLikeInfrastructure("Fetch Failed")).toBe(true);
   });
 });

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -19,6 +19,38 @@ import {
 } from "./eval-scoring";
 import { BACKGROUND_EVAL_ENDPOINT_TYPES } from "./provider-eligibility";
 
+// ── Infrastructure Error Classifier (BI-INST-008 circuit breaker) ──────────
+//
+// Patterns that indicate the probe path itself was broken, not the model
+// being probed. When an all-inconclusive eval matches one of these
+// patterns we skip the auto-retire so the operator can fix the
+// infrastructure and the next eval can give the model a fair chance.
+const INFRASTRUCTURE_ERROR_PATTERNS: RegExp[] = [
+  /No eligible endpoints/i,
+  /No active endpoint manifests/i,
+  /operation was aborted due to timeout/i,
+  /network error/i,
+  /fetch failed/i,
+  /ECONNREFUSED/i,
+  /ENOTFOUND/i,
+  /socket hang up/i,
+  /Docker Model Runner is not running/i,
+  /could not resolve host/i,
+];
+
+/**
+ * Classify an eval error string as infrastructure vs model-quality.
+ * Returns true if the error indicates a broken probe path (no route,
+ * network failure, runner not started, etc.) — in which case the
+ * auto-retire circuit breaker should NOT retire the model.
+ *
+ * Returns false for null/unknown errors so they fall through to the
+ * existing retire-on-failure behaviour (preserves backward compat).
+ */
+export function errorLooksLikeInfrastructure(error: string | null): boolean {
+  return error !== null && INFRASTRUCTURE_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
 // ── Score Computation ────────────────────────────────────────────────────────
 
 /** Compute new dimension score from eval result and previous score. */
@@ -359,10 +391,26 @@ export async function runDimensionEval(
     .flatMap((d) => d.testResults)
     .find((t) => t.error)?.error ?? null;
 
-  // If ALL dimensions are inconclusive, the model is unusable — retire it.
+  // If ALL dimensions are inconclusive, the model MIGHT be unusable.
   // This covers: model removed (404), deprecated, wrong API type (400),
   // auth restrictions, and any other consistent failure pattern.
-  if (allInconclusive && firstError) {
+  //
+  // BI-INST-008 circuit breaker: do NOT retire on infrastructure errors
+  // (no route, network timeout, connection refused, etc.). Those errors
+  // describe a broken probe path, not a broken model. The 2026-05-23
+  // cold-install dogfood hit this: every probe failed with
+  // "No eligible endpoints for task 'conversation'" (a routing bug in
+  // the probe runner — now fixed by BI-INST-007), and the resulting
+  // all-inconclusive verdict retired every local ModelProfile row,
+  // leaving the platform with zero usable models. Recovery required
+  // manual SQL un-retirement.
+  //
+  // errorLooksLikeInfrastructure is exported for unit testing — the
+  // classifier is the only behavior change here that's worth a focused
+  // test, and keeping it pure makes that test trivial.
+  const looksLikeInfrastructure = errorLooksLikeInfrastructure(firstError);
+
+  if (allInconclusive && firstError && !looksLikeInfrastructure) {
     await prisma.modelProfile.update({
       where: { providerId_modelId: { providerId, modelId } },
       data: {
@@ -372,6 +420,10 @@ export async function runDimensionEval(
       },
     });
     console.log(`[eval-runner] Auto-retired ${providerId}/${modelId}: all tests failed — ${firstError.slice(0, 100)}`);
+  } else if (allInconclusive && looksLikeInfrastructure) {
+    console.warn(
+      `[eval-runner] All dimensions inconclusive for ${providerId}/${modelId} but error looks like infrastructure — NOT retiring. Error: ${firstError?.slice(0, 200)}`,
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

Combined fix for **BI-INST-007** + **BI-INST-008** under epic `EP-INSTALL-HARDENING-2026-05-23`. These are the two install-blocking bugs from today's cold-install dogfood — together they completely brick the AI Coworker on every fresh install.

## The chicken-and-egg

| Step | What happens |
|---|---|
| 1 | Fresh install. ModelProfile has 4 rows from Sync, all `active`. EndpointTaskPerformance has 0 LLM rows. |
| 2 | Run Probes button clicked (or background eval triggers). |
| 3 | `endpoint-test-runner.ts` calls `routeAndCall(..., {taskType: conversation})`. |
| 4 | `loadEndpointManifests` queries EndpointTaskPerformance, returns []. |
| 5 | routeAndCall throws `No eligible endpoints for task conversation`. |
| 6 | All probes fail with the same error. |
| 7 | `eval-runner.ts` sees `allInconclusive && firstError`, retires every ModelProfile. |
| 8 | Router now has zero `modelStatus=active` rows for `local` provider. |
| 9 | AI Coworker shows "AI provider is temporarily unavailable" forever. |

Today's session exposed every step of this chain. Manual recovery required `UPDATE ModelProfile SET modelStatus=active WHERE providerId=local` via SQL.

## Fix

### BI-INST-007 — probe runner calls model directly

`apps/web/lib/operate/endpoint-test-runner.ts` already knows the specific `providerId` and `modelId` for each probe — it's testing a known model, not routing. Replace `routeAndCall` with `callProvider(providerId, modelId, messages, systemPrompt, tools)`. Bypasses manifest loading entirely.

### BI-INST-008 — auto-retire circuit breaker

`apps/web/lib/routing/eval-runner.ts` auto-retires on `allInconclusive && firstError`. Added `errorLooksLikeInfrastructure()` classifier — when the error matches network / no-route / runner-not-started / ECONNREFUSED / ENOTFOUND / etc., log a warning but DON'T retire. Lets the operator fix infra and re-test rather than losing every model on first transient failure.

## Files

- `apps/web/lib/operate/endpoint-test-runner.ts` — `runProbe` + `runScenario` use `callProvider` directly, drop `downgraded` check (impossible when calling a specific endpoint)
- `apps/web/lib/routing/eval-runner.ts` — added `errorLooksLikeInfrastructure` exported pure function; auto-retire conditional on `!looksLikeInfrastructure`
- `apps/web/lib/routing/eval-runner.test.ts` — 12 new test cases for the classifier (real error strings from today + negative cases like JSON parse failures that SHOULD still retire)

## Why one PR

Co-dependent on fresh install. Either bug alone leaves the install path broken:
- Fix #007 alone → probes work, but a single transient network blip still retires every model
- Fix #008 alone → probes still fail with "No eligible endpoints", coworker still unusable

Must ship together to actually unblock.

## Test plan

- [ ] Existing eval-runner.test.ts (`computeNewScore`, `detectDrift`) still pass
- [ ] New `errorLooksLikeInfrastructure` tests pass (12 cases)
- [ ] On a fresh install with no manifests: click Run Probes, expect probesPassed > 0
- [ ] Confirm `ModelProfile.modelStatus` stays `active` after probes complete (no auto-retirement)
- [ ] Simulate a genuine model-quality failure (JSON parse error): confirm retirement still fires
- [ ] AI Ops Engineer responds to "hello" without manual SQL un-retirement

Refs spec [#1045](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1045) section 6.3.
