### PR TITLE
fix: prefer IPv4 loopback for local MCP clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ MCP bearer tokens use the `dpfmcp_...` pattern and are issued from Admin > Platf
 **Token rotation — Claude Code and Codex:** Both tools read the token from the `DPF_MCP_BEARER_TOKEN` Windows user environment variable. `.mcp.json` references it as `${DPF_MCP_BEARER_TOKEN}`; Codex does the same via `bearer_token_env_var` in `~/.codex/config.toml`. Token rotation from Admin > Platform Development > MCP is:
 ```powershell
 [System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', '<new-token>', 'User')
-Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{"token":"<new-token>"}'
+Invoke-RestMethod -Method Post -Uri 'http://127.0.0.1:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{"token":"<new-token>"}'
 ```
 Then retry the MCP call in the running session. No file edits. No re-registration.
 

--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -147,7 +147,7 @@ describe("McpTokenManager", () => {
         vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_COPYABLE"}}}}',
         syncCommand: ".\\scripts\\seed-worktree-mcp.ps1",
         envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_COPYABLE', 'User')",
-        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_COPYABLE\"}'",
+        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://127.0.0.1:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_COPYABLE\"}'",
       },
     });
 
@@ -179,7 +179,7 @@ describe("McpTokenManager", () => {
         vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer ${env:DPF_MCP_BEARER_TOKEN}"}}}}',
         syncCommand: ".\\scripts\\seed-worktree-mcp.ps1",
         envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_COPYABLE', 'User')",
-        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_COPYABLE\"}'",
+        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://127.0.0.1:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_COPYABLE\"}'",
       },
     });
 
@@ -211,7 +211,7 @@ describe("McpTokenManager", () => {
         vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_ROTATED"}}}}',
         syncCommand: ".\\scripts\\seed-worktree-mcp.ps1",
         envPowerShell: "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_ROTATED', 'User')",
-        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_ROTATED\"}'",
+        runtimeRefreshPowerShell: "Invoke-RestMethod -Method Post -Uri 'http://127.0.0.1:3000/api/mcp/token/refresh' -ContentType 'application/json' -Body '{\"token\":\"dpfmcp_ROTATED\"}'",
       },
     });
 

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -456,7 +456,7 @@ describe("issueMyMcpToken", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unreachable");
     expect(result.plaintext).toBe("dpfmcp_SECRET");
-    expect(result.setupSnippets.claudeCode).toContain("http://localhost:3000/api/mcp/v1");
+    expect(result.setupSnippets.claudeCode).toContain("http://127.0.0.1:3000/api/mcp/v1");
     expect(result.setupSnippets.claudeCode).toContain("Bearer ${DPF_MCP_BEARER_TOKEN}");
     expect(result.setupSnippets.vscode).toContain("Bearer ${env:DPF_MCP_BEARER_TOKEN}");
     expect(result.setupSnippets.codex).toContain('bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"');

--- a/apps/web/lib/auth/mcp-setup-snippets.test.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { buildSetupSnippets } from "./mcp-setup-snippets";
 
 const BASE = "http://localhost:3000";
+const LOCAL_MCP_URL = "http://127.0.0.1:3000/api/mcp/v1";
+const LOCAL_REFRESH_URL = "http://127.0.0.1:3000/api/mcp/token/refresh";
 const TOKEN = "dpfmcp_TESTTOKEN";
 
 describe("buildSetupSnippets", () => {
@@ -10,7 +12,7 @@ describe("buildSetupSnippets", () => {
     const parsed = JSON.parse(claudeCode) as Record<string, unknown>;
     const dpf = (parsed.mcpServers as Record<string, unknown>).dpf as Record<string, unknown>;
     expect(dpf.type).toBe("http");
-    expect(dpf.url).toBe(`${BASE}/api/mcp/v1`);
+    expect(dpf.url).toBe(LOCAL_MCP_URL);
     expect((dpf.headers as Record<string, string>).Authorization).toBe("Bearer ${DPF_MCP_BEARER_TOKEN}");
     expect(claudeCode).not.toContain(TOKEN);
   });
@@ -21,7 +23,7 @@ describe("buildSetupSnippets", () => {
     expect("mcpServers" in parsed).toBe(false);
     const dpf = (parsed.servers as Record<string, unknown>).dpf as Record<string, unknown>;
     expect(dpf.type).toBe("http");
-    expect(dpf.url).toBe(`${BASE}/api/mcp/v1`);
+    expect(dpf.url).toBe(LOCAL_MCP_URL);
     expect((dpf.headers as Record<string, string>).Authorization).toBe("Bearer ${env:DPF_MCP_BEARER_TOKEN}");
     expect(vscode).not.toContain(TOKEN);
   });
@@ -29,7 +31,7 @@ describe("buildSetupSnippets", () => {
   it("codex uses bearer_token_env_var instead of embedding the secret", () => {
     const { codex } = buildSetupSnippets(TOKEN, BASE);
     expect(codex).toContain("[mcp_servers.dpf]");
-    expect(codex).toContain(`url = "${BASE}/api/mcp/v1"`);
+    expect(codex).toContain(`url = "${LOCAL_MCP_URL}"`);
     expect(codex).toContain('bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"');
     expect(codex).not.toContain(TOKEN);
   });
@@ -40,7 +42,7 @@ describe("buildSetupSnippets", () => {
     expect(envPowerShell).toBe(
       "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_UNIQUETOKEN', 'User')",
     );
-    expect(runtimeRefreshPowerShell).toContain(`${BASE}/api/mcp/token/refresh`);
+    expect(runtimeRefreshPowerShell).toContain(LOCAL_REFRESH_URL);
     expect(runtimeRefreshPowerShell).toContain(`"token":"${t}"`);
   });
 
@@ -48,6 +50,18 @@ describe("buildSetupSnippets", () => {
     const { claudeCode, runtimeRefreshPowerShell } = buildSetupSnippets(TOKEN, "https://dpf.example.com");
     expect(claudeCode).toContain("https://dpf.example.com/api/mcp/v1");
     expect(runtimeRefreshPowerShell).toContain("https://dpf.example.com/api/mcp/token/refresh");
+  });
+
+  it("preserves a non-localhost HTTP baseUrl for LAN installs", () => {
+    const { claudeCode, runtimeRefreshPowerShell } = buildSetupSnippets(TOKEN, "http://192.168.0.200:3000");
+    expect(claudeCode).toContain("http://192.168.0.200:3000/api/mcp/v1");
+    expect(runtimeRefreshPowerShell).toContain("http://192.168.0.200:3000/api/mcp/token/refresh");
+  });
+
+  it("normalizes IPv6 loopback baseUrl to IPv4 for local clients", () => {
+    const { claudeCode, runtimeRefreshPowerShell } = buildSetupSnippets(TOKEN, "http://[::1]:3000");
+    expect(claudeCode).toContain(LOCAL_MCP_URL);
+    expect(runtimeRefreshPowerShell).toContain(LOCAL_REFRESH_URL);
   });
 
   it("JSON setup outputs are valid JSON", () => {

--- a/apps/web/lib/auth/mcp-setup-snippets.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.ts
@@ -20,9 +20,25 @@ function psSingleQuoted(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+function normalizeLocalClientBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  try {
+    const parsed = new URL(trimmed);
+    const hostname = parsed.hostname.toLowerCase();
+    if (parsed.protocol === "http:" && (hostname === "localhost" || hostname === "::1" || hostname === "[::1]")) {
+      parsed.hostname = "127.0.0.1";
+      return parsed.toString().replace(/\/+$/, "");
+    }
+  } catch {
+    return trimmed;
+  }
+  return trimmed;
+}
+
 export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetupSnippets {
-  const url = `${baseUrl}/api/mcp/v1`;
-  const refreshUrl = `${baseUrl}/api/mcp/token/refresh`;
+  const clientBaseUrl = normalizeLocalClientBaseUrl(baseUrl);
+  const url = `${clientBaseUrl}/api/mcp/v1`;
+  const refreshUrl = `${clientBaseUrl}/api/mcp/token/refresh`;
   const httpEntry = {
     type: "http",
     url,

--- a/docs/superpowers/plans/2026-05-24-mcp-local-ipv4-client-config.md
+++ b/docs/superpowers/plans/2026-05-24-mcp-local-ipv4-client-config.md
@@ -1,0 +1,50 @@
+# MCP Local IPv4 Client Config Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent DPF MCP client setup from regenerating `localhost` URLs that can hang on Windows IPv6 loopback.
+
+**Architecture:** Normalize only local HTTP client-facing URLs from `localhost` to `127.0.0.1` in the shared MCP setup snippet helper, so Admin token issuance and the CLI share one behavior. Update the worktree sync script and docs command to use the same IPv4 loopback endpoint while preserving non-localhost LAN and HTTPS URLs unchanged.
+
+**Tech Stack:** Next.js/TypeScript helper tests with Vitest, Windows PowerShell sync script, AGENTS.md operational docs.
+
+---
+
+### Task 1: Shared MCP Setup Snippet Normalization
+
+**Files:**
+- Modify: `apps/web/lib/auth/mcp-setup-snippets.test.ts`
+- Modify: `apps/web/lib/auth/mcp-setup-snippets.ts`
+
+- [x] **Step 1: Write failing tests** for `http://localhost:3000` producing `http://127.0.0.1:3000` in Claude Code, VS Code, Codex, and runtime refresh snippets, while preserving `https://dpf.example.com`.
+- [x] **Step 2: Run focused Vitest** and confirm the new test fails because URLs still contain `localhost`.
+- [x] **Step 3: Implement minimal URL normalization** in the shared helper.
+- [x] **Step 4: Re-run focused Vitest** and confirm it passes.
+
+### Task 2: Sync Script and Docs Alignment
+
+**Files:**
+- Modify: `scripts/sync-mcp-worktrees.ps1`
+- Modify: `AGENTS.md`
+
+- [x] **Step 1: Update the sync script MCP URL** to `http://127.0.0.1:3000/api/mcp/v1`.
+- [x] **Step 2: Update AGENTS.md token refresh command** to use `127.0.0.1`.
+- [x] **Step 3: Inspect generated snippets/tests** so no source setup path still emits local `localhost`.
+
+### Task 3: Verification
+
+**Files:**
+- No additional source files.
+
+- [x] **Step 1: Run focused MCP setup tests.**
+- [x] **Step 2: Run the related MCP token action tests.**
+- [x] **Step 3: Verify live MCP still answers through Codex.**
+- [x] **Step 4: Report whether local untracked `.mcp.json` files also need regeneration or repair.**
+
+### Evidence
+
+- Focused Vitest: `apps/web/lib/auth/mcp-setup-snippets.test.ts`, `apps/web/lib/auth/mcp-host-writer.test.ts`, `apps/web/lib/actions/mcp-tokens.test.ts`, and `apps/web/components/admin/McpTokenManager.test.tsx`.
+- Typecheck: `pnpm --filter web typecheck`.
+- Production build: `cd apps/web && pnpm exec next build`.
+- Live MCP smoke: `http://127.0.0.1:3000/api/mcp/v1` `tools/list` succeeded.
+- Local repair: root `.mcp.json` and `.vscode/mcp.json` were updated to `127.0.0.1`.

--- a/scripts/sync-mcp-worktrees.ps1
+++ b/scripts/sync-mcp-worktrees.ps1
@@ -25,7 +25,7 @@ param(
 )
 
 $mcpJsonPath = Join-Path $RepoRoot ".mcp.json"
-$mcpUrl = "http://localhost:3000/api/mcp/v1"
+$mcpUrl = "http://127.0.0.1:3000/api/mcp/v1"
 $rotating = $PSBoundParameters.ContainsKey("Token")
 
 # -- Step 1: Resolve token ----------------------------------------------------


### PR DESCRIPTION
## Summary
- Normalize local HTTP MCP setup snippets from `localhost`/IPv6 loopback to `127.0.0.1` while preserving LAN and HTTPS base URLs.
- Align MCP token issuance tests, token-manager expectations, the worktree sync script, and AGENTS.md token-refresh docs.
- Add the implementation plan/evidence note for the MCP local IPv4 client-config repair.

## Root Cause
Portal token issuance and worktree sync paths could regenerate local MCP client URLs as `http://localhost:3000/api/mcp/v1`. On Windows, client resolution can prefer IPv6 loopback and time out even while the portal endpoint is healthy over IPv4.

## Verification
- `pnpm --filter web exec vitest run lib/auth/mcp-setup-snippets.test.ts lib/auth/mcp-host-writer.test.ts lib/actions/mcp-tokens.test.ts components/admin/McpTokenManager.test.tsx` - 4 files / 86 tests passed.
- `pnpm --filter web typecheck` - passed.
- `cd apps/web && pnpm exec next build` - passed; existing Edge-runtime/NFT warnings remain unrelated to this MCP URL fix.
- Direct JSON-RPC smoke against `http://127.0.0.1:3000/api/mcp/v1` `tools/list` succeeded with 152 tools.