### PR TITLE
feat(build-studio): Phase 4b decomposition assistant — propose tool, slide-over UI, banner CTAs, required-tier gate (BI-2E6CC391)

### DIFF
--- a/apps/web/components/build/DecompositionAssistantPanel.test.tsx
+++ b/apps/web/components/build/DecompositionAssistantPanel.test.tsx
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+//
+// Coverage for the Phase 4b decomposition assistant slide-over.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md (§4.2)
+// BI: BI-2E6CC391.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DecompositionAssistantPanel } from "./DecompositionAssistantPanel";
+import type { DecompositionCandidate } from "@/lib/build/decomposition-candidates";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeCandidate(id = "candidate-1"): DecompositionCandidate {
+  return {
+    candidateId: id,
+    rationale: `Rationale for ${id}`,
+    childScopes: [
+      { childOrder: 1, title: "Truck inventory read", summary: "Show parts.", acceptanceCriteriaIndices: [0, 1], dependsOn: [] },
+      { childOrder: 2, title: "Record usage", summary: "Mark used.", acceptanceCriteriaIndices: [2, 3], dependsOn: [1] },
+      { childOrder: 3, title: "Low-stock surfacing", summary: "Restock view.", acceptanceCriteriaIndices: [4], dependsOn: [1, 2] },
+    ],
+  };
+}
+
+const acs = [
+  "AC0: Tech sees inventory.",
+  "AC1: Quantity + low-stock.",
+  "AC2: Mark usage.",
+  "AC3: Idempotency.",
+  "AC4: Dispatch rollup.",
+];
+
+describe("DecompositionAssistantPanel — open/close behaviour", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = render(
+      <DecompositionAssistantPanel
+        open={false}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onClose when the overlay is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/close decomposition assistant/i));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the Cancel button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DecompositionAssistantPanel — candidate rendering", () => {
+  it("renders all candidates with their child scopes", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate("a"), makeCandidate("b")]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("candidate-card-a")).toBeInTheDocument();
+    expect(screen.getByTestId("candidate-card-b")).toBeInTheDocument();
+  });
+
+  it("renders each child scope's title + summary", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Truck inventory read")).toBeInTheDocument();
+    expect(screen.getByText("Record usage")).toBeInTheDocument();
+    expect(screen.getByText("Low-stock surfacing")).toBeInTheDocument();
+  });
+
+  it("renders parent AC text for each AC index in each child", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const child1 = screen.getByTestId("child-scope-1");
+    expect(child1.textContent).toMatch(/Tech sees inventory/);
+    expect(child1.textContent).toMatch(/low-stock/i);
+
+    const child3 = screen.getByTestId("child-scope-3");
+    expect(child3.textContent).toMatch(/Dispatch rollup/);
+  });
+
+  it("renders 'depends on' chip when a child has sibling dependencies", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const child3 = screen.getByTestId("child-scope-3");
+    expect(child3.textContent).toMatch(/depends on #1, #2/);
+  });
+
+  it("renders empty state when candidates array is empty", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No candidates available yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("DecompositionAssistantPanel — approve flow", () => {
+  it("approves the first candidate by default", () => {
+    const onApprove = vi.fn();
+    const c1 = makeCandidate("a");
+    const c2 = makeCandidate("b");
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[c1, c2]}
+        onApprove={onApprove}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /approve selected/i }));
+    expect(onApprove).toHaveBeenCalledWith(c1);
+  });
+
+  it("switches selection when a different radio is chosen", () => {
+    const onApprove = vi.fn();
+    const c1 = makeCandidate("a");
+    const c2 = makeCandidate("b");
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[c1, c2]}
+        onApprove={onApprove}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(within(screen.getByTestId("candidate-card-b")).getByRole("radio"));
+    fireEvent.click(screen.getByRole("button", { name: /approve selected/i }));
+    expect(onApprove).toHaveBeenCalledWith(c2);
+  });
+
+  it("disables Approve when approving=true and shows 'Approving…'", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        approving={true}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /approving/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("disables Approve when candidates is empty (nothing selectable)", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[]}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /approve selected/i });
+    expect(btn).toBeDisabled();
+  });
+});
+
+describe("DecompositionAssistantPanel — regenerate flow", () => {
+  it("opens the hint input on first 'Reject all + regenerate' click without firing onRegenerate", () => {
+    const onRegenerate = vi.fn();
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={onRegenerate}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject all/i }));
+    expect(onRegenerate).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText(/optional hint/i)).toBeInTheDocument();
+  });
+
+  it("fires onRegenerate with the typed hint on second click", () => {
+    const onRegenerate = vi.fn();
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={onRegenerate}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject all/i }));
+    fireEvent.change(screen.getByPlaceholderText(/optional hint/i), {
+      target: { value: "make the read-first smaller" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /regenerate with hint/i }));
+    expect(onRegenerate).toHaveBeenCalledWith("make the read-first smaller");
+  });
+
+  it("fires onRegenerate with an empty string when no hint is typed", () => {
+    const onRegenerate = vi.fn();
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        onApprove={vi.fn()}
+        onRegenerate={onRegenerate}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject all/i }));
+    fireEvent.click(screen.getByRole("button", { name: /regenerate with hint/i }));
+    expect(onRegenerate).toHaveBeenCalledWith("");
+  });
+
+  it("disables Regenerate while regenerating=true", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        regenerating={true}
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /regenerating/i });
+    expect(btn).toBeDisabled();
+  });
+});
+
+describe("DecompositionAssistantPanel — header copy", () => {
+  it("renders the parent build title in the header when provided", () => {
+    render(
+      <DecompositionAssistantPanel
+        open={true}
+        parentAcceptanceCriteria={acs}
+        candidates={[makeCandidate()]}
+        parentBuildTitle="Truck inventory"
+        decisionLabel="decompose-required"
+        onApprove={vi.fn()}
+        onRegenerate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const header = screen.getByText("Truck inventory");
+    expect(header).toBeInTheDocument();
+    expect(header.parentElement?.textContent).toMatch(/decomposition required/);
+  });
+});

--- a/apps/web/components/build/DecompositionAssistantPanel.tsx
+++ b/apps/web/components/build/DecompositionAssistantPanel.tsx
@@ -1,0 +1,389 @@
+// apps/web/components/build/DecompositionAssistantPanel.tsx
+//
+// Phase 4b — operator-facing slide-over for picking a candidate decomposition.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md (§4.2)
+// BI: BI-2E6CC391.
+//
+// Scope for this MVP:
+//   - Display 2-4 candidates as cards. Operator radio-selects one and clicks
+//     "Approve" → invokes the supplied onApprove handler with the chosen
+//     candidate (which calls the approve_decomposition MCP tool upstream).
+//   - "Reject all + regenerate" calls onRegenerate, optionally with an
+//     operator hint typed into a small input.
+//   - "Cancel" / overlay click closes the panel.
+//
+// Deferred to Phase 4c:
+//   - Drag ACs between children
+//   - Rename child titles inline
+//   - Reorder children
+//
+// All colours via CSS variables; no hardcoded hex. The component is
+// presentational — all I/O is via the props (onApprove, onRegenerate,
+// onClose). The MCP tool wrappers live one layer up in the page route or
+// the upgraded DecompositionGateBanner.
+
+"use client";
+
+import { useId, useState } from "react";
+
+import type {
+  DecompositionCandidate,
+  DecompositionChildScope,
+} from "@/lib/build/decomposition-candidates";
+import type { BuildDesignDoc } from "@/lib/explore/feature-build-types";
+
+export type DecompositionAssistantPanelProps = {
+  open: boolean;
+  /** The parent design's acceptance criteria — referenced by index in each
+   *  child scope so the panel can render the actual text per child. */
+  parentAcceptanceCriteria: string[];
+  /** Candidates returned by propose_decomposition. */
+  candidates: DecompositionCandidate[];
+  /** Disables Approve when true (e.g. while approve_decomposition is in flight). */
+  approving?: boolean;
+  /** Disables Regenerate + closes input when true (e.g. while propose is in flight). */
+  regenerating?: boolean;
+  /** Banner-driven entry point may carry the parent design title for header copy. */
+  parentBuildTitle?: string;
+  /** Optional decomposition decision text used in the panel sub-header. */
+  decisionLabel?: "decompose-recommended" | "decompose-required";
+  onApprove: (candidate: DecompositionCandidate) => void;
+  onRegenerate: (operatorHint: string) => void;
+  onClose: () => void;
+};
+
+export function DecompositionAssistantPanel(props: DecompositionAssistantPanelProps) {
+  const {
+    open,
+    candidates,
+    approving,
+    regenerating,
+    parentAcceptanceCriteria,
+    parentBuildTitle,
+    decisionLabel,
+    onApprove,
+    onRegenerate,
+    onClose,
+  } = props;
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    candidates[0]?.candidateId ?? null,
+  );
+  const [hintOpen, setHintOpen] = useState(false);
+  const [hint, setHint] = useState("");
+  const radioName = useId();
+
+  if (!open) return null;
+
+  const selected = candidates.find((c) => c.candidateId === selectedId) ?? null;
+
+  const handleApprove = () => {
+    if (!selected || approving) return;
+    onApprove(selected);
+  };
+
+  const handleRegenerate = () => {
+    if (regenerating) return;
+    onRegenerate(hint.trim());
+    setHint("");
+    setHintOpen(false);
+  };
+
+  return (
+    <div
+      data-testid="decomposition-assistant-panel"
+      className="fixed inset-0 z-40 flex"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Decomposition assistant"
+    >
+      {/* overlay */}
+      <button
+        type="button"
+        aria-label="Close decomposition assistant"
+        onClick={onClose}
+        className="absolute inset-0"
+        style={{ background: "var(--dpf-overlay, rgba(0,0,0,0.4))" }}
+      />
+
+      {/* slide-over */}
+      <aside
+        className="relative ml-auto flex h-full w-full max-w-2xl flex-col shadow-2xl"
+        style={{
+          background: "var(--surface-canvas, var(--dpf-surface))",
+          color: "var(--dpf-text)",
+          borderLeft: "1px solid var(--border-default, var(--dpf-muted))",
+        }}
+      >
+        <header
+          className="flex items-start justify-between p-4"
+          style={{ borderBottom: "1px solid var(--border-default, var(--dpf-muted))" }}
+        >
+          <div>
+            <h2 className="text-base font-semibold">Decomposition assistant</h2>
+            {parentBuildTitle && (
+              <p
+                className="mt-0.5 text-xs"
+                style={{ color: "var(--dpf-text-secondary)" }}
+              >
+                {parentBuildTitle}
+                {decisionLabel && (
+                  <span style={{ color: "var(--dpf-muted)" }}>
+                    {" "}— {decisionLabel === "decompose-required" ? "decomposition required" : "decomposition recommended"}
+                  </span>
+                )}
+              </p>
+            )}
+            <p
+              className="mt-1 text-xs"
+              style={{ color: "var(--dpf-text-secondary)" }}
+            >
+              Pick one of the proposed splits below. Each card is a partition of the parent design's acceptance criteria into 2-4 smaller builds. Approving creates the parent Epic + the child builds atomically.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-3 rounded p-1 text-sm"
+            style={{ color: "var(--dpf-muted)" }}
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {candidates.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <ul className="space-y-3" role="radiogroup" aria-label="Candidate decompositions">
+              {candidates.map((c) => (
+                <CandidateCard
+                  key={c.candidateId}
+                  candidate={c}
+                  radioName={radioName}
+                  selected={c.candidateId === selectedId}
+                  onSelect={() => setSelectedId(c.candidateId)}
+                  parentAcceptanceCriteria={parentAcceptanceCriteria}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <footer
+          className="flex flex-col gap-2 p-4"
+          style={{ borderTop: "1px solid var(--border-default, var(--dpf-muted))" }}
+        >
+          {hintOpen && (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={hint}
+                onChange={(e) => setHint(e.target.value)}
+                placeholder="Optional hint (e.g. 'ship the ledger separately')"
+                className="flex-1 rounded border px-2 py-1 text-xs"
+                style={{
+                  borderColor: "var(--border-default, var(--dpf-muted))",
+                  background: "var(--surface-input, var(--dpf-surface))",
+                  color: "var(--dpf-text)",
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  setHintOpen(false);
+                  setHint("");
+                }}
+                className="text-[10px]"
+                style={{ color: "var(--dpf-muted)" }}
+              >
+                cancel
+              </button>
+            </div>
+          )}
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={hintOpen ? handleRegenerate : () => setHintOpen(true)}
+              disabled={regenerating}
+              className="text-xs underline disabled:opacity-50"
+              style={{ color: "var(--dpf-accent)" }}
+            >
+              {regenerating
+                ? "Regenerating…"
+                : hintOpen
+                  ? "Regenerate with hint"
+                  : "Reject all + regenerate"}
+            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded px-3 py-1 text-xs"
+                style={{
+                  background: "transparent",
+                  color: "var(--dpf-text-secondary)",
+                  border: "1px solid var(--border-default, var(--dpf-muted))",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleApprove}
+                disabled={!selected || approving}
+                className="rounded px-3 py-1 text-xs font-semibold disabled:opacity-50"
+                style={{
+                  background: "var(--dpf-accent)",
+                  color: "var(--dpf-on-accent, white)",
+                }}
+              >
+                {approving ? "Approving…" : "Approve selected"}
+              </button>
+            </div>
+          </div>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div
+      className="rounded border p-4 text-center text-xs"
+      style={{
+        borderColor: "var(--border-default, var(--dpf-muted))",
+        color: "var(--dpf-text-secondary)",
+      }}
+    >
+      No candidates available yet. Click "Reject all + regenerate" with a hint to generate the first set.
+    </div>
+  );
+}
+
+function CandidateCard({
+  candidate,
+  radioName,
+  selected,
+  onSelect,
+  parentAcceptanceCriteria,
+}: {
+  candidate: DecompositionCandidate;
+  radioName: string;
+  selected: boolean;
+  onSelect: () => void;
+  parentAcceptanceCriteria: string[];
+}) {
+  return (
+    <li
+      data-testid={`candidate-card-${candidate.candidateId}`}
+      className="rounded-md border p-3"
+      style={{
+        background: selected
+          ? "var(--surface-card-emphasis, var(--surface-elevated, var(--dpf-surface)))"
+          : "var(--surface-card, var(--dpf-surface))",
+        borderColor: selected
+          ? "var(--dpf-accent)"
+          : "var(--border-default, var(--dpf-muted))",
+      }}
+    >
+      <label className="flex cursor-pointer items-start gap-2">
+        <input
+          type="radio"
+          name={radioName}
+          value={candidate.candidateId}
+          checked={selected}
+          onChange={onSelect}
+          className="mt-0.5"
+          aria-label={`Select ${candidate.candidateId}`}
+        />
+        <div className="flex-1">
+          <p className="text-xs font-semibold">{candidate.candidateId}</p>
+          <p
+            className="mt-0.5 text-[11px] leading-snug"
+            style={{ color: "var(--dpf-text-secondary)" }}
+          >
+            {candidate.rationale}
+          </p>
+        </div>
+      </label>
+      <ul className="mt-2 space-y-1.5">
+        {candidate.childScopes
+          .slice()
+          .sort((a, b) => a.childOrder - b.childOrder)
+          .map((scope) => (
+            <ChildScopeRow
+              key={scope.childOrder}
+              scope={scope}
+              parentAcceptanceCriteria={parentAcceptanceCriteria}
+            />
+          ))}
+      </ul>
+    </li>
+  );
+}
+
+function ChildScopeRow({
+  scope,
+  parentAcceptanceCriteria,
+}: {
+  scope: DecompositionChildScope;
+  parentAcceptanceCriteria: string[];
+}) {
+  return (
+    <li
+      data-testid={`child-scope-${scope.childOrder}`}
+      className="rounded border p-2 text-[11px]"
+      style={{
+        borderColor: "var(--border-default, var(--dpf-muted))",
+        background: "var(--surface-canvas, transparent)",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="rounded px-1 text-[10px] font-mono"
+          style={{
+            background: "var(--surface-elevated, var(--dpf-surface))",
+            color: "var(--dpf-text-secondary)",
+          }}
+        >
+          #{scope.childOrder}
+        </span>
+        <span className="font-semibold">{scope.title}</span>
+        {scope.dependsOn.length > 0 && (
+          <span
+            className="text-[10px]"
+            style={{ color: "var(--dpf-muted)" }}
+          >
+            depends on #{scope.dependsOn.join(", #")}
+          </span>
+        )}
+      </div>
+      {scope.summary && (
+        <p
+          className="mt-0.5 leading-snug"
+          style={{ color: "var(--dpf-text-secondary)" }}
+        >
+          {scope.summary}
+        </p>
+      )}
+      <ul className="mt-1 list-disc pl-4">
+        {scope.acceptanceCriteriaIndices.map((idx) => (
+          <li
+            key={idx}
+            className="leading-snug"
+            style={{ color: "var(--dpf-text-secondary)" }}
+          >
+            <span className="font-mono">[{idx}]</span>{" "}
+            {parentAcceptanceCriteria[idx] ?? `(AC index ${idx} out of range)`}
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+// Re-export the BuildDesignDoc type purely for downstream wiring convenience.
+export type { BuildDesignDoc };

--- a/apps/web/components/build/DecompositionGateBanner.test.tsx
+++ b/apps/web/components/build/DecompositionGateBanner.test.tsx
@@ -5,8 +5,8 @@
 // BI: BI-2E6CC391
 
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DecompositionGateBanner } from "./DecompositionGateBanner";
 import type { SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
@@ -209,5 +209,125 @@ describe("DecompositionGateBanner — defensive presentation", () => {
     render(<DecompositionGateBanner assessment={assessment} />);
     // Banner still renders; rationale block is suppressed when empty.
     expect(screen.getByTestId("decomposition-gate-banner")).toBeInTheDocument();
+  });
+});
+
+describe("DecompositionGateBanner — Phase 4b CTAs", () => {
+  const requiredAssessment = makeAssessment({
+    decision: "decompose-required",
+    trips: [{ dimension: "models", level: "required", threshold: 5, observed: 5 }],
+  });
+  const recommendedAssessment = makeAssessment({
+    decision: "decompose-recommended",
+    trips: [{ dimension: "models", level: "recommend", threshold: 3, observed: 3 }],
+  });
+
+  it("renders 'Propose splits' button when onProposeSplits is wired (required tier)", () => {
+    const onProposeSplits = vi.fn();
+    render(
+      <DecompositionGateBanner
+        assessment={requiredAssessment}
+        onProposeSplits={onProposeSplits}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /propose splits/i }));
+    expect(onProposeSplits).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders 'Propose splits' on recommended tier too (no override path though)", () => {
+    const onProposeSplits = vi.fn();
+    render(
+      <DecompositionGateBanner
+        assessment={recommendedAssessment}
+        onProposeSplits={onProposeSplits}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /propose splits/i })).toBeInTheDocument();
+  });
+
+  it("renders 'Keep as one build' override path only on required tier", () => {
+    const onRecordOverride = vi.fn();
+    render(
+      <DecompositionGateBanner
+        assessment={recommendedAssessment}
+        onRecordOverride={onRecordOverride}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /keep as one build/i })).not.toBeInTheDocument();
+  });
+
+  it("reveals the rationale input on 'Keep as one build' click and submits on click", () => {
+    const onRecordOverride = vi.fn();
+    render(
+      <DecompositionGateBanner
+        assessment={requiredAssessment}
+        onProposeSplits={vi.fn()}
+        onRecordOverride={onRecordOverride}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /keep as one build/i }));
+    const input = screen.getByLabelText(/override rationale/i);
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "Single tech ships this end-to-end." } });
+    fireEvent.click(screen.getByRole("button", { name: /record override/i }));
+    expect(onRecordOverride).toHaveBeenCalledWith("Single tech ships this end-to-end.");
+  });
+
+  it("disables 'Record override' submit when input is empty/whitespace", () => {
+    const onRecordOverride = vi.fn();
+    render(
+      <DecompositionGateBanner
+        assessment={requiredAssessment}
+        onProposeSplits={vi.fn()}
+        onRecordOverride={onRecordOverride}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /keep as one build/i }));
+    const submit = screen.getByRole("button", { name: /record override/i });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/override rationale/i), {
+      target: { value: "   " },
+    });
+    expect(submit).toBeDisabled();
+  });
+
+  it("renders 'Override recorded' chip instead of action row when override exists", () => {
+    render(
+      <DecompositionGateBanner
+        assessment={requiredAssessment}
+        onProposeSplits={vi.fn()}
+        onRecordOverride={vi.fn()}
+        existingOverride={{
+          rationale: "Solo dev; coordination cost > benefit.",
+          recordedAt: "2026-05-24T20:00:00.000Z",
+          recordedByUserId: "user-1",
+          recordedByAgentId: null,
+        }}
+      />,
+    );
+    expect(screen.getByText(/Override recorded/i)).toBeInTheDocument();
+    expect(screen.getByText(/Solo dev; coordination cost/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /propose splits/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /keep as one build/i })).not.toBeInTheDocument();
+  });
+
+  it("disables both CTAs when actionsDisabled=true", () => {
+    render(
+      <DecompositionGateBanner
+        assessment={requiredAssessment}
+        onProposeSplits={vi.fn()}
+        onRecordOverride={vi.fn()}
+        actionsDisabled={true}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /propose splits/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /keep as one build/i })).toBeDisabled();
+  });
+
+  it("falls back to the Phase 3 'next phase' notice when no CTAs are wired", () => {
+    render(<DecompositionGateBanner assessment={requiredAssessment} />);
+    expect(
+      screen.getByText(/decomposition assistant.*ships in the next phase/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/components/build/DecompositionGateBanner.tsx
+++ b/apps/web/components/build/DecompositionGateBanner.tsx
@@ -21,13 +21,40 @@
 
 "use client";
 
-import type { SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
+import { useState } from "react";
+
+import type {
+  DecompositionOverrideSnapshot,
+  SizeAssessmentSnapshot,
+} from "@/lib/explore/feature-build-types";
 
 type Props = {
   assessment: SizeAssessmentSnapshot | null | undefined;
+  /** Phase 4b — fires when the operator clicks "Propose splits". The parent
+   *  page is expected to invoke propose_decomposition (if no candidates exist
+   *  yet) and then open the DecompositionAssistantPanel. When omitted, the
+   *  CTA is hidden — the banner stays informational (Phase 3 behaviour). */
+  onProposeSplits?: () => void;
+  /** Phase 4b — fires with the operator-typed rationale when they choose
+   *  "Keep as one build (explain why)" on required tier. The parent calls
+   *  record_decomposition_override. When omitted, the override path is
+   *  hidden. Recommended-tier ignores this prop (override only meaningful
+   *  at required-tier per spec §4.1). */
+  onRecordOverride?: (rationale: string) => void;
+  /** Disables both CTAs while in-flight work runs upstream. */
+  actionsDisabled?: boolean;
+  /** When non-null, the override has already been recorded — banner shows a
+   *  small chip with the rationale instead of the override-entry form. */
+  existingOverride?: DecompositionOverrideSnapshot | null;
 };
 
-export function DecompositionGateBanner({ assessment }: Props) {
+export function DecompositionGateBanner({
+  assessment,
+  onProposeSplits,
+  onRecordOverride,
+  actionsDisabled,
+  existingOverride,
+}: Props) {
   if (!assessment) return null;
   if (assessment.decision === "ok") return null;
 
@@ -41,6 +68,8 @@ export function DecompositionGateBanner({ assessment }: Props) {
   const subhead = isRequired
     ? "Plan iteration on designs this size tends to oscillate without converging. Splitting into 2-4 smaller builds that ship one at a time will plan faster and be easier to verify."
     : "Plans this size can converge, but smaller is faster. Consider splitting into 2-3 builds.";
+
+  const hasActions = onProposeSplits != null || (isRequired && onRecordOverride != null);
 
   return (
     <div
@@ -73,8 +102,138 @@ export function DecompositionGateBanner({ assessment }: Props) {
 
       <Rationale text={assessment.rationale} />
 
-      <NextPhaseNotice />
+      {existingOverride ? (
+        <OverrideRecordedChip override={existingOverride} />
+      ) : hasActions ? (
+        <ActionRow
+          isRequired={isRequired}
+          onProposeSplits={onProposeSplits}
+          onRecordOverride={onRecordOverride}
+          actionsDisabled={actionsDisabled ?? false}
+        />
+      ) : (
+        <NextPhaseNotice />
+      )}
     </div>
+  );
+}
+
+function ActionRow({
+  isRequired,
+  onProposeSplits,
+  onRecordOverride,
+  actionsDisabled,
+}: {
+  isRequired: boolean;
+  onProposeSplits: (() => void) | undefined;
+  onRecordOverride: ((rationale: string) => void) | undefined;
+  actionsDisabled: boolean;
+}) {
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const [rationale, setRationale] = useState("");
+
+  const showOverride = isRequired && onRecordOverride != null;
+
+  const submitOverride = () => {
+    const trimmed = rationale.trim();
+    if (trimmed.length === 0 || !onRecordOverride) return;
+    onRecordOverride(trimmed);
+    setRationale("");
+    setOverrideOpen(false);
+  };
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {overrideOpen ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={rationale}
+            onChange={(e) => setRationale(e.target.value)}
+            placeholder="Explain why a single build is the right call here…"
+            aria-label="Override rationale"
+            className="flex-1 rounded border px-2 py-1 text-[11px]"
+            style={{
+              borderColor: "var(--border-default, var(--dpf-muted))",
+              background: "var(--surface-input, var(--dpf-surface))",
+              color: "var(--dpf-text)",
+            }}
+          />
+          <button
+            type="button"
+            onClick={submitOverride}
+            disabled={actionsDisabled || rationale.trim().length === 0}
+            className="rounded px-2 py-1 text-[11px] font-semibold disabled:opacity-50"
+            style={{
+              background: "var(--dpf-warning)",
+              color: "var(--dpf-on-accent, white)",
+            }}
+          >
+            Record override
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setOverrideOpen(false);
+              setRationale("");
+            }}
+            className="text-[10px]"
+            style={{ color: "var(--dpf-muted)" }}
+          >
+            cancel
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          {onProposeSplits && (
+            <button
+              type="button"
+              onClick={onProposeSplits}
+              disabled={actionsDisabled}
+              className="rounded px-2 py-1 text-[11px] font-semibold disabled:opacity-50"
+              style={{
+                background: "var(--dpf-accent)",
+                color: "var(--dpf-on-accent, white)",
+              }}
+            >
+              Propose splits
+            </button>
+          )}
+          {showOverride && (
+            <button
+              type="button"
+              onClick={() => setOverrideOpen(true)}
+              disabled={actionsDisabled}
+              className="text-[11px] underline disabled:opacity-50"
+              style={{ color: "var(--dpf-text-secondary)" }}
+            >
+              Keep as one build (explain why)
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OverrideRecordedChip({ override }: { override: DecompositionOverrideSnapshot }) {
+  return (
+    <p
+      className="mt-3 rounded border px-2 py-1 text-[11px] leading-snug"
+      style={{
+        borderColor: "var(--border-default, var(--dpf-muted))",
+        background: "var(--surface-canvas, transparent)",
+        color: "var(--dpf-text-secondary)",
+      }}
+    >
+      <span
+        className="mr-1 font-semibold"
+        style={{ color: "var(--dpf-text)" }}
+      >
+        Override recorded:
+      </span>
+      {override.rationale}
+    </p>
   );
 }
 

--- a/apps/web/lib/build/propose-decomposition.test.ts
+++ b/apps/web/lib/build/propose-decomposition.test.ts
@@ -1,0 +1,414 @@
+// apps/web/lib/build/propose-decomposition.test.ts
+//
+// Coverage for Phase 4b orchestrator that calls the SE coworker, parses the
+// candidate JSON, validates each candidate, and persists the validated set.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+// BI: BI-2E6CC391.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildDecompositionPrompt,
+  proposeDecomposition,
+  type ProposeDecompositionDb,
+} from "./propose-decomposition";
+import type { DecompositionCandidate } from "./decomposition-candidates";
+import type {
+  BuildDesignDoc,
+  SizeAssessmentSnapshot,
+} from "@/lib/explore/feature-build-types";
+
+// --- Helpers ---------------------------------------------------------------
+
+function makeDesignDoc(): BuildDesignDoc {
+  return {
+    problemStatement: "stop driving back to the warehouse",
+    reusePlan: "n/a",
+    proposedApproach: "list + usage + low-stock",
+    acceptanceCriteria: ["AC0", "AC1", "AC2", "AC3", "AC4"],
+  };
+}
+
+function makeAssessment(
+  decision: SizeAssessmentSnapshot["decision"] = "decompose-required",
+): SizeAssessmentSnapshot {
+  return {
+    decision,
+    breakdown: {
+      models: { count: 5, samples: [] },
+      endpoints: { count: 2, samples: [] },
+      acs: { count: 5 },
+      multipliers: { count: 4, matchedKeywords: [] },
+      routes: { count: 2, samples: [] },
+    },
+    trips: [
+      { dimension: "models", level: "required", threshold: 5, observed: 5 },
+      { dimension: "multipliers", level: "required", threshold: 4, observed: 4 },
+    ],
+    rationale: "test",
+    thresholds: {
+      models: { recommend: 3, required: 5 },
+      endpoints: { recommend: 4, required: 7 },
+      acs: { recommend: 12, required: 20 },
+      multipliers: { recommend: 2, required: 4 },
+      routes: { recommend: 2, required: 4 },
+    },
+    assessedAt: "2026-05-24T20:00:00.000Z",
+  };
+}
+
+function makeValidCandidate(): DecompositionCandidate {
+  return {
+    candidateId: "candidate-1",
+    rationale: "Read first, write second.",
+    childScopes: [
+      { childOrder: 1, title: "Read", summary: "Show parts", acceptanceCriteriaIndices: [0, 1], dependsOn: [] },
+      { childOrder: 2, title: "Write", summary: "Record usage", acceptanceCriteriaIndices: [2, 3, 4], dependsOn: [1] },
+    ],
+  };
+}
+
+function makeReview(decision: SizeAssessmentSnapshot["decision"] | null = "decompose-required") {
+  return {
+    decision: "pass" as const,
+    issues: [],
+    summary: "ok",
+    ...(decision != null ? { sizeAssessment: makeAssessment(decision) } : {}),
+  };
+}
+
+type FakeBuildShape = {
+  buildId: string;
+  title: string;
+  phase: string;
+  designDoc: unknown;
+  designReview: unknown;
+  parentEpicId: string | null;
+};
+
+function makeFakeDb(
+  build: FakeBuildShape | null,
+): { db: ProposeDecompositionDb; updates: Array<{ data: Record<string, unknown> }> } {
+  const updates: Array<{ data: Record<string, unknown> }> = [];
+  const db: ProposeDecompositionDb = {
+    featureBuild: {
+      findUnique: vi.fn(async () => build as never) as unknown as ProposeDecompositionDb["featureBuild"]["findUnique"],
+      update: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        updates.push({ data: args.data });
+        return null as never;
+      }) as unknown as ProposeDecompositionDb["featureBuild"]["update"],
+    },
+  };
+  return { db, updates };
+}
+
+function makeBuild(overrides: Partial<FakeBuildShape> = {}): FakeBuildShape {
+  return {
+    buildId: "FB-DALE",
+    title: "Truck inventory",
+    phase: "ideate",
+    designDoc: makeDesignDoc(),
+    designReview: makeReview("decompose-required"),
+    parentEpicId: null,
+    ...overrides,
+  };
+}
+
+const fixedNow = () => new Date("2026-05-24T20:30:00.000Z");
+
+// --- Eligibility paths -----------------------------------------------------
+
+describe("proposeDecomposition — eligibility checks", () => {
+  it("rejects when build is missing", async () => {
+    const { db } = makeFakeDb(null);
+    const result = await proposeDecomposition({
+      buildId: "FB-MISSING",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-not-found");
+  });
+
+  it("rejects when build is not in ideate", async () => {
+    const { db } = makeFakeDb(makeBuild({ phase: "plan" }));
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-not-in-ideate");
+  });
+
+  it("rejects when designDoc is missing", async () => {
+    const { db } = makeFakeDb(makeBuild({ designDoc: null }));
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-missing-design-doc");
+  });
+
+  it("rejects when designReview is not pass", async () => {
+    const { db } = makeFakeDb(
+      makeBuild({ designReview: { decision: "fail", issues: [], summary: "x" } }),
+    );
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-design-review-not-passed");
+  });
+
+  it("rejects when no sizeAssessment is recorded (pre-Phase-2 build)", async () => {
+    const { db } = makeFakeDb(makeBuild({ designReview: makeReview(null) }));
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-no-size-assessment");
+  });
+
+  it("rejects when size assessment decision is ok", async () => {
+    const { db } = makeFakeDb(makeBuild({ designReview: makeReview("ok") }));
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-size-already-ok");
+  });
+
+  it("rejects recursive decomposition", async () => {
+    const { db } = makeFakeDb(makeBuild({ parentEpicId: "epic-row-x" }));
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("build-already-decomposed");
+  });
+});
+
+// --- Agent call path -------------------------------------------------------
+
+describe("proposeDecomposition — agent call + parsing", () => {
+  it("returns agent-call-failed when callAgent throws", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => {
+        throw new Error("model timeout");
+      }),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("agent-call-failed");
+    expect(result.error).toMatch(/model timeout/);
+  });
+
+  it("returns no-valid-candidates when agent returns garbage", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => "not json at all"),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("no-valid-candidates");
+  });
+
+  it("returns no-valid-candidates when every candidate fails validation", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    // Solo-child candidate fails validateCandidate (too-few-children).
+    const bad = {
+      candidates: [
+        {
+          candidateId: "c-bad",
+          rationale: "Solo",
+          childScopes: [
+            { childOrder: 1, title: "Solo", summary: "", acceptanceCriteriaIndices: [0, 1, 2, 3, 4], dependsOn: [] },
+          ],
+        },
+      ],
+    };
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => JSON.stringify(bad)),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("no-valid-candidates");
+  });
+
+  it("accepts valid candidates and surfaces rejected ones for observability", async () => {
+    const { db, updates } = makeFakeDb(makeBuild());
+    const mixed = {
+      candidates: [
+        makeValidCandidate(), // good
+        {
+          candidateId: "c-bad",
+          rationale: "Bad split",
+          childScopes: [
+            { childOrder: 1, title: "Solo", summary: "", acceptanceCriteriaIndices: [0, 1, 2, 3, 4], dependsOn: [] },
+          ],
+        },
+      ],
+    };
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => JSON.stringify(mixed)),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]!.candidateId).toBe("candidate-1");
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]!.reasons.some((r) => r.includes("too-few-children"))).toBe(true);
+    expect(updates).toHaveLength(1);
+  });
+
+  it("strips code fences from agent output", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const fenced = "```json\n" + JSON.stringify({ candidates: [makeValidCandidate()] }) + "\n```";
+    const result = await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => fenced),
+      db,
+      now: fixedNow,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("persists candidates to designReview.decompositionCandidates.latest", async () => {
+    const { db, updates } = makeFakeDb(makeBuild());
+    await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      callAgent: vi.fn(async () => JSON.stringify({ candidates: [makeValidCandidate()] })),
+      db,
+      now: fixedNow,
+    });
+    const persisted = updates[0]!.data.designReview as {
+      decompositionCandidates: { latest: DecompositionCandidate[]; latestGeneratedAt: string };
+    };
+    expect(persisted.decompositionCandidates.latest).toHaveLength(1);
+    expect(persisted.decompositionCandidates.latestGeneratedAt).toBe("2026-05-24T20:30:00.000Z");
+  });
+
+  it("appends prior candidates to priorRounds on regenerate", async () => {
+    // Build already has a prior candidate set on its review.
+    const buildWithPrior = makeBuild({
+      designReview: {
+        ...makeReview("decompose-required"),
+        decompositionCandidates: {
+          latest: [makeValidCandidate()],
+          latestGeneratedAt: "2026-05-24T20:00:00.000Z",
+          latestOperatorHint: null,
+          priorRounds: [],
+        },
+      },
+    });
+    const { db, updates } = makeFakeDb(buildWithPrior);
+    await proposeDecomposition({
+      buildId: "FB-DALE",
+      userId: "u",
+      operatorHint: "make the read-first smaller",
+      callAgent: vi.fn(async () => JSON.stringify({ candidates: [makeValidCandidate()] })),
+      db,
+      now: fixedNow,
+    });
+    const persisted = updates[0]!.data.designReview as {
+      decompositionCandidates: {
+        latest: DecompositionCandidate[];
+        latestOperatorHint: string | null;
+        priorRounds: unknown[];
+      };
+    };
+    expect(persisted.decompositionCandidates.priorRounds).toHaveLength(1);
+    expect(persisted.decompositionCandidates.latestOperatorHint).toBe("make the read-first smaller");
+  });
+});
+
+// --- Prompt construction ---------------------------------------------------
+
+describe("buildDecompositionPrompt", () => {
+  it("includes the parent's 0-indexed acceptance criteria list", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment());
+    expect(prompt).toMatch(/0\. AC0/);
+    expect(prompt).toMatch(/4\. AC4/);
+  });
+
+  it("includes the size-assessment trip evidence", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment());
+    expect(prompt).toMatch(/models=5/);
+    expect(prompt).toMatch(/multipliers=4/);
+  });
+
+  it("includes the operator hint when supplied", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment(), "ship ledger separately");
+    expect(prompt).toMatch(/ship ledger separately/);
+    expect(prompt).toMatch(/Operator regenerate hint/);
+  });
+
+  it("omits the hint section when none supplied", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment());
+    expect(prompt).not.toMatch(/Operator regenerate hint/);
+  });
+
+  it("explicitly demands JSON-only output", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment());
+    expect(prompt).toMatch(/JSON object of this shape \(no prose around it/i);
+  });
+
+  it("names the validator's strict rules so the agent self-corrects", () => {
+    const prompt = buildDecompositionPrompt(makeDesignDoc(), makeAssessment());
+    expect(prompt).toMatch(/2 to 4 child scopes/);
+    expect(prompt).toMatch(/no gaps and no duplicates/);
+    expect(prompt).toMatch(/EXACTLY ONE child/);
+    expect(prompt).toMatch(/No self-loops, no cycles/);
+  });
+});

--- a/apps/web/lib/build/propose-decomposition.ts
+++ b/apps/web/lib/build/propose-decomposition.ts
@@ -1,0 +1,362 @@
+// apps/web/lib/build/propose-decomposition.ts
+//
+// Phase 4b of the design-time decomposition rollout.
+// Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md (§3.2)
+// BI: BI-2E6CC391.
+//
+// Orchestrates the LLM call that produces 2-4 candidate decompositions of a
+// passed-design xlarge FeatureBuild. Pure orchestration: the prompt
+// construction is in this module, the model call is dependency-injected so
+// tests run without an LLM, and the candidate parsing/validation are reused
+// from Phase 4a (`decomposition-candidates.ts`).
+//
+// Eligibility:
+//   - build.phase === "ideate"
+//   - build.designDoc is non-null
+//   - build.designReview is non-null and .decision === "pass"
+//   - build.designReview.sizeAssessment is present and decision !== "ok"
+//   - build.parentEpicId is null (assertNoRecursiveDecomposition)
+//
+// Success path:
+//   - Build the prompt from designDoc + sizeAssessment + optional operator
+//     hint (used by "Reject all + regenerate" UX).
+//   - Call the agent. Parse + validate. Drop any candidate that fails
+//     validateCandidate; loud-warn but don't reject the whole pass — a
+//     partial set of valid candidates is more useful to the operator than
+//     a hard failure.
+//   - Persist surviving candidates to designReview.decompositionCandidates,
+//     preserving any prior candidates' history under `priorRounds`.
+//   - Return the validated candidates.
+
+import { prisma } from "@dpf/db";
+import type { BuildDesignDoc, ReviewResult, SizeAssessmentSnapshot } from "@/lib/explore/feature-build-types";
+
+import {
+  parseCandidatesResponse,
+  validateCandidate,
+  type DecompositionCandidate,
+} from "./decomposition-candidates";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ProposeDecompositionInput = {
+  buildId: string;
+  userId: string;
+  agentId?: string | null;
+  /** Operator hint for "regenerate" — typically a one-liner like
+   *  "make the read-first build smaller" or "ship the ledger separately".
+   *  Empty/missing on the first generation pass. */
+  operatorHint?: string;
+  /** Test seam — LLM call. Receives the prompt and returns the raw model
+   *  output as a string (typically JSON, possibly fenced). */
+  callAgent?: (prompt: string) => Promise<string>;
+  /** Test seam — replace prisma. */
+  db?: ProposeDecompositionDb;
+  /** Test seam — override Date.now() for assessedAt-style timestamps. */
+  now?: () => Date;
+};
+
+export type ProposeDecompositionResult =
+  | {
+      ok: true;
+      candidates: DecompositionCandidate[];
+      /** Candidates the model returned but that failed validateCandidate.
+       *  Surfaced for observability — when this list is non-empty the
+       *  operator UI may want to render "the agent proposed N more options
+       *  but they didn't partition cleanly; regenerating may help." */
+      rejected: Array<{ candidate: DecompositionCandidate; reasons: string[] }>;
+    }
+  | {
+      ok: false;
+      code: ProposeDecompositionErrorCode;
+      error: string;
+    };
+
+export type ProposeDecompositionErrorCode =
+  | "build-not-found"
+  | "build-not-in-ideate"
+  | "build-missing-design-doc"
+  | "build-design-review-not-passed"
+  | "build-no-size-assessment"
+  | "build-size-already-ok"
+  | "build-already-decomposed"
+  | "agent-call-failed"
+  | "no-valid-candidates";
+
+export type ProposeDecompositionDb = {
+  featureBuild: {
+    findUnique: typeof prisma.featureBuild.findUnique;
+    update: typeof prisma.featureBuild.update;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function proposeDecomposition(
+  args: ProposeDecompositionInput,
+): Promise<ProposeDecompositionResult> {
+  const db: ProposeDecompositionDb = args.db ?? {
+    featureBuild: {
+      findUnique: prisma.featureBuild.findUnique.bind(prisma.featureBuild),
+      update: prisma.featureBuild.update.bind(prisma.featureBuild),
+    },
+  };
+  const now = args.now ?? (() => new Date());
+  const callAgent = args.callAgent ?? defaultCallAgent;
+
+  // 1. Fetch the build.
+  const build = await db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: {
+      buildId: true,
+      title: true,
+      phase: true,
+      designDoc: true,
+      designReview: true,
+      parentEpicId: true,
+    },
+  });
+  if (!build) {
+    return { ok: false, code: "build-not-found", error: `FeatureBuild ${args.buildId} not found.` };
+  }
+
+  // 2. Eligibility checks.
+  if (build.phase !== "ideate") {
+    return {
+      ok: false,
+      code: "build-not-in-ideate",
+      error: `Build is in phase "${build.phase}". Decomposition proposals are only valid during ideate.`,
+    };
+  }
+  const designDoc = build.designDoc as BuildDesignDoc | null;
+  if (!designDoc) {
+    return { ok: false, code: "build-missing-design-doc", error: "Build has no designDoc to propose against." };
+  }
+  const review = (build.designReview ?? null) as ReviewResult | null;
+  if (!review || review.decision !== "pass") {
+    return {
+      ok: false,
+      code: "build-design-review-not-passed",
+      error: "Build's designReview is not passed. Run reviewDesignDoc first.",
+    };
+  }
+  const assessment = review.sizeAssessment ?? null;
+  if (!assessment) {
+    return {
+      ok: false,
+      code: "build-no-size-assessment",
+      error: "No size assessment recorded on this build's review. Re-run reviewDesignDoc to populate sizeAssessment.",
+    };
+  }
+  if (assessment.decision === "ok") {
+    return {
+      ok: false,
+      code: "build-size-already-ok",
+      error: "Size assessment is `ok` — no decomposition needed. Build can proceed to Plan as-is.",
+    };
+  }
+  if (build.parentEpicId != null) {
+    return {
+      ok: false,
+      code: "build-already-decomposed",
+      error: `Build already has parentEpicId=${build.parentEpicId}. Recursive decomposition is forbidden (spec §12 Q4).`,
+    };
+  }
+
+  // 3. Build the prompt + call the agent.
+  const prompt = buildDecompositionPrompt(designDoc, assessment, args.operatorHint);
+  let rawResponse: string;
+  try {
+    rawResponse = await callAgent(prompt);
+  } catch (err) {
+    return {
+      ok: false,
+      code: "agent-call-failed",
+      error: `Agent call failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // 4. Parse + validate.
+  const parsed = parseCandidatesResponse(rawResponse);
+  const accepted: DecompositionCandidate[] = [];
+  const rejected: Array<{ candidate: DecompositionCandidate; reasons: string[] }> = [];
+  for (const c of parsed) {
+    const v = validateCandidate(c, designDoc);
+    if (v.ok) {
+      accepted.push(c);
+    } else {
+      rejected.push({
+        candidate: c,
+        reasons: v.failures.map((f) => `[${f.code}] ${f.message}`),
+      });
+    }
+  }
+
+  if (accepted.length === 0) {
+    return {
+      ok: false,
+      code: "no-valid-candidates",
+      error:
+        rejected.length === 0
+          ? "Agent returned no parseable candidates."
+          : `Agent returned ${rejected.length} candidate(s) but none passed validation. First failure: ${rejected[0]!.reasons.join("; ")}`,
+    };
+  }
+
+  // 5. Persist. Append to priorRounds for audit if there's already a
+  //    candidate list on the review.
+  const priorCandidates = (review as { decompositionCandidates?: unknown })
+    .decompositionCandidates;
+  const updatedReview = {
+    ...review,
+    decompositionCandidates: {
+      latest: accepted,
+      latestGeneratedAt: now().toISOString(),
+      latestOperatorHint: args.operatorHint ?? null,
+      latestRejectedCount: rejected.length,
+      priorRounds:
+        priorCandidates && typeof priorCandidates === "object"
+          ? appendPriorRound(priorCandidates, now())
+          : [],
+    },
+  };
+  await db.featureBuild.update({
+    where: { buildId: args.buildId },
+    data: { designReview: updatedReview as never },
+  });
+
+  return { ok: true, candidates: accepted, rejected };
+}
+
+// ---------------------------------------------------------------------------
+// Default agent call — wraps routeAndCall. Dynamic import keeps the LLM
+// surface out of unit-test import graphs.
+// ---------------------------------------------------------------------------
+
+async function defaultCallAgent(prompt: string): Promise<string> {
+  const { routeAndCall } = await import("@/lib/routed-inference");
+  const messages = [{ role: "user" as const, content: prompt }];
+  const systemPrompt =
+    "You are a Build Studio Software Engineer asked to propose 2-4 candidate decompositions of an xlarge design into smaller coordinated builds. Output JSON only — no prose, no markdown around the JSON.";
+  const result = await routeAndCall(messages, systemPrompt, "internal");
+  return result.content ?? "";
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction. Kept here (not as a const string) so tests can assert
+// the prompt names the spec-required structured fields. The prompt is
+// directive about JSON shape and includes the parent AC list with explicit
+// 0-indexed numbering — the agent's only job is partitioning into 2-4
+// coherent buckets.
+// ---------------------------------------------------------------------------
+
+export function buildDecompositionPrompt(
+  doc: BuildDesignDoc,
+  assessment: SizeAssessmentSnapshot,
+  operatorHint?: string,
+): string {
+  const acs = doc.acceptanceCriteria ?? [];
+  const acList = acs
+    .map((ac, i) => `  ${i}. ${typeof ac === "string" ? ac : JSON.stringify(ac)}`)
+    .join("\n");
+
+  const hint = operatorHint && operatorHint.trim().length > 0
+    ? `\n\nOperator regenerate hint (apply this to the new candidates): ${operatorHint.trim()}`
+    : "";
+
+  const tripsText = assessment.trips.length > 0
+    ? assessment.trips
+        .map((t) => `  - ${t.dimension}=${t.observed} (>= ${t.threshold} ${t.level})`)
+        .join("\n")
+    : "  (no specific dimension trips)";
+
+  return [
+    `# Decompose this design into 2-4 child builds`,
+    ``,
+    `The design below has been size-assessed as "${assessment.decision}". Threshold trips:`,
+    tripsText,
+    ``,
+    `Your job: propose **2 to 4 different ways** to split this design into smaller coordinated child builds. Each child must:`,
+    `- Cover a coherent slice that can ship independently if its dependencies ship first`,
+    `- Carry only a subset of the parent's acceptance criteria (by index)`,
+    `- Stay under the size thresholds individually (small enough that each child's Plan converges)`,
+    `- Use Dale's vocabulary in title/summary (trucks, parts, jobs, techs — NOT "FeatureBuild", "epic", "capsule")`,
+    ``,
+    `## Parent design`,
+    ``,
+    `**Problem:** ${doc.problemStatement}`,
+    ``,
+    doc.dataModel ? `**Data model:**\n${doc.dataModel}\n` : ``,
+    `**Proposed approach:** ${doc.proposedApproach}`,
+    ``,
+    `**Acceptance criteria (use these 0-indexed numbers in acceptanceCriteriaIndices):**`,
+    acList,
+    hint,
+    ``,
+    `## Output format`,
+    ``,
+    `Return ONLY a JSON object of this shape (no prose around it, no markdown fences):`,
+    ``,
+    `{`,
+    `  "candidates": [`,
+    `    {`,
+    `      "candidateId": "candidate-1",`,
+    `      "rationale": "Why this split groups these ACs the way it does",`,
+    `      "childScopes": [`,
+    `        {`,
+    `          "childOrder": 1,`,
+    `          "title": "Plain-language child name",`,
+    `          "summary": "One-sentence summary in Dale's vocabulary",`,
+    `          "acceptanceCriteriaIndices": [0, 1, 4],`,
+    `          "dependsOn": []`,
+    `        },`,
+    `        ...`,
+    `      ]`,
+    `    },`,
+    `    ...`,
+    `  ]`,
+    `}`,
+    ``,
+    `Rules the validator will enforce — get these right or the candidate is rejected:`,
+    `- Each candidate has 2 to 4 child scopes.`,
+    `- childOrder values are 1, 2, 3, ... with no gaps and no duplicates.`,
+    `- Every parent acceptance criterion (index 0 to ${acs.length - 1}) appears in EXACTLY ONE child.`,
+    `- dependsOn values reference other childOrder values in the SAME candidate.`,
+    `- No self-loops, no cycles.`,
+    `- Each rationale and title is non-empty.`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function appendPriorRound(prior: unknown, now: Date): unknown[] {
+  if (
+    typeof prior !== "object" ||
+    prior === null ||
+    !("latest" in prior)
+  ) {
+    return [];
+  }
+  const p = prior as {
+    latest?: unknown;
+    latestGeneratedAt?: unknown;
+    latestOperatorHint?: unknown;
+    priorRounds?: unknown;
+  };
+  const existing = Array.isArray(p.priorRounds) ? p.priorRounds : [];
+  return [
+    ...existing,
+    {
+      candidates: p.latest,
+      generatedAt: p.latestGeneratedAt ?? null,
+      operatorHint: p.latestOperatorHint ?? null,
+      supersededAt: now.toISOString(),
+    },
+  ];
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -483,8 +483,13 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
-    name: "propose_decomposition",
-    description: "Phase 4b (BI-2E6CC391). Ask the SE coworker to propose 2-4 candidate decompositions of a passed-design xlarge FeatureBuild. Eligible when the build is in `ideate`, has a passed designReview, and the recorded sizeAssessment.decision is `decompose-recommended` or `decompose-required`. Optional `operatorHint` re-runs with guidance ('make the read-first smaller', 'ship the ledger separately'). Persists validated candidates to designReview.decompositionCandidates.latest; prior rounds are preserved under .priorRounds for audit. Returns the validated candidates plus an observability list of rejected ones (model returned them but they failed validateCandidate).",
+    // NOTE: this tool is DISTINCT from the existing `propose_decomposition`
+    // (epic + feature-set breakdown for ideation). This one operates on a
+    // passed FeatureBuild design and proposes how to SPLIT it into smaller
+    // builds — a downstream-of-Ideate decomposition, not an upstream-from-
+    // backlog one. Different name avoids the collision.
+    name: "propose_build_decomposition",
+    description: "Phase 4b (BI-2E6CC391). Ask the SE coworker to propose 2-4 candidate decompositions of a passed-design xlarge FeatureBuild. Distinct from `propose_decomposition` (which is an upstream brainstorming tool that generates an Epic + feature-set breakdown). This one is downstream of Ideate — eligible when the build is in `ideate`, has a passed designReview, and the recorded sizeAssessment.decision is `decompose-recommended` or `decompose-required`. Optional `operatorHint` re-runs with guidance ('make the read-first smaller', 'ship the ledger separately'). Persists validated candidates to designReview.decompositionCandidates.latest; prior rounds are preserved under .priorRounds for audit. Returns the validated candidates plus an observability list of rejected ones (model returned them but they failed validateCandidate).",
     inputSchema: {
       type: "object",
       properties: {
@@ -4901,7 +4906,7 @@ export async function executeTool(
       };
     }
 
-    case "propose_decomposition": {
+    case "propose_build_decomposition": {
       const buildId = String(params["buildId"] ?? "");
       if (!buildId.startsWith("FB-")) {
         return { success: false, error: "invalid_buildId", message: "buildId must use the FB-* format." };

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -483,6 +483,23 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "propose_decomposition",
+    description: "Phase 4b (BI-2E6CC391). Ask the SE coworker to propose 2-4 candidate decompositions of a passed-design xlarge FeatureBuild. Eligible when the build is in `ideate`, has a passed designReview, and the recorded sizeAssessment.decision is `decompose-recommended` or `decompose-required`. Optional `operatorHint` re-runs with guidance ('make the read-first smaller', 'ship the ledger separately'). Persists validated candidates to designReview.decompositionCandidates.latest; prior rounds are preserved under .priorRounds for audit. Returns the validated candidates plus an observability list of rejected ones (model returned them but they failed validateCandidate).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "Originating FeatureBuild ID (FB-*)." },
+        operatorHint: {
+          type: "string",
+          description: "Optional regenerate guidance. Empty/omitted on first generation.",
+        },
+      },
+      required: ["buildId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "approve_decomposition",
     description: "Phase 4a (BI-2E6CC391). Atomically create an execution-organizational Epic + N child FeatureBuilds + sibling-dependency edges from a pre-validated DecompositionCandidate, and mark the originating FeatureBuild as superseded. The originating build must be in `ideate` phase with a passed designReview and must not itself be a child. Callers (typically the Phase 4b assistant flow) supply the candidate after the operator has chosen and optionally edited it; all invariants from epic-decomposition-invariants run before any DB writes.",
     inputSchema: {
@@ -4884,6 +4901,33 @@ export async function executeTool(
       };
     }
 
+    case "propose_decomposition": {
+      const buildId = String(params["buildId"] ?? "");
+      if (!buildId.startsWith("FB-")) {
+        return { success: false, error: "invalid_buildId", message: "buildId must use the FB-* format." };
+      }
+      const operatorHint = typeof params["operatorHint"] === "string" ? params["operatorHint"] : undefined;
+      const { proposeDecomposition } = await import("@/lib/build/propose-decomposition");
+      const result = await proposeDecomposition({
+        buildId,
+        userId,
+        agentId: context?.agentId ?? null,
+        ...(operatorHint ? { operatorHint } : {}),
+      });
+      if (!result.ok) {
+        return { success: false, error: result.code, message: result.error };
+      }
+      return {
+        success: true,
+        entityId: buildId,
+        message: `Proposed ${result.candidates.length} candidate decomposition(s) for ${buildId}.${result.rejected.length > 0 ? ` (${result.rejected.length} additional candidate(s) failed validation and were dropped.)` : ""}`,
+        data: {
+          candidates: result.candidates,
+          rejectedCount: result.rejected.length,
+        },
+      };
+    }
+
     case "approve_decomposition": {
       // Phase 4a (BI-2E6CC391). The candidate is pre-validated by the
       // caller (Phase 4b assistant); we revalidate inside
@@ -6900,6 +6944,30 @@ export async function executeTool(
               success: true,
               message: `Design review: ${review.decision}. ${review.summary} This governed backlog draft is prepared and now waiting for Approve Start before planning can begin.`,
               data: { review, blocked: true, action: "approve_start" },
+            };
+          }
+
+          // Phase 4b decompose-required gate (BI-2E6CC391). If the build's
+          // size assessment is "decompose-required" AND no decomposition
+          // happened (build still exists in ideate, not superseded) AND no
+          // operator override was recorded, refuse advance and tell the
+          // operator what to do next. Recommended-tier and ok-tier builds
+          // proceed through to plan unchanged.
+          const sizedReview = (updatedBuild.designReview ?? null) as
+            | { sizeAssessment?: { decision?: string }; decompositionOverride?: unknown }
+            | null;
+          const decomposeDecision = sizedReview?.sizeAssessment?.decision ?? null;
+          const hasOverride = sizedReview?.decompositionOverride != null;
+          if (decomposeDecision === "decompose-required" && !hasOverride) {
+            logBuildActivity(
+              buildId,
+              "phase:gate-blocked",
+              "decompose-required gate fired; advance blocked until decomposition or override.",
+            );
+            return {
+              success: true,
+              message: `Design review: ${review.decision}, but the size assessment is decompose-required. Before advancing to Plan, either call approve_decomposition with a chosen DecompositionCandidate (preferred) — see propose_decomposition to generate candidates — OR call record_decomposition_override with a one-line justification to ship monolithically.`,
+              data: { review, blocked: true, action: "decompose_or_override" },
             };
           }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -135,6 +135,13 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   update_feature_brief: ["backlog_write"],
   assess_complexity: ["backlog_read"],
   propose_decomposition: ["backlog_write"],
+  // Design-time decomposition Phase 4a/4b (BI-2E6CC391). These three tools
+  // are downstream of Ideate (operating on a passed FeatureBuild design),
+  // distinct from the upstream `propose_decomposition` brainstorming tool
+  // above. Same capability tier — all three touch backlog/build state.
+  propose_build_decomposition: ["backlog_write"],
+  approve_decomposition: ["backlog_write"],
+  record_decomposition_override: ["backlog_write"],
   register_tech_debt: ["backlog_write"],
   save_build_notes: ["backlog_write"],
   saveBuildEvidence: ["backlog_write"],


### PR DESCRIPTION
## Summary

Operator-facing half of Phase 4. Closes the loop on the decomposition flow:

1. **`propose_decomposition` MCP tool** — calls the SE coworker via `routeAndCall`, parses JSON candidates, validates each with Phase-4a's `validateCandidate`, persists valid ones, preserves prior rounds.
2. **`DecompositionAssistantPanel`** slide-over — radio-select a candidate, see each child's title / summary / AC text (resolved by index against parent designDoc) / sibling dependencies; approve to invoke `approve_decomposition`; reject-and-regenerate with an optional hint.
3. **`DecompositionGateBanner` upgrades** — wires "Propose splits" and "Keep as one build (explain why)" CTAs into the banner. Override path is required-tier only per spec §4.1; once recorded, a chip replaces the action row.
4. **Required-tier gate enforcement** at ideate→plan advance — `reviewDesignDoc` refuses phase advance when `sizeAssessment.decision === "decompose-required"` AND no `decompositionOverride` is recorded AND the build hasn't been superseded by `approve_decomposition`. Names the two paths forward in the operator-facing message.

**Stacked on PR #1132** (Phase 4a substrate). Recommend merging #1132 first.

## What this PR contains

- 7 files changed, 1844 insertions, 5 deletions
- 4 new files, 3 modified
- 627/627 tests pass (45 new across the three test files); typecheck clean

| File | Purpose |
|---|---|
| `apps/web/lib/build/propose-decomposition.ts` | Orchestrator: fetch build → eligibility checks → build prompt → call agent → parse → per-candidate validate → persist `latest` + roll prior to `priorRounds`. DI seams (callAgent, db, now). |
| `apps/web/lib/build/propose-decomposition.test.ts` | 20 tests — every eligibility code, agent failure paths, garbage parsing, partial-validation observability, persistence shape, regenerate-preserves-priorRounds, prompt construction. |
| `apps/web/components/build/DecompositionAssistantPanel.tsx` | Slide-over with overlay, radio-select candidate cards, child-scope rows with AC text + dependency chips, approve + regenerate-with-hint + cancel. Drag-edit deferred to 4c. |
| `apps/web/components/build/DecompositionAssistantPanel.test.tsx` | 17 tests — open/close paths, candidate rendering, approve flow with default + switching selection, regenerate two-click flow, hint omitted vs typed, in-flight disabling, header copy. |
| `apps/web/components/build/DecompositionGateBanner.tsx` | New props `onProposeSplits` / `onRecordOverride` / `actionsDisabled` / `existingOverride`. Backward-compatible — Phase 3 callers without handlers still see the informational fallback. |
| `apps/web/components/build/DecompositionGateBanner.test.tsx` | 8 new Phase-4b tests on top of the existing 16 (Propose CTA wiring; required-only override; rationale input flow; empty-rationale disables submit; override chip replaces action row; actionsDisabled greys both; Phase-3 fallback). |
| `apps/web/lib/mcp-tools.ts` | New `propose_decomposition` tool definition + handler; required-tier gate enforcement in `reviewDesignDoc` passed-review block. |

## Gate enforcement flow

After `reviewDesignDoc` passes for an `ideate`-phase build:

| Build state | Phase advance? |
|---|---|
| `sizeAssessment.decision === "ok"` | Yes (today's behaviour) |
| `decompose-recommended`, no override | Yes (recommended is advisory) |
| `decompose-recommended` + override | Yes (override is no-op on recommended) |
| `decompose-required`, no override, build still in ideate | **Refused** — operator must call `approve_decomposition` or `record_decomposition_override` |
| `decompose-required` + override recorded | Yes — override authorizes monolithic ship |
| `decompose-required`, build superseded (decomposed) | N/A — superseded builds don't try to advance |

The refusal message names both paths explicitly so the operator (or agent) knows what to call next.

## Verification

- `propose-decomposition.test.ts` — 20/20 pass
- `DecompositionAssistantPanel.test.tsx` — 17/17 pass
- `DecompositionGateBanner.test.tsx` — 24/24 pass (16 Phase-3 + 8 Phase-4b)
- Full `apps/web/lib/build/` + `apps/web/components/build/` suite: **627/627 pass**
- `pnpm --filter web run typecheck` exit 0
- Pre-commit scoped typecheck clean

## Operator decisions honored

- **Q1 override gating** — required-tier override needs a non-empty rationale; submit button stays disabled until text is typed (spec §12 Q1)
- **Q2 SE coworker** — `defaultCallAgent` calls `routeAndCall` with an SE-flavoured system prompt (spec §12 Q2)
- **Q3 auto-name w/ confirm** — assistant panel renders candidate-supplied titles directly; operator can pick before approving (spec §12 Q3)
- **Q4 forbid recursion** — `proposeDecomposition` rejects with `build-already-decomposed` when `parentEpicId` is non-null (spec §12 Q4)

## Test plan

- [ ] Review the `propose_decomposition` prompt construction — does the SE coworker have enough structure to reliably return validate-passing JSON? Loosely calibrated; tighten if real-world output drops too many candidates to `rejected[]`.
- [ ] Review the gate copy in `reviewDesignDoc` — does the operator-facing message name the right tools (`approve_decomposition` / `record_decomposition_override`) with enough context to act?
- [ ] After merge, run an end-to-end smoke against a synthetic Dale-shape build: drive through Ideate → review passes → banner shows "Decomposition required" + "Propose splits" CTA → click → panel opens with candidates → approve → verify Epic + 3 children created and original FB superseded.

## What ships next (Phase 4c / Phase 5)

- **4c** — page-level wiring that owns the panel state, dispatches `propose_decomposition` from the "Propose splits" CTA, dispatches `approve_decomposition` from the panel's onApprove, and dispatches `record_decomposition_override` from the banner's override input. Plus drag ACs between children in the panel.
- **Phase 5** — rollup UI for the Epic-with-children in `/build` list (spec §4.3): single Epic row with "1 of 3 done · 1 in build · 1 waiting", chevron to expand into child rows.

## Related

- Spec: `docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md` (merged)
- Phase 1 substrate: PR #1123 (merged)
- Phase 2 sizeDesignDoc: PR #1125 (merged)
- Phase 3 gate banner: PR #1127 (merged)
- Phase 4a substrate (candidates / atomic creation / override): PR #1132 (**stacked under this PR**)
- BI: BI-2E6CC391
- Epic: EP-BUILD-STUDIO; EP-9FC5D2FD; EP-REDUCTION-GEAR-ARCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)