### PR TITLE
fix(security): close 77 js/log-injection alerts (24 files, inline JSON.stringify)

### DIFF
--- a/apps/web/app/api/agent/send/route.ts
+++ b/apps/web/app/api/agent/send/route.ts
@@ -116,7 +116,8 @@ export async function POST(request: NextRequest): Promise<Response> {
       });
     } catch (err) {
       agentEventBus.markIdle(input.threadId);
-      console.error("[api/agent/send] background execution failed:", err);
+      console.error("[api/agent/send] background execution failed: %s",
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
       const errorMessage = err instanceof Error ? err.message : "Agent execution failed";
       const systemMessageId = await persistBackgroundFailureMessage({
         threadId: input.threadId,

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -527,7 +527,7 @@ export function EaCanvas({
         initialX: x,
         initialY: y,
       });
-      if ("error" in result) { console.warn("addElementToView error:", result.error); return; }
+      if ("error" in result) { console.warn("addElementToView error: %s", JSON.stringify(result.error)); return; }
       window.location.reload();
     })();
   }
@@ -638,7 +638,7 @@ export function EaCanvas({
               initialX: pendingDrop.x,
               initialY: pendingDrop.y,
             });
-            if ("error" in result) { console.warn(result.error); }
+            if ("error" in result) { console.warn(JSON.stringify(result.error)); }
             setPendingDrop(null);
             window.location.reload();
           }}

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1030,10 +1030,12 @@ export async function sendMessage(input: {
   // Log tools available so we can diagnose why a model claims it can't see a
   // tool that should be in scope. Logged for every coworker call, not just
   // build-phase ones — chat coworkers on /workspace etc. were silent before.
+  // CodeQL js/log-injection: input.routeContext + agent.agentId + tool
+  // names are user-influenced. JSON.stringify on each interpolation.
   console.log(
-    `[tools] route=${input.routeContext} agent=${agent.agentId} ` +
-    `${activeBuildPhase ? `buildPhase=${activeBuildPhase} ` : ""}` +
-    `count=${availableTools.length} tools=[${availableTools.map(t => t.name).join(", ")}]`,
+    `[tools] route=${JSON.stringify(input.routeContext)} agent=${JSON.stringify(agent.agentId)} ` +
+    `${activeBuildPhase ? `buildPhase=${JSON.stringify(activeBuildPhase)} ` : ""}` +
+    `count=${availableTools.length} tools=[${availableTools.map(t => JSON.stringify(t.name)).join(", ")}]`,
   );
   if (activeBuildPhase) {
 
@@ -1621,7 +1623,7 @@ export async function sendMessage(input: {
               { routeContext: input.routeContext },
             );
 
-            console.log(`[coworker] saveBuildEvidence result: success=${saveResult.success}, msg=${saveResult.message?.slice(0, 100)}`);
+            console.log(`[coworker] saveBuildEvidence result: success=${saveResult.success}, msg=${JSON.stringify(saveResult.message?.slice(0, 100))}`);
 
             if (saveResult.success) {
               const approach = String((ideateResult.designDoc as Record<string, unknown>).proposedApproach ?? "").trim();
@@ -1635,7 +1637,7 @@ export async function sendMessage(input: {
                 console.log(`[coworker] Running reviewDesignDoc...`);
                 agentEventBus.emit(input.threadId, { type: "tool:start", tool: "design_review", iteration: 0 });
                 const reviewResult = await executeTool("reviewDesignDoc", {}, user.id!, { routeContext: input.routeContext });
-                console.log(`[coworker] reviewDesignDoc result: success=${reviewResult.success}, msg=${reviewResult.message?.slice(0, 100)}`);
+                console.log(`[coworker] reviewDesignDoc result: success=${reviewResult.success}, msg=${JSON.stringify(reviewResult.message?.slice(0, 100))}`);
                 agentEventBus.emit(input.threadId, { type: "tool:complete", tool: "design_review", success: reviewResult.success });
 
                 const reviewDecision = (reviewResult.data as { review?: { decision?: string }; blocked?: boolean } | undefined);
@@ -1827,8 +1829,8 @@ export async function sendMessage(input: {
       `[quality-gate] Response too short (${responseContent.length} chars). ` +
       `Raw from loop (${rawResponseBeforeSanitize.length} chars): ${JSON.stringify(rawResponseBeforeSanitize.slice(0, 500))} | ` +
       `After sanitize: ${JSON.stringify(responseContent)} | ` +
-      `Provider: ${responseProviderId}/${responseModelId} | ` +
-      `Route: ${input.routeContext}`,
+      `Provider: ${JSON.stringify(responseProviderId)}/${JSON.stringify(responseModelId)} | ` +
+      `Route: ${JSON.stringify(input.routeContext)}`,
     );
     const providerHint = responseProviderId
       ? `Provider ${responseProviderId}/${responseModelId} returned an empty response.`

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -402,7 +402,9 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : "unknown error";
     // CodeQL #39 (js/tainted-format-string): taskId via format-arg.
-    console.error("[agent-task-scheduler] Task %s failed:", taskId, errMsg);
+    console.error("[agent-task-scheduler] Task %s failed: %s",
+      JSON.stringify(taskId),
+      JSON.stringify(errMsg));
 
     const ref = taskRunRef;
     if (ref) {

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -298,7 +298,7 @@ export async function configureProvider(input: {
       usageUrl: providerForFinance.consoleUrl ?? providerForFinance.docsUrl ?? undefined,
     }).catch((error) => {
       console.warn(
-        `[ai-provider-finance] failed to seed finance bridge for ${input.providerId}: ${error instanceof Error ? error.message : String(error)}`,
+        `[ai-provider-finance] failed to seed finance bridge for ${JSON.stringify(input.providerId)}: ${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
       );
     });
   }
@@ -713,7 +713,7 @@ export async function runScheduledJobNow(jobId: string): Promise<void> {
     await runProviderCatalogReconciliationIfDue();
     return;
   }
-  console.warn(`runScheduledJobNow: unknown jobId "${jobId}"`);
+  console.warn(`runScheduledJobNow: unknown jobId ${JSON.stringify(jobId)}`);
 }
 
 // ─── Model profiling ──────────────────────────────────────────────────────────

--- a/apps/web/lib/actions/assurance.ts
+++ b/apps/web/lib/actions/assurance.ts
@@ -48,8 +48,8 @@ export async function getBuildBomSummary(buildId: string): Promise<BomSummary> {
     return await getLatestBomSummaryForBuild(prisma, buildId);
   } catch (err) {
     console.error(
-      `[tool-trace] failed to load build BOM summary buildId=${buildId} error=${
-        err instanceof Error ? err.message : String(err)
+      `[tool-trace] failed to load build BOM summary buildId=${JSON.stringify(buildId)} error=${
+        JSON.stringify(err instanceof Error ? err.message : String(err))
       }`,
     );
     return missingBomSummary();

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -637,7 +637,7 @@ export async function advanceBuildPhase(
     // This runs async so the phase transition returns immediately.
     // Progress streams via SSE event bus.
     autoExecuteBuild(buildId).catch((err) =>
-      console.error(`[build] autoExecuteBuild failed for ${buildId}:`, err),
+      console.error(`[build] autoExecuteBuild failed for ${JSON.stringify(buildId)}: ${err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err))}`),
     );
   }
 
@@ -795,7 +795,9 @@ export async function resetBuildExecution(buildId: string): Promise<void> {
   // format string) to avoid CodeQL js/tainted-format-string on the user-
   // routable identifier.
   autoExecuteBuild(buildId).catch((err) =>
-    console.error("[build] resetBuildExecution failed for", buildId, err),
+    console.error("[build] resetBuildExecution failed for %s: %s",
+      JSON.stringify(buildId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err))),
   );
 }
 
@@ -825,7 +827,9 @@ export async function retryBuildExecution(buildId: string): Promise<void> {
 
   // Fire-and-forget retry — picks up from failed step
   autoExecuteBuild(buildId).catch((err) =>
-    console.error(`[build] retryBuildExecution failed for ${buildId}:`, err),
+    console.error("[build] retryBuildExecution failed for %s: %s",
+      JSON.stringify(buildId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err))),
   );
 }
 
@@ -1072,8 +1076,10 @@ export async function resumeBuildImplementation(buildId: string): Promise<Resume
   }).catch(() => {});
 
   autoExecuteBuild(buildId).catch((err) =>
-    // CodeQL #42 (js/tainted-format-string): buildId via format-arg.
-    console.error("[build] resumeBuildImplementation failed for %s:", buildId, err),
+    // CodeQL #42 (js/tainted-format-string) + js/log-injection.
+    console.error("[build] resumeBuildImplementation failed for %s: %s",
+      JSON.stringify(buildId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err))),
   );
 
   return {
@@ -1382,7 +1388,7 @@ export async function shipBuild(input: {
           version: result.version,
         });
         if (backupResult.pushed) {
-          console.log(`[shipBuild] git backup pushed for ${input.buildId}`);
+          console.log(`[shipBuild] git backup pushed for ${JSON.stringify(input.buildId)}`);
         } else if (backupResult.error && backupResult.error !== "No git remote URL configured") {
           console.warn(`[shipBuild] git backup failed: ${backupResult.error}`);
         }

--- a/apps/web/lib/build-review-verification-trigger.ts
+++ b/apps/web/lib/build-review-verification-trigger.ts
@@ -20,12 +20,12 @@ export async function queueBuildReviewVerification(buildId: string): Promise<voi
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(
-      `[tool-trace] build/review.verify enqueue failed buildId=${buildId} error=${message}`,
+      `[tool-trace] build/review.verify enqueue failed buildId=${JSON.stringify(buildId)} error=${JSON.stringify(message)}`,
     );
     await markVerificationEnqueueFailed(buildId, message).catch((persistErr) => {
       console.error(
-        `[tool-trace] failed to mark uxVerificationStatus=failed buildId=${buildId} error=${
-          persistErr instanceof Error ? persistErr.message : String(persistErr)
+        `[tool-trace] failed to mark uxVerificationStatus=failed buildId=${JSON.stringify(buildId)} error=${
+          JSON.stringify(persistErr instanceof Error ? persistErr.message : String(persistErr))
         }`,
       );
     });

--- a/apps/web/lib/deliberation/activation.ts
+++ b/apps/web/lib/deliberation/activation.ts
@@ -192,7 +192,7 @@ export async function resolve(
     const explicitPattern = await getPattern(explicit);
     if (!explicitPattern) {
       console.warn(
-        `[deliberation] explicit pattern slug "${explicit}" not found in registry; returning null. ` +
+        `[deliberation] explicit pattern slug ${JSON.stringify(explicit)} not found in registry; returning null. ` +
           `Typo in caller? Known patterns live under deliberation/ and DeliberationPattern table.`,
       );
       return null;

--- a/apps/web/lib/govern/activate-provider.ts
+++ b/apps/web/lib/govern/activate-provider.ts
@@ -133,7 +133,9 @@ export async function activateProvider(
     // facing source; passing it inside the format-string template lets it
     // act as a format directive (%s, %j etc). Use the format-arg form so
     // console treats it as a value.
-    console.warn("[activateProvider] MCP link activation failed for %s:", providerId, err);
+    console.warn("[activateProvider] MCP link activation failed for %s: %s",
+      JSON.stringify(providerId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
   }
 
   // 4. Activate sibling provider (codex↔chatgpt bidirectional sync)
@@ -142,7 +144,9 @@ export async function activateProvider(
       await activateLinkedSibling(providerId, opts);
     } catch (err) {
       // CodeQL #44 — see #43 comment above.
-      console.warn("[activateProvider] Sibling activation failed for %s:", providerId, err);
+      console.warn("[activateProvider] Sibling activation failed for %s: %s",
+        JSON.stringify(providerId),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
     }
   }
 
@@ -161,19 +165,19 @@ export async function activateProvider(
         // CodeQL #45 — format-arg form per #43 comment.
         console.warn(
           "[activateProvider] Discovery warning for %s (trigger=%s): %s",
-          providerId,
-          opts.trigger,
-          result.error,
+          JSON.stringify(providerId),
+          JSON.stringify(opts.trigger),
+          JSON.stringify(result.error),
         );
       }
     } catch (err) {
       warning = err instanceof Error ? err.message : String(err);
       // CodeQL #46 — format-arg form per #43 comment.
       console.warn(
-        "[activateProvider] Discovery failed for %s (trigger=%s):",
-        providerId,
-        opts.trigger,
-        err,
+        "[activateProvider] Discovery failed for %s (trigger=%s): %s",
+        JSON.stringify(providerId),
+        JSON.stringify(opts.trigger),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
       );
     }
   }
@@ -195,7 +199,9 @@ export async function activateProvider(
     });
   } catch (err) {
     // CodeQL — last activate-provider alert; format-arg form per #43 comment.
-    console.warn("[activateProvider] Model restoration failed for %s:", providerId, err);
+    console.warn("[activateProvider] Model restoration failed for %s: %s",
+      JSON.stringify(providerId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
   }
 
   return { providerId, status: "active", clearance, discovered, profiled, warning };

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -28,7 +28,9 @@ import {
 export async function getDecryptedCredential(providerId: string) {
   const cred = await prisma.credentialEntry.findUnique({ where: { providerId } });
   if (!cred) {
-    console.warn(`[credentials] getDecryptedCredential("${providerId}") → null: row not found`);
+    // CodeQL js/log-injection: providerId is user-influenced. JSON.stringify
+    // is a CodeQL-recognised sanitiser — escapes CR/LF, quotes the value.
+    console.warn(`[credentials] getDecryptedCredential(${JSON.stringify(providerId)}) → null: row not found`);
     return null;
   }
   const secretRef    = cred.secretRef    ? decryptSecret(cred.secretRef)    : null;
@@ -40,8 +42,11 @@ export async function getDecryptedCredential(providerId: string) {
     .some(v => v?.startsWith("enc:"));
   const allFailed = hadEncrypted && !secretRef && !clientSecret && !cachedToken && !refreshToken;
   if (allFailed) {
-    console.warn(`[credentials] All encrypted fields for "${providerId}" failed to decrypt — re-configure this provider.`);
-    console.warn(`[credentials] Diagnostic for ${providerId}: ` +
+    // CodeQL js/log-injection: providerId is user-influenced. JSON.stringify
+    // is a CodeQL-recognised sanitiser — escapes CR/LF, quotes the value.
+    const safeProviderId = JSON.stringify(providerId);
+    console.warn(`[credentials] All encrypted fields for ${safeProviderId} failed to decrypt — re-configure this provider.`);
+    console.warn(`[credentials] Diagnostic for ${safeProviderId}: ` +
       `secretRef=${cred.secretRef ? `enc(${cred.secretRef.slice(0,8)})→${secretRef ? "ok" : "null"}` : "none"}, ` +
       `clientSecret=${cred.clientSecret ? `enc(${cred.clientSecret.slice(0,8)})→${clientSecret ? "ok" : "null"}` : "none"}, ` +
       `cachedToken=${cred.cachedToken ? `enc(${cred.cachedToken.slice(0,8)})→${cachedToken ? "ok" : "null"}` : "none"}, ` +
@@ -52,8 +57,12 @@ export async function getDecryptedCredential(providerId: string) {
     if (cred.status !== "key_rotated") {
       prisma.credentialEntry
         .update({ where: { providerId }, data: { status: "key_rotated" } })
-        // CodeQL #47 (js/tainted-format-string): providerId is user-influenced.
-        .catch((err) => console.warn("[credentials] Failed to mark %s as key_rotated:", providerId, err));
+        // CodeQL #47 (js/tainted-format-string) + js/log-injection:
+        // providerId is user-influenced. JSON.stringify is the recognised
+        // sanitiser; the format string is constant so %s can't be hijacked.
+        .catch((err) => console.warn("[credentials] Failed to mark %s as key_rotated: %s",
+          JSON.stringify(providerId),
+          err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err))));
     }
     return null;
   }
@@ -259,15 +268,17 @@ export async function discoverChatGptBackendModels(
         },
       }));
 
+    // CodeQL js/log-injection: providerId + modelId user-influenced.
     console.log(
-      `[discovery] ChatGPT backend returned ${models.length} models for ${providerId}: ` +
-      `[${models.map(m => m.modelId).join(", ")}]`,
+      `[discovery] ChatGPT backend returned ${models.length} models for ${JSON.stringify(providerId)}: ` +
+      `[${models.map(m => JSON.stringify(m.modelId)).join(", ")}]`,
     );
 
     return { models };
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Fetch error";
-    console.warn(`[discovery] ChatGPT backend discovery failed for ${providerId}: ${msg}`);
+    // CodeQL js/log-injection: providerId + msg user-influenced.
+    console.warn(`[discovery] ChatGPT backend discovery failed for ${JSON.stringify(providerId)}: ${JSON.stringify(msg)}`);
     return { models: [], error: msg };
   }
 }
@@ -436,7 +447,8 @@ export async function discoverModelsInternal(
               retiredReason: `Model no longer listed by provider after ${newMissedCount} discovery cycles`,
             },
           });
-          console.log(`[discovery] Retired model ${known.modelId} from ${providerId} (missed ${newMissedCount} discoveries)`);
+          // CodeQL js/log-injection: modelId + providerId user-influenced.
+          console.log(`[discovery] Retired model ${JSON.stringify(known.modelId)} from ${JSON.stringify(providerId)} (missed ${newMissedCount} discoveries)`);
         }
       }
     }
@@ -534,7 +546,7 @@ export async function profileModelsInternal(
           retiredReason: "Model not accessible with provider credential type",
         },
       });
-      console.log(`[profiling] Retired restricted model ${m.modelId} from ${providerId}`);
+      console.log(`[profiling] Retired restricted model ${JSON.stringify(m.modelId)} from ${JSON.stringify(providerId)}`);
       continue; // skip normal profiling for this model
     }
     const card = extractModelCardWithFallback(providerId, m.modelId, m.rawMetadata);
@@ -564,7 +576,7 @@ export async function profileModelsInternal(
           retiredReason: `Deprecated by provider${card.deprecationDate ? ` (${card.deprecationDate.toISOString().split("T")[0]})` : ""}`,
         },
       });
-      console.log(`[profiling] Auto-retired deprecated model ${m.modelId} from ${providerId}`);
+      console.log(`[profiling] Auto-retired deprecated model ${JSON.stringify(m.modelId)} from ${JSON.stringify(providerId)}`);
       continue;
     }
 
@@ -593,7 +605,7 @@ export async function profileModelsInternal(
           retiredReason: `Deprecation date passed: ${card.deprecationDate.toISOString().split("T")[0]}`,
         },
       });
-      console.log(`[profiling] Auto-retired past-deprecation model ${m.modelId} from ${providerId}`);
+      console.log(`[profiling] Auto-retired past-deprecation model ${JSON.stringify(m.modelId)} from ${JSON.stringify(providerId)}`);
       continue;
     }
 
@@ -631,7 +643,7 @@ export async function profileModelsInternal(
       && existingProfile.rawMetadataHash !== card.rawMetadataHash;
     if (driftDetected) {
       console.log(
-        `[drift] Provider metadata changed for ${providerId}/${m.modelId} — hash ${existingProfile.rawMetadataHash!.slice(0, 8)}→${card.rawMetadataHash.slice(0, 8)}`
+        `[drift] Provider metadata changed for ${JSON.stringify(providerId)}/${JSON.stringify(m.modelId)} — hash ${existingProfile.rawMetadataHash!.slice(0, 8)}→${card.rawMetadataHash.slice(0, 8)}`
       );
       // For seed-level profiles, allow scores to be re-derived on this sync.
       // For evaluated/admin profiles, flag for admin review via driftDetectedAt.
@@ -645,7 +657,7 @@ export async function profileModelsInternal(
           where: { providerId_modelId: { providerId, modelId: m.modelId } },
           data: { driftDetectedAt: new Date() },
         });
-        console.log(`[drift] ${providerId}/${m.modelId} has evaluated/admin profile — flagged for review`);
+        console.log(`[drift] ${JSON.stringify(providerId)}/${JSON.stringify(m.modelId)} has evaluated/admin profile — flagged for review`);
       }
     }
 
@@ -967,8 +979,8 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
       const knownModels = KNOWN_PROVIDER_MODELS[providerId];
       if (knownModels) {
         console.log(
-          `[auto-discover] Dynamic discovery returned 0 for ${providerId}` +
-          (discovery.error ? ` (${discovery.error})` : "") +
+          `[auto-discover] Dynamic discovery returned 0 for ${JSON.stringify(providerId)}` +
+          (discovery.error ? ` (${JSON.stringify(discovery.error)})` : "") +
           `. Falling back to known catalog (${knownModels.length} models).`,
         );
         result = await seedKnownModels(providerId, knownModels);
@@ -979,7 +991,7 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    console.error(`[auto-discover] Failed for ${providerId}: ${message}`);
+    console.error(`[auto-discover] Failed for ${JSON.stringify(providerId)}: ${JSON.stringify(message)}`);
     result = { discovered: 0, profiled: 0, error: message };
   }
 
@@ -1001,7 +1013,7 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
       });
       if (!canQueueBackgroundModelEvals(provider ?? {})) {
         console.log(
-          `[auto-discover] Skipping background evals for ${providerId}: ${backgroundModelEvalSkipReason(provider)}`,
+          `[auto-discover] Skipping background evals for ${JSON.stringify(providerId)}: ${JSON.stringify(backgroundModelEvalSkipReason(provider))}`,
         );
         return result;
       }
@@ -1013,11 +1025,14 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
       for (const event of buildAutoDiscoveryEvalEvents(providerId, models)) {
         await inngest.send(event);
       }
-      console.log(`[auto-discover] Queued background evals for ${models.length} model(s) on ${providerId}`);
+      console.log(`[auto-discover] Queued background evals for ${models.length} model(s) on ${JSON.stringify(providerId)}`);
     } catch (err) {
       // Non-fatal — catalog scores are usable even without live eval.
-      // CodeQL #48 (js/tainted-format-string): providerId via format-arg.
-      console.warn("[auto-discover] Failed to queue background evals for %s:", providerId, err);
+      // CodeQL #48 (js/tainted-format-string) + js/log-injection: constant
+      // format string + JSON.stringify on each tainted positional arg.
+      console.warn("[auto-discover] Failed to queue background evals for %s: %s",
+        JSON.stringify(providerId),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
     }
   }
 
@@ -1139,6 +1154,6 @@ async function seedKnownModels(
     profiled++;
   }
 
-  console.log(`[auto-discover] Seeded ${discovered} known models for ${providerId}`);
+  console.log(`[auto-discover] Seeded ${discovered} known models for ${JSON.stringify(providerId)}`);
   return { discovered, profiled };
 }

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -96,7 +96,7 @@ export async function runBuildPipeline(params: {
     const hasNoCapture = !fbRow?.diffPatch || fbRow.diffPatch.length === 0;
     if (hasNoCapture) {
       console.log(
-        `[build-pipeline] self-heal: ${buildId} is "complete" but has empty diffPatch — rewinding to re-run stepComplete capture`,
+        `[build-pipeline] self-heal: ${JSON.stringify(buildId)} is "complete" but has empty diffPatch — rewinding to re-run stepComplete capture`,
       );
       // Rewind to "code_generated". getResumeStep then advances to "tests_run",
       // and the orchestration loop dispatches stepComplete (which is the
@@ -527,7 +527,7 @@ async function stepComplete(
   });
 
   console.log(
-    `[build-pipeline] stepComplete: captured ${fullDiff.length} bytes diff + ${commitHashes.length} commits for ${buildId}`,
+    `[build-pipeline] stepComplete: captured ${fullDiff.length} bytes diff + ${commitHashes.length} commits for ${JSON.stringify(buildId)}`,
   );
 
   return state;

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -134,7 +134,7 @@ async function normalizeSandboxBranchArtifacts(branchName: string): Promise<void
       `chore: untrack sandbox generated artifacts on ${branchName}`,
     ),
   ).catch((err) => {
-    console.warn(`[build-branch] artifact prune commit skipped on ${branchName}: ${(err as Error).message?.slice(0, 200)}`);
+    console.warn(`[build-branch] artifact prune commit skipped on ${JSON.stringify(branchName)}: ${JSON.stringify((err as Error).message?.slice(0, 200))}`);
   });
 }
 
@@ -513,13 +513,13 @@ export async function startBuildBranch(buildId: string): Promise<SandboxSourceCu
       targetRef: identity.clientBranch,
       blockUnknown: true,
     });
-    console.log(`[build-branch] Resumed build branch: ${branchName}`);
+    console.log(`[build-branch] Resumed build branch: ${JSON.stringify(branchName)}`);
   } else {
     await execSandboxGit(
       `git -C ${WORKSPACE} checkout -b "${branchName}"`,
     );
     await normalizeSandboxBranchArtifacts(branchName);
-    console.log(`[build-branch] Created build branch: ${branchName} from ${identity.clientBranch}`);
+    console.log(`[build-branch] Created build branch: ${JSON.stringify(branchName)} from ${JSON.stringify(identity.clientBranch)}`);
   }
   const finalSourceCurrency = await inspectCurrentSandboxSourceCurrency(
     upstreamVerified ? "origin/main" : identity.clientBranch,

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -223,10 +223,10 @@ async function writeAudit(data: {
     // execution).
     // CodeQL #49 (js/tainted-format-string): tool/source names are user-influenced.
     console.error(
-      "[governed-execute] audit write failed tool=%s source=%s:",
-      data.toolName,
-      data.source,
-      err,
+      "[governed-execute] audit write failed tool=%s source=%s: %s",
+      JSON.stringify(data.toolName),
+      JSON.stringify(data.source),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
     );
     return null;
   }
@@ -302,10 +302,10 @@ async function writeReceipt(data: {
   } catch (err) {
     // CodeQL #50 (js/tainted-format-string): tool/build names via format-args.
     console.error(
-      "[governed-execute] receipt write failed tool=%s build=%s:",
-      data.toolName,
-      data.buildId,
-      err,
+      "[governed-execute] receipt write failed tool=%s build=%s: %s",
+      JSON.stringify(data.toolName),
+      JSON.stringify(data.buildId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
     );
   }
 }
@@ -345,10 +345,10 @@ async function runPostToolHooks(event: ToolLifecyclePostEvent): Promise<void> {
     } catch (err) {
       // CodeQL #51 (js/tainted-format-string): hook/tool names via format-args.
       console.error(
-        "[governed-execute] post-tool hook failed hook=%s tool=%s:",
-        hook.id,
-        event.toolName,
-        err,
+        "[governed-execute] post-tool hook failed hook=%s tool=%s: %s",
+        JSON.stringify(hook.id),
+        JSON.stringify(event.toolName),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
       );
     }
   }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -208,7 +208,7 @@ export function sanitizeToolParams(
     if (stringValues.length > 0 && stringValues.every(s => s.trim() === "")) {
       if (!cleaned) cleaned = { ...params };
       delete cleaned[key];
-      console.log(`[sanitize] ${toolName}: stripped empty optional object param "${key}"`);
+      console.log(`[sanitize] ${JSON.stringify(toolName)}: stripped empty optional object param ${JSON.stringify(key)}`);
     }
   }
   return cleaned ?? params;
@@ -6391,7 +6391,10 @@ export async function executeTool(
         }
         normalizedValue = normalizedPlan.plan;
 
-        console.log(`[saveBuildEvidence] buildPlan validated: ${fileStructure.length} files, ${tasks.length} tasks`);
+        // CodeQL js/log-injection: .length is numeric so safe, but CodeQL
+        // tracks the parent array as tainted. Number() coercion is a
+        // recognised sanitiser.
+        console.log(`[saveBuildEvidence] buildPlan validated: ${Number(fileStructure.length)} files, ${Number(tasks.length)} tasks`);
       }
 
       // ── taskResults shape validation ─────────────────────────────────────
@@ -6550,7 +6553,8 @@ export async function executeTool(
           });
         }
       } catch (err) {
-        console.warn("[deliberation] failed to record build review trail", err);
+        console.warn("[deliberation] failed to record build review trail: %s",
+          err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
       }
 
       // Failed review → structured recovery instructions, no auto-advance
@@ -6864,7 +6868,8 @@ export async function executeTool(
           });
         }
       } catch (err) {
-        console.warn("[deliberation] failed to record build review trail", err);
+        console.warn("[deliberation] failed to record build review trail: %s",
+          err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
       }
 
       // Failed review → structured recovery instructions, no auto-advance
@@ -7601,7 +7606,7 @@ export async function executeTool(
         ];
         const blocked = BLOCKED_PATTERNS.find(p => p.test(command));
         if (blocked) {
-          console.warn(`[run_sandbox_command] BLOCKED: ${command.slice(0, 200)}`);
+          console.warn(`[run_sandbox_command] BLOCKED: ${JSON.stringify(command.slice(0, 200))}`);
           return {
             success: false,
             error: "Command blocked by safety policy.",
@@ -7654,7 +7659,7 @@ export async function executeTool(
 
           // No output — actual sandbox connectivity issue
           const errMsg = execErr.message?.slice(0, 2000) || "Command failed";
-          console.error(`[run_sandbox_command] FAILED (no output): ${command.slice(0, 100)} -> ${errMsg.slice(0, 200)}`);
+          console.error(`[run_sandbox_command] FAILED (no output): ${JSON.stringify(command.slice(0, 100))} -> ${JSON.stringify(errMsg.slice(0, 200))}`);
           return { success: false, error: errMsg, message: `Command failed: ${command.slice(0, 100)}`, data: { command, output: errMsg } };
         }
       }
@@ -9579,7 +9584,7 @@ export async function executeTool(
       if (colonGlobMatch) {
         query = colonGlobMatch[1]!.trim();
         opts.glob = colonGlobMatch[2]!.trim();
-        console.log(`[search_project_files] Auto-split combined query: "${params.query}" → query="${query}" glob="${opts.glob}"`);
+        console.log(`[search_project_files] Auto-split combined query: ${JSON.stringify(params.query)} → query=${JSON.stringify(query)} glob=${JSON.stringify(opts.glob)}`);
       }
 
       if (typeof params.glob === "string" && !opts.glob) opts.glob = params.glob;
@@ -9815,7 +9820,7 @@ export async function executeTool(
               }).catch(() => {});
             }
           } else {
-            console.warn("[propose_file_change] git commit failed:", result.error);
+            console.warn("[propose_file_change] git commit failed: %s", JSON.stringify(result.error));
           }
         }
       } catch (err) {
@@ -12867,11 +12872,12 @@ export async function executeTool(
   }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // CodeQL #52 (js/tainted-format-string): keep the format string constant
-    // so a `%s` inside an attacker-controlled toolName cannot consume the
-    // next argument. toolName + msg are passed as additional args; node's
-    // util.format only honours specifiers in the literal first arg.
-    console.error("[executeTool] Uncaught exception in tool %s: %s", toolName, msg);
+    // CodeQL #52 (js/tainted-format-string) + js/log-injection: keep the
+    // format string constant so a `%s` inside an attacker-controlled
+    // toolName cannot consume the next argument, AND JSON.stringify each
+    // tainted positional arg so CR/LF can't forge log lines.
+    console.error("[executeTool] Uncaught exception in tool %s: %s",
+      JSON.stringify(toolName), JSON.stringify(msg));
     return { success: false, error: msg, message: `Tool ${toolName} failed: ${msg}` };
   }
 }

--- a/apps/web/lib/observability/heartbeat.ts
+++ b/apps/web/lib/observability/heartbeat.ts
@@ -40,7 +40,9 @@ export async function heartbeat(taskRunId: string): Promise<boolean> {
     // format string) to satisfy CodeQL's externally-controlled-format-string
     // rule. console APIs treat the first arg as a format string in some
     // runtimes; keeping it a literal avoids the warning.
-    console.warn("[heartbeat] write failed for", taskRunId, err instanceof Error ? err.message : err);
+    console.warn("[heartbeat] write failed for %s: %s",
+      JSON.stringify(taskRunId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)));
     return true;
   }
 }
@@ -68,10 +70,9 @@ export async function withHeartbeatTicker<T>(
       intervalMs = Math.floor(threshold.heartbeatTimeoutSeconds * 1000 / 3);
     } catch (err) {
       console.warn(
-        "[withHeartbeatTicker] threshold lookup failed for",
-        taskRunId,
-        "using 60s default —",
-        err instanceof Error ? err.message : err,
+        "[withHeartbeatTicker] threshold lookup failed for %s using 60s default — %s",
+        JSON.stringify(taskRunId),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
       );
     }
   }

--- a/apps/web/lib/operate/backups/neo4j-restore-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-restore-runner.ts
@@ -58,8 +58,11 @@ interface ScriptOutcome {
 }
 
 function restoreTraceLog(...parts: unknown[]) {
+  // CodeQL js/log-injection: parts may contain user-influenced values
+  // (restore-job parameters). JSON.stringify each part neutralises CR/LF.
   // eslint-disable-next-line no-console
-  console.log("[restore-trace][neo4j]", ...parts);
+  console.log("[restore-trace][neo4j] %s",
+    parts.map((p) => typeof p === "string" ? JSON.stringify(p) : JSON.stringify(p)).join(" "));
 }
 
 async function fileSha256(absolutePath: string): Promise<string> {

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -85,8 +85,10 @@ export interface RestoreArgs {
 type PrismaLike = typeof import("@dpf/db").prisma;
 
 function restoreTraceLog(...parts: unknown[]) {
+  // CodeQL js/log-injection: parts may contain user-influenced values.
   // eslint-disable-next-line no-console
-  console.log("[restore-trace]", ...parts);
+  console.log("[restore-trace] %s",
+    parts.map((p) => typeof p === "string" ? JSON.stringify(p) : JSON.stringify(p)).join(" "));
 }
 
 async function fileSha256(absolutePath: string): Promise<string> {

--- a/apps/web/lib/operate/backups/qdrant-restore-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-restore-runner.ts
@@ -57,8 +57,10 @@ interface ScriptOutcome {
 }
 
 function restoreTraceLog(...parts: unknown[]) {
+  // CodeQL js/log-injection: parts may contain user-influenced values.
   // eslint-disable-next-line no-console
-  console.log("[restore-trace][qdrant]", ...parts);
+  console.log("[restore-trace][qdrant] %s",
+    parts.map((p) => typeof p === "string" ? JSON.stringify(p) : JSON.stringify(p)).join(" "));
 }
 
 async function fileSha256(absolutePath: string): Promise<string> {

--- a/apps/web/lib/release/branding-presets.ts
+++ b/apps/web/lib/release/branding-presets.ts
@@ -110,7 +110,7 @@ function ensureContrast(fg: string, bg: string, minRatio: number): string {
       ) {
         console.warn(
           `ensureContrast: nudged lightness by ${Math.abs(l - originalL).toFixed(1)}% ` +
-          `(${originalL.toFixed(1)} → ${l.toFixed(1)}) for ${fg} against ${bg}`
+          `(${originalL.toFixed(1)} → ${l.toFixed(1)}) for ${JSON.stringify(fg)} against ${JSON.stringify(bg)}`
         );
       }
       return candidate;

--- a/apps/web/lib/security/safe-spawn.ts
+++ b/apps/web/lib/security/safe-spawn.ts
@@ -169,7 +169,7 @@ export function sanitizeEnv(
       // Not a console.error because the spawn itself can still proceed —
       // we degrade gracefully by stripping the var, not failing the call.
       // eslint-disable-next-line no-console
-      console.warn(`[safe-spawn] Dropped dangerous env var "${k}" before spawn.`);
+      console.warn(`[safe-spawn] Dropped dangerous env var ${JSON.stringify(k)} before spawn.`);
       continue;
     }
     // CodeQL #201 (js/remote-property-injection): even after the
@@ -225,7 +225,7 @@ export function safeSpawn(
     const message = err instanceof Error ? err.message : String(err);
     // Audit signal so reject reasons are greppable in logs.
     // eslint-disable-next-line no-console
-    console.warn(`[safe-spawn] Rejected: ${message}`);
+    console.warn(`[safe-spawn] Rejected: ${JSON.stringify(message)}`);
     return { ok: false, error: message };
   }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -350,7 +350,7 @@ export function isToolAllowedByGrants(
   // This prevents silent permission escalation when new tools are added without
   // a corresponding grant mapping.
   if (!requiredGrants) {
-    console.warn(`[agent-grants] Tool "${toolName}" has no TOOL_TO_GRANTS entry — denied by default`);
+    console.warn(`[agent-grants] Tool ${JSON.stringify(toolName)} has no TOOL_TO_GRANTS entry — denied by default`);
     return false;
   }
   // Agent must have at least ONE of the required grants

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -978,7 +978,7 @@ export async function runAgenticLoop(params: {
     if (lastResult?.providerId === "local" && executedTools.length >= 8) {
       console.warn(
         `[agentic-loop] local model spun through ${executedTools.length} tool calls without converging on a text answer. ` +
-        `Exiting early with diagnostic. agent=${agentId} route=${routeContext}`,
+        `Exiting early with diagnostic. agent=${JSON.stringify(agentId)} route=${JSON.stringify(routeContext)}`,
       );
       return {
         content: buildLocalToolCallFailureMessage(lastResult),
@@ -1364,7 +1364,7 @@ export async function runAgenticLoop(params: {
           result.providerId === "local"
         ) {
           console.warn(
-            `[agentic-loop] local model produced text-only response for tool-backed turn; returning diagnostic instead of issuing a second nudge. agent=${agentId} route=${routeContext}`,
+            `[agentic-loop] local model produced text-only response for tool-backed turn; returning diagnostic instead of issuing a second nudge. agent=${JSON.stringify(agentId)} route=${JSON.stringify(routeContext)}`,
           );
           return {
             content: buildLocalToolCallFailureMessage(result),
@@ -1583,7 +1583,7 @@ export async function runAgenticLoop(params: {
 
       const durationMs = Date.now() - toolStartMs;
       const resultPreview = (toolResult.message ?? "").slice(0, 200);
-      console.log(`[agentic-tool] RESULT iter=${iteration} tool=${tc.name} success=${toolResult.success} duration=${durationMs}ms msg=${resultPreview}`);
+      console.log(`[agentic-tool] RESULT iter=${iteration} tool=${JSON.stringify(tc.name)} success=${toolResult.success} duration=${durationMs}ms msg=${JSON.stringify(resultPreview)}`);
 
       // Sandbox circuit breaker: track consecutive unavailable responses
       if (!toolResult.success && (toolResult.error ?? toolResult.message ?? "").includes("No sandbox slots available")) {

--- a/apps/web/tests/build-lifecycle.test.ts
+++ b/apps/web/tests/build-lifecycle.test.ts
@@ -101,7 +101,7 @@ async function getPhase(): Promise<BuildPhase> {
 
 async function callTool(name: string, params: Record<string, unknown> = {}) {
   const result = await executeTool(name, params, testUserId, TEST_CONTEXT);
-  console.log(`  [${name}] ${result.success ? "OK" : "FAIL"}: ${result.message.slice(0, 120)}`);
+  console.log(`  [${JSON.stringify(name)}] ${result.success ? "OK" : "FAIL"}: ${JSON.stringify(result.message.slice(0, 120))}`);
   return result;
 }
 
@@ -202,7 +202,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
         } as unknown as import("@dpf/db").Prisma.InputJsonValue,
       },
     });
-    console.log(`\n  Created test build: ${testBuildId}\n`);
+    console.log(`\n  Created test build: ${JSON.stringify(testBuildId)}\n`);
   });
 
   afterAll(async () => {
@@ -363,7 +363,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
     // That's expected. The diff is already saved above.
     const result = await callTool("deploy_feature", {});
     // May fail due to no sandbox — that's ok, we pre-wrote the diff
-    console.log(`  [deploy_feature] ${result.success ? "OK" : "Expected: " + result.error}`);
+    console.log(`  [deploy_feature] ${result.success ? "OK" : "Expected: " + JSON.stringify(result.error)}`);
   });
 
   it("registers digital product from build", async () => {
@@ -373,7 +373,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
       portfolioSlug: "for_employees",
       versionBump: "minor",
     });
-    console.log(`  [register] ${result.success ? "OK" : "FAIL"}: ${result.message.slice(0, 150)}`);
+    console.log(`  [register] ${result.success ? "OK" : "FAIL"}: ${JSON.stringify(result.message.slice(0, 150))}`);
     // May fail if portfolio doesn't exist, but tests the pipeline
     if (result.success) {
       expect(result.message).toBeTruthy();
@@ -382,7 +382,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
 
   it("creates build epic for backlog tracking", async () => {
     const result = await callTool("create_build_epic", { buildId: testBuildId });
-    console.log(`  [create_build_epic] ${result.success ? "OK" : "FAIL"}: ${result.message.slice(0, 150)}`);
+    console.log(`  [create_build_epic] ${result.success ? "OK" : "FAIL"}: ${JSON.stringify(result.message.slice(0, 150))}`);
   });
 
   it("checks deployment window", async () => {
@@ -391,7 +391,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
       risk_level: "low",
     });
     expect(result.success).toBe(true);
-    console.log(`  [check_deployment_windows] ${result.message.slice(0, 150)}`);
+    console.log(`  [check_deployment_windows] ${JSON.stringify(result.message.slice(0, 150))}`);
   });
 
   it("executes promotion to production", async () => {
@@ -420,7 +420,7 @@ describeBuildLifecycle("Build Studio full lifecycle", () => {
     const result = await callTool("execute_promotion", {
       promotion_id: promotion.id,
     });
-    console.log(`  [execute_promotion] ${result.success ? "OK" : "FAIL"}: ${result.message.slice(0, 200)}`);
+    console.log(`  [execute_promotion] ${result.success ? "OK" : "FAIL"}: ${JSON.stringify(result.message.slice(0, 200))}`);
   });
 
   it("advances to complete after ship", async () => {


### PR DESCRIPTION
## Summary

Closes every open \`js/log-injection\` alert (77 sites across 24 files) by inline-wrapping each user-influenced interpolation in \`JSON.stringify()\` — CodeQL's native log-injection sanitiser.

## Why inline JSON.stringify, not the sanitizeForLog helper

PR #998's local CodeQL model pack was silently ignored by \`github/codeql-action\` (Task #25 follow-up). \`sanitizeForLog\` is therefore not recognised at scan time. \`JSON.stringify\` is a CodeQL-native sanitiser that needs no model pack and matches the established pattern in \`assurance.ts\` from earlier burn-down work.

## What it does at runtime

\`JSON.stringify(value)\` escapes CR/LF and quotes the value, so an attacker-controlled \`tool\nname\nadmin = true\` becomes the literal string \`"tool\\nname\\nadmin = true"\` in logs — one line, unambiguous, no forged fields.

Minor cosmetic change: logged values now appear quoted (e.g. \`tool="foo"\` instead of \`tool=foo\`). Same readability.

## Files touched (24 files, 77 sites)

| File | Sites |
|---|---|
| \`apps/web/lib/inference/ai-provider-internals.ts\` | 18 |
| \`apps/web/lib/mcp-tools.ts\` | 10 |
| \`apps/web/tests/build-lifecycle.test.ts\` | 6 |
| \`apps/web/lib/govern/activate-provider.ts\` | 5 |
| \`apps/web/lib/actions/build.ts\` | 5 |
| \`apps/web/lib/actions/agent-coworker.ts\` | 4 |
| \`apps/web/lib/tak/agentic-loop.ts\` | 3 |
| \`apps/web/lib/mcp-governed-execute.ts\` | 3 |
| \`apps/web/lib/integrate/sandbox/build-branch.ts\` | 3 |
| 15 other files | 1-2 each |

Three \`restoreTraceLog\` helpers in \`apps/web/lib/operate/backups/*\` got a unified per-arg JSON.stringify wrapper so every future call automatically sanitises.

## Verification

- [x] Typecheck passes (pre-commit hook ran clean on every commit)
- [ ] Next CodeQL scan post-merge: \`js/log-injection\` open count = 0

## Combined burn-down state (post-merge + scan)

| Severity | Before this PR | After |
|---|---|---|
| Critical | 0 | 0 |
| High | 7 (closing on prior PR scan) | 0 |
| Medium | 88 | ~11 (remaining non-log-injection: http-to-file-access × 7, file-access-to-http × 3, indirect-command-line-injection × 1) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)