### PR TITLE
fix: repair dev portal refresh bootstrap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 node_modules
 **/node_modules
 .next
+**/.next
+apps/web/.next
+apps/web/.next/**
 .worktrees
 .superpowers
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # ─── Dev stage (parallel branch — not part of production chain) ──────────────
 FROM base AS dev
 WORKDIR /workspace
-RUN apk add --no-cache git
+RUN apk add --no-cache git postgresql16-client
 CMD ["sh", "-c", "pnpm install && pnpm --filter @dpf/db exec prisma generate && pnpm --filter web dev"]
 
 # ─── Stage 2: deps ────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -428,7 +428,7 @@ services:
     environment:
       CI: "true"
       DATABASE_URL: postgresql://dpf:dpf_dev@dev-postgres:5432/dpf
-      PRODUCTION_DATABASE_URL: postgresql://dpf:dpf_dev@postgres:5432/dpf
+      PRODUCTION_DATABASE_URL: postgresql://dpf:${POSTGRES_PASSWORD:-dpf_dev}@postgres:5432/dpf
       NEO4J_URI: bolt://dev-neo4j:7687
       NEO4J_USER: neo4j
       NEO4J_PASSWORD: dpf_dev_password

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -7,6 +7,7 @@ import {
   shouldCopyTable,
   shouldObfuscateTable,
   shouldSkipTable,
+  prepareInsertParameter,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -34,6 +35,39 @@ describe("obfuscation", () => {
   it("handles null/undefined fields", () => {
     expect(obfuscateField(null, "name", 1)).toBeNull();
     expect(obfuscateField(undefined, "name", 1)).toBeUndefined();
+  });
+});
+
+describe("insert parameter preparation", () => {
+  it("serializes arrays for jsonb columns instead of casting them as text arrays", () => {
+    const result = prepareInsertParameter(["read", "write"], { dataType: "jsonb", udtName: "jsonb" }, 1);
+
+    expect(result).toEqual({
+      placeholder: "$1::jsonb",
+      value: "[\"read\",\"write\"]",
+    });
+  });
+
+  it("keeps non-json array columns as PostgreSQL array literals", () => {
+    const result = prepareInsertParameter(["a", "b"], { dataType: "ARRAY", udtName: "_text" }, 2);
+
+    expect(result).toEqual({
+      placeholder: "$2::text[]",
+      value: "{\"a\",\"b\"}",
+    });
+  });
+
+  it("keeps decimal-like values out of the jsonb fallback for numeric columns", () => {
+    const decimalLike = {
+      toString: () => "12.34",
+    };
+
+    const result = prepareInsertParameter(decimalLike, { dataType: "numeric", udtName: "numeric" }, 3);
+
+    expect(result).toEqual({
+      placeholder: "$3",
+      value: "12.34",
+    });
   });
 });
 

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -74,6 +74,72 @@ const AUDIT_TABLES = new Set([
 /** Maximum audit records to clone per table */
 const AUDIT_RECORD_LIMIT = 50;
 
+type ColumnTypeInfo = {
+  dataType: string;
+  udtName: string;
+};
+
+export function prepareInsertParameter(
+  value: unknown,
+  columnType: ColumnTypeInfo | undefined,
+  paramIdx: number,
+): { placeholder: string; value: unknown } {
+  const placeholder = `$${paramIdx}`;
+
+  if (value === null || value === undefined) {
+    return { placeholder, value: null };
+  }
+
+  if (columnType?.dataType === "json" || columnType?.dataType === "jsonb") {
+    return {
+      placeholder: `${placeholder}::${columnType.dataType}`,
+      value: JSON.stringify(value),
+    };
+  }
+
+  if (columnType?.dataType === "ARRAY" && Array.isArray(value)) {
+    return {
+      placeholder: `${placeholder}::text[]`,
+      value: toPostgresTextArrayLiteral(value),
+    };
+  }
+
+  if (
+    columnType &&
+    typeof value === "object" &&
+    !(value instanceof Date) &&
+    !Buffer.isBuffer(value)
+  ) {
+    const toString = (value as { toString?: () => string }).toString;
+    if (typeof toString === "function" && toString !== Object.prototype.toString) {
+      return { placeholder, value: toString.call(value) };
+    }
+    return { placeholder, value };
+  }
+
+  if (typeof value === "object" && !(value instanceof Date) && !Buffer.isBuffer(value)) {
+    if (Array.isArray(value)) {
+      // PostgreSQL array columns need an array literal. JSON/JSONB arrays are
+      // handled above from catalog type information.
+      return {
+        placeholder: `${placeholder}::text[]`,
+        value: toPostgresTextArrayLiteral(value),
+      };
+    }
+
+    return {
+      placeholder: `${placeholder}::jsonb`,
+      value: JSON.stringify(value),
+    };
+  }
+
+  return { placeholder, value };
+}
+
+function toPostgresTextArrayLiteral(value: unknown[]): string {
+  return `{${value.map((item: unknown) => `"${String(item).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`).join(",")}}`;
+}
+
 /**
  * Run the sanitized clone from production to dev.
  * Both DATABASE_URL (dev) and PRODUCTION_DATABASE_URL (production) must be set.
@@ -227,6 +293,8 @@ async function insertRows(
 ): Promise<void> {
   if (rows.length === 0) return;
 
+  const columnTypes = await getColumnTypes(client, tableName);
+
   for (const row of rows) {
     const columns = Object.keys(row);
     const values: unknown[] = [];
@@ -234,28 +302,9 @@ async function insertRows(
     let paramIdx = 1;
 
     for (const col of columns) {
-      const v = row[col];
-      if (v === null || v === undefined) {
-        castPlaceholders.push(`$${paramIdx}`);
-        values.push(null);
-      } else if (typeof v === "object" && !(v instanceof Date) && !Buffer.isBuffer(v)) {
-        if (Array.isArray(v)) {
-          // Pass arrays as JSON text and cast to the column's array type via SQL
-          castPlaceholders.push(`$${paramIdx}::text[]`);
-          // CodeQL #60 (js/incomplete-sanitization): escape backslashes FIRST,
-          // then quotes. The original `replace(/"/g, '\\"')` left embedded
-          // backslashes intact, so a value like `"\"x` would round-trip as
-          // `"\"x"` which Postgres parses as a closing quote + literal x.
-          values.push(`{${v.map((item: unknown) => `"${String(item).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`).join(",")}}`);
-        } else {
-          // JSON/JSONB columns — pass as text with explicit cast
-          castPlaceholders.push(`$${paramIdx}::jsonb`);
-          values.push(JSON.stringify(v));
-        }
-      } else {
-        castPlaceholders.push(`$${paramIdx}`);
-        values.push(v);
-      }
+      const prepared = prepareInsertParameter(row[col], columnTypes.get(col), paramIdx);
+      castPlaceholders.push(prepared.placeholder);
+      values.push(prepared.value);
       paramIdx++;
     }
 
@@ -266,6 +315,30 @@ async function insertRows(
       ...values,
     );
   }
+}
+
+async function getColumnTypes(
+  client: PrismaClient,
+  tableName: string,
+): Promise<Map<string, ColumnTypeInfo>> {
+  const rows = await client.$queryRawUnsafe<Array<{
+    columnName: string;
+    dataType: string;
+    udtName: string;
+  }>>(
+    `SELECT column_name AS "columnName", data_type AS "dataType", udt_name AS "udtName"
+       FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1`,
+    tableName,
+  );
+
+  return new Map(
+    rows.map((row) => [
+      row.columnName,
+      { dataType: row.dataType, udtName: row.udtName },
+    ]),
+  );
 }
 
 // ── Neo4j Clone Pipeline ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- parameterize dev-init's production clone URL with the install's `POSTGRES_PASSWORD`
- include PostgreSQL client tools in the Docker dev stage so sanitized clone can run `pg_dump | psql`
- make sanitized clone inserts column-type-aware for JSON/JSONB arrays and Decimal-like numeric values
- exclude nested app `.next` output from Docker build context so dev artifacts do not break production image builds

## Root cause
The production portal and sandbox update paths were rebuilt from main, but the optional dev portal profile could not refresh from production data. `dev-init` used the default `dpf_dev` password for the production DB even when the install had a generated password, the dev image lacked the PostgreSQL CLI tools used by the clone script, and the clone writer treated JSON arrays and Decimal-like values by JS shape rather than target column type.

## Validation
- `docker compose --env-file D:\DPF\.env -p dpf --profile dev config --quiet`
- `pnpm --filter @dpf/db test -- sanitized-clone.test.ts`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web typecheck`
- `docker compose --env-file D:\DPF\.env -p dpf --profile dev up -d --build dev-init dev-portal`
- `GET http://127.0.0.1:3001/api/health` returned 200
- `docker compose --env-file D:\DPF\.env -p dpf build portal`