### PR TITLE
docs(agent): nudge code graph before substrate sweeps

### DIFF
--- a/.claude/commands/executing-plans.md
+++ b/.claude/commands/executing-plans.md
@@ -8,6 +8,8 @@ source: superpowers v5.0.5
 
 Load plan, review critically, execute all tasks, report when complete.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 ## The Process
 
 ### Step 1: Load and Review Plan

--- a/.claude/commands/spec-document-reviewer.md
+++ b/.claude/commands/spec-document-reviewer.md
@@ -9,6 +9,8 @@ source: superpowers v5.0.5
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 **Dispatch after:** Spec document is written.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 ```
 Task tool (general-purpose):
   description: "Review spec document"

--- a/.claude/commands/subagent-driven-development.md
+++ b/.claude/commands/subagent-driven-development.md
@@ -8,6 +8,8 @@ source: superpowers v5.0.5
 
 Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 **Why subagents:** Fresh context per task. Precisely crafted instructions. Never inherit session history. Preserves coordinator context.
 
 **Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration

--- a/.claude/commands/writing-plans.md
+++ b/.claude/commands/writing-plans.md
@@ -10,6 +10,8 @@ source: superpowers v5.0.5
 
 Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 Save plans to: `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 
 ## Bite-Sized Task Granularity

--- a/docs/Reference/superpowers/prompts/spec-document-reviewer.md
+++ b/docs/Reference/superpowers/prompts/spec-document-reviewer.md
@@ -3,6 +3,8 @@
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 **Dispatch after:** Spec document is written.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 ```
 Task tool (general-purpose):
   description: "Review spec document"

--- a/docs/Reference/superpowers/skills/executing-plans.md
+++ b/docs/Reference/superpowers/skills/executing-plans.md
@@ -8,6 +8,8 @@ source: superpowers v5.0.5
 
 Load plan, review critically, execute all tasks, report when complete.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 ## The Process
 
 ### Step 1: Load and Review Plan

--- a/docs/Reference/superpowers/skills/subagent-driven-development.md
+++ b/docs/Reference/superpowers/skills/subagent-driven-development.md
@@ -8,6 +8,8 @@ source: superpowers v5.0.5
 
 Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 **Why subagents:** Fresh context per task. Precisely crafted instructions. Never inherit session history. Preserves coordinator context.
 
 **Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration

--- a/docs/Reference/superpowers/skills/writing-plans.md
+++ b/docs/Reference/superpowers/skills/writing-plans.md
@@ -10,6 +10,8 @@ source: superpowers v5.0.5
 
 Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
 
+Before manual file reads for substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 Save plans to: `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 
 ## Bite-Sized Task Granularity

--- a/prompts/route-persona/explore-orchestrator.prompt.md
+++ b/prompts/route-persona/explore-orchestrator.prompt.md
@@ -80,6 +80,8 @@ The runtime grants come from [`packages/db/data/agent_registry.json`](../../../p
 
 Stage discipline. Every Explore conversation maps to one of the four §5.2 stages. When the user asks something, the first step is "which stage?" If the question spans stages, name them and propose a sequence.
 
+Code graph first for substrate sweeps. Before manual file reads for architecture or planning substrate sweeps, try `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph. Example: `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })`.
+
 Delegate, integrate, decide. Your turn structure:
 
 1. Identify which §5.2 stage the question is about.


### PR DESCRIPTION
## Summary
- Add code graph MCP nudges to the DPF planning/execution/review command prompts.
- Keep the mirrored `docs/Reference/superpowers` prompts aligned with the project command prompts.
- Add the same nudge to the Explore Orchestrator prompt for architecture/planning substrate sweeps.

## Investigation notes
- `mcp__dpf__search_code_graph({ query: "principle wiki frontmatter ingest", limit: 10 })` was callable but returned no matches for the exact planning query.
- Manual `rg` against the same theme produced a very large, noisy result set, which confirms the original friction: agents need a better first-reach nudge and a graceful fallback path.
- `mcp__dpf__get_code_graph_freshness` exists and reported a ready graph, but also reported `workspaceDirty: true` even though the root checkout was clean; freshness surfacing still needs a harness/runtime follow-up.

## Verification
- `git diff --check`
- `rg -n "mcp__dpf__search_code_graph" .claude\commands docs\Reference\superpowers prompts\route-persona\explore-orchestrator.prompt.md`
- `pnpm install --frozen-lockfile --prefer-offline` (fresh worktree dependency hydration)
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passed with existing Edge-runtime/Turbopack warnings)

## Follow-ups filed
- IP-D7261: Surface code graph freshness at agent session start.
- IP-11E7C: Suggest code graph after repeated grep bursts.
- IP-79EB9: Measure DPF code MCP usage by tool.
