### PR TITLE
spec: founder kernel evolution discipline + 4 promoted principles (BI-746268A1)

### DIFF
--- a/docs/founder-kernel/wiki/principles/make-silent-failures-observable.md
+++ b/docs/founder-kernel/wiki/principles/make-silent-failures-observable.md
@@ -1,0 +1,151 @@
+---
+title: Make silent failures observable
+slug: make-silent-failures-observable
+pageKind: principle
+status: published
+abstract: Every "nothing happened" code path must emit a structured signal — a log line, a typed return value, a tracking record. A silent no-op is invisible work; invisible work is undebuggable, untrackable, and erodes operator trust.
+principleTier: core
+principleDirection: Emit a structured signal (log line, typed return, tracking record) on every "nothing happened" code path so silent failures become queryable.
+principleDimensionVector: {"evidence_density": 1.0, "governance_compliance": 0.6, "long_term_maintainability": 0.5, "human_cognitive_load": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleConsumerArchetype: ai-coworker-universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+---
+
+# Make silent failures observable
+
+**A code path that does nothing must say so.** Whether the path
+returned early because of an empty input, skipped a step because a
+precondition wasn't met, or genuinely had no work to do, the fact that
+nothing happened is itself a signal — and the signal has to leave a
+record.
+
+A silent no-op is invisible work. Invisible work cannot be debugged,
+cannot be tracked, cannot be calibrated against, and erodes operator
+trust the moment the operator notices the thing-that-should-have-happened
+didn't happen.
+
+## What "observable silent failure" looks like
+
+- A function that returns `null` because a lookup found nothing emits
+  `[surface.no-match]` log line with the lookup key, the call site, and a
+  tracking BI reference if the no-match represents work to do later.
+- A scheduled job that exits early because the queue was empty writes a
+  heartbeat record so the operator can tell the difference between "job
+  ran, queue was empty" and "job didn't run."
+- A contribution flow that aborts because DCO wasn't signed returns a
+  typed `{ outcome: 'aborted', reason: 'dco-missing', missingArtifacts: [...] }`
+  instead of `{ success: true, prUrl: null }`.
+- A seed step that skips a row because the FK target is missing emits
+  `[seed.skip]` with the row identifier and the missing FK, not a silent
+  pass.
+
+## Why this exists
+
+Three concrete examples from the platform's recent history:
+
+- **Governed-upgrade `resolveTargetSha`** (PR #1076): when the resolver
+  finds no target SHA, it now logs `self-upgrade.no-target` with a
+  tracking BI. Earlier behavior was a silent `null` return — the
+  self-upgrade loop simply did nothing, and the operator had no signal
+  that anything had even tried.
+- **Hive contribution silent-success** (memory
+  `project_hive_contribution_gaps`, PR #137): the earlier
+  `contribute_to_hive` returned `{ success: true, prUrl: null }` when
+  the contribution actually failed on missing DCO / missing token / PR
+  creation error. Three months of "contribution mode never works" traced
+  to that single silent no-op return shape. The fix was structured
+  failure outcomes — same surface, honest signal.
+- **Reduction Gear `slipDetected` + `slipReason`** (PR #1075): every
+  GearInterface record carries a `slipDetected` boolean and
+  `slipReason` taxonomy (`novel-context`, `failed-outcome`,
+  `human-override`, `cost-overrun`, `safety-block`, ...). Non-compounding
+  work becomes queryable; the operator can sort by slip reason and see
+  exactly why the gear train isn't transmitting torque.
+
+The silent-failure alternative — let the code path return early without
+emitting anything — produces three predictable failure modes:
+
+1. **Cannot diagnose.** The operator sees an outcome (or the absence of
+   one) and has no record of why. Diagnosis becomes archeology.
+2. **Cannot calibrate.** Trust calibration and graduation logic depend
+   on outcome attribution. A silent no-op contributes nothing to either —
+   the gear train spins without registering torque or slip.
+3. **Cannot prevent recurrence.** A silent failure that happens twice
+   is indistinguishable from a silent failure that happens a hundred
+   times. The pattern compounds invisibly.
+
+## What "structured signal" means
+
+Not every signal needs to be a log line at WARN severity. The
+signal must:
+
+- **Be discoverable.** A grep / log query / DB query lands on it
+  reliably when an operator goes looking.
+- **Carry the why.** Not just "function exited early" — the reason,
+  with enough identifiers to find the source row / record / input.
+- **Be cheap.** A `[surface.no-match]` log line at DEBUG is fine for
+  high-frequency no-ops; the goal is observability, not noise.
+- **Compose with the rest of the platform's evidence stream.**
+  GearInterface records, ToolExecution rows, tool-trace lines all
+  serve as structured signals.
+
+## When silent return is acceptable
+
+- **Inside a hot loop where the no-op is the dominant case** (e.g.
+  iterating a sparse array; cache lookups on a miss-heavy surface).
+  In those cases the *outer* surface emits the aggregate signal once
+  per call boundary, not per inner iteration.
+- **When the return type itself carries the signal** (e.g. a `Result<T>`
+  type whose `None` variant is structurally distinguishable from `Some`
+  by every consumer). The "signal" is the typed return, not a log line.
+
+The bar: a future debugger looking at this no-op must be able to tell
+*that it happened*, *why*, and *whether to care* — without re-running
+the original execution.
+
+## The contract
+
+Before merging a code path that can return early without doing the work
+the caller expected:
+
+1. **Name the no-op.** What does it look like from the caller's side?
+2. **Emit a signal.** Log line, typed return, or tracking record.
+3. **Make the signal queryable.** Future-you needs to find these by grep
+   or by DB query.
+4. **Decide whether to track.** If the no-op represents future work,
+   file a tracking BI in the same PR.
+
+## Anti-patterns
+
+- `if (!precondition) return;` with no log line and no typed return.
+- `{ success: true, prUrl: null }` or other shapes that conflate success
+  with no-op.
+- `try { ... } catch { /* ignore */ }` — the swallowed exception is the
+  failure that just went silent.
+- Early-return at the top of a function with no record that the call
+  even happened.
+
+## Related principles
+
+- [`fail-fast-explain-clearly`](fail-fast-explain-clearly.md) — paired
+  discipline; this principle covers the no-op case (nothing went wrong,
+  nothing happened, no record of why), `fail-fast` covers the error case
+- [`evidence-before-diagnosis`](evidence-before-diagnosis.md) — depends
+  on this; you can't query underlying state for diagnosis if the
+  underlying state was never recorded
+- [`check-tool-signals-first`](check-tool-signals-first.md) — the
+  caller-side counterpart; the tool's return value is the signal the
+  caller reads
+
+## Spec references
+
+- [Reduction Gear Architecture spec](../../../superpowers/specs/2026-05-24-reduction-gear-architecture-design.md) — §3.1 slipDetected / slipReason
+- [Governed-upgrade plan](../../../superpowers/plans/2026-05-23-governed-platform-upgrade-phase-0-and-1.md) — `self-upgrade.no-target` instrumentation
+- [Founder kernel evolution discipline spec](../../../superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) — §6.3 promotion record

--- a/docs/founder-kernel/wiki/principles/mirror-dont-migrate.md
+++ b/docs/founder-kernel/wiki/principles/mirror-dont-migrate.md
@@ -1,0 +1,125 @@
+---
+title: Mirror, don't migrate
+slug: mirror-dont-migrate
+pageKind: principle
+status: published
+abstract: When evolving substrate, mirror the canonical source into a runtime model and derive consumers from the mirror — rather than destructively replacing the canonical source with a new schema.
+principleTier: core
+principleDirection: Mirror canonical source data into a runtime model and derive consumers from the mirror, rather than destructively replacing the canonical source with a new schema.
+principleDimensionVector: {"long_term_maintainability": 0.8, "blast_radius": -0.7, "schema_grounding": 0.6, "speed_to_value": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - data-model
+  - engineering-flow
+principleRingScope:
+  - ring-3-archetype
+  - ring-4-sandbox-prod
+principlePublic: false
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+---
+
+# Mirror, don't migrate
+
+**When you need to evolve substrate, prefer adding a runtime mirror that
+reads from the canonical source and exposes a typed surface, over
+destructively replacing the canonical source with a new schema.**
+
+The mirror pattern keeps the old source authoritative through the
+transition, lets new consumers read from the typed runtime surface, and
+defers the cutover decision until evidence supports it.
+
+## What "mirror, don't migrate" looks like
+
+- **Phase 0:** identify the canonical source (a JSON file, an env var, an
+  existing table, a third-party API). Don't touch it.
+- **Phase 1:** add a runtime model (a Prisma row, a derived API endpoint,
+  a typed in-memory cache) whose only job is to reflect the canonical source.
+  Updates flow `source → mirror`. Reads happen against the mirror.
+- **Phase 2:** migrate consumers one at a time to read from the mirror.
+  The canonical source stays authoritative throughout.
+- **Phase 3 (optional, often never):** once every consumer reads from the
+  mirror and writes against it, retire the canonical source on a deliberate
+  cutover, not as a side effect of the new code landing.
+
+## Why this exists
+
+Two concrete examples from the platform's recent history:
+
+- **Governed-upgrade Phase 1** (PR #1076): `version.json` is the canonical
+  source for the installed bundle. Phase 1 added a `PlatformConfig.bundleSha`
+  mirror updated on platform boot, exposed `/api/platform/version`, and
+  surfaced a UI surface — without touching `version.json`'s role as the
+  source of truth on disk. A future Phase 2 can move to DB-authoritative,
+  but not until the mirror has shown it can serve every consumer.
+- **Reduction Gear Architecture** (PR #1075): `GearInterface` is proposed
+  as a dual-emit envelope alongside existing event tables
+  (`ToolExecution`, `BuildPhaseRun`, `RuntimeVerification`), NOT as a
+  replacement. The existing tables remain authoritative for their owning
+  surfaces; GearInterface becomes the common operator timeline only after
+  emitters prove correctness, retention, and Cockpit usability.
+
+The migrate-destructively alternative — drop the old table, point all
+consumers at the new one in one PR — produces three predictable failure modes:
+
+1. **Lost evidence.** Operator data living in the old table is gone
+   the moment the migration drops it. Recovery costs hours.
+2. **Atomic-PR blast radius.** Every consumer must change in the same PR,
+   so review takes longer, rollback is harder, and one missed call site
+   breaks the platform.
+3. **No graceful fallback.** If the new schema turns out to need a column
+   that wasn't anticipated, you have to migrate again on top of a
+   half-functional substrate.
+
+## When mirroring is the wrong default
+
+- **Bug-fix migrations.** If the canonical source has a defect that
+  every consumer experiences, fix the source — don't mirror the bug into
+  a runtime layer.
+- **Tiny consumers (< 3 call sites).** The mirror overhead isn't worth it
+  for a one-shot rewrite where the cutover is mechanical.
+- **Schema changes the framework requires.** Prisma column renames, for
+  instance, are physical — there is no mirroring possible around them.
+  Pair with `schema-honesty-over-aspirational-naming` so the name change
+  doesn't smuggle new meaning into the rename.
+
+## The contract
+
+Before opening a PR that replaces an existing source of truth, ask:
+
+1. **Who is the current canonical source?** Name it.
+2. **Why must I replace it rather than mirror it?** Document the reason.
+3. **What evidence do I have that the mirror is unworkable?** A claim of
+   "easier to just migrate" is not evidence.
+4. **What's the rollback path?** If you can't draw a one-line rollback for
+   the destructive option, the mirror is the architecturally sound choice.
+
+## Anti-patterns
+
+- "I'll just drop the old table and rebuild from this new one" without
+  evidence that every consumer is moved.
+- A new schema named for the future state, populated by a destructive
+  migration from the old one, with no fallback.
+- "We'll just deprecate the old API in this PR" — deprecation without a
+  mirror means the deprecation is the cutover.
+
+## Related principles
+
+- [`schema-honesty-over-aspirational-naming`](schema-honesty-over-aspirational-naming.md) —
+  paired discipline; the mirror should be named for what it carries today,
+  not the aspirational future shape
+- [`one-data-model`](one-data-model.md) — the architectural reason
+  ("not two integrated"); this principle is the migration-time pattern that
+  honors it through the transition
+- [`never-wipe-db-for-code-fixes`](never-wipe-db-for-code-fixes.md) —
+  destructive substrate change is the extreme case; this principle is the
+  general posture
+
+## Spec references
+
+- [Reduction Gear Architecture spec](../../../superpowers/specs/2026-05-24-reduction-gear-architecture-design.md) — §3.1, §4 dual-emit strategy
+- [Founder kernel evolution discipline spec](../../../superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) — §6.1 promotion record

--- a/docs/founder-kernel/wiki/principles/schema-honesty-over-aspirational-naming.md
+++ b/docs/founder-kernel/wiki/principles/schema-honesty-over-aspirational-naming.md
@@ -1,0 +1,129 @@
+---
+title: Schema honesty over aspirational naming
+slug: schema-honesty-over-aspirational-naming
+pageKind: principle
+status: published
+abstract: Name columns, types, and models for what they hold today. Defer aspirational names until the substrate actually carries the aspirational meaning. A misnamed schema misleads every reader and every consumer.
+principleTier: core
+principleDirection: Name columns, types, and models for what they hold today; defer aspirational names until the substrate actually carries the aspirational meaning.
+principleDimensionVector: {"schema_grounding": 0.9, "long_term_maintainability": 0.7, "evidence_density": 0.5, "human_cognitive_load": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - data-model
+  - engineering-flow
+principleRingScope:
+  - ring-2-workflow
+  - ring-3-archetype
+principlePublic: false
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+---
+
+# Schema honesty over aspirational naming
+
+**A column, type, model, or API field name is a promise about what it
+contains. If the name promises more than the substrate currently holds,
+every reader misreads it and every consumer codes against the promise
+rather than the reality.**
+
+Defer aspirational names until the substrate actually carries the
+aspirational meaning. A column named `currentSha` that holds a SHA is
+honest. A column named `currentVersion` that also holds only a SHA is a
+lie waiting to confuse the next reader.
+
+## What "schema honesty" looks like
+
+- A column that stores a Git SHA today and may store semantic versions
+  later is named `currentSha` today, not `currentVersion`. The rename
+  happens in the PR that actually changes what the column holds.
+- A model named `StorefrontArchetype` that genuinely stores
+  archetype-bootstrap data stays `StorefrontArchetype`. The runtime
+  capability calibration that would live elsewhere gets its own table
+  (`ArchetypeCapabilityProfile`), not a JSON blob hidden inside the
+  bootstrap model.
+- An enum value `pending_review` that currently means "waiting for
+  human" is named `pending_review`, not `pending_triage`, until the
+  triage workflow actually exists.
+
+## Why this exists
+
+Two concrete examples from the platform's recent work:
+
+- **Governed-upgrade plan** (PR #1076) explicitly kept SHA-named columns
+  (`currentSha`, `targetSha`) until the substrate would carry versions.
+  The Phase 2 versioning work renames in the same PR that introduces
+  version semantics — not before.
+- **Reduction Gear Architecture** (PR #1075) explicitly rejected
+  smuggling runtime-evolving capability data into the existing
+  `StorefrontArchetype` JSON fields. The spec proposes a separate
+  `ArchetypeCapabilityProfile` association table so the bootstrap-template
+  model keeps its honest scope, and the runtime calibration data gets a
+  name that reflects what it is.
+
+The misnamed-schema alternative — pick the aspirational name now to
+"save a rename later" — produces three predictable failure modes:
+
+1. **Every reader gets the wrong mental model.** A code reviewer reads
+   `currentVersion` and reasons about version semantics; the actual data is
+   a SHA, and the reasoning is wrong.
+2. **Consumers write code against the name, not the truth.** A future
+   service that depends on `currentVersion` being a semantic version
+   breaks the day a SHA shows up in the field. The schema lies; the
+   consumer crashes.
+3. **The rename you "saved" still happens.** When the substrate finally
+   carries the aspirational meaning, the column has to change either
+   way — and now it has consumers built on the wrong assumption.
+
+## When aspirational naming is acceptable
+
+- **Greenfield models with no consumers yet.** A new `ReleaseManifest`
+  table that ships with no readers can be named for its full intended
+  shape, because there are no current consumers to mislead.
+- **External standards.** If the data is a OAGIS / FHIR / OTel
+  attribute name, the standard's naming wins — schema honesty defers
+  to standards-alignment, not the other way around.
+- **A documented "this will hold X within N weeks" plan.** If a PR
+  description names the rename's trigger (e.g. "rename to
+  `currentVersion` in Phase 2 of `EP-PLATFORM-UPGRADE` when semver
+  semantics land"), the aspirational name is acceptable because the
+  honesty restoration is scheduled.
+
+## The contract
+
+Before naming any column, type, model, or API field:
+
+1. **Name what it holds today.** Not what you hope it will hold.
+2. **If the future name is different, document the rename trigger.** In
+   the spec or PR description, not as a `// TODO` comment.
+3. **Default to the SHA-name pattern.** Columns named for the literal
+   shape of the data they hold (SHA, URL, slug, timestamp) age better
+   than columns named for abstractions (version, identifier, name).
+
+## Anti-patterns
+
+- Naming a column `version` when it stores a SHA.
+- Naming a table `Workflow` when it stores BuildStudio phase runs only
+  (call it `BuildPhaseRun` until it generalizes).
+- Naming an enum value for the future workflow stage instead of the
+  current state.
+- A schema field that stores `null` today because "we'll fill it in
+  Phase 2" — either drop the field or document the trigger.
+
+## Related principles
+
+- [`mirror-dont-migrate`](mirror-dont-migrate.md) — paired discipline;
+  the mirror should be named honestly too
+- [`strongly-typed-string-enums`](strongly-typed-string-enums.md) — type
+  shape discipline; this is the name-meaning counterpart
+- [`single-source-of-truth`](single-source-of-truth.md) — the
+  architectural reason names must be honest
+
+## Spec references
+
+- [Governed-upgrade plan](../../../superpowers/plans/2026-05-23-governed-platform-upgrade-phase-0-and-1.md) — SHA-naming decision
+- [Reduction Gear Architecture spec](../../../superpowers/specs/2026-05-24-reduction-gear-architecture-design.md) — StorefrontArchetype scope decision
+- [Founder kernel evolution discipline spec](../../../superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) — §6.2 promotion record

--- a/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
+++ b/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
@@ -1,0 +1,156 @@
+---
+title: Substrate cleanup before substrate addition
+slug: substrate-cleanup-before-substrate-addition
+pageKind: principle
+status: published
+abstract: When adding a new substrate layer, consolidate the existing layer first. A Phase-0 cleanup pass that shrinks fragmentation beats a Phase-1 layer-on every time — and most "we'll clean up later" plans never come back to do it.
+principleTier: core
+principleDirection: Consolidate existing substrate before adding new substrate to it; a Phase-0 cleanup pass beats a Phase-1 layer-on every time.
+principleDimensionVector: {"long_term_maintainability": 0.8, "reusability": 0.6, "schema_grounding": 0.5, "speed_to_value": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - engineering-flow
+  - data-model
+  - portfolio
+principleRingScope:
+  - ring-2-workflow
+  - ring-3-archetype
+principlePublic: false
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+---
+
+# Substrate cleanup before substrate addition
+
+**Before adding a new substrate layer to the platform — a new table, a
+new event stream, a new coordination primitive, a new spec area — first
+consolidate the existing substrate the new layer will sit on.** A
+Phase-0 cleanup pass that shrinks fragmentation pays for itself many
+times over. A "we'll clean it up later" plan almost never returns to do
+the cleanup, because the new layer has already cemented the old
+fragmentation in place.
+
+## What "cleanup before addition" looks like
+
+- **Reserve 20% of implementation capacity** for refactoring existing
+  event/evidence/coordination seams before adding new emitters or
+  consumers. Treat the budget as non-optional, not as slack.
+- **Phase 0 of any multi-phase plan consolidates.** Phase 1+ adds. If a
+  plan starts at Phase 1 with no Phase 0, ask why the cleanup didn't
+  fit; the answer is usually "we didn't think we needed it" — which is
+  the classic reason the substrate keeps fragmenting.
+- **The cleanup PR ships first**, alone, with its own evidence. The
+  addition PR depends on the cleanup landing.
+
+## Why this exists
+
+Two concrete examples from the platform's recent work:
+
+- **Reduction Gear Architecture** (PR #1075) explicitly reserves at
+  least 20% of implementation capacity for "refactoring existing
+  event/evidence seams before adding new emitters." Quoting the spec:
+  *"The intent is to shrink fragmentation, not layer one more table over
+  unclear boundaries."* The architect's review forced this discipline
+  in — the original draft would have added GearInterface on top of the
+  existing fragmentation, locking it in.
+- **Governed-upgrade plan** (PR #1076) Phase 0 consolidates `version.json`
+  parsing and validation BEFORE Phase 1 introduces the PlatformConfig
+  mirror. Phase 1 doesn't dual-parse — it depends on the canonical
+  parser from Phase 0. Skipping Phase 0 would have meant two parsers,
+  silently drifting forever.
+
+The addition-without-cleanup alternative — ship the new layer and tell
+yourself you'll come back to refactor — produces three predictable
+failure modes:
+
+1. **The new layer cements the old fragmentation.** Now there are N+1
+   coordination mechanisms instead of N, and the new one depends on
+   the old shape staying frozen.
+2. **The "later" cleanup never happens.** Engineering attention moves
+   to the next addition. A year later the substrate has three layers
+   of partially-overlapping primitives and no one remembers which one
+   to use.
+3. **Operator cognitive load grows linearly with substrate count.**
+   The Reduction Gear spec named this explicitly: "the CEO cannot *see*
+   what's happening across procedural + A2A + specialist invocations +
+   gates + evidence with one query, in one view, on one timeline." That
+   surface is the cost of accreted substrate.
+
+## When skipping Phase 0 is acceptable
+
+- **The new substrate is genuinely orthogonal.** If you're adding a
+  surface that has zero overlap with existing primitives (rare), there
+  is nothing to consolidate first. The default assumption is that this
+  is wrong — verify before believing it (see
+  `verify-substrate-before-proposing-new`).
+- **The existing substrate is already clean.** If a recent audit
+  confirmed the fragmentation isn't there, you can ship Phase 1 first.
+  Cite the audit in the PR.
+- **Genuinely urgent fix.** A security-critical addition can ship before
+  cleanup if the cleanup would block the fix. File the Phase 0 cleanup
+  as a follow-up BI in the same PR, with a clear merge target — and
+  honor it.
+
+## How cleanup discipline interacts with the discovery / naming pair
+
+This principle is part of a three-step progression:
+
+1. **`verify-substrate-before-proposing-new`** — discovery: does the
+   thing I want to add already exist? (Answer: probably yes.)
+2. **`substrate-cleanup-before-substrate-addition`** (this one) —
+   sequencing: even if a new layer is justified, consolidate the
+   existing substrate first.
+3. **`schema-honesty-over-aspirational-naming`** — naming: name the new
+   layer for what it holds, not what you hope it will hold.
+
+A clean substrate addition runs all three. Missing any one produces a
+recognizable failure mode in the resulting code.
+
+## The contract
+
+Before opening a PR that adds a new substrate layer:
+
+1. **List the existing primitives the new layer will sit on or
+   compose with.**
+2. **Identify the fragmentation.** Are there N near-identical event
+   shapes? N similar-purpose tables? N gate models?
+3. **Decide what Phase 0 looks like.** Even if Phase 0 is "merge two
+   activity tables into one," do it first.
+4. **Land Phase 0 on its own.** The new addition depends on it; don't
+   bundle.
+5. **If Phase 0 is "no cleanup needed," document the audit.** Otherwise
+   the discipline is satisfied by ceremony, not evidence.
+
+## Anti-patterns
+
+- A plan that goes straight to Phase 1 with the new addition and lists
+  "refactor existing X" as Phase N+2 — that refactor will never ship.
+- A new table that conceptually overlaps an existing one, shipped
+  without merging or consolidating the older one.
+- "We'll add the new shape, and consumers can migrate gradually" — most
+  consumers won't migrate.
+- Bundling cleanup and addition into one PR — review becomes
+  unreviewable, rollback becomes impossible.
+
+## Related principles
+
+- [`verify-substrate-before-proposing-new`](verify-substrate-before-proposing-new.md) —
+  paired discipline; discovery (does X exist?) precedes sequencing
+  (cleanup before adding)
+- [`schema-audit-before-features`](schema-audit-before-features.md) —
+  data-model-scoped sibling; this principle generalizes to all
+  substrate, not just schema
+- [`one-data-model`](one-data-model.md) — the architectural reason
+  fragmentation is expensive
+- [`architecture-over-shortcuts`](architecture-over-shortcuts.md) — the
+  20% refactoring budget posture this principle operationalizes
+
+## Spec references
+
+- [Reduction Gear Architecture spec](../../../superpowers/specs/2026-05-24-reduction-gear-architecture-design.md) — §0 architect verdict, 20% refactor budget
+- [Governed-upgrade plan](../../../superpowers/plans/2026-05-23-governed-platform-upgrade-phase-0-and-1.md) — Phase 0 consolidation
+- [Founder kernel evolution discipline spec](../../../superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) — §6.4 promotion record

--- a/docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md
+++ b/docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md
@@ -1,0 +1,843 @@
+---
+title: Founder kernel evolution discipline — ring-scoped consultation, promotion + retirement contract, and four candidate principles
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+status: draft
+specKind: design
+backlogItem: BI-746268A1
+epic: EP-REDUCTION-GEAR-ARCH
+relatedSpecs:
+  - docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md
+  - docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md
+  - docs/superpowers/specs/2026-05-24-runtime-kernel-commandments.md
+relatedPlans:
+  - docs/superpowers/plans/2026-05-22-principle-scope-refactor.md
+relatedPrinciples:
+  - docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md
+  - docs/founder-kernel/wiki/principles/schema-audit-before-features.md
+  - docs/founder-kernel/wiki/principles/single-source-of-truth.md
+  - docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+---
+
+# Founder kernel evolution discipline
+
+## Summary
+
+The DPF founder kernel is 58 principles strong and growing. Three failure modes
+are imminent if growth is left ungoverned:
+
+1. **Dimensionality bloat** — every new principle adds a new axis to the
+   decision-aggregation vector. Past ~80 principles, signal degrades into noise.
+2. **Universal-scope-by-default** — most "universal" principles get loaded into
+   every prompt at every ring, even when they have nothing to say about the
+   action at hand. Cognitive load rises linearly per action.
+3. **Overlap without dedup** — `verify-substrate-before-proposing-new`,
+   `schema-audit-before-features`, and `consult-specs-first` already overlap;
+   nothing prevents a fourth near-duplicate from being added next week.
+
+The Reduction Gear Architecture (PR #1075) supplies the missing scoping lattice:
+five concentric rings (Ring 1 Coworker → Ring 5 Hive) plus an external
+coordination plane. This spec proposes using that lattice as an **orthogonal
+second scope axis** on every principle — independent of the existing
+domain-context axis (`build-studio`, `engineering-flow`, `finance`, etc.) — and
+defines the promotion/retirement contract that keeps the kernel a load-bearing
+decision vector instead of a documentation pile.
+
+It then promotes four candidate principles surfaced organically by the Reduction
+Gear and governed-upgrade work, under the new discipline.
+
+This spec is additive. No existing principle file is destroyed; no existing
+field is repurposed (schema honesty). The scope-refactor plan from 2026-05-22
+remains the authoritative cleanup for `principleConsumerArchetype` /
+`principleConsumerContexts` and is consciously not duplicated here.
+
+## 1. Why
+
+### 1.1 The articulated concern
+
+Mark, 2026-05-24: *"Specs are heavy adds to the principles, so need to apply
+this smartly to align future work and not get bogged down with too much detail
+in every action."*
+
+The kernel works as a decision aggregation today because most decisions face a
+small enough principle field that the structured-alignment math (`buildOptionScores`
+in [apps/web/lib/wiki/principle-decide.ts:321](../../../apps/web/lib/wiki/principle-decide.ts))
+returns a useful signal. As the kernel grows, three things happen:
+
+- Decision composites accumulate small contributions from every principle
+  regardless of relevance — the runner-up margin shrinks toward `tieMargin`
+  (default 0.2), the `low` confidence flag fires on every call, and the
+  recommendation becomes "human review required" by default.
+- Prompt context for each coworker call carries more commandments than the
+  call actually binds. Today's `COMMANDMENT_RETRIEVAL_CAP = 10` mitigates this
+  but doesn't fix it — once there are 20 commandments, picking which 10
+  becomes itself a decision, and the cut is currently arbitrary
+  (Postgres-order LIMIT).
+- New principles drift toward duplicating existing ones because the bar for
+  "is this already covered?" is informal grep, not a structural overlap check.
+
+### 1.2 Mission alignment
+
+This work is high-leverage because every other DPF spec inherits the kernel's
+shape:
+
+- **Trusted AI Kernel (TAK) positioning.** A kernel that bloats into noise is
+  exactly the failure mode TAK exists to refute. "Our kernel scales because
+  consultation is bounded, not unbounded" is a load-bearing TAK claim.
+- **Reduction Gear loop integrity.** Every ring boundary in the Reduction
+  Gear spec relies on `principle_decide` for autonomy and graduation
+  decisions. If the math degrades with kernel size, the graduation signal
+  becomes noisier as the kernel matures — exactly backwards.
+- **Hive economic moat.** The hive ships `FeaturePack` today and will ship
+  `CalibratedCapabilityPack` after the Reduction Gear lands. The kernel is
+  the thing every install consults to decide whether to accept incoming
+  calibration. A kernel that doesn't scope decisions cleanly to a ring is a
+  kernel that accepts hive priors at the wrong ring.
+- **Verify-substrate-before-proposing-new** (existing core principle). The
+  substrate sweep done for this spec found the scope-refactor plan and the
+  full taxonomy registry. Reusing them is the whole point.
+
+### 1.3 Why not just keep adding principles
+
+Three reasons the status quo of "add a principle whenever a pattern is
+observed twice" stops working:
+
+1. **No retirement pressure.** Existing principles never sunset. A principle
+   that was load-bearing in 2026-04 (e.g. `keep-root-clone-as-merge-worktree`)
+   may have been superseded by `worktree-per-session` + `worktree-base-origin-main`
+   without anyone deleting the older one. Lint catches missing fields, not
+   redundancy.
+2. **No dimension orthogonality check.** New principles can introduce new
+   `principleDimensionVector` keys via PR review (lint blocks unknown
+   dimensions), but nothing checks whether a new dimension is genuinely
+   orthogonal to existing ones. `governance_compliance` and `blast_radius`
+   are nearly co-linear in the current vector field — adding a fifth
+   near-redundant axis would not be caught.
+3. **No ring-scoping mechanism.** A principle about Ring 5 hive federation
+   (when one is written) would, with today's filters, surface in a Ring 1
+   coworker capability-improvement call — irrelevantly. The cost of that
+   irrelevant injection is paid every call, forever.
+
+### 1.4 Mission-critical non-goals
+
+- **Do NOT delete principle files.** Retirement is `status: archived` (already
+  in the `WIKI_PAGE_STATUSES` enum). The history of a retired principle is
+  evidence; deletion erases it.
+- **Do NOT add a new "ring" enum that competes with `principleConsumerArchetype`
+  or `principleConsumerContexts`.** Rings are an orthogonal axis. Contexts
+  describe *which domain* (data-model, ui, finance); rings describe *which
+  depth of agentic loop* (coworker iteration vs hive federation). A principle
+  can be Ring 2 + context `ui` simultaneously.
+- **Do NOT implement the runtime gating in this spec.** Implementation is a
+  downstream BI under EP-REDUCTION-GEAR-ARCH. This spec defines the contract.
+
+## 2. Current substrate truth (verified 2026-05-24)
+
+The substrate sweep checked every claim made below against the live worktree.
+
+### 2.1 Taxonomy registry — what exists
+
+[packages/db/src/wiki-taxonomy.ts](../../../packages/db/src/wiki-taxonomy.ts):
+
+| Constant | Shape | Today's coverage |
+|---|---|---|
+| `PRINCIPLE_TIERS` | `["commandment", "core", "contextual"]` | Used by every principle |
+| `PRINCIPLE_TIER_DEFAULT_WEIGHT` | `{commandment: 1.0, core: 0.4, contextual: 0.1}` | Authors can override with `principleWeight` + rationale |
+| `PRINCIPLE_TIER_CAPS` | `{commandment: null, core: 30, contextual: null}` | Commandment cap removed 2026-05-22; core has soft cap (warn-severity lint) |
+| `PRINCIPLE_APPLIES_TO` | `["in_platform_coworker", "external_coding_agent", "human"]` | **Population filter** — who the calling actor is |
+| `PRINCIPLE_CONSUMER_ARCHETYPES` | `["universal", "ai-coworker-universal", "generalist", "specialist", "route-domain-specific"]` | Independent axis from `PRINCIPLE_APPLIES_TO` |
+| `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` | 12 governed slugs (`build-studio`, `engineering-flow`, `ui`, `data-model`, `mcp`, `release`, `marketing`, `compliance`, `discovery`, `finance`, `storefront`, `portfolio`) | Not a closed enum; validated by `isPrincipleConsumerContextSlug` (kebab-case shape) |
+| `PRINCIPLE_DIMENSIONS` | 14 axes (`long_term_maintainability`, `blast_radius`, `reusability`, `evidence_density`, `human_cognitive_load`, `capacity_utilization`, `governance_compliance`, `public_safety`, `speed_to_value`, `schema_grounding`, `operational_independence`, `data_privacy`, `cost_efficiency`, `vendor_lock_in`) | Closed enum; lint blocks unknown keys |
+| `PRINCIPLE_DECIDE_DEFAULTS.maxPrinciples` | 20 | Hard ceiling on principles per `principle_decide` call |
+
+### 2.2 Retrieval — what exists
+
+[apps/web/lib/wiki/principle-recall.ts](../../../apps/web/lib/wiki/principle-recall.ts)
+implements `recallPrincipleContext` which today:
+
+- Returns commandments from Postgres for the calling population (cap 10 via
+  `COMMANDMENT_RETRIEVAL_CAP`).
+- Returns top-K core principles from Qdrant filtered by `principleAppliesTo`
+  (population) — does NOT filter by `principleConsumerContexts`.
+- Returns contextual principles above `contextualSimilarityThreshold = 0.75`
+  filtered by `principleAppliesTo` — does NOT filter by contexts.
+
+**Gap:** The 2026-05-22 scope-refactor plan (Phase B) proposes adding
+`consumerContexts: string[]` filtering to `recallPrincipleContext` and
+`principle_decide`. That gap is still open. This spec assumes Phase B lands
+and builds on top of it.
+
+### 2.3 Lint — what exists
+
+[apps/web/lib/wiki/principle-lint-detectors.ts](../../../apps/web/lib/wiki/principle-lint-detectors.ts):
+
+| Detector | Severity | Blocks publish |
+|---|---|---|
+| `principle-missing-tier` | error | yes |
+| `principle-missing-applies-to` | error | yes |
+| `principle-missing-direction` | error (commandment/core) / warn (contextual) | tier-gated |
+| `principle-missing-vector` | error (commandment) / warn (core) / off (contextual) | tier-gated |
+| `principle-vector-dimension-mismatch` | warn | no |
+| `principle-unknown-dimension` | error | yes |
+| `principle-tier-weight-mismatch` | warn | no |
+| `principle-public-missing-rationale` | warn | no |
+| `principle-public-unsafe-marker` | warn | no |
+| `principle-runtime-enforcement-*` | varies | yes for invalid regex / mode |
+
+### 2.4 Decision math — what exists
+
+[apps/web/lib/wiki/principle-decide.ts](../../../apps/web/lib/wiki/principle-decide.ts)
+implements:
+
+- `computeStructuredAlignment` — normalized dot product over the principle's
+  declared dimensions; missing option features count as 0 with
+  `missingDimensions` reported.
+- `computeSemanticAlignment` — cosine similarity between option embedding and
+  `principleDirection` embedding; fallback when the principle has no vector.
+- `decide(options, principles, config)` — composite scoring with three
+  guardrails: `tieMargin` (low-confidence when margin < 0.2),
+  `semanticFallbackWarnRatio` (weak coverage when > 40% semantic),
+  `commandmentConflictThreshold` (flag when a commandment contributes
+  < -0.5 to the winning option).
+
+### 2.5 Population distribution across 58 principles
+
+Counts are the pre-existing kernel as of 2026-05-24, NOT including the four
+candidate principles promoted in §6 of this spec. After this PR ships, the
+totals shift to 62 principles (16 commandment / 40 core / 6 contextual;
+14 universal / 12 ai-coworker-universal / 1 specialist / 35 route-domain-specific).
+
+| Tier | Count (pre-existing) |
+|---|---|
+| commandment | 16 |
+| core | 36 |
+| contextual | 6 |
+
+| Consumer archetype | Count (pre-existing) |
+|---|---|
+| universal | 14 |
+| ai-coworker-universal | 11 |
+| generalist | 0 |
+| specialist | 1 |
+| route-domain-specific | 32 |
+
+(`generalist` is in the `PRINCIPLE_CONSUMER_ARCHETYPES` enum but has no
+authored principles today; included here so the absence is intentional, not
+an oversight.)
+
+The 2026-05-22 scope-refactor plan has already landed Phase A (tagging).
+What's missing is the orthogonal ring-scope axis and the promotion-discipline
+contract.
+
+## 3. The ring-scope axis
+
+### 3.1 New frontmatter field — `principleRingScope`
+
+**Proposed addition to `wiki-frontmatter.ts`:**
+
+```typescript
+export type WikiPageFrontmatter = {
+  // ...existing fields stay unchanged...
+  /** Ring(s) of the Reduction Gear Architecture this principle binds.
+   *  Independent axis from principleConsumerArchetype / principleConsumerContexts.
+   *  Empty / omitted → universal-ring (binds at every ring) BUT lint warns at
+   *  `principle-ring-scope-overuse` threshold (>30% universal-ring, mirroring
+   *  the existing universal-archetype guard). */
+  principleRingScope?: string[];
+};
+```
+
+**Proposed addition to `wiki-taxonomy.ts`:**
+
+```typescript
+export const PRINCIPLE_RING_SCOPES = [
+  "ring-1-coworker",        // Individual coworker capability iteration
+  "ring-2-workflow",        // Build Studio phases, A2A handoffs, deliberations
+  "ring-3-archetype",       // Vertical/industry segment calibration
+  "ring-4-sandbox-prod",    // Promotions, releases, in-prod outcomes
+  "ring-5-hive",            // Cross-install federation
+  "external-coordination",  // Suppliers / partners / customers
+  "universal-ring",         // Binds at every ring (must be earned, not default)
+] as const;
+export type PrincipleRingScope = (typeof PRINCIPLE_RING_SCOPES)[number];
+
+export function isPrincipleRingScope(value: unknown): value is PrincipleRingScope {
+  return (
+    typeof value === "string" &&
+    (PRINCIPLE_RING_SCOPES as readonly string[]).includes(value)
+  );
+}
+```
+
+**Schema migration:** an additive `principleRingScope String[] @default([])` on
+`WikiPage` mirroring the existing `principleAppliesTo` column. No
+backwards-incompatible change.
+
+**Schema honesty note:** ring-scope values are a closed enum validated by
+`isPrincipleRingScope`, not free-form slugs — so they live in a separate
+namespace from `principleConsumerContexts` (free-form kebab-case slugs
+validated by `isPrincipleConsumerContextSlug`). The `ring-` prefix on
+five of the seven values is a readability convention, not a collision
+guard; `external-coordination` and `universal-ring` carry their own
+distinctive shapes for the same reason. A principle that has both
+`principleRingScope: ["ring-2-workflow"]` and
+`principleConsumerContexts: ["engineering-flow"]` is the expected case — depth
+and domain are independent.
+
+### 3.2 What each ring scope means in practice
+
+| Ring scope | Calls that should consult it | Example existing principles after backfill |
+|---|---|---|
+| `ring-1-coworker` | Capability self-improvement, coworker skill acquisition, tool-trace evaluation | `selective-memory-not-total-recall`, `diversity-of-thought`, `specialization-over-generalization` |
+| `ring-2-workflow` | Build Studio phase transitions, deliberations, A2A handoffs | `orchestrator-worker-pattern`, `structured-handoffs-not-conversation-history`, `external-and-internal-work-share-gates` |
+| `ring-3-archetype` | Archetype calibration, vertical-specific routing, capability profiles | (none today — surface as Ring 3 instrumentation lands) |
+| `ring-4-sandbox-prod` | Promotion gates, release decisions, runtime verification | `release-qa-plan`, `test-in-the-portal-build`, `plan-before-install-paths` |
+| `ring-5-hive` | Hive contribution gates, calibrated-trust ingest, FeaturePack evaluation | (none today — surface as Ring 4↔5 instrumentation lands) |
+| `external-coordination` | Federated / bridged / customer-facing GearInterface emits | (none today — surface as external plane work begins) |
+| `universal-ring` | Decisions at any ring (rare; must be earned) | `architecture-over-shortcuts`, `never-fabricate`, `single-source-of-truth` |
+
+### 3.3 Backfill posture
+
+Backfilling 58 principles with ring scope is a separate cleanup BI (parallel
+to Phase A of the scope-refactor plan). This spec ships:
+
+- The taxonomy and schema additions
+- A backfill default of `["universal-ring"]` for every existing principle so
+  no current behavior changes
+- A lint detector (`principle-ring-scope-overuse`) that fires at warn
+  severity if > 30% of principles are tagged `universal-ring`. The bar
+  mirrors the scope-refactor plan's `principle-universal-overuse`
+  detector (proposed in Phase D, not yet shipped) — both guard against
+  default-to-broadest tagging.
+
+The backfill BI walks the 58 files and assigns narrower scope where the
+principle's body makes the ring obvious. The four new principles promoted in
+this spec ship with explicit ring scope from day one — they set the example.
+
+## 4. Promotion discipline
+
+### 4.1 Eligibility — when is a principle promotable?
+
+A pattern is eligible for promotion to a principle when **all four** conditions
+are met:
+
+1. **Organic use across ≥2 specs or plans.** The pattern shows up in at least
+   two independent specs/plans/Build Studio drafts where the authors did not
+   know about each other's use. Counterexample: a principle proposed because
+   it was useful in one PR and no one else has hit it yet.
+2. **Operator-ratified, or unambiguous from a kernel-violation incident.** The
+   pattern was either explicitly endorsed by the operator (e.g. memory file or
+   feedback comment), or surfaced as the corrective from a documented incident
+   (e.g. the 2026-05-23 volume-wipe drove `never-wipe-db-for-code-fixes` to
+   commandment tier).
+3. **No existing principle covers the same decision moment with ≥0.85
+   structured alignment.** Overlap detection (§4.3) must run first.
+4. **The pattern names a decision moment, not a state.** "Always X" or "Before
+   Y, do Z" are decisions. "X is true" is a fact and belongs in a `summary`
+   or `entity` wiki page, not a principle.
+
+Failure mode if any of (1)–(4) is skipped: the kernel accumulates principles
+that don't bind decisions, which dilutes the aggregation vector without adding
+signal.
+
+### 4.2 Ring-scope assignment — narrowest-applicable default
+
+The default for a new principle is **the narrowest ring scope that still
+covers the decisions it actually binds**. Specifically:
+
+- If the principle's `principleDirection` references a primitive that lives
+  at exactly one ring (e.g. `FeatureBuild`, `BuildPhaseRun` → Ring 2;
+  `ReleaseBundle`, `RuntimeVerification` → Ring 4), the ring scope is that
+  single ring.
+- If the principle binds two adjacent rings (e.g. a calibration discipline
+  that emits at Ring 2 and is consumed at Ring 3), tag both ring scopes
+  explicitly. Do not generalize to `universal-ring`.
+- `universal-ring` must be earned: the principle's body must show that at
+  least three of the five rings need this binding, with examples per ring.
+  Lint detector `principle-ring-scope-overuse` warns when the kernel exceeds
+  30% universal-ring tagging.
+
+This mirrors the scope-refactor plan's `universal` archetype discipline —
+narrow by default, broad only when justified.
+
+### 4.3 Overlap detection — structural alignment before promotion
+
+Before a new principle is merged, the author MUST run a structured-alignment
+check against the existing kernel and record the result in the principle file
+(new optional frontmatter field `principleOverlapScan`):
+
+```yaml
+principleOverlapScan:
+  highestAlignment: 0.72
+  highestAlignmentSlug: schema-audit-before-features
+  rationale: |
+    Adjacent but not redundant — schema-audit-before-features is data-model-scoped;
+    this principle generalizes to substrate-scoped sequencing across rings.
+```
+
+**Threshold rule:**
+- `highestAlignment ≤ 0.70` → ship freely.
+- `0.70 < highestAlignment ≤ 0.85` → ship only with a paragraph in the body
+  explaining why the new principle is *additive* to the closest existing one
+  (typical: different decision moment, different ring, different consumer).
+- `highestAlignment > 0.85` → do NOT ship as a new principle. Either extend
+  the existing principle (which is a one-PR change to its file) or document
+  why this is a genuinely orthogonal sibling worth the dimension cost. The
+  default outcome is rejection.
+
+**How to run the scan:** call the existing `principle_decide` MCP tool with
+the candidate principle's `principleDirection` as a single option, and the
+full existing kernel as the principle field. The contribution ledger names
+the closest matches by alignment. Pure read; no side effects.
+
+The scan is mechanical, not subjective. Adding the check to the PR
+description (and to the frontmatter) is the audit trail.
+
+### 4.4 Dimension orthogonality
+
+Every new principle should reuse existing dimensions from the 14-entry
+`PRINCIPLE_DIMENSIONS` registry whenever possible. A new dimension requires:
+
+1. A PR that adds the dimension to `PRINCIPLE_DIMENSIONS` in
+   `wiki-taxonomy.ts`.
+2. A documented orthogonality claim in the PR: the new dimension is not
+   ≥0.7 correlated with any existing dimension in the current vector field
+   (correlation measurable as cosine-similarity over the principles that use
+   both dimensions, weighted by tier).
+3. At least two principles that would use the new dimension (the "build for
+   what you have, not what you might need" check).
+
+Today's registry has near-co-linear pairs (`governance_compliance` /
+`blast_radius` track each other for ~70% of principles that use both). The
+registry should be pruned in a separate cleanup BI, not by this spec, but
+the orthogonality bar prevents new co-linear additions.
+
+### 4.5 Retirement
+
+A principle becomes a retirement candidate when **any one** of:
+
+1. **Superseded.** A newer principle covers its decision moment with broader
+   or sharper framing. Retirement leaves a pointer in the new principle's
+   body to the retired one.
+2. **Promoted into the runtime kernel commandments.** A principle that gains
+   a `principleRuntimeEnforcement` block is still a principle — it is not
+   retired. Promotion to runtime enforcement is additive, not replacing.
+3. **Decayed.** The principle has not been consulted by `principle_decide`
+   in N months (telemetry exists via the `[principle-decide-trace]` log
+   pattern; the cutoff is a separate operational decision).
+
+Retirement mechanics:
+- Set `status: archived` on the wiki frontmatter (existing enum value).
+- Leave the file in place — git history is evidence.
+- Append a `## Retired` section to the body with date and reason.
+- Update the recall query to exclude archived principles from the live
+  vector field (already the case for Qdrant searches — they filter
+  `status: published`; commandment retrieval needs the same filter added).
+
+## 5. Tiered-consultation discipline
+
+### 5.1 The calling-context envelope
+
+Every call into `principle_decide` and `recallPrincipleContext` already carries
+`callingPopulation` ("who is asking"). This spec extends the envelope with:
+
+```typescript
+export type PrincipleConsultationContext = {
+  callingPopulation: PrincipleAppliesToPopulation; // existing
+  consumerContexts?: string[];                     // proposed by scope-refactor Phase B
+  ringScope?: PrincipleRingScope[];                // new — this spec
+  isCrossRing?: boolean;                           // new — Ring N↔N+1 boundary actions
+};
+```
+
+The `ringScope` field carries the rings the calling action binds. Examples:
+
+- An autonomous capability self-improvement loop in a Ring 1 coworker passes
+  `ringScope: ["ring-1-coworker"]`.
+- A Build Studio phase transition passes `ringScope: ["ring-2-workflow"]`.
+- A GearInterface emit at the Ring 1→2 boundary passes
+  `ringScope: ["ring-1-coworker", "ring-2-workflow"]` and `isCrossRing: true`.
+- A hive contribution call passes
+  `ringScope: ["ring-4-sandbox-prod", "ring-5-hive"]` and `isCrossRing: true`.
+- A purely architectural design-time decision (e.g. inside a spec) passes
+  `ringScope: ["universal-ring"]` and consults the full universal-ring slice
+  plus commandments.
+
+A small registry `apps/web/lib/wiki/calling-ring-map.ts` (proposed) maps
+calling surfaces to default ring scopes — same pattern as the
+`consumer-context-map.ts` proposed by the scope-refactor plan. The two maps
+compose; callers can override either explicitly.
+
+### 5.2 Retrieval contract
+
+Updated `recallPrincipleContext` rules (additive to scope-refactor Phase B):
+
+1. **Commandment branch** (always inject): filter by population AND ring-scope
+   intersection with the caller. A commandment scoped `universal-ring`
+   always passes; a commandment scoped `ring-4-sandbox-prod` only passes
+   when the caller declared Ring 4. Cap stays at 10.
+2. **Core branch** (top-K Qdrant): same filters — population, consumer
+   contexts (Phase B), ring scope intersection. Cap stays at `coreLimit`
+   default 5.
+3. **Contextual branch** (above similarity threshold): same filters. Cap
+   stays at `contextualLimit` default 5.
+
+**Cognitive-load bound:**
+
+```
+principles_consulted_per_decision ≤ commandment_cap (10)
+                                 + core_limit       (5)
+                                 + contextual_limit (5)
+                                 = 20 (matches PRINCIPLE_DECIDE_DEFAULTS.maxPrinciples)
+```
+
+This bound is **independent of total kernel size**. A 500-principle kernel
+returns the same 20 to a single decision as a 58-principle kernel does today.
+The math degrades only via the structured-alignment dot product (which is
+per-principle and bounded), not via more principles entering each call.
+
+### 5.3 Commandment-tier override
+
+Commandments override ring-scope filtering only when their `principleRingScope`
+intersects the caller OR is `universal-ring`. The intent is the opposite of
+"commandments ignore scope" — it's "commandments are non-negotiable within
+their declared scope, and a commandment scoped to one ring binds work at that
+ring with no override available."
+
+A Ring 4 commandment cannot block a Ring 1 action. If a rule must bind every
+ring, its author must declare `principleRingScope: ["universal-ring"]` and
+justify it in the body. This forces a conscious choice instead of
+universal-by-omission.
+
+### 5.4 Telemetry
+
+A new structured log line `[principle-recall-trace]` records:
+
+- Caller's `callingPopulation`, `consumerContexts`, `ringScope`
+- Count of commandments / core / contextual returned
+- Slugs of principles that scored highest contribution
+- Slugs of principles that were excluded by ring-scope filter (so we can
+  detect ring-scoping bugs — if a principle is being excluded everywhere,
+  its scope is probably wrong)
+
+Mirrors the existing `[tool-trace]` pattern in `project_tool_trace_logging`
+memory and the `[kernel-gate-trace]` in the runtime commandments spec.
+
+## 6. Four candidate principles promoted in this spec
+
+Each candidate is profiled below; the principle files themselves live at
+`docs/founder-kernel/wiki/principles/<slug>.md` and ship in the same PR as
+this spec.
+
+### 6.1 mirror-dont-migrate
+
+- **Tier:** `core`
+- **Ring scope:** `["ring-3-archetype", "ring-4-sandbox-prod"]`
+- **Consumer archetype:** `route-domain-specific`
+- **Consumer contexts:** `["data-model", "engineering-flow"]`
+- **Direction:** Mirror canonical source data into a runtime model and derive
+  consumers from the mirror, rather than destructively replacing the canonical
+  source with a new schema.
+- **Dimension vector:**
+  ```json
+  {"long_term_maintainability": 0.8, "blast_radius": -0.7,
+   "schema_grounding": 0.6, "speed_to_value": -0.3}
+  ```
+- **Why surfaced:** Governed-upgrade Phase 1
+  (`version.json` → `PlatformConfig` mirror → `/api/platform/version` → UI)
+  and Reduction Gear (GearInterface dual-emit alongside existing event tables)
+  both use this pattern without naming it. The Reduction Gear spec explicitly
+  warns against "replacing mature local write models with one generic
+  polymorphic table before command semantics are stable."
+- **Overlap scan vs existing kernel:** closest match
+  `one-data-model` (alignment ≈ 0.62) — paired-but-distinct; one-data-model
+  is the design-time anti-pattern ("don't integrate two SoRs"), this is the
+  migration-time pattern ("mirror, don't replace").
+
+### 6.2 schema-honesty-over-aspirational-naming
+
+- **Tier:** `core`
+- **Ring scope:** `["ring-2-workflow", "ring-3-archetype"]`
+- **Consumer archetype:** `route-domain-specific`
+- **Consumer contexts:** `["data-model", "engineering-flow"]`
+- **Direction:** Name columns, types, and models for what they hold today;
+  defer aspirational names until the substrate actually carries the
+  aspirational meaning.
+- **Dimension vector:**
+  ```json
+  {"schema_grounding": 0.9, "long_term_maintainability": 0.7,
+   "evidence_density": 0.5, "human_cognitive_load": 0.3}
+  ```
+- **Why surfaced:** Governed-upgrade plan kept SHA-named columns
+  (`currentSha`, `targetSha`) until the substrate would actually carry
+  versions; Reduction Gear spec explicitly rejected `StorefrontArchetype`
+  for runtime-evolving capability and proposed a separate
+  `ArchetypeCapabilityProfile` table rather than overloading the existing
+  name. Both efforts use the discipline without articulating it.
+- **Overlap scan vs existing kernel:** closest match
+  `strongly-typed-string-enums` (alignment ≈ 0.55) — about TYPE shape;
+  this is about NAME truth. Adjacent, not redundant.
+
+### 6.3 make-silent-failures-observable
+
+- **Tier:** `core`
+- **Ring scope:** `["universal-ring"]` (genuinely binds every ring — earned)
+- **Consumer archetype:** `ai-coworker-universal`
+- **Consumer contexts:** *(none — ai-coworker-universal does not use contexts)*
+- **Direction:** Emit a structured signal on every "nothing happened" code
+  path so silent failures become queryable.
+- **Dimension vector:**
+  ```json
+  {"evidence_density": 1.0, "governance_compliance": 0.6,
+   "long_term_maintainability": 0.5, "human_cognitive_load": -0.3}
+  ```
+- **Why surfaced:** Governed-upgrade `resolveTargetSha` null-return now
+  logs `self-upgrade.no-target` with tracking BI rather than failing
+  silently; Reduction Gear spec specifies `slipDetected` + `slipReason` on
+  every GearInterface record so non-compounding work is queryable. The
+  memory `project_hive_contribution_gaps` documents that earlier silent
+  `success: true, prUrl: null` returns broke the entire contribution mode
+  until silent-failure observability was added. Three independent surfaces
+  using the discipline without naming it = clear promotion signal.
+- **Universal-ring justification:** Ring 1 coworker tool calls (silent
+  no-op returns), Ring 2 Build Studio phase skips, Ring 4 release
+  reconciliation, Ring 5 hive contribution failures all need this — at
+  least three rings demonstrably bind, meeting the §4.2 universal-ring bar.
+- **Overlap scan vs existing kernel:** closest match
+  `fail-fast-explain-clearly` (alignment ≈ 0.67) — `fail-fast` is about
+  errors (something went wrong); this is about non-events (nothing went
+  wrong, nothing happened, no record of why). Different failure mode,
+  different evidence shape, paired-but-distinct.
+
+### 6.4 substrate-cleanup-before-substrate-addition
+
+- **Tier:** `core`
+- **Ring scope:** `["ring-2-workflow", "ring-3-archetype"]`
+- **Consumer archetype:** `route-domain-specific`
+- **Consumer contexts:** `["engineering-flow", "data-model", "portfolio"]`
+- **Direction:** Consolidate existing substrate before adding new substrate
+  to it; a Phase-0 cleanup pass beats a Phase-1 layer-on every time.
+- **Dimension vector:**
+  ```json
+  {"long_term_maintainability": 0.8, "reusability": 0.6,
+   "schema_grounding": 0.5, "speed_to_value": -0.4}
+  ```
+- **Why surfaced:** Reduction Gear spec explicitly reserves 20% of
+  implementation capacity for refactoring existing event/evidence seams
+  before adding new emitters: *"The intent is to shrink fragmentation, not
+  layer one more table over unclear boundaries."* Governed-upgrade plan
+  Phase 0 consolidates `version.json` parsing before Phase 1 builds the
+  PlatformConfig mirror. Same discipline; not articulated.
+- **Overlap scan vs existing kernel:** closest matches
+  `verify-substrate-before-proposing-new` (alignment ≈ 0.78) and
+  `schema-audit-before-features` (alignment ≈ 0.72). Both are in the
+  `0.70 < x ≤ 0.85` band, so the body must justify additivity:
+  - `verify-substrate-before-proposing-new` is the **discovery** discipline
+    ("does X already exist before you propose it?"); this is the
+    **sequencing** discipline ("when adding a new layer, consolidate the
+    existing one first").
+  - `schema-audit-before-features` is data-model-scoped; this is
+    substrate-scoped across all rings.
+  - The three together form a discovery → cleanup → naming progression
+    rather than three competing rules.
+
+## 7. Audit table — all 58 existing principles
+
+Columns:
+
+- **Slug** — file slug
+- **Tier** — commandment / core / contextual
+- **Archetype** — current `principleConsumerArchetype`
+- **Recommended ring scope** — first-pass; the backfill BI confirms
+- **Overlap notes** — paired-but-distinct (PBD), supersedes-candidate (SC),
+  or — if none
+- **Retire?** — N (no), C (candidate), R (recommended in same PR)
+
+| Slug | Tier | Archetype | Recommended ring scope | Overlap notes | Retire? |
+|---|---|---|---|---|---|
+| all-changes-land-via-pr | commandment | route-domain-specific | universal-ring | — | N |
+| always-push-after-committing | contextual | route-domain-specific | universal-ring | PBD: branch-guard-before-implementation | N |
+| architecture-over-shortcuts | commandment | universal | universal-ring | — | N |
+| autonomous-directives-are-blanket-approval | core | ai-coworker-universal | ring-1-coworker, ring-2-workflow | — | N |
+| backlog-lives-in-postgresql | core | route-domain-specific | universal-ring | — | N |
+| branch-guard-before-implementation | core | route-domain-specific | universal-ring | PBD: always-push-after-committing | N |
+| build-gate-mandatory | commandment | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | PBD: release-qa-plan, test-in-the-portal-build | N |
+| check-epic-overlap-before-creating | contextual | route-domain-specific | ring-2-workflow | — | N |
+| check-tool-signals-first | core | ai-coworker-universal | ring-1-coworker | — | N |
+| consult-specs-first | core | universal | universal-ring | PBD: verify-substrate-before-proposing-new (different decision moment) | N |
+| contextualize-before-transforming | core | universal | universal-ring | — | N |
+| db-fallback-explicit | contextual | route-domain-specific | ring-1-coworker | — | N |
+| dco-sign-off-required | commandment | route-domain-specific | universal-ring | — | N |
+| design-research-required | core | universal | universal-ring | PBD: research-and-use-standards (research stance) | N |
+| destructive-actions-require-explicit-go | commandment | ai-coworker-universal | universal-ring | — | N |
+| diversity-of-thought | core | ai-coworker-universal | ring-1-coworker | — | N |
+| do-the-work-dont-task-the-operator | commandment | ai-coworker-universal | ring-1-coworker, ring-2-workflow | PBD: never-ask-user-to-run-commands (escalation form) | N |
+| evidence-before-diagnosis | core | ai-coworker-universal | ring-1-coworker | — | N |
+| external-and-internal-work-share-gates | core | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | — | N |
+| fail-fast-explain-clearly | core | ai-coworker-universal | ring-1-coworker | PBD: make-silent-failures-observable (this spec; different failure mode) | N |
+| fix-the-seed-not-the-runtime | core | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | — | N |
+| human-in-the-loop-at-phase-boundaries | commandment | universal | ring-2-workflow, ring-4-sandbox-prod | — | N |
+| keep-root-clone-as-merge-worktree | contextual | route-domain-specific | universal-ring | SC: covered by worktree-per-session + worktree-base-origin-main | C |
+| live-state-over-seed-data | core | route-domain-specific | universal-ring | PBD: backlog-lives-in-postgresql | N |
+| mention-uncommitted-changes | contextual | route-domain-specific | universal-ring | — | N |
+| never-ask-user-to-run-commands | commandment | ai-coworker-universal | ring-1-coworker, ring-2-workflow | — | N |
+| never-fabricate | commandment | universal | universal-ring | — | N |
+| never-wipe-db-for-code-fixes | commandment | ai-coworker-universal | universal-ring | — | N |
+| no-assumptions | commandment | universal | universal-ring | — | N |
+| no-hardcoded-colors | commandment | route-domain-specific | ring-2-workflow | — | N |
+| one-concern-per-pr | core | route-domain-specific | universal-ring | — | N |
+| one-data-model | core | route-domain-specific | ring-3-archetype, ring-4-sandbox-prod, universal-ring | PBD: mirror-dont-migrate (this spec; migration-time counterpart) | N |
+| orchestrator-worker-pattern | core | route-domain-specific | ring-2-workflow | — | N |
+| organization-canonical-identity | core | route-domain-specific | universal-ring | PBD: single-source-of-truth (specific application) | N |
+| plan-before-install-paths | contextual | route-domain-specific | ring-4-sandbox-prod | — | N |
+| prefer-self-hosted-infrastructure | core | universal | universal-ring | — | N |
+| principal-convergence | core | route-domain-specific | universal-ring | PBD: organization-canonical-identity (different identity surface) | N |
+| release-qa-plan | core | route-domain-specific | ring-4-sandbox-prod | PBD: build-gate-mandatory, test-in-the-portal-build | N |
+| research-and-use-standards | commandment | universal | universal-ring | PBD: design-research-required (commandment vs spec discipline) | N |
+| research-before-implementing | core | universal | universal-ring | PBD: research-and-use-standards (external standards vs internal substrate) | N |
+| responsible-capacity-utilization | core | universal | universal-ring | — | N |
+| schema-audit-before-features | core | route-domain-specific | ring-2-workflow, ring-3-archetype | PBD: substrate-cleanup-before-substrate-addition (this spec; broader scope) | N |
+| security-fix-needs-regression-test-first | core | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | — | N |
+| selective-memory-not-total-recall | core | ai-coworker-universal | ring-1-coworker | — | N |
+| single-source-of-truth | commandment | universal | universal-ring | PBD: one-data-model (rule vs application) | N |
+| specialization-over-generalization | core | specialist | ring-1-coworker, ring-2-workflow | — | N |
+| state-results-directly | core | universal | ring-1-coworker | — | N |
+| strongly-typed-string-enums | core | route-domain-specific | ring-2-workflow, ring-3-archetype | PBD: schema-honesty-over-aspirational-naming (this spec; type shape vs name) | N |
+| structural-verification-is-not-functional | commandment | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | PBD: test-in-the-portal-build (live-install vs unit) | N |
+| structured-handoffs-not-conversation-history | core | ai-coworker-universal | ring-2-workflow | — | N |
+| sweep-main-before-trusting-worktree-specs | core | route-domain-specific | universal-ring | — | N |
+| test-in-the-portal-build | commandment | route-domain-specific | ring-2-workflow, ring-4-sandbox-prod | PBD: build-gate-mandatory, release-qa-plan | N |
+| tool-evaluation-pipeline | core | route-domain-specific | ring-1-coworker | — | N |
+| tools-must-be-self-documenting | core | route-domain-specific | ring-1-coworker | — | N |
+| trust-the-data-spine | core | route-domain-specific | ring-3-archetype, ring-4-sandbox-prod | — | N |
+| verify-substrate-before-proposing-new | core | universal | universal-ring | PBD: schema-audit-before-features, substrate-cleanup-before-substrate-addition (this spec; discovery vs cleanup) | N |
+| worktree-base-origin-main | core | route-domain-specific | universal-ring | PBD: worktree-per-session | N |
+| worktree-per-session | core | route-domain-specific | universal-ring | PBD: worktree-base-origin-main | N |
+
+**Summary:**
+- Four new principles in §6 ship in the same PR with explicit ring scope
+  and overlap-scan results; not duplicated in this table.
+- 1 retirement candidate: `keep-root-clone-as-merge-worktree` (superseded by
+  the worktree-per-session + worktree-base-origin-main pair). Retirement
+  decision deferred to the backfill BI; this spec does not retire it.
+- 13 paired-but-distinct clusters surfaced. All retain.
+- Candidate orthogonal dimension audit shows likely co-linearity between
+  `governance_compliance` and `blast_radius` across ~70% of principles that
+  use both. Recommended to a separate dimension-audit BI (out of scope here).
+
+### 7.1 Build-Studio commandment naming clarification
+
+`build-gate-mandatory` and `test-in-the-portal-build` both fire at the
+ring-2/ring-4 boundary. The cluster of `build-gate-mandatory` +
+`release-qa-plan` + `test-in-the-portal-build` +
+`structural-verification-is-not-functional` is a coherent family of
+"is this really done?" rules at different decision moments. None is
+strictly redundant with another; all four are retained.
+
+### 7.2 Candidate orthogonal dimensions surfaced for future audit
+
+The 14-dimension registry was audited against the 58 principles. Co-linearity
+observations (not actionable in this spec):
+
+- `governance_compliance` ↔ `blast_radius`: ~70% co-direction
+- `evidence_density` ↔ `schema_grounding`: ~60% co-direction
+- `human_cognitive_load` ↔ `speed_to_value`: ~55% co-direction (inverse)
+
+These are signal-degrading enough to justify a future dimension-pruning BI
+but not severe enough to block this spec. Logged here for the next reviewer.
+
+## 8. Acceptance criteria
+
+This spec ships when:
+
+1. **Spec text merged** at the path declared in §0 frontmatter.
+2. **Four principle files merged** with the frontmatter shapes described in
+   §6 (ring scope, dimensions, archetype, contexts, overlap scan, body).
+3. **No existing principle file modified destructively.** Additive
+   cross-reference updates allowed (e.g. adding a `Related principles`
+   pointer to a new principle).
+4. **No code changes in this spec.** Schema and taxonomy proposals are
+   captured as `Proposed addition to ...` blocks; the implementing PR is a
+   separate BI under EP-REDUCTION-GEAR-ARCH.
+5. **Backlog item BI-746268A1 marked `done`** with resolution citing the
+   merged PR.
+6. **Downstream BI filed** for: schema migration + taxonomy registry
+   addition + lint detector + recall extension + backfill of `principleRingScope`
+   on all 58 existing principles. That BI is the implementation of this
+   spec.
+
+## 9. Trade-offs and open questions
+
+### 9.1 Ring scope vs consumer context — orthogonal or merge?
+
+**Question:** could `principleRingScope` be merged into
+`principleConsumerContexts` as additional governed slugs (e.g.
+`ring-2-workflow` becomes a context)?
+
+**Lean: keep orthogonal.** Rings describe depth of the agentic loop;
+contexts describe domain. A principle like `no-hardcoded-colors` is Ring 2
+(it fires during BS workflow phases) AND context `ui` — the two answer
+different filtering questions. Collapsing them sacrifices the orthogonality
+that makes the recall math bounded. Records the choice; revisitable if the
+audit shows ≥80% redundancy between any ring and any context.
+
+### 9.2 Should `universal-ring` exist at all?
+
+**Question:** the bar for `universal-ring` is high; would forcing every
+principle to enumerate specific rings produce better hygiene?
+
+**Lean: keep universal-ring with the 30% lint warn.** Some principles
+(e.g. `never-fabricate`) genuinely bind every ring and enumerating five
+ring scopes per file is friction without signal. The lint guard captures
+overuse; the field is honest about what it claims.
+
+### 9.3 Overlap scan threshold
+
+**Question:** is 0.85 alignment the right rejection bar?
+
+**Lean: ship at 0.85, revisit after first 5 promoted principles.** A
+threshold that's too tight rejects useful additive principles; too loose
+admits redundancy. 0.85 is high enough that genuine duplicates flag while
+adjacent-but-distinct passes. The four candidates in §6 all sit between
+0.55 and 0.78 — none would be rejected under the proposed rule.
+
+### 9.4 Implementing the runtime gating
+
+**Question:** when does §5.2's bounded-consultation rule become a runtime
+contract, not a spec promise?
+
+**Lean: separate BI under EP-REDUCTION-GEAR-ARCH.** This spec defines the
+contract; the downstream BI implements the schema migration, taxonomy
+addition, lint detector, recall extension, and calling-ring map. Splitting
+keeps the spec PR focused on principles and contracts.
+
+### 9.5 Dimension-pruning audit
+
+**Question:** the co-linearity findings in §7.2 suggest the dimension
+registry has redundancy. Prune now or later?
+
+**Lean: later.** Pruning dimensions retires data from existing principle
+vectors and re-derives `principleDimensions` across the kernel — a heavy
+edit that warrants its own design pass. Capture as a follow-up BI; out of
+scope here.
+
+## 10. Out of scope
+
+- **Implementation of the runtime gating.** Separate downstream BI.
+- **Backfill of `principleRingScope` across 58 existing principles.**
+  Separate cleanup BI (parallel to scope-refactor Phase A).
+- **Promotion of principles beyond the four in §6.** Other candidates
+  (e.g. a "graduation events are explicit" principle from the Reduction
+  Gear trust ladder) are captured in the audit but not promoted in this
+  session.
+- **Changes to the runtime kernel commandments spec.** Cross-referenced
+  only — that spec governs execution-time enforcement and is adjacent,
+  not overlapping.
+- **Dimension-pruning audit.** Captured as follow-up; not in this spec.
+
+## 11. Definition of done
+
+- This spec file merged to `main` via DCO-signed PR
+- Four principle files merged to `main` in the same PR or in a paired PR
+- BI-746268A1 marked `done` with resolution citing the merged PR
+- Downstream implementation BI filed under EP-REDUCTION-GEAR-ARCH


### PR DESCRIPTION
## Summary

Adds [`2026-05-24-founder-kernel-evolution-discipline-design.md`](docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) under `EP-REDUCTION-GEAR-ARCH`, plus four candidate principles promoted under the new discipline.

The spec solves three failure modes that become imminent as the kernel grows past ~80 principles:
- **Dimensionality bloat** — every new principle adds an axis to the decision-aggregation vector.
- **Universal-scope-by-default** — most "universal" principles get loaded into every prompt at every ring even when they say nothing about the action at hand.
- **Overlap without dedup** — `verify-substrate-before-proposing-new`, `schema-audit-before-features`, `consult-specs-first` already overlap; nothing prevents a fourth near-duplicate next week.

The Reduction Gear Architecture (PR #1075) supplies the missing scoping lattice: 5 rings + external coordination + universal. This PR uses that as an orthogonal axis (`principleRingScope`) alongside the existing domain-context axis (`principleConsumerContexts`).

## What's in the spec

- §2 — verified substrate sweep (every claim grepped against live `wiki-taxonomy.ts`, `principle-recall.ts`, `principle-lint-detectors.ts`)
- §3 — new `principleRingScope` field (additive; no existing field repurposed)
- §4 — promotion discipline: 4-condition eligibility, narrowest-applicable ring scope, structured overlap scan with 0.70/0.85 bands, dimension orthogonality, retirement via existing `status: archived`
- §5 — tiered-consultation contract: bounded principles-per-decision (=20) independent of kernel size; commandment override is scope-respecting, not scope-bypassing
- §6 — four candidate principle profiles
- §7 — audit table for all 58 pre-existing principles with recommended ring scope and overlap notes; 1 retirement candidate flagged (`keep-root-clone-as-merge-worktree`)
- §8–§11 — acceptance criteria, trade-offs, out-of-scope, definition of done

## Four promoted principles (all `core` tier)

- [`mirror-dont-migrate`](docs/founder-kernel/wiki/principles/mirror-dont-migrate.md) — ring-3, ring-4
- [`schema-honesty-over-aspirational-naming`](docs/founder-kernel/wiki/principles/schema-honesty-over-aspirational-naming.md) — ring-2, ring-3
- [`make-silent-failures-observable`](docs/founder-kernel/wiki/principles/make-silent-failures-observable.md) — universal-ring (earned with 3-rings proof in §6.3)
- [`substrate-cleanup-before-substrate-addition`](docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md) — ring-2, ring-3

## Standing rules honored

- **Verify substrate before proposing new** — discovered the in-flight 2026-05-22 scope-refactor plan and built additively on top, didn't duplicate
- **Schema honesty** — `principleRingScope` is a new field, NOT overloading `principleAppliesTo` or `principleConsumerContexts` to mean depth
- **Mirror, don't migrate** (one of the promoted principles!) — additive schema/taxonomy proposals; no existing principle file destroyed; default backfill `["universal-ring"]` preserves current behavior
- **Research before implementing** — read all 58 existing principle files before writing the audit table or claiming any redundancy

## Out of scope (downstream BI under EP-REDUCTION-GEAR-ARCH)

- Schema migration for `principleRingScope` column
- Taxonomy registry additions (`PRINCIPLE_RING_SCOPES`, `isPrincipleRingScope`)
- Lint detector `principle-ring-scope-overuse`
- Recall extension to filter by ring scope
- Backfill of `principleRingScope` across all 58 pre-existing principles
- Retirement of `keep-root-clone-as-merge-worktree` (deferred to backfill BI)
- Dimension-pruning audit (co-linearity findings logged in §7.2)

## Review process applied

Spec-document-reviewer dispatched after first draft; flagged tier-count arithmetic error in §2.5 (off by 4 in opposite directions) and ring-scope incoherence on three principles tagging both narrow rings AND `universal-ring` (violates the narrowest-applicable rule the spec itself defines). Both corrections applied before commit.

## Test plan

- [x] No code changes — spec + four principle markdown files only
- [x] All claims in §2 substrate-truth section grepped against live worktree
- [x] All four principle files include required frontmatter (tier, applies-to, archetype, direction, dimensions, vector)
- [x] Cross-links between the four principles and existing kernel verified to point at real files
- [x] Spec frontmatter `relatedSpecs` / `relatedPrinciples` paths verified
- [ ] Downstream wiki ingest will silently drop `principleRingScope` until schema lands — this is the expected interim state

Closes the spec deliverable of BI-746268A1; implementation BI to be filed under EP-REDUCTION-GEAR-ARCH after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)