### PR TITLE
Capacity-aware feedback escalation: spec + Phase 0 implementation

### DIFF
--- a/docs/superpowers/plans/2026-05-24-feedback-substrate-cleanup.md
+++ b/docs/superpowers/plans/2026-05-24-feedback-substrate-cleanup.md
@@ -1,0 +1,1541 @@
+# Feedback Substrate Cleanup (Phase 0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Consolidate the four current writers of `PlatformIssueReport` through one server writer, introduce status constants (vocabulary), teach the issue-report triage cron to skip support-flow statuses, and clean theme-token violations in the two touched feedback fallback UI files — all as pure refactor, no new product behavior.
+
+**Architecture:** A single `createPlatformIssueReport()` writer in `apps/web/lib/quality/platform-issue-reports.ts` becomes the only path that creates rows in `PlatformIssueReport`. It applies length limits, resolves `portfolioId`/`digitalProductId` defaults, generates the `PIR-XXXXX` `reportId`, and validates `status` against `ISSUE_REPORT_STATUS` constants exported from `apps/web/lib/quality/issue-report-status.ts`. The three call sites (`POST /api/quality/report`, `reportQualityIssue()` server action, `report_quality_issue` MCP tool handler) all become thin adapters over the writer. The crash boundary continues to call `POST /api/quality/report` and inherits the consolidation. The Inngest cron `issue-report-triage` switches its `where: { status: "open" }` filter to use the new `ISSUE_REPORT_STATUS.OPEN` constant, so any future status drift (e.g. `support_triage`) cannot be silently swept into BIs.
+
+**Tech Stack:** TypeScript, Next.js 15 App Router, Prisma 5, Vitest 4.1.5, Inngest, pnpm workspace.
+
+**Lane:** This plan is a Phase 0 pure refactor with invariants — the carveout under `feedback_no_manual_prs` for "deps/cleanup/governance/urgent hotfixes." It is a maintenance-class PR opened directly by Claude (not routed through Build Studio). Phase 1+ slices that introduce new product behavior (support-mode coworker, capacity routing, bridge wiring) MUST be filed as BIs and run through Build Studio per `feedback_build_studio_for_all_development`.
+
+---
+
+## Spec anchor
+
+- Spec: [`docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md`](../specs/2026-05-24-capacity-aware-feedback-escalation-design.md), §8 Phase 0 (lines 349–368), §6.2 status vocabulary (lines 186–199), §7.2 UI requirements (lines 332–346)
+- PR for spec: [#1110](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1110)
+- Suggested epic: `EP-9FC5D2FD` (Build Studio first-customer experience hardening) — fits because the cleanup directly enables the Dale-on-Build-Studio escalation slices that come next
+
+## Scope and non-scope
+
+**In scope** (this plan only):
+
+- One server-side writer for `PlatformIssueReport`
+- Status constants module (all 9 statuses defined; only `OPEN` actively used in this phase)
+- Three call-site migrations (route handler, server action, MCP tool handler)
+- Cron uses status constant; defensive test that a `support_triage` row is not converted
+- Theme-token cleanup in `FeedbackButton.tsx` and `FeedbackForm.tsx` only
+- Unit tests for the writer covering: ID format, length truncation, defaults, status validation
+- Live UX verification per `structural-verification-is-not-functional` kernel
+
+**Out of scope** (later phases):
+
+- `triggerKind`, `coalesceKey`, `coalesceBucket`, `escalationPolicy`, `capacityDecision`, `supportSummary`, `resolvedAt` schema fields (Phase 2/3)
+- `FeedbackEventDetail` typed contract (Phase 1)
+- Coworker support mode behavior (Phase 1)
+- `assessFeedbackRouting()` (Phase 2)
+- `fileUpstreamFeedback()` tool / bridge wiring (Phase 3)
+- Implicit hard-failure triggers beyond what already exists (Phase 4)
+- Reverse channel via `Notification` (Phase 5)
+- Voice STT (Phase 6)
+- UI debt in `IssueReportPanel.tsx` and `TokenExpiryBanner.tsx` (out of scope per spec §7.2)
+
+## Pre-flight check
+
+Before Task 1, verify branch state:
+
+```bash
+git status                                 # expect clean
+git log --oneline origin/main..HEAD        # expect 0 commits (or only this plan's commit)
+pnpm --filter web typecheck                # expect green baseline
+pnpm --filter web exec vitest run lib/operate/issue-report-triage.test.ts
+                                           # expect existing cron test to pass — this is the baseline
+```
+
+If typecheck or the baseline triage test fails, stop and reconcile before touching production code.
+
+---
+
+## Task 1: Status Constants Module
+
+**Files:**
+- Create: `apps/web/lib/quality/issue-report-status.ts`
+- Create: `apps/web/lib/quality/issue-report-status.test.ts`
+
+Purpose: a single, importable source of truth for the 9 statuses defined in spec §6.2. Only `OPEN` is actively used in Phase 0; the rest are defined so later phases cannot invent strings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/lib/quality/issue-report-status.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  ISSUE_REPORT_STATUS,
+  SUPPORT_FLOW_STATUSES,
+  isSupportFlowStatus,
+  type IssueReportStatus,
+} from "./issue-report-status";
+
+describe("ISSUE_REPORT_STATUS", () => {
+  it("defines all 9 statuses from spec §6.2", () => {
+    expect(ISSUE_REPORT_STATUS).toEqual({
+      OPEN: "open",
+      SUPPORT_TRIAGE: "support_triage",
+      RESOLVED_LOCALLY: "resolved_locally",
+      TRIAGED_LOCAL: "triaged_local",
+      AWAITING_ESCALATION_ACK: "awaiting_escalation_ack",
+      UPSTREAM_PENDING: "upstream_pending",
+      UPSTREAM_FILED: "upstream_filed",
+      RESOLVED_UPSTREAM: "resolved_upstream",
+      SUPPRESSED: "suppressed",
+    });
+  });
+
+  it("SUPPORT_FLOW_STATUSES contains the 4 statuses the cron must skip", () => {
+    expect(SUPPORT_FLOW_STATUSES).toEqual([
+      "support_triage",
+      "awaiting_escalation_ack",
+      "upstream_pending",
+      "upstream_filed",
+    ]);
+  });
+
+  it("isSupportFlowStatus returns true for support-flow statuses", () => {
+    expect(isSupportFlowStatus("support_triage")).toBe(true);
+    expect(isSupportFlowStatus("upstream_filed")).toBe(true);
+  });
+
+  it("isSupportFlowStatus returns false for open and terminal statuses", () => {
+    expect(isSupportFlowStatus("open")).toBe(false);
+    expect(isSupportFlowStatus("resolved_locally")).toBe(false);
+    expect(isSupportFlowStatus("triaged_local")).toBe(false);
+    expect(isSupportFlowStatus("resolved_upstream")).toBe(false);
+    expect(isSupportFlowStatus("suppressed")).toBe(false);
+  });
+
+  it("IssueReportStatus union type compiles for every value", () => {
+    const statuses: IssueReportStatus[] = [
+      "open",
+      "support_triage",
+      "resolved_locally",
+      "triaged_local",
+      "awaiting_escalation_ack",
+      "upstream_pending",
+      "upstream_filed",
+      "resolved_upstream",
+      "suppressed",
+    ];
+    expect(statuses).toHaveLength(9);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter web exec vitest run lib/quality/issue-report-status.test.ts
+```
+
+Expect: `Cannot find module './issue-report-status'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/web/lib/quality/issue-report-status.ts`:
+
+```ts
+/**
+ * PlatformIssueReport status vocabulary.
+ *
+ * Defined in spec §6.2 of
+ * docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md.
+ *
+ * Only OPEN is actively used in Phase 0. Later phases will activate the
+ * SUPPORT_TRIAGE / *_ESCALATION* / UPSTREAM_* / RESOLVED_* / SUPPRESSED
+ * statuses. Constants are defined now so no writer invents strings later.
+ */
+export const ISSUE_REPORT_STATUS = {
+  OPEN: "open",
+  SUPPORT_TRIAGE: "support_triage",
+  RESOLVED_LOCALLY: "resolved_locally",
+  TRIAGED_LOCAL: "triaged_local",
+  AWAITING_ESCALATION_ACK: "awaiting_escalation_ack",
+  UPSTREAM_PENDING: "upstream_pending",
+  UPSTREAM_FILED: "upstream_filed",
+  RESOLVED_UPSTREAM: "resolved_upstream",
+  SUPPRESSED: "suppressed",
+} as const;
+
+export type IssueReportStatus =
+  (typeof ISSUE_REPORT_STATUS)[keyof typeof ISSUE_REPORT_STATUS];
+
+/**
+ * Statuses owned by the support flow. The generic issue-report-triage cron
+ * must skip these — they are managed by coworker support mode, not by the
+ * auto-BI conversion path.
+ */
+export const SUPPORT_FLOW_STATUSES: ReadonlyArray<IssueReportStatus> = [
+  ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+  ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK,
+  ISSUE_REPORT_STATUS.UPSTREAM_PENDING,
+  ISSUE_REPORT_STATUS.UPSTREAM_FILED,
+];
+
+export function isSupportFlowStatus(status: string): boolean {
+  return (SUPPORT_FLOW_STATUSES as ReadonlyArray<string>).includes(status);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter web exec vitest run lib/quality/issue-report-status.test.ts
+```
+
+Expect: 5 tests pass.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expect: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/lib/quality/issue-report-status.ts apps/web/lib/quality/issue-report-status.test.ts
+git commit -s -m "feat(quality): add IssueReportStatus constants (Phase 0 step 1)"
+```
+
+---
+
+## Task 2: Shared Writer — Failing Test for ID, Length, Defaults
+
+**Files:**
+- Create: `apps/web/lib/quality/platform-issue-reports.test.ts`
+
+Purpose: lock down the contract of the new writer before writing it. Tests cover ID format, length truncation, default status, default product/portfolio resolution, status validation. We mock Prisma — no DB in unit tests.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/lib/quality/platform-issue-reports.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Hoisted Prisma mock — must be declared before the import under test
+const prismaMock = vi.hoisted(() => ({
+  platformIssueReport: { create: vi.fn() },
+  portfolio: { findUnique: vi.fn() },
+  digitalProduct: { findUnique: vi.fn() },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
+
+import { createPlatformIssueReport } from "./platform-issue-reports";
+import { ISSUE_REPORT_STATUS } from "./issue-report-status";
+
+beforeEach(() => {
+  prismaMock.platformIssueReport.create.mockReset();
+  prismaMock.portfolio.findUnique.mockReset();
+  prismaMock.digitalProduct.findUnique.mockReset();
+  prismaMock.platformIssueReport.create.mockResolvedValue({});
+  prismaMock.digitalProduct.findUnique.mockResolvedValue({ id: "dp-portal" });
+});
+
+describe("createPlatformIssueReport", () => {
+  it("generates a PIR-XXXXX reportId", async () => {
+    const result = await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+    });
+    expect(result.reportId).toMatch(/^PIR-[A-Z0-9]{5}$/);
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.reportId).toBe(result.reportId);
+  });
+
+  it("defaults status to OPEN when not provided", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+    });
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.status).toBeUndefined();
+    // status defaults via Prisma schema default("open"); writer must not override
+  });
+
+  it("accepts a status from ISSUE_REPORT_STATUS", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+    });
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.status).toBe("support_triage");
+  });
+
+  it("rejects an unknown status", async () => {
+    await expect(
+      createPlatformIssueReport({
+        type: "user_report",
+        title: "Test",
+        source: "manual",
+        status: "bogus" as never,
+      }),
+    ).rejects.toThrow(/unknown status/i);
+  });
+
+  it("truncates title to 500 chars", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "x".repeat(600),
+      source: "manual",
+    });
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.title.length).toBe(500);
+  });
+
+  it("truncates description to 10000 chars", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      description: "x".repeat(15000),
+    });
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.description.length).toBe(10000);
+  });
+
+  it("truncates errorStack to 20000 chars", async () => {
+    await createPlatformIssueReport({
+      type: "runtime_error",
+      title: "Test",
+      source: "crash_boundary",
+      errorStack: "x".repeat(25000),
+    });
+    const createArgs = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(createArgs?.data.errorStack.length).toBe(20000);
+  });
+
+  it("truncates routeContext, userAgent, type, source, severity", async () => {
+    await createPlatformIssueReport({
+      type: "x".repeat(60),
+      severity: "x".repeat(30),
+      title: "Test",
+      source: "x".repeat(50),
+      routeContext: "x".repeat(600),
+      userAgent: "x".repeat(600),
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.type.length).toBe(50);
+    expect(args?.data.severity.length).toBe(20);
+    expect(args?.data.source.length).toBe(30);
+    expect(args?.data.routeContext.length).toBe(500);
+    expect(args?.data.userAgent.length).toBe(500);
+  });
+
+  it("resolves digitalProductId to dpf-portal when not provided", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+    });
+    expect(prismaMock.digitalProduct.findUnique).toHaveBeenCalledWith({
+      where: { productId: "dpf-portal" },
+      select: { id: true },
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.digitalProductId).toBe("dp-portal");
+  });
+
+  it("does NOT re-resolve digitalProductId when caller provides one", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      digitalProductId: "dp-other",
+    });
+    expect(prismaMock.digitalProduct.findUnique).not.toHaveBeenCalled();
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.digitalProductId).toBe("dp-other");
+  });
+
+  it("resolves portfolioId from routeContext when not provided", async () => {
+    prismaMock.portfolio.findUnique.mockResolvedValue({ id: "pf-platform" });
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      routeContext: "/platform/ai/providers",
+    });
+    expect(prismaMock.portfolio.findUnique).toHaveBeenCalledWith({
+      where: { slug: "foundational" },
+      select: { id: true },
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.portfolioId).toBe("pf-platform");
+  });
+
+  it("does NOT resolve portfolioId when caller provides one", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      routeContext: "/platform/ai/providers",
+      portfolioId: "pf-explicit",
+    });
+    expect(prismaMock.portfolio.findUnique).not.toHaveBeenCalled();
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.portfolioId).toBe("pf-explicit");
+  });
+
+  it("passes through threadId / taskRunId / featureBuildId / reportedById", async () => {
+    await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+      reportedById: "u-1",
+      threadId: "t-1",
+      taskRunId: "tr-1",
+      featureBuildId: "fb-1",
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.reportedById).toBe("u-1");
+    expect(args?.data.threadId).toBe("t-1");
+    expect(args?.data.taskRunId).toBe("tr-1");
+    expect(args?.data.featureBuildId).toBe("fb-1");
+  });
+
+  it("returns { reportId } on success", async () => {
+    const result = await createPlatformIssueReport({
+      type: "user_report",
+      title: "Test",
+      source: "manual",
+    });
+    expect(result).toEqual({ reportId: expect.stringMatching(/^PIR-/) });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter web exec vitest run lib/quality/platform-issue-reports.test.ts
+```
+
+Expect: `Cannot find module './platform-issue-reports'`.
+
+- [ ] **Step 3: Commit the test (red)**
+
+```bash
+git add apps/web/lib/quality/platform-issue-reports.test.ts
+git commit -s -m "test(quality): platform-issue-reports writer contract (red, Phase 0)"
+```
+
+---
+
+## Task 3: Shared Writer — Implementation
+
+**Files:**
+- Create: `apps/web/lib/quality/platform-issue-reports.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `apps/web/lib/quality/platform-issue-reports.ts`:
+
+```ts
+import { prisma } from "@dpf/db";
+import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "./issue-report-status";
+
+// Field length limits — matched to existing writers and Prisma schema column widths.
+const LIMITS = {
+  type: 50,
+  severity: 20,
+  source: 30,
+  title: 500,
+  description: 10_000,
+  routeContext: 500,
+  errorStack: 20_000,
+  userAgent: 500,
+} as const;
+
+// Same route → portfolio slug map used today by reportQualityIssue().
+// Kept colocated so a future move of the action does not orphan the resolution.
+const ROUTE_PORTFOLIO_MAP: Record<string, string> = {
+  "/portfolio": "foundational",
+  "/ea": "foundational",
+  "/inventory": "foundational",
+  "/platform": "foundational",
+  "/admin": "foundational",
+  "/ops": "manufacturing_and_delivery",
+  "/employee": "for_employees",
+  "/customer": "products_and_services_sold",
+};
+
+function resolvePortfolioSlug(routeContext: string | null | undefined): string | null {
+  if (!routeContext) return null;
+  for (const [prefix, slug] of Object.entries(ROUTE_PORTFOLIO_MAP)) {
+    if (routeContext === prefix || routeContext.startsWith(prefix + "/")) return slug;
+  }
+  return null;
+}
+
+function generateReportId(): string {
+  return "PIR-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+}
+
+const VALID_STATUSES = new Set<string>(Object.values(ISSUE_REPORT_STATUS));
+
+function trimTo(value: string | null | undefined, max: number): string | null {
+  if (value == null) return null;
+  return value.slice(0, max);
+}
+
+export interface CreatePlatformIssueReportInput {
+  // Required
+  type: string;
+  title: string;
+  source: string;
+
+  // Optional with safe defaults
+  severity?: string;
+  description?: string | null;
+  routeContext?: string | null;
+  errorStack?: string | null;
+  userAgent?: string | null;
+
+  // Identity / linkage
+  reportedById?: string | null;
+  threadId?: string | null;
+  taskRunId?: string | null;
+  featureBuildId?: string | null;
+
+  // Ownership — resolved automatically if not provided
+  portfolioId?: string | null;
+  digitalProductId?: string | null;
+
+  // Status — defaults to schema default ("open") when omitted
+  status?: IssueReportStatus;
+}
+
+/**
+ * The single server-side writer for PlatformIssueReport.
+ *
+ * All entry points (POST /api/quality/report, reportQualityIssue() server
+ * action, report_quality_issue MCP tool handler, crash boundary) MUST go
+ * through this function. New entry points should too.
+ *
+ * Behavior:
+ *  - Generates a fresh PIR-XXXXX reportId.
+ *  - Applies length limits matched to the Prisma column widths.
+ *  - Defaults digitalProductId to the dpf-portal product when not provided.
+ *  - Resolves portfolioId from routeContext via ROUTE_PORTFOLIO_MAP when not provided.
+ *  - Validates status against ISSUE_REPORT_STATUS; rejects unknown values.
+ *  - Leaves status undefined when not provided so the Prisma schema default
+ *    ("open") applies — supports cron contract.
+ *
+ * Privacy / non-identifiability transforms (redactHostnames, secret scan,
+ * coworker-synthesized summaries) are intentionally OUT of scope for Phase 0
+ * — they live in the upstream-escalation path added in Phase 3.
+ */
+export async function createPlatformIssueReport(
+  input: CreatePlatformIssueReportInput,
+): Promise<{ reportId: string }> {
+  if (input.status !== undefined && !VALID_STATUSES.has(input.status)) {
+    throw new Error(`createPlatformIssueReport: unknown status "${input.status}"`);
+  }
+
+  const digitalProductId =
+    input.digitalProductId ??
+    (await prisma.digitalProduct
+      .findUnique({ where: { productId: "dpf-portal" }, select: { id: true } })
+      .then((p) => p?.id ?? null));
+
+  let portfolioId: string | null = input.portfolioId ?? null;
+  if (portfolioId == null) {
+    const slug = resolvePortfolioSlug(input.routeContext);
+    if (slug) {
+      const pf = await prisma.portfolio.findUnique({
+        where: { slug },
+        select: { id: true },
+      });
+      portfolioId = pf?.id ?? null;
+    }
+  }
+
+  const reportId = generateReportId();
+
+  await prisma.platformIssueReport.create({
+    data: {
+      reportId,
+      type: input.type.slice(0, LIMITS.type),
+      severity: (input.severity ?? "medium").slice(0, LIMITS.severity),
+      title: input.title.slice(0, LIMITS.title),
+      description: trimTo(input.description ?? null, LIMITS.description),
+      routeContext: trimTo(input.routeContext ?? null, LIMITS.routeContext),
+      errorStack: trimTo(input.errorStack ?? null, LIMITS.errorStack),
+      userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
+      reportedById: input.reportedById ?? null,
+      threadId: input.threadId ?? null,
+      taskRunId: input.taskRunId ?? null,
+      featureBuildId: input.featureBuildId ?? null,
+      source: input.source.slice(0, LIMITS.source),
+      portfolioId,
+      digitalProductId,
+      ...(input.status !== undefined ? { status: input.status } : {}),
+    },
+  });
+
+  return { reportId };
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```bash
+pnpm --filter web exec vitest run lib/quality/platform-issue-reports.test.ts
+```
+
+Expect: all 14 tests in the file pass.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expect: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/quality/platform-issue-reports.ts
+git commit -s -m "feat(quality): createPlatformIssueReport unified writer (Phase 0)"
+```
+
+---
+
+## Task 4: Migrate POST /api/quality/report
+
+**Files:**
+- Modify: `apps/web/app/api/quality/report/route.ts`
+- Create: `apps/web/app/api/quality/report/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/app/api/quality/report/route.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const writerMock = vi.hoisted(() => ({
+  createPlatformIssueReport: vi.fn(),
+}));
+
+vi.mock("@/lib/quality/platform-issue-reports", () => writerMock);
+
+import { POST } from "./route";
+
+beforeEach(() => {
+  writerMock.createPlatformIssueReport.mockReset();
+  writerMock.createPlatformIssueReport.mockResolvedValue({ reportId: "PIR-TEST1" });
+});
+
+function makeReq(body: unknown): Request {
+  return new Request("http://localhost/api/quality/report", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/quality/report", () => {
+  it("delegates to createPlatformIssueReport with normalized input", async () => {
+    const res = await POST(makeReq({
+      type: "runtime_error",
+      title: "Boom",
+      description: "Something broke",
+      severity: "high",
+      routeContext: "/build/123",
+      errorStack: "Error: x",
+      userAgent: "Mozilla/5.0",
+      source: "crash_boundary",
+      userId: "u-9",
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, reportId: "PIR-TEST1" });
+
+    expect(writerMock.createPlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "runtime_error",
+        title: "Boom",
+        description: "Something broke",
+        severity: "high",
+        routeContext: "/build/123",
+        errorStack: "Error: x",
+        userAgent: "Mozilla/5.0",
+        source: "crash_boundary",
+        reportedById: "u-9",
+      }),
+    );
+  });
+
+  it("defaults source to manual when not provided", async () => {
+    await POST(makeReq({ type: "user_report", title: "Hi" }));
+    const args = writerMock.createPlatformIssueReport.mock.calls[0]?.[0];
+    expect(args?.source).toBe("manual");
+  });
+
+  it("returns 413 when content-length exceeds 64KiB", async () => {
+    const req = new Request("http://localhost/api/quality/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "content-length": "70000" },
+      body: JSON.stringify({ type: "user_report", title: "x" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+    expect(writerMock.createPlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 on writer error", async () => {
+    writerMock.createPlatformIssueReport.mockRejectedValue(new Error("db"));
+    const res = await POST(makeReq({ type: "user_report", title: "x" }));
+    expect(res.status).toBe(500);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter web exec vitest run app/api/quality/report/route.test.ts
+```
+
+Expect: failures because the route still calls Prisma directly.
+
+- [ ] **Step 3: Replace route.ts with the adapter**
+
+Replace the entire body of `apps/web/app/api/quality/report/route.ts` with:
+
+```ts
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const contentLength = parseInt(request.headers.get("content-length") ?? "0", 10);
+    if (contentLength > 65536) {
+      return Response.json({ ok: false, error: "Too large" }, { status: 413 });
+    }
+
+    const body = (await request.json()) as Record<string, unknown>;
+
+    const { reportId } = await createPlatformIssueReport({
+      type: String(body.type ?? "user_report"),
+      title: String(body.title ?? "Untitled report"),
+      source: String(body.source ?? "manual"),
+      severity: typeof body.severity === "string" ? body.severity : "medium",
+      description: typeof body.description === "string" ? body.description : null,
+      routeContext: typeof body.routeContext === "string" ? body.routeContext : null,
+      errorStack: typeof body.errorStack === "string" ? body.errorStack : null,
+      userAgent: typeof body.userAgent === "string" ? body.userAgent : null,
+      reportedById: typeof body.userId === "string" ? body.userId : null,
+      portfolioId: typeof body.portfolioId === "string" ? body.portfolioId : null,
+      digitalProductId: typeof body.digitalProductId === "string" ? body.digitalProductId : null,
+    });
+
+    return Response.json({ ok: true, reportId });
+  } catch {
+    return Response.json({ ok: false }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter web exec vitest run app/api/quality/report/route.test.ts
+```
+
+Expect: 4 tests pass.
+
+- [ ] **Step 5: Re-run the writer's own tests as a sanity check**
+
+```bash
+pnpm --filter web exec vitest run lib/quality/
+```
+
+Expect: 19 tests pass (5 from status + 14 from writer).
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/app/api/quality/report/route.ts apps/web/app/api/quality/report/route.test.ts
+git commit -s -m "refactor(api/quality): route handler delegates to shared writer (Phase 0)"
+```
+
+---
+
+## Task 5: Migrate `reportQualityIssue()` server action
+
+**Files:**
+- Modify: `apps/web/lib/actions/quality.ts:6-78` (drop `ROUTE_PORTFOLIO_MAP`, `resolvePortfolioSlug`, and the `prisma.platformIssueReport.create` block; delegate to the shared writer)
+- Create: `apps/web/lib/actions/quality.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/lib/actions/quality.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const authMock = vi.hoisted(() => ({ auth: vi.fn() }));
+const writerMock = vi.hoisted(() => ({ createPlatformIssueReport: vi.fn() }));
+
+vi.mock("@/lib/auth", () => authMock);
+vi.mock("@/lib/quality/platform-issue-reports", () => writerMock);
+vi.mock("@dpf/db", () => ({ prisma: {} })); // unused after migration
+
+import { reportQualityIssue } from "./quality";
+
+beforeEach(() => {
+  authMock.auth.mockReset();
+  writerMock.createPlatformIssueReport.mockReset();
+  writerMock.createPlatformIssueReport.mockResolvedValue({ reportId: "PIR-Q1" });
+});
+
+describe("reportQualityIssue", () => {
+  it("resolves userId from auth and delegates to writer", async () => {
+    authMock.auth.mockResolvedValue({ user: { id: "u-1" } });
+
+    const result = await reportQualityIssue({
+      type: "user_report",
+      title: "Hello",
+      routeContext: "/platform",
+      severity: "medium",
+    });
+
+    expect(result).toEqual({ reportId: "PIR-Q1" });
+    expect(writerMock.createPlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "user_report",
+        title: "Hello",
+        routeContext: "/platform",
+        severity: "medium",
+        reportedById: "u-1",
+        source: "ai_assisted",
+      }),
+    );
+  });
+
+  it("uses null reportedById when no session", async () => {
+    authMock.auth.mockResolvedValue(null);
+    await reportQualityIssue({
+      type: "feedback",
+      title: "x",
+      routeContext: "/admin",
+    });
+    const args = writerMock.createPlatformIssueReport.mock.calls[0]?.[0];
+    expect(args?.reportedById).toBeNull();
+  });
+
+  it("returns { error } when writer throws", async () => {
+    authMock.auth.mockResolvedValue(null);
+    writerMock.createPlatformIssueReport.mockRejectedValue(new Error("db"));
+    const result = await reportQualityIssue({
+      type: "user_report",
+      title: "x",
+      routeContext: "/admin",
+    });
+    expect(result).toEqual({ error: "Failed to create report" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter web exec vitest run lib/actions/quality.test.ts
+```
+
+Expect: failures because `reportQualityIssue` still calls Prisma directly.
+
+- [ ] **Step 3: Replace `reportQualityIssue()` body**
+
+In `apps/web/lib/actions/quality.ts`:
+
+- DELETE lines 6–24 (the `ROUTE_PORTFOLIO_MAP` and `resolvePortfolioSlug` — they live in the writer now).
+- REPLACE lines 26–78 (the entire `reportQualityIssue()` function) with:
+
+```ts
+export async function reportQualityIssue(input: {
+  type: "runtime_error" | "user_report" | "feedback";
+  title: string;
+  description?: string;
+  severity?: string;
+  routeContext: string;
+  errorStack?: string;
+  source?: string;
+}): Promise<{ reportId: string } | { error: string }> {
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+
+  try {
+    const { reportId } = await createPlatformIssueReport({
+      type: input.type,
+      title: input.title,
+      source: input.source ?? "ai_assisted",
+      severity: input.severity ?? "medium",
+      description: input.description ?? null,
+      routeContext: input.routeContext,
+      errorStack: input.errorStack ?? null,
+      reportedById: userId,
+    });
+    return { reportId };
+  } catch {
+    return { error: "Failed to create report" };
+  }
+}
+```
+
+- ADD this import at the top (after the existing imports):
+
+```ts
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+```
+
+- The `prisma` import is still needed for the admin query helpers (`getIssueReports`, `updateIssueReportStatus`, `getIssueReportStats`) — leave them untouched.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter web exec vitest run lib/actions/quality.test.ts
+```
+
+Expect: 3 tests pass.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/lib/actions/quality.ts apps/web/lib/actions/quality.test.ts
+git commit -s -m "refactor(actions/quality): reportQualityIssue delegates to shared writer (Phase 0)"
+```
+
+---
+
+## Task 6: Migrate `report_quality_issue` MCP tool handler
+
+**Files:**
+- Modify: `apps/web/lib/mcp-tools.ts:5664-5678`
+
+The handler currently inlines `prisma.platformIssueReport.create`. Migration: delegate to the shared writer while preserving the response shape and passing through `context?.routeContext` when available.
+
+- [ ] **Step 1: Add the writer import at the top of mcp-tools.ts**
+
+Find the existing imports block in `apps/web/lib/mcp-tools.ts` and add:
+
+```ts
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+```
+
+- [ ] **Step 2: Replace the `case "report_quality_issue"` handler block**
+
+Locate lines 5664–5678 (the `case "report_quality_issue":` block). Replace the entire `case` body with:
+
+```ts
+    case "report_quality_issue": {
+      const { reportId } = await createPlatformIssueReport({
+        type: String(params["type"] ?? "user_report"),
+        title: String(params["title"] ?? "Untitled"),
+        source: "ai_assisted",
+        ...(typeof params["description"] === "string"
+          ? { description: params["description"] }
+          : {}),
+        severity: String(params["severity"] ?? "medium"),
+        reportedById: userId,
+        ...(typeof context?.routeContext === "string"
+          ? { routeContext: context.routeContext }
+          : {}),
+      });
+      return { success: true, entityId: reportId, message: `Filed report ${reportId}` };
+    }
+```
+
+Note: this adds `routeContext` pass-through where it was previously dropped. That is consistent with the spec's "normalize route... capture where available" Phase 0 directive and matches what other MCP handlers already do (e.g. the `recordExternalEvidence` calls in nearby cases).
+
+- [ ] **Step 3: Sanity check existing MCP test still typechecks**
+
+There is no dedicated unit test for this MCP handler. Run the existing broad test:
+
+```bash
+pnpm --filter web exec vitest run lib/mcp-tools-sandbox-admin.test.ts
+pnpm --filter web typecheck
+```
+
+Expect: no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/mcp-tools.ts
+git commit -s -m "refactor(mcp): report_quality_issue handler delegates to shared writer (Phase 0)"
+```
+
+---
+
+## Task 7: Cron uses status constant + skip test
+
+**Files:**
+- Modify: `apps/web/lib/queue/functions/issue-report-triage.ts:38`
+- Modify: `apps/web/lib/operate/issue-report-triage.test.ts` (add new test only — keep existing tests untouched)
+
+- [ ] **Step 1: Add failing test for support-flow skip**
+
+In `apps/web/lib/operate/issue-report-triage.test.ts`, add this new `describe` block at the bottom of the file (after the existing tests):
+
+```ts
+describe("triage cron filter excludes support-flow statuses", () => {
+  it("getOpenReports filter is exactly ISSUE_REPORT_STATUS.OPEN", async () => {
+    // This is a contract test for the queue function's filter shape.
+    // It guards against accidentally widening the filter to include
+    // support_triage, awaiting_escalation_ack, upstream_pending, or upstream_filed.
+    const { ISSUE_REPORT_STATUS, SUPPORT_FLOW_STATUSES } = await import(
+      "@/lib/quality/issue-report-status"
+    );
+
+    expect(ISSUE_REPORT_STATUS.OPEN).toBe("open");
+    expect(SUPPORT_FLOW_STATUSES).not.toContain("open");
+    expect(SUPPORT_FLOW_STATUSES).toContain("support_triage");
+    expect(SUPPORT_FLOW_STATUSES).toContain("awaiting_escalation_ack");
+    expect(SUPPORT_FLOW_STATUSES).toContain("upstream_pending");
+    expect(SUPPORT_FLOW_STATUSES).toContain("upstream_filed");
+  });
+
+  it("triageIssueReports does not process a support_triage report passed in", async () => {
+    // Defensive: if the cron ever receives a support_triage row (e.g. via a
+    // changed query), buildIssueBacklogItem still runs — so the protection
+    // must live at the query layer, not the pure-function layer. This test
+    // documents the boundary: triageIssueReports trusts its input, the cron
+    // filter is the gate. See queue/functions/issue-report-triage.ts.
+    const supportReport = {
+      ...report,
+      id: "r-support",
+      reportId: "PIR-SUP01",
+    };
+    const created: unknown[] = [];
+    await triageIssueReports(triageDeps({
+      getOpenReports: async () => [supportReport],
+      createBacklogItem: async (data: unknown) => { created.push(data); },
+    }));
+    // Pure function still processes whatever is handed in — gate is in queue layer.
+    expect(created).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify them**
+
+```bash
+pnpm --filter web exec vitest run lib/operate/issue-report-triage.test.ts
+```
+
+Expect: existing tests still pass + the new 2 tests pass (the second test passes today because nothing prevents the pure function from processing; the failure mode is in the production query, which Step 3 protects).
+
+- [ ] **Step 3: Update the cron to use the status constant**
+
+In `apps/web/lib/queue/functions/issue-report-triage.ts`:
+
+- Add this import at the top after the existing imports:
+
+```ts
+import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
+```
+
+- Replace line 38:
+
+```ts
+            where: { status: "open" },
+```
+
+with:
+
+```ts
+            where: { status: ISSUE_REPORT_STATUS.OPEN },
+```
+
+- [ ] **Step 4: Re-run the test suite**
+
+```bash
+pnpm --filter web exec vitest run lib/operate/issue-report-triage.test.ts
+pnpm --filter web typecheck
+```
+
+Expect: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/queue/functions/issue-report-triage.ts apps/web/lib/operate/issue-report-triage.test.ts
+git commit -s -m "refactor(cron/issue-report-triage): use ISSUE_REPORT_STATUS.OPEN (Phase 0)"
+```
+
+---
+
+## Task 8: Theme tokens — `FeedbackButton.tsx`
+
+**Files:**
+- Modify: `apps/web/components/feedback/FeedbackButton.tsx`
+
+Replace inline `rgba(...)` and hex colors with DPF theme tokens (per spec §7.2). Behavior must not change — visual fidelity should remain close, but the fallback form is not the healthy-install primary UX, so exact pixel-match is not required.
+
+- [ ] **Step 1: Replace the styles**
+
+Replace the entire file body. The current button uses fixed inline styles for the bottom-left bubble plus the fallback dropdown. Convert both to Tailwind classes that reference DPF theme variables:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { FeedbackForm } from "./FeedbackForm";
+
+type Props = {
+  userId?: string | null;
+};
+
+export function FeedbackButton({ userId }: Props) {
+  const pathname = usePathname();
+  const [showForm, setShowForm] = useState(false);
+
+  function handleClick() {
+    const event = new CustomEvent("open-agent-feedback");
+    document.dispatchEvent(event);
+
+    setTimeout(() => {
+      const panel = document.querySelector("[data-agent-panel]");
+      if (!panel) {
+        setShowForm(true);
+      }
+    }, 500);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        title="Send feedback"
+        className="fixed bottom-[60px] left-4 z-[49] flex items-center gap-1.5 rounded-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]/70 px-3.5 py-1.5 text-[11px] font-normal text-[var(--dpf-muted)] shadow-md backdrop-blur-sm transition-colors hover:text-[var(--dpf-text)]"
+      >
+        Feedback
+      </button>
+
+      {showForm && (
+        <div
+          className="fixed bottom-[100px] left-4 z-50 w-[300px] overflow-hidden rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] shadow-xl backdrop-blur"
+        >
+          <div className="px-3 pt-2.5 text-xs font-semibold text-[var(--dpf-text)]">
+            Send Feedback
+          </div>
+          <FeedbackForm
+            routeContext={pathname}
+            {...(userId != null && { userId })}
+            source="manual"
+            onClose={() => setShowForm(false)}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Grep the file for any remaining hardcoded color tokens**
+
+```bash
+pnpm --filter web exec grep -nE "rgba\(|#[0-9a-fA-F]{3,6}|var\(--dpf" apps/web/components/feedback/FeedbackButton.tsx || true
+```
+
+Expect: zero `rgba(` or `#hex` matches. Any remaining `var(--dpf-*)` references are correct.
+
+- [ ] **Step 3: Re-run affected tests**
+
+```bash
+pnpm --filter web typecheck
+pnpm --filter web exec vitest run components/feedback
+```
+
+(There are no existing tests for `FeedbackButton`. The typecheck is the gate.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/components/feedback/FeedbackButton.tsx
+git commit -s -m "style(feedback): FeedbackButton uses DPF theme tokens (Phase 0)"
+```
+
+---
+
+## Task 9: Theme tokens — `FeedbackForm.tsx`
+
+**Files:**
+- Modify: `apps/web/components/feedback/FeedbackForm.tsx`
+
+- [ ] **Step 1: Replace the styles**
+
+Replace the entire file body. Convert inline `style={{ background: "rgba(...)" }}` and friends to Tailwind theme-token classes. Keep all behavior (state, submission, queue fallback message) identical.
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { submitReport } from "@/lib/quality-queue";
+
+type Props = {
+  routeContext: string;
+  userId?: string | null;
+  errorMessage?: string;
+  errorStack?: string;
+  source?: string;
+  onClose?: () => void;
+};
+
+export function FeedbackForm({
+  routeContext,
+  userId,
+  errorMessage,
+  errorStack,
+  source,
+  onClose,
+}: Props) {
+  const [type, setType] = useState<string>(errorMessage ? "runtime_error" : "user_report");
+  const [description, setDescription] = useState(errorMessage ?? "");
+  const [submitted, setSubmitted] = useState(false);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [queued, setQueued] = useState(false);
+
+  async function handleSubmit() {
+    const result = await submitReport({
+      type,
+      title: description.slice(0, 100) || "User report",
+      description,
+      severity: type === "runtime_error" ? "high" : "medium",
+      routeContext,
+      ...(errorStack !== undefined && { errorStack }),
+      source: source ?? "manual",
+      ...(userId != null && { userId }),
+    });
+    if (result.ok && result.reportId) {
+      setReportId(result.reportId);
+    } else {
+      setQueued(true);
+    }
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div className="p-4 text-center text-sm text-[var(--dpf-text)]">
+        {reportId
+          ? `Thanks! Report ${reportId} filed. The platform team has been notified.`
+          : queued
+            ? "Saved — will be sent when connectivity is restored."
+            : "Saved — will be sent when connectivity is restored."}
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="mx-auto mt-3 block rounded-md border border-[var(--dpf-border)] px-3 py-1 text-xs text-[var(--dpf-text)]"
+          >
+            Close
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-3 text-sm text-[var(--dpf-text)]">
+      <div className="mb-2">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5 text-xs text-[var(--dpf-text)]"
+        >
+          <option value="runtime_error">Bug Report</option>
+          <option value="feedback">Suggestion</option>
+          <option value="user_report">Question</option>
+        </select>
+      </div>
+      <div className="mb-2">
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe what happened or what you'd like to see..."
+          rows={4}
+          className="w-full resize-y rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5 text-xs text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!description.trim()}
+          className="flex-1 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Submit
+        </button>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)]"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify no hardcoded colors remain**
+
+```bash
+pnpm --filter web exec grep -nE "rgba\(|#[0-9a-fA-F]{3,6}" apps/web/components/feedback/FeedbackForm.tsx || true
+```
+
+Expect: zero matches.
+
+- [ ] **Step 3: Typecheck + run vitest for feedback area**
+
+```bash
+pnpm --filter web typecheck
+pnpm --filter web exec vitest run components/feedback
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/components/feedback/FeedbackForm.tsx
+git commit -s -m "style(feedback): FeedbackForm uses DPF theme tokens (Phase 0)"
+```
+
+---
+
+## Task 10: Full test sweep + build
+
+Per `feedback_run_full_tests_before_push`: vitest must run locally before push, not just typecheck.
+
+- [ ] **Step 1: Full vitest run for the web app**
+
+```bash
+pnpm --filter web exec vitest run
+```
+
+Expect: all tests pass. If any unrelated suite fails, investigate before proceeding — do not push.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+- [ ] **Step 3: Production build (Turbopack NFT exposure surface)**
+
+```bash
+cd apps/web && pnpm exec next build
+```
+
+Expect: build succeeds. Warning counts may rise/fall; per `project_turbopack_nft_cascade_math`, large warning numbers usually trace to a small number of source roots — investigate only if new warning *root causes* appear.
+
+---
+
+## Task 11: Live UX verification (the structural-verification-is-not-functional gate)
+
+Per kernel commandment: code-green is not done. Drive the three writers on the Live portal and confirm rows are equivalent in shape to before.
+
+- [ ] **Step 1: Start (or confirm) the Live portal at `http://localhost:3000`**
+
+```bash
+docker ps --format '{{.Names}}' | grep -E "portal|postgres"
+```
+
+Confirm `dpf-postgres-1` and the portal container are listed. If not running, follow the standard portal-up procedure (do not modify infra without explicit approval — see `feedback_docker_explicit_approval`). The agent runs the system; do not ask the user to do this.
+
+If your local Compose project name differs, container names may be `dpf-postgres-2` or similar — `docker ps --format '{{.Names}}' | grep postgres` is authoritative. Use whatever name appears.
+
+- [ ] **Step 2: Snapshot a baseline count**
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT source, COUNT(*) FROM \"PlatformIssueReport\" GROUP BY source ORDER BY source;"
+```
+
+Record the counts. They are your before-baseline.
+
+- [ ] **Step 3: Drive the manual Feedback path**
+
+Open `http://localhost:3000` in Chrome MCP. Click the Feedback button. If the coworker panel intercepts, dismiss it so the fallback form appears; submit "Phase 0 verification — manual" as a Question.
+
+Confirm via SQL:
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT \"reportId\", source, type, \"routeContext\", \"reportedById\" IS NOT NULL AS has_user, \"portfolioId\" IS NOT NULL AS has_portfolio, \"digitalProductId\" IS NOT NULL AS has_product FROM \"PlatformIssueReport\" ORDER BY \"createdAt\" DESC LIMIT 1;"
+```
+
+Expect: source `manual`, type `user_report`, routeContext populated, product populated. Auth depends on whether you are signed in.
+
+- [ ] **Step 4: Drive the crash boundary path**
+
+The least invasive route is the auto-report-on-mount path inside `app/(shell)/error.tsx`: navigate to any route that already errors (check current `PlatformIssueReport` rows with `source='crash_boundary'` in the last day for examples), or use Chrome MCP devtools to navigate to a route that throws (e.g., a malformed dynamic param) so the boundary fires naturally.
+
+If no live crash surface exists, use the fallback: click "Send feedback" from any active error page and submit a note. Avoid editing source code purely for verification — that creates churn.
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT \"reportId\", source, type, \"errorStack\" IS NOT NULL AS has_stack FROM \"PlatformIssueReport\" WHERE source='crash_boundary' ORDER BY \"createdAt\" DESC LIMIT 2;"
+```
+
+Expect: two rows (auto-report on mount + the user submission), both `source=crash_boundary`, both with stack populated.
+
+- [ ] **Step 5: Drive the MCP `report_quality_issue` tool**
+
+Open the coworker, ask it: "File a quality issue: title 'Phase 0 verification — MCP', type user_report." The coworker should call `report_quality_issue`.
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT \"reportId\", source, type, \"routeContext\" FROM \"PlatformIssueReport\" WHERE source='ai_assisted' ORDER BY \"createdAt\" DESC LIMIT 1;"
+```
+
+Expect: source `ai_assisted`, `routeContext` populated (this is the new behavior added in Task 6 — verify it landed).
+
+- [ ] **Step 6: Confirm cron skips a hand-inserted support_triage row**
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "INSERT INTO \"PlatformIssueReport\" (id, \"reportId\", type, severity, status, title, description, source, \"createdAt\", \"updatedAt\") VALUES ('test-supp-1', 'PIR-SUP99', 'user_report', 'medium', 'support_triage', 'Phase 0 cron skip test', 'should not become a BI', 'manual', NOW(), NOW());"
+```
+
+Trigger the cron via the Inngest dev surface or wait up to 15 min, then:
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT status FROM \"PlatformIssueReport\" WHERE \"reportId\"='PIR-SUP99';"
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "SELECT COUNT(*) FROM \"BacklogItem\" WHERE body LIKE '%PIR-SUP99%';"
+```
+
+Expect: status remains `support_triage`; no `BacklogItem` rows referencing `PIR-SUP99`.
+
+- [ ] **Step 7: Cleanup the test row**
+
+```bash
+docker exec dpf-postgres-1 psql -U postgres -d dpf -c \
+  "DELETE FROM \"PlatformIssueReport\" WHERE \"reportId\"='PIR-SUP99';"
+```
+
+- [ ] **Step 8: Write a dynamic-analysis report**
+
+Per `feedback_dynamic_analysis_is_evidence`: write a short prose report covering exactly what was driven, what was observed in the DB, and the sign-off. Save as `docs/superpowers/evidence/2026-05-24-feedback-substrate-cleanup-verification.md`. Include the before/after `SELECT source, COUNT(*)` snapshots and the cron-skip evidence.
+
+- [ ] **Step 9: Commit the evidence**
+
+```bash
+git add docs/superpowers/evidence/2026-05-24-feedback-substrate-cleanup-verification.md
+git commit -s -m "evidence: Phase 0 feedback substrate verification (live portal)"
+```
+
+---
+
+## Task 12: PR overlap sweep, push, open PR
+
+Per `feedback_pr_overlap_check_before_pushing`: sweep recent main commits + open PRs touching the feedback or issue-report surface before pushing.
+
+- [ ] **Step 1: Sweep**
+
+```bash
+git fetch origin
+git log --oneline HEAD..origin/main -- "apps/web/lib/quality/" "apps/web/lib/actions/quality.ts" "apps/web/lib/queue/functions/issue-report-triage.ts" "apps/web/app/api/quality/" "apps/web/components/feedback/" "apps/web/lib/mcp-tools.ts" || true
+gh pr list --state open --limit 30 --json number,title,headRefName --jq '.[] | "#\(.number) \(.title)"' | grep -iE "feedback|issue-report|quality"
+```
+
+If overlap exists: stop, reconcile with the overlapping author, re-evaluate the plan.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "Phase 0: feedback substrate cleanup (BI for spec #1110)" --body "$(cat <<'EOF'
+## Summary
+
+- One server-side writer (`createPlatformIssueReport`) replaces four inlined `prisma.platformIssueReport.create` call sites
+- New status vocabulary in `apps/web/lib/quality/issue-report-status.ts` (all 9 statuses defined; only `OPEN` used in this phase)
+- Cron `quality/issue-report-triage` now filters on `ISSUE_REPORT_STATUS.OPEN` so future `support_triage` rows cannot be silently swept into BIs
+- Theme-token cleanup in `FeedbackButton.tsx` and `FeedbackForm.tsx` only
+
+Pure refactor + invariants — no product behavior change. This is Phase 0 of the spec at [#1110](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1110); subsequent phases are blocked on this landing.
+
+## Acceptance criteria (spec §8 Phase 0)
+
+- [x] Existing manual feedback, crash feedback, and coworker `report_quality_issue` still create reports
+- [x] The issue-report triage cron still converts generic `open` reports to BIs
+- [x] A `support_triage` report is not converted by the cron
+- [x] No touched feedback UI contains hardcoded color tokens
+
+## Test plan
+
+- [x] `pnpm --filter web exec vitest run` — green
+- [x] `pnpm --filter web typecheck` — green
+- [x] `cd apps/web && pnpm exec next build` — green
+- [x] Live UX verification on `http://localhost:3000` (evidence doc included)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Post-PR checklist
+
+- [ ] CI green (DCO, lint, typecheck, test, build)
+- [ ] No new Turbopack NFT warning *root causes* introduced
+- [ ] PR review by code reviewer (use `pr-review-toolkit:code-reviewer`)
+- [ ] After merge: file the Phase 1 BI under `EP-9FC5D2FD` and re-enter the spec → plan loop with `writing-plans` for Phase 1 only
+
+## Notes on what's intentionally NOT in this plan
+
+- No Prisma schema migration. The new `triggerKind`, `coalesceKey`, `escalationPolicy`, etc. fields from spec §6.2 are deferred to Phase 2/3 where they earn their keep. Adding them now would be schema churn without a consumer.
+- No `Notification` table changes. Reverse channel is Phase 5.
+- No coworker behavior change. Support mode entry is Phase 1.
+- No bridge wiring. `escalateToUpstreamIssue` is not yet called from any Phase 0 path.
+- No changes to `IssueReportPanel.tsx` or `TokenExpiryBanner.tsx` color tokens — out of scope per spec §7.2.
+
+These deferrals are intentional and protect the 20% refactor budget from sprawling.

--- a/docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md
+++ b/docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md
@@ -1,0 +1,516 @@
+# Capacity-Aware Feedback Escalation Design
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft - architect revision applied 2026-05-24 |
+| Date | 2026-05-24 |
+| Backlog item | To be filed after sign-off. Live MCP check on 2026-05-24 found no exact existing item for this design; closest active context is `EP-9FC5D2FD` (Build Studio first-customer experience hardening), `EP-REDUCTION-GEAR-ARCH` (cross-ring substrate), and the open `BI-PIR-*` issue-report stream. |
+| Epic recommendation | Start as a focused BI under `EP-9FC5D2FD` if the first slice is Dale/Build Studio support escalation. Create `EP-FEEDBACK-CAPACITY-ROUTING` only if the scope expands into a platform-wide issue-report substrate beyond the Dale/Build Studio path. |
+| Related substrate | [`apps/web/components/feedback/`](../../../apps/web/components/feedback); [`apps/web/components/agent/AgentCoworkerShell.tsx`](../../../apps/web/components/agent/AgentCoworkerShell.tsx); [`apps/web/app/api/quality/report/route.ts`](../../../apps/web/app/api/quality/report/route.ts); [`apps/web/lib/actions/quality.ts`](../../../apps/web/lib/actions/quality.ts); [`apps/web/lib/operate/issue-report-triage.ts`](../../../apps/web/lib/operate/issue-report-triage.ts); [`apps/web/lib/queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts); [`apps/web/lib/integrate/issue-bridge.ts`](../../../apps/web/lib/integrate/issue-bridge.ts); [`apps/web/lib/integrate/identity-privacy.ts`](../../../apps/web/lib/integrate/identity-privacy.ts); `PlatformIssueReport`; `Notification`; `PlatformNotification`; `PlatformDevConfig.contributionMode` |
+| Related specs | [Quality feedback (2026-03-14)](2026-03-14-quality-feedback-design.md); [Platform feedback loop (2026-03-16)](2026-03-16-platform-feedback-loop-design.md); [Pseudonymous identity and backlog issue bridge (2026-04-18)](2026-04-18-pseudonymous-identity-and-backlog-issue-bridge-design.md); [AI capacity continuity (2026-05-12)](2026-05-12-ai-capacity-continuity-design.md); [Reduction gear architecture (2026-05-24)](2026-05-24-reduction-gear-architecture-design.md); [Vertical workspace home (2026-05-24)](2026-05-24-vertical-workspace-home-design.md) |
+| Scope | The operator Feedback path from a non-technical user such as Dale through coworker support triage, local resolution, local BI creation, or upstream GitHub Issue escalation. |
+| Out of scope | Feature implementation in this thread; voice STT until Phase 6; replacing the general backlog system; making GitHub Issues the canonical store for all local issue reports; GearInterface schema design beyond an optional future observation emission. |
+
+---
+
+## Architect Verdict
+
+The original plan has the right product instinct: Feedback must stop being a local dead end. Dale should not have to know whether a failure belongs in a local BI, Build Studio, Admin issue reports, GitHub Issues, or a maintainer's head. The platform should do that routing.
+
+The plan needed four architectural corrections before implementation:
+
+1. **The current issue-report substrate is fragmented.** `POST /api/quality/report`, `reportQualityIssue()`, the `report_quality_issue` MCP tool, crash-boundary writes, and coworker-runtime writes all create `PlatformIssueReport` rows with different context fidelity. Phase 0 must consolidate that before adding a new escalation layer.
+2. **The current triage cron will race the new flow.** `quality/issue-report-triage` selects every `PlatformIssueReport(status="open")`, creates a local BI, and marks the report `acknowledged`. Support-mode reports need a distinct status/source path so the cron does not convert upstream-worthy feedback into ordinary local backlog before capacity assessment runs.
+3. **The bridge policy is not what the draft assumed.** `escalateToUpstreamIssue()` supports `kind: "issue-report"`, but it explicitly skips `fork_only`. If the product wants an exceptional "send this one critical report upstream" path for fork-only installs, that is a deliberate contribution-policy extension with audit state, not a wrapper around the existing function.
+4. **The reverse channel should use the right notification model.** `PlatformNotification` is global/admin-style and has no `userId` or `deepLink`; Dale-facing resolution updates belong in `Notification`. `PlatformNotification` can still carry admin/global feedback health.
+
+This design therefore starts with cleanup, then adds capacity routing.
+
+## 1. Problem
+
+Today, a non-technical operator has one visible instinct when something does not work: click Feedback or describe the problem to the coworker. The system then splinters:
+
+- manual feedback writes a `PlatformIssueReport`;
+- crash boundaries auto-write a `PlatformIssueReport`;
+- coworker runtime stalls can write a `PlatformIssueReport`;
+- the issue-report triage cron turns open reports into local BIs;
+- backlog and epic rows can be escalated upstream through `issue-bridge.ts`;
+- the Feedback click opens the coworker shell, but does not carry a first-class support mode or capacity decision.
+
+That is close, but not coherent. The missing product contract is:
+
+> Feedback is the operator's single "help me with this" affordance. The platform tries to resolve locally first, then decides whether the work should become local backlog or an upstream project issue.
+
+Without this, Dale hits four dead ends:
+
+1. The local model or provider configuration cannot handle the work.
+2. The issue is too architectural for Dale to decompose.
+3. The fix belongs in the upstream platform repo, not his install.
+4. A hard failure gives him no language for what broke.
+
+## 2. Capacity Terms
+
+This spec uses **resolution capacity**, not just model rate capacity.
+
+| Term | Meaning | Existing anchor |
+| ---- | ------- | --------------- |
+| Model capability capacity | Whether the active providers can solve the class of task. | `ModelProvider`, `ModelProfile`, `AgentModelConfig`, routing tier checks, `loadBuildStudioCapability()` |
+| Runtime/rate capacity | Whether a provider is available and under rate limits. | `checkModelCapacity()` in routing pipeline |
+| Local delivery capacity | Whether this install can safely fix, verify, and ship the change locally. | Build Studio, sandbox, MCP grants, user authority, active build state |
+| Upstream project capacity | Whether the right path is a pseudonymous GitHub Issue for maintainers. | `issue-bridge.ts`, GitHub Issues, contribution policy |
+| Human attention capacity | Whether Dale is able to approve, clarify, or continue. | PAR acknowledgement, coworker support mode, notifications |
+
+The function proposed below should be named around the routing question, not the rate-limit question. Recommended name: `assessFeedbackRouting()`.
+
+## 3. Current Repo Truth
+
+| Area | Verified current behavior | Design implication |
+| ---- | ------------------------- | ------------------ |
+| Feedback entry | `HeaderFeedbackButton` and `FeedbackButton` dispatch `CustomEvent("open-agent-feedback")` with no detail payload. Both fall back to `FeedbackForm` if no panel appears. | Keep the one-click entry, but define a typed event detail contract with `triggerKind`, route, optional build/thread hints, and an initial support prompt. |
+| Coworker shell | `AgentCoworkerShell` listens for `open-agent-feedback` and `open-agent-panel`, opens the panel, and can send `autoMessage` / `welcomeMessage` if present. | No new shell is needed. Add support-mode event detail and prompt wiring; do not create a separate chat surface. |
+| Manual issue creation | `POST /api/quality/report` writes `PlatformIssueReport` without auth, thread, task, active build lookup, or route-to-portfolio resolution. `reportQualityIssue()` does route-to-portfolio and auth-backed user resolution. The MCP `report_quality_issue` tool writes a smaller row with `source: "ai_assisted"`. | Phase 0 should create one server-side issue-report writer used by route handler, server action, and MCP tool. |
+| Crash boundary | `apps/web/app/(shell)/error.tsx` auto-posts a critical `runtime_error` report and lets the user add context. | Hard-failure capture already exists; Phase 4 should dispatch the support/escalation event from this path after the local report exists. |
+| Issue-report triage | `quality/issue-report-triage` runs every 15 minutes, converts all `status: "open"` reports into BIs, marks them `acknowledged`, and separately files spike BIs. | New support-mode reports cannot remain plain `open` while awaiting capacity assessment. |
+| Issue bridge | `issue-bridge.ts` supports `EscalationKind = "backlog" | "epic" | "issue-report"`, builds redacted GitHub Issues, and records `upstreamIssueNumber`, `upstreamIssueUrl`, `upstreamSyncedAt`. It skips `fork_only`. | Reuse the bridge, but extend its policy contract explicitly for exceptional fork-only feedback if approved. |
+| Privacy | `identity-privacy.ts` provides stable pseudonym identity and `redactHostnames()`. | Keep pseudonym as the only upstream identity. Add pre-send secret scanning and synthesized summaries before bridge call. |
+| Notifications | `Notification` has `userId`, `type`, `title`, `body`, `deepLink`, `read`. `PlatformNotification` has global `severity`, `category`, `subjectId`, `message`, `resolvedAt`. | User-visible feedback resolution uses `Notification`; admin/system health uses `PlatformNotification`. |
+| Build Studio capacity | `loadBuildStudioCapability()` already decides whether Build Studio has a strong remote provider with tool use and >=32K context. | Feedback routing should consume this helper when route/build context indicates Build Studio, not duplicate provider-tier logic. |
+| UI debt | Feedback fallback and Admin issue-report UI still contain hardcoded rgba/hex color styles in several places. | Phase 0 refactor must clean the touched feedback surfaces to DPF theme tokens before adding new UI states. |
+
+## 4. Research and Benchmarking
+
+### 4.1 Open-source / source-available patterns
+
+| System | Relevant pattern | Adopt | Reject |
+| ------ | ---------------- | ----- | ------ |
+| Sentry User Feedback / Issues | Feedback can be collected anywhere, attached to issue context, and queried as an issue category. Issue detail pages co-locate feedback, attachments, replays, activity, and linked GitHub/Jira issues. Sources: [Sentry User Feedback](https://docs.sentry.io/product/user-feedback/), [Sentry Issue Details](https://docs.sentry.io/product/issues/issue-details/). | Treat user feedback as issue-like evidence with route/error context and lifecycle state. | Do not copy Sentry's identity model or default to shipping screenshots/replays upstream. DPF privacy rules are stricter. |
+| GlitchTip | Open-source Sentry-compatible error tracking receives error events through Sentry SDKs and groups them into an issue queue. Source: [GlitchTip documentation](https://glitchtip.com/documentation/). | Keep crash/error capture protocol-compatible in spirit: small structured envelope, grouping/coalescing, self-hostable posture. | Do not introduce a second external error tracker for this slice. |
+| GitLab Service Desk / Issues | Customers can send bug reports, feature requests, or feedback without knowing the GitLab instance; Service Desk tickets become regular issues. Sources: [GitLab Service Desk](https://docs.gitlab.com/user/project/service_desk/), [GitLab Issues](https://docs.gitlab.com/user/project/issues/). | Let non-technical operators enter through a familiar support surface while maintainers work in an issue tracker. | Do not expose raw tracker mechanics to Dale or require him to choose project/request types. |
+
+### 4.2 Commercial patterns
+
+| System | Relevant pattern | Adopt | Reject |
+| ------ | ---------------- | ----- | ------ |
+| Linear Customer Requests | Customer requests link source feedback to issues/projects and can preserve the source link, customer impact, and importance. Source: [Linear Customer Requests](https://linear.app/docs/customer-requests). | Model feedback as a source-linked request behind an issue, with importance/capacity reason stored locally. | Do not sync customer identity, domain, revenue, or tenant details upstream. |
+| Jira Service Management | Request types organize incoming customer requests and can be grouped in a portal. Source: [Atlassian request types](https://support.atlassian.com/jira-service-management-cloud/docs/categorize-customer-requests-into-request-types/). | Use internal classification after capture to route work efficiently. | Do not make Dale pick categories/severity before he can ask for help. |
+| GitHub Issues | PR descriptions or commit messages can link to and automatically close Issues with supported keywords when merged to the default branch. Source: [GitHub linked issues and PRs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). | Use GitHub Issue state and linked PR closure as the upstream resolution signal. | Do not rely only on GitHub email/web UI for the operator-facing closure loop. |
+
+### 4.3 Standards
+
+OpenTelemetry's log data model separates timestamps, severity, structured bodies, and exception attributes. Source: [OpenTelemetry Logs Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/). DPF should align the feedback event envelope with that shape where useful: `triggerKind`, severity, observed timestamp, route/resource attributes, and an optional structured error body. The local `PlatformIssueReport` remains the domain model; OTel alignment is for event hygiene and future export, not a dependency.
+
+## 5. Design Principles
+
+1. **One operator affordance, multiple routed outcomes.** Dale clicks one thing; the platform chooses local help, local BI, or upstream issue.
+2. **Local resolution first, but not forever.** The coworker attempts a bounded support loop, then records why it stopped.
+3. **No hidden race with triage.** Reports in support triage are not eligible for the generic issue-report-to-BI cron until the support flow chooses that path.
+4. **GitHub Issues is canonical only after upstream escalation.** Before that, `PlatformIssueReport` is the local canonical record.
+5. **Privacy is structural.** Upstream bodies use pseudonym identity, `redactHostnames()`, secret scanning, and coworker-synthesized summaries instead of raw transcript dumps.
+6. **Contribution policy stays visible.** `fork_only` exceptional escalation requires explicit operator acknowledgement and audit fields. It must not silently weaken private-install posture.
+7. **User notifications are local.** Dale receives a DPF `Notification` with a route deep link; GitHub is a secondary external reference.
+8. **20 percent refactor budget is mandatory.** The first implementation slice cleans the feedback/reporting substrate before adding new routing behavior.
+
+## 6. Future Architecture
+
+```text
+Operator clicks Feedback or a hard trigger fires
+        |
+        v
+Typed feedback event detail is built
+        |
+        v
+createPlatformIssueReport() writes one local canonical row
+        |
+        v
+Coworker support mode opens on the existing AgentCoworkerShell
+        |
+        v
+Bounded local-resolution loop
+        |
+        +--> resolved locally
+        |       - status: resolved_locally
+        |       - optional ImprovementSignal / telemetry
+        |
+        +--> local work needed and install can handle it
+        |       - status: triaged_local
+        |       - create or link local BI
+        |
+        +--> capacity insufficient or hard-failure upstream path
+                - status: awaiting_escalation_ack or upstream_pending
+                - synthesize safe issue body
+                - pre-send privacy/secret checks
+                - fileUpstreamFeedback() calls the bridge
+                - status: upstream_filed
+                - Dale gets local confirmation with DPF state + GitHub link
+```
+
+### 6.1 Trigger Contract
+
+Add a typed payload for `open-agent-feedback` and keep `open-agent-panel` compatibility:
+
+```ts
+type FeedbackTriggerKind =
+  | "manual"
+  | "runtime-error"
+  | "grant-denied"
+  | "structural-verification-fail"
+  | "coworker-stall"
+  | "issue-spike";
+
+type FeedbackEventDetail = {
+  triggerKind: FeedbackTriggerKind;
+  routeContext: string;
+  title?: string;
+  description?: string;
+  errorStack?: string;
+  userAgent?: string;
+  featureBuildId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  sourceId?: string;
+  autoFilePolicy?: "ask" | "auto-hard-failure";
+};
+```
+
+The event opens the coworker with an auto-message such as:
+
+> I can help with what is stuck on this page. I will first try to resolve it here. If it looks like the project team needs to fix the platform, I will package a safe report for you to approve.
+
+Hard-failure triggers may create the local report immediately and then open the coworker with status text. They should not require Dale to describe the crash before anything is captured.
+
+### 6.2 PlatformIssueReport State
+
+Current schema uses free-form `status`. This design should introduce constants before new states are written.
+
+Recommended state vocabulary:
+
+| Status | Meaning |
+| ------ | ------- |
+| `open` | Generic issue report not yet claimed by support triage. Existing cron may process these. |
+| `support_triage` | Coworker is attempting local resolution; generic BI cron must skip. |
+| `resolved_locally` | Coworker resolved or explained the issue without creating BI/upstream. |
+| `triaged_local` | Converted or linked to local backlog. |
+| `awaiting_escalation_ack` | Coworker recommends upstream escalation and needs human acknowledgement. |
+| `upstream_pending` | Auto-file or acknowledged escalation is in progress. |
+| `upstream_filed` | GitHub Issue exists and local row has upstream issue fields. |
+| `resolved_upstream` | Upstream issue closed and local user notification emitted. |
+| `suppressed` | Duplicate, automated warmup, spam, or unsafe report suppressed. |
+
+Add these constants near the quality/reporting code and any MCP schema that exposes report status. Per AGENTS.md enum discipline, do not let one writer invent a status string alone.
+
+Recommended additive fields:
+
+```prisma
+model PlatformIssueReport {
+  // existing fields...
+  triggerKind                String?
+  coalesceKey                String?
+  coalesceBucket             String?
+  occurrenceCount            Int       @default(1)
+  lastSeenAt                 DateTime?
+  escalationAcknowledgedAt   DateTime?
+  escalationAcknowledgedById String?
+  escalationPolicy           String?   // selective | contribute_all | fork_only_exception
+  capacityDecision           String?   // resolved_locally | local_bi | upstream | ask
+  capacityDecisionReasons    Json?
+  supportSummary             String?   @db.Text
+  resolvedAt                 DateTime?
+
+  @@index([coalesceKey, coalesceBucket])
+  @@index([status, createdAt])
+}
+```
+
+`agentThreadId` should not be added; the current schema already has `threadId`.
+
+### 6.3 Coalescing
+
+The draft's `(reportedById, routeContext, 10min)` index is not a clean Prisma/Postgres primitive. Use a deterministic key:
+
+```text
+coalesceKey = sha256(reportedById-or-session + routeContext + triggerKind + normalizedErrorSignature)
+coalesceBucket = UTC timestamp floored to 10 minutes, formatted as YYYYMMDDHHmm
+```
+
+On create, the service looks for the same `(coalesceKey, coalesceBucket)` and updates `occurrenceCount`, `lastSeenAt`, and append-only context rather than creating another row. A future migration can make this a partial unique index if the service-level guard proves insufficient, but do not start with an expression index that the application cannot reason about.
+
+### 6.4 Capacity Routing Decision
+
+`assessFeedbackRouting(context)` returns:
+
+```ts
+type FeedbackRoutingDecision =
+  | { route: "resolved_locally"; reasons: string[] }
+  | { route: "local_bi"; reasons: string[]; suggestedBacklogTitle: string }
+  | { route: "upstream"; reasons: string[]; acknowledgement: "not_required" | "required" }
+  | { route: "ask"; reasons: string[]; prompt: string };
+```
+
+Inputs:
+
+| Signal | Source | Routing use |
+| ------ | ------ | ----------- |
+| Trigger kind | Event detail | `runtime-error`, `grant-denied`, and `structural-verification-fail` start as high-severity and may skip the generic local-BI path. |
+| Build Studio capability | `loadBuildStudioCapability()` when route/build context indicates Build Studio | If no strong remote provider exists, route toward provider guidance rather than upstream code issue unless the product bug is independent of local setup. |
+| Build/task state | `FeatureBuild`, `TaskRun`, `AgentThread`, existing issue reports | Repeated phase failure, repeated tool loop, or cross-build context mismatch can justify upstream. |
+| Model/provider telemetry | routing decision logs, `NoEligibleEndpointsError`, provider status/rate capacity | Distinguish "connect provider" from "platform broke". |
+| Authority/grants | MCP insufficient scope, tool grants, user role | Grant-denied can be a local admin action, upstream product gap, or documentation issue depending on context. |
+| Coworker support loop result | bounded support-mode transcript and tool results | If the coworker cannot converge after a small number of turns, record a reason and stop. |
+| Dale explicit escape | "tell the project", "someone needs to fix the platform" | Route `ask` or `upstream` depending on contribution mode and privacy checks. |
+
+The function is pure at the decision layer. Dependencies are passed in as snapshots so unit tests can cover all branches without Prisma.
+
+### 6.5 Contribution Mode Semantics
+
+Current repo truth from `issue-bridge.ts`:
+
+- `fork_only` skips upstream escalation.
+- `selective` allows caller-prompted escalation.
+- `contribute_all` allows caller auto-escalation per routing policy.
+
+Future contract:
+
+| Mode | Behavior |
+| ---- | -------- |
+| `contribute_all` | Upstream filing may be automatic for hard failures and insufficient-capacity routing once privacy checks pass. Coworker still reports what it did. |
+| `selective` | Upstream filing requires Dale acknowledgement except for narrowly defined hard failures if the platform owner has enabled hard-failure auto-file. |
+| `fork_only` | Default is no upstream filing. A critical one-shot exception may be offered only as an explicit PAR-style acknowledgement: "This install is private by default. I can send a pseudonymous project issue for this one platform failure." Store `escalationPolicy="fork_only_exception"` and `escalationAcknowledgedAt`. |
+
+Implementation must extend the bridge API or add a dedicated policy wrapper. Do not pass through the current `fork_only` guard and pretend the issue was filed.
+
+### 6.6 Privacy Envelope
+
+Upstream payloads contain:
+
+- install pseudonym from `getPlatformIdentity()`;
+- route class and route path when safe;
+- trigger kind;
+- severity;
+- anonymized error class / first stack line;
+- build phase and stable public build id only when safe;
+- coworker-synthesized summary;
+- local public `reportId`;
+- `hive:submitted`, `hive:platform-issue-report`, `severity:*`, and `capacity:*` labels.
+
+Upstream payloads never contain:
+
+- `reportedById`, user email, user name, tenant/customer name, organization name, brand assets, secrets, raw transcript, raw business-specific description, or local machine names.
+
+Privacy gates:
+
+1. Coworker writes a synthesized summary instead of sending Dale's raw note.
+2. `redactHostnames()` runs over every outbound string.
+3. Secret scan runs on title/body/stack before `postIssue()`.
+4. If any gate fails, set status `suppressed` or `awaiting_escalation_ack` with a safe explanation; do not send.
+
+## 7. UX Contract
+
+### 7.1 Operator-Facing Behavior
+
+Feedback should feel like asking a capable coworker for help, not submitting a form into a void.
+
+**Manual click:**
+
+- Header action can remain compact, but the first panel copy should be plain: "What is stuck?"
+- The coworker says it will try to solve locally first.
+- Dale is not shown category, severity, contribution mode, or GitHub language up front.
+- If upstream is recommended, the coworker explains why in one sentence and asks for acknowledgement when policy requires it.
+
+**Hard failure:**
+
+- The error page says the platform captured the crash.
+- Optional textbox remains for "What were you doing?"
+- If auto-file policy applies, the page/coworker says a pseudonymous project issue was filed and shows the local status first.
+
+**Resolved upstream:**
+
+- Dale gets a local `Notification` with `deepLink` back to the originating route and body text that explains the fix/update in non-technical language.
+- The GitHub link is secondary, for traceability.
+
+### 7.2 UI Design Requirements
+
+Implementation must follow DPF theme-aware styling:
+
+- No hardcoded hex, `rgba(...)`, or Tailwind gray/red/yellow classes in touched feedback surfaces.
+- Use `text-[var(--dpf-text)]`, `text-[var(--dpf-muted)]`, `bg-[var(--dpf-surface-1)]`, `bg-[var(--dpf-surface-2)]`, `border-[var(--dpf-border)]`, and `bg-[var(--dpf-accent)]`.
+- The fallback form remains functional without the coworker panel, but it is not the healthy-install primary UX.
+- Buttons use clear commands and compact icons where the existing icon system is present.
+- Mobile/narrow viewport: the support panel must not obscure the error page's recovery controls.
+
+Existing debt to clean when touched:
+
+- `FeedbackButton.tsx` hardcoded inline colors and rounded glass styles.
+- `FeedbackForm.tsx` hardcoded rgba border/background styles.
+- `IssueReportPanel.tsx` hardcoded severity/status colors and rgba surfaces.
+- `TokenExpiryBanner.tsx` uses hardcoded color classes; not in core scope unless reused for feedback notifications.
+
+## 8. Implementation Slices
+
+### Phase 0: Substrate Cleanup and Refactor Allocation
+
+Goal: spend the mandatory first 20 percent on reducing feedback/reporting fragmentation before new behavior lands.
+
+Scope:
+
+- Create a single server writer, e.g. `apps/web/lib/quality/platform-issue-reports.ts`.
+- Route `POST /api/quality/report`, `reportQualityIssue()`, and MCP `report_quality_issue` through that writer.
+- Define `PlatformIssueReport` status/source/trigger constants.
+- Add support-triage statuses and update `issue-report-triage` to skip `support_triage`, `awaiting_escalation_ack`, `upstream_pending`, and `upstream_filed`.
+- Normalize route, user, `threadId`, `taskRunId`, `featureBuildId`, source, and user-agent capture where available.
+- Clean theme-token violations in touched feedback fallback UI.
+- Add unit tests proving the old entry points still create equivalent rows.
+
+Acceptance:
+
+- Existing manual feedback, crash feedback, and coworker `report_quality_issue` still create reports.
+- The issue-report triage cron still converts generic `open` reports to BIs.
+- A `support_triage` report is not converted by the cron.
+- No touched feedback UI contains hardcoded color tokens outside allowed exceptions.
+
+### Phase 1: Support-Mode Entry
+
+Goal: Feedback click opens the existing coworker shell in support mode with context.
+
+Scope:
+
+- Add typed `FeedbackEventDetail`.
+- Update `HeaderFeedbackButton` and `FeedbackButton` to pass route and trigger kind.
+- Add support auto-message/welcome copy.
+- Attach active build/thread context when route is `/build` and a build is active.
+- Create local `PlatformIssueReport(status="support_triage")` at support start or first meaningful user message.
+
+Acceptance:
+
+- Dale clicks Feedback on `/build`; the coworker opens with support copy and no category form.
+- If the shell is unavailable, fallback form still posts.
+- Created report has `routeContext`, `triggerKind`, `threadId` when available, and status `support_triage`.
+
+### Phase 2: Local Resolution and Routing Decision
+
+Goal: support mode makes a bounded local attempt and records a routing decision.
+
+Scope:
+
+- Implement pure `assessFeedbackRouting()`.
+- Add fixtures for Build Studio provider-gate, repeated phase failure, grant-denied, runtime crash, and explicit Dale escape.
+- Use `loadBuildStudioCapability()` for Build Studio provider-capability checks.
+- Record `capacityDecision`, `capacityDecisionReasons`, and `supportSummary`.
+
+Acceptance:
+
+- Unit tests cover every decision branch.
+- Live portal support scenario: answerable local question resolves locally and sets `resolved_locally`.
+- Local-BI scenario sets `triaged_local` and creates/links backlog through the existing backlog path.
+
+### Phase 3: Upstream Bridge Wiring
+
+Goal: upstream-worthy feedback files a safe GitHub Issue and updates the local row.
+
+Scope:
+
+- Add `fileUpstreamFeedback()` coworker tool or server action.
+- Extend bridge policy for `fork_only_exception` only if ratified.
+- Add `capacity:*` labels.
+- Add privacy/secret scan gate before `postIssue()`.
+- Make bridge idempotent on existing `upstreamIssueNumber`.
+
+Acceptance:
+
+- `selective` mode asks before filing.
+- `contribute_all` mode can auto-file hard failures after privacy checks.
+- `fork_only` mode cannot file silently; explicit acknowledgement is stored.
+- Upstream issue URL/number are persisted on the report.
+
+### Phase 4: Implicit Triggers
+
+Goal: hard failures and structural blockers feed the same support/escalation path.
+
+Scope:
+
+- Crash boundary dispatches a hard-failure event after local report capture.
+- MCP insufficient-scope/grant-denied paths can raise a typed event or create a support report.
+- Build Studio structural-verification failures can create a support report linked to `featureBuildId`/`taskRunId`.
+
+Acceptance:
+
+- Runtime crash creates local report, opens/queues support path, and does not require Dale to choose a category.
+- Grant-denied scenario distinguishes local admin action from upstream product gap.
+- Structural-verification failure links to the originating build/run.
+
+### Phase 5: Reverse Channel and Notifications
+
+Goal: upstream closure becomes a local operator-facing update.
+
+Scope:
+
+- Prefer webhook where install reachability and auth are configured.
+- Add scheduled polling fallback for installs without inbound reachability.
+- On upstream issue closed, update report status `resolved_upstream`.
+- Create user `Notification` for `reportedById` with route `deepLink`.
+- Use `PlatformNotification` only for admin/global feedback health.
+
+Acceptance:
+
+- Closing a test GitHub Issue creates a local user notification.
+- Notification opens the original route or a local report detail page.
+- No duplicate notification is created on repeated webhook/poll.
+
+### Phase 6: Voice STT Hook
+
+Goal: Dale can speak the feedback.
+
+Scope:
+
+- Reuse the existing STT surface only after it is functionally verified on the live install.
+- Voice text enters the same support-mode path.
+
+Acceptance:
+
+- Dale clicks Feedback, speaks the problem, sees transcript, and support routing continues normally.
+
+## 9. Verification Gates
+
+Structural tests are necessary but not sufficient.
+
+| Phase | Required tests | Required live UX verification |
+| ----- | -------------- | ----------------------------- |
+| 0 | Writer unit tests, cron skip tests, UI token audit for touched files | Manual feedback, crash feedback, and MCP/coworker report all create rows. |
+| 1 | Event payload and shell auto-message tests | Click Feedback on `/build` and a non-build route; verify coworker support mode and fallback. |
+| 2 | Pure routing matrix tests | Dale local-help scenario resolves without upstream; architectural Build Studio scenario recommends upstream/local BI correctly. |
+| 3 | Bridge policy, idempotency, privacy scan tests | File to a test repo or dry-run GitHub adapter; verify upstream fields persisted. |
+| 4 | Trigger-specific tests | Drive crash boundary and grant-denied scenario on live portal. |
+| 5 | Webhook/poll idempotency tests | Close test issue and observe DPF `Notification` in the UI. |
+| 6 | STT route/unit tests | Speak or simulate audio through live install; transcript enters support flow. |
+
+Build gates for implementation:
+
+- `pnpm --filter web exec vitest run` for affected tests.
+- `pnpm --filter web typecheck`.
+- `cd apps/web && pnpm exec next build`.
+- Live Docker-served UX verification for any UI path.
+- Prisma migration applies cleanly if schema changes land.
+
+## 10. Open Decisions
+
+1. **Fork-only exceptional escalation:** approve or reject the one-shot critical upstream path. Recommendation: approve only with explicit acknowledgement and audit fields.
+2. **GitHub webhook vs polling priority:** implement polling first if install reachability is unreliable; add webhook as the preferred path when platform reachability is configured.
+3. **Report detail UX:** decide whether Dale's deep link returns to the originating route with a small update tray, or a dedicated local report detail page. Recommendation: route first, detail page later if reports need history.
+4. **GearInterface emission:** do not add GearInterface writes in the first implementation slice. After Phase 3, consider dual-emitting feedback escalation as a ring-boundary observation if the Reduction Gear Phase 0 writer service is already available.
+5. **Admin issue-report page ownership:** if this flow grows beyond Dale/Build Studio, file a separate UI-hardening BI for Admin issue reports instead of mixing admin queue redesign into support-mode delivery.
+
+## 11. Connections to Adjacent Work
+
+- **Dale persona:** `docs/personas/dale-hvac.md` and `docs/dogfood/2026-05-23-dale-hvac-build-studio.md` are the primary verification scenario sources.
+- **AI Capacity Continuity:** this design handles an immediate capacity-exceeded feedback path. It should not become a second capacity scheduler.
+- **Reduction Gear:** feedback escalation can later become a GearInterface observation at the operator-to-platform boundary, but this spec's first job is to clean and route issue reports.
+- **Vertical Workspace Home:** vertical homes should expose the same Feedback affordance, but this spec owns behavior after the click.
+- **Quality feedback:** this spec extends the existing three-path quality feedback model; it does not replace crash-boundary or offline queue resilience.
+
+## 12. Next Step After Sign-Off
+
+Do not implement feature code directly from this design. After review sign-off:
+
+1. File or link the first BI under the selected epic.
+2. Feed this spec to `writing-plans` for Phase 0 only.
+3. Keep Phase 0 as a cleanup/refactor PR with evidence.
+4. Plan Phase 1 only after Phase 0 lands or the cleanup branch is ready for review.


### PR DESCRIPTION
This PR carries the **spec**, **Phase 0 plan**, **Phase 0 implementation**, and **live verification evidence** for the capacity-aware feedback escalation work.

## Spec ([`docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md`](docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md))

One operator affordance ("Feedback") → typed event detail with `triggerKind` → coworker support mode → `assessFeedbackRouting()` returns `resolved_locally | local_bi | upstream | ask` → upstream path **reuses** existing `escalateToUpstreamIssue({ kind: "issue-report" })` (per architect's 5th correction — no parallel GitHub API writer).

Five architect corrections applied: substrate consolidation (Phase 0); cron race prevention via status vocabulary; `fork_only_exception` policy with audit fields; reverse channel via `Notification` (user-facing) not `PlatformNotification` (admin/global); reuse `issue-bridge.ts` for all upstream filing.

7 BS-shippable phases sequenced (0–6); writing-plans is invoked phase-by-phase as each lands.

## Phase 0 plan ([`docs/superpowers/plans/2026-05-24-feedback-substrate-cleanup.md`](docs/superpowers/plans/2026-05-24-feedback-substrate-cleanup.md))

12 TDD tasks. Pure refactor + invariants. Maintenance-class PR lane (per `feedback_no_manual_prs` carveout); Phase 1+ go through Build Studio.

## Phase 0 implementation (this branch)

- **`createPlatformIssueReport()` unified writer** in `apps/web/lib/quality/platform-issue-reports.ts` — single server-side path that all 4 callers go through, applies length limits, defaults `digitalProductId` to dpf-portal, resolves `portfolioId` from `routeContext`, validates `status`
- **`ISSUE_REPORT_STATUS` constants** in `apps/web/lib/quality/issue-report-status.ts` — all 9 statuses defined per spec §6.2; `SUPPORT_FLOW_STATUSES` + `isSupportFlowStatus()` helpers
- **Three writer call-sites migrated**: `POST /api/quality/report`, `reportQualityIssue()` server action, `report_quality_issue` MCP tool handler (now also passes `routeContext` from `context?.routeContext`)
- **Cron uses constant**: `lib/queue/functions/issue-report-triage.ts` filter is now `where: { status: ISSUE_REPORT_STATUS.OPEN }`
- **Theme tokens**: `FeedbackButton.tsx` and `FeedbackForm.tsx` — zero `rgba(`/`#hex` matches remain
- **Tests**: +28 new (5 status + 14 writer + 4 route + 3 server action + 2 cron contract)

## Verification ([`docs/superpowers/evidence/2026-05-24-feedback-substrate-cleanup-verification.md`](docs/superpowers/evidence/2026-05-24-feedback-substrate-cleanup-verification.md))

- `pnpm test` → **7900 / 7900 passed** (15 skipped, 18 todo)
- `pnpm typecheck` → clean
- `pnpm exec next build` → green
- Live HTTP POST through portal → 200 + persisted row in correct shape
- Live cron-skip: hand-rolled `support_triage` row, `WHERE status='open'` returns 0; row stays at `support_triage`
- Baseline counts restored after cleanup

## Acceptance criteria (spec §8 Phase 0)

- [x] Existing manual feedback, crash feedback, and coworker `report_quality_issue` still create reports
- [x] Issue-report triage cron still converts generic `open` reports to BIs
- [x] `support_triage` report is NOT converted by the cron
- [x] No touched feedback UI contains hardcoded color tokens

## Phase 1+ explicitly deferred

- `triggerKind`, `coalesceKey`, `escalationPolicy`, `capacityDecision`, `supportSummary` schema fields → Phase 2/3
- `FeedbackEventDetail` typed contract → Phase 1
- Coworker support mode behavior, `assessFeedbackRouting()`, bridge wiring, implicit triggers, reverse channel `Notification`, voice STT → Phases 1–6

These deferrals protect the 20% refactor budget from sprawling.

## Test plan for reviewer

- [ ] Verify spec architecture is sound (especially the 5 architect corrections)
- [ ] Verify Phase 0 stays strictly within refactor scope (no Phase 1+ behavior leakage)
- [ ] Verify the writer length-limit, status-validation, and default-resolution behavior is what you want
- [ ] CI green: DCO, typecheck, test, build
- [ ] After merge: Phase 1 plan can be requested via `writing-plans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)