### PR TITLE
fix: clarify Build Studio provider gating

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -113,11 +113,11 @@ export default async function BuildPage({ searchParams }: PageProps) {
   if (!capability.ok) {
     const isOnlyLocal = capability.reason === "only_local_provider_active";
     const heading = isOnlyLocal
-      ? "Connect a stronger AI to start building"
-      : "Build Studio needs a stronger AI model";
+      ? "Connect a code-capable AI runner to start building"
+      : "Build Studio needs a code-capable AI runner";
     const body = isOnlyLocal
-      ? "Build Studio writes code and orchestrates tools for you. The local AI on this install can chat, but it isn't strong enough for that work yet. Connect one of the providers below — it takes about a minute — and the build flow opens up."
-      : "Build Studio needs a model that can write code and use tools at production quality. The AI providers configured on this install don't include one yet. Connect one of the providers below to get started.";
+      ? "Build Studio writes code and orchestrates tools for you. The local AI on this install can chat, but it is not the right runner for production code work yet. Connect a subscription CLI path or an API-key provider below, then the build flow opens up."
+      : "Build Studio needs an active runner that can write code and use tools at production quality. ChatGPT/OpenAI Codex can satisfy this through OAuth and Codex CLI; OpenAI and Anthropic API keys are separate pay-per-token licensing paths.";
     return (
       <div className="flex items-start justify-center min-h-[60vh] px-6 py-10">
         <div className="max-w-2xl w-full space-y-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-8 shadow-sm">

--- a/apps/web/lib/build/build-studio-capability-db.test.ts
+++ b/apps/web/lib/build/build-studio-capability-db.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProfile: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { loadBuildStudioCapability } from "./build-studio-capability";
+
+const mockModelProfileFindMany = vi.mocked(prisma.modelProfile.findMany);
+
+describe("loadBuildStudioCapability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queries active chat and code model profiles so Codex CLI can satisfy the Build Studio gate", async () => {
+    mockModelProfileFindMany.mockResolvedValue([
+      {
+        providerId: "codex",
+        modelId: "gpt-5.3-codex",
+        supportsToolUse: true,
+        maxInputTokens: null,
+        provider: { name: "OpenAI Codex" },
+      },
+    ] as unknown as Awaited<ReturnType<typeof prisma.modelProfile.findMany>>);
+
+    const result = await loadBuildStudioCapability();
+
+    expect(mockModelProfileFindMany).toHaveBeenCalledWith({
+      where: {
+        modelClass: { in: ["chat", "code"] },
+        modelStatus: { in: ["active", "degraded"] },
+        provider: { status: "active" },
+      },
+      select: {
+        providerId: true,
+        modelId: true,
+        supportsToolUse: true,
+        maxInputTokens: true,
+        provider: { select: { name: true } },
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.satisfyingProviderNames).toEqual(["OpenAI Codex"]);
+    }
+  });
+});

--- a/apps/web/lib/build/build-studio-capability.test.ts
+++ b/apps/web/lib/build/build-studio-capability.test.ts
@@ -27,6 +27,28 @@ describe("deriveBuildStudioCapability", () => {
     }
   });
 
+  it("explains subscription and API-key provider paths separately", () => {
+    expect(SUGGESTED_PROVIDERS).toEqual([
+      {
+        name: "ChatGPT / OpenAI Codex - Subscription sign-in",
+        description: "Recommended: sign in with OpenAI OAuth. Build Studio uses the Codex CLI path; no API key needed.",
+        recommended: true,
+      },
+      {
+        name: "OpenAI API key",
+        description: "Separate OpenAI platform billing. Use this when you want pay-per-token API usage instead of ChatGPT plan limits.",
+      },
+      {
+        name: "Anthropic API key",
+        description: "Separate Anthropic Console billing. Use this when Claude subscription limits are paused or exhausted.",
+      },
+      {
+        name: "Google Gemini API key",
+        description: "Useful for light or backup routing. Free-tier keys have lower quotas than paid API or subscription CLI paths.",
+      },
+    ]);
+  });
+
   it("returns only_local_provider_active when only Docker Model Runner has under-tier models", () => {
     const result = deriveBuildStudioCapability([
       model({

--- a/apps/web/lib/build/build-studio-capability.ts
+++ b/apps/web/lib/build/build-studio-capability.ts
@@ -53,17 +53,21 @@ export interface SuggestedProvider {
 
 export const SUGGESTED_PROVIDERS: ReadonlyArray<SuggestedProvider> = [
   {
-    name: "Claude (Anthropic) — Subscription sign-in",
-    description: "Easiest path: sign in with an existing Claude account. No API key needed.",
+    name: "ChatGPT / OpenAI Codex - Subscription sign-in",
+    description: "Recommended: sign in with OpenAI OAuth. Build Studio uses the Codex CLI path; no API key needed.",
     recommended: true,
   },
   {
-    name: "Google Gemini",
-    description: "Generous free tier; quick API-key setup.",
+    name: "OpenAI API key",
+    description: "Separate OpenAI platform billing. Use this when you want pay-per-token API usage instead of ChatGPT plan limits.",
   },
   {
-    name: "OpenAI",
-    description: "Widely used; API-key setup.",
+    name: "Anthropic API key",
+    description: "Separate Anthropic Console billing. Use this when Claude subscription limits are paused or exhausted.",
+  },
+  {
+    name: "Google Gemini API key",
+    description: "Useful for light or backup routing. Free-tier keys have lower quotas than paid API or subscription CLI paths.",
   },
 ];
 
@@ -145,7 +149,8 @@ export function deriveBuildStudioCapability(models: ActiveProviderModel[]): Buil
 export async function loadBuildStudioCapability(): Promise<BuildStudioCapability> {
   const profiles = await prisma.modelProfile.findMany({
     where: {
-      modelClass: "chat",
+      modelClass: { in: ["chat", "code"] },
+      modelStatus: { in: ["active", "degraded"] },
       provider: { status: "active" },
     },
     select: {

--- a/apps/web/lib/integrate/build-studio-config.test.ts
+++ b/apps/web/lib/integrate/build-studio-config.test.ts
@@ -20,8 +20,11 @@ const mockFindUnique = vi.mocked(prisma.platformConfig.findUnique);
 const mockProviderFindMany = vi.mocked(prisma.modelProvider.findMany);
 const mockCredentialFindUnique = vi.mocked(prisma.credentialEntry.findUnique);
 
-function providerRow(providerId: string): Awaited<ReturnType<typeof prisma.modelProvider.findMany>>[number] {
-  return { providerId } as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>[number];
+function providerRow(
+  providerId: string,
+  status: "active" | "inactive" | "unconfigured" = "active",
+): Awaited<ReturnType<typeof prisma.modelProvider.findMany>>[number] {
+  return { providerId, status } as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>[number];
 }
 
 function credentialRow(status: "ok" | "configured" | "pending"): NonNullable<Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>> {
@@ -113,6 +116,22 @@ describe("getBuildStudioConfig", () => {
     const config = await getBuildStudioConfig();
     expect(config.provider).toBe("claude");
     expect(config.claudeProviderId).toBe("anthropic-sub");
+    expect(config.codexProviderId).toBe("chatgpt");
+  });
+
+  it("ignores inactive CLI providers when auto-detecting dispatch engine", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    mockProviderFindMany
+      .mockResolvedValueOnce([providerRow("anthropic-sub", "inactive")])
+      .mockResolvedValueOnce([providerRow("chatgpt", "active")]);
+    mockCredentialFindUnique
+      .mockResolvedValueOnce(credentialRow("ok"))
+      .mockResolvedValueOnce(credentialRow("ok"));
+
+    const config = await getBuildStudioConfig();
+
+    expect(config.provider).toBe("codex");
+    expect(config.claudeProviderId).toBe("");
     expect(config.codexProviderId).toBe("chatgpt");
   });
 

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -28,7 +28,7 @@ async function findConfiguredProvider(cliEngine: string): Promise<string> {
   // Find providers tagged with this CLI engine
   const providers = await prisma.modelProvider.findMany({
     where: { cliEngine },
-    select: { providerId: true },
+    select: { providerId: true, status: true },
     orderBy: { providerId: "asc" },
   });
 
@@ -36,6 +36,7 @@ async function findConfiguredProvider(cliEngine: string): Promise<string> {
 
   // Check which ones have working credentials
   for (const p of providers) {
+    if (p.status !== "active") continue;
     const cred = await prisma.credentialEntry.findUnique({
       where: { providerId: p.providerId },
       select: { status: true },
@@ -49,7 +50,7 @@ async function findConfiguredProvider(cliEngine: string): Promise<string> {
 
 /**
  * Auto-detect the best dispatch provider based on what's configured.
- * Prefers Claude over Codex; falls back to agentic if nothing configured.
+ * Prefers active Claude over active Codex; falls back to agentic if nothing configured.
  */
 async function autoDetectConfig(): Promise<BuildStudioDispatchConfig> {
   const claudeId = await findConfiguredProvider("claude");


### PR DESCRIPTION
## Summary
- Treat active Codex code-model profiles as satisfying the Build Studio capability gate, so ChatGPT/OpenAI OAuth plus Codex CLI is not mislabeled as insufficient.
- Update the Build Studio provider-gate copy to separate subscription CLI paths from OpenAI/Anthropic API-key billing paths.
- Make Build Studio dispatch auto-detect ignore inactive CLI providers, so an inactive Claude subscription does not outrank an active Codex credential.

## Research grounding
- OpenAI docs: Codex is available through eligible ChatGPT plans, and Codex CLI can authenticate with a ChatGPT account or API key.
- OpenAI billing docs: ChatGPT and API billing are managed separately.
- Anthropic docs: Claude Code supports subscription login and API/Console-backed access, while usage limits apply across Claude surfaces.
- Gemini docs: API keys/free tiers exist, but free API-key use has lower quotas than paid/subscription routes.

## Verification
- pnpm --filter web exec vitest run lib/build/build-studio-capability.test.ts lib/build/build-studio-capability-db.test.ts lib/integrate/build-studio-config.test.ts
- pnpm --filter web typecheck
- pnpm --filter web build
- Playwright smoke on http://127.0.0.1:3105/build: Build Studio rendered, old provider gate absent, screenshot captured at output/playwright/build-studio-provider-copy.png