### PR TITLE
fix(ui): accurate labeling for Endpoint Performance Run Probes/Tests

### DIFF
--- a/apps/web/components/platform/EndpointPerformancePanel.tsx
+++ b/apps/web/components/platform/EndpointPerformancePanel.tsx
@@ -149,7 +149,7 @@ export default function EndpointPerformancePanel({
         </div>
         <div className="text-[10px] text-[var(--dpf-muted)] mt-1">
           {testMessage && <span style={{ color: "var(--dpf-accent)" }}>{testMessage} </span>}
-          Optional diagnostics. The platform automatically tests providers on startup and when they are configured.
+          Re-run model evaluations. Required for routing — run once after pulling new models so the router can pick them. Each run also produces evidence visible in the Recent Evaluations tab below.
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Resolves **BI-INST-006** under epic `EP-INSTALL-HARDENING-2026-05-23`.

The Endpoint Performance panel (`components/platform/EndpointPerformancePanel.tsx`) advertised:

> *"Optional diagnostics. The platform automatically tests providers on startup and when they are configured."*

Both claims are false on a fresh install in current state:

1. **"Optional"** — without running probes there are zero `EndpointTaskPerformance` rows for LLM tasks. The router's `loadEndpointManifests` returns empty and every LLM call fails with `No eligible endpoints for task X`. Probes are **required** for routing to work.
2. **"Automatically tests providers on startup"** — there is no auto-probe-on-startup mechanism yet. That capability is BI-INST-001 (still open, captured under spec PR #1045 §6.3). Until it ships, manually clicking Run Probes is the only path to populate routing manifests.

Customers landing on this panel saw the label, assumed they could skip the diagnostics, and ended up with a broken AI Coworker.

## Fix

One-line text change. New caption is accurate to current behavior:

> *"Re-run model evaluations. Required for routing — run once after pulling new models so the router can pick them. Each run also produces evidence visible in the Recent Evaluations tab below."*

When BI-INST-001 (auto-probe on portal boot) ships, this caption can be relaxed back to "optional" since operator action will only matter for re-evaluation, not initial setup. Until then, the caption matches reality.

## Test plan

- [ ] Visit `/platform/ai/providers/<providerId>` on a fresh install
- [ ] Scroll to the Endpoint Performance section
- [ ] Confirm the new caption shows; the misleading "automatic tests on startup" claim is gone

Refs spec [#1045](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1045) §6.3.
