### PR TITLE
fix: avoid quiescence cold-start login lockout

### DIFF
--- a/apps/web/lib/proxy/quiescence-gate.test.ts
+++ b/apps/web/lib/proxy/quiescence-gate.test.ts
@@ -6,7 +6,7 @@
  * with NextAuth wrapping is covered manually via dogfooding once
  * BI-QUIESCE-006 (banner + state route end-to-end) lands.
  */
-import { describe, expect, it, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 import {
   _resetProxyQuiescenceCache,
@@ -22,6 +22,10 @@ import {
 
 beforeEach(() => {
   _resetProxyQuiescenceCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 const normalState: ProxyQuiescenceState = {
@@ -285,21 +289,16 @@ describe("checkQuiescenceForRequest — fail policy integration", () => {
     void fetchImpl;
   });
 
-  it("fail-closed for mutations when state route returns unknown + no prior memory", async () => {
-    const req = makeRequest("https://example.com/api/portal", { method: "POST" });
-    // Simulate: mutation, unknown state, no last-known → coerce to draining.
-    const conservative: ProxyQuiescenceState = {
-      level: "draining",
-      runId: null,
-      enteredAt: null,
-      version: "x",
-      bundleHash: "y",
-    };
-    const d = evaluateGate(req, conservative);
-    expect(d.kind).toBe("block");
-    if (d.kind === "block") {
-      expect(d.response.status).toBe(503);
-    }
+  it("fails open for mutations when state route returns unknown + no prior non-normal memory", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("state route timed out");
+    });
+
+    const req = makeRequest("https://example.com/login", { method: "POST" });
+    const decision = await checkQuiescenceForRequest(req, "https://example.com");
+
+    expect(decision.kind).toBe("pass");
+    expect(decision.state.level).toBe("normal");
   });
 
   it("preserves last-known non-normal state for mutations on route failure", async () => {
@@ -311,12 +310,20 @@ describe("checkQuiescenceForRequest — fail policy integration", () => {
     await fetchQuiescenceState("https://x", { fetchImpl: fetchOk, now: 1000 });
     expect(getLastKnownNonNormal()?.level).toBe("draining");
 
-    // Now subsequent mutations during a fetch failure should use that
-    // memory, not synthesize a fresh "draining" — caller-side decision in
-    // checkQuiescenceForRequest.
-    const remembered = getLastKnownNonNormal();
-    expect(remembered).not.toBeNull();
-    expect(remembered?.runId).toBe("Q1");
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("state route timed out");
+    });
+
+    const req = makeRequest("https://example.com/api/portal", { method: "POST" });
+    const decision = await checkQuiescenceForRequest(req, "https://example.com");
+
+    expect(decision.kind).toBe("block");
+    expect(decision.state.level).toBe("draining");
+    expect(decision.state.runId).toBe("Q1");
+    if (decision.kind === "block") {
+      expect(decision.response.status).toBe(503);
+      expect(decision.response.headers.get("x-quiescence-run-id")).toBe("Q1");
+    }
   });
 
   // Note: full checkQuiescenceForRequest integration test would mock the

--- a/apps/web/lib/proxy/quiescence-gate.ts
+++ b/apps/web/lib/proxy/quiescence-gate.ts
@@ -196,8 +196,7 @@ export type GateDecision =
  *
  * Pass `effectiveStateForUnknown` to invoke the fail-open / fail-closed
  * policy: caller decides what state to substitute when level is "unknown".
- *   - For mutations: pass getLastKnownNonNormal() ?? a synthetic
- *     {level: "draining"} (fail-closed default)
+ *   - For mutations: preserve getLastKnownNonNormal(); otherwise fail open.
  *   - For reads: pass {level: "normal"} (fail-open)
  */
 export function evaluateGate(
@@ -286,18 +285,13 @@ export async function checkQuiescenceForRequest(
 ): Promise<GateDecision> {
   const state = await fetchQuiescenceState(origin);
   if (state.level === "unknown") {
-    // Fail policy: preserve last known non-normal for mutations; fail
-    // open for reads.
+    // Fail policy: preserve last known non-normal for mutations; fail open
+    // when there is no evidence this Edge process has observed a drain.
     if (isMutationRequest(req)) {
       const fallback = getLastKnownNonNormal();
       if (fallback) return evaluateGate(req, fallback);
-      // No memory of prior state — be conservative for mutations and
-      // refuse. Reads will fall through to the "open" branch below.
-      const conservative: ProxyQuiescenceState = {
-        ...state,
-        level: "draining",
-      };
-      return evaluateGate(req, conservative);
+      const open: ProxyQuiescenceState = { ...state, level: "normal" };
+      return evaluateGate(req, open);
     }
     // Read: fail open.
     const open: ProxyQuiescenceState = { ...state, level: "normal" };


### PR DESCRIPTION
## Summary
- allow the quiescence proxy gate to fail open for mutations when the state route is unknown and this Edge process has no remembered drain
- keep the existing fail-closed behavior when a prior non-normal quiescence state was observed
- add regression coverage for cold-start login/action lockout and remembered-drain preservation

## Root cause
After the latest quiescence work, the proxy fetches `/api/internal/quiescence-state` with a 750 ms timeout. On the Docker-served portal that endpoint can take 1-3 seconds after restart, so the proxy saw `unknown` and synthesized `draining` for POSTs. That blocked login even though the persisted quiescence state was `normal`.

## Validation
- `pnpm --filter web exec vitest run lib/proxy/quiescence-gate.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `docker compose --env-file D:\DPF\.env -p dpf build --no-cache portal portal-init sandbox`
- Docker-served Playwright smoke: login as `admin@dpf.local`, open `/admin/platform-development`, confirm the panel renders and the old `dpf-upstream` pathspec error is absent