### PR TITLE
feat(portfolio): add maturity rollup read model

### DIFF
--- a/apps/web/lib/maturity/capability-maturity-data.test.ts
+++ b/apps/web/lib/maturity/capability-maturity-data.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getCapabilityMaturityForPortfolioNode,
+  type CapabilityMaturityAssessmentRecord,
+} from "./capability-maturity-data";
+
+function assessment(
+  overrides: Partial<CapabilityMaturityAssessmentRecord> = {},
+): CapabilityMaturityAssessmentRecord {
+  return {
+    id: "a1",
+    assessmentId: "ACPM-SAMPLE",
+    name: "Sample capability",
+    portfolioId: "port-1",
+    taxonomyNodeId: "tax-1",
+    capabilityCategory: "runtime",
+    riskTier: "standard",
+    maturityScore: 3,
+    confidenceGrade: "claimed",
+    installScope: "canonical",
+    productizationStatus: "not_eligible",
+    hasContinuousEvidence: false,
+    evidenceFreshnessAt: null,
+    lastGovernanceReviewAt: null,
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+describe("getCapabilityMaturityForPortfolioNode", () => {
+  it("derives targets, effective maturity, lifecycle mode, and dependency block annotations", async () => {
+    const gateway = assessment({
+      id: "a2",
+      assessmentId: "ACPM-MCP-TOOL-GOVERNANCE",
+      name: "MCP gateway",
+      capabilityCategory: "tool_gateway",
+      riskTier: "elevated",
+      maturityScore: 2,
+      hasContinuousEvidence: true,
+      evidenceFreshnessAt: new Date("2026-05-20T12:00:00.000Z"),
+      taxonomyNodeId: "tax-gateway",
+    });
+    const prisma = {
+      capabilityMaturityAssessment: {
+        findMany: vi.fn().mockResolvedValue([
+          assessment({
+            id: "a1",
+            assessmentId: "ACPM-RUNTIME-CONTROL",
+            name: "Runtime control",
+            capabilityCategory: "runtime",
+            riskTier: "elevated",
+            maturityScore: 4,
+            hasContinuousEvidence: true,
+            evidenceFreshnessAt: new Date("2026-05-20T12:00:00.000Z"),
+            dependencies: [{ dependency: gateway }],
+          }),
+        ]),
+      },
+    };
+
+    const result = await getCapabilityMaturityForPortfolioNode({
+      prisma,
+      portfolioId: "port-1",
+      taxonomyNodeId: "tax-1",
+      installScope: "canonical",
+      now: new Date("2026-05-21T12:00:00.000Z"),
+    });
+
+    expect(prisma.capabilityMaturityAssessment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { portfolioId: "port-1", installScope: "canonical", taxonomyNodeId: "tax-1" },
+      }),
+    );
+    expect(result.summary).toMatchObject({ total: 1, belowTarget: 1, investment: 1, operations: 0 });
+    expect(result.rows[0]).toMatchObject({
+      assessmentId: "ACPM-RUNTIME-CONTROL",
+      confidenceGrade: "evidenced",
+      mvpTargetScore: 4,
+      effectiveMaturity: 2,
+      lifecycleMode: "investment",
+      productizationOverlay: "none",
+      blockedByDependencies: [
+        { assessmentId: "ACPM-MCP-TOOL-GOVERNANCE", name: "MCP gateway", effectiveMaturity: 2 },
+      ],
+    });
+  });
+
+  it("preserves operations lifecycle when productization overlay is candidate", async () => {
+    const prisma = {
+      capabilityMaturityAssessment: {
+        findMany: vi.fn().mockResolvedValue([
+          assessment({
+            id: "b1",
+            assessmentId: "ACPM-PRODUCTIZABLE",
+            name: "Productizable capability",
+            riskTier: "standard",
+            maturityScore: 4,
+            productizationStatus: "candidate",
+            hasContinuousEvidence: true,
+            evidenceFreshnessAt: new Date("2026-05-20T12:00:00.000Z"),
+            lastGovernanceReviewAt: new Date("2026-05-15T12:00:00.000Z"),
+          }),
+        ]),
+      },
+    };
+
+    const result = await getCapabilityMaturityForPortfolioNode({
+      prisma,
+      portfolioId: "port-1",
+      installScope: "canonical",
+      now: new Date("2026-05-21T12:00:00.000Z"),
+    });
+
+    expect(result.rows[0]).toMatchObject({
+      confidenceGrade: "verified",
+      lifecycleMode: "operations",
+      productizationOverlay: "candidate",
+    });
+    expect(result.summary).toMatchObject({ total: 1, belowTarget: 0, investment: 0, operations: 1 });
+  });
+
+  it("demotes stale evidence by one maturity point without demoting claimed bootstrap rows", async () => {
+    const prisma = {
+      capabilityMaturityAssessment: {
+        findMany: vi.fn().mockResolvedValue([
+          assessment({
+            id: "stale",
+            assessmentId: "ACPM-STALE",
+            name: "Stale evidence capability",
+            maturityScore: 3,
+            hasContinuousEvidence: true,
+            evidenceFreshnessAt: new Date("2026-02-01T12:00:00.000Z"),
+          }),
+          assessment({
+            id: "claimed",
+            assessmentId: "ACPM-CLAIMED",
+            name: "Claimed bootstrap capability",
+            maturityScore: 3,
+            hasContinuousEvidence: false,
+            evidenceFreshnessAt: null,
+            lastGovernanceReviewAt: null,
+          }),
+        ]),
+      },
+    };
+
+    const result = await getCapabilityMaturityForPortfolioNode({
+      prisma,
+      portfolioId: "port-1",
+      installScope: "canonical",
+      now: new Date("2026-05-21T12:00:00.000Z"),
+    });
+
+    expect(result.rows.find((row) => row.assessmentId === "ACPM-STALE")).toMatchObject({
+      confidenceGrade: "stale",
+      effectiveMaturity: 2,
+      lifecycleMode: "investment",
+    });
+    expect(result.rows.find((row) => row.assessmentId === "ACPM-CLAIMED")).toMatchObject({
+      confidenceGrade: "claimed",
+      effectiveMaturity: 3,
+      lifecycleMode: "operations",
+    });
+  });
+
+  it("rejects missing installScope so scores from different install scopes never aggregate silently", async () => {
+    const prisma = { capabilityMaturityAssessment: { findMany: vi.fn().mockResolvedValue([]) } };
+
+    await expect(
+      getCapabilityMaturityForPortfolioNode({
+        prisma,
+        portfolioId: "port-1",
+        installScope: undefined as never,
+        now: new Date(),
+      }),
+    ).rejects.toThrow(/installScope/);
+
+    expect(prisma.capabilityMaturityAssessment.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/maturity/capability-maturity-data.ts
+++ b/apps/web/lib/maturity/capability-maturity-data.ts
@@ -1,0 +1,250 @@
+import {
+  CAPABILITY_INSTALL_SCOPES,
+  deriveConfidenceGrade,
+  deriveEffectiveMaturity,
+  deriveMvpTargetScore,
+  type CapabilityInstallScope,
+  type CapabilityMaturityCategory,
+  type CapabilityMaturityConfidenceGrade,
+  type CapabilityMaturityRiskTier,
+  type CapabilityProductizationStatus,
+} from "@dpf/db/capability-maturity";
+
+const DEPENDENCY_INCLUDE_DEPTH = 16;
+
+export type CapabilityMaturityAssessmentRecord = {
+  id: string;
+  assessmentId: string;
+  name: string;
+  portfolioId: string;
+  taxonomyNodeId?: string | null;
+  capabilityCategory: CapabilityMaturityCategory;
+  riskTier: CapabilityMaturityRiskTier;
+  maturityScore: number;
+  confidenceGrade: CapabilityMaturityConfidenceGrade;
+  installScope: CapabilityInstallScope;
+  productizationStatus: CapabilityProductizationStatus;
+  hasContinuousEvidence: boolean;
+  evidenceFreshnessAt: Date | null;
+  lastGovernanceReviewAt: Date | null;
+  operationalSurface?: string | null;
+  existingPrimitives?: unknown;
+  maturityGaps?: unknown;
+  evidenceSources?: unknown;
+  hiveMindSignals?: unknown;
+  kernelPrinciples?: string[];
+  dependencies?: Array<{ dependency: CapabilityMaturityAssessmentRecord }>;
+};
+
+export type CapabilityMaturityLifecycleMode = "investment" | "operations";
+export type CapabilityMaturityProductizationOverlay =
+  | "none"
+  | "eligible"
+  | "candidate"
+  | "productized";
+
+export type CapabilityMaturityDependencyBlock = {
+  assessmentId: string;
+  name: string;
+  effectiveMaturity: number;
+};
+
+export type CapabilityMaturityRow = {
+  id: string;
+  assessmentId: string;
+  name: string;
+  portfolioId: string;
+  taxonomyNodeId: string | null;
+  capabilityCategory: CapabilityMaturityCategory;
+  riskTier: CapabilityMaturityRiskTier;
+  maturityScore: number;
+  mvpTargetScore: number;
+  effectiveMaturity: number;
+  confidenceGrade: CapabilityMaturityConfidenceGrade;
+  installScope: CapabilityInstallScope;
+  lifecycleMode: CapabilityMaturityLifecycleMode;
+  productizationStatus: CapabilityProductizationStatus;
+  productizationOverlay: CapabilityMaturityProductizationOverlay;
+  gapToTarget: number;
+  blockedByDependencies: CapabilityMaturityDependencyBlock[];
+  operationalSurface: string | null;
+  existingPrimitives: unknown;
+  maturityGaps: unknown;
+  evidenceSources: unknown;
+  hiveMindSignals: unknown;
+  kernelPrinciples: string[];
+};
+
+export type CapabilityMaturitySummary = {
+  total: number;
+  belowTarget: number;
+  investment: number;
+  operations: number;
+  productizationOverlays: number;
+};
+
+export type CapabilityMaturityRollup = {
+  rows: CapabilityMaturityRow[];
+  summary: CapabilityMaturitySummary;
+};
+
+type CapabilityMaturityFindManyArgs = {
+  where: {
+    portfolioId: string;
+    installScope: CapabilityInstallScope;
+    taxonomyNodeId?: string;
+  };
+  include: Record<string, unknown>;
+  orderBy: Array<Record<string, "asc" | "desc">>;
+};
+
+export type CapabilityMaturityPrisma = {
+  capabilityMaturityAssessment: {
+    findMany(args: CapabilityMaturityFindManyArgs): Promise<CapabilityMaturityAssessmentRecord[]>;
+  };
+};
+
+export type GetCapabilityMaturityInput = {
+  prisma: CapabilityMaturityPrisma;
+  portfolioId: string;
+  taxonomyNodeId?: string | null;
+  installScope: CapabilityInstallScope;
+  now?: Date;
+};
+
+function dependencyInclude(depth: number): Record<string, unknown> {
+  if (depth <= 0) {
+    return { include: { dependency: true } };
+  }
+
+  return {
+    include: {
+      dependency: {
+        include: {
+          dependencies: dependencyInclude(depth - 1),
+        },
+      },
+    },
+  };
+}
+
+function assertInstallScope(installScope: CapabilityInstallScope | null | undefined): CapabilityInstallScope {
+  if (!installScope || !CAPABILITY_INSTALL_SCOPES.includes(installScope)) {
+    throw new Error("installScope is required for capability maturity rollups.");
+  }
+  return installScope;
+}
+
+function productizationOverlay(
+  status: CapabilityProductizationStatus,
+): CapabilityMaturityProductizationOverlay {
+  return status === "eligible" || status === "candidate" || status === "productized"
+    ? status
+    : "none";
+}
+
+function deriveRow(
+  record: CapabilityMaturityAssessmentRecord,
+  now: Date,
+  cache: Map<string, CapabilityMaturityRow>,
+): CapabilityMaturityRow {
+  const cached = cache.get(record.id);
+  if (cached) return cached;
+
+  const dependencyRows = (record.dependencies ?? []).map(({ dependency }) =>
+    deriveRow(dependency, now, cache),
+  );
+  const confidenceGrade = deriveConfidenceGrade({
+    now,
+    evidenceFreshnessAt: record.evidenceFreshnessAt,
+    lastGovernanceReviewAt: record.lastGovernanceReviewAt,
+    hasContinuousEvidence: record.hasContinuousEvidence,
+  });
+  const mvpTargetScore = deriveMvpTargetScore(record.riskTier);
+  const effectiveMaturity = deriveEffectiveMaturity({
+    maturityScore: record.maturityScore,
+    dependencyEffectiveMaturities: dependencyRows.map((row) => row.effectiveMaturity),
+    confidenceGrade,
+  });
+  const lifecycleMode = effectiveMaturity >= mvpTargetScore ? "operations" : "investment";
+
+  const row: CapabilityMaturityRow = {
+    id: record.id,
+    assessmentId: record.assessmentId,
+    name: record.name,
+    portfolioId: record.portfolioId,
+    taxonomyNodeId: record.taxonomyNodeId ?? null,
+    capabilityCategory: record.capabilityCategory,
+    riskTier: record.riskTier,
+    maturityScore: record.maturityScore,
+    mvpTargetScore,
+    effectiveMaturity,
+    confidenceGrade,
+    installScope: record.installScope,
+    lifecycleMode,
+    productizationStatus: record.productizationStatus,
+    productizationOverlay: productizationOverlay(record.productizationStatus),
+    gapToTarget: Math.max(0, mvpTargetScore - effectiveMaturity),
+    blockedByDependencies: dependencyRows
+      .filter((dependency) => dependency.effectiveMaturity < record.maturityScore)
+      .map((dependency) => ({
+        assessmentId: dependency.assessmentId,
+        name: dependency.name,
+        effectiveMaturity: dependency.effectiveMaturity,
+      })),
+    operationalSurface: record.operationalSurface ?? null,
+    existingPrimitives: record.existingPrimitives ?? [],
+    maturityGaps: record.maturityGaps ?? [],
+    evidenceSources: record.evidenceSources ?? [],
+    hiveMindSignals: record.hiveMindSignals ?? [],
+    kernelPrinciples: record.kernelPrinciples ?? [],
+  };
+
+  cache.set(record.id, row);
+  return row;
+}
+
+function summarize(rows: CapabilityMaturityRow[]): CapabilityMaturitySummary {
+  const investment = rows.filter((row) => row.lifecycleMode === "investment").length;
+  const operations = rows.length - investment;
+  const productizationOverlays = rows.filter(
+    (row) => row.productizationOverlay !== "none",
+  ).length;
+
+  return {
+    total: rows.length,
+    belowTarget: investment,
+    investment,
+    operations,
+    productizationOverlays,
+  };
+}
+
+export async function getCapabilityMaturityForPortfolioNode(
+  input: GetCapabilityMaturityInput,
+): Promise<CapabilityMaturityRollup> {
+  const installScope = assertInstallScope(input.installScope);
+  const where: CapabilityMaturityFindManyArgs["where"] = {
+    portfolioId: input.portfolioId,
+    installScope,
+  };
+  if (input.taxonomyNodeId) {
+    where.taxonomyNodeId = input.taxonomyNodeId;
+  }
+
+  const records = await input.prisma.capabilityMaturityAssessment.findMany({
+    where,
+    include: {
+      dependencies: dependencyInclude(DEPENDENCY_INCLUDE_DEPTH),
+    },
+    orderBy: [{ name: "asc" }, { assessmentId: "asc" }],
+  });
+  const now = input.now ?? new Date();
+  const cache = new Map<string, CapabilityMaturityRow>();
+  const rows = records.map((record) => deriveRow(record, now, cache));
+
+  return {
+    rows,
+    summary: summarize(rows),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a single portfolio maturity rollup read model under `apps/web/lib/maturity`.
- Derives MVP target score, confidence grade, effective maturity, lifecycle mode, productization overlay, gap-to-target, and dependency block annotations from `CapabilityMaturityAssessment` records.
- Keeps install-scope isolation explicit so canonical, dogfood, and customer overlay scores do not aggregate silently.

## Verification
- `pnpm --filter web test lib/maturity/capability-maturity-data.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` completed successfully. Existing Edge Runtime warnings remain unrelated.
