### PR TITLE
fix(security): switch Semgrep to `semgrep ci` + SEMGREP_APP_TOKEN

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,26 +5,37 @@ name: Semgrep Security Scan
 # Complements (not replaces) the CodeQL gate. CodeQL is post-merge analytical;
 # Semgrep is pre-merge syntactic. The two catch different patterns — keep both.
 #
+# `semgrep ci` vs the previous `semgrep scan` invocation:
+#   The original workflow used `semgrep scan --config=p/...` with explicit
+#   community rulesets. Acceptance test in demo PR #1061 found that the
+#   unauthenticated community registry loads only ~150 rules for our TS files,
+#   and those rules missed hardcoded AWS keys, Math.random() for tokens, and
+#   eval(). `semgrep ci` is the canonical CI command — when SEMGREP_APP_TOKEN
+#   is set, it pulls the full registry plus any policies configured in the
+#   Semgrep AppSec Platform (free tier for open-source projects). Without
+#   the token, it gracefully falls back to a community default ruleset.
+#
+# Setup (one-time, repo-owner task):
+#   See docs/security/semgrep.md → "Activating the full ruleset" for the
+#   semgrep.dev account + GitHub repo secret steps. Until SEMGREP_APP_TOKEN
+#   is present, the scan runs with the same limited coverage demo PR #1061
+#   surfaced. The workflow does NOT fail if the token is missing — graceful
+#   degradation, not a hard requirement.
+#
 # Why pull_request (not pull_request_target):
-#   pull_request_target gives the workflow access to secrets but checks out the
-#   base ref by default, requiring careful PR-head handling to scan the change.
-#   DPF currently has no external fork-PR contribution flow; pull_request keeps
-#   the trust boundary clean. If fork PRs become routine, add a sibling workflow
-#   that runs in pull_request_target and uploads SARIF only.
+#   pull_request_target gives the workflow access to secrets but checks out
+#   the base ref by default. DPF currently has no external fork-PR flow;
+#   pull_request keeps the trust boundary clean.
 #
-# Severity gating:
-#   --severity ERROR --severity WARNING — these block the PR. INFO findings are
-#   filtered out (no comment-only surfacing in v1). When Semgrep AppSec Platform
-#   integration lands, the block/comment split moves to rule metadata.
-#
-# Baseline:
-#   --baseline-commit limits the scan diff to changes against origin/main, so
-#   pre-existing patterns don't surface on unrelated PRs (mirrors the inflow-gate
-#   strategy for CodeQL).
+# Baseline / diff scanning:
+#   SEMGREP_BASELINE_REF (canonical for `semgrep ci`) limits the scan diff
+#   to changes against origin/<base_ref>, so pre-existing patterns don't
+#   surface on unrelated PRs.
 #
 # Custom rules:
-#   .github/semgrep/ is reserved for DPF-specific rule files (.yml). Empty for
-#   v1 — added if the burn-down replay shows gaps in standard rulesets.
+#   .github/semgrep/ is reserved for DPF-specific rule files (.yml). Empty
+#   today — populated when a pattern not covered by the platform ruleset
+#   needs targeted coverage.
 
 on:
   pull_request:
@@ -33,8 +44,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Least-privilege default. SARIF upload needs security-events:write at the job
-# level (granted below).
 permissions:
   contents: read
 
@@ -46,72 +55,49 @@ jobs:
   semgrep:
     name: Semgrep Scan
     runs-on: ubuntu-latest
-    # Skip on Dependabot PRs — they're scanned post-merge by the push trigger,
-    # and Dependabot lacks the token scope to upload SARIF in any case.
+    # Skip on Dependabot PRs — those are covered by the post-merge push trigger.
     if: github.actor != 'dependabot[bot]'
     timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
     container:
-      # Pinned to the official Semgrep image. Renovate/Dependabot will track
-      # bumps via the docker-image ecosystem.
       image: semgrep/semgrep:1.163.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Full history needed for --baseline-commit diff scanning.
+          # Full history needed for SEMGREP_BASELINE_REF diff scanning.
           fetch-depth: 0
 
-      - name: Resolve baseline commit
-        id: baseline
-        env:
-          BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
-        run: |
-          set -euo pipefail
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # On PRs we already have origin/<base_ref> from checkout. On push to
-          # main, baseline against the parent of the head commit so scan diffs
-          # the merge introducing the change rather than re-scanning history.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASELINE_SHA="$(git rev-parse "origin/${BASE_REF}")"
-          else
-            BASELINE_SHA="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
-          fi
-          echo "sha=${BASELINE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Baseline commit: ${BASELINE_SHA}"
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Semgrep scan
-        id: scan
+      - name: Semgrep ci
         env:
-          # Disable Semgrep usage metrics (offline, opt-out per privacy policy).
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          # Disable Semgrep usage metrics by default. The platform integration
+          # still works for findings reporting; only anonymous CLI usage stats
+          # are suppressed. Override to "on" if telemetry is desired.
           SEMGREP_SEND_METRICS: "off"
-          BASELINE_SHA: ${{ steps.baseline.outputs.sha }}
+          # On PRs: diff against the base branch so only PR-introduced findings
+          # surface. On push to main: no baseline (full scan of touched files).
+          SEMGREP_BASELINE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
         run: |
           set -euo pipefail
-          # --error: non-zero exit if any finding remains after baseline diff.
-          # --severity filter: only ERROR + WARNING block. INFO is dropped.
-          # --sarif-output: machine-readable findings for Code Scanning upload.
-          semgrep scan \
-            --config=p/security-audit \
-            --config=p/typescript \
-            --config=p/javascript \
-            --config=p/nextjs \
-            --config=p/owasp-top-ten \
-            --config=p/github-actions \
-            --config=p/secrets \
-            --severity=ERROR \
-            --severity=WARNING \
-            --baseline-commit="${BASELINE_SHA}" \
-            --sarif-output=semgrep.sarif \
-            --error \
-            --metrics=off \
-            --timeout=60 \
-            --timeout-threshold=3
+          # --sarif-output emits findings in SARIF for GitHub Code Scanning.
+          # `semgrep ci` exit codes:
+          #   0  no blocking findings
+          #   1  blocking findings present
+          #   2  configuration / fatal error
+          # Block-vs-audit per finding is driven by rule metadata + (when the
+          # AppSec Platform is connected) per-rule mode configured at
+          # semgrep.dev. Without an SEMGREP_APP_TOKEN, all default-blocking
+          # rules block.
+          semgrep ci --sarif-output=semgrep.sarif
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif

--- a/docs/security/semgrep.md
+++ b/docs/security/semgrep.md
@@ -2,7 +2,7 @@
 
 Companion to the [CodeQL inflow gate](README.md). Semgrep runs on every pull
 request against `main` and on pushes to `main`, blocking the PR if it
-introduces patterns the standard rulesets flag at ERROR or WARNING severity.
+introduces patterns Semgrep flags as blocking (rule metadata–driven).
 
 ## Why two scanners
 
@@ -12,27 +12,64 @@ CodeQL and Semgrep cover overlapping but non-identical territory:
 |---|---|---|
 | Trigger timing | Post-merge analytical (via the inflow gate diff) | Pre-merge syntactic |
 | Strength | Cross-procedural taint, framework-aware data flow | Fast pattern matching, large ruleset ecosystem |
-| Sanitiser model | Custom data-extension packs only | Inline `# nosemgrep` + rule-level metadata |
+| Sanitiser model | Custom data-extension packs only | Inline `// nosemgrep` + rule-level metadata |
 | Custom rules | CodeQL packs (more work to author) | YAML rules in `.github/semgrep/` |
 
 Keep both. Findings that one tool misses, the other often catches.
 
-## Rulesets in use
+## Activating the full ruleset (one-time setup)
 
-The workflow (`.github/workflows/security-scan.yml`) runs Semgrep with the
-following Semgrep Registry rulesets:
+Without an `SEMGREP_APP_TOKEN` repo secret, `semgrep ci` runs against the
+unauthenticated community registry, which loads only ~150 of ~700 rules for
+TypeScript and misses common patterns (verified in demo PR #1061: hardcoded
+AWS keys, `Math.random()` for tokens, and `eval()` all went undetected).
 
-- `p/security-audit` — language-agnostic security baseline
-- `p/typescript` — TS-specific patterns
-- `p/javascript` — JS-specific patterns
-- `p/nextjs` — Next.js-specific patterns (App Router, server actions, etc.)
-- `p/owasp-top-ten` — OWASP Top 10 coverage
-- `p/github-actions` — workflow injection, action pinning, secret handling
-- `p/secrets` — hard-coded credential detection
+To unlock the full registry (free for open-source projects):
 
-DPF-specific custom rules live in `.github/semgrep/*.yml` (empty in v1 — added
-only when burn-down evidence shows the standard rulesets miss a pattern we care
-about, per the "verify substrate before proposing new" principle).
+1. Sign in at https://semgrep.dev with the GitHub account that owns the
+   repo.
+2. Create a project pointing at
+   `OpenDigitalProductFactory/opendigitalproductfactory`.
+3. **Settings → Tokens** → generate a CI token, copy the value.
+4. In the GitHub repo: **Settings → Secrets and variables → Actions →
+   New repository secret**.
+   - Name: `SEMGREP_APP_TOKEN`
+   - Value: the token from step 3.
+5. Next PR's Semgrep Scan check picks up the secret automatically; no
+   workflow change needed.
+
+The workflow degrades gracefully if the secret is absent — scans still
+run, just with the limited community ruleset.
+
+## What `semgrep ci` runs
+
+The workflow at `.github/workflows/security-scan.yml` invokes:
+
+```bash
+semgrep ci --sarif-output=semgrep.sarif
+```
+
+With `SEMGREP_APP_TOKEN` set, this:
+
+- Pulls the full Semgrep Registry (security-audit, language packs, OWASP,
+  secrets, GitHub Actions, framework-specific) plus any custom policies
+  configured at https://semgrep.dev for this project.
+- Diffs against `SEMGREP_BASELINE_REF` (set to `origin/<base_ref>` on PRs)
+  so only PR-introduced findings surface.
+- Honors rule metadata for block-vs-audit decisions. Default-blocking
+  rules block; audit-mode rules surface as warnings without failing the
+  build.
+
+DPF-specific custom rules live in `.github/semgrep/*.yml` (empty today —
+populated when the platform ruleset misses a DPF-specific pattern).
+
+## Telemetry
+
+The workflow sets `SEMGREP_SEND_METRICS=off` to suppress anonymous CLI
+usage stats. With `SEMGREP_APP_TOKEN` set, scan findings are still reported
+to the Semgrep AppSec Platform dashboard — that's the point of the token.
+This is metadata about *findings*, not source code; the source itself
+never leaves the runner.
 
 ## Run locally
 
@@ -40,27 +77,20 @@ about, per the "verify substrate before proposing new" principle).
 # Install once
 pip install semgrep
 
+# Authenticate (uses the same token machinery as CI; one-time)
+semgrep login
+
 # Scan the current branch's diff against main
-semgrep scan \
-  --config=p/security-audit \
-  --config=p/typescript \
-  --config=p/javascript \
-  --config=p/nextjs \
-  --config=p/owasp-top-ten \
-  --config=p/github-actions \
-  --config=p/secrets \
-  --severity=ERROR \
-  --severity=WARNING \
-  --baseline-commit="$(git merge-base HEAD origin/main)" \
-  --error
+SEMGREP_BASELINE_REF=$(git merge-base HEAD origin/main) semgrep ci
 ```
 
-For a fast smoke test, `semgrep --config=auto .` uses Semgrep's recommended
-config but skips the explicit ruleset list above.
+Without `semgrep login`, the local scan runs with the same limited
+community ruleset CI does without the token.
 
 ## Suppressing a finding
 
-If a finding is a true false positive (and you can defend that to a reviewer):
+If a finding is a true false positive (and you can defend that to a
+reviewer):
 
 ```ts
 // nosemgrep: javascript.lang.security.audit.code-string-concat-eval.code-string-concat-eval — JSON template literal, no user input
@@ -68,35 +98,37 @@ const out = `{"ok":${flag}}`;
 ```
 
 Required form:
+
 - `nosemgrep:` prefix
-- Full rule ID (the part after the last `.` in Semgrep's output is enough, but
-  the full ID is unambiguous and what reviewers expect)
-- An em-dash or `—` followed by a one-line justification
+- Full rule ID (the part after the last `.` in Semgrep's output is enough,
+  but the full ID is unambiguous and what reviewers expect)
+- An em-dash `—` followed by a one-line justification
 
 Suppressions without a justification fail review. Suppressions covering a
-range of code (block-level) belong in `.github/semgrep/` as a targeted rule
-exclusion with a `metadata.justification:` field, not inline.
+range of code (block-level) belong in `.github/semgrep/` as a targeted
+rule exclusion with a `metadata.justification:` field, not inline.
 
 ## Dismissing a finding in GitHub Code Scanning
 
-For findings that surface in the Code Scanning UI (after SARIF upload), the
-dismissal flow is:
+For findings surfaced via SARIF upload to the Code Scanning UI:
 
-1. Open the alert in GitHub Code Scanning (`Security > Code scanning`).
+1. Open the alert in **Security → Code scanning**.
 2. Dismiss with one of: `false positive`, `won't fix`, `used in tests`.
-3. **Required:** add a justification comment citing either a kernel principle
-   from [`docs/founder-kernel/wiki/principles/`](../founder-kernel/wiki/principles/),
-   a tracked BI/Epic, or a PR that explains why the pattern is safe in this
-   codebase.
+3. **Required:** add a justification comment citing either a kernel
+   principle from [`docs/founder-kernel/wiki/principles/`](../founder-kernel/wiki/principles/),
+   a tracked BI/Epic, or a PR that explains why the pattern is safe in
+   this codebase.
 
-The reviewer for the next PR in the affected area is expected to verify the
-dismissal makes sense. Dismissals without justification are reverted.
+The reviewer for the next PR in the affected area is expected to verify
+the dismissal makes sense. Dismissals without justification are reverted.
 
 ## Adding a custom DPF rule
 
-Drop a YAML file under `.github/semgrep/dpf-*.yml`. The workflow does not yet
-load this directory — when the first rule is authored, the workflow's
-`semgrep scan` invocation must add `--config=.github/semgrep/`.
+Drop a YAML file under `.github/semgrep/dpf-*.yml`. `semgrep ci`
+auto-discovers `.semgrep.yml` files in the repo when `SEMGREP_RULES_FILE`
+is unset, but custom rules in a directory require an explicit
+`--config=.github/semgrep/` flag. When the first rule lands, update the
+workflow's `semgrep ci` invocation accordingly.
 
 Rule template:
 
@@ -113,29 +145,29 @@ rules:
       owasp: A09:2021 — Security Logging and Monitoring Failures
       justification: |
         Closed 77 such alerts in PR #1056. CodeQL recognises JSON.stringify
-        as a sanitiser; Semgrep should too.
+        as a sanitiser; Semgrep doesn't recognise wrapper helpers either,
+        so this rule fills the gap directly.
     patterns:
       # ... pattern definitions
 ```
 
 ## Expected runtime
 
-A diff scan of a typical PR completes in well under a minute. Full-tree scans
-(post-merge push to main) take 2–4 minutes. If a PR scan takes longer than
-~3 minutes, it usually means `--baseline-commit` didn't resolve correctly and
-the scan is running full-tree — check the workflow log for the resolved
-baseline SHA.
+A diff scan of a typical PR completes in well under a minute. Full-tree
+scans (post-merge push to main) take 2–4 minutes. If a PR scan takes
+longer than ~3 minutes, it usually means `SEMGREP_BASELINE_REF` didn't
+resolve correctly and the scan is running full-tree — check the workflow
+log for the resolved baseline ref.
 
 ## Workflow guarantees
 
-The workflow at `.github/workflows/security-scan.yml`:
+`.github/workflows/security-scan.yml`:
 
-- Runs on `pull_request` to `main` (not `pull_request_target` — DPF lacks an
-  external fork-PR flow today; adding it requires explicit trust-boundary
-  review).
-- Uploads SARIF to GitHub Code Scanning so findings appear inline on the PR
-  Files tab and in the Security tab.
-- Skips on Dependabot PRs (those are covered by the post-merge `push` trigger).
-- Blocks merge on any ERROR or WARNING finding introduced by the PR.
-- Filters out INFO findings entirely in v1; see the workflow's header comment
-  for the upgrade path when block/comment split is needed.
+- Runs on `pull_request` to `main` (not `pull_request_target` — DPF has
+  no external fork-PR flow today).
+- Uploads SARIF to GitHub Code Scanning so findings appear inline on the
+  PR Files tab and in the Security tab.
+- Skips on Dependabot PRs (those are covered by the post-merge `push`
+  trigger).
+- Degrades gracefully if `SEMGREP_APP_TOKEN` is absent — still scans, but
+  against the limited community ruleset.


### PR DESCRIPTION
## Summary
Forward-fix for [#1058](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1058) — switches the Semgrep workflow from `semgrep scan --config=p/...` to the canonical `semgrep ci` invocation that consumes `SEMGREP_APP_TOKEN`.

## Why
Acceptance test on demo PR [#1061](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1061) (closed without merging) revealed:

| Iteration | Filter / config | Rules loaded | Findings on deliberate AWS keys + Math.random + eval |
|---|---|---|---|
| 1 | `--severity ERROR WARNING` | 126 / 696 | **0** |
| 2 | (same — second push) | 126 / 696 | **0** |
| 3 | No severity filter | 148 / 713 | **0** |

Decisive log line:
> `(need more rules? semgrep login for additional free Semgrep Registry rules)`

The unauthenticated community registry is significantly limited. Hardcoded `AKIAIOSFODNN7EXAMPLE`, `Math.random()` for tokens, `eval(payload)` — all missed. The fuller ruleset (OWASP, secrets, framework-specific) requires `SEMGREP_APP_TOKEN`.

## What changes
- `semgrep scan --config=p/...` → `semgrep ci`. The `ci` subcommand reads `SEMGREP_APP_TOKEN`, pulls the full registry, and uses rule metadata to decide block-vs-audit per finding.
- Removed the `--severity` filter. Semgrep 1.163's flag only accepts legacy `INFO|WARNING|ERROR`; modern rules tag `CRITICAL|HIGH|MEDIUM|LOW` in metadata and were silently filtered out. Metadata-driven blocking replaces it.
- `--baseline-commit` → `SEMGREP_BASELINE_REF` env (canonical for `semgrep ci`).
- SARIF upload gated on file existence so config errors don't blow up the post step.

## One-time owner setup (you, Mark)
Without `SEMGREP_APP_TOKEN` the workflow degrades gracefully — runs against the limited community ruleset, doesn't fail. To unlock the full registry (free for OSS projects):

1. Sign in at https://semgrep.dev with the GitHub account that owns the repo.
2. Create a project pointing at `OpenDigitalProductFactory/opendigitalproductfactory`.
3. **Settings → Tokens** → generate a CI token, copy the value.
4. In GitHub: **Settings → Secrets and variables → Actions → New repository secret**:
   - Name: `SEMGREP_APP_TOKEN`
   - Value: the token.
5. Next PR's Semgrep Scan picks it up automatically.

Full setup walkthrough in `docs/security/semgrep.md` → "Activating the full ruleset".

## Telemetry note
`SEMGREP_SEND_METRICS=off` suppresses anonymous CLI usage stats. With the token set, scan findings metadata is sent to semgrep.dev (that's the point of the integration); source code itself never leaves the runner.

## Test plan
- [ ] This PR's Semgrep Scan runs and passes (graceful degradation works pre-secret).
- [ ] After you add `SEMGREP_APP_TOKEN`, open a follow-up demo with a hardcoded AWS-style key and confirm it's now caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)