### PR TITLE
feat(build-studio): dispatch history root-cause display + backfill (BI-594B76AB)

### DIFF
--- a/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
@@ -2,6 +2,7 @@
 
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { BuildDispatchHistoryCard } from "./BuildDispatchHistoryCard";
 import type { BuildDispatchAttemptView } from "@/lib/build/dispatch-attempts";
@@ -36,6 +37,70 @@ describe("BuildDispatchHistoryCard", () => {
     expect(screen.getByText("Add dispatch telemetry")).toBeInTheDocument();
     expect(screen.getByText(/exit 1.*usage-limit/)).toBeInTheDocument();
     expect(screen.getByText("gpt-5.3-codex")).toBeInTheDocument();
-    expect(screen.getByText("ERROR: You've hit your usage limit.")).toBeInTheDocument();
+    // ERROR text now appears as the diagnosis line (rootCauseSummary) and is
+    // also inside the collapsed <details> raw output. Use getAllByText since
+    // it may appear in two places.
+    expect(screen.getAllByText("ERROR: You've hit your usage limit.").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+function attempt(overrides: Partial<BuildDispatchAttemptView> = {}): BuildDispatchAttemptView {
+  return {
+    id: "att-1",
+    buildId: "FB-X",
+    taskTitle: "Task A",
+    specialist: null,
+    providerId: null,
+    model: null,
+    attemptNumber: 1,
+    startedAt: "2026-05-24T00:00:00Z",
+    completedAt: "2026-05-24T00:00:05Z",
+    durationMs: 5000,
+    exitCode: 1,
+    success: false,
+    failureAxis: "usage-limit",
+    stdoutExcerpt: "Reading prompt from stdin...\nUsage limit reached for the day.",
+    stderrExcerpt: null,
+    rootCauseSummary: "Usage limit reached for the day.",
+    rootCauseHash: "deadbeefcafe1234",
+    ...overrides,
+  };
+}
+
+describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => {
+  it("renders rootCauseSummary as the visible diagnosis line when present", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toContain("Usage limit reached for the day.");
+  });
+
+  it("falls back to failureAxis text when rootCauseSummary is null", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard
+        attempts={[attempt({ rootCauseSummary: null, failureAxis: "timeout", stdoutExcerpt: null })]}
+      />,
+    );
+    expect(html).toMatch(/\btimeout\b/i);
+  });
+
+  it("places stdoutExcerpt inside a <details> element, not the default visible body", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toMatch(/<details[\s>]/);
+    const detailsMatch = html.match(/<details[\s\S]*?<\/details>/);
+    expect(detailsMatch).not.toBeNull();
+    expect(detailsMatch![0]).toContain("Reading prompt from stdin");
+  });
+
+  it("does not duplicate the rootCauseSummary outside the expected places", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const occurrences = (html.match(/Usage limit reached for the day\./g) ?? []).length;
+    // Once in the visible diagnosis line, possibly once inside the raw <details>
+    // because stdoutExcerpt contains the same string after the prologue.
+    expect(occurrences).toBeGreaterThanOrEqual(1);
+    expect(occurrences).toBeLessThanOrEqual(2);
+  });
+
+  it("uses a <summary> label that names the raw section", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toMatch(/<summary[^>]*>[^<]*Raw[^<]*<\/summary>/i);
   });
 });

--- a/apps/web/components/build/BuildDispatchHistoryCard.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.tsx
@@ -19,22 +19,37 @@ export function BuildDispatchHistoryCard({ attempts }: Props) {
       <div className="mt-3 space-y-2">
         {attempts.length === 0 ? (
           <p className="text-xs text-[var(--dpf-muted)]">No dispatch attempts recorded yet.</p>
-        ) : attempts.map((attempt) => (
-          <div key={attempt.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span className="font-medium text-[var(--dpf-text)]">{attempt.taskTitle}</span>
-              <span className="text-[var(--dpf-muted)]">exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}</span>
+        ) : attempts.map((attempt) => {
+          const diagnosis = attempt.rootCauseSummary ?? attempt.failureAxis;
+          const rawOutput = attempt.stdoutExcerpt ?? attempt.stderrExcerpt;
+          return (
+            <div key={attempt.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-[var(--dpf-text)]">{attempt.taskTitle}</span>
+                <span className="text-[var(--dpf-muted)]">exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}</span>
+              </div>
+              <div
+                className="mt-1 text-[var(--dpf-text)]"
+                title="Classified diagnosis — derived from stdout/stderr and the failure axis."
+              >
+                {diagnosis}
+              </div>
+              {attempt.model && (
+                <div className="mt-1 text-[var(--dpf-muted)]">{attempt.model}</div>
+              )}
+              {rawOutput && (
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-[10px] uppercase text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+                    Raw stdout/stderr
+                  </summary>
+                  <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] text-[var(--dpf-muted)]">
+                    {rawOutput}
+                  </pre>
+                </details>
+              )}
             </div>
-            {attempt.model && (
-              <div className="mt-1 text-[var(--dpf-muted)]">{attempt.model}</div>
-            )}
-            {(attempt.stdoutExcerpt || attempt.stderrExcerpt) && (
-              <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] text-[var(--dpf-muted)]">
-                {attempt.stdoutExcerpt ?? attempt.stderrExcerpt}
-              </pre>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/lib/build/dispatch-attempts.test.ts
+++ b/apps/web/lib/build/dispatch-attempts.test.ts
@@ -3,6 +3,7 @@ import {
   buildDispatchAttemptData,
   classifyDispatchFailureAxis,
   lineMatchesFailureAxis,
+  recomputeRootCauseSummary,
   recordBuildDispatchAttempt,
 } from "./dispatch-attempts";
 import type { BuildFailureAxis } from "./progress-visibility-types";
@@ -225,5 +226,53 @@ describe("lineMatchesFailureAxis", () => {
     expect(lineMatchesFailureAxis("error TS2345: Argument type mismatch", "typecheck-failure")).toBe(true);
     expect(lineMatchesFailureAxis("workspace prompt prepared", "out-of-scope-noise")).toBe(false);
     expect(lineMatchesFailureAxis("out-of-scope workspace noise detected", "out-of-scope-noise")).toBe(true);
+  });
+});
+
+describe("recomputeRootCauseSummary (BI-594B76AB)", () => {
+  it("returns the axis-matched line when the stdout excerpt contains one", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...\nYou've hit your usage limit for today.",
+      stderrExcerpt: null,
+      failureAxis: "usage-limit",
+    });
+    expect(result.toLowerCase()).toMatch(/usage limit/);
+    expect(result.toLowerCase()).not.toMatch(/reading prompt from stdin/);
+  });
+
+  it("falls back to the first non-prologue line when no axis line is found", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...\nSomething else happened.",
+      stderrExcerpt: null,
+      failureAxis: "unknown",
+    });
+    expect(result).toBe("Something else happened.");
+  });
+
+  it("falls back to the axis name when both excerpts are null", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: null,
+      stderrExcerpt: null,
+      failureAxis: "timeout",
+    });
+    expect(result).toBe("timeout");
+  });
+
+  it("falls back to the axis name when both excerpts are empty strings", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "",
+      stderrExcerpt: "",
+      failureAxis: "rate-limit",
+    });
+    expect(result).toBe("rate-limit");
+  });
+
+  it("reads the stderr excerpt when stdout has only prologue", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...",
+      stderrExcerpt: "auth error: unauthorized request",
+      failureAxis: "auth",
+    });
+    expect(result.toLowerCase()).toContain("unauthorized");
   });
 });

--- a/apps/web/lib/build/dispatch-attempts.ts
+++ b/apps/web/lib/build/dispatch-attempts.ts
@@ -193,7 +193,7 @@ export async function getDispatchHistoryForBuild(buildId: string): Promise<Build
   }));
 }
 
-function extractRootCauseSummary(stdout: string, stderr: string, fallback: BuildFailureAxis): string {
+export function extractRootCauseSummary(stdout: string, stderr: string, fallback: BuildFailureAxis): string {
   const combined = `${stdout}\n${stderr}`;
   const lines = combined
     .split(/\r?\n/)
@@ -239,7 +239,7 @@ export function lineMatchesFailureAxis(line: string, axis: BuildFailureAxis): bo
   }
 }
 
-function isCliPrologueLine(line: string): boolean {
+export function isCliPrologueLine(line: string): boolean {
   const normalized = line.toLowerCase();
   return normalized === "reading prompt from stdin..."
     || normalized.startsWith("reading prompt from stdin")

--- a/apps/web/lib/build/dispatch-attempts.ts
+++ b/apps/web/lib/build/dispatch-attempts.ts
@@ -247,6 +247,26 @@ export function isCliPrologueLine(line: string): boolean {
     || normalized.startsWith("codex ");
 }
 
+/**
+ * Re-derive `rootCauseSummary` for a row using the persisted excerpts and the
+ * already-classified failure axis. Used by the 2026-05-24 backfill script to
+ * normalize pre-hardening rows whose original `rootCauseSummary` captured the
+ * Codex CLI prologue instead of the diagnostic line.
+ *
+ * Pure. The matcher operates on the 500-char excerpts, not the full original
+ * output — this is acceptable because (a) the recomputed result is at least as
+ * good as the prologue text it replaces, and (b) it matches what the operator
+ * sees when expanding the dispatch history card's raw section. See spec §4.2
+ * of the 2026-05-24 dispatch-history root-cause display spec.
+ */
+export function recomputeRootCauseSummary(row: {
+  stdoutExcerpt: string | null;
+  stderrExcerpt: string | null;
+  failureAxis: BuildFailureAxis;
+}): string {
+  return extractRootCauseSummary(row.stdoutExcerpt ?? "", row.stderrExcerpt ?? "", row.failureAxis);
+}
+
 function excerpt(value: string): string | null {
   const trimmed = value.trim();
   return trimmed ? trimmed.slice(0, 500) : null;

--- a/apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts
+++ b/apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts
@@ -1,0 +1,97 @@
+// apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts
+//
+// One-shot operator-runnable backfill for BI-594B76AB.
+// Recomputes BuildDispatchAttempt.rootCauseSummary for rows whose persisted
+// value is just the Codex CLI prologue, using the post-hardening matcher
+// logic. Idempotent — re-running produces the same result because the second
+// pass finds no remaining prologue-matched rows.
+//
+// Run via:
+//   pnpm --filter web exec tsx scripts/backfill-dispatch-root-cause-2026-05.ts
+//
+// Per feedback_no_mass_bash this script is NOT auto-run at boot. Per
+// feedback_db_seed_migration_sync, since this normalizes platform diagnostic
+// data and does not change schema, it lives here as a script rather than as
+// a Prisma migration.
+
+import { createHash } from "crypto";
+import { prisma } from "@dpf/db";
+import {
+  isCliPrologueLine,
+  normalizeRootCauseForHash,
+  recomputeRootCauseSummary,
+} from "../lib/build/dispatch-attempts";
+import type { BuildFailureAxis } from "../lib/build/progress-visibility-types";
+
+type Counters = { scanned: number; updated: number; skipped: number; errored: number };
+
+function hashRootCause(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+async function main(): Promise<Counters> {
+  const counters: Counters = { scanned: 0, updated: 0, skipped: 0, errored: 0 };
+
+  // Pull only rows with a non-null rootCauseSummary; client-side filter on the
+  // prologue pattern. The table is small (one row per dispatch attempt) so
+  // an in-memory filter is acceptable.
+  const rows = await prisma.buildDispatchAttempt.findMany({
+    where: { rootCauseSummary: { not: null } },
+    select: {
+      id: true,
+      rootCauseSummary: true,
+      stdoutExcerpt: true,
+      stderrExcerpt: true,
+      failureAxis: true,
+    },
+  });
+
+  for (const row of rows) {
+    counters.scanned += 1;
+    const summary = row.rootCauseSummary?.trim() ?? "";
+    if (!summary) {
+      counters.skipped += 1;
+      continue;
+    }
+    if (!isCliPrologueLine(summary)) {
+      counters.skipped += 1;
+      continue;
+    }
+    try {
+      const recomputed = recomputeRootCauseSummary({
+        stdoutExcerpt: row.stdoutExcerpt,
+        stderrExcerpt: row.stderrExcerpt,
+        failureAxis: row.failureAxis as BuildFailureAxis,
+      });
+      if (recomputed === row.rootCauseSummary) {
+        // Idempotent no-op — same result as already stored.
+        counters.skipped += 1;
+        continue;
+      }
+      const hash = hashRootCause(`${row.failureAxis}:${normalizeRootCauseForHash(recomputed)}`);
+      await prisma.buildDispatchAttempt.update({
+        where: { id: row.id },
+        data: { rootCauseSummary: recomputed, rootCauseHash: hash },
+      });
+      counters.updated += 1;
+    } catch (err) {
+      counters.errored += 1;
+      // eslint-disable-next-line no-console
+      console.warn(`[backfill] failed to update row ${row.id}:`, err);
+    }
+  }
+
+  return counters;
+}
+
+main()
+  .then((counters) => {
+    // eslint-disable-next-line no-console
+    console.log("[backfill] done:", counters);
+    return prisma.$disconnect();
+  })
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[backfill] fatal:", err);
+    return prisma.$disconnect().finally(() => process.exit(1));
+  });

--- a/docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md
+++ b/docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md
@@ -1,0 +1,619 @@
+# Build Studio dispatch history — root-cause display + backfill (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make Build Studio dispatch history show the classified root cause first (`rootCauseSummary` if set, else `failureAxis` text), demote raw stdout/stderr to a collapsed `<details>` audit section, and provide an operator-runnable backfill script that recomputes `rootCauseSummary` on pre-hardening rows.
+
+**Architecture:** Two atomic changes in one PR — (a) a render-layer change in `BuildDispatchHistoryCard.tsx` plus a small symbol-visibility change in `dispatch-attempts.ts` and a new pure `recomputeRootCauseSummary` helper; (b) a one-shot `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts` that filters rows where the persisted `rootCauseSummary` matches `isCliPrologueLine` and rewrites them. No schema migration. No new columns. No auto-run.
+
+**Tech Stack:** Next.js 15 / React / TypeScript / Vitest / Prisma / pnpm.
+
+**Spec:** [`docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md`](../specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md) (BI-594B76AB, EP-BUILD-STUDIO).
+
+---
+
+## Hard constraints (carried from spec §5 + §8)
+
+Out of scope; touching any of these turns this into a different plan:
+
+- No change to `BuildDispatchAttempt` schema (no new columns, no renames, no migrations).
+- No reclassification of `failureAxis` on existing rows.
+- No matcher logic changes inside `extractRootCauseSummary` — symbol visibility only (private → exported).
+- No streaming / live-update work.
+- No surfacing of `rootCauseSummary` outside the dispatch history card (no canvas chip, no notification).
+- The backfill script does not auto-run at boot or on startup (per `feedback_no_mass_bash`).
+- No change to `excerpt()` truncation (500-char limit on `stdoutExcerpt` / `stderrExcerpt` stays).
+
+Scope-violation check: before push, run `git diff origin/main --stat` and verify the diff touches only:
+- `apps/web/lib/build/dispatch-attempts.ts`
+- `apps/web/lib/build/dispatch-attempts.test.ts`
+- `apps/web/components/build/BuildDispatchHistoryCard.tsx`
+- `apps/web/components/build/BuildDispatchHistoryCard.test.tsx`
+- `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts`
+- `docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md` (already committed)
+- `docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md` (this file)
+
+---
+
+## Task 1 — Export `extractRootCauseSummary` and `isCliPrologueLine`
+
+**Files:**
+- Modify: `apps/web/lib/build/dispatch-attempts.ts` (lines 196, 242)
+
+**Step 1: Change `function` to `export function` on both helpers.**
+
+At `apps/web/lib/build/dispatch-attempts.ts` line 196:
+
+```ts
+function extractRootCauseSummary(stdout: string, stderr: string, fallback: BuildFailureAxis): string {
+```
+
+becomes:
+
+```ts
+export function extractRootCauseSummary(stdout: string, stderr: string, fallback: BuildFailureAxis): string {
+```
+
+At line 242:
+
+```ts
+function isCliPrologueLine(line: string): boolean {
+```
+
+becomes:
+
+```ts
+export function isCliPrologueLine(line: string): boolean {
+```
+
+**Step 2: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean. (Pure visibility change; no callers should break since adding `export` is strictly additive.)
+
+**Step 3: Commit.**
+
+```bash
+git add apps/web/lib/build/dispatch-attempts.ts
+git commit -s -m "refactor(build-studio): export extractRootCauseSummary + isCliPrologueLine
+
+Phase 1 of BI-594B76AB. Pure symbol-visibility change — both helpers
+remain implementations-of-record in dispatch-attempts.ts; the upcoming
+recomputeRootCauseSummary helper and the backfill script consume them
+as public API. No logic change."
+```
+
+---
+
+## Task 2 — Add `recomputeRootCauseSummary` + unit tests
+
+**Files:**
+- Modify: `apps/web/lib/build/dispatch-attempts.ts` (add new exported function)
+- Modify: `apps/web/lib/build/dispatch-attempts.test.ts` (add tests for it)
+
+**Step 1: Write the failing tests.**
+
+Append to `apps/web/lib/build/dispatch-attempts.test.ts`:
+
+```ts
+describe("recomputeRootCauseSummary", () => {
+  it("returns the axis-matched line when the stdout excerpt contains one", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...\nYou've hit your usage limit for today.",
+      stderrExcerpt: null,
+      failureAxis: "usage-limit",
+    });
+    expect(result).toMatch(/usage limit/i);
+    expect(result.toLowerCase()).not.toMatch(/reading prompt from stdin/);
+  });
+
+  it("falls back to the first non-prologue line when no axis line is found", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...\nSomething else happened.",
+      stderrExcerpt: null,
+      failureAxis: "unknown",
+    });
+    expect(result).toBe("Something else happened.");
+  });
+
+  it("falls back to the axis name when both excerpts are null", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: null,
+      stderrExcerpt: null,
+      failureAxis: "timeout",
+    });
+    expect(result).toBe("timeout");
+  });
+
+  it("falls back to the axis name when both excerpts are empty strings", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "",
+      stderrExcerpt: "",
+      failureAxis: "rate-limit",
+    });
+    expect(result).toBe("rate-limit");
+  });
+
+  it("reads the stderr excerpt when stdout has only prologue", () => {
+    const result = recomputeRootCauseSummary({
+      stdoutExcerpt: "Reading prompt from stdin...",
+      stderrExcerpt: "auth error: unauthorized request",
+      failureAxis: "auth",
+    });
+    expect(result.toLowerCase()).toContain("unauthorized");
+  });
+});
+```
+
+Add the import at the top of the test file:
+
+```ts
+import { recomputeRootCauseSummary } from "./dispatch-attempts";
+```
+
+(Adjust to merge with existing imports from `./dispatch-attempts`.)
+
+**Step 2: Run the failing tests.**
+
+```bash
+pnpm --filter web exec vitest run lib/build/dispatch-attempts.test.ts
+```
+
+Expected: 5 new failures all citing "recomputeRootCauseSummary is not defined" or undefined-import.
+
+**Step 3: Implement `recomputeRootCauseSummary`.**
+
+Append to `apps/web/lib/build/dispatch-attempts.ts` (after the existing `extractRootCauseSummary` and `isCliPrologueLine` block, before `excerpt()`):
+
+```ts
+/**
+ * Re-derive `rootCauseSummary` for a row using the persisted excerpts and the
+ * already-classified failure axis. Used by the 2026-05-24 backfill script to
+ * normalize pre-hardening rows whose original `rootCauseSummary` captured the
+ * Codex CLI prologue instead of the diagnostic line.
+ *
+ * Pure. The matcher operates on the 500-char excerpts, not the full original
+ * output — this is acceptable because (a) the recomputed result is at least as
+ * good as the prologue text it replaces, and (b) it matches what the operator
+ * sees when expanding the dispatch history card's raw section. See spec §4.2.
+ */
+export function recomputeRootCauseSummary(row: {
+  stdoutExcerpt: string | null;
+  stderrExcerpt: string | null;
+  failureAxis: BuildFailureAxis;
+}): string {
+  return extractRootCauseSummary(row.stdoutExcerpt ?? "", row.stderrExcerpt ?? "", row.failureAxis);
+}
+```
+
+**Step 4: Run the tests and verify all 5 pass.**
+
+```bash
+pnpm --filter web exec vitest run lib/build/dispatch-attempts.test.ts
+```
+
+Expected: all green.
+
+**Step 5: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+**Step 6: Commit.**
+
+```bash
+git add apps/web/lib/build/dispatch-attempts.ts apps/web/lib/build/dispatch-attempts.test.ts
+git commit -s -m "feat(build-studio): add recomputeRootCauseSummary helper (BI-594B76AB)
+
+Pure wrapper around extractRootCauseSummary that accepts a row-shape
+(stdoutExcerpt, stderrExcerpt, failureAxis) instead of raw output args.
+Consumed by the upcoming backfill script and the dispatch history card
+render path. Five unit tests cover prologue-suppression, fallback to
+first non-prologue line, fallback to axis name, and stderr-only paths."
+```
+
+---
+
+## Task 3 — Render `rootCauseSummary` in `BuildDispatchHistoryCard`
+
+**Files:**
+- Modify: `apps/web/components/build/BuildDispatchHistoryCard.tsx`
+- Modify: `apps/web/components/build/BuildDispatchHistoryCard.test.tsx`
+
+**Step 1: Write the failing tests.**
+
+Read the existing test file first (it already exercises this component) and append the new assertions. The pattern follows the existing tests:
+
+```ts
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { BuildDispatchHistoryCard } from "./BuildDispatchHistoryCard";
+import type { BuildDispatchAttemptView } from "@/lib/build/dispatch-attempts";
+
+function attempt(overrides: Partial<BuildDispatchAttemptView> = {}): BuildDispatchAttemptView {
+  return {
+    id: "att-1",
+    buildId: "FB-X",
+    taskTitle: "Task A",
+    specialist: null,
+    providerId: null,
+    model: null,
+    attemptNumber: 1,
+    startedAt: "2026-05-24T00:00:00Z",
+    completedAt: "2026-05-24T00:00:05Z",
+    durationMs: 5000,
+    exitCode: 1,
+    success: false,
+    failureAxis: "usage-limit",
+    stdoutExcerpt: "Reading prompt from stdin...\nUsage limit reached for the day.",
+    stderrExcerpt: null,
+    rootCauseSummary: "Usage limit reached for the day.",
+    rootCauseHash: "deadbeefcafe1234",
+    ...overrides,
+  };
+}
+
+describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => {
+  it("renders rootCauseSummary as the visible diagnosis line when present", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toContain("Usage limit reached for the day.");
+  });
+
+  it("falls back to failureAxis text when rootCauseSummary is null", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard attempts={[attempt({ rootCauseSummary: null, failureAxis: "timeout" })]} />,
+    );
+    expect(html).toMatch(/\btimeout\b/i);
+  });
+
+  it("places stdoutExcerpt inside a <details> element, not the default visible body", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toMatch(/<details[\s>]/);
+    // The prologue text is in stdoutExcerpt, which now lives inside <details>.
+    // Capture the substring from <details> open to </details> close and assert
+    // the prologue text is inside that range.
+    const detailsMatch = html.match(/<details[\s\S]*?<\/details>/);
+    expect(detailsMatch).not.toBeNull();
+    expect(detailsMatch![0]).toContain("Reading prompt from stdin");
+  });
+
+  it("does not duplicate the rootCauseSummary inside the raw <details>", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const occurrences = (html.match(/Usage limit reached for the day\./g) ?? []).length;
+    // Once in the visible diagnosis line. The stdoutExcerpt also contains this
+    // string after the prologue — accept up to 2 occurrences (visible + raw).
+    expect(occurrences).toBeGreaterThanOrEqual(1);
+    expect(occurrences).toBeLessThanOrEqual(2);
+  });
+
+  it("uses a <summary> label that names the raw section", () => {
+    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    expect(html).toMatch(/<summary[^>]*>.*Raw.*<\/summary>/i);
+  });
+});
+```
+
+**Step 2: Run the failing tests.**
+
+```bash
+pnpm --filter web exec vitest run components/build/BuildDispatchHistoryCard.test.tsx
+```
+
+Expected: 5 new failures all on the new assertions (current card neither renders `rootCauseSummary` nor uses `<details>`).
+
+**Step 3: Update `BuildDispatchHistoryCard.tsx`.**
+
+Replace the mapped row body (lines 22-37 of the existing file) so each attempt renders:
+
+```tsx
+{attempts.map((attempt) => {
+  const diagnosis = attempt.rootCauseSummary ?? attempt.failureAxis;
+  const rawOutput = attempt.stdoutExcerpt ?? attempt.stderrExcerpt;
+  return (
+    <div key={attempt.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-medium text-[var(--dpf-text)]">{attempt.taskTitle}</span>
+        <span className="text-[var(--dpf-muted)]">exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}</span>
+      </div>
+      <div
+        className="mt-1 text-[var(--dpf-text)]"
+        title="Classified diagnosis — derived from stdout/stderr and the failure axis."
+      >
+        {diagnosis}
+      </div>
+      {attempt.model && (
+        <div className="mt-1 text-[var(--dpf-muted)]">{attempt.model}</div>
+      )}
+      {rawOutput && (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-[10px] uppercase text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+            Raw stdout/stderr
+          </summary>
+          <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] text-[var(--dpf-muted)]">
+            {rawOutput}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+})}
+```
+
+The `<details>` element is native HTML and needs no client state. The component remains `"use client"` (no change to the `"use client"` directive at the top).
+
+**Step 4: Run the tests and verify all pass.**
+
+```bash
+pnpm --filter web exec vitest run components/build/BuildDispatchHistoryCard.test.tsx
+```
+
+Expected: all green.
+
+**Step 5: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+**Step 6: Commit.**
+
+```bash
+git add apps/web/components/build/BuildDispatchHistoryCard.tsx apps/web/components/build/BuildDispatchHistoryCard.test.tsx
+git commit -s -m "feat(build-studio): dispatch history shows classified root cause first (BI-594B76AB)
+
+Renders rootCauseSummary (or failureAxis text when null) as the
+operator-facing diagnosis line; demotes raw stdout/stderr to a
+collapsed <details> audit section. Internal symbols + the underlying
+BuildDispatchAttemptView shape unchanged. Five tests cover visible
+diagnosis, fallback path, <details> placement, no-duplicate render,
+and the raw summary label."
+```
+
+---
+
+## Task 4 — Backfill script
+
+**Files:**
+- Create: `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts`
+
+**Step 1: Write the script.**
+
+```ts
+// apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts
+//
+// One-shot operator-runnable backfill for BI-594B76AB.
+// Recomputes BuildDispatchAttempt.rootCauseSummary for rows whose persisted
+// value is just the Codex CLI prologue, using the post-hardening matcher
+// logic. Idempotent — re-running produces the same result because the second
+// pass finds no remaining prologue-matched rows.
+//
+// Run via:
+//   pnpm --filter web exec tsx scripts/backfill-dispatch-root-cause-2026-05.ts
+//
+// Per feedback_no_mass_bash this script is NOT auto-run at boot. Per
+// feedback_db_seed_migration_sync, since this normalizes platform diagnostic
+// data and does not change schema, it lives here as a script rather than as
+// a Prisma migration.
+
+import { createHash } from "crypto";
+import { prisma } from "@dpf/db";
+import {
+  isCliPrologueLine,
+  recomputeRootCauseSummary,
+  normalizeRootCauseForHash,
+} from "../lib/build/dispatch-attempts";
+import type { BuildFailureAxis } from "../lib/build/progress-visibility-types";
+
+type Counters = { scanned: number; updated: number; skipped: number; errored: number };
+
+function hashRootCause(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+async function main(): Promise<Counters> {
+  const counters: Counters = { scanned: 0, updated: 0, skipped: 0, errored: 0 };
+
+  // Pull only rows with a non-null rootCauseSummary; client-side filter on the
+  // prologue pattern. The table is small (one row per dispatch attempt) so
+  // an in-memory filter is acceptable.
+  const rows = await prisma.buildDispatchAttempt.findMany({
+    where: { rootCauseSummary: { not: null } },
+    select: {
+      id: true,
+      rootCauseSummary: true,
+      stdoutExcerpt: true,
+      stderrExcerpt: true,
+      failureAxis: true,
+    },
+  });
+
+  for (const row of rows) {
+    counters.scanned += 1;
+    const summary = row.rootCauseSummary?.trim() ?? "";
+    if (!summary) {
+      counters.skipped += 1;
+      continue;
+    }
+    if (!isCliPrologueLine(summary)) {
+      counters.skipped += 1;
+      continue;
+    }
+    try {
+      const recomputed = recomputeRootCauseSummary({
+        stdoutExcerpt: row.stdoutExcerpt,
+        stderrExcerpt: row.stderrExcerpt,
+        failureAxis: row.failureAxis as BuildFailureAxis,
+      });
+      if (recomputed === row.rootCauseSummary) {
+        // Idempotent no-op — same result as already stored.
+        counters.skipped += 1;
+        continue;
+      }
+      const hash = hashRootCause(`${row.failureAxis}:${normalizeRootCauseForHash(recomputed)}`);
+      await prisma.buildDispatchAttempt.update({
+        where: { id: row.id },
+        data: { rootCauseSummary: recomputed, rootCauseHash: hash },
+      });
+      counters.updated += 1;
+    } catch (err) {
+      counters.errored += 1;
+      // eslint-disable-next-line no-console
+      console.warn(`[backfill] failed to update row ${row.id}:`, err);
+    }
+  }
+
+  return counters;
+}
+
+main()
+  .then((counters) => {
+    // eslint-disable-next-line no-console
+    console.log("[backfill] done:", counters);
+    return prisma.$disconnect();
+  })
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[backfill] fatal:", err);
+    return prisma.$disconnect().finally(() => process.exit(1));
+  });
+```
+
+**Step 2: Check that `normalizeRootCauseForHash` is exported.**
+
+```bash
+grep -n "export function normalizeRootCauseForHash\|^function normalizeRootCauseForHash" apps/web/lib/build/dispatch-attempts.ts
+```
+
+If the function is module-private, add `export` to it (line 263 area). This is the same kind of pure-symbol-visibility change as Task 1.
+
+If a change is needed, modify `dispatch-attempts.ts` and add a one-line `git add` for that file in this commit.
+
+**Step 3: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean. (The script imports from `@dpf/db` and from sibling `lib/` files; tsc resolves these via the existing `apps/web/tsconfig.json` path aliases.)
+
+**Step 4: Verify the script does not auto-run.**
+
+```bash
+grep -n "backfill-dispatch-root-cause" apps/web/server.js docker-entrypoint.sh apps/web/instrumentation.ts 2>/dev/null || echo "no auto-run references found"
+```
+
+Expected: "no auto-run references found". Any hit means the script got wired into a boot path by mistake — remove it.
+
+**Step 5: Commit.**
+
+```bash
+git add apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts apps/web/lib/build/dispatch-attempts.ts
+git commit -s -m "feat(build-studio): one-shot backfill for pre-hardening dispatch root-cause rows (BI-594B76AB)
+
+Operator-runnable script (NOT auto-run at boot per feedback_no_mass_bash)
+that recomputes rootCauseSummary on rows where the persisted value
+matches isCliPrologueLine. Idempotent. No schema change.
+
+Recomputes rootCauseHash to keep the hash/summary pair consistent.
+Logs { scanned, updated, skipped, errored } counts and exits cleanly."
+```
+
+---
+
+## Task 5 — Final verification + push + PR
+
+**Step 1: Full vitest run on the touched scope.**
+
+```bash
+pnpm --filter web exec vitest run lib/build/dispatch-attempts.test.ts components/build/BuildDispatchHistoryCard.test.tsx
+```
+
+Expected: all green.
+
+**Step 2: Broader test slice — make sure nothing adjacent broke.**
+
+```bash
+pnpm --filter web exec vitest run lib/build components/build
+```
+
+Expected: all green.
+
+**Step 3: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+**Step 4: Scope-violation sanity check.**
+
+```bash
+git diff origin/main --stat
+```
+
+Expected: only the seven files listed in the Hard constraints section above.
+
+**Step 5: Overlap sweep.**
+
+```bash
+git fetch origin main --quiet
+git log origin/main --oneline -10 --grep="dispatch\|root.cause\|BI-594B76AB" -i
+gh pr list --state open --limit 30 --json number,title --jq '.[] | select(.title | test("dispatch|root.cause|BI-594B"; "i")) | .title'
+```
+
+Expected: no overlap with concurrent work. If a sibling PR touches `dispatch-attempts.ts` or `BuildDispatchHistoryCard.tsx`, rebase + re-verify before pushing.
+
+**Step 6: Push.**
+
+```bash
+git push -u origin claude/dispatch-history-root-cause
+```
+
+**Step 7: Open the PR.**
+
+```bash
+gh pr create --title "feat(build-studio): dispatch history root-cause display + backfill (BI-594B76AB)" --body "$(cat <<'EOF'
+## Summary
+
+Closes BI-594B76AB. Two complementary changes shipping together:
+
+1. **UI render fallback.** `BuildDispatchHistoryCard` now shows `rootCauseSummary` (or `failureAxis` text when null) as the operator-facing diagnosis line. Raw stdout/stderr moves into a collapsed `<details>` audit section, accessible but not leading.
+2. **One-shot backfill.** `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts` recomputes `rootCauseSummary` on rows whose persisted value matches `isCliPrologueLine` (i.e. pre-hardening rows still carrying the Codex CLI prologue). Idempotent. NOT auto-run at boot (per `feedback_no_mass_bash`).
+
+Spec: `docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md`.
+Plan: `docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md`.
+
+## Out of scope (per spec §5 + §8)
+
+No schema change. No `failureAxis` reclassification. No matcher logic change (symbol visibility only). No streaming. No auto-run.
+
+## Test plan
+
+- [x] `pnpm --filter web exec vitest run lib/build/dispatch-attempts.test.ts components/build/BuildDispatchHistoryCard.test.tsx` — green.
+- [x] `pnpm --filter web typecheck` — clean.
+- [x] `git diff origin/main --stat` — only 7 expected files touched (5 code/test + 2 spec/plan docs).
+- [ ] **Post-merge operator step:** run `pnpm --filter web exec tsx scripts/backfill-dispatch-root-cause-2026-05.ts` on the live install and confirm the printed `{ scanned, updated, skipped, errored }` counters look sane.
+- [ ] **Post-merge UX:** open `/build?buildId=<some-pre-hardening-build>` on the Live portal — confirm the dispatch history card shows the classified summary first and the raw output is collapsed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done-criteria (from spec §10)
+
+- [ ] Spec + plan committed.
+- [ ] Single PR landing card render change + `recomputeRootCauseSummary` + backfill script + tests.
+- [ ] After merge, operator runs the backfill once and confirms the dispatch history card shows clean root-cause lines for a known pre-hardening build.
+- [ ] BI-594B76AB closes on merge + post-merge backfill confirmation.

--- a/docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md
+++ b/docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md
@@ -1,0 +1,161 @@
+---
+title: Build Studio dispatch history — show classified root cause, backfill old rows
+date: 2026-05-24
+status: proposal — awaiting operator review
+owner: Mark Bodman (CEO) — proposed by agent
+backlog-item: BI-594B76AB
+epic: EP-BUILD-STUDIO
+supersedes: (none — additive to the 2026-05-19 command-spine slice)
+relates-to:
+  - docs/superpowers/specs/2026-05-19-build-studio-single-status-command-spine-design.md (the matcher hardening this spec follows up on)
+  - docs/superpowers/plans/2026-05-19-build-studio-single-status-command-spine.md
+  - apps/web/lib/build/dispatch-attempts.ts (extractRootCauseSummary, isCliPrologueLine)
+  - apps/web/components/build/BuildDispatchHistoryCard.tsx
+  - packages/db/prisma/schema.prisma (BuildDispatchAttempt model)
+---
+
+# Build Studio dispatch history — show classified root cause, backfill old rows
+
+## 1. Problem (from BI-594B76AB)
+
+Live verification on 2026-05-20 against `/build?buildId=FB-71FB3A53` showed dispatch attempts correctly classified as `usage-limit`, but:
+
+- Historical `BuildDispatchAttempt.rootCauseSummary` values still contained Codex CLI prologue text (e.g. `"Reading prompt from stdin..."`) rather than the actual diagnostic line.
+- The dispatch history UI displays `stdoutExcerpt` directly — so even when the matcher writes a clean `rootCauseSummary` today, the operator still sees the prologue-laden raw output first.
+
+The 2026-05-19 command-spine slice hardened `extractRootCauseSummary` for future attempts (added `isCliPrologueLine` filtering, `lineMatchesFailureAxis` lookup). Two gaps remain:
+
+1. **Persisted rows are stale.** Pre-hardening rows still carry prologue text in `rootCauseSummary`.
+2. **The UI never reads `rootCauseSummary`.** `BuildDispatchHistoryCard.tsx` renders `stdoutExcerpt ?? stderrExcerpt` in a `<pre>` block; the classified field is never surfaced.
+
+Both gaps are small. They are complementary, not alternatives.
+
+## 2. Repo truth check (verified 2026-05-24 in this worktree)
+
+- `BuildDispatchAttempt.rootCauseSummary` is `String? @db.Text` in `packages/db/prisma/schema.prisma`. The matcher slices output at 200 chars in `extractRootCauseSummary` (line 204/207); `stdoutExcerpt` / `stderrExcerpt` are independently sliced at 500 chars in the `excerpt()` helper (line 252). These two truncation lengths are intentional and distinct — they appear in adjacent sections of this spec without conflation.
+- `extractRootCauseSummary` (apps/web/lib/build/dispatch-attempts.ts:196-208) is **pure** — depends only on stdout, stderr, and the already-classified `failureAxis`. Re-running it over existing rows is deterministic. **It is currently module-private** (declared as `function`, not `export function`); ditto `isCliPrologueLine` (line 242). Phase-1 implementation must add `export` to both — they become public API the moment the backfill script and `recomputeRootCauseSummary` consume them. This is a small symbol-visibility change, not a logic change.
+- `BuildDispatchHistoryCard` (apps/web/components/build/BuildDispatchHistoryCard.tsx:31-34) currently renders `stdoutExcerpt ?? stderrExcerpt` raw. `rootCauseSummary` and `failureAxis` are both available on the row but unused in the card; `failureAxis` is shown as a tiny label on the header row.
+- `getDispatchHistoryForBuild` (dispatch-attempts.ts:180-194) projects all fields including `rootCauseSummary` and `rootCauseHash`. No projection change needed.
+- Existing tests live in `apps/web/lib/build/dispatch-attempts.test.ts`, `apps/web/components/build/BuildDispatchHistoryCard.test.tsx` (Phase-1 regression file already in place from PR #1083 sibling change is unrelated). New tests slot beside these.
+
+No part of this work touches schema, MCP contracts, RuntimeTarget kinds, or sandbox isolation — it is render-layer + idempotent data normalization only.
+
+## 3. Designs evaluated
+
+### Design A — UI-only display fallback
+
+Render `rootCauseSummary` as the primary user-facing line; keep `stdoutExcerpt`/`stderrExcerpt` as a collapsible "raw output" section. Leave persisted rows untouched.
+
+- **Pro:** Smallest diff. No data migration. Reversible.
+- **Pro:** Even pre-hardening rows benefit somewhat — the classified `failureAxis` chip is already shown; the `rootCauseSummary` text will still be wrong on old rows, but the prologue text gets demoted to a "raw" section the operator opens deliberately.
+- **Con:** Pre-hardening rows still display prologue text as their `rootCauseSummary`. The fix lands halfway.
+- **Verdict:** Necessary but not sufficient.
+
+### Design B — Backfill-only
+
+One-time migration: re-run `extractRootCauseSummary` over existing rows using their stored `stdoutExcerpt` and `stderrExcerpt` plus the already-classified `failureAxis`. Don't touch the UI.
+
+- **Pro:** Cleans up persisted state once.
+- **Con:** The UI still shows `stdoutExcerpt` raw, so today's behavior is unchanged for operators reading the card. Backfilled `rootCauseSummary` sits unused.
+- **Con:** The matcher needs the *full* stdout/stderr, not the 500-char excerpt that was persisted. Backfilling against the excerpt may produce a different result than running against the original output. (This is acceptable for `lineMatchesFailureAxis` lookup since per-line matching works on excerpts, but worth naming.)
+- **Verdict:** Necessary but not sufficient.
+
+### Design C — UI display fallback + backfill (RECOMMENDED)
+
+Both at once. UI rendering changes so the classified summary leads; backfill normalizes persisted rows so old attempts also benefit.
+
+- **Pro:** Closes both gaps in one slice.
+- **Pro:** The backfill is idempotent — re-running it produces the same result; future schema migrations cannot accidentally regress prior fixes.
+- **Pro:** Test coverage is straightforward: unit test the new render branch, unit test the backfill function, snapshot-test the card with a row that has prologue-y stdout but a clean classified summary.
+- **Con:** Two areas of change in one PR. Mitigated by keeping each change atomic in its own commit.
+- **Verdict:** Recommended.
+
+## 4. Specification (Design C)
+
+### 4.1 UI render change
+
+Modify `apps/web/components/build/BuildDispatchHistoryCard.tsx` so each attempt row shows, in order:
+
+1. **Header line (unchanged):** task title, `exit {n} · {failureAxis}` chip.
+2. **Root-cause line (NEW):** `rootCauseSummary` rendered as a single-line, lightly emphasized string. When `rootCauseSummary` is `null` (success or matcher returned nothing useful), fall back to the `failureAxis` value itself (`"timeout"`, `"usage-limit"`, etc.). Show a short tooltip on hover indicating this is the classified diagnosis.
+3. **Model line (unchanged):** model identifier, if any.
+4. **Raw output (DEMOTED):** the existing `<pre>` block with `stdoutExcerpt ?? stderrExcerpt` is hidden behind a `<details><summary>Raw output</summary>…</details>` so it stays available for audit but doesn't lead. The `<summary>` reads `"Raw stdout/stderr"` with a chevron.
+
+The card is a `"use client"` component but uses `<details>` (native HTML — no React state needed). No new dependencies.
+
+### 4.2 Backfill — pure function + one-time runner
+
+Add a new exported pure function `recomputeRootCauseSummary(row)` to `apps/web/lib/build/dispatch-attempts.ts`. It accepts a row with `stdoutExcerpt`, `stderrExcerpt`, and `failureAxis`, and returns the value `extractRootCauseSummary` would produce today.
+
+Note the **excerpt-vs-full-output asymmetry**: when the row was originally written, the matcher saw full stdout/stderr; the persisted excerpts are 500-char truncations. The backfill therefore operates on the 500-char view, which may produce a slightly different result than the original full-output run. This is acceptable because (a) the new result is at least as good as the old prologue text, and (b) the recomputed value matches what an operator would see when reading the stored excerpt — making the UI and the persisted field consistent.
+
+Add a one-time runner script `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts` that:
+
+1. Reads all `BuildDispatchAttempt` rows where `rootCauseSummary` is non-null AND matches the prologue-detection pattern (`isCliPrologueLine` returns true on the trimmed value — this requires `isCliPrologueLine` to be exported from `dispatch-attempts.ts` per §2 above).
+2. Recomputes `rootCauseSummary` via `recomputeRootCauseSummary`.
+3. If the recomputed value differs, updates `rootCauseSummary` and `rootCauseHash` in place.
+4. Logs `{ updated, skipped, errored }` counts and exits.
+
+The script is **operator-runnable**, not a Prisma migration — Prisma migrations are reserved for schema changes (cf. `feedback_db_seed_migration_sync`). The script is idempotent: running it twice produces the same result as running it once because the second run finds no remaining prologue-matched rows.
+
+The script lands as a documented one-shot under `apps/web/scripts/` alongside existing utility scripts. It is NOT wired into the boot path (per `feedback_no_mass_bash` — no auto-run heavy commands at startup). The operator runs it via `pnpm --filter web exec tsx scripts/backfill-dispatch-root-cause-2026-05.ts` after this PR ships.
+
+### 4.3 Tests
+
+- `apps/web/lib/build/dispatch-attempts.test.ts` — add unit tests for `recomputeRootCauseSummary`:
+  - Prologue-only stdout + classified `usage-limit` axis → returns the axis-matched line if present, else returns the axis name as fallback.
+  - Already-clean stdout + axis match → returns the matching line (no regression on already-clean data).
+  - Empty/null excerpts → returns the axis name.
+- `apps/web/components/build/BuildDispatchHistoryCard.test.tsx` — extend the existing test file:
+  - Renders `rootCauseSummary` as the visible diagnosis line when present.
+  - Falls back to `failureAxis` text when `rootCauseSummary` is null.
+  - Raw output is inside a `<details>` and is NOT in the default-rendered text path (assert by querying for `<details>` element + checking that `stdoutExcerpt` content is inside its DOM subtree).
+
+### 4.4 What stays unchanged
+
+- `BuildDispatchAttempt` schema — no column changes, no new columns. `rootCauseHash` continues to be the post-normalization SHA hash; the backfill updates it alongside `rootCauseSummary` to keep the pair consistent.
+- `extractRootCauseSummary` itself — already correct. `recomputeRootCauseSummary` is a thin wrapper that constructs the args from a row shape.
+- `classifyDispatchFailureAxis` — already correct.
+- Any MCP tool or external contract — none reference `rootCauseSummary` shape; this is internal.
+
+## 5. Non-goals
+
+- Streaming dispatch updates from in-flight builds (separate effort; live progress is the command-spine slice's other half).
+- Re-classifying `failureAxis` for old rows. The axis was correctly classified by `classifyDispatchFailureAxis` at write time; only the *summary line* was sometimes wrong.
+- Schema migrations. No new columns, no renames.
+- Touching the `stdoutExcerpt` / `stderrExcerpt` storage (still 500-char truncation, still in the same column).
+
+## 6. Verification
+
+Per `feedback_structural_not_functional` / `feedback_dynamic_analysis_is_evidence`:
+
+- Vitest on `apps/web/lib/build/dispatch-attempts.test.ts` and `apps/web/components/build/BuildDispatchHistoryCard.test.tsx` — must pass with the new assertions.
+- `pnpm --filter web typecheck` — must pass.
+- After merge, on the running Live portal (`localhost:3000/build?buildId=…`): the dispatch history card shows the classified summary line first; the raw output section is collapsed; on a build with a known pre-hardening attempt, running the backfill script then refreshing the page shows the rewritten summary text.
+
+## 7. Migration / rollback
+
+- No schema migration; the backfill script is operator-runnable and reversible if needed (re-run is idempotent; the old prologue text is preserved in `stdoutExcerpt` and can be observed via the `<details>` raw section).
+- No customer install impact at boot — script does not auto-run.
+- UI render change is pure rendering; rollback is git revert of the card component.
+
+## 8. Out of scope (carry to follow-on BIs if surfaced during review)
+
+- Reclassifying `failureAxis` retroactively.
+- Surfacing `rootCauseSummary` outside the dispatch history card (e.g., as a Build Studio canvas chip).
+- Improving the `extractRootCauseSummary` matcher itself — the 2026-05-19 slice owns that.
+- Streaming live updates while a dispatch is mid-flight.
+
+## 9. Open decisions
+
+1. **Approve Design C (UI + backfill in one PR)?** Recommendation: yes.
+2. **Operator-run backfill vs. boot-time backfill?** Recommendation: operator-run, per `feedback_no_mass_bash`.
+3. **Surface the recomputed `rootCauseSummary` with a small "recomputed 2026-05-24" tag in the UI?** Recommendation: no — the recomputed result is the *correct* result; tagging it as "recomputed" implies it's somehow lower-quality than a freshly-written row, which is misleading. The script's exit log carries the audit trail.
+
+## 10. Definition of done
+
+- Spec reviewed and accepted or revised.
+- Plan file under `docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md`.
+- Single PR landing: card render change + `recomputeRootCauseSummary` + backfill script + tests.
+- After merge, operator runs the backfill once and confirms the dispatch history card shows clean root-cause lines for a known pre-hardening build.
+- BI-594B76AB closes on merge + post-merge backfill confirmation.


### PR DESCRIPTION
## Summary

Closes BI-594B76AB. Two complementary changes shipping together:

1. **UI render fallback.** `BuildDispatchHistoryCard` now shows `rootCauseSummary` (or `failureAxis` text when null) as the operator-facing diagnosis line. Raw stdout/stderr moves into a collapsed native `<details>` audit section, accessible but not leading.
2. **One-shot backfill.** `apps/web/scripts/backfill-dispatch-root-cause-2026-05.ts` recomputes `rootCauseSummary` on rows whose persisted value matches `isCliPrologueLine` (i.e. pre-hardening rows still carrying the Codex CLI prologue). Idempotent. **NOT auto-run at boot** (per `feedback_no_mass_bash`).

The 2026-05-19 command-spine slice hardened `extractRootCauseSummary` for future attempts; this PR closes the two remaining gaps it left — old rows weren't backfilled and the UI never read the field anyway.

**Spec:** [`docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md`](../blob/claude/dispatch-history-root-cause/docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md)
**Plan:** [`docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md`](../blob/claude/dispatch-history-root-cause/docs/superpowers/plans/2026-05-24-build-studio-dispatch-history-root-cause-display.md)

## Commits (5)

1. `spec(build-studio):` — design doc
2. `plan(build-studio):` — 5-task implementation plan
3. `refactor(build-studio):` — export `extractRootCauseSummary` + `isCliPrologueLine` (pure visibility; no logic change)
4. `feat(build-studio):` — `recomputeRootCauseSummary` helper + 5 unit tests
5. `feat(build-studio):` — card render change + 5 render tests (existing 1 test still green)
6. `feat(build-studio):` — one-shot backfill script

## Out of scope (per spec §5 + §8)

No schema change. No `failureAxis` reclassification. No matcher logic change (symbol visibility only). No streaming. No auto-run. No surfacing of root cause outside the dispatch history card.

## Verification

- [x] `pnpm --filter web exec vitest run lib/build/dispatch-attempts.test.ts components/build/BuildDispatchHistoryCard.test.tsx` — 20/20 green
- [x] `pnpm --filter web exec vitest run lib/build components/build` — 541/541 green
- [x] `pnpm --filter web typecheck` — clean (pre-commit hook ran on every commit)
- [x] `git diff origin/main --stat` — 7 expected files, no scope violations
- [x] Rebased onto fresh `origin/main` (picked up #1092 + #1093 cleanly)

## Test plan (post-merge)

- [ ] **Operator step:** run `pnpm --filter web exec tsx scripts/backfill-dispatch-root-cause-2026-05.ts` on the live install. Confirm the printed `{ scanned, updated, skipped, errored }` counters look sane (errored should be 0).
- [ ] **UX:** open `/build?buildId=<some-pre-hardening-build>` on the Live portal — confirm the dispatch history card shows the classified summary first and the raw output is collapsed into a `Raw stdout/stderr` details disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)