### PR TITLE
demo(security): DoD acceptance — verify SEMGREP_APP_TOKEN catches AWS keys — DO NOT MERGE

### DIFF
--- a/apps/web/lib/security/__demo-pre-pr-gate.ts
+++ b/apps/web/lib/security/__demo-pre-pr-gate.ts
@@ -1,0 +1,17 @@
+/**
+ * DO NOT MERGE — definition-of-done acceptance demo for the Semgrep gate.
+ *
+ * Verifies that after PR #1064 wired `semgrep ci` to consume
+ * SEMGREP_APP_TOKEN, the gate now catches obvious bad patterns the
+ * unauthenticated community ruleset missed.
+ *
+ * Single-pattern test: a canonical AWS-format access key pair. If the
+ * SEMGREP_APP_TOKEN secret is correctly set on the repo, p/secrets +
+ * the platform secrets ruleset should flag both lines as blocking
+ * findings. If it doesn't, the secret is missing or scoped wrong.
+ *
+ * Branch will be closed without merging once the result is captured.
+ */
+
+export const AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+export const AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";


### PR DESCRIPTION
Final acceptance check for the shift-left security sequence (#1058, #1059, #1060, #1064).

Single deliberate pattern: a canonical AWS access key pair using the official example values (`AKIAIOSFODNN7EXAMPLE`).

**Expected outcome:** Semgrep Scan FAILS with `generic.secrets.security.detected-aws-access-key-id` (or equivalent) on both lines, proving the SEMGREP_APP_TOKEN secret is wired and the full registry is loaded. Will close this PR after capturing the result.