### PR TITLE
feat(safety): Claude Code transcript snapshot hook (BI-C8655C8C)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,30 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"D:\\DPF\\scripts\\safety\\transcript-snapshot.ps1\"",
+            "shell": "powershell",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"D:\\DPF\\scripts\\safety\\transcript-snapshot.ps1\"",
+            "shell": "powershell",
+            "async": false
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/docs/operations/session-transcript-recovery.md
+++ b/docs/operations/session-transcript-recovery.md
@@ -1,0 +1,97 @@
+# Claude Code session transcript recovery — operator guide
+
+**Audience:** DPF operators after an incident (machine crash, volume wipe, agent gone rogue).
+**Spec lineage:** BI-C8655C8C in `EP-DR-HARDENING-2026-05-23` (2026-05-23 volume-wipe incident).
+**Related:** [`runtime-kernel-commandments.md`](runtime-kernel-commandments.md), the postgres trial-restore mechanism.
+
+## Why this exists
+
+The 2026-05-23 overnight session wiped Docker volumes AND its own Claude Code transcript was lost. Without the transcript we couldn't answer: *what destructive actions ran? why did the agent think that was needed? what state was destroyed?*
+
+This feature copies the active Claude Code session transcript to a durable location OUTSIDE the install root, so a future incident (volume wipe, install-dir rm, ransomware) leaves a forensic trail intact.
+
+## How it works
+
+A Claude Code `PostToolUse` hook fires after every tool call. The hook script (`scripts/safety/transcript-snapshot.ps1`) reads the hook payload, then copies the in-flight transcript file to:
+
+```
+$DPF_BACKUPS_HOST_PATH/session-transcripts/<YYYY-MM-DD>/<session-id>.jsonl
+```
+
+(`$DPF_BACKUPS_HOST_PATH` defaults to `$DPF_DIR-backups\` per BI-8004BCD8 — a sibling of the install, OUTSIDE the directory that reinstall would wipe.)
+
+A `SessionEnd` hook fires the same script unconditionally on session end (clear, logout, prompt-exit, etc.) so the final state is always captured.
+
+## What's NOT snapshotted
+
+To keep hook overhead negligible:
+
+- **Read-only tool calls** (`Read`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `TodoWrite`, `TaskList`, `TaskGet`) — they don't change state, so the snapshot wouldn't capture anything new.
+- **Bursts of tool calls within 2 minutes of the last snapshot** — throttled. Worst-case data loss is 2 minutes of actions, not the full session.
+
+`SessionEnd` is always honored regardless of throttle, so the final snapshot is guaranteed.
+
+## How to find a snapshot after an incident
+
+```powershell
+# Most recent N snapshots across all sessions
+Get-ChildItem $env:DPF_DIR-backups\session-transcripts -Recurse -Filter '*.jsonl' |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 10 FullName, Length, LastWriteTime
+```
+
+Each `.jsonl` is the Claude Code native transcript format (one JSON object per line, each entry is a message / tool call / tool result). Tools like `jq` read it natively:
+
+```bash
+# Last 5 tool calls from a specific session
+jq -c 'select(.type == "tool_use")' \
+   "/d/DPF-backups/session-transcripts/2026-05-24/<session-id>.jsonl" \
+   | tail -5
+```
+
+## How to retrieve the transcript inside Claude Code
+
+A snapshot file is identical in format to the original. To resume from a snapshot:
+
+```powershell
+# Copy back to Claude Code's project dir for the same project
+$slug = 'D--DPF'  # for D:\DPF; replace : with --, \ with --
+$snapshot = "D:\DPF-backups\session-transcripts\2026-05-24\<session-id>.jsonl"
+$dest = "$env:USERPROFILE\.claude\projects\$slug\<session-id>.jsonl"
+Copy-Item $snapshot $dest -Force
+# Then in Claude Code: /resume <session-id>
+```
+
+## Where the audit trail lives
+
+Every snapshot writes one JSON line to `$DPF_BACKUPS_HOST_PATH/session-transcripts/.snapshot.log`:
+
+```json
+{"timestamp":"2026-05-24T17:31:42.123Z","session_id":"abc-123","hook_event":"PostToolUse","tool_name":"Bash","snapshot_path":"…","size_bytes":1234,"install_root":"D:\\DPF","backups_root":"D:\\DPF-backups"}
+```
+
+Grep this when investigating an incident — gives you the full sequence of snapshots taken across all sessions.
+
+## Retention
+
+- **30 days by default** — older day-dirs pruned automatically on every hook invocation (cheap; only top-level `YYYY-MM-DD` dirs are inspected).
+- Pruning runs in the snapshot script itself, so no separate cron is needed.
+- To change retention, edit `$retentionDays = 30` in `transcript-snapshot.ps1`.
+
+## How to disable
+
+Edit `.claude/settings.json` and remove the `PostToolUse` + `SessionEnd` entries that reference `transcript-snapshot.ps1`. Restart Claude Code. Re-running `install-dpf.ps1` will re-add them — the installer assumes snapshotting is on by default.
+
+## Known limits
+
+- **Windows-only in slice 1.** A POSIX hook (`transcript-snapshot.sh`) ships alongside the PowerShell version but `.claude/settings.json` only wires the PowerShell command today, matching the existing `WorktreeCreate` hook convention. Cross-platform hook wiring is a follow-up when DPF macOS/Linux installer matures.
+- **The hook fires AFTER each tool call.** The snapshot from just BEFORE a destructive action survives; nothing captures the state during the action itself (irrelevant — there's nothing to snapshot at the moment of destruction).
+- **The throttle means up to 2 minutes of conversation can be lost** during a crash mid-session-burst. The BI accepts this trade-off — "worst-case data loss is the last N actions, not the entire session" was the explicit ask.
+- **Snapshots include conversation contents.** If a session contained secrets / credentials, they will be on disk under `$DPF_BACKUPS_HOST_PATH`. Protect that directory the same way you protect any backup tree.
+
+## Composition with other DR-hardening features
+
+- **Snapshots land in `$DPF_BACKUPS_HOST_PATH`** (BI-8004BCD8) — sibling of the install, survives reinstall.
+- **Runtime kernel commandments** (BI-43F95F77) protect the backups dir from accidental `Remove-Item -Recurse` or `docker volume rm` patterns.
+- **Postgres trial-restore** (BI-31C9FBDF) verifies the backups themselves are restorable; the same volume that hosts the transcript snapshots is implicitly health-checked.
+- **Worktree janitor** (BI-E5002629) ensures session-end cleanup doesn't accidentally take the transcript with it (worktree removal does NOT touch `~/.claude/projects/` or `$DPF_BACKUPS_HOST_PATH`).

--- a/scripts/safety/transcript-snapshot.Tests.ps1
+++ b/scripts/safety/transcript-snapshot.Tests.ps1
@@ -1,0 +1,249 @@
+# scripts/safety/transcript-snapshot.Tests.ps1
+#
+# Pester 5 tests for the Claude Code transcript snapshot hook.
+#
+# Run: pwsh -NoProfile -Command "Invoke-Pester -Path scripts/safety/transcript-snapshot.Tests.ps1 -Output Detailed"
+#
+# Strategy: invoke the script as a child pwsh process (matches how Claude
+# Code's hook runner spawns it) with stdin JSON payloads. Fixture install
+# root + backups dir under TestDrive so the script's $PSScriptRoot-based
+# install-root resolution finds the test fixture, not the real install.
+
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+BeforeAll {
+    $script:HookScriptSource = Join-Path $PSScriptRoot 'transcript-snapshot.ps1'
+
+    function New-TestFixture {
+        [CmdletBinding()]
+        param([Parameter(Mandatory)][string] $RootPath)
+        $installRoot = Join-Path $RootPath 'install'
+        $scriptsDir  = Join-Path $installRoot 'scripts\safety'
+        $backupsDir  = Join-Path $RootPath 'backups'
+        $transcript  = Join-Path $RootPath 'sample.jsonl'
+
+        New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $backupsDir -Force | Out-Null
+        Copy-Item -LiteralPath $script:HookScriptSource -Destination (Join-Path $scriptsDir 'transcript-snapshot.ps1')
+        Set-Content -LiteralPath $transcript -Value '{"type":"user","content":"hello"}'
+
+        return [PSCustomObject]@{
+            InstallRoot = $installRoot
+            HookScript  = Join-Path $scriptsDir 'transcript-snapshot.ps1'
+            BackupsDir  = $backupsDir
+            Transcript  = $transcript
+        }
+    }
+
+    function Invoke-Hook {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)][string] $HookScript,
+            [Parameter(Mandatory)][string] $BackupsDir,
+            [Parameter(Mandatory)][hashtable] $Payload
+        )
+        $json = $Payload | ConvertTo-Json -Compress
+        $env:DPF_BACKUPS_HOST_PATH = $BackupsDir
+        $json | & pwsh -NoProfile -File $HookScript
+        return $LASTEXITCODE
+    }
+
+    function Get-SnapshotCount {
+        param([Parameter(Mandatory)][string] $BackupsDir)
+        @(Get-ChildItem -Recurse -LiteralPath (Join-Path $BackupsDir 'session-transcripts') `
+            -Filter '*.jsonl' -ErrorAction SilentlyContinue).Count
+    }
+
+    function Clear-HookState {
+        param([Parameter(Mandatory)][string] $SessionId)
+        $stateFile = Join-Path $env:USERPROFILE ".claude\hook-state\$SessionId.last-snapshot"
+        Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe "transcript-snapshot.ps1 — happy paths" {
+    BeforeEach {
+        # Per-test subdir under TestDrive — TestDrive is per-Describe in Pester 5,
+        # so without a unique suffix the backups dir accumulates across It blocks.
+        $perTestRoot = Join-Path $TestDrive ("happy-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-TestFixture -RootPath $perTestRoot
+        $script:SessionId = "test-$([Guid]::NewGuid().ToString('N').Substring(0,12))"
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    AfterEach {
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    It "snapshots on first PostToolUse with a non-readonly tool" {
+        $exit = Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        }
+        $exit | Should -Be 0
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 1
+    }
+
+    It "snapshots on SessionEnd unconditionally" {
+        $exit = Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            hook_event_name = 'SessionEnd'
+            reason          = 'clear'
+        }
+        $exit | Should -Be 0
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 1
+    }
+
+    It "writes one JSON line per snapshot to the audit log" {
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        } | Out-Null
+        $log = Join-Path $script:Fixture.BackupsDir 'session-transcripts\.snapshot.log'
+        Test-Path $log | Should -Be $true
+        # Wrap in @(...) so .Count works even when Get-Content returns a scalar
+        # for a single-line file (same PowerShell array-unwrap pattern as in
+        # worktree-janitor-lib.psm1).
+        $lines = @(Get-Content -LiteralPath $log)
+        $lines.Count | Should -Be 1
+        $entry = $lines[0] | ConvertFrom-Json
+        $entry.session_id | Should -Be $script:SessionId
+        $entry.hook_event | Should -Be 'PostToolUse'
+        $entry.tool_name | Should -Be 'Bash'
+    }
+}
+
+Describe "transcript-snapshot.ps1 — throttle" {
+    BeforeEach {
+        $perTestRoot = Join-Path $TestDrive ("throttle-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-TestFixture -RootPath $perTestRoot
+        $script:SessionId = "throttle-$([Guid]::NewGuid().ToString('N').Substring(0,12))"
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    AfterEach {
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    It "skips a second PostToolUse within the throttle window" {
+        $payload = @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        }
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload $payload | Out-Null
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload $payload | Out-Null
+        # Should still be 1 snapshot, not 2; log should have only 1 line.
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 1
+        $log = Join-Path $script:Fixture.BackupsDir 'session-transcripts\.snapshot.log'
+        @(Get-Content -LiteralPath $log).Count | Should -Be 1
+    }
+
+    It "SessionEnd ignores the throttle and still snapshots" {
+        # Prime: PostToolUse sets the throttle state.
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        } | Out-Null
+        # Immediately follow with SessionEnd — should still log a 2nd entry.
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            hook_event_name = 'SessionEnd'
+            reason          = 'clear'
+        } | Out-Null
+        $log = Join-Path $script:Fixture.BackupsDir 'session-transcripts\.snapshot.log'
+        $lines = @(Get-Content -LiteralPath $log)
+        $lines.Count | Should -Be 2
+        ($lines | ForEach-Object { ($_ | ConvertFrom-Json).hook_event }) | Should -Contain 'SessionEnd'
+    }
+}
+
+Describe "transcript-snapshot.ps1 — read-only tool skip" {
+    BeforeEach {
+        $perTestRoot = Join-Path $TestDrive ("ro-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-TestFixture -RootPath $perTestRoot
+        $script:SessionId = "ro-$([Guid]::NewGuid().ToString('N').Substring(0,12))"
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    AfterEach {
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    It "skips PostToolUse for Read" {
+        Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Read'
+            hook_event_name = 'PostToolUse'
+        } | Out-Null
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 0
+    }
+
+    It "skips PostToolUse for Glob, Grep, WebFetch, WebSearch" {
+        foreach ($tool in @('Glob', 'Grep', 'WebFetch', 'WebSearch')) {
+            Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+                session_id      = $script:SessionId
+                transcript_path = $script:Fixture.Transcript
+                tool_name       = $tool
+                hook_event_name = 'PostToolUse'
+            } | Out-Null
+        }
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 0
+    }
+}
+
+Describe "transcript-snapshot.ps1 — defensive paths" {
+    BeforeEach {
+        $perTestRoot = Join-Path $TestDrive ("defensive-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-TestFixture -RootPath $perTestRoot
+        $script:SessionId = "defensive-$([Guid]::NewGuid().ToString('N').Substring(0,12))"
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    AfterEach {
+        Clear-HookState -SessionId $script:SessionId
+    }
+
+    It "exits 0 silently on empty stdin (no payload)" {
+        $env:DPF_BACKUPS_HOST_PATH = $script:Fixture.BackupsDir
+        '' | & pwsh -NoProfile -File $script:Fixture.HookScript
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It "exits 0 silently on malformed JSON" {
+        $env:DPF_BACKUPS_HOST_PATH = $script:Fixture.BackupsDir
+        '{not-json' | & pwsh -NoProfile -File $script:Fixture.HookScript
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It "exits 0 silently when transcript_path does not exist" {
+        $exit = Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            session_id      = $script:SessionId
+            transcript_path = (Join-Path $TestDrive 'does-not-exist.jsonl')
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        }
+        $exit | Should -Be 0
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 0
+    }
+
+    It "exits 0 silently when session_id is missing" {
+        $exit = Invoke-Hook -HookScript $script:Fixture.HookScript -BackupsDir $script:Fixture.BackupsDir -Payload @{
+            transcript_path = $script:Fixture.Transcript
+            tool_name       = 'Bash'
+            hook_event_name = 'PostToolUse'
+        }
+        $exit | Should -Be 0
+        (Get-SnapshotCount -BackupsDir $script:Fixture.BackupsDir) | Should -Be 0
+    }
+}

--- a/scripts/safety/transcript-snapshot.ps1
+++ b/scripts/safety/transcript-snapshot.ps1
@@ -1,0 +1,175 @@
+#Requires -Version 5.1
+# scripts/safety/transcript-snapshot.ps1
+#
+# Out-of-band snapshot of Claude Code session transcripts.
+#
+# BI:   BI-C8655C8C (EP-DR-HARDENING-2026-05-23)
+# Lessons: 2026-05-23 overnight session wiped Docker volumes AND its own
+# Claude Code transcript was lost — no forensic trace remained. This hook
+# breaks that pattern by copying the active transcript to a durable
+# location after every Nth tool call (PostToolUse) and on session end
+# (SessionEnd). The location lives OUTSIDE the install root so a future
+# repo-tree wipe cannot destroy the audit trail.
+#
+# Invoked by Claude Code hooks defined in .claude/settings.json. Receives
+# a JSON payload on stdin:
+#   {
+#     "session_id": "<uuid>",
+#     "transcript_path": "C:/Users/.../.claude/projects/<slug>/<uuid>.jsonl",
+#     "tool_name": "Bash",
+#     "hook_event_name": "PostToolUse"
+#   }
+#
+# Exit 0 ALWAYS — a snapshot failure must never block the user's tool call.
+# Failures are logged to the snapshot dir + surfaced via the operator's
+# existing readiness card pattern.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Continue'  # never throw out of a hook
+
+# Read stdin payload. Pester-friendly: callers can also pass via STDIN-piped string.
+$rawPayload = [Console]::In.ReadToEnd()
+if (-not $rawPayload) { exit 0 }
+
+try {
+    $payload = $rawPayload | ConvertFrom-Json
+} catch {
+    # Malformed payload from harness — log and exit cleanly.
+    exit 0
+}
+
+$sessionId      = $payload.session_id
+$transcriptPath = $payload.transcript_path
+$toolName       = $payload.tool_name
+$hookEvent      = $payload.hook_event_name
+
+if (-not $sessionId -or -not $transcriptPath) { exit 0 }
+if (-not (Test-Path -LiteralPath $transcriptPath)) { exit 0 }
+
+# ─── Resolve $DPF_DIR + $DPF_BACKUPS_HOST_PATH ──────────────────────────────
+#
+# Three-source resolution chain:
+#   1. $env:DPF_BACKUPS_HOST_PATH (operator override)
+#   2. <install-root>/.env DPF_BACKUPS_HOST_PATH= line
+#   3. <install-root>-backups (default convention per BI-8004BCD8)
+#
+# Install root is derived from the script's own location: this script lives
+# at $DPF_DIR/scripts/safety/transcript-snapshot.ps1, so $PSScriptRoot/../.. is
+# the install root.
+
+$installRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+
+$backupsHostPath = $null
+if ($env:DPF_BACKUPS_HOST_PATH) {
+    $backupsHostPath = $env:DPF_BACKUPS_HOST_PATH
+} elseif (Test-Path -LiteralPath (Join-Path $installRoot '.env')) {
+    $envLine = Select-String -LiteralPath (Join-Path $installRoot '.env') -Pattern '^DPF_BACKUPS_HOST_PATH=(.+)$' -ErrorAction SilentlyContinue
+    if ($envLine) {
+        $backupsHostPath = $envLine.Matches[0].Groups[1].Value.Trim()
+    }
+}
+if (-not $backupsHostPath) {
+    $backupsHostPath = "$installRoot-backups"
+}
+
+# ─── Snapshot destination ────────────────────────────────────────────────────
+
+$dateDir       = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+$snapshotRoot  = Join-Path $backupsHostPath 'session-transcripts'
+$snapshotDay   = Join-Path $snapshotRoot $dateDir
+$snapshotFile  = Join-Path $snapshotDay "$sessionId.jsonl"
+$stateDir      = Join-Path $env:USERPROFILE '.claude\hook-state'
+$stateFile     = Join-Path $stateDir "$sessionId.last-snapshot"
+$logFile       = Join-Path $snapshotRoot '.snapshot.log'
+
+# ─── Read-only tool allowlist (PostToolUse skip) ────────────────────────────
+#
+# Skip snapshotting after pure read-only ops — they don't change state, so
+# the snapshot wouldn't capture anything new. SessionEnd always snapshots.
+
+$readOnlyTools = @('Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch', 'TodoWrite', 'TaskList', 'TaskGet')
+if ($hookEvent -eq 'PostToolUse' -and $toolName -and ($readOnlyTools -contains $toolName)) {
+    exit 0
+}
+
+# ─── Throttle (PostToolUse only; SessionEnd is always honored) ───────────────
+#
+# Snapshot at most once per $throttleSeconds even under heavy tool-call
+# bursts. State file holds the last-snapshot epoch as a single integer.
+
+$throttleSeconds = 120  # 2 minutes — fast enough to limit data loss, slow
+                        # enough to keep hook overhead negligible.
+
+if ($hookEvent -eq 'PostToolUse' -and (Test-Path -LiteralPath $stateFile)) {
+    try {
+        $lastEpoch = [int64](Get-Content -LiteralPath $stateFile -Raw).Trim()
+        $nowEpoch = [int64]([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())
+        if (($nowEpoch - $lastEpoch) -lt $throttleSeconds) {
+            exit 0
+        }
+    } catch {
+        # Corrupt state file — fall through and snapshot, then overwrite.
+    }
+}
+
+# ─── Snapshot ────────────────────────────────────────────────────────────────
+
+try {
+    if (-not (Test-Path -LiteralPath $snapshotDay)) {
+        New-Item -ItemType Directory -Path $snapshotDay -Force | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $stateDir)) {
+        New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+    }
+    # Copy-Item with Force overwrites existing destination. We always
+    # overwrite — the latest snapshot supersedes prior ones for this session.
+    Copy-Item -LiteralPath $transcriptPath -Destination $snapshotFile -Force
+    [int64]([DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) | Set-Content -LiteralPath $stateFile -Encoding ASCII
+
+    # Audit log line.
+    $sizeBytes = (Get-Item -LiteralPath $snapshotFile).Length
+    $logLine = ConvertTo-Json -Compress -InputObject @{
+        timestamp       = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        session_id      = $sessionId
+        hook_event      = $hookEvent
+        tool_name       = $toolName
+        snapshot_path   = $snapshotFile
+        size_bytes      = $sizeBytes
+        install_root    = $installRoot
+        backups_root    = $backupsHostPath
+    }
+    Add-Content -LiteralPath $logFile -Value $logLine -Encoding UTF8
+} catch {
+    # Last-resort: write the failure to a sidecar log so the operator sees
+    # snapshots stopped working without the hook ever blocking Claude Code.
+    try {
+        $errLine = ConvertTo-Json -Compress -InputObject @{
+            timestamp  = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            session_id = $sessionId
+            error      = "$($_.Exception.Message)"
+        }
+        Add-Content -LiteralPath $logFile -Value $errLine -Encoding UTF8 -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+# ─── Retention pruning (best-effort, cheap, on every invocation) ─────────────
+#
+# Delete day-dirs older than $retentionDays. The pruner is intentionally
+# cheap — we only touch the top-level YYYY-MM-DD dirs. If a directory
+# can't be removed (file lock, permission), skip silently.
+
+$retentionDays = 30
+try {
+    if (Test-Path -LiteralPath $snapshotRoot) {
+        $cutoff = (Get-Date).AddDays(-$retentionDays)
+        Get-ChildItem -LiteralPath $snapshotRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^\d{4}-\d{2}-\d{2}$' -and $_.LastWriteTime -lt $cutoff } |
+            ForEach-Object {
+                Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+            }
+    }
+} catch {}
+
+exit 0

--- a/scripts/safety/transcript-snapshot.sh
+++ b/scripts/safety/transcript-snapshot.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# scripts/safety/transcript-snapshot.sh
+#
+# POSIX counterpart of transcript-snapshot.ps1 — out-of-band Claude Code
+# transcript snapshot.
+#
+# BI:   BI-C8655C8C (EP-DR-HARDENING-2026-05-23)
+# Lessons: 2026-05-23 incident lost the entire forensic trail.
+#
+# Invoked by Claude Code hooks (.claude/settings.json). Receives a JSON
+# payload on stdin:
+#   { "session_id": "...", "transcript_path": "...",
+#     "tool_name": "...", "hook_event_name": "PostToolUse"|"SessionEnd" }
+#
+# Requires: jq (mandated by the install-dpf.sh preflight added for the
+# kernel-commandment shell guard — same dependency).
+#
+# Exit 0 ALWAYS — a snapshot failure must never block the user's tool call.
+
+set -u
+
+# Read payload from stdin.
+PAYLOAD="$(cat || true)"
+[ -n "$PAYLOAD" ] || exit 0
+
+# jq required; absent jq = silent skip (don't break Claude Code).
+command -v jq >/dev/null 2>&1 || exit 0
+
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null)"
+TRANSCRIPT_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.transcript_path // empty' 2>/dev/null)"
+TOOL_NAME="$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // empty' 2>/dev/null)"
+HOOK_EVENT="$(printf '%s' "$PAYLOAD" | jq -r '.hook_event_name // empty' 2>/dev/null)"
+
+[ -n "$SESSION_ID" ] || exit 0
+[ -n "$TRANSCRIPT_PATH" ] || exit 0
+[ -f "$TRANSCRIPT_PATH" ] || exit 0
+
+# ─── Resolve install root + $DPF_BACKUPS_HOST_PATH ──────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BACKUPS_HOST_PATH=""
+if [ -n "${DPF_BACKUPS_HOST_PATH:-}" ]; then
+    BACKUPS_HOST_PATH="$DPF_BACKUPS_HOST_PATH"
+elif [ -f "$INSTALL_ROOT/.env" ]; then
+    BACKUPS_HOST_PATH="$(sed -n 's/^DPF_BACKUPS_HOST_PATH=\(.*\)/\1/p' "$INSTALL_ROOT/.env" 2>/dev/null | head -1)"
+fi
+if [ -z "$BACKUPS_HOST_PATH" ]; then
+    BACKUPS_HOST_PATH="${INSTALL_ROOT}-backups"
+fi
+
+# ─── Skip read-only tools on PostToolUse ─────────────────────────────────────
+
+case "$HOOK_EVENT" in
+    PostToolUse)
+        case "$TOOL_NAME" in
+            Read|Glob|Grep|WebFetch|WebSearch|TodoWrite|TaskList|TaskGet)
+                exit 0 ;;
+        esac ;;
+esac
+
+# ─── Snapshot destination + throttle state ──────────────────────────────────
+
+DATE_DIR="$(date -u +%Y-%m-%d)"
+SNAPSHOT_ROOT="$BACKUPS_HOST_PATH/session-transcripts"
+SNAPSHOT_DAY="$SNAPSHOT_ROOT/$DATE_DIR"
+SNAPSHOT_FILE="$SNAPSHOT_DAY/$SESSION_ID.jsonl"
+STATE_DIR="${HOME}/.claude/hook-state"
+STATE_FILE="$STATE_DIR/$SESSION_ID.last-snapshot"
+LOG_FILE="$SNAPSHOT_ROOT/.snapshot.log"
+
+THROTTLE_SECONDS=120
+
+# Throttle: skip when last snapshot was <$THROTTLE_SECONDS ago. SessionEnd
+# always honored.
+if [ "$HOOK_EVENT" = "PostToolUse" ] && [ -f "$STATE_FILE" ]; then
+    LAST_EPOCH="$(cat "$STATE_FILE" 2>/dev/null || echo 0)"
+    NOW_EPOCH="$(date +%s)"
+    if [ "$LAST_EPOCH" -gt 0 ] 2>/dev/null && [ $((NOW_EPOCH - LAST_EPOCH)) -lt "$THROTTLE_SECONDS" ]; then
+        exit 0
+    fi
+fi
+
+# ─── Snapshot ────────────────────────────────────────────────────────────────
+
+mkdir -p "$SNAPSHOT_DAY" "$STATE_DIR" 2>/dev/null
+if cp -f "$TRANSCRIPT_PATH" "$SNAPSHOT_FILE" 2>/dev/null; then
+    date +%s > "$STATE_FILE"
+    SIZE_BYTES="$(wc -c < "$SNAPSHOT_FILE" | tr -d ' ')"
+    TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+    LOG_LINE="$(jq -c -n \
+        --arg ts "$TIMESTAMP" \
+        --arg sid "$SESSION_ID" \
+        --arg he "$HOOK_EVENT" \
+        --arg tn "$TOOL_NAME" \
+        --arg sp "$SNAPSHOT_FILE" \
+        --argjson sz "$SIZE_BYTES" \
+        --arg ir "$INSTALL_ROOT" \
+        --arg br "$BACKUPS_HOST_PATH" \
+        '{timestamp:$ts,session_id:$sid,hook_event:$he,tool_name:$tn,snapshot_path:$sp,size_bytes:$sz,install_root:$ir,backups_root:$br}' \
+        2>/dev/null)"
+    [ -n "$LOG_LINE" ] && printf '%s\n' "$LOG_LINE" >> "$LOG_FILE" 2>/dev/null
+else
+    # Snapshot failed — write a single error line. Never block.
+    TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+    printf '{"timestamp":"%s","session_id":"%s","error":"snapshot copy failed"}\n' \
+        "$TIMESTAMP" "$SESSION_ID" >> "$LOG_FILE" 2>/dev/null || true
+fi
+
+# ─── Retention pruning (best-effort) ────────────────────────────────────────
+
+RETENTION_DAYS=30
+if [ -d "$SNAPSHOT_ROOT" ]; then
+    find "$SNAPSHOT_ROOT" -maxdepth 1 -type d -name '????-??-??' -mtime "+$RETENTION_DAYS" \
+        -exec rm -rf {} + 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Closes **BI-C8655C8C** in the **EP-DR-HARDENING-2026-05-23** epic. Breaks the *"rogue agent + broken state + no forensic trace"* triad the 2026-05-23 incident hit by copying the active Claude Code session transcript to a durable location OUTSIDE the install root.

The 2026-05-23 overnight session wiped Docker volumes AND its own Claude Code transcript was lost — no way to answer *what destructive actions ran, why the agent thought that was needed, what state was destroyed*. This PR ensures the next incident leaves a forensic trail intact.

## Mechanism

| Layer | What | File |
|---|---|---|
| **Hook script (Windows)** | Reads Claude Code hook payload (`session_id`, `transcript_path`, `tool_name`, `hook_event_name`) from stdin; copies the in-flight transcript to `$DPF_BACKUPS_HOST_PATH/session-transcripts/<YYYY-MM-DD>/<session-id>.jsonl`. | `scripts/safety/transcript-snapshot.ps1` |
| **Hook script (POSIX)** | jq-based counterpart for macOS / Linux installs. | `scripts/safety/transcript-snapshot.sh` |
| **Hook wiring** | `.claude/settings.json` registers the script as `PostToolUse` (async) + `SessionEnd` (sync). Matches the convention of the existing `WorktreeCreate` hook. | `.claude/settings.json` |
| **Pester tests** | 11 tests covering happy path, throttle, SessionEnd-ignores-throttle, read-only skip across 5 tools, and 4 defensive paths. | `scripts/safety/transcript-snapshot.Tests.ps1` |
| **Operator doc** | What gets snapshotted, how to find a snapshot after an incident, how to `/resume` from one, retention, disable instructions. | `docs/operations/session-transcript-recovery.md` |

## Behavior

- **PostToolUse** — snapshot after writeful tool calls (`Bash`, `Edit`, `Write`, MCP tool calls, etc.). Throttled to one snapshot per 2 minutes so high-tool-call bursts don't generate redundant work.
- **PostToolUse on read-only tools** (`Read` / `Glob` / `Grep` / `WebFetch` / `WebSearch` / `TodoWrite` / `TaskList` / `TaskGet`) — skipped entirely. They don't change state.
- **SessionEnd** — always snapshot, regardless of throttle. Guarantees the final state is captured even after a 5-second burst.
- **Always exit 0.** A snapshot failure must never block the user's tool call. Failures get logged to a sidecar file in the snapshot dir.

## Three-source backups-path resolution

1. `$env:DPF_BACKUPS_HOST_PATH` (operator override)
2. `<install-root>/.env` `DPF_BACKUPS_HOST_PATH=` line (parsed)
3. `<install-root>-backups` (default convention per [BI-8004BCD8](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1062))

This means snapshots land in the same out-of-install-root dir as the postgres backups, picking up all the durability properties that BI-8004BCD8 + BI-31C9FBDF (trial-restore) shipped earlier in the epic.

## Live verification

End-to-end test against the actual script with stub payloads (one ad-hoc PowerShell harness, then formalized as 11 Pester tests):

```
1) First PostToolUse: exit=0 snaps=1     ✓
2) Throttled PostToolUse: exit=0 snaps=1 ✓ (no second snapshot within 2 min)
3) Read-only PostToolUse: exit=0          ✓ (skip)
4) SessionEnd: exit=0                     ✓ (snapshots despite throttle)
5) Log lines: 2 (PostToolUse + SessionEnd, full context per line)
```

## Tests

- [x] Pester 5: **11/11 pass** in `transcript-snapshot.Tests.ps1`.
- [x] `[Parser]::ParseFile` clean on both `transcript-snapshot.ps1` and the existing PowerShell scripts.
- [x] `sh -n` clean on `transcript-snapshot.sh`.
- [x] `.claude/settings.json` parses as valid JSON.

## Composition with prior DR-hardening this epic

- **Snapshot dir is `$DPF_BACKUPS_HOST_PATH`** (BI-8004BCD8) — sibling of install, survives reinstall.
- **Runtime kernel commandments** (BI-43F95F77) protect the backups dir from accidental `Remove-Item -Recurse` or `docker volume rm`.
- **Postgres trial-restore** (BI-31C9FBDF) verifies the volume hosting transcripts is healthy.
- **Worktree janitor** (BI-E5002629) doesn't touch `~/.claude/projects/` or `$DPF_BACKUPS_HOST_PATH`, so cleanup never takes transcripts with it.

## Trade-offs called out for review

1. **2-minute throttle window** — worst-case data loss is 2 minutes of conversation during a mid-burst crash. The BI explicitly accepts "worst-case data loss is the last N actions, not the entire session". Easy to tune in the script if you want tighter (e.g. 30 s) or looser (e.g. 10 min).
2. **30-day retention** — matches the worktree-janitor log rotation shipped earlier today for consistency. Easy to extend; the pruner only inspects top-level `YYYY-MM-DD` dirs so cost is negligible.
3. **`.claude/settings.json` uses hardcoded `D:\DPF\` path** matching the existing `WorktreeCreate` hook convention. Installs at non-default paths require operator to edit the hook command — same constraint as the existing hook. A future PR could template all three hooks (WorktreeCreate, PostToolUse, SessionEnd) at install time once the install-path-templating story is solved holistically.
4. **POSIX hook script ships but isn't wired** in `.claude/settings.json` — matches the Windows-first convention DPF currently uses. POSIX hook wiring is a follow-up when the macOS/Linux installer matures.

## Two PowerShell footguns recorded during the test run

1. **`Get-Content` unwraps single-line files to a scalar string**, breaking `.Count`. Wrapping with `@(...)` forces array semantics. Same pattern I hit yesterday in the worktree-janitor library — worth noting as a recurring shape.
2. **Pester 5 `TestDrive` is per-`Describe`, not per-`It`** — multiple tests in the same `Describe` share the same temp dir, so cross-test state contamination is real. Fixed by adding a per-`It` GUID-suffixed subdir inside `TestDrive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
