### PR TITLE
fix(build-studio): start_ideate/scout_research target the user's actual build (BI-F4A30FCB)

### DIFF
--- a/apps/web/lib/build/ideate-build-resolution.test.ts
+++ b/apps/web/lib/build/ideate-build-resolution.test.ts
@@ -1,0 +1,163 @@
+// apps/web/lib/build/ideate-build-resolution.test.ts
+//
+// Regression coverage for BI-F4A30FCB (Dale dogfood 2026-05-24).
+//
+// Two Build Studio tools (start_ideate_research, start_scout_research) used
+// to silently mis-target whichever ideate-phase build had the highest
+// updatedAt — meaning when multiple builds were in ideate concurrently, the
+// user's research request would land on an unrelated build. Bug hid behind
+// success:true responses. These tests pin the resolveIdeateBuildForToolPure
+// helper's behavior so the same class of bug can't reintroduce.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveIdeateBuildForToolPure,
+  type IdeateBuildResolverDeps,
+} from "./ideate-build-resolution";
+
+function makeDeps(overrides: Partial<IdeateBuildResolverDeps> = {}): IdeateBuildResolverDeps {
+  return {
+    findUniqueBuild: vi.fn().mockResolvedValue(null),
+    findIdeateBuilds: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe("resolveIdeateBuildForToolPure (BI-F4A30FCB regression)", () => {
+  describe("explicit contextBuildId path", () => {
+    it("returns the explicit build when it exists and is in ideate", async () => {
+      const findUniqueBuild = vi.fn().mockResolvedValue({
+        buildId: "FB-DALE",
+        phase: "ideate",
+      });
+      const findIdeateBuilds = vi.fn();
+
+      const result = await resolveIdeateBuildForToolPure(
+        { contextBuildId: "FB-DALE", toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toEqual({ buildId: "FB-DALE" });
+      expect(findUniqueBuild).toHaveBeenCalledWith("FB-DALE");
+      // Critical: should NOT have fallen through to the findMany path.
+      expect(findIdeateBuilds).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the explicit build doesn't exist", async () => {
+      const findUniqueBuild = vi.fn().mockResolvedValue(null);
+      const findIdeateBuilds = vi.fn();
+
+      const result = await resolveIdeateBuildForToolPure(
+        { contextBuildId: "FB-DOES-NOT-EXIST", toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toBe(null);
+      expect(result.refusal?.success).toBe(false);
+      expect(result.refusal?.message).toContain("Couldn't find that build");
+      expect(findIdeateBuilds).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the explicit build is past ideate (plan/build/review/ship)", async () => {
+      const findUniqueBuild = vi.fn().mockResolvedValue({
+        buildId: "FB-IN-PLAN",
+        phase: "plan",
+      });
+      const findIdeateBuilds = vi.fn();
+
+      const result = await resolveIdeateBuildForToolPure(
+        { contextBuildId: "FB-IN-PLAN", toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toBe(null);
+      expect(result.refusal?.success).toBe(false);
+      expect(result.refusal?.message).toContain("plan");
+      expect(findIdeateBuilds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("implicit fallback path (no contextBuildId)", () => {
+    it("accepts the single ideate build when exactly one exists", async () => {
+      const findUniqueBuild = vi.fn();
+      const findIdeateBuilds = vi.fn().mockResolvedValue([{ buildId: "FB-ONLY-ONE" }]);
+
+      const result = await resolveIdeateBuildForToolPure(
+        { toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toEqual({ buildId: "FB-ONLY-ONE" });
+      // Sanity: findUnique should not have been called when no contextBuildId.
+      expect(findUniqueBuild).not.toHaveBeenCalled();
+    });
+
+    it("refuses when zero ideate builds exist", async () => {
+      const findIdeateBuilds = vi.fn().mockResolvedValue([]);
+
+      const result = await resolveIdeateBuildForToolPure(
+        { toolName: "start_ideate_research" },
+        makeDeps({ findIdeateBuilds }),
+      );
+
+      expect(result.build).toBe(null);
+      expect(result.refusal?.success).toBe(false);
+      expect(result.refusal?.message).toContain("planning conversation");
+    });
+
+    it("REFUSES when 2+ ideate builds exist — the exact bug this regression test guards against", async () => {
+      // The bug: pre-fix, this case silently picked the most-recently-
+      // updated build, cross-contaminating its state. The new behavior is
+      // to refuse so the failure is loud rather than silent.
+      const findIdeateBuilds = vi.fn().mockResolvedValue([
+        { buildId: "FB-NEWER" },
+        { buildId: "FB-OLDER" },
+      ]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await resolveIdeateBuildForToolPure(
+        { toolName: "start_ideate_research" },
+        makeDeps({ findIdeateBuilds }),
+      );
+
+      expect(result.build).toBe(null);
+      expect(result.refusal?.success).toBe(false);
+      // User-facing message must be plain English (rule #13 — no schema names,
+      // no build IDs leaked).
+      expect(result.refusal?.message).not.toContain("FB-NEWER");
+      expect(result.refusal?.message).not.toContain("FB-OLDER");
+      expect(result.refusal?.message).not.toContain("featureBuildId");
+      // The engineering hint must be logged for the operator to find.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("context.featureBuildId"),
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("cross-contamination scenario (the exact Dale dogfood repro)", () => {
+    it("targets the user's build FB-DALE when contextBuildId=FB-DALE, even when FB-OTHER has a newer updatedAt", async () => {
+      // Repro: two builds in ideate; FB-OTHER updated more recently. Pre-fix,
+      // the tool's `findFirst orderBy updatedAt desc` would have grabbed
+      // FB-OTHER. Post-fix, the explicit contextBuildId wins and findMany
+      // never runs.
+      const findUniqueBuild = vi.fn().mockResolvedValue({
+        buildId: "FB-DALE",
+        phase: "ideate",
+      });
+      const findIdeateBuilds = vi.fn();
+
+      const result = await resolveIdeateBuildForToolPure(
+        { contextBuildId: "FB-DALE", toolName: "start_ideate_research" },
+        makeDeps({ findUniqueBuild, findIdeateBuilds }),
+      );
+
+      expect(result.build).toEqual({ buildId: "FB-DALE" });
+      // findMany must never run when explicit buildId is honored — the
+      // bug lives in the fallback path; explicit-buildId must short-circuit.
+      expect(findIdeateBuilds).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/lib/build/ideate-build-resolution.ts
+++ b/apps/web/lib/build/ideate-build-resolution.ts
@@ -1,0 +1,113 @@
+// apps/web/lib/build/ideate-build-resolution.ts
+//
+// BI-F4A30FCB (Dale dogfood 2026-05-24).
+//
+// Resolves the build that an ideate-phase tool (start_ideate_research,
+// start_scout_research, ...) should act on.
+//
+// The prior pattern was
+//   prisma.featureBuild.findFirst({
+//     where: { phase: "ideate" },
+//     orderBy: { updatedAt: "desc" },
+//   })
+// which silently cross-contaminates state when multiple builds are in ideate
+// concurrently — the user's request landed on whichever unrelated build's
+// `updatedAt` was most recent. The bug hid behind a `success: true` response
+// so neither the user nor the agent had any way to see the mismatch.
+//
+// Resolution order:
+//   1. Explicit `contextBuildId` from the agent's `featureBuildId` — verify
+//      the build exists AND is currently in ideate; reject otherwise.
+//   2. No explicit buildId AND exactly one ideate-phase build exists →
+//      assume that build (single-operator, single-build case).
+//   3. No explicit buildId AND 0 or 2+ ideate builds → refuse with a clear,
+//      operator-actionable error rather than silently mis-targeting.
+//
+// Lives in its own file (rather than inline in mcp-tools.ts) so the
+// regression tests can mock Prisma without dragging in mcp-tools.ts's full
+// import surface.
+
+// Mirror of ToolResult from mcp-tools.ts (kept inline to avoid pulling that
+// file's full import surface into the regression test).
+type ToolResult = {
+  success: boolean;
+  entityId?: string;
+  message: string;
+  error?: string;
+  data?: Record<string, unknown>;
+};
+
+export type IdeateBuildResolverDeps = {
+  findUniqueBuild: (buildId: string) => Promise<{ buildId: string; phase: string } | null>;
+  findIdeateBuilds: () => Promise<Array<{ buildId: string }>>;
+};
+
+export type IdeateBuildResolution =
+  | { build: { buildId: string }; refusal?: never }
+  | { build: null; refusal: ToolResult };
+
+export async function resolveIdeateBuildForToolPure(
+  args: { contextBuildId?: string; toolName: string },
+  deps: IdeateBuildResolverDeps,
+): Promise<IdeateBuildResolution> {
+  // Path 1: explicit buildId from agent context.
+  if (args.contextBuildId) {
+    const explicit = await deps.findUniqueBuild(args.contextBuildId);
+    if (!explicit) {
+      return {
+        build: null,
+        refusal: {
+          success: false,
+          message:
+            "Couldn't find that build to start research on. The system may have removed or renamed it — try selecting a build from the list and asking again.",
+        },
+      };
+    }
+    if (explicit.phase !== "ideate") {
+      return {
+        build: null,
+        refusal: {
+          success: false,
+          message:
+            `That build has already moved past the planning conversation — it's now in the ${explicit.phase} phase. Research is only started during the planning conversation. Pick a build that's still in planning, or continue the work this build is currently in.`,
+        },
+      };
+    }
+    return { build: { buildId: explicit.buildId } };
+  }
+
+  // Path 2 / 3: no explicit buildId — only accept the implicit "latest"
+  // when exactly one ideate-phase build exists.
+  const ideateBuilds = await deps.findIdeateBuilds();
+  if (ideateBuilds.length === 0) {
+    return {
+      build: null,
+      refusal: {
+        success: false,
+        message:
+          "There isn't a planning conversation open right now. Start a new feature first, then ask me to research it.",
+      },
+    };
+  }
+  if (ideateBuilds.length === 1) {
+    return { build: { buildId: ideateBuilds[0]!.buildId } };
+  }
+
+  // 2+ ideate builds and no explicit buildId. This means the agentic loop
+  // didn't pipe featureBuildId into the tool context. Log + refuse so the
+  // failure is loud rather than silent (this is the exact symptom Dale's
+  // dogfood surfaced — concurrent ideate builds cross-contaminating).
+  console.warn(
+    `[ideate-build-resolution] ${args.toolName} called without context.featureBuildId while ${ideateBuilds.length} builds are in ideate. ` +
+      "Cannot pick the correct target — refusing rather than silently mis-targeting. " +
+      "Fix: ensure runAgenticLoop.featureBuildId flows into the tool context (see agentic-loop.ts → governedExecuteTool).",
+  );
+  return {
+    build: null,
+    refusal: {
+      success: false,
+      message:
+        "I couldn't tell which build you wanted me to research — the system is processing several feature conversations right now. Open the specific feature you want and ask again from inside it.",
+    },
+  };
+}

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -32,6 +32,15 @@ export type GovernedExecuteContext = {
   taskRunId?: string;
   apiTokenId?: string;
   /**
+   * Build the user is currently messaging from. Plumbed by runAgenticLoop
+   * (via its `featureBuildId` param) so phase-scoped tools like
+   * start_ideate_research / start_scout_research target the correct build
+   * instead of fishing for "latest in phase X" — which silently
+   * cross-contaminates state when multiple builds are in the same phase
+   * (BI-F4A30FCB, Dale dogfood 2026-05-24).
+   */
+  featureBuildId?: string;
+  /**
    * Governed Hermes learning Slice 1: active coworker skill for this call.
    * Set by runAgenticLoop when the parent run is attributed to a specific
    * skill invocation. Persisted to ToolExecution.skillId so reflection and
@@ -166,6 +175,7 @@ async function callExecuteTool(
     threadId?: string;
     routeContext?: string;
     taskRunId?: string;
+    featureBuildId?: string;
   },
 ): Promise<ToolResult> {
   if (_executeToolOverride) return _executeToolOverride(toolName, params, userId, ctx);
@@ -442,6 +452,7 @@ export async function governedExecuteTool(
       threadId: args.context?.threadId,
       routeContext: args.context?.routeContext,
       taskRunId: args.context?.taskRunId,
+      featureBuildId: args.context?.featureBuildId,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown tool error";

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -81,7 +81,20 @@ import { ROUTE_AGENT_MAP_ENTRIES } from "@/lib/tak/agent-routing";
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type BuildPhaseTag = "ideate" | "plan" | "build" | "review" | "ship";
-type ToolExecutionContext = { routeContext?: string; agentId?: string; threadId?: string; taskRunId?: string };
+type ToolExecutionContext = {
+  routeContext?: string;
+  agentId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  /**
+   * Build the user is currently messaging from. Plumbed by agentic-loop.ts
+   * from runAgenticLoop's `featureBuildId` param so phase-scoped tools can
+   * target the correct build instead of fishing for "latest in phase X" —
+   * which silently cross-contaminates state when multiple concurrent builds
+   * are in the same phase (BI-F4A30FCB, Dale dogfood 2026-05-24).
+   */
+  featureBuildId?: string;
+};
 
 /** MCP tool annotation hints (from MCP spec + n8n-MCP pattern).
  *  These let the agent router and governance layer make safety decisions
@@ -4188,6 +4201,31 @@ function redactFunctionalFailureText(text: string): string {
   return text
     .replace(/\bdpfmcp_[A-Za-z0-9_-]+/g, "[redacted-token]")
     .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]");
+}
+
+// BI-F4A30FCB (Dale dogfood 2026-05-24): see ideate-build-resolution.ts for
+// the why. Re-exported here so existing imports keep working; new callers
+// should import from "@/lib/build/ideate-build-resolution".
+import { resolveIdeateBuildForToolPure } from "@/lib/build/ideate-build-resolution";
+
+export async function resolveIdeateBuildForTool(args: {
+  contextBuildId?: string;
+  toolName: string;
+}) {
+  return resolveIdeateBuildForToolPure(args, {
+    findUniqueBuild: async (buildId) =>
+      prisma.featureBuild.findUnique({
+        where: { buildId },
+        select: { buildId: true, phase: true },
+      }),
+    findIdeateBuilds: async () =>
+      prisma.featureBuild.findMany({
+        where: { phase: "ideate" },
+        orderBy: { updatedAt: "desc" },
+        select: { buildId: true },
+        take: 2, // only need to distinguish 0 / 1 / 2+
+      }),
+  });
 }
 
 export async function executeTool(
@@ -9577,32 +9615,37 @@ export async function executeTool(
       // agent-coworker.ts after the agentic loop returns. We just persist
       // the user context so the dispatch knows what to research.
       const scope = String(params.reusabilityScope ?? "parameterizable");
-      const context = String(params.userContext ?? "");
+      const userCtx = String(params.userContext ?? "");
 
-      // Store the research request on the build record
-      const activeBuild = await prisma.featureBuild.findFirst({
-        where: { phase: "ideate" },
-        orderBy: { updatedAt: "desc" },
-        select: { buildId: true },
+      // BI-F4A30FCB (Dale dogfood 2026-05-24): resolve the target build
+      // from agent context first. The previous "findFirst by phase=ideate
+      // ordered by updatedAt" silently mis-targeted whenever multiple
+      // builds were in ideate concurrently — the user's request landed on
+      // an unrelated build whose updatedAt happened to be newer.
+      const activeBuild = await resolveIdeateBuildForTool({
+        contextBuildId: context?.featureBuildId,
+        toolName: "start_ideate_research",
       });
-      if (activeBuild) {
-        await prisma.featureBuild.update({
-          where: { buildId: activeBuild.buildId },
-          data: {
-            buildExecState: {
-              ideateResearchRequested: true,
-              reusabilityScope: scope,
-              userContext: context,
-              requestedAt: new Date().toISOString(),
-            },
-          },
-        });
+      if (!activeBuild.build) {
+        return activeBuild.refusal;
       }
+
+      await prisma.featureBuild.update({
+        where: { buildId: activeBuild.build.buildId },
+        data: {
+          buildExecState: {
+            ideateResearchRequested: true,
+            reusabilityScope: scope,
+            userContext: userCtx,
+            requestedAt: new Date().toISOString(),
+          },
+        },
+      });
 
       return {
         success: true,
         message: "Research started. Searching the codebase and drafting the design document — this takes about 1-2 minutes. Tell the user you're researching now. IMPORTANT: Do NOT call saveBuildEvidence with field 'designDoc' — the research system saves the design document and runs the review automatically when research completes. Just wait and tell the user.",
-        data: { reusabilityScope: scope, userContext: context },
+        data: { reusabilityScope: scope, userContext: userCtx, buildId: activeBuild.build.buildId },
       };
     }
 
@@ -9610,13 +9653,21 @@ export async function executeTool(
       // Scout dispatch: similar to ideate research, but runs a fast parallel search + URL fetch
       const externalUrls = (params.externalUrls as string[] | undefined) ?? [];
 
-      const activeBuild = await prisma.featureBuild.findFirst({
-        where: { phase: "ideate" },
-        orderBy: { updatedAt: "desc" },
+      // BI-F4A30FCB (Dale dogfood 2026-05-24): resolve the target build
+      // from agent context first; see start_ideate_research comment above.
+      const resolved = await resolveIdeateBuildForTool({
+        contextBuildId: context?.featureBuildId,
+        toolName: "start_scout_research",
+      });
+      if (!resolved.build) {
+        return resolved.refusal;
+      }
+      const activeBuild = await prisma.featureBuild.findUnique({
+        where: { buildId: resolved.build.buildId },
         select: { buildId: true, buildExecState: true, scoutFindings: true },
       });
       if (!activeBuild) {
-        return { success: false, message: "No active ideate build found." };
+        return { success: false, message: "Active ideate build vanished between resolve and read — try again." };
       }
 
       const current = activeBuild.buildExecState as Record<string, unknown> | null;

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1579,6 +1579,11 @@ export async function runAgenticLoop(params: {
             taskRunId: taskRunId ?? undefined,
             apiTokenId: apiTokenId ?? undefined,
             skillId: activeSkillId ?? undefined,
+            // BI-F4A30FCB (Dale dogfood 2026-05-24): plumb the build the
+            // user is messaging from into tool context so phase-scoped
+            // tools (start_ideate_research, start_scout_research) can
+            // target the correct build instead of "latest in phase".
+            featureBuildId: params.featureBuildId ?? undefined,
           },
           source: "agentic-loop",
         });


### PR DESCRIPTION
## Summary

Surgical fix for a CRITICAL multi-build correctness bug discovered via Dale dogfood Phase E (2026-05-24).

`start_ideate_research` and `start_scout_research` used to resolve "the active build" with `findFirst({ where: { phase: "ideate" }, orderBy: { updatedAt: "desc" } })`. When multiple builds are in ideate concurrently — common the moment Build Studio sees real use — the user's research request silently lands on whichever unrelated build had the freshest `updatedAt`. Bug hides behind `success: true` so neither the user nor the agent has any way to see the mismatch.

## How it was discovered

Driving Dale's FB-6F7D6AC4 (truck-parts inventory) through Ideate on the new production-bundled portal serving merged PR #1070. Mid-conversation, the agent called `start_ideate_research` with Dale's userContext correctly summarized. Direct DB query confirmed the userContext got written to `FB-291BC06C` (an unrelated Portal self-upgrade build, fresher updatedAt) instead. Dale's actual build got nothing. The agent told Dale "researching now" and Dale waited ~10 minutes for a design being generated against the wrong feature.

```
buildId      | userContext-in-execState
FB-291BC06C  | "user wants technicians to see what parts..."   <- WRONG BUILD
FB-6F7D6AC4  | (empty)                                          <- Dale's actual build
```

Full repro evidence + tool execution trace are in BI-F4A30FCB.

## Fix shape

1. **Plumb `featureBuildId` through the tool context.** `agentic-loop.ts` already had `params.featureBuildId` in scope (it's been there since the build phase guard added it); just needed to forward it through `governedExecuteTool → ToolExecutionContext`.
2. **Extract a pure `resolveIdeateBuildForToolPure` helper** to its own file ([apps/web/lib/build/ideate-build-resolution.ts](apps/web/lib/build/ideate-build-resolution.ts)). Three-path resolution:
   - Explicit `contextBuildId` → verify exists + is in ideate → return it.
   - No explicit buildId + exactly 1 ideate build → return it (single-operator case stays working).
   - No explicit buildId + 0 or 2+ ideate builds → REFUSE with a plain-English message; log the wiring gap for the operator.
3. **Both tools use the new helper** instead of the old findFirst-by-phase pattern.
4. **User-facing messages obey IDENTITY_BLOCK rule #13** — no build IDs, no schema names, no infrastructure terms leak. The engineering hint (`Fix: ensure runAgenticLoop.featureBuildId flows into the tool context`) goes to `console.warn`, not the user-facing response.

The pure helper lives outside `mcp-tools.ts` so the regression test can mock its two dependencies without dragging in mcp-tools.ts's full import surface (which also pulls in workspace packages that are currently flaky for local typecheck).

## Test plan

- [x] `pnpm exec vitest run lib/build/ideate-build-resolution.test.ts` — **7/7 pass** locally
- [x] Branched off latest `origin/main`; no overlap with other open PRs
- [x] DCO signed
- [ ] CI typecheck (runs in clean env; host typecheck artifact unrelated to this PR)
- [ ] Manual repro post-merge: with 2+ ideate builds, message into the older one — verify scout/ideate target THAT build, not the newest

## What's covered (regression suite)

- explicit contextBuildId returns the right build when it's in ideate
- explicit contextBuildId refuses when the build doesn't exist
- explicit contextBuildId refuses when the build is past ideate
- no contextBuildId + single ideate build → returns it
- no contextBuildId + zero ideate builds → refuses
- no contextBuildId + 2+ ideate builds → refuses + warn-logs the wiring gap
- the exact Dale dogfood repro: contextBuildId=FB-DALE wins even when another ideate build has a newer updatedAt; findMany must never run

## What's NOT in this PR

- Audit of other phase-scoped tools (plan/build/review/ship) for the same class of bug — none currently use the bad pattern (`grep -nE "findFirst.*phase|where: *\{ *phase:" lib/mcp-tools.ts` returns only the 2 fixed sites + 1 unrelated aggregate count). Worth a broader audit later but not urgent.
- D31 (BI-78499309) progress-visibility for long-running async tools — separate BI, separate PR.
- Anything else from EP-9FC5D2FD.

## References

- Memory: `feedback_check_tool_signals_first` — this BI exists because the agent's `success:true` response masked the actual failure for 10+ minutes during dogfood; DB query was the decisive evidence
- Memory: `feedback_evidence_before_diagnosis`
- BI-F4A30FCB, EP-9FC5D2FD

🤖 Generated with [Claude Code](https://claude.com/claude-code)