### PR TITLE
fix(portal): stop startup self-call storms

### DIFF
--- a/apps/web/app/api/inngest/route.ts
+++ b/apps/web/app/api/inngest/route.ts
@@ -1,8 +1,8 @@
 import { serve } from "inngest/next";
 import { inngest } from "@/lib/queue/inngest-client";
-import { allFunctions } from "@/lib/queue/functions";
+import { getInngestFunctionsForRuntime } from "@/lib/queue/functions";
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
-  functions: allFunctions,
+  functions: getInngestFunctionsForRuntime(),
 });

--- a/apps/web/components/shell/ModelWarmup.test.tsx
+++ b/apps/web/components/shell/ModelWarmup.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModelWarmup } from "./ModelWarmup";
+
+describe("ModelWarmup", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it("does not perform synthetic report or MCP calls on mount", () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const dispatchSpy = vi.spyOn(document, "dispatchEvent");
+
+    render(<ModelWarmup />);
+
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/shell/ModelWarmup.tsx
+++ b/apps/web/components/shell/ModelWarmup.tsx
@@ -1,73 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-
 /**
- * Fires a tiny inference call on mount to warm up the local AI model.
- * Shows a status banner while the model is loading into memory.
- * Runs once per page load — subsequent calls are fast because keep_alive=-1 keeps the model loaded.
+ * Reserved for future model-readiness UI. It must not perform hidden network
+ * warmups: shell mount side effects created real issue reports and destabilized
+ * the portal during startup.
  */
 export function ModelWarmup() {
-  const warmedUp = useRef(false);
-
-  useEffect(() => {
-    if (warmedUp.current) return;
-    warmedUp.current = true;
-
-    async function warmup() {
-      // Show banner
-      document.dispatchEvent(new CustomEvent("status-banner", {
-        detail: { id: "model-warmup", text: "Loading AI model into memory... first response may take a moment.", type: "info" },
-      }));
-
-      try {
-        const start = Date.now();
-        const res = await fetch("/api/quality/report", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            type: "system_warmup",
-            title: "Model warmup ping",
-            source: "warmup",
-          }),
-        });
-
-        // Also ping the AI to force model load — use a tiny message
-        await fetch("/api/mcp/call", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            name: "report_quality_issue",
-            arguments: { type: "feedback", title: "System warmup check", description: "Automated warmup — ignore this." },
-          }),
-        }).catch(() => {});
-
-        const elapsed = Date.now() - start;
-
-        // Dismiss the loading banner
-        document.dispatchEvent(new CustomEvent("status-banner-dismiss", { detail: "model-warmup" }));
-
-        // If it took more than 5 seconds, the model was cold-loading
-        if (elapsed > 5000) {
-          document.dispatchEvent(new CustomEvent("status-banner", {
-            detail: { id: "model-ready", text: "AI model loaded and ready.", type: "success" },
-          }));
-          // Auto-dismiss after 5 seconds
-          setTimeout(() => {
-            document.dispatchEvent(new CustomEvent("status-banner-dismiss", { detail: "model-ready" }));
-          }, 5000);
-        } else {
-          // Model was already loaded — no banner needed
-        }
-      } catch {
-        document.dispatchEvent(new CustomEvent("status-banner-dismiss", { detail: "model-warmup" }));
-      }
-    }
-
-    // Delay warmup slightly so the page renders first
-    const timer = setTimeout(warmup, 2000);
-    return () => clearTimeout(timer);
-  }, []);
-
   return null;
 }

--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { warnIfLegacyHiveTokenEnvSet, syncPlatformVersionOnBoot } from "./instrumentation";
+import {
+  areOptionalStartupTasksEnabled,
+  isInngestSelfSyncOnBootEnabled,
+  isStartupModelRevalidationEnabled,
+  warnIfLegacyHiveTokenEnvSet,
+  syncPlatformVersionOnBoot,
+} from "./instrumentation";
 
 const syncPlatformVersionConfigMock = vi.fn();
 
@@ -76,5 +82,53 @@ describe("syncPlatformVersionOnBoot", () => {
     expect(error.mock.calls[0]![0]).toContain("[platform-version]");
     expect(error.mock.calls[0]![0]).toContain("Failed");
     expect(error.mock.calls[0]![1]).toBe(boom);
+  });
+});
+
+describe("isStartupModelRevalidationEnabled", () => {
+  it("requires explicit opt-in before startup revalidation runs", () => {
+    expect(isStartupModelRevalidationEnabled({})).toBe(false);
+    expect(
+      isStartupModelRevalidationEnabled({
+        DPF_STARTUP_MODEL_REVALIDATION_ENABLED: "false",
+      }),
+    ).toBe(false);
+    expect(
+      isStartupModelRevalidationEnabled({
+        DPF_STARTUP_MODEL_REVALIDATION_ENABLED: "true",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isInngestSelfSyncOnBootEnabled", () => {
+  it("requires explicit opt-in before the portal self-registers with Inngest on boot", () => {
+    expect(isInngestSelfSyncOnBootEnabled({})).toBe(false);
+    expect(
+      isInngestSelfSyncOnBootEnabled({
+        DPF_INNGEST_SELF_SYNC_ON_BOOT_ENABLED: "false",
+      }),
+    ).toBe(false);
+    expect(
+      isInngestSelfSyncOnBootEnabled({
+        DPF_INNGEST_SELF_SYNC_ON_BOOT_ENABLED: "true",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("areOptionalStartupTasksEnabled", () => {
+  it("requires explicit opt-in before nonessential startup maintenance runs", () => {
+    expect(areOptionalStartupTasksEnabled({})).toBe(false);
+    expect(
+      areOptionalStartupTasksEnabled({
+        DPF_OPTIONAL_STARTUP_TASKS_ENABLED: "false",
+      }),
+    ).toBe(false);
+    expect(
+      areOptionalStartupTasksEnabled({
+        DPF_OPTIONAL_STARTUP_TASKS_ENABLED: "true",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,6 +1,8 @@
 // Next.js instrumentation hook — runs once on server startup.
 // See: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
 
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+
 /**
  * Logs a deprecation notice when HIVE_CONTRIBUTION_TOKEN is set in the
  * environment. Exported so the instrumentation module's startup behavior
@@ -18,6 +20,24 @@ export function warnIfLegacyHiveTokenEnvSet(
       "Support for this env var will be removed 60 days after the next release.",
   );
   return true;
+}
+
+export function isStartupModelRevalidationEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, "DPF_STARTUP_MODEL_REVALIDATION_ENABLED");
+}
+
+export function isInngestSelfSyncOnBootEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, "DPF_INNGEST_SELF_SYNC_ON_BOOT_ENABLED");
+}
+
+export function areOptionalStartupTasksEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, "DPF_OPTIONAL_STARTUP_TASKS_ENABLED");
 }
 
 /**
@@ -104,12 +124,19 @@ export async function register() {
     // logs loudly on failure but does not block startup.
     void syncPlatformVersionOnBoot();
 
+    const optionalStartupTasksEnabled = areOptionalStartupTasksEnabled();
+    if (!optionalStartupTasksEnabled) {
+      console.log("[instrumentation] Optional startup maintenance skipped (disabled)");
+    }
+
     // Register ScheduledJob rows so the calendar shows discovery events.
     // Actual execution handled by Inngest cron functions (lib/queue/functions/).
-    const { registerScheduledJobs } = await import("@/lib/operate/discovery-scheduler");
-    registerScheduledJobs().catch((err) =>
-      console.error("[instrumentation] Failed to register discovery jobs:", err),
-    );
+    if (optionalStartupTasksEnabled) {
+      const { registerScheduledJobs } = await import("@/lib/operate/discovery-scheduler");
+      registerScheduledJobs().catch((err) =>
+        console.error("[instrumentation] Failed to register discovery jobs:", err),
+      );
+    }
 
     // Self-sync our function catalog with the Inngest server.
     // In self-hosted mode (INNGEST_DEV=0) the Inngest server does NOT auto-
@@ -118,7 +145,7 @@ export async function register() {
     // Hitting our own PUT /api/inngest triggers the serve() handler to
     // register/refresh the app with the Inngest server. Runs after a small
     // delay to give Next.js time to bind the HTTP listener.
-    if (process.env.INNGEST_BASE_URL) {
+    if (process.env.INNGEST_BASE_URL && isInngestSelfSyncOnBootEnabled()) {
       const appUrl = process.env.APP_URL ?? "http://localhost:3000";
       setTimeout(async () => {
         let lastErr: unknown = null;
@@ -141,6 +168,8 @@ export async function register() {
           `Background jobs (brand extract, evals, etc.) will not dispatch until this succeeds.`,
         );
       }, 3_000);
+    } else if (process.env.INNGEST_BASE_URL) {
+      console.log("[inngest-sync] Boot self-registration skipped (disabled)");
     }
 
     // ── Pin audit invariant ────────────────────────────────────────────────
@@ -149,31 +178,40 @@ export async function register() {
     // Pin rows are not removed on read, so a stray one from a legacy seed
     // or manual admin change would silently override routing for that agent.
     // Surface any surviving pins loudly so they get noticed and cleared.
-    setTimeout(async () => {
-      try {
-        const { prisma } = await import("@dpf/db");
-        const pinnedAgents = await prisma.agentModelConfig.findMany({
-          where: {
-            OR: [
-              { pinnedProviderId: { not: null } },
-              { pinnedModelId: { not: null } },
-            ],
-          },
-          select: { agentId: true, pinnedProviderId: true, pinnedModelId: true },
-        });
-        if (pinnedAgents.length > 0) {
-          console.warn(
-            `[pin-audit] ${pinnedAgents.length} AgentModelConfig row(s) carry a pin. Routing should be tier-based; pins override it. Clear them or document why: ` +
-              pinnedAgents
-                .map((a) => `${a.agentId}=${a.pinnedProviderId ?? "?"}/${a.pinnedModelId ?? "?"}`)
-                .join(", "),
-          );
+    if (optionalStartupTasksEnabled) {
+      setTimeout(async () => {
+        try {
+          const { prisma } = await import("@dpf/db");
+          const pinnedAgents = await prisma.agentModelConfig.findMany({
+            where: {
+              OR: [
+                { pinnedProviderId: { not: null } },
+                { pinnedModelId: { not: null } },
+              ],
+            },
+            select: {
+              agentId: true,
+              pinnedProviderId: true,
+              pinnedModelId: true,
+            },
+          });
+          if (pinnedAgents.length > 0) {
+            console.warn(
+              `[pin-audit] ${pinnedAgents.length} AgentModelConfig row(s) carry a pin. Routing should be tier-based; pins override it. Clear them or document why: ` +
+                pinnedAgents
+                  .map(
+                    (a) =>
+                      `${a.agentId}=${a.pinnedProviderId ?? "?"}/${a.pinnedModelId ?? "?"}`,
+                  )
+                  .join(", "),
+            );
+          }
+        } catch (err) {
+          // Non-fatal; guard is advisory.
+          console.warn("[pin-audit] check failed:", err);
         }
-      } catch (err) {
-        // Non-fatal; guard is advisory.
-        console.warn("[pin-audit] check failed:", err);
-      }
-    }, 20_000);
+      }, 20_000);
+    }
 
     // ── First-boot auto-provisioning ───────────────────────────────────────
     // Runs 15s after startup. Detects active providers with zero model
@@ -191,136 +229,161 @@ export async function register() {
     // evals' new circuit breaker (BI-INST-008, eval-runner.ts
     // errorLooksLikeInfrastructure) keeps a single transient failure from
     // poisoning every model.
-    setTimeout(async () => {
-      try {
-        const { prisma } = await import("@dpf/db");
-        const { canRunStartupModelDiscovery } = await import(
-          "@/lib/routing/provider-eligibility"
-        );
-        const activeProviders = await prisma.modelProvider.findMany({
-          where: { status: { in: ["active", "degraded"] } },
-          select: {
-            providerId: true,
-            endpointType: true,
-            category: true,
-            serviceKind: true,
-            authMethod: true,
-            cliEngine: true,
-          },
-        });
-
-        for (const provider of activeProviders.filter(canRunStartupModelDiscovery)) {
-          const { providerId } = provider;
-          const profileCount = await prisma.modelProfile.count({
-            where: { providerId },
+    if (optionalStartupTasksEnabled) {
+      setTimeout(async () => {
+        try {
+          const { prisma } = await import("@dpf/db");
+          const { canRunStartupModelDiscovery } = await import(
+            "@/lib/routing/provider-eligibility"
+          );
+          const activeProviders = await prisma.modelProvider.findMany({
+            where: { status: { in: ["active", "degraded"] } },
+            select: {
+              providerId: true,
+              endpointType: true,
+              category: true,
+              serviceKind: true,
+              authMethod: true,
+              cliEngine: true,
+            },
           });
-          if (profileCount === 0) {
-            console.log(`[first-boot] Provider "${providerId}" is active but has 0 model profiles — running auto-discovery...`);
-            const { autoDiscoverAndProfile } = await import(
-              "@/lib/inference/ai-provider-internals"
-            );
-            const result = await autoDiscoverAndProfile(providerId);
-            console.log(`[first-boot] ${providerId}: discovered=${result.discovered}, profiled=${result.profiled}${result.error ? ` (${result.error})` : ""}`);
 
-            // BI-INST-001 — enqueue background dimension evals for each
-            // freshly profiled model. Without this step the router stays
-            // empty of EndpointTaskPerformance rows and every LLM task
-            // throws "No eligible endpoints" until the operator manually
-            // clicks Run Probes. Inngest enforces concurrency=2 on
-            // ai/eval.run so this doesn't swamp local model runners.
-            if (result.profiled > 0) {
-              await enqueueFirstBootEvals(providerId);
+          for (const provider of activeProviders.filter(canRunStartupModelDiscovery)) {
+            const { providerId } = provider;
+            const profileCount = await prisma.modelProfile.count({
+              where: { providerId },
+            });
+            if (profileCount === 0) {
+              console.log(
+                `[first-boot] Provider "${providerId}" is active but has 0 model profiles — running auto-discovery...`,
+              );
+              const { autoDiscoverAndProfile } = await import(
+                "@/lib/inference/ai-provider-internals"
+              );
+              const result = await autoDiscoverAndProfile(providerId);
+              console.log(
+                `[first-boot] ${providerId}: discovered=${result.discovered}, profiled=${result.profiled}${result.error ? ` (${result.error})` : ""}`,
+              );
+
+              // BI-INST-001 — enqueue background dimension evals for each
+              // freshly profiled model. Without this step the router stays
+              // empty of EndpointTaskPerformance rows and every LLM task
+              // throws "No eligible endpoints" until the operator manually
+              // clicks Run Probes. Inngest enforces concurrency=2 on
+              // ai/eval.run so this doesn't swamp local model runners.
+              if (result.profiled > 0) {
+                await enqueueFirstBootEvals(providerId);
+              }
             }
           }
+        } catch (err) {
+          console.warn("[first-boot] Auto-provisioning failed (non-fatal):", err);
         }
-      } catch (err) {
-        console.warn("[first-boot] Auto-provisioning failed (non-fatal):", err);
-      }
-    }, 15_000);
+      }, 15_000);
+    }
 
-    // ── Periodic revalidation ──────────────────────────────────────────────
-    // EP-MODEL-CAP-001-D: Startup revalidation — runs 90–120s after startup.
-    // Jitter avoids thundering-herd when multiple replicas start simultaneously.
-    // This handles ongoing model status changes (new models, deprecated models)
-    // for providers that already have profiles.
-    const STARTUP_DELAY_MS = 90_000 + Math.floor(Math.random() * 30_000);
-    const { Pool } = await import("pg");
-    const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
-    setTimeout(async () => {
-      try {
-        const { runModelRevalidation } = await import(
-          "@/lib/inference/model-revalidation"
-        );
-        await runModelRevalidation({ source: "startup" }, pgPool);
-      } catch (err) {
-        console.warn(
-          "[model-revalidation] Startup revalidation failed (non-fatal):",
-          err,
-        );
-      } finally {
-        await pgPool.end().catch(() => {});
-      }
-    }, STARTUP_DELAY_MS);
+    if (isStartupModelRevalidationEnabled()) {
+      // ── Periodic revalidation ────────────────────────────────────────────
+      // EP-MODEL-CAP-001-D: Startup revalidation — runs 90–120s after startup.
+      // Jitter avoids thundering-herd when multiple replicas start simultaneously.
+      // This handles ongoing model status changes (new models, deprecated models)
+      // for providers that already have profiles.
+      const STARTUP_DELAY_MS = 90_000 + Math.floor(Math.random() * 30_000);
+      const { Pool } = await import("pg");
+      const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
+      setTimeout(async () => {
+        try {
+          const { runModelRevalidation } = await import(
+            "@/lib/inference/model-revalidation"
+          );
+          await runModelRevalidation({ source: "startup" }, pgPool);
+        } catch (err) {
+          console.warn(
+            "[model-revalidation] Startup revalidation failed (non-fatal):",
+            err,
+          );
+        } finally {
+          await pgPool.end().catch(() => {});
+        }
+      }, STARTUP_DELAY_MS);
+    } else {
+      console.log("[model-revalidation] Startup revalidation skipped (disabled)");
+    }
 
     // ── Sandbox slot pool initialization ──────────────────────────────────
     // Resets all SandboxSlot rows to "available" on every boot.
     // Handles stale slots from portal crashes without manual intervention:
     // if the portal dies mid-pipeline the new instance immediately frees any
     // held slots so queued builds don't wait indefinitely.
-    setTimeout(async () => {
-      try {
-        const { initializePool } = await import("@/lib/integrate/sandbox/sandbox-pool");
-        await initializePool();
-        console.log("[sandbox-pool] Slot pool initialized (all slots reset to available)");
-      } catch (err) {
-        console.error("[sandbox-pool] Failed to initialize slot pool:", err);
-      }
-
-      // Belt-and-suspenders stale-slot reclaim: runs 30 s after boot then
-      // every 30 min. Targets slots held by builds that are no longer in the
-      // 'build' phase OR that have a terminal buildExecState (complete/failed)
-      // despite being in 'build' phase — catches the rare case where the
-      // pipeline finished without releasing the slot.
-      async function reclaimStaleSandboxSlots() {
+    if (optionalStartupTasksEnabled) {
+      setTimeout(async () => {
         try {
-          const { prisma } = await import("@dpf/db");
-          const staleSlots = await prisma.sandboxSlot.findMany({
-            where: {
-              status: "in_use",
-              buildId: { not: null },
-              acquiredAt: { lt: new Date(Date.now() - 120 * 60 * 1000) }, // > 2 h old
-            },
-          });
-
-          for (const slot of staleSlots) {
-            if (!slot.buildId) continue;
-            const build = await prisma.featureBuild.findUnique({
-              where: { buildId: slot.buildId },
-              select: { phase: true, buildExecState: true },
-            });
-            const execState = build?.buildExecState as { step?: string } | null;
-            const execTerminal = execState?.step === "complete" || execState?.step === "failed";
-            const phaseLeft = !build || build.phase !== "build";
-
-            if (phaseLeft || execTerminal) {
-              await prisma.sandboxSlot.update({
-                where: { id: slot.id },
-                data: { status: "available", buildId: null, userId: null, releasedAt: new Date() },
-              });
-              console.log(
-                `[sandbox-pool] Reclaimed stale slot ${slot.slotIndex} from ${slot.buildId}` +
-                ` (phase=${build?.phase ?? "not found"}, execStep=${execState?.step ?? "null"})`,
-              );
-            }
-          }
+          const { initializePool } = await import(
+            "@/lib/integrate/sandbox/sandbox-pool"
+          );
+          await initializePool();
+          console.log(
+            "[sandbox-pool] Slot pool initialized (all slots reset to available)",
+          );
         } catch (err) {
-          console.warn("[sandbox-pool] Stale slot reclaim failed (non-fatal):", err);
+          console.error("[sandbox-pool] Failed to initialize slot pool:", err);
         }
-      }
 
-      await reclaimStaleSandboxSlots();
-      setInterval(reclaimStaleSandboxSlots, 30 * 60 * 1000);
-    }, 5_000);
+        // Belt-and-suspenders stale-slot reclaim: runs 30 s after boot then
+        // every 30 min. Targets slots held by builds that are no longer in the
+        // 'build' phase OR that have a terminal buildExecState (complete/failed)
+        // despite being in 'build' phase — catches the rare case where the
+        // pipeline finished without releasing the slot.
+        async function reclaimStaleSandboxSlots() {
+          try {
+            const { prisma } = await import("@dpf/db");
+            const staleSlots = await prisma.sandboxSlot.findMany({
+              where: {
+                status: "in_use",
+                buildId: { not: null },
+                acquiredAt: { lt: new Date(Date.now() - 120 * 60 * 1000) }, // > 2 h old
+              },
+            });
+
+            for (const slot of staleSlots) {
+              if (!slot.buildId) continue;
+              const build = await prisma.featureBuild.findUnique({
+                where: { buildId: slot.buildId },
+                select: { phase: true, buildExecState: true },
+              });
+              const execState = build?.buildExecState as { step?: string } | null;
+              const execTerminal =
+                execState?.step === "complete" || execState?.step === "failed";
+              const phaseLeft = !build || build.phase !== "build";
+
+              if (phaseLeft || execTerminal) {
+                await prisma.sandboxSlot.update({
+                  where: { id: slot.id },
+                  data: {
+                    status: "available",
+                    buildId: null,
+                    userId: null,
+                    releasedAt: new Date(),
+                  },
+                });
+                console.log(
+                  `[sandbox-pool] Reclaimed stale slot ${slot.slotIndex} from ${slot.buildId}` +
+                    ` (phase=${build?.phase ?? "not found"}, execStep=${execState?.step ?? "null"})`,
+                );
+              }
+            }
+          } catch (err) {
+            console.warn(
+              "[sandbox-pool] Stale slot reclaim failed (non-fatal):",
+              err,
+            );
+          }
+        }
+
+        await reclaimStaleSandboxSlots();
+        setInterval(reclaimStaleSandboxSlots, 30 * 60 * 1000);
+      }, 5_000);
+    }
 
     // ── CREDENTIAL_ENCRYPTION_KEY fail-loud guard ──────────────────────────
     // Refuses to boot in production when the credential store contains

--- a/apps/web/lib/proxy/quiescence-gate.test.ts
+++ b/apps/web/lib/proxy/quiescence-gate.test.ts
@@ -267,6 +267,21 @@ describe("fetchQuiescenceState — cache + timeout", () => {
 });
 
 describe("checkQuiescenceForRequest — fail policy integration", () => {
+  it("does not fetch quiescence state for the state route itself", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(normalState), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = makeRequest("https://example.com/api/internal/quiescence-state", {
+      method: "GET",
+    });
+    const decision = await checkQuiescenceForRequest(req, "https://example.com");
+
+    expect(decision.kind).toBe("pass");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fail-open for reads when state route returns unknown", async () => {
     const fetchImpl = (async () => {
       throw new Error("ECONNREFUSED");

--- a/apps/web/lib/proxy/quiescence-gate.ts
+++ b/apps/web/lib/proxy/quiescence-gate.ts
@@ -179,6 +179,16 @@ export function getLastKnownNonNormal(): ProxyQuiescenceState | null {
   return lastKnownNonNormal;
 }
 
+function getAllowListedPassState(): ProxyQuiescenceState {
+  return stateCache?.state ?? {
+    level: "normal",
+    runId: null,
+    enteredAt: null,
+    version: "unknown",
+    bundleHash: "unknown",
+  };
+}
+
 // ─── Gating decision ──────────────────────────────────────────────────────
 
 /**
@@ -283,6 +293,10 @@ export async function checkQuiescenceForRequest(
   req: NextRequest,
   origin: string,
 ): Promise<GateDecision> {
+  if (isAllowListed(req.nextUrl.pathname)) {
+    return evaluateGate(req, getAllowListedPassState());
+  }
+
   const state = await fetchQuiescenceState(origin);
   if (state.level === "unknown") {
     // Fail policy: preserve last known non-normal for mutations; fail open

--- a/apps/web/lib/queue/functions/index.test.ts
+++ b/apps/web/lib/queue/functions/index.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { hiveScoutIngest } from "./hive-scout-ingest";
-import { allFunctions } from "./index";
+import {
+  allFunctions,
+  getInngestFunctionsForRuntime,
+  scheduledFunctions,
+} from "./index";
+import { issueReportTriage } from "./issue-report-triage";
+import { routeWorkItem } from "./route-work-item";
 
-describe("queue registry", () => {
-  it("does not register the legacy standalone Hive Scout cron path", () => {
-    expect(allFunctions).not.toContain(hiveScoutIngest);
+describe("getInngestFunctionsForRuntime", () => {
+  it("omits scheduled cron functions unless explicitly enabled", () => {
+    const functions = getInngestFunctionsForRuntime({});
+
+    expect(functions).not.toContain(issueReportTriage);
+    expect(functions).toContain(routeWorkItem);
+  });
+
+  it("includes scheduled cron functions when explicitly enabled", () => {
+    const functions = getInngestFunctionsForRuntime({
+      DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED: "true",
+    });
+
+    expect(functions).toEqual(allFunctions);
+    expect(functions).toEqual(expect.arrayContaining(scheduledFunctions));
   });
 });

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -33,20 +33,32 @@ import {
   neo4jBackupRequested,
   qdrantBackupRequested,
 } from "./postgres-daily-backup";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
-export const allFunctions = [
+export const scheduledFunctions = [
   prometheusPoll,
   fullDiscoverySweep,
   modelDiscoveryRefresh,
   infraPrune,
-  rateRecovery,
-  mcpCatalogSync,
   codeGraphReconcileScheduled,
-  codeGraphReconcileEvent,
-  routeWorkItem,
   issueReportTriage,
   agentTaskDispatch,
   taskrunWatchdog,
+  governedBacklogTeeUpScheduled,
+  tokenExpiryMonitor,
+  wikiLint,
+  skillMetricsAggregator,
+  skillCurator,
+  allBackupsDailyScheduled,
+  postgresDailyBackupScheduled,
+  selfUpgradeScheduled,
+];
+
+export const eventFunctions = [
+  rateRecovery,
+  mcpCatalogSync,
+  codeGraphReconcileEvent,
+  routeWorkItem,
   evalBackground,
   probeBackground,
   brandExtract,
@@ -54,20 +66,28 @@ export const allFunctions = [
   assuranceBomGenerate,
   assuranceScanRun,
   deliberationRun,
-  governedBacklogTeeUpScheduled,
   governedBacklogTeeUpRequested,
-  tokenExpiryMonitor,
-  wikiLint,
   gitPromotionSandboxVerification,
-  skillMetricsAggregator,
-  skillCurator,
-  allBackupsDailyScheduled,
-  postgresDailyBackupScheduled,
   postgresBackupRequested,
   postgresTrialRestoreRequested,
   neo4jBackupRequested,
   qdrantBackupRequested,
-  selfUpgradeScheduled,
   selfUpgradeManual,
   quiescenceRun,
 ];
+
+export const allFunctions = [...scheduledFunctions, ...eventFunctions];
+
+export function areScheduledInngestFunctionsEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, "DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED");
+}
+
+export function getInngestFunctionsForRuntime(
+  env: Record<string, string | undefined> = process.env,
+) {
+  return areScheduledInngestFunctionsEnabled(env)
+    ? allFunctions
+    : eventFunctions;
+}

--- a/apps/web/lib/runtime/env-flags.ts
+++ b/apps/web/lib/runtime/env-flags.ts
@@ -1,0 +1,8 @@
+export function envFlagEnabled(
+  env: Record<string, string | undefined>,
+  name: string,
+): boolean {
+  const raw = env[name];
+  if (!raw) return false;
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}


### PR DESCRIPTION
## Summary
- stop the quiescence proxy from recursively fetching its own state route
- disable hidden shell model warmup side effects that created synthetic quality reports
- gate optional startup maintenance, Inngest self-sync, model revalidation, and scheduled Inngest cron functions behind explicit opt-in flags

## Verification
- pnpm --filter web exec vitest run lib/proxy/quiescence-gate.test.ts instrumentation.test.ts components/shell/ModelWarmup.test.tsx lib/queue/functions/index.test.ts
- pnpm --filter web typecheck
- docker build -t dpf-portal --target runner -f Dockerfile .
- docker compose up -d --no-build --force-recreate portal-init portal
- live portal check: restart count 0, CPU settled below 1%, fd count 25, /api/health 4-78ms during stability watch, /login 166ms