### PR TITLE
fix(grants): map approve_decomposition + record_decomposition_override (INV-1 unblock)

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -135,6 +135,13 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   update_feature_brief: ["backlog_write"],
   assess_complexity: ["backlog_read"],
   propose_decomposition: ["backlog_write"],
+  // Phase 4a decomposition write surfaces (BI-2E6CC391, PR #1132). approve_decomposition
+  // atomically creates an Epic + N child FeatureBuilds + dependency edges + supersedes
+  // the originating build — both backlog creation and a build-promotion-equivalent gate.
+  // record_decomposition_override writes designReview.decompositionOverride for audit
+  // when the operator proceeds monolithically on a decompose-required build.
+  approve_decomposition: ["backlog_write", "build_promote"],
+  record_decomposition_override: ["backlog_write"],
   register_tech_debt: ["backlog_write"],
   save_build_notes: ["backlog_write"],
   saveBuildEvidence: ["backlog_write"],


### PR DESCRIPTION
## Summary

PR [#1132](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1132) (Phase 4a decomposition substrate, merged 2026-05-25 ~03:00 UTC) added two tools to `PLATFORM_TOOLS` in `apps/web/lib/mcp-tools.ts` without adding entries to `TOOL_TO_GRANTS` in `apps/web/lib/tak/agent-grants.ts`. The audit-routing-spec-boot-invariants script's INV-1 catches this — every PR opened against main since #1132 fails CI:

```
[INV-1] 2 PLATFORM_TOOLS entries have no TOOL_TO_GRANTS mapping
Tools (default-deny, unreachable from any coworker chat):
  approve_decomposition, record_decomposition_override
```

Surfaced by [PR #1134](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1134) CI run [26381515293](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/26381515293/job/77651563563). #1134 is pure docs/kernel YAML — no TypeScript or grant-table touches. Cross-PR collision per `feedback_continuous_overlap_check`.

## Fix

Two entries added to `TOOL_TO_GRANTS`:

| Tool | Grants | Rationale |
|---|---|---|
| `approve_decomposition` | `["backlog_write", "build_promote"]` | Atomically creates an Epic + N child FeatureBuilds + sibling dependency edges + supersedes the originating build. Both backlog creation AND a build-promotion-equivalent gate. Mirrors sibling tools (`propose_decomposition` = backlog_write, `promote_to_build_studio` = build_promote). |
| `record_decomposition_override` | `["backlog_write"]` | Writes `designReview.decompositionOverride` for audit when the operator proceeds monolithically on a decompose-required build. Audit-only evidence write. |

## Verification

Local replay of the audit script's INV-1 regex against the worktree:

- Pre-fix: `MISSING={approve_decomposition, record_decomposition_override}` ✓ matches CI
- Post-fix: `MISSING=(empty)` ✓
- Counts: 191 PLATFORM_TOOLS / 198 TOOL_TO_GRANTS keys

## Pre-commit typecheck note

`node_modules` is not installed in the throwaway worktree this fix was authored in, so the pre-commit typecheck hook could not run. Skipped per the hook's documented `DPF_SKIP_TYPECHECK=1` escape hatch. The change is mechanically safe — two entries in a `Record<string, string[]>` matching the existing pattern, no schema/type changes. **CI runs the real typecheck on the merge.**

## Class

Bug fix / routing-invariant regression. Per `feedback_build_studio_for_all_development`, routing-invariant fixes are urgent-hotfix class — OK for Claude to open directly outside the BS pipeline.

## BI filing

Pending — MCP backlog endpoint was unreachable at fix time. Will follow up with a BI under `EP-BUILD-STUDIO` once MCP recovers, linking this PR and #1132.

## Related

- Surfacing PR: #1134 (open, blocked on this fix)
- Introducing PR: #1132 (merged 2026-05-25)
- Audit script: [apps/web/scripts/audit-routing-spec-boot-invariants.ts:91-119](apps/web/scripts/audit-routing-spec-boot-invariants.ts)
- CI workflow: `.github/workflows/audit-routing-invariants.yml`

## Test plan

- [ ] CI's routing-invariants audit passes (`INV-1` resolved, `new: 0`)
- [ ] CI typecheck passes (the worktree-local skip is replaced by CI's real check)
- [ ] After merge: re-run #1134's CI to confirm the upstream collision clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)