### PR TITLE
docs(testing): document pre-PR test gate + add mobile jest-pin CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
       - name: Run guard
         run: node scripts/check-no-bare-working-write.mjs
 
+  mobile-jest-pin-guard:
+    name: Mobile Jest Pin Guard
+    runs-on: ubuntu-latest
+    # Asserts apps/mobile stays on jest ^29.x. PR #1053 walked back a
+    # Dependabot bump to jest 30 that broke every mobile test and blocked
+    # every open PR for hours. Without this guard a future bump silently
+    # re-introduces the same break. See docs/testing/pre-pr-gate.md.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Run guard
+        run: node scripts/check-mobile-jest-pin.mjs
+
   routing-contract:
     name: Routing Tier Contract
     runs-on: ubuntu-latest

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -1,0 +1,108 @@
+# Pre-PR test gate
+
+Every pull request against `main` runs the full DPF unit-test suite as a
+binding merge gate. **Tests run before merge — if they fail, fix in place,
+don't push-and-pray.**
+
+## What runs
+
+The root `pnpm test` script invokes:
+
+```
+pnpm --filter web test       # vitest — apps/web
+pnpm --filter @dpf/db test   # vitest — packages/db
+pnpm --filter mobile test    # jest   — apps/mobile (Expo + React Native)
+```
+
+All three must pass. As of 2026-05-17 the consolidated suite contains 5,980
+tests at 0 failures on `main`.
+
+## Where it runs
+
+Wired up in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) under
+the `Unit Tests` job. The job:
+
+1. Provisions a Postgres 16-alpine service for tests that need a real DB
+   (the `@dpf/db` suite primarily).
+2. Installs deps with the frozen lockfile.
+3. Generates the Prisma client and applies migrations.
+4. Runs `pnpm test`.
+
+CI fails the PR check if any test fails. Branch protection requires the
+check to pass before merge.
+
+## Run locally
+
+Before pushing, run the suite that covers the files you touched:
+
+```bash
+# Touched apps/web?
+pnpm --filter web test
+
+# Touched packages/db?
+pnpm --filter @dpf/db test
+
+# Touched apps/mobile?
+pnpm --filter mobile test
+
+# All three (matches CI):
+pnpm test
+```
+
+The `apps/web` suite alone runs in roughly 2–4 minutes on a modern laptop;
+the full root `pnpm test` adds another 1–2 minutes for `@dpf/db` and the
+mobile jest suite.
+
+## The pre-commit typecheck gate
+
+A separate guard at `.githooks/pre-commit` runs `pnpm --filter <affected>
+typecheck` on TypeScript commits and rejects the commit on failure. It does
+**not** run vitest/jest — that's CI's job. The hook is auto-wired by
+`postinstall` (`scripts/set-hooks-path.mjs` sets `core.hooksPath`). Emergency
+bypass: `DPF_SKIP_TYPECHECK=1 git commit ...`.
+
+This means the local feedback loop is:
+
+1. Pre-commit hook catches type errors before they leave your machine.
+2. CI's `Unit Tests` job catches behavioural regressions before merge.
+3. CI's `Production Build` job catches Next.js build-time errors (a
+   superset of typecheck — some errors only surface at build).
+
+## Test runner pins (must hold)
+
+Two test-runner pins are load-bearing and enforced in CI:
+
+### `apps/mobile` jest must stay on `^29.x`
+
+Enforced by [`scripts/check-mobile-jest-pin.mjs`](../../scripts/check-mobile-jest-pin.mjs)
+via the `Mobile Jest Pin Guard` job in `ci.yml`.
+
+**History.** Dependabot bumped jest to v30 in PR #1037. The bump silently
+broke every mobile test simultaneously and blocked every open PR for hours.
+PR #1053 reverted to jest `~29.7.0`. The current jest-expo (~56) does not
+yet support jest 30. Without this guard, the next Dependabot pass would
+re-introduce the same break.
+
+**If you need to bump jest 30+.** Confirm jest-expo compatibility upstream
+first, then remove this guard in the same PR that bumps the version and add
+a note here describing the compatibility evidence.
+
+### `apps/web` and `packages/db` vitest
+
+Previously pinned to `^4.1.5` because vitest 4.1.6+ broke
+`@testing-library/jest-dom`'s vitest type augmentation. As of 2026-05-22 the
+pin was lifted via a `packageExtensions` workaround in `pnpm-workspace.yaml`
+(see PR #1055). No CI guard is needed — the workaround makes future vitest
+bumps safe. If `toBeInTheDocument`-style assertions regress on a future
+bump, restore the pin or extend the workaround.
+
+## What this gate is NOT
+
+- **Not an e2e gate.** The Playwright suite under `tests/e2e/` runs
+  separately on demand and is not blocking. See
+  [`tests/e2e/platform-qa-plan.md`](../../tests/e2e/platform-qa-plan.md).
+- **Not a security gate.** That's [Semgrep](../security/semgrep.md) (pre-PR)
+  and CodeQL via the [inflow gate](../security/README.md) (post-PR).
+- **Not a UX gate.** UX verification is part of the manual build gate —
+  see §5 of [`AGENTS.md`](../../AGENTS.md). Tests passing does not mean the
+  feature works in the running app.

--- a/scripts/check-mobile-jest-pin.mjs
+++ b/scripts/check-mobile-jest-pin.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * CI guard — apps/mobile must stay on jest ^29.x.
+ *
+ * Background
+ * ----------
+ * PR #1053 ("fix(mobile): downgrade jest 30 → 29 — restores mobile test suite")
+ * walked back a Dependabot-driven bump to jest 30 that broke every mobile
+ * test simultaneously and blocked every open PR for hours. jest 30 changes
+ * defaults that jest-expo 56.x is not yet compatible with.
+ *
+ * This script asserts the pin holds. It runs in CI as a binding gate so a
+ * future Dependabot PR cannot silently re-introduce the same break.
+ *
+ * When this script fails
+ * ----------------------
+ *   1. Confirm the pin is intentional (it is, as of this writing).
+ *   2. Close the offending dependency bump PR with a comment pointing at
+ *      PR #1053 and this script.
+ *   3. If jest 30 is now safe (jest-expo compatibility landed, etc.),
+ *      remove or relax this guard in the same PR that does the bump.
+ *      Don't bypass — fix the guard.
+ *
+ * Exit codes
+ * ----------
+ *   0  Pin OK.
+ *   1  Pin violated (jest devDep missing or not satisfying ^29).
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const MOBILE_PKG = resolve("apps/mobile/package.json");
+const REQUIRED_MAJOR = 29;
+
+let pkg;
+try {
+  pkg = JSON.parse(await readFile(MOBILE_PKG, "utf8"));
+} catch (err) {
+  console.error(`ERROR: Could not read ${MOBILE_PKG}: ${err.message}`);
+  process.exit(1);
+}
+
+const declared = pkg.devDependencies?.jest;
+if (typeof declared !== "string") {
+  console.error("ERROR: apps/mobile devDependencies.jest is missing.");
+  console.error("Expected a string satisfying ^29 (e.g. '~29.7.0' or '^29.7.0').");
+  process.exit(1);
+}
+
+// Extract the major version from the leading numeric segment after stripping
+// range operator characters (^ ~ >= = etc.).
+const match = declared.match(/^[~^>=<\s]*(\d+)\./);
+if (!match) {
+  console.error(`ERROR: Could not parse major version from jest devDep "${declared}".`);
+  console.error("Expected a semver range like '^29.7.0' or '~29.7.0'.");
+  process.exit(1);
+}
+
+const major = Number(match[1]);
+if (major !== REQUIRED_MAJOR) {
+  console.error(`ERROR: apps/mobile jest is pinned to "${declared}" (major ${major}).`);
+  console.error(`The mobile suite requires jest ^${REQUIRED_MAJOR}.x — see PR #1053.`);
+  console.error("");
+  console.error("If this bump is intentional and jest-expo compatibility has");
+  console.error("landed, remove this guard in scripts/check-mobile-jest-pin.mjs");
+  console.error("in the same PR that bumps the version, and document the");
+  console.error("compatibility evidence in docs/testing/pre-pr-gate.md.");
+  process.exit(1);
+}
+
+console.log(`✓ apps/mobile jest pin OK ("${declared}" — major ${major}).`);


### PR DESCRIPTION
## Summary
- New [`docs/testing/pre-pr-gate.md`](docs/testing/pre-pr-gate.md) documents the existing pre-PR test gate (root `pnpm test` → web/db/mobile, ~5,980 tests at 0 failures since #693/#694, already wired into `ci.yml`).
- New [`scripts/check-mobile-jest-pin.mjs`](scripts/check-mobile-jest-pin.mjs) + a `Mobile Jest Pin Guard` job in `ci.yml` block Dependabot bumps of `apps/mobile` past jest 29.

## Why
PR #1037 silently bumped `apps/mobile` jest 29 → 30. The bump broke every mobile test simultaneously and blocked every open PR for hours. PR #1053 walked it back. Without a guard, the next Dependabot pass re-introduces the same break.

## What's intentionally not here
- **No parallel `test-gate.yml` workflow** — `ci.yml` already runs `pnpm test` on every PR. A second runner would double CI cost without adding signal.
- **No vitest pin guard** — the `^4.1.5` pin from #871 was lifted via the `packageExtensions` workaround in #1055; future bumps are safe.
- **No JSON test-report artifact** — CI annotations already surface on the PR Checks tab.

## Test plan
- [x] Guard smoke-tested locally: passes on current `~29.7.0`, fails with the expected error when temporarily bumped to `^30.0.0`.
- [ ] CI passes (Unit Tests + the new Mobile Jest Pin Guard).
- [ ] Verify the new job appears in the PR Checks list.

## Sequenced with
- [#1058](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1058) — Semgrep pre-PR scan workflow.
- PR (forthcoming) — Tighten CodeQL inflow gate to include MEDIUM + baseline reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)