### PR TITLE
feat(db): add capability maturity assessment schema

### DIFF
--- a/packages/db/prisma/migrations/20260524234500_agent_control_plane_maturity/migration.sql
+++ b/packages/db/prisma/migrations/20260524234500_agent_control_plane_maturity/migration.sql
@@ -1,0 +1,97 @@
+-- CreateTable
+CREATE TABLE "CapabilityMaturityAssessment" (
+    "id" TEXT NOT NULL,
+    "assessmentId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "capabilityCategory" TEXT NOT NULL,
+    "riskTier" TEXT NOT NULL,
+    "maturityScore" INTEGER NOT NULL,
+    "confidenceGrade" TEXT NOT NULL DEFAULT 'claimed',
+    "strategicOwnership" TEXT NOT NULL,
+    "vendorReplacementConfidence" TEXT NOT NULL DEFAULT 'low',
+    "installScope" TEXT NOT NULL DEFAULT 'canonical',
+    "archetypeScope" TEXT,
+    "productizationStatus" TEXT NOT NULL DEFAULT 'not_eligible',
+    "productizationStatusChangedAt" TIMESTAMP(3),
+    "parityChecklistEvidence" JSONB NOT NULL DEFAULT '[]',
+    "existingPrimitives" JSONB NOT NULL DEFAULT '[]',
+    "maturityGaps" JSONB NOT NULL DEFAULT '[]',
+    "evidenceSources" JSONB NOT NULL DEFAULT '[]',
+    "hiveMindSignals" JSONB NOT NULL DEFAULT '[]',
+    "kernelPrinciples" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "operationalSurface" TEXT,
+    "hasContinuousEvidence" BOOLEAN NOT NULL DEFAULT false,
+    "evidenceFreshnessAt" TIMESTAMP(3),
+    "lastGovernanceReviewAt" TIMESTAMP(3),
+    "lastAssessmentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "assessedBy" TEXT NOT NULL DEFAULT 'seed',
+    "portfolioId" TEXT NOT NULL,
+    "taxonomyNodeId" TEXT,
+    "eaElementId" TEXT,
+    "digitalProductId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CapabilityMaturityAssessment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CapabilityMaturityDependency" (
+    "id" TEXT NOT NULL,
+    "assessmentId" TEXT NOT NULL,
+    "dependencyId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CapabilityMaturityDependency_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CapabilityMaturityAssessment_assessmentId_key" ON "CapabilityMaturityAssessment"("assessmentId");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_portfolioId_idx" ON "CapabilityMaturityAssessment"("portfolioId");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_taxonomyNodeId_idx" ON "CapabilityMaturityAssessment"("taxonomyNodeId");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_eaElementId_idx" ON "CapabilityMaturityAssessment"("eaElementId");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_digitalProductId_idx" ON "CapabilityMaturityAssessment"("digitalProductId");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_capabilityCategory_idx" ON "CapabilityMaturityAssessment"("capabilityCategory");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_riskTier_idx" ON "CapabilityMaturityAssessment"("riskTier");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_installScope_idx" ON "CapabilityMaturityAssessment"("installScope");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityAssessment_productizationStatus_idx" ON "CapabilityMaturityAssessment"("productizationStatus");
+
+-- CreateIndex
+CREATE INDEX "CapabilityMaturityDependency_dependencyId_idx" ON "CapabilityMaturityDependency"("dependencyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CapabilityMaturityDependency_assessmentId_dependencyId_key" ON "CapabilityMaturityDependency"("assessmentId", "dependencyId");
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityAssessment" ADD CONSTRAINT "CapabilityMaturityAssessment_portfolioId_fkey" FOREIGN KEY ("portfolioId") REFERENCES "Portfolio"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityAssessment" ADD CONSTRAINT "CapabilityMaturityAssessment_taxonomyNodeId_fkey" FOREIGN KEY ("taxonomyNodeId") REFERENCES "TaxonomyNode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityAssessment" ADD CONSTRAINT "CapabilityMaturityAssessment_eaElementId_fkey" FOREIGN KEY ("eaElementId") REFERENCES "EaElement"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityAssessment" ADD CONSTRAINT "CapabilityMaturityAssessment_digitalProductId_fkey" FOREIGN KEY ("digitalProductId") REFERENCES "DigitalProduct"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityDependency" ADD CONSTRAINT "CapabilityMaturityDependency_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "CapabilityMaturityAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CapabilityMaturityDependency" ADD CONSTRAINT "CapabilityMaturityDependency_dependencyId_fkey" FOREIGN KEY ("dependencyId") REFERENCES "CapabilityMaturityAssessment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -559,6 +559,7 @@ model Portfolio {
   epicPortfolios         EpicPortfolio[]
   inventoryEntities      InventoryEntity[]
   portfolioQualityIssues PortfolioQualityIssue[]
+  capabilityMaturityAssessments CapabilityMaturityAssessment[]
   knowledgeArticles      KnowledgeArticlePortfolio[]
   valueStreamTeams       ValueStreamTeam[]
   workQueues             WorkQueue[]
@@ -588,6 +589,7 @@ model DigitalProduct {
   featureBuilds                FeatureBuild[]
   inventoryEntities            InventoryEntity[]
   portfolioQualityIssues       PortfolioQualityIssue[]
+  capabilityMaturityAssessments CapabilityMaturityAssessment[]
   versions                     ProductVersion[]
   serviceOfferings             ServiceOffering[]
   quoteLineItems               QuoteLineItem[]
@@ -913,6 +915,7 @@ model TaxonomyNode {
   fingerprintRules         DiscoveryFingerprintRule[]
   inventoryEntities        InventoryEntity[]
   portfolioQualityIssues   PortfolioQualityIssue[]
+  capabilityMaturityAssessments CapabilityMaturityAssessment[]
   triageSelectionDecisions DiscoveryTriageDecision[]     @relation("DiscoveryTriageDecisionSelectedTaxonomy")
   taxonomyProposalParents  TaxonomyProposal[]            @relation("TaxonomyProposalParent")
   createdTaxonomyProposals TaxonomyProposal[]            @relation("TaxonomyProposalCreatedNode")
@@ -5395,11 +5398,73 @@ model EaElement {
   toRelationships         EaRelationship[]              @relation("ToElement")
   viewElements            EaViewElement[]
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityEaElementLinks")
+  capabilityMaturityAssessments CapabilityMaturityAssessment[]
 
   @@index([portfolioId])
   @@index([taxonomyNodeId])
   @@index([digitalProductId])
   @@index([elementTypeId])
+}
+
+model CapabilityMaturityAssessment {
+  id                            String                         @id @default(cuid())
+  assessmentId                  String                         @unique
+  name                          String
+  capabilityCategory            String
+  riskTier                      String
+  maturityScore                 Int
+  confidenceGrade               String                         @default("claimed")
+  strategicOwnership            String
+  vendorReplacementConfidence   String                         @default("low")
+  installScope                  String                         @default("canonical")
+  archetypeScope                String?
+  productizationStatus          String                         @default("not_eligible")
+  productizationStatusChangedAt DateTime?
+  parityChecklistEvidence       Json                           @default("[]")
+  existingPrimitives            Json                           @default("[]")
+  maturityGaps                  Json                           @default("[]")
+  evidenceSources               Json                           @default("[]")
+  hiveMindSignals               Json                           @default("[]")
+  kernelPrinciples              String[]                       @default([])
+  operationalSurface            String?
+  hasContinuousEvidence         Boolean                        @default(false)
+  evidenceFreshnessAt           DateTime?
+  lastGovernanceReviewAt        DateTime?
+  lastAssessmentAt              DateTime                       @default(now())
+  assessedBy                    String                         @default("seed")
+  portfolioId                   String
+  taxonomyNodeId                String?
+  eaElementId                   String?
+  digitalProductId              String?
+  createdAt                     DateTime                       @default(now())
+  updatedAt                     DateTime                       @updatedAt
+  portfolio                     Portfolio                      @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+  taxonomyNode                  TaxonomyNode?                  @relation(fields: [taxonomyNodeId], references: [id], onDelete: SetNull)
+  eaElement                     EaElement?                     @relation(fields: [eaElementId], references: [id], onDelete: SetNull)
+  digitalProduct                DigitalProduct?                @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
+  dependencies                  CapabilityMaturityDependency[] @relation("CapabilityMaturityDependencyFrom")
+  dependents                    CapabilityMaturityDependency[] @relation("CapabilityMaturityDependencyTo")
+
+  @@index([portfolioId])
+  @@index([taxonomyNodeId])
+  @@index([eaElementId])
+  @@index([digitalProductId])
+  @@index([capabilityCategory])
+  @@index([riskTier])
+  @@index([installScope])
+  @@index([productizationStatus])
+}
+
+model CapabilityMaturityDependency {
+  id           String                       @id @default(cuid())
+  assessmentId String
+  dependencyId String
+  createdAt    DateTime                     @default(now())
+  assessment   CapabilityMaturityAssessment @relation("CapabilityMaturityDependencyFrom", fields: [assessmentId], references: [id], onDelete: Cascade)
+  dependency   CapabilityMaturityAssessment @relation("CapabilityMaturityDependencyTo", fields: [dependencyId], references: [id], onDelete: Cascade)
+
+  @@unique([assessmentId, dependencyId])
+  @@index([dependencyId])
 }
 
 model BusinessCapability {

--- a/packages/db/test/capability-maturity-schema.test.ts
+++ b/packages/db/test/capability-maturity-schema.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "../src/client";
+import { Prisma } from "../generated/client/client";
+
+const TEST_PORTFOLIO_SLUG = "capability-maturity-test";
+const TEST_TAXONOMY_NODE_ID = "capability-maturity-test/root";
+const TEST_ASSESSMENT_A = "ACPM-TEST-RUNTIME";
+const TEST_ASSESSMENT_B = "ACPM-TEST-GATEWAY";
+
+async function clearTestRows() {
+  await prisma.capabilityMaturityDependency.deleteMany({
+    where: {
+      OR: [
+        { assessment: { assessmentId: { in: [TEST_ASSESSMENT_A, TEST_ASSESSMENT_B] } } },
+        { dependency: { assessmentId: { in: [TEST_ASSESSMENT_A, TEST_ASSESSMENT_B] } } },
+      ],
+    },
+  });
+  await prisma.capabilityMaturityAssessment.deleteMany({
+    where: { assessmentId: { in: [TEST_ASSESSMENT_A, TEST_ASSESSMENT_B] } },
+  });
+  await prisma.taxonomyNode.deleteMany({
+    where: { nodeId: TEST_TAXONOMY_NODE_ID },
+  });
+  await prisma.portfolio.deleteMany({
+    where: { slug: TEST_PORTFOLIO_SLUG },
+  });
+}
+
+beforeEach(async () => {
+  await clearTestRows();
+});
+
+afterAll(async () => {
+  await clearTestRows();
+  await prisma.$disconnect();
+});
+
+describe("CapabilityMaturityAssessment prisma schema", () => {
+  it("exposes generated model delegates", () => {
+    expect(Prisma.ModelName.CapabilityMaturityAssessment).toBe(
+      "CapabilityMaturityAssessment",
+    );
+    expect(Prisma.ModelName.CapabilityMaturityDependency).toBe(
+      "CapabilityMaturityDependency",
+    );
+    expect(prisma.capabilityMaturityAssessment).toBeDefined();
+    expect(prisma.capabilityMaturityDependency).toBeDefined();
+  });
+
+  it("stores scored capability assessments and dependency edges", async () => {
+    const portfolio = await prisma.portfolio.create({
+      data: {
+        slug: TEST_PORTFOLIO_SLUG,
+        name: "Capability Maturity Test",
+      },
+    });
+    const taxonomyNode = await prisma.taxonomyNode.create({
+      data: {
+        nodeId: TEST_TAXONOMY_NODE_ID,
+        name: "Capability maturity test root",
+        portfolioId: portfolio.id,
+      },
+    });
+
+    const gateway = await prisma.capabilityMaturityAssessment.create({
+      data: {
+        assessmentId: TEST_ASSESSMENT_B,
+        name: "MCP gateway",
+        capabilityCategory: "tool_gateway",
+        riskTier: "elevated",
+        maturityScore: 3,
+        strategicOwnership: "owned_core",
+        portfolioId: portfolio.id,
+        taxonomyNodeId: taxonomyNode.id,
+        existingPrimitives: ["ToolExecution"],
+        maturityGaps: ["scope UX"],
+        evidenceSources: [],
+        hiveMindSignals: [],
+        kernelPrinciples: ["single-source-of-truth"],
+      },
+    });
+
+    const runtime = await prisma.capabilityMaturityAssessment.create({
+      data: {
+        assessmentId: TEST_ASSESSMENT_A,
+        name: "Runtime control",
+        capabilityCategory: "runtime",
+        riskTier: "elevated",
+        maturityScore: 3,
+        confidenceGrade: "claimed",
+        strategicOwnership: "owned_core",
+        vendorReplacementConfidence: "low",
+        installScope: "canonical",
+        productizationStatus: "not_eligible",
+        portfolioId: portfolio.id,
+        taxonomyNodeId: taxonomyNode.id,
+        parityChecklistEvidence: [],
+        existingPrimitives: ["WorkCapsule"],
+        maturityGaps: ["mandatory wrapper"],
+        evidenceSources: [],
+        hiveMindSignals: [],
+        kernelPrinciples: ["architecture-over-shortcuts"],
+        operationalSurface: "/portfolio/foundational",
+        hasContinuousEvidence: false,
+        assessedBy: "vitest",
+      },
+    });
+
+    await prisma.capabilityMaturityDependency.create({
+      data: {
+        assessmentId: runtime.id,
+        dependencyId: gateway.id,
+      },
+    });
+
+    const loaded = await prisma.capabilityMaturityAssessment.findUniqueOrThrow({
+      where: { assessmentId: TEST_ASSESSMENT_A },
+      include: {
+        portfolio: true,
+        taxonomyNode: true,
+        dependencies: { include: { dependency: true } },
+      },
+    });
+
+    expect(loaded.portfolio.slug).toBe(TEST_PORTFOLIO_SLUG);
+    expect(loaded.taxonomyNode?.nodeId).toBe(TEST_TAXONOMY_NODE_ID);
+    expect(loaded.confidenceGrade).toBe("claimed");
+    expect(loaded.installScope).toBe("canonical");
+    expect(loaded.productizationStatus).toBe("not_eligible");
+    expect(loaded.dependencies).toHaveLength(1);
+    expect(loaded.dependencies[0]?.dependency.assessmentId).toBe(TEST_ASSESSMENT_B);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `CapabilityMaturityAssessment` as the canonical persisted substrate for agent-control-plane capability maturity scoring, evidence, hive-mind signals, ownership, and productization status.
- Adds `CapabilityMaturityDependency` to model capability dependency edges without overloading taxonomy or EA relationship tables.
- Links assessments to `Portfolio` and optional `TaxonomyNode`, `DigitalProduct`, and `EaElement` anchors so the four-portfolio taxonomy can become both a gap-analysis surface and an operational-management surface.

## Architecture notes

- `TaxonomyNode` remains the placement/classification surface, not maturity score state.
- `BusinessCapability` remains business capability mapping and is not reused for agent-control-plane maturity.
- `PortfolioQualityIssue` remains operational defect tracking, not capability assessment state.
- `EaElement` can anchor architectural capability identity, while maturity state remains time-aware and evidence-bearing in the companion assessment model.
- WWMD/principle consultation was used for the schema direction; the companion-model approach matched the merged specification and keeps the platform from recreating vendor/integration sprawl inside the data model.

## Validation

- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter @dpf/db exec prisma migrate diff --from-schema <origin-main-schema> --to-schema prisma/schema.prisma --script` matched the checked-in migration
- Fresh scratch DB: `prisma migrate deploy` applied all 249 migrations including `20260524234500_agent_control_plane_maturity`
- `pnpm --filter @dpf/db test capability-maturity-schema.test.ts`
- `pnpm --filter @dpf/db test capability-maturity.test.ts`
- `pnpm --filter @dpf/db typecheck`
- `git diff --check`
- `pnpm --filter web build` passed; existing Edge Runtime warnings remain unrelated to this schema slice
