### PR TITLE
fix(ui): OllamaManagement Refresh button also syncs ModelProfile rows

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -116,7 +116,11 @@ export default async function ProviderDetailPage({ params }: Props) {
       )}
 
       {(providerId === "local" || providerId === "ollama") && (
-        <OllamaManagement canWrite={canWrite} vramGb={hardwareInfo?.vramGb ?? null} />
+        <OllamaManagement
+          canWrite={canWrite}
+          vramGb={hardwareInfo?.vramGb ?? null}
+          providerId={providerId}
+        />
       )}
 
       {pw.provider.costPerformanceNotes && (

--- a/apps/web/components/platform/OllamaManagement.tsx
+++ b/apps/web/components/platform/OllamaManagement.tsx
@@ -8,6 +8,7 @@ import {
   type OllamaModelInfo,
   type OllamaRunningModel,
 } from "@/lib/actions/ollama-management";
+import { discoverModels, profileModels } from "@/lib/actions/ai-providers";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
 
@@ -145,9 +146,14 @@ function normaliseModelId(name: string): string {
 type Props = {
   canWrite: boolean;
   vramGb?: number | null;
+  // Provider whose models are managed by this panel. Required to route the
+  // post-list discover+profile sync through the right provider. Optional for
+  // backward compat: when omitted, refresh() only reloads the displayed list
+  // (legacy behaviour, BI-INST-004 unfixed).
+  providerId?: string;
 };
 
-export function OllamaManagement({ canWrite, vramGb }: Props) {
+export function OllamaManagement({ canWrite, vramGb, providerId }: Props) {
   const [models, setModels] = useState<OllamaModelInfo[]>([]);
   const [running, setRunning] = useState<OllamaRunningModel[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -159,11 +165,52 @@ export function OllamaManagement({ canWrite, vramGb }: Props) {
   const [copied, setCopied] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [advancedInput, setAdvancedInput] = useState("");
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
 
-  useEffect(() => { refresh(); }, []);
+  // Initial load: just reload the displayed list. Skip the discover+profile
+  // sync on first mount to avoid redundant work (the parent page-level Sync
+  // Models & Profiles button already fires on user demand).
+  useEffect(() => { refreshList(); }, []);
 
+  // Reloads the displayed list only — used by useEffect on mount and as the
+  // last step of refresh() after the sync completes.
+  function refreshList() {
+    startTransition(async () => {
+      const [modelsResult, runningResult] = await Promise.all([
+        listOllamaModels(),
+        getOllamaRunningModels(),
+      ]);
+      setModels(modelsResult.models);
+      setRunning(runningResult.models);
+      setError(modelsResult.error ?? runningResult.error ?? null);
+      setLoaded(true);
+    });
+  }
+
+  // BI-INST-004: the visible Refresh button now ALSO runs discoverModels +
+  // profileModels so newly-pulled models become routable. Previously only
+  // refreshed the displayed list, which left ModelProfile rows stale and
+  // confused users who expected "Refresh" to make new models usable.
+  // Sync is a no-op when providerId isn't passed (legacy callers).
   function refresh() {
     startTransition(async () => {
+      if (providerId) {
+        setSyncMessage("Discovering models...");
+        const discovery = await discoverModels(providerId);
+        if (discovery.discovered > 0) {
+          setSyncMessage("Syncing routing profiles...");
+          const profResult = await profileModels(providerId);
+          setSyncMessage(profResult.error
+            ? `Profile error: ${profResult.error}`
+            : `${profResult.profiled} profiled, ${profResult.failed} failed`);
+        } else {
+          setSyncMessage("No models to sync");
+        }
+        // Auto-clear the status message after a short window so the panel
+        // doesn't accumulate stale state.
+        setTimeout(() => setSyncMessage(null), 4000);
+      }
+
       const [modelsResult, runningResult] = await Promise.all([
         listOllamaModels(),
         getOllamaRunningModels(),
@@ -229,23 +276,31 @@ export function OllamaManagement({ canWrite, vramGb }: Props) {
           <h2 style={{ fontSize: 14, fontWeight: 600, color: "var(--dpf-text)", margin: 0 }}>
             Installed Models
           </h2>
-          <button
-            type="button"
-            onClick={refresh}
-            disabled={isPending}
-            style={{
-              fontSize: 11,
-              padding: "4px 10px",
-              borderRadius: 4,
-              border: "1px solid var(--dpf-border)",
-              background: "transparent",
-              color: "var(--dpf-muted)",
-              cursor: "pointer",
-              opacity: isPending ? 0.5 : 1,
-            }}
-          >
-            Refresh
-          </button>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            {syncMessage && (
+              <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{syncMessage}</span>
+            )}
+            <button
+              type="button"
+              onClick={refresh}
+              disabled={isPending}
+              title={providerId
+                ? "Reload the list AND sync newly-pulled models into routing profiles."
+                : "Reload the displayed list."}
+              style={{
+                fontSize: 11,
+                padding: "4px 10px",
+                borderRadius: 4,
+                border: "1px solid var(--dpf-border)",
+                background: "transparent",
+                color: "var(--dpf-muted)",
+                cursor: "pointer",
+                opacity: isPending ? 0.5 : 1,
+              }}
+            >
+              {isPending && syncMessage ? "Syncing..." : "Refresh"}
+            </button>
+          </div>
         </div>
 
         {/* Summary bar */}


### PR DESCRIPTION
## Summary

Resolves **BI-INST-004** under epic `EP-INSTALL-HARDENING-2026-05-23`.

The Installed Models section on `/platform/ai/providers/<id>` exposes a **Refresh** button. After pulling a new Docker Model Runner model via CLI, that button LOOKS like the obvious next action. But it only reloaded the displayed list — no propagation to `ModelProfile`, so the router still couldn't route to the new model.

The actually-correct action (Sync Models & Profiles) is on a DIFFERENT button in a different section of the same page. Customers clicked Refresh, saw the model appear in the list, and assumed they were done.

## Fix

When `providerId` is passed, `refresh()` now runs the same discover + profile chain as the parent page's Sync Models & Profiles button before reloading the list, with inline status (`Discovering models...` → `Syncing routing profiles...` → `N profiled, M failed`). The button label flips to "Syncing..." during the sync.

## Backward compatibility

- `providerId` is an **optional** prop. Callers without provider context get the legacy list-reload-only behaviour and a matching tooltip.
- The page-level Sync Models & Profiles button on `ProviderDetailForm` is unchanged. It remains the IT-pro affordance with the full discovery + profiling status. The OllamaManagement Refresh is the user-friendly equivalent matching plumber-grade UX expectations: *"I clicked Refresh, my new model is usable now."*

## Files

- `apps/web/components/platform/OllamaManagement.tsx` — `refresh()` now also calls `discoverModels` + `profileModels` when `providerId` is set; surfaces inline sync status near the button; added tooltip explaining the new behaviour
- `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx` — passes `providerId={providerId}` to OllamaManagement

## Test plan

- [ ] Pull a new model from the CLI (e.g. `docker model pull ai/qwen3:8B-Q4_K_M`)
- [ ] Visit `/platform/ai/providers/local`
- [ ] Click **Refresh** in the Installed Models section
- [ ] Confirm:
  - [ ] Status text shows "Discovering models..." then "Syncing routing profiles..." then "N profiled, M failed"
  - [ ] The new model row gets a tier badge (Strong/Adequate)
  - [ ] AI Coworker can route to the new model immediately
- [ ] Confirm legacy callers (no `providerId` prop) still get list-only refresh behaviour with the matching tooltip

Refs spec [#1045](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1045) §6.3.
