### PR TITLE
feat(installer): suggest roomy non-C drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Windows installer is a self-contained PowerShell script that clones the repo
 # Step 1 — download the installer (run from any directory)
 iwr -UseBasicParsing https://raw.githubusercontent.com/OpenDigitalProductFactory/opendigitalproductfactory/main/install-dpf.ps1 -OutFile install-dpf.ps1
 
-# Step 2 — run it (will prompt for install directory; defaults to C:\DPF)
+# Step 2 - run it (prompts for install directory; may suggest a non-C drive)
 powershell -ExecutionPolicy Bypass -File install-dpf.ps1
 ```
 

--- a/docs/superpowers/plans/2026-05-25-windows-installer-drive-suggestion.md
+++ b/docs/superpowers/plans/2026-05-25-windows-installer-drive-suggestion.md
@@ -1,0 +1,91 @@
+# Windows Installer Drive Suggestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Windows installer recommend a non-C install drive when C is low on space, check disk space against the selected install drive, and warn when Docker Desktop storage is still on a crowded C drive.
+
+**Architecture:** Keep `install-dpf.ps1` self-contained because README documents downloading that single script before the repo exists. Add pure helper functions inside the installer, expose a `-LibraryOnly` test seam, and cover the behavior with Pester tests that dot-source the installer without running the install flow.
+
+**Tech Stack:** PowerShell 5.1-compatible installer script, Pester 5 tests, existing DPF Windows install documentation.
+
+---
+
+### Task 1: Installer Helper Test Seam
+
+**Files:**
+- Modify: `install-dpf.ps1`
+- Create: `scripts/installer/windows-install-drive.Tests.ps1`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a Pester test that dot-sources `install-dpf.ps1 -LibraryOnly` and expects helper functions such as `Get-DPFDriveInventory`, `Get-DPFInstallDriveRecommendation`, `Get-DPFInstallDriveFreeSpace`, and `Get-DPFDockerStorageRecommendation` to exist.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pwsh -NoProfile -Command "Invoke-Pester -Path scripts/installer/windows-install-drive.Tests.ps1 -Output Detailed"`
+
+Expected: FAIL because the helper functions and `-LibraryOnly` test seam do not exist yet.
+
+- [ ] **Step 3: Add the minimal test seam**
+
+Move the install-directory prompt below helper function declarations and add `[switch]$LibraryOnly`; when it is set, the script returns after loading helper functions and before prompting, writing files, or starting installer steps.
+
+- [ ] **Step 4: Run the test to verify the seam loads**
+
+Run the same Pester command. Expected: helper-existence tests pass or fail only on not-yet-implemented helper behavior.
+
+### Task 2: Drive Recommendation Behavior
+
+**Files:**
+- Modify: `install-dpf.ps1`
+- Test: `scripts/installer/windows-install-drive.Tests.ps1`
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Cover these cases:
+- when `C:` has less than the recommended free-space threshold and `D:` has room, default to `D:\DPF`;
+- when `D:` is too small but `E:` has room, default to `E:\DPF`;
+- when `C:` has enough room, keep `C:\DPF`;
+- the disk-space check resolves the selected install drive rather than hardcoding `C:`.
+
+- [ ] **Step 2: Run the tests red**
+
+Run: `pwsh -NoProfile -Command "Invoke-Pester -Path scripts/installer/windows-install-drive.Tests.ps1 -Output Detailed"`
+
+Expected: FAIL with missing or incorrect recommendation behavior.
+
+- [ ] **Step 3: Implement the minimal helper functions**
+
+Add pure helper functions that normalize fixed-drive inventory, sort non-C candidates by drive letter, pick the first drive meeting the recommended threshold, and resolve free space for the selected install root.
+
+- [ ] **Step 4: Wire the prompt and hardware check**
+
+Use the helper result when the installer is not already running from a repo checkout, print the plain-English recommendation before `Read-Host`, and replace the hardware check's `DeviceID='C:'` lookup with a selected-install-drive lookup.
+
+- [ ] **Step 5: Run focused tests green**
+
+Run the Pester command and fix any regression.
+
+### Task 3: Docker Storage Warning and Docs
+
+**Files:**
+- Modify: `install-dpf.ps1`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-03-14-windows-installer-design.md`
+- Test: `scripts/installer/windows-install-drive.Tests.ps1`
+
+- [ ] **Step 1: Write failing warning tests**
+
+Cover a Docker Desktop data path under `C:\Users\<user>\AppData\Local\Docker\wsl\disk`, a crowded `C:`, and a non-C fixed drive with enough room. Expected target: `<drive>\DockerDesktop\wsl\disk`.
+
+- [ ] **Step 2: Implement warning-only behavior**
+
+Print a warning/suggestion during the install prompt. Do not move Docker storage automatically.
+
+- [ ] **Step 3: Update docs**
+
+Update README's default language and the Windows installer spec so `C:\DPF` is the default only when no better non-C drive recommendation is available.
+
+- [ ] **Step 4: Verify and commit**
+
+Run Pester, inspect the diff, then commit with `git commit -s` and push the branch.

--- a/docs/superpowers/specs/2026-03-14-windows-installer-design.md
+++ b/docs/superpowers/specs/2026-03-14-windows-installer-design.md
@@ -87,6 +87,10 @@ Step 8 of 8: Opening your portal!
 
 **Note:** Hardware detection (Step 5) happens BEFORE starting containers so the installer can configure Docker Desktop resource allocation and select the appropriate AI model. The hardware profile is passed to the portal container via environment variables and written to `PlatformConfig.host_profile` during the migration/seed step.
 
+**Install drive selection:** The one-file Windows installer still uses `C:\DPF` as the plain default when no better host signal exists, but it MUST inspect fixed local drives before prompting. If `C:` is below the recommended free-space threshold and the next non-`C:` fixed drive has room, the prompt defaults to that drive (for example `D:\DPF`) and explains the recommendation in plain English. The later hardware disk check MUST measure the selected install drive, not hardcode `C:`.
+
+**Docker Desktop storage note:** If Docker Desktop already exists and its WSL data disk is on a crowded `C:` drive, the installer may print a warning-only relocation target such as `D:\DockerDesktop\wsl\disk`. The installer MUST NOT move Docker Desktop storage automatically during the normal install flow.
+
 ### Credentials
 
 The installer generates a random admin password (16 chars, alphanumeric) during setup. No hardcoded default password. The password is displayed once in the terminal and also written to `C:\DPF\.admin-credentials` (a file the user can reference if they lose the terminal output). The platform should enforce a password change on first login as a follow-up enhancement.

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1,32 +1,10 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 param(
     [string]$InstallDir,
-    [string]$Version = "latest"
+    [string]$Version = "latest",
+    [switch]$LibraryOnly
 )
 $ErrorActionPreference = "Stop"
-
-# Determine a sensible default: if the script already sits in a project
-# directory (has docker-compose.yml), default to that path.
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-if (-not $InstallDir) {
-    if (Test-Path "$scriptDir\docker-compose.yml") {
-        $defaultDir = $scriptDir
-    } else {
-        $defaultDir = "C:\DPF"
-    }
-
-    Write-Host ""
-    Write-Host "Where would you like to install Digital Product Factory?" -ForegroundColor Cyan
-    $answer = Read-Host "  Install directory [$defaultDir]"
-    if ([string]::IsNullOrWhiteSpace($answer)) {
-        $InstallDir = $defaultDir
-    } else {
-        $InstallDir = $answer.Trim()
-    }
-}
-$DPF_DIR = [System.IO.Path]::GetFullPath($InstallDir)
-$PROGRESS_FILE = "$DPF_DIR\.install-progress"
-$AUTOSTART_TASK_NAME = "DPF-AutoStart"
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -101,6 +79,265 @@ function Register-DPFStartupTask {
         return $false
     }
 }
+
+function Format-DPFGigabytes {
+    param([double]$Value)
+
+    if ([math]::Abs($Value - [math]::Round($Value)) -lt 0.05) {
+        return ([math]::Round($Value)).ToString("0")
+    }
+    return $Value.ToString("0.0")
+}
+
+function Get-DPFDriveDeviceIDFromPath {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $root = [System.IO.Path]::GetPathRoot($Path)
+    if ($root -match "^([A-Za-z]:)") {
+        return $matches[1].ToUpperInvariant()
+    }
+    return $null
+}
+
+function Get-DPFDriveInventory {
+    param([object[]]$LogicalDisks)
+
+    if (-not $LogicalDisks) {
+        try {
+            $LogicalDisks = @(Get-CimInstance Win32_LogicalDisk -Filter "DriveType=3")
+        } catch {
+            return @()
+        }
+    }
+
+    $inventory = foreach ($disk in $LogicalDisks) {
+        $driveType = if ($null -ne $disk.DriveType) { [int]$disk.DriveType } else { 3 }
+        if ($driveType -ne 3) { continue }
+
+        $deviceId = ([string]$disk.DeviceID).TrimEnd("\").ToUpperInvariant()
+        if ($deviceId -notmatch "^[A-Z]:$") { continue }
+
+        $freeGB = if ($disk.PSObject.Properties.Name -contains "FreeGB") {
+            [double]$disk.FreeGB
+        } elseif ($null -ne $disk.FreeSpace) {
+            [math]::Round([double]$disk.FreeSpace / 1GB, 1)
+        } else {
+            0
+        }
+
+        $sizeGB = if ($disk.PSObject.Properties.Name -contains "SizeGB") {
+            [double]$disk.SizeGB
+        } elseif ($null -ne $disk.Size) {
+            [math]::Round([double]$disk.Size / 1GB, 1)
+        } else {
+            0
+        }
+
+        [PSCustomObject]@{
+            DeviceID   = $deviceId
+            FreeGB     = $freeGB
+            SizeGB     = $sizeGB
+            VolumeName = $disk.VolumeName
+        }
+    }
+
+    return @($inventory | Sort-Object DeviceID)
+}
+
+function Get-DPFDriveFromInventory {
+    param(
+        [object[]]$DriveInventory = @(),
+        [Parameter(Mandatory)][string]$DeviceID
+    )
+
+    $normalized = $DeviceID.TrimEnd("\").ToUpperInvariant()
+    return $DriveInventory | Where-Object { $_.DeviceID -eq $normalized } | Select-Object -First 1
+}
+
+function Join-DPFDrivePath {
+    param(
+        [Parameter(Mandatory)][string]$DeviceID,
+        [Parameter(Mandatory)][string]$ChildPath
+    )
+
+    return "$($DeviceID.TrimEnd("\"))\$($ChildPath.TrimStart("\"))"
+}
+
+function Get-DPFInstallDriveRecommendation {
+    param(
+        [object[]]$DriveInventory = @(),
+        [string]$DefaultInstallDir = "C:\DPF",
+        [double]$RecommendedFreeGB = 50
+    )
+
+    $defaultDrive = Get-DPFDriveDeviceIDFromPath -Path $DefaultInstallDir
+    $defaultDriveInfo = if ($defaultDrive) {
+        Get-DPFDriveFromInventory -DriveInventory $DriveInventory -DeviceID $defaultDrive
+    } else {
+        $null
+    }
+
+    $result = [PSCustomObject]@{
+        Recommended      = $false
+        InstallDir       = $DefaultInstallDir
+        RecommendedDrive = $defaultDrive
+        Message          = $null
+    }
+
+    if ($defaultDrive -ne "C:" -or -not $defaultDriveInfo) {
+        return $result
+    }
+
+    if ([double]$defaultDriveInfo.FreeGB -ge $RecommendedFreeGB) {
+        return $result
+    }
+
+    $candidate = $DriveInventory |
+        Where-Object { $_.DeviceID -ne "C:" -and [double]$_.FreeGB -ge $RecommendedFreeGB } |
+        Sort-Object DeviceID |
+        Select-Object -First 1
+
+    if (-not $candidate) {
+        return $result
+    }
+
+    $installDir = Join-DPFDrivePath -DeviceID $candidate.DeviceID -ChildPath "DPF"
+    return [PSCustomObject]@{
+        Recommended      = $true
+        InstallDir       = $installDir
+        RecommendedDrive = $candidate.DeviceID
+        Message          = "C: has $(Format-DPFGigabytes $defaultDriveInfo.FreeGB) GB free; $($candidate.DeviceID) has $(Format-DPFGigabytes $candidate.FreeGB) GB free, so $installDir is the suggested install location."
+    }
+}
+
+function Get-DPFInstallDriveFreeSpace {
+    param(
+        [Parameter(Mandatory)][string]$InstallDir,
+        [object[]]$DriveInventory = @()
+    )
+
+    $installDrive = Get-DPFDriveDeviceIDFromPath -Path $InstallDir
+    if (-not $installDrive) {
+        return [PSCustomObject]@{
+            DeviceID = $null
+            FreeGB   = 0
+            Missing  = $true
+        }
+    }
+
+    $driveInfo = Get-DPFDriveFromInventory -DriveInventory $DriveInventory -DeviceID $installDrive
+    if (-not $driveInfo) {
+        return [PSCustomObject]@{
+            DeviceID = $installDrive
+            FreeGB   = 0
+            Missing  = $true
+        }
+    }
+
+    return [PSCustomObject]@{
+        DeviceID = $driveInfo.DeviceID
+        FreeGB   = [double]$driveInfo.FreeGB
+        Missing  = $false
+    }
+}
+
+function Get-DPFDockerDesktopDataPath {
+    $candidate = Join-Path $env:LOCALAPPDATA "Docker\wsl\disk"
+    if (Test-Path -LiteralPath $candidate) {
+        return $candidate
+    }
+    return $null
+}
+
+function Get-DPFDockerStorageRecommendation {
+    param(
+        [object[]]$DriveInventory = @(),
+        [string]$DockerDataPath,
+        [double]$RecommendedFreeGB = 100
+    )
+
+    $result = [PSCustomObject]@{
+        ShouldWarn  = $false
+        CurrentPath = $DockerDataPath
+        TargetPath  = $null
+        Message     = $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($DockerDataPath)) {
+        return $result
+    }
+
+    $currentDrive = Get-DPFDriveDeviceIDFromPath -Path $DockerDataPath
+    if ($currentDrive -ne "C:") {
+        return $result
+    }
+
+    $cDrive = Get-DPFDriveFromInventory -DriveInventory $DriveInventory -DeviceID "C:"
+    if (-not $cDrive -or [double]$cDrive.FreeGB -ge $RecommendedFreeGB) {
+        return $result
+    }
+
+    $candidate = $DriveInventory |
+        Where-Object { $_.DeviceID -ne "C:" -and [double]$_.FreeGB -ge $RecommendedFreeGB } |
+        Sort-Object DeviceID |
+        Select-Object -First 1
+
+    if (-not $candidate) {
+        return $result
+    }
+
+    $targetPath = Join-DPFDrivePath -DeviceID $candidate.DeviceID -ChildPath "DockerDesktop\wsl\disk"
+    return [PSCustomObject]@{
+        ShouldWarn  = $true
+        CurrentPath = $DockerDataPath
+        TargetPath  = $targetPath
+        Message     = "Docker Desktop stores Linux data on C: at $DockerDataPath. If Docker storage starts filling C:, use $targetPath as the relocation target. The installer will not move Docker storage automatically."
+    }
+}
+
+if ($LibraryOnly -or $env:DPF_INSTALLER_LIBRARY_ONLY -eq "1") {
+    return
+}
+
+# Determine a sensible default: if the script already sits in a project
+# directory (has docker-compose.yml), default to that path. For one-file
+# downloads, prefer the next fixed non-C drive when C is short on space.
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$driveInventory = Get-DPFDriveInventory
+if (-not $InstallDir) {
+    $installDriveRecommendation = $null
+    if (Test-Path "$scriptDir\docker-compose.yml") {
+        $defaultDir = $scriptDir
+    } else {
+        $installDriveRecommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory $driveInventory `
+            -DefaultInstallDir "C:\DPF"
+        $defaultDir = $installDriveRecommendation.InstallDir
+    }
+
+    Write-Host ""
+    Write-Host "Where would you like to install Digital Product Factory?" -ForegroundColor Cyan
+    if ($installDriveRecommendation -and $installDriveRecommendation.Recommended) {
+        Write-Host "  Suggestion: $($installDriveRecommendation.Message)" -ForegroundColor Yellow
+    }
+
+    $dockerStorageRecommendation = Get-DPFDockerStorageRecommendation `
+        -DriveInventory $driveInventory `
+        -DockerDataPath (Get-DPFDockerDesktopDataPath)
+    if ($dockerStorageRecommendation.ShouldWarn) {
+        Write-Host "  Docker storage note: $($dockerStorageRecommendation.Message)" -ForegroundColor Yellow
+    }
+
+    $answer = Read-Host "  Install directory [$defaultDir]"
+    if ([string]::IsNullOrWhiteSpace($answer)) {
+        $InstallDir = $defaultDir
+    } else {
+        $InstallDir = $answer.Trim()
+    }
+}
+$DPF_DIR = [System.IO.Path]::GetFullPath($InstallDir)
+$PROGRESS_FILE = "$DPF_DIR\.install-progress"
+$AUTOSTART_TASK_NAME = "DPF-AutoStart"
 
 $GHCR_PORTAL = "ghcr.io/opendigitalproductfactory/dpf-portal"
 $GHCR_SANDBOX = "ghcr.io/opendigitalproductfactory/dpf-sandbox"
@@ -558,7 +795,7 @@ services:
       retries: 10
       start_period: 30s
 
-  # ─── Sandbox Database (isolated from production) ────────────────────
+  # Sandbox Database (isolated from production)
   sandbox-postgres:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -575,7 +812,7 @@ services:
       retries: 5
       start_period: 10s
 
-  # ─── Sandbox Init (migrations on sandbox DB) ──────────────────────
+  # Sandbox Init (migrations on sandbox DB)
   sandbox-init:
     image: $($GHCR_PORTAL):$Version
     command: ["/docker-entrypoint.sh"]
@@ -588,7 +825,7 @@ services:
       sandbox-postgres:
         condition: service_healthy
 
-  # ─── Sandbox (isolated build environment for Build Studio) ──────────
+  # Sandbox (isolated build environment for Build Studio)
   sandbox:
     image: $($GHCR_SANDBOX):$Version
     restart: unless-stopped
@@ -610,8 +847,8 @@ services:
       sandbox-init:
         condition: service_completed_successfully
 
-  # ─── Promoter (autonomous deployment pipeline) ─────────────────────
-  # One-shot container — triggered by Build Studio ship phase or ops UI.
+  # Promoter (autonomous deployment pipeline)
+  # One-shot container -- triggered by Build Studio ship phase or ops UI.
   promoter:
     image: dpf-promoter:latest
     entrypoint: ["/promoter/promote.sh"]
@@ -1062,7 +1299,7 @@ if (-not (Test-StepDone "hardware")) {
     $cpu = Get-CimInstance Win32_Processor
     $mem = Get-CimInstance Win32_ComputerSystem
     $gpu = Get-CimInstance Win32_VideoController | Where-Object { $_.Name -match "NVIDIA" } | Select-Object -First 1
-    $disk = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'"
+    $disk = Get-DPFInstallDriveFreeSpace -InstallDir $DPF_DIR -DriveInventory (Get-DPFDriveInventory)
 
     $totalRAM_GB = [math]::Round($mem.TotalPhysicalMemory / 1GB, 1)
     $gpuName = if ($gpu) { $gpu.Name } else { $null }
@@ -1080,7 +1317,7 @@ if (-not (Test-StepDone "hardware")) {
             $gpuVRAM_GB = [math]::Round($gpu.AdapterRAM / 1GB, 1)
         }
     }
-    $diskFree_GB = [math]::Round($disk.FreeSpace / 1GB, 1)
+    $diskFree_GB = [double]$disk.FreeGB
 
     $hwSummary = "$totalRAM_GB GB RAM, $($cpu.NumberOfCores)-core CPU"
     if ($gpuName) { $hwSummary += ", $gpuName ($gpuVRAM_GB GB VRAM)" }
@@ -1090,7 +1327,7 @@ if (-not (Test-StepDone "hardware")) {
     # Mirrors apps/web/lib/inference/bootstrap-first-run.ts MODEL_TIERS so the
     # installer's pre-portal model pull agrees with the portal's post-boot
     # bootstrap. Tags are the exact Docker Hub published forms (verified
-    # against https://hub.docker.com/r/ai/qwen3/tags 2026-05-23) — lowercase
+    # against https://hub.docker.com/r/ai/qwen3/tags 2026-05-23) -- lowercase
     # short forms (`ai/qwen3:14b`) 404 against Docker Model Runner.
     #
     # Why Qwen3 over Gemma: the platform's Coworkers catalog tiers Qwen3 as
@@ -1119,7 +1356,8 @@ if (-not (Test-StepDone "hardware")) {
 
     # Check disk space
     if ($diskFree_GB -lt 5) {
-        Write-Warn "Not enough disk space. The platform needs about 5 GB free. You have $diskFree_GB GB."
+        $diskLabel = if ($disk.DeviceID) { $disk.DeviceID } else { "the selected install drive" }
+        Write-Warn "Not enough disk space on $diskLabel. The platform needs about 5 GB free. You have $diskFree_GB GB."
         exit 1
     }
 
@@ -1130,12 +1368,13 @@ if (-not (Test-StepDone "hardware")) {
         ramGB = $totalRAM_GB
         gpuName = $gpuName
         gpuVramGB = $gpuVRAM_GB
+        installDrive = $disk.DeviceID
         diskFreeGB = $diskFree_GB
         selectedModel = $selectedModel
         detectedAt = (Get-Date -Format "o")
     } | ConvertTo-Json -Compress
 
-    # Docker Model Runner uses Docker Desktop's built-in GPU support — no override needed.
+    # Docker Model Runner uses Docker Desktop's built-in GPU support -- no override needed.
 
     # Save for later steps
     $hostProfile | Set-Content "$DPF_DIR\.host-profile.json"
@@ -1193,7 +1432,7 @@ GF_ADMIN_PASSWORD=$adminPass
 #
 # Also handles two upgrade paths:
 #   1. Operators upgrading from PR #1040: the dpf-reinstall.ps1 / uninstall
-#      preserve dance moved backups to $DPF_DIR-backups\ — that location IS
+#      preserve dance moved backups to $DPF_DIR-backups\ -- that location IS
 #      the permanent home now, so leave them alone.
 #   2. Operators upgrading from pre-#1040 (backups still in-tree at
 #      $DPF_DIR\backups\): migrate them forward so the new bind mount sees
@@ -1346,7 +1585,7 @@ if (-not (Test-StepDone "started")) {
     docker compose up -d
     $ErrorActionPreference = $oldEAP
 
-    # Sync postgres password — if the volume was reused from a prior install,
+    # Sync postgres password -- if the volume was reused from a prior install,
     # the DB user still has the old password. Update it to match the new .env.
     Write-Action "Syncing database credentials..."
     $envPgPass = (Get-Content "$DPF_DIR\.env" | Select-String "^POSTGRES_PASSWORD=(.+)$").Matches.Groups[1].Value
@@ -1432,11 +1671,11 @@ if (-not (Test-StepDone "model")) {
     #
     # Docker Model Runner is DISABLED by default in fresh Docker Desktop
     # installs. Without explicitly enabling it first, `docker model pull`
-    # fails with "Docker Model Runner is not running" — but the exit code
+    # fails with "Docker Model Runner is not running" -- but the exit code
     # behavior is inconsistent across versions, so the user ends up with
     # .selected-model set, no actual model on disk, and the portal's
     # AI Coworker silently broken ("AI provider is temporarily unavailable"
-    # on first portal load). Enabling is idempotent — no-op if already on.
+    # on first portal load). Enabling is idempotent -- no-op if already on.
     Write-Action "Enabling Docker Model Runner..."
     $oldEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
@@ -1450,7 +1689,7 @@ if (-not (Test-StepDone "model")) {
         Write-Warn "Then re-run this installer."
     } else {
         # Enable GPU-backed inference. Docker Desktop ships this OFF by default
-        # — without it, llama-server processes run on CPU + system RAM instead
+        # Without it, llama-server processes run on CPU + system RAM instead
         # of VRAM, inference is 10-50x slower, and every downstream operation
         # (probes, coworker calls, model evals) silently degrades. The
         # `docker desktop enable model-runner --gpu enable` subcommand is

--- a/scripts/installer/windows-install-drive.Tests.ps1
+++ b/scripts/installer/windows-install-drive.Tests.ps1
@@ -1,0 +1,161 @@
+# scripts/installer/windows-install-drive.Tests.ps1
+#
+# Pester 5 tests for the Windows installer drive recommendation helpers.
+#
+# Run: pwsh -NoProfile -Command "Invoke-Pester -Path scripts/installer/windows-install-drive.Tests.ps1 -Output Detailed"
+
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:InstallerPath = Join-Path $script:RepoRoot 'install-dpf.ps1'
+    . $script:InstallerPath -LibraryOnly
+
+    function New-TestLogicalDisk {
+        param(
+            [Parameter(Mandatory)][string] $DeviceID,
+            [Parameter(Mandatory)][double] $FreeGB,
+            [double] $SizeGB = 500,
+            [int] $DriveType = 3,
+            [string] $VolumeName = ''
+        )
+
+        [PSCustomObject]@{
+            DeviceID   = $DeviceID
+            FreeSpace  = [int64]($FreeGB * 1GB)
+            Size       = [int64]($SizeGB * 1GB)
+            DriveType  = $DriveType
+            VolumeName = $VolumeName
+        }
+    }
+}
+
+Describe "Windows installer drive recommendation" {
+    It "loads installer helper functions without running the installer flow" {
+        Get-Command Get-DPFDriveInventory -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Get-DPFInstallDriveRecommendation -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Get-DPFInstallDriveFreeSpace -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Get-DPFDockerStorageRecommendation -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+
+    It "recommends D:\DPF when C is below the recommended free-space threshold and D has room" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 20
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 250
+        )
+
+        $recommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory $drives `
+            -DefaultInstallDir 'C:\DPF' `
+            -RecommendedFreeGB 50
+
+        $recommendation.Recommended | Should -Be $true
+        $recommendation.InstallDir | Should -Be 'D:\DPF'
+        $recommendation.RecommendedDrive | Should -Be 'D:'
+        $recommendation.Message | Should -Match 'C: has 20 GB free'
+        $recommendation.Message | Should -Match 'D: has 250 GB free'
+    }
+
+    It "uses the next drive letter with room rather than the largest drive" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 12
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 75
+            New-TestLogicalDisk -DeviceID 'E:' -FreeGB 900
+        )
+
+        $recommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory $drives `
+            -DefaultInstallDir 'C:\DPF' `
+            -RecommendedFreeGB 50
+
+        $recommendation.InstallDir | Should -Be 'D:\DPF'
+        $recommendation.RecommendedDrive | Should -Be 'D:'
+    }
+
+    It "skips too-small non-C drives and recommends the next letter that has room" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 12
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 40
+            New-TestLogicalDisk -DeviceID 'E:' -FreeGB 125
+        )
+
+        $recommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory $drives `
+            -DefaultInstallDir 'C:\DPF' `
+            -RecommendedFreeGB 50
+
+        $recommendation.InstallDir | Should -Be 'E:\DPF'
+        $recommendation.RecommendedDrive | Should -Be 'E:'
+    }
+
+    It "keeps C:\DPF when C already has enough room" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 120
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 250
+        )
+
+        $recommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory $drives `
+            -DefaultInstallDir 'C:\DPF' `
+            -RecommendedFreeGB 50
+
+        $recommendation.Recommended | Should -Be $false
+        $recommendation.InstallDir | Should -Be 'C:\DPF'
+    }
+
+    It "keeps the default install path when no drive inventory is available" {
+        $recommendation = Get-DPFInstallDriveRecommendation `
+            -DriveInventory @() `
+            -DefaultInstallDir 'C:\DPF' `
+            -RecommendedFreeGB 50
+
+        $recommendation.Recommended | Should -Be $false
+        $recommendation.InstallDir | Should -Be 'C:\DPF'
+    }
+
+    It "reports free space for the selected install drive instead of hardcoding C" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 3
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 250
+        )
+
+        $installDrive = Get-DPFInstallDriveFreeSpace -InstallDir 'D:\DPF' -DriveInventory $drives
+
+        $installDrive.DeviceID | Should -Be 'D:'
+        $installDrive.FreeGB | Should -Be 250
+    }
+}
+
+Describe "Docker Desktop storage warning" {
+    It "suggests a non-C Docker storage target when Docker data is on a crowded C drive" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 30
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 500
+        )
+
+        $recommendation = Get-DPFDockerStorageRecommendation `
+            -DriveInventory $drives `
+            -DockerDataPath 'C:\Users\owner\AppData\Local\Docker\wsl\disk' `
+            -RecommendedFreeGB 100
+
+        $recommendation.ShouldWarn | Should -Be $true
+        $recommendation.CurrentPath | Should -Be 'C:\Users\owner\AppData\Local\Docker\wsl\disk'
+        $recommendation.TargetPath | Should -Be 'D:\DockerDesktop\wsl\disk'
+        $recommendation.Message | Should -Match 'Docker Desktop stores Linux data on C:'
+        $recommendation.Message | Should -Match 'D:\\DockerDesktop\\wsl\\disk'
+    }
+
+    It "does not warn when Docker data is already off C" {
+        $drives = Get-DPFDriveInventory -LogicalDisks @(
+            New-TestLogicalDisk -DeviceID 'C:' -FreeGB 30
+            New-TestLogicalDisk -DeviceID 'D:' -FreeGB 500
+        )
+
+        $recommendation = Get-DPFDockerStorageRecommendation `
+            -DriveInventory $drives `
+            -DockerDataPath 'D:\DockerDesktop\wsl\disk' `
+            -RecommendedFreeGB 100
+
+        $recommendation.ShouldWarn | Should -Be $false
+    }
+}


### PR DESCRIPTION
## Summary
- Add self-contained Windows installer helpers that inspect fixed local drives and suggest the next non-C drive with enough free space when C is tight.
- Make hardware disk-space detection measure the selected install drive instead of hardcoding C:.
- Add a warning-only Docker Desktop storage suggestion for crowded C-drive installs, plus docs and a small implementation plan artifact.

## Verification
- `pwsh -NoProfile -Command '$tokens = $null; $errors = $null; [System.Management.Automation.Language.Parser]::ParseFile("install-dpf.ps1", [ref]$tokens, [ref]$errors) | Out-Null; if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }'`
- `pwsh -NoProfile -Command '$result = Invoke-Pester -Path scripts/installer/windows-install-drive.Tests.ps1 -Output Detailed -PassThru; if ($result.FailedCount -gt 0) { exit 1 }'` (9 passed)
- `rg -n "[^\\x00-\\x7F]" install-dpf.ps1 scripts/installer/windows-install-drive.Tests.ps1` (no matches)
- `git diff --check`
- `pnpm --filter @dpf/db exec prisma generate`
- `pnpm --filter web build` (passed; existing Edge-runtime warnings remain)
