### PR TITLE
demo(security): DoD acceptance — verify gitleaks blocks AWS keys — DO NOT MERGE

### DIFF
--- a/apps/web/lib/security/__demo-gitleaks-gate.ts
+++ b/apps/web/lib/security/__demo-gitleaks-gate.ts
@@ -1,13 +1,21 @@
 /**
  * DO NOT MERGE — definition-of-done acceptance demo for the gitleaks gate.
  *
- * Single canonical AWS-format access key pair. If the gitleaks workflow
- * (PR #1069) is wired correctly, the Secrets Scan check on this PR will
- * FAIL with an `aws-access-token` finding (and the secret-key value
- * matching the AWS secret-access-key pattern), blocking merge.
+ * Previous attempt used AKIAIOSFODNN7EXAMPLE — AWS's canonical doc example,
+ * which gitleaks default config explicitly allowlists. The allowlist is
+ * correct behavior (prevents false positives in docs/fixtures); the demo
+ * just picked a bad value.
  *
- * Will be closed without merging once the result is captured.
+ * This revision uses a synthetic-but-not-allowlisted AKIA-format string
+ * and a synthetic GitHub PAT-format string. Both should match gitleaks'
+ * aws-access-token + github-pat rules and trip the gate.
+ *
+ * Will be closed without merging once captured.
  */
 
-export const AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
-export const AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+// aws-access-token: regex \b((?:AKIA|ABIA|ACCA)[A-Z0-9]{16})\b
+// 16 chars after AKIA, none matching the documented-example allowlist.
+export const FAKE_AWS_ACCESS_KEY_ID = "AKIAZZQ9PLMNT4XYRSVB";
+
+// github-pat: prefix `ghp_` + 36 chars of [a-zA-Z0-9].
+export const FAKE_GITHUB_PAT = "ghp_aB3kLpQrS5tUvW7xY9zA1bC2dE4fG6hI8jK0";

--- a/apps/web/lib/security/__demo-gitleaks-gate.ts
+++ b/apps/web/lib/security/__demo-gitleaks-gate.ts
@@ -1,0 +1,13 @@
+/**
+ * DO NOT MERGE — definition-of-done acceptance demo for the gitleaks gate.
+ *
+ * Single canonical AWS-format access key pair. If the gitleaks workflow
+ * (PR #1069) is wired correctly, the Secrets Scan check on this PR will
+ * FAIL with an `aws-access-token` finding (and the secret-key value
+ * matching the AWS secret-access-key pattern), blocking merge.
+ *
+ * Will be closed without merging once the result is captured.
+ */
+
+export const AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+export const AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";


### PR DESCRIPTION
Definition-of-done acceptance for [#1069](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1069). Single canonical AWS access-key pair in apps/web/lib/security/__demo-gitleaks-gate.ts. Expected: Secrets Scan check FAILS with an aws-access-token finding, blocking merge. Will be closed after capturing the result.