### PR TITLE
test: align build specialist prompt contract

### DIFF
--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import {
@@ -9,6 +9,8 @@ import {
   type FeatureBuildRow,
 } from "@/lib/feature-build-types";
 import type { PortalContextEnvelope } from "@/lib/portal-context";
+
+afterEach(cleanup);
 
 const routerMocks = vi.hoisted(() => ({
   refresh: vi.fn(),

--- a/apps/web/lib/tak/build-specialist-prompt.test.ts
+++ b/apps/web/lib/tak/build-specialist-prompt.test.ts
@@ -14,8 +14,8 @@ const PROMPT_PATH = join(REPO_ROOT, "prompts", "route-persona", "build-specialis
 const prompt = readFileSync(PROMPT_PATH, "utf-8");
 
 describe("build-specialist.prompt.md (Operator Contract)", () => {
-  it("has frontmatter version 5 (ideate tool guidance + describe_model guard)", () => {
-    expect(prompt).toMatch(/^version:\s*5$/m);
+  it("has frontmatter version 6 (DPF patterns guidance + describe_model guard)", () => {
+    expect(prompt).toMatch(/^version:\s*6$/m);
   });
 
   it("preserves the role-defining sections", () => {
@@ -48,6 +48,12 @@ describe("build-specialist.prompt.md (Operator Contract)", () => {
     // explicitly disallows describe_model for design-time research.
     expect(prompt).toMatch(/start_ideate_research/);
     expect(prompt).toMatch(/describe_model.*build phase/i);
+  });
+
+  it("points structural decisions at the DPF architecture patterns reference", () => {
+    expect(prompt).toMatch(/docs\/architecture\/dpf-patterns\.md/);
+    expect(prompt).toMatch(/Before proposing new structure/i);
+    expect(prompt).toMatch(/When in \*\*Plan\*\*.*new substrate/i);
   });
 
   it("references all nine contract clauses by intent", () => {


### PR DESCRIPTION
## Summary
- Align the build-specialist structural test with the prompt's version 6 frontmatter.
- Add coverage that the prompt references the DPF architecture patterns guide required by the version 6 update.

## Verification
- pnpm --filter web exec vitest run lib/tak/build-specialist-prompt.test.ts
- git diff --check
- pre-commit hook: staged gitleaks scan and scoped typecheck