### PR TITLE
fix: repair quiescence guard and voice storage CI

### DIFF
--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -564,6 +564,7 @@ export async function captureActiveSessionBlockers(opts?: {
       taskRunId: true,
       title: true,
       buildId: true,
+      status: true,
       lastHeartbeatAt: true,
       startedAt: true,
     },
@@ -574,12 +575,13 @@ export async function captureActiveSessionBlockers(opts?: {
       surface: "coworker.reasoning-loop",
       detectionClass: "A",
       kind: "hard",
-      blockerSignal: { class: "A", model: "TaskRun", rowId: row.taskRunId, status: "working" },
+      blockerSignal: { class: "A", model: "TaskRun", rowId: row.taskRunId, status: row.status },
       estimatedWaitMs: 30_000, // typical iteration boundary; worst ~3min
       evidence: {
         taskRunId: row.taskRunId,
         title: row.title,
         buildId: row.buildId,
+        status: row.status,
         startedAt: row.startedAt.toISOString(),
         lastHeartbeatAt: row.lastHeartbeatAt?.toISOString() ?? null,
       },

--- a/apps/web/lib/voice-synthesis/storage-root.test.ts
+++ b/apps/web/lib/voice-synthesis/storage-root.test.ts
@@ -26,6 +26,13 @@ describe("resolveVoiceStorageRoot", () => {
     }).replace(/\\/g, "/")).toBe("/workspace/data/uploads")
   })
 
+  it("keeps Windows project roots absolute on non-Windows runners", () => {
+    expect(resolveVoiceStorageRoot({
+      projectRoot: "D:/DPF",
+      cwd: "/workspace/apps/web",
+    }).replace(/\\/g, "/")).toBe("D:/DPF/data/uploads")
+  })
+
   it("falls back from apps/web to the repository data/uploads directory", () => {
     expect(resolveVoiceStorageRoot({
       cwd: "D:/DPF/apps/web",

--- a/apps/web/lib/voice-synthesis/storage-root.ts
+++ b/apps/web/lib/voice-synthesis/storage-root.ts
@@ -12,15 +12,24 @@ function nonEmpty(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null
 }
 
+function pathApiFor(value: string): typeof path {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\") ? path.win32 : path
+}
+
+function joinStorageRoot(root: string): string {
+  return pathApiFor(root).join(root, "data", "uploads")
+}
+
 export function resolveVoiceStorageRoot(input: ResolveVoiceStorageRootInput = {}): string {
   const uploadStoragePath = nonEmpty(input.uploadStoragePath ?? process.env.UPLOAD_STORAGE_PATH)
   if (uploadStoragePath) return uploadStoragePath
 
   const hostSourceMount = nonEmpty(input.hostSourceMount ?? process.env.DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT)
-  if (hostSourceMount) return path.join(hostSourceMount, "data", "uploads")
+  if (hostSourceMount) return joinStorageRoot(hostSourceMount)
 
   const projectRoot = nonEmpty(input.projectRoot ?? process.env.PROJECT_ROOT)
-  if (projectRoot) return path.join(projectRoot, "data", "uploads")
+  if (projectRoot) return joinStorageRoot(projectRoot)
 
-  return path.resolve(input.cwd ?? process.cwd(), "..", "..", "data", "uploads")
+  const cwd = input.cwd ?? process.cwd()
+  return pathApiFor(cwd).resolve(cwd, "..", "..", "data", "uploads")
 }


### PR DESCRIPTION
## Summary

- Snapshots the actual `TaskRun.status` in quiescence blockers instead of hardcoding `status: "working"`, so the stall-detection guard stays strict without a new allowlist.
- Preserves Windows absolute voice storage paths when tests or runtime execute on non-Windows hosts, fixing the Linux CI unit failure from PR #1116.

## Verification

- `node scripts/check-no-bare-working-write.mjs`
- `pnpm --filter web exec vitest run lib/voice-synthesis/storage-root.test.ts lib/self-upgrade/quiescence.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`