### PR TITLE
fix(init): resolve catalog source in packaged portal

### DIFF
--- a/packages/db/scripts/reconcile-catalog-capabilities.test.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCatalogHash, diffExcludingOverrides, catalogEntryToProfileFields } from "./reconcile-catalog-capabilities";
+import { buildCatalogHash, diffExcludingOverrides, catalogEntryToProfileFields, resolveKnownProviderModelsPath } from "./reconcile-catalog-capabilities";
 import type { KnownModel } from "../../../apps/web/lib/routing/known-provider-models";
 import { EMPTY_CAPABILITIES } from "../../../apps/web/lib/routing/model-card-types";
 
@@ -67,6 +67,22 @@ describe("catalogEntryToProfileFields", () => {
     expect(fields.toolFidelity).toBe(80);
     expect((fields.capabilities as any).toolUse).toBe(true);
     expect(fields.modelStatus).toBe("active");
+  });
+});
+
+describe("resolveKnownProviderModelsPath", () => {
+  it("resolves the packaged app source path when the repo app path is not present", () => {
+    const scriptDir = "C:\\app\\packages\\db\\scripts";
+    const packagedRoot = "C:\\app\\apps\\web-src";
+    const packagedCatalog = "C:\\app\\apps\\web-src\\lib\\routing\\known-provider-models.ts";
+
+    const resolved = resolveKnownProviderModelsPath({
+      scriptDir,
+      packagedWebSourceRoot: packagedRoot,
+      exists: (candidate) => candidate === packagedCatalog,
+    });
+
+    expect(resolved).toBe(packagedCatalog);
   });
 });
 

--- a/packages/db/scripts/reconcile-catalog-capabilities.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.ts
@@ -12,10 +12,19 @@
  * Run via: pnpm --filter @dpf/db exec tsx scripts/reconcile-catalog-capabilities.ts
  */
 import { createHash } from "crypto";
-import { pathToFileURL } from "url";
+import { existsSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
 import { prisma } from "../src/client";
-import { KNOWN_PROVIDER_MODELS } from "../../../apps/web/lib/routing/known-provider-models";
 import type { KnownModel } from "../../../apps/web/lib/routing/known-provider-models";
+
+type KnownProviderModelsByProvider = Record<string, KnownModel[]>;
+
+export type CatalogPathResolutionOptions = {
+  scriptDir?: string;
+  packagedWebSourceRoot?: string;
+  exists?: (candidate: string) => boolean;
+};
 
 export type ProfileUpdateShape = {
   supportsToolUse: boolean;
@@ -42,6 +51,26 @@ export type ProfileUpdateShape = {
   metadataSource: string;
   metadataConfidence: string;
 };
+
+export function resolveKnownProviderModelsPath(
+  options: CatalogPathResolutionOptions = {},
+): string {
+  const scriptDir = options.scriptDir ?? dirname(fileURLToPath(import.meta.url));
+  const exists = options.exists ?? existsSync;
+  const repoCatalog = resolve(scriptDir, "../../../apps/web/lib/routing/known-provider-models.ts");
+  const packagedCatalog = resolve(
+    options.packagedWebSourceRoot ?? "/app/apps/web-src",
+    "lib/routing/known-provider-models.ts",
+  );
+
+  return [repoCatalog, packagedCatalog].find((candidate) => exists(candidate)) ?? repoCatalog;
+}
+
+export async function loadKnownProviderModels(): Promise<KnownProviderModelsByProvider> {
+  const catalogPath = resolveKnownProviderModelsPath();
+  const catalogModule = await import(pathToFileURL(catalogPath).href);
+  return catalogModule.KNOWN_PROVIDER_MODELS as KnownProviderModelsByProvider;
+}
 
 /** Recursively sorts all object keys for stable serialization. */
 function sortedJson(obj: unknown): unknown {
@@ -150,6 +179,7 @@ async function logChanges(
 }
 
 async function reconcile(): Promise<void> {
+  const KNOWN_PROVIDER_MODELS = await loadKnownProviderModels();
   let created = 0;
   let updated = 0;
   let skipped = 0;


### PR DESCRIPTION
## Summary
- Resolve the model catalog reconciliation script from the packaged `/app/apps/web-src` source tree when the standalone runtime does not include `/app/apps/web/lib`.
- Add a regression test for the packaged source path fallback.

## Verification
- `pnpm --filter @dpf/db exec vitest run scripts/reconcile-catalog-capabilities.test.ts`
- `pnpm --filter @dpf/db exec prisma generate`
- `pnpm --filter @dpf/db typecheck`
- `scripts/build-images.ps1 -NoCache -Services portal,portal-init,sandbox`
- `docker compose up -d`
- `docker compose logs --tail=220 portal-init` confirmed `Catalog reconciliation: 0 created, 0 updated, 0 skipped (discovery/admin-owned), 8 unchanged.` and `OK Catalog reconciliation complete`
- `http://127.0.0.1:3000` returned HTTP 200
- `/api/platform/image-version` returned `268e1a2ff8822160a6e081b78367960b16c3233c`

## Runtime Recovery Notes
- Docker Desktop control plane was wedged and recovered with a full Docker/WSL restart.
- Docker storage was relocated from `C:\Users\Mark Bodman\AppData\Local\Docker\wsl\disk` to `D:\DockerDesktop\wsl\disk` with a junction left at the original path.