### PR TITLE
fix(build-studio): look up BacklogItem by id (cuid FK), not itemId, in Ideate auto-dispatch

### DIFF
--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -106,8 +106,11 @@ describe("dispatchIdeateForApprovedBuild", () => {
   });
 
   it("dispatches research and saves designDoc evidence on the happy path", async () => {
+    // 2026-05-24: originatingBacklogItemId is a FK to BacklogItem.id (cuid),
+    // not BacklogItem.itemId (BI-XXXXX semantic id). Use a cuid-shaped value
+    // here so the lookup matches what production code does.
     mockPrisma.featureBuild.findUnique.mockResolvedValue({
-      originatingBacklogItemId: "BI-1",
+      originatingBacklogItemId: "cmpj4gz5605xx01o6lzxt278g",
       designDoc: null,
       title: "Fallback Title",
       description: "Fallback description.",
@@ -132,6 +135,16 @@ describe("dispatchIdeateForApprovedBuild", () => {
     const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
 
     expect(outcome.kind).toBe("dispatched-success");
+    // Regression guard: PR #947 looked up BacklogItem by itemId here, which
+    // always missed because originatingBacklogItemId stores the cuid FK to
+    // BacklogItem.id. Live evidence captured on FB-B77B8CC4 2026-05-24.
+    // Without this assertion the prior mock setup (which ignored the where
+    // clause) hid the bug from tests.
+    expect(mockPrisma.backlogItem.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "cmpj4gz5605xx01o6lzxt278g" },
+      }),
+    );
     expect(mockDispatchIdeateResearch).toHaveBeenCalledWith(
       expect.objectContaining({
         featureTitle: "BI Title",

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -104,8 +104,17 @@ export async function dispatchIdeateForApprovedBuild(params: {
     }
 
     // Fetch the BI title + body for the research context.
+    //
+    // 2026-05-24: FeatureBuild.originatingBacklogItemId is a FK to BacklogItem.id
+    // (the cuid PK), not BacklogItem.itemId (the semantic BI-XXXXX). PR #947
+    // looked up by itemId here, which always missed because the FK stores the
+    // cuid value. The dispatch then short-circuited with `skipped-no-bi` and
+    // a "data inconsistency" message — masking a code bug as data corruption.
+    // Live evidence captured during FB-B77B8CC4 smoke test 2026-05-24.
+    // Same mock-faked-the-schema class of failure as the businessContext bug
+    // that PR #1030 fixed in this same file.
     const bi = await prisma.backlogItem.findUnique({
-      where: { itemId: build.originatingBacklogItemId },
+      where: { id: build.originatingBacklogItemId },
       select: { title: true, body: true },
     });
 


### PR DESCRIPTION
## Summary

- Same class of failure as PR #1030, **second instance in the same file** — also from PR #947.
- `FeatureBuild.originatingBacklogItemId` is a FK to `BacklogItem.id` (cuid PK), not `BacklogItem.itemId` (the BI-XXXXX semantic). PR #947 looked up by `itemId` → `findUnique` always returned null → auto-dispatch short-circuited with `skipped-no-bi` and a misleading "data inconsistency" message that masked the code bug as data corruption.
- Live evidence captured 2026-05-24 on FB-B77B8CC4 (BI-8627BE51 smoke test, created specifically to verify PR #1030's businessContext fix). The Prisma throw is gone (#1030's fix works), but the next step still misses every time.

## Live activity log evidence

```
approve_start    @ 17:44:51.312Z  "Start approved for governed backlog draft"
ideate_dispatch  @ 17:44:51.315Z  "Skipped auto-dispatch: originatingBacklogItemId
                                   cmpj4gz5605xx01o6lzxt278g did not resolve to a
                                   BacklogItem row — data inconsistency."
```

Direct DB confirmation:
```sql
SELECT id, "itemId", title FROM "BacklogItem" WHERE id = 'cmpj4gz5605xx01o6lzxt278g';
-- returns the BI; just keyed wrong in code
```

## Changes

1. `ideate-on-approval.ts:108` — `where: { itemId: ... }` → `where: { id: ... }` with a comment explaining the FK semantics + history.
2. `ideate-on-approval.test.ts` — happy-path mock updated to use a cuid-shape value for `originatingBacklogItemId` so the lookup matches production semantics.
3. **Added explicit where-shape regression assertion** — `expect(mockPrisma.backlogItem.findUnique).toHaveBeenCalledWith({ where: { id: "..." } })`. This same assertion pattern (asserting Prisma `where:` shape, not just return value) would have caught both this and the businessContext bug from PR #1030 at PR-#947 time.

## Why the existing tests didn't catch this

Both bugs (the businessContext select and now the itemId lookup) share the same failure mode: the test mocks `findUnique.mockResolvedValue({...})` without asserting the `where:` argument shape. The mock happily accepts any lookup key and returns the canned value, so production code with the wrong key passes tests that work against real Prisma would fail.

## Kernel principle

`structural-verification-is-not-functional` — same commandment-tier principle PR #1030 invoked, now applied to its sibling. Two instances of the same mock-faked-the-schema pattern in one file is enough signal to consider a substrate change: require explicit `where`-shape assertions on Prisma mocks in this codebase.

## Test plan

- [x] `pnpm --filter web typecheck` — green locally
- [x] `vitest run lib/actions lib/integrate` — 197 files, 1687 passed, 5 todo
- [ ] CI green
- [ ] Post-merge: re-run smoke test on FB-B77B8CC4 — expect `ideate_dispatch` row to show "Dispatching ideate research via …" (not "Skipped auto-dispatch: data inconsistency")

🤖 Generated with [Claude Code](https://claude.com/claude-code)