### PR TITLE
fix(boot): enqueue dimension evals for freshly profiled models

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -20,6 +20,56 @@ export function warnIfLegacyHiveTokenEnvSet(
   return true;
 }
 
+/**
+ * Enqueue background dimension evals for every active ModelProfile under the
+ * given provider. Sends one `ai/eval.run` event per model so Inngest dispatches
+ * them with the function's own concurrency cap (limit 2) and retry policy.
+ * Errors are swallowed because this runs in startup context — the operator
+ * can re-trigger via Run Probes if anything fails. Exported for testing.
+ *
+ * BI-INST-001: this is the missing step in the first-boot auto-provisioning
+ * chain. Without it, ModelProfile rows existed but EndpointTaskPerformance
+ * was empty, so the router rejected every LLM task with "No eligible
+ * endpoints found."
+ */
+export async function enqueueFirstBootEvals(providerId: string): Promise<{
+  enqueued: number;
+  error: string | null;
+}> {
+  try {
+    const { prisma } = await import("@dpf/db");
+    const profiles = await prisma.modelProfile.findMany({
+      where: {
+        providerId,
+        modelStatus: "active",
+        retiredAt: null,
+      },
+      select: { modelId: true },
+    });
+    if (profiles.length === 0) return { enqueued: 0, error: null };
+
+    const { inngest } = await import("@/lib/queue/inngest-client");
+    await inngest.send(
+      profiles.map((p) => ({
+        name: "ai/eval.run",
+        data: {
+          endpointId: providerId,
+          modelId: p.modelId,
+          userId: "first-boot",
+        },
+      })),
+    );
+    console.log(
+      `[first-boot] Enqueued ${profiles.length} dimension eval(s) for ${providerId} (background via Inngest)`,
+    );
+    return { enqueued: profiles.length, error: null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[first-boot] Failed to enqueue evals for ${providerId}: ${msg}`);
+    return { enqueued: 0, error: msg };
+  }
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NEXT_PHASE !== "phase-production-build") {
     // Fire the deprecation warning up front so operators see it on first
@@ -103,6 +153,16 @@ export async function register() {
     // post-init SQL activated providers but no discovery has run yet).
     // This eliminates the need to manually click "Update Providers" or
     // "Run Eval" — the platform is ready to route immediately.
+    //
+    // BI-INST-001 (2026-05-23): the original first-boot hook stopped after
+    // discoverModels + profileModels. ModelProfile rows existed but the
+    // router still failed every LLM task with "No active endpoint manifests
+    // found" because no probes had populated EndpointTaskPerformance. This
+    // hook now enqueues `ai/eval.run` events for each freshly-profiled
+    // model so dimension evals run in the background via Inngest. The
+    // evals' new circuit breaker (BI-INST-008, eval-runner.ts
+    // errorLooksLikeInfrastructure) keeps a single transient failure from
+    // poisoning every model.
     setTimeout(async () => {
       try {
         const { prisma } = await import("@dpf/db");
@@ -133,6 +193,16 @@ export async function register() {
             );
             const result = await autoDiscoverAndProfile(providerId);
             console.log(`[first-boot] ${providerId}: discovered=${result.discovered}, profiled=${result.profiled}${result.error ? ` (${result.error})` : ""}`);
+
+            // BI-INST-001 — enqueue background dimension evals for each
+            // freshly profiled model. Without this step the router stays
+            // empty of EndpointTaskPerformance rows and every LLM task
+            // throws "No eligible endpoints" until the operator manually
+            // clicks Run Probes. Inngest enforces concurrency=2 on
+            // ai/eval.run so this doesn't swamp local model runners.
+            if (result.profiled > 0) {
+              await enqueueFirstBootEvals(providerId);
+            }
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

Resolves **BI-INST-001** under epic `EP-INSTALL-HARDENING-2026-05-23`.

The Next.js instrumentation hook already ran a first-boot auto-provisioning block 15 s after startup — it found active providers with zero ModelProfile rows and called `autoDiscoverAndProfile()` to create them. Then **stopped**.

The resulting ModelProfile rows existed but `EndpointTaskPerformance` was empty, so the router rejected every LLM task with `No eligible endpoints found for task X`. Customer-facing symptom: AI Coworker permanently stuck at *"AI provider is temporarily unavailable"* until the operator found the buried Run Probes button.

## Fix

After `autoDiscoverAndProfile` succeeds, enqueue one `ai/eval.run` event per freshly active `ModelProfile` via the existing Inngest pipeline (`lib/queue/functions/eval-background.ts`). The function already has concurrency=2 and a retry policy so multiple new models don't swamp the local model runner.

Each eval runs `runDimensionEval` — which now uses the BI-INST-008 circuit breaker from [#1050](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1050) so a single transient infra failure can't poison every model.

Extracted `enqueueFirstBootEvals(providerId)` as an **exported helper** so the logic is testable without invoking the full `register()` side-effects chain.

## End-to-end first-boot path (with all today's PRs merged)

1. `install-dpf.ps1` enables Docker Model Runner + GPU + pulls qwen3 ([#1044](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1044) + [#1046](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1046) + [#1047](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1047))
2. Portal boots, instrumentation.ts kicks in at +15 s
3. `autoDiscoverAndProfile` creates `ModelProfile` rows
4. **DB trigger** recomputes `ModelProvider.capabilityTier` to `max(profiles)` ([#1049](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1049))
5. **`enqueueFirstBootEvals`** dispatches `ai/eval.run` events ← **this PR**
6. Inngest runs `runDimensionEval` per model with the circuit breaker active ([#1050](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1050))
7. `EndpointTaskPerformance` rows populate
8. Router can now match coworker → eligible endpoint
9. AI Coworker responds to "hello"

**No manual buttons. No SQL un-retirement. The chain works without human intervention from install-completion through coworker-response.**

## Files

- `apps/web/instrumentation.ts` — added `enqueueFirstBootEvals(providerId)` helper export + a call to it inside the existing 15 s auto-provisioning setTimeout, after `autoDiscoverAndProfile`. ~50 lines added.

## Test plan

- [ ] On fresh install with no ModelProfile rows: portal boots, 15 s later `[first-boot]` logs show discovery + profile + enqueue
- [ ] Inngest queue shows `ai/eval.run` events for each profiled model
- [ ] Events drain (concurrency=2 means up to 2 in flight)
- [ ] `EndpointTaskPerformance` rows accumulate as evals complete
- [ ] AI Coworker responds successfully without clicking Run Probes manually
- [ ] BI-INST-008 circuit breaker fires correctly if a probe hits an infra error (no auto-retirement)

Refs spec [#1045](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1045) §6.3.
