### PR TITLE
docs(prompts): wire DPF patterns-doc reference into Build Studio sub-agents (BI-DA509566)

### DIFF
--- a/prompts/specialist/data-architect.prompt.md
+++ b/prompts/specialist/data-architect.prompt.md
@@ -3,7 +3,7 @@ name: data-architect
 displayName: Data Architect
 description: Prisma schema design, migrations, model validation, index optimization. Build Studio sandbox sub-agent.
 category: specialist
-version: 2
+version: 3
 
 agent_id: AGT-BUILD-DA
 reports_to: HR-200
@@ -35,7 +35,7 @@ You are dispatched by AGT-WS-BUILD (the route-level Software Engineer at `/build
 
 - **Schema soundness**: every model has explicit relations, every foreign key has an index, every enum value matches the canonical CLAUDE.md vocabulary.
 - **Reversible migrations**: every migration runs `validate_schema` before `prisma migrate dev`. Migrations that fail validation never reach the DB.
-- **Pattern fidelity**: existing models are read before new ones are authored. New models match the conventions of the rest of the schema.
+- **Pattern fidelity**: existing models are read before new ones are authored. New models match the conventions of the rest of the schema. Before proposing a new model, enum, or status value, consult [`docs/architecture/dpf-patterns.md`](../../docs/architecture/dpf-patterns.md) §1.3 (capsule vs FeatureBuild vs Sandbox vs RuntimeTarget — pick the right substrate) and §2.7 (grep before adding). The most common schema-author failure mode is proposing `WorkItem` when `BacklogItem` already covers it, or a new status enum when the column already carries the discriminator.
 - **Type-clean exit**: `pnpm exec tsc --noEmit` passes after `prisma generate`. No type errors leak into Build Studio's review phase.
 
 # Interfaces With

--- a/prompts/specialist/frontend-engineer.prompt.md
+++ b/prompts/specialist/frontend-engineer.prompt.md
@@ -3,7 +3,7 @@ name: frontend-engineer
 displayName: Frontend Engineer
 description: Pages, components, CSS variables, semantic HTML, accessibility, responsive layout. Build Studio sub-agent.
 category: specialist
-version: 2
+version: 3
 
 agent_id: AGT-BUILD-FE
 reports_to: HR-200
@@ -117,6 +117,8 @@ The platform uses CSS custom properties for theming. NEVER use hardcoded hex col
 **Animation (Tailwind):** `animate-fade-in` (200ms ease-out), `animate-slide-up` (250ms ease-out), `animate-scale-in` (200ms ease-out). Use `animationDelay` for staggered list entrances.
 
 ## Component Patterns
+
+> When UI work crosses backend boundaries (data fetching, server-action wiring, new state primitives), consult [`docs/architecture/dpf-patterns.md`](../../docs/architecture/dpf-patterns.md) for DPF-novel patterns and kernel-forbidden anti-patterns. The UI-specific anti-patterns below are still the primary surface for component work.
 
 - No component library (no shadcn, Radix, MUI) — all components are hand-rolled with Tailwind utility classes.
 - Framework: Next.js 16 App Router with React 19 — use `"use client"` for interactive components.

--- a/prompts/specialist/software-engineer.prompt.md
+++ b/prompts/specialist/software-engineer.prompt.md
@@ -3,7 +3,7 @@ name: software-engineer
 displayName: Software Engineer
 description: API routes, server actions, business logic, imports/exports wiring. Build Studio sandbox sub-agent.
 category: specialist
-version: 2
+version: 3
 
 agent_id: AGT-BUILD-SE
 reports_to: HR-200
@@ -33,7 +33,7 @@ You are dispatched by AGT-WS-BUILD (the route-level Software Engineer at `/build
 
 # Accountable For
 
-- **Pattern fidelity**: existing routes/actions/handlers are read before new ones are authored. Imports, exports, naming, and error handling match the surrounding code.
+- **Pattern fidelity**: existing routes/actions/handlers are read before new ones are authored. Imports, exports, naming, and error handling match the surrounding code. Before authoring code that introduces new structure (new server-action shape, new error-handling approach, new background job, new substrate touch), consult [`docs/architecture/dpf-patterns.md`](../../docs/architecture/dpf-patterns.md) — it names DPF-novel patterns (GearInterface emission, WWMD consultation, capsule/build/sandbox/runtime-target picking, PAR) and kernel-forbidden anti-patterns (wipe-db, provider-pinning, patch-the-runtime-not-the-seed, structural-verification-claimed-as-functional, diagnose-without-evidence, ask-the-operator-to-run-commands, add-substrate-without-grepping). Textbook patterns (Next.js / Prisma / GoF) are not redocumented; you already know them.
 - **Schema-aware code**: when code touches data, the schema is read first via `describe_model` or by reading `schema.prisma`. No guessed field names.
 - **Search-first behaviour**: similar features are located via `search_sandbox` before being authored. Duplicate implementations are surfaced, not created.
 - **Type-clean exit**: `pnpm exec tsc --noEmit` passes before you finish. No type errors leak into Build Studio's review phase.


### PR DESCRIPTION
## Summary

- v2 follow-up to BI-C2992336 / PR #1121 (merged). v1 wired the patterns doc into the route-persona Software Engineer coworker (the *director*). This PR wires it into the three Build Studio sub-agents that actually author code (the *authors*).
- Three one-sentence edits + three version bumps. No new content — all pointing at `docs/architecture/dpf-patterns.md` shipped in v1.

## Edits

| Prompt | Agent | v | Change |
|---|---|---|---|
| [software-engineer.prompt.md](prompts/specialist/software-engineer.prompt.md) | AGT-BUILD-SE | 2→3 | Extends existing "Pattern fidelity" bullet. SE writes server actions + business logic, touches data — most exposed to the §2 anti-patterns. |
| [data-architect.prompt.md](prompts/specialist/data-architect.prompt.md) | AGT-BUILD-DA | 2→3 | Extends existing "Pattern fidelity" bullet, pointing at §1.3 (substrate picking) and §2.7 (grep before adding). Schema authors are the ones who reach for `WorkItem` when `BacklogItem` already covers it. |
| [frontend-engineer.prompt.md](prompts/specialist/frontend-engineer.prompt.md) | AGT-BUILD-FE | 2→3 | One-line cross-link in existing "Component Patterns" section. FE has its own L152 "UI Quality Anti-Patterns" section already; the cross-link helps when UI work crosses backend boundaries. |

## Out of scope

- `prompts/specialist/architecture-agent.prompt.md`, `architecture-definition-agent.prompt.md`, `architecture-guardrail-agent.prompt.md` — Portfolio/EA architecture-tier specialists, different layer than feature-build.
- QA sub-agent — doesn't author code, only runs verification.

## Class

Documentation + prompt update. Per `feedback_build_studio_for_all_development`, governance class — opened directly by Claude.

## Related

- Backlog: BI-DA509566 (linked to `EP-BUILD-STUDIO`)
- Parent: BI-C2992336 / [PR #1121](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1121) (merged) — v1, route-persona + patterns doc
- Grandparent spec: PR #1115 (merged) — Build Studio design-time decomposition, §12 Q2

## Test plan

- [ ] Manual review of the three edited prompts — each still reads cleanly end-to-end
- [ ] Confirm patterns-doc cross-links resolve from each prompt's relative path

🤖 Generated with [Claude Code](https://claude.com/claude-code)