### PR TITLE
feat(build-studio): Phase 3 decomposition gate banner — Ideate-exit surface (BI-2E6CC391)

### DIFF
--- a/apps/web/components/build/DecompositionGateBanner.test.tsx
+++ b/apps/web/components/build/DecompositionGateBanner.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+//
+// Coverage for the Phase 3 decomposition gate banner.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md (§4.1)
+// BI: BI-2E6CC391
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DecompositionGateBanner } from "./DecompositionGateBanner";
+import type { SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
+
+// The web test runner has no global setup file, so each component test
+// must clean up its own DOM after every case or React Testing Library
+// queries will see leftover renders from prior tests.
+afterEach(() => {
+  cleanup();
+});
+
+function makeAssessment(
+  overrides: Partial<SizeAssessmentSnapshot> = {},
+): SizeAssessmentSnapshot {
+  return {
+    decision: "ok",
+    breakdown: {
+      models: { count: 0, samples: [] },
+      endpoints: { count: 0, samples: [] },
+      acs: { count: 0 },
+      multipliers: { count: 0, matchedKeywords: [] },
+      routes: { count: 0, samples: [] },
+    },
+    trips: [],
+    rationale: "Design fits one Plan.",
+    thresholds: {
+      models: { recommend: 3, required: 5 },
+      endpoints: { recommend: 4, required: 7 },
+      acs: { recommend: 12, required: 20 },
+      multipliers: { recommend: 2, required: 4 },
+      routes: { recommend: 2, required: 4 },
+    },
+    assessedAt: "2026-05-24T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("DecompositionGateBanner — self-gating", () => {
+  it("renders nothing when assessment is null", () => {
+    const { container } = render(<DecompositionGateBanner assessment={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when assessment is undefined", () => {
+    const { container } = render(<DecompositionGateBanner assessment={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when decision is ok", () => {
+    const { container } = render(
+      <DecompositionGateBanner assessment={makeAssessment({ decision: "ok" })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("DecompositionGateBanner — decompose-recommended (soft tone)", () => {
+  const assessment = makeAssessment({
+    decision: "decompose-recommended",
+    breakdown: {
+      models: { count: 3, samples: ["ModelA", "ModelB", "ModelC"] },
+      endpoints: { count: 1, samples: ["GET /api/x"] },
+      acs: { count: 8 },
+      multipliers: { count: 1, matchedKeywords: ["idempotency"] },
+      routes: { count: 1, samples: ["/x"] },
+    },
+    trips: [{ dimension: "models", level: "recommend", threshold: 3, observed: 3 }],
+    rationale: "Design is large. Observed: 3 models, 1 endpoints, 8 ACs, 1 ACs with complexity multipliers, 1 routes. Recommend-threshold trips: models=3>=3. Consider decomposing into 2-3 smaller builds for faster Plan convergence; not blocking.",
+  });
+
+  it("renders the banner with the 'recommended' tone", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    const banner = screen.getByTestId("decomposition-gate-banner");
+    expect(banner).toHaveAttribute("data-tone", "recommended");
+    expect(screen.getByText(/Decomposition recommended/i)).toBeInTheDocument();
+  });
+
+  it("uses softer 'worth considering' headline copy", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    expect(screen.getByText(/Worth considering/i)).toBeInTheDocument();
+    expect(screen.queryByText(/bigger than fits in one build/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the observed breakdown", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    // Breakdown items render the count + label in the same <li>; the
+    // rationale paragraph also mentions some labels (e.g. "complexity
+    // multipliers"). Assert against the banner's full textContent which
+    // unambiguously identifies the count-label pairing.
+    const banner = screen.getByTestId("decomposition-gate-banner");
+    expect(banner.textContent).toMatch(/3 DB models/);
+    expect(banner.textContent).toMatch(/8 acceptance criteria/);
+    expect(banner.textContent).toMatch(/1 ACs with complexity multipliers/);
+  });
+
+  it("renders the threshold trip evidence", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    // Exact match on the label string — avoids matching the rationale's
+    // "REQUIRED-threshold trips:" substring (case-insensitive collides).
+    expect(screen.getByText("Threshold trips")).toBeInTheDocument();
+  });
+
+  it("renders the deterministic rationale verbatim", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    expect(screen.getByText(/Design is large\. Observed/)).toBeInTheDocument();
+  });
+
+  it("renders the 'next phase' notice (Phase 3 is informational only)", () => {
+    render(<DecompositionGateBanner assessment={assessment} />);
+    expect(
+      screen.getByText(/decomposition assistant.*ships in the next phase/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("DecompositionGateBanner — decompose-required (strong tone)", () => {
+  // Mirrors the Dale truck-parts result from spec §1.1.
+  const daleAssessment = makeAssessment({
+    decision: "decompose-required",
+    breakdown: {
+      models: {
+        count: 5,
+        samples: [
+          "InventoryItem",
+          "InventoryTransaction",
+          "LocationInventory",
+          "MobileInventoryLocation",
+          "MobileInventoryLocationType",
+        ],
+      },
+      endpoints: { count: 2, samples: ["POST /api/inventory/usage", "GET /api/my-inventory"] },
+      acs: { count: 25 },
+      multipliers: {
+        count: 4,
+        matchedKeywords: ["append-only-ledger", "idempotency", "multi-tenant", "optimistic-locking"],
+      },
+      routes: { count: 2, samples: ["/dispatch", "/my-inventory"] },
+    },
+    trips: [
+      { dimension: "models", level: "required", threshold: 5, observed: 5 },
+      { dimension: "acs", level: "required", threshold: 20, observed: 25 },
+      { dimension: "multipliers", level: "required", threshold: 4, observed: 4 },
+    ],
+    rationale:
+      "Design is xlarge. Observed: 5 models, 2 endpoints, 25 ACs, 4 ACs with complexity multipliers, 2 routes. REQUIRED-threshold trips: models=5>=5; acs=25>=20; multipliers=4>=4. Recommendation: decompose into 2-4 child builds before Plan, OR narrow the design and re-run Ideate.",
+  });
+
+  it("renders with the 'required' tone", () => {
+    render(<DecompositionGateBanner assessment={daleAssessment} />);
+    const banner = screen.getByTestId("decomposition-gate-banner");
+    expect(banner).toHaveAttribute("data-tone", "required");
+    expect(screen.getByText(/Decomposition required/i)).toBeInTheDocument();
+  });
+
+  it("uses stronger 'bigger than fits in one build' headline copy", () => {
+    render(<DecompositionGateBanner assessment={daleAssessment} />);
+    expect(screen.getByText(/bigger than fits in one build/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Worth considering/i)).not.toBeInTheDocument();
+  });
+
+  it("renders each required-tier trip as a separate list item", () => {
+    render(<DecompositionGateBanner assessment={daleAssessment} />);
+    const tripsList = screen.getByText("Threshold trips").parentElement;
+    expect(tripsList).toBeTruthy();
+    expect(tripsList!.textContent).toMatch(/models = 5/);
+    expect(tripsList!.textContent).toMatch(/acs = 25/);
+    expect(tripsList!.textContent).toMatch(/multipliers = 4/);
+  });
+
+  it("renders the Dale-specific observation counts", () => {
+    render(<DecompositionGateBanner assessment={daleAssessment} />);
+    const banner = screen.getByTestId("decomposition-gate-banner");
+    expect(banner.textContent).toMatch(/5 DB models/);
+    expect(banner.textContent).toMatch(/25 acceptance criteria/);
+    expect(banner.textContent).toMatch(/4 ACs with complexity multipliers/);
+  });
+
+  it("renders the deterministic rationale naming the required-tier trips", () => {
+    render(<DecompositionGateBanner assessment={daleAssessment} />);
+    expect(screen.getByText(/REQUIRED-threshold trips/)).toBeInTheDocument();
+  });
+});
+
+describe("DecompositionGateBanner — defensive presentation", () => {
+  it("handles empty trips array gracefully (renders no trips block)", () => {
+    const assessment = makeAssessment({
+      decision: "decompose-recommended",
+      trips: [],
+      rationale: "Design is large.",
+    });
+    render(<DecompositionGateBanner assessment={assessment} />);
+    expect(screen.queryByText("Threshold trips")).not.toBeInTheDocument();
+  });
+
+  it("handles empty rationale (renders no rationale paragraph)", () => {
+    const assessment = makeAssessment({
+      decision: "decompose-required",
+      rationale: "",
+    });
+    render(<DecompositionGateBanner assessment={assessment} />);
+    // Banner still renders; rationale block is suppressed when empty.
+    expect(screen.getByTestId("decomposition-gate-banner")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/build/DecompositionGateBanner.tsx
+++ b/apps/web/components/build/DecompositionGateBanner.tsx
@@ -1,0 +1,153 @@
+// apps/web/components/build/DecompositionGateBanner.tsx
+//
+// Phase 3 of the design-time decomposition rollout — informational banner
+// surfaced after a passed design review when the deterministic sizeDesignDoc
+// counter (Phase 2) decided the design is `decompose-recommended` or
+// `decompose-required`.
+//
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-
+//   decomposition-design.md (§4.1 "Decomposition prompt at Ideate exit").
+// BI: BI-2E6CC391.
+//
+// Phase 3 is informational only: the operator sees the size rationale, the
+// trip evidence, and a notice that the decomposition assistant lands in the
+// next phase. No "Propose splits" call-to-action (Phase 4), no override text
+// field (Phase 4), no enforcement.
+//
+// Returns `null` for null assessments and for decision="ok" so the component
+// can be unconditionally mounted inside `<DesignDocSection>` — it self-gates.
+//
+// All colours come from DPF theme tokens; no hardcoded hex.
+
+"use client";
+
+import type { SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
+
+type Props = {
+  assessment: SizeAssessmentSnapshot | null | undefined;
+};
+
+export function DecompositionGateBanner({ assessment }: Props) {
+  if (!assessment) return null;
+  if (assessment.decision === "ok") return null;
+
+  const isRequired = assessment.decision === "decompose-required";
+  const tone = isRequired ? "required" : "recommended";
+
+  const headline = isRequired
+    ? "Heads up — this design is bigger than fits in one build."
+    : "Worth considering — this design is on the larger side.";
+
+  const subhead = isRequired
+    ? "Plan iteration on designs this size tends to oscillate without converging. Splitting into 2-4 smaller builds that ship one at a time will plan faster and be easier to verify."
+    : "Plans this size can converge, but smaller is faster. Consider splitting into 2-3 builds.";
+
+  return (
+    <div
+      data-testid="decomposition-gate-banner"
+      data-tone={tone}
+      className="mt-3 rounded-md border p-3 text-xs"
+      style={{
+        background: "var(--surface-elevated, var(--dpf-surface))",
+        borderColor: isRequired
+          ? "var(--border-warning-subtle, var(--dpf-warning))"
+          : "var(--border-info-subtle, var(--dpf-muted))",
+        color: "var(--dpf-text)",
+      }}
+    >
+      <div
+        className="text-[10px] uppercase tracking-wider"
+        style={{ color: isRequired ? "var(--dpf-warning)" : "var(--dpf-muted)" }}
+      >
+        {isRequired ? "Decomposition required" : "Decomposition recommended"}
+      </div>
+
+      <p className="mt-1 font-semibold leading-snug">{headline}</p>
+      <p className="mt-1 leading-snug" style={{ color: "var(--dpf-text-secondary)" }}>
+        {subhead}
+      </p>
+
+      <ObservedBreakdown assessment={assessment} />
+
+      <TripList assessment={assessment} />
+
+      <Rationale text={assessment.rationale} />
+
+      <NextPhaseNotice />
+    </div>
+  );
+}
+
+function ObservedBreakdown({ assessment }: { assessment: SizeAssessmentSnapshot }) {
+  const { breakdown } = assessment;
+  const items: Array<{ label: string; value: number }> = [
+    { label: "DB models", value: breakdown.models.count },
+    { label: "API endpoints", value: breakdown.endpoints.count },
+    { label: "acceptance criteria", value: breakdown.acs.count },
+    { label: "ACs with complexity multipliers", value: breakdown.multipliers.count },
+    { label: "UI routes", value: breakdown.routes.count },
+  ];
+  return (
+    <ul
+      className="mt-2 grid grid-cols-2 gap-x-3 gap-y-0.5"
+      style={{ color: "var(--dpf-text-secondary)" }}
+    >
+      {items.map((it) => (
+        <li key={it.label} className="text-[11px]">
+          <span className="font-mono">{it.value}</span> {it.label}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function TripList({ assessment }: { assessment: SizeAssessmentSnapshot }) {
+  if (assessment.trips.length === 0) return null;
+  return (
+    <div className="mt-2">
+      <div
+        className="text-[10px] uppercase tracking-wider"
+        style={{ color: "var(--dpf-muted)" }}
+      >
+        Threshold trips
+      </div>
+      <ul className="mt-0.5 list-disc pl-4">
+        {assessment.trips.map((trip) => (
+          <li
+            key={`${trip.dimension}-${trip.level}`}
+            className="text-[11px] leading-snug"
+            style={{ color: "var(--dpf-text-secondary)" }}
+          >
+            <span className="font-mono">{trip.dimension}</span> = {trip.observed}{" "}
+            (≥ {trip.threshold} {trip.level})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Rationale({ text }: { text: string }) {
+  if (!text) return null;
+  return (
+    <p
+      className="mt-2 text-[11px] italic leading-snug"
+      style={{ color: "var(--dpf-text-secondary)" }}
+    >
+      {text}
+    </p>
+  );
+}
+
+function NextPhaseNotice() {
+  return (
+    <p
+      className="mt-2 text-[10px] leading-snug"
+      style={{ color: "var(--dpf-muted)" }}
+    >
+      The decomposition assistant (which proposes splits and creates child
+      builds under one Epic) ships in the next phase. Until then this banner
+      is informational — your build advances to Plan as today.
+    </p>
+  );
+}

--- a/apps/web/components/build/ReviewPanel.tsx
+++ b/apps/web/components/build/ReviewPanel.tsx
@@ -15,6 +15,7 @@ import type {
 import { safeRenderValue } from "@/lib/safe-render";
 import { normalizeTaskResults, type NormalizedTaskResults } from "@/lib/build/task-results";
 import { normalizeVerificationOutput, type NormalizedVerificationOutput } from "@/lib/build/verification-output";
+import { DecompositionGateBanner } from "@/components/build/DecompositionGateBanner";
 
 type Props = {
   build: FeatureBuildRow;
@@ -263,6 +264,9 @@ function DesignDocSection({
           )}
           {review && (
             <ReviewBadgeBlock decision={review.decision} summary={review.summary} issues={review.issues} />
+          )}
+          {review?.decision === "pass" && (
+            <DecompositionGateBanner assessment={review.sizeAssessment ?? null} />
           )}
         </div>
       )}

--- a/apps/web/lib/build/size-design-doc.ts
+++ b/apps/web/lib/build/size-design-doc.ts
@@ -32,21 +32,20 @@
 // and are overridable per call (the eventual PlatformConfig key
 // `build-studio-decomposition` will load overrides at the call site).
 
-import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+import type { BuildDesignDoc, SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
-export type SizeDecision = "ok" | "decompose-recommended" | "decompose-required";
+// Re-export the canonical SizeAssessment shape from feature-build-types as
+// SizeAssessment so callers of sizeDesignDoc and readers of
+// designReview.sizeAssessment use the same type. Single source of truth.
+export type SizeAssessment = SizeAssessmentSnapshot;
 
-export type SizeThresholds = {
-  models: { recommend: number; required: number };
-  endpoints: { recommend: number; required: number };
-  acs: { recommend: number; required: number };
-  multipliers: { recommend: number; required: number };
-  routes: { recommend: number; required: number };
-};
+export type SizeDecision = SizeAssessment["decision"];
+
+export type SizeThresholds = SizeAssessment["thresholds"];
 
 export const DEFAULT_SIZE_THRESHOLDS: SizeThresholds = {
   models: { recommend: 3, required: 5 },
@@ -56,29 +55,12 @@ export const DEFAULT_SIZE_THRESHOLDS: SizeThresholds = {
   routes: { recommend: 2, required: 4 },
 };
 
-export type SizeBreakdown = {
-  models: { count: number; samples: string[] };
-  endpoints: { count: number; samples: string[] };
-  acs: { count: number };
-  multipliers: { count: number; matchedKeywords: string[] };
-  routes: { count: number; samples: string[] };
-};
-
-export type SizeTrip = {
-  dimension: keyof SizeThresholds;
-  level: "recommend" | "required";
-  threshold: number;
-  observed: number;
-};
-
-export type SizeAssessment = {
-  decision: SizeDecision;
-  breakdown: SizeBreakdown;
-  trips: SizeTrip[];
-  rationale: string;
-  thresholds: SizeThresholds;
-  assessedAt: string;
-};
+// Derive breakdown / trip shapes from the canonical SizeAssessment type so
+// any future change to the snapshot stays consistent across producers and
+// consumers (sizeDesignDoc here, ReviewPanel banner in components/build/,
+// any future Hive analytics).
+export type SizeBreakdown = SizeAssessment["breakdown"];
+export type SizeTrip = SizeAssessment["trips"][number];
 
 // ---------------------------------------------------------------------------
 // Main entry point

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -93,6 +93,47 @@ export type ReviewResult = {
      *  signal that the feature scope may be too large to converge. */
     oscillating?: boolean;
   };
+  /** Deterministic size assessment of the reviewed design. Populated by
+   *  reviewDesignDoc when designReview is the result of an Ideate-phase
+   *  review (not Plan-phase). Phase 2 of the design-time decomposition
+   *  rollout (BI-2E6CC391, spec
+   *  docs/superpowers/specs/2026-05-24-build-studio-design-time-
+   *  decomposition-design.md). Phase 3 reads this to render the gate
+   *  banner; Phase 4 reads it to gate the decomposition assistant.
+   *  Absent on Plan-phase reviews and on builds reviewed before Phase 2
+   *  shipped. */
+  sizeAssessment?: SizeAssessmentSnapshot;
+};
+
+/** Snapshot of the sizeDesignDoc output as persisted on a ReviewResult.
+ *  Kept structurally compatible with `SizeAssessment` in
+ *  apps/web/lib/build/size-design-doc.ts so client code can import either
+ *  type. Defined here (rather than imported) so the ReviewResult shape has
+ *  no module-graph dependency on the sizing logic. */
+export type SizeAssessmentSnapshot = {
+  decision: "ok" | "decompose-recommended" | "decompose-required";
+  breakdown: {
+    models: { count: number; samples: string[] };
+    endpoints: { count: number; samples: string[] };
+    acs: { count: number };
+    multipliers: { count: number; matchedKeywords: string[] };
+    routes: { count: number; samples: string[] };
+  };
+  trips: Array<{
+    dimension: "models" | "endpoints" | "acs" | "multipliers" | "routes";
+    level: "recommend" | "required";
+    threshold: number;
+    observed: number;
+  }>;
+  rationale: string;
+  thresholds: {
+    models: { recommend: number; required: number };
+    endpoints: { recommend: number; required: number };
+    acs: { recommend: number; required: number };
+    multipliers: { recommend: number; required: number };
+    routes: { recommend: number; required: number };
+  };
+  assessedAt: string;
 };
 
 export type ReusabilityAnalysis = {


### PR DESCRIPTION
## Summary

- Third phase of the design-time decomposition rollout. Surfaces the Phase 2 `sizeDesignDoc` assessment to the operator as an informational banner inside the Build Studio `ReviewPanel`, after a design review passes.
- **Informational only per spec §10** — no "Propose splits" CTA, no override field, no enforcement. The decomposition assistant + child-creation atomic txn ship in Phase 4.
- Self-gating component: returns null when assessment is missing or `decision === "ok"`, so it can be unconditionally mounted in the `DesignDocSection` and the existing layout is unchanged for designs that fit one Plan.

## What this PR contains

- `apps/web/components/build/DecompositionGateBanner.tsx` — pure presentational component, ~140 LoC. CSS variables only.
- `apps/web/components/build/DecompositionGateBanner.test.tsx` — 16 cases including the Dale composite fixture from spec §1.1.
- `apps/web/components/build/ReviewPanel.tsx` — single insertion in `DesignDocSection` (after the existing `ReviewBadgeBlock`), gated on `review.decision === "pass"`. Failed-review banners stay focused on the issues to address.
- `apps/web/lib/explore/feature-build-types.ts` — `ReviewResult` gains optional `sizeAssessment` field. New `SizeAssessmentSnapshot` type is the canonical shape.
- `apps/web/lib/build/size-design-doc.ts` — re-exports `SizeAssessmentSnapshot` as `SizeAssessment`; derives `SizeBreakdown` / `SizeTrip` from it so the producer and the persisted JSON stay in lockstep.

## Visual tone

| Decision | Border | Headline |
|---|---|---|
| `decompose-required` | `var(--border-warning-subtle)` (warning) | "Heads up — this design is bigger than fits in one build." |
| `decompose-recommended` | `var(--border-info-subtle)` (info) | "Worth considering — this design is on the larger side." |
| `ok` or null | (banner not rendered) | — |

Both modes render:
- Tone-coded headline + sub-headline (action-flavoured for required, advisory for recommended)
- Observed breakdown grid: `5 DB models`, `25 acceptance criteria`, `4 ACs with complexity multipliers`, etc.
- Threshold trips list: `models = 5 (≥ 5 required)`, one row per trip
- The deterministic rationale string verbatim (so the operator's mental model matches the audit trail)
- A short "next phase" notice explaining that the decomposition assistant ships next

## Verification

- 16 banner component tests pass — self-gating, tone differentiation, breakdown rendering, trip-list rendering, rationale verbatim, defensive paths (empty trips, empty rationale).
- Dale composite fixture (5 models, 25 ACs, 4 multipliers with idempotency / optimistic-locking / append-only-ledger / multi-tenant keywords) renders with the `required` tone and lists 3 required-tier trips.
- Full `apps/web/components/build/` + `apps/web/lib/build/` suite: 533/533 pass.
- `pnpm --filter web run typecheck` exit 0.
- Pre-commit scoped typecheck clean.

## Why the type unification matters

This PR also collapses what was almost a fork: `SizeAssessment` (defined in `size-design-doc.ts`) and the shape the banner needs to read from `designReview.sizeAssessment` would have drifted independently otherwise. Now `SizeAssessmentSnapshot` in `feature-build-types.ts` is the single source of truth, and `size-design-doc.ts` re-exports + derives. Producer and consumers can't drift apart silently.

## Test plan

- [ ] After merge, drive a synthetic large design through Build Studio Ideate, pass review, and verify the banner appears under the design doc section with the right tone and observation counts.
- [ ] Drive a small design through and verify the banner does NOT appear (`ok` → null).
- [ ] Verify dark-mode + light-mode rendering — CSS variables only, but eyeball the border/background contrast.

## What ships next

- **Phase 4**: the decomposition assistant. Adds a "Propose splits" CTA to the banner (required tier), launches the agent that proposes 2-4 candidate decompositions, and on operator approval atomically creates the parent Epic and N child FeatureBuilds (Phase 1 substrate already in place). The override text field for required-tier "keep as one build" also lands in Phase 4.

## Related

- Spec: `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md` §4.1 (merged)
- Phase 1 substrate (Epic.designDoc, parentEpicId, FeatureBuildDependency): PR #1123 (merged)
- Phase 2 sizeDesignDoc counter (the producer of `sizeAssessment`): PR #1125 (merged)
- Empirical anchor: `docs/dogfood/2026-05-23-dale-hvac-build-studio.md`
- BI: BI-2E6CC391
- Epic: EP-BUILD-STUDIO; EP-9FC5D2FD; EP-REDUCTION-GEAR-ARCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)