### PR TITLE
fix: trust managed workspace during source refresh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -160,7 +160,16 @@ workspace_path_matches_image_source() {
   return 1
 }
 
+ensure_workspace_safe_directory() {
+  if [ -d "$WORKSPACE/.git" ]; then
+    git config --global --get-all safe.directory 2>/dev/null | grep -qxF "$WORKSPACE" \
+      || git config --global --add safe.directory "$WORKSPACE" >/dev/null 2>&1 \
+      || true
+  fi
+}
+
 workspace_has_user_changes() {
+  ensure_workspace_safe_directory
   cd "$WORKSPACE"
   ensure_workspace_git_excludes
   # Older source-volume bootstraps accidentally tracked dependency stores.
@@ -197,6 +206,7 @@ ensure_workspace_git_excludes() {
 }
 
 commit_workspace_snapshot() {
+  ensure_workspace_safe_directory
   cd "$WORKSPACE"
   git config user.email "build-studio@dpf.local"
   git config user.name "DPF Build Studio"
@@ -221,6 +231,7 @@ elif [ -d "$WORKSPACE" ] && [ ! -f "$WORKSPACE/.dpf-version" ]; then
 
   # Initialise git — force-create branches to be idempotent on partial failure
   git init -b dpf-upstream
+  ensure_workspace_safe_directory
   git config user.email "build-studio@dpf.local"
   git config user.name "DPF Build Studio"
   ensure_workspace_git_excludes

--- a/scripts/lib/docker-entrypoint-source-volume.test.mjs
+++ b/scripts/lib/docker-entrypoint-source-volume.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const entrypoint = readFileSync(new URL("../../docker-entrypoint.sh", import.meta.url), "utf8");
+
+function functionBody(name) {
+  const match = entrypoint.match(new RegExp(`${name}\\(\\) \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `${name} function should exist`);
+  return match[1];
+}
+
+test("source-volume refresh marks /workspace as a Git safe directory before status checks", () => {
+  const body = functionBody("ensure_workspace_safe_directory");
+  assert.match(body, /safe\.directory/);
+  assert.match(body, /\$WORKSPACE/);
+
+  const userChangeBody = functionBody("workspace_has_user_changes");
+  assert.ok(
+    userChangeBody.indexOf("ensure_workspace_safe_directory") <
+      userChangeBody.indexOf("git rm -r --cached"),
+    "workspace change detection should add the safe-directory allowance before Git status operations",
+  );
+});
+
+test("source-volume snapshot commits add the safe-directory allowance before local Git config", () => {
+  const snapshotBody = functionBody("commit_workspace_snapshot");
+  assert.ok(
+    snapshotBody.indexOf("ensure_workspace_safe_directory") <
+      snapshotBody.indexOf("git config user.email"),
+    "snapshot commit should add the safe-directory allowance before local Git config writes",
+  );
+
+  assert.match(
+    entrypoint,
+    /git init -b dpf-upstream\s+ensure_workspace_safe_directory\s+git config user\.email/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a managed `/workspace` Git safe-directory guard in `docker-entrypoint.sh`
- call it before source-volume status checks, snapshot commits, and first bootstrap local Git config
- add a structural regression test for the entrypoint source-volume refresh path

## Root cause
`sandbox-init` runs the same source-volume refresh as `portal-init`, but an existing managed `/workspace` volume can have Git ownership that differs from the init process. Git then refuses local repo operations with `detected dubious ownership`, and later local config writes fail with `fatal: not in a git directory`, preventing the sandbox runtime from starting.

## Validation
- `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
- `docker run --rm -v "${PWD}\\docker-entrypoint.sh:/tmp/docker-entrypoint.sh:ro" alpine:3.20 sh -n /tmp/docker-entrypoint.sh`
- `docker compose --env-file D:\DPF\.env -p dpf build portal portal-init sandbox-init sandbox`
- `docker compose --env-file D:\DPF\.env -p dpf up -d sandbox-init sandbox`
- `GET http://127.0.0.1:3035/api/health` returned 200
