### PR TITLE
fix: trust workspace before platform update git operations

### DIFF
--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -138,6 +138,31 @@ describe("applyPlatformUpdate", () => {
     }
   });
 
+  it("marks the workspace as a Git safe directory before reading merge state", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockExistsSync.mockReturnValue(true);
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.includes("--diff-filter=U")) {
+        cb(null, { stdout: "", stderr: "" });
+        return;
+      }
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("conflicts");
+    expect(mockExec.mock.calls[0]?.[0]).toBe(
+      "git config --global --add safe.directory '/workspace' >/dev/null 2>&1 || true",
+    );
+    expect(mockExec.mock.calls[1]?.[0]).toBe("git diff --name-only --diff-filter=U");
+  });
+
   it("returns clean-merge after a successful no-conflict merge and clears the pending flag", async () => {
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       updatePending: true,

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -735,6 +735,21 @@ const UPDATE_UPSTREAM_BRANCH = "dpf-upstream";
 const UPDATE_WORK_BRANCH = "my-changes";
 const PLATFORM_UPDATE_SOURCE_PATHS = ["apps/web", "packages"] as const;
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function ensureWorkspaceSafeDirectory(
+  execUpdate: ExecUpdate,
+  gitOpts: ExecUpdateOptions,
+  workspace: string,
+): Promise<void> {
+  await execUpdate(
+    `git config --global --add safe.directory ${shellQuote(workspace)} >/dev/null 2>&1 || true`,
+    gitOpts,
+  );
+}
+
 async function gitBranchExists(
   execUpdate: ExecUpdate,
   gitOpts: ExecUpdateOptions,
@@ -869,6 +884,8 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     // Check for in-progress merge from a previous interrupted run
     const { existsSync } = lazyFs();
     const { resolve: resolvePath } = lazyPath();
+
+    await ensureWorkspaceSafeDirectory(execUpdate, gitOpts, workspace);
 
     if (existsSync(resolvePath(workspace, ".git", "MERGE_HEAD"))) {
       const conflicts = await collectPlatformUpdateConflicts(


### PR DESCRIPTION
## Summary
- Marks the managed workspace as a Git safe directory before the platform update action runs any Git status, diff, branch, checkout, or merge command.
- Adds a regression test for the pending-update button path so the portal action is protected independently of init-container bootstrap logic.

## Root Cause
Sandbox/dev-style Docker volumes can have `/workspace` owned by a different UID than the app process. The init path already handled this, but the in-portal `applyPlatformUpdate` action did not, so the button path could fail on Git's dubious-ownership guard before it reached the managed update branches.

## Validation
- `pnpm --filter web exec vitest run lib/actions/platform-dev-config.apply.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`