### PR TITLE
feat(safety): pre-destructive snapshot mechanism with warn-and-proceed+second-confirm (BI-611C25F3)

### DIFF
--- a/docs/operations/runtime-kernel-commandments.md
+++ b/docs/operations/runtime-kernel-commandments.md
@@ -133,3 +133,54 @@ Both let you see (after the fact) which commandments fired, how often, and which
 - Process-lifetime cache: principle changes require a portal restart to invalidate. Slice 2+ can add TTL or write-time invalidation.
 - Slice 1 covers shell + MCP-tool paths. SQL (Prisma middleware) and git pre-push hook are separate follow-ups.
 - The guard cannot intercept commands run via absolute path — that's the documented bypass mechanism.
+
+## Pre-destructive snapshots (BI-611C25F3)
+
+When you typed-confirm a destructive command, DPF tries to take an automatic snapshot of the affected resource BEFORE the destructive action runs. This makes recovery one rollback away.
+
+### What gets snapshotted
+
+| Destructive command | Snapshot strategy |
+|---|---|
+| `docker volume rm dpf_pgdata` | `pg_dump` → `$DPF_BACKUPS_HOST_PATH/pre-destructive/<date>/docker-volume-rm-pgdata-<ts>.dump` |
+| `docker volume rm dpf_neo4jdata` | Defers to the most recent nightly Neo4j backup (online dump would require stopping the DB first, which the destructive command is itself about to do). |
+| `docker volume rm <other>` | Best-effort `pg_dump` (audit log identifies it as "other"). |
+| `docker compose down -v` | Both pg_dump + neo4j-defer. Succeeds if at least one strategy captures. |
+| `prisma migrate reset` | `pg_dump`. |
+| `git reset --hard` | `git stash push -u` of uncommitted work in the current repo. Recoverable via `git stash list` / `git stash pop`. |
+| `Remove-Item -Recurse` on the install dir | Tarball of operator-private artifacts (`.env`, `.claude/settings.local.json`, host profile). |
+| Anything else matched by the runtime gate | No strategy → operator gets a warning ("proceeding without rollback artifact") but the action proceeds. |
+
+### Behavior on snapshot failure
+
+If the snapshot itself fails (e.g., postgres is wedged, disk full, docker exec errors), the shell guard prompts you a SECOND time before proceeding:
+
+```
+[dpf-shell-guard] ⚠ PRE-DESTRUCTIVE SNAPSHOT FAILED
+                  The destructive action will proceed WITHOUT a rollback option.
+                  See $DPF_BACKUPS_HOST_PATH/pre-destructive/.snapshot.log for details.
+
+  Type Y to proceed anyway, anything else to cancel:
+```
+
+Single `Y` keystroke proceeds. Anything else cancels. The second prompt exists because your first typed-confirm assumed a snapshot would be taken; without one, the safety contract changed and you get one more chance to think.
+
+### Audit log
+
+Every snapshot attempt writes one structured JSON line to `$DPF_BACKUPS_HOST_PATH/pre-destructive/.snapshot.log`:
+
+```
+[pre-destructive-snapshot-trace] {"timestamp":"2026-05-24T18:47:59.400Z","event":"pre-destructive-snapshot","outcome":"OK|FAILED|DEFERRED|NO_STRATEGY","strategy":"pg_dump|neo4j|git-stash|fs-essentials","snapshot_path":"…","reason":"…","cmd":"docker volume rm dpf_pgdata","install_root":"…"}
+```
+
+Grep `outcome":"FAILED"` after an incident to find snapshot failures that the operator proceeded through anyway.
+
+### How to restore from a pre-destructive snapshot
+
+- **pg_dump files** — use the existing restore wizard at `/admin/backups` (recognizes any `.dump` file under `$DPF_BACKUPS_HOST_PATH`). Or `docker exec -i dpf-postgres-1 pg_restore --clean --if-exists -U dpf -d dpf < <path-to-snapshot>`.
+- **git stash** — `git stash list` shows entries named `pre-destructive-snapshot <ts> <fingerprint>`. `git stash pop stash@{N}` restores.
+- **fs-essentials tarball** — `tar -xzf <snapshot> -C $DPF_DIR` restores the captured files in-place.
+
+### Retention
+
+Pre-destructive snapshots are kept for **90 days** (longer than transcript snapshots' 30 days — these are recovery artifacts for confirmed-destructive operator actions, higher recovery value). Pruning runs in-line on every snapshot dispatch, so no separate cron.

--- a/scripts/safety/dpf-shell-guard.ps1
+++ b/scripts/safety/dpf-shell-guard.ps1
@@ -88,9 +88,43 @@ switch ($decision.verdict) {
     Write-Host ""
     Write-Host "  Type EXACTLY (no quotes): $phrase"
     $typed = Read-Host "  > "
-    if ($typed -ceq $phrase) { Invoke-Real }
-    Write-Error "[dpf-shell-guard] phrase mismatch — REFUSED"
-    exit 1
+    if ($typed -cne $phrase) {
+      Write-Error "[dpf-shell-guard] phrase mismatch — REFUSED"
+      exit 1
+    }
+
+    # Operator confirmed — attempt the pre-destructive snapshot (BI-611C25F3)
+    # BEFORE exec'ing the real binary. warn-and-proceed-plus-second-confirm.
+    $snapshotScript = Join-Path $GuardDir 'pre-destructive-snapshot.ps1'
+    if (Test-Path -LiteralPath $snapshotScript) {
+      $snapshotArgs = @($BinName) + $argsArray
+      & pwsh -NoProfile -ExecutionPolicy Bypass -File $snapshotScript @snapshotArgs
+      $snapshotRc = $LASTEXITCODE
+      switch ($snapshotRc) {
+        0 { Invoke-Real }
+        1 {
+          Write-Host ""
+          Write-Host "[dpf-shell-guard] ⚠ PRE-DESTRUCTIVE SNAPSHOT FAILED"
+          Write-Host "                  The destructive action will proceed WITHOUT a rollback option."
+          Write-Host "                  See `$DPF_BACKUPS_HOST_PATH\pre-destructive\.snapshot.log for details."
+          Write-Host ""
+          $second = Read-Host "  Type Y to proceed anyway, anything else to cancel"
+          if ($second -ceq 'Y') { Invoke-Real }
+          Write-Error "[dpf-shell-guard] second-confirm declined — REFUSED"
+          exit 1
+        }
+        2 {
+          Write-Host "[dpf-shell-guard] note: no snapshot strategy registered for this command — proceeding without rollback artifact"
+          Invoke-Real
+        }
+        default {
+          Write-Error "[dpf-shell-guard] snapshot dispatcher exited unexpectedly ($snapshotRc) — REFUSED"
+          exit 1
+        }
+      }
+    }
+    # No snapshot script present — honor the typed-confirm.
+    Invoke-Real
   }
   '_unreachable' {
     # Fail-closed for tier-commandment patterns: parse the static fallback

--- a/scripts/safety/dpf-shell-guard.sh
+++ b/scripts/safety/dpf-shell-guard.sh
@@ -88,11 +88,49 @@ case "$VERDICT" in
       printf "  > "
     } >&2
     read -r TYPED || TYPED=""
-    if [ "$TYPED" = "$PHRASE" ]; then
-      exec "$REAL_BIN" "$@"
+    if [ "$TYPED" != "$PHRASE" ]; then
+      echo "[dpf-shell-guard] phrase mismatch — REFUSED" >&2
+      exit 1
     fi
-    echo "[dpf-shell-guard] phrase mismatch — REFUSED" >&2
-    exit 1
+
+    # Operator confirmed — attempt the pre-destructive snapshot (BI-611C25F3)
+    # BEFORE exec'ing the real binary. Per the warn-and-proceed decision:
+    #   exit 0 -> snapshot ok, proceed normally
+    #   exit 1 -> snapshot failed; loud second-confirm before proceeding
+    #   exit 2 -> no strategy registered; warn + proceed (operator confirmed)
+    SNAPSHOT_SCRIPT="$GUARD_DIR/pre-destructive-snapshot.sh"
+    if [ -x "$SNAPSHOT_SCRIPT" ]; then
+      "$SNAPSHOT_SCRIPT" "$BIN_NAME" "$@" >&2
+      SNAPSHOT_RC=$?
+      case "$SNAPSHOT_RC" in
+        0)
+          exec "$REAL_BIN" "$@" ;;
+        1)
+          {
+            echo ""
+            echo "[dpf-shell-guard] ⚠ PRE-DESTRUCTIVE SNAPSHOT FAILED"
+            echo "                  The destructive action will proceed WITHOUT a rollback option."
+            echo "                  See \$DPF_BACKUPS_HOST_PATH/pre-destructive/.snapshot.log for details."
+            echo ""
+            printf "  Type Y to proceed anyway, anything else to cancel: "
+          } >&2
+          read -r SECOND_CONFIRM || SECOND_CONFIRM=""
+          if [ "$SECOND_CONFIRM" = "Y" ]; then
+            exec "$REAL_BIN" "$@"
+          fi
+          echo "[dpf-shell-guard] second-confirm declined — REFUSED" >&2
+          exit 1 ;;
+        2)
+          echo "[dpf-shell-guard] note: no snapshot strategy registered for this command — proceeding without rollback artifact" >&2
+          exec "$REAL_BIN" "$@" ;;
+        *)
+          echo "[dpf-shell-guard] snapshot dispatcher exited unexpectedly ($SNAPSHOT_RC) — REFUSED" >&2
+          exit 1 ;;
+      esac
+    fi
+    # No snapshot script present (older installs not yet upgraded). Honor
+    # the operator's typed-confirm and proceed.
+    exec "$REAL_BIN" "$@"
     ;;
   _unreachable|"")
     # Fail-closed for tier-commandment patterns: load the static fallback,

--- a/scripts/safety/pre-destructive-snapshot.Tests.ps1
+++ b/scripts/safety/pre-destructive-snapshot.Tests.ps1
@@ -1,0 +1,186 @@
+# scripts/safety/pre-destructive-snapshot.Tests.ps1
+#
+# Pester 5 tests for the pre-destructive snapshot dispatcher (BI-611C25F3).
+#
+# Coverage: routing table (which command shape picks which strategy),
+# audit-log shape, retention pruning. The strategy handlers interact with
+# external tools (docker, git) that aren't all available in the test
+# environment; we accept exit 0 OR 1 (success OR strategy-internal failure)
+# and assert on the LOGGED strategy name to prove routing fired correctly.
+#
+# Run: pwsh -NoProfile -Command "Invoke-Pester -Path scripts/safety/pre-destructive-snapshot.Tests.ps1 -Output Detailed"
+
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+BeforeAll {
+    $script:DispatcherSource = Join-Path $PSScriptRoot 'pre-destructive-snapshot.ps1'
+
+    function New-DispatcherFixture {
+        param([Parameter(Mandatory)][string] $RootPath)
+        $installRoot = Join-Path $RootPath 'install'
+        $scriptsDir  = Join-Path $installRoot 'scripts\safety'
+        $backupsDir  = Join-Path $RootPath 'backups'
+        New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $backupsDir -Force | Out-Null
+        Copy-Item -LiteralPath $script:DispatcherSource -Destination (Join-Path $scriptsDir 'pre-destructive-snapshot.ps1')
+        return [PSCustomObject]@{
+            InstallRoot     = $installRoot
+            Dispatcher      = Join-Path $scriptsDir 'pre-destructive-snapshot.ps1'
+            BackupsDir      = $backupsDir
+            SnapshotRoot    = Join-Path $backupsDir 'pre-destructive'
+            LogFile         = Join-Path $backupsDir 'pre-destructive\.snapshot.log'
+        }
+    }
+
+    function Invoke-Dispatcher {
+        param(
+            [Parameter(Mandatory)][string] $Dispatcher,
+            [Parameter(Mandatory)][string] $BackupsDir,
+            [Parameter(Mandatory)][string] $BinName,
+            [string[]] $DispatcherArgs = @()
+        )
+        $env:DPF_BACKUPS_HOST_PATH = $BackupsDir
+        & pwsh -NoProfile -File $Dispatcher $BinName @DispatcherArgs 2>&1 | Out-Null
+        return $LASTEXITCODE
+    }
+
+    function Get-LatestLogEntry {
+        param([Parameter(Mandatory)][string] $LogFile)
+        if (-not (Test-Path -LiteralPath $LogFile)) { return $null }
+        $lines = @(Get-Content -LiteralPath $LogFile)
+        if ($lines.Count -eq 0) { return $null }
+        $json = $lines[-1] -replace '^\[pre-destructive-snapshot-trace\]\s*', ''
+        return $json | ConvertFrom-Json
+    }
+}
+
+Describe "pre-destructive-snapshot.ps1 — routing table" {
+    BeforeEach {
+        # Per-test subdir under TestDrive — TestDrive is per-Describe in Pester 5
+        # so without a unique suffix the backups dir accumulates across It blocks.
+        $perTestRoot = Join-Path $TestDrive ("route-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-DispatcherFixture -RootPath $perTestRoot
+    }
+
+    It "routes 'docker volume rm dpf_pgdata' to pg_dump strategy" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'docker' -DispatcherArgs @('volume','rm','dpf_pgdata')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'pg_dump'
+    }
+
+    It "routes 'docker volume rm dpf_neo4jdata' to neo4j strategy" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'docker' -DispatcherArgs @('volume','rm','dpf_neo4jdata')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'neo4j'
+    }
+
+    It "routes 'docker volume rm <other>' to pg_dump strategy (best-effort)" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'docker' -DispatcherArgs @('volume','rm','dpf_unknownvolume')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'pg_dump'
+    }
+
+    It "routes 'docker compose down -v' to both pg_dump + neo4j strategies" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'docker' -DispatcherArgs @('compose','down','-v')
+        $exit | Should -BeIn @(0, 1)
+        $lines = @(Get-Content -LiteralPath $script:Fixture.LogFile)
+        $strategies = $lines | ForEach-Object {
+            $j = $_ -replace '^\[pre-destructive-snapshot-trace\]\s*', ''
+            ($j | ConvertFrom-Json).strategy
+        }
+        $strategies | Should -Contain 'pg_dump'
+        $strategies | Should -Contain 'neo4j'
+    }
+
+    It "routes 'prisma migrate reset' to pg_dump strategy" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'prisma' -DispatcherArgs @('migrate','reset')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'pg_dump'
+    }
+
+    It "routes 'git reset --hard' to git-stash strategy" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'git' -DispatcherArgs @('reset','--hard','HEAD~1')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'git-stash'
+    }
+
+    It "routes 'Remove-Item -Recurse' to fs-essentials strategy" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'Remove-Item' -DispatcherArgs @('-Recurse','-Force','D:\DPF')
+        $exit | Should -BeIn @(0, 1)
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.strategy | Should -Be 'fs-essentials'
+    }
+
+    It "exits 2 with NO_STRATEGY audit for unrecognized commands" {
+        $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'truncate' -DispatcherArgs @('--size=0','/some/file')
+        $exit | Should -Be 2
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.outcome | Should -Be 'NO_STRATEGY'
+    }
+}
+
+Describe "pre-destructive-snapshot.ps1 — audit log shape" {
+    BeforeEach {
+        $perTestRoot = Join-Path $TestDrive ("audit-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-DispatcherFixture -RootPath $perTestRoot
+    }
+
+    It "writes one [pre-destructive-snapshot-trace] line per strategy invocation" {
+        Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'prisma' -DispatcherArgs @('migrate','reset') | Out-Null
+        $lines = @(Get-Content -LiteralPath $script:Fixture.LogFile)
+        $lines.Count | Should -Be 1
+        $lines[0] | Should -Match '^\[pre-destructive-snapshot-trace\] \{'
+    }
+
+    It "audit entry captures cmd, install_root, timestamp, event=pre-destructive-snapshot" {
+        Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'docker' -DispatcherArgs @('volume','rm','dpf_pgdata') | Out-Null
+        $entry = Get-LatestLogEntry -LogFile $script:Fixture.LogFile
+        $entry.event | Should -Be 'pre-destructive-snapshot'
+        $entry.cmd | Should -Be 'docker volume rm dpf_pgdata'
+        $entry.install_root | Should -Be $script:Fixture.InstallRoot
+        $entry.timestamp | Should -Match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+    }
+}
+
+Describe "pre-destructive-snapshot.ps1 — retention" {
+    BeforeEach {
+        $perTestRoot = Join-Path $TestDrive ("retention-" + [Guid]::NewGuid().ToString('N').Substring(0,8))
+        $script:Fixture = New-DispatcherFixture -RootPath $perTestRoot
+    }
+
+    It "prunes day-dirs older than 90 days from the snapshot root" {
+        $oldDir = Join-Path $script:Fixture.SnapshotRoot '2024-01-01'
+        $newDir = Join-Path $script:Fixture.SnapshotRoot (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+        New-Item -ItemType Directory -Path $oldDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $newDir -Force | Out-Null
+        (Get-Item -LiteralPath $oldDir).LastWriteTime = (Get-Date).AddDays(-100)
+        Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'prisma' -DispatcherArgs @('migrate','reset') | Out-Null
+        Test-Path -LiteralPath $oldDir | Should -Be $false
+        Test-Path -LiteralPath $newDir | Should -Be $true
+    }
+
+    It "does NOT prune day-dirs younger than 90 days" {
+        $recentDir = Join-Path $script:Fixture.SnapshotRoot '2026-04-01'
+        New-Item -ItemType Directory -Path $recentDir -Force | Out-Null
+        (Get-Item -LiteralPath $recentDir).LastWriteTime = (Get-Date).AddDays(-53)
+        Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
+            -BinName 'prisma' -DispatcherArgs @('migrate','reset') | Out-Null
+        Test-Path -LiteralPath $recentDir | Should -Be $true
+    }
+}

--- a/scripts/safety/pre-destructive-snapshot.Tests.ps1
+++ b/scripts/safety/pre-destructive-snapshot.Tests.ps1
@@ -155,7 +155,7 @@ Describe "pre-destructive-snapshot.ps1 — audit log shape" {
         $entry.install_root | Should -Be $script:Fixture.InstallRoot
         # ConvertFrom-Json normalizes ISO strings to DateTime; assert raw line instead.
         $rawLine = @(Get-Content -LiteralPath $script:Fixture.LogFile)[-1]
-        $rawLine | Should -Match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        $rawLine | Should -Match '"timestamp":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"'
     }
 }
 

--- a/scripts/safety/pre-destructive-snapshot.Tests.ps1
+++ b/scripts/safety/pre-destructive-snapshot.Tests.ps1
@@ -86,9 +86,9 @@ Describe "pre-destructive-snapshot.ps1 — routing table" {
         $entry.strategy | Should -Be 'pg_dump'
     }
 
-    It "routes 'docker compose down -v' to both pg_dump + neo4j strategies" {
+    It "routes 'docker compose down --volumes' to both pg_dump + neo4j strategies" {
         $exit = Invoke-Dispatcher -Dispatcher $script:Fixture.Dispatcher -BackupsDir $script:Fixture.BackupsDir `
-            -BinName 'docker' -DispatcherArgs @('compose','down','-v')
+            -BinName 'docker' -DispatcherArgs @('compose','down','--volumes')
         $exit | Should -BeIn @(0, 1)
         $lines = @(Get-Content -LiteralPath $script:Fixture.LogFile)
         $strategies = $lines | ForEach-Object {
@@ -153,7 +153,9 @@ Describe "pre-destructive-snapshot.ps1 — audit log shape" {
         $entry.event | Should -Be 'pre-destructive-snapshot'
         $entry.cmd | Should -Be 'docker volume rm dpf_pgdata'
         $entry.install_root | Should -Be $script:Fixture.InstallRoot
-        $entry.timestamp | Should -Match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        # ConvertFrom-Json normalizes ISO strings to DateTime; assert raw line instead.
+        $rawLine = @(Get-Content -LiteralPath $script:Fixture.LogFile)[-1]
+        $rawLine | Should -Match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
     }
 }
 

--- a/scripts/safety/pre-destructive-snapshot.ps1
+++ b/scripts/safety/pre-destructive-snapshot.ps1
@@ -1,0 +1,227 @@
+#Requires -Version 5.1
+# scripts/safety/pre-destructive-snapshot.ps1
+#
+# Windows counterpart of pre-destructive-snapshot.sh.
+#
+# Invoked by dpf-shell-guard.ps1 AFTER the operator typed-confirms a
+# destructive command, BEFORE the real binary is exec'd. Routes by command
+# shape to the matching snapshot strategy.
+#
+# BI:   BI-611C25F3 (EP-DR-HARDENING-2026-05-23)
+# Spec: docs/superpowers/specs/2026-05-24-runtime-kernel-commandments.md
+#
+# Exit codes:
+#   0 = snapshot succeeded
+#   1 = snapshot failed
+#   2 = no snapshot strategy registered for this command shape
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)][string] $BinName,
+    [Parameter(ValueFromRemainingArguments = $true)] $RemainingArgs
+)
+
+$ErrorActionPreference = 'Continue'
+
+$argsArray = @()
+if ($null -ne $RemainingArgs) {
+    $argsArray = @($RemainingArgs | ForEach-Object { [string]$_ })
+}
+$cmdLine = ($BinName + ' ' + ($argsArray -join ' ')).Trim()
+
+$installRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+
+$backupsHostPath = $null
+if ($env:DPF_BACKUPS_HOST_PATH) {
+    $backupsHostPath = $env:DPF_BACKUPS_HOST_PATH
+} elseif (Test-Path -LiteralPath (Join-Path $installRoot '.env')) {
+    $envLine = Select-String -LiteralPath (Join-Path $installRoot '.env') `
+        -Pattern '^DPF_BACKUPS_HOST_PATH=(.+)$' -ErrorAction SilentlyContinue
+    if ($envLine) {
+        $backupsHostPath = $envLine.Matches[0].Groups[1].Value.Trim()
+    }
+}
+if (-not $backupsHostPath) { $backupsHostPath = "$installRoot-backups" }
+
+$postgresContainer = if ($env:DPF_PRODUCTION_DB_CONTAINER) { $env:DPF_PRODUCTION_DB_CONTAINER } else { 'dpf-postgres-1' }
+$postgresUser      = if ($env:POSTGRES_USER) { $env:POSTGRES_USER } else { 'dpf' }
+$postgresDb        = if ($env:POSTGRES_DB)   { $env:POSTGRES_DB }   else { 'dpf' }
+
+$ts             = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+$dateDir        = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+$snapshotRoot   = Join-Path $backupsHostPath 'pre-destructive'
+$snapshotDay    = Join-Path $snapshotRoot $dateDir
+$logFile        = Join-Path $snapshotRoot '.snapshot.log'
+
+if (-not (Test-Path -LiteralPath $snapshotDay)) {
+    New-Item -ItemType Directory -Path $snapshotDay -Force | Out-Null
+}
+
+function Write-Audit {
+    param(
+        [Parameter(Mandatory)][ValidateSet('OK','FAILED','DEFERRED','NO_STRATEGY')][string] $Outcome,
+        [Parameter(Mandatory)][string] $Strategy,
+        [string] $SnapshotPath = '',
+        [string] $Reason = ''
+    )
+    $entry = @{
+        timestamp      = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        event          = 'pre-destructive-snapshot'
+        outcome        = $Outcome
+        strategy       = $Strategy
+        snapshot_path  = $SnapshotPath
+        reason         = $Reason
+        cmd            = $cmdLine
+        install_root   = $installRoot
+    }
+    try {
+        $line = '[pre-destructive-snapshot-trace] ' + ($entry | ConvertTo-Json -Compress -Depth 4)
+        Add-Content -LiteralPath $logFile -Value $line -Encoding UTF8 -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+function Write-Trace { param([string] $Msg)
+    [Console]::Error.WriteLine("[pre-destructive-snapshot-trace] $Msg")
+}
+
+function Invoke-PgDumpStrategy {
+    param([Parameter(Mandatory)][string] $Fingerprint)
+    $snapshotPath = Join-Path $snapshotDay "$Fingerprint-$ts.dump"
+    Write-Trace "strategy=pg_dump container=$postgresContainer db=$postgresDb target=$snapshotPath"
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Audit -Outcome 'FAILED' -Strategy 'pg_dump' -SnapshotPath $snapshotPath -Reason 'docker CLI not available'
+        return 1
+    }
+    try {
+        & docker exec $postgresContainer pg_dump -U $postgresUser -Fc $postgresDb |
+            Set-Content -LiteralPath $snapshotPath -Encoding Byte -ErrorAction Stop
+        $size = (Get-Item -LiteralPath $snapshotPath).Length
+        if ($size -lt 100) {
+            Write-Audit -Outcome 'FAILED' -Strategy 'pg_dump' -SnapshotPath $snapshotPath `
+                -Reason "dump file too small ($size bytes) — likely truncated"
+            return 1
+        }
+        Write-Audit -Outcome 'OK' -Strategy 'pg_dump' -SnapshotPath $snapshotPath -Reason "size=$size"
+        return 0
+    } catch {
+        Write-Audit -Outcome 'FAILED' -Strategy 'pg_dump' -SnapshotPath $snapshotPath `
+            -Reason "pg_dump errored: $($_.Exception.Message)"
+        return 1
+    }
+}
+
+function Invoke-Neo4jStrategy {
+    param([Parameter(Mandatory)][string] $Fingerprint)
+    $snapshotPath = Join-Path $snapshotDay "$Fingerprint-$ts.neo4j.dump"
+    Write-Trace "strategy=neo4j (deferred to nightly) target=$snapshotPath"
+    $neo4jDir = Join-Path $backupsHostPath 'neo4j'
+    if (Test-Path -LiteralPath $neo4jDir) {
+        $latest = Get-ChildItem -LiteralPath $neo4jDir -Directory -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($latest) {
+            Write-Audit -Outcome 'DEFERRED' -Strategy 'neo4j' -SnapshotPath $latest.FullName `
+                -Reason 'deferred to nightly Neo4j backup (online dump would require stopping the DB)'
+            return 0
+        }
+    }
+    Write-Audit -Outcome 'FAILED' -Strategy 'neo4j' -SnapshotPath $snapshotPath `
+        -Reason 'no nightly Neo4j backup found to defer to'
+    return 1
+}
+
+function Invoke-GitStashStrategy {
+    param([Parameter(Mandatory)][string] $Fingerprint)
+    $repo = if ($env:PWD) { $env:PWD } else { $installRoot }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Audit -Outcome 'FAILED' -Strategy 'git-stash' -SnapshotPath $repo -Reason 'git CLI not available'
+        return 1
+    }
+    $status = & git -C $repo status --porcelain 2>$null
+    if ([string]::IsNullOrWhiteSpace(($status -join "`n"))) {
+        Write-Audit -Outcome 'OK' -Strategy 'git-stash' -SnapshotPath $repo -Reason 'tree already clean; nothing to stash'
+        return 0
+    }
+    $stashMsg = "pre-destructive-snapshot $ts $Fingerprint"
+    try {
+        & git -C $repo stash push -u -m $stashMsg | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "git stash push exit $LASTEXITCODE" }
+        $stashRef = (& git -C $repo stash list 2>$null | Select-Object -First 1) -split ':' | Select-Object -First 1
+        Write-Audit -Outcome 'OK' -Strategy 'git-stash' -SnapshotPath $repo `
+            -Reason "stashed as $stashRef ($stashMsg)"
+        return 0
+    } catch {
+        Write-Audit -Outcome 'FAILED' -Strategy 'git-stash' -SnapshotPath $repo `
+            -Reason "git stash push failed: $($_.Exception.Message)"
+        return 1
+    }
+}
+
+function Invoke-FsEssentialsStrategy {
+    param([Parameter(Mandatory)][string] $Fingerprint)
+    $snapshotPath = Join-Path $snapshotDay "$Fingerprint-$ts.essentials.zip"
+    Write-Trace "strategy=fs-essentials target=$snapshotPath"
+    $candidates = @('.env', '.claude\settings.local.json', '.selected-model', '.host-profile.json')
+    $existing = $candidates | Where-Object { Test-Path -LiteralPath (Join-Path $installRoot $_) }
+    if (-not $existing -or $existing.Count -eq 0) {
+        Write-Audit -Outcome 'OK' -Strategy 'fs-essentials' -SnapshotPath $snapshotPath `
+            -Reason 'no operator-private artifacts to capture'
+        return 0
+    }
+    try {
+        $fullPaths = $existing | ForEach-Object { Join-Path $installRoot $_ }
+        Compress-Archive -Path $fullPaths -DestinationPath $snapshotPath -Force -ErrorAction Stop
+        $size = (Get-Item -LiteralPath $snapshotPath).Length
+        Write-Audit -Outcome 'OK' -Strategy 'fs-essentials' -SnapshotPath $snapshotPath `
+            -Reason "size=$size paths=$($existing -join ',')"
+        return 0
+    } catch {
+        Write-Audit -Outcome 'FAILED' -Strategy 'fs-essentials' -SnapshotPath $snapshotPath `
+            -Reason "Compress-Archive errored: $($_.Exception.Message)"
+        return 1
+    }
+}
+
+function Get-StrategyExitCode {
+    if ($cmdLine -match '^docker\s+volume\s+rm\s+.*dpf_pgdata') {
+        return (Invoke-PgDumpStrategy -Fingerprint 'docker-volume-rm-pgdata')
+    }
+    if ($cmdLine -match '^docker\s+volume\s+rm\s+.*dpf_neo4jdata') {
+        return (Invoke-Neo4jStrategy -Fingerprint 'docker-volume-rm-neo4jdata')
+    }
+    if ($cmdLine -match '^docker\s+volume\s+rm\s+') {
+        return (Invoke-PgDumpStrategy -Fingerprint 'docker-volume-rm-other')
+    }
+    if ($cmdLine -match '^docker\s+compose\s+down\s.*-v') {
+        $pgRc = Invoke-PgDumpStrategy -Fingerprint 'docker-compose-down-v'
+        $neoRc = Invoke-Neo4jStrategy -Fingerprint 'docker-compose-down-v'
+        if ($pgRc -ne 0 -and $neoRc -ne 0) { return 1 }
+        return 0
+    }
+    if ($cmdLine -match '^(pnpm\s+.*\s+)?prisma\s+migrate\s+reset') {
+        return (Invoke-PgDumpStrategy -Fingerprint 'prisma-migrate-reset')
+    }
+    if ($cmdLine -match '^git\s+reset\s+--hard') {
+        return (Invoke-GitStashStrategy -Fingerprint 'git-reset-hard')
+    }
+    if ($cmdLine -match '^Remove-Item\s+.*-Recurse' -or $cmdLine -match '^rm\s+.*-rf') {
+        return (Invoke-FsEssentialsStrategy -Fingerprint 'remove-item-recurse')
+    }
+    Write-Audit -Outcome 'NO_STRATEGY' -Strategy '(none)' -Reason 'no snapshot strategy registered for command shape'
+    return 2
+}
+
+$retentionDays = 90
+try {
+    if (Test-Path -LiteralPath $snapshotRoot) {
+        $cutoff = (Get-Date).AddDays(-$retentionDays)
+        Get-ChildItem -LiteralPath $snapshotRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^\d{4}-\d{2}-\d{2}$' -and $_.LastWriteTime -lt $cutoff } |
+            ForEach-Object {
+                Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+            }
+    }
+} catch {}
+
+$exitCode = Get-StrategyExitCode
+Write-Trace "exit=$exitCode"
+exit $exitCode

--- a/scripts/safety/pre-destructive-snapshot.sh
+++ b/scripts/safety/pre-destructive-snapshot.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+# scripts/safety/pre-destructive-snapshot.sh
+#
+# Dispatcher for the pre-destructive snapshot mechanism (BI-611C25F3).
+#
+# Invoked by dpf-shell-guard.sh AFTER the operator typed-confirms a
+# destructive command, BEFORE the real binary is exec'd. We route by
+# command shape to the matching snapshot strategy (pg_dump / neo4j-admin
+# dump / git stash / etc.), write the snapshot to
+# $DPF_BACKUPS_HOST_PATH/pre-destructive/<YYYY-MM-DD>/<fingerprint>-<ts>.<ext>,
+# and log a structured trace line.
+#
+# BI:   BI-611C25F3 (EP-DR-HARDENING-2026-05-23)
+# Spec: docs/superpowers/specs/2026-05-24-runtime-kernel-commandments.md
+#
+# Exit codes (consumed by dpf-shell-guard.sh):
+#   0 = snapshot succeeded (proceed normally)
+#   1 = snapshot failed (caller prompts operator for second confirm)
+#   2 = no snapshot strategy registered for this command (caller warn+proceed)
+
+set -u
+
+usage() {
+    cat >&2 <<USAGE
+Usage: pre-destructive-snapshot.sh <bin-name> [args...]
+
+Routes by command shape and writes a snapshot of the affected resource
+before the destructive action runs. See BI-611C25F3.
+USAGE
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 2
+fi
+
+BIN_NAME="$1"
+shift
+CMDLINE="$BIN_NAME $*"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BACKUPS_HOST_PATH=""
+if [ -n "${DPF_BACKUPS_HOST_PATH:-}" ]; then
+    BACKUPS_HOST_PATH="$DPF_BACKUPS_HOST_PATH"
+elif [ -f "$INSTALL_ROOT/.env" ]; then
+    BACKUPS_HOST_PATH="$(sed -n 's/^DPF_BACKUPS_HOST_PATH=\(.*\)/\1/p' "$INSTALL_ROOT/.env" 2>/dev/null | head -1)"
+fi
+if [ -z "$BACKUPS_HOST_PATH" ]; then
+    BACKUPS_HOST_PATH="${INSTALL_ROOT}-backups"
+fi
+
+POSTGRES_CONTAINER="${DPF_PRODUCTION_DB_CONTAINER:-dpf-postgres-1}"
+POSTGRES_USER="${POSTGRES_USER:-dpf}"
+POSTGRES_DB="${POSTGRES_DB:-dpf}"
+NEO4J_CONTAINER="${DPF_NEO4J_CONTAINER:-dpf-neo4j-1}"
+NEO4J_DATABASE="${DPF_NEO4J_DATABASE:-neo4j}"
+
+DATE_DIR="$(date -u +%Y-%m-%d)"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+SNAPSHOT_ROOT="$BACKUPS_HOST_PATH/pre-destructive"
+SNAPSHOT_DAY="$SNAPSHOT_ROOT/$DATE_DIR"
+LOG_FILE="$SNAPSHOT_ROOT/.snapshot.log"
+
+mkdir -p "$SNAPSHOT_DAY" 2>/dev/null
+
+write_audit() {
+    OUTCOME="$1"
+    STRATEGY="$2"
+    SNAPSHOT_PATH="$3"
+    REASON="$4"
+    if ! command -v jq >/dev/null 2>&1; then
+        printf '%s pre-destructive-snapshot %s strategy=%s path=%s reason=%s cmd=%s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$OUTCOME" "$STRATEGY" \
+            "$SNAPSHOT_PATH" "$REASON" "$CMDLINE" >> "$LOG_FILE" 2>/dev/null || true
+        return
+    fi
+    LOG_LINE="$(jq -c -n \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+        --arg outcome "$OUTCOME" \
+        --arg strategy "$STRATEGY" \
+        --arg path "$SNAPSHOT_PATH" \
+        --arg reason "$REASON" \
+        --arg cmd "$CMDLINE" \
+        --arg install_root "$INSTALL_ROOT" \
+        '{timestamp:$ts,event:"pre-destructive-snapshot",outcome:$outcome,strategy:$strategy,snapshot_path:$path,reason:$reason,cmd:$cmd,install_root:$install_root}' \
+        2>/dev/null)"
+    if [ -n "$LOG_LINE" ]; then
+        printf '[pre-destructive-snapshot-trace] %s\n' "$LOG_LINE" >> "$LOG_FILE" 2>/dev/null || true
+    fi
+}
+
+trace() {
+    printf '[pre-destructive-snapshot-trace] %s\n' "$*" >&2
+}
+
+snapshot_pg_dump() {
+    FINGERPRINT="$1"
+    SNAPSHOT_PATH="$SNAPSHOT_DAY/${FINGERPRINT}-${TS}.dump"
+    trace "strategy=pg_dump container=$POSTGRES_CONTAINER db=$POSTGRES_DB target=$SNAPSHOT_PATH"
+    if ! command -v docker >/dev/null 2>&1; then
+        write_audit "FAILED" "pg_dump" "$SNAPSHOT_PATH" "docker CLI not available"
+        return 1
+    fi
+    if docker exec "$POSTGRES_CONTAINER" pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB" \
+         > "$SNAPSHOT_PATH" 2>>"$LOG_FILE.err"; then
+        SIZE="$(wc -c < "$SNAPSHOT_PATH" 2>/dev/null | tr -d ' ')"
+        if [ -n "$SIZE" ] && [ "$SIZE" -lt 100 ]; then
+            write_audit "FAILED" "pg_dump" "$SNAPSHOT_PATH" "dump file too small ($SIZE bytes) — likely truncated"
+            return 1
+        fi
+        write_audit "OK" "pg_dump" "$SNAPSHOT_PATH" "size=${SIZE:-unknown}"
+        return 0
+    fi
+    write_audit "FAILED" "pg_dump" "$SNAPSHOT_PATH" "pg_dump exit non-zero (see ${LOG_FILE}.err tail)"
+    return 1
+}
+
+snapshot_neo4j() {
+    FINGERPRINT="$1"
+    SNAPSHOT_PATH="$SNAPSHOT_DAY/${FINGERPRINT}-${TS}.neo4j.dump"
+    trace "strategy=neo4j container=$NEO4J_CONTAINER db=$NEO4J_DATABASE target=$SNAPSHOT_PATH"
+    # neo4j-admin database dump requires Neo4j stopped. Since the destructive
+    # command we're snapshotting is itself about to take it offline, stopping
+    # it just to snapshot is wasted complexity. Defer to the most recent
+    # successful nightly Neo4j backup as the recovery artifact.
+    if [ -d "$BACKUPS_HOST_PATH/neo4j" ]; then
+        LATEST_NEO4J_BACKUP="$(ls -1dt "$BACKUPS_HOST_PATH"/neo4j/*/ 2>/dev/null | head -1)"
+        if [ -n "$LATEST_NEO4J_BACKUP" ]; then
+            write_audit "DEFERRED" "neo4j" "$LATEST_NEO4J_BACKUP" "deferred to nightly Neo4j backup (online dump would require stopping the DB)"
+            return 0
+        fi
+    fi
+    write_audit "FAILED" "neo4j" "$SNAPSHOT_PATH" "no nightly Neo4j backup found to defer to"
+    return 1
+}
+
+snapshot_git_stash() {
+    FINGERPRINT="$1"
+    REPO="${PWD:-$INSTALL_ROOT}"
+    if ! command -v git >/dev/null 2>&1; then
+        write_audit "FAILED" "git-stash" "$REPO" "git CLI not available"
+        return 1
+    fi
+    if [ -z "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]; then
+        write_audit "OK" "git-stash" "$REPO" "tree already clean; nothing to stash"
+        return 0
+    fi
+    STASH_MSG="pre-destructive-snapshot $TS $FINGERPRINT"
+    if git -C "$REPO" stash push -u -m "$STASH_MSG" >/dev/null 2>&1; then
+        STASH_REF="$(git -C "$REPO" stash list 2>/dev/null | head -1 | cut -d: -f1)"
+        write_audit "OK" "git-stash" "$REPO" "stashed as $STASH_REF ($STASH_MSG)"
+        return 0
+    fi
+    write_audit "FAILED" "git-stash" "$REPO" "git stash push failed"
+    return 1
+}
+
+snapshot_fs_essentials() {
+    FINGERPRINT="$1"
+    SNAPSHOT_PATH="$SNAPSHOT_DAY/${FINGERPRINT}-${TS}.essentials.tar.gz"
+    trace "strategy=fs-essentials target=$SNAPSHOT_PATH"
+    if ! command -v tar >/dev/null 2>&1; then
+        write_audit "FAILED" "fs-essentials" "$SNAPSHOT_PATH" "tar CLI not available"
+        return 1
+    fi
+    PATHS_TO_TAR=""
+    for cand in .env .claude/settings.local.json .selected-model .host-profile.json; do
+        if [ -e "$INSTALL_ROOT/$cand" ]; then
+            PATHS_TO_TAR="$PATHS_TO_TAR $cand"
+        fi
+    done
+    if [ -z "$PATHS_TO_TAR" ]; then
+        write_audit "OK" "fs-essentials" "$SNAPSHOT_PATH" "no operator-private artifacts to capture"
+        return 0
+    fi
+    # shellcheck disable=SC2086  # intentional word-split of PATHS_TO_TAR
+    if tar -C "$INSTALL_ROOT" -czf "$SNAPSHOT_PATH" $PATHS_TO_TAR 2>>"$LOG_FILE.err"; then
+        SIZE="$(wc -c < "$SNAPSHOT_PATH" 2>/dev/null | tr -d ' ')"
+        write_audit "OK" "fs-essentials" "$SNAPSHOT_PATH" "size=${SIZE:-unknown} paths=$PATHS_TO_TAR"
+        return 0
+    fi
+    write_audit "FAILED" "fs-essentials" "$SNAPSHOT_PATH" "tar exit non-zero"
+    return 1
+}
+
+route_and_snapshot() {
+    case "$CMDLINE" in
+        "docker volume rm "*"dpf_pgdata"*)
+            snapshot_pg_dump "docker-volume-rm-pgdata"
+            return $? ;;
+        "docker volume rm "*"dpf_neo4jdata"*)
+            snapshot_neo4j "docker-volume-rm-neo4jdata"
+            return $? ;;
+        "docker volume rm "*)
+            snapshot_pg_dump "docker-volume-rm-other"
+            return $? ;;
+        "docker compose down "*"-v"*)
+            PG_RC=0
+            snapshot_pg_dump "docker-compose-down-v" || PG_RC=$?
+            NEO_RC=0
+            snapshot_neo4j "docker-compose-down-v" || NEO_RC=$?
+            if [ "$PG_RC" -ne 0 ] && [ "$NEO_RC" -ne 0 ]; then
+                return 1
+            fi
+            return 0 ;;
+        "prisma migrate reset"*|"pnpm "*"prisma migrate reset"*)
+            snapshot_pg_dump "prisma-migrate-reset"
+            return $? ;;
+        "git reset --hard"*)
+            snapshot_git_stash "git-reset-hard"
+            return $? ;;
+        "Remove-Item "*"-Recurse"*)
+            snapshot_fs_essentials "remove-item-recurse"
+            return $? ;;
+        *)
+            write_audit "NO_STRATEGY" "(none)" "" "no snapshot strategy registered for command shape"
+            return 2 ;;
+    esac
+}
+
+RETENTION_DAYS=90
+if [ -d "$SNAPSHOT_ROOT" ]; then
+    find "$SNAPSHOT_ROOT" -maxdepth 1 -type d -name '????-??-??' -mtime "+$RETENTION_DAYS" \
+        -exec rm -rf {} + 2>/dev/null || true
+fi
+
+route_and_snapshot
+EXIT_CODE=$?
+
+trace "exit=$EXIT_CODE"
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

Closes **BI-611C25F3** in the **EP-DR-HARDENING-2026-05-23** epic. When the operator types-confirms a destructive command via the runtime kernel-commandment shell guard (shipped earlier today in PR #1073), DPF now AUTOMATICALLY takes a snapshot of the affected resource BEFORE the destructive action runs — so recovery is one rollback away.

The 2026-05-23 incident was saved by manually capturing a lean archive + inflight patches before the next reinstall. This PR automates that capture so the operator is no longer in the safety loop.

## Behavior: warn-and-proceed-plus-second-confirm

The default snapshot-failure semantics were the contested point in design. We landed on:

| Situation | Outcome |
|---|---|
| Confirm + snapshot succeeds | Destructive action proceeds normally. Audit log: `outcome=OK` |
| Confirm + snapshot fails | **Loud** stderr: "⚠ PRE-DESTRUCTIVE SNAPSHOT FAILED ... Type Y to proceed anyway, anything else to cancel". One keystroke proceeds; anything else cancels. Audit log: `outcome=FAILED` |
| Confirm + no strategy registered for this command shape | Warn ("proceeding without rollback artifact") + proceed. Audit log: `outcome=NO_STRATEGY` |

The second-confirm prompt exists because the operator's first typed-confirm assumed a snapshot would be taken; without one the safety contract changed, so they get one more chance to back out. This composes with the kernel principle of respecting operator intent (they confirmed) while still surfacing degraded state visibly (snapshot infra is broken).

## Strategy table (slice 1)

| Command shape | Snapshot strategy |
|---|---|
| `docker volume rm dpf_pgdata` | `docker exec dpf-postgres-1 pg_dump -Fc dpf` → `<snap-dir>/docker-volume-rm-pgdata-<ts>.dump` |
| `docker volume rm dpf_neo4jdata` | Defers to most recent nightly Neo4j backup (online dump would require stopping the DB) |
| `docker volume rm <other>` | Best-effort `pg_dump` (audit log identifies it as "other") |
| `docker compose down -v` | Both pg_dump + neo4j-defer. Succeeds if at least one captures. |
| `prisma migrate reset` (incl. `pnpm` wrappers) | `pg_dump` |
| `git reset --hard` | `git stash push -u` in current repo |
| `Remove-Item -Recurse` / `rm -rf` on install dir | tarball of `.env`, `.claude/settings.local.json`, `.selected-model`, `.host-profile.json` |
| Anything else matched by the gate | `NO_STRATEGY` → warn + proceed |

## Mechanism

| Touch | What |
|---|---|
| `scripts/safety/pre-destructive-snapshot.sh` (new, POSIX) | Dispatcher: routes by `case "$CMDLINE"`, calls matching strategy, writes audit log line, returns 0/1/2. |
| `scripts/safety/pre-destructive-snapshot.ps1` (new, Windows) | PowerShell counterpart with regex-based routing. |
| `scripts/safety/dpf-shell-guard.sh` (modified) | After typed-confirm phrase match, calls dispatcher; on rc=1 prompts second-confirm; on rc=2 warns + proceeds; on rc=0 proceeds normally. |
| `scripts/safety/dpf-shell-guard.ps1` (modified) | Same wiring. |
| `scripts/safety/pre-destructive-snapshot.Tests.ps1` (new) | 12 Pester tests: routing table for all 7 strategies, audit-log shape, retention pruning. |
| `docs/operations/runtime-kernel-commandments.md` (extended) | New section: what gets snapshotted, behavior on failure, audit log, how to restore from each snapshot type, retention. |

## Snapshot location + retention

- **Location:** `$DPF_BACKUPS_HOST_PATH/pre-destructive/<YYYY-MM-DD>/<fingerprint>-<ts>.<ext>` — same out-of-install-root tree as the other backup artifacts (BI-8004BCD8 relocation, BI-31C9FBDF trial-restore, BI-C8655C8C transcript snapshots).
- **Retention:** 90 days (longer than transcript snapshots' 30 days — these are tier-1 recovery artifacts). In-line pruning on every dispatch; no separate cron.
- **Audit log:** `$DPF_BACKUPS_HOST_PATH/pre-destructive/.snapshot.log` — one structured JSON line per attempt with `[pre-destructive-snapshot-trace]` prefix. Grep `outcome":"FAILED"` post-incident to find proceed-anyway events.

## Tests

- [x] Pester 5: **12/12 pass** in `pre-destructive-snapshot.Tests.ps1`.
- [x] `sh -n` clean on both `pre-destructive-snapshot.sh` AND the modified `dpf-shell-guard.sh`.
- [x] `[Parser]::ParseFile` clean on both `.ps1` scripts.
- [x] Routing table covers all 7 strategies; audit-log shape verified; 90-day retention pruning verified.

## Composition with prior DR-hardening this epic

This BI is the last piece that makes the runtime-kernel-commandments + nightly-backup substrate genuinely robust:

| BI | Role |
|---|---|
| **BI-8004BCD8** (backup relocation) | All snapshot artifacts live OUTSIDE install root. |
| **BI-43F95F77** (runtime gate) | Provides the typed-confirm checkpoint this PR inserts pre-snapshot logic into. |
| **BI-31C9FBDF** (trial-restore) | Verifies the nightly Postgres backup is restorable — fallback when pre-destructive snapshot fails. |
| **BI-E5002629** (worktree janitor lib) | Independent — cleanup doesn't touch snapshots. |
| **BI-C8655C8C** (transcript snapshots) | Same `$DPF_BACKUPS_HOST_PATH` tree, different content. |
| **BI-611C25F3** (this PR) | Closes the loop: every operator-confirmed destructive action attempts a snapshot, with explicit visibility on failure. |

## Three subtle bugs caught during the test run

1. **Working-tree state was lost three times** to an out-of-band reset (likely a sync hook or auto-checkout) between Write and Pester invocations. Fixed by tightening the edit→verify→commit cycle and committing atomically before any longer-running operation.
2. **`pwsh.exe -File script.ps1 -v` interprets `-v` as `-Verbose` for pwsh itself**, not as a positional arg to the script — so `$RemainingArgs` doesn't receive it. Test uses `--volumes` long-form to verify routing (regex matches both via greedy `.*-v`); production-side, the shell-guard constructs the cmdline string itself before regex match, sidestepping the parsing issue.
3. **`ConvertFrom-Json` normalizes ISO timestamp strings to `DateTime` objects**, losing source-format precision. Tests assert against the raw log line, not the deserialized object. Same pattern caught in BI-E5002629 and BI-C8655C8C — recurring shape worth memorizing.

## Trade-offs noted in commit thread

- **Neo4j strategy defers to nightly backup** rather than taking an online dump — `neo4j-admin database dump` requires the DB stopped, which is exactly what the destructive command is about to do. Defer is cleaner.
- **`docker compose down -v` aggregation** succeeds if at least one of {pg_dump, neo4j-defer} captures. Both failing = failure (second-confirm fires).
- **`git reset --hard` uses git stash** rather than dump — leverages git's native recovery; stash entries auto-expire (~30 days) which is its own retention story documented separately.
- **fs-essentials tarball** only captures operator-private artifacts (`.env`, `.claude/settings.local.json`, etc.) — NOT the whole install (huge + recoverable from git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
