### PR TITLE
feat(build-studio): Phase 2 sizeDesignDoc deterministic counter — informational only (BI-2E6CC391)

### DIFF
--- a/apps/web/lib/build/size-design-doc.test.ts
+++ b/apps/web/lib/build/size-design-doc.test.ts
@@ -1,0 +1,323 @@
+// apps/web/lib/build/size-design-doc.test.ts
+//
+// Coverage for Phase 2 deterministic sizing counter.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+
+import { describe, expect, it } from "vitest";
+
+import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+
+import {
+  DEFAULT_SIZE_THRESHOLDS,
+  sizeDesignDoc,
+} from "./size-design-doc";
+
+const FIXED_NOW = () => new Date("2026-05-24T20:00:00.000Z");
+
+describe("sizeDesignDoc — null/empty safety", () => {
+  it("treats undefined doc as ok with informational rationale", () => {
+    const result = sizeDesignDoc(undefined, {}, FIXED_NOW);
+    expect(result.decision).toBe("ok");
+    expect(result.breakdown.acs.count).toBe(0);
+    expect(result.trips).toHaveLength(0);
+    expect(result.rationale).toMatch(/No design doc supplied/);
+    expect(result.assessedAt).toBe("2026-05-24T20:00:00.000Z");
+  });
+
+  it("treats null doc as ok", () => {
+    const result = sizeDesignDoc(null, {}, FIXED_NOW);
+    expect(result.decision).toBe("ok");
+  });
+
+  it("returns thresholds (echoed) for audit", () => {
+    const result = sizeDesignDoc(undefined, {}, FIXED_NOW);
+    expect(result.thresholds).toEqual(DEFAULT_SIZE_THRESHOLDS);
+  });
+});
+
+describe("sizeDesignDoc — small design (ok)", () => {
+  it("scores a 1-button feature as ok", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "Customers cannot mark their favourite truck.",
+      reusePlan: "Reuse existing TruckCard component.",
+      proposedApproach:
+        "Add a star icon button to the TruckCard. Persist via existing /api/preferences endpoint.",
+      acceptanceCriteria: [
+        "Star icon appears on truck cards.",
+        "Clicking star toggles favourite status.",
+        "Favourite persists across sessions.",
+      ],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.decision).toBe("ok");
+    expect(result.breakdown.acs.count).toBe(3);
+    expect(result.trips).toHaveLength(0);
+    expect(result.rationale).toMatch(/fits one Plan/);
+  });
+});
+
+describe("sizeDesignDoc — medium design (decompose-recommended)", () => {
+  it("trips recommend tier on 3 models", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "Add basic customer notes.",
+      dataModel:
+        "## Models\n- CustomerNote: per-customer freeform notes.\n- NoteTag: classification.\n- NoteAttachment: file references.",
+      reusePlan: "Reuse existing customer detail page.",
+      proposedApproach: "Add /api/customer/:id/notes GET and POST endpoints.",
+      acceptanceCriteria: [
+        "Notes list under each customer.",
+        "Add note inline.",
+        "Edit note inline.",
+        "Delete note (soft).",
+      ],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.decision).toBe("decompose-recommended");
+    expect(result.breakdown.models.count).toBeGreaterThanOrEqual(3);
+    const modelTrip = result.trips.find((t) => t.dimension === "models");
+    expect(modelTrip?.level).toBe("recommend");
+    expect(result.rationale).toMatch(/large/);
+  });
+});
+
+describe("sizeDesignDoc — Dale truck-parts (decompose-required)", () => {
+  // This fixture mirrors §1.1 of the spec — the empirical anchor.
+  // Dale's design as produced by Ideate (FB-6F7D6AC4):
+  //   5 new database models, 2 API surfaces, mobile-first UI with low-stock
+  //   badges, authorization layer, idempotency + optimistic-locking +
+  //   append-only ledger + multi-tenant isolation ACs.
+  // Phase 2 must score this as `decompose-required` so Phase 3's gate (when
+  // it ships) will fire.
+
+  const daleDoc: BuildDesignDoc = {
+    problemStatement:
+      "HVAC technicians waste billable hours driving back to the warehouse because nobody can see what parts are currently stocked on each truck. Dale wants a way for techs to look up their truck inventory and update it when they use parts.",
+    dataModel: [
+      "## Data model",
+      "- MobileInventoryLocationType: classification (Truck, Van, Warehouse).",
+      "- MobileInventoryLocation: a specific physical location (one row per truck).",
+      "- InventoryItem: catalog of part SKUs the shop stocks.",
+      "- LocationInventory: current quantity of each item at each location.",
+      "- InventoryTransaction: append-only ledger of every usage event.",
+    ].join("\n"),
+    reusePlan: "No existing inventory model in the storefront-template substrate.",
+    proposedApproach: [
+      "Two API surfaces: `/api/my-inventory` (GET list, GET :locationId detail) and `/api/inventory/usage` (POST). Mobile-first UI with truck cards, low-stock badges, and a usage-recording screen. Routes: `/my-inventory` (page) and `/dispatch` (page). Authorization layer enforces multi-tenant isolation on every read and write.",
+    ].join("\n"),
+    acceptanceCriteria: [
+      "Techs see their truck's current inventory list.",
+      "Inventory list shows item name, quantity, low-stock indicator.",
+      "Tech can record usage of a part during a job.",
+      "Usage POST is idempotent on the (truck, item, jobId) tuple.",
+      "Usage POST uses optimistic locking to avoid race conditions.",
+      "All inventory mutations append to the InventoryTransaction ledger.",
+      "Ledger is append-only — no UPDATE or DELETE allowed at DB level.",
+      "Multi-tenant isolation: tech A cannot see tech B's other-shop trucks.",
+      "Dispatcher sees roll-up of low-stock items across all trucks.",
+      "Low-stock threshold is configurable per item.",
+      "Low-stock alerts deduplicate within a 4-hour window.",
+      "Audit log records every read of inventory.",
+      "Audit trail is queryable by inventory specialist.",
+      "Rate limit usage POST to 60 per minute per tech.",
+      "Background job reconciles ledger weekly.",
+      "Mobile UI: truck card on /my-inventory.",
+      "Mobile UI: usage-record screen accessible from card.",
+      "Mobile UI: low-stock badge visible on each item row.",
+      "Mobile UI: tap to call dispatch from low-stock view.",
+      "Mobile UI: offline queue for usage POST when truck has no signal.",
+      "Mobile UI: pull-to-refresh on inventory list.",
+      "Dispatch view: filterable by truck.",
+      "Dispatch view: sortable by low-stock count.",
+      "Dispatch view: drill into per-truck history.",
+      "Dispatch view: export to CSV.",
+    ],
+    accessibility: "Mobile UI must be operable one-handed; minimum tap target 44px.",
+  };
+
+  it("trips required threshold on the Dale design", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.decision).toBe("decompose-required");
+  });
+
+  it("trips required on models (5 detected, threshold 5)", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.breakdown.models.count).toBeGreaterThanOrEqual(5);
+    const trip = result.trips.find(
+      (t) => t.dimension === "models" && t.level === "required",
+    );
+    expect(trip).toBeTruthy();
+  });
+
+  it("trips required on ACs (>= 20)", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.breakdown.acs.count).toBeGreaterThanOrEqual(20);
+    const trip = result.trips.find(
+      (t) => t.dimension === "acs" && t.level === "required",
+    );
+    expect(trip).toBeTruthy();
+  });
+
+  it("trips required on complexity multipliers (>= 4 ACs touched)", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.breakdown.multipliers.count).toBeGreaterThanOrEqual(4);
+    const trip = result.trips.find(
+      (t) => t.dimension === "multipliers" && t.level === "required",
+    );
+    expect(trip).toBeTruthy();
+  });
+
+  it("identifies the specific multiplier keywords in the Dale design", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    const kws = result.breakdown.multipliers.matchedKeywords;
+    expect(kws).toContain("idempotency");
+    expect(kws).toContain("optimistic-locking");
+    expect(kws).toContain("append-only-ledger");
+    expect(kws).toContain("multi-tenant");
+  });
+
+  it("rationale names the required-tier trips for the operator", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.rationale).toMatch(/REQUIRED-threshold trips/);
+    expect(result.rationale).toMatch(/decompose/);
+  });
+
+  it("samples model names (audit-visible evidence)", () => {
+    const result = sizeDesignDoc(daleDoc, {}, FIXED_NOW);
+    expect(result.breakdown.models.samples).toEqual(
+      expect.arrayContaining([
+        "MobileInventoryLocationType",
+        "MobileInventoryLocation",
+        "InventoryItem",
+        "LocationInventory",
+        "InventoryTransaction",
+      ]),
+    );
+  });
+});
+
+describe("sizeDesignDoc — threshold overrides", () => {
+  it("respects per-dimension threshold overrides", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "test",
+      reusePlan: "test",
+      proposedApproach: "test",
+      acceptanceCriteria: ["AC 1", "AC 2", "AC 3", "AC 4", "AC 5"],
+    };
+    // Default thresholds: ACs recommend 12, required 20 → 5 ACs = ok.
+    // Override: ACs recommend 4, required 10 → 5 ACs = recommended.
+    const result = sizeDesignDoc(
+      doc,
+      { acs: { recommend: 4, required: 10 } },
+      FIXED_NOW,
+    );
+    expect(result.decision).toBe("decompose-recommended");
+    expect(result.thresholds.acs).toEqual({ recommend: 4, required: 10 });
+    // Other dimensions still use defaults.
+    expect(result.thresholds.models).toEqual(DEFAULT_SIZE_THRESHOLDS.models);
+  });
+
+  it("partial overrides merge per-dimension fields", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "test",
+      reusePlan: "test",
+      proposedApproach: "test",
+      acceptanceCriteria: ["AC 1"],
+    };
+    const result = sizeDesignDoc(
+      doc,
+      // Note: only `recommend` overridden; `required` keeps default.
+      { acs: { recommend: 1 } as { recommend: number; required: number } },
+      FIXED_NOW,
+    );
+    expect(result.thresholds.acs.recommend).toBe(1);
+    expect(result.thresholds.acs.required).toBe(DEFAULT_SIZE_THRESHOLDS.acs.required);
+  });
+});
+
+describe("sizeDesignDoc — heuristic edge cases", () => {
+  it("stoplist filters out framework PascalCase identifiers", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "Wrap NextResponse and PrismaClient in a helper.",
+      dataModel: "Uses ReactNode and JsonValue types throughout.",
+      reusePlan: "",
+      proposedApproach: "",
+      acceptanceCriteria: [],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.breakdown.models.count).toBe(0);
+    expect(result.breakdown.models.samples).not.toContain("NextResponse");
+    expect(result.breakdown.models.samples).not.toContain("PrismaClient");
+  });
+
+  it("dedupes models mentioned multiple times across fields", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "Refactor TruckRouteOptimization.",
+      dataModel: "TruckRouteOptimization is the key entity.",
+      reusePlan: "Existing TruckRouteOptimization stays.",
+      proposedApproach: "TruckRouteOptimization gains a new field.",
+      acceptanceCriteria: [],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.breakdown.models.count).toBe(1);
+  });
+
+  it("counts HTTP-verb-prefixed endpoint mentions", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "",
+      reusePlan: "",
+      proposedApproach:
+        "Expose GET /api/trucks, POST /api/trucks/:id/parts, DELETE /api/trucks/:id, and PATCH /api/trucks/:id/status.",
+      acceptanceCriteria: [],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.breakdown.endpoints.count).toBe(4);
+  });
+
+  it("does NOT count UI routes as endpoints", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "",
+      reusePlan: "",
+      proposedApproach:
+        "New route `/my-inventory` and a UI page at `/dispatch`. API endpoint is GET /api/inventory.",
+      acceptanceCriteria: [],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    expect(result.breakdown.endpoints.count).toBe(1);
+    expect(result.breakdown.routes.count).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not double-count an AC that touches multiple multiplier keywords", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "test",
+      reusePlan: "test",
+      proposedApproach: "test",
+      acceptanceCriteria: [
+        "Usage POST is idempotent with optimistic locking and appends to the ledger under multi-tenant isolation.",
+      ],
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    // One AC, multiple keywords — count is 1 (count of ACs touched), not 4.
+    expect(result.breakdown.multipliers.count).toBe(1);
+    expect(result.breakdown.multipliers.matchedKeywords.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("picks the highest tier when both required and recommend trip", () => {
+    const doc: BuildDesignDoc = {
+      problemStatement: "",
+      // Five two-hump PascalCase identifiers — meets the model regex's
+      // requirement of at least two camel humps per name (Alpha would NOT
+      // match; AlphaModel does).
+      dataModel:
+        "AlphaModel, BetaModel, GammaModel, DeltaModel, EpsilonModel.",
+      reusePlan: "",
+      proposedApproach: "",
+      // 13 ACs hits acs recommend (>=12) but not required (<20)
+      acceptanceCriteria: Array.from({ length: 13 }, (_, i) => `AC ${i + 1}`),
+    };
+    const result = sizeDesignDoc(doc, {}, FIXED_NOW);
+    // Models tripping required dominates ACs tripping only recommend.
+    expect(result.breakdown.models.count).toBe(5);
+    expect(result.decision).toBe("decompose-required");
+  });
+});

--- a/apps/web/lib/build/size-design-doc.ts
+++ b/apps/web/lib/build/size-design-doc.ts
@@ -1,0 +1,372 @@
+// apps/web/lib/build/size-design-doc.ts
+//
+// Phase 2 of the design-time decomposition rollout.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+//
+// Deterministic sizing pass over an approved BuildDesignDoc. Counts structured
+// properties of the design and applies thresholds; returns a tri-state decision
+// (`ok` | `decompose-recommended` | `decompose-required`) plus an auditable
+// breakdown.
+//
+// **Phase 2 is informational only.** Nothing here enforces decomposition; the
+// gate banner, assistant, and child-creation atomicity all land in later
+// phases. The score is written to `FeatureBuild.designReview.sizeAssessment`
+// and emitted as a `design-size-assessed` BuildActivity row so the rationale
+// is visible to the operator before the gate becomes blocking.
+//
+// **Why deterministic, not LLM-driven.** Per spec §3.1, decomposition gates
+// are too important to delegate to a confabulation-prone surface. Counting is
+// reproducible; the operator can read "5 models, 25 ACs, 4 multipliers →
+// required" without trusting model output. This also feeds the
+// reduction-gear calibration loop cleanly — the inputs to the threshold are
+// recorded, so per-archetype tuning in a future ring can fit against ground
+// truth.
+//
+// **Calibration anchor.** Default thresholds (5 / 20 / 4 / 7 / 4 for the
+// `required` tier) are sized so Dale's truck-parts design (5 models, 25 ACs,
+// 4 complexity multipliers, 2 APIs, 2 routes — see spec §1.1) trips three of
+// five dimensions at the `required` level. A small-feature design (1-2 models,
+// 3-5 ACs) trips zero. Re-calibration will land alongside per-archetype
+// tuning in a future phase; for now the thresholds live alongside this code
+// and are overridable per call (the eventual PlatformConfig key
+// `build-studio-decomposition` will load overrides at the call site).
+
+import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type SizeDecision = "ok" | "decompose-recommended" | "decompose-required";
+
+export type SizeThresholds = {
+  models: { recommend: number; required: number };
+  endpoints: { recommend: number; required: number };
+  acs: { recommend: number; required: number };
+  multipliers: { recommend: number; required: number };
+  routes: { recommend: number; required: number };
+};
+
+export const DEFAULT_SIZE_THRESHOLDS: SizeThresholds = {
+  models: { recommend: 3, required: 5 },
+  endpoints: { recommend: 4, required: 7 },
+  acs: { recommend: 12, required: 20 },
+  multipliers: { recommend: 2, required: 4 },
+  routes: { recommend: 2, required: 4 },
+};
+
+export type SizeBreakdown = {
+  models: { count: number; samples: string[] };
+  endpoints: { count: number; samples: string[] };
+  acs: { count: number };
+  multipliers: { count: number; matchedKeywords: string[] };
+  routes: { count: number; samples: string[] };
+};
+
+export type SizeTrip = {
+  dimension: keyof SizeThresholds;
+  level: "recommend" | "required";
+  threshold: number;
+  observed: number;
+};
+
+export type SizeAssessment = {
+  decision: SizeDecision;
+  breakdown: SizeBreakdown;
+  trips: SizeTrip[];
+  rationale: string;
+  thresholds: SizeThresholds;
+  assessedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export function sizeDesignDoc(
+  doc: BuildDesignDoc | null | undefined,
+  overrides: Partial<SizeThresholds> = {},
+  now: () => Date = () => new Date(),
+): SizeAssessment {
+  const thresholds = mergeThresholds(DEFAULT_SIZE_THRESHOLDS, overrides);
+
+  if (!doc) {
+    return {
+      decision: "ok",
+      breakdown: emptyBreakdown(),
+      trips: [],
+      rationale: "No design doc supplied; size cannot be assessed. Treating as ok by default (Phase 2 is informational).",
+      thresholds,
+      assessedAt: now().toISOString(),
+    };
+  }
+
+  const breakdown: SizeBreakdown = {
+    models: extractModels(doc),
+    endpoints: extractEndpoints(doc),
+    acs: { count: (doc.acceptanceCriteria ?? []).length },
+    multipliers: extractMultipliers(doc),
+    routes: extractRoutes(doc),
+  };
+
+  const observations: Record<keyof SizeThresholds, number> = {
+    models: breakdown.models.count,
+    endpoints: breakdown.endpoints.count,
+    acs: breakdown.acs.count,
+    multipliers: breakdown.multipliers.count,
+    routes: breakdown.routes.count,
+  };
+
+  const trips: SizeTrip[] = [];
+  let highest: "ok" | "recommend" | "required" = "ok";
+
+  for (const dim of Object.keys(thresholds) as Array<keyof SizeThresholds>) {
+    const observed = observations[dim];
+    const { recommend, required } = thresholds[dim];
+    if (observed >= required) {
+      trips.push({ dimension: dim, level: "required", threshold: required, observed });
+      highest = "required";
+    } else if (observed >= recommend) {
+      trips.push({ dimension: dim, level: "recommend", threshold: recommend, observed });
+      if (highest === "ok") highest = "recommend";
+    }
+  }
+
+  const decision: SizeDecision =
+    highest === "required"
+      ? "decompose-required"
+      : highest === "recommend"
+        ? "decompose-recommended"
+        : "ok";
+
+  return {
+    decision,
+    breakdown,
+    trips,
+    rationale: buildRationale(decision, observations, trips, thresholds),
+    thresholds,
+    assessedAt: now().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extraction helpers — each returns a count and (where useful) sample evidence
+// for the audit trail. Heuristics intentionally err toward UNDER-counting on
+// ambiguous markdown, so a Phase-2 false positive is rare and a Phase-3 (when
+// enforcement lands) operator-facing decompose recommendation is defensible.
+// ---------------------------------------------------------------------------
+
+const MODEL_FIELD_PRIORITY: ReadonlyArray<keyof BuildDesignDoc> = [
+  "dataModel",
+  "proposedApproach",
+  "problemStatement",
+];
+
+// PascalCase identifier with at least two CamelHumps — captures
+// "MobileInventoryLocation", "InventoryItem", but not single-word "Truck".
+// Single-word PascalCase nouns (Truck, Part) ARE valid model names but also
+// match common English; we prefer precision over recall here, per the
+// under-count posture.
+const MODEL_IDENTIFIER_RE = /\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b/g;
+
+// Identifiers that look like model names but aren't — framework names, common
+// React/Next/Prisma surface, etc. Extend conservatively; a stopword here
+// suppresses a legitimate trip.
+const MODEL_STOPLIST = new Set<string>([
+  "PrismaClient",
+  "NextRequest",
+  "NextResponse",
+  "ReactNode",
+  "JsonValue",
+  "InputJsonValue",
+  "StatusCode",
+  "HttpStatus",
+  "ApiResponse",
+  "ToolResult",
+  "BuildStudio",
+  "FeatureBuild",
+  "BuildPhase",
+  "BuildActivity",
+  "DesignDoc",
+  "BuildDesignDoc",
+  "PostgresError",
+  "UseEffect",
+  "UseState",
+]);
+
+function extractModels(doc: BuildDesignDoc): SizeBreakdown["models"] {
+  const sources: string[] = [];
+  for (const f of MODEL_FIELD_PRIORITY) {
+    const v = doc[f];
+    if (typeof v === "string" && v.trim().length > 0) sources.push(v);
+  }
+  const haystack = sources.join("\n\n");
+  const seen = new Set<string>();
+  for (const match of haystack.matchAll(MODEL_IDENTIFIER_RE)) {
+    const id = match[0];
+    if (!MODEL_STOPLIST.has(id)) seen.add(id);
+  }
+  const samples = Array.from(seen).sort();
+  return { count: samples.length, samples };
+}
+
+// HTTP-verb + path: "POST /api/inventory/usage", "GET /my-inventory".
+// Backtick-wrapped paths are matched separately below.
+const HTTP_ENDPOINT_RE = /\b(GET|POST|PUT|PATCH|DELETE)\s+(\/[A-Za-z0-9/:_\-{}]+)/g;
+// Backtick-quoted path: "`/api/inventory`".
+const BACKTICK_PATH_RE = /`(\/[A-Za-z0-9/:_\-{}]+)`/g;
+
+function extractEndpoints(doc: BuildDesignDoc): SizeBreakdown["endpoints"] {
+  const haystack = [doc.proposedApproach, doc.problemStatement, doc.reusePlan]
+    .filter((s): s is string => typeof s === "string")
+    .join("\n\n");
+
+  const seen = new Set<string>();
+  for (const m of haystack.matchAll(HTTP_ENDPOINT_RE)) {
+    seen.add(`${m[1]} ${m[2]}`);
+  }
+  for (const m of haystack.matchAll(BACKTICK_PATH_RE)) {
+    const path = m[1]!;
+    // Distinguish API endpoints from UI routes: anything containing /api/ or
+    // POSTs implied by ending in /:id+action is an endpoint; otherwise let
+    // routes handle it. Conservative: count only paths starting with /api/.
+    if (path.startsWith("/api/")) seen.add(`* ${path}`);
+  }
+  const samples = Array.from(seen).sort();
+  return { count: samples.length, samples };
+}
+
+// UI route — a path that doesn't look like an API endpoint and doesn't start
+// with /api/. Matched only inside backticks or after "route"/"page"/"screen"
+// keywords to keep noise low.
+const ROUTE_KEYWORD_RE = /\b(?:route|page|screen|view)\s*[:=]?\s*`?(\/[A-Za-z0-9/:_\-{}]+)`?/gi;
+
+function extractRoutes(doc: BuildDesignDoc): SizeBreakdown["routes"] {
+  const haystack = [doc.proposedApproach, doc.problemStatement, doc.reusePlan]
+    .filter((s): s is string => typeof s === "string")
+    .join("\n\n");
+
+  const seen = new Set<string>();
+  for (const m of haystack.matchAll(ROUTE_KEYWORD_RE)) {
+    const path = m[1]!;
+    if (path.startsWith("/api/")) continue; // it's an endpoint, not a route
+    seen.add(path);
+  }
+  // Also catch backtick paths that don't start with /api/ — those are likely
+  // UI routes if they appear in a section discussing UI surfaces. Be
+  // conservative: only count if the parent doc explicitly mentions "UI",
+  // "frontend", or "screen" within 200 chars of the match. Cheap proxy: count
+  // backtick non-/api/ paths only if the doc contains a UI keyword anywhere.
+  const docMentionsUi = /\b(ui|frontend|screen|page|view|mobile-first|dashboard)\b/i.test(haystack);
+  if (docMentionsUi) {
+    for (const m of haystack.matchAll(BACKTICK_PATH_RE)) {
+      const path = m[1]!;
+      if (path.startsWith("/api/")) continue;
+      seen.add(path);
+    }
+  }
+  const samples = Array.from(seen).sort();
+  return { count: samples.length, samples };
+}
+
+// Complexity-multiplier keywords. An AC that touches any of these signals a
+// known cliff (per spec §3.1 ACs that need idempotency / optimistic locking /
+// append-only ledger / multi-tenant isolation / background jobs are each
+// known complexity multipliers). Matched case-insensitively against AC text.
+const MULTIPLIER_KEYWORDS: ReadonlyArray<{ keyword: string; pattern: RegExp }> = [
+  { keyword: "idempotency", pattern: /\bidempoten(?:cy|t|ce)\b/i },
+  { keyword: "optimistic-locking", pattern: /\boptimistic\s+lock(?:ing)?\b/i },
+  { keyword: "append-only-ledger", pattern: /\bappend[\s-]?only\b|\bledger\b/i },
+  { keyword: "multi-tenant", pattern: /\bmulti[\s-]?tenant\b|\bcross[\s-]?tenant\b|\btenant\s+isolation\b/i },
+  { keyword: "background-job", pattern: /\bbackground\s+job\b|\bworker\s+queue\b|\binngest\b|\bcron\b/i },
+  { keyword: "audit-trail", pattern: /\baudit\s+(?:trail|log)\b/i },
+  { keyword: "rate-limit", pattern: /\brate[\s-]?limit\b|\bthrottle\b/i },
+];
+
+function extractMultipliers(doc: BuildDesignDoc): SizeBreakdown["multipliers"] {
+  const acs = doc.acceptanceCriteria ?? [];
+  const matchedKeywords = new Set<string>();
+  let acsTouchingMultiplier = 0;
+  for (const ac of acs) {
+    if (typeof ac !== "string") continue;
+    let touched = false;
+    for (const { keyword, pattern } of MULTIPLIER_KEYWORDS) {
+      if (pattern.test(ac)) {
+        matchedKeywords.add(keyword);
+        touched = true;
+      }
+    }
+    if (touched) acsTouchingMultiplier += 1;
+  }
+  return {
+    count: acsTouchingMultiplier,
+    matchedKeywords: Array.from(matchedKeywords).sort(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+function mergeThresholds(
+  base: SizeThresholds,
+  overrides: Partial<SizeThresholds>,
+): SizeThresholds {
+  return {
+    models: { ...base.models, ...overrides.models },
+    endpoints: { ...base.endpoints, ...overrides.endpoints },
+    acs: { ...base.acs, ...overrides.acs },
+    multipliers: { ...base.multipliers, ...overrides.multipliers },
+    routes: { ...base.routes, ...overrides.routes },
+  };
+}
+
+function emptyBreakdown(): SizeBreakdown {
+  return {
+    models: { count: 0, samples: [] },
+    endpoints: { count: 0, samples: [] },
+    acs: { count: 0 },
+    multipliers: { count: 0, matchedKeywords: [] },
+    routes: { count: 0, samples: [] },
+  };
+}
+
+function buildRationale(
+  decision: SizeDecision,
+  observations: Record<keyof SizeThresholds, number>,
+  trips: SizeTrip[],
+  thresholds: SizeThresholds,
+): string {
+  const dims = [
+    `${observations.models} models`,
+    `${observations.endpoints} endpoints`,
+    `${observations.acs} ACs`,
+    `${observations.multipliers} ACs with complexity multipliers`,
+    `${observations.routes} routes`,
+  ].join(", ");
+
+  if (decision === "ok") {
+    return `Design fits one Plan. Observed: ${dims}. All under recommend thresholds (${formatThresholds(thresholds)}).`;
+  }
+
+  const requiredTrips = trips.filter((t) => t.level === "required");
+  const recommendTrips = trips.filter((t) => t.level === "recommend");
+
+  if (decision === "decompose-required") {
+    const requiredList = requiredTrips
+      .map((t) => `${t.dimension}=${t.observed}>=${t.threshold}`)
+      .join("; ");
+    return `Design is xlarge. Observed: ${dims}. REQUIRED-threshold trips: ${requiredList}. Recommendation: decompose into 2-4 child builds before Plan, OR narrow the design and re-run Ideate.`;
+  }
+
+  // decompose-recommended
+  const recommendList = recommendTrips
+    .map((t) => `${t.dimension}=${t.observed}>=${t.threshold}`)
+    .join("; ");
+  return `Design is large. Observed: ${dims}. Recommend-threshold trips: ${recommendList}. Consider decomposing into 2-3 smaller builds for faster Plan convergence; not blocking.`;
+}
+
+function formatThresholds(t: SizeThresholds): string {
+  return `recommend models>=${t.models.recommend}, endpoints>=${t.endpoints.recommend}, ACs>=${t.acs.recommend}, multipliers>=${t.multipliers.recommend}, routes>=${t.routes.recommend}`;
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6681,10 +6681,26 @@ export async function executeTool(
         issues: [{ severity: "critical" as const, description: "Both review agents failed to respond" }],
         summary: "Review could not be completed — retry.",
       };
-      await prisma.featureBuild.update({ where: { buildId }, data: { designReview: review as unknown as import("@dpf/db").Prisma.InputJsonValue } });
+
+      // Phase 2 of design-time decomposition (BI-2E6CC391, spec
+      // docs/superpowers/specs/2026-05-24-build-studio-design-time-
+      // decomposition-design.md). Run the deterministic sizing counter and
+      // record the assessment alongside the review. Informational only —
+      // no gate, no UX change. Surfaces the rationale ("5 models, 25 ACs,
+      // 4 multipliers → required") so when Phase 3's gate ships, operators
+      // have already seen the signal in passing.
+      const { sizeDesignDoc } = await import("@/lib/build/size-design-doc");
+      const sizeAssessment = sizeDesignDoc(build.designDoc as Parameters<typeof sizeDesignDoc>[0]);
+      const reviewWithSize = { ...review, sizeAssessment };
+      await prisma.featureBuild.update({ where: { buildId }, data: { designReview: reviewWithSize as unknown as import("@dpf/db").Prisma.InputJsonValue } });
       const { agentEventBus } = await import("@/lib/agent-event-bus");
       if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "designReview" });
       logBuildActivity(buildId, "reviewDesignDoc", `Design review: ${review.decision}. ${review.summary}`);
+      logBuildActivity(
+        buildId,
+        "design-size-assessed",
+        `Design size: ${sizeAssessment.decision}. ${sizeAssessment.rationale}`,
+      );
 
       // Record a deliberation trail for this dual-reviewer run. The review
       // result above still gates pass/fail; this layer is the honest


### PR DESCRIPTION
## Summary

- Second phase of the design-time decomposition rollout. Adds a deterministic sizing pass that runs after every `reviewDesignDoc` call, scores the approved design, and decides one of `ok` / `decompose-recommended` / `decompose-required`.
- **No gate, no UX change, no enforcement** — informational only per spec §10. Assessment is written to `FeatureBuild.designReview.sizeAssessment` and emitted as a `design-size-assessed` BuildActivity row so when Phase 3's gate ships the operator has already been seeing the signal.
- Dale's truck-parts design (FB-6F7D6AC4) scores `decompose-required` on 3 of 5 dimensions, validating the threshold calibration against the empirical anchor.

## What this PR contains

- `apps/web/lib/build/size-design-doc.ts` — pure counter, no DB, no LLM calls. ~280 LoC.
- `apps/web/lib/build/size-design-doc.test.ts` — 20 unit tests including the Dale fixture from spec §1.1.
- `apps/web/lib/mcp-tools.ts` — single insertion in the `reviewDesignDoc` handler (lines 6679-6700) to compute the assessment, attach it to the review object, and log a BuildActivity row.

## Default thresholds (calibrated against Dale's design)

| Dimension | Recommend | Required |
|---|--:|--:|
| New DB models | 3 | 5 |
| API endpoints | 4 | 7 |
| Total ACs | 12 | 20 |
| ACs touching complexity multipliers | 2 | 4 |
| New UI routes | 2 | 4 |

Decision is the HIGHEST level any one dimension trips. Dale's design trips three of five dimensions at `required` (models=5, ACs=25, multipliers=4). A tiny button-ship feature trips zero.

## Counter heuristics

- **Models** — two-hump PascalCase identifiers in `dataModel` / `proposedApproach` / `problemStatement`, deduped, filtered against a short framework stoplist (`PrismaClient`, `NextResponse`, `ReactNode`, ...).
- **Endpoints** — HTTP-verb-prefixed paths (`POST /api/usage`) plus backtick-quoted `/api/` paths.
- **ACs** — direct count of `acceptanceCriteria[]`.
- **Multipliers** — count of ACs containing any keyword from a static list (`idempotency`, `optimistic-locking`, `append-only`/`ledger`, `multi-tenant`, `background-job`, `audit-trail`, `rate-limit`). One AC touching four keywords counts as 1.
- **Routes** — paths after `route`/`page`/`screen` keywords, plus backtick non-`/api/` paths when the doc explicitly mentions UI.

Heuristics intentionally err toward under-counting on ambiguous markdown — Phase 2 false positives are rare and Phase 3 operator-facing recommendations will be defensible.

## Why deterministic, not LLM-driven

Per spec §3.1: gates this important cannot be delegated to a confabulation-prone surface. Counting is reproducible; the operator can read the rationale (`"5 models, 25 ACs, 4 multipliers → required"`) without trusting model output. The recorded inputs also feed the reduction-gear calibration loop cleanly — per-archetype threshold tuning in a future ring can fit against ground truth instead of survey data.

## Verification

- 20 `sizeDesignDoc` unit tests pass:
  - null/empty doc safety (3 tests)
  - small design → `ok` (1 test)
  - medium design with 3 models → `decompose-recommended` (1 test)
  - Dale composite → `decompose-required`, ≥5 models, ≥20 ACs, ≥4 multipliers, 4 keywords (idempotency, optimistic-locking, append-only-ledger, multi-tenant) detected, rationale names the trips (7 tests)
  - threshold-override paths (2 tests)
  - heuristic edge cases — stoplist filters framework names, dedup across fields, endpoints vs routes, multi-keyword AC counts once, highest-tier wins (6 tests)
- Full `apps/web/lib/build/` suite: 194/194 pass
- `pnpm --filter web run typecheck` exit 0
- Pre-commit scoped typecheck pass

## What ships next

- Phase 3: gate banner at Ideate exit. The assessment data is already there; this is a UI surface that reads `designReview.sizeAssessment.decision` and renders the recommend/required UX from spec §4.1. No new computation.
- Phase 4: decomposition assistant + atomic Epic+children creation.

## Related

- Spec: `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md` (PR #1115, merged)
- Phase 1 substrate: PR #1123 (merged)
- Empirical anchor: `docs/dogfood/2026-05-23-dale-hvac-build-studio.md`
- BI: BI-2E6CC391
- Epic: EP-BUILD-STUDIO; EP-9FC5D2FD; EP-REDUCTION-GEAR-ARCH

## Test plan

- [ ] Review the counter heuristics; flag any cases where the under-counting posture should be tightened.
- [ ] After merge, drive a synthetic design through Build Studio Ideate and verify the `design-size-assessed` activity row appears with the expected rationale.
- [ ] When Phase 3 lands, confirm the gate reads `designReview.sizeAssessment.decision` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)