### PR TITLE
docs(kernel): promote PAR + governance-approves-evidence-not-provenance to founder kernel (BI-0DF248B4)

### DIFF
--- a/docs/architecture/dpf-patterns.md
+++ b/docs/architecture/dpf-patterns.md
@@ -103,7 +103,7 @@ Result is `{ recommendation, confidence, perPrincipleLedger, ... }`. Persist the
 
 **Failure mode it prevents.** Two sessions silently working the same surface, one sweeping the other's staged files into its commit, overlapping PRs, lost work. Empirically documented in memory across multiple incidents in 2026-05 (`feedback_git_commit_only_for_concurrent_sessions`, `feedback_worktree_per_session`, `feedback_pr_overlap_check_before_pushing`, `feedback_continuous_overlap_check`).
 
-**Kernel:** memory feedback `feedback_propose_acknowledge_reassign` (commandment-tier, candidate for kernel promotion). Related kernel pages: [`worktree-per-session`](../founder-kernel/wiki/principles/worktree-per-session.md), [`worktree-base-origin-main`](../founder-kernel/wiki/principles/worktree-base-origin-main.md), [`sweep-main-before-trusting-worktree-specs`](../founder-kernel/wiki/principles/sweep-main-before-trusting-worktree-specs.md), [`mention-uncommitted-changes`](../founder-kernel/wiki/principles/mention-uncommitted-changes.md).
+**Kernel:** [`propose-acknowledge-reassign`](../founder-kernel/wiki/principles/propose-acknowledge-reassign.md) (commandment-tier). Related: [`worktree-per-session`](../founder-kernel/wiki/principles/worktree-per-session.md), [`worktree-base-origin-main`](../founder-kernel/wiki/principles/worktree-base-origin-main.md), [`sweep-main-before-trusting-worktree-specs`](../founder-kernel/wiki/principles/sweep-main-before-trusting-worktree-specs.md), [`mention-uncommitted-changes`](../founder-kernel/wiki/principles/mention-uncommitted-changes.md).
 
 ---
 
@@ -117,7 +117,7 @@ Result is `{ recommendation, confidence, perPrincipleLedger, ... }`. Persist the
 
 **Why this exists.** Asymmetric trust by provenance compounds: once "Mark's stuff skips review," the platform stops detecting Mark's mistakes; once "the coworker's stuff is suspect by default," the coworker can never accumulate trust. Both failure modes erode the autonomy ladder the platform is built around.
 
-**Kernel:** memory feedback `feedback_governance_approves_evidence_not_provenance` (operator-ratified 2026-05-18, candidate for kernel promotion). Related: [`human-in-the-loop-at-phase-boundaries`](../founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md), [`evidence-before-diagnosis`](../founder-kernel/wiki/principles/evidence-before-diagnosis.md), [`structural-verification-is-not-functional`](../founder-kernel/wiki/principles/structural-verification-is-not-functional.md).
+**Kernel:** [`governance-approves-evidence-not-provenance`](../founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md) (core-tier). Related: [`human-in-the-loop-at-phase-boundaries`](../founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md), [`evidence-before-diagnosis`](../founder-kernel/wiki/principles/evidence-before-diagnosis.md), [`structural-verification-is-not-functional`](../founder-kernel/wiki/principles/structural-verification-is-not-functional.md).
 
 ---
 

--- a/docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md
+++ b/docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md
@@ -1,0 +1,88 @@
+---
+title: Governance approves evidence, not provenance
+slug: governance-approves-evidence-not-provenance
+pageKind: principle
+status: published
+abstract: A draft advances through a phase gate when the evidence the gate requires is present and passes review — regardless of who or what produced the evidence. Gate logic depends on evidence fields, never on producer identity.
+principleTier: core
+principleDirection: Evaluate phase-gate decisions on the quality of evidence presented; never gate on producer identity (which agent dispatched, whether a human or coworker authored, whether the work came through Build Studio or an external branch).
+principleDimensionVector: {"governance_compliance": 1.0, "evidence_density": 0.9, "reusability": 0.7, "long_term_maintainability": 0.6, "human_cognitive_load": -0.2}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - build-studio
+  - engineering-flow
+principlePublic: false
+authoredAt: 2026-05-18
+authoredBy: mark-bodman
+principleOverlapScan:
+  highestAlignment: 0.60
+  highestAlignmentSlug: human-in-the-loop-at-phase-boundaries
+  rationale: |
+    Adjacent but orthogonal. human-in-the-loop-at-phase-boundaries defines WHERE gates fire
+    (the phase boundary, not per-call); this principle defines WHAT they evaluate (evidence,
+    not producer identity). The two compose — a gate fires at a boundary AND evaluates
+    evidence. structural-verification-is-not-functional is the narrower second-closest:
+    it names what counts as evidence at the ship gate specifically, while this principle is
+    the general rule across all gates. Mechanical scan via principle_decide could not be run
+    at promotion time (MCP endpoint unreachable); estimates above are based on reading of
+    nearby principles. Recommend re-running the scan post-merge for telemetry.
+---
+
+# Governance approves evidence, not provenance
+
+**A Build Studio draft advances through a phase when the evidence required by the gate is present and passes review** — regardless of whether Build Studio dispatched the specialists that produced the evidence, whether the operator hand-coded the change, whether the work came through an external branch, or whether a different coworker produced the artifact. Governance evaluates evidence quality, not producer identity.
+
+Operator-ratified 2026-05-18 in the PR #761 discussion, when evaluating how to handle a draft stuck in `ideate` after the implementation PR had already landed independently. The principle-based answer: *use the gates with the available evidence; never mark complete to bypass the gates.*
+
+## The rule
+
+When a phase gate is invoked:
+
+1. **Read the evidence fields the gate requires** (`designDoc`, `buildPlan`, `verificationOut`, `acceptanceMet`, `phaseHandoff`, etc.).
+2. **Run the gate's evaluation against that evidence** — does it pass on quality, completeness, and the gate's specific predicates?
+3. **Advance if the evaluation passes; block if it fails.** The decision is identical regardless of who or what produced the evidence.
+
+Producer identity is a useful audit field, not a gate input.
+
+## Two ways this gets violated
+
+**Path A — bypassing the gate.** "The PR already landed; just mark the draft complete." This skips review entirely. The draft moves to `complete` without the gate's evidence checks ever firing. Future audits cannot reconstruct whether the work actually met the gate's quality bar — only that someone clicked a button.
+
+**Path B — gating on producer.** Gate logic that contains `if (producerAgent === "AGT-ORCH-300") { allow }` or `if (sourceBranch.startsWith("claude/")) { require extra review }`. This makes the gate brittle (new producers need code changes), discriminatory (identical evidence quality, different gate decision), and unable to handle the legitimate case of an external producer with strong evidence.
+
+Both paths reach the same failure mode: governance signal degrades because the gate stops being a function of evidence.
+
+## How to apply
+
+- **When a draft is stuck behind a gate but external evidence satisfies the gate's requirements**, seed the evidence fields (`saveBuildEvidence` for each missing field, or `save_phase_handoff` for cross-phase transitions) and advance through the existing gate. Each transition still runs `checkPhaseGate` — nothing is rubber-stamped.
+- **When designing a new lifecycle gate**, the gate's input shape must be the evidence the gate needs, not the identity of the actor or the path that produced it. No "did Build Studio dispatch this" checks. No "is the author the spec owner" checks. Only evidence-quality checks.
+- **When reviewing a PR that adds a gate**, look for producer-conditional logic and reject it. The reviewer's question is "does this gate pass identical evidence identically?" — if not, it is a provenance gate masquerading as an evidence gate.
+
+## When this principle conflicts with others
+
+It can appear to conflict with [`destructive-actions-require-explicit-go`](destructive-actions-require-explicit-go.md) (some destructive actions *do* require fresh operator approval per call) and with HITL gates that require human acknowledgement. The resolution: those principles add **additional** requirements on top of evidence quality (a fresh approval is itself evidence the gate requires), they do not subtract the evidence requirement. A destructive action with operator approval but no evidence still does not advance; an action with strong evidence but no fresh approval still does not advance. Both fire when both apply.
+
+## Anti-pattern
+
+- **"Mark complete and skip the gates" as a shortcut.** This is the standing operator-forbidden move, no matter how strong the external evidence appears. The principle is to *use* the gates with the available evidence, not bypass them.
+- **Gate logic that branches on `producer` / `dispatcher` / `sourceAgent` fields.** Audit log, yes. Gate input, no.
+- **Asymmetric trust by author identity** ("Mark's commits skip review; coworker commits get full review"). This compounds in two directions: the platform stops detecting Mark's mistakes, and the coworker can never accumulate trust. Both erode the autonomy ladder.
+
+## Why one rule, not a per-case enumeration
+
+Per [`verify-substrate-before-proposing-new`](verify-substrate-before-proposing-new.md), the alternative is a growing list of "external branch ok if X," "operator hotfix ok if Y," "hand-coded BI ok if Z" exceptions. Each exception is a gate that the next producer scenario will not fit. One rule — *gate on evidence* — generalizes to every future "non-Build-Studio producer" scenario without code changes to the gate.
+
+## Related principles
+
+- [`human-in-the-loop-at-phase-boundaries`](human-in-the-loop-at-phase-boundaries.md) — defines where the gates fire; this principle defines what they evaluate.
+- [`evidence-before-diagnosis`](evidence-before-diagnosis.md) — the upstream form for runtime claims; the same shape applies at gate decisions.
+- [`structural-verification-is-not-functional`](structural-verification-is-not-functional.md) — names what counts as evidence at the ship gate specifically.
+- [`structured-handoffs-not-conversation-history`](structured-handoffs-not-conversation-history.md) — the artifact shape phase handoffs produce so the next gate has structured evidence to read.
+- [`verify-substrate-before-proposing-new`](verify-substrate-before-proposing-new.md) — why one principle generalizes better than a per-producer rule list.

--- a/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
+++ b/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
@@ -1,0 +1,102 @@
+---
+title: Propose, Acknowledge, Reassign (PAR)
+slug: propose-acknowledge-reassign
+pageKind: principle
+status: published
+abstract: Concurrent work — operator↔agent, agent↔agent, session↔session — collides when state mutates from more than one pen without an acknowledged handoff token. Either side proposes; the named owner explicitly acknowledges; reassignment back is also explicit.
+principleTier: commandment
+principleDirection: Before mutating any artifact, propose ownership to the named owner and wait for explicit acknowledgement recorded as state; never assume implicit consent from silence; reassignment back is also explicit.
+principleDimensionVector: {"governance_compliance": 0.9, "evidence_density": 0.7, "long_term_maintainability": 0.6, "human_cognitive_load": -0.3, "speed_to_value": -0.2}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - universal-ring
+principleConsumerArchetype: universal
+principlePublic: false
+authoredAt: 2026-05-22
+authoredBy: mark-bodman
+principleOverlapScan:
+  highestAlignment: 0.55
+  highestAlignmentSlug: worktree-per-session
+  rationale: |
+    Adjacent but not redundant. worktree-per-session is a concrete physical-isolation tactic
+    at the filesystem layer; PAR is the upstream protocol that explains why such tactics are
+    needed and generalises to operator/agent, agent/agent, and session/review-pass handoffs
+    that do not touch git at all. human-in-the-loop-at-phase-boundaries is the narrowest
+    second-closest (phase-boundary approval is the canonical operator-acknowledgement
+    surface, but PAR covers handoffs that have no phase to anchor on). Mechanical scan via
+    principle_decide could not be run at promotion time (MCP endpoint unreachable); estimates
+    above are based on reading of nearby principles. Recommend re-running the scan
+    post-merge for telemetry.
+---
+
+# Propose, Acknowledge, Reassign (PAR)
+
+**Concurrent work collides when state mutates from more than one pen without an acknowledged handoff token.** PAR is the upstream protocol that prevents this — it does not depend on whether the actors are operator + agent, two coworker agents, two Claude sessions in different worktrees, or one session running alongside a chief-architect review pass on the same artifact. The shape is identical in every case.
+
+## The three steps
+
+1. **Propose.** Either side names a piece of work, a decision, or an action and assigns a candidate owner.
+2. **Acknowledge.** The named owner explicitly accepts, modifies, or declines. **No mutation begins without this token.** The token is recorded as **state, not chat text** — a capsule lease, a `ToolExecution` row, a `DecisionInteraction` outcome, an operator click on a card.
+3. **Reassign.** Completion *or* mid-stream hand-back is also explicit: `session_detach(disposition)`, `release_capsule_scope`, a WWMD `escalate` / `defer`, a PR opened against the owner's branch. Silent abandonment is not a valid reassignment.
+
+The cycle then repeats. Either side can initiate the next Propose.
+
+## Why this exists
+
+Triggering incident 2026-05-22: a session was asking sequential clarification questions on a spec while a chief-architect pass was mid-edit on the same artifact. Two pens, no handoff token, collision. The clarification-question loop felt fuzzy because ownership was fuzzy.
+
+Four prior concurrency-collision rules are downstream symptoms of the same missing principle:
+
+- [`worktree-per-session`](worktree-per-session.md) — each concurrent session in its own worktree (collision prevention by physical isolation).
+- `feedback_git_commit_only_for_concurrent_sessions` (memory) — `git commit --only <paths>` to scope the commit (collision prevention at the commit layer).
+- `feedback_pr_overlap_check_before_pushing` (memory) — sweep main + open PRs before pushing (collision detection before merge).
+- `feedback_continuous_overlap_check` (memory) — re-sweep before every push in long autonomous runs (collision detection during long-lived ownership).
+
+All four work. PAR is what makes them composable instead of an enumerated list of cases.
+
+## Operating rules
+
+- **No actor mutates an artifact that is currently in an acknowledged-by-another-actor state** without first proposing reassignment and receiving acknowledgement.
+- **Sequential clarification questions to an operator who is mid-edit on the artifact are a PAR violation.** The propose step must hold for explicit acknowledgement first.
+- **Idle acknowledgements expire on a heartbeat budget.** Expired ownership is *not* silently reassigned — it surfaces as `stale` for explicit adopt-orphan. Per [`idle-is-not-abandoned`](../../../../) (memory `feedback_idle_is_not_abandoned`), staleness thresholds must absorb operator travel + weekly rate-limit resets (default 7d minimum).
+- **WWMD `escalate` and `defer` are reassignments to the operator UI**, not chat pings.
+- **End every turn with a concrete proposed next step + named owner** (a reassign-back), never "Done." / "Investigating." / "Your call." This is the per-turn shape of PAR's reassign step.
+
+## The acknowledgement-as-state requirement
+
+The acknowledgement token must be queryable later. Chat text is not queryable — it lives in a transcript that decays. Acceptable acknowledgement surfaces:
+
+- `WorkCapsule.claimedByActor` + `lastHeartbeatAt` (soft lease, with expiry)
+- `FeatureBuild.phase` advancement + `phaseRuns` row (hard state transition, with audit trail)
+- `DecisionInteraction.humanOutcome` (WWMD-mediated decision, with rationale)
+- `ToolExecution` row for a proposal-mode tool that the operator approved (explicit click, with payload)
+- A PR opened against a specific base branch (git is the audit trail)
+
+Unacceptable acknowledgement surfaces:
+
+- "I'll take it" in chat (no row written)
+- A coworker assuming silence == consent
+- An operator's last message being interpreted as a blanket approval for everything subsequent
+
+## Anti-pattern
+
+- Two Claude sessions in the same worktree, both staging files, one sweeping the other's stage into its commit via `git add -A`.
+- An autonomous agent that sees a stale capsule and silently picks up the work without filing an adopt-orphan proposal first.
+- A spec-review thread that opens PRs against the spec author's working branch while the author is still editing the spec.
+- A coworker that asks "want me to continue?" three times in a row — that is a missing acknowledgement from the *prior* turn surfacing as repeated proposals instead of an actual ack.
+
+## Penalty
+
+This is a **commandment-tier** principle. The collisions PAR prevents are not bugs — they are protocol violations. The recovery cost of a single collision (lost staged work, overlapping PRs needing surgical revert, two sessions debugging the same bug from different worktree states) typically exceeds the entire savings of every "I'll just take it without asking" shortcut combined.
+
+## Related principles
+
+- [`worktree-per-session`](worktree-per-session.md) — physical isolation at the filesystem layer; PAR is the protocol on top.
+- [`worktree-base-origin-main`](worktree-base-origin-main.md) — every new ownership cycle starts from a clean base.
+- [`structured-handoffs-not-conversation-history`](structured-handoffs-not-conversation-history.md) — the durable artifact PAR's reassign step produces.
+- [`human-in-the-loop-at-phase-boundaries`](human-in-the-loop-at-phase-boundaries.md) — phase-boundary approval is the canonical operator-acknowledgement surface.
+- [`do-the-work-dont-task-the-operator`](do-the-work-dont-task-the-operator.md) — when reassigning back to the operator, propose a concrete next step, not a generic "your call."
+- [`mention-uncommitted-changes`](mention-uncommitted-changes.md) — surfaces the working-tree state PAR needs to compute "who owns this right now."


### PR DESCRIPTION
## Summary

- v3 in the DPF-patterns-doc thread (v1 PR #1121 merged, v2 PR #1130 open). Promotes the two principles cited in `docs/architecture/dpf-patterns.md` §1.4 + §1.5 from memory-only to canonical founder-kernel pages — so they ship with every install and external coders can see them.
- Two new kernel pages + one patterns-doc footnote update.
- Follows the founder-kernel-evolution-discipline spec (PR #1081, merged) — both pages satisfy §4.1 eligibility and include `principleOverlapScan` frontmatter.

## What's new

| File | Tier | Ring scope | Direction |
|---|---|---|---|
| [propose-acknowledge-reassign.md](docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md) | commandment | universal-ring | Three-step protocol: Propose / Acknowledge / Reassign. Either side proposes; ack recorded as state, not chat. |
| [governance-approves-evidence-not-provenance.md](docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md) | core | ring-2-workflow + ring-4-sandbox-prod | Gates evaluate evidence fields; never branch on producer identity. |

`docs/architecture/dpf-patterns.md` §1.4 + §1.5 footnotes flipped from "memory feedback (candidate for promotion)" to direct kernel-page links.

## Eligibility check vs PR #1081 §4

| Condition | PAR | governance-evidence |
|---|---|---|
| §4.1.1 Organic use ≥2 specs/plans | ✓ Four downstream concurrency-collision memory rules + 2026-05-22 triggering incident | ✓ Spec `2026-05-18-build-studio-thread-management-design.md` §12.2, PR #761, PR #756, and now `dpf-patterns.md` §1.5 (PR #1121) |
| §4.1.2 Operator-ratified | ✓ Memory tagged commandment-tier | ✓ Memory: "Operator-ratified 2026-05-18" |
| §4.1.3 No existing ≥0.85 overlap | ✓ 0.55 vs worktree-per-session | ✓ 0.60 vs human-in-the-loop-at-phase-boundaries |
| §4.1.4 Names a decision moment | ✓ "Before mutating, propose…" | ✓ "When a gate fires, evaluate evidence…" |

## Overlap scan caveat (§4.3)

Both pages include `principleOverlapScan` frontmatter with manual estimates + rationale. The mechanical `principle_decide` MCP scan was unavailable at promotion time (portal not running in this worktree). Estimates are well below the 0.70 ship-freely threshold and based on reading nearby principles directly. **Recommend re-running the scan post-merge for telemetry calibration** — if either comes back >0.70, append a body paragraph per §4.3 threshold rule.

## Dimensions

Both pages reuse existing keys from `PRINCIPLE_DIMENSIONS` in `packages/db/src/wiki-taxonomy.ts:144`. No new dimensions introduced (§4.4 bar is high: orthogonality claim + ≥2 principles using it).

## Out of scope

- Updating the personal memory notes (`feedback_propose_acknowledge_reassign.md`, `feedback_governance_approves_evidence_not_provenance.md`) under `C:\Users\Mark Bodman\.claude\projects\D--DPF\memory\` to redirect at the new kernel pages — those are outside the repo and Mark integrates them on his own cadence.
- Updating `MEMORY.md`'s "Promoted to kernel" index — same reason; personal memory file.

## Class

Documentation + kernel evolution. Per `feedback_build_studio_for_all_development`, governance class — opened directly by Claude.

## Related

- Backlog: BI-0DF248B4 (linked to `EP-BUILD-STUDIO`)
- Predecessors: PR #1121 (v1 patterns doc, merged) + PR #1130 (v2 sub-agent prompts, open)
- Governing spec: [PR #1081 (merged)](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1081) — founder kernel evolution discipline, §4

## Test plan

- [ ] Manual review of the two kernel pages — frontmatter conforms to existing convention, dimension keys are valid, ring scope matches the principle's actual binding
- [ ] Verify cross-links in §1.4 + §1.5 of `dpf-patterns.md` resolve to the new kernel pages
- [ ] Post-merge: re-run `principle_decide` overlap scan against both new pages with the full kernel in scope; confirm `highestAlignment ≤ 0.70` matches the manual estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)