### PR TITLE
fix: stabilize gear archetype context

### DIFF
--- a/apps/web/lib/gear-interface/emit-ring-2-3.test.ts
+++ b/apps/web/lib/gear-interface/emit-ring-2-3.test.ts
@@ -3,7 +3,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const gearRows = new Map<string, Record<string, unknown>>();
-let storefrontConfig: { archetypeId: string } | null = null;
+let storefrontConfig: {
+  archetypeId: string;
+  archetype: { archetypeId: string } | null;
+} | null = null;
 let featureBuild: Record<string, unknown> | null = null;
 
 vi.mock("@dpf/db", () => ({
@@ -34,7 +37,10 @@ import { prisma } from "@dpf/db";
 beforeEach(() => {
   gearRows.clear();
   vi.clearAllMocks();
-  storefrontConfig = { archetypeId: "hvac" };
+  storefrontConfig = {
+    archetypeId: "cuid-storefront-archetype-fk",
+    archetype: { archetypeId: "hvac-contractor" },
+  };
   featureBuild = {
     id: "fb-id-1",
     buildId: "FB-ABC123",
@@ -50,7 +56,7 @@ beforeEach(() => {
 });
 
 describe("emitRing23FromCompletedShip", () => {
-  it("emits a Ring 2→3 outward record with archetypeContext from the active StorefrontConfig", async () => {
+  it("emits a Ring 2→3 outward record with the semantic StorefrontArchetype.archetypeId slug", async () => {
     await emitRing23FromCompletedShip("FB-ABC123");
     expect(prisma.gearInterface.create).toHaveBeenCalledOnce();
     const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as {
@@ -58,15 +64,34 @@ describe("emitRing23FromCompletedShip", () => {
     }).data;
     expect(data.innerRing).toBe(2);
     expect(data.outerRing).toBe(3);
-    expect(data.archetypeContext).toBe("hvac");
+    expect(data.archetypeContext).toBe("hvac-contractor");
     expect(data.torqueTechnical).toBe(1.0);
     expect(data.outcomeType).toBe("transmission");
   });
 
-  it("skips honestly when no StorefrontConfig exists — does not emit", async () => {
+  it("emits an observable archetype-unresolved slip when no StorefrontConfig exists", async () => {
     storefrontConfig = null;
     await emitRing23FromCompletedShip("FB-ABC123");
-    expect(prisma.gearInterface.create).not.toHaveBeenCalled();
+    expect(prisma.gearInterface.create).toHaveBeenCalledOnce();
+    const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    }).data;
+    expect(data.innerRing).toBe(2);
+    expect(data.outerRing).toBe(3);
+    expect(data.archetypeContext).toBeNull();
+    expect(data.outcomeType).toBe("slip");
+    expect(data.slipDetected).toBe(true);
+    expect(data.slipReason).toBe("archetype-unresolved");
+  });
+
+  it("emits an archetype-unresolved slip when the config relation is missing", async () => {
+    storefrontConfig = { archetypeId: "cuid-storefront-archetype-fk", archetype: null };
+    await emitRing23FromCompletedShip("FB-ABC123");
+    const data = (vi.mocked(prisma.gearInterface.create).mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    }).data;
+    expect(data.archetypeContext).toBeNull();
+    expect(data.slipReason).toBe("archetype-unresolved");
   });
 
   it("is no-op when phase is not 'ship'", async () => {

--- a/apps/web/lib/gear-interface/emit-ring-2-3.ts
+++ b/apps/web/lib/gear-interface/emit-ring-2-3.ts
@@ -15,20 +15,23 @@
 // BI:   BI-861C4959
 
 import { prisma } from "@dpf/db";
-import { featureBuildShipToRing23Input } from "./source-adapters/feature-build-ship";
+import {
+  featureBuildArchetypeUnresolvedToRing23Input,
+  featureBuildShipToRing23Input,
+} from "./source-adapters/feature-build-ship";
 import { emitGearInterface } from "./writer";
 
 /**
- * Resolve the active archetype id for this install. Returns null when no
- * StorefrontConfig exists yet (fresh install / setup not run) so the caller
- * can skip the Ring 2→3 emit honestly rather than emit with a fabricated
- * archetype.
+ * Resolve the active semantic archetype slug for this install. Returns null
+ * when no StorefrontConfig/archetype relation exists yet so the caller can
+ * emit an observable unresolved slip rather than fabricate context.
  */
 async function resolveArchetypeContext(): Promise<string | null> {
   const config = await prisma.storefrontConfig.findFirst({
-    select: { archetypeId: true },
+    orderBy: { updatedAt: "desc" },
+    select: { archetype: { select: { archetypeId: true } } },
   });
-  return config?.archetypeId ?? null;
+  return config?.archetype?.archetypeId ?? null;
 }
 
 /**
@@ -57,14 +60,6 @@ export async function emitRing23FromCompletedShip(buildId: string): Promise<void
   if (build.phase !== "ship") return; // belt-and-braces — caller should already gate
 
   const archetypeContext = await resolveArchetypeContext();
-  if (!archetypeContext) {
-    console.warn(
-      "[gear-interface] Ring 2→3 emit skipped: no StorefrontConfig.archetypeId resolved for this install",
-      { buildId },
-    );
-    return;
-  }
-
   // shipSucceeded heuristic: phase reached ship AND build was not abandoned.
   // If UX verification ran, prefer its verdict. Acceptance signal — when
   // present — is the strongest input.
@@ -80,17 +75,23 @@ export async function emitRing23FromCompletedShip(buildId: string): Promise<void
     else if (am.met === false || am.status === "not-met") acceptanceMet = false;
   }
 
-  const input = featureBuildShipToRing23Input({
+  const source = {
     id: build.id,
     buildId: build.buildId,
     title: build.title,
-    archetypeContext,
     claimedByAgentId: build.claimedByAgentId,
     codingProvider: build.codingProvider,
-    shipSucceeded,
-    acceptanceMet,
     completedAt: build.updatedAt,
-  });
+  };
+
+  const input = archetypeContext
+    ? featureBuildShipToRing23Input({
+        ...source,
+        archetypeContext,
+        shipSucceeded,
+        acceptanceMet,
+      })
+    : featureBuildArchetypeUnresolvedToRing23Input(source);
 
   await emitGearInterface(input);
 }

--- a/apps/web/lib/gear-interface/source-adapters/feature-build-ship.test.ts
+++ b/apps/web/lib/gear-interface/source-adapters/feature-build-ship.test.ts
@@ -1,7 +1,11 @@
 // apps/web/lib/gear-interface/source-adapters/feature-build-ship.test.ts
 
 import { describe, it, expect } from "vitest";
-import { featureBuildShipToRing23Input, type FeatureBuildShipSource } from "./feature-build-ship";
+import {
+  featureBuildArchetypeUnresolvedToRing23Input,
+  featureBuildShipToRing23Input,
+  type FeatureBuildShipSource,
+} from "./feature-build-ship";
 import { validateGearInterfaceInput } from "../writer";
 
 function source(overrides: Partial<FeatureBuildShipSource> = {}): FeatureBuildShipSource {
@@ -84,5 +88,26 @@ describe("featureBuildShipToRing23Input", () => {
     expect(
       featureBuildShipToRing23Input(source({ ringRatioConsumed: 12 })).ratioConsumed,
     ).toBe(12);
+  });
+
+  it("can emit a Ring 2→3 archetype-unresolved slip without fabricating context", () => {
+    const input = featureBuildArchetypeUnresolvedToRing23Input({
+      id: "fb-1",
+      buildId: "FB-ABC123",
+      title: "Add invoice export",
+      claimedByAgentId: "agent-build-specialist",
+      codingProvider: "claude-cli",
+      completedAt: new Date("2026-05-24T18:00:00Z"),
+    });
+
+    expect(input.innerRing).toBe(2);
+    expect(input.outerRing).toBe(3);
+    expect(input.archetypeContext).toBeNull();
+    expect(input.outcomeType).toBe("slip");
+    expect(input.slipDetected).toBe(true);
+    expect(input.slipReason).toBe("archetype-unresolved");
+    expect(input.idempotencyKeySuffix).toBe("archetype-unresolved");
+    expect(input.rationale).toMatch(/not onboarded/i);
+    expect(() => validateGearInterfaceInput(input)).not.toThrow();
   });
 });

--- a/apps/web/lib/gear-interface/source-adapters/feature-build-ship.ts
+++ b/apps/web/lib/gear-interface/source-adapters/feature-build-ship.ts
@@ -39,6 +39,16 @@ export interface FeatureBuildShipSource {
   ringRatioConsumed?: number;
 }
 
+export interface FeatureBuildArchetypeUnresolvedSource {
+  /** FeatureBuild.id — used as the canonical shaftSourceId. */
+  id: string;
+  buildId: string;
+  title: string;
+  claimedByAgentId: string | null;
+  codingProvider: string | null;
+  completedAt: Date;
+}
+
 /**
  * Compose a Ring 2→3 outward GearInterfaceInput from a shipped FeatureBuild.
  *
@@ -105,5 +115,48 @@ export function featureBuildShipToRing23Input(
     graderType: "automated",
     graderId: "feature-build-ship.completePhase",
     organizationId: options.organizationId ?? null,
+  };
+}
+
+/**
+ * Compose the documented exception path for a shipped build that cannot be
+ * attributed to a vertical because the install has no resolvable archetype.
+ */
+export function featureBuildArchetypeUnresolvedToRing23Input(
+  source: FeatureBuildArchetypeUnresolvedSource,
+  options: { organizationId?: string | null } = {},
+): GearInterfaceInput {
+  const agentIdForTriple =
+    source.claimedByAgentId ??
+    source.codingProvider ??
+    `unknown-agent:${source.buildId}`;
+
+  return {
+    interfaceClass: "internal-adjacent",
+    transmissionDirection: "outward",
+    innerRing: 2,
+    outerRing: 3,
+    shaftSourceType: "phase-run",
+    shaftSourceId: `${source.id}-ship`,
+    sourceEventAt: source.completedAt,
+    actorType: "system",
+    actorId: "gear-interface.archetype-resolver",
+    intent: "resolve-feature-build-archetype",
+    capabilityName: "feature-build-ship",
+    capabilityVocabularyVersion: "raw-v0",
+    archetypeContext: null,
+    agentIdForTriple,
+    torqueTechnical: 0,
+    torqueConfidence: 1,
+    ratioConsumed: 5,
+    outcomeType: "slip",
+    slipDetected: true,
+    slipReason: "archetype-unresolved",
+    graderType: "automated",
+    graderId: "gear-interface.archetype-resolver",
+    rationale:
+      "Install is not onboarded to a resolvable vertical archetype; Ring 2→3 attribution cannot be safely written.",
+    organizationId: options.organizationId ?? null,
+    idempotencyKeySuffix: "archetype-unresolved",
   };
 }

--- a/apps/web/lib/gear-interface/types.ts
+++ b/apps/web/lib/gear-interface/types.ts
@@ -58,7 +58,8 @@ export type SlipReason =
   | "manifest-invalid"
   | "signature-invalid"
   | "seed-delta-conflict"
-  | "source-unindexed";
+  | "source-unindexed"
+  | "archetype-unresolved";
 
 export type AutonomyTier =
   | "hitl-required"

--- a/apps/web/lib/gear-interface/writer.test.ts
+++ b/apps/web/lib/gear-interface/writer.test.ts
@@ -180,6 +180,32 @@ describe("validateGearInterfaceInput", () => {
     ).toThrow(/archetypeContext/);
   });
 
+  it("allows missing Ring 2→3 archetypeContext only for archetype-unresolved slip rows", () => {
+    expect(() =>
+      validateGearInterfaceInput({
+        ...ring12Input(),
+        innerRing: 2,
+        outerRing: 3,
+        outcomeType: "slip",
+        slipDetected: true,
+        slipReason: "archetype-unresolved",
+        archetypeContext: null,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      validateGearInterfaceInput({
+        ...ring12Input(),
+        innerRing: 2,
+        outerRing: 3,
+        outcomeType: "slip",
+        slipDetected: true,
+        slipReason: "failed-outcome",
+        archetypeContext: null,
+      }),
+    ).toThrow(/archetypeContext/);
+  });
+
   it("allows null archetypeContext at Ring 1→2", () => {
     expect(() => validateGearInterfaceInput(ring12Input())).not.toThrow();
   });

--- a/apps/web/lib/gear-interface/writer.ts
+++ b/apps/web/lib/gear-interface/writer.ts
@@ -55,6 +55,10 @@ class GearInterfaceValidationError extends Error {}
  */
 export function validateGearInterfaceInput(input: GearInterfaceInput): void {
   const direction = input.transmissionDirection ?? "outward";
+  const isArchetypeUnresolvedSlip =
+    input.outcomeType === "slip" &&
+    input.slipDetected === true &&
+    input.slipReason === "archetype-unresolved";
 
   if (input.interfaceClass === "internal-adjacent") {
     if (input.innerRing == null || input.outerRing == null) {
@@ -137,7 +141,8 @@ export function validateGearInterfaceInput(input: GearInterfaceInput): void {
     input.interfaceClass === "internal-adjacent" &&
     input.innerRing != null &&
     input.innerRing >= 2 &&
-    !input.archetypeContext
+    !input.archetypeContext &&
+    !isArchetypeUnresolvedSlip
   ) {
     throw new GearInterfaceValidationError(
       `archetypeContext is required at Ring ${input.innerRing}↔${input.outerRing} (spec §3.3)`,

--- a/apps/web/scripts/seed-gear-interface-phase-1.ts
+++ b/apps/web/scripts/seed-gear-interface-phase-1.ts
@@ -95,8 +95,11 @@ async function main() {
 
   console.log("[gear-phase1] emitting Ring 2→3 transmission with archetype context...");
   // Resolve archetype from the live install — same path the production Ring 2→3 emitter uses.
-  const storefront = await prisma.storefrontConfig.findFirst({ select: { archetypeId: true } });
-  const archetypeContext = storefront?.archetypeId ?? "demo-archetype-no-install";
+  const storefront = await prisma.storefrontConfig.findFirst({
+    orderBy: { updatedAt: "desc" },
+    select: { archetype: { select: { archetypeId: true } } },
+  });
+  const archetypeContext = storefront?.archetype?.archetypeId ?? null;
   const ring23 = await emitGearInterface({
     interfaceClass: "internal-adjacent",
     innerRing: 2,
@@ -111,12 +114,18 @@ async function main() {
     capabilityName: "feature-build-ship",
     archetypeContext,
     agentIdForTriple: AGENT,
-    torqueTechnical: 1.0,
-    torqueConfidence: 0.9,
+    torqueTechnical: archetypeContext ? 1.0 : 0,
+    torqueConfidence: archetypeContext ? 0.9 : 1,
     ratioConsumed: 5,
-    outcomeType: "transmission",
+    outcomeType: archetypeContext ? "transmission" : "slip",
+    slipDetected: !archetypeContext,
+    slipReason: archetypeContext ? null : "archetype-unresolved",
     graderType: "automated",
-    graderId: "feature-build-ship.completePhase",
+    graderId: archetypeContext ? "feature-build-ship.completePhase" : "gear-interface.archetype-resolver",
+    rationale: archetypeContext
+      ? null
+      : "Install is not onboarded to a resolvable vertical archetype; Ring 2→3 seed attribution cannot be safely written.",
+    idempotencyKeySuffix: archetypeContext ? undefined : "archetype-unresolved",
   });
   console.log("  →", ring23);
 

--- a/packages/db/prisma/migrations/20260524210500_backfill_gear_interface_archetype_context/migration.sql
+++ b/packages/db/prisma/migrations/20260524210500_backfill_gear_interface_archetype_context/migration.sql
@@ -1,0 +1,29 @@
+-- BI-44C34478 — GearInterface Ring 2+ archetypeContext must carry the
+-- portable StorefrontArchetype.archetypeId slug, not an install-local FK.
+
+-- One-time cleanup for rows emitted before the Ring 2→3 emitter resolved the
+-- semantic slug. Only rows whose context exactly matches a StorefrontArchetype
+-- primary key are rewritten.
+UPDATE "GearInterface" gi
+SET "archetypeContext" = sa."archetypeId"
+FROM "StorefrontArchetype" sa
+WHERE gi."interfaceClass" = 'internal-adjacent'
+  AND gi."innerRing" >= 2
+  AND gi."archetypeContext" = sa."id";
+
+-- Preserve the Ring 2+ invariant at the database boundary. The only accepted
+-- null context at Ring 2+ is the explicit observable setup/onboarding failure
+-- path, which the Cockpit can surface through slip-by-reason.
+ALTER TABLE "GearInterface"
+  ADD CONSTRAINT "GearInterface_ring2_archetype_context_check"
+  CHECK (
+    "interfaceClass" <> 'internal-adjacent'
+    OR "innerRing" IS NULL
+    OR "innerRing" < 2
+    OR "archetypeContext" IS NOT NULL
+    OR (
+      "outcomeType" = 'slip'
+      AND "slipDetected" = true
+      AND "slipReason" = 'archetype-unresolved'
+    )
+  );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -9295,6 +9295,7 @@ model GearInterface {
   /// 'novel-context' | 'failed-outcome' | 'human-override' | 'cost-overrun'
   /// | 'safety-block' | 'rate-limit' | 'capability-gap' | 'migration-destructive'
   /// | 'manifest-invalid' | 'signature-invalid' | 'seed-delta-conflict' | 'source-unindexed'
+  /// | 'archetype-unresolved'
   slipReason       String?
 
   // Cost — Decimal because this joins AI cost governance + finance views

--- a/packages/db/test/gear-interface-archetype-context-migration.test.ts
+++ b/packages/db/test/gear-interface-archetype-context-migration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationPath = path.join(
+  __dirname,
+  "../prisma/migrations/20260524210500_backfill_gear_interface_archetype_context/migration.sql",
+);
+
+describe("GearInterface archetypeContext backfill migration", () => {
+  it("rewrites FK-valued Ring 2+ archetype contexts to semantic StorefrontArchetype.archetypeId slugs", () => {
+    const sql = fs.readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain('UPDATE "GearInterface"');
+    expect(sql).toContain('FROM "StorefrontArchetype"');
+    expect(sql).toContain('"archetypeContext" = sa."archetypeId"');
+    expect(sql).toContain('gi."archetypeContext" = sa."id"');
+    expect(sql).toContain('gi."innerRing" >= 2');
+  });
+
+  it("adds the Ring 2+ invariant exception only for archetype-unresolved slips", () => {
+    const sql = fs.readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain('"GearInterface_ring2_archetype_context_check"');
+    expect(sql).toContain('"slipReason" = \'archetype-unresolved\'');
+    expect(sql).toContain('"slipDetected" = true');
+    expect(sql).toContain('"outcomeType" = \'slip\'');
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve Ring 2->3 GearInterface archetype context from `StorefrontConfig.archetype.archetypeId` so new rows carry stable semantic slugs instead of install-local FK/cuid values.
- Add the observable `archetype-unresolved` slip path for installs without a resolvable storefront archetype, and preserve the Ring >=2 context invariant for all other rows.
- Add a Prisma migration that backfills FK-valued GearInterface rows and adds a DB-level invariant check, plus migration guard coverage.
- Update the Phase 1 seed path to use the same semantic resolver/unresolved-slip behavior.

## Backlog
- Implements `BI-44C34478` under `EP-REDUCTION-GEAR-ARCH`.
- Related vertical long-tail workspace-home BIs were queued separately under the same epic: `BI-134B247A`, `BI-57BC53E0`, `BI-52E4939B`, `BI-FB7FD753`, `BI-96A3C7A9`, `BI-43A682A2`, `BI-EF03E915`, `BI-02845133`.

## Verification
- `pnpm --filter web exec vitest run lib/gear-interface` -> 11 files, 107 tests passed.
- `pnpm --filter @dpf/db exec vitest run test/gear-interface-archetype-context-migration.test.ts` -> 1 file, 2 tests passed.
- `pnpm --filter web typecheck` passed.
- `pnpm --filter @dpf/db typecheck` passed.
- `pnpm --filter web exec next build` passed, generated 112/112 static pages; existing Turbopack Edge-runtime warnings remain around platform version/image-version, discovery collectors, Prisma generated client, and next.config.mjs NFT tracing.
- `pnpm --filter @dpf/db exec prisma migrate status` passed with the local host-mapped `DATABASE_URL`; schema is up to date with 246 migrations.
- DB spot check after migration deploy/status showed 0 FK-valued Ring >=2 rows matching `StorefrontArchetype.id`, 1 semantic Ring >=2 row matching `StorefrontArchetype.archetypeId`, and slip-by-reason output including `archetype-unresolved|1`.

## Notes
- This PR intentionally does not implement worker-home UI rendering or a permanent downstream FK-normalization shim.
