### PR TITLE
feat(build-studio): Phase 4a decomposition substrate — candidates, atomic creation, override, MCP tools (BI-2E6CC391)

### DIFF
--- a/apps/web/lib/build/approve-decomposition.test.ts
+++ b/apps/web/lib/build/approve-decomposition.test.ts
@@ -1,0 +1,434 @@
+// apps/web/lib/build/approve-decomposition.test.ts
+//
+// Coverage for Phase 4a atomic Epic-and-children creation.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ApproveDecompositionDb,
+  TxShape,
+} from "./approve-decomposition";
+import { approveDecomposition } from "./approve-decomposition";
+import type { DecompositionCandidate } from "./decomposition-candidates";
+
+// --- Fake DB harness -------------------------------------------------------
+
+type FakeBuild = {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: string;
+  designDoc: unknown;
+  designReview: unknown;
+  parentEpicId: string | null;
+  originatingBacklogItemId: string | null;
+  digitalProductId: string | null;
+  portfolioId: string | null;
+  accountableEmployeeId: string | null;
+  createdById: string;
+};
+
+type RecordedWrites = {
+  epicCreates: Array<Record<string, unknown>>;
+  childBuildCreates: Array<Record<string, unknown>>;
+  dependencyCreates: Array<Record<string, unknown>>;
+  buildUpdates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>;
+  backlogItemUpdates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>;
+  activities: Array<Record<string, unknown>>;
+};
+
+function makeFakeDb(build: FakeBuild | null): {
+  db: ApproveDecompositionDb;
+  writes: RecordedWrites;
+} {
+  const writes: RecordedWrites = {
+    epicCreates: [],
+    childBuildCreates: [],
+    dependencyCreates: [],
+    buildUpdates: [],
+    backlogItemUpdates: [],
+    activities: [],
+  };
+
+  let epicRowSeq = 0;
+  let buildRowSeq = 0;
+
+  const tx: TxShape = {
+    epic: {
+      create: vi.fn(async ({ data }) => {
+        writes.epicCreates.push(data);
+        return { id: `epic-row-${++epicRowSeq}`, epicId: data.epicId as string };
+      }),
+    },
+    featureBuild: {
+      create: vi.fn(async ({ data }) => {
+        writes.childBuildCreates.push(data);
+        return { id: `build-row-${++buildRowSeq}`, buildId: data.buildId as string };
+      }),
+      update: vi.fn(async (args) => {
+        writes.buildUpdates.push(args);
+        return null;
+      }),
+    },
+    featureBuildDependency: {
+      create: vi.fn(async ({ data }) => {
+        writes.dependencyCreates.push(data);
+        return null;
+      }),
+    },
+    backlogItem: {
+      update: vi.fn(async (args) => {
+        writes.backlogItemUpdates.push(args);
+        return null;
+      }),
+    },
+    buildActivity: {
+      create: vi.fn(async ({ data }) => {
+        writes.activities.push(data);
+        return null;
+      }),
+    },
+  };
+
+  const db: ApproveDecompositionDb = {
+    featureBuild: {
+      findUnique: vi.fn(async () => build) as unknown as ApproveDecompositionDb["featureBuild"]["findUnique"],
+    },
+    $transaction: vi.fn(async (fn) => fn(tx)) as unknown as ApproveDecompositionDb["$transaction"],
+  };
+
+  return { db, writes };
+}
+
+function makeBuild(overrides: Partial<FakeBuild> = {}): FakeBuild {
+  return {
+    id: "build-row-parent",
+    buildId: "FB-PARENT",
+    title: "Truck inventory",
+    phase: "ideate",
+    designDoc: {
+      problemStatement: "stop driving back",
+      reusePlan: "n/a",
+      proposedApproach: "list + usage",
+      acceptanceCriteria: ["AC0", "AC1", "AC2", "AC3", "AC4"],
+    },
+    designReview: { decision: "pass", issues: [], summary: "ok" },
+    parentEpicId: null,
+    originatingBacklogItemId: "bi-row-001",
+    digitalProductId: null,
+    portfolioId: null,
+    accountableEmployeeId: null,
+    createdById: "user-1",
+    ...overrides,
+  };
+}
+
+function makeCandidate(): DecompositionCandidate {
+  return {
+    candidateId: "cand-1",
+    rationale: "Read first, write second, low-stock third.",
+    childScopes: [
+      { childOrder: 1, title: "Read", summary: "Show parts", acceptanceCriteriaIndices: [0], dependsOn: [] },
+      { childOrder: 2, title: "Usage", summary: "Mark used", acceptanceCriteriaIndices: [1, 2], dependsOn: [1] },
+      { childOrder: 3, title: "Low-stock", summary: "Restock view", acceptanceCriteriaIndices: [3, 4], dependsOn: [1, 2] },
+    ],
+  };
+}
+
+const fixedNow = () => new Date("2026-05-24T20:00:00.000Z");
+
+// Each test that needs deterministic ids calls makeIdGen() to get its own
+// counter — sharing a module-level idGen lets state leak between tests
+// (children get FB-CHILD22 in the third test if the prior tests already
+// burned 21 increments).
+function makeIdGen(): { epicId: () => string; childBuildId: () => string } {
+  let n = 0;
+  return {
+    epicId: () => "EP-TESTEPIC",
+    childBuildId: () => `FB-CHILD${++n}`,
+  };
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe("approveDecomposition — eligibility checks", () => {
+  it("returns build-not-found when the buildId does not exist", async () => {
+    const { db } = makeFakeDb(null);
+    const result = await approveDecomposition({
+      buildId: "FB-MISSING",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-not-found");
+  });
+
+  it("rejects when build is not in ideate phase", async () => {
+    const { db } = makeFakeDb(makeBuild({ phase: "plan" }));
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-not-in-ideate");
+  });
+
+  it("rejects when build has no designDoc", async () => {
+    const { db } = makeFakeDb(makeBuild({ designDoc: null }));
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-missing-design-doc");
+  });
+
+  it("rejects when designReview is not pass", async () => {
+    const { db } = makeFakeDb(
+      makeBuild({ designReview: { decision: "fail", issues: [], summary: "x" } }),
+    );
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-design-review-not-passed");
+  });
+
+  it("rejects recursive decomposition (build already has parentEpicId)", async () => {
+    const { db } = makeFakeDb(makeBuild({ parentEpicId: "epic-row-other" }));
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-already-decomposed");
+  });
+
+  it("rejects malformed candidate (e.g. only 1 child)", async () => {
+    const bad: DecompositionCandidate = {
+      candidateId: "cand-bad",
+      rationale: "single child",
+      childScopes: [
+        { childOrder: 1, title: "Solo", summary: "", acceptanceCriteriaIndices: [0, 1, 2, 3, 4], dependsOn: [] },
+      ],
+    };
+    const { db } = makeFakeDb(makeBuild());
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: bad,
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("candidate-validation-failed");
+  });
+});
+
+describe("approveDecomposition — happy path (Dale scenario)", () => {
+  it("creates one Epic, three children, two dependency edges atomically", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      agentId: "agent-1",
+      db,
+      now: fixedNow,
+      idGen: {
+        epicId: () => "EP-TESTEPIC",
+        childBuildId: (() => {
+          let n = 0;
+          return () => `FB-CHILD${++n}`;
+        })(),
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.epicId).toBe("EP-TESTEPIC");
+    expect(result.childBuildIds).toEqual(["FB-CHILD1", "FB-CHILD2", "FB-CHILD3"]);
+
+    expect(writes.epicCreates).toHaveLength(1);
+    expect(writes.childBuildCreates).toHaveLength(3);
+    expect(writes.dependencyCreates).toHaveLength(3); // 1->none, 2->1, 3->{1,2}
+    expect(writes.buildUpdates).toHaveLength(1); // supersession of parent
+    expect(writes.backlogItemUpdates).toHaveLength(1); // active swap
+  });
+
+  it("copies parent designReview onto every child (transitive approval)", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(result.ok).toBe(true);
+    for (const c of writes.childBuildCreates) {
+      expect(c.designReview).toEqual({ decision: "pass", issues: [], summary: "ok" });
+    }
+  });
+
+  it("derives each child's designDoc to the right AC subset", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    const child1 = writes.childBuildCreates[0]!;
+    const child1Doc = child1.designDoc as { acceptanceCriteria: string[] };
+    expect(child1Doc.acceptanceCriteria).toEqual(["AC0"]);
+
+    const child2 = writes.childBuildCreates[1]!;
+    const child2Doc = child2.designDoc as { acceptanceCriteria: string[] };
+    expect(child2Doc.acceptanceCriteria).toEqual(["AC1", "AC2"]);
+
+    const child3 = writes.childBuildCreates[2]!;
+    const child3Doc = child3.designDoc as { acceptanceCriteria: string[] };
+    expect(child3Doc.acceptanceCriteria).toEqual(["AC3", "AC4"]);
+  });
+
+  it("marks the originating build superseded with phase=failed + supersededByEpicId + abandonReason", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    const update = writes.buildUpdates[0]!;
+    expect(update.where).toEqual({ buildId: "FB-PARENT" });
+    expect(update.data.phase).toBe("failed");
+    expect(update.data.supersededByEpicId).toBe("epic-row-1"); // row id, not epicId string
+    expect(update.data.abandonReason).toBe("decomposed-into-epic:EP-TESTEPIC");
+    expect(update.data.abandonedAt).toBeInstanceOf(Date);
+  });
+
+  it("swaps the backlog item from activeBuildId to activeEpicId", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    const biUpdate = writes.backlogItemUpdates[0]!;
+    expect(biUpdate.where).toEqual({ id: "bi-row-001" });
+    expect(biUpdate.data.activeBuildId).toBeNull();
+    expect(biUpdate.data.activeEpicId).toBe("epic-row-1");
+  });
+
+  it("does not touch backlog item when originating build has no BI", async () => {
+    const { db, writes } = makeFakeDb(makeBuild({ originatingBacklogItemId: null }));
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(writes.backlogItemUpdates).toHaveLength(0);
+  });
+
+  it("preserves Q5 hybrid: child builds carry originatingBacklogItemId AND Epic also carries it", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(writes.epicCreates[0]!.originatingBacklogItemId).toBe("bi-row-001");
+    for (const c of writes.childBuildCreates) {
+      expect(c.originatingBacklogItemId).toBe("bi-row-001");
+    }
+  });
+
+  it("records decompositionState on the Epic with operator + agent + timestamp", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      agentId: "agent-42",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    const epic = writes.epicCreates[0]!;
+    const state = epic.decompositionState as {
+      sourceBuildId: string;
+      candidateId: string;
+      approvedByUserId: string;
+      approvedByAgentId: string | null;
+      approvedAt: string;
+      partition: unknown[];
+    };
+    expect(state.sourceBuildId).toBe("FB-PARENT");
+    expect(state.candidateId).toBe("cand-1");
+    expect(state.approvedByUserId).toBe("user-1");
+    expect(state.approvedByAgentId).toBe("agent-42");
+    expect(state.approvedAt).toBe("2026-05-24T20:00:00.000Z");
+    expect(state.partition).toHaveLength(3);
+  });
+
+  it("logs one activity on the parent and one per child", async () => {
+    const { db, writes } = makeFakeDb(makeBuild());
+    await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(writes.activities).toHaveLength(4);
+    expect(writes.activities[0]!.buildId).toBe("FB-PARENT");
+    expect(writes.activities[0]!.tool).toBe("approveDecomposition");
+    const childBuildIds = writes.activities.slice(1).map((a) => a.buildId);
+    expect(childBuildIds).toEqual(["FB-CHILD1", "FB-CHILD2", "FB-CHILD3"]);
+  });
+});

--- a/apps/web/lib/build/approve-decomposition.ts
+++ b/apps/web/lib/build/approve-decomposition.ts
@@ -1,0 +1,408 @@
+// apps/web/lib/build/approve-decomposition.ts
+//
+// Phase 4a of the design-time decomposition rollout.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+//
+// Atomic creation of an execution-organizational Epic + N child FeatureBuilds
+// + sibling-dependency edges, plus supersession of the originating
+// FeatureBuild. All in one Prisma transaction so the system never observes a
+// half-decomposed state.
+//
+// Phase 4a is server-side substrate: the caller supplies an already-validated
+// `DecompositionCandidate` (e.g. via the MCP tool wrapper). The slide-over UI
+// that lets the operator pick a candidate, plus the LLM-call orchestration
+// that proposes candidates, both land in Phase 4b.
+//
+// Operator decisions honored (spec §12):
+//   - Q4: assertNoRecursiveDecomposition guards against decomposing a child.
+//   - Q5: child FeatureBuild.originatingBacklogItemId is preserved AND
+//         Epic.originatingBacklogItemId is set (hybrid FK).
+//   - Q6: no new BuildPhase values. The superseded original sets
+//         phase="failed" with supersededByEpicId; the new signal for
+//         "this FB was decomposed rather than failed" is `supersededByEpicId
+//         !== null`, not a new phase value. Downstream UI reads both.
+//
+// All invariants from apps/web/lib/build/epic-decomposition-invariants.ts
+// fire on the proposed shape before any rows are written. Loud failure on
+// violation per the invariant module's discipline.
+
+import { prisma } from "@dpf/db";
+import { generateBuildId } from "@/lib/explore/feature-build-types";
+import type { BuildDesignDoc, ReviewResult } from "@/lib/explore/feature-build-types";
+
+import {
+  candidateToChildDesignDocs,
+  validateCandidate,
+  type DecompositionCandidate,
+} from "./decomposition-candidates";
+import {
+  DecompositionInvariantError,
+  assertChildDesignReviewTransitive,
+  assertChildOrderWellFormed,
+  assertDependencyEdgeWellFormed,
+  assertEpicHasContractIfDecomposed,
+  assertNoCycle,
+  assertNoRecursiveDecomposition,
+} from "./epic-decomposition-invariants";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ApproveDecompositionInput = {
+  buildId: string;
+  candidate: DecompositionCandidate;
+  userId: string;
+  agentId?: string | null;
+  /** Test seam: override timestamp. */
+  now?: () => Date;
+  /** Test seam: provide a fake prisma client (Prisma.TransactionClient-shaped
+   *  enough for our needs). Defaults to the real `prisma` import. */
+  db?: ApproveDecompositionDb;
+  /** Test seam: override id generators so tests can assert deterministic ids. */
+  idGen?: { epicId: () => string; childBuildId: () => string };
+};
+
+export type ApproveDecompositionResult =
+  | {
+      ok: true;
+      epicId: string;
+      childBuildIds: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+      code: ApproveDecompositionErrorCode;
+    };
+
+export type ApproveDecompositionErrorCode =
+  | "build-not-found"
+  | "build-not-in-ideate"
+  | "build-missing-design-doc"
+  | "build-design-review-not-passed"
+  | "build-already-decomposed"
+  | "candidate-validation-failed"
+  | "invariant-violation";
+
+// The minimal Prisma-shaped surface this module touches. Useful for tests
+// (pass a fake) and clear documentation of what writes happen.
+export type ApproveDecompositionDb = {
+  featureBuild: {
+    findUnique: typeof prisma.featureBuild.findUnique;
+  };
+  $transaction: <T>(
+    fn: (tx: TxShape) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type TxShape = {
+  epic: {
+    create: (args: { data: Record<string, unknown> }) => Promise<{ id: string; epicId: string }>;
+  };
+  featureBuild: {
+    create: (args: { data: Record<string, unknown> }) => Promise<{ id: string; buildId: string }>;
+    update: (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => Promise<unknown>;
+  };
+  featureBuildDependency: {
+    create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+  };
+  backlogItem: {
+    update: (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => Promise<unknown>;
+  };
+  buildActivity: {
+    create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function approveDecomposition(
+  args: ApproveDecompositionInput,
+): Promise<ApproveDecompositionResult> {
+  const now = args.now ?? (() => new Date());
+  const db: ApproveDecompositionDb = args.db ?? {
+    featureBuild: { findUnique: prisma.featureBuild.findUnique.bind(prisma.featureBuild) },
+    $transaction: ((fn) => prisma.$transaction(fn as never)) as ApproveDecompositionDb["$transaction"],
+  };
+  const idGen = args.idGen ?? {
+    epicId: () => `EP-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+    childBuildId: () => generateBuildId(),
+  };
+
+  // 1. Fetch the originating FB.
+  const build = await db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: {
+      id: true,
+      buildId: true,
+      title: true,
+      phase: true,
+      designDoc: true,
+      designReview: true,
+      parentEpicId: true,
+      originatingBacklogItemId: true,
+      digitalProductId: true,
+      portfolioId: true,
+      accountableEmployeeId: true,
+      createdById: true,
+    },
+  });
+  if (!build) {
+    return { ok: false, code: "build-not-found", error: `FeatureBuild ${args.buildId} not found.` };
+  }
+
+  // 2. Eligibility checks.
+  if (build.phase !== "ideate") {
+    return {
+      ok: false,
+      code: "build-not-in-ideate",
+      error: `Build is in phase "${build.phase}". Decomposition is only allowed during ideate.`,
+    };
+  }
+  const designDoc = build.designDoc as BuildDesignDoc | null;
+  if (!designDoc) {
+    return { ok: false, code: "build-missing-design-doc", error: "Build has no designDoc to decompose." };
+  }
+  const review = (build.designReview ?? null) as ReviewResult | null;
+  if (!review || review.decision !== "pass") {
+    return {
+      ok: false,
+      code: "build-design-review-not-passed",
+      error: "Build's designReview is not yet passed. Run reviewDesignDoc first.",
+    };
+  }
+
+  // 3. Recursive-decomposition guard (spec Q4).
+  try {
+    assertNoRecursiveDecomposition({ id: build.id, parentEpicId: build.parentEpicId });
+  } catch (err) {
+    if (err instanceof DecompositionInvariantError) {
+      return {
+        ok: false,
+        code: "build-already-decomposed",
+        error: err.message,
+      };
+    }
+    throw err;
+  }
+
+  // 4. Candidate validation — pure, against the parent designDoc.
+  const validateRes = validateCandidate(args.candidate, designDoc);
+  if (!validateRes.ok) {
+    const summary = validateRes.failures
+      .map((f) => `[${f.code}] ${f.message}`)
+      .join("; ");
+    return {
+      ok: false,
+      code: "candidate-validation-failed",
+      error: `Candidate failed validation: ${summary}`,
+    };
+  }
+
+  // 5. Build the proposed child docs + dependency edges. Run all invariants
+  //    BEFORE the transaction so a failure rolls back cheaply (no DB work
+  //    needed yet).
+  const epicIdLogical = idGen.epicId();
+  const childDocs = candidateToChildDesignDocs(args.candidate, designDoc);
+  const childBuildLogicalIds = childDocs.map(() => idGen.childBuildId());
+
+  // Invariant 1: parent will have featureBuilds → must carry designDoc.
+  try {
+    assertEpicHasContractIfDecomposed({
+      designDoc,
+      featureBuilds: childDocs,
+    });
+
+    // Invariant 2 + 3: per-child review-transitivity and well-formed childOrder.
+    for (const child of childDocs) {
+      assertChildDesignReviewTransitive(
+        {
+          parentEpicId: "logical-epic", // placeholder; the real epic.id comes from tx
+          designReview: review,
+        },
+        { id: "logical-epic", designReview: review },
+      );
+      assertChildOrderWellFormed({
+        parentEpicId: "logical-epic",
+        childOrder: child.childOrder,
+      });
+    }
+
+    // Invariant 4 + 5: dependency edges and acyclic graph.
+    // Map candidate's childOrder → logical buildId (we don't have real ids
+    // yet; the invariant only checks string equality between the dependent's
+    // and dependsOn's parentEpicId, so "logical-epic" suffices here.)
+    const orderToLogicalId = new Map<number, string>();
+    for (let i = 0; i < childDocs.length; i++) {
+      orderToLogicalId.set(childDocs[i]!.childOrder, childBuildLogicalIds[i]!);
+    }
+    const proposedEdges: Array<{ dependentBuildId: string; dependsOnBuildId: string }> = [];
+    for (const scope of args.candidate.childScopes) {
+      const dependentId = orderToLogicalId.get(scope.childOrder)!;
+      for (const depOrder of scope.dependsOn) {
+        const dependsOnId = orderToLogicalId.get(depOrder)!;
+        assertDependencyEdgeWellFormed({
+          dependent: { id: dependentId, parentEpicId: "logical-epic" },
+          dependsOn: { id: dependsOnId, parentEpicId: "logical-epic" },
+          parentEpicId: "logical-epic",
+        });
+        proposedEdges.push({ dependentBuildId: dependentId, dependsOnBuildId: dependsOnId });
+      }
+    }
+    // Cycle check against the FULL proposed edge set (not one-by-one with
+    // an empty baseline) — the validator already proved the candidate's
+    // own dependency graph is acyclic, but assertNoCycle here is the
+    // belt-and-braces verification against the invariant module.
+    if (proposedEdges.length > 0) {
+      const first = proposedEdges[0]!;
+      const rest = proposedEdges.slice(1);
+      assertNoCycle({ existingEdges: rest, newEdge: first });
+    }
+  } catch (err) {
+    if (err instanceof DecompositionInvariantError) {
+      return {
+        ok: false,
+        code: "invariant-violation",
+        error: `Invariant violation (${err.code}): ${err.message}`,
+      };
+    }
+    throw err;
+  }
+
+  // 6. Atomic transaction.
+  const decompositionState = {
+    sourceBuildId: build.buildId,
+    candidateId: args.candidate.candidateId,
+    candidateRationale: args.candidate.rationale,
+    approvedAt: now().toISOString(),
+    approvedByUserId: args.userId,
+    approvedByAgentId: args.agentId ?? null,
+    partition: args.candidate.childScopes.map((s) => ({
+      childOrder: s.childOrder,
+      title: s.title,
+      summary: s.summary,
+      acceptanceCriteriaIndices: s.acceptanceCriteriaIndices.slice(),
+      dependsOn: s.dependsOn.slice(),
+    })),
+  };
+
+  const txResult = await db.$transaction(async (tx) => {
+    const createdEpic = await tx.epic.create({
+      data: {
+        epicId: epicIdLogical,
+        title: build.title,
+        status: "open",
+        submittedById: args.userId,
+        agentId: args.agentId ?? null,
+        designDoc: designDoc as never,
+        designReview: review as never,
+        decompositionState: decompositionState as never,
+        ...(build.originatingBacklogItemId
+          ? { originatingBacklogItemId: build.originatingBacklogItemId }
+          : {}),
+      },
+    });
+
+    // Create children with real epic.id.
+    const orderToRealBuildId = new Map<number, string>();
+    const orderToRealRowId = new Map<number, string>();
+    for (let i = 0; i < childDocs.length; i++) {
+      const child = childDocs[i]!;
+      const childBuildLogical = childBuildLogicalIds[i]!;
+      const created = await tx.featureBuild.create({
+        data: {
+          buildId: childBuildLogical,
+          title: child.title,
+          phase: "plan", // children go straight to plan (Q6 — no blocked-on-sibling)
+          parentEpicId: createdEpic.id,
+          childOrder: child.childOrder,
+          designDoc: child.designDoc as never,
+          designReview: review as never,
+          createdById: args.userId,
+          ...(build.originatingBacklogItemId
+            ? { originatingBacklogItemId: build.originatingBacklogItemId }
+            : {}),
+          ...(build.digitalProductId ? { digitalProductId: build.digitalProductId } : {}),
+          ...(build.portfolioId ? { portfolioId: build.portfolioId } : {}),
+          ...(build.accountableEmployeeId
+            ? { accountableEmployeeId: build.accountableEmployeeId }
+            : {}),
+        },
+      });
+      orderToRealBuildId.set(child.childOrder, created.buildId);
+      orderToRealRowId.set(child.childOrder, created.id);
+    }
+
+    // Create dependency edges.
+    for (const scope of args.candidate.childScopes) {
+      const dependentRowId = orderToRealRowId.get(scope.childOrder)!;
+      for (const depOrder of scope.dependsOn) {
+        const dependsOnRowId = orderToRealRowId.get(depOrder)!;
+        await tx.featureBuildDependency.create({
+          data: {
+            dependentBuildId: dependentRowId,
+            dependsOnBuildId: dependsOnRowId,
+            parentEpicId: createdEpic.id,
+          },
+        });
+      }
+    }
+
+    // Supersede the originating FB.
+    await tx.featureBuild.update({
+      where: { buildId: build.buildId },
+      data: {
+        phase: "failed", // Q6 — no new phase value. The decomposition signal is supersededByEpicId.
+        supersededByEpicId: createdEpic.id,
+        abandonedAt: now(),
+        abandonReason: `decomposed-into-epic:${createdEpic.epicId}`,
+      },
+    });
+
+    // Swap the backlog item's active link from build → epic (if any).
+    if (build.originatingBacklogItemId) {
+      await tx.backlogItem.update({
+        where: { id: build.originatingBacklogItemId },
+        data: {
+          activeBuildId: null,
+          activeEpicId: createdEpic.id,
+        },
+      });
+    }
+
+    // Log activity on the originating build.
+    await tx.buildActivity.create({
+      data: {
+        buildId: build.buildId,
+        tool: "approveDecomposition",
+        summary: `Decomposed into Epic ${createdEpic.epicId} with ${childDocs.length} child build(s).`,
+      },
+    });
+
+    // Log activity on each new child build.
+    for (let i = 0; i < childDocs.length; i++) {
+      const childBuildId = orderToRealBuildId.get(childDocs[i]!.childOrder)!;
+      await tx.buildActivity.create({
+        data: {
+          buildId: childBuildId,
+          tool: "approveDecomposition",
+          summary: `Created as child #${childDocs[i]!.childOrder} of Epic ${createdEpic.epicId} (from FB ${build.buildId}).`,
+        },
+      });
+    }
+
+    return {
+      epicId: createdEpic.epicId,
+      childBuildIds: Array.from(orderToRealBuildId.values()),
+    };
+  });
+
+  return {
+    ok: true,
+    epicId: txResult.epicId,
+    childBuildIds: txResult.childBuildIds,
+  };
+}

--- a/apps/web/lib/build/decomposition-candidates.test.ts
+++ b/apps/web/lib/build/decomposition-candidates.test.ts
@@ -1,0 +1,385 @@
+// apps/web/lib/build/decomposition-candidates.test.ts
+//
+// Coverage for Phase 4a candidate parsing + validation.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+
+import { describe, expect, it } from "vitest";
+
+import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+
+import {
+  candidateToChildDesignDocs,
+  parseCandidatesResponse,
+  validateCandidate,
+  type DecompositionCandidate,
+} from "./decomposition-candidates";
+
+function makeDoc(overrides: Partial<BuildDesignDoc> = {}): BuildDesignDoc {
+  return {
+    problemStatement: "Stop techs driving back to the warehouse.",
+    reusePlan: "No existing inventory substrate.",
+    proposedApproach: "Inventory list + usage POST + low-stock badge.",
+    acceptanceCriteria: [
+      "AC1: Tech sees truck inventory.",
+      "AC2: Tech records usage.",
+      "AC3: Idempotency on usage POST.",
+      "AC4: Low-stock badge on UI.",
+      "AC5: Dispatch rollup view.",
+    ],
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<DecompositionCandidate> = {}): DecompositionCandidate {
+  return {
+    candidateId: "candidate-1",
+    rationale: "Split read from usage from rollup.",
+    childScopes: [
+      {
+        childOrder: 1,
+        title: "Truck inventory read",
+        summary: "Show parts on each truck.",
+        acceptanceCriteriaIndices: [0],
+        dependsOn: [],
+      },
+      {
+        childOrder: 2,
+        title: "Record usage",
+        summary: "Mark parts used.",
+        acceptanceCriteriaIndices: [1, 2],
+        dependsOn: [1],
+      },
+      {
+        childOrder: 3,
+        title: "Low-stock surfacing",
+        summary: "Restock visibility.",
+        acceptanceCriteriaIndices: [3, 4],
+        dependsOn: [1, 2],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("parseCandidatesResponse — happy paths", () => {
+  it("parses a bare array of candidates", () => {
+    const raw = JSON.stringify([makeCandidate()]);
+    const parsed = parseCandidatesResponse(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.candidateId).toBe("candidate-1");
+    expect(parsed[0]!.childScopes).toHaveLength(3);
+  });
+
+  it("parses a {candidates: [...]} envelope", () => {
+    const raw = JSON.stringify({ candidates: [makeCandidate()] });
+    const parsed = parseCandidatesResponse(raw);
+    expect(parsed).toHaveLength(1);
+  });
+
+  it("strips ```json fences", () => {
+    const raw = "```json\n" + JSON.stringify([makeCandidate()]) + "\n```";
+    const parsed = parseCandidatesResponse(raw);
+    expect(parsed).toHaveLength(1);
+  });
+
+  it("fills defaults for missing fields", () => {
+    const raw = JSON.stringify([
+      {
+        rationale: "Some rationale",
+        childScopes: [{ childOrder: 1, title: "Foo" }],
+      },
+    ]);
+    const parsed = parseCandidatesResponse(raw);
+    expect(parsed[0]!.candidateId).toBe("candidate-1"); // generated default
+    expect(parsed[0]!.childScopes[0]!.summary).toBe("");
+    expect(parsed[0]!.childScopes[0]!.acceptanceCriteriaIndices).toEqual([]);
+    expect(parsed[0]!.childScopes[0]!.dependsOn).toEqual([]);
+  });
+});
+
+describe("parseCandidatesResponse — failure paths", () => {
+  it("returns [] on malformed JSON", () => {
+    expect(parseCandidatesResponse("not json")).toEqual([]);
+    expect(parseCandidatesResponse("{ truncated:")).toEqual([]);
+  });
+
+  it("returns [] on unexpected top-level shape", () => {
+    expect(parseCandidatesResponse(JSON.stringify("string"))).toEqual([]);
+    expect(parseCandidatesResponse(JSON.stringify({ foo: "bar" }))).toEqual([]);
+    expect(parseCandidatesResponse(JSON.stringify(null))).toEqual([]);
+  });
+
+  it("skips non-object items inside the candidates array", () => {
+    const raw = JSON.stringify([null, "string", makeCandidate(), 42]);
+    const parsed = parseCandidatesResponse(raw);
+    expect(parsed).toHaveLength(1);
+  });
+});
+
+describe("validateCandidate — happy paths", () => {
+  it("accepts a well-formed candidate that partitions all ACs", () => {
+    const result = validateCandidate(makeCandidate(), makeDoc());
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a 2-child partition", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "Read", summary: "x", acceptanceCriteriaIndices: [0, 3], dependsOn: [] },
+        { childOrder: 2, title: "Write", summary: "y", acceptanceCriteriaIndices: [1, 2, 4], dependsOn: [1] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a 4-child partition (max allowed)", () => {
+    const doc = makeDoc({
+      acceptanceCriteria: ["a", "b", "c", "d", "e", "f", "g", "h"],
+    });
+    const candidate: DecompositionCandidate = {
+      candidateId: "c4",
+      rationale: "Four-way split",
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "a", acceptanceCriteriaIndices: [0, 1], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "b", acceptanceCriteriaIndices: [2, 3], dependsOn: [1] },
+        { childOrder: 3, title: "C", summary: "c", acceptanceCriteriaIndices: [4, 5], dependsOn: [2] },
+        { childOrder: 4, title: "D", summary: "d", acceptanceCriteriaIndices: [6, 7], dependsOn: [3] },
+      ],
+    };
+    const result = validateCandidate(candidate, doc);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateCandidate — failure paths", () => {
+  it("rejects too few children (< 2)", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        {
+          childOrder: 1,
+          title: "Solo",
+          summary: "x",
+          acceptanceCriteriaIndices: [0, 1, 2, 3, 4],
+          dependsOn: [],
+        },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("too-few-children");
+  });
+
+  it("rejects too many children (> 4)", () => {
+    const doc = makeDoc({
+      acceptanceCriteria: ["a", "b", "c", "d", "e"],
+    });
+    const candidate: DecompositionCandidate = {
+      candidateId: "c5",
+      rationale: "Five-way split",
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [1], dependsOn: [] },
+        { childOrder: 3, title: "C", summary: "", acceptanceCriteriaIndices: [2], dependsOn: [] },
+        { childOrder: 4, title: "D", summary: "", acceptanceCriteriaIndices: [3], dependsOn: [] },
+        { childOrder: 5, title: "E", summary: "", acceptanceCriteriaIndices: [4], dependsOn: [] },
+      ],
+    };
+    const result = validateCandidate(candidate, doc);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("too-many-children");
+  });
+
+  it("rejects missing AC coverage", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [2], dependsOn: [] },
+        // ACs 3 and 4 are not assigned to anyone.
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code).filter((c) => c === "missing-ac-coverage").length).toBe(2);
+  });
+
+  it("rejects duplicate AC coverage", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [2, 3, 4], dependsOn: [] },
+        // AC 2 is in BOTH children.
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("duplicate-ac-coverage");
+  });
+
+  it("rejects out-of-range AC index", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4, 99], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("ac-index-out-of-range");
+  });
+
+  it("rejects duplicate childOrder", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 1, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("duplicate-child-order");
+  });
+
+  it("rejects non-sequential childOrder (e.g. 1, 3 instead of 1, 2)", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 3, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("non-sequential-child-order");
+  });
+
+  it("rejects self-dependency", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [1] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("self-dependency");
+  });
+
+  it("rejects dependency targeting missing childOrder", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [99] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("missing-dependency-target");
+  });
+
+  it("rejects dependency cycles", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1], dependsOn: [3] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [2], dependsOn: [1] },
+        { childOrder: 3, title: "C", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [2] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("dependency-cycle");
+  });
+
+  it("rejects empty child title", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("empty-title");
+  });
+
+  it("rejects empty rationale", () => {
+    const candidate = makeCandidate({ rationale: "  " });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("empty-rationale");
+  });
+
+  it("rejects empty child scope (no ACs assigned)", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2, 3, 4], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [], dependsOn: [] },
+      ],
+    });
+    const result = validateCandidate(candidate, makeDoc());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.failures.map((f) => f.code)).toContain("empty-child-scope");
+  });
+});
+
+describe("candidateToChildDesignDocs", () => {
+  it("derives child designDocs with the right AC subsets and sorted order", () => {
+    const doc = makeDoc();
+    const candidate = makeCandidate({
+      childScopes: [
+        // Deliberately scrambled to test sort.
+        { childOrder: 2, title: "Record usage", summary: "Mark parts used.", acceptanceCriteriaIndices: [1, 2], dependsOn: [1] },
+        { childOrder: 1, title: "Read", summary: "Show parts.", acceptanceCriteriaIndices: [0], dependsOn: [] },
+        { childOrder: 3, title: "Low-stock", summary: "Restock view.", acceptanceCriteriaIndices: [3, 4], dependsOn: [1, 2] },
+      ],
+    });
+    const docs = candidateToChildDesignDocs(candidate, doc);
+    expect(docs.map((d) => d.childOrder)).toEqual([1, 2, 3]);
+    expect(docs[0]!.designDoc.acceptanceCriteria).toEqual(["AC1: Tech sees truck inventory."]);
+    expect(docs[1]!.designDoc.acceptanceCriteria).toEqual([
+      "AC2: Tech records usage.",
+      "AC3: Idempotency on usage POST.",
+    ]);
+    expect(docs[2]!.designDoc.acceptanceCriteria).toEqual([
+      "AC4: Low-stock badge on UI.",
+      "AC5: Dispatch rollup view.",
+    ]);
+  });
+
+  it("uses the child scope's summary as proposedApproach when present", () => {
+    const docs = candidateToChildDesignDocs(makeCandidate(), makeDoc());
+    expect(docs[0]!.designDoc.proposedApproach).toBe("Show parts on each truck.");
+  });
+
+  it("falls back to the parent's proposedApproach when scope summary is empty", () => {
+    const candidate = makeCandidate({
+      childScopes: [
+        { childOrder: 1, title: "A", summary: "", acceptanceCriteriaIndices: [0, 1, 2], dependsOn: [] },
+        { childOrder: 2, title: "B", summary: "", acceptanceCriteriaIndices: [3, 4], dependsOn: [] },
+      ],
+    });
+    const docs = candidateToChildDesignDocs(candidate, makeDoc());
+    expect(docs[0]!.designDoc.proposedApproach).toBe("Inventory list + usage POST + low-stock badge.");
+  });
+
+  it("preserves parent's problemStatement and reusePlan on every child", () => {
+    const docs = candidateToChildDesignDocs(makeCandidate(), makeDoc());
+    for (const d of docs) {
+      expect(d.designDoc.problemStatement).toBe("Stop techs driving back to the warehouse.");
+      expect(d.designDoc.reusePlan).toBe("No existing inventory substrate.");
+    }
+  });
+});

--- a/apps/web/lib/build/decomposition-candidates.ts
+++ b/apps/web/lib/build/decomposition-candidates.ts
@@ -1,0 +1,373 @@
+// apps/web/lib/build/decomposition-candidates.ts
+//
+// Phase 4a of the design-time decomposition rollout.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+//
+// Type definitions, parsing, validation, and child-designDoc derivation for
+// the decomposition-assistant flow. Phase 4a ships the server-side substrate;
+// the LLM call that produces candidates and the operator slide-over that
+// picks one both land in Phase 4b.
+//
+// A DecompositionCandidate is a proposed partition of a parent design's
+// acceptance criteria into 2-4 coherent child scopes, each producing a
+// FeatureBuild that implements a subset of the parent's contract. Dependency
+// edges between siblings are also part of the candidate so the operator can
+// see "child B depends on child A" before approving.
+//
+// `parseCandidatesResponse` is permissive on shape (accepts both bare
+// `Candidate[]` and `{ candidates: Candidate[] }` envelopes, because LLM
+// output varies); `validateCandidate` is strict (rejects shapes that would
+// violate the Phase 1 invariants downstream). Both are pure — caller passes
+// the parent design and the candidate; we never read from Prisma here.
+
+import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type DecompositionChildScope = {
+  /** 1-indexed position within the parent Epic. Determines build creation
+   *  order and rollup display order. */
+  childOrder: number;
+  /** Operator-facing title in the persona's vocabulary (truck/parts/job for
+   *  Dale), not platform vocabulary. Becomes FeatureBuild.title. */
+  title: string;
+  /** One-sentence summary the assistant slide-over and rollup UI render. */
+  summary: string;
+  /** Indices into the parent's `designDoc.acceptanceCriteria[]`. The child's
+   *  derived designDoc contains exactly these ACs. Must be non-empty;
+   *  partition (every parent AC appears in exactly one child) is asserted
+   *  at the candidate level. */
+  acceptanceCriteriaIndices: number[];
+  /** childOrder values within THIS candidate that this child depends on.
+   *  Empty = no sibling deps. Cycles rejected at validate-time. */
+  dependsOn: number[];
+};
+
+export type DecompositionCandidate = {
+  /** Stable identifier within the persisted candidate list. The operator
+   *  selects by this id when approving. */
+  candidateId: string;
+  /** Plain-language rationale for THIS partition. Surfaces in the
+   *  slide-over so the operator understands why the agent grouped these ACs
+   *  together rather than another way. */
+  rationale: string;
+  /** 2-4 child scopes in childOrder order. */
+  childScopes: DecompositionChildScope[];
+};
+
+export type ValidationFailure = {
+  code: ValidationFailureCode;
+  message: string;
+  /** Optional reference to the offending child scope (1-indexed). */
+  childOrder?: number;
+};
+
+export type ValidationFailureCode =
+  | "no-children"
+  | "too-few-children"
+  | "too-many-children"
+  | "duplicate-child-order"
+  | "non-sequential-child-order"
+  | "missing-ac-coverage"
+  | "duplicate-ac-coverage"
+  | "ac-index-out-of-range"
+  | "empty-child-scope"
+  | "self-dependency"
+  | "missing-dependency-target"
+  | "dependency-cycle"
+  | "empty-title"
+  | "empty-rationale";
+
+export type ValidateResult =
+  | { ok: true }
+  | { ok: false; failures: ValidationFailure[] };
+
+// Constraints (matches spec §3.2 "2-4 candidate decompositions").
+const MIN_CHILDREN = 2;
+const MAX_CHILDREN = 4;
+
+// ---------------------------------------------------------------------------
+// parseCandidatesResponse — permissive
+// ---------------------------------------------------------------------------
+
+export function parseCandidatesResponse(raw: string): DecompositionCandidate[] {
+  // Strip code fences if the LLM wrapped the JSON in ```json ... ```.
+  const stripped = stripCodeFences(raw.trim());
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch {
+    return [];
+  }
+
+  // Accept either `{ candidates: [...] }` or bare `[...]`.
+  const candidatesRaw = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.candidates)
+      ? parsed.candidates
+      : null;
+
+  if (!candidatesRaw) return [];
+
+  const out: DecompositionCandidate[] = [];
+  for (let i = 0; i < candidatesRaw.length; i++) {
+    const c = candidatesRaw[i];
+    if (!isRecord(c)) continue;
+    const scopesRaw = Array.isArray(c.childScopes) ? c.childScopes : [];
+    const childScopes: DecompositionChildScope[] = [];
+    for (const s of scopesRaw) {
+      if (!isRecord(s)) continue;
+      const scope: DecompositionChildScope = {
+        childOrder: numberOr(s.childOrder, 0),
+        title: stringOr(s.title, ""),
+        summary: stringOr(s.summary, ""),
+        acceptanceCriteriaIndices: numberArrayOr(s.acceptanceCriteriaIndices, []),
+        dependsOn: numberArrayOr(s.dependsOn, []),
+      };
+      childScopes.push(scope);
+    }
+    out.push({
+      candidateId: stringOr(c.candidateId, `candidate-${i + 1}`),
+      rationale: stringOr(c.rationale, ""),
+      childScopes,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// validateCandidate — strict
+// ---------------------------------------------------------------------------
+
+export function validateCandidate(
+  candidate: DecompositionCandidate,
+  parentDoc: BuildDesignDoc,
+): ValidateResult {
+  const failures: ValidationFailure[] = [];
+  const parentAcCount = (parentDoc.acceptanceCriteria ?? []).length;
+
+  if (candidate.rationale.trim().length === 0) {
+    failures.push({ code: "empty-rationale", message: "Candidate rationale is empty." });
+  }
+
+  const children = candidate.childScopes;
+  if (children.length === 0) {
+    failures.push({ code: "no-children", message: "Candidate has no child scopes." });
+  } else if (children.length < MIN_CHILDREN) {
+    failures.push({
+      code: "too-few-children",
+      message: `Candidate must have at least ${MIN_CHILDREN} child scopes; found ${children.length}.`,
+    });
+  } else if (children.length > MAX_CHILDREN) {
+    failures.push({
+      code: "too-many-children",
+      message: `Candidate must have at most ${MAX_CHILDREN} child scopes; found ${children.length}.`,
+    });
+  }
+
+  // childOrder must be the 1..N sequence with no gaps and no dupes.
+  const orderSeen = new Set<number>();
+  for (const scope of children) {
+    if (scope.title.trim().length === 0) {
+      failures.push({
+        code: "empty-title",
+        message: "Child scope has empty title.",
+        childOrder: scope.childOrder,
+      });
+    }
+    if (scope.acceptanceCriteriaIndices.length === 0) {
+      failures.push({
+        code: "empty-child-scope",
+        message: "Child scope has no acceptance criteria assigned.",
+        childOrder: scope.childOrder,
+      });
+    }
+    if (orderSeen.has(scope.childOrder)) {
+      failures.push({
+        code: "duplicate-child-order",
+        message: `Duplicate childOrder=${scope.childOrder}.`,
+        childOrder: scope.childOrder,
+      });
+    }
+    orderSeen.add(scope.childOrder);
+  }
+  // Sequence check (after dup check). Expect orderSeen to be {1, 2, ..., N}.
+  for (let i = 1; i <= children.length; i++) {
+    if (!orderSeen.has(i)) {
+      failures.push({
+        code: "non-sequential-child-order",
+        message: `childOrder must be 1..${children.length} with no gaps; ${i} is missing.`,
+      });
+    }
+  }
+
+  // AC coverage: every parent AC appears in exactly one child.
+  const acAssignment = new Map<number, number>(); // ac index -> first child it appears in
+  const duplicateAcs = new Set<number>();
+  for (const scope of children) {
+    for (const acIdx of scope.acceptanceCriteriaIndices) {
+      if (acIdx < 0 || acIdx >= parentAcCount) {
+        failures.push({
+          code: "ac-index-out-of-range",
+          message: `Acceptance criterion index ${acIdx} is out of range (parent has ${parentAcCount} ACs).`,
+          childOrder: scope.childOrder,
+        });
+        continue;
+      }
+      if (acAssignment.has(acIdx)) {
+        duplicateAcs.add(acIdx);
+      } else {
+        acAssignment.set(acIdx, scope.childOrder);
+      }
+    }
+  }
+  for (const dup of duplicateAcs) {
+    failures.push({
+      code: "duplicate-ac-coverage",
+      message: `Acceptance criterion index ${dup} is assigned to multiple child scopes.`,
+    });
+  }
+  for (let i = 0; i < parentAcCount; i++) {
+    if (!acAssignment.has(i)) {
+      failures.push({
+        code: "missing-ac-coverage",
+        message: `Parent acceptance criterion index ${i} is not assigned to any child scope.`,
+      });
+    }
+  }
+
+  // Dependency edges within the candidate.
+  const validOrders = new Set(children.map((c) => c.childOrder));
+  for (const scope of children) {
+    for (const dep of scope.dependsOn) {
+      if (dep === scope.childOrder) {
+        failures.push({
+          code: "self-dependency",
+          message: `Child scope childOrder=${scope.childOrder} cannot depend on itself.`,
+          childOrder: scope.childOrder,
+        });
+      } else if (!validOrders.has(dep)) {
+        failures.push({
+          code: "missing-dependency-target",
+          message: `Child scope childOrder=${scope.childOrder} depends on missing childOrder=${dep}.`,
+          childOrder: scope.childOrder,
+        });
+      }
+    }
+  }
+
+  // Cycle detection among childOrder edges (DFS three-colour).
+  if (hasDependencyCycle(children)) {
+    failures.push({
+      code: "dependency-cycle",
+      message: "Dependency graph among child scopes has a cycle.",
+    });
+  }
+
+  return failures.length === 0 ? { ok: true } : { ok: false, failures };
+}
+
+// ---------------------------------------------------------------------------
+// candidateToChildDesignDocs — derive each child's designDoc from the parent
+// by ACSV (acceptance-criteria subset projection). Keeps the parent's
+// problemStatement and reusePlan (children inherit context), narrows
+// proposedApproach to a child-scoped one-liner, and filters
+// acceptanceCriteria to the child's indices.
+// ---------------------------------------------------------------------------
+
+export function candidateToChildDesignDocs(
+  candidate: DecompositionCandidate,
+  parentDoc: BuildDesignDoc,
+): Array<{ childOrder: number; title: string; designDoc: BuildDesignDoc }> {
+  return candidate.childScopes
+    .slice()
+    .sort((a, b) => a.childOrder - b.childOrder)
+    .map((scope) => ({
+      childOrder: scope.childOrder,
+      title: scope.title,
+      designDoc: {
+        problemStatement: parentDoc.problemStatement,
+        ...(parentDoc.dataModel ? { dataModel: parentDoc.dataModel } : {}),
+        ...(parentDoc.existingCodeAudit
+          ? { existingCodeAudit: parentDoc.existingCodeAudit }
+          : {}),
+        ...(parentDoc.existingFunctionalityAudit
+          ? { existingFunctionalityAudit: parentDoc.existingFunctionalityAudit }
+          : {}),
+        reusePlan: parentDoc.reusePlan,
+        proposedApproach: scope.summary || parentDoc.proposedApproach,
+        acceptanceCriteria: scope.acceptanceCriteriaIndices.map(
+          (i) => parentDoc.acceptanceCriteria![i]!,
+        ),
+        ...(parentDoc.reusabilityAnalysis
+          ? { reusabilityAnalysis: parentDoc.reusabilityAnalysis }
+          : {}),
+        ...(parentDoc.accessibility ? { accessibility: parentDoc.accessibility } : {}),
+      },
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function stripCodeFences(s: string): string {
+  // Strip ```json\n ... \n``` or ```\n ... \n``` wrappers.
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/m.exec(s);
+  return fenced ? fenced[1]!.trim() : s;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function numberOr(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+function stringOr(v: unknown, fallback: string): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function numberArrayOr(v: unknown, fallback: number[]): number[] {
+  if (!Array.isArray(v)) return fallback;
+  const out: number[] = [];
+  for (const item of v) {
+    if (typeof item === "number" && Number.isFinite(item)) out.push(item);
+  }
+  return out;
+}
+
+function hasDependencyCycle(children: DecompositionChildScope[]): boolean {
+  // childOrder is the node id; dependsOn lists predecessors.
+  const adj = new Map<number, number[]>();
+  for (const s of children) {
+    adj.set(s.childOrder, s.dependsOn.slice());
+  }
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const colour = new Map<number, number>();
+
+  function dfs(node: number): boolean {
+    colour.set(node, GRAY);
+    for (const next of adj.get(node) ?? []) {
+      const c = colour.get(next) ?? WHITE;
+      if (c === GRAY) return true;
+      if (c === WHITE && dfs(next)) return true;
+    }
+    colour.set(node, BLACK);
+    return false;
+  }
+
+  for (const node of adj.keys()) {
+    if ((colour.get(node) ?? WHITE) === WHITE) {
+      if (dfs(node)) return true;
+    }
+  }
+  return false;
+}

--- a/apps/web/lib/build/decomposition-override.test.ts
+++ b/apps/web/lib/build/decomposition-override.test.ts
@@ -1,0 +1,192 @@
+// apps/web/lib/build/decomposition-override.test.ts
+//
+// Coverage for Phase 4a operator override on required-tier decomposition.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md §12 Q1
+// BI: BI-2E6CC391.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { recordDecompositionOverride, type RecordDecompositionOverrideDb } from "./decomposition-override";
+
+function makeReview(decision: "ok" | "decompose-recommended" | "decompose-required" | null) {
+  return {
+    decision: "pass" as const,
+    issues: [],
+    summary: "ok",
+    ...(decision
+      ? {
+          sizeAssessment: {
+            decision,
+            breakdown: {
+              models: { count: 5, samples: [] },
+              endpoints: { count: 2, samples: [] },
+              acs: { count: 25 },
+              multipliers: { count: 4, matchedKeywords: [] },
+              routes: { count: 2, samples: [] },
+            },
+            trips: [],
+            rationale: "test",
+            thresholds: {
+              models: { recommend: 3, required: 5 },
+              endpoints: { recommend: 4, required: 7 },
+              acs: { recommend: 12, required: 20 },
+              multipliers: { recommend: 2, required: 4 },
+              routes: { recommend: 2, required: 4 },
+            },
+            assessedAt: "2026-05-24T20:00:00.000Z",
+          },
+        }
+      : {}),
+  };
+}
+
+function makeFakeDb(designReview: unknown, buildExists = true): {
+  db: RecordDecompositionOverrideDb;
+  writes: {
+    updates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>;
+    activities: Array<Record<string, unknown>>;
+  };
+} {
+  const writes = {
+    updates: [] as Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>,
+    activities: [] as Array<Record<string, unknown>>,
+  };
+  const db: RecordDecompositionOverrideDb = {
+    featureBuild: {
+      findUnique: vi.fn(async () =>
+        buildExists ? ({ buildId: "FB-DALE", designReview } as never) : null,
+      ) as unknown as RecordDecompositionOverrideDb["featureBuild"]["findUnique"],
+      update: vi.fn(async (args) => {
+        writes.updates.push(args as never);
+        return null as never;
+      }) as unknown as RecordDecompositionOverrideDb["featureBuild"]["update"],
+    },
+    buildActivity: {
+      create: vi.fn(async ({ data }) => {
+        writes.activities.push(data as never);
+        return null as never;
+      }) as unknown as RecordDecompositionOverrideDb["buildActivity"]["create"],
+    },
+  };
+  return { db, writes };
+}
+
+const fixedNow = () => new Date("2026-05-24T20:00:00.000Z");
+
+describe("recordDecompositionOverride — success path", () => {
+  it("records override on a required-tier build", async () => {
+    const { db, writes } = makeFakeDb(makeReview("decompose-required"));
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "Single tech ships this end-to-end; splitting adds coordination cost.",
+      userId: "user-1",
+      agentId: "agent-9",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.override.rationale).toMatch(/Single tech/);
+    expect(result.override.recordedAt).toBe("2026-05-24T20:00:00.000Z");
+    expect(result.override.recordedByUserId).toBe("user-1");
+    expect(result.override.recordedByAgentId).toBe("agent-9");
+
+    // Persisted shape on designReview.
+    expect(writes.updates).toHaveLength(1);
+    const updatedReview = writes.updates[0]!.data.designReview as {
+      decompositionOverride: { rationale: string };
+    };
+    expect(updatedReview.decompositionOverride.rationale).toMatch(/Single tech/);
+
+    // Activity row.
+    expect(writes.activities).toHaveLength(1);
+    expect(writes.activities[0]!.tool).toBe("recordDecompositionOverride");
+  });
+
+  it("defaults recordedByAgentId to null when no agentId supplied", async () => {
+    const { db } = makeFakeDb(makeReview("decompose-required"));
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "Operator override.",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.override.recordedByAgentId).toBeNull();
+  });
+});
+
+describe("recordDecompositionOverride — failure paths", () => {
+  it("rejects empty rationale", async () => {
+    const { db } = makeFakeDb(makeReview("decompose-required"));
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "   ",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("empty-rationale");
+  });
+
+  it("rejects when build does not exist", async () => {
+    const { db } = makeFakeDb(makeReview("decompose-required"), /*buildExists*/ false);
+    const result = await recordDecompositionOverride({
+      buildId: "FB-MISSING",
+      rationale: "ok",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-not-found");
+  });
+
+  it("rejects when no size assessment is recorded", async () => {
+    // designReview present but no sizeAssessment field.
+    const { db } = makeFakeDb({ decision: "pass", issues: [], summary: "pre-Phase-2 build" });
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "ok",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("no-size-assessment");
+  });
+
+  it("rejects on recommended-tier (single-click path, no override needed)", async () => {
+    const { db } = makeFakeDb(makeReview("decompose-recommended"));
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "ok",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("override-not-applicable");
+  });
+
+  it("rejects on ok-tier (no decomposition needed)", async () => {
+    const { db } = makeFakeDb(makeReview("ok"));
+    const result = await recordDecompositionOverride({
+      buildId: "FB-DALE",
+      rationale: "ok",
+      userId: "user-1",
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("override-not-applicable");
+  });
+});

--- a/apps/web/lib/build/decomposition-override.ts
+++ b/apps/web/lib/build/decomposition-override.ts
@@ -1,0 +1,143 @@
+// apps/web/lib/build/decomposition-override.ts
+//
+// Phase 4a — operator "Keep as one build" override for required-tier
+// decomposition recommendations.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+//
+// When sizeDesignDoc returns `decompose-required`, the operator can choose to
+// proceed monolithically by recording an explicit one-line justification.
+// Spec §12 Q1: "allowed, but must require a one-line justification and must
+// be recorded in FeatureBuild.designReview.decompositionOverride".
+//
+// Phase 4a writes the override; nothing yet ENFORCES it (i.e. nothing blocks
+// proceeding to Plan without an override). Enforcement lands in Phase 4b
+// alongside the UI gate. For now, the data shape exists and can be queried
+// for audit + hive-contribution context.
+//
+// Override is only meaningful at the `decompose-required` tier; the
+// `decompose-recommended` tier is single-click "keep as one build" per spec
+// §4.1 — no override row is recorded. This module rejects override writes
+// against ok / recommended assessments to keep the audit signal clean.
+
+import { prisma } from "@dpf/db";
+import type { ReviewResult } from "@/lib/explore/feature-build-types";
+
+export type DecompositionOverride = {
+  rationale: string;
+  recordedAt: string;
+  recordedByUserId: string;
+  recordedByAgentId: string | null;
+};
+
+export type RecordDecompositionOverrideInput = {
+  buildId: string;
+  rationale: string;
+  userId: string;
+  agentId?: string | null;
+  /** Test seam — override timestamp. */
+  now?: () => Date;
+  /** Test seam — replace prisma. */
+  db?: RecordDecompositionOverrideDb;
+};
+
+export type RecordDecompositionOverrideResult =
+  | { ok: true; override: DecompositionOverride }
+  | { ok: false; code: RecordDecompositionOverrideErrorCode; error: string };
+
+export type RecordDecompositionOverrideErrorCode =
+  | "build-not-found"
+  | "empty-rationale"
+  | "no-size-assessment"
+  | "override-not-applicable";
+
+export type RecordDecompositionOverrideDb = {
+  featureBuild: {
+    findUnique: typeof prisma.featureBuild.findUnique;
+    update: typeof prisma.featureBuild.update;
+  };
+  buildActivity: {
+    create: typeof prisma.buildActivity.create;
+  };
+};
+
+export async function recordDecompositionOverride(
+  args: RecordDecompositionOverrideInput,
+): Promise<RecordDecompositionOverrideResult> {
+  const rationale = args.rationale.trim();
+  if (rationale.length === 0) {
+    return {
+      ok: false,
+      code: "empty-rationale",
+      error: "Override rationale is required and must be non-empty.",
+    };
+  }
+
+  const now = args.now ?? (() => new Date());
+  const db: RecordDecompositionOverrideDb = args.db ?? {
+    featureBuild: {
+      findUnique: prisma.featureBuild.findUnique.bind(prisma.featureBuild),
+      update: prisma.featureBuild.update.bind(prisma.featureBuild),
+    },
+    buildActivity: {
+      create: prisma.buildActivity.create.bind(prisma.buildActivity),
+    },
+  };
+
+  const build = await db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: { buildId: true, designReview: true },
+  });
+  if (!build) {
+    return {
+      ok: false,
+      code: "build-not-found",
+      error: `FeatureBuild ${args.buildId} not found.`,
+    };
+  }
+
+  const review = (build.designReview ?? null) as ReviewResult | null;
+  const decision = review?.sizeAssessment?.decision ?? null;
+
+  if (decision == null) {
+    return {
+      ok: false,
+      code: "no-size-assessment",
+      error: "No size assessment recorded on this build's designReview. Run reviewDesignDoc first.",
+    };
+  }
+  if (decision !== "decompose-required") {
+    return {
+      ok: false,
+      code: "override-not-applicable",
+      error: `Override is only meaningful when size decision is "decompose-required"; current decision is "${decision}". For "decompose-recommended" the operator proceeds without recording an override.`,
+    };
+  }
+
+  const override: DecompositionOverride = {
+    rationale,
+    recordedAt: now().toISOString(),
+    recordedByUserId: args.userId,
+    recordedByAgentId: args.agentId ?? null,
+  };
+
+  const updatedReview: ReviewResult & { decompositionOverride: DecompositionOverride } = {
+    ...review!,
+    decompositionOverride: override,
+  };
+
+  await db.featureBuild.update({
+    where: { buildId: args.buildId },
+    data: { designReview: updatedReview as never },
+  });
+
+  await db.buildActivity.create({
+    data: {
+      buildId: args.buildId,
+      tool: "recordDecompositionOverride",
+      summary: `Operator override recorded: keeping monolithic. Rationale: ${rationale}`,
+    },
+  });
+
+  return { ok: true, override };
+}

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -103,6 +103,20 @@ export type ReviewResult = {
    *  Absent on Plan-phase reviews and on builds reviewed before Phase 2
    *  shipped. */
   sizeAssessment?: SizeAssessmentSnapshot;
+  /** Operator override recorded when the build's size assessment is
+   *  `decompose-required` but the operator chose to proceed
+   *  monolithically. Phase 4a writes this; Phase 4b enforces the gate by
+   *  blocking advance-to-plan unless either decomposition happened OR an
+   *  override exists. Spec §12 Q1. */
+  decompositionOverride?: DecompositionOverrideSnapshot;
+};
+
+/** Persisted shape of the "keep as one build" operator override. */
+export type DecompositionOverrideSnapshot = {
+  rationale: string;
+  recordedAt: string;
+  recordedByUserId: string;
+  recordedByAgentId: string | null;
 };
 
 /** Snapshot of the sizeDesignDoc output as persisted on a ReviewResult.

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -483,6 +483,56 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "approve_decomposition",
+    description: "Phase 4a (BI-2E6CC391). Atomically create an execution-organizational Epic + N child FeatureBuilds + sibling-dependency edges from a pre-validated DecompositionCandidate, and mark the originating FeatureBuild as superseded. The originating build must be in `ideate` phase with a passed designReview and must not itself be a child. Callers (typically the Phase 4b assistant flow) supply the candidate after the operator has chosen and optionally edited it; all invariants from epic-decomposition-invariants run before any DB writes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "Originating FeatureBuild ID (FB-*)." },
+        candidate: {
+          type: "object",
+          description: "The DecompositionCandidate to materialize. See apps/web/lib/build/decomposition-candidates.ts for the full shape.",
+          properties: {
+            candidateId: { type: "string" },
+            rationale: { type: "string" },
+            childScopes: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  childOrder: { type: "number" },
+                  title: { type: "string" },
+                  summary: { type: "string" },
+                  acceptanceCriteriaIndices: { type: "array", items: { type: "number" } },
+                  dependsOn: { type: "array", items: { type: "number" } },
+                },
+                required: ["childOrder", "title", "acceptanceCriteriaIndices", "dependsOn"],
+              },
+            },
+          },
+          required: ["candidateId", "rationale", "childScopes"],
+        },
+      },
+      required: ["buildId", "candidate"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "record_decomposition_override",
+    description: "Phase 4a (BI-2E6CC391). Record the operator's 'keep as one build' override on a FeatureBuild whose size assessment is decompose-required. Writes designReview.decompositionOverride for audit and hive-contribution context. Only valid on decompose-required builds; recommended-tier builds proceed without recording an override (single-click path per spec §4.1). Does not enforce — Phase 4b's gate is the consumer of this record.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "FeatureBuild ID (FB-*)." },
+        rationale: { type: "string", description: "Non-empty one-line justification for proceeding monolithically." },
+      },
+      required: ["buildId", "rationale"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "update_backlog_item",
     description: "Update an existing backlog item's editable fields. Use update_backlog_item_status for triaged status transitions, triage_backlog_item to triage, size_backlog_item for effortSize, and link_backlog_item_to_epic for epic linkage — those have their own audit and validation.",
     inputSchema: {
@@ -4833,6 +4883,64 @@ export async function executeTool(
         },
       };
     }
+
+    case "approve_decomposition": {
+      // Phase 4a (BI-2E6CC391). The candidate is pre-validated by the
+      // caller (Phase 4b assistant); we revalidate inside
+      // approveDecomposition's pipeline before any DB writes.
+      const buildId = String(params["buildId"] ?? "");
+      const candidateRaw = params["candidate"];
+      if (!buildId.startsWith("FB-")) {
+        return { success: false, error: "invalid_buildId", message: "buildId must use the FB-* format." };
+      }
+      if (!candidateRaw || typeof candidateRaw !== "object") {
+        return { success: false, error: "invalid_candidate", message: "candidate must be an object matching the DecompositionCandidate shape." };
+      }
+      const { approveDecomposition } = await import("@/lib/build/approve-decomposition");
+      const result = await approveDecomposition({
+        buildId,
+        candidate: candidateRaw as Parameters<typeof approveDecomposition>[0]["candidate"],
+        userId,
+        agentId: context?.agentId ?? null,
+      });
+      if (!result.ok) {
+        return { success: false, error: result.code, message: result.error };
+      }
+      return {
+        success: true,
+        entityId: result.epicId,
+        message: `Decomposed ${buildId} into Epic ${result.epicId} with ${result.childBuildIds.length} child build(s).`,
+        data: {
+          epicId: result.epicId,
+          childBuildIds: result.childBuildIds,
+        },
+      };
+    }
+
+    case "record_decomposition_override": {
+      const buildId = String(params["buildId"] ?? "");
+      const rationale = String(params["rationale"] ?? "");
+      if (!buildId.startsWith("FB-")) {
+        return { success: false, error: "invalid_buildId", message: "buildId must use the FB-* format." };
+      }
+      const { recordDecompositionOverride } = await import("@/lib/build/decomposition-override");
+      const result = await recordDecompositionOverride({
+        buildId,
+        rationale,
+        userId,
+        agentId: context?.agentId ?? null,
+      });
+      if (!result.ok) {
+        return { success: false, error: result.code, message: result.error };
+      }
+      return {
+        success: true,
+        entityId: buildId,
+        message: `Decomposition override recorded for ${buildId}.`,
+        data: { override: result.override },
+      };
+    }
+
     case "update_backlog_item": {
       const existing = await prisma.backlogItem.findUnique({ where: { itemId: String(params["itemId"]) } });
       if (!existing) return { success: false, error: "Item not found", message: `Item ${String(params["itemId"])} not found` };


### PR DESCRIPTION
## Summary

- Server-side substrate for the design-time decomposition assistant. Candidate parsing + validation, atomic Epic-and-children creation in one Prisma transaction, operator override write, and two new MCP tools.
- **Reviewable in isolation.** No UI yet (Phase 4b ships the slide-over). No LLM call yet (Phase 4b ships `propose_decomposition`). 4a focuses entirely on the data-and-invariants surface — DB-side testable with a fake Prisma harness.
- 49 new unit tests pass; full `apps/web/lib/build/` suite 243/243; typecheck clean.

## What this PR contains

| File | Purpose |
|---|---|
| `apps/web/lib/build/decomposition-candidates.ts` | Types + permissive parse (LLM JSON variants) + strict validate (2-4 children, full + non-duplicate AC coverage, no cycles, no self-loops, sequential childOrder, non-empty rationale/title/scope) + `candidateToChildDesignDocs` projection. |
| `apps/web/lib/build/approve-decomposition.ts` | Atomic Prisma transaction. Eligibility gate → revalidate candidate → run all Phase-1 invariants on proposed shape → single txn creates Epic + N children + dependency edges, supersedes original FB, swaps BI activeBuildId → activeEpicId, logs activities. |
| `apps/web/lib/build/decomposition-override.ts` | `recordDecompositionOverride` for the operator "keep as one build" path on required-tier. Rejects on missing build / empty rationale / no sizeAssessment / recommended-or-ok tier. |
| `apps/web/lib/mcp-tools.ts` | New tools `approve_decomposition` and `record_decomposition_override`. Both `manage_backlog` capability, `sideEffect: true`. |
| `apps/web/lib/explore/feature-build-types.ts` | `ReviewResult.decompositionOverride?: DecompositionOverrideSnapshot` (additive, non-breaking). |

## Operator decisions honored (spec §12)

| Q | Decision | How |
|---|---|---|
| Q4 | Forbid recursion | `assertNoRecursiveDecomposition` runs before any DB write; rejects with code `build-already-decomposed`. |
| Q5 | Hybrid originator FK | `Epic.originatingBacklogItemId` AND child `FeatureBuild.originatingBacklogItemId` both carry the BI id (tested explicitly). |
| Q6 | No new BuildPhase values | Originating FB supersession uses `phase: "failed"` + `supersededByEpicId` + `abandonReason: "decomposed-into-epic:<id>"`. The canonical "decomposed vs error" signal is `supersededByEpicId !== null`. |

## Atomic transaction shape (what one approval writes)

For Dale's 3-child decomposition (the test fixture):

1. **1 Epic** — `Epic.create` with `designDoc`, `designReview`, `decompositionState` (sourceBuildId, candidateId, rationale, approver, partition with per-child indices + dependencies), and `originatingBacklogItemId`.
2. **3 FeatureBuilds** — one per child scope, each with `parentEpicId`, `childOrder` (1-indexed), transitive `designReview`, derived `designDoc` (parent ACs filtered to this child's indices), and Q5-hybrid `originatingBacklogItemId`.
3. **3 FeatureBuildDependency edges** — `FB-CHILD2 → FB-CHILD1`, `FB-CHILD3 → FB-CHILD1`, `FB-CHILD3 → FB-CHILD2`.
4. **1 FeatureBuild update** — original FB superseded.
5. **1 BacklogItem update** — `activeBuildId: null`, `activeEpicId: <new>`.
6. **4 BuildActivity rows** — one on the parent, three on the children.

All eight `prisma.*.create/update` calls happen inside a single `$transaction` callback. Tests pin this shape with a fake Prisma harness.

## Verification

- `decomposition-candidates.test.ts`: 27 tests — parsing happy + malformed paths, validate happy + every failure code, `candidateToChildDesignDocs` projection + sort + fallback.
- `approve-decomposition.test.ts`: 15 tests — every eligibility-failure code, full Dale-scenario happy path, transitive designReview, AC subset derivation, supersession shape (phase + supersededByEpicId + abandonReason), BI swap, Q5 hybrid FK, decompositionState fields, activity emission count + targets.
- `decomposition-override.test.ts`: 7 tests — success + every failure code.
- Full `apps/web/lib/build/` suite: 243/243 pass.
- `pnpm --filter web run typecheck` exit 0.
- Pre-commit scoped typecheck clean.

## Test plan

- [ ] Review the invariant-before-write order in `approve-decomposition.ts` — confirm all Phase-1 invariants run on the proposed shape BEFORE any tx callback runs (no partial DB state on invariant violation).
- [ ] Verify Q6 supersession choice — `phase: "failed"` + `supersededByEpicId !== null` is a clean signal for downstream UI consumers (Phase 4b/5 work).
- [ ] After merge, write a synthetic integration test (or drive through MCP directly) to exercise the real Prisma path against a dev DB — the unit tests use a fake; this is the live-DB smoke that 4a's substrate handles a real Dale-shape candidate.

## What ships next

**Phase 4b** — the operator-facing half:

- `propose_decomposition` MCP tool: orchestrates the LLM call (SE coworker reads the design doc + size assessment, returns 2-4 candidates as structured JSON, parsed via `parseCandidatesResponse`, persisted to `designReview.decompositionCandidates`).
- Decomposition assistant slide-over (spec §4.2) — cards for each candidate, drag ACs between children, single-click approve.
- `DecompositionGateBanner` (Phase 3) gains the "Propose splits" + "Keep as one build (text override)" CTAs that call into the 4a APIs.
- Enforcement: ideate→plan advance refuses on `decompose-required` builds unless either decomposition happened (build is now superseded) or override was recorded.

## Related

- Spec: `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md` (merged)
- Phase 1 substrate: PR #1123 (merged)
- Phase 2 sizeDesignDoc: PR #1125 (merged)
- Phase 3 gate banner: PR #1127 (merged)
- BI: BI-2E6CC391
- Epic: EP-BUILD-STUDIO; EP-9FC5D2FD; EP-REDUCTION-GEAR-ARCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)