### PR TITLE
feat(wiki): backfill principleRingScope on 58 pre-existing principles (BI-4AA1074B Slice 3)

### DIFF
--- a/docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md
+++ b/docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/always-push-after-committing.md
+++ b/docs/founder-kernel/wiki/principles/always-push-after-committing.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+++ b/docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: This is DPF's stated technical posture — adopters need to know the platform will choose the sound option even when a faster hack is available.

--- a/docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md
+++ b/docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md
@@ -10,6 +10,9 @@ principleDimensionVector: {"human_cognitive_load": 0.9, "speed_to_value": 0.7, "
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/backlog-lives-in-postgresql.md
+++ b/docs/founder-kernel/wiki/principles/backlog-lives-in-postgresql.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - portfolio

--- a/docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md
+++ b/docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/build-gate-mandatory.md
+++ b/docs/founder-kernel/wiki/principles/build-gate-mandatory.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/check-epic-overlap-before-creating.md
+++ b/docs/founder-kernel/wiki/principles/check-epic-overlap-before-creating.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - portfolio

--- a/docs/founder-kernel/wiki/principles/check-tool-signals-first.md
+++ b/docs/founder-kernel/wiki/principles/check-tool-signals-first.md
@@ -10,6 +10,8 @@ principleDimensionVector: {"evidence_density": 0.9, "speed_to_value": 0.6, "sche
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/consult-specs-first.md
+++ b/docs/founder-kernel/wiki/principles/consult-specs-first.md
@@ -11,6 +11,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/contextualize-before-transforming.md
+++ b/docs/founder-kernel/wiki/principles/contextualize-before-transforming.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: false
 principlePublicRationale: ""

--- a/docs/founder-kernel/wiki/principles/db-fallback-explicit.md
+++ b/docs/founder-kernel/wiki/principles/db-fallback-explicit.md
@@ -9,6 +9,8 @@ principleDimensionVector: {"evidence_density": 0.6, "governance_compliance": 0.4
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - mcp

--- a/docs/founder-kernel/wiki/principles/dco-sign-off-required.md
+++ b/docs/founder-kernel/wiki/principles/dco-sign-off-required.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/design-research-required.md
+++ b/docs/founder-kernel/wiki/principles/design-research-required.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: Adopters and contributors should see DPF's research discipline — every spec defends its design choices against the field, not against intuition.

--- a/docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md
+++ b/docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md
@@ -10,6 +10,8 @@ principleDimensionVector: {"blast_radius": 1.0, "governance_compliance": 0.9, "e
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/diversity-of-thought.md
+++ b/docs/founder-kernel/wiki/principles/diversity-of-thought.md
@@ -9,6 +9,8 @@ principleDimensionVector: {"long_term_maintainability": 0.5, "evidence_density":
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: true
 principlePublicRationale: Documents why DPF agents have distinct cognitive frames, not just different tool lists — adopters designing their own coworkers need this guidance.

--- a/docs/founder-kernel/wiki/principles/do-the-work-dont-task-the-operator.md
+++ b/docs/founder-kernel/wiki/principles/do-the-work-dont-task-the-operator.md
@@ -9,6 +9,9 @@ principleDimensionVector: {"human_cognitive_load": -1.0, "speed_to_value": 0.6, 
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 principlePublicRationale: ""

--- a/docs/founder-kernel/wiki/principles/evidence-before-diagnosis.md
+++ b/docs/founder-kernel/wiki/principles/evidence-before-diagnosis.md
@@ -10,6 +10,8 @@ principleDimensionVector: {"evidence_density": 1.0, "schema_grounding": 0.8, "lo
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/external-and-internal-work-share-gates.md
+++ b/docs/founder-kernel/wiki/principles/external-and-internal-work-share-gates.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/fail-fast-explain-clearly.md
+++ b/docs/founder-kernel/wiki/principles/fail-fast-explain-clearly.md
@@ -9,6 +9,8 @@ principleDimensionVector: {"evidence_density": 0.8, "blast_radius": 0.5, "speed_
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: true
 principlePublicRationale: Adopters need to know that DPF agents surface errors directly rather than masking them through retries.

--- a/docs/founder-kernel/wiki/principles/fix-the-seed-not-the-runtime.md
+++ b/docs/founder-kernel/wiki/principles/fix-the-seed-not-the-runtime.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md
+++ b/docs/founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: Documents DPF's HITL governance posture for adopters and contributors — anyone running the platform needs to know where approvals are required and where the agent operates autonomously.

--- a/docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md
+++ b/docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/live-state-over-seed-data.md
+++ b/docs/founder-kernel/wiki/principles/live-state-over-seed-data.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md
+++ b/docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md
+++ b/docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md
@@ -10,6 +10,9 @@ principleDimensionVector: {"human_cognitive_load": 1.0, "governance_compliance":
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-17

--- a/docs/founder-kernel/wiki/principles/never-fabricate.md
+++ b/docs/founder-kernel/wiki/principles/never-fabricate.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: A non-negotiable AI-agent rule that adopters need to see clearly — agents that fabricate undermine the platform's evidence-based posture.

--- a/docs/founder-kernel/wiki/principles/never-wipe-db-for-code-fixes.md
+++ b/docs/founder-kernel/wiki/principles/never-wipe-db-for-code-fixes.md
@@ -10,6 +10,8 @@ principleDimensionVector: {"blast_radius": 1.0, "data_privacy": 0.7, "governance
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/no-assumptions.md
+++ b/docs/founder-kernel/wiki/principles/no-assumptions.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: Assumption-driven errors cause irreversible actions and eroded trust. Adopters need to know agents will verify before acting.

--- a/docs/founder-kernel/wiki/principles/no-hardcoded-colors.md
+++ b/docs/founder-kernel/wiki/principles/no-hardcoded-colors.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - ui

--- a/docs/founder-kernel/wiki/principles/one-concern-per-pr.md
+++ b/docs/founder-kernel/wiki/principles/one-concern-per-pr.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/one-data-model.md
+++ b/docs/founder-kernel/wiki/principles/one-data-model.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-3-archetype
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md
+++ b/docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - build-studio

--- a/docs/founder-kernel/wiki/principles/organization-canonical-identity.md
+++ b/docs/founder-kernel/wiki/principles/organization-canonical-identity.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-3-archetype
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/plan-before-install-paths.md
+++ b/docs/founder-kernel/wiki/principles/plan-before-install-paths.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/prefer-self-hosted-infrastructure.md
+++ b/docs/founder-kernel/wiki/principles/prefer-self-hosted-infrastructure.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: DPF positions itself as a sovereign AI-native platform. Operators who adopt DPF should understand that the platform's default posture is to own its capabilities, not rent them — and that external APIs are explicitly opt-in, not the default.

--- a/docs/founder-kernel/wiki/principles/principal-convergence.md
+++ b/docs/founder-kernel/wiki/principles/principal-convergence.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-3-archetype
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/release-qa-plan.md
+++ b/docs/founder-kernel/wiki/principles/release-qa-plan.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - release

--- a/docs/founder-kernel/wiki/principles/research-and-use-standards.md
+++ b/docs/founder-kernel/wiki/principles/research-and-use-standards.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: DPF's identity as a standards-anchored platform (IT4IT, CSDM, TOGAF, MCP) makes this commandment product-facing — adopters should expect every design choice to defend itself against published standards.

--- a/docs/founder-kernel/wiki/principles/research-before-implementing.md
+++ b/docs/founder-kernel/wiki/principles/research-before-implementing.md
@@ -11,6 +11,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
+++ b/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: A core DPF stance — adopters need to understand the platform's posture on idle vs. active coworker time and the governance gates that bound autonomous work.

--- a/docs/founder-kernel/wiki/principles/schema-audit-before-features.md
+++ b/docs/founder-kernel/wiki/principles/schema-audit-before-features.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-3-archetype
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/security-fix-needs-regression-test-first.md
+++ b/docs/founder-kernel/wiki/principles/security-fix-needs-regression-test-first.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/selective-memory-not-total-recall.md
+++ b/docs/founder-kernel/wiki/principles/selective-memory-not-total-recall.md
@@ -9,6 +9,8 @@ principleDimensionVector: {"long_term_maintainability": 0.7, "schema_grounding":
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: true
 principlePublicRationale: Adopters using DPF's memory layer need to know what belongs there and what doesn't, before they fill it with noise.

--- a/docs/founder-kernel/wiki/principles/single-source-of-truth.md
+++ b/docs/founder-kernel/wiki/principles/single-source-of-truth.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: Adopters consuming DPF need to know that every rule has exactly one canonical home — duplication is the failure mode the platform actively prevents.

--- a/docs/founder-kernel/wiki/principles/specialization-over-generalization.md
+++ b/docs/founder-kernel/wiki/principles/specialization-over-generalization.md
@@ -9,6 +9,9 @@ principleDimensionVector: {"blast_radius": 0.7, "human_cognitive_load": -0.5, "r
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
 principleConsumerArchetype: specialist
 principlePublic: true
 principlePublicRationale: Documents DPF's agentic architecture posture for adopters and contributors building specialist coworkers.

--- a/docs/founder-kernel/wiki/principles/state-results-directly.md
+++ b/docs/founder-kernel/wiki/principles/state-results-directly.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: universal
 principlePublic: true
 principlePublicRationale: This is part of DPF's communication style for coworkers — adopters configuring agents need to know the platform's default voice is terse and outcome-first.

--- a/docs/founder-kernel/wiki/principles/strongly-typed-string-enums.md
+++ b/docs/founder-kernel/wiki/principles/strongly-typed-string-enums.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-3-archetype
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/structural-verification-is-not-functional.md
+++ b/docs/founder-kernel/wiki/principles/structural-verification-is-not-functional.md
@@ -11,6 +11,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/structured-handoffs-not-conversation-history.md
+++ b/docs/founder-kernel/wiki/principles/structured-handoffs-not-conversation-history.md
@@ -9,6 +9,8 @@ principleDimensionVector: {"long_term_maintainability": 0.6, "schema_grounding":
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: ai-coworker-universal
 principlePublic: true
 principlePublicRationale: Adopters building multi-phase agent workflows need to know that DPF's handoffs are typed artifacts, not transcripts.

--- a/docs/founder-kernel/wiki/principles/sweep-main-before-trusting-worktree-specs.md
+++ b/docs/founder-kernel/wiki/principles/sweep-main-before-trusting-worktree-specs.md
@@ -11,6 +11,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/test-in-the-portal-build.md
+++ b/docs/founder-kernel/wiki/principles/test-in-the-portal-build.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/tool-evaluation-pipeline.md
+++ b/docs/founder-kernel/wiki/principles/tool-evaluation-pipeline.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - mcp

--- a/docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md
+++ b/docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-1-coworker
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - mcp

--- a/docs/founder-kernel/wiki/principles/trust-the-data-spine.md
+++ b/docs/founder-kernel/wiki/principles/trust-the-data-spine.md
@@ -10,6 +10,9 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-3-archetype
+  - ring-4-sandbox-prod
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - data-model

--- a/docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md
+++ b/docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md
@@ -11,6 +11,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - universal-ring
 principleConsumerArchetype: universal
 principlePublic: false
 authoredAt: 2026-05-18

--- a/docs/founder-kernel/wiki/principles/worktree-base-origin-main.md
+++ b/docs/founder-kernel/wiki/principles/worktree-base-origin-main.md
@@ -11,6 +11,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/docs/founder-kernel/wiki/principles/worktree-per-session.md
+++ b/docs/founder-kernel/wiki/principles/worktree-per-session.md
@@ -10,6 +10,8 @@ principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
   - human
+principleRingScope:
+  - ring-2-workflow
 principleConsumerArchetype: route-domain-specific
 principleConsumerContexts:
   - engineering-flow

--- a/scripts/one-shot/backfill-principle-ring-scope.mjs
+++ b/scripts/one-shot/backfill-principle-ring-scope.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// One-shot backfill for BI-4AA1074B Slice 3: insert principleRingScope
+// frontmatter on every pre-existing principle file per the audit table in
+// docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md §7
+// (tightened from the first-pass recommendation — see Slice 3 PR body for
+// the ~10 cases where execution diverged from the draft table).
+//
+// Safe to re-run: insertion is idempotent (skips files already carrying
+// `principleRingScope:`). Throws on unknown slugs so a typo in the
+// mapping doesn't silently miss a file.
+//
+// After this script runs, the 4 already-scoped principles from PR #1081
+// (mirror-dont-migrate, schema-honesty-over-aspirational-naming,
+// make-silent-failures-observable, substrate-cleanup-before-substrate-addition)
+// remain untouched — they ship explicit scope from day one.
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PRINCIPLES_DIR = join(
+  __dirname,
+  "..",
+  "..",
+  "docs",
+  "founder-kernel",
+  "wiki",
+  "principles",
+);
+
+// Mapping derived from spec §7 audit table with coherence corrections:
+// - Tightened ~10 engineering-flow rules to ring-2-workflow only (they
+//   don't genuinely bind every ring — they bind code work).
+// - Tightened one-data-model + organization-canonical-identity +
+//   principal-convergence to identity/data-model rings only.
+// - Kept architecture-only commandments (never-fabricate, no-assumptions,
+//   architecture-over-shortcuts) at universal-ring — those genuinely bind.
+//
+// Final universal-ring count: 15 of 58 pre-existing (25.9%), under the
+// 30% lint discipline threshold.
+const SCOPE_MAP = {
+  "all-changes-land-via-pr": ["ring-2-workflow"],
+  "always-push-after-committing": ["ring-2-workflow"],
+  "architecture-over-shortcuts": ["universal-ring"],
+  "autonomous-directives-are-blanket-approval": [
+    "ring-1-coworker",
+    "ring-2-workflow",
+  ],
+  "backlog-lives-in-postgresql": ["ring-2-workflow"],
+  "branch-guard-before-implementation": ["ring-2-workflow"],
+  "build-gate-mandatory": ["ring-2-workflow", "ring-4-sandbox-prod"],
+  "check-epic-overlap-before-creating": ["ring-2-workflow"],
+  "check-tool-signals-first": ["ring-1-coworker"],
+  "consult-specs-first": ["universal-ring"],
+  "contextualize-before-transforming": ["universal-ring"],
+  "db-fallback-explicit": ["ring-1-coworker"],
+  "dco-sign-off-required": ["ring-2-workflow"],
+  "design-research-required": ["universal-ring"],
+  "destructive-actions-require-explicit-go": ["universal-ring"],
+  "diversity-of-thought": ["ring-1-coworker"],
+  "do-the-work-dont-task-the-operator": [
+    "ring-1-coworker",
+    "ring-2-workflow",
+  ],
+  "evidence-before-diagnosis": ["ring-1-coworker"],
+  "external-and-internal-work-share-gates": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "fail-fast-explain-clearly": ["ring-1-coworker"],
+  "fix-the-seed-not-the-runtime": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "human-in-the-loop-at-phase-boundaries": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "keep-root-clone-as-merge-worktree": ["ring-2-workflow"],
+  "live-state-over-seed-data": ["universal-ring"],
+  "mention-uncommitted-changes": ["ring-2-workflow"],
+  "never-ask-user-to-run-commands": [
+    "ring-1-coworker",
+    "ring-2-workflow",
+  ],
+  "never-fabricate": ["universal-ring"],
+  "never-wipe-db-for-code-fixes": ["universal-ring"],
+  "no-assumptions": ["universal-ring"],
+  "no-hardcoded-colors": ["ring-2-workflow"],
+  "one-concern-per-pr": ["ring-2-workflow"],
+  "one-data-model": ["ring-3-archetype", "ring-4-sandbox-prod"],
+  "orchestrator-worker-pattern": ["ring-2-workflow"],
+  "organization-canonical-identity": ["ring-3-archetype"],
+  "plan-before-install-paths": ["ring-4-sandbox-prod"],
+  "prefer-self-hosted-infrastructure": ["universal-ring"],
+  "principal-convergence": ["ring-3-archetype"],
+  "release-qa-plan": ["ring-4-sandbox-prod"],
+  "research-and-use-standards": ["universal-ring"],
+  "research-before-implementing": ["universal-ring"],
+  "responsible-capacity-utilization": ["universal-ring"],
+  "schema-audit-before-features": [
+    "ring-2-workflow",
+    "ring-3-archetype",
+  ],
+  "security-fix-needs-regression-test-first": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "selective-memory-not-total-recall": ["ring-1-coworker"],
+  "single-source-of-truth": ["universal-ring"],
+  "specialization-over-generalization": [
+    "ring-1-coworker",
+    "ring-2-workflow",
+  ],
+  "state-results-directly": ["ring-1-coworker"],
+  "strongly-typed-string-enums": [
+    "ring-2-workflow",
+    "ring-3-archetype",
+  ],
+  "structural-verification-is-not-functional": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "structured-handoffs-not-conversation-history": ["ring-2-workflow"],
+  "sweep-main-before-trusting-worktree-specs": ["ring-2-workflow"],
+  "test-in-the-portal-build": [
+    "ring-2-workflow",
+    "ring-4-sandbox-prod",
+  ],
+  "tool-evaluation-pipeline": ["ring-1-coworker"],
+  "tools-must-be-self-documenting": ["ring-1-coworker"],
+  "trust-the-data-spine": [
+    "ring-3-archetype",
+    "ring-4-sandbox-prod",
+  ],
+  "verify-substrate-before-proposing-new": ["universal-ring"],
+  "worktree-base-origin-main": ["ring-2-workflow"],
+  "worktree-per-session": ["ring-2-workflow"],
+};
+
+// Already-scoped from PR #1081 — skip silently rather than fail.
+const ALREADY_SCOPED = new Set([
+  "mirror-dont-migrate",
+  "schema-honesty-over-aspirational-naming",
+  "make-silent-failures-observable",
+  "substrate-cleanup-before-substrate-addition",
+]);
+
+function renderRingScopeBlock(scopes) {
+  const lines = ["principleRingScope:"];
+  for (const scope of scopes) lines.push(`  - ${scope}`);
+  return lines.join("\n") + "\n";
+}
+
+let touched = 0;
+let skipped = 0;
+let alreadyScoped = 0;
+
+const files = readdirSync(PRINCIPLES_DIR).filter((f) => f.endsWith(".md"));
+const unknown = [];
+
+for (const fileName of files) {
+  const slug = fileName.replace(/\.md$/, "");
+  if (ALREADY_SCOPED.has(slug)) {
+    alreadyScoped++;
+    continue;
+  }
+  const scopes = SCOPE_MAP[slug];
+  if (!scopes) {
+    unknown.push(slug);
+    continue;
+  }
+
+  const path = join(PRINCIPLES_DIR, fileName);
+  const raw = readFileSync(path, "utf8");
+
+  // Idempotency: skip if the file already has principleRingScope.
+  if (/^principleRingScope:/m.test(raw)) {
+    skipped++;
+    continue;
+  }
+
+  // Insert the new block before the `principleConsumerArchetype:` line in
+  // the frontmatter. Every audited principle has that line per the §7
+  // spec table, so this anchor is reliable.
+  const block = renderRingScopeBlock(scopes);
+  const updated = raw.replace(
+    /^(principleConsumerArchetype:)/m,
+    `${block}$1`,
+  );
+
+  if (updated === raw) {
+    throw new Error(
+      `Failed to insert principleRingScope into ${fileName} — no ` +
+        `'principleConsumerArchetype:' anchor found. Inspect the file.`,
+    );
+  }
+
+  writeFileSync(path, updated, "utf8");
+  touched++;
+}
+
+// Fail loud on slug typos in the mapping vs. the file system.
+if (unknown.length > 0) {
+  console.error(
+    `\nERROR: principle slugs present on disk but missing from SCOPE_MAP:`,
+  );
+  for (const slug of unknown) console.error(`  - ${slug}`);
+  console.error("Add them to SCOPE_MAP or remove the stale file.");
+  process.exit(1);
+}
+
+// Also fail if the mapping has slugs not on disk (typos in the mapping).
+const onDisk = new Set(files.map((f) => f.replace(/\.md$/, "")));
+const orphans = Object.keys(SCOPE_MAP).filter((s) => !onDisk.has(s));
+if (orphans.length > 0) {
+  console.error(`\nERROR: SCOPE_MAP entries with no matching file:`);
+  for (const slug of orphans) console.error(`  - ${slug}`);
+  process.exit(1);
+}
+
+console.log(`Backfill complete:`);
+console.log(`  touched: ${touched}`);
+console.log(`  skipped (already had principleRingScope): ${skipped}`);
+console.log(`  already-scoped (new in PR #1081): ${alreadyScoped}`);
+console.log(`  total files: ${files.length}`);


### PR DESCRIPTION
## Summary

Backfill slice (3 of 3) implementing the ring-scope assignments from spec [`2026-05-24-founder-kernel-evolution-discipline-design.md`](docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md) §7. Depends on [PR #1087](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1087) (Slice 1, merged) which shipped the schema column + lint validator.

After this PR, every principle in the kernel carries explicit `principleRingScope`. The lint detector `principle-ring-scope-unknown` validates each value on every ingest; `principle-ring-scope-overuse` tracks toward the 30% universal-ring discipline (we sit at 25.8% — under the bar).

## Final distribution

62 total principles (58 backfilled + 4 from PR #1081):

| Scope | Count | % |
|---|---|---|
| universal-ring (alone) | 16 | 25.8% |
| ring-1-coworker (with/without ring-2) | 13 | 21.0% |
| ring-2-workflow (alone) | 15 | 24.2% |
| ring-2 + ring-3 | 2 | 3.2% |
| ring-2 + ring-4 | 7 | 11.3% |
| ring-3-archetype (alone or with ring-4) | 4 | 6.5% |
| ring-4-sandbox-prod (alone) | 2 | 3.2% |
| external-coordination | 0 | 0% |
| ring-5-hive | 0 | 0% |

Ring-5 / external-coordination are zero today — those rings haven't started spinning yet (per the Reduction Gear spec PR #1075). Future principles surfacing as the hive federation lands will populate them.

## Divergence from spec §7 first-pass

Spec §7's recommendation tagged ~28 principles `universal-ring` (48%), which would have triggered the lint warn on every one. Tightened during execution to honor the spec's own §4.2 narrowest-applicable-default rule:

- **Engineering-flow rules** (PR / commit / worktree / branch / DCO / uncommitted-mention / orchestrator-worker) → `ring-2-workflow` only. These bind code work, not finance/storefront coworker work.
- **Identity / data-model rules** (`organization-canonical-identity`, `principal-convergence`, `one-data-model`) → `ring-3-archetype` (and `ring-4-sandbox-prod` for `one-data-model`) instead of universal-ring.
- **Architecture commandments** that genuinely bind every ring (`architecture-over-shortcuts`, `never-fabricate`, `no-assumptions`, `research-and-use-standards`, `single-source-of-truth`, `verify-substrate-before-proposing-new`, etc.) kept at `universal-ring`.

The merged spec §7 table stays as the first-pass recommendation; the commit message and this PR body capture the execution divergence for future readers.

## Mechanism

[`scripts/one-shot/backfill-principle-ring-scope.mjs`](scripts/one-shot/backfill-principle-ring-scope.mjs) carries the full mapping. It inserts `principleRingScope:` block before the `principleConsumerArchetype:` line in each frontmatter. The script is idempotent (skips files already carrying the field) and fails loud on mapping vs. file-system slug mismatches (no silent skip — honors `make-silent-failures-observable`).

## Retirement candidate (deferred)

[`keep-root-clone-as-merge-worktree`](docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md) was flagged in spec §7 as a retirement candidate (superseded by `worktree-per-session` + `worktree-base-origin-main`). **NOT retired in this PR** — that decision needs operator confirmation. Tagged `ring-2-workflow` as a regular backfill so it doesn't sit in limbo.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts` | 46 passed (incl. the founder-kernel walker test that exercises `extractPrinciplePayload` on every file) |
| `grep -l 'universal-ring' docs/founder-kernel/wiki/principles/*.md \| wc -l` | 16 / 62 = 25.8% (under 30% threshold) |
| All 58 modified files compile under the seed walker | Yes (no validation throws) |

## Out of scope

- **Slice 2** (recall + decide retrieval extension to filter by ring scope) — separate follow-up PR
- Retirement of `keep-root-clone-as-merge-worktree` — deferred to operator confirmation
- Further tightening of additional principles below universal-ring — captured here as backfill snapshot; future cleanup BIs can iterate

## Standing rules honored

- DCO signed
- Branched off `origin/main`, scoped commit via explicit paths
- Pre-commit typecheck hook: no TS files staged, skipped
- Overlap sweep: PR #1089 (transcript snapshot) is unrelated; no conflict
- Make-silent-failures-observable: backfill script fails loud on slug mismatches (mapping vs. disk) — no silent skip
- Schema-honesty: each principle's ring scope reflects what the principle actually binds today, not what it might cover in some future ring

Part of BI-4AA1074B (large effort, 3 PRs). Slice 1 (PR #1087) merged. Slice 2 (retrieval extension) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)