### PR TITLE
feat(topology): phase 1 — Live portal / Build runtime / Contributor preview naming + IA

### DIFF
--- a/.claude/skills/dev-portal-start/SKILL.md
+++ b/.claude/skills/dev-portal-start/SKILL.md
@@ -1,31 +1,34 @@
 ---
 name: dev-portal-start
-description: Use when you need to verify portal source changes in a running browser without rebuilding the production portal image. Triggers — making any edit under apps/web/ that needs visual or HTTP-level confirmation; iterating on /build, /platform, /admin, or any other server-rendered route; debugging a UX change against real workspace data; reproducing a customer-visible bug in a worktree before opening a PR. Don't use for unit-test-only changes (no portal needed) or for changes that need the production-bundled portal specifically (rebuild that image instead).
+description: Use when a DPF contributor needs to verify worktree edits on the **Contributor preview** runtime (port 3001) without rebuilding the Live portal image. Triggers — making any edit under apps/web/ that needs visual or HTTP-level confirmation; iterating on /build, /platform, /admin, or any other server-rendered route; debugging a UX change against real workspace data; reproducing a customer-visible bug in a worktree before opening a PR. This is a CONTRIBUTOR-ONLY workflow; customer installs do not ship the Contributor preview by default. Don't use for unit-test-only changes (no preview needed) or for changes that need the production-bundled Live portal specifically (rebuild that image instead).
 ---
 
 # dev-portal-start
 
 ## Overview
 
-Brings up the `dev-portal` Next.js hot-reload service against the **live** DPF databases on `http://localhost:3001`, leaving the production-bundle portal on `:3000` untouched as the stable reference. Every source edit under `apps/web/` is visible within a few seconds (or one container restart for file-watcher-stubborn cases).
+Brings up the **Contributor preview** runtime — the `dev-portal` Next.js hot-reload service on `http://localhost:3001` — against the live DPF databases, leaving the Live portal on `:3000` untouched as the stable reference. Every source edit under `apps/web/` is visible within a few seconds (or one container restart for file-watcher-stubborn cases).
 
-This eliminates the ~2-minute portal-rebuild loop that otherwise gates every edit-verify cycle.
+This eliminates the ~2-minute Live-portal-rebuild loop that otherwise gates every edit-verify cycle.
+
+The Contributor preview is a **DPF-contributor-only** surface, gated behind the `dev` compose profile. Customer installs (e.g. Dale's HVAC shop) do not ship it by default and do not see a `:3001` URL. If you are not a DPF contributor editing the platform source, you do not need this skill.
 
 ## When to Use
 
-**Symptoms that trigger this skill:**
+**Symptoms that trigger this skill (contributor workflow):**
 
 - "I changed `apps/web/app/(shell)/build/page.tsx` and want to see it."
 - "I need to verify the gate fires on a real install before merging."
-- "The production portal at :3000 shows old code — how do I see my edits?"
+- "The Live portal at :3000 shows old code — how do I see my edits?"
 - "I edited `loadBuildStudioCapability` and tests pass; need to see the live UX."
 - "I'm reproducing a customer-reported bug in a worktree."
 
 **Do not use when:**
 
 - The change is unit-test-only (run `pnpm exec vitest` and you're done).
-- The change is to the production-bundle build itself (Docker image content, entrypoint, etc.) — rebuild `portal` instead.
+- The change is to the Live-portal-bundle build itself (Docker image content, entrypoint, etc.) — rebuild `portal` instead.
 - The change is to non-portal services (sandbox, adp, browser-use) — those have their own rebuild cycles.
+- You are not a DPF contributor. End users and customer-install operators interact with Build Studio's Live preview through the canvas, not through `:3001`.
 
 ## Core Pattern
 
@@ -35,7 +38,7 @@ Agent edits `apps/web/.../page.tsx`. Tests pass. Agent wants to verify in browse
 
 ```
 Agent: "I'll rebuild the portal image."          (~2 min, every edit)
-Agent: "Wait, that restarts the prod portal."
+Agent: "Wait, that restarts the Live portal."
 Agent: "Maybe dev-portal? Let me look it up..."  (5 min reading compose files)
 Agent: "Why doesn't dev-portal see live data?"   (10 min debugging dev-init DB clone)
 Agent: "Why is my edit not loading?"             (10 min on Windows-Docker file watch)
@@ -132,7 +135,7 @@ The override path is relative (`docker-compose.dev-against-live-db.yml`) — mea
 
 ### Mistake 8 — Treating dev-portal data as throwaway
 
-This is intentional: dev-portal writes to the LIVE DB. A coding mistake under `apps/web/` that mutates DB state will affect the production portal at `:3000` too. Keep `:3000` as the safety reference; use `:3001` knowingly.
+This is intentional: the Contributor preview (`dev-portal`) writes to the LIVE DB. A coding mistake under `apps/web/` that mutates DB state will affect the Live portal at `:3000` too. Keep `:3000` as the safety reference; use `:3001` knowingly.
 
 ## When to Tear Down
 

--- a/apps/web/components/build/OpenSandboxButton.test.tsx
+++ b/apps/web/components/build/OpenSandboxButton.test.tsx
@@ -22,11 +22,11 @@ describe("OpenSandboxButton", () => {
     expect(html).toMatch(/href="http:\/\/localhost:5555"/);
   });
 
-  it('renders the canonical label format "Open sandbox · driving: {code}"', () => {
+  it('renders the canonical label format "Open live preview · driving: {code}"', () => {
     const html = renderToStaticMarkup(
       <OpenSandboxButton drivingBuildCode="FB-B33E84B5" sandboxUrl="http://localhost:5555" />,
     );
-    expect(html).toContain("Open sandbox");
+    expect(html).toContain("Open live preview");
     expect(html).toContain("driving: FB-B33E84B5");
   });
 

--- a/apps/web/components/build/OpenSandboxButton.tsx
+++ b/apps/web/components/build/OpenSandboxButton.tsx
@@ -1,12 +1,18 @@
 // apps/web/components/build/OpenSandboxButton.tsx
 //
-// Single shared "Open sandbox" button. Lives in the BuildStudio footer; the
-// per-build Preview tab is removed in this redesign because the sandbox is
-// shared across all in-flight builds (project_self_upgrade_kills_in_session_ux).
+// Single shared "Open live preview" button. Lives in the BuildStudio footer;
+// the per-build Preview tab is removed in this redesign because the sandbox
+// (the underlying compose service) is shared across all in-flight builds
+// (project_self_upgrade_kills_in_session_ux). The component file name
+// (OpenSandboxButton) is kept for symbol stability per the 2026-05-24 portal
+// topology consolidation spec §8.3.
 //
 // Per the design spec §1 (Footer) and §6 (component contract):
 //   - Renders <a target="_blank" rel="noopener noreferrer"> — rel is non-optional.
-//   - Label: "Open sandbox · driving: {code | 'idle'}".
+//   - Label: "Open live preview · driving: {code | 'idle'}". The component
+//     name (OpenSandboxButton) and the underlying URL still point at the
+//     "sandbox" compose service — only the user-facing string flipped
+//     per the 2026-05-24 portal topology consolidation spec §8.1.
 //   - Disabled visual + aria-disabled when sandboxUrl is empty.
 //   - Deterministic driver via sandbox-driver helper (R1 from peer review).
 //

--- a/apps/web/lib/build/customer-facing-strings.test.ts
+++ b/apps/web/lib/build/customer-facing-strings.test.ts
@@ -1,0 +1,30 @@
+// apps/web/lib/build/customer-facing-strings.test.ts
+//
+// Phase-1 regression: customer-facing Build Studio strings must not expose
+// the word "sandbox" as the noun the user reads. Spec
+// docs/superpowers/specs/2026-05-24-portal-topology-consolidation-design.md
+// §8.1 — "Build Studio footer/button label should be 'Live preview', not
+// 'Open sandbox'". Technical diagnostics may still use "sandbox" (compose
+// service names, RuntimeTarget kinds, Prisma models); this test only guards
+// the user-facing copy in the BuildStudio canvas footer.
+import { describe, it, expect } from "vitest";
+import { formatSandboxLabel } from "./sandbox-driver";
+
+describe("Build Studio customer-facing labels — phase 1 regression", () => {
+  it("footer button label does not contain the word 'sandbox'", () => {
+    const idle = formatSandboxLabel(null);
+    const driving = formatSandboxLabel("FB-DEADBEEF");
+    expect(idle.toLowerCase()).not.toMatch(/sandbox/);
+    expect(driving.toLowerCase()).not.toMatch(/sandbox/);
+  });
+
+  it("footer button label uses 'Live preview' as the user-facing noun", () => {
+    expect(formatSandboxLabel(null)).toMatch(/live preview/i);
+    expect(formatSandboxLabel("FB-DEADBEEF")).toMatch(/live preview/i);
+  });
+
+  it("driving build code is still visible to the user", () => {
+    expect(formatSandboxLabel("FB-DEADBEEF")).toContain("FB-DEADBEEF");
+    expect(formatSandboxLabel(null).toLowerCase()).toContain("idle");
+  });
+});

--- a/apps/web/lib/build/sandbox-driver.test.ts
+++ b/apps/web/lib/build/sandbox-driver.test.ts
@@ -101,10 +101,10 @@ describe("computeDrivingBuild", () => {
 
 describe("formatSandboxLabel", () => {
   it("renders the driving build code when provided", () => {
-    expect(formatSandboxLabel("FB-B33E84B5")).toBe("Open sandbox · driving: FB-B33E84B5");
+    expect(formatSandboxLabel("FB-B33E84B5")).toBe("Open live preview · driving: FB-B33E84B5");
   });
 
   it('renders "idle" when there is no driver', () => {
-    expect(formatSandboxLabel(null)).toBe("Open sandbox · driving: idle");
+    expect(formatSandboxLabel(null)).toBe("Open live preview · driving: idle");
   });
 });

--- a/apps/web/lib/build/sandbox-driver.ts
+++ b/apps/web/lib/build/sandbox-driver.ts
@@ -5,7 +5,11 @@
 //
 // Per the design spec §1 (footer) and §6 (OpenSandboxButton):
 //   - All builds share one sandbox (project_self_upgrade_kills_in_session_ux).
-//   - The footer button always shows ONE label: "Open sandbox · driving: {code}".
+//   - The footer button always shows ONE label:
+//       "Open live preview · driving: {code}"
+//     The internal symbol name (formatSandboxLabel) and the "sandbox" compose
+//     service it points at are unchanged — only the user-facing label flipped
+//     per 2026-05-24 portal topology consolidation spec §8.1.
 //   - "Driving" = the build whose preview port is live; on ties, the most
 //     recently active. When nothing is running, label says "idle".
 //
@@ -69,7 +73,12 @@ export function isValidSandboxPort(port: number | null | undefined): port is num
 }
 
 /** Format the label used by OpenSandboxButton. Stays in this module so the
- *  string contract is centralized. */
+ *  string contract is centralized.
+ *
+ *  Customer-facing wording: "Live preview" (the user-job-named role per the
+ *  portal topology consolidation spec). The function name keeps "Sandbox"
+ *  because that is the compose-service the link points at — the rename is
+ *  *user-facing only*, not a code-symbol rename. See spec §6 and §8.3. */
 export function formatSandboxLabel(drivingBuildCode: string | null): string {
-  return `Open sandbox · driving: ${drivingBuildCode ?? "idle"}`;
+  return `Open live preview · driving: ${drivingBuildCode ?? "idle"}`;
 }

--- a/docs/operations/dpf-production-runtime.md
+++ b/docs/operations/dpf-production-runtime.md
@@ -2,20 +2,36 @@
 
 > **Substrate scope:** the conventions below describe the **Single VM substrate** (local Windows install today; macOS / native Linux per the [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)). Cloud substrates (Managed container service, Managed Kubernetes) and packaging targets (TAPPaaS module, marketplace image, Helm chart) carry substrate-specific runtime conventions in [`docs/superpowers/specs/2026-05-09-cloud-deployment-design.md`](../superpowers/specs/2026-05-09-cloud-deployment-design.md). The shared canonical contracts are in the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md).
 
-This install runs with three distinct local runtime roles:
+This install runs three local runtime roles:
 
-- `http://localhost:3000` = production-served portal
-- `http://localhost:3001` = `dev-portal` developer runtime
-- `http://localhost:3035` = sandbox runtime / Build Studio isolation
+| Role | Surface | Backed by | Used for |
+| --- | --- | --- | --- |
+| **Live portal** | `http://localhost:3000` | `portal` service, production Next.js bundle, live install DBs | Final acceptance. End users and operators. The only runtime that satisfies customer-zero verification. |
+| **Build runtime** (aka *Live preview*) | `http://localhost:3035` | `sandbox` service, agent-capable Next.js dev server, `sandbox-postgres` | Build Studio agent execution and the in-canvas Live preview. Not a final-acceptance surface. |
+| **Contributor preview** | `http://localhost:3001` | `dev-portal` service (profile-gated), Next.js dev hot-reload, isolated dev DBs by default | DPF contributors verifying worktree edits before opening a PR. Not shipped by default to customer installs. |
 
 ## Rules
 
-- Never use ad hoc `pnpm dev`, `next dev`, or `next start` on port `3000` for customer-zero verification.
-- Verify shipped behavior against the Docker `portal` service on `http://localhost:3000`.
-- Use `dev-portal` on `3001` for interactive developer runtime work when you need a local non-production app surface.
-- Use sandbox on `3035` for isolated Build Studio / governed build behavior.
-- Promote changes through branch, PR, verification, and rebuild flow rather than treating the production-served runtime as a scratch environment.
+- Final acceptance always targets the Docker-served **Live portal** on `http://localhost:3000`.
+- Never use ad-hoc `pnpm dev`, `next dev`, or `next start` on port 3000 for customer-zero verification.
+- The **Build runtime** is the agent execution surface; humans see it through Build Studio's in-canvas preview (the footer "Open live preview" button) rather than treating it as a developer scratch surface.
+- The **Contributor preview** is opt-in via the `dev` compose profile. A plain `docker compose up -d` does not start it, and customer installs do not ship it by default.
+- Promote changes through branch → PR → verification → image rebuild flow rather than treating the Live portal as a scratch environment.
 
-## Why This Matters
+## Why this matters
 
 This machine hosts the real Open Digital Product Factory production instance. The runtime split is therefore not just a local developer convenience; it is part of the operating model DPF expects customers to follow as well.
+
+Customer installs (e.g. Dale's HVAC shop) see only the Live portal and the Build runtime. The Contributor preview is a DPF-contributor surface, gated behind the `dev` compose profile and not surfaced in the customer install UX.
+
+## Terminology mapping
+
+These names appear in the operator-facing UI, docs, and skills. The compose-service / container / port facts behind them are unchanged in Phase 1 and remain visible in diagnostics:
+
+| User-facing name | Compose service | `RuntimeTarget.kind` | Port |
+| --- | --- | --- | --- |
+| Live portal | `portal` | `root-portal` | 3000 |
+| Build runtime / Live preview | `sandbox` | `build-sandbox` | 3035 |
+| Contributor preview | `dev-portal` | `dev-portal` | 3001 |
+
+See [Runtime glossary](runtime-glossary.md) for the canonical definitions.

--- a/docs/operations/runtime-glossary.md
+++ b/docs/operations/runtime-glossary.md
@@ -1,0 +1,43 @@
+# Runtime Glossary
+
+Canonical definitions for the three local runtime roles on a DPF install. This is the source of truth that operator-facing UI, docs, and skills point at. Diagnostic surfaces (Platform Development, Admin, runtime-target health) may continue to expose the technical compose-service and container facts.
+
+## Live portal
+
+The production-served Next.js bundle on `http://localhost:3000`. Backed by the `portal` compose service, the live install databases (`postgres`, `neo4j`, `qdrant`), and the install's bundled image. The **only** runtime that satisfies customer-zero verification. Self-upgrade, MCP config writes, promotion, backups, and sandbox orchestration all live here.
+
+- Compose service: `portal`
+- `RuntimeTarget.kind`: `root-portal`
+- Mutated by: the autonomous promoter pipeline (image rebuild). Never edited in place.
+
+## Build runtime (also called *Live preview* in Build Studio UI)
+
+The Build Studio agent execution and preview surface on `http://localhost:3035`. Backed by the `sandbox` compose service, the `sandbox-postgres` isolated database, and the `Dockerfile.sandbox` image (which bundles the Codex and Claude Code CLIs plus `bubblewrap`). Humans interact with it through the Build Studio canvas (in-iframe preview + footer "Open live preview" button); they do not edit source files in it directly.
+
+- Compose service: `sandbox`
+- `RuntimeTarget.kind`: `build-sandbox`
+- Mutated by: Build Studio orchestrator only. The "Live preview" name is the user-facing label; the compose-service name `sandbox` remains in diagnostics.
+
+## Contributor preview
+
+A profile-gated Next.js dev hot-reload server on `http://localhost:3001`. Backed by the `dev-portal` compose service (under `profiles: ["dev"]`), with a host-bind-mounted worktree at `/workspace` and isolated dev databases by default. The opt-in `docker-compose.dev-against-live-db.yml` override can point it at the live DBs for realistic verification, at the contributor's own risk.
+
+- Compose service: `dev-portal`
+- `RuntimeTarget.kind`: `dev-portal`
+- Mutated by: a DPF contributor's IDE editing the worktree on the host.
+- Not shipped by default to customer installs. A plain `docker compose up -d` does not start it.
+
+## Diagnostic surfaces (where technical names still appear)
+
+The following surfaces continue to use compose-service, container, and port names because they exist to expose the platform's real state:
+
+- Platform Development → Runtime Targets
+- Build Studio → Sandbox Control / Admin Recovery (per the 2026-05-22 sandbox-admin spec)
+- `docker compose ps` / `docker ps` operator output
+- MCP tool input/output schemas
+- Log lines and error messages
+
+## Related
+
+- [DPF Production Runtime](dpf-production-runtime.md) — the rules around how these runtimes are used
+- [Portal topology consolidation spec](../superpowers/specs/2026-05-24-portal-topology-consolidation-design.md) — the design rationale, Phase 2 prerequisites, and benchmarks

--- a/docs/superpowers/plans/2026-05-24-portal-topology-consolidation-phase-1.md
+++ b/docs/superpowers/plans/2026-05-24-portal-topology-consolidation-phase-1.md
@@ -1,0 +1,768 @@
+# Portal Topology Consolidation — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Land the Phase 1 slice of the portal-topology consolidation spec — operator-facing terminology, IA, docs, skill reframing, optional profile aliasing, and regression checks — without touching compose service names, volume names, `RuntimeTarget.kind`, Prisma models, `sandboxId` references, DB isolation, the dev image's tool surface, or Build Studio parallelism.
+
+**Architecture:** Three runtime roles remain (Live portal `:3000`, Build runtime `:3035`, Contributor preview `:3001`). Phase 1 changes what *customer-facing* surfaces *say*: the Build Studio footer button reads "Live preview" not "Open sandbox", the operations runtime doc is rewritten in role-first language, the user-guide Build Studio pages stop using "sandbox" as the customer-facing noun, and the dev-portal-start skill is reframed as contributor-only. Technical diagnostics keep showing the real service/container/port facts.
+
+**Tech Stack:** Next.js 15 / React / TypeScript / Vitest / pnpm workspaces / Docker Compose / Markdown docs.
+
+**Spec:** [`docs/superpowers/specs/2026-05-24-portal-topology-consolidation-design.md`](../specs/2026-05-24-portal-topology-consolidation-design.md) (PR [#1078](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1078)).
+
+---
+
+## Hard constraints (carried from spec §8.3)
+
+These are out of scope for Phase 1; touching any of them turns this into a different plan:
+
+- No rename of compose services (`sandbox`, `dev-portal`, `sandbox-postgres`, `dev-postgres`, `dev-neo4j`, `dev-qdrant`, `dev-init`, `portal-init`).
+- No rename of Docker volumes (`sandbox_workspace`, `sandbox_pgdata`, `dev_pgdata`, `dev_neo4jdata`, `dev_qdrant_data`, `dev_node_modules`).
+- No change to `RuntimeTarget.kind` enum values (`root-portal`, `build-sandbox`, `dev-portal`).
+- No rename of Prisma models (`Sandbox`, `SandboxSlot`), fields (`sandboxId`), or any DB column referencing sandbox.
+- No DB-isolation change. Sandbox-postgres stays. Dev-portal's default isolated dev DBs stay; the live-DB override stays opt-in.
+- No Docker socket on `dev-portal`. No agent CLIs (`@openai/codex`, `@anthropic-ai/claude-code`) added to the `dev` Dockerfile target.
+- No Build Studio parallelism rework. `DPF_SANDBOX_POOL_SIZE` and `sandbox-pool.ts` stay untouched.
+- No rename of test IDs (`BUILD_STUDIO_TEST_IDS.openSandbox`) or component file names (`OpenSandboxButton.tsx`) — internal symbols stay stable.
+
+Scope-violation check: before merging the PR, run `git diff origin/main --stat` and verify the diff touches only docs, user-facing strings, tests asserting those strings, optional `package.json` script additions, and (if approved) the `dev-portal` compose `profiles` field.
+
+---
+
+## Sequencing rationale
+
+Tasks are ordered so that:
+1. The headline customer-facing string (the Build Studio footer label) changes first — that change carries the highest user-visible value and the smallest risk surface.
+2. Docs follow code so the user-guide describes what the UI actually shows.
+3. The optional compose-profile alias is last and gated behind a self-contained verification step.
+4. Regression check is added before any docs/UI change so the test fails first, then the change makes it pass (TDD).
+
+Commit per task. Each commit is independently revertable.
+
+---
+
+## Task 1 — Add the customer-facing-label regression test (failing)
+
+**Why first:** Establish the assertion that customer-facing Build Studio surfaces do not show "sandbox" as the noun the user reads, before the change. The test fails initially against `formatSandboxLabel`'s current output (`"Open sandbox · driving: …"`).
+
+**Files:**
+- Create: `apps/web/lib/build/customer-facing-strings.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// apps/web/lib/build/customer-facing-strings.test.ts
+//
+// Phase-1 regression: customer-facing Build Studio strings must not expose
+// the word "sandbox" as the noun the user reads. Spec
+// docs/superpowers/specs/2026-05-24-portal-topology-consolidation-design.md
+// §8.1 — "Build Studio footer/button label should be 'Live preview', not
+// 'Open sandbox'". Technical diagnostics may still use "sandbox" (compose
+// service names, RuntimeTarget kinds, Prisma models); this test only guards
+// the user-facing copy in the BuildStudio canvas footer.
+import { describe, it, expect } from "vitest";
+import { formatSandboxLabel } from "./sandbox-driver";
+
+describe("Build Studio customer-facing labels — phase 1 regression", () => {
+  it("footer button label does not contain the word 'sandbox'", () => {
+    const idle = formatSandboxLabel(null);
+    const driving = formatSandboxLabel("FB-DEADBEEF");
+    expect(idle.toLowerCase()).not.toMatch(/sandbox/);
+    expect(driving.toLowerCase()).not.toMatch(/sandbox/);
+  });
+
+  it("footer button label uses 'Live preview' as the user-facing noun", () => {
+    expect(formatSandboxLabel(null)).toMatch(/live preview/i);
+    expect(formatSandboxLabel("FB-DEADBEEF")).toMatch(/live preview/i);
+  });
+
+  it("driving build code is still visible to the user", () => {
+    expect(formatSandboxLabel("FB-DEADBEEF")).toContain("FB-DEADBEEF");
+    expect(formatSandboxLabel(null).toLowerCase()).toContain("idle");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/build/customer-facing-strings.test.ts
+```
+
+Expected: 3 failing assertions, all on the substring check (current label is `"Open sandbox · driving: …"`).
+
+**Step 3: Commit the failing test**
+
+```bash
+git add apps/web/lib/build/customer-facing-strings.test.ts
+git commit -s -m "test(build-studio): add phase-1 regression for customer-facing labels"
+```
+
+The test is committed RED — this is the intentional TDD anchor. Task 2 turns it green.
+
+---
+
+## Task 2 — Flip the Build Studio footer label to "Live preview"
+
+**Files:**
+- Modify: `apps/web/lib/build/sandbox-driver.ts` (the `formatSandboxLabel` function, line ~73)
+- Modify: `apps/web/components/build/OpenSandboxButton.test.tsx` (any existing snapshot/string assertions on the old label)
+
+**Step 1: Read existing test expectations**
+
+```bash
+pnpm --filter web exec vitest run apps/web/components/build/OpenSandboxButton.test.tsx --reporter=verbose 2>&1 | head -50
+```
+
+Confirm which assertions reference the old `"Open sandbox · driving"` string.
+
+**Step 2: Update `formatSandboxLabel`**
+
+In `apps/web/lib/build/sandbox-driver.ts`, replace:
+
+```ts
+export function formatSandboxLabel(drivingBuildCode: string | null): string {
+  return `Open sandbox · driving: ${drivingBuildCode ?? "idle"}`;
+}
+```
+
+with:
+
+```ts
+export function formatSandboxLabel(drivingBuildCode: string | null): string {
+  // Customer-facing footer label. Per spec
+  // docs/superpowers/specs/2026-05-24-portal-topology-consolidation-design.md
+  // §8.1, the user-facing noun is "Live preview" — the build runtime that the
+  // sandbox container serves. Internal symbol name (formatSandboxLabel) stays
+  // stable because Phase 1 explicitly does not rename internal sandbox refs.
+  return `Open live preview · driving: ${drivingBuildCode ?? "idle"}`;
+}
+```
+
+Also update the leading comment block in the same file (lines 6-10 of `sandbox-driver.ts`) so the string contract documented there matches the new output. Replace `"Open sandbox · driving: {code}"` with `"Open live preview · driving: {code}"`.
+
+**Step 3: Update `OpenSandboxButton.test.tsx`**
+
+Update any assertion that reads the old label exactly. Use grep to find them:
+
+```bash
+pnpm --filter web exec vitest run apps/web/components/build/OpenSandboxButton.test.tsx 2>&1 | grep -i "open sandbox\|label\|sandbox · driving"
+```
+
+For each failing assertion, swap `"Open sandbox · driving:"` → `"Open live preview · driving:"`.
+
+**Step 4: Update the leading comment in `OpenSandboxButton.tsx`**
+
+In `apps/web/components/build/OpenSandboxButton.tsx`, replace the line:
+
+```
+//   - Label: "Open sandbox · driving: {code | 'idle'}".
+```
+
+with:
+
+```
+//   - Label: "Open live preview · driving: {code | 'idle'}".
+```
+
+The component name `OpenSandboxButton`, the props type, and the test ID stay stable (phase 1 explicitly does not rename internal symbols).
+
+**Step 5: Run the regression test and verify it passes**
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/build/customer-facing-strings.test.ts apps/web/components/build/OpenSandboxButton.test.tsx
+```
+
+Expected: both files green.
+
+**Step 6: Run the broader Build Studio test slice**
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/build apps/web/components/build
+```
+
+Expected: green. If any other tests assert the old label substring, fix them in this same commit (do not commit half a label change).
+
+**Step 7: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+**Step 8: Commit**
+
+```bash
+git add apps/web/lib/build/sandbox-driver.ts apps/web/components/build/OpenSandboxButton.tsx apps/web/components/build/OpenSandboxButton.test.tsx
+git commit -s -m "feat(build-studio): customer-facing footer reads 'Live preview' not 'Open sandbox'"
+```
+
+---
+
+## Task 3 — Rewrite `docs/operations/dpf-production-runtime.md` in role-first language
+
+**Files:**
+- Modify: `docs/operations/dpf-production-runtime.md` (full rewrite of body; keep the substrate-scope blockquote at the top)
+
+**Step 1: Replace the body (lines 5-22)**
+
+Keep lines 1-3 unchanged. Replace everything from line 5 onward with:
+
+```markdown
+This install runs three local runtime roles:
+
+| Role | Surface | Backed by | Used for |
+| --- | --- | --- | --- |
+| **Live portal** | `http://localhost:3000` | `portal` service, production Next.js bundle, live install DBs | Final acceptance. End users and operators. The only runtime that satisfies customer-zero verification. |
+| **Build runtime** (aka *Live preview*) | `http://localhost:3035` | `sandbox` service, agent-capable Next.js dev server, `sandbox-postgres` | Build Studio agent execution and the in-canvas Live preview. Not a final-acceptance surface. |
+| **Contributor preview** | `http://localhost:3001` | `dev-portal` service (profile-gated), Next.js dev hot-reload, isolated dev DBs by default | DPF contributors verifying worktree edits before opening a PR. Not shipped by default to customer installs. |
+
+## Rules
+
+- Final acceptance always targets the Docker-served **Live portal** on `http://localhost:3000`.
+- Never use ad-hoc `pnpm dev`, `next dev`, or `next start` on port 3000 for customer-zero verification.
+- The **Build runtime** is the agent execution surface; humans see it through Build Studio's in-canvas preview (the footer "Open live preview" button) rather than treating it as a developer scratch surface.
+- The **Contributor preview** is opt-in via the `dev` compose profile. A plain `docker compose up -d` does not start it, and customer installs do not ship it by default.
+- Promote changes through branch → PR → verification → image rebuild flow rather than treating the Live portal as a scratch environment.
+
+## Why this matters
+
+This machine hosts the real Open Digital Product Factory production instance. The runtime split is therefore not just a local developer convenience; it is part of the operating model DPF expects customers to follow as well.
+
+Customer installs (e.g. Dale's HVAC shop) see only the Live portal and the Build runtime. The Contributor preview is a DPF-contributor surface, gated behind the `dev` compose profile and not surfaced in the customer install UX.
+
+## Terminology mapping
+
+These names appear in the operator-facing UI, docs, and skills. The compose-service / container / port facts behind them are unchanged in Phase 1 and remain visible in diagnostics:
+
+| User-facing name | Compose service | `RuntimeTarget.kind` | Port |
+| --- | --- | --- | --- |
+| Live portal | `portal` | `root-portal` | 3000 |
+| Build runtime / Live preview | `sandbox` | `build-sandbox` | 3035 |
+| Contributor preview | `dev-portal` | `dev-portal` | 3001 |
+
+See [Runtime glossary](runtime-glossary.md) for the canonical definitions.
+```
+
+**Step 2: Verify the link target exists**
+
+The new doc references `runtime-glossary.md` — that's created in Task 4. The link will be broken until Task 4 lands. Acceptable for a multi-commit slice; check the link once Task 4 is in.
+
+**Step 3: Commit**
+
+The new body references `runtime-glossary.md`, which Task 4 creates. Acknowledge the forward link in the commit message so reviewers do not flag a "broken link" mid-slice:
+
+```bash
+git add docs/operations/dpf-production-runtime.md
+git commit -s -m "docs(operations): rewrite production-runtime doc in role-first language
+
+Forward-references docs/operations/runtime-glossary.md, added in the next
+commit (Task 4). Link resolves once both commits are applied."
+```
+
+---
+
+## Task 4 — Create `docs/operations/runtime-glossary.md`
+
+**Files:**
+- Create: `docs/operations/runtime-glossary.md`
+
+**Step 1: Write the glossary**
+
+```markdown
+# Runtime Glossary
+
+Canonical definitions for the three local runtime roles on a DPF install. This is the source of truth that operator-facing UI, docs, and skills point at. Diagnostic surfaces (Platform Development, Admin, runtime-target health) may continue to expose the technical compose-service and container facts.
+
+## Live portal
+
+The production-served Next.js bundle on `http://localhost:3000`. Backed by the `portal` compose service, the live install databases (`postgres`, `neo4j`, `qdrant`), and the install's bundled image. The **only** runtime that satisfies customer-zero verification. Self-upgrade, MCP config writes, promotion, backups, and sandbox orchestration all live here.
+
+- Compose service: `portal`
+- `RuntimeTarget.kind`: `root-portal`
+- Mutated by: the autonomous promoter pipeline (image rebuild). Never edited in place.
+
+## Build runtime (also called *Live preview* in Build Studio UI)
+
+The Build Studio agent execution and preview surface on `http://localhost:3035`. Backed by the `sandbox` compose service, the `sandbox-postgres` isolated database, and the `Dockerfile.sandbox` image (which bundles the Codex and Claude Code CLIs plus `bubblewrap`). Humans interact with it through the Build Studio canvas (in-iframe preview + footer "Open live preview" button); they do not edit source files in it directly.
+
+- Compose service: `sandbox`
+- `RuntimeTarget.kind`: `build-sandbox`
+- Mutated by: Build Studio orchestrator only. The "Live preview" name is the user-facing label; the compose-service name `sandbox` remains in diagnostics.
+
+## Contributor preview
+
+A profile-gated Next.js dev hot-reload server on `http://localhost:3001`. Backed by the `dev-portal` compose service (under `profiles: ["dev"]`), with a host-bind-mounted worktree at `/workspace` and isolated dev databases by default. The opt-in `docker-compose.dev-against-live-db.yml` override can point it at the live DBs for realistic verification, at the contributor's own risk.
+
+- Compose service: `dev-portal`
+- `RuntimeTarget.kind`: `dev-portal`
+- Mutated by: a DPF contributor's IDE editing the worktree on the host.
+- Not shipped by default to customer installs. A plain `docker compose up -d` does not start it.
+
+## Diagnostic surfaces (where technical names still appear)
+
+The following surfaces continue to use compose-service, container, and port names because they exist to expose the platform's real state:
+
+- Platform Development → Runtime Targets
+- Build Studio → Sandbox Control / Admin Recovery (per the 2026-05-22 sandbox-admin spec)
+- `docker compose ps` / `docker ps` operator output
+- MCP tool input/output schemas
+- Log lines and error messages
+
+## Related
+
+- [DPF Production Runtime](dpf-production-runtime.md) — the rules around how these runtimes are used
+- [Portal topology consolidation spec](../superpowers/specs/2026-05-24-portal-topology-consolidation-design.md) — the design rationale, Phase 2 prerequisites, and benchmarks
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/operations/runtime-glossary.md
+git commit -s -m "docs(operations): add runtime glossary (Live portal / Build runtime / Contributor preview)"
+```
+
+---
+
+## Task 5 — Update `docs/user-guide/build-studio/index.md` "Sandbox" key concept
+
+**Files:**
+- Modify: `docs/user-guide/build-studio/index.md` (Key Concepts section, line 20)
+
+**Step 1: Replace the "Sandbox" bullet**
+
+In `docs/user-guide/build-studio/index.md`, replace line 20:
+
+```markdown
+- **Sandbox** — An isolated execution environment where generated code runs safely without affecting the production platform. Each sandbox has its own database, file system, and network.
+```
+
+with:
+
+```markdown
+- **Build runtime** — The isolated execution environment where the AI Coworker generates and tests code. Has its own database, file system, and network — completely separated from the live platform. The Build Studio canvas surfaces it as **Live preview**; the technical name *sandbox* still appears in diagnostics. See [Build Runtime](sandbox.md) for the full operating model.
+```
+
+**Step 2: Verify other strings in this file**
+
+Re-read the file end-to-end and check for remaining customer-facing "sandbox" references that should become "Build runtime" or "Live preview":
+
+```bash
+grep -n -i sandbox docs/user-guide/build-studio/index.md
+```
+
+Only **lines 20 and 24** carry the customer-facing "sandbox" noun in `index.md`. Line 22 already reads `**Live Preview** — During the Build phase, …` and stays unchanged. Edits:
+- Line 20: the **Sandbox** bullet — replaced by the **Build runtime** bullet per Step 1.
+- Line 24 (Promotion): change `"moving a completed feature from the sandbox into production"` → `"moving a completed feature from the Build runtime into production"`.
+
+If grep surfaces other matches (e.g. anchor links to `sandbox.md`), leave them — Task 6 keeps the file path `sandbox.md` stable for URL stability.
+
+**Step 3: Commit**
+
+```bash
+git add docs/user-guide/build-studio/index.md
+git commit -s -m "docs(build-studio): use 'Build runtime' / 'Live preview' in user-guide index"
+```
+
+---
+
+## Task 6 — Reframe `docs/user-guide/build-studio/sandbox.md` as the Build runtime page
+
+The file name `sandbox.md` stays stable (URL stability — existing inbound links should not break). The page title, framing, and customer-facing copy become "Build runtime"; the technical detail (compose service name, container IDs, port numbers) stays so diagnostics still find what they need.
+
+**Files:**
+- Modify: `docs/user-guide/build-studio/sandbox.md`
+
+**Step 1: Update the frontmatter title**
+
+```yaml
+---
+title: "Build Runtime (Sandbox)"
+area: build-studio
+order: 3
+lastUpdated: 2026-05-24
+updatedBy: Claude (Software Engineer)
+---
+```
+
+**Step 2: Update the Overview section (lines 9-15)**
+
+Replace with:
+
+```markdown
+## Overview
+
+The **Build runtime** — surfaced as **Live preview** in the Build Studio canvas — is the isolated execution environment where your AI Coworker builds, tests, and refines features before they reach the Live portal. Each Build runtime instance has its own database, file system, and runtime, completely separated from the live platform. Nothing the AI Coworker does in the Build runtime can affect your production system.
+
+The Build runtime is not the long-lived source of truth for your code. It starts from the install's shared workspace, runs validation work safely, and can be recreated whenever needed. The technical name behind it is *sandbox* — that name continues to appear in diagnostic surfaces (Platform Development → Runtime Targets, Admin Recovery, log lines, and MCP schemas).
+
+This isolation is what makes it safe for the AI to experiment freely: modifying code, running database migrations, restarting services, and iterating on your feedback without risk.
+```
+
+**Step 3: Update the "Sandbox Isolation" section header (line 31)**
+
+Rename to `## Build Runtime Isolation`. Keep the table contents as-is — they reference the actual container names (`dpf-postgres-1`, `dpf-sandbox-postgres-1`) which is diagnostic and stays accurate.
+
+**Step 4: Update the "Sandbox Pool" section header (line 85)**
+
+Rename to `## Build Runtime Pool`. Body keeps the technical pool description (the `DPF_SANDBOX_POOL_SIZE` env var name does not change in Phase 1).
+
+**Step 5: Update the "From Sandbox to Production" section header (line 99)**
+
+Rename to `## From Build Runtime to Live Portal`. Update body text to use "Build runtime" instead of "sandbox" in the narrative; keep `deploy_feature` tool reference unchanged.
+
+**Step 6: Update the "AI Coworker Tools" intro (line 46)**
+
+Change `"working inside the sandbox"` → `"working inside the Build runtime"`. The tool names (`write_sandbox_file`, `read_sandbox_file`, etc.) stay unchanged — those are MCP-bound identifiers.
+
+**Step 7: Update Troubleshooting headings (line 138)**
+
+Change `"Sandbox not ready"` → `"Build runtime not ready"`. Keep the technical body explaining the `/workspace/` path and sandbox-postgres details.
+
+**Step 8: Update remaining narrative references**
+
+Run:
+
+```bash
+grep -n -E "\bsandbox\b" docs/user-guide/build-studio/sandbox.md | grep -v "DPF_SANDBOX_POOL_SIZE\|sandbox-postgres\|dpf-sandbox\|write_sandbox\|read_sandbox\|edit_sandbox\|search_sandbox\|list_sandbox\|run_sandbox\|iterate_sandbox\|sandbox\.md"
+```
+
+For each remaining hit that is *narrative copy a user reads* (not a tool name, env var, container name, or filename), replace `sandbox` with `Build runtime` in that sentence. Leave anything that names a technical artifact alone.
+
+**Step 9: Spot-check that relative doc links still resolve**
+
+Markdown isn't type-checked, but the inbound links to `sandbox.md` (from `index.md` and elsewhere) need to keep working since Task 6 preserves the file path. Spot-check:
+
+```bash
+grep -n "sandbox.md\|sandbox)" docs/user-guide/build-studio/sandbox.md docs/user-guide/build-studio/index.md
+```
+
+Confirm all relative links still resolve to existing files.
+
+**Step 10: Commit**
+
+```bash
+git add docs/user-guide/build-studio/sandbox.md
+git commit -s -m "docs(build-studio): reframe sandbox page as 'Build Runtime' (file path unchanged)"
+```
+
+---
+
+## Task 7 — Reframe `.claude/skills/dev-portal-start/SKILL.md` as contributor-only
+
+**Files:**
+- Modify: `.claude/skills/dev-portal-start/SKILL.md` (skill folder name stays — phase 1 does not rename the skill)
+
+**Step 1: Update the frontmatter description**
+
+Replace the description in the frontmatter with:
+
+```yaml
+---
+name: dev-portal-start
+description: Use when a DPF contributor needs to verify worktree edits on the **Contributor preview** runtime (port 3001) without rebuilding the Live portal image. Triggers — making any edit under apps/web/ that needs visual or HTTP-level confirmation; iterating on /build, /platform, /admin, or any other server-rendered route; debugging a UX change against real workspace data; reproducing a customer-visible bug in a worktree before opening a PR. This is a CONTRIBUTOR-ONLY workflow; customer installs do not ship the Contributor preview by default. Don't use for unit-test-only changes (no preview needed) or for changes that need the production-bundled Live portal specifically (rebuild that image instead).
+---
+```
+
+The skill folder name (`dev-portal-start`) stays so existing invocations do not break.
+
+**Step 2: Update the Overview section**
+
+Replace the first body section (after the `# dev-portal-start` heading) with:
+
+```markdown
+## Overview
+
+Brings up the **Contributor preview** runtime — the `dev-portal` Next.js hot-reload service on `http://localhost:3001` — against the live DPF databases, leaving the Live portal on `:3000` untouched as the stable reference. Every source edit under `apps/web/` is visible within a few seconds (or one container restart for file-watcher-stubborn cases).
+
+This eliminates the ~2-minute Live-portal-rebuild loop that otherwise gates every edit-verify cycle.
+
+The Contributor preview is a **DPF-contributor-only** surface, gated behind the `dev` compose profile. Customer installs (e.g. Dale's HVAC shop) do not ship it by default and do not see a `:3001` URL. If you are not a DPF contributor editing the platform source, you do not need this skill.
+```
+
+**Step 3: Update the "When to Use" / "Symptoms" section**
+
+Replace the bullet list of symptoms with language that says "the Live portal" instead of "the production portal":
+
+```markdown
+**Symptoms that trigger this skill (contributor workflow):**
+
+- "I changed `apps/web/app/(shell)/build/page.tsx` and want to see it."
+- "I need to verify the gate fires on a real install before merging."
+- "The Live portal at :3000 shows old code — how do I see my edits?"
+- "I edited `loadBuildStudioCapability` and tests pass; need to see the live UX."
+- "I'm reproducing a customer-reported bug in a worktree."
+
+**Do not use when:**
+
+- The change is unit-test-only (run `pnpm exec vitest` and you're done).
+- The change is to the Live-portal-bundle build itself (Docker image content, entrypoint, etc.) — rebuild `portal` instead.
+- The change is to non-portal services (sandbox, adp, browser-use) — those have their own rebuild cycles.
+- You are not a DPF contributor. End users and customer-install operators interact with Build Studio's Live preview through the canvas, not through `:3001`.
+```
+
+**Step 4: Touch up the rest of the body**
+
+Run:
+
+```bash
+grep -n -E "production portal|dev-portal\.|prod portal" .claude/skills/dev-portal-start/SKILL.md
+```
+
+For each occurrence in narrative copy, replace `production portal` → `Live portal` and qualify `dev-portal` with `Contributor preview` on first use per section. Leave the docker-command examples unchanged (the compose service name `dev-portal` remains, since the service is not being renamed in Phase 1).
+
+**Step 5: Commit**
+
+```bash
+git add .claude/skills/dev-portal-start/SKILL.md
+git commit -s -m "docs(skill): reframe dev-portal-start as Contributor preview (contributor-only)"
+```
+
+---
+
+## Task 8 — Add a `contributor:preview` package.json script
+
+**Files:**
+- Modify: `package.json` (scripts block, line 6-25)
+
+**Step 1: Add the script**
+
+Insert a new line after the existing `dev:portal` entry (line 9) so the scripts block reads:
+
+```json
+  "scripts": {
+    "dev": "pnpm --filter web dev",
+    "dev:web": "pnpm --filter web dev",
+    "dev:portal": "docker compose up -d dev-portal",
+    "contributor:preview": "docker compose --profile dev up -d dev-portal",
+    "dev:prod-runtime": "docker compose up -d portal",
+    "dev:sandbox": "docker compose up -d sandbox",
+```
+
+`dev:portal` stays for backward compatibility; `contributor:preview` is the canonical Phase-1 name and includes the `--profile dev` flag explicitly (required for the profile-gated service per `dev-portal-start` SKILL.md mistake #2).
+
+**Step 2: Verify the JSON is well-formed**
+
+```bash
+node -e "require('./package.json')"
+```
+
+Expected: no output (silent success).
+
+**Step 3: Commit**
+
+```bash
+git add package.json
+git commit -s -m "chore(scripts): add contributor:preview alias for dev-portal bring-up"
+```
+
+---
+
+## Task 9 (OPTIONAL) — Compose profile alias `dev` → `contributor`
+
+**Decision gate:** Only execute this task if Mark approves it in PR review. The Phase-1 spec marks profile aliasing as "Optional but allowed" (§8.2). It is backward-compatible (both profile names continue to work). Skip this task by default; do not skip the verification step at the end of the plan because of it.
+
+**Files:**
+- Modify: `docker-compose.yml` (the five `dev`-profile services)
+
+**Step 1: Add `contributor` to each profiled service**
+
+For each of `dev-postgres`, `dev-neo4j`, `dev-qdrant`, `dev-init`, and `dev-portal` in `docker-compose.yml`, change:
+
+```yaml
+    profiles: ["dev"]
+```
+
+to:
+
+```yaml
+    profiles: ["dev", "contributor"]
+```
+
+**Step 2: Verify with `docker compose config`**
+
+```bash
+docker compose --profile contributor config --services | sort
+```
+
+Expected: includes `dev-portal`, `dev-postgres`, `dev-neo4j`, `dev-qdrant`, `dev-init` plus the always-on services.
+
+```bash
+docker compose --profile dev config --services | sort
+```
+
+Expected: identical to above (backward compatibility preserved).
+
+**Step 3: Update the Contributor preview skill body**
+
+In `.claude/skills/dev-portal-start/SKILL.md`, add a note under "First bring-up" that either profile flag works:
+
+```markdown
+Note: both `--profile dev` (legacy) and `--profile contributor` (canonical Phase 1 name) bring up the same service set. Use whichever the surrounding tooling already references.
+```
+
+**Step 4: Commit**
+
+```bash
+git add docker-compose.yml .claude/skills/dev-portal-start/SKILL.md
+git commit -s -m "chore(compose): alias dev profile to also accept 'contributor' (backward-compatible)"
+```
+
+---
+
+## Task 10 — Final verification slice
+
+**Step 1: Full vitest run on the touched scope**
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/build apps/web/components/build
+```
+
+Expected: all green.
+
+**Step 2: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+**Step 3: Scope-violation sanity check**
+
+```bash
+git diff origin/main --stat
+```
+
+Confirm the diff touches only:
+
+- `apps/web/lib/build/sandbox-driver.ts` (label string + comments)
+- `apps/web/lib/build/customer-facing-strings.test.ts` (new regression test)
+- `apps/web/components/build/OpenSandboxButton.tsx` (comment update)
+- `apps/web/components/build/OpenSandboxButton.test.tsx` (assertion updates)
+- `docs/operations/dpf-production-runtime.md` (rewrite)
+- `docs/operations/runtime-glossary.md` (new)
+- `docs/user-guide/build-studio/index.md` (key concept rewording)
+- `docs/user-guide/build-studio/sandbox.md` (page reframing, file path unchanged)
+- `.claude/skills/dev-portal-start/SKILL.md` (contributor framing)
+- `package.json` (`contributor:preview` script)
+- (Optional Task 9) `docker-compose.yml` (profile alias only)
+
+If the diff touches anything outside this set, stop and audit — phase 1 has been violated.
+
+**Step 4: Docker-served Live portal UX verification**
+
+Bring up the Live portal and walk the Build Studio canvas to confirm the footer label reads "Open live preview" not "Open sandbox":
+
+```bash
+docker compose up -d portal
+until curl -sf http://localhost:3000/api/health >/dev/null 2>&1; do sleep 3; done
+```
+
+Drive the UI via Claude-in-Chrome (per `feedback_prefer_portal_ux_for_shared_actions`):
+1. Navigate to `http://localhost:3000/build`.
+2. Open a feature build (or land on the dashboard).
+3. Read the footer button label. Expected: "Open live preview · driving: <code or idle>".
+4. Hover/click does not break (component is still an `<a>` to the same sandbox URL).
+
+Record the verification in the PR description with a screenshot (or browser-use evidence).
+
+**Step 5: Contributor preview smoke (only if Task 9 ran or SKILL.md narrative changed)**
+
+```bash
+docker compose --profile dev up -d dev-portal
+until curl -sf http://localhost:3001/api/health >/dev/null 2>&1; do sleep 3; done
+```
+
+Land on `http://localhost:3001/build` and confirm the page renders. Tear down:
+
+```bash
+docker compose --profile dev rm -sf dev-portal
+```
+
+**Step 6: RuntimeTarget invariant sanity check**
+
+```bash
+grep -rn "RuntimeTarget.kind\|'root-portal'\|'build-sandbox'\|'dev-portal'" apps/web/lib/runtime-coordination | head -20
+```
+
+Expected: all three enum values still present in `apps/web/lib/runtime-coordination/types.ts`. Phase 1 did not touch them.
+
+**Step 7: Sweep for overlap with concurrent sessions**
+
+```bash
+git fetch origin main --quiet
+git log origin/main --oneline -10 | head
+gh pr list --state open --limit 30 --json number,title,headRefName --jq '.[] | "\(.number)  \(.headRefName)  \(.title)"'
+```
+
+If any new commit or open PR touches the same files, rebase + recheck before pushing.
+
+---
+
+## PR submission
+
+**Step 1: Push branch**
+
+```bash
+git push -u origin <current-branch>
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(topology): phase 1 — Live portal / Build runtime / Contributor preview naming + IA" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of the portal topology consolidation spec ([#1078](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1078)). Operator-facing terminology and IA only — no compose service rename, no enum change, no DB-isolation change, no Build Studio parallelism rework.
+
+- Build Studio footer label: `Open sandbox` → `Open live preview`. Internal symbols (`OpenSandboxButton`, `formatSandboxLabel`, test IDs) unchanged.
+- `docs/operations/dpf-production-runtime.md` rewritten in role-first language (Live portal / Build runtime / Contributor preview).
+- New `docs/operations/runtime-glossary.md` carries canonical definitions.
+- `docs/user-guide/build-studio/index.md` and `sandbox.md` reframed; file paths preserved.
+- `.claude/skills/dev-portal-start/SKILL.md` reframed as contributor-only.
+- `package.json` adds `contributor:preview` alias for the dev-portal bring-up.
+- (Optional, gated on PR review) `docker-compose.yml` aliases `dev` profile to also accept `contributor`.
+
+## Out of scope (per spec §8.3)
+
+No compose service / volume / RuntimeTarget.kind / Prisma model rename. No DB-isolation change. No Docker socket on dev-portal.
+
+## Test plan
+
+- [x] `pnpm --filter web exec vitest run apps/web/lib/build apps/web/components/build` — green.
+- [x] `pnpm --filter web typecheck` — clean.
+- [x] `git diff origin/main --stat` — only files listed in spec §8.1 + plan §10 step 3.
+- [x] Live portal `http://localhost:3000/build` — footer reads "Open live preview".
+- [x] Contributor preview `http://localhost:3001` — comes up cleanly (only if Task 9 ran).
+- [x] `RuntimeTarget.kind` values (`root-portal` / `build-sandbox` / `dev-portal`) still in `types.ts`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase 2 follow-ups (NOT in this plan)
+
+Filed as a separate decision per spec §9. Linked to live `BI-2E6CC391` (Build Studio concurrent Feature Builds) and worktree-hygiene epic. Do not start any of these in this PR:
+
+- Worktree-native Build Studio parallelism.
+- Preview routing per worktree / per build.
+- Codex/Claude/bubblewrap sidecar extraction from `Dockerfile.sandbox`.
+- Per-build data-isolation contract.
+- `RuntimeTarget.kind` enum migration (when/if surfaces collapse).
+- Sandbox-admin parity for the unified runtime control plane.
+
+---
+
+## Done-criteria checklist (from spec §15)
+
+- [ ] Phase 1 PR changes only user-facing terminology, docs, skills/scripts, tests, and optional profile aliasing.
+- [ ] The PR does not rename compose services, volumes, Prisma models, or `RuntimeTarget.kind` values.
+- [ ] Customer-facing flows no longer expose "sandbox" where the user's job is simply to preview a build.
+- [ ] Technical diagnostics still expose the actual service/container/port facts.
+- [ ] Final acceptance remains the Docker-served Live portal on `:3000`.
+- [ ] Spec benchmarks in §2.1 are cited where any decision needs them (e.g., the `contributor:preview` script choice cites the Compose profiles benchmark).

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -17,11 +17,11 @@ Build Studio is not a separate code universe. It works from the install's shared
 - **Phases** — The five stages every feature moves through: Ideate (define the problem), Plan (design the solution), Build (generate and test code), Review (quality gates), Ship (deploy to production).
 - **Feature Brief** — The structured output of the Ideate phase. It captures the problem, desired outcome, constraints, and acceptance criteria. Everything downstream is built from this.
 - **AI Coworker** — The Software Engineer agent that works with you through each phase. It searches the codebase, writes code, runs tests, and deploys features. You guide it with plain language.
-- **Sandbox** — An isolated execution environment where generated code runs safely without affecting the production platform. Each sandbox has its own database, file system, and network.
+- **Build runtime** — The isolated execution environment where the AI Coworker generates and tests code. Has its own database, file system, and network — completely separated from the live platform. The Build Studio canvas surfaces it as **Live preview**; the technical name *sandbox* still appears in diagnostics. See [Build Runtime](sandbox.md) for the full operating model.
 - **Shared Workspace** — The durable source workspace for this install. Build Studio reads and writes here, and in customizable installs VS Code uses the same codebase.
 - **Live Preview** — During the Build phase, a real-time preview shows the generated UI in an iframe. The preview updates automatically as the AI Coworker writes code.
 - **Quality Gates** — Automated checks between phases. Each gate requires specific evidence before the feature can advance (design review, plan review, test results, typecheck).
-- **Promotion** — The process of moving a completed feature from the sandbox into production. Includes database backup, image rebuild, health check, and automatic rollback on failure.
+- **Promotion** — The process of moving a completed feature from the Build runtime into production. Includes database backup, image rebuild, health check, and automatic rollback on failure.
 
 ## What You Can Do
 
@@ -45,7 +45,7 @@ The AI Coworker creates an implementation plan listing the files to create or mo
 
 ### Build
 
-The AI Coworker generates code inside an isolated sandbox. You can see the live preview update in real time. It runs tests and typecheck after generating code. If tests fail, it attempts to fix them automatically. You can ask for changes at any time.
+The AI Coworker generates code inside the isolated Build runtime. You can see the live preview update in real time. It runs tests and typecheck after generating code. If tests fail, it attempts to fix them automatically. You can ask for changes at any time.
 
 ### Review
 

--- a/docs/user-guide/build-studio/sandbox.md
+++ b/docs/user-guide/build-studio/sandbox.md
@@ -1,16 +1,16 @@
 ---
-title: "Sandbox Development Environment"
+title: "Build Runtime (Sandbox)"
 area: build-studio
 order: 3
-lastUpdated: 2026-03-30
+lastUpdated: 2026-05-24
 updatedBy: Claude (Software Engineer)
 ---
 
 ## Overview
 
-The sandbox is an isolated execution environment where your AI Coworker builds, tests, and refines features before they reach production. Each sandbox has its own database, file system, and runtime — completely separated from the live platform. Nothing the AI Coworker does in the sandbox can affect your production system.
+The **Build runtime** — surfaced as **Live preview** in the Build Studio canvas — is the isolated execution environment where your AI Coworker builds, tests, and refines features before they reach the Live portal. Each Build runtime instance has its own database, file system, and runtime, completely separated from the live platform. Nothing the AI Coworker does in the Build runtime can affect your production system.
 
-The sandbox is not the long-lived source of truth for your code. It starts from the install's shared workspace, runs validation work safely, and can be recreated whenever needed.
+The Build runtime is not the long-lived source of truth for your code. It starts from the install's shared workspace, runs validation work safely, and can be recreated whenever needed. The technical name behind it is *sandbox* — that name continues to appear in diagnostic surfaces (Platform Development → Runtime Targets, Admin Recovery, log lines, and MCP schemas).
 
 This isolation is what makes it safe for the AI to experiment freely: modifying code, running database migrations, restarting services, and iterating on your feedback without risk.
 
@@ -18,32 +18,32 @@ This isolation is what makes it safe for the AI to experiment freely: modifying 
 
 When you create a new feature in Build Studio and the AI Coworker begins the Build phase, the platform:
 
-1. **Acquires a sandbox slot** from the pool of available containers
-2. **Copies the active shared project source** from the running portal workspace into the sandbox workspace
+1. **Acquires a Build runtime slot** from the pool of available containers (technical name: *sandbox slot*)
+2. **Copies the active shared project source** from the running Live portal workspace into the Build runtime workspace
 3. **Installs dependencies** (`pnpm install`, Prisma client generation)
-4. **Runs database migrations** against the sandbox's own PostgreSQL instance
-5. **Seeds the sandbox database** with a copy of your production data so the AI works with realistic information
+4. **Runs database migrations** against the Build runtime's own PostgreSQL instance
+5. **Seeds the Build runtime database** with a copy of your live data so the AI works with realistic information
 6. **Starts a preview server** so you can see the feature as it is being built
 7. **Creates a git baseline** so changes can be tracked as a clean diff for promotion
 
 This process takes roughly 60 to 90 seconds. Once complete, the AI Coworker has a fully functional copy of the platform to work with.
 
-## Sandbox Isolation
+## Build Runtime Isolation
 
-Each sandbox is isolated from production at every layer:
+Each Build runtime instance is isolated from the Live portal at every layer:
 
-| Layer | Production | Sandbox |
+| Layer | Live portal | Build runtime |
 |-------|-----------|---------|
 | **Database** | `dpf-postgres-1` (your live data) | `dpf-sandbox-postgres-1` (separate instance, seeded copy) |
-| **File system** | Portal application at `/app` | Sandbox workspace at `/workspace` (Docker volume) |
-| **Network** | Full access to all services | No access to production credentials or Docker socket |
+| **File system** | Portal application at `/app` | Build runtime workspace at `/workspace` (Docker volume) |
+| **Network** | Full access to all services | No access to live credentials or Docker socket |
 | **Resources** | Unrestricted | 2 CPU cores, 4 GB memory, 10 GB disk |
 
-The sandbox has no access to your `.env` file, secrets, API keys, or the Docker socket. It cannot start, stop, or modify production containers. Schema changes and database migrations in the sandbox do not touch the production database.
+The Build runtime has no access to your `.env` file, secrets, API keys, or the Docker socket. It cannot start, stop, or modify the Live portal's containers. Schema changes and database migrations in the Build runtime do not touch the live database.
 
 ## AI Coworker Tools
 
-The AI Coworker has a complete set of development tools for working inside the sandbox. These tools are purpose-built to be safe (sandbox-only) and on par with what a professional developer uses:
+The AI Coworker has a complete set of development tools for working inside the Build runtime. These tools are purpose-built to be safe (Build-runtime-only) and on par with what a professional developer uses. The tool names retain the `sandbox` prefix because they are MCP-bound identifiers and a Phase 1 rename would break callers; the user-facing description has switched to "Build runtime":
 
 ### File Operations
 
@@ -64,49 +64,49 @@ The AI Coworker has a complete set of development tools for working inside the s
 
 | Tool | What it does |
 |------|-------------|
-| **run_sandbox_command** | Run any shell command inside the sandbox. Used for builds, tests, linting, git operations, dependency management, and verification. |
+| **run_sandbox_command** | Run any shell command inside the Build runtime. Used for builds, tests, linting, git operations, dependency management, and verification. |
 | **run_sandbox_tests** | Run the full test suite and typecheck. Optionally enables auto-fix mode, which diagnoses failures and attempts fixes up to three times. |
 
 ### Code Generation
 
 | Tool | What it does |
 |------|-------------|
-| **generate_code** | Send a high-level instruction to the coding agent. It analyzes the existing codebase for patterns, generates the code, writes it to the sandbox, and starts the dev server. |
+| **generate_code** | Send a high-level instruction to the coding agent. It analyzes the existing codebase for patterns, generates the code, writes it to the Build runtime, and starts the dev server. |
 | **iterate_sandbox** | Send a refinement instruction to improve existing code. The agent reads the current state, applies changes, and updates the preview. |
 
 ### Deployment
 
 | Tool | What it does |
 |------|-------------|
-| **deploy_feature** | Extract the changes from the sandbox as a git diff and submit them for promotion to production. This triggers the approval workflow. |
+| **deploy_feature** | Extract the changes from the Build runtime as a git diff and submit them for promotion to the Live portal. This triggers the approval workflow. |
 
 These tools are how the AI Coworker does real development work — not by running arbitrary shell scripts, but through purpose-built operations that handle encoding, path resolution, and error reporting cleanly.
 
-## Sandbox Pool
+## Build Runtime Pool
 
-The platform maintains a pool of sandbox containers so multiple features can be developed concurrently. By default, the pool has one slot (configurable via `DPF_SANDBOX_POOL_SIZE`).
+The platform maintains a pool of Build runtime containers so multiple features can be developed concurrently. By default, the pool has one slot (configurable via `DPF_SANDBOX_POOL_SIZE`).
 
-Each slot is a pre-created Docker container that gets assigned to a build when needed and returned to the pool when the build completes, fails, or is cancelled. If all slots are in use, the platform falls back to the legacy persistent sandbox container.
+Each slot is a pre-created Docker container that gets assigned to a build when needed and returned to the pool when the build completes, fails, or is cancelled. If all slots are in use, the platform falls back to the legacy persistent Build runtime container.
 
 You can monitor pool status from the Build Studio dashboard, which shows how many slots are available and which builds are using them.
 
 ## Live Preview
 
-During the Build phase, a preview panel shows the feature as the AI Coworker builds it. The preview server runs inside the sandbox on port 3000 and serves an auto-refreshing HTML page.
+During the Build phase, a preview panel shows the feature as the AI Coworker builds it. The preview server runs inside the Build runtime on port 3000 and serves an auto-refreshing HTML page.
 
 As the AI Coworker creates or modifies files, the preview updates automatically. If the preview content has not been generated yet, you see a "Building Your Feature" spinner that refreshes every five seconds.
 
-## From Sandbox to Production
+## From Build Runtime to Live Portal
 
 When the feature is ready to ship, the AI Coworker (or you) triggers the `deploy_feature` tool. This:
 
-1. Extracts a clean git diff of all changes made in the sandbox since the baseline
+1. Extracts a clean git diff of all changes made in the Build runtime since the baseline
 2. Creates a **ChangePromotion** record linking the feature build to the promotion pipeline
 3. Submits the promotion for approval
 
-Once approved, the autonomous promotion pipeline takes over. It builds a new portal image that includes the sandbox changes, swaps it into production, runs health checks, and rolls back automatically if anything fails. See [Feature Deployment](deployment.md) for the full eleven-step pipeline.
+Once approved, the autonomous promotion pipeline takes over. It builds a new Live portal image that includes the Build runtime changes, swaps it into production, runs health checks, and rolls back automatically if anything fails. See [Feature Deployment](deployment.md) for the full eleven-step pipeline.
 
-The key insight is that the sandbox diff contains only the changes needed for that validation run — not the entire codebase. The sandbox exists to execute and verify work safely, not to replace the install's shared development workspace.
+The key insight is that the Build runtime diff contains only the changes needed for that validation run — not the entire codebase. The Build runtime exists to execute and verify work safely, not to replace the install's shared development workspace.
 
 ## Shared Workspace Relationship
 
@@ -114,13 +114,13 @@ Build Studio uses the install's shared workspace as its authoring source:
 
 - in ready-to-go installs, Build Studio is the guided interface over that workspace
 - in customizable installs, Build Studio and VS Code use the same workspace and branch
-- the sandbox starts from that shared workspace, then adds isolation for preview, tests, and migration rehearsal
+- the Build runtime starts from that shared workspace, then adds isolation for preview, tests, and migration rehearsal
 
 See [Development Workspace](../development-workspace) for the full operating model.
 
 ## What the AI Coworker Can and Cannot Do
 
-**Can do in the sandbox:**
+**Can do in the Build runtime:**
 - Create, read, edit, and delete any file in the workspace
 - Run shell commands (build, test, lint, git)
 - Install or update dependencies
@@ -128,19 +128,19 @@ See [Development Workspace](../development-workspace) for the full operating mod
 - Start dev servers and preview builds
 - Search the codebase and analyze patterns
 
-**Cannot do from the sandbox:**
-- Access production credentials, API keys, or secrets
-- Connect to the production database
-- Start, stop, or modify production containers
+**Cannot do from the Build runtime:**
+- Access live credentials, API keys, or secrets
+- Connect to the live database
+- Start, stop, or modify Live portal containers
 - Access the Docker socket or host filesystem
 - Make network requests to internal services (other than npm registry for dependencies)
 
 ## Troubleshooting
 
-**"Sandbox not ready"** — The sandbox workspace may not have finished initializing. Dependencies take 60-90 seconds to install on first use. Wait and retry.
+**"Build runtime not ready"** — The Build runtime workspace may not have finished initializing. Dependencies take 60-90 seconds to install on first use. Wait and retry.
 
-**"File not found"** — The AI Coworker may be looking for a file using the production path (`/app/...`) instead of the sandbox path. Sandbox files live under `/workspace/`. The tools handle this translation automatically, but `run_sandbox_command` does not.
+**"File not found"** — The AI Coworker may be looking for a file using the Live portal path (`/app/...`) instead of the Build runtime path. Build runtime files live under `/workspace/`. The tools handle this translation automatically, but `run_sandbox_command` does not.
 
-**"Typecheck failed"** — The sandbox runs the same TypeScript compiler as production. If the typecheck fails, the AI Coworker can use `run_sandbox_tests` with `auto_fix: true` to diagnose and fix the issue automatically (up to three attempts).
+**"Typecheck failed"** — The Build runtime runs the same TypeScript compiler as the Live portal. If the typecheck fails, the AI Coworker can use `run_sandbox_tests` with `auto_fix: true` to diagnose and fix the issue automatically (up to three attempts).
 
-**Build stuck in a phase** — Each pipeline step has retry limits. If a step exhausts retries, the build is marked as failed and the sandbox slot is released. You can create a new feature build to start fresh.
+**Build stuck in a phase** — Each pipeline step has retry limits. If a step exhausts retries, the build is marked as failed and the Build runtime slot is released. You can create a new feature build to start fresh.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "pnpm --filter web dev",
     "dev:web": "pnpm --filter web dev",
     "dev:portal": "docker compose up -d dev-portal",
+    "contributor:preview": "docker compose --profile dev up -d dev-portal",
     "dev:prod-runtime": "docker compose up -d portal",
     "dev:sandbox": "docker compose up -d sandbox",
     "build": "pnpm --filter web build",


### PR DESCRIPTION
## Summary

Phase 1 implementation of the portal topology consolidation spec (merged [#1078](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1078)). Operator-facing terminology and IA only — no compose service rename, no enum change, no DB-isolation change, no Build Studio parallelism rework.

**Headline UX change:** Build Studio footer button label `Open sandbox · driving: …` → `Open live preview · driving: …`. Internal symbols (`OpenSandboxButton`, `formatSandboxLabel`, `BUILD_STUDIO_TEST_IDS.openSandbox`) unchanged.

**Docs:**
- `docs/operations/dpf-production-runtime.md` rewritten in role-first language (Live portal / Build runtime / Contributor preview).
- New `docs/operations/runtime-glossary.md` carries canonical definitions.
- `docs/user-guide/build-studio/index.md` Key Concept "Sandbox" → "Build runtime"; Promotion narrative updated.
- `docs/user-guide/build-studio/sandbox.md` reframed as the Build Runtime page; file path unchanged (URL stability).
- `.claude/skills/dev-portal-start/SKILL.md` reframed as contributor-only.
- `package.json` adds `contributor:preview` alias for the dev-portal bring-up (`dev:portal` kept for backward compat).

**Plan doc:** [`docs/superpowers/plans/2026-05-24-portal-topology-consolidation-phase-1.md`](../blob/claude/topology-phase-1-naming/docs/superpowers/plans/2026-05-24-portal-topology-consolidation-phase-1.md) — was reviewed and READY TO EXECUTE before this branch opened.

## TDD anchor

Task 1 committed `apps/web/lib/build/customer-facing-strings.test.ts` RED (assertions failed against the old "Open sandbox" label). Task 2 flipped `formatSandboxLabel` to turn it green. Regression now guards customer-facing copy against re-introducing "sandbox" as the user-facing noun.

## Explicitly out of scope (per spec §8.3)

No rename of compose services, Docker volumes, `RuntimeTarget.kind` enum values, Prisma models, `sandboxId` references, MCP tool names, or test IDs. No Docker socket on dev-portal. No agent CLIs in the dev Dockerfile target. No Build Studio parallelism rework. No DB-isolation change.

## Verification

- [x] `pnpm --filter web exec vitest run lib/build components/build` — 531 passed (0 failed)
- [x] `pnpm --filter web typecheck` — clean
- [x] `git diff origin/main --stat` — 12 expected files, no scope violations:
  - 6 in `apps/web/{components,lib}/build/*` (label flip + tests + regression)
  - 1 skill (`.claude/skills/dev-portal-start/SKILL.md`)
  - 3 docs (operations runtime + glossary + user-guide)
  - 1 user-guide sandbox.md (page reframe, file path preserved)
  - 1 plan doc (`docs/superpowers/plans/...phase-1.md`)
  - 1 `package.json` script addition
- [x] `RuntimeTarget.kind` enum values (`root-portal` / `build-sandbox` / `dev-portal`) still present across 7 runtime-coordination files
- [x] Rebased onto fresh `origin/main` (picked up #1082 gear-interface PR cleanly, no conflicts)

## Test plan (post-merge)

- [ ] Image rebuild + Live portal self-upgrade — confirm `:3000/build` footer reads "Open live preview · driving: …" in the real browser. Functional verification follows the standard ship pipeline; pre-merge verification was structural (vitest + typecheck) plus diff-stat scope check.
- [ ] Spot-check `docs/user-guide/build-studio/index.md` rendered through portal `/docs` route after deploy.

## Phase 2 follow-ups (NOT in this PR)

Filed in spec §9 as a separate decision linked to live `BI-2E6CC391`. Includes: worktree-native BS parallelism, preview routing, sidecarized agent tooling, per-build data isolation, RuntimeTarget enum migration, sandbox-admin parity for unified runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)