### PR TITLE
docs: add vertical workspace persona anchors

### DIFF
--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -5,27 +5,37 @@ This directory holds persona case-study documents that serve two jobs at once:
 - Marketing substrate: narrative, quotes, before/after copy, and concrete pain points that can be reused in site copy, decks, onboarding, and customer conversations.
 - Test substrate: re-runnable dogfood scenarios that prove the platform still works for that persona as DPF evolves.
 
-Each persona gets one Markdown file named `<name>-<vertical>.md`. The first real persona is [Dale, HVAC owner](dale-hvac.md), extracted from the Build Studio dogfood thread at [docs/dogfood/2026-05-23-dale-hvac-build-studio.md](../dogfood/2026-05-23-dale-hvac-build-studio.md) and the live `EP-9FC5D2FD` backlog state.
+Each persona gets one Markdown file named `<name>-<vertical>.md`. The first real persona is [Dale, HVAC owner](dale-hvac.md), extracted from the Build Studio dogfood thread at [docs/dogfood/2026-05-23-dale-hvac-build-studio.md](../dogfood/2026-05-23-dale-hvac-build-studio.md) and the live `EP-9FC5D2FD` backlog state. The first vertical workspace-home peer wave is tied to the [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md) and the live `EP-REDUCTION-GEAR-ARCH` backlog.
 
 ## Library Rules
 
 - Keep the persona voice concrete. Write from the operator's daily reality, not from platform capability names.
 - Keep marketing and testing together. If a story claims value, the same file should say how to re-run the flow.
 - Ground every dogfood finding in the dogfood log, live backlog, or source code. Do not invent shipped status from memory.
-- Before adding new Build Studio dogfood runs for peer personas, check live backlog for Dale's D38 blocker (`BI-4396EFEC`). At library creation time on 2026-05-24, it was still captured/triaging, so new persona Build Studio runs should wait.
-- When a persona build ships a reusable feature, record its archetype applicability. "Reusable" does not mean "useful for every business."
+- Treat backlog snapshots as dated. Re-query the live backlog before gating new work on a persona file.
+- Anchor every archetype to the catalog. Personas reference `StorefrontArchetype.archetypeId` and `category` strings that exist in `packages/storefront-templates/src/archetypes/`; if the natural leaf is missing, link the tracked work instead of implying it ships today.
+- Anchor every coworker name to seed reality before a dogfood run. If a coworker is designed but not seeded, say so and simulate it through the generic build/chat flow.
+- Before adding new Build Studio dogfood runs for peer personas, check Dale's D38 blocker (`BI-4396EFEC`). As of 2026-05-24, it remains `triaging`; peer runs should wait until a fresh Dale run proves plan-iteration convergence.
+- When a persona build ships a reusable feature, record its archetype applicability. Reusable does not mean useful for every business.
 
 ## Current Files
 
-| Persona | Vertical | Source state | First feature smoke |
-| ------- | -------- | ------------ | ------------------- |
-| [Dale](dale-hvac.md) | HVAC / field service | Dogfooded through Build Studio phases, with live backlog items through D38 | Truck stock tracker |
+| Persona | Vertical | Archetype/category | Source state | Workspace-home BI | First feature smoke |
+| ------- | -------- | ------------------ | ------------ | ----------------- | ------------------- |
+| [Dale](dale-hvac.md) | HVAC / field service | target `hvac-contractor`; category `trades-maintenance` | Dogfooded through Build Studio phases, with live backlog items through D38 | `BI-CE6AF925` | Dispatch board plus truck-stock visibility |
+| [Linda](linda-clinic.md) | Clinic scheduling | `dental-practice`; category `healthcare-wellness` | Defined from vertical-home design; not dogfooded yet | `BI-8954667A` | Appointment readiness and practitioner capacity |
+| [Marisol](marisol-retail.md) | Retail merchandising | `retail-goods`; category `retail-goods` | Defined from vertical-home design; not dogfooded yet | `BI-3F3B535D` | Order tasks, low stock, receiving, returns, and location signals |
 
 ## Candidate Queue
 
-These names are placeholders until each has a grounded first-feature run or a deliberately scoped research pass:
+These are queued until each has a grounded first-feature run or a deliberately scoped research pass:
 
-- Pat - professional services operator
-- Linda - healthcare/wellness scheduler or clinic operator
-- Roberto - food/hospitality owner-operator
-- Marisol - retail or beauty/personal-care operator
+| Candidate | Working role | Target category | Current backlog anchor |
+| --------- | ------------ | --------------- | ---------------------- |
+| Pat | Professional services operator | `professional-services` | `BI-57BC53E0` |
+| Roberto | Food/hospitality owner-operator | `food-hospitality` | `BI-52E4939B` |
+| Aaliyah | Education/training coordinator | `education-training` | `BI-134B247A` |
+| Carmen | HOA/property operations coordinator | `hoa-property-management` | `BI-96A3C7A9` |
+| Grace | Nonprofit program manager | `nonprofit-community` | `BI-EF03E915` |
+
+Do not expand the persona library by inventing generic archetype stories. Each new file should be linked to a specific workspace-home backlog item or a real dogfood run.

--- a/docs/personas/dale-hvac.md
+++ b/docs/personas/dale-hvac.md
@@ -6,7 +6,7 @@
 - **Size**: 4 trucks; small owner-operated shop. Employee count, revenue, and geography were not specified in the dogfood source.
 - **Tech baseline**: Types with two fingers, has never opened a terminal, and calls every tool an "app."
 - **What they don't have**: A simple way for technicians to know what parts are on each truck, plus a software-building experience that speaks shop language instead of platform language.
-- **Archetype**: Target leaf `hvac-contractor`; current category `trades-maintenance`. The field-service spec notes that the category exists but the HVAC leaf archetype still needs to be added.
+- **Archetype**: Target leaf `hvac-contractor`; current category `trades-maintenance`. The catalog seeds `facilities-maintenance`, `plumber`, `electrician`, `cleaning-service`, and `landscaping`; `hvac-contractor` is not yet seeded.
 - **IT4IT value streams they care about**: `strategy-to-portfolio`, `requirement-to-deploy`, `request-to-fulfill`, `detect-to-correct`, `deploy-to-operate`.
 
 ## The narrative (marketing-grade)
@@ -33,12 +33,12 @@ The source Build Studio build is `FB-6F7D6AC4`, under Dale's hardening epic `EP-
 ## What the platform needs to be like for them
 
 - **Vocabulary** they expect: trucks, techs, parts, warehouse, jobs, service calls, customers, look up, update the list, pull parts, restock, on my way.
-- **Vocabulary to avoid**: FeatureBuild, work capsule, branch, build ID, model route, MCP tool, evidence, taxonomy, IT4IT, schema, designDoc, buildPlan, sandbox container.
-- **Coworkers** they need active: Build Studio Software Engineer for the first feature; Dispatcher for daily schedule and customer updates; Inventory Specialist for truck stock and restock prompts; Field Technician helper for mobile job updates.
+- **Vocabulary to avoid**: FeatureBuild, work capsule, branch, build ID, model route, MCP tool, evidence, taxonomy, IT4IT, schema, designDoc, buildPlan, sandbox container, GearInterface, torque, ring, slip, cockpit.
+- **Coworkers** they need active: Build Studio Software Engineer for the first feature; Dispatcher-style coworker for daily schedule and customer updates; Field Technician-style coworker for mobile job and parts-used updates. The Dispatcher and Field Technician roles are designed in the field-service spec but must be checked against seed reality before a dogfood run.
 - **Critical features**: obvious "start a build" entry, provider readiness gate, multiline intake, visible long-running progress, correct active-build targeting, review-loop convergence, plain-language status banners, live preview tied to the active build, internal ID hiding, truck inventory lookup/update, and archetype-aware hive applicability.
 - **Mostly irrelevant at first touch**: architecture maps, code intelligence chips, model/provider IDs, branch/capsule metadata, raw admin backlog mechanics, generic portfolio language, and release internals.
 - **Surfaces they'll touch first**: `/welcome`, `/login`, `/workspace`, `/build`, `/platform/ai/providers` only if setup is blocked, live preview, and later a mobile or technician surface for truck stock.
-- **Surfaces they should NEVER see**: tool traces, admin internals, raw model IDs, Git branch names, MCP/tool names, schema field names, internal failure handlers, IT4IT/EA jargon, or unrelated platform self-upgrade work.
+- **Surfaces they should NEVER see**: tool traces, admin internals, raw model IDs, Git branch names, MCP/tool names, schema field names, internal failure handlers, IT4IT/EA jargon, GearInterface terms, or unrelated platform self-upgrade work.
 
 ## Marketing extractables
 
@@ -64,6 +64,7 @@ The source Build Studio build is `FB-6F7D6AC4`, under Dale's hardening epic `EP-
 - Re-run Plan iteration for the truck-stock feature and confirm review iterations converge or stop with a clear split-scope recommendation. It must not oscillate between task granularities for 30 minutes. Link: `BI-4396EFEC`.
 - Force or simulate a max-iteration fallback and confirm the recovery message remains deterministic and domain-correct. It must not suggest unrelated finance reports while Dale is building truck inventory. Link: `BI-0C19AFDD`.
 - Switch between two builds, then open live preview from Dale's build. The preview must open the active truck-stock build, not a stale "driving" build from another thread. Link: `BI-EEC5A5ED`.
+- Open `/workspace` as Dale's install once `BI-CE6AF925` lands and confirm the first viewport is a dispatch board with today's jobs, unscheduled jobs, technician load, customer update failures, parts/units, and coworker handoffs.
 - When the truck-stock feature is ready for hive contribution, confirm applicability metadata limits it to field-service/mobile-inventory archetypes by default. A dental practice, law firm, or restaurant install should not see it as a recommended feature. Link: `BI-76E66F9B`.
 - Smoke the shipped feature itself: create two trucks, add parts to each, look up parts from a technician view, mark one part used, and confirm restock visibility updates.
 
@@ -109,4 +110,6 @@ Live backlog check on 2026-05-24 showed these non-done items under `EP-9FC5D2FD`
 
 - Primary dogfood log: [2026-05-23 Dale HVAC Build Studio dogfood](../dogfood/2026-05-23-dale-hvac-build-studio.md).
 - Field-service archetype and architecture grounding: [Field Service Trades design](../superpowers/specs/2026-05-19-field-service-trades-ai-dispatch-design.md) and [Field Service Sprint 1 plan](../superpowers/plans/2026-05-19-field-service-sprint-1.md).
-- Live backlog source at creation: MCP `list_backlog_items(epicId="EP-9FC5D2FD")` and `get_backlog_item("BI-4396EFEC")`.
+- Workspace-home anchor: [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md).
+- Archetype seed reality: `packages/storefront-templates/src/archetypes/trades-maintenance.ts`.
+- Live backlog source at creation: MCP `list_backlog_items(epicId="EP-9FC5D2FD")`, `get_backlog_item("BI-4396EFEC")`, `get_backlog_item("BI-CE6AF925")`, and `list_backlog_items(epicId="EP-REDUCTION-GEAR-ARCH")` on 2026-05-24.

--- a/docs/personas/linda-clinic.md
+++ b/docs/personas/linda-clinic.md
@@ -1,0 +1,82 @@
+# Linda, Scheduler at a neighborhood dental practice - DPF persona
+
+## Snapshot
+
+- **Business**: Independent dental practice serving families and returning patients through exams, hygiene appointments, emergency visits, and treatment plans.
+- **Size**: Small clinic with a front desk, several treatment rooms, dentists, hygienists, and part-time admin coverage. Exact revenue and geography are not specified.
+- **Tech baseline**: Comfortable with scheduling software, email/SMS reminders, scanned forms, and spreadsheets, but not with platform administration or software delivery terms.
+- **What they don't have**: One calm view that says whether today's and tomorrow's appointments are actually ready: forms complete, patient confirmed, practitioner load sane, and follow-ups queued.
+- **Archetype**: Seeded leaf `dental-practice`; category `healthcare-wellness`.
+- **IT4IT value streams they care about**: `request-to-fulfill`, `detect-to-correct`, `deploy-to-operate`.
+
+## The narrative (marketing-grade)
+
+Linda's day starts before the first patient walks in. She is checking who confirmed, who still needs forms, whether a new patient is missing intake paperwork, whether a hygienist is overbooked, and which appointment is likely to no-show because the reminder bounced. None of those problems look dramatic on a dashboard, but each one can knock the whole morning sideways.
+
+The practice already has software. What Linda needs is the missing connective tissue: a front-desk home that shows the work exactly as she thinks about it. If a patient is ready, it should be obvious. If a form is missing, it should be in her face before the patient arrives. If a practitioner is overloaded, the system should say that in plain clinic language, not bury it in an operations report.
+
+For Linda, DPF is valuable when it makes the schedule less fragile. The platform should feel like a second set of eyes at the desk: quiet, privacy-aware, and specific enough that she can act before a queue forms in the waiting room.
+
+## What they ask DPF to build (the first feature)
+
+"I want tomorrow's schedule to show which patients are ready, which forms are missing, and where the hygienists are overloaded."
+
+First-feature smoke scope:
+
+- Show today's and tomorrow's appointments.
+- Mark each appointment as ready, needs forms, needs confirmation, or needs follow-up.
+- Highlight no-show risk from missing or failed reminders.
+- Show practitioner and hygienist capacity by time block.
+- Queue patient follow-ups without exposing platform internals.
+
+Primary workspace-home backlog item: `BI-8954667A`.
+
+## What the platform needs to be like for them
+
+- **Vocabulary** they expect: patients, appointments, chairs, dentists, hygienists, practitioner load, forms, intake, confirmations, reminders, no-shows, follow-up calls, ready for visit.
+- **Coworkers** they need active: a clinic scheduler or patient-engagement coworker for reminders, missing forms, and follow-up calls; no field-service Dispatcher is needed. Before dogfood, verify the seed state for any named coworker and simulate missing roles through the generic Build Studio coworker if needed.
+- **Features** that are critical vs irrelevant: critical features are schedule readiness, missing-form detection, failed reminder visibility, practitioner capacity, patient follow-up tasks, privacy-aware copy, and translated coworker handoffs. Irrelevant at first touch: truck inventory, warehouse stock, POS merchandising, platform architecture, raw model/provider details, and GearInterface terminology.
+- **Surfaces** they'll touch first and what should be on them: `/workspace` should open to a schedule board with readiness and exceptions above generic KPIs; `/build` should accept the appointment-readiness request in clinic language; any patient-facing form reminder should remain previewable without exposing admin internals.
+- **Surfaces** they should NEVER see: model IDs, MCP/tool names, schema fields, internal audit mechanics, raw autonomy decisions, gear/ring/torque/slip/cockpit language, or unrelated platform release work.
+
+## Marketing extractables
+
+- "Linda is not asking for another calendar. She is asking to know whether the day is going to hold together."
+- "A missing form is not paperwork; it is a waiting-room delay that can ripple across every appointment after it."
+- "DPF helps the front desk see tomorrow's problems while there is still time to fix them."
+- **Before/after hero block**: Before DPF, Linda pieces together readiness from reminders, forms, and mental notes. After DPF, the schedule shows which patients are ready, which appointments need action, and where practitioner capacity is starting to bend.
+- **Feature soundbites**: Appointment readiness replaces calendar guesswork; missing forms become early warnings; failed reminders create follow-up tasks; practitioner load is visible before the waiting room backs up; clinic language keeps the platform out of the patient's way.
+- **Permission to use?** Pseudonym/synthetic persona. Not a real customer story unless replaced with a customer-approved case study.
+
+## Test scenarios (re-runnable dogfood)
+
+- With substrate BI `BI-1CCC6264` complete, configure a `dental-practice` / `healthcare-wellness` install and confirm `/workspace` resolves to the clinic contribution rather than the platform fallback.
+- With projection BI `BI-3E8D2CF5` complete, render a missing-form signal and a failed reminder as clinic-native needs-review items, not GearInterface or Governor copy.
+- Drive `BI-8954667A` on the Live portal with fixture-backed appointments: one ready appointment, one missing forms, one failed reminder, one no-show risk, and one overloaded practitioner block.
+- Confirm the first viewport prioritizes schedule readiness, queue exceptions, missing forms, and practitioner load before generic business KPIs.
+- On mobile, confirm the readiness and exceptions slots stay ahead of lower-priority cards.
+- Start Linda's first-feature Build Studio request only after `BI-4396EFEC` has been functionally verified against Dale's flow; confirm plan iterations converge or stop with split-scope guidance.
+
+## Dogfood history
+
+| Date | Phase reached | Deficiencies surfaced | Outcome |
+| ---- | ------------- | --------------------- | ------- |
+| 2026-05-24 | Persona defined from vertical-home design | None yet; not dogfooded | Ready as a peer-story and future Build Studio smoke once Dale's D38 blocker is cleared. |
+
+## Open BIs from this persona's dogfooding
+
+No Linda-specific dogfood deficiencies yet.
+
+Related live backlog anchors:
+
+- `BI-8954667A` - Clinic scheduler workspace home; live status `open`.
+- `BI-1CCC6264` - Vertical workspace home substrate; live status `open`.
+- `BI-3E8D2CF5` - Vertical workspace home projection service; live status `open`.
+- `BI-4396EFEC` - Dale D38 plan-iteration divergence; live status `triaging`, gating new peer-persona Build Studio sessions.
+
+## Source evidence
+
+- Workspace-home anchor: [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md).
+- Archetype seed reality: `packages/storefront-templates/src/archetypes/healthcare-wellness.ts`.
+- Vocabulary grounding: `apps/web/lib/storefront/archetype-vocabulary.ts`.
+- Live backlog source at creation: MCP `get_backlog_item("BI-8954667A")`, `get_backlog_item("BI-1CCC6264")`, `get_backlog_item("BI-3E8D2CF5")`, and `get_backlog_item("BI-4396EFEC")` on 2026-05-24.

--- a/docs/personas/marisol-retail.md
+++ b/docs/personas/marisol-retail.md
@@ -1,0 +1,82 @@
+# Marisol, Merchandiser at a two-location specialty retail shop - DPF persona
+
+## Snapshot
+
+- **Business**: Specialty retail shop selling curated home goods through two physical locations plus a small online storefront.
+- **Size**: Small multi-location shop with store associates, a back-room receiving rhythm, and owner/operator oversight. Exact revenue and geography are not specified.
+- **Tech baseline**: Comfortable with POS, ecommerce orders, spreadsheets, barcode/stock tools, and text/email follow-up, but not with platform administration or software delivery terms.
+- **What they don't have**: One workboard that combines open order tasks, low stock, incoming inventory, return exceptions, and location-level sales signals before customers discover the gap first.
+- **Archetype**: Seeded leaf `retail-goods`; category `retail-goods`.
+- **IT4IT value streams they care about**: `request-to-fulfill`, `detect-to-correct`, `deploy-to-operate`.
+
+## The narrative (marketing-grade)
+
+Marisol's work is a constant negotiation between what the system says is available and what the shelf actually looks like. A product can sell out in one location while sitting untouched in another. A delivery can arrive without being received cleanly. A return can create a resale question. An online order can look simple until the item is on the wrong shelf in the wrong store.
+
+She does not need a beautiful analytics page at 8 a.m. She needs a merchandising board that says what needs action now: which orders are waiting, which SKUs are low, what arrived today, which returns need a decision, and whether one location's demand should move stock from the other. The value is in turning retail noise into a short, trusted action list.
+
+DPF works for Marisol when it respects the floor. The system should speak in products, SKUs, locations, stockroom, orders, returns, receiving, and restock - not platform language. If the board is right, the shop feels less reactive by noon.
+
+## What they ask DPF to build (the first feature)
+
+"I want one home screen that tells me which orders need action, what's running low, and what arrived today."
+
+First-feature smoke scope:
+
+- Show open order tasks by location.
+- Highlight low-stock SKUs and suggested restock actions.
+- Show incoming inventory that needs receiving or count confirmation.
+- Flag return exceptions that need a resale, refund, or vendor decision.
+- Show simple location-level sales signals without turning the home into a finance report.
+
+Primary workspace-home backlog item: `BI-3F3B535D`.
+
+## What the platform needs to be like for them
+
+- **Vocabulary** they expect: products, SKUs, variants, stock, low stock, back room, receiving, orders, pickup, shipping, returns, restock, transfers, locations, register, sales today.
+- **Coworkers** they need active: a merchandising or inventory coworker for low-stock and receiving exceptions, plus a customer follow-up coworker for order/return messages. A Dispatcher coworker is irrelevant unless the store later adds local delivery.
+- **Features** that are critical vs irrelevant: critical features are order task queues, low-stock thresholds, receiving tasks, return exceptions, location-level signals, manual count adjustments, and archetype-aware applicability. Irrelevant at first touch: clinic appointment readiness, technician load, warehouse-truck stock, platform architecture, raw model/provider details, and GearInterface terminology.
+- **Surfaces** they'll touch first and what should be on them: `/workspace` should open to a merchandising board; `/build` should accept the first-feature request in retail language; any generated feature should preview inventory/order behavior against the active build.
+- **Surfaces** they should NEVER see: schema fields, tool traces, Git branches, model IDs, MCP/tool names, raw autonomy labels, gear/ring/torque/slip/cockpit language, or unrelated admin backlog mechanics.
+
+## Marketing extractables
+
+- "Marisol does not need another report. She needs the store to tell her what needs action before the customer does."
+- "Low stock is not just an inventory metric; it is a missed sale waiting to happen."
+- "DPF turns a messy retail morning into a short list: orders, stock, receiving, returns."
+- **Before/after hero block**: Before DPF, Marisol checks POS, ecommerce, stock counts, and receiving notes separately. After DPF, the home screen shows the orders, low-stock items, incoming inventory, returns, and location signals that matter today.
+- **Feature soundbites**: Open order tasks stay visible until resolved; low-stock exceptions become restock actions; receiving work is part of the daily board; returns are treated as decisions, not clutter; location signals help small teams move stock before demand shifts.
+- **Permission to use?** Pseudonym/synthetic persona. Not a real customer story unless replaced with a customer-approved case study.
+
+## Test scenarios (re-runnable dogfood)
+
+- With substrate BI `BI-1CCC6264` complete, configure a `retail-goods` install and confirm `/workspace` resolves to the retail contribution rather than the platform fallback.
+- With projection BI `BI-3E8D2CF5` complete, render low-stock and return-exception signals as retail-native needs-review items, not GearInterface or Governor copy.
+- Drive `BI-3F3B535D` on the Live portal with fixture-backed data: one open pickup order, one shipping task, one low-stock SKU, one incoming inventory receipt, one return exception, and one location-level sales signal.
+- Confirm the first viewport prioritizes order tasks, low-stock exceptions, receiving, and returns before generic business KPIs.
+- On mobile, confirm the most urgent retail slots stay ahead of lower-priority cards and do not collapse into unreadable summary text.
+- Start Marisol's first-feature Build Studio request only after `BI-4396EFEC` has been functionally verified against Dale's flow; confirm the feature contribution is not recommended to clinic or field-service archetypes by default.
+
+## Dogfood history
+
+| Date | Phase reached | Deficiencies surfaced | Outcome |
+| ---- | ------------- | --------------------- | ------- |
+| 2026-05-24 | Persona defined from vertical-home design | None yet; not dogfooded | Ready as a peer-story and future Build Studio smoke once Dale's D38 blocker is cleared. |
+
+## Open BIs from this persona's dogfooding
+
+No Marisol-specific dogfood deficiencies yet.
+
+Related live backlog anchors:
+
+- `BI-3F3B535D` - Retail merchandiser workspace home; live status `open`.
+- `BI-1CCC6264` - Vertical workspace home substrate; live status `open`.
+- `BI-3E8D2CF5` - Vertical workspace home projection service; live status `open`.
+- `BI-4396EFEC` - Dale D38 plan-iteration divergence; live status `triaging`, gating new peer-persona Build Studio sessions.
+
+## Source evidence
+
+- Workspace-home anchor: [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md).
+- Archetype seed reality: `packages/storefront-templates/src/archetypes/retail-goods.ts`.
+- Vocabulary grounding: `apps/web/lib/storefront/archetype-vocabulary.ts`.
+- Live backlog source at creation: MCP `get_backlog_item("BI-3F3B535D")`, `get_backlog_item("BI-1CCC6264")`, `get_backlog_item("BI-3E8D2CF5")`, and `get_backlog_item("BI-4396EFEC")` on 2026-05-24.

--- a/docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md
+++ b/docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md
@@ -481,6 +481,22 @@ The contribution substrate should be proven with HVAC first, then filed as separ
 
 The category fallback should be useful but less specific. Exact archetype contributions win when available.
 
+### 7.1 Overall design evaluation
+
+The overall design is architecturally sound: it keeps `/workspace` as the employee landing surface, preserves the current platform command center as a fallback/operator mode, and introduces vertical homes through typed contributions instead of route forks. The resolver / contribution / projection split is the right durability boundary because each vertical can bring its own vocabulary, layout, and first-view priority while still reading canonical records and translated GearInterface / Calibrator / Governor signals.
+
+The remaining design risk is not the substrate shape; it is validation drift. A table of archetypes is still too abstract unless each implementation BI has a named worker whose day can be replayed. Every vertical-home BI should therefore have a persona case-study document under `docs/personas/` before Build Studio starts the feature. The persona owns the smoke: what the worker asks for, what the first viewport must show, which jargon must be hidden, which coworkers are relevant, and which canonical records must render in the Live portal.
+
+This pass creates the first-wave persona anchors:
+
+| Persona | Persona file | Archetype / category | Workspace-home BI | First-feature smoke |
+| ------- | ------------ | -------------------- | ----------------- | ------------------- |
+| Dale | [`docs/personas/dale-hvac.md`](../../personas/dale-hvac.md) | target `hvac-contractor` / category `trades-maintenance` | `BI-CE6AF925` | Dispatch board plus truck-stock visibility: today's service calls, unscheduled jobs, technician load, customer update failures, parts/units, and coworker handoffs. |
+| Linda | [`docs/personas/linda-clinic.md`](../../personas/linda-clinic.md) | `dental-practice` / category `healthcare-wellness` | `BI-8954667A` | Schedule board: ready appointments, missing forms, no-show risk, practitioner capacity, and patient follow-ups. |
+| Marisol | [`docs/personas/marisol-retail.md`](../../personas/marisol-retail.md) | `retail-goods` / category `retail-goods` | `BI-3F3B535D` | Merchandising board: open order tasks, low stock, incoming inventory, return exceptions, and location-level sales signals. |
+
+Substrate BIs `BI-1CCC6264` and `BI-3E8D2CF5` remain shared prerequisites. As of the 2026-05-24 live backlog check, all three first-wave vertical BIs above are open under `EP-REDUCTION-GEAR-ARCH`. Dale's prior Build Studio blocker `BI-4396EFEC` is still `triaging`; do not run new peer-persona Build Studio sessions until a fresh Dale run proves the plan-iteration divergence no longer traps first-feature work.
+
 ## 8. Unconfigured State
 
 When a business has a `StorefrontArchetype` but no matching home contribution:
@@ -616,6 +632,7 @@ BIs 1 and 2 are substrate; they unblock BIs 3–5 and any future vertical. Each 
 This spec pass produces:
 
 - A written spec at `docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md`.
+- First-wave persona coverage under `docs/personas/` for the HVAC, clinic, and retail workspace-home variants.
 - Follow-on implementation BIs under `EP-REDUCTION-GEAR-ARCH`.
 - Execution evidence attached to `BI-89C19AAF`.
 


### PR DESCRIPTION
## Summary
- Adds first-wave persona coverage for Dale, Linda, and Marisol under docs/personas.
- Updates the persona library index with archetype/category, workspace-home BI, and candidate queue mapping.
- Adds an overall design evaluation and persona coverage matrix to the vertical workspace home spec.

## Verification
- Queried live DPF backlog via MCP for EP-REDUCTION-GEAR-ARCH, BI-1CCC6264, BI-3E8D2CF5, BI-CE6AF925, BI-8954667A, BI-3F3B535D, and BI-4396EFEC.
- Ran git show --check --pretty=format: HEAD.
- Ran Markdown link sanity over the changed docs.
- Pre-commit hook ran local gitleaks scan: no leaks found.

Docs-only change; no app build or UI verification run.