### PR TITLE
docs: align archetype narrative and workspace visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # Open Digital Product Factory
 
-**The platform that builds itself.** An open-source, AI-native digital product management platform under human governance. Single-org install on your hardware; opt-in cross-install contribution through the Hive Mind.
+**The platform that builds itself.** An open-source, AI-native operating platform for small businesses and product teams under human governance. A DPF install starts from a market archetype, gives the business a customer portal and internal workspace in its own vocabulary, and puts purposed AI coworkers at the center of daily work. Single-org install on your hardware; opt-in cross-install contribution through the Hive Mind.
 
 > **For potential users and customers, start at [opendigitalproductfactory.com](https://opendigitalproductfactory.com)** — the canonical product tour with capability inventory, archetypes, coworker workforce, maturity surface, and standards conformance.
 >
 > **This README is for people working with the project source** — contributors, integrators, and anyone running the install scripts or modifying the codebase.
+
+---
+
+## Product posture
+
+DPF's user story is now archetype-led rather than module-led:
+
+- Pick the business type first: HVAC, clinic, retail, nonprofit, HOA, professional services, software platform, and other small-business categories.
+- The selected archetype shapes the customer portal, internal workspace vocabulary, worker home, marketing posture, and feature-contribution applicability.
+- AI coworkers are the primary interaction surface. They are purposed by role and route, but every side effect still goes through role checks, agent grants, approval gates, and audit logs.
+- Voice is an optional coworker modality: speech-to-text for input, text-to-speech for narrated decision/profile output where consent and provider setup allow it.
+- Build Studio is the governed self-development surface, but it is still being hardened. Use it honestly: ready for guided platform work and evidence capture, not a claim that every complex source change is fully autonomous today.
+
+User-facing narrative lives in [Market Archetypes And Coworkers](docs/user-guide/market-archetypes.md), with proof personas under [docs/personas/](docs/personas/).
 
 ---
 
@@ -76,7 +90,7 @@ bash install-dpf.sh --headless --release
 
 Terraform modules for the cloud-VM path live under [`infra/terraform/single-vm/{aws,gcp,azure}/`](infra/terraform/single-vm/).
 
-The installer asks one question — **Ready to go** (pre-built images; Build Studio is the development surface) or **Customizable** (full source clone; Build Studio and a local IDE share the same workspace). Both modes include the full platform; the difference is whether direct IDE access is part of the supported workflow. Login credentials are saved to `.env` / `.admin-credentials` at the end of installation.
+The installer asks one question — **Ready to go** (pre-built images; Build Studio is the governed development surface) or **Customizable** (full source clone; Build Studio and a local IDE share the same workspace). Both modes include the full platform; the difference is whether direct IDE access is part of the supported workflow. For serious source changes while Build Studio continues hardening, use Customizable mode. Login credentials are saved to `.env` / `.admin-credentials` at the end of installation.
 
 If you hit a wall — happy-path success stories and "the installer hit a wall at step X" failures are equally useful — open an issue using the [Install verification report template](.github/ISSUE_TEMPLATE/install_verification.md) and attach the bundle produced by `bash install-dpf.sh doctor`.
 
@@ -235,6 +249,8 @@ Longer-form contributor guidance — full branch model, PR checklist, local veri
 
 - [docs/README.md](docs/README.md) — documentation index
 - [docs/user-guide/](docs/user-guide/) — operator-facing guides, bundled into the portal's in-app help
+- [docs/user-guide/market-archetypes.md](docs/user-guide/market-archetypes.md) — archetype-led user narrative and coworker positioning
+- [docs/personas/](docs/personas/) — persona proof library for archetype-led marketing and dogfood testing
 - [docs/install/](docs/install/) — per-platform install runbooks
 - [docs/architecture/](docs/architecture/) — runtime, deployment, standards, governance
 - [docs/superpowers/specs/](docs/superpowers/specs/) — dated design specs (the "why" record)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,9 @@
 
 > Looking for a pre-install tour you can share with people who don't have the platform yet? See [index.html](index.html) — a single-page overview that links into the rest of this directory.
 
-This directory holds the long-form documentation that accompanies the Open Digital Product Factory source tree. It's split into two audiences:
+This directory holds the long-form documentation that accompanies the Open Digital Product Factory source tree. It is split into three practical audiences:
 
+- **Market and operator** docs explain the platform from the business archetype outward: what kind of business this is, which coworkers help, and what daily work improves.
 - **User-facing** docs live under [user-guide/](user-guide/) and are also bundled into the portal's in-app help pages at runtime.
 - **Architecture and contributor** docs live under [architecture/](architecture/) and (for internal development tracking) [superpowers/](superpowers/).
 
@@ -13,6 +14,7 @@ If you're looking for the one-page project overview, start at the repo-root [REA
 
 Entry points for people using the platform day-to-day:
 
+- [Market Archetypes And Coworkers](user-guide/market-archetypes.md) — the canonical user-facing explanation of archetypes, purposed coworkers, voice, and Build Studio's current boundary.
 - [Getting Started](user-guide/getting-started/index.md) — what the platform does, how navigation works, and where your AI coworker lives.
 - [Developer Setup](user-guide/getting-started/developer-setup.md) — running the codebase locally with pnpm + Docker sidecars.
 - [Dev Container Setup](user-guide/getting-started/dev-container.md) — fully containerized alternative that needs only Docker Desktop and VS Code.
@@ -22,10 +24,16 @@ Entry points for people using the platform day-to-day:
 
 Domain-specific operating guides (admin, AI workforce, build studio, compliance, customers, finance, HR, operations, platform, portfolios, products, storefront, wiki, workspace) live in their own folders under [user-guide/](user-guide/).
 
+## Market proof
+
+- [Persona Library](personas/README.md) — evidence-backed archetype stories that double as marketing substrate and re-runnable dogfood scenarios.
+- [Dale HVAC](personas/dale-hvac.md), [Linda Clinic](personas/linda-clinic.md), and [Marisol Retail](personas/marisol-retail.md) are the current proof set for vertical workspace homes.
+
 ## Source-of-truth boundaries
 
-- [Repo README](../README.md) is the project overview, install posture, and capability inventory.
-- [index.html](index.html) is the public pre-install website.
+- [Repo README](../README.md) is the source-facing project overview and install posture.
+- [index.html](index.html) is the public pre-install website and marketing tour.
+- [user-guide/market-archetypes.md](user-guide/market-archetypes.md) is the canonical archetype/coworker narrative for user-facing docs.
 - [user-guide/](user-guide/) is operational product help and contextual in-app documentation.
 - [architecture/](architecture/) is current architecture, standards, and conformance context.
 - [superpowers/](superpowers/) is design history, audits, and implementation planning. It can support decisions, but it is not onboarding copy.

--- a/docs/index.html
+++ b/docs/index.html
@@ -311,7 +311,7 @@
     <img class="hero-logo" src="assets/logos/OpenDigitalProductFactory.png" alt="Open Digital Product Factory" width="934" height="688" />
     <h1>Open Digital Product Factory</h1>
     <p class="lede">
-      An open, AI-native platform that helps your organization build and run itself. DPF gives small teams and regulated enterprises the same digital-product, architecture, compliance, and AI-workforce capabilities that have historically been locked behind expensive enterprise suites &mdash; running on your own hardware, governed end-to-end, and extensible by AI coworkers under human approval.
+      An open, AI-native platform that helps a business run from its own archetype. DPF gives small teams a customer portal, an internal workspace, and purposed AI coworkers that speak the language of the work &mdash; HVAC jobs, clinic appointments, retail stock, nonprofit programs, HOA requests &mdash; while keeping every meaningful action governed end-to-end on your own hardware.
     </p>
     <div class="cta-row">
       <a class="btn primary" href="#install-on-windows">Install on Windows</a>
@@ -326,12 +326,12 @@
         <span>Bundled local AI, single-org install, no data leaves your environment unless you opt in.</span>
       </div>
       <div class="hero-highlight">
-        <strong>15 named AI coworkers, governed</strong>
-        <span>Default-deny tool gating, identity for agents (GAID), and an audit log every action passes through.</span>
+        <strong>Purposed AI coworkers, governed</strong>
+        <span>Role-bound helpers for setup, marketing, operations, finance, compliance, customers, and platform work.</span>
       </div>
       <div class="hero-highlight">
-        <strong>Builds itself, with humans in the loop</strong>
-        <span>Build Studio drafts new features in a sandbox; humans approve design, code impact, and acceptance; merges land via PR.</span>
+        <strong>Archetype first</strong>
+        <span>The selected market archetype shapes portal copy, worker vocabulary, daily boards, and reusable-feature fit.</span>
       </div>
     </div>
   </div>
@@ -364,7 +364,7 @@
   <section id="install-on-windows">
     <h2>Install on Windows</h2>
     <p class="sub">
-      Open PowerShell and paste one of the snippets below. The installer asks a single question &mdash; <strong>Ready to go</strong> (pre-built images, Build Studio is the development surface) or <strong>Customizable</strong> (full source clone, Build Studio and a local IDE share the same workspace) &mdash; and handles everything else: Docker Desktop, WSL2, hardware detection, AI model selection, credential generation, and auto-start.
+      Open PowerShell and paste one of the snippets below. The installer asks a single question &mdash; <strong>Ready to go</strong> (pre-built images and guided portal surfaces) or <strong>Customizable</strong> (full source clone, Build Studio and a local IDE share the same workspace) &mdash; and handles everything else: Docker Desktop, WSL2, hardware detection, AI model selection, credential generation, and auto-start. Use Customizable for serious source edits while Build Studio hardening continues.
     </p>
     <div class="install">
       <h3>Recommended: with the GitHub CLI</h3>
@@ -431,7 +431,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
     <div class="grid">
       <div class="card">
         <h3>User Guide</h3>
-        <p>Day-to-day operating guidance for everyone who uses the platform &mdash; getting started, AI coworkers, Build Studio, Edge Nodes, wiki, managed documents, compliance, finance, HR, customers, and more.</p>
+        <p>Day-to-day operating guidance for everyone who uses the platform &mdash; market archetypes, getting started, AI coworkers, Build Studio, Edge Nodes, wiki, managed documents, compliance, finance, HR, customers, and more.</p>
       </div>
       <div class="card">
         <h3>Architecture &amp; Standards</h3>
@@ -463,7 +463,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       <div class="pillar">
         <div class="tag">Direction</div>
         <strong>A platform that grows from within.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Build Studio drafts new features in a sandbox; humans review the design and UX; approved changes deploy automatically. No developer is required on the hot path.</p>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Build Studio is the governed self-development surface: it drafts, records evidence, and prepares changes through review gates. Complex source work can still use VS Code in customizable installs while Build Studio continues hardening.</p>
       </div>
       <div class="pillar">
         <div class="tag">Hive Mind</div>
@@ -487,8 +487,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         <tr><td>Compliance &amp; Regulatory</td><td>Onboard regulations and standards, map controls to obligations, collect evidence, track posture, and manage licensing readiness.</td></tr>
         <tr><td>Financial Management</td><td>Invoices, suppliers and bills, purchase orders, banking and reconciliation, AI-spend visibility.</td></tr>
         <tr><td>Enterprise Architecture</td><td>Model the application, technology, and business layers with ArchiMate notation; graph-backed via Neo4j.</td></tr>
-        <tr><td>Storefront</td><td>Public-facing storefront for products and services with booking, donations, and checkout. Driven by an industry archetype that seeds sections, vocabulary, finance profile, and design.</td></tr>
-        <tr><td>Build Studio</td><td>A guided five-phase pipeline (ideate, plan, build, review, ship) with AI coworkers, sandbox execution, code intelligence, impact reports, and PR-based promotion.</td></tr>
+        <tr><td>Archetype-led portal</td><td>Public-facing storefront or service portal plus internal vocabulary for the selected business type. Driven by an archetype that seeds sections, flows, item templates, finance assumptions, marketing posture, and worker-home direction.</td></tr>
+        <tr><td>Build Studio</td><td>A guided five-phase pipeline (ideate, plan, build, review, ship) with AI coworkers, sandbox execution, code intelligence, impact reports, and promotion or PR handoff where configured. Active hardening is underway for oversized-build decomposition and safer portal upgrades.</td></tr>
         <tr><td>Operations &amp; Backlog</td><td>Manage delivery work with epics, items, priorities, and status tracking. Coworkers create, triage, size, and link items through governed MCP tools.</td></tr>
         <tr><td>AI Workforce</td><td>Provider configuration, dynamic model discovery, capability-tier routing, operations map, capacity continuity, capability-needs review, agent registry, and per-agent grants.</td></tr>
         <tr><td>Wiki &amp; Managed Documents</td><td>Governed platform knowledge, founder-kernel principles, source citations, linting, maintained documents, versions, references, and publication state.</td></tr>
@@ -515,8 +515,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="pillar">
         <div class="tag">Archetypes</div>
-        <strong>Pick an industry &mdash; the platform reshapes itself.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Twelve industry archetypes ship with the platform. Choosing one bootstraps your storefront sections, vocabulary, booking and form rules, finance profile, and design system in one move. The archetype is the single source of truth for industry; downstream surfaces read from it rather than from a separately editable string.</p>
+        <strong>Pick a market archetype &mdash; the platform reshapes itself.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Twelve market categories and 45 leaf archetype templates ship with the platform. Choosing one bootstraps the customer portal, vocabulary, booking and form rules, finance assumptions, marketing posture, and internal worker-home direction. The archetype is the single source of truth for industry; downstream surfaces read from it rather than from a separately editable string.</p>
       </div>
       <div class="pillar">
         <div class="tag">Common Skills</div>
@@ -532,9 +532,9 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   </section>
 
   <section id="archetypes">
-    <h2>Twelve industry archetypes ship in the box</h2>
+    <h2>Twelve market categories, 45 leaf archetypes</h2>
     <p class="sub">
-      Archetypes are the bootstrap mechanism that turns a fresh install into a working business setup. Each one carries its own role hierarchy, process workflows, capability seeds, finance assumptions, and storefront design. Archetypes can be customized after install &mdash; or contributed back as new templates other installs can adopt.
+      Archetypes are the bootstrap mechanism that turns a fresh install into a working business setup. Each one carries storefront design, vocabulary, role emphasis, process defaults, finance assumptions, and marketing posture. The next design wave extends the same archetype into internal workspace homes: dispatch boards for trades, appointment-readiness boards for clinics, merchandising boards for retail, and equivalent daily boards for other categories.
     </p>
     <div class="grid">
       <div class="card"><h3>Healthcare &amp; Wellness</h3><p>Clinics, practitioners, wellness providers; appointment-centric flows.</p></div>
@@ -555,7 +555,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="coworkers">
     <h2>Meet the coworker workforce</h2>
     <p class="sub">
-      Coworkers are role-bound AI personas, each scoped to a value stream, each with its own grant set and skill library. They are the platform&rsquo;s primary surface for getting work done &mdash; you talk to the coworker who owns the area you&rsquo;re working in, and the platform routes you correctly based on the page you&rsquo;re on.
+      Coworkers are role-bound AI personas, each scoped to a value stream, each with its own grant set and skill library. They are the platform&rsquo;s primary surface for getting work done &mdash; you talk to the coworker who owns the area you&rsquo;re working in, and the platform routes you correctly based on the page, active archetype, and permissions in play.
     </p>
     <div class="grid">
       <div class="card"><h3>onboarding-coo</h3><p>Hosts first-run setup. Introduces the platform, explains AI providers, walks through identity, branding, and finance configuration.</p></div>
@@ -579,7 +579,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="build-studio">
     <h2>Build Studio: the five-phase pipeline</h2>
     <p class="sub">
-      Build Studio is how the platform extends itself. A user (or a coworker on a user&rsquo;s behalf) proposes a feature, and the request flows through five governed phases. Each phase has its own gate &mdash; nothing advances until the previous gate&rsquo;s artifacts are present and acceptable. Code intelligence and impact reports help reviewers understand what changed before a promotion or PR moves forward.
+      Build Studio is how the platform extends itself. A user (or a coworker on a user&rsquo;s behalf) proposes a feature, and the request flows through five governed phases. Each phase has its own gate &mdash; nothing advances until the previous gate&rsquo;s artifacts are present and acceptable. It is actively being hardened, so treat it as the governed evidence and development surface, not a promise that every complex source change is already fully autonomous.
     </p>
     <table class="guide">
       <thead>
@@ -608,8 +608,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         </tr>
         <tr>
           <td><strong>5. Ship</strong></td>
-          <td>Delivery. Pull request opened against <code>main</code> with required CI checks and DCO sign-off; merged; version tagged. Hive contribution mode (<code>fork_only</code>, <code>selective</code>, or <code>contribute_all</code>) decides whether the change is also offered upstream.</td>
-          <td>Merged PR, deployment confirmation, optional hive contribution PR.</td>
+          <td>Delivery. Promotion evidence is prepared; where configured, a pull request opens against <code>main</code> with required CI checks and DCO sign-off. Hive contribution mode (<code>fork_only</code>, <code>selective</code>, or <code>contribute_all</code>) decides whether the change is also offered upstream.</td>
+          <td>PR/promotion record, deployment or handoff confirmation, optional hive contribution PR.</td>
         </tr>
       </tbody>
     </table>
@@ -617,6 +617,11 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       Build Studio captures phase-by-phase evidence so the path from idea to ship is fully reconstructable &mdash; the same evidence trail the compliance module uses when it asks &ldquo;what changed and who authorized it?&rdquo;
     </p>
     <div class="pillars" style="margin-top:18px;">
+      <div class="pillar">
+        <div class="tag">Design-time decomposition</div>
+        <strong>Oversized builds split before Plan churn.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The Dale HVAC dogfood run exposed a real cliff: a feature can be directionally correct but too large for one Build Studio plan. The new design-time decomposition work keeps one parent design contract and creates smaller child builds before plan review oscillates.</p>
+      </div>
       <div class="pillar">
         <div class="tag">Concurrency</div>
         <strong>Sandbox slot pool with queued builds.</strong>
@@ -683,8 +688,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="pillar">
         <div class="tag">Persona Voice Layer</div>
-        <strong>WWTD: coworkers speak, and they sound different.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled speaches (faster-whisper) STT service is the default for voice input. The Persona Voice Layer adds per-coworker TTS profiles &mdash; admin-configurable so each persona has a distinct voice for spoken decision rationales and read-back of design and review outputs.</p>
+        <strong>WWTD: coworkers can speak, without gaining authority.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled speaches (faster-whisper) STT service is the default path for voice input where enabled. TTS profiles are optional enrichment for spoken decision rationales and read-back of profile output. Voice never changes approval, confidence, or audit rules, and real-person voice requires consent.</p>
       </div>
       <div class="pillar">
         <div class="tag">Operations map</div>
@@ -1041,6 +1046,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       <tbody>
         <tr><td>User Guide index</td><td><a href="/user-guide/">user-guide/</a></td></tr>
         <tr><td>Getting started</td><td><a href="/user-guide/getting-started/">user-guide/getting-started</a></td></tr>
+        <tr><td>Market archetypes and coworkers</td><td><a href="/user-guide/market-archetypes">user-guide/market-archetypes</a></td></tr>
         <tr><td>AI coworker</td><td><a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a></td></tr>
         <tr><td>Roles &amp; access</td><td><a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a></td></tr>
         <tr><td>Development workspace</td><td><a href="/user-guide/development-workspace">user-guide/development-workspace</a></td></tr>
@@ -1158,7 +1164,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         <tr>
           <td>Build Studio (5 phases)</td>
           <td><strong>Production</strong></td>
-          <td>End-to-end lifecycle complete through ship with sandbox execution, review evidence, code intelligence, and PR-based promotion.</td>
+          <td>Governed lifecycle through ship with sandbox execution, review evidence, code intelligence, and promotion or PR handoff where configured; hardening continues for oversized builds and safer portal upgrades.</td>
         </tr>
         <tr>
           <td>Coworker workforce, grants, tool gating</td>
@@ -1166,9 +1172,9 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
           <td>Default-deny grants, route-scoped agent identity, immutable directive injection, audit log all live.</td>
         </tr>
         <tr>
-          <td>Archetypes (12 industries)</td>
+          <td>Archetypes (12 categories, 45 leaf templates)</td>
           <td><strong>Production</strong></td>
-          <td>Bootstrap on storefront setup; sections, vocabulary, finance profile, design system seeded.</td>
+          <td>Bootstrap on storefront setup; sections, vocabulary, finance profile, design system, marketing posture, and workspace-home direction seeded.</td>
         </tr>
         <tr>
           <td>LDAP / Active Directory / Entra federation</td>
@@ -1406,7 +1412,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         </tr>
         <tr>
           <td><strong>Custom archetype creation and refinement</strong></td>
-          <td>A path to add and refine industry archetypes beyond the bundled twelve, including parameterizable vocabulary, finance profile, and design tokens.</td>
+          <td>A path to add and refine market archetypes beyond the bundled catalog, including parameterizable vocabulary, finance profile, design tokens, and worker-home composition.</td>
         </tr>
         <tr>
           <td><strong>IT service provider (MSP) archetype</strong></td>
@@ -1473,7 +1479,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="card">
         <h3>Do I need a developer to use it?</h3>
-        <p>No. Build Studio is the development surface for the platform; AI coworkers carry out the build, with humans reviewing design and acceptance. The customizable install adds a local IDE for developers who want one.</p>
+        <p>No for day-to-day business operation. Archetypes, the portal, and AI coworkers are meant for operators. For changing the platform itself, Build Studio is the governed development surface, and customizable installs can pair it with a local IDE while that surface continues to mature.</p>
       </div>
       <div class="card">
         <h3>What if I do not want to run AI locally?</h3>
@@ -1489,7 +1495,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="card">
         <h3>What does the install include?</h3>
-        <p>Portal, init container, Postgres, Neo4j, Qdrant, Inngest, Redis, the local model runner, and on-demand sandbox containers. Twelve industry archetypes, fifteen named coworkers, the skill registry, and a seeded role hierarchy come pre-loaded.</p>
+        <p>Portal, init container, Postgres, Neo4j, Qdrant, Inngest, Redis, the local model runner, and on-demand sandbox containers. Twelve market categories, 45 leaf archetype templates, purposed coworkers, the skill registry, and a seeded role hierarchy come pre-loaded.</p>
       </div>
       <div class="card">
         <h3>How do I uninstall?</h3>
@@ -1501,7 +1507,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="card">
         <h3>What does the &ldquo;ready-to-go&rdquo; vs &ldquo;customizable&rdquo; install mean?</h3>
-        <p>Ready-to-go uses pre-built images; Build Studio is the only development surface. Customizable clones the source and shares the workspace with a local IDE. Same platform either way; you can switch later.</p>
+        <p>Ready-to-go uses pre-built images and the guided portal surfaces. Customizable clones the source and shares the workspace with Build Studio plus a local IDE. Same platform either way; customizable is the safer choice for serious source edits while Build Studio hardening continues.</p>
       </div>
       <div class="card">
         <h3>Where do I file an issue or suggest a feature?</h3>

--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -5,7 +5,11 @@ This directory holds persona case-study documents that serve two jobs at once:
 - Marketing substrate: narrative, quotes, before/after copy, and concrete pain points that can be reused in site copy, decks, onboarding, and customer conversations.
 - Test substrate: re-runnable dogfood scenarios that prove the platform still works for that persona as DPF evolves.
 
+For the user-facing product framing that these personas support, see [Market Archetypes And Coworkers](../user-guide/market-archetypes.md). That page is the canonical narrative; persona files are proof and test fixtures, not a second product overview.
+
 Each persona gets one Markdown file named `<name>-<vertical>.md`. The first real persona is [Dale, HVAC owner](dale-hvac.md), extracted from the Build Studio dogfood thread at [docs/dogfood/2026-05-23-dale-hvac-build-studio.md](../dogfood/2026-05-23-dale-hvac-build-studio.md) and the live `EP-9FC5D2FD` backlog state. The first vertical workspace-home peer wave is tied to the [Vertical Workspace Home design](../superpowers/specs/2026-05-24-vertical-workspace-home-design.md) and the live `EP-REDUCTION-GEAR-ARCH` backlog.
+
+The current proof set intentionally spans three general market verticals: field service (Dale), healthcare scheduling (Linda), and retail merchandising (Marisol). New personas should keep that market-vertical discipline: they must show how the archetype changes the daily work surface, coworker emphasis, vocabulary, and reusable feature applicability.
 
 ## Library Rules
 

--- a/docs/superpowers/specs/2026-05-24-dales-ac-repair-workspace-home-visual-design.md
+++ b/docs/superpowers/specs/2026-05-24-dales-ac-repair-workspace-home-visual-design.md
@@ -2,24 +2,46 @@
 
 | Field | Value |
 | ----- | ----- |
-| Status | Draft visual direction |
+| Status | Reviewed by chief architect — accepted with edits |
 | Date | 2026-05-24 |
 | Backlog item | `BI-5656E9C3` |
-| Follow-on implementation | `BI-CE6AF925` |
-| Primitive library | `BI-5B8FE5C1` |
+| Persona | [Dale, owner of a 4-truck HVAC repair shop](../../personas/dale-hvac.md) |
+| Archetype | `hvac-contractor` (category `trades-maintenance`) — **persona-validation visual for the first proving install of this archetype** |
+| Substrate spec | [Vertical Workspace Home design](2026-05-24-vertical-workspace-home-design.md) — defines the resolver, contribution manifest, slot covenant, projection service, and verification protocol this spec depends on |
+| Anchor spec | [Reduction Gear Architecture](2026-05-24-reduction-gear-architecture-design.md) §5.5 (audience layering), §5.6 (vertical workspace home) |
+| Follow-on implementation | `BI-CE6AF925` (HVAC dispatcher workspace home — substrate spec §11.2 item 3) |
+| Primitive library | `BI-5B8FE5C1` (vertical workspace primitive library from the substrate spec follow-on queue) |
 | Mockup | [`docs/superpowers/mockups/2026-05-24-dales-ac-repair-workspace-home.html`](../mockups/2026-05-24-dales-ac-repair-workspace-home.html) |
+| Scope | Visual paradigm validation for the HVAC dispatcher first viewport; persona/vocabulary anchoring; primitive→slot mapping |
+| Out of scope | Implementation code; substrate changes; routing decisions; vocabulary catalog edits to `archetype-vocabulary.ts` (those land with the implementation BI) |
+
+## Architect verdict
+
+**Accepted as the first vertical-archetype visual anchor under `EP-REDUCTION-GEAR-ARCH`.** Dispatch day-board is the correct paradigm for HVAC — it matches the substrate spec's §6 wireframe, the persona vocabulary in [`dale-hvac.md`](../../personas/dale-hvac.md), and the ServiceTitan/Housecall Pro/Jobber dispatch-first conventions. The mockup uses DPF CSS tokens throughout (no hardcoded hex), and the six rendered panels map cleanly to the substrate's slot covenant.
+
+**Corrections folded into this revision:**
+
+1. **Substrate traceability** — explicit link to the vertical-workspace-home substrate spec; visual slots now mapped to the §5.5 **slot covenant** (today/now, exceptions, coworker-handoffs) with the rest scored as enrichment slots.
+2. **Primitive→slot mapping table** added — implementer no longer has to guess which primitive from `BI-5B8FE5C1` powers which slot.
+3. **Vocabulary discipline** — the "Avoided vocabulary" list is now the *single canonical reference* to the substrate spec §10 banned-copy list (not a parallel list that can drift). "Required vocabulary" is anchored to the persona doc, not re-stated here.
+4. **Open design questions decided** — all three open questions have architect defaults so the implementer can proceed without a separate clarification round. The questions are preserved as alternates the design pass can override with evidence.
+5. **Verification protocol added** — mockup-to-implementation acceptance criteria, mobile-collapse priority order, first-viewport density budget, accessibility floor, and D-defect alignment (which visible defects from the Dale dogfood this surface must not reintroduce).
+6. **Sequencing constraint** — `BI-CE6AF925` cannot land until substrate `BI-1CCC6264` (resolver + registry) and `BI-3E8D2CF5` (projection service) ship. Spelled out in §Implementation Implications.
+7. **Persona vs archetype** — clarified in the frontmatter: this is *persona-validation* for the *archetype*. Dale is the validating user; `hvac-contractor` is the routing key. Future HVAC installs reuse this contribution without inheriting Dale-specific naming.
+
+**Not folded in (deferred to design pass):** the exact map widget (Mapbox vs. Leaflet vs. simple SVG bounding box) is a primitive-library decision under `BI-5B8FE5C1` and should not be pinned here. The visual paradigm only requires that a route-risk overlay exists; the rendering technology is the primitive library's call.
 
 ## Purpose
 
 Dale's AC Repair should not land on a generic platform dashboard. The first screen should look like the working board of a four-truck HVAC shop: what needs dispatch, where the techs are, which customers need updates, what parts are missing, and which coworker suggestions are ready for Dale to approve.
 
-This mockup is a browser-rendered approximation, not implementation code. It is meant to validate the visual paradigm before `BI-CE6AF925` builds the actual HVAC dispatcher home on the workspace-home substrate. The screen is also a proof of reuse: each visible tile is an instance of a workspace-home primitive that should be available to other verticals and business-archetype setups.
+This mockup is a browser-rendered approximation, not implementation code. It validates the visual paradigm before `BI-CE6AF925` builds the actual HVAC dispatcher home on the [vertical workspace home substrate](2026-05-24-vertical-workspace-home-design.md). It is also the **first vertical-archetype visual anchor** and a proof of reuse: clinic, retail, MSP, training, and other archetype visuals should match its structural discipline while rebinding the same primitive families to their own daily work.
 
 ## Visual Paradigm
 
 The recommended pattern is a **dispatch day board**:
 
-- Top summary strip: hot counts only, sized for scan speed.
+- Top summary strip: hot counts only, sized for scan speed. **Density budget: ≤6 metric chips, ≤1 line of text per chip.** No marketing hero, no oversized "Welcome back, Dale" greeting, no decorative gradients above the board.
 - Left column: jobs that need a decision, especially unassigned, emergency, parts-blocked, and unconfirmed calls.
 - Center: technician/truck lanes with current job, next job, load, and truck-stock hints.
 - Right: customer/site map with route-risk callouts.
@@ -42,6 +64,38 @@ The Dale screen should not create Dale-only widgets. It composes reusable primit
 
 `BI-5B8FE5C1` should define these primitives as typed widget families with canonical data contracts, mobile behavior, empty states, action affordances, and banned-copy protection. Vertical BIs such as `BI-CE6AF925` should provide the contribution manifest, vocabulary, data binding, and layout composition.
 
+**First-viewport budget.** On 1366×768 (the floor laptop resolution for SMB owner-operators), the summary strip, left queue column, and at least the first technician lane must fit above the fold without scrolling. The map, truck stock, customer updates, and coworker handoffs are below-fold acceptable. Mobile collapse order is specified in [Mobile Collapse Order](#mobile-collapse-order) below.
+
+### Slot covenant mapping
+
+Per the [substrate spec §5.5 slot covenant](2026-05-24-vertical-workspace-home-design.md#55-contribution-manifest), every vertical home MUST include three slots: today/now, exceptions/needs-review, and coworker-handoffs. The Dale visual maps as follows:
+
+| Substrate slot (covenant) | Dale visual surface | Mockup panel |
+| ------------------------- | ------------------- | ------------ |
+| **today/now** (mandatory) | Technician schedule and load | "Technician schedule and load" |
+| **exceptions / needs-review** (mandatory) | Jobs needing attention (unassigned + emergency + parts-blocked + unconfirmed) | "Jobs needing attention" |
+| **coworker-handoffs / PAR** (mandatory) | Help waiting for Dale's go-ahead | "Coworker handoffs" |
+| Enrichment | Customer & route map | "Customer and route map" |
+| Enrichment | Truck stock + restock | "Truck stock and restock" |
+| Enrichment | Failed customer updates | "Customer updates" |
+
+Implementer note: the three covenant slots are non-removable. Enrichment slots may be reordered or omitted by future archetype variants (e.g., a city-center plumber install may not need the map), but the covenant trio is required by the substrate's type-level constraint.
+
+### Primitive → slot mapping
+
+`BI-5B8FE5C1` (vertical workspace primitive library) provides reusable display primitives. Dale's home composes them as:
+
+| Slot | Primary primitive | Supporting primitives |
+| ---- | ----------------- | --------------------- |
+| Jobs needing attention | Queue | Exception chip, customer-update status |
+| Technician schedule and load | Schedule/capacity lane | Load meter, current/next job card |
+| Customer and route map | Map | Route-risk overlay |
+| Truck stock and restock | Inventory/restock list | Low-stock badge |
+| Customer updates | Communication exception list | Retry control |
+| Coworker handoffs | Coworker handoff (PAR) list | Ack / reassign control |
+
+If a required primitive does not exist in `BI-5B8FE5C1` at implementation time, the implementer files a primitive BI **and waits** — they do not invent an inline component that bypasses the primitive library. Primitive sprawl is what kills consistency across future archetype homes (clinic, retail, MSP).
+
 ## Research Anchors
 
 - [ServiceTitan Dispatching Home](https://help.servicetitan.com/docs/dispatching) centers office staff on technician schedules, job appointments, dispatch boards, job trays, alerts, holds, and cancellations.
@@ -52,18 +106,72 @@ The Dale screen should not create Dale-only widgets. It composes reusable primit
 
 ## Implementation Implications
 
-`BI-CE6AF925` should treat this as the target first viewport:
+`BI-CE6AF925` should treat this as the target first viewport.
 
-- Required slots: dispatch queue, technician lanes, customer/site map, truck stock, failed customer updates, coworker handoffs.
-- Required primitives from `BI-5B8FE5C1`: queue, map, schedule/capacity, inventory/restock, communication exception, coworker handoff.
-- Required vocabulary: jobs, service calls, techs, trucks, parts, warehouse, customers, on-my-way, restock.
-- Avoided vocabulary: platform substrate, build IDs, GearInterface, ring, torque, slip, cockpit, calibration, contribution model.
-- Business-archetype setup implication: after setup selects `hvac-contractor` or the `trades-maintenance` fallback, the setup flow should show that the dispatcher home is included, list the primitive widgets being activated, and verify required setup data or honest empty states. Dale should not need to configure a dashboard after choosing the archetype.
+**Sequencing constraint.** `BI-CE6AF925` is downstream of the substrate spec's `BI-1CCC6264` (resolver + registry) and `BI-3E8D2CF5` (projection service). Per the [substrate spec §11.2](2026-05-24-vertical-workspace-home-design.md#112-follow-on-bis-filed-under-ep-reduction-gear-arch-from-this-spec-pass), HVAC dispatcher implementation cannot start Ideate until those substrate BIs ship. If the implementer reaches a phase gate and the substrate is not ready, the correct response is to escalate — not to inline a workaround that fragments the contribution registry.
 
-## Open Design Questions
+**Business-archetype setup implication.** After setup selects `hvac-contractor` or the `trades-maintenance` fallback, the setup flow should show that the dispatcher home is included, list the primitive widgets being activated, and verify required setup data or honest empty states. Dale should not need to configure a dashboard after choosing the archetype.
 
-1. Should technician lanes be horizontally scrollable on tablet, or collapsed into a prioritized list?
-2. Should the customer/site map be visible by default on mobile, or behind a "Map" tab after the hot queue?
-3. Should truck-stock exceptions be shown as a shared shop list first, or attached primarily to each truck lane?
+**Required slots:** see the [slot covenant mapping table](#slot-covenant-mapping) — three covenant slots + three enrichment slots, six total.
 
-These should be resolved in the Dale design pass before implementation begins.
+**Required primitives from `BI-5B8FE5C1`:** see the [primitive → slot mapping table](#primitive--slot-mapping). If a required primitive is missing at implementation time, file a primitive BI and wait — do not inline-invent.
+
+**Required vocabulary:** inherited from the [Dale persona vocabulary list](../../personas/dale-hvac.md#what-the-platform-needs-to-be-like-for-them). Do not re-state in this spec; persona is the single source of truth so future HVAC installs that override persona stay consistent.
+
+**Avoided vocabulary:** the canonical banned-copy list lives in the [substrate spec §10](2026-05-24-vertical-workspace-home-design.md#10-verification-strategy-for-implementation). Do not maintain a parallel list here — it will drift. The substrate-spec list is enforced by vitest assertion at implementation time.
+
+**D-defect alignment (Dale dogfood).** The Dale persona dogfood ([`dale-hvac.md`](../../personas/dale-hvac.md#dogfood-history)) surfaced visible defects the HVAC dispatcher home MUST NOT reintroduce:
+
+- **D33 (`BI-62442F75`):** no tool names (`reviewDesignDoc`, `loadWorkspaceHomeSignals`, etc.) in any user-visible banner, slot title, or status chip.
+- **D34 (`BI-EEC5A5ED`):** the dispatch board does not show stale build pointers; if a coworker handoff references a build, the link must resolve to the active build for *this* archetype install.
+- **G1 / G2 / D14 / D33:** no FeatureBuild IDs, work-capsule slugs, git branch chips, schema field names, MCP tool names, or `BI-` codes leak into worker UI copy. They may appear in admin/diagnostic drawers only.
+
+These D-defects are the bar for "doesn't feel like an engineer console" and are mandatory in the §Verification protocol.
+
+### Mobile collapse order
+
+Per substrate spec §5.5 `mobileCollapse` semantics, slot priority drives both desktop sort and mobile collapse order. Dale's order:
+
+| Priority | Slot | Mobile (≤640px) |
+| -------- | ---- | --------------- |
+| 1 | Jobs needing attention (exceptions) | Visible |
+| 2 | Technician schedule and load (today/now) — collapsed to a one-lane "current/next" card | Visible |
+| 3 | Coworker handoffs (PAR) | Visible |
+| 4 | Failed customer updates | Visible (compact list) |
+| 5 | Truck stock and restock | Behind "More" |
+| 6 | Customer & route map | Behind "Map" tab |
+
+Mobile-first invariant: the three covenant slots are always above the fold on mobile. Enrichment slots can collapse, but workers must always see *what's broken*, *what's now*, and *what needs my ack* without scrolling.
+
+### Accessibility floor
+
+- Do not rely on color alone (anchor spec §5.4): every status chip carries icon + text + tone in addition to color. Restock = `low` badge + text, not just red.
+- Keyboard navigation: dispatcher work is keyboard-heavy. Slots must be reachable in tab order; the queue (Jobs needing attention) must be the first interactive landmark after the topbar.
+- Focus visible on every interactive control. No `:focus { outline: none }` without a replacement.
+- All panels carry `aria-label` (mockup already does this — preserve in implementation).
+- The map slot must remain functional with the map disabled — implementer cannot make critical state visible only through a map overlay.
+
+## Verification
+
+The [substrate spec §10 verification protocol](2026-05-24-vertical-workspace-home-design.md#10-verification-strategy-for-implementation) applies in full. **Visual-acceptance additions for this spec:**
+
+- Render the implementation at `http://localhost:3000/workspace` on the live portal address from repo-root `AUTH_URL` / `APP_URL` (not Contributor preview, not `127.0.0.1`, not LAN IP) with the HVAC fixture seeded.
+- Side-by-side compare against the mockup at [`docs/superpowers/mockups/2026-05-24-dales-ac-repair-workspace-home.html`](../mockups/2026-05-24-dales-ac-repair-workspace-home.html). Acceptance criteria:
+  - Same six panels in the same grid topology.
+  - Same density (≤6 metric chips, no marketing hero).
+  - DPF CSS tokens only — confirm zero hardcoded hex/rgb values in the implementation diff.
+  - Three covenant slots above the fold at 1366×768.
+  - Mobile collapse order matches the table above at 375×667.
+- **HVAC fixture (required, not optional):** seed 4 trucks, 4 technicians, 7 service calls (at least 1 unassigned, 1 parts-blocked, 1 unconfirmed, 1 emergency, 1 late), 1 failed customer notification, 1 Governor `require-hitl` handoff awaiting Dale's ack. The mockup's hand-crafted data is the canonical fixture shape; the implementation seed should reproduce it.
+- Banned-copy assertion (substrate §10) runs against every rendered slot — fails on `cockpit`, `ring`, `torque`, `slip`, `wear`, `triple`, `shaft`, `calibration`, `contribution model`, plus the D-defect terms (`reviewDesignDoc`, `FeatureBuild`, `BI-`, `MCP`, raw git branch names).
+- Dynamic-analysis report: drove the board, observed each slot rendering real fixture records, and recorded signed-off evidence per the platform QA plan — not a screenshot dump.
+
+## Design Questions — architect defaults
+
+The three originally-open questions are decided as defaults so implementation can proceed. The design pass may override any with evidence; absent evidence, ship the default.
+
+1. **Technician lanes on tablet (≥768px, <1280px): default = horizontal scroll with sticky lane labels.** Collapsing to a prioritized list loses the "who's free in the next hour" scan that's the lane view's entire reason for existing. A four-truck shop fits comfortably horizontally; ten-truck shops will too with snap-points.
+2. **Customer/site map on mobile: default = behind a "Map" tab after the hot queue.** Mobile dispatchers care about the queue and pending acks first; the map is decision support, not the decision surface. Always-visible map on mobile crowds the covenant slots.
+3. **Truck-stock exceptions: default = surfaced first as a shared shop list (the "Truck stock and restock" panel), with per-truck stock badges inside each technician lane as secondary affordance.** A shared list catches restock-before-tomorrow patterns the dispatcher needs to act on; per-truck badges catch the in-the-moment "do we have the part" question. Both surfaces, with the shop list as the primary.
+
+If the design pass produces a counter-recommendation, document the evidence and update this spec in the same PR that overrides the default.

--- a/docs/user-guide/build-studio/deployment.md
+++ b/docs/user-guide/build-studio/deployment.md
@@ -2,19 +2,19 @@
 title: "Feature Deployment"
 area: build-studio
 order: 2
-lastUpdated: 2026-03-29
-updatedBy: Claude (Software Engineer)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
 
 ## Overview
 
-When a feature passes all quality gates in Build Studio, it enters the Ship phase. The platform handles deployment autonomously — backing up your database, building a new version of the application with your feature included, swapping it into production, and verifying everything works. If anything goes wrong, it rolls back automatically.
+When a feature passes all quality gates in Build Studio, it enters the Ship phase. Where promotion is enabled for the install, the platform prepares a governed deployment: backing up your database, building a new version of the application with your feature included, swapping it into production, and verifying everything works. If anything goes wrong, rollback protection applies.
 
 You do not need to understand Docker, databases, or deployment tools. The platform manages the entire process and reports the result in plain language.
 
 ## How Deployment Works
 
-The deployment pipeline has eleven steps, all automated:
+The deployment pipeline has eleven governed steps when promotion is enabled:
 
 1. **Validate** — Confirms the promotion has been approved and is ready to deploy
 2. **Window check** — Verifies the current time falls within a deployment window (if configured). Emergency changes bypass this check.
@@ -62,7 +62,7 @@ When your feature is ready to ship, the AI Coworker runs through these steps in 
 3. **Create backlog epic** — Adds the feature to the operations backlog for visibility
 4. **Contribution assessment** — If sharing is enabled, evaluates whether the feature could benefit the wider community. You choose whether to share.
 5. **Pull request and security gates** — Creates a pull request on the codebase with automated security checks: secret detection, backdoor scanning, architecture compliance, dependency audit, and destructive operation scanning. If all checks pass and the build is fully verified, the PR auto-merges. If any check fails, the PR is flagged for human review with details of what needs attention.
-6. **Deploy** — Checks the deployment window and triggers the autonomous deployment pipeline described above
+6. **Deploy** — Checks the deployment window and triggers the governed deployment pipeline described above where promotion is enabled
 
 ## Database Backups
 

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -2,8 +2,8 @@
 title: "Build Studio"
 area: build-studio
 order: 1
-lastUpdated: 2026-03-29
-updatedBy: Claude (Software Engineer)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
 
 ## Overview
@@ -11,6 +11,12 @@ updatedBy: Claude (Software Engineer)
 Build Studio is the platform's feature development environment. It guides a new capability from initial idea through to a shipped, tested, and deployed feature using a five-phase pipeline. AI agents assist at each phase, handling research, planning, code generation, and deployment while keeping a human in control of decisions.
 
 Build Studio is not a separate code universe. It works from the install's shared development workspace. In customizable installs, that means Build Studio and VS Code operate on the same source tree while the portal continues to own review, evidence, and governed promotion.
+
+## Current Maturity
+
+Build Studio is real, but it is still being hardened. It should be described as the governed self-development surface and evidence trail, not as a fully autonomous replacement for every developer workflow today.
+
+Recent hardening work includes plan-review trajectory, design-time decomposition for oversized builds, activity quiescence for safer portal upgrades, and voice/follow-up guards in coworker chat. Complex source changes may still need VS Code in customizable installs while Build Studio keeps the design, review, test, and promotion record.
 
 ## Key Concepts
 
@@ -21,7 +27,7 @@ Build Studio is not a separate code universe. It works from the install's shared
 - **Shared Workspace** — The durable source workspace for this install. Build Studio reads and writes here, and in customizable installs VS Code uses the same codebase.
 - **Live Preview** — During the Build phase, a real-time preview shows the generated UI in an iframe. The preview updates automatically as the AI Coworker writes code.
 - **Quality Gates** — Automated checks between phases. Each gate requires specific evidence before the feature can advance (design review, plan review, test results, typecheck).
-- **Promotion** — The process of moving a completed feature from the Build runtime into production. Includes database backup, image rebuild, health check, and automatic rollback on failure.
+- **Promotion** — The governed process for moving a completed feature from the Build runtime into production where the install is configured for it. Includes evidence capture, backup/rebuild/health-check discipline, and rollback planning.
 
 ## What You Can Do
 
@@ -30,7 +36,7 @@ Build Studio is not a separate code universe. It works from the install's shared
 - Approve the plan and watch the AI Coworker build and test the feature
 - See the live preview of your feature as it is being built
 - Review test results and acceptance criteria before shipping
-- Ship the feature to production with automatic deployment and rollback protection
+- Prepare the feature for governed promotion with recorded evidence, health checks, and rollback planning
 - Track active builds and their current phase from the Build Studio dashboard
 
 ## The Five Phases
@@ -53,12 +59,13 @@ Quality gates verify the feature is ready: all tests pass, typecheck is clean, a
 
 ### Ship
 
-The AI Coworker registers the feature as a digital product, creates a promotion record, and triggers the autonomous deployment pipeline. The platform backs up the database, builds a new version with the feature, swaps it into production, and verifies health. See [Feature Deployment](deployment) for the full process.
+The AI Coworker prepares the promotion record and evidence. Where promotion is enabled, the platform backs up the database, builds a new version with the feature, swaps it into production, and verifies health. Where the surface is still hardening, keep the promotion record honest and finish through the supported source workflow. See [Feature Deployment](deployment) for the full process.
 
 ## Related
 
 - [Feature Deployment](deployment) — How the deployment pipeline works, safety guarantees, and rollback
 - [Development Workspace](../development-workspace) — How Build Studio, VS Code, policy states, and validation environments fit together
+- [Market Archetypes And Coworkers](../market-archetypes) — Why user-facing docs should lead with business work before Build Studio internals
 
 ## Documentation Deliverables
 

--- a/docs/user-guide/build-studio/sandbox.md
+++ b/docs/user-guide/build-studio/sandbox.md
@@ -3,7 +3,7 @@ title: "Build Runtime (Sandbox)"
 area: build-studio
 order: 3
 lastUpdated: 2026-05-24
-updatedBy: Claude (Software Engineer)
+updatedBy: Codex
 ---
 
 ## Overview
@@ -104,7 +104,7 @@ When the feature is ready to ship, the AI Coworker (or you) triggers the `deploy
 2. Creates a **ChangePromotion** record linking the feature build to the promotion pipeline
 3. Submits the promotion for approval
 
-Once approved, the autonomous promotion pipeline takes over. It builds a new Live portal image that includes the Build runtime changes, swaps it into production, runs health checks, and rolls back automatically if anything fails. See [Feature Deployment](deployment.md) for the full eleven-step pipeline.
+Once approved, the governed promotion pipeline takes over where promotion is enabled. It builds a new Live portal image that includes the Build runtime changes, swaps it into production, runs health checks, and rolls back automatically if anything fails. See [Feature Deployment](deployment.md) for the full eleven-step pipeline.
 
 The key insight is that the Build runtime diff contains only the changes needed for that validation run — not the entire codebase. The Build runtime exists to execute and verify work safely, not to replace the install's shared development workspace.
 

--- a/docs/user-guide/getting-started/ai-coworker.md
+++ b/docs/user-guide/getting-started/ai-coworker.md
@@ -2,15 +2,22 @@
 title: "AI Coworker"
 area: getting-started
 order: 3
-lastUpdated: 2026-03-21
-updatedBy: Claude (COO)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
+
+## The Short Version
+
+DPF coworkers are purposed helpers, not a generic chatbot. The coworker on a page understands the page, the selected business archetype, the user's role, and the tools that coworker is allowed to propose.
+
+For the broader product framing, see [Market Archetypes And Coworkers](../market-archetypes.md).
 
 ## How It Works
 
 The AI coworker is available on every page via the floating button in the bottom-right corner. It understands:
 
 - **What page you're on** — it knows the domain context (compliance, HR, operations, etc.)
+- **What business archetype is active** — customer-facing and internal language should follow the selected archetype where that surface has been configured
 - **What data is visible** — it can read the current page's content
 - **What actions are available** — it has tools specific to the current area
 
@@ -31,6 +38,12 @@ Four skills appear on every page:
 - **Add a skill** — Extend the page with a new quick action
 - **Evaluate this page** — Check the page for usability and accessibility issues
 
+## Voice
+
+Where enabled, the microphone path sends dictated text into the same coworker message flow as typing. Voice does not bypass permissions or approvals.
+
+Narrated output is separate. Text-to-speech can read decision rationales or persona-profile output when a voice profile is configured, but text remains the primary governed answer. A real-person voice requires explicit consent before training.
+
 ## Authority & Approvals
 
 The coworker operates within a two-layer authorization model:
@@ -50,3 +63,4 @@ When you need to add an external tool (MCP server, npm package, API), the cowork
 - The coworker can create backlog items, register products, assign roles, and more — it's not just a chatbot
 - If the coworker proposes an action (like creating a record), you'll see an approval prompt before anything changes
 - Each conversation is tied to the page context. If you switch pages, the coworker knows the new context
+- Ask in the words of your business. "Which trucks need restock?" or "Which appointments are missing forms?" is better than guessing the platform's internal module name.

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -2,27 +2,26 @@
 title: "Getting Started"
 area: getting-started
 order: 1
-lastUpdated: 2026-03-21
-updatedBy: Claude (COO)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
 
 ## Welcome to the Digital Product Factory
 
-The Digital Product Factory (DPF) is an integrated platform for managing your organization's digital products, workforce, compliance, and operations — all in one place.
+The Digital Product Factory (DPF) is an integrated platform for running and improving your business with AI coworkers under human governance. It starts by asking what kind of business you run, then shapes the customer portal, internal workspace, vocabulary, and coworker help around that archetype.
+
+If you are new, start with the business story before the internal platform map: [Market Archetypes And Coworkers](../market-archetypes.md).
 
 ## What You Can Do
 
-- **Portfolio Management** — Organize digital products into four portfolios with health metrics, investment tracking, and lifecycle management
-- **HR & Workforce** — Manage employees, roles, reviews, timesheets, and organizational structure
-- **Customer Relationship Management** — Track customer accounts, sales pipeline from lead to order, and engagement history
-- **Compliance & Regulatory** — Onboard regulations and standards, map controls to obligations, collect evidence, and track compliance posture
-- **Financial Management** — Create invoices, manage suppliers and bills, handle purchase orders
-- **Enterprise Architecture** — Model your organization's application, technology, and business layers with ArchiMate notation
-- **Storefront** — Set up a public-facing storefront for your products and services with booking, donations, and checkout
-- **Build Studio** — Develop new features through a guided 5-phase pipeline with AI assistance
-- **Operations** — Manage your delivery backlog with epics, priorities, and status tracking
+- **Choose a market archetype** — Start from HVAC, clinic, retail, nonprofit, HOA, professional services, software platform, and other business shapes rather than a blank admin console.
+- **Launch a customer portal** — Set up a public-facing storefront or service portal with the right sections, forms, booking/enquiry flow, and vocabulary.
+- **Work from an archetype-native workspace** — Daily boards should speak in jobs, patients, orders, volunteers, residents, or whatever the selected business actually uses.
+- **Use AI coworkers** — Each area has a purposed coworker with bounded tools, approvals, and audit logging.
+- **Run operations** — Manage customers, finance, compliance, HR, portfolio, backlog, wiki, and platform health from one governed surface.
+- **Improve the install** — Use Build Studio and, in customizable installs, VS Code to make governed changes from the shared workspace.
 
-If you installed in customizable mode, Build Studio and VS Code are intended to complement each other from the same shared workspace. Production promotion and community contribution still flow through the portal's governed process. See the [Development Workspace](../development-workspace) guide for details.
+If you installed in customizable mode, Build Studio and VS Code are intended to complement each other from the same shared workspace. Build Studio is actively hardening and remains the governed evidence/promotion surface; VS Code is still the right companion for complex source edits today. See the [Development Workspace](../development-workspace) guide for details.
 
 ## Navigation
 
@@ -30,22 +29,23 @@ The top navigation bar shows the areas you have access to based on your role:
 
 | Nav Item | Area | What It's For |
 |----------|------|---------------|
-| My Workspace | Dashboard | Your daily view — calendar, activity feed, quick actions |
+| My Workspace | Daily work | Your daily view, tailored by archetype where a vertical workspace home exists |
 | Portfolio | Portfolio Management | View product portfolios, health metrics, investments |
 | Backlog | Operations | Manage work items, epics, delivery priorities |
 | Inventory | Product Inventory | Browse products, lifecycle stages, stage-gate readiness |
 | EA Modeler | Enterprise Architecture | Architecture diagrams, reference models, value streams |
 | AI Workforce | Platform & AI | Provider configuration, model routing, agent management |
-| Build | Build Studio | Feature development pipeline |
+| Build | Build Studio | Governed feature development and evidence capture |
 
 Additional areas accessible via navigation within pages: Compliance, Finance, HR, Customers, Storefront, Admin.
 
 ## Your AI Coworker
 
-Every page has an AI coworker available via the floating action button in the bottom-right corner. The coworker understands what page you're on and can help with page-specific tasks. See the [AI Coworker Guide](ai-coworker) for details.
+Every page has an AI coworker available via the floating action button in the bottom-right corner. The coworker understands what page you are on, what kind of business the install is configured for, and which actions are allowed on that surface. Some installs also enable voice input; narrated output is opt-in and governed by profile/consent rules. See the [AI Coworker Guide](ai-coworker) for details.
 
 ## Next Steps
 
 - [Roles & Access](roles-and-access) — Understand platform roles and what each one can do
+- [Market Archetypes And Coworkers](../market-archetypes) — Understand how archetypes, coworkers, and voice fit together
 - [AI Coworker](ai-coworker) — Learn how to work with the AI assistant
 - [Development Workspace](../development-workspace) — Learn how Build Studio, VS Code, policy states, and validation environments fit together

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,15 +1,16 @@
 ---
 title: "User Guide"
-description: "Day-to-day operating guide for the Open Digital Product Factory platform - getting started, AI coworkers, Build Studio, compliance, finance, HR, customers, wiki, workspace, and more."
-lastUpdated: 2026-05-14
+description: "Day-to-day operating guide for the Open Digital Product Factory platform - market archetypes, AI coworkers, Build Studio, compliance, finance, HR, customers, wiki, workspace, and more."
+lastUpdated: 2026-05-24
 ---
 
 The User Guide is the day-to-day operating manual for everyone who works in the platform. The same pages are bundled into the portal's in-app help at runtime, so what you see here matches what you see when you press the help button inside the product.
 
-If you're brand new, start at [Getting Started](getting-started/). The other sections are organized by the work you do, not by the screens you click.
+If you're brand new, start with [Market Archetypes And Coworkers](market-archetypes), then [Getting Started](getting-started/). The other sections are organized by the work you do, not by the screens you click.
 
 ## Start here
 
+- [Market Archetypes And Coworkers](market-archetypes) — how the selected business type shapes the portal, workspace, vocabulary, coworkers, voice, and marketing posture.
 - [Getting Started](getting-started/) — what the platform does, how navigation works, and where your AI coworker lives.
 - [Roles & Access](getting-started/roles-and-access) — the platform roles and what each one can do.
 - [AI Coworker](getting-started/ai-coworker) — working with the context-aware assistant on every screen.
@@ -38,7 +39,7 @@ Each of these is the operating manual for one part of the platform. The pages ar
 
 ## Architecture and standards
 
-The runtime architecture, the Trusted AI Kernel (TAK), the Global AI Agent Identification & Governance (GAID) standard, and the platform's conformance assessment live under the [Architecture section](../architecture/platform-overview/).
+The runtime architecture, the Trusted AI Kernel (TAK), the Global AI Agent Identification & Governance (GAID) standard, and the platform's conformance assessment live under the [Architecture section](../architecture/platform-overview.md).
 
 ## Specifications and plans
 

--- a/docs/user-guide/market-archetypes.md
+++ b/docs/user-guide/market-archetypes.md
@@ -1,0 +1,94 @@
+---
+title: "Market Archetypes And Coworkers"
+area: getting-started
+order: 2
+lastUpdated: 2026-05-24
+updatedBy: Codex
+---
+
+## Why This Page Exists
+
+DPF should be explained from the business outward. A shop owner, clinic scheduler, retail merchandiser, or nonprofit coordinator should first see how the platform helps their kind of business run better. The internal platform machinery matters, but it belongs underneath the work people came to do.
+
+The practical model is:
+
+1. Pick a market archetype.
+2. Get a customer-facing portal and internal workspace that use the right vocabulary.
+3. Work with purposed AI coworkers for the daily jobs that business actually has.
+4. Grow the install through governed improvements when the business needs something new.
+
+## What An Archetype Controls
+
+An archetype is more than a storefront template. It is the business shape selected for the install.
+
+- **Customer portal shape**: public sections, item/service templates, booking or enquiry flows, form fields, calls to action, and brandable copy.
+- **Internal workspace shape**: the daily board workers should see first, such as dispatch, appointment readiness, merchandising, or program operations.
+- **Vocabulary**: the words people use in that business. HVAC users see jobs, trucks, parts, techs, and restock; clinics see appointments, forms, patients, practitioners, and follow-ups.
+- **Coworker emphasis**: which AI coworkers should be prominent, which skills they can offer, and which handoffs should appear on the daily board.
+- **Marketing posture**: the offers, proof points, content prompts, and campaign ideas should inherit from the same archetype that shaped the customer portal.
+- **Contribution applicability**: reusable features should be recommended to matching archetypes first, not sprayed across every install.
+
+Implementation source of truth: `StorefrontConfig.archetypeId` selects the install's `StorefrontArchetype`. The archetype catalog lives in `packages/storefront-templates/src/archetypes/`.
+
+## Current Market Coverage
+
+The source catalog currently contains 12 market categories and 45 leaf archetype templates. The public docs should usually describe the categories first, then use leaf archetypes when a concrete example helps.
+
+| Category | Example shape |
+| --- | --- |
+| Healthcare and wellness | dental practice, physiotherapy, optician, therapy |
+| Beauty and personal care | salon, spa, personal care services |
+| Trades and maintenance | facilities maintenance, plumber, electrician, cleaning, landscaping; HVAC is the next targeted leaf |
+| Professional services | consultants, agencies, advisors |
+| Software platform | software products and SaaS-style businesses |
+| Education and training | tutoring, training providers, schools, instructors |
+| Pet services | veterinary, grooming, walking, boarding |
+| Food and hospitality | restaurants, catering, reservations, events |
+| Retail and goods | retail shops, artisan goods, florist-style selling |
+| Fitness and recreation | gyms, studios, classes, leagues |
+| Nonprofit and community | donations, programs, volunteers, membership |
+| HOA and property management | residents, dues, violations, service requests |
+
+The first three persona anchors are:
+
+- [Dale, HVAC owner](../personas/dale-hvac.md): dispatch, truck stock, technician readiness, customer update exceptions.
+- [Linda, dental scheduler](../personas/linda-clinic.md): appointment readiness, missing forms, reminder follow-up, practitioner load.
+- [Marisol, retail merchandiser](../personas/marisol-retail.md): order tasks, low stock, receiving, returns, location signals.
+
+## Coworkers Are The Work Surface
+
+DPF should not feel like a pile of admin modules with a chatbot bolted on. The intended experience is that a small business gets a set of purposed coworkers around the work it already understands.
+
+- The onboarding coworker helps with first-run setup and explains provider, identity, branding, and finance choices in plain language.
+- The storefront and marketing coworkers help turn the selected archetype into offers, content, campaigns, and proof assets.
+- Operations, finance, compliance, customer, HR, and platform coworkers help with the areas they own.
+- Future vertical coworkers should be named by the work they perform: dispatcher, clinic scheduler, merchandising assistant, program coordinator, service desk, or similar.
+
+Every coworker remains governed. User role, agent grants, tool scopes, approval requirements, and audit logging still apply. "Purposed" means the coworker knows the job; it does not mean the coworker gets unbounded authority.
+
+## Voice Fits Here
+
+Voice is part of making the coworker surface natural, not a separate product promise.
+
+- Speech-to-text is the default input path for coworker dictation where voice input is enabled.
+- Text-to-speech is opt-in enrichment for narrated decision rationales and profile output.
+- Persona voice never changes authority. The same approval, confidence, escalation, and audit rules apply whether a rationale is read as text or spoken aloud.
+- Real-person voice profiles require explicit consent before training.
+
+See [Decision Perspective & Persona Voice](ai-workforce/decision-perspective.md) for the implementation and governance details.
+
+## Build Studio Boundary
+
+Build Studio is the governed self-development surface for changing the platform, but it is not the first thing every small-business user should have to understand. The customer story should lead with archetypes, daily work, and coworkers.
+
+Current truth as of 2026-05-24: Build Studio is being actively hardened. Recent work added plan-review trajectory, design-time decomposition for oversized builds, activity quiescence for safer portal upgrades, and voice playback/follow-up guards. The platform should be honest that complex source changes may still use VS Code in customizable installs while Build Studio continues maturing.
+
+## Documentation Rule
+
+When writing user-facing docs:
+
+- Lead with the business archetype and the person doing the work.
+- Use the operator's vocabulary before platform vocabulary.
+- Explain AI coworkers as role-bound helpers at the center of the workflow.
+- Keep internal architecture, Build Studio mechanics, MCP, schema, and IDs below the fold or in contributor docs.
+- Link to persona files for proof and testing, but do not invent customer stories without evidence.

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -2,8 +2,8 @@
 title: "Operations"
 area: operations
 order: 1
-lastUpdated: 2026-03-29
-updatedBy: Claude (Software Engineer)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
 
 ## Overview
@@ -36,9 +36,9 @@ Operations is the delivery backlog for the platform. It tracks the work items, e
 The Promotions tab in Operations shows all features that have been through the Build Studio ship phase. Each promotion has a status:
 
 - **Pending** — Feature shipped but not yet reviewed for deployment
-- **Approved** — Ready to deploy. Click "Deploy Now" to trigger the autonomous deployment pipeline.
+- **Approved** — Ready to deploy where promotion is enabled. Click "Deploy Now" to trigger the governed deployment pipeline.
 - **Executing** — Deployment in progress. The promoter is building and swapping the application.
 - **Deployed** — Successfully deployed to production. Health check passed.
 - **Rolled Back** — Deployment failed and was automatically reversed. Check the deployment log for details.
 
-When you click "Deploy Now", the platform starts the promoter service which handles the entire process autonomously. The page updates automatically while deployment is in progress.
+When you click "Deploy Now", the platform starts the promoter service for the governed deployment workflow. The page updates automatically while deployment is in progress.

--- a/docs/user-guide/storefront/index.md
+++ b/docs/user-guide/storefront/index.md
@@ -2,17 +2,19 @@
 title: "Storefront"
 area: storefront
 order: 1
-lastUpdated: 2026-03-21
-updatedBy: Claude (COO)
+lastUpdated: 2026-05-24
+updatedBy: Codex
 ---
 
 ## Overview
 
 The Storefront is the public-facing side of the platform — the interface your customers and visitors see. It is fully configurable and supports multiple engagement models: browsing a product catalogue, booking a service, making a donation, or submitting an enquiry.
 
+The storefront is also the most visible expression of the selected market archetype. The same archetype should shape the public portal, the worker home, the marketing coworker, and the vocabulary used across the install.
+
 ## Key Concepts
 
-- **Archetypes** — The type of storefront you're running (e.g., service booking, product catalogue, donation page). The archetype determines which sections and flows are available.
+- **Archetypes** — The type of business you are running. The archetype determines which sections, item templates, booking/enquiry flows, vocabulary, and marketing assumptions are available. It should be treated as the install's business-shape source of truth, not just a theme.
 - **Sections** — Configurable blocks that make up the storefront pages: hero, featured items, booking calendar, checkout, testimonials, etc.
 - **Items** — The products or services listed for sale or booking. Each item has a price, description, and availability settings.
 - **Domain Routing** — The storefront serves your organization's public experience under its configured path or domain with its selected branding.
@@ -25,3 +27,7 @@ The Storefront is the public-facing side of the platform — the interface your 
 - Add, edit, or remove items available for purchase or booking
 - Manage the booking calendar — set availability, block dates, assign service providers
 - Review and respond to enquiries arriving in the storefront inbox
+
+## Related
+
+- [Market Archetypes And Coworkers](../market-archetypes.md) — how archetypes connect the storefront, worker home, marketing, and AI coworkers.


### PR DESCRIPTION
## Summary

- Reframes the public README/docs/user guide around market archetypes, purposed coworkers, voice as an optional modality, and the honest Build Studio maturity boundary.
- Adds `docs/user-guide/market-archetypes.md` as the canonical user-facing archetype/coworker narrative and links it from the docs index, persona library, storefront, and getting-started pages.
- Tightens the Dale HVAC workspace-home visual spec with reusable primitive composition, slot covenant mapping, setup implications, verification criteria, and long-tail archetype reuse language.
- Cleans older deployment/promotion wording so user docs no longer overstate Build Studio as fully autonomous for every complex source change.

## Verification

- `git diff --check origin/main...HEAD`
- Markdown relative-link scan across touched docs: 13 files checked
- Placeholder/stale-copy scan for `](#)`, TODO/TBD, stale autonomous deployment/PR wording, and broken placeholder anchors
- Archetype catalog count: 45 `archetypeId` leaf templates confirmed from `packages/storefront-templates/src/archetypes/*.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passes; existing Edge-runtime Node-API warnings remain)
- Playwright static render smoke of `docs/index.html` at 1366x768: verified hero H1, archetype-led lede, archetype section heading, guide link, and nonblank screenshot