### PR TITLE
feat(gear-interface): Reduction Gear Phase 0 — Ring 1→2 pilot foundation (BI-85CB31F0)

### DIFF
--- a/apps/web/app/(shell)/admin/cockpit/page.tsx
+++ b/apps/web/app/(shell)/admin/cockpit/page.tsx
@@ -1,0 +1,424 @@
+// apps/web/app/(shell)/admin/cockpit/page.tsx
+//
+// Reduction Gear Cockpit — read-only MVP (Phase 0).
+//
+// Operator-facing gear-train diagnostic surface. First viewport shows the four
+// ring interfaces with torque / slip / cost / sample size; below are the slip
+// reason rollup, top-N degrading triples, recent events with drill-through,
+// and the graduations panel (empty until Phase 1).
+//
+// Per spec §5.4: dense ops surface, DPF tokens only, no nested cards, every
+// number clickable, honest "unknown" state. Phase 0 emits only at Ring 1→2 —
+// the other rings show "no data" until their emitters land.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §5
+// BI:   BI-85CB31F0
+
+import Link from "next/link";
+import { ArrowRight, ArrowUpRight, ArrowDownLeft, AlertTriangle, CheckCircle, Award, GitMerge } from "lucide-react";
+import {
+  defaultWindow,
+  getInterfaceTorqueReadings,
+  getSlipByReason,
+  getTripleWearReadings,
+  getRecentGraduations,
+  listRecentGearInterfaceRows,
+  type InterfaceTorqueReading,
+} from "@/lib/gear-interface";
+
+// All four ring interfaces. Phase 0 only emits at 1→2; the others render as
+// "no data" lanes so the operator sees the gear train honestly, not hidden.
+const ALL_INTERFACES: Array<{ innerRing: number; outerRing: number; label: string }> = [
+  { innerRing: 1, outerRing: 2, label: "Ring 1→2  Coworker → Workflow" },
+  { innerRing: 2, outerRing: 3, label: "Ring 2→3  Workflow → Archetype" },
+  { innerRing: 3, outerRing: 4, label: "Ring 3→4  Archetype → Sandbox/Prod" },
+  { innerRing: 4, outerRing: 5, label: "Ring 4→5  Sandbox/Prod → Hive" },
+];
+
+function formatTorque(value: number): string {
+  return (value * 100).toFixed(0) + "%";
+}
+
+function formatPercent(value: number): string {
+  return (value * 100).toFixed(1) + "%";
+}
+
+function formatCost(usd: number): string {
+  if (usd === 0) return "$0";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function torqueColor(value: number): string {
+  if (value >= 0.9) return "#4ade80"; // healthy green
+  if (value >= 0.6) return "#fbbf24"; // warning amber
+  return "#f87171"; // degraded red
+}
+
+function findReadings(
+  all: InterfaceTorqueReading[],
+  innerRing: number,
+  outerRing: number,
+): InterfaceTorqueReading[] {
+  return all.filter((r) => r.innerRing === innerRing && r.outerRing === outerRing);
+}
+
+function summarizeInterface(readings: InterfaceTorqueReading[]) {
+  if (readings.length === 0) {
+    return null;
+  }
+  const total = readings.reduce((acc, r) => acc + r.totalRecords, 0);
+  const weightedTorque =
+    total === 0
+      ? 0
+      : readings.reduce((acc, r) => acc + r.meanTorqueTechnical * r.totalRecords, 0) / total;
+  const slipCount = readings.reduce((acc, r) => acc + r.slipCount, 0);
+  const slipRate = total === 0 ? 0 : slipCount / total;
+  const totalCost = readings.reduce((acc, r) => acc + r.totalCostUsd, 0);
+  const graduations = readings.reduce((acc, r) => acc + r.graduationCount, 0);
+  return { total, weightedTorque, slipRate, totalCost, graduations };
+}
+
+export default async function CockpitPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ ring?: string; days?: string }>;
+}) {
+  const params = (await searchParams) ?? {};
+  const days = Math.max(1, Math.min(90, Number(params.days ?? "7") || 7));
+  const now = new Date();
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - days);
+  const window = { start, end: now };
+
+  // Aggregate fetches in parallel — every Cockpit panel reads from the same window
+  const [interfaceReadings, slipByReason, wear, graduations, recentRows] = await Promise.all([
+    getInterfaceTorqueReadings(window),
+    getSlipByReason(window),
+    getTripleWearReadings(window, { minSampleSize: 1 }),
+    getRecentGraduations(window, { limit: 10 }),
+    listRecentGearInterfaceRows(window, {}, { limit: 50 }),
+  ]);
+
+  const totalRows = interfaceReadings.reduce((acc, r) => acc + r.totalRecords, 0);
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header band ----------------------------------------------------- */}
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)] flex items-center gap-2">
+            <GitMerge size={18} className="text-[var(--dpf-accent)]" />
+            Reduction Gear Cockpit
+          </h1>
+          <p className="text-xs text-[var(--dpf-muted)] mt-1">
+            Operator diagnostic view — torque, slip, wear, cost, graduations across the agentic gear train.
+            <span className="ml-2 italic">Phase 0 emits at Ring 1→2 only.</span>
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-[var(--dpf-muted)]">Window:</span>
+          {[1, 7, 30].map((d) => (
+            <Link
+              key={d}
+              href={`?days=${d}`}
+              className="px-2 py-1 rounded border text-[var(--dpf-text)]"
+              style={{
+                borderColor: "var(--dpf-border)",
+                background: d === days ? "var(--dpf-surface-2)" : "var(--dpf-surface-1)",
+              }}
+            >
+              {d}d
+            </Link>
+          ))}
+          <span className="text-[var(--dpf-muted)] ml-3">
+            {totalRows} record{totalRows === 1 ? "" : "s"} in window
+          </span>
+        </div>
+      </div>
+
+      {/* Ring overview band ----------------------------------------------- */}
+      <section
+        className="rounded border p-4"
+        style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-1)" }}
+      >
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">Gear interfaces</h2>
+        <div className="space-y-2">
+          {ALL_INTERFACES.map(({ innerRing, outerRing, label }) => {
+            const outward = findReadings(interfaceReadings, innerRing, outerRing).filter(
+              (r) => r.transmissionDirection === "outward",
+            );
+            const inward = findReadings(interfaceReadings, innerRing, outerRing).filter(
+              (r) => r.transmissionDirection === "inward",
+            );
+            const outSummary = summarizeInterface(outward);
+            const inSummary = summarizeInterface(inward);
+            const noData = !outSummary && !inSummary;
+            return (
+              <div
+                key={`${innerRing}-${outerRing}`}
+                className="flex items-stretch gap-3 px-3 py-2 rounded border"
+                style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-2)" }}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-[var(--dpf-text)] flex items-center gap-2">
+                    {label}
+                    {noData && (
+                      <span
+                        className="text-[10px] font-bold px-1.5 py-0.5 rounded"
+                        style={{ background: "var(--dpf-bg)", color: "var(--dpf-muted)", border: "1px solid var(--dpf-border)" }}
+                      >
+                        NO DATA
+                      </span>
+                    )}
+                  </div>
+                  {noData && (
+                    <div className="text-[11px] text-[var(--dpf-muted)] mt-0.5">
+                      {innerRing === 1
+                        ? "no records — pilot waiting on a completed Build Studio phase run"
+                        : "emitter not active in Phase 0"}
+                    </div>
+                  )}
+                </div>
+                {outSummary && (
+                  <Link
+                    href={`?days=${days}&ring=${innerRing}-${outerRing}&dir=outward`}
+                    className="flex items-center gap-3 px-3 rounded hover:underline"
+                    style={{ background: "var(--dpf-bg)" }}
+                  >
+                    <ArrowUpRight size={14} className="text-[var(--dpf-muted)]" />
+                    <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
+                      outward
+                      <div className="text-[var(--dpf-text)] text-xs font-semibold mt-0.5">
+                        {outSummary.total} rec
+                      </div>
+                    </div>
+                    <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
+                      torque
+                      <div className="text-xs font-semibold mt-0.5" style={{ color: torqueColor(outSummary.weightedTorque) }}>
+                        {formatTorque(outSummary.weightedTorque)}
+                      </div>
+                    </div>
+                    <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
+                      slip
+                      <div className="text-xs font-semibold mt-0.5 text-[var(--dpf-text)]">
+                        {formatPercent(outSummary.slipRate)}
+                      </div>
+                    </div>
+                    <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
+                      cost
+                      <div className="text-xs font-semibold mt-0.5 text-[var(--dpf-text)]">
+                        {formatCost(outSummary.totalCost)}
+                      </div>
+                    </div>
+                    {outSummary.graduations > 0 && (
+                      <Award size={14} className="text-[var(--dpf-accent)]" aria-label={`${outSummary.graduations} graduations`} />
+                    )}
+                  </Link>
+                )}
+                {inSummary && (
+                  <Link
+                    href={`?days=${days}&ring=${innerRing}-${outerRing}&dir=inward`}
+                    className="flex items-center gap-3 px-3 rounded hover:underline"
+                    style={{ background: "var(--dpf-bg)" }}
+                  >
+                    <ArrowDownLeft size={14} className="text-[var(--dpf-muted)]" />
+                    <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
+                      inward
+                      <div className="text-[var(--dpf-text)] text-xs font-semibold mt-0.5">
+                        {inSummary.total} rec
+                      </div>
+                    </div>
+                  </Link>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Two-column band: slip rollup + triple wear ----------------------- */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <section
+          className="rounded border p-4"
+          style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-1)" }}
+        >
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3 flex items-center gap-2">
+            <AlertTriangle size={14} className="text-[var(--dpf-muted)]" />
+            Slip by reason
+          </h2>
+          {slipByReason.length === 0 ? (
+            <p className="text-xs text-[var(--dpf-muted)]">
+              No slip detected in the window. (Healthy state — or no emitter activity yet.)
+            </p>
+          ) : (
+            <table className="w-full text-xs">
+              <thead className="text-[var(--dpf-muted)] text-left">
+                <tr>
+                  <th className="font-medium pb-1">Reason</th>
+                  <th className="font-medium pb-1 text-right">Count</th>
+                  <th className="font-medium pb-1 text-right">Cost burned</th>
+                </tr>
+              </thead>
+              <tbody className="text-[var(--dpf-text)]">
+                {slipByReason.map((row) => (
+                  <tr key={row.slipReason} className="border-t" style={{ borderColor: "var(--dpf-border)" }}>
+                    <td className="py-1.5">{row.slipReason}</td>
+                    <td className="py-1.5 text-right">{row.count}</td>
+                    <td className="py-1.5 text-right">{formatCost(row.totalCostUsd)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <section
+          className="rounded border p-4"
+          style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-1)" }}
+        >
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3 flex items-center gap-2">
+            <CheckCircle size={14} className="text-[var(--dpf-muted)]" />
+            Triple wear (lowest torque first)
+          </h2>
+          {wear.length === 0 ? (
+            <p className="text-xs text-[var(--dpf-muted)]">
+              No capability×archetype×agent triples observed yet.
+            </p>
+          ) : (
+            <table className="w-full text-xs">
+              <thead className="text-[var(--dpf-muted)] text-left">
+                <tr>
+                  <th className="font-medium pb-1">Agent</th>
+                  <th className="font-medium pb-1">Capability</th>
+                  <th className="font-medium pb-1">Archetype</th>
+                  <th className="font-medium pb-1 text-right">n</th>
+                  <th className="font-medium pb-1 text-right">Torque</th>
+                </tr>
+              </thead>
+              <tbody className="text-[var(--dpf-text)]">
+                {wear.slice(0, 10).map((row, i) => (
+                  <tr
+                    key={`${row.agentIdForTriple}-${row.capabilityName}-${row.archetypeContext ?? "null"}-${i}`}
+                    className="border-t"
+                    style={{ borderColor: "var(--dpf-border)" }}
+                  >
+                    <td className="py-1.5 truncate max-w-[140px]">{row.agentIdForTriple}</td>
+                    <td className="py-1.5 truncate max-w-[140px]">{row.capabilityName}</td>
+                    <td className="py-1.5 text-[var(--dpf-muted)]">{row.archetypeContext ?? "—"}</td>
+                    <td className="py-1.5 text-right">{row.sampleSize}</td>
+                    <td className="py-1.5 text-right font-semibold" style={{ color: torqueColor(row.meanTorqueTechnical) }}>
+                      {formatTorque(row.meanTorqueTechnical)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      </div>
+
+      {/* Graduations band (always present so operators see "no events yet") */}
+      <section
+        className="rounded border p-4"
+        style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-1)" }}
+      >
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3 flex items-center gap-2">
+          <Award size={14} className="text-[var(--dpf-accent)]" />
+          Recent graduations
+        </h2>
+        {graduations.length === 0 ? (
+          <p className="text-xs text-[var(--dpf-muted)]">
+            No graduations in the window. (Calibrator + Autonomy Governor land in Phase 1; until then,
+            no triple can graduate.)
+          </p>
+        ) : (
+          <ul className="space-y-1 text-xs text-[var(--dpf-text)]">
+            {graduations.map((g) => (
+              <li key={g.id} className="flex items-center gap-2">
+                <span className="text-[var(--dpf-muted)]">{g.recordedAt.toISOString()}</span>
+                <span className="font-semibold">{g.capabilityName}</span>
+                <span className="text-[var(--dpf-muted)]">×</span>
+                <span>{g.archetypeContext ?? "any-archetype"}</span>
+                <span className="text-[var(--dpf-muted)]">×</span>
+                <span>{g.agentIdForTriple}</span>
+                <span className="text-[var(--dpf-muted)] mx-1">
+                  Ring {g.innerRing}→{g.outerRing}
+                </span>
+                <span>
+                  {g.fromAutonomy} <ArrowRight size={10} className="inline mx-1" /> {g.toAutonomy}
+                </span>
+                {g.sampleSize != null && <span className="text-[var(--dpf-muted)]">(n={g.sampleSize})</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Recent events band — drill-down evidence ------------------------- */}
+      <section
+        className="rounded border p-4"
+        style={{ borderColor: "var(--dpf-border)", background: "var(--dpf-surface-1)" }}
+      >
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">Recent transmissions</h2>
+        {recentRows.length === 0 ? (
+          <p className="text-xs text-[var(--dpf-muted)]">
+            No GearInterface records in the window. Trigger a Build Studio phase completion to produce
+            the first Ring 1→2 emit, or expand the window.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead className="text-[var(--dpf-muted)] text-left">
+                <tr>
+                  <th className="font-medium pb-1">When</th>
+                  <th className="font-medium pb-1">Ring</th>
+                  <th className="font-medium pb-1">Capability</th>
+                  <th className="font-medium pb-1">Source</th>
+                  <th className="font-medium pb-1">Actor</th>
+                  <th className="font-medium pb-1 text-right">Torque</th>
+                  <th className="font-medium pb-1">Outcome</th>
+                  <th className="font-medium pb-1">Grader</th>
+                </tr>
+              </thead>
+              <tbody className="text-[var(--dpf-text)]">
+                {recentRows.map((row) => (
+                  <tr key={row.id} className="border-t" style={{ borderColor: "var(--dpf-border)" }}>
+                    <td className="py-1.5 text-[var(--dpf-muted)] whitespace-nowrap">
+                      {row.recordedAt.toISOString().slice(11, 19)}
+                    </td>
+                    <td className="py-1.5">
+                      {row.innerRing != null && row.outerRing != null
+                        ? `${row.innerRing}→${row.outerRing}`
+                        : row.transmissionDirection}
+                    </td>
+                    <td className="py-1.5 truncate max-w-[180px]">{row.capabilityName}</td>
+                    <td className="py-1.5 text-[var(--dpf-muted)] truncate max-w-[180px]" title={row.shaftSourceId}>
+                      {row.shaftSourceType}
+                    </td>
+                    <td className="py-1.5 truncate max-w-[120px]">{row.actorId}</td>
+                    <td className="py-1.5 text-right font-semibold" style={{ color: torqueColor(row.torqueTechnical) }}>
+                      {formatTorque(row.torqueTechnical)}
+                    </td>
+                    <td className="py-1.5">
+                      {row.slipDetected ? (
+                        <span className="text-[#f87171]">slip{row.slipReason ? `: ${row.slipReason}` : ""}</span>
+                      ) : (
+                        row.outcomeType
+                      )}
+                    </td>
+                    <td className="py-1.5 text-[var(--dpf-muted)]">{row.graderType}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <p className="text-[10px] text-[var(--dpf-muted)] italic">
+        Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md · BI-85CB31F0 · Phase 0 (Ring 1→2 pilot)
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/admin/admin-nav.ts
+++ b/apps/web/components/admin/admin-nav.ts
@@ -62,12 +62,14 @@ export const ADMIN_FAMILIES: AdminFamily[] = [
       "/admin/issue-reports",
       "/admin/diagnostics",
       "/admin/backups",
+      "/admin/cockpit",
     ],
     subItems: [
       { label: "Platform Development", href: "/admin/platform-development" },
       { label: "Issue Reports", href: "/admin/issue-reports" },
       { label: "Diagnostics", href: "/admin/diagnostics" },
       { label: "Backups", href: "/admin/backups" },
+      { label: "Cockpit", href: "/admin/cockpit" },
     ],
   },
 ];

--- a/apps/web/lib/gear-interface/emit-ring-1-2.test.ts
+++ b/apps/web/lib/gear-interface/emit-ring-1-2.test.ts
@@ -1,0 +1,136 @@
+// apps/web/lib/gear-interface/emit-ring-1-2.test.ts
+//
+// Integration-style tests for the Ring 1→2 emit path. Mocks @dpf/db so the
+// suite runs without a live DB, and validates the producer → adapter → writer
+// chain end-to-end across a few fixture outcomes.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildPhaseFixture } from "./test-fixtures";
+
+const gearRows = new Map<string, Record<string, unknown>>();
+let nextId = 1;
+
+const buildFromFixture = (outcome: "clean" | "abandoned" | "ux-failed" | "with-retries") =>
+  buildPhaseFixture({ outcome });
+
+let currentFixture = buildFromFixture("clean");
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    buildPhaseRun: {
+      findUnique: vi.fn(async () => ({
+        ...currentFixture.phaseRun,
+        // Decimal stand-in: emit-ring-1-2 calls .toString() on costUsd
+        costUsd: { toString: () => currentFixture.phaseRun.costUsd },
+      })),
+    },
+    featureBuild: {
+      findUnique: vi.fn(async () => ({
+        claimedByAgentId: currentFixture.signals.claimedByAgentId,
+        codingProvider: currentFixture.signals.codingProvider,
+        uxVerificationStatus: currentFixture.signals.uxVerificationStatus,
+        acceptanceMet:
+          currentFixture.signals.acceptanceMet === true
+            ? { met: true }
+            : currentFixture.signals.acceptanceMet === false
+              ? { met: false }
+              : null,
+        abandonedAt: currentFixture.signals.abandoned
+          ? new Date(currentFixture.phaseRun.completedAt!.getTime() - 1000)
+          : null,
+        abandonReason: currentFixture.signals.abandonReason,
+      })),
+    },
+    buildDispatchAttempt: {
+      findMany: vi.fn(async () => {
+        const failed = currentFixture.signals.worstFailureAxis
+          ? [{ failureAxis: currentFixture.signals.worstFailureAxis, success: false }]
+          : [];
+        const extras = Array.from({
+          length: currentFixture.signals.attemptCount - failed.length,
+        }).map(() => ({ failureAxis: "unknown", success: true }));
+        return [...failed, ...extras];
+      }),
+    },
+    gearInterface: {
+      findUnique: vi.fn(async ({ where }: { where: { idempotencyKey: string } }) => {
+        return gearRows.get(where.idempotencyKey) ?? null;
+      }),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const row = {
+          id: `gear-${nextId++}`,
+          schemaVersion: 1,
+          recordedAt: new Date(),
+          slipDetected: false,
+          ...data,
+        };
+        gearRows.set(String(data.idempotencyKey), row);
+        return row;
+      }),
+    },
+  },
+  Prisma: {},
+}));
+
+import { emitRing12FromCompletedPhase } from "./emit-ring-1-2";
+import { prisma } from "@dpf/db";
+
+beforeEach(() => {
+  gearRows.clear();
+  nextId = 1;
+  vi.clearAllMocks();
+  currentFixture = buildFromFixture("clean");
+});
+
+describe("emitRing12FromCompletedPhase", () => {
+  it("emits one Ring 1→2 transmission for a cleanly-completed phase", async () => {
+    currentFixture = buildFromFixture("clean");
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+
+    expect(prisma.gearInterface.create).toHaveBeenCalledOnce();
+    const call = vi.mocked(prisma.gearInterface.create).mock.calls[0]![0];
+    const data = call.data as Record<string, unknown>;
+    expect(data.innerRing).toBe(1);
+    expect(data.outerRing).toBe(2);
+    expect(data.outcomeType).toBe("transmission");
+    expect(data.torqueTechnical).toBe(1.0);
+    expect(data.shaftSourceType).toBe("phase-run");
+    expect(data.archetypeContext).toBeNull();
+  });
+
+  it("emits a slip with torque=0 when the build was abandoned", async () => {
+    currentFixture = buildFromFixture("abandoned");
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+
+    const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as { data: Record<string, unknown> }).data;
+    expect(data.outcomeType).toBe("slip");
+    expect(data.torqueTechnical).toBe(0);
+    expect(data.rationale).toContain("operator-veto");
+  });
+
+  it("emits a slip when UX verification failed", async () => {
+    currentFixture = buildFromFixture("ux-failed");
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+    const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as { data: Record<string, unknown> }).data;
+    expect(data.outcomeType).toBe("slip");
+    expect(data.torqueTechnical).toBe(0);
+  });
+
+  it("records a slip-with-retries as partial torque + rate-limit reason", async () => {
+    currentFixture = buildFromFixture("with-retries");
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+    const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as { data: Record<string, unknown> }).data;
+    expect(data.outcomeType).toBe("slip");
+    expect(data.slipReason).toBe("rate-limit");
+    expect(Number(data.torqueTechnical)).toBeGreaterThan(0);
+    expect(Number(data.torqueTechnical)).toBeLessThan(1);
+  });
+
+  it("is idempotent — second call with same phase does NOT create a new row", async () => {
+    currentFixture = buildFromFixture("clean");
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+    await emitRing12FromCompletedPhase(currentFixture.buildId, currentFixture.phase);
+    expect(prisma.gearInterface.create).toHaveBeenCalledOnce();
+    expect(gearRows.size).toBe(1);
+  });
+});

--- a/apps/web/lib/gear-interface/emit-ring-1-2.ts
+++ b/apps/web/lib/gear-interface/emit-ring-1-2.ts
@@ -1,0 +1,135 @@
+// apps/web/lib/gear-interface/emit-ring-1-2.ts
+//
+// Reduction Gear Phase 0 — Ring 1→2 (Coworker → Workflow) emitter.
+//
+// The single production emit path for Phase 0. Called immediately after a
+// BuildPhaseRun completes its source-of-truth write. Fetches the FeatureBuild
+// outcome signals + dispatch-attempt history, normalizes via the phase-run
+// adapter, and emits one GearInterface row.
+//
+// Non-blocking: every failure is logged and swallowed. The build flow must
+// never depend on this emit succeeding.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.1
+// BI:   BI-85CB31F0
+
+import { prisma } from "@dpf/db";
+import {
+  phaseRunToRing12Input,
+  type PhaseName,
+  type PhaseOutcomeSignals,
+  type PhaseRunSource,
+} from "./source-adapters/phase-run";
+import { emitGearInterface } from "./writer";
+
+/**
+ * Read FeatureBuild + most recent dispatch attempts for the phase window and
+ * normalize them into PhaseOutcomeSignals. Pure-ish — only reads, no writes.
+ */
+export async function loadPhaseOutcomeSignals(
+  buildId: string,
+  phaseStartedAt: Date,
+  phaseCompletedAt: Date,
+): Promise<PhaseOutcomeSignals | null> {
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: {
+      claimedByAgentId: true,
+      codingProvider: true,
+      uxVerificationStatus: true,
+      acceptanceMet: true,
+      abandonedAt: true,
+      abandonReason: true,
+    },
+  });
+
+  if (!build) return null;
+
+  const attempts = await prisma.buildDispatchAttempt.findMany({
+    where: {
+      buildId,
+      startedAt: { gte: phaseStartedAt, lte: phaseCompletedAt },
+    },
+    select: { failureAxis: true, success: true },
+  });
+
+  const failedAttempts = attempts.filter((a) => !a.success);
+  const worstFailureAxis =
+    failedAttempts.length > 0
+      ? (failedAttempts.find((a) => a.failureAxis !== "unknown")?.failureAxis ??
+          failedAttempts[0]!.failureAxis)
+      : null;
+
+  // FeatureBuild.acceptanceMet is JSON; treat truthy as accepted, missing/null
+  // as unknown, explicit false as rejected. Phase 0 uses a simple shape check.
+  let acceptanceMet: boolean | null = null;
+  if (build.acceptanceMet && typeof build.acceptanceMet === "object") {
+    const am = build.acceptanceMet as { met?: unknown; status?: unknown };
+    if (am.met === true || am.status === "met") acceptanceMet = true;
+    else if (am.met === false || am.status === "not-met") acceptanceMet = false;
+  }
+
+  return {
+    claimedByAgentId: build.claimedByAgentId,
+    codingProvider: build.codingProvider,
+    uxVerificationStatus: build.uxVerificationStatus as PhaseOutcomeSignals["uxVerificationStatus"],
+    acceptanceMet,
+    abandoned: build.abandonedAt != null && build.abandonedAt <= phaseCompletedAt,
+    abandonReason: build.abandonReason,
+    worstFailureAxis,
+    attemptCount: attempts.length,
+  };
+}
+
+/**
+ * Read the canonical BuildPhaseRun row and shape it as the PhaseRunSource the
+ * adapter consumes. Decimal costs are coerced to string for adapter input.
+ */
+async function loadPhaseRunSource(
+  buildId: string,
+  phase: PhaseName,
+): Promise<PhaseRunSource | null> {
+  const row = await prisma.buildPhaseRun.findUnique({
+    where: { buildId_phase: { buildId, phase } },
+  });
+  if (!row || !row.completedAt) return null;
+
+  return {
+    id: row.id,
+    buildId: row.buildId,
+    phase: row.phase as PhaseName,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    durationMs: row.durationMs,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    costUsd: row.costUsd ? row.costUsd.toString() : null,
+    inferenceCount: row.inferenceCount,
+    providerId: row.providerId,
+  };
+}
+
+/**
+ * Public entry — called from completeBuildPhaseRun() after the source row
+ * settles. Idempotent (writer upserts on idempotencyKey), so replays / retries
+ * are safe.
+ */
+export async function emitRing12FromCompletedPhase(
+  buildId: string,
+  phase: PhaseName,
+): Promise<void> {
+  const phaseRunSource = await loadPhaseRunSource(buildId, phase);
+  if (!phaseRunSource || !phaseRunSource.completedAt) return;
+
+  const signals = await loadPhaseOutcomeSignals(
+    buildId,
+    phaseRunSource.startedAt,
+    phaseRunSource.completedAt,
+  );
+  if (!signals) return;
+
+  const input = phaseRunToRing12Input(phaseRunSource, signals);
+  if (!input) return;
+
+  await emitGearInterface(input);
+}

--- a/apps/web/lib/gear-interface/index.ts
+++ b/apps/web/lib/gear-interface/index.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/gear-interface/index.ts
+//
+// Reduction Gear Phase 0 — public surface for the gear-interface library.
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md
+
+export type {
+  GearInterfaceInput,
+  InterfaceClass,
+  TransmissionDirection,
+  ShaftSourceType,
+  ActorType,
+  OutcomeType,
+  SlipReason,
+  AutonomyTier,
+  GraderType,
+  ExternalCounterpartyType,
+} from "./types";
+
+export {
+  emitGearInterface,
+  deriveIdempotencyKey,
+  validateGearInterfaceInput,
+  GearInterfaceValidationError,
+  type EmitResult,
+} from "./writer";
+
+export {
+  emitRing12FromCompletedPhase,
+  loadPhaseOutcomeSignals,
+} from "./emit-ring-1-2";
+
+export {
+  isOtelExportEnabled,
+  buildOtelAttributes,
+  buildOtelSpanName,
+  type GearInterfaceRow,
+} from "./otel-exporter";
+
+export {
+  defaultWindow,
+  getInterfaceTorqueReadings,
+  getSlipByReason,
+  getTripleWearReadings,
+  getRecentGraduations,
+  listRecentGearInterfaceRows,
+  getGearInterfaceRowById,
+  type QueryWindow,
+  type RingInterface,
+  type InterfaceFilter,
+  type InterfaceTorqueReading,
+  type SlipByReason,
+  type TripleWearReading,
+  type GraduationEvent,
+  type GearRowSummary,
+} from "./query";

--- a/apps/web/lib/gear-interface/otel-exporter.test.ts
+++ b/apps/web/lib/gear-interface/otel-exporter.test.ts
@@ -1,0 +1,148 @@
+// apps/web/lib/gear-interface/otel-exporter.test.ts
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildOtelAttributes,
+  buildOtelSpanName,
+  isOtelExportEnabled,
+  type GearInterfaceRow,
+} from "./otel-exporter";
+
+const baseRow: GearInterfaceRow = {
+  id: "gear-1",
+  schemaVersion: 1,
+  recordedAt: new Date("2026-05-24T16:00:00Z"),
+  sourceEventAt: new Date("2026-05-24T15:59:00Z"),
+  idempotencyKey: "internal-adjacent:1:2:outward:phase-run:pr-1:transmission",
+  organizationId: null,
+  interfaceClass: "internal-adjacent",
+  transmissionDirection: "outward",
+  innerRing: 1,
+  outerRing: 2,
+  externalCounterpartyType: null,
+  externalCounterpartyId: null,
+  shaftSourceType: "phase-run",
+  shaftSourceId: "pr-1",
+  actorType: "agent",
+  actorId: "agent-build",
+  actorPrincipalId: null,
+  intent: "complete-phase-build",
+  capabilityName: "build-phase-build",
+  capabilityVocabularyVersion: "raw-v0",
+  archetypeContext: null,
+  agentIdForTriple: "agent-build",
+  torqueTechnical: 1.0,
+  torqueValue: null,
+  torqueConfidence: 0.9,
+  ratioConsumed: 8,
+  outcomeType: "transmission",
+  slipDetected: false,
+  slipReason: null,
+  // Prisma's Decimal type stringifies; tests pass a string-compatible stand-in.
+  costUsd: null,
+  inputTokens: 12000,
+  outputTokens: 4500,
+  cacheCreationInputTokens: null,
+  cacheReadInputTokens: null,
+  reasoningOutputTokens: null,
+  durationMs: 1800000,
+  graduationFromAutonomy: null,
+  graduationToAutonomy: null,
+  graduationSampleSize: null,
+  graduationGovernorRef: null,
+  graderType: "automated",
+  graderId: "build-phase-run.completeBuildPhaseRun",
+  rationale: null,
+  otelTraceId: null,
+  otelSpanId: null,
+};
+
+beforeEach(() => {
+  delete process.env.DPF_GEAR_OTEL_EXPORT;
+});
+
+describe("isOtelExportEnabled", () => {
+  it("is disabled by default", () => {
+    expect(isOtelExportEnabled()).toBe(false);
+  });
+  it("is enabled when flag=1", () => {
+    process.env.DPF_GEAR_OTEL_EXPORT = "1";
+    expect(isOtelExportEnabled()).toBe(true);
+  });
+  it("is enabled when flag=true", () => {
+    process.env.DPF_GEAR_OTEL_EXPORT = "true";
+    expect(isOtelExportEnabled()).toBe(true);
+  });
+});
+
+describe("buildOtelSpanName", () => {
+  it("renders outward internal-adjacent as ring{n}_to_ring{n+1}", () => {
+    expect(buildOtelSpanName(baseRow)).toBe(
+      "dpf.gear.transmit ring1_to_ring2 build-phase-build",
+    );
+  });
+  it("renders inward as ring{n}_from_ring{n+1}", () => {
+    expect(
+      buildOtelSpanName({ ...baseRow, transmissionDirection: "inward" }),
+    ).toBe("dpf.gear.transmit ring1_from_ring2 build-phase-build");
+  });
+  it("renders external classes with capability suffix", () => {
+    expect(
+      buildOtelSpanName({
+        ...baseRow,
+        interfaceClass: "external-federated",
+        innerRing: null,
+        outerRing: null,
+      }),
+    ).toBe("dpf.gear.external external-federated build-phase-build");
+  });
+});
+
+describe("buildOtelAttributes", () => {
+  it("emits dpf.gear.* attributes", () => {
+    const attrs = buildOtelAttributes(baseRow);
+    expect(attrs["dpf.gear.interface_class"]).toBe("internal-adjacent");
+    expect(attrs["dpf.gear.transmission_direction"]).toBe("outward");
+    expect(attrs["dpf.gear.inner_ring"]).toBe(1);
+    expect(attrs["dpf.gear.outer_ring"]).toBe(2);
+    expect(attrs["dpf.gear.torque.technical"]).toBe(1.0);
+    expect(attrs["dpf.gear.torque.confidence"]).toBe(0.9);
+    expect(attrs["dpf.gear.outcome_type"]).toBe("transmission");
+  });
+
+  it("maps shaft source type to gen_ai.operation.name", () => {
+    const attrs = buildOtelAttributes(baseRow);
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_workflow");
+
+    const toolAttrs = buildOtelAttributes({
+      ...baseRow,
+      shaftSourceType: "tool-execution",
+    });
+    expect(toolAttrs["gen_ai.operation.name"]).toBe("execute_tool");
+  });
+
+  it("emits gen_ai.usage.* token fields when present", () => {
+    const attrs = buildOtelAttributes(baseRow);
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe(12000);
+    expect(attrs["gen_ai.usage.output_tokens"]).toBe(4500);
+  });
+
+  it("omits null/optional fields cleanly", () => {
+    const attrs = buildOtelAttributes(baseRow);
+    expect(attrs).not.toHaveProperty("dpf.gear.slip.reason");
+    expect(attrs).not.toHaveProperty("dpf.gear.capability.archetype_context");
+    expect(attrs).not.toHaveProperty("dpf.gear.graduation.from_autonomy");
+  });
+
+  it("includes archetype and slip details when set", () => {
+    const attrs = buildOtelAttributes({
+      ...baseRow,
+      archetypeContext: "hvac",
+      slipDetected: true,
+      slipReason: "rate-limit",
+    });
+    expect(attrs["dpf.gear.capability.archetype_context"]).toBe("hvac");
+    expect(attrs["dpf.gear.slip.detected"]).toBe(true);
+    expect(attrs["dpf.gear.slip.reason"]).toBe("rate-limit");
+  });
+});

--- a/apps/web/lib/gear-interface/otel-exporter.ts
+++ b/apps/web/lib/gear-interface/otel-exporter.ts
@@ -1,0 +1,140 @@
+// apps/web/lib/gear-interface/otel-exporter.ts
+//
+// Reduction Gear Phase 0 — best-effort OTel projection of GearInterface rows.
+//
+// Behind the DPF_GEAR_OTEL_EXPORT feature flag. When disabled (default) the
+// exporter is a no-op so production deployments don't pay an OTel SDK weight
+// they don't use. When enabled, it builds the attribute payload per spec §3.2:
+// OTel-native attributes (gen_ai.*) for the things OTel already standardizes,
+// and dpf.gear.* for what OTel is still silent on.
+//
+// Phase 0 does not depend on @opentelemetry/api as a runtime dep. We resolve
+// the SDK lazily and degrade to a structured log line if it isn't installed,
+// so the GearInterface DB write remains canonical and unblocked.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §3.2
+
+import { Prisma } from "@dpf/db";
+
+export type GearInterfaceRow = Prisma.GearInterfaceGetPayload<Record<string, never>>;
+
+const FLAG_ENV = "DPF_GEAR_OTEL_EXPORT";
+
+export function isOtelExportEnabled(): boolean {
+  const v = process.env[FLAG_ENV];
+  return v === "1" || v === "true" || v === "TRUE";
+}
+
+/**
+ * Build the OTel attribute payload for a GearInterface row. Pure — exposed for
+ * tests. Maps OTel-native attributes where the GenAI/MCP semconv covers it,
+ * and dpf.gear.* for DPF-specific dimensions OTel doesn't standardize yet.
+ */
+export function buildOtelAttributes(row: GearInterfaceRow): Record<string, unknown> {
+  const attrs: Record<string, unknown> = {
+    // dpf.gear.* — DPF-specific dimensions
+    "dpf.gear.schema_version": row.schemaVersion,
+    "dpf.gear.interface_class": row.interfaceClass,
+    "dpf.gear.transmission_direction": row.transmissionDirection,
+    "dpf.gear.shaft.source_type": row.shaftSourceType,
+    "dpf.gear.shaft.source_id": row.shaftSourceId,
+    "dpf.gear.capability.name": row.capabilityName,
+    "dpf.gear.capability.vocabulary_version": row.capabilityVocabularyVersion,
+    "dpf.gear.torque.technical": row.torqueTechnical,
+    "dpf.gear.torque.confidence": row.torqueConfidence,
+    "dpf.gear.ratio_consumed": row.ratioConsumed,
+    "dpf.gear.outcome_type": row.outcomeType,
+    "dpf.gear.slip.detected": row.slipDetected,
+    "dpf.gear.grader.type": row.graderType,
+  };
+
+  if (row.innerRing != null) attrs["dpf.gear.inner_ring"] = row.innerRing;
+  if (row.outerRing != null) attrs["dpf.gear.outer_ring"] = row.outerRing;
+  if (row.archetypeContext) attrs["dpf.gear.capability.archetype_context"] = row.archetypeContext;
+  if (row.torqueValue != null) attrs["dpf.gear.torque.value"] = row.torqueValue;
+  if (row.slipReason) attrs["dpf.gear.slip.reason"] = row.slipReason;
+  if (row.graderId) attrs["dpf.gear.grader.id"] = row.graderId;
+  if (row.rationale) attrs["dpf.gear.grader.rationale"] = row.rationale;
+  if (row.costUsd != null) attrs["dpf.gear.cost.usd"] = row.costUsd.toString();
+  if (row.graduationFromAutonomy) attrs["dpf.gear.graduation.from_autonomy"] = row.graduationFromAutonomy;
+  if (row.graduationToAutonomy) attrs["dpf.gear.graduation.to_autonomy"] = row.graduationToAutonomy;
+  if (row.graduationSampleSize != null) attrs["dpf.gear.graduation.sample_size"] = row.graduationSampleSize;
+  if (row.externalCounterpartyType) attrs["dpf.gear.external.counterparty_type"] = row.externalCounterpartyType;
+  if (row.externalCounterpartyId) attrs["dpf.gear.external.counterparty_id"] = row.externalCounterpartyId;
+
+  // gen_ai.* — OTel-native attributes. Tokens map directly; operation name is
+  // exporter-derived (we cannot guess invoke_agent vs execute_tool from the
+  // outcome alone, so we map the shaft source type into an operation hint and
+  // let downstream pipelines refine).
+  const operationByShaft: Record<string, string> = {
+    "tool-execution": "execute_tool",
+    "a2a-thread": "invoke_workflow",
+    "phase-run": "invoke_workflow",
+    deliberation: "invoke_workflow",
+    "runtime-verification": "invoke_workflow",
+  };
+  const op = operationByShaft[row.shaftSourceType];
+  if (op) attrs["gen_ai.operation.name"] = op;
+
+  if (row.inputTokens != null) attrs["gen_ai.usage.input_tokens"] = row.inputTokens;
+  if (row.outputTokens != null) attrs["gen_ai.usage.output_tokens"] = row.outputTokens;
+  if (row.cacheCreationInputTokens != null) {
+    attrs["gen_ai.usage.cache_creation_input_tokens"] = row.cacheCreationInputTokens;
+  }
+  if (row.cacheReadInputTokens != null) {
+    attrs["gen_ai.usage.cache_read_input_tokens"] = row.cacheReadInputTokens;
+  }
+  if (row.reasoningOutputTokens != null) {
+    attrs["gen_ai.usage.reasoning_output_tokens"] = row.reasoningOutputTokens;
+  }
+
+  return attrs;
+}
+
+/** Span name per spec §3.2. */
+export function buildOtelSpanName(row: GearInterfaceRow): string {
+  if (row.interfaceClass === "internal-adjacent") {
+    const dir = row.transmissionDirection === "inward" ? "from" : "to";
+    return `dpf.gear.transmit ring${row.innerRing}_${dir}_ring${row.outerRing} ${row.capabilityName}`;
+  }
+  return `dpf.gear.external ${row.interfaceClass} ${row.capabilityName}`;
+}
+
+/**
+ * Export one GearInterface row to OTel. No-op when the feature flag is off.
+ * Falls back to a structured console log when @opentelemetry/api isn't
+ * resolvable — keeps the DB write canonical regardless of SDK state.
+ */
+export async function exportGearInterfaceToOtel(row: GearInterfaceRow): Promise<void> {
+  if (!isOtelExportEnabled()) return;
+
+  const spanName = buildOtelSpanName(row);
+  const attributes = buildOtelAttributes(row);
+
+  type OtelApi = {
+    trace: {
+      getTracer: (name: string) => {
+        startSpan: (
+          name: string,
+          options: { startTime?: Date; attributes: Record<string, unknown> },
+        ) => { end: (when?: Date) => void };
+      };
+    };
+  };
+
+  let api: OtelApi | null = null;
+  try {
+    api = (await import("@opentelemetry/api")) as unknown as OtelApi;
+  } catch {
+    // SDK not installed; log the payload so it is observable.
+    console.log("[gear-interface][otel] (no SDK)", JSON.stringify({ spanName, attributes }));
+    return;
+  }
+
+  const tracer = api.trace.getTracer("dpf.gear");
+  const span = tracer.startSpan(spanName, {
+    startTime: row.sourceEventAt ?? row.recordedAt,
+    attributes,
+  });
+  span.end(row.recordedAt);
+}

--- a/apps/web/lib/gear-interface/query.ts
+++ b/apps/web/lib/gear-interface/query.ts
@@ -1,0 +1,353 @@
+// apps/web/lib/gear-interface/query.ts
+//
+// Reduction Gear Phase 0 — read API for the Cockpit.
+//
+// All Cockpit aggregate readings (torque, slip, wear, lubrication, heat,
+// graduation) compute from this module. Drill-down resolves a single row and
+// its source event. Per spec §5.3, no Cockpit panel should independently
+// reconcile fragmented event tables — every aggregate goes through here.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §5
+
+import { prisma } from "@dpf/db";
+
+export type RingInterface = "1-2" | "2-3" | "3-4" | "4-5";
+
+export interface QueryWindow {
+  /** Inclusive. */
+  start: Date;
+  /** Exclusive. */
+  end: Date;
+}
+
+export interface InterfaceFilter {
+  innerRing?: number;
+  outerRing?: number;
+  transmissionDirection?: "outward" | "inward" | "lateral";
+}
+
+/**
+ * Default window for the Cockpit overview — last 7 days. Callers may override.
+ */
+export function defaultWindow(now: Date = new Date()): QueryWindow {
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - 7);
+  return { start, end: now };
+}
+
+// ── Aggregate readings ───────────────────────────────────────────────────────
+
+export interface InterfaceTorqueReading {
+  innerRing: number | null;
+  outerRing: number | null;
+  transmissionDirection: string;
+  totalRecords: number;
+  meanTorqueTechnical: number;
+  meanTorqueConfidence: number;
+  slipCount: number;
+  slipRate: number;
+  graduationCount: number;
+  totalCostUsd: number;
+}
+
+/**
+ * Per-interface torque summary for the overview ring panel. Returns one row
+ * per (innerRing, outerRing, transmissionDirection) tuple that appeared in the
+ * window.
+ */
+export async function getInterfaceTorqueReadings(
+  window: QueryWindow,
+): Promise<InterfaceTorqueReading[]> {
+  const rows = await prisma.gearInterface.findMany({
+    where: { recordedAt: { gte: window.start, lt: window.end } },
+    select: {
+      innerRing: true,
+      outerRing: true,
+      transmissionDirection: true,
+      torqueTechnical: true,
+      torqueConfidence: true,
+      slipDetected: true,
+      outcomeType: true,
+      costUsd: true,
+    },
+  });
+
+  const bucket = new Map<string, InterfaceTorqueReading & {
+    sumTechnical: number;
+    sumConfidence: number;
+  }>();
+
+  for (const row of rows) {
+    const key = `${row.innerRing ?? "null"}:${row.outerRing ?? "null"}:${row.transmissionDirection}`;
+    const existing = bucket.get(key);
+    const cost = row.costUsd ? Number(row.costUsd.toString()) : 0;
+    if (existing) {
+      existing.totalRecords += 1;
+      existing.sumTechnical += row.torqueTechnical;
+      existing.sumConfidence += row.torqueConfidence;
+      existing.slipCount += row.slipDetected ? 1 : 0;
+      existing.graduationCount += row.outcomeType === "graduation" ? 1 : 0;
+      existing.totalCostUsd += cost;
+    } else {
+      bucket.set(key, {
+        innerRing: row.innerRing,
+        outerRing: row.outerRing,
+        transmissionDirection: row.transmissionDirection,
+        totalRecords: 1,
+        meanTorqueTechnical: 0,
+        meanTorqueConfidence: 0,
+        slipCount: row.slipDetected ? 1 : 0,
+        slipRate: 0,
+        graduationCount: row.outcomeType === "graduation" ? 1 : 0,
+        totalCostUsd: cost,
+        sumTechnical: row.torqueTechnical,
+        sumConfidence: row.torqueConfidence,
+      });
+    }
+  }
+
+  return Array.from(bucket.values())
+    .map(({ sumTechnical, sumConfidence, ...r }) => ({
+      ...r,
+      meanTorqueTechnical: r.totalRecords > 0 ? sumTechnical / r.totalRecords : 0,
+      meanTorqueConfidence: r.totalRecords > 0 ? sumConfidence / r.totalRecords : 0,
+      slipRate: r.totalRecords > 0 ? r.slipCount / r.totalRecords : 0,
+    }))
+    .sort((a, b) => {
+      // null rings sort last
+      const aRing = a.innerRing ?? 99;
+      const bRing = b.innerRing ?? 99;
+      if (aRing !== bRing) return aRing - bRing;
+      return a.transmissionDirection.localeCompare(b.transmissionDirection);
+    });
+}
+
+export interface SlipByReason {
+  slipReason: string;
+  count: number;
+  totalCostUsd: number;
+}
+
+/**
+ * Slip rollup keyed by reason — the diagnostic of "what kind of friction is
+ * happening." Optional ring filter narrows to a specific interface.
+ */
+export async function getSlipByReason(
+  window: QueryWindow,
+  filter: InterfaceFilter = {},
+): Promise<SlipByReason[]> {
+  const rows = await prisma.gearInterface.findMany({
+    where: {
+      recordedAt: { gte: window.start, lt: window.end },
+      slipDetected: true,
+      ...(filter.innerRing != null ? { innerRing: filter.innerRing } : {}),
+      ...(filter.outerRing != null ? { outerRing: filter.outerRing } : {}),
+      ...(filter.transmissionDirection
+        ? { transmissionDirection: filter.transmissionDirection }
+        : {}),
+    },
+    select: { slipReason: true, costUsd: true },
+  });
+
+  const bucket = new Map<string, SlipByReason>();
+  for (const row of rows) {
+    const reason = row.slipReason ?? "uncategorized";
+    const existing = bucket.get(reason);
+    const cost = row.costUsd ? Number(row.costUsd.toString()) : 0;
+    if (existing) {
+      existing.count += 1;
+      existing.totalCostUsd += cost;
+    } else {
+      bucket.set(reason, { slipReason: reason, count: 1, totalCostUsd: cost });
+    }
+  }
+  return Array.from(bucket.values()).sort((a, b) => b.count - a.count);
+}
+
+export interface TripleWearReading {
+  agentIdForTriple: string;
+  capabilityName: string;
+  archetypeContext: string | null;
+  sampleSize: number;
+  meanTorqueTechnical: number;
+  trailingFailures: number;
+  lastSeenAt: Date;
+}
+
+/**
+ * Per-triple wear reading — which {agent, capability, archetype} combinations
+ * are degrading? Sorted by mean torque ascending so the worst surfaces first.
+ */
+export async function getTripleWearReadings(
+  window: QueryWindow,
+  options: { minSampleSize?: number } = {},
+): Promise<TripleWearReading[]> {
+  const minSample = options.minSampleSize ?? 1;
+
+  const rows = await prisma.gearInterface.findMany({
+    where: { recordedAt: { gte: window.start, lt: window.end } },
+    select: {
+      agentIdForTriple: true,
+      capabilityName: true,
+      archetypeContext: true,
+      torqueTechnical: true,
+      recordedAt: true,
+    },
+    orderBy: { recordedAt: "desc" },
+  });
+
+  const bucket = new Map<
+    string,
+    TripleWearReading & { sumTechnical: number }
+  >();
+  for (const row of rows) {
+    const key = `${row.agentIdForTriple}::${row.capabilityName}::${row.archetypeContext ?? "null"}`;
+    const existing = bucket.get(key);
+    const failure = row.torqueTechnical < 0.5 ? 1 : 0;
+    if (existing) {
+      existing.sampleSize += 1;
+      existing.sumTechnical += row.torqueTechnical;
+      existing.trailingFailures += failure;
+      if (row.recordedAt > existing.lastSeenAt) existing.lastSeenAt = row.recordedAt;
+    } else {
+      bucket.set(key, {
+        agentIdForTriple: row.agentIdForTriple,
+        capabilityName: row.capabilityName,
+        archetypeContext: row.archetypeContext,
+        sampleSize: 1,
+        meanTorqueTechnical: 0,
+        trailingFailures: failure,
+        lastSeenAt: row.recordedAt,
+        sumTechnical: row.torqueTechnical,
+      });
+    }
+  }
+
+  return Array.from(bucket.values())
+    .filter((r) => r.sampleSize >= minSample)
+    .map(({ sumTechnical, ...r }) => ({
+      ...r,
+      meanTorqueTechnical: r.sampleSize > 0 ? sumTechnical / r.sampleSize : 0,
+    }))
+    .sort((a, b) => a.meanTorqueTechnical - b.meanTorqueTechnical);
+}
+
+export interface GraduationEvent {
+  id: string;
+  recordedAt: Date;
+  agentIdForTriple: string;
+  capabilityName: string;
+  archetypeContext: string | null;
+  fromAutonomy: string;
+  toAutonomy: string;
+  sampleSize: number | null;
+  governorRef: string | null;
+  innerRing: number | null;
+  outerRing: number | null;
+}
+
+export async function getRecentGraduations(
+  window: QueryWindow,
+  options: { limit?: number } = {},
+): Promise<GraduationEvent[]> {
+  const rows = await prisma.gearInterface.findMany({
+    where: {
+      recordedAt: { gte: window.start, lt: window.end },
+      outcomeType: "graduation",
+    },
+    orderBy: { recordedAt: "desc" },
+    take: options.limit ?? 20,
+  });
+  return rows
+    .filter((r) => r.graduationFromAutonomy && r.graduationToAutonomy)
+    .map((r) => ({
+      id: r.id,
+      recordedAt: r.recordedAt,
+      agentIdForTriple: r.agentIdForTriple,
+      capabilityName: r.capabilityName,
+      archetypeContext: r.archetypeContext,
+      fromAutonomy: r.graduationFromAutonomy!,
+      toAutonomy: r.graduationToAutonomy!,
+      sampleSize: r.graduationSampleSize,
+      governorRef: r.graduationGovernorRef,
+      innerRing: r.innerRing,
+      outerRing: r.outerRing,
+    }));
+}
+
+// ── Drill-down ────────────────────────────────────────────────────────────────
+
+export interface GearRowSummary {
+  id: string;
+  recordedAt: Date;
+  innerRing: number | null;
+  outerRing: number | null;
+  transmissionDirection: string;
+  shaftSourceType: string;
+  shaftSourceId: string;
+  actorType: string;
+  actorId: string;
+  capabilityName: string;
+  archetypeContext: string | null;
+  torqueTechnical: number;
+  torqueConfidence: number;
+  outcomeType: string;
+  slipDetected: boolean;
+  slipReason: string | null;
+  costUsd: string | null;
+  graderType: string;
+}
+
+/**
+ * Recent rows for the Cockpit's row table. Filterable by ring interface and
+ * outcome type so drill-throughs from aggregates remain consistent.
+ */
+export async function listRecentGearInterfaceRows(
+  window: QueryWindow,
+  filter: InterfaceFilter & { outcomeType?: string; slipOnly?: boolean } = {},
+  options: { limit?: number } = {},
+): Promise<GearRowSummary[]> {
+  const rows = await prisma.gearInterface.findMany({
+    where: {
+      recordedAt: { gte: window.start, lt: window.end },
+      ...(filter.innerRing != null ? { innerRing: filter.innerRing } : {}),
+      ...(filter.outerRing != null ? { outerRing: filter.outerRing } : {}),
+      ...(filter.transmissionDirection
+        ? { transmissionDirection: filter.transmissionDirection }
+        : {}),
+      ...(filter.outcomeType ? { outcomeType: filter.outcomeType } : {}),
+      ...(filter.slipOnly ? { slipDetected: true } : {}),
+    },
+    orderBy: { recordedAt: "desc" },
+    take: options.limit ?? 50,
+    select: {
+      id: true,
+      recordedAt: true,
+      innerRing: true,
+      outerRing: true,
+      transmissionDirection: true,
+      shaftSourceType: true,
+      shaftSourceId: true,
+      actorType: true,
+      actorId: true,
+      capabilityName: true,
+      archetypeContext: true,
+      torqueTechnical: true,
+      torqueConfidence: true,
+      outcomeType: true,
+      slipDetected: true,
+      slipReason: true,
+      costUsd: true,
+      graderType: true,
+    },
+  });
+
+  return rows.map((r) => ({
+    ...r,
+    costUsd: r.costUsd ? r.costUsd.toString() : null,
+  }));
+}
+
+export async function getGearInterfaceRowById(id: string) {
+  return prisma.gearInterface.findUnique({ where: { id } });
+}

--- a/apps/web/lib/gear-interface/source-adapters/adapter-run-telemetry.ts
+++ b/apps/web/lib/gear-interface/source-adapters/adapter-run-telemetry.ts
@@ -1,0 +1,107 @@
+// apps/web/lib/gear-interface/source-adapters/adapter-run-telemetry.ts
+//
+// Reduction Gear Phase 0 — AdapterRunTelemetry → GearInterface adapter.
+//
+// AdapterRunTelemetry is the AI-call telemetry envelope — one row per inference
+// call. Phase 0 does NOT emit per-inference GearInterface rows; volume would be
+// extreme. The adapter is kept pure for Phase 1 sampling and for fixture tests.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.1
+
+import type { GearInterfaceInput, SlipReason } from "../types";
+
+export interface AdapterRunTelemetrySource {
+  id: string;
+  threadId: string | null;
+  agentId: string | null;
+  buildId: string | null;
+  adapterKind: string;
+  providerId: string;
+  modelId: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  status: string;
+  refusalReason: string | null;
+  errorClass: string | null;
+  inputTokens: number | null;
+  cachedInputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  outputTokens: number | null;
+  reasoningTokens: number | null;
+  estimatedCostUsd: string | number | null;
+  toolCallsTotal: number;
+  toolCallsInvalid: number;
+  schemaDriftDetected: boolean;
+  capabilitiesUsed: string[];
+}
+
+function statusToOutcome(status: string): {
+  torqueTechnical: number;
+  outcomeType: GearInterfaceInput["outcomeType"];
+  slipReason: SlipReason | null;
+} {
+  switch (status) {
+    case "success":
+      return { torqueTechnical: 1.0, outcomeType: "transmission", slipReason: null };
+    case "refusal":
+      return { torqueTechnical: 0.0, outcomeType: "slip", slipReason: "safety-block" };
+    case "policy-block":
+      return { torqueTechnical: 0.0, outcomeType: "slip", slipReason: "safety-block" };
+    case "timeout":
+      return { torqueTechnical: 0.0, outcomeType: "slip", slipReason: "failed-outcome" };
+    case "cancelled":
+      return { torqueTechnical: 0.0, outcomeType: "slip", slipReason: "human-override" };
+    case "error":
+    default:
+      return { torqueTechnical: 0.0, outcomeType: "slip", slipReason: "failed-outcome" };
+  }
+}
+
+/**
+ * Normalize one AdapterRunTelemetry row into a Ring 1→2 input.
+ * The agentId may be null on probes/eval runs — those are excluded by callers
+ * before reaching this adapter. We still defend with a default.
+ */
+export function adapterRunTelemetryToRing12Input(
+  source: AdapterRunTelemetrySource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const { torqueTechnical, outcomeType, slipReason } = statusToOutcome(source.status);
+
+  // Use schema drift / invalid tool calls as a secondary slip signal.
+  const slipDetected =
+    outcomeType === "slip" || source.toolCallsInvalid > 0 || source.schemaDriftDetected;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 1,
+    outerRing: 2,
+    shaftSourceType: "tool-execution",
+    shaftSourceId: source.id,
+    sourceEventAt: source.startedAt,
+    actorType: "agent",
+    actorId: source.agentId ?? `unknown-agent:${source.providerId}`,
+    intent: `inference:${source.adapterKind}`,
+    capabilityName: `inference:${source.providerId}/${source.modelId}`,
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: null,
+    agentIdForTriple: source.agentId ?? `unknown-agent:${source.providerId}`,
+    torqueTechnical,
+    torqueConfidence: 0.85,
+    ratioConsumed: 1,
+    outcomeType,
+    slipDetected,
+    slipReason,
+    costUsd: source.estimatedCostUsd ?? null,
+    inputTokens: source.inputTokens,
+    outputTokens: source.outputTokens,
+    cacheCreationInputTokens: source.cacheCreationInputTokens,
+    cacheReadInputTokens: source.cachedInputTokens,
+    reasoningOutputTokens: source.reasoningTokens,
+    durationMs: source.durationMs,
+    graderType: "runtime-check",
+    organizationId: options.organizationId ?? null,
+  };
+}

--- a/apps/web/lib/gear-interface/source-adapters/contract-stubs.test.ts
+++ b/apps/web/lib/gear-interface/source-adapters/contract-stubs.test.ts
@@ -1,0 +1,182 @@
+// apps/web/lib/gear-interface/source-adapters/contract-stubs.test.ts
+//
+// Contract tests for Ring 2→3, 3→4, 4→5 adapters that are NOT emitted in
+// production during Phase 0. We still validate their shape so the spec contract
+// is mechanized and so Phase 1+ wiring inherits a tested baseline.
+//
+// Each contract test confirms:
+//   - The adapter produces a valid GearInterfaceInput
+//   - The writer's validator accepts it (idempotency key derives cleanly)
+//   - Required archetypeContext is set for Ring 2→3 and beyond
+
+import { describe, it, expect } from "vitest";
+import { deriveIdempotencyKey, validateGearInterfaceInput } from "../writer";
+import { runtimeVerificationToRing34Input } from "./runtime-verification";
+import { promotionToRing34Input } from "./promotion";
+import { featurePackToRing45Input } from "./feature-pack";
+import {
+  toolExecutionToRing12Input,
+} from "./tool-execution";
+import { adapterRunTelemetryToRing12Input } from "./adapter-run-telemetry";
+
+describe("contract stub: RuntimeVerification → Ring 3→4", () => {
+  const source = {
+    id: "rv-1",
+    verificationId: "rv-1",
+    kind: "deployment-smoke",
+    status: "pass",
+    runtimeTargetId: "rt-1",
+    featureBuildId: "fb-1",
+    gitPromotionCandidateId: null,
+    startedAt: new Date("2026-05-24T15:00:00Z"),
+    completedAt: new Date("2026-05-24T15:01:00Z"),
+    archetypeContext: "hvac",
+    agentId: "agent-runtime",
+  };
+
+  it("produces a valid Ring 3→4 record with archetypeContext", () => {
+    const input = runtimeVerificationToRing34Input(source);
+    expect(input.innerRing).toBe(3);
+    expect(input.outerRing).toBe(4);
+    expect(input.archetypeContext).toBe("hvac");
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
+    expect(deriveIdempotencyKey(input)).toBe(
+      "internal-adjacent:3:4:outward:runtime-verification:rv-1:transmission",
+    );
+  });
+
+  it("rejects without archetypeContext (Ring 3→4 requires it)", () => {
+    const input = runtimeVerificationToRing34Input({ ...source, archetypeContext: "" });
+    // empty string is truthy-false for our nullish path; force null:
+    expect(() =>
+      validateGearInterfaceInput({ ...input, archetypeContext: null }),
+    ).toThrow(/archetypeContext/);
+  });
+});
+
+describe("contract stub: Promotion → Ring 3→4", () => {
+  it("produces a valid Ring 3→4 promotion record", () => {
+    const input = promotionToRing34Input({
+      id: "gpc-1",
+      promotionKind: "GitPromotionCandidate",
+      archetypeContext: "hvac",
+      agentId: "agent-release",
+      success: true,
+      recordedAt: new Date("2026-05-24T15:30:00Z"),
+    });
+    expect(input.innerRing).toBe(3);
+    expect(input.outerRing).toBe(4);
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
+  });
+});
+
+describe("contract stub: FeaturePack → Ring 4↔5 external-federated", () => {
+  it("produces a valid lateral external-federated record", () => {
+    const input = featurePackToRing45Input({
+      id: "fp-1",
+      direction: "outward",
+      peerInstallPseudonym: "anon-install-7f8a",
+      agentId: "agent-hive",
+      archetypeContext: "hvac",
+      success: true,
+      failureReason: null,
+      recordedAt: new Date("2026-05-24T15:45:00Z"),
+    });
+    expect(input.interfaceClass).toBe("external-federated");
+    expect(input.transmissionDirection).toBe("lateral");
+    expect(input.externalCounterpartyType).toBe("peer-install");
+    expect(input.externalCounterpartyId).toBe("anon-install-7f8a");
+    expect(input.innerRing).toBeNull();
+    expect(input.outerRing).toBeNull();
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
+  });
+});
+
+describe("contract stub: ToolExecution → Ring 1→2", () => {
+  it("normalizes a successful tool call", () => {
+    const input = toolExecutionToRing12Input({
+      id: "te-1",
+      threadId: "t-1",
+      agentId: "agent-build-specialist",
+      userId: "u-1",
+      toolName: "create_backlog_item",
+      success: true,
+      executionMode: "governed",
+      routeContext: "/api/mcp/v1",
+      durationMs: 120,
+      createdAt: new Date(),
+      capabilityId: "backlog/create",
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: null,
+    });
+    expect(input.outcomeType).toBe("transmission");
+    expect(input.capabilityName).toBe("backlog/create");
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
+  });
+});
+
+describe("contract stub: AdapterRunTelemetry → Ring 1→2", () => {
+  it("normalizes a successful inference", () => {
+    const input = adapterRunTelemetryToRing12Input({
+      id: "art-1",
+      threadId: null,
+      agentId: "agent-build-specialist",
+      buildId: "build-1",
+      adapterKind: "anthropic-messages",
+      providerId: "anthropic",
+      modelId: "claude-opus-4-7",
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      durationMs: 800,
+      status: "success",
+      refusalReason: null,
+      errorClass: null,
+      inputTokens: 1200,
+      cachedInputTokens: 800,
+      cacheCreationInputTokens: 100,
+      outputTokens: 400,
+      reasoningTokens: 50,
+      estimatedCostUsd: 0.012,
+      toolCallsTotal: 3,
+      toolCallsInvalid: 0,
+      schemaDriftDetected: false,
+      capabilitiesUsed: ["tool_use"],
+    });
+    expect(input.outcomeType).toBe("transmission");
+    expect(input.cacheReadInputTokens).toBe(800);
+    expect(input.reasoningOutputTokens).toBe(50);
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
+  });
+
+  it("normalizes a refusal as a slip with safety-block reason", () => {
+    const input = adapterRunTelemetryToRing12Input({
+      id: "art-2",
+      threadId: null,
+      agentId: "agent-build-specialist",
+      buildId: "build-1",
+      adapterKind: "anthropic-messages",
+      providerId: "anthropic",
+      modelId: "claude-opus-4-7",
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      durationMs: 200,
+      status: "refusal",
+      refusalReason: "policy",
+      errorClass: null,
+      inputTokens: 200,
+      cachedInputTokens: null,
+      cacheCreationInputTokens: null,
+      outputTokens: 20,
+      reasoningTokens: null,
+      estimatedCostUsd: null,
+      toolCallsTotal: 0,
+      toolCallsInvalid: 0,
+      schemaDriftDetected: false,
+      capabilitiesUsed: [],
+    });
+    expect(input.outcomeType).toBe("slip");
+    expect(input.slipReason).toBe("safety-block");
+    expect(input.slipDetected).toBe(true);
+  });
+});

--- a/apps/web/lib/gear-interface/source-adapters/feature-pack.ts
+++ b/apps/web/lib/gear-interface/source-adapters/feature-pack.ts
@@ -1,0 +1,65 @@
+// apps/web/lib/gear-interface/source-adapters/feature-pack.ts
+//
+// Reduction Gear Phase 0 — FeaturePack → GearInterface adapter (CONTRACT STUB).
+//
+// FeaturePack is the existing Hive contribution artifact. In Phase 3 this
+// adapter drives Ring 4↔5 outward records when contribute_to_hive runs and
+// inward records when hive-scout-ingest pulls. Phase 0 does NOT emit production
+// records — the adapter is a typed contract for Phase 3 implementation.
+//
+// Privacy note: per spec §7.1, raw torque histograms travel through the
+// CalibratedCapabilityPack creation flow, which is governed by contribute_to_hive.
+// This adapter never emits histogram payload — only the existence and outcome
+// of the cross-install handshake.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.4, §7
+
+import type { GearInterfaceInput } from "../types";
+
+export interface FeaturePackContributionSource {
+  id: string;
+  /** Outward push from this install, or inward pull from another. */
+  direction: "outward" | "inward";
+  /** Pseudonymized identifier of the other install — never raw PII. */
+  peerInstallPseudonym: string;
+  agentId: string;
+  archetypeContext: string;
+  success: boolean;
+  failureReason: string | null;
+  recordedAt: Date;
+}
+
+export function featurePackToRing45Input(
+  source: FeaturePackContributionSource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const torqueTechnical = source.success ? 1.0 : 0.0;
+
+  return {
+    interfaceClass: "external-federated",
+    transmissionDirection: source.direction === "outward" ? "lateral" : "lateral",
+    innerRing: null,
+    outerRing: null,
+    externalCounterpartyType: "peer-install",
+    externalCounterpartyId: source.peerInstallPseudonym,
+    shaftSourceType: "feature-pack",
+    shaftSourceId: source.id,
+    sourceEventAt: source.recordedAt,
+    actorType: "agent",
+    actorId: source.agentId,
+    intent: source.direction === "outward" ? "contribute_to_hive" : "hive_scout_ingest",
+    capabilityName: "hive-federation",
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: source.archetypeContext,
+    agentIdForTriple: source.agentId,
+    torqueTechnical,
+    torqueConfidence: 0.95,
+    ratioConsumed: 1,
+    outcomeType: source.success ? "transmission" : "slip",
+    slipDetected: !source.success,
+    slipReason: source.success ? null : "failed-outcome",
+    graderType: "runtime-check",
+    rationale: source.failureReason,
+    organizationId: options.organizationId ?? null,
+  };
+}

--- a/apps/web/lib/gear-interface/source-adapters/phase-run.test.ts
+++ b/apps/web/lib/gear-interface/source-adapters/phase-run.test.ts
@@ -1,0 +1,139 @@
+// apps/web/lib/gear-interface/source-adapters/phase-run.test.ts
+
+import { describe, it, expect } from "vitest";
+import {
+  phaseRunToRing12Input,
+  _internals,
+  type PhaseOutcomeSignals,
+  type PhaseRunSource,
+} from "./phase-run";
+
+const completedAt = new Date("2026-05-24T16:00:00Z");
+const startedAt = new Date("2026-05-24T15:30:00Z");
+
+function basePhaseRun(overrides: Partial<PhaseRunSource> = {}): PhaseRunSource {
+  return {
+    id: "phaserun-build-123-build",
+    buildId: "build-123",
+    phase: "build",
+    startedAt,
+    completedAt,
+    durationMs: 30 * 60 * 1000,
+    inputTokens: 12_000,
+    outputTokens: 4_500,
+    costUsd: "0.142",
+    inferenceCount: 8,
+    providerId: "anthropic",
+    ...overrides,
+  };
+}
+
+function baseSignals(overrides: Partial<PhaseOutcomeSignals> = {}): PhaseOutcomeSignals {
+  return {
+    claimedByAgentId: "agent-build-specialist",
+    codingProvider: "claude-cli",
+    uxVerificationStatus: "complete",
+    acceptanceMet: true,
+    abandoned: false,
+    abandonReason: null,
+    worstFailureAxis: null,
+    attemptCount: 1,
+    ...overrides,
+  };
+}
+
+describe("phaseRunToRing12Input", () => {
+  it("returns null when the phase has not completed", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun({ completedAt: null }),
+      baseSignals(),
+    );
+    expect(input).toBeNull();
+  });
+
+  it("emits a transmission with torque=1.0 on clean completion", () => {
+    const input = phaseRunToRing12Input(basePhaseRun(), baseSignals());
+    expect(input).not.toBeNull();
+    expect(input!.outcomeType).toBe("transmission");
+    expect(input!.torqueTechnical).toBe(1.0);
+    expect(input!.slipDetected).toBe(false);
+    expect(input!.slipReason).toBeNull();
+    expect(input!.innerRing).toBe(1);
+    expect(input!.outerRing).toBe(2);
+    expect(input!.ratioConsumed).toBe(8);
+    expect(input!.capabilityName).toBe("build-phase-build");
+    expect(input!.agentIdForTriple).toBe("agent-build-specialist");
+  });
+
+  it("emits a slip when the build was abandoned", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun(),
+      baseSignals({ abandoned: true, abandonReason: "operator-veto" }),
+    );
+    expect(input!.outcomeType).toBe("slip");
+    expect(input!.torqueTechnical).toBe(0);
+    expect(input!.rationale).toContain("operator-veto");
+  });
+
+  it("emits a slip when UX verification failed", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun(),
+      baseSignals({ uxVerificationStatus: "failed" }),
+    );
+    expect(input!.outcomeType).toBe("slip");
+    expect(input!.torqueTechnical).toBe(0);
+  });
+
+  it("emits partial torque when a dispatch attempt failed but the phase completed", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun(),
+      baseSignals({ worstFailureAxis: "rate-limit", attemptCount: 2 }),
+    );
+    expect(input!.outcomeType).toBe("slip");
+    expect(input!.torqueTechnical).toBeLessThan(1.0);
+    expect(input!.slipDetected).toBe(true);
+    expect(input!.slipReason).toBe("rate-limit");
+  });
+
+  it("falls back to coding provider when no claimed coworker", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun(),
+      baseSignals({ claimedByAgentId: null }),
+    );
+    expect(input!.agentIdForTriple).toBe("claude-cli");
+  });
+
+  it("never throws when both agent attributions are null", () => {
+    const input = phaseRunToRing12Input(
+      basePhaseRun(),
+      baseSignals({ claimedByAgentId: null, codingProvider: null }),
+    );
+    expect(input!.agentIdForTriple).toContain("unknown-agent");
+  });
+
+  it("leaves archetypeContext null at Ring 1→2 (spec §3.3)", () => {
+    const input = phaseRunToRing12Input(basePhaseRun(), baseSignals());
+    expect(input!.archetypeContext).toBeNull();
+  });
+
+  it("propagates cost + token rollup verbatim from the phase run", () => {
+    const input = phaseRunToRing12Input(basePhaseRun(), baseSignals());
+    expect(input!.costUsd).toBe("0.142");
+    expect(input!.inputTokens).toBe(12_000);
+    expect(input!.outputTokens).toBe(4_500);
+    expect(input!.durationMs).toBe(30 * 60 * 1000);
+  });
+});
+
+describe("phase-run internals", () => {
+  it("maps rate-limit failure axis to slip reason", () => {
+    expect(_internals.failureAxisToSlipReason("rate-limit")).toBe("rate-limit");
+  });
+  it("maps unknown axis to null (not a slip we can categorize)", () => {
+    expect(_internals.failureAxisToSlipReason("unknown")).toBeNull();
+    expect(_internals.failureAxisToSlipReason(null)).toBeNull();
+  });
+  it("falls back to failed-outcome for unmapped axes", () => {
+    expect(_internals.failureAxisToSlipReason("weird-new-axis")).toBe("failed-outcome");
+  });
+});

--- a/apps/web/lib/gear-interface/source-adapters/phase-run.ts
+++ b/apps/web/lib/gear-interface/source-adapters/phase-run.ts
@@ -1,0 +1,184 @@
+// apps/web/lib/gear-interface/source-adapters/phase-run.ts
+//
+// Reduction Gear Phase 0 — Ring 1→2 primary source adapter.
+//
+// Build Studio BuildPhaseRun completion is the outer shaft (Ring 2 advance);
+// the inner shaft is the set of coworker actions (ToolExecution rows,
+// AdapterRunTelemetry inferences, BuildDispatchAttempt records) that occurred
+// within the phase's [startedAt, completedAt] window.
+//
+// This adapter does NOT touch the DB. Higher layers fetch the source rows and
+// call here with the assembled context. That keeps adapters pure, testable,
+// and the Ring 1→2 hook responsible for orchestration. (Spec §9.1 refactor
+// allocation: "Normalize source-event adapters with one function per source type.")
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.1
+
+import type { GearInterfaceInput } from "../types";
+import type { SlipReason } from "../types";
+
+export type PhaseName = "ideate" | "plan" | "build" | "review" | "ship";
+
+export interface PhaseRunSource {
+  /** PhaseRun row id — the canonical shaftSourceId for the emit. */
+  id: string;
+  buildId: string;
+  phase: PhaseName;
+  startedAt: Date;
+  completedAt: Date | null;
+  durationMs: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: string | number | null;
+  inferenceCount: number;
+  providerId: string | null;
+}
+
+/**
+ * Outcome signals derived from the surrounding FeatureBuild. The hook is
+ * responsible for fetching these — keeping them out of the adapter signature
+ * keeps it pure.
+ */
+export interface PhaseOutcomeSignals {
+  /** From FeatureBuild — used to pick the agent triple. */
+  claimedByAgentId: string | null;
+  codingProvider: string | null;
+
+  /** From FeatureBuild.uxVerificationStatus + acceptanceMet — drives torqueTechnical. */
+  uxVerificationStatus: "complete" | "failed" | "running" | "skipped" | null;
+  acceptanceMet: boolean | null;
+
+  /** Whether the build was abandoned at or after this phase. */
+  abandoned: boolean;
+  abandonReason: string | null;
+
+  /** From BuildDispatchAttempt — failure axis if any attempt in this phase failed. */
+  worstFailureAxis: string | null;
+  attemptCount: number;
+}
+
+/**
+ * Map a Build Studio dispatch failureAxis string to a GearInterface slip
+ * reason. Kept as a small lookup so unknown axes surface explicitly rather
+ * than silently dropping into a default.
+ */
+function failureAxisToSlipReason(axis: string | null): SlipReason | null {
+  if (!axis || axis === "unknown") return null;
+  const map: Record<string, SlipReason> = {
+    "rate-limit": "rate-limit",
+    timeout: "failed-outcome",
+    "tool-fabrication": "capability-gap",
+    "schema-drift": "capability-gap",
+    "policy-block": "safety-block",
+    "cost-overrun": "cost-overrun",
+    "human-override": "human-override",
+  };
+  return map[axis] ?? "failed-outcome";
+}
+
+/**
+ * Compute torqueTechnical for a phase completion from outcome signals.
+ *
+ * Pass criteria: phase completed, no failures, UX verification not failed.
+ * Partial:       completed but had retries / warnings.
+ * Fail:          abandoned, or acceptance not met, or UX verification failed.
+ */
+function computeTorqueTechnical(signals: PhaseOutcomeSignals): number {
+  if (signals.abandoned) return 0;
+  if (signals.uxVerificationStatus === "failed") return 0;
+  if (signals.acceptanceMet === false) return 0;
+  if (signals.worstFailureAxis && signals.worstFailureAxis !== "unknown") {
+    // Phase finished despite a failed attempt — partial credit
+    return 0.5;
+  }
+  if (signals.attemptCount > 1) {
+    // Multiple attempts needed; technically succeeded but inefficient
+    return 0.75;
+  }
+  return 1.0;
+}
+
+/**
+ * Confidence in the automated grading. Lower when we are filling in gaps from
+ * "ran cleanly" signals alone; higher when UX verification or acceptance gives
+ * an explicit answer.
+ */
+function computeTorqueConfidence(signals: PhaseOutcomeSignals): number {
+  if (signals.uxVerificationStatus === "complete" || signals.uxVerificationStatus === "failed") {
+    return 0.9;
+  }
+  if (signals.acceptanceMet === true || signals.acceptanceMet === false) {
+    return 0.8;
+  }
+  if (signals.abandoned) return 0.95;
+  return 0.6;
+}
+
+/**
+ * Build the canonical Ring 1→2 input for a completed BuildPhaseRun.
+ *
+ * Returns null when the phase has not actually completed yet — the caller
+ * should not emit pre-completion (the row would be incomplete).
+ */
+export function phaseRunToRing12Input(
+  phaseRun: PhaseRunSource,
+  signals: PhaseOutcomeSignals,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput | null {
+  if (!phaseRun.completedAt) return null;
+
+  const torqueTechnical = computeTorqueTechnical(signals);
+  const torqueConfidence = computeTorqueConfidence(signals);
+  const slipReason = failureAxisToSlipReason(signals.worstFailureAxis);
+  const slipDetected = torqueTechnical < 1.0 || slipReason !== null;
+
+  // Agent triple resolution — prefer the explicitly claimed coworker, fall
+  // back to the coding provider id, and finally to "unknown" so the triple
+  // remains queryable.
+  const agentIdForTriple =
+    signals.claimedByAgentId ??
+    signals.codingProvider ??
+    `unknown-agent:${phaseRun.buildId}`;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 1,
+    outerRing: 2,
+    shaftSourceType: "phase-run",
+    shaftSourceId: phaseRun.id,
+    sourceEventAt: phaseRun.completedAt,
+    actorType: "agent",
+    actorId: agentIdForTriple,
+    intent: `complete-phase-${phaseRun.phase}`,
+    capabilityName: `build-phase-${phaseRun.phase}`,
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: null, // Ring 1→2 is allowed null (spec §3.3)
+    agentIdForTriple,
+    torqueTechnical,
+    torqueValue: null, // Phase 0 — value attribution deferred (spec §11.2)
+    torqueConfidence,
+    ratioConsumed: phaseRun.inferenceCount,
+    outcomeType: torqueTechnical >= 1.0 ? "transmission" : "slip",
+    slipDetected,
+    slipReason,
+    costUsd: phaseRun.costUsd ?? null,
+    inputTokens: phaseRun.inputTokens || null,
+    outputTokens: phaseRun.outputTokens || null,
+    durationMs: phaseRun.durationMs ?? null,
+    graderType: "automated",
+    graderId: "build-phase-run.completeBuildPhaseRun",
+    rationale:
+      signals.abandoned && signals.abandonReason
+        ? `abandoned: ${signals.abandonReason}`
+        : null,
+    organizationId: options.organizationId ?? null,
+  };
+}
+
+// Exposed for tests.
+export const _internals = {
+  computeTorqueTechnical,
+  computeTorqueConfidence,
+  failureAxisToSlipReason,
+};

--- a/apps/web/lib/gear-interface/source-adapters/promotion.ts
+++ b/apps/web/lib/gear-interface/source-adapters/promotion.ts
@@ -1,0 +1,56 @@
+// apps/web/lib/gear-interface/source-adapters/promotion.ts
+//
+// Reduction Gear Phase 0 — Promotion → GearInterface adapter (CONTRACT STUB).
+//
+// GitPromotionCandidate / ChangePromotion / ProductVersion / ReleaseBundle
+// drive Ring 3→4 (Archetype → Sandbox/Production) outward records on promotion
+// and Ring 4↔5 records when release manifests cross the install boundary
+// (governed-upgrade Phase 2 — see spec §9.9).
+//
+// Phase 0 does NOT emit. This is the typed contract for Phase 1+ wiring.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.3, §9.9
+
+import type { GearInterfaceInput } from "../types";
+
+export interface PromotionSource {
+  id: string;
+  /** "GitPromotionCandidate" | "ChangePromotion" | "ProductVersion" | "ReleaseBundle" */
+  promotionKind: string;
+  archetypeContext: string;
+  agentId: string;
+  success: boolean;
+  recordedAt: Date;
+}
+
+export function promotionToRing34Input(
+  source: PromotionSource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const torqueTechnical = source.success ? 1.0 : 0.0;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 3,
+    outerRing: 4,
+    shaftSourceType: "promotion",
+    shaftSourceId: source.id,
+    sourceEventAt: source.recordedAt,
+    actorType: "system",
+    actorId: source.agentId,
+    intent: `promote:${source.promotionKind}`,
+    capabilityName: `promotion:${source.promotionKind}`,
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: source.archetypeContext,
+    agentIdForTriple: source.agentId,
+    torqueTechnical,
+    torqueConfidence: 0.9,
+    ratioConsumed: 1,
+    outcomeType: source.success ? "transmission" : "slip",
+    slipDetected: !source.success,
+    slipReason: source.success ? null : "failed-outcome",
+    graderType: "runtime-check",
+    organizationId: options.organizationId ?? null,
+  };
+}

--- a/apps/web/lib/gear-interface/source-adapters/runtime-verification.ts
+++ b/apps/web/lib/gear-interface/source-adapters/runtime-verification.ts
@@ -1,0 +1,69 @@
+// apps/web/lib/gear-interface/source-adapters/runtime-verification.ts
+//
+// Reduction Gear Phase 0 — RuntimeVerification → GearInterface adapter (CONTRACT STUB).
+//
+// RuntimeVerification is the typed verification event that already attaches to
+// RuntimeTarget / WorkCapsule / FeatureBuild / GitPromotionCandidate. It will
+// drive Ring 3→4 (Archetype → Sandbox/Production) outward records and Ring 4→5
+// inward records (release verification arriving back at the install).
+//
+// Phase 0 does NOT emit production records here. The contract is captured as a
+// typed adapter so the writer's invariant checks (archetypeContext required at
+// Ring 2→3 and beyond) are exercised by tests. Production emission unlocks in
+// Phase 1+ once archetype context resolution lands.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.3, §4.4
+
+import type { GearInterfaceInput } from "../types";
+
+export interface RuntimeVerificationSource {
+  id: string;
+  verificationId: string;
+  kind: string;
+  status: string;
+  runtimeTargetId: string | null;
+  featureBuildId: string | null;
+  gitPromotionCandidateId: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  /** Resolved archetype id from the surrounding entity — REQUIRED for Ring 2→3+. */
+  archetypeContext: string;
+  /** Agent that performed or initiated the verification. */
+  agentId: string;
+}
+
+export function runtimeVerificationToRing34Input(
+  source: RuntimeVerificationSource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const torqueTechnical = source.status === "pass" || source.status === "complete" ? 1.0 : 0.0;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 3,
+    outerRing: 4,
+    shaftSourceType: "runtime-verification",
+    shaftSourceId: source.id,
+    sourceEventAt: source.completedAt ?? source.startedAt,
+    actorType: "system",
+    actorId: source.agentId,
+    intent: `verify:${source.kind}`,
+    capabilityName: `runtime-verification:${source.kind}`,
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: source.archetypeContext,
+    agentIdForTriple: source.agentId,
+    torqueTechnical,
+    torqueConfidence: 0.9,
+    ratioConsumed: 1,
+    outcomeType: torqueTechnical >= 1.0 ? "transmission" : "slip",
+    slipDetected: torqueTechnical < 1.0,
+    slipReason: torqueTechnical < 1.0 ? "failed-outcome" : null,
+    durationMs:
+      source.startedAt && source.completedAt
+        ? source.completedAt.getTime() - source.startedAt.getTime()
+        : null,
+    graderType: "runtime-check",
+    organizationId: options.organizationId ?? null,
+  };
+}

--- a/apps/web/lib/gear-interface/source-adapters/tool-execution.ts
+++ b/apps/web/lib/gear-interface/source-adapters/tool-execution.ts
@@ -1,0 +1,73 @@
+// apps/web/lib/gear-interface/source-adapters/tool-execution.ts
+//
+// Reduction Gear Phase 0 — ToolExecution → GearInterface adapter.
+//
+// ToolExecution is one of the Ring 1 inner-shaft event types. Phase 0 does NOT
+// emit per-tool-execution GearInterface rows (that would multiply volume by
+// every governed tool call). This adapter exists so the contract is well-typed
+// and tested, ready for Phase 1 when per-tool granularity is added behind a
+// per-source feature flag.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §4.1
+
+import type { GearInterfaceInput } from "../types";
+
+export interface ToolExecutionSource {
+  id: string;
+  threadId: string;
+  agentId: string;
+  userId: string;
+  toolName: string;
+  success: boolean;
+  executionMode: string;
+  routeContext: string | null;
+  durationMs: number | null;
+  createdAt: Date;
+  capabilityId: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+}
+
+/**
+ * Normalize a ToolExecution row into a Ring 1→2 GearInterfaceInput.
+ *
+ * This is a 1:1 mapping of one tool call to one transmission record. Phase 0
+ * does NOT call this in production; it's kept as a pure adapter for tests and
+ * Phase 1 wiring.
+ */
+export function toolExecutionToRing12Input(
+  source: ToolExecutionSource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const torqueTechnical = source.success ? 1.0 : 0.0;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 1,
+    outerRing: 2,
+    shaftSourceType: "tool-execution",
+    shaftSourceId: source.id,
+    sourceEventAt: source.createdAt,
+    actorType: "agent",
+    actorId: source.agentId,
+    intent: source.toolName,
+    capabilityName: source.capabilityId ?? source.toolName,
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: null,
+    agentIdForTriple: source.agentId,
+    torqueTechnical,
+    torqueConfidence: 0.7, // tool success/fail is a strong but imperfect signal
+    ratioConsumed: 1, // one tool call = one inner-ring event
+    outcomeType: source.success ? "transmission" : "slip",
+    slipDetected: !source.success,
+    slipReason: source.success ? null : "failed-outcome",
+    costUsd: source.costUsd,
+    inputTokens: source.inputTokens,
+    outputTokens: source.outputTokens,
+    durationMs: source.durationMs,
+    graderType: "runtime-check",
+    organizationId: options.organizationId ?? null,
+  };
+}

--- a/apps/web/lib/gear-interface/test-fixtures.ts
+++ b/apps/web/lib/gear-interface/test-fixtures.ts
@@ -1,0 +1,140 @@
+// apps/web/lib/gear-interface/test-fixtures.ts
+//
+// Reduction Gear Phase 0 — coherent fixture builders for tests.
+//
+// Per spec §9.1 refactoring allocation: "Add test helpers that can build a
+// coherent phase-run evidence fixture without copy-pasted JSON blobs."
+//
+// These builders return a related set of source-row shapes (PhaseRun +
+// outcome signals + adapter telemetry + dispatch attempts) that all agree on
+// the same buildId / agent / phase window, so adapter and emit tests don't
+// re-invent fixture geometry per file.
+
+import type {
+  PhaseOutcomeSignals,
+  PhaseRunSource,
+} from "./source-adapters/phase-run";
+import type { AdapterRunTelemetrySource } from "./source-adapters/adapter-run-telemetry";
+import type { ToolExecutionSource } from "./source-adapters/tool-execution";
+import type { GearInterfaceInput } from "./types";
+
+export interface BuildPhaseFixture {
+  buildId: string;
+  phase: "ideate" | "plan" | "build" | "review" | "ship";
+  agentId: string;
+  phaseRun: PhaseRunSource;
+  signals: PhaseOutcomeSignals;
+  inferences: AdapterRunTelemetrySource[];
+  toolExecutions: ToolExecutionSource[];
+}
+
+export interface FixtureOptions {
+  buildId?: string;
+  phase?: BuildPhaseFixture["phase"];
+  agentId?: string;
+  startedAt?: Date;
+  /** "clean" (default) | "abandoned" | "ux-failed" | "with-retries" */
+  outcome?: "clean" | "abandoned" | "ux-failed" | "with-retries";
+  inferenceCount?: number;
+}
+
+/**
+ * Build a coherent Build Studio phase fixture. All produced rows share the
+ * same buildId, agent, and time window so emit-path tests can assert
+ * end-to-end transmission without bespoke wiring.
+ */
+export function buildPhaseFixture(opts: FixtureOptions = {}): BuildPhaseFixture {
+  const buildId = opts.buildId ?? "fixture-build-1";
+  const phase = opts.phase ?? "build";
+  const agentId = opts.agentId ?? "agent-build-specialist";
+  const startedAt = opts.startedAt ?? new Date("2026-05-24T15:00:00Z");
+  const completedAt = new Date(startedAt.getTime() + 30 * 60 * 1000);
+  const inferenceCount = opts.inferenceCount ?? 6;
+  const outcome = opts.outcome ?? "clean";
+
+  const phaseRun: PhaseRunSource = {
+    id: `phaserun-${buildId}-${phase}`,
+    buildId,
+    phase,
+    startedAt,
+    completedAt,
+    durationMs: 30 * 60 * 1000,
+    inputTokens: inferenceCount * 1500,
+    outputTokens: inferenceCount * 600,
+    costUsd: (inferenceCount * 0.018).toFixed(6),
+    inferenceCount,
+    providerId: "anthropic",
+  };
+
+  const signals: PhaseOutcomeSignals = {
+    claimedByAgentId: agentId,
+    codingProvider: "claude-cli",
+    uxVerificationStatus:
+      outcome === "ux-failed" ? "failed" : outcome === "clean" || outcome === "with-retries" ? "complete" : null,
+    acceptanceMet: outcome === "abandoned" ? null : outcome === "ux-failed" ? false : true,
+    abandoned: outcome === "abandoned",
+    abandonReason: outcome === "abandoned" ? "operator-veto" : null,
+    worstFailureAxis: outcome === "with-retries" ? "rate-limit" : null,
+    attemptCount: outcome === "with-retries" ? 2 : 1,
+  };
+
+  const inferences: AdapterRunTelemetrySource[] = Array.from({ length: inferenceCount }).map(
+    (_, i) => ({
+      id: `art-${buildId}-${phase}-${i}`,
+      threadId: `thread-${buildId}`,
+      agentId,
+      buildId,
+      adapterKind: "anthropic-messages",
+      providerId: "anthropic",
+      modelId: "claude-opus-4-7",
+      startedAt: new Date(startedAt.getTime() + i * 60 * 1000),
+      finishedAt: new Date(startedAt.getTime() + i * 60 * 1000 + 4000),
+      durationMs: 4000,
+      status: "success",
+      refusalReason: null,
+      errorClass: null,
+      inputTokens: 1500,
+      cachedInputTokens: 800,
+      cacheCreationInputTokens: 100,
+      outputTokens: 600,
+      reasoningTokens: 50,
+      estimatedCostUsd: "0.018",
+      toolCallsTotal: 2,
+      toolCallsInvalid: 0,
+      schemaDriftDetected: false,
+      capabilitiesUsed: ["tool_use"],
+    }),
+  );
+
+  const toolExecutions: ToolExecutionSource[] = Array.from({ length: inferenceCount * 2 }).map(
+    (_, i) => ({
+      id: `te-${buildId}-${phase}-${i}`,
+      threadId: `thread-${buildId}`,
+      agentId,
+      userId: "user-1",
+      toolName: i % 2 === 0 ? "create_backlog_item" : "search_project_files",
+      success: true,
+      executionMode: "governed",
+      routeContext: "/build",
+      durationMs: 120,
+      createdAt: new Date(startedAt.getTime() + i * 30 * 1000),
+      capabilityId: null,
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: null,
+    }),
+  );
+
+  return { buildId, phase, agentId, phaseRun, signals, inferences, toolExecutions };
+}
+
+/**
+ * Sanity helper — verifies that the fixture's normalized Ring 1→2 input
+ * passes writer validation. Used inside tests to fail fast when the fixture
+ * geometry itself drifts.
+ */
+export function assertFixtureProducesValidInput(
+  input: GearInterfaceInput | null,
+): asserts input is GearInterfaceInput {
+  if (!input) throw new Error("fixture produced null input");
+}

--- a/apps/web/lib/gear-interface/types.ts
+++ b/apps/web/lib/gear-interface/types.ts
@@ -1,0 +1,154 @@
+// apps/web/lib/gear-interface/types.ts
+//
+// Reduction Gear Phase 0 — GearInterface input shapes and enum literals.
+//
+// Adapters (source-adapters/*) produce GearInterfaceInput; the writer service
+// validates, derives the idempotency key, and upserts. Enum literals are
+// duplicated here as TypeScript string-literal unions because Prisma stores
+// them as plain strings (the DB CHECK constraints enforce membership).
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §3.1
+// BI:   BI-85CB31F0
+
+export type InterfaceClass =
+  | "internal-adjacent"
+  | "external-federated"
+  | "external-bridged"
+  | "external-customer";
+
+export type TransmissionDirection = "outward" | "inward" | "lateral";
+
+export type ShaftSourceType =
+  | "tool-execution"
+  | "phase-run"
+  | "capsule"
+  | "promotion"
+  | "feature-pack"
+  | "a2a-thread"
+  | "deliberation"
+  | "runtime-verification"
+  | "decision-interaction"
+  | "external-po"
+  | "external-invoice"
+  | "external-handoff"
+  | "platform-upgrade-run"
+  | "release-manifest"
+  | "channel-manifest"
+  | "migration-classifier"
+  | "seed-delta-manifest";
+
+export type ActorType = "agent" | "human" | "system";
+
+export type OutcomeType =
+  | "transmission"
+  | "slip"
+  | "graduation"
+  | "veto"
+  | "calibration-update";
+
+export type SlipReason =
+  | "novel-context"
+  | "failed-outcome"
+  | "human-override"
+  | "cost-overrun"
+  | "safety-block"
+  | "rate-limit"
+  | "capability-gap"
+  | "migration-destructive"
+  | "manifest-invalid"
+  | "signature-invalid"
+  | "seed-delta-conflict"
+  | "source-unindexed";
+
+export type AutonomyTier =
+  | "hitl-required"
+  | "hitl-fallback"
+  | "auto-confirm"
+  | "auto-silent";
+
+export type GraderType = "human" | "automated" | "deliberation" | "runtime-check";
+
+export type ExternalCounterpartyType =
+  | "supplier"
+  | "partner"
+  | "customer"
+  | "peer-install";
+
+/**
+ * Normalized input an adapter produces for the writer service.
+ *
+ * The writer derives `idempotencyKey` from these fields when not provided
+ * explicitly. Adapters MAY pass `idempotencyKeySuffix` when one source event
+ * produces multiple GearInterface rows (e.g., a single phase emitting both a
+ * transmission and a graduation), to disambiguate the otherwise-identical key.
+ */
+export interface GearInterfaceInput {
+  // Location of the transmission
+  interfaceClass: InterfaceClass;
+  transmissionDirection?: TransmissionDirection;
+  innerRing?: number | null;
+  outerRing?: number | null;
+  externalCounterpartyType?: ExternalCounterpartyType | null;
+  externalCounterpartyId?: string | null;
+
+  // Source event
+  shaftSourceType: ShaftSourceType;
+  shaftSourceId: string;
+  sourceEventAt?: Date | null;
+  actorType: ActorType;
+  actorId: string;
+  actorPrincipalId?: string | null;
+  intent: string;
+
+  // Capability triple
+  capabilityName: string;
+  capabilityVocabularyVersion?: string;
+  archetypeContext?: string | null;
+  agentIdForTriple: string;
+
+  // Mechanical readings
+  torqueTechnical: number;
+  torqueValue?: number | null;
+  torqueConfidence: number;
+  ratioConsumed: number;
+  outcomeType: OutcomeType;
+  slipDetected?: boolean;
+  slipReason?: SlipReason | null;
+
+  // Cost
+  costUsd?: number | string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheCreationInputTokens?: number | null;
+  cacheReadInputTokens?: number | null;
+  reasoningOutputTokens?: number | null;
+  durationMs?: number | null;
+
+  // Autonomy / graduation
+  graduationFromAutonomy?: AutonomyTier | null;
+  graduationToAutonomy?: AutonomyTier | null;
+  graduationSampleSize?: number | null;
+  graduationGovernorRef?: string | null;
+
+  // Provenance
+  graderType: GraderType;
+  graderId?: string | null;
+  rationale?: string | null;
+
+  // OTel correlation (optional)
+  otelTraceId?: string | null;
+  otelSpanId?: string | null;
+
+  // Org scoping (optional; single-org installs may pass null)
+  organizationId?: string | null;
+
+  /** Optional suffix when one source event emits multiple rows. */
+  idempotencyKeySuffix?: string;
+
+  /**
+   * Explicit override. Most callers should let the writer derive this from the
+   * other fields — the documented format is the contract. Pass only when the
+   * derived key would collide with another legitimate row.
+   */
+  idempotencyKey?: string;
+}

--- a/apps/web/lib/gear-interface/writer.test.ts
+++ b/apps/web/lib/gear-interface/writer.test.ts
@@ -1,0 +1,224 @@
+// apps/web/lib/gear-interface/writer.test.ts
+//
+// Tests for the GearInterface writer service: idempotency key derivation,
+// invariant validation (spec §3.1), and upsert/replay safety.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const gearRows = new Map<string, Record<string, unknown>>();
+let nextId = 1;
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    gearInterface: {
+      findUnique: vi.fn(async ({ where }: { where: { idempotencyKey: string } }) => {
+        const row = gearRows.get(where.idempotencyKey);
+        return row ?? null;
+      }),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const row = {
+          id: `gear-${nextId++}`,
+          recordedAt: new Date(),
+          schemaVersion: 1,
+          slipDetected: false,
+          capabilityVocabularyVersion: "raw-v0",
+          transmissionDirection: "outward",
+          ...data,
+        };
+        gearRows.set(String(data.idempotencyKey), row);
+        return row;
+      }),
+    },
+  },
+  Prisma: {},
+}));
+
+import {
+  emitGearInterface,
+  deriveIdempotencyKey,
+  validateGearInterfaceInput,
+  GearInterfaceValidationError,
+} from "./writer";
+import type { GearInterfaceInput } from "./types";
+
+beforeEach(() => {
+  gearRows.clear();
+  nextId = 1;
+  vi.clearAllMocks();
+});
+
+function ring12Input(overrides: Partial<GearInterfaceInput> = {}): GearInterfaceInput {
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 1,
+    outerRing: 2,
+    shaftSourceType: "phase-run",
+    shaftSourceId: "phase-run-abc",
+    actorType: "agent",
+    actorId: "agent-build-specialist",
+    intent: "complete-phase",
+    capabilityName: "complete-phase",
+    agentIdForTriple: "agent-build-specialist",
+    torqueTechnical: 1.0,
+    torqueConfidence: 0.8,
+    ratioConsumed: 7,
+    outcomeType: "transmission",
+    graderType: "automated",
+    ...overrides,
+  };
+}
+
+describe("deriveIdempotencyKey", () => {
+  it("produces the documented format", () => {
+    const key = deriveIdempotencyKey(ring12Input());
+    expect(key).toBe("internal-adjacent:1:2:outward:phase-run:phase-run-abc:transmission");
+  });
+
+  it("renders missing rings as 'null'", () => {
+    const key = deriveIdempotencyKey({
+      ...ring12Input(),
+      interfaceClass: "external-federated",
+      transmissionDirection: "lateral",
+      innerRing: null,
+      outerRing: null,
+      externalCounterpartyType: "peer-install",
+    });
+    expect(key).toBe(
+      "external-federated:null:null:lateral:phase-run:phase-run-abc:transmission",
+    );
+  });
+
+  it("appends suffix when provided", () => {
+    const key = deriveIdempotencyKey({
+      ...ring12Input(),
+      idempotencyKeySuffix: "graduation",
+    });
+    expect(key.endsWith(":graduation")).toBe(true);
+  });
+
+  it("defaults to outward direction when omitted", () => {
+    const { transmissionDirection: _, ...rest } = ring12Input();
+    void _;
+    const key = deriveIdempotencyKey(rest as GearInterfaceInput);
+    expect(key).toContain(":outward:");
+  });
+});
+
+describe("validateGearInterfaceInput", () => {
+  it("accepts a valid Ring 1→2 outward record", () => {
+    expect(() => validateGearInterfaceInput(ring12Input())).not.toThrow();
+  });
+
+  it("rejects internal-adjacent without rings", () => {
+    expect(() =>
+      validateGearInterfaceInput({ ...ring12Input(), innerRing: null, outerRing: null }),
+    ).toThrow(GearInterfaceValidationError);
+  });
+
+  it("rejects internal-adjacent with non-adjacent rings", () => {
+    expect(() =>
+      validateGearInterfaceInput({ ...ring12Input(), innerRing: 1, outerRing: 3 }),
+    ).toThrow(/outerRing = innerRing \+ 1/);
+  });
+
+  it("rejects out-of-range rings", () => {
+    expect(() =>
+      validateGearInterfaceInput({ ...ring12Input(), innerRing: 0, outerRing: 1 }),
+    ).toThrow(/1\.\.5/);
+  });
+
+  it("rejects lateral direction on internal-adjacent", () => {
+    expect(() =>
+      validateGearInterfaceInput({ ...ring12Input(), transmissionDirection: "lateral" }),
+    ).toThrow(/lateral/);
+  });
+
+  it("requires externalCounterpartyType on external-* classes", () => {
+    expect(() =>
+      validateGearInterfaceInput({
+        ...ring12Input(),
+        interfaceClass: "external-federated",
+        transmissionDirection: "lateral",
+        innerRing: null,
+        outerRing: null,
+      }),
+    ).toThrow(/externalCounterpartyType/);
+  });
+
+  it("requires graduation fields when outcomeType=graduation", () => {
+    expect(() =>
+      validateGearInterfaceInput({ ...ring12Input(), outcomeType: "graduation" }),
+    ).toThrow(/graduation/);
+  });
+
+  it("accepts a complete graduation record", () => {
+    expect(() =>
+      validateGearInterfaceInput({
+        ...ring12Input(),
+        outcomeType: "graduation",
+        graduationFromAutonomy: "hitl-required",
+        graduationToAutonomy: "hitl-fallback",
+        graduationGovernorRef: "di-123",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects torque values outside [0,1]", () => {
+    expect(() => validateGearInterfaceInput({ ...ring12Input(), torqueTechnical: 1.5 })).toThrow();
+    expect(() => validateGearInterfaceInput({ ...ring12Input(), torqueConfidence: -0.1 })).toThrow();
+    expect(() => validateGearInterfaceInput({ ...ring12Input(), torqueValue: 2 })).toThrow();
+  });
+
+  it("requires archetypeContext at Ring 2→3 and beyond", () => {
+    expect(() =>
+      validateGearInterfaceInput({
+        ...ring12Input(),
+        innerRing: 2,
+        outerRing: 3,
+      }),
+    ).toThrow(/archetypeContext/);
+  });
+
+  it("allows null archetypeContext at Ring 1→2", () => {
+    expect(() => validateGearInterfaceInput(ring12Input())).not.toThrow();
+  });
+});
+
+describe("emitGearInterface", () => {
+  it("creates a row on first call", async () => {
+    const result = await emitGearInterface(ring12Input());
+    expect(result).not.toBeNull();
+    expect(result!.isNew).toBe(true);
+    expect(gearRows.size).toBe(1);
+  });
+
+  it("is idempotent — second emit with same derived key returns the existing row", async () => {
+    const first = await emitGearInterface(ring12Input());
+    const second = await emitGearInterface(ring12Input());
+    expect(first!.id).toBe(second!.id);
+    expect(second!.isNew).toBe(false);
+    expect(gearRows.size).toBe(1);
+  });
+
+  it("differentiates rows by idempotencyKeySuffix when one source emits multiple records", async () => {
+    const a = await emitGearInterface(ring12Input({ idempotencyKeySuffix: "primary" }));
+    const b = await emitGearInterface(ring12Input({ idempotencyKeySuffix: "graduation" }));
+    expect(a!.id).not.toBe(b!.id);
+    expect(gearRows.size).toBe(2);
+  });
+
+  it("returns null on validation failure rather than throwing", async () => {
+    const result = await emitGearInterface(
+      ring12Input({ torqueTechnical: 99, innerRing: 0, outerRing: 1 }),
+    );
+    expect(result).toBeNull();
+    expect(gearRows.size).toBe(0);
+  });
+
+  it("derives idempotencyKey deterministically across calls", async () => {
+    const a = await emitGearInterface(ring12Input());
+    const b = await emitGearInterface(ring12Input());
+    expect(a!.idempotencyKey).toBe(b!.idempotencyKey);
+  });
+});

--- a/apps/web/lib/gear-interface/writer.ts
+++ b/apps/web/lib/gear-interface/writer.ts
@@ -1,0 +1,251 @@
+// apps/web/lib/gear-interface/writer.ts
+//
+// Reduction Gear Phase 0 — single writer service for the GearInterface stream.
+//
+// All emission MUST go through emitGearInterface(). Do not scatter
+// `prisma.gearInterface.create(...)` calls across the codebase — spec §9.1
+// reserves the 20% refactoring allocation specifically to keep this seam clean.
+//
+// The writer:
+//   1. Derives a deterministic idempotency key (or accepts an explicit override)
+//   2. Validates spec §3.1 invariants pre-write (better errors than DB CHECK)
+//   3. Upserts on conflict so dual-emit retries / replays are safe
+//   4. Best-effort emission to the OTel exporter when the feature flag is on
+//   5. Never throws — failures log and return null. Adapters that need to know
+//      success can inspect the return.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §3.1
+// BI:   BI-85CB31F0
+
+import { prisma } from "@dpf/db";
+import { exportGearInterfaceToOtel } from "./otel-exporter";
+import type { GearInterfaceInput } from "./types";
+
+/**
+ * Derive the deterministic idempotency key from the input.
+ *
+ * Format (spec §3.1):
+ *   {interfaceClass}:{innerRing}:{outerRing}:{transmissionDirection}:{shaftSourceType}:{shaftSourceId}:{outcomeType}[:{suffix}]
+ *
+ * `innerRing` / `outerRing` are rendered as `null` when absent so external
+ * records still produce stable keys.
+ */
+export function deriveIdempotencyKey(input: GearInterfaceInput): string {
+  const direction = input.transmissionDirection ?? "outward";
+  const inner = input.innerRing == null ? "null" : String(input.innerRing);
+  const outer = input.outerRing == null ? "null" : String(input.outerRing);
+  const base = [
+    input.interfaceClass,
+    inner,
+    outer,
+    direction,
+    input.shaftSourceType,
+    input.shaftSourceId,
+    input.outcomeType,
+  ].join(":");
+  return input.idempotencyKeySuffix ? `${base}:${input.idempotencyKeySuffix}` : base;
+}
+
+class GearInterfaceValidationError extends Error {}
+
+/**
+ * Validate invariants from spec §3.1 before write. The DB has matching CHECK
+ * constraints, but pre-write validation produces clearer error messages and
+ * makes the contract testable without a live DB.
+ */
+export function validateGearInterfaceInput(input: GearInterfaceInput): void {
+  const direction = input.transmissionDirection ?? "outward";
+
+  if (input.interfaceClass === "internal-adjacent") {
+    if (input.innerRing == null || input.outerRing == null) {
+      throw new GearInterfaceValidationError(
+        "internal-adjacent requires innerRing and outerRing",
+      );
+    }
+    if (input.innerRing < 1 || input.innerRing > 5 || input.outerRing < 1 || input.outerRing > 5) {
+      throw new GearInterfaceValidationError(
+        `ring numbers must be 1..5 (got inner=${input.innerRing}, outer=${input.outerRing})`,
+      );
+    }
+    if (input.outerRing !== input.innerRing + 1) {
+      throw new GearInterfaceValidationError(
+        `internal-adjacent requires outerRing = innerRing + 1 (got inner=${input.innerRing}, outer=${input.outerRing})`,
+      );
+    }
+    if (direction === "lateral") {
+      throw new GearInterfaceValidationError(
+        "internal-adjacent must use direction='outward' or 'inward', not 'lateral'",
+      );
+    }
+  }
+
+  if (input.interfaceClass.startsWith("external-")) {
+    if (!input.externalCounterpartyType) {
+      throw new GearInterfaceValidationError(
+        `${input.interfaceClass} requires externalCounterpartyType`,
+      );
+    }
+  }
+
+  if (direction === "lateral" && !input.interfaceClass.startsWith("external-")) {
+    throw new GearInterfaceValidationError(
+      "direction='lateral' is reserved for external-* interfaceClass values",
+    );
+  }
+
+  if (input.outcomeType === "graduation") {
+    if (
+      !input.graduationFromAutonomy ||
+      !input.graduationToAutonomy ||
+      !input.graduationGovernorRef
+    ) {
+      throw new GearInterfaceValidationError(
+        "outcomeType='graduation' requires graduationFromAutonomy, graduationToAutonomy, and graduationGovernorRef",
+      );
+    }
+  }
+
+  if (input.torqueTechnical < 0 || input.torqueTechnical > 1) {
+    throw new GearInterfaceValidationError(
+      `torqueTechnical must be in [0,1] (got ${input.torqueTechnical})`,
+    );
+  }
+  if (input.torqueConfidence < 0 || input.torqueConfidence > 1) {
+    throw new GearInterfaceValidationError(
+      `torqueConfidence must be in [0,1] (got ${input.torqueConfidence})`,
+    );
+  }
+  if (
+    input.torqueValue != null &&
+    (input.torqueValue < 0 || input.torqueValue > 1)
+  ) {
+    throw new GearInterfaceValidationError(
+      `torqueValue must be in [0,1] when present (got ${input.torqueValue})`,
+    );
+  }
+
+  if (input.ratioConsumed < 0 || !Number.isInteger(input.ratioConsumed)) {
+    throw new GearInterfaceValidationError(
+      `ratioConsumed must be a non-negative integer (got ${input.ratioConsumed})`,
+    );
+  }
+
+  // Ring 2→3 and outer interfaces require archetype context (spec §3.3). At
+  // Ring 1→2 archetype context is allowed null because the work may be
+  // archetype-agnostic.
+  if (
+    input.interfaceClass === "internal-adjacent" &&
+    input.innerRing != null &&
+    input.innerRing >= 2 &&
+    !input.archetypeContext
+  ) {
+    throw new GearInterfaceValidationError(
+      `archetypeContext is required at Ring ${input.innerRing}↔${input.outerRing} (spec §3.3)`,
+    );
+  }
+}
+
+export interface EmitResult {
+  id: string;
+  idempotencyKey: string;
+  isNew: boolean;
+}
+
+/**
+ * Emit one GearInterface row. Idempotent — repeated calls with the same
+ * derived key upsert the same row. Never throws; logs and returns null on
+ * failure so a DB hiccup never blocks the producing flow.
+ */
+export async function emitGearInterface(
+  input: GearInterfaceInput,
+): Promise<EmitResult | null> {
+  try {
+    validateGearInterfaceInput(input);
+  } catch (err) {
+    console.warn(
+      "[gear-interface] Validation failed; skipping emit:",
+      { shaftSourceType: input.shaftSourceType, shaftSourceId: input.shaftSourceId },
+      err,
+    );
+    return null;
+  }
+
+  const idempotencyKey = input.idempotencyKey ?? deriveIdempotencyKey(input);
+  const direction = input.transmissionDirection ?? "outward";
+
+  const data = {
+    idempotencyKey,
+    organizationId: input.organizationId ?? null,
+    interfaceClass: input.interfaceClass,
+    transmissionDirection: direction,
+    innerRing: input.innerRing ?? null,
+    outerRing: input.outerRing ?? null,
+    externalCounterpartyType: input.externalCounterpartyType ?? null,
+    externalCounterpartyId: input.externalCounterpartyId ?? null,
+    shaftSourceType: input.shaftSourceType,
+    shaftSourceId: input.shaftSourceId,
+    sourceEventAt: input.sourceEventAt ?? null,
+    actorType: input.actorType,
+    actorId: input.actorId,
+    actorPrincipalId: input.actorPrincipalId ?? null,
+    intent: input.intent,
+    capabilityName: input.capabilityName,
+    capabilityVocabularyVersion: input.capabilityVocabularyVersion ?? "raw-v0",
+    archetypeContext: input.archetypeContext ?? null,
+    agentIdForTriple: input.agentIdForTriple,
+    torqueTechnical: input.torqueTechnical,
+    torqueValue: input.torqueValue ?? null,
+    torqueConfidence: input.torqueConfidence,
+    ratioConsumed: input.ratioConsumed,
+    outcomeType: input.outcomeType,
+    slipDetected: input.slipDetected ?? false,
+    slipReason: input.slipReason ?? null,
+    costUsd: input.costUsd != null ? input.costUsd.toString() : null,
+    inputTokens: input.inputTokens ?? null,
+    outputTokens: input.outputTokens ?? null,
+    cacheCreationInputTokens: input.cacheCreationInputTokens ?? null,
+    cacheReadInputTokens: input.cacheReadInputTokens ?? null,
+    reasoningOutputTokens: input.reasoningOutputTokens ?? null,
+    durationMs: input.durationMs ?? null,
+    graduationFromAutonomy: input.graduationFromAutonomy ?? null,
+    graduationToAutonomy: input.graduationToAutonomy ?? null,
+    graduationSampleSize: input.graduationSampleSize ?? null,
+    graduationGovernorRef: input.graduationGovernorRef ?? null,
+    graderType: input.graderType,
+    graderId: input.graderId ?? null,
+    rationale: input.rationale ?? null,
+    otelTraceId: input.otelTraceId ?? null,
+    otelSpanId: input.otelSpanId ?? null,
+  };
+
+  try {
+    // Upsert keyed on idempotencyKey. On a conflict we leave the existing row
+    // alone (first write wins) — replays should be no-ops, not silent rewrites.
+    const existing = await prisma.gearInterface.findUnique({
+      where: { idempotencyKey },
+      select: { id: true },
+    });
+
+    if (existing) {
+      return { id: existing.id, idempotencyKey, isNew: false };
+    }
+
+    const row = await prisma.gearInterface.create({ data });
+
+    // Best-effort OTel projection. Never blocks the DB write.
+    void exportGearInterfaceToOtel(row).catch((err) => {
+      console.warn("[gear-interface] OTel export failed:", err);
+    });
+
+    return { id: row.id, idempotencyKey, isNew: true };
+  } catch (err) {
+    console.warn(
+      "[gear-interface] Failed to write GearInterface row:",
+      { idempotencyKey, shaftSourceType: input.shaftSourceType },
+      err,
+    );
+    return null;
+  }
+}
+
+export { GearInterfaceValidationError };

--- a/apps/web/lib/integrate/build-phase-run.ts
+++ b/apps/web/lib/integrate/build-phase-run.ts
@@ -14,8 +14,12 @@
 // never blocks the phase transition itself.
 //
 // Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §Phase 3
+//
+// Reduction Gear Phase 0: completeBuildPhaseRun also dual-emits a Ring 1→2
+// GearInterface record after the source row settles (BI-85CB31F0).
 
 import { prisma } from "@dpf/db";
+import { emitRing12FromCompletedPhase } from "@/lib/gear-interface/emit-ring-1-2";
 
 export type BuildPhaseName = "ideate" | "plan" | "build" | "review" | "ship";
 
@@ -118,6 +122,17 @@ export async function completeBuildPhaseRun(
       `[build-phase-run] Phase ${phase} complete: ${inferenceCount} calls, ` +
       `${inputTokens + outputTokens} tokens, ${costUsd != null ? `$${Number(costUsd).toFixed(4)}` : "cost unknown"}`,
     );
+
+    // Reduction Gear Ring 1→2 dual-emit (BI-85CB31F0). Non-blocking: any
+    // failure must never affect the phase-run write above. The emitter pulls
+    // its own outcome signals from FeatureBuild + BuildDispatchAttempt.
+    void emitRing12FromCompletedPhase(buildId, phase).catch((err) => {
+      console.warn(
+        "[gear-interface] Ring 1→2 emit failed for completed phase:",
+        { buildId, phase },
+        err,
+      );
+    });
   } catch (err) {
     console.warn("[build-phase-run] Failed to complete phase run:", { buildId, phase }, err);
   }

--- a/docs/superpowers/decisions/2026-05-24-gear-interface-retention.md
+++ b/docs/superpowers/decisions/2026-05-24-gear-interface-retention.md
@@ -1,0 +1,125 @@
+# GearInterface Retention Baseline (Phase 0)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-24 |
+| Status | Accepted |
+| Spec | docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md |
+| BI | BI-85CB31F0 |
+| Epic | EP-REDUCTION-GEAR-ARCH |
+
+## Context
+
+Per spec §11(10), the GearInterface row stream is expected to grow quickly
+once emitters expand beyond the Ring 1→2 pilot:
+
+> "With high-volume emitters, a busy install could write 10^4-10^6
+> GearInterface rows/day. Choose partitioning/retention in Phase 0 before
+> enabling emitters beyond Ring 1→2."
+
+Phase 0 emits at one interface (Ring 1→2, one row per completed
+`BuildPhaseRun`), so realistic volume during the pilot is on the order of
+tens to low hundreds of rows per day per install. The infrastructure
+question is not "how do we keep the pilot fast" — it is "what shape do we
+freeze now so adding Ring 1→2 per-tool-execution emission, Ring 2→3
+archetype calibration, Ring 3→4 promotion emission, and Ring 4↔5 hive
+federation in Phase 1+ does not require an emergency redesign of the table?"
+
+## Decision
+
+### Hot retention window
+
+Keep all GearInterface rows in the primary `GearInterface` table for **90
+days** of recorded data. Within this window, no aggregation or downsampling
+— the Cockpit, Calibrator, and Autonomy Governor read row-level evidence
+directly.
+
+90 days is chosen to span (a) the longest reasonable feedback loop on
+graduation eligibility (Phase 1 will surface real triples once enough
+samples accrue), and (b) several monthly review cycles. Operators can
+extend the window via env var (`DPF_GEAR_HOT_RETENTION_DAYS`) without a
+schema change.
+
+### Partitioning
+
+Defer native PostgreSQL partitioning to Phase 2. Phase 0's volume does not
+warrant it. When partitioning lands, the natural key is `recordedAt`
+month — `GearInterface_YYYY_MM` partitions, with the parent table acting
+as the read view. The existing `(organizationId, recordedAt)` and
+`(innerRing, outerRing, transmissionDirection, recordedAt)` indexes are
+already partition-friendly because they lead with non-recordedAt columns
+or pair with recordedAt as the suffix.
+
+The schema's `recordedAt` is `DateTime DEFAULT now()` — partition-pruning
+compatible.
+
+### Cold-tier strategy (Phase 5 sunset)
+
+For rows older than 90 days, the Phase 5 cleanup spec will decide between:
+
+- (A) Detach old monthly partitions to a `gear_interface_cold` schema,
+  queryable but excluded from default Cockpit reads.
+- (B) Project to compact aggregate rows in a `GearInterfaceAggregate` table
+  keyed by `{innerRing, outerRing, capabilityName, archetypeContext, day}`
+  with torque histogram + slip rollup. Discard the raw rows.
+
+Phase 0 makes no commitment between (A) and (B). The deciding factor is
+whether the Calibrator (Phase 1) needs raw-row replay for its rolling
+windows. If it does, (A) wins. If the rolling window can run on monthly
+aggregates, (B) wins.
+
+What Phase 0 commits to: **pruning is deterministic and based on
+`recordedAt`**. No row in GearInterface depends on any other row, so
+pruning by date is safe.
+
+### Per-source emission ceiling
+
+To avoid a single source flooding the stream, Phase 0 documents an
+emission ceiling per source type. The writer service does NOT enforce
+this in code (validation of emitter density belongs in the Calibrator,
+Phase 1), but Phase 0 audits emitter density before adding any new
+source:
+
+| Shaft source type | Phase 0 ceiling | Note |
+| --- | --- | --- |
+| `phase-run` | 1 row per `BuildPhaseRun.completedAt` | Active in pilot |
+| `tool-execution` | 0 rows (adapter exists, no production emit) | Phase 1 — likely sampled, not 1:1 |
+| `runtime-verification` | 0 rows | Phase 1 — Ring 3→4, archetype-scoped |
+| `promotion` | 0 rows | Phase 1 — Ring 3→4 |
+| `feature-pack` | 0 rows | Phase 3 — Ring 4↔5 hive federation |
+| `migration-classifier` / `seed-delta-manifest` / `channel-manifest` | 0 rows | Phase 2 of governed-upgrade — Ring 4↔5 inward |
+
+Any new emitter must update this table in a follow-up commit before
+production wiring.
+
+### Idempotency / replay-safety
+
+The writer derives a deterministic `idempotencyKey` per spec §3.1. Replay
+is safe: a re-run of the same source event upserts the same row. This
+guarantees retention reasoning is monotonic — pruning by `recordedAt`
+never breaks dual-emit retries because retries within the hot window
+target the same row.
+
+## Consequences
+
+- **Phase 0 needs no new pruning job.** Hot retention is the only
+  retention; nothing leaves the table yet.
+- **Phase 2 must add a pruning Inngest function** when total row count
+  approaches the threshold (concrete: `GearInterface` row count > 1M, or
+  table size > 5GB).
+- **No archive table in Phase 0.** Adding one before we know whether the
+  Calibrator needs raw replay would lock in the wrong abstraction.
+- **The Cockpit query API hard-codes a 7-day default window** but accepts
+  longer ranges up to 90 days. Phase 2 will revisit when materialized
+  aggregates land per spec §11(11).
+
+## Open follow-ups (Phase 1+)
+
+1. Decide cold-tier path (A vs B) once the Calibrator's data shape is
+   firm.
+2. Add the pruning Inngest function with a configurable retention
+   window.
+3. Verify partition compatibility once `gen_random_uuid()` / cuid id
+   generation does not interfere with detach/attach.
+4. Audit emitter density across Ring 1→2 per-tool-execution + Ring 2→3
+   archetype calibration before enabling those emitters in production.

--- a/packages/db/prisma/migrations/20260524160000_add_gear_interface_phase_0/migration.sql
+++ b/packages/db/prisma/migrations/20260524160000_add_gear_interface_phase_0/migration.sql
@@ -1,0 +1,159 @@
+-- Reduction Gear Phase 0 — GearInterface canonical observation envelope.
+--
+-- Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §3.1
+-- BI:   BI-85CB31F0 (Phase 0 pilot)
+-- Epic: EP-REDUCTION-GEAR-ARCH
+--
+-- One row per "transmission" at a ring interface in the agentic gear train.
+-- Phase 0 emits at Ring 1→2 (Coworker → Workflow) only; outer rings get
+-- contract stubs but no production dual-emission yet.
+--
+-- Authority model: existing source tables (ToolExecution, AdapterRunTelemetry,
+-- BuildPhaseRun, FeatureBuild, RuntimeVerification, …) remain authoritative
+-- write models. This table dual-emits alongside them — it never replaces them.
+
+CREATE TABLE "GearInterface" (
+    "id" TEXT NOT NULL,
+    "schemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sourceEventAt" TIMESTAMP(3),
+    "idempotencyKey" TEXT NOT NULL,
+    "organizationId" TEXT,
+
+    "interfaceClass" TEXT NOT NULL,
+    "transmissionDirection" TEXT NOT NULL DEFAULT 'outward',
+    "innerRing" INTEGER,
+    "outerRing" INTEGER,
+    "externalCounterpartyType" TEXT,
+    "externalCounterpartyId" TEXT,
+
+    "shaftSourceType" TEXT NOT NULL,
+    "shaftSourceId" TEXT NOT NULL,
+    "actorType" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "actorPrincipalId" TEXT,
+    "intent" TEXT NOT NULL,
+
+    "capabilityName" TEXT NOT NULL,
+    "capabilityVocabularyVersion" TEXT NOT NULL DEFAULT 'raw-v0',
+    "archetypeContext" TEXT,
+    "agentIdForTriple" TEXT NOT NULL,
+
+    "torqueTechnical" DOUBLE PRECISION NOT NULL,
+    "torqueValue" DOUBLE PRECISION,
+    "torqueConfidence" DOUBLE PRECISION NOT NULL,
+    "ratioConsumed" INTEGER NOT NULL,
+    "outcomeType" TEXT NOT NULL,
+    "slipDetected" BOOLEAN NOT NULL DEFAULT false,
+    "slipReason" TEXT,
+
+    "costUsd" DECIMAL(12, 6),
+    "inputTokens" INTEGER,
+    "outputTokens" INTEGER,
+    "cacheCreationInputTokens" INTEGER,
+    "cacheReadInputTokens" INTEGER,
+    "reasoningOutputTokens" INTEGER,
+    "durationMs" INTEGER,
+
+    "graduationFromAutonomy" TEXT,
+    "graduationToAutonomy" TEXT,
+    "graduationSampleSize" INTEGER,
+    "graduationGovernorRef" TEXT,
+
+    "graderType" TEXT NOT NULL,
+    "graderId" TEXT,
+    "rationale" TEXT,
+
+    "otelTraceId" TEXT,
+    "otelSpanId" TEXT,
+
+    CONSTRAINT "GearInterface_pkey" PRIMARY KEY ("id")
+);
+
+-- Idempotency / replay-safety: writer service derives a deterministic key per
+-- (interfaceClass, ring direction, source event, outcome). Duplicates upsert.
+CREATE UNIQUE INDEX "GearInterface_idempotencyKey_key" ON "GearInterface"("idempotencyKey");
+
+-- Cockpit time-range queries by org
+CREATE INDEX "GearInterface_organizationId_recordedAt_idx" ON "GearInterface"("organizationId", "recordedAt");
+
+-- Cockpit by-interface drill-downs ("Ring 2→3 outward in last 7 days")
+CREATE INDEX "GearInterface_innerRing_outerRing_transmissionDirection_recordedAt_idx"
+    ON "GearInterface"("innerRing", "outerRing", "transmissionDirection", "recordedAt");
+
+-- Capability×archetype rollups for the Calibrator (Phase 1) and wear queries
+CREATE INDEX "GearInterface_capabilityName_archetypeContext_recordedAt_idx"
+    ON "GearInterface"("capabilityName", "archetypeContext", "recordedAt");
+
+-- Per-triple trust queries — the unit of trust per spec §3.3
+CREATE INDEX "GearInterface_agentIdForTriple_capabilityName_archetypeContext_idx"
+    ON "GearInterface"("agentIdForTriple", "capabilityName", "archetypeContext");
+
+-- Drill from a GearInterface row back to its source event row
+CREATE INDEX "GearInterface_shaftSourceType_shaftSourceId_idx"
+    ON "GearInterface"("shaftSourceType", "shaftSourceId");
+
+-- Outcome filtering ("show me all slips this week", "show me graduations today")
+CREATE INDEX "GearInterface_outcomeType_recordedAt_idx" ON "GearInterface"("outcomeType", "recordedAt");
+
+-- Invariant checks — kept as CHECK constraints because they encode the schema
+-- contract from spec §3.1 and must hold for every row regardless of which
+-- emitter wrote it. Writer service also validates pre-write for better errors.
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_interfaceClass_check"
+    CHECK ("interfaceClass" IN ('internal-adjacent', 'external-federated', 'external-bridged', 'external-customer'));
+
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_transmissionDirection_check"
+    CHECK ("transmissionDirection" IN ('outward', 'inward', 'lateral'));
+
+-- internal-adjacent requires inner + outer ring with outer = inner + 1, both 1..5
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_internal_adjacent_rings_check"
+    CHECK (
+        ("interfaceClass" <> 'internal-adjacent')
+        OR (
+            "innerRing" IS NOT NULL
+            AND "outerRing" IS NOT NULL
+            AND "innerRing" BETWEEN 1 AND 5
+            AND "outerRing" BETWEEN 1 AND 5
+            AND "outerRing" = "innerRing" + 1
+        )
+    );
+
+-- lateral direction is reserved for external classes only
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_lateral_external_only_check"
+    CHECK (
+        ("transmissionDirection" <> 'lateral')
+        OR ("interfaceClass" LIKE 'external-%')
+    );
+
+-- external-* requires counterparty type
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_external_counterparty_type_check"
+    CHECK (
+        ("interfaceClass" NOT LIKE 'external-%')
+        OR ("externalCounterpartyType" IS NOT NULL)
+    );
+
+-- graduation outcome requires from/to autonomy + governor ref
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_graduation_fields_check"
+    CHECK (
+        ("outcomeType" <> 'graduation')
+        OR (
+            "graduationFromAutonomy" IS NOT NULL
+            AND "graduationToAutonomy" IS NOT NULL
+            AND "graduationGovernorRef" IS NOT NULL
+        )
+    );
+
+-- torque components are 0..1
+ALTER TABLE "GearInterface"
+    ADD CONSTRAINT "GearInterface_torque_ranges_check"
+    CHECK (
+        "torqueTechnical" >= 0 AND "torqueTechnical" <= 1
+        AND "torqueConfidence" >= 0 AND "torqueConfidence" <= 1
+        AND ("torqueValue" IS NULL OR ("torqueValue" >= 0 AND "torqueValue" <= 1))
+    );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,68 +35,68 @@ enum BriefStatus {
 }
 
 model User {
-  id                           String                        @id @default(cuid())
-  email                        String                        @unique
-  passwordHash                 String
-  isActive                     Boolean                       @default(true)
-  isSuperuser                  Boolean                       @default(false)
-  createdAt                    DateTime                      @default(now())
-  approvedProposals            AgentActionProposal[]         @relation("ProposalDecisions")
-  agentThreads                 AgentThread[]
-  apiTokens                    ApiToken[]
-  mcpApiTokens                 McpApiToken[]
-  backlogSubmissions           BacklogItem[]                 @relation("BacklogSubmissions")
-  customEvalDimsApproved       CustomEvalDimension[]         @relation("CustomEvalDimensionApprover")
-  customEvalDimsCreated        CustomEvalDimension[]         @relation("CustomEvalDimensionCreator")
-  grantedDelegations           DelegationGrant[]             @relation("DelegationGrantGrantor")
-  employeeProfile              EmployeeProfile?
-  authoredEmploymentEvents     EmploymentEvent[]
-  epicSubmissions              Epic[]                        @relation("EpicSubmissions")
-  externalEvidenceRecords      ExternalEvidenceRecord[]
-  featureBuilds                FeatureBuild[]
-  improvementReviews           ImprovementProposal[]         @relation("ImprovementReviews")
-  improvementSubmissions       ImprovementProposal[]         @relation("ImprovementSubmissions")
-  notifications                Notification[]
-  requestedPasswordResetTokens PasswordResetToken[]          @relation("PasswordResetRequestedBy")
-  passwordResetTokens          PasswordResetToken[]          @relation("PasswordResetForUser")
-  issueReports                 PlatformIssueReport[]
-  policyRulesCreated           PolicyRule[]                  @relation("PolicyRuleCreator")
-  pushDevices                  PushDeviceRegistration[]
-  taskRequirementsApproved     TaskRequirement[]             @relation("TaskRequirementApprover")
-  taskRequirementsCreated      TaskRequirement[]             @relation("TaskRequirementCreator")
-  teamMemberships              TeamMembership[]
-  groups                       UserGroup[]
-  userSkills                   UserSkill[]                   @relation("UserSkillCreator")
-  invoicesCreated              Invoice[]                     @relation("InvoiceCreations")
-  paymentsCreated              Payment[]                     @relation("PaymentCreations")
-  engagementAssignments        Engagement[]                  @relation("EngagementAssignments")
-  opportunityAssignments       Opportunity[]                 @relation("OpportunityAssignments")
-  activitiesCreated            Activity[]                    @relation("ActivityCreations")
-  quotesCreated                Quote[]                       @relation("QuoteCreations")
-  billsCreated                 Bill[]                        @relation("BillCreations")
-  posCreated                   PurchaseOrder[]               @relation("PurchaseOrderCreations")
-  approvalRules                ApprovalRule[]                @relation("ApprovalRuleApprover")
-  billApprovals                BillApproval[]                @relation("BillApprovalResponses")
-  recurringSchedulesCreated    RecurringSchedule[]           @relation("RecurringScheduleCreations")
-  expenseApprovals             ExpenseClaim[]                @relation("ExpenseApprovals")
-  platformSetupProgress        PlatformSetupProgress?        @relation("UserSetupProgress")
-  taskRuns                     TaskRun[]
-  businessModelRoleAssignments BusinessModelRoleAssignment[]
-  platformDevConfigs           PlatformDevConfig[]           @relation("PlatformDevConfiguredBy")
-  platformDevDcoAcceptances    PlatformDevConfig[]           @relation("PlatformDevDcoAcceptedBy")
-  agentModelConfigs            AgentModelConfig[]            @relation("AgentModelConfiguredBy")
-  knowledgeArticles            KnowledgeArticle[]            @relation("KnowledgeArticleAuthor")
-  knowledgeRevisions           KnowledgeArticleRevision[]    @relation("KnowledgeRevisionCreator")
-  wikiRevisions                WikiPageRevision[]            @relation("WikiRevisionCreator")
-  wikiIngestEvents             WikiIngestEvent[]             @relation("WikiIngestEventUser")
-  workItemAssignments          WorkItem[]                    @relation("WorkItemAssignee")
-  workSchedule                 WorkSchedule?
-  adminActivities              AdminActivity[]
-  userFacts                    UserFact[]
-  decisionEscalationsResolved  EscalationCapture[]           @relation("DecisionEscalationResolverUser")
+  id                            String                        @id @default(cuid())
+  email                         String                        @unique
+  passwordHash                  String
+  isActive                      Boolean                       @default(true)
+  isSuperuser                   Boolean                       @default(false)
+  createdAt                     DateTime                      @default(now())
+  approvedProposals             AgentActionProposal[]         @relation("ProposalDecisions")
+  agentThreads                  AgentThread[]
+  apiTokens                     ApiToken[]
+  mcpApiTokens                  McpApiToken[]
+  backlogSubmissions            BacklogItem[]                 @relation("BacklogSubmissions")
+  customEvalDimsApproved        CustomEvalDimension[]         @relation("CustomEvalDimensionApprover")
+  customEvalDimsCreated         CustomEvalDimension[]         @relation("CustomEvalDimensionCreator")
+  grantedDelegations            DelegationGrant[]             @relation("DelegationGrantGrantor")
+  employeeProfile               EmployeeProfile?
+  authoredEmploymentEvents      EmploymentEvent[]
+  epicSubmissions               Epic[]                        @relation("EpicSubmissions")
+  externalEvidenceRecords       ExternalEvidenceRecord[]
+  featureBuilds                 FeatureBuild[]
+  improvementReviews            ImprovementProposal[]         @relation("ImprovementReviews")
+  improvementSubmissions        ImprovementProposal[]         @relation("ImprovementSubmissions")
+  notifications                 Notification[]
+  requestedPasswordResetTokens  PasswordResetToken[]          @relation("PasswordResetRequestedBy")
+  passwordResetTokens           PasswordResetToken[]          @relation("PasswordResetForUser")
+  issueReports                  PlatformIssueReport[]
+  policyRulesCreated            PolicyRule[]                  @relation("PolicyRuleCreator")
+  pushDevices                   PushDeviceRegistration[]
+  taskRequirementsApproved      TaskRequirement[]             @relation("TaskRequirementApprover")
+  taskRequirementsCreated       TaskRequirement[]             @relation("TaskRequirementCreator")
+  teamMemberships               TeamMembership[]
+  groups                        UserGroup[]
+  userSkills                    UserSkill[]                   @relation("UserSkillCreator")
+  invoicesCreated               Invoice[]                     @relation("InvoiceCreations")
+  paymentsCreated               Payment[]                     @relation("PaymentCreations")
+  engagementAssignments         Engagement[]                  @relation("EngagementAssignments")
+  opportunityAssignments        Opportunity[]                 @relation("OpportunityAssignments")
+  activitiesCreated             Activity[]                    @relation("ActivityCreations")
+  quotesCreated                 Quote[]                       @relation("QuoteCreations")
+  billsCreated                  Bill[]                        @relation("BillCreations")
+  posCreated                    PurchaseOrder[]               @relation("PurchaseOrderCreations")
+  approvalRules                 ApprovalRule[]                @relation("ApprovalRuleApprover")
+  billApprovals                 BillApproval[]                @relation("BillApprovalResponses")
+  recurringSchedulesCreated     RecurringSchedule[]           @relation("RecurringScheduleCreations")
+  expenseApprovals              ExpenseClaim[]                @relation("ExpenseApprovals")
+  platformSetupProgress         PlatformSetupProgress?        @relation("UserSetupProgress")
+  taskRuns                      TaskRun[]
+  businessModelRoleAssignments  BusinessModelRoleAssignment[]
+  platformDevConfigs            PlatformDevConfig[]           @relation("PlatformDevConfiguredBy")
+  platformDevDcoAcceptances     PlatformDevConfig[]           @relation("PlatformDevDcoAcceptedBy")
+  agentModelConfigs             AgentModelConfig[]            @relation("AgentModelConfiguredBy")
+  knowledgeArticles             KnowledgeArticle[]            @relation("KnowledgeArticleAuthor")
+  knowledgeRevisions            KnowledgeArticleRevision[]    @relation("KnowledgeRevisionCreator")
+  wikiRevisions                 WikiPageRevision[]            @relation("WikiRevisionCreator")
+  wikiIngestEvents              WikiIngestEvent[]             @relation("WikiIngestEventUser")
+  workItemAssignments           WorkItem[]                    @relation("WorkItemAssignee")
+  workSchedule                  WorkSchedule?
+  adminActivities               AdminActivity[]
+  userFacts                     UserFact[]
+  decisionEscalationsResolved   EscalationCapture[]           @relation("DecisionEscalationResolverUser")
   triggeredDecisionInteractions DecisionInteraction[]         @relation("DecisionInteractionTriggeredByUser")
-  scheduledAgentTasks          ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
-  addedLocalities              City[]                        @relation("CityAddedByUser")
+  scheduledAgentTasks           ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
+  addedLocalities               City[]                        @relation("CityAddedByUser")
 }
 
 model UserGroup {
@@ -219,32 +219,32 @@ model TeamMembership {
 }
 
 model Principal {
-  id                    String           @id @default(cuid())
-  principalId           String           @unique
-  kind                  String
-  status                String           @default("active")
-  displayName           String
-  aliases               PrincipalAlias[]
-  communicationChannelBindings CommunicationChannelBinding[]
-  communicationChannelSessions CommunicationChannelSession[]
+  id                                  String                              @id @default(cuid())
+  principalId                         String                              @unique
+  kind                                String
+  status                              String                              @default("active")
+  displayName                         String
+  aliases                             PrincipalAlias[]
+  communicationChannelBindings        CommunicationChannelBinding[]
+  communicationChannelSessions        CommunicationChannelSession[]
   // Per AGENTS.md §11 (Principal convergence, 2026-05-09): EdgeNode
   // identity lives on Principal + PrincipalAlias, with EdgeNode as a
   // host-attributes side table keyed by `principalId`. 1:1 cardinality.
-  edgeNode              EdgeNode?        @relation("EdgeNodeIdentity")
-  edgeNodesApproved     EdgeNode[]       @relation("EdgeNodeApprover")
-  bootstrapTokensIssued BootstrapToken[] @relation("BootstrapTokenIssuer")
-  ownedDocuments        Document[]       @relation("DocumentOwner")
-  createdDocuments      Document[]       @relation("DocumentCreator")
-  documentVersions      DocumentVersion[] @relation("DocumentVersionCreator")
-  documentReferences    DocumentReference[] @relation("DocumentReferenceCreator")
-  documentAccessGrants  DocumentAccessGrant[] @relation("DocumentAccessGrantPrincipal")
-  documentAccessGrantsCreated DocumentAccessGrant[] @relation("DocumentAccessGrantCreator")
-  documentLifecycleEvents DocumentLifecycleEvent[] @relation("DocumentLifecycleActor")
-  ownedDecisionPerspectiveProfiles DecisionPerspectiveProfile[] @relation("DecisionPerspectiveProfileOwner")
+  edgeNode                            EdgeNode?                           @relation("EdgeNodeIdentity")
+  edgeNodesApproved                   EdgeNode[]                          @relation("EdgeNodeApprover")
+  bootstrapTokensIssued               BootstrapToken[]                    @relation("BootstrapTokenIssuer")
+  ownedDocuments                      Document[]                          @relation("DocumentOwner")
+  createdDocuments                    Document[]                          @relation("DocumentCreator")
+  documentVersions                    DocumentVersion[]                   @relation("DocumentVersionCreator")
+  documentReferences                  DocumentReference[]                 @relation("DocumentReferenceCreator")
+  documentAccessGrants                DocumentAccessGrant[]               @relation("DocumentAccessGrantPrincipal")
+  documentAccessGrantsCreated         DocumentAccessGrant[]               @relation("DocumentAccessGrantCreator")
+  documentLifecycleEvents             DocumentLifecycleEvent[]            @relation("DocumentLifecycleActor")
+  ownedDecisionPerspectiveProfiles    DecisionPerspectiveProfile[]        @relation("DecisionPerspectiveProfileOwner")
   promotedDecisionPerspectiveVersions DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersionPromoter")
-  decisionEscalationsResolved EscalationCapture[] @relation("DecisionEscalationResolverPrincipal")
-  createdAt             DateTime         @default(now())
-  updatedAt             DateTime         @updatedAt
+  decisionEscalationsResolved         EscalationCapture[]                 @relation("DecisionEscalationResolverPrincipal")
+  createdAt                           DateTime                            @default(now())
+  updatedAt                           DateTime                            @updatedAt
 }
 
 model PrincipalAlias {
@@ -262,85 +262,85 @@ model PrincipalAlias {
 }
 
 model EmployeeProfile {
-  id                        String                  @id @default(cuid())
-  employeeId                String                  @unique
-  userId                    String?                 @unique
-  firstName                 String
-  middleName                String?
-  lastName                  String
-  displayName               String
-  workEmail                 String?
-  personalEmail             String?
-  phoneWork                 String?
-  status                    String                  @default("onboarding")
-  employmentTypeId          String?
-  departmentId              String?
-  positionId                String?
-  managerEmployeeId         String?
-  dottedLineManagerId       String?
-  workLocationId            String?
-  timezone                  String?
-  startDate                 DateTime?
-  confirmationDate          DateTime?
-  endDate                   DateTime?
-  createdAt                 DateTime                @default(now())
-  updatedAt                 DateTime                @updatedAt
-  phoneMobile               String?
-  phoneEmergency            String?
-  accountableItems          BacklogItem[]           @relation("ItemAccountable")
-  calendarEvents            CalendarEvent[]
-  calendarSyncs             CalendarSync[]
+  id                           String                        @id @default(cuid())
+  employeeId                   String                        @unique
+  userId                       String?                       @unique
+  firstName                    String
+  middleName                   String?
+  lastName                     String
+  displayName                  String
+  workEmail                    String?
+  personalEmail                String?
+  phoneWork                    String?
+  status                       String                        @default("onboarding")
+  employmentTypeId             String?
+  departmentId                 String?
+  positionId                   String?
+  managerEmployeeId            String?
+  dottedLineManagerId          String?
+  workLocationId               String?
+  timezone                     String?
+  startDate                    DateTime?
+  confirmationDate             DateTime?
+  endDate                      DateTime?
+  createdAt                    DateTime                      @default(now())
+  updatedAt                    DateTime                      @updatedAt
+  phoneMobile                  String?
+  phoneEmergency               String?
+  accountableItems             BacklogItem[]                 @relation("ItemAccountable")
+  calendarEvents               CalendarEvent[]
+  calendarSyncs                CalendarSync[]
   communicationChannelBindings CommunicationChannelBinding[]
-  auditsPerformed           ComplianceAudit[]       @relation("AuditAuditor")
-  complianceAuditLogs       ComplianceAuditLog[]    @relation("ComplianceAuditLogActor")
-  evidenceCollected         ComplianceEvidence[]    @relation("EvidenceCollector")
-  incidentsReported         ComplianceIncident[]    @relation("IncidentReporter")
-  controlOwnership          Control[]               @relation("ControlOwner")
-  correctiveActionsOwned    CorrectiveAction[]      @relation("CorrectiveActionOwner")
-  correctiveActionsVerified CorrectiveAction[]      @relation("CorrectiveActionVerifier")
-  headedDepartments         Department[]            @relation("DepartmentHead")
-  addresses                 EmployeeAddress[]
-  department                Department?             @relation("DepartmentEmployees", fields: [departmentId], references: [id])
-  dottedLineManager         EmployeeProfile?        @relation("EmployeeDottedManager", fields: [dottedLineManagerId], references: [id])
-  dottedLineReports         EmployeeProfile[]       @relation("EmployeeDottedManager")
-  employmentType            EmploymentType?         @relation(fields: [employmentTypeId], references: [id])
-  manager                   EmployeeProfile?        @relation("EmployeeManager", fields: [managerEmployeeId], references: [id])
-  directReports             EmployeeProfile[]       @relation("EmployeeManager")
-  position                  Position?               @relation(fields: [positionId], references: [id])
-  user                      User?                   @relation(fields: [userId], references: [id])
-  workLocation              WorkLocation?           @relation(fields: [workLocationId], references: [id])
-  employmentEvents          EmploymentEvent[]
-  accountableEpics          Epic[]                  @relation("EpicAccountable")
-  accountableBuilds         FeatureBuild[]          @relation("BuildAccountable")
-  feedbackGiven             FeedbackNote[]          @relation("FeedbackFrom")
-  feedbackReceived          FeedbackNote[]          @relation("FeedbackTo")
-  leaveBalances             LeaveBalance[]
-  leaveApprovals            LeaveRequest[]          @relation("LeaveApprovals")
-  leaveRequests             LeaveRequest[]
-  obligationOwnership       Obligation[]            @relation("ObligationOwner")
-  onboardingTasks           OnboardingTask[]
-  policiesApproved          Policy[]                @relation("PolicyApprover")
-  policiesOwned             Policy[]                @relation("PolicyOwner")
-  policyAcknowledgments     PolicyAcknowledgment[]  @relation("PolicyAcknowledgments")
-  alertsReviewed            RegulatoryAlert[]       @relation("AlertReviewer")
-  scansTriggered            RegulatoryMonitorScan[] @relation("ScanTriggerer")
-  regulatorySubmissions     RegulatorySubmission[]  @relation("SubmissionSubmitter")
-  requirementCompletions    RequirementCompletion[] @relation("RequirementCompletions")
-  reviewInstances           ReviewInstance[]        @relation("ReviewsAsEmployee")
-  reviewsAsReviewer         ReviewInstance[]        @relation("ReviewsAsReviewer")
-  riskAssessments           RiskAssessment[]        @relation("RiskAssessor")
-  terminationRecord         TerminationRecord?
-  timesheetApprovals        TimesheetPeriod[]       @relation("TimesheetApprovals")
-  timesheets                TimesheetPeriod[]
-  expenseClaims             ExpenseClaim[]          @relation("ExpenseClaims")
-  serviceProviders          ServiceProvider[]
-  aiProviderContracts       SupplierContract[]      @relation("AiContractOwner")
-  aiFinanceWorkItems        FinanceWorkItem[]       @relation("AiFinanceWorkItemOwner")
-  changeRequestsRequested   ChangeRequest[]         @relation("ChangeRequestedBy")
-  changeRequestsAssessed    ChangeRequest[]         @relation("ChangeAssessedBy")
-  changeRequestsApproved    ChangeRequest[]         @relation("ChangeApprovedBy")
-  changeRequestsExecuted    ChangeRequest[]         @relation("ChangeExecutedBy")
-  standardChangesApproved   StandardChangeCatalog[] @relation("StandardChangeApprover")
+  auditsPerformed              ComplianceAudit[]             @relation("AuditAuditor")
+  complianceAuditLogs          ComplianceAuditLog[]          @relation("ComplianceAuditLogActor")
+  evidenceCollected            ComplianceEvidence[]          @relation("EvidenceCollector")
+  incidentsReported            ComplianceIncident[]          @relation("IncidentReporter")
+  controlOwnership             Control[]                     @relation("ControlOwner")
+  correctiveActionsOwned       CorrectiveAction[]            @relation("CorrectiveActionOwner")
+  correctiveActionsVerified    CorrectiveAction[]            @relation("CorrectiveActionVerifier")
+  headedDepartments            Department[]                  @relation("DepartmentHead")
+  addresses                    EmployeeAddress[]
+  department                   Department?                   @relation("DepartmentEmployees", fields: [departmentId], references: [id])
+  dottedLineManager            EmployeeProfile?              @relation("EmployeeDottedManager", fields: [dottedLineManagerId], references: [id])
+  dottedLineReports            EmployeeProfile[]             @relation("EmployeeDottedManager")
+  employmentType               EmploymentType?               @relation(fields: [employmentTypeId], references: [id])
+  manager                      EmployeeProfile?              @relation("EmployeeManager", fields: [managerEmployeeId], references: [id])
+  directReports                EmployeeProfile[]             @relation("EmployeeManager")
+  position                     Position?                     @relation(fields: [positionId], references: [id])
+  user                         User?                         @relation(fields: [userId], references: [id])
+  workLocation                 WorkLocation?                 @relation(fields: [workLocationId], references: [id])
+  employmentEvents             EmploymentEvent[]
+  accountableEpics             Epic[]                        @relation("EpicAccountable")
+  accountableBuilds            FeatureBuild[]                @relation("BuildAccountable")
+  feedbackGiven                FeedbackNote[]                @relation("FeedbackFrom")
+  feedbackReceived             FeedbackNote[]                @relation("FeedbackTo")
+  leaveBalances                LeaveBalance[]
+  leaveApprovals               LeaveRequest[]                @relation("LeaveApprovals")
+  leaveRequests                LeaveRequest[]
+  obligationOwnership          Obligation[]                  @relation("ObligationOwner")
+  onboardingTasks              OnboardingTask[]
+  policiesApproved             Policy[]                      @relation("PolicyApprover")
+  policiesOwned                Policy[]                      @relation("PolicyOwner")
+  policyAcknowledgments        PolicyAcknowledgment[]        @relation("PolicyAcknowledgments")
+  alertsReviewed               RegulatoryAlert[]             @relation("AlertReviewer")
+  scansTriggered               RegulatoryMonitorScan[]       @relation("ScanTriggerer")
+  regulatorySubmissions        RegulatorySubmission[]        @relation("SubmissionSubmitter")
+  requirementCompletions       RequirementCompletion[]       @relation("RequirementCompletions")
+  reviewInstances              ReviewInstance[]              @relation("ReviewsAsEmployee")
+  reviewsAsReviewer            ReviewInstance[]              @relation("ReviewsAsReviewer")
+  riskAssessments              RiskAssessment[]              @relation("RiskAssessor")
+  terminationRecord            TerminationRecord?
+  timesheetApprovals           TimesheetPeriod[]             @relation("TimesheetApprovals")
+  timesheets                   TimesheetPeriod[]
+  expenseClaims                ExpenseClaim[]                @relation("ExpenseClaims")
+  serviceProviders             ServiceProvider[]
+  aiProviderContracts          SupplierContract[]            @relation("AiContractOwner")
+  aiFinanceWorkItems           FinanceWorkItem[]             @relation("AiFinanceWorkItemOwner")
+  changeRequestsRequested      ChangeRequest[]               @relation("ChangeRequestedBy")
+  changeRequestsAssessed       ChangeRequest[]               @relation("ChangeAssessedBy")
+  changeRequestsApproved       ChangeRequest[]               @relation("ChangeApprovedBy")
+  changeRequestsExecuted       ChangeRequest[]               @relation("ChangeExecutedBy")
+  standardChangesApproved      StandardChangeCatalog[]       @relation("StandardChangeApprover")
 
   @@index([status])
   @@index([departmentId])
@@ -897,27 +897,27 @@ model ServiceOffering {
 }
 
 model TaxonomyNode {
-  id                       String                     @id @default(cuid())
-  nodeId                   String                     @unique
+  id                       String                        @id @default(cuid())
+  nodeId                   String                        @unique
   name                     String
   portfolioId              String?
   parentId                 String?
-  status                   String                     @default("active")
+  status                   String                        @default("active")
   governance               Json?
   description              String?
   enrichment               Json?
   backlogItems             BacklogItem[]
   products                 DigitalProduct[]
   eaElements               EaElement[]
-  businessCapabilityLinks      BusinessCapabilityTraceLink[] @relation("BusinessCapabilityTaxonomyLinks")
+  businessCapabilityLinks  BusinessCapabilityTraceLink[] @relation("BusinessCapabilityTaxonomyLinks")
   fingerprintRules         DiscoveryFingerprintRule[]
   inventoryEntities        InventoryEntity[]
   portfolioQualityIssues   PortfolioQualityIssue[]
-  triageSelectionDecisions DiscoveryTriageDecision[]  @relation("DiscoveryTriageDecisionSelectedTaxonomy")
-  taxonomyProposalParents  TaxonomyProposal[]         @relation("TaxonomyProposalParent")
-  createdTaxonomyProposals TaxonomyProposal[]         @relation("TaxonomyProposalCreatedNode")
-  parent                   TaxonomyNode?              @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children                 TaxonomyNode[]             @relation("TaxonomyTree")
+  triageSelectionDecisions DiscoveryTriageDecision[]     @relation("DiscoveryTriageDecisionSelectedTaxonomy")
+  taxonomyProposalParents  TaxonomyProposal[]            @relation("TaxonomyProposalParent")
+  createdTaxonomyProposals TaxonomyProposal[]            @relation("TaxonomyProposalCreatedNode")
+  parent                   TaxonomyNode?                 @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children                 TaxonomyNode[]                @relation("TaxonomyTree")
 }
 
 model TaxonomyProposal {
@@ -945,51 +945,51 @@ model TaxonomyProposal {
 }
 
 model BacklogItem {
-  id                    String                   @id @default(cuid())
-  itemId                String                   @unique
-  title                 String
-  status                String
-  type                  String
-  body                  String?
-  createdAt             DateTime                 @default(now())
-  updatedAt             DateTime                 @updatedAt
-  priority              Int?
-  digitalProductId      String?
-  taxonomyNodeId        String?
-  epicId                String?
-  source                String?
-  triageOutcome         String?
-  effortSize            String?
-  proposedOutcome       String?
-  activeBuildId         String?                  @unique
-  duplicateOfId         String?
-  resolution            String?
-  abandonReason         String?
-  stalenessDetectedAt   DateTime?
-  occurrenceCount       Int                      @default(1)
-  lastSeenAt            DateTime?
-  submittedById         String?
-  completedAt           DateTime?
-  agentId               String?
-  accountableEmployeeId String?
-  claimedById           String?
-  claimedByAgentId      String?
-  claimedAt             DateTime?
-  claimStatus           String?
-  upstreamIssueNumber   Int?
-  upstreamIssueUrl      String?
-  upstreamSyncedAt      DateTime?
-  accountableEmployee   EmployeeProfile?         @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
-  activeBuild           FeatureBuild?            @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
-  digitalProduct        DigitalProduct?          @relation(fields: [digitalProductId], references: [id])
-  duplicateOf           BacklogItem?             @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
-  duplicates            BacklogItem[]            @relation("BacklogItemDuplicates")
-  epic                  Epic?                    @relation(fields: [epicId], references: [id])
-  featureBuilds         FeatureBuild[]           @relation("BacklogItemOriginator")
-  submittedBy           User?                    @relation("BacklogSubmissions", fields: [submittedById], references: [id])
-  taxonomyNode          TaxonomyNode?            @relation(fields: [taxonomyNodeId], references: [id])
-  activities            BacklogItemActivity[]
-  coworkerNeeds         CoworkerCapabilityNeed[] @relation("BacklogItemCoworkerCapabilityNeeds")
+  id                      String                        @id @default(cuid())
+  itemId                  String                        @unique
+  title                   String
+  status                  String
+  type                    String
+  body                    String?
+  createdAt               DateTime                      @default(now())
+  updatedAt               DateTime                      @updatedAt
+  priority                Int?
+  digitalProductId        String?
+  taxonomyNodeId          String?
+  epicId                  String?
+  source                  String?
+  triageOutcome           String?
+  effortSize              String?
+  proposedOutcome         String?
+  activeBuildId           String?                       @unique
+  duplicateOfId           String?
+  resolution              String?
+  abandonReason           String?
+  stalenessDetectedAt     DateTime?
+  occurrenceCount         Int                           @default(1)
+  lastSeenAt              DateTime?
+  submittedById           String?
+  completedAt             DateTime?
+  agentId                 String?
+  accountableEmployeeId   String?
+  claimedById             String?
+  claimedByAgentId        String?
+  claimedAt               DateTime?
+  claimStatus             String?
+  upstreamIssueNumber     Int?
+  upstreamIssueUrl        String?
+  upstreamSyncedAt        DateTime?
+  accountableEmployee     EmployeeProfile?              @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
+  activeBuild             FeatureBuild?                 @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
+  digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
+  duplicateOf             BacklogItem?                  @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
+  duplicates              BacklogItem[]                 @relation("BacklogItemDuplicates")
+  epic                    Epic?                         @relation(fields: [epicId], references: [id])
+  featureBuilds           FeatureBuild[]                @relation("BacklogItemOriginator")
+  submittedBy             User?                         @relation("BacklogSubmissions", fields: [submittedById], references: [id])
+  taxonomyNode            TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
+  activities              BacklogItemActivity[]
+  coworkerNeeds           CoworkerCapabilityNeed[]      @relation("BacklogItemCoworkerCapabilityNeeds")
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityBacklogLinks")
 }
 
@@ -1351,15 +1351,15 @@ model IntegrationToolCallLog {
 // Source-attributed import review queue for external provider records.
 // Stores review/link posture only; raw provider payloads stay outside DPF.
 model IntegrationImportBatch {
-  id                  String   @id @default(cuid())
-  batchRef            String   @unique
+  id                  String    @id @default(cuid())
+  batchRef            String    @unique
   sourceProvider      String
   providerEnvironment String?
   sourceTimestamp     DateTime?
-  status              String   @default("reviewing")
+  status              String    @default("reviewing")
   createdById         String?
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   records IntegrationImportStagedRecord[]
 
@@ -1368,24 +1368,24 @@ model IntegrationImportBatch {
 }
 
 model IntegrationImportStagedRecord {
-  id                      String   @id @default(cuid())
+  id                      String    @id @default(cuid())
   importBatchId           String
   sourceProvider          String
   entityFamily            String
   externalId              String
   sourceTimestamp         DateTime?
   ownerSide               String
-  reviewStatus            String   @default("candidate")
+  reviewStatus            String    @default("candidate")
   proposedLocalEntityType String
   proposedLocalId         String?
-  proposedLocalStatus     String   @default("candidate")
-  proposedLocalConfidence String   @default("low")
+  proposedLocalStatus     String    @default("candidate")
+  proposedLocalConfidence String    @default("low")
   proposedLocalReason     String
   displayFields           Json
   sourceFingerprint       String
-  readOnly                Boolean  @default(true)
-  createdAt               DateTime @default(now())
-  updatedAt               DateTime @updatedAt
+  readOnly                Boolean   @default(true)
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
 
   batch IntegrationImportBatch @relation(fields: [importBatchId], references: [id], onDelete: Cascade)
 
@@ -1393,6 +1393,7 @@ model IntegrationImportStagedRecord {
   @@index([sourceProvider, entityFamily, externalId], map: "integration_import_record_source_family_external_idx")
   @@index([reviewStatus])
 }
+
 model OAuthPendingFlow {
   id           String   @id @default(cuid())
   state        String   @unique
@@ -2110,72 +2111,71 @@ model AuthorizationDecisionLog {
 }
 
 model CustomerAccount {
-  id                 String                      @id @default(cuid())
-  accountId          String                      @unique
-  name               String
-  status             String                      @default("prospect")
+  id                     String                      @id @default(cuid())
+  accountId              String                      @unique
+  name                   String
+  status                 String                      @default("prospect")
   // prospect | qualified | onboarding | active | at_risk | suspended | closed
-  website            String?
-  industry           String?
-  employeeCount      Int?
-  annualRevenue      Decimal?
-  currency           String                      @default("GBP")
-  notes              String?
-  sourceSystem       String?
-  sourceId           String?
-  parentAccountId    String?
-  createdAt          DateTime                    @default(now())
-  updatedAt          DateTime                    @updatedAt
-  invites            AccountInvite[]
-  contacts           CustomerContact[]
-  contactRoles       ContactAccountRole[]
-  customerSites      CustomerSite[]
-  configurationItems CustomerConfigurationItem[]
-  edgeNodes          EdgeNode[]
-  edgeBootstrapTokens BootstrapToken[]
-  discoveryRuns      DiscoveryRun[]
-  discoveryConnections DiscoveryConnection[]
-  parentAccount      CustomerAccount?            @relation("AccountHierarchy", fields: [parentAccountId], references: [id])
-  childAccounts      CustomerAccount[]           @relation("AccountHierarchy")
-  invoices           Invoice[]
-  engagements        Engagement[]
-  opportunities      Opportunity[]
-  activities         Activity[]
-  quotes             Quote[]
-  salesOrders        SalesOrder[]
-  recurringSchedules RecurringSchedule[]
-  inventoryEntities       InventoryEntity[]       @relation("InventoryEntityCustomerAccount")
-  inventoryRelationships  InventoryRelationship[] @relation("InventoryRelationshipCustomerAccount")
+  website                String?
+  industry               String?
+  employeeCount          Int?
+  annualRevenue          Decimal?
+  currency               String                      @default("GBP")
+  notes                  String?
+  sourceSystem           String?
+  sourceId               String?
+  parentAccountId        String?
+  createdAt              DateTime                    @default(now())
+  updatedAt              DateTime                    @updatedAt
+  invites                AccountInvite[]
+  contacts               CustomerContact[]
+  contactRoles           ContactAccountRole[]
+  customerSites          CustomerSite[]
+  configurationItems     CustomerConfigurationItem[]
+  edgeNodes              EdgeNode[]
+  edgeBootstrapTokens    BootstrapToken[]
+  discoveryRuns          DiscoveryRun[]
+  discoveryConnections   DiscoveryConnection[]
+  parentAccount          CustomerAccount?            @relation("AccountHierarchy", fields: [parentAccountId], references: [id])
+  childAccounts          CustomerAccount[]           @relation("AccountHierarchy")
+  invoices               Invoice[]
+  engagements            Engagement[]
+  opportunities          Opportunity[]
+  activities             Activity[]
+  quotes                 Quote[]
+  salesOrders            SalesOrder[]
+  recurringSchedules     RecurringSchedule[]
+  inventoryEntities      InventoryEntity[]           @relation("InventoryEntityCustomerAccount")
+  inventoryRelationships InventoryRelationship[]     @relation("InventoryRelationshipCustomerAccount")
 
   @@index([status])
   @@index([parentAccountId])
 }
 
-
 model CustomerSite {
-  id                 String                      @id @default(cuid())
-  siteId             String                      @unique
-  accountId          String
-  name               String
-  siteType           String                      @default("office")
-  status             String                      @default("active")
-  primaryAddressId   String?
-  timezone           String?
-  accessInstructions String?
-  hoursNotes         String?
-  serviceNotes       String?
-  createdAt          DateTime                    @default(now())
-  updatedAt          DateTime                    @updatedAt
-  account            CustomerAccount             @relation(fields: [accountId], references: [id], onDelete: Cascade)
-  primaryAddress     Address?                    @relation(fields: [primaryAddressId], references: [id])
-  configurationItems CustomerConfigurationItem[]
-  nodes              CustomerSiteNode[]
-  edgeNodes          EdgeNode[]
-  edgeBootstrapTokens BootstrapToken[]
-  discoveryRuns      DiscoveryRun[]
-  discoveryConnections DiscoveryConnection[]
-  inventoryEntities       InventoryEntity[]       @relation("InventoryEntityCustomerSite")
-  inventoryRelationships  InventoryRelationship[] @relation("InventoryRelationshipCustomerSite")
+  id                     String                      @id @default(cuid())
+  siteId                 String                      @unique
+  accountId              String
+  name                   String
+  siteType               String                      @default("office")
+  status                 String                      @default("active")
+  primaryAddressId       String?
+  timezone               String?
+  accessInstructions     String?
+  hoursNotes             String?
+  serviceNotes           String?
+  createdAt              DateTime                    @default(now())
+  updatedAt              DateTime                    @updatedAt
+  account                CustomerAccount             @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  primaryAddress         Address?                    @relation(fields: [primaryAddressId], references: [id])
+  configurationItems     CustomerConfigurationItem[]
+  nodes                  CustomerSiteNode[]
+  edgeNodes              EdgeNode[]
+  edgeBootstrapTokens    BootstrapToken[]
+  discoveryRuns          DiscoveryRun[]
+  discoveryConnections   DiscoveryConnection[]
+  inventoryEntities      InventoryEntity[]           @relation("InventoryEntityCustomerSite")
+  inventoryRelationships InventoryRelationship[]     @relation("InventoryRelationshipCustomerSite")
 
   @@index([accountId])
   @@index([primaryAddressId])
@@ -2326,32 +2326,32 @@ model RecipePerformance {
 // Captures observed adapter capabilities per (adapterKind, adapterVersion).
 // Replaces hand-maintained capability tables with probe-populated rows.
 model AdapterCapabilityProfile {
-  id                          String   @id @default(cuid())
-  adapterKind                 String   // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
-  adapterVersion              String   // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
-  probedAt                    DateTime
-  probedBy                    String   // host/process identity, for cache invalidation across replicas
+  id             String   @id @default(cuid())
+  adapterKind    String // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
+  adapterVersion String // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
+  probedAt       DateTime
+  probedBy       String // host/process identity, for cache invalidation across replicas
 
   // Observed capabilities — booleans, not aspirations
-  supportsStreamingEvents     Boolean
-  supportsMcpAttach           Boolean
-  supportsMcpAttachPerInvoke  Boolean  // Claude Code: yes (--mcp-config); Codex: no (static config only)
-  supportsSubagents           Boolean
-  supportsHooks               Boolean
-  supportsPlanState           Boolean
-  supportsTodoState           Boolean
-  supportsWebFetch            Boolean
-  supportsWebSearch           Boolean
-  supportsSessionResume       Boolean
-  supportsExtendedThinking    Boolean
-  supportsOutputSchema        Boolean
+  supportsStreamingEvents    Boolean
+  supportsMcpAttach          Boolean
+  supportsMcpAttachPerInvoke Boolean // Claude Code: yes (--mcp-config); Codex: no (static config only)
+  supportsSubagents          Boolean
+  supportsHooks              Boolean
+  supportsPlanState          Boolean
+  supportsTodoState          Boolean
+  supportsWebFetch           Boolean
+  supportsWebSearch          Boolean
+  supportsSessionResume      Boolean
+  supportsExtendedThinking   Boolean
+  supportsOutputSchema       Boolean
 
   // Operating envelope
-  maxInteractiveLatencyMs     Int      // wall-clock budget for first event
-  supportedAuthModes          String[] // "api-key" | "oauth" | "local"
+  maxInteractiveLatencyMs Int // wall-clock budget for first event
+  supportedAuthModes      String[] // "api-key" | "oauth" | "local"
 
   // Known landmines (Codex example: --json silently ignored when MCP active)
-  knownDegradations           Json?    // [{ trigger: string, behavior: string, source: string }]
+  knownDegradations Json? // [{ trigger: string, behavior: string, source: string }]
 
   @@unique([adapterKind, adapterVersion])
   @@index([adapterKind, probedAt])
@@ -2362,19 +2362,19 @@ model AdapterCapabilityProfile {
 // usage, and schema-drift detection. Supports single/shadow/race execution
 // modes via raceCohortId grouping. Feeds nightly outcome scoring (§6.4).
 model AdapterRunTelemetry {
-  id                  String    @id @default(cuid())
-  threadId            String?   // null for non-coworker runs (probes, eval)
-  agentMessageId      String?   // joins to AgentMessage when applicable
-  buildId             String?   // for Build Studio dispatch via the substrate
-  agentId             String?   // attribution (PR #607 convention)
-  skillId             String?   // active skill at run time (PR #623 precedent)
-  adapterKind         String
-  adapterVersion      String
-  providerId          String
-  modelId             String
+  id             String  @id @default(cuid())
+  threadId       String? // null for non-coworker runs (probes, eval)
+  agentMessageId String? // joins to AgentMessage when applicable
+  buildId        String? // for Build Studio dispatch via the substrate
+  agentId        String? // attribution (PR #607 convention)
+  skillId        String? // active skill at run time (PR #623 precedent)
+  adapterKind    String
+  adapterVersion String
+  providerId     String
+  modelId        String
 
-  executionMode       String    // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
-  raceCohortId        String?   // groups concurrent race/shadow runs
+  executionMode String // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
+  raceCohortId  String? // groups concurrent race/shadow runs
 
   startedAt           DateTime
   finishedAt          DateTime?
@@ -2382,28 +2382,28 @@ model AdapterRunTelemetry {
   firstEventLatencyMs Int?
 
   // Outcome dimensions (spec §5.4)
-  status              String    // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
-  httpStatus          Int?      // raw HTTP status code from the provider (null for CLI adapters and successes without errors)
-  refusalReason       String?
-  errorClass          String?
-  inputTokens         Int?
-  cachedInputTokens   Int?
-  cacheCreationInputTokens Int?  // tokens written into the Anthropic prompt cache this call
-  outputTokens        Int?
+  status                   String // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
+  httpStatus               Int? // raw HTTP status code from the provider (null for CLI adapters and successes without errors)
+  refusalReason            String?
+  errorClass               String?
+  inputTokens              Int?
+  cachedInputTokens        Int?
+  cacheCreationInputTokens Int? // tokens written into the Anthropic prompt cache this call
+  outputTokens             Int?
 
-  reasoningTokens     Int?
-  estimatedCostUsd    Decimal?  @db.Decimal(10, 6)
-  quotaPoolConsumed   String?   // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
+  reasoningTokens   Int?
+  estimatedCostUsd  Decimal? @db.Decimal(10, 6)
+  quotaPoolConsumed String? // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
 
-  toolCallsTotal      Int       @default(0)
-  toolCallsInvalid    Int       @default(0) // fabricated tool names, schema mismatches
-  capabilitiesUsed    String[]  // which capability booleans were actually exercised this run
-  schemaDriftDetected Boolean   @default(false) // adapter emitted unexpected event shape
+  toolCallsTotal      Int      @default(0)
+  toolCallsInvalid    Int      @default(0) // fabricated tool names, schema mismatches
+  capabilitiesUsed    String[] // which capability booleans were actually exercised this run
+  schemaDriftDetected Boolean  @default(false) // adapter emitted unexpected event shape
 
-  userAccepted        Boolean?  // null = not yet decided; true = message kept; false = retried/discarded
-  acceptedAt          DateTime?
+  userAccepted Boolean? // null = not yet decided; true = message kept; false = retried/discarded
+  acceptedAt   DateTime?
 
-  rawEventDigest      String?   // sha256 of normalized event log, for cross-adapter equivalence checks
+  rawEventDigest String? // sha256 of normalized event log, for cross-adapter equivalence checks
 
   @@index([adapterKind, startedAt])
   @@index([raceCohortId])
@@ -2417,8 +2417,8 @@ model AdapterRunTelemetry {
 model AgentBudgetEvent {
   id          String   @id @default(cuid())
   agentId     String
-  buildRunId  String?  // FK intentionally soft — build runs may be ephemeral
-  eventKind   String   // "inference" | "tool_call" | "budget_exceeded"
+  buildRunId  String? // FK intentionally soft — build runs may be ephemeral
+  eventKind   String // "inference" | "tool_call" | "budget_exceeded"
   amountUsd   Decimal  @db.Decimal(10, 6)
   tokensTotal Int?
   modelId     String?
@@ -2439,19 +2439,19 @@ model AgentBudgetEvent {
 // Per spec §9, no-op cleanups are NOT logged to avoid bloating the table
 // — quality regression is detected from the rows we do write.
 model TranscriptCleanupAudit {
-  id                   String   @id @default(cuid())
-  threadId             String?
-  agentMessageId       String?
-  userId               String?
-  rawText              String   @db.Text
-  cleanedText          String   @db.Text
-  levenshteinRatio     Float
-  injectionSuspected   Boolean  @default(false)
-  injectionIndicators  String[] // populated when injectionSuspected = true
-  providerId           String?  // cleanup-pass provider; null when short-circuited before LLM
-  modelId              String?
-  durationMs           Int?
-  createdAt            DateTime @default(now())
+  id                  String   @id @default(cuid())
+  threadId            String?
+  agentMessageId      String?
+  userId              String?
+  rawText             String   @db.Text
+  cleanedText         String   @db.Text
+  levenshteinRatio    Float
+  injectionSuspected  Boolean  @default(false)
+  injectionIndicators String[] // populated when injectionSuspected = true
+  providerId          String? // cleanup-pass provider; null when short-circuited before LLM
+  modelId             String?
+  durationMs          Int?
+  createdAt           DateTime @default(now())
 
   @@index([createdAt])
   @@index([injectionSuspected])
@@ -2670,8 +2670,8 @@ model Organization {
   wikiLintFindings              WikiLintFinding[]
   documents                     Document[]
   decisionPerspectiveProfiles   DecisionPerspectiveProfile[]
-  integrationCoverageProviders  IntegrationCoverageProvider[] @relation("OrgToCoverageProviders")
-  integrationRoleCoverages      IntegrationRoleCoverage[]     @relation("OrgToCoverageCells")
+  integrationCoverageProviders  IntegrationCoverageProvider[]  @relation("OrgToCoverageProviders")
+  integrationRoleCoverages      IntegrationRoleCoverage[]      @relation("OrgToCoverageCells")
 }
 
 model BusinessContext {
@@ -3233,8 +3233,8 @@ model DiscoveryRun {
   confirmedEntities       InventoryEntity[]                 @relation("InventoryEntityConfirmedRun")
   confirmedRelations      InventoryRelationship[]           @relation("InventoryRelationshipConfirmedRun")
   edgeNode                EdgeNode?                         @relation("EdgeNodeDiscoveryRuns", fields: [edgeNodeId], references: [id])
-  customerAccount         CustomerAccount?                   @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
-  customerSite            CustomerSite?                      @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
+  customerAccount         CustomerAccount?                  @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
+  customerSite            CustomerSite?                     @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
 
   @@unique([edgeNodeId, runKey])
   @@index([edgeNodeId])
@@ -3586,7 +3586,7 @@ model AgentThread {
 
   // Specialist subtask thread spawning (feat/agent-thread-spawning)
   parentThreadId String?
-  childCount     Int       @default(0)
+  childCount     Int           @default(0)
   cancelledAt    DateTime?
   idempotencyKey String?
   terminalError  Json?
@@ -3723,38 +3723,38 @@ model AdminActivity {
 }
 
 model ToolExecution {
-  id            String                @id @default(cuid())
-  threadId      String
-  agentId       String
-  userId        String
-  toolName      String
-  parameters    Json
-  result        Json
-  success       Boolean
-  executionMode String
-  routeContext  String?
-  durationMs    Int?
-  createdAt     DateTime              @default(now())
+  id                      String                   @id @default(cuid())
+  threadId                String
+  agentId                 String
+  userId                  String
+  toolName                String
+  parameters              Json
+  result                  Json
+  success                 Boolean
+  executionMode           String
+  routeContext            String?
+  durationMs              Int?
+  createdAt               DateTime                 @default(now())
   // Phase 3: audit enrichment — nullable; backfill via backfill-capability-ids.ts
-  auditClass    String?
-  capabilityId  String?
-  summary       String?
+  auditClass              String?
+  capabilityId            String?
+  summary                 String?
   // External MCP transport (spec §13) — set when the tool call originated from
   // a Bearer-token authenticated request through /api/mcp/v1.
-  apiTokenId    String?
+  apiTokenId              String?
   // Autonomous coworker runtime Slice 1: nullable parent TaskRun link.
   // Persisted by mcp-governed-execute.ts when context.taskRunId is provided.
-  taskRunId     String?
+  taskRunId               String?
   // Governed Hermes learning Slice 1: nullable active skill attribution.
-  skillId       String?
+  skillId                 String?
   // EP-COST-001 Phase 1: token metering for AI-backed tool execution paths.
   // Populated by tools that make inference calls (design system generation,
   // code review, etc.). Non-inference tools (file reads, sandbox runs) leave these null.
-  inputTokens   Int?
-  outputTokens  Int?
-  costUsd       Float?
-  receipt       ToolExecutionReceipt?
-  assuranceRun  AssuranceRun?
+  inputTokens             Int?
+  outputTokens            Int?
+  costUsd                 Float?
+  receipt                 ToolExecutionReceipt?
+  assuranceRun            AssuranceRun?
   documentLifecycleEvents DocumentLifecycleEvent[]
 
   @@index([agentId, createdAt])
@@ -3900,25 +3900,25 @@ model Document {
 }
 
 model DocumentVersion {
-  id                         String              @id @default(cuid())
-  documentId                 String
-  version                    Int
-  title                      String
-  contentFormat              String
-  contentText                String?             @db.Text
-  contentBlobId              String?
-  contentSha256              String?
-  sizeBytes                  Int?
-  summary                    String?             @db.Text
-  createdByPrincipalId       String?
-  createdAt                  DateTime            @default(now())
-  document                   Document            @relation("DocumentVersions", fields: [documentId], references: [id], onDelete: Cascade)
-  currentForDocuments        Document[]          @relation("DocumentCurrentVersion")
-  contentBlob                DocumentBlob?       @relation(fields: [contentBlobId], references: [id], onDelete: SetNull)
-  createdByPrincipal         Principal?          @relation("DocumentVersionCreator", fields: [createdByPrincipalId], references: [id])
-  sourceReferences           DocumentReference[] @relation("DocumentReferenceSourceVersion")
-  targetReferences           DocumentReference[] @relation("DocumentReferenceTargetVersion")
-  renditions                 DocumentRendition[]
+  id                   String              @id @default(cuid())
+  documentId           String
+  version              Int
+  title                String
+  contentFormat        String
+  contentText          String?             @db.Text
+  contentBlobId        String?
+  contentSha256        String?
+  sizeBytes            Int?
+  summary              String?             @db.Text
+  createdByPrincipalId String?
+  createdAt            DateTime            @default(now())
+  document             Document            @relation("DocumentVersions", fields: [documentId], references: [id], onDelete: Cascade)
+  currentForDocuments  Document[]          @relation("DocumentCurrentVersion")
+  contentBlob          DocumentBlob?       @relation(fields: [contentBlobId], references: [id], onDelete: SetNull)
+  createdByPrincipal   Principal?          @relation("DocumentVersionCreator", fields: [createdByPrincipalId], references: [id])
+  sourceReferences     DocumentReference[] @relation("DocumentReferenceSourceVersion")
+  targetReferences     DocumentReference[] @relation("DocumentReferenceTargetVersion")
+  renditions           DocumentRendition[]
 
   @@unique([documentId, version])
   @@index([documentId])
@@ -3929,14 +3929,14 @@ model DocumentVersion {
 }
 
 model DocumentBlob {
-  id          String              @id @default(cuid())
-  sha256      String              @unique
-  storageKey  String              @unique
-  mimeType    String?
-  sizeBytes   Int
-  createdAt   DateTime            @default(now())
-  versions    DocumentVersion[]
-  renditions  DocumentRendition[]
+  id         String              @id @default(cuid())
+  sha256     String              @unique
+  storageKey String              @unique
+  mimeType   String?
+  sizeBytes  Int
+  createdAt  DateTime            @default(now())
+  versions   DocumentVersion[]
+  renditions DocumentRendition[]
 
   @@index([sizeBytes])
 }
@@ -3996,17 +3996,17 @@ model DocumentAccessGrant {
 }
 
 model DocumentLifecycleEvent {
-  id                   String         @id @default(cuid())
-  documentId           String
-  fromState            String?
-  toState              String
-  reason               String?        @db.Text
-  actorPrincipalId     String?
-  toolExecutionId      String?
-  createdAt            DateTime       @default(now())
-  document             Document       @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  actorPrincipal       Principal?     @relation("DocumentLifecycleActor", fields: [actorPrincipalId], references: [id])
-  toolExecution        ToolExecution? @relation(fields: [toolExecutionId], references: [id])
+  id               String         @id @default(cuid())
+  documentId       String
+  fromState        String?
+  toState          String
+  reason           String?        @db.Text
+  actorPrincipalId String?
+  toolExecutionId  String?
+  createdAt        DateTime       @default(now())
+  document         Document       @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  actorPrincipal   Principal?     @relation("DocumentLifecycleActor", fields: [actorPrincipalId], references: [id])
+  toolExecution    ToolExecution? @relation(fields: [toolExecutionId], references: [id])
 
   @@index([documentId, createdAt])
   @@index([toState])
@@ -4520,7 +4520,7 @@ model BomComponentOccurrence {
 }
 
 model AssuranceFinding {
-  id                  String        @id @default(cuid())
+  id                  String          @id @default(cuid())
   findingKey          String
   assuranceRunId      String?
   findingKind         String
@@ -4532,32 +4532,32 @@ model AssuranceFinding {
   vendorIdentifier    String
   sourceSeverity      String?
   policySeverity      String
-  releaseImpact       String        @default("track")
-  reachability        String        @default("unknown")
-  exposure            String        @default("unknown")
-  identifierStability String        @default("strong")
-  reopenCount         Int           @default(0)
-  status              String        @default("open")
-  firstSeenAt         DateTime      @default(now())
-  lastSeenAt          DateTime      @default(now())
+  releaseImpact       String          @default("track")
+  reachability        String          @default("unknown")
+  exposure            String          @default("unknown")
+  identifierStability String          @default("strong")
+  reopenCount         Int             @default(0)
+  status              String          @default("open")
+  firstSeenAt         DateTime        @default(now())
+  lastSeenAt          DateTime        @default(now())
   resolvedAt          DateTime?
   acceptedUntil       DateTime?
   ownerAgentId        String?
   ownerUserId         String?
-  source              Json          @default("{}")
-  evidence            Json          @default("{}")
-  remediationHint     Json          @default("{}")
-  createdAt           DateTime      @default(now())
-  updatedAt           DateTime      @updatedAt
+  source              Json            @default("{}")
+  evidence            Json            @default("{}")
+  remediationHint     Json            @default("{}")
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
   buildId             String?
   digitalProductId    String?
   bomDocumentId       String?
   bomComponentId      String?
-  assuranceRun        AssuranceRun? @relation(fields: [assuranceRunId], references: [id], onDelete: SetNull)
-  build               FeatureBuild? @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
+  assuranceRun        AssuranceRun?   @relation(fields: [assuranceRunId], references: [id], onDelete: SetNull)
+  build               FeatureBuild?   @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
   digitalProduct      DigitalProduct? @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
-  bomDocument         BomDocument?  @relation(fields: [bomDocumentId], references: [id], onDelete: SetNull)
-  bomComponent        BomComponent? @relation(fields: [bomComponentId], references: [id], onDelete: SetNull)
+  bomDocument         BomDocument?    @relation(fields: [bomDocumentId], references: [id], onDelete: SetNull)
+  bomComponent        BomComponent?   @relation(fields: [bomComponentId], references: [id], onDelete: SetNull)
 
   @@unique([findingKey])
   @@index([findingKind, status])
@@ -4573,17 +4573,17 @@ model AssuranceFinding {
 }
 
 model Sandbox {
-  id                   String       @id @default(cuid())
+  id                   String          @id @default(cuid())
   buildId              String
   providerId           String
   agentId              String?
   portalInstanceId     String
   state                String
-  startedAt            DateTime     @default(now())
+  startedAt            DateTime        @default(now())
   destroyedAt          DateTime?
   previewUrl           String?
   capabilitiesSnapshot Json
-  featureBuild         FeatureBuild @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
+  featureBuild         FeatureBuild    @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
   runtimeTargets       RuntimeTarget[]
 
   @@index([buildId])
@@ -4591,10 +4591,10 @@ model Sandbox {
 }
 
 model GitPromotionCandidate {
-  id                      String    @id @default(cuid())
-  candidateId             String    @unique
-  provider                String    @default("github")
-  deliveryKey             String    @unique
+  id                      String                @id @default(cuid())
+  candidateId             String                @unique
+  provider                String                @default("github")
+  deliveryKey             String                @unique
   eventName               String
   repositoryFullName      String
   repositoryCloneUrl      String?
@@ -4602,7 +4602,7 @@ model GitPromotionCandidate {
   branch                  String?
   beforeSha               String?
   afterSha                String?
-  status                  String    @default("queued")
+  status                  String                @default("queued")
   statusReason            String?
   sandboxProviderId       String?
   sandboxId               String?
@@ -4610,8 +4610,8 @@ model GitPromotionCandidate {
   verificationCompletedAt DateTime?
   verificationResult      Json?
   payload                 Json?
-  createdAt               DateTime  @default(now())
-  updatedAt               DateTime  @updatedAt
+  createdAt               DateTime              @default(now())
+  updatedAt               DateTime              @updatedAt
   runtimeVerifications    RuntimeVerification[]
 
   @@index([status, createdAt])
@@ -4619,18 +4619,18 @@ model GitPromotionCandidate {
 }
 
 model SandboxSlot {
-  id          String    @id @default(cuid())
-  slotIndex   Int       @unique
-  containerId String
-  port        Int
-  status      String    @default("available")
-  buildId     String?   @unique
-  userId      String?
-  acquiredAt  DateTime?
-  releasedAt  DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  runtimeTargets           RuntimeTarget[]
+  id             String          @id @default(cuid())
+  slotIndex      Int             @unique
+  containerId    String
+  port           Int
+  status         String          @default("available")
+  buildId        String?         @unique
+  userId         String?
+  acquiredAt     DateTime?
+  releasedAt     DateTime?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  runtimeTargets RuntimeTarget[]
 
   @@index([status])
 }
@@ -4765,42 +4765,42 @@ model PromotionBackup {
 // ─── Task Governance Runtime ──────────────────────────────────────
 
 model TaskRun {
-  id                 String            @id @default(cuid())
-  taskRunId          String            @unique
-  userId             String
-  threadId           String?
-  contextId          String?
-  buildId            String?
-  initiatingAgentId  String?
-  currentAgentId     String?
-  parentTaskRunId    String?
-  routeContext       String?
-  title              String
-  objective          String            @db.Text
-  source             String            @default("coworker") // coworker | build | skill | proactive
+  id                   String                @id @default(cuid())
+  taskRunId            String                @unique
+  userId               String
+  threadId             String?
+  contextId            String?
+  buildId              String?
+  initiatingAgentId    String?
+  currentAgentId       String?
+  parentTaskRunId      String?
+  routeContext         String?
+  title                String
+  objective            String                @db.Text
+  source               String                @default("coworker") // coworker | build | skill | proactive
   /// A2A-aligned task states: submitted | working | input-required | auth-required | completed | failed | canceled | rejected | archived
-  status             String            @default("submitted")
-  authorityScope     Json?
-  a2aMetadata        Json?
-  progressPayload    Json?
-  repeatedPatternKey String?
-  templateId         String?
-  startedAt          DateTime          @default(now())
-  completedAt        DateTime?
-  archivedAt         DateTime?
+  status               String                @default("submitted")
+  authorityScope       Json?
+  a2aMetadata          Json?
+  progressPayload      Json?
+  repeatedPatternKey   String?
+  templateId           String?
+  startedAt            DateTime              @default(now())
+  completedAt          DateTime?
+  archivedAt           DateTime?
   // Cooperative heartbeat written by long-running loops (agent runtime,
   // deliberation rounds, sandbox pipeline, Codex CLI) so the watchdog can
   // distinguish a live task from a wedged one. See BI-4ab6be39 §6.1.
-  lastHeartbeatAt    DateTime?
-  createdAt          DateTime          @default(now())
-  updatedAt          DateTime          @updatedAt
-  user               User              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  nodes              TaskNode[]
-  messages           TaskMessage[]
-  artifacts          TaskArtifact[]
-  deliberationRuns   DeliberationRun[]
+  lastHeartbeatAt      DateTime?
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  user                 User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  nodes                TaskNode[]
+  messages             TaskMessage[]
+  artifacts            TaskArtifact[]
+  deliberationRuns     DeliberationRun[]
   decisionInteractions DecisionInteraction[]
-  stallEvents        StallEvent[]
+  stallEvents          StallEvent[]
 
   @@index([userId, status])
   @@index([threadId])
@@ -4820,23 +4820,23 @@ model TaskRun {
 // abandon, escalate). Used by the Build Studio phase panel history
 // strip and as candidate WWMD profile material in v2.
 model StallEvent {
-  id                   String    @id @default(cuid())
-  taskRunId            String
-  buildId              String?
-  phase                String?   // FeatureBuild.phase at detection time
-  reason               String    // "heartbeat_timeout" | "total_timeout" | "never_started" | "parent_stalled" | "parent_abandoned"
-  detectedAt           DateTime  @default(now())
-  lastHeartbeatAt      DateTime?
-  startedAt            DateTime
-  thresholdHeartbeatS  Int
-  thresholdTotalS      Int
-  outcome              String?   // null (pending) | "retry" | "abandoned" | "escalated" | "auto-recovered"
-  outcomeAt            DateTime?
-  outcomeBy            String?   // User.id of operator who acted; null if watchdog auto-action
-  notes                String?   @db.Text
-  createdAt            DateTime  @default(now())
+  id                  String    @id @default(cuid())
+  taskRunId           String
+  buildId             String?
+  phase               String? // FeatureBuild.phase at detection time
+  reason              String // "heartbeat_timeout" | "total_timeout" | "never_started" | "parent_stalled" | "parent_abandoned"
+  detectedAt          DateTime  @default(now())
+  lastHeartbeatAt     DateTime?
+  startedAt           DateTime
+  thresholdHeartbeatS Int
+  thresholdTotalS     Int
+  outcome             String? // null (pending) | "retry" | "abandoned" | "escalated" | "auto-recovered"
+  outcomeAt           DateTime?
+  outcomeBy           String? // User.id of operator who acted; null if watchdog auto-action
+  notes               String?   @db.Text
+  createdAt           DateTime  @default(now())
 
-  taskRun              TaskRun   @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
+  taskRun TaskRun @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
 
   @@index([taskRunId])
   @@index([buildId])
@@ -5208,32 +5208,32 @@ model EaDqRule {
 }
 
 model EaElement {
-  id                String               @id @default(cuid())
-  elementTypeId     String
-  name              String
-  description       String?
-  properties        Json                 @default("{}")
-  lifecycleStage    String               @default("plan")
-  lifecycleStatus   String               @default("draft")
-  createdById       String?
-  digitalProductId  String?
-  infraCiKey        String?
-  portfolioId       String?
-  taxonomyNodeId    String?
-  syncedAt          DateTime?
-  refinementLevel   String?
-  itValueStream     String?
-  ontologyRole      String?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
-  conformanceIssues EaConformanceIssue[]
-  digitalProduct    DigitalProduct?      @relation(fields: [digitalProductId], references: [id])
-  elementType       EaElementType        @relation(fields: [elementTypeId], references: [id])
-  portfolio         Portfolio?           @relation(fields: [portfolioId], references: [id])
-  taxonomyNode      TaxonomyNode?        @relation(fields: [taxonomyNodeId], references: [id])
-  fromRelationships EaRelationship[]     @relation("FromElement")
-  toRelationships   EaRelationship[]     @relation("ToElement")
-  viewElements      EaViewElement[]
+  id                      String                        @id @default(cuid())
+  elementTypeId           String
+  name                    String
+  description             String?
+  properties              Json                          @default("{}")
+  lifecycleStage          String                        @default("plan")
+  lifecycleStatus         String                        @default("draft")
+  createdById             String?
+  digitalProductId        String?
+  infraCiKey              String?
+  portfolioId             String?
+  taxonomyNodeId          String?
+  syncedAt                DateTime?
+  refinementLevel         String?
+  itValueStream           String?
+  ontologyRole            String?
+  createdAt               DateTime                      @default(now())
+  updatedAt               DateTime                      @updatedAt
+  conformanceIssues       EaConformanceIssue[]
+  digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
+  elementType             EaElementType                 @relation(fields: [elementTypeId], references: [id])
+  portfolio               Portfolio?                    @relation(fields: [portfolioId], references: [id])
+  taxonomyNode            TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
+  fromRelationships       EaRelationship[]              @relation("FromElement")
+  toRelationships         EaRelationship[]              @relation("ToElement")
+  viewElements            EaViewElement[]
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityEaElementLinks")
 
   @@index([portfolioId])
@@ -7589,7 +7589,7 @@ model BuildStudioStallThreshold {
   heartbeatTimeoutSeconds  Int
   totalPhaseTimeoutSeconds Int
   updatedAt                DateTime @updatedAt
-  updatedBy                String?  // User.id of last operator edit; null if seeded
+  updatedBy                String? // User.id of last operator edit; null if seeded
 
   @@index([scope])
 }
@@ -8000,19 +8000,19 @@ model WikiPage {
   // docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §9.
   // Storage-layer accepts incomplete principle data; required-field gating
   // lives in lint detectors (spec §14).
-  principleTier              String? // commandment | core | contextual
-  principleDirection         String?  @db.Text
-  principleWeight            Float?
-  principleWeightRationale   String?  @db.Text
-  principleDimensionVector   Json?
-  principleDimensions        String[] @default([])
-  principleAppliesTo         String[] @default([]) // in_platform_coworker | external_coding_agent | human
+  principleTier               String? // commandment | core | contextual
+  principleDirection          String?  @db.Text
+  principleWeight             Float?
+  principleWeightRationale    String?  @db.Text
+  principleDimensionVector    Json?
+  principleDimensions         String[] @default([])
+  principleAppliesTo          String[] @default([]) // in_platform_coworker | external_coding_agent | human
   // Consumer archetype + contexts — spec §8A. Independent axis from
   // principleAppliesTo; coherence rules in §8A.1 are enforced by lint.
-  principleConsumerArchetype String? // universal | ai-coworker-universal | generalist | specialist | route-domain-specific
-  principleConsumerContexts  String[] @default([]) // governed kebab-case slugs (e.g., "build-studio")
-  principlePublic            Boolean  @default(false)
-  principlePublicRationale   String?  @db.Text
+  principleConsumerArchetype  String? // universal | ai-coworker-universal | generalist | specialist | route-domain-specific
+  principleConsumerContexts   String[] @default([]) // governed kebab-case slugs (e.g., "build-studio")
+  principlePublic             Boolean  @default(false)
+  principlePublicRationale    String?  @db.Text
   // Runtime enforcement payload for tier-1 commandments (spec 2026-05-24).
   // Shape: {interactiveMode, autonomousMode, patterns: [{kind, regex|toolName, rationale}]}
   // Consumed by apps/web/lib/kernel/runtime-gate.ts at execution time;
@@ -8431,13 +8431,13 @@ model DeliberationRun {
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 
-  taskRun         TaskRun                @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
-  pattern         DeliberationPattern    @relation(fields: [patternId], references: [id])
-  outcome         DeliberationOutcome?
-  issueSets       DeliberationIssueSet[]
-  claims          ClaimRecord[]
-  evidenceBundles EvidenceBundle[]
-  branchNodes     TaskNode[]             @relation("DeliberationRunBranchNodes")
+  taskRun              TaskRun                @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
+  pattern              DeliberationPattern    @relation(fields: [patternId], references: [id])
+  outcome              DeliberationOutcome?
+  issueSets            DeliberationIssueSet[]
+  claims               ClaimRecord[]
+  evidenceBundles      EvidenceBundle[]
+  branchNodes          TaskNode[]             @relation("DeliberationRunBranchNodes")
   decisionInteractions DecisionInteraction[]
 
   @@index([taskRunId])
@@ -8539,32 +8539,32 @@ model EvidenceSource {
 }
 
 model DecisionPerspectiveProfile {
-  id                  String                  @id @default(cuid())
-  profileId           String                  @unique
-  name                String
-  kind                String
-  scope               Json                    @default("{}")
-  ownerOrganizationId String?
-  ownerPrincipalId    String?
-  fallbackProfileId   String?
-  currentVersionId    String?                 @unique
-  defaultResolver     Json?
-  autonomyPolicy      Json                    @default("{}")
-  status              String                  @default("active")
-  personaConfig       Json?
-  voiceEnabled        Boolean                 @default(false)
-  createdAt           DateTime                @default(now())
-  updatedAt           DateTime                @updatedAt
-  ownerOrganization   Organization?           @relation(fields: [ownerOrganizationId], references: [id], onDelete: SetNull)
-  ownerPrincipal      Principal?              @relation("DecisionPerspectiveProfileOwner", fields: [ownerPrincipalId], references: [id], onDelete: SetNull)
-  fallbackProfile     DecisionPerspectiveProfile? @relation("DecisionPerspectiveProfileFallback", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
-  fallbackChildren    DecisionPerspectiveProfile[] @relation("DecisionPerspectiveProfileFallback")
-  currentVersion      DecisionPerspectiveProfileVersion? @relation("DecisionPerspectiveProfileCurrentVersion", fields: [currentVersionId], references: [versionId], onDelete: SetNull)
-  versions            DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersions")
-  materials           PerspectiveMaterial[]
-  interactions        DecisionInteraction[]   @relation("DecisionInteractionProfile")
-  fallbackInteractions DecisionInteraction[]  @relation("DecisionInteractionFallbackProfile")
-  voiceProfile        VoiceProfile?
+  id                   String                              @id @default(cuid())
+  profileId            String                              @unique
+  name                 String
+  kind                 String
+  scope                Json                                @default("{}")
+  ownerOrganizationId  String?
+  ownerPrincipalId     String?
+  fallbackProfileId    String?
+  currentVersionId     String?                             @unique
+  defaultResolver      Json?
+  autonomyPolicy       Json                                @default("{}")
+  status               String                              @default("active")
+  personaConfig        Json?
+  voiceEnabled         Boolean                             @default(false)
+  createdAt            DateTime                            @default(now())
+  updatedAt            DateTime                            @updatedAt
+  ownerOrganization    Organization?                       @relation(fields: [ownerOrganizationId], references: [id], onDelete: SetNull)
+  ownerPrincipal       Principal?                          @relation("DecisionPerspectiveProfileOwner", fields: [ownerPrincipalId], references: [id], onDelete: SetNull)
+  fallbackProfile      DecisionPerspectiveProfile?         @relation("DecisionPerspectiveProfileFallback", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
+  fallbackChildren     DecisionPerspectiveProfile[]        @relation("DecisionPerspectiveProfileFallback")
+  currentVersion       DecisionPerspectiveProfileVersion?  @relation("DecisionPerspectiveProfileCurrentVersion", fields: [currentVersionId], references: [versionId], onDelete: SetNull)
+  versions             DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersions")
+  materials            PerspectiveMaterial[]
+  interactions         DecisionInteraction[]               @relation("DecisionInteractionProfile")
+  fallbackInteractions DecisionInteraction[]               @relation("DecisionInteractionFallbackProfile")
+  voiceProfile         VoiceProfile?
 
   @@index([kind, status])
   @@index([ownerOrganizationId])
@@ -8573,17 +8573,17 @@ model DecisionPerspectiveProfile {
 }
 
 model DecisionPerspectiveProfileVersion {
-  id                    String                     @id @default(cuid())
-  versionId             String                     @unique
+  id                    String                      @id @default(cuid())
+  versionId             String                      @unique
   profileId             String
   versionNumber         Int
   materialFingerprint   String
   changeSummary         String?
   promotedByPrincipalId String?
-  createdAt             DateTime                   @default(now())
-  profile               DecisionPerspectiveProfile @relation("DecisionPerspectiveProfileVersions", fields: [profileId], references: [profileId], onDelete: Cascade)
+  createdAt             DateTime                    @default(now())
+  profile               DecisionPerspectiveProfile  @relation("DecisionPerspectiveProfileVersions", fields: [profileId], references: [profileId], onDelete: Cascade)
   currentForProfile     DecisionPerspectiveProfile? @relation("DecisionPerspectiveProfileCurrentVersion")
-  promotedByPrincipal   Principal?                 @relation("DecisionPerspectiveProfileVersionPromoter", fields: [promotedByPrincipalId], references: [id], onDelete: SetNull)
+  promotedByPrincipal   Principal?                  @relation("DecisionPerspectiveProfileVersionPromoter", fields: [promotedByPrincipalId], references: [id], onDelete: SetNull)
   materials             PerspectiveMaterial[]
   interactions          DecisionInteraction[]
 
@@ -8593,27 +8593,27 @@ model DecisionPerspectiveProfileVersion {
 }
 
 model PerspectiveMaterial {
-  id               String                     @id @default(cuid())
-  materialId       String                     @unique
+  id               String                             @id @default(cuid())
+  materialId       String                             @unique
   profileId        String
   profileVersionId String?
   sourceType       String
-  sourceRef        Json                       @default("{}")
-  scope            Json                       @default("{}")
-  domainClass      String                     @default("plan-readiness")
-  direction        String                     @default("neutral")
-  domains          String[]                   @default([])
-  freshness        String                     @default("current")
-  evidenceGrade    String                     @default("A")
+  sourceRef        Json                               @default("{}")
+  scope            Json                               @default("{}")
+  domainClass      String                             @default("plan-readiness")
+  direction        String                             @default("neutral")
+  domains          String[]                           @default([])
+  freshness        String                             @default("current")
+  evidenceGrade    String                             @default("A")
   stalenessPolicy  Json?
   lastValidatedAt  DateTime?
-  confidenceWeight Float                      @default(0.5)
-  reviewStatus     String                     @default("draft")
-  promotionState   String                     @default("candidate")
-  summary          String?                    @db.Text
-  createdAt        DateTime                   @default(now())
-  updatedAt        DateTime                   @updatedAt
-  profile          DecisionPerspectiveProfile @relation(fields: [profileId], references: [profileId], onDelete: Cascade)
+  confidenceWeight Float                              @default(0.5)
+  reviewStatus     String                             @default("draft")
+  promotionState   String                             @default("candidate")
+  summary          String?                            @db.Text
+  createdAt        DateTime                           @default(now())
+  updatedAt        DateTime                           @updatedAt
+  profile          DecisionPerspectiveProfile         @relation(fields: [profileId], references: [profileId], onDelete: Cascade)
   profileVersion   DecisionPerspectiveProfileVersion? @relation(fields: [profileVersionId], references: [versionId], onDelete: SetNull)
 
   @@index([profileId, freshness])
@@ -8627,8 +8627,8 @@ model PerspectiveMaterial {
 }
 
 model DecisionInteraction {
-  id                String                     @id @default(cuid())
-  interactionId     String                     @unique
+  id                String                            @id @default(cuid())
+  interactionId     String                            @unique
   profileId         String
   profileVersionId  String
   fallbackProfileId String?
@@ -8639,28 +8639,28 @@ model DecisionInteraction {
   routeContext      String?
   phaseFrom         String?
   phaseTo           String?
-  domainClass       String                     @default("plan-readiness")
-  question          String                     @db.Text
-  options           Json                       @default("[]")
-  evidenceBundle    Json                       @default("{}")
-  sources           Json                       @default("[]")
-  rationale         String?                    @db.Text
+  domainClass       String                            @default("plan-readiness")
+  question          String                            @db.Text
+  options           Json                              @default("[]")
+  evidenceBundle    Json                              @default("{}")
+  sources           Json                              @default("[]")
+  rationale         String?                           @db.Text
   riskTier          String
   confidenceBefore  Float?
   confidenceAfter   Float?
   outcomeType       String
-  principleConflict Boolean                    @default(false)
-  outcomePayload    Json                       @default("{}")
+  principleConflict Boolean                           @default(false)
+  outcomePayload    Json                              @default("{}")
   humanOutcome      Json?
-  createdAt         DateTime                   @default(now())
-  updatedAt         DateTime                   @updatedAt
-  profile           DecisionPerspectiveProfile @relation("DecisionInteractionProfile", fields: [profileId], references: [profileId], onDelete: Cascade)
+  createdAt         DateTime                          @default(now())
+  updatedAt         DateTime                          @updatedAt
+  profile           DecisionPerspectiveProfile        @relation("DecisionInteractionProfile", fields: [profileId], references: [profileId], onDelete: Cascade)
   profileVersion    DecisionPerspectiveProfileVersion @relation(fields: [profileVersionId], references: [versionId], onDelete: Restrict)
-  fallbackProfile   DecisionPerspectiveProfile? @relation("DecisionInteractionFallbackProfile", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
-  build             FeatureBuild?              @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
-  taskRun           TaskRun?                   @relation(fields: [taskRunId], references: [taskRunId], onDelete: SetNull)
-  deliberationRun   DeliberationRun?           @relation(fields: [deliberationRunId], references: [id], onDelete: SetNull)
-  triggeredByUser   User?                      @relation("DecisionInteractionTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
+  fallbackProfile   DecisionPerspectiveProfile?       @relation("DecisionInteractionFallbackProfile", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
+  build             FeatureBuild?                     @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
+  taskRun           TaskRun?                          @relation(fields: [taskRunId], references: [taskRunId], onDelete: SetNull)
+  deliberationRun   DeliberationRun?                  @relation(fields: [deliberationRunId], references: [id], onDelete: SetNull)
+  triggeredByUser   User?                             @relation("DecisionInteractionTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
   escalationCapture EscalationCapture?
   deferralCapture   DeferralCapture?
   voiceOutput       DecisionInteractionVoiceOutput?
@@ -8726,19 +8726,19 @@ model DeferralCapture {
 //
 
 model VoiceConsentRecord {
-  id                      String         @id @default(cuid())
-  subjectName             String
-  subjectEmail            String?
-  consentMethod           String
-  authorizedUseCases      String[]       @default([])
-  authorizedLanguages     String[]       @default(["en"])
-  authorizedTerritories   String[]       @default(["global"])
-  expiresAt               DateTime
-  capturedByPrincipalId   String
-  evidenceRef             String?
-  revokedAt               DateTime?
-  createdAt               DateTime       @default(now())
-  voiceProfiles           VoiceProfile[]
+  id                    String         @id @default(cuid())
+  subjectName           String
+  subjectEmail          String?
+  consentMethod         String
+  authorizedUseCases    String[]       @default([])
+  authorizedLanguages   String[]       @default(["en"])
+  authorizedTerritories String[]       @default(["global"])
+  expiresAt             DateTime
+  capturedByPrincipalId String
+  evidenceRef           String?
+  revokedAt             DateTime?
+  createdAt             DateTime       @default(now())
+  voiceProfiles         VoiceProfile[]
 
   @@index([capturedByPrincipalId])
 }
@@ -8771,16 +8771,16 @@ model VoiceProfile {
 // No longer written to — Chatterbox replaces async training with zero-shot
 // reference audio registration. Table drop deferred to schema-cleanup PR.
 model VoiceTrainingJob {
-  id              String       @id @default(cuid())
-  voiceProfileId  String
-  status          String       @default("pending")
-  providerJobId   String?
-  inputSamples    Json         @default("[]")
-  errorMessage    String?
-  startedAt       DateTime?
-  completedAt     DateTime?
-  createdAt       DateTime     @default(now())
-  voiceProfile    VoiceProfile @relation(fields: [voiceProfileId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  voiceProfileId String
+  status         String       @default("pending")
+  providerJobId  String?
+  inputSamples   Json         @default("[]")
+  errorMessage   String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  createdAt      DateTime     @default(now())
+  voiceProfile   VoiceProfile @relation(fields: [voiceProfileId], references: [id], onDelete: Cascade)
 
   @@index([voiceProfileId, status])
 }
@@ -8851,11 +8851,11 @@ model EdgeNode {
   // here as a denormalized JSON array for fast read; the
   // EdgeNodeCapability rows are the source of truth for per-capability
   // mode + status.
-  capabilities Json
+  capabilities      Json
   // Free-form: hostname, host fingerprint, operator-assigned tags.
   // Hostname / IP intentionally not first-class fields per Wazuh-IP-as-key
   // anti-pattern (R&B section).
-  metadata     Json?
+  metadata          Json?
   customerAccountId String?
   customerSiteId    String?
   scopePolicy       Json?
@@ -8890,16 +8890,16 @@ model EdgeNode {
   updatedAt DateTime @updatedAt
 
   // Relations
-  principal      Principal            @relation("EdgeNodeIdentity", fields: [principalId], references: [id], onDelete: Cascade)
-  approvedBy     Principal?           @relation("EdgeNodeApprover", fields: [approvedByPrincipalId], references: [id])
-  customerAccount CustomerAccount?     @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
-  customerSite    CustomerSite?        @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
-  capabilityRows EdgeNodeCapability[]
-  discoveryRuns  DiscoveryRun[]       @relation("EdgeNodeDiscoveryRuns")
+  principal                    Principal             @relation("EdgeNodeIdentity", fields: [principalId], references: [id], onDelete: Cascade)
+  approvedBy                   Principal?            @relation("EdgeNodeApprover", fields: [approvedByPrincipalId], references: [id])
+  customerAccount              CustomerAccount?      @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
+  customerSite                 CustomerSite?         @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
+  capabilityRows               EdgeNodeCapability[]
+  discoveryRuns                DiscoveryRun[]        @relation("EdgeNodeDiscoveryRuns")
   targetedDiscoveryConnections DiscoveryConnection[] @relation("EdgeNodeTargetedDiscoveryConnections")
-  consumedTokens BootstrapToken[]     @relation("BootstrapTokenConsumer")
-  events         EdgeEvent[]          @relation("EdgeNodeEvents")
-  changes        ChangeEvent[]        @relation("EdgeNodeChanges")
+  consumedTokens               BootstrapToken[]      @relation("BootstrapTokenConsumer")
+  events                       EdgeEvent[]           @relation("EdgeNodeEvents")
+  changes                      ChangeEvent[]         @relation("EdgeNodeChanges")
 
   @@index([trustState])
   @@index([status])
@@ -8950,7 +8950,7 @@ model BootstrapToken {
   // bulk enrollment) or installer-side issuance (the installer runs
   // with host access already, so a flag carrying that intent is no
   // weaker than the install path itself).
-  autoApprove Boolean @default(false)
+  autoApprove             Boolean @default(false)
   targetCustomerAccountId String?
   targetCustomerSiteId    String?
   scopePolicy             Json?
@@ -9195,4 +9195,121 @@ model CliPoolStatus {
   updatedAt         DateTime  @updatedAt
 
   @@index([adapterType, resetAt])
+}
+
+// ─── Reduction Gear Phase 0 — GearInterface canonical observation envelope ────
+//
+// One row per "transmission" at a ring interface in the agentic gear train.
+// Phase 0 emits at Ring 1→2 (Coworker → Workflow) only; outer rings get
+// contract stubs but no production dual-emission yet.
+//
+// Spec: docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md §3.1
+// BI:   BI-85CB31F0 (Phase 0 pilot)
+// Epic: EP-REDUCTION-GEAR-ARCH
+//
+// Authority model: existing source tables (ToolExecution, AdapterRunTelemetry,
+// BuildPhaseRun, FeatureBuild, RuntimeVerification, …) remain the authoritative
+// write models for their domains. GearInterface dual-emits alongside them as a
+// normalized read/evidence/calibration stream. NEVER migrate or mutate source
+// tables to fit this stream.
+model GearInterface {
+  id             String    @id @default(cuid())
+  schemaVersion  Int       @default(1)
+  recordedAt     DateTime  @default(now())
+  sourceEventAt  DateTime?
+  /// Deterministic key for upsert/replay; see writer service derivation.
+  /// Format: {interfaceClass}:{innerRing}:{outerRing}:{transmissionDirection}:{shaftSourceType}:{shaftSourceId}:{outcomeType}[:{suffix}]
+  idempotencyKey String    @unique
+  organizationId String?
+
+  // Where this transmission happens
+  /// 'internal-adjacent' (Ring N ↔ N+1) | 'external-federated' (other DPF install)
+  /// | 'external-bridged' (non-DPF via adapter) | 'external-customer' (read-only slice)
+  interfaceClass           String
+  /// 'outward' (inner→outer compounding) | 'inward' (outer→inner learning/release/priors)
+  /// | 'lateral' (external peer/federated only; never internal)
+  transmissionDirection    String  @default("outward")
+  /// 1..5; required for internal-adjacent
+  innerRing                Int?
+  /// 1..5; for internal-adjacent, equals innerRing + 1
+  outerRing                Int?
+  /// 'supplier' | 'partner' | 'customer' | 'peer-install'; required when interfaceClass='external-*'
+  externalCounterpartyType String?
+  /// Pseudonymized identifier — never store raw counterparty PII here
+  externalCounterpartyId   String?
+
+  // What event crossed the boundary (polymorphic source — FK-by-string)
+  /// 'tool-execution' | 'phase-run' | 'capsule' | 'promotion' | 'feature-pack'
+  /// | 'a2a-thread' | 'deliberation' | 'runtime-verification' | 'decision-interaction'
+  /// | 'external-po' | 'external-invoice' | 'external-handoff'
+  /// | 'platform-upgrade-run' | 'release-manifest' | 'channel-manifest'
+  /// | 'migration-classifier' | 'seed-delta-manifest'
+  shaftSourceType  String
+  /// FK-by-string into the source table's id column (or external reference id)
+  shaftSourceId    String
+  /// 'agent' | 'human' | 'system'
+  actorType        String
+  actorId          String
+  actorPrincipalId String?
+  /// Canonical capability name — Phase 0 emits raw intent verbatim (capabilityVocabularyVersion='raw-v0')
+  intent           String
+
+  // The thing being graded — the capability triple
+  capabilityName              String
+  capabilityVocabularyVersion String  @default("raw-v0")
+  /// Null only at Ring 1→2 and explicitly archetype-agnostic system work
+  archetypeContext            String?
+  agentIdForTriple            String
+
+  // Mechanical readings — see spec §3.4
+  /// 0..1 — pass=1.0, partial=0.5, fail=0.0 with severity adjustments
+  torqueTechnical  Float
+  /// 0..1 — business-outcome attribution; null until value-signal wiring lands
+  torqueValue      Float?
+  /// 0..1 — grader confidence in the score
+  torqueConfidence Float
+  /// How many inner-ring events fed this outer-ring advance (gear ratio)
+  ratioConsumed    Int
+  /// 'transmission' | 'slip' | 'graduation' | 'veto' | 'calibration-update'
+  outcomeType      String
+  slipDetected     Boolean @default(false)
+  /// 'novel-context' | 'failed-outcome' | 'human-override' | 'cost-overrun'
+  /// | 'safety-block' | 'rate-limit' | 'capability-gap' | 'migration-destructive'
+  /// | 'manifest-invalid' | 'signature-invalid' | 'seed-delta-conflict' | 'source-unindexed'
+  slipReason       String?
+
+  // Cost — Decimal because this joins AI cost governance + finance views
+  costUsd                  Decimal? @db.Decimal(12, 6)
+  inputTokens              Int?
+  outputTokens             Int?
+  cacheCreationInputTokens Int?
+  cacheReadInputTokens     Int?
+  reasoningOutputTokens    Int?
+  durationMs               Int?
+
+  // Trust / autonomy state at this interface — see spec §6.2 governor mapping
+  /// 'hitl-required' | 'hitl-fallback' | 'auto-confirm' | 'auto-silent'
+  graduationFromAutonomy String?
+  graduationToAutonomy   String?
+  graduationSampleSize   Int?
+  /// DecisionInteraction id — graduation audit link
+  graduationGovernorRef  String?
+
+  // Provenance — HITL is the training signal
+  /// 'human' | 'automated' | 'deliberation' | 'runtime-check'
+  graderType String
+  graderId   String?
+  /// Captured when graderType='human'
+  rationale  String?
+
+  // OTel correlation (best-effort; export not required for write)
+  otelTraceId String?
+  otelSpanId  String?
+
+  @@index([organizationId, recordedAt])
+  @@index([innerRing, outerRing, transmissionDirection, recordedAt])
+  @@index([capabilityName, archetypeContext, recordedAt])
+  @@index([agentIdForTriple, capabilityName, archetypeContext])
+  @@index([shaftSourceType, shaftSourceId])
+  @@index([outcomeType, recordedAt])
 }


### PR DESCRIPTION
## Summary

Implements Phase 0 of the **Reduction Gear Architecture** spec (§9.1). One narrow, high-signal interface (Ring 1→2, Coworker → Workflow) proven in production via dual-emit, with the substrate (model, writer, query API, Cockpit, OTel exporter, retention strategy) ready for Phase 1+ expansion.

- **Substrate:** `GearInterface` Prisma model + CHECK-constrained migration; single writer service with deterministic idempotency key + upsert-on-conflict; one source adapter per source type
- **Ring 1→2 wire point:** `completeBuildPhaseRun` dual-emits a non-blocking GearInterface record after the source row settles
- **Cockpit MVP:** read-only `/admin/cockpit` with concentric ring overview, slip-by-reason / triple-wear / graduations / recent-events panels, honest NO DATA lanes for rings without emitters
- **OTel exporter:** behind `DPF_GEAR_OTEL_EXPORT` flag, maps to `gen_ai.*` where the semconv covers it and `dpf.gear.*` where it doesn't
- **55 unit + integration tests** added, all passing
- **Retention ADR** committed; partitioning deferred to Phase 2, cold-tier choice deferred to Phase 5

## Out of scope (Phase 1+)

- Calibrator service, Autonomy Governor / WWMD generalization
- Ring 2→3 archetype-context emitter, production dual-emission outside Ring 1→2
- Sunset of legacy event tables
- External coordination plane

## Test plan

- [x] `pnpm --filter web exec tsc --noEmit` clean
- [x] `pnpm typecheck` clean across `@dpf/db`, `@dpf/types`, `@dpf/validators`, `@dpf/api-client`
- [x] 55 new gear-interface tests pass (writer, adapters, contract stubs, OTel, end-to-end emit)
- [x] Existing `build-phase-run.test.ts` (7 tests) still passes after hook addition
- [x] `pnpm --filter web build` succeeds; `/admin/cockpit` route compiled
- [x] Pre-commit scoped typecheck passes
- [ ] Manual: drive `/admin/cockpit` in the running portal once the migration is applied; trigger a Build Studio phase completion and confirm the row lands (post-merge, requires live install)
- [ ] OTel collector verification deferred per spec §11(12) — feature flag off in this PR

## Note for reviewers

`packages/db/prisma/schema.prisma` shows a large diff because `prisma format` re-aligned column widths across the file after inserting the new model. Use `git diff -w packages/db/prisma/schema.prisma` to see the substantive change cleanly (the GearInterface model at the file end).

## Pre-existing test flake observed

`apps/web/lib/mcp-tools-sandbox-admin.test.ts:90` times out under full-suite load (passes in 1.27s standalone). Not introduced by this PR — `mcp-tools.ts` does not import `gear-interface` — but worth noting.

Spec: `docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md`
Epic: `EP-REDUCTION-GEAR-ARCH`
BI:   `BI-85CB31F0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)