### PR TITLE
feat(build-studio): Phase 1 substrate — Epic-as-parent + child FeatureBuilds + dependency edges (BI-2E6CC391)

### DIFF
--- a/apps/web/lib/build/epic-decomposition-invariants.test.ts
+++ b/apps/web/lib/build/epic-decomposition-invariants.test.ts
@@ -1,0 +1,395 @@
+// apps/web/lib/build/epic-decomposition-invariants.test.ts
+//
+// Coverage for Phase 1 substrate invariants.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DecompositionInvariantError,
+  assertChildDesignReviewTransitive,
+  assertChildOrderWellFormed,
+  assertDependencyEdgeWellFormed,
+  assertEpicHasContractIfDecomposed,
+  assertNoCycle,
+  assertNoRecursiveDecomposition,
+} from "./epic-decomposition-invariants";
+
+function expectInvariantError(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error(`expected DecompositionInvariantError(${code}) but no error was thrown`);
+  } catch (err) {
+    if (!(err instanceof DecompositionInvariantError)) {
+      throw err;
+    }
+    expect(err.code).toBe(code);
+  }
+}
+
+describe("assertEpicHasContractIfDecomposed", () => {
+  it("passes when Epic has no FeatureBuild children (portfolio-organizational use)", () => {
+    expect(() =>
+      assertEpicHasContractIfDecomposed({ designDoc: null, featureBuilds: [] }),
+    ).not.toThrow();
+  });
+
+  it("passes when Epic has children AND a designDoc (execution-organizational use)", () => {
+    expect(() =>
+      assertEpicHasContractIfDecomposed({
+        designDoc: { sections: [] },
+        featureBuilds: [{}, {}, {}],
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when Epic has children but no designDoc", () => {
+    expectInvariantError(
+      () =>
+        assertEpicHasContractIfDecomposed({
+          designDoc: null,
+          featureBuilds: [{}],
+        }),
+      "epic-without-contract",
+    );
+  });
+
+  it("treats undefined featureBuilds as no children", () => {
+    expect(() =>
+      assertEpicHasContractIfDecomposed({ designDoc: null }),
+    ).not.toThrow();
+  });
+});
+
+describe("assertChildDesignReviewTransitive", () => {
+  const parent = { id: "epic-1", designReview: { passed: true, summary: "ok" } };
+
+  it("passes for top-level builds (no parentEpicId)", () => {
+    expect(() =>
+      assertChildDesignReviewTransitive(
+        { parentEpicId: null, designReview: null },
+        parent,
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when child's designReview matches parent's exactly", () => {
+    expect(() =>
+      assertChildDesignReviewTransitive(
+        { parentEpicId: "epic-1", designReview: { passed: true, summary: "ok" } },
+        parent,
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when child's designReview is a structurally equal object", () => {
+    expect(() =>
+      assertChildDesignReviewTransitive(
+        {
+          parentEpicId: "epic-1",
+          designReview: { summary: "ok", passed: true }, // key order differs
+        },
+        { id: "epic-1", designReview: { passed: true, summary: "ok" } },
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws when child's parentEpicId does not match parent argument id", () => {
+    expectInvariantError(
+      () =>
+        assertChildDesignReviewTransitive(
+          { parentEpicId: "epic-OTHER", designReview: parent.designReview },
+          parent,
+        ),
+      "child-parent-mismatch",
+    );
+  });
+
+  it("throws when child's designReview diverges from parent's", () => {
+    expectInvariantError(
+      () =>
+        assertChildDesignReviewTransitive(
+          { parentEpicId: "epic-1", designReview: { passed: false } },
+          parent,
+        ),
+      "child-review-divergence",
+    );
+  });
+
+  it("throws when parent has a review but child has null", () => {
+    expectInvariantError(
+      () =>
+        assertChildDesignReviewTransitive(
+          { parentEpicId: "epic-1", designReview: null },
+          parent,
+        ),
+      "child-review-divergence",
+    );
+  });
+});
+
+describe("assertDependencyEdgeWellFormed", () => {
+  const dependent = { id: "FB-2", parentEpicId: "epic-1" };
+  const dependsOn = { id: "FB-1", parentEpicId: "epic-1" };
+
+  it("passes for a well-formed in-Epic edge", () => {
+    expect(() =>
+      assertDependencyEdgeWellFormed({ dependent, dependsOn, parentEpicId: "epic-1" }),
+    ).not.toThrow();
+  });
+
+  it("throws on self-dependency", () => {
+    expectInvariantError(
+      () =>
+        assertDependencyEdgeWellFormed({
+          dependent: { id: "FB-1", parentEpicId: "epic-1" },
+          dependsOn: { id: "FB-1", parentEpicId: "epic-1" },
+          parentEpicId: "epic-1",
+        }),
+      "self-dependency",
+    );
+  });
+
+  it("throws when dependent's parentEpicId differs from edge parentEpicId", () => {
+    expectInvariantError(
+      () =>
+        assertDependencyEdgeWellFormed({
+          dependent: { id: "FB-2", parentEpicId: "epic-OTHER" },
+          dependsOn,
+          parentEpicId: "epic-1",
+        }),
+      "cross-epic-dependent",
+    );
+  });
+
+  it("throws when dependsOn's parentEpicId differs from edge parentEpicId", () => {
+    expectInvariantError(
+      () =>
+        assertDependencyEdgeWellFormed({
+          dependent,
+          dependsOn: { id: "FB-1", parentEpicId: "epic-OTHER" },
+          parentEpicId: "epic-1",
+        }),
+      "cross-epic-dependson",
+    );
+  });
+
+  it("throws when dependent has null parentEpicId (top-level build)", () => {
+    expectInvariantError(
+      () =>
+        assertDependencyEdgeWellFormed({
+          dependent: { id: "FB-2", parentEpicId: null },
+          dependsOn,
+          parentEpicId: "epic-1",
+        }),
+      "cross-epic-dependent",
+    );
+  });
+});
+
+describe("assertNoCycle", () => {
+  it("passes on an empty graph with a single new edge", () => {
+    expect(() =>
+      assertNoCycle({
+        existingEdges: [],
+        newEdge: { dependentBuildId: "FB-2", dependsOnBuildId: "FB-1" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("passes on a linear chain (Dale scenario: 3 builds, 2 edges)", () => {
+    // FB-3 -> FB-2 -> FB-1 (Low-stock depends on Record-usage depends on Read)
+    expect(() =>
+      assertNoCycle({
+        existingEdges: [{ dependentBuildId: "FB-2", dependsOnBuildId: "FB-1" }],
+        newEdge: { dependentBuildId: "FB-3", dependsOnBuildId: "FB-2" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("passes when adding an edge with a build that already exists in the graph", () => {
+    expect(() =>
+      assertNoCycle({
+        existingEdges: [{ dependentBuildId: "FB-2", dependsOnBuildId: "FB-1" }],
+        newEdge: { dependentBuildId: "FB-3", dependsOnBuildId: "FB-1" }, // 3 also depends on 1, no cycle
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws on a direct two-node cycle", () => {
+    expectInvariantError(
+      () =>
+        assertNoCycle({
+          existingEdges: [{ dependentBuildId: "FB-1", dependsOnBuildId: "FB-2" }],
+          newEdge: { dependentBuildId: "FB-2", dependsOnBuildId: "FB-1" },
+        }),
+      "dependency-cycle",
+    );
+  });
+
+  it("throws on a three-node cycle (FB-3 -> FB-1 -> FB-2 -> FB-3)", () => {
+    expectInvariantError(
+      () =>
+        assertNoCycle({
+          existingEdges: [
+            { dependentBuildId: "FB-3", dependsOnBuildId: "FB-1" },
+            { dependentBuildId: "FB-1", dependsOnBuildId: "FB-2" },
+          ],
+          newEdge: { dependentBuildId: "FB-2", dependsOnBuildId: "FB-3" },
+        }),
+      "dependency-cycle",
+    );
+  });
+});
+
+describe("assertNoRecursiveDecomposition", () => {
+  it("passes for a top-level FeatureBuild (no parentEpicId)", () => {
+    expect(() =>
+      assertNoRecursiveDecomposition({ id: "FB-TOP", parentEpicId: null }),
+    ).not.toThrow();
+  });
+
+  it("throws when originating build is itself a child", () => {
+    expectInvariantError(
+      () =>
+        assertNoRecursiveDecomposition({ id: "FB-CHILD", parentEpicId: "epic-1" }),
+      "recursive-decomposition",
+    );
+  });
+});
+
+describe("assertChildOrderWellFormed", () => {
+  it("passes when parentEpicId is null and childOrder is null (top-level build)", () => {
+    expect(() =>
+      assertChildOrderWellFormed({ parentEpicId: null, childOrder: null }),
+    ).not.toThrow();
+  });
+
+  it("passes when parentEpicId is set and childOrder is a positive integer", () => {
+    for (const order of [1, 2, 3, 42]) {
+      expect(() =>
+        assertChildOrderWellFormed({ parentEpicId: "epic-1", childOrder: order }),
+      ).not.toThrow();
+    }
+  });
+
+  it("throws when parentEpicId is null but childOrder is set", () => {
+    expectInvariantError(
+      () =>
+        assertChildOrderWellFormed({ parentEpicId: null, childOrder: 1 }),
+      "invalid-child-order",
+    );
+  });
+
+  it("throws when parentEpicId is set but childOrder is null", () => {
+    expectInvariantError(
+      () =>
+        assertChildOrderWellFormed({ parentEpicId: "epic-1", childOrder: null }),
+      "invalid-child-order",
+    );
+  });
+
+  it("throws on childOrder = 0 (must be 1-indexed)", () => {
+    expectInvariantError(
+      () =>
+        assertChildOrderWellFormed({ parentEpicId: "epic-1", childOrder: 0 }),
+      "invalid-child-order",
+    );
+  });
+
+  it("throws on negative childOrder", () => {
+    expectInvariantError(
+      () =>
+        assertChildOrderWellFormed({ parentEpicId: "epic-1", childOrder: -3 }),
+      "invalid-child-order",
+    );
+  });
+
+  it("throws on non-integer childOrder", () => {
+    expectInvariantError(
+      () =>
+        assertChildOrderWellFormed({ parentEpicId: "epic-1", childOrder: 1.5 }),
+      "invalid-child-order",
+    );
+  });
+});
+
+describe("Dale composite scenario (end-to-end fixture)", () => {
+  // Mirror of §3.2 of the spec: 1 Epic + 3 children + 2 dependency edges.
+  // The full set of invariant assertions should pass; this is the bar
+  // declared in spec §13 ("data model can represent one active Epic with
+  // three child FeatureBuilds and normalized dependency edges").
+
+  const parentEpic = {
+    id: "epic-truck-inventory",
+    designDoc: { title: "Truck inventory", sections: ["read", "usage", "low-stock"] },
+    designReview: { passed: true, summary: "Truck inventory design approved" },
+  };
+
+  const childRead = {
+    id: "FB-READ",
+    parentEpicId: "epic-truck-inventory",
+    childOrder: 1,
+    designReview: parentEpic.designReview,
+  };
+  const childUsage = {
+    id: "FB-USAGE",
+    parentEpicId: "epic-truck-inventory",
+    childOrder: 2,
+    designReview: parentEpic.designReview,
+  };
+  const childLowStock = {
+    id: "FB-LOWSTOCK",
+    parentEpicId: "epic-truck-inventory",
+    childOrder: 3,
+    designReview: parentEpic.designReview,
+  };
+
+  it("all six invariants pass for the well-formed Dale scenario", () => {
+    expect(() =>
+      assertEpicHasContractIfDecomposed({
+        designDoc: parentEpic.designDoc,
+        featureBuilds: [childRead, childUsage, childLowStock],
+      }),
+    ).not.toThrow();
+
+    for (const child of [childRead, childUsage, childLowStock]) {
+      expect(() =>
+        assertChildDesignReviewTransitive(child, parentEpic),
+      ).not.toThrow();
+      expect(() => assertChildOrderWellFormed(child)).not.toThrow();
+    }
+    // assertNoRecursiveDecomposition deliberately NOT called for children
+    // here — it fires only when a child build is the proposed originator
+    // for a NEW Epic, not for plain existence checks. See its dedicated
+    // describe block above for that path.
+  });
+
+  it("dependency edges FB-USAGE -> FB-READ and FB-LOWSTOCK -> FB-USAGE are well-formed and acyclic", () => {
+    expect(() =>
+      assertDependencyEdgeWellFormed({
+        dependent: childUsage,
+        dependsOn: childRead,
+        parentEpicId: parentEpic.id,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      assertDependencyEdgeWellFormed({
+        dependent: childLowStock,
+        dependsOn: childUsage,
+        parentEpicId: parentEpic.id,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      assertNoCycle({
+        existingEdges: [
+          { dependentBuildId: "FB-USAGE", dependsOnBuildId: "FB-READ" },
+        ],
+        newEdge: { dependentBuildId: "FB-LOWSTOCK", dependsOnBuildId: "FB-USAGE" },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/lib/build/epic-decomposition-invariants.ts
+++ b/apps/web/lib/build/epic-decomposition-invariants.ts
@@ -1,0 +1,277 @@
+// apps/web/lib/build/epic-decomposition-invariants.ts
+//
+// Phase 1 substrate for design-time decomposition.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+//
+// Pure invariant assertions executed at the application layer — Prisma's schema
+// encodes nullability and FK shape, but the cross-row semantic rules (parent
+// must carry a contract, child review is transitive, dependency edges must stay
+// within one Epic, the dependency graph must be acyclic, recursive
+// decomposition is forbidden in Phase 1) live here.
+//
+// All functions are pure: callers fetch the relevant rows from Prisma and pass
+// them in. This keeps the unit tests fast and DB-free, and means the same
+// invariants can run inside the same transaction that performs the write
+// (Prisma transaction callback receives a tx client; the caller queries with
+// it, then calls these).
+//
+// Failure mode: throw `DecompositionInvariantError` with a stable `code`. The
+// caller decides whether to surface the error to the user, abort the
+// transaction, or escalate. Loud failure is intentional — silent skips on
+// invariant violation cause exactly the seed-side foot-guns documented in
+// `project_silent_seed_skips_audit` and `project_agent_grant_seeding_gap`.
+
+export class DecompositionInvariantError extends Error {
+  constructor(
+    public readonly code: DecompositionInvariantCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DecompositionInvariantError";
+  }
+}
+
+export type DecompositionInvariantCode =
+  | "epic-without-contract"
+  | "child-parent-mismatch"
+  | "child-review-divergence"
+  | "self-dependency"
+  | "cross-epic-dependent"
+  | "cross-epic-dependson"
+  | "dependency-cycle"
+  | "recursive-decomposition"
+  | "invalid-child-order";
+
+// ---------------------------------------------------------------------------
+// 1. An Epic with FeatureBuild children must carry a designDoc contract.
+//
+// Portfolio-organizational Epics (the existing use today) have only
+// `BacklogItem[]` and no `designDoc` — they remain valid. The invariant
+// fires only when an Epic gains at least one `FeatureBuild` child, at
+// which point the parent contract must exist.
+// ---------------------------------------------------------------------------
+
+export function assertEpicHasContractIfDecomposed(epic: {
+  designDoc: unknown | null;
+  featureBuilds?: ReadonlyArray<unknown> | null;
+}): void {
+  const hasChildren = (epic.featureBuilds?.length ?? 0) > 0;
+  if (hasChildren && epic.designDoc == null) {
+    throw new DecompositionInvariantError(
+      "epic-without-contract",
+      "Epic has child FeatureBuilds but no designDoc. Execution-organizational Epics must carry the immutable design contract.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Child design-review approval is transitive from parent at creation.
+//
+// The parent Epic's `designReview` (set when `reviewDesignDoc` passed in
+// Ideate) IS the child's review approval. Children skip `reviewDesignDoc`
+// and go straight to Plan. To preserve auditability the child's
+// `designReview` must equal the parent's at creation time.
+// ---------------------------------------------------------------------------
+
+export function assertChildDesignReviewTransitive(
+  child: { parentEpicId: string | null; designReview: unknown | null },
+  parent: { id: string; designReview: unknown | null },
+): void {
+  if (child.parentEpicId == null) return; // top-level build; no parent to transit from
+  if (child.parentEpicId !== parent.id) {
+    throw new DecompositionInvariantError(
+      "child-parent-mismatch",
+      `Child's parentEpicId (${child.parentEpicId}) does not match supplied parent Epic id (${parent.id}).`,
+    );
+  }
+  if (!designReviewsEquivalent(child.designReview, parent.designReview)) {
+    throw new DecompositionInvariantError(
+      "child-review-divergence",
+      "Child's designReview does not match parent Epic's. At child creation, the parent's review approval must be copied to the child.",
+    );
+  }
+}
+
+function designReviewsEquivalent(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  // Structural equality, order-insensitive at object-key level. Both sides
+  // are JSON-shaped artifacts written from the reviewDesignDoc tool; they
+  // typically arrive in the same insertion order, but the invariant must
+  // not depend on that — a serialization round-trip can re-key.
+  return canonicalJson(a) === canonicalJson(b);
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 3. A dependency edge must stay within one Epic, and a build cannot depend
+//    on itself.
+//
+// Cross-Epic dependency edges would imply that one Epic's children
+// coordinate with another Epic's, which collapses the "each Epic is one
+// coordinated body of work" framing. Self-loops are nonsensical and would
+// cause the rollup logic to deadlock immediately.
+// ---------------------------------------------------------------------------
+
+export function assertDependencyEdgeWellFormed(args: {
+  dependent: { id: string; parentEpicId: string | null };
+  dependsOn: { id: string; parentEpicId: string | null };
+  parentEpicId: string;
+}): void {
+  const { dependent, dependsOn, parentEpicId } = args;
+  if (dependent.id === dependsOn.id) {
+    throw new DecompositionInvariantError(
+      "self-dependency",
+      `FeatureBuild ${dependent.id} cannot depend on itself.`,
+    );
+  }
+  if (dependent.parentEpicId !== parentEpicId) {
+    throw new DecompositionInvariantError(
+      "cross-epic-dependent",
+      `Dependent build's parentEpicId (${dependent.parentEpicId ?? "null"}) does not match the dependency edge's parentEpicId (${parentEpicId}).`,
+    );
+  }
+  if (dependsOn.parentEpicId !== parentEpicId) {
+    throw new DecompositionInvariantError(
+      "cross-epic-dependson",
+      `DependsOn build's parentEpicId (${dependsOn.parentEpicId ?? "null"}) does not match the dependency edge's parentEpicId (${parentEpicId}).`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Adding a new dependency edge must not create a cycle.
+//
+// Iterative DFS with three-colour marking. Caller passes the full set of
+// existing edges (within the parent Epic — cross-Epic edges are already
+// rejected by (3)) plus the proposed new edge.
+// ---------------------------------------------------------------------------
+
+export function assertNoCycle(args: {
+  existingEdges: ReadonlyArray<{ dependentBuildId: string; dependsOnBuildId: string }>;
+  newEdge: { dependentBuildId: string; dependsOnBuildId: string };
+}): void {
+  const { existingEdges, newEdge } = args;
+  const allEdges = [...existingEdges, newEdge];
+
+  // Adjacency list: node -> nodes it depends on.
+  const adj = new Map<string, string[]>();
+  const nodes = new Set<string>();
+  for (const edge of allEdges) {
+    const list = adj.get(edge.dependentBuildId) ?? [];
+    list.push(edge.dependsOnBuildId);
+    adj.set(edge.dependentBuildId, list);
+    nodes.add(edge.dependentBuildId);
+    nodes.add(edge.dependsOnBuildId);
+  }
+
+  // Three-colour DFS. WHITE = unvisited, GRAY = in current DFS stack,
+  // BLACK = fully processed. A GRAY-target back edge is a cycle.
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const colour = new Map<string, number>();
+
+  const dfs = (root: string): boolean => {
+    const stack: Array<{ node: string; iter: Iterator<string> }> = [];
+    colour.set(root, GRAY);
+    stack.push({ node: root, iter: (adj.get(root) ?? [])[Symbol.iterator]() });
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]!;
+      const next = frame.iter.next();
+      if (next.done) {
+        colour.set(frame.node, BLACK);
+        stack.pop();
+        continue;
+      }
+      const child = next.value;
+      const c = colour.get(child) ?? WHITE;
+      if (c === GRAY) return true;
+      if (c === BLACK) continue;
+      colour.set(child, GRAY);
+      stack.push({ node: child, iter: (adj.get(child) ?? [])[Symbol.iterator]() });
+    }
+    return false;
+  };
+
+  for (const node of nodes) {
+    if ((colour.get(node) ?? WHITE) === WHITE) {
+      if (dfs(node)) {
+        throw new DecompositionInvariantError(
+          "dependency-cycle",
+          `Adding edge ${newEdge.dependentBuildId} -> ${newEdge.dependsOnBuildId} would create a cycle in the FeatureBuildDependency graph.`,
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Recursive decomposition is forbidden in Phase 1 (Mark's §12 Q4 decision).
+//
+// A FeatureBuild with `parentEpicId` set cannot itself be decomposed — it
+// cannot become the originating build for another Epic. If a child build
+// hits Plan oscillation, the operator must amend the parent Epic's design
+// (per §5 of the spec) or abandon the child, not nest a grandchild Epic.
+// ---------------------------------------------------------------------------
+
+export function assertNoRecursiveDecomposition(originatingBuild: {
+  id: string;
+  parentEpicId: string | null;
+}): void {
+  if (originatingBuild.parentEpicId != null) {
+    throw new DecompositionInvariantError(
+      "recursive-decomposition",
+      `FeatureBuild ${originatingBuild.id} already has parentEpicId=${originatingBuild.parentEpicId}; recursive decomposition is forbidden in Phase 1. Amend the parent Epic's design or abandon the child instead.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. childOrder is 1-indexed when set; null is allowed only for top-level
+//    (non-child) builds.
+//
+// Uniqueness of childOrder within a parent is enforced by the caller at
+// creation time (and could be promoted to a partial unique index in a
+// future migration); this assertion guards only the per-row well-formedness.
+// ---------------------------------------------------------------------------
+
+export function assertChildOrderWellFormed(child: {
+  parentEpicId: string | null;
+  childOrder: number | null;
+}): void {
+  if (child.parentEpicId == null) {
+    if (child.childOrder != null) {
+      throw new DecompositionInvariantError(
+        "invalid-child-order",
+        "childOrder must be null when parentEpicId is null (top-level builds carry no ordering within an Epic).",
+      );
+    }
+    return;
+  }
+  if (child.childOrder == null) {
+    throw new DecompositionInvariantError(
+      "invalid-child-order",
+      "childOrder is required when parentEpicId is set.",
+    );
+  }
+  if (!Number.isInteger(child.childOrder) || child.childOrder < 1) {
+    throw new DecompositionInvariantError(
+      "invalid-child-order",
+      `childOrder must be a positive integer (1-indexed); got ${child.childOrder}.`,
+    );
+  }
+}

--- a/packages/db/prisma/migrations/20260524230000_build_decomposition_substrate/migration.sql
+++ b/packages/db/prisma/migrations/20260524230000_build_decomposition_substrate/migration.sql
@@ -1,0 +1,76 @@
+-- Build Studio design-time decomposition — Phase 1 substrate.
+-- Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+-- BI: BI-2E6CC391
+--
+-- All changes additive; no destructive operations. Existing FeatureBuilds and
+-- Epics work unchanged. New nullable columns + new FeatureBuildDependency table.
+
+-- AlterTable
+ALTER TABLE "BacklogItem" ADD COLUMN     "activeEpicId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Epic" ADD COLUMN     "decompositionState" JSONB,
+ADD COLUMN     "designDoc" JSONB,
+ADD COLUMN     "designReview" JSONB,
+ADD COLUMN     "originatingBacklogItemId" TEXT;
+
+-- AlterTable
+ALTER TABLE "FeatureBuild" ADD COLUMN     "childOrder" INTEGER,
+ADD COLUMN     "parentEpicId" TEXT,
+ADD COLUMN     "supersededByEpicId" TEXT;
+
+-- CreateTable
+CREATE TABLE "FeatureBuildDependency" (
+    "id" TEXT NOT NULL,
+    "dependentBuildId" TEXT NOT NULL,
+    "dependsOnBuildId" TEXT NOT NULL,
+    "parentEpicId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeatureBuildDependency_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FeatureBuildDependency_parentEpicId_idx" ON "FeatureBuildDependency"("parentEpicId");
+
+-- CreateIndex
+CREATE INDEX "FeatureBuildDependency_dependsOnBuildId_idx" ON "FeatureBuildDependency"("dependsOnBuildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeatureBuildDependency_dependentBuildId_dependsOnBuildId_key" ON "FeatureBuildDependency"("dependentBuildId", "dependsOnBuildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BacklogItem_activeEpicId_key" ON "BacklogItem"("activeEpicId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Epic_originatingBacklogItemId_key" ON "Epic"("originatingBacklogItemId");
+
+-- CreateIndex
+CREATE INDEX "Epic_originatingBacklogItemId_idx" ON "Epic"("originatingBacklogItemId");
+
+-- CreateIndex
+CREATE INDEX "FeatureBuild_parentEpicId_childOrder_idx" ON "FeatureBuild"("parentEpicId", "childOrder");
+
+-- CreateIndex
+CREATE INDEX "FeatureBuild_supersededByEpicId_idx" ON "FeatureBuild"("supersededByEpicId");
+
+-- AddForeignKey
+ALTER TABLE "BacklogItem" ADD CONSTRAINT "BacklogItem_activeEpicId_fkey" FOREIGN KEY ("activeEpicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Epic" ADD CONSTRAINT "Epic_originatingBacklogItemId_fkey" FOREIGN KEY ("originatingBacklogItemId") REFERENCES "BacklogItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureBuild" ADD CONSTRAINT "FeatureBuild_parentEpicId_fkey" FOREIGN KEY ("parentEpicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureBuild" ADD CONSTRAINT "FeatureBuild_supersededByEpicId_fkey" FOREIGN KEY ("supersededByEpicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureBuildDependency" ADD CONSTRAINT "FeatureBuildDependency_dependentBuildId_fkey" FOREIGN KEY ("dependentBuildId") REFERENCES "FeatureBuild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureBuildDependency" ADD CONSTRAINT "FeatureBuildDependency_dependsOnBuildId_fkey" FOREIGN KEY ("dependsOnBuildId") REFERENCES "FeatureBuild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureBuildDependency" ADD CONSTRAINT "FeatureBuildDependency_parentEpicId_fkey" FOREIGN KEY ("parentEpicId") REFERENCES "Epic"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -962,6 +962,7 @@ model BacklogItem {
   effortSize              String?
   proposedOutcome         String?
   activeBuildId           String?                       @unique
+  activeEpicId            String?                       @unique
   duplicateOfId           String?
   resolution              String?
   abandonReason           String?
@@ -981,6 +982,8 @@ model BacklogItem {
   upstreamSyncedAt        DateTime?
   accountableEmployee     EmployeeProfile?              @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
   activeBuild             FeatureBuild?                 @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
+  activeEpic              Epic?                         @relation("BacklogItemActiveEpic", fields: [activeEpicId], references: [id])
+  originatingEpic         Epic?                         @relation("EpicOriginatingItem")
   digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
   duplicateOf             BacklogItem?                  @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
   duplicates              BacklogItem[]                 @relation("BacklogItemDuplicates")
@@ -1153,29 +1156,44 @@ model RuntimeVerification {
 }
 
 model Epic {
-  id                    String           @id @default(cuid())
-  epicId                String           @unique
-  title                 String
-  description           String?
-  status                String           @default("open")
-  priority              Int?
-  createdAt             DateTime         @default(now())
-  updatedAt             DateTime         @updatedAt
-  submittedById         String?
-  agentId               String?
-  completedAt           DateTime?
-  accountableEmployeeId String?
-  claimedById           String?
-  claimedByAgentId      String?
-  claimedAt             DateTime?
-  claimStatus           String?
-  upstreamIssueNumber   Int?
-  upstreamIssueUrl      String?
-  upstreamSyncedAt      DateTime?
-  items                 BacklogItem[]
-  accountableEmployee   EmployeeProfile? @relation("EpicAccountable", fields: [accountableEmployeeId], references: [id])
-  submittedBy           User?            @relation("EpicSubmissions", fields: [submittedById], references: [id])
-  portfolios            EpicPortfolio[]
+  id                       String                   @id @default(cuid())
+  epicId                   String                   @unique
+  title                    String
+  description              String?
+  status                   String                   @default("open")
+  priority                 Int?
+  createdAt                DateTime                 @default(now())
+  updatedAt                DateTime                 @updatedAt
+  submittedById            String?
+  agentId                  String?
+  completedAt              DateTime?
+  accountableEmployeeId    String?
+  claimedById              String?
+  claimedByAgentId         String?
+  claimedAt                DateTime?
+  claimStatus              String?
+  upstreamIssueNumber      Int?
+  upstreamIssueUrl         String?
+  upstreamSyncedAt         DateTime?
+  // Design-time decomposition substrate (Phase 1, spec
+  // docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md).
+  // Null on portfolio-organizational Epics (the existing use); populated on
+  // execution-organizational Epics created via the decomposition gate.
+  designDoc                Json?
+  designReview             Json?
+  decompositionState       Json?
+  originatingBacklogItemId String?                  @unique
+  items                    BacklogItem[]
+  originatingBacklogItem   BacklogItem?             @relation("EpicOriginatingItem", fields: [originatingBacklogItemId], references: [id])
+  activeForBacklogItem     BacklogItem?             @relation("BacklogItemActiveEpic")
+  featureBuilds            FeatureBuild[]           @relation("EpicFeatureBuilds")
+  supersededBuilds         FeatureBuild[]           @relation("EpicSupersededBuilds")
+  dependencies             FeatureBuildDependency[] @relation("EpicDependencies")
+  accountableEmployee      EmployeeProfile?         @relation("EpicAccountable", fields: [accountableEmployeeId], references: [id])
+  submittedBy              User?                    @relation("EpicSubmissions", fields: [submittedById], references: [id])
+  portfolios               EpicPortfolio[]
+
+  @@index([originatingBacklogItemId])
 }
 
 model EpicPortfolio {
@@ -4321,6 +4339,14 @@ model FeatureBuild {
   abandonedAt              DateTime?
   abandonReason            String?
   draftApprovedAt          DateTime?
+  // Design-time decomposition substrate (Phase 1). When non-null, this build
+  // is a child of an execution-organizational Epic; its plan implements a
+  // subset of the parent Epic's designDoc ACs. Recursive decomposition is
+  // forbidden (a child cannot itself be decomposed) — enforced at the
+  // invariant layer, not the schema.
+  parentEpicId             String?
+  childOrder               Int?
+  supersededByEpicId       String?
   activities               BuildActivity[]
   dispatchAttempts         BuildDispatchAttempt[]
   artifactRevisions        BuildArtifactRevision[]
@@ -4331,11 +4357,15 @@ model FeatureBuild {
   phaseRuns                BuildPhaseRun[]
   toolExecutionReceipts    ToolExecutionReceipt[]
   taxonomyProposals        TaxonomyProposal[]
+  dependenciesOut          FeatureBuildDependency[] @relation("DependentBuild")
+  dependenciesIn           FeatureBuildDependency[] @relation("DependsOnBuild")
   activeForBacklogItem     BacklogItem?            @relation("BacklogItemActiveBuild")
   accountableEmployee      EmployeeProfile?        @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
   createdBy                User                    @relation(fields: [createdById], references: [id])
   digitalProduct           DigitalProduct?         @relation(fields: [digitalProductId], references: [id])
   originator               BacklogItem?            @relation("BacklogItemOriginator", fields: [originatingBacklogItemId], references: [id])
+  parentEpic               Epic?                   @relation("EpicFeatureBuilds", fields: [parentEpicId], references: [id])
+  supersededByEpic         Epic?                   @relation("EpicSupersededBuilds", fields: [supersededByEpicId], references: [id])
   releaseBundle            ReleaseBundle?          @relation(fields: [releaseBundleId], references: [id])
   productVersions          ProductVersion[]
   promotionBackups         PromotionBackup[]
@@ -4350,6 +4380,29 @@ model FeatureBuild {
   @@index([digitalProductId])
   @@index([originatingBacklogItemId])
   @@index([releaseBundleId])
+  @@index([parentEpicId, childOrder])
+  @@index([supersededByEpicId])
+}
+
+// FeatureBuildDependency — sibling-dependency edges between child FeatureBuilds
+// within the same parent Epic. Phase 1 substrate for design-time decomposition.
+// Invariants (enforced at apps/web/lib/build/epic-decomposition-invariants.ts):
+//   - dependent.parentEpicId === dependsOn.parentEpicId === this.parentEpicId
+//   - dependent.id !== dependsOn.id (no self-loops)
+//   - the dependency graph is acyclic
+model FeatureBuildDependency {
+  id               String       @id @default(cuid())
+  dependentBuildId String
+  dependsOnBuildId String
+  parentEpicId     String
+  createdAt        DateTime     @default(now())
+  dependent        FeatureBuild @relation("DependentBuild", fields: [dependentBuildId], references: [id], onDelete: Cascade)
+  dependsOn        FeatureBuild @relation("DependsOnBuild", fields: [dependsOnBuildId], references: [id], onDelete: Cascade)
+  parentEpic       Epic         @relation("EpicDependencies", fields: [parentEpicId], references: [id], onDelete: Cascade)
+
+  @@unique([dependentBuildId, dependsOnBuildId])
+  @@index([parentEpicId])
+  @@index([dependsOnBuildId])
 }
 
 model BusinessBuildBrief {


### PR DESCRIPTION
## Summary

- Substrate-only first slice of the design-time decomposition spec (spec PR #1115).
- Adds the schema + invariants Build Studio needs to represent an execution-organizational Epic with N child FeatureBuilds and normalized sibling-dependency edges.
- No decomposition gate, no assistant, no UI yet — those land in later phases. Acceptance bar from spec §13: all existing builds list/promote normally; new data model can represent one active Epic with three child FeatureBuilds and normalized dependency edges.
- All new columns nullable; no destructive ops; no new `BuildPhase` values (per spec §12 Q6 deferral).

## Schema additions (additive)

- **Epic**: `designDoc` / `designReview` / `decompositionState` (JSON), plus `originatingBacklogItemId` (hybrid per Q5 — keeps child originator FK intact for audit/reporting compatibility), `featureBuilds` relation, `supersededBuilds` relation, `dependencies` relation.
- **FeatureBuild**: `parentEpicId`, `childOrder`, `supersededByEpicId`, plus reverse relations (`dependenciesOut` / `dependenciesIn`) and indexes on `(parentEpicId, childOrder)` and `supersededByEpicId`.
- **BacklogItem**: `activeEpicId` `@unique` (mirrors existing `activeBuildId` shape; reverse on `Epic.activeForBacklogItem`).
- **New `FeatureBuildDependency`** join table with `parentEpicId` denormalized for invariant enforcement; `@@unique(dependentBuildId, dependsOnBuildId)`; `ON DELETE CASCADE` from both endpoint builds and the parent Epic.

Migration `20260524230000_build_decomposition_substrate` generated via `prisma migrate diff` between pre/post schema snapshots. No data backfill; existing rows get nulls on new columns.

## Application-layer invariants

`apps/web/lib/build/epic-decomposition-invariants.ts` — pure functions, dependency-injected so tests run without a DB:

- `assertEpicHasContractIfDecomposed` — Epic with FB children must carry `designDoc`.
- `assertChildDesignReviewTransitive` — child's `designReview` equals parent's at creation (canonical-JSON deep equality, key-order-insensitive).
- `assertDependencyEdgeWellFormed` — dependent + dependsOn share `parentEpicId`; no self-loops.
- `assertNoCycle` — three-colour DFS catches direct and N-node cycles in the dependency graph.
- `assertNoRecursiveDecomposition` — a child FB cannot be the originator of a new Epic (Q4 `forbid-recursion`).
- `assertChildOrderWellFormed` — 1-indexed positive integer when set; null only when `parentEpicId` is null.

Loud failure via typed `DecompositionInvariantError` with stable `code` strings; mirrors the seed-side anti-silent-skip discipline captured in `project_silent_seed_skips_audit`.

## Verification

- 31 invariant unit tests pass, including the Dale composite fixture (1 Epic + 3 children + 2 dependency edges per spec §3.2).
- Full `apps/web/lib/build/` suite: 174/174 pass.
- `pnpm --filter web run typecheck` clean (exit 0).
- `pnpm --filter @dpf/db run typecheck` clean.

## Test plan

- [ ] Review schema diff — verify each new field/relation matches spec §3.5 (Epic.designDoc/designReview/decompositionState; FeatureBuild.parentEpicId/childOrder/supersededByEpicId; BacklogItem.activeEpicId; FeatureBuildDependency join table).
- [ ] Verify hybrid `originatingBacklogItemId` (Q5 decision) — `Epic.originatingBacklogItemId` added AND `FeatureBuild.originatingBacklogItemId` preserved.
- [ ] Run `pnpm --filter web exec vitest run lib/build/epic-decomposition-invariants.test.ts` — expect 31/31 pass.
- [ ] Apply migration to a fresh DB; confirm existing seeded data still loads.
- [ ] Confirm no breaking changes to existing FB-by-BI consumers (read-model preservation).

## Related

- Spec: PR #1115 `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md`
- Empirical anchor: `docs/dogfood/2026-05-23-dale-hvac-build-studio.md` (Phase H)
- D38 visibility chip: PR #1107
- Coordination primitive (future amendment flow): PR #1093 spec + PR #1114 implementation
- BI: BI-2E6CC391
- Epic: EP-BUILD-STUDIO; EP-9FC5D2FD (Dale hardening); EP-REDUCTION-GEAR-ARCH (instrumentation alignment)

## What ships next (deferred to follow-up PRs)

- Phase 2: `sizeDesignDoc` deterministic counter at Ideate exit (informational only)
- Phase 3: gate banner at Ideate exit
- Phase 4: decomposition assistant + atomic Epic+children creation
- Phase 5: rollup UI in `/build`
- Phase 6+: blocked-on-sibling auto-promotion, trajectory-chip-as-button, amendment flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)