### PR TITLE
fix(portal): recover updater banner and pending edge sweeps

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -12,6 +12,7 @@ import { QueueFlusher } from "@/components/feedback/QueueFlusher";
 import { StatusBanner } from "@/components/shell/StatusBanner";
 import { UpdatePendingBanner } from "@/components/shell/UpdatePendingBanner";
 import { PlatformBanner } from "@/components/platform/PlatformBanner";
+import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
 import { SetupOverlay } from "@/components/setup/SetupOverlay";
 import { getShellNavSections } from "@/lib/permissions";
@@ -139,9 +140,11 @@ export default async function ShellLayout({ children }: { children: React.ReactN
             }
           />
         )}
-        <PlatformBanner />
-        <StatusBanner />
-        <UpdatePendingBanner />
+        <ShellBannerOverlay>
+          <PlatformBanner />
+          <StatusBanner />
+          <UpdatePendingBanner />
+        </ShellBannerOverlay>
         <Header
           platformRole={user.platformRole}
           brandName={organization?.name ?? "Open Digital Product Factory"}

--- a/apps/web/components/platform/PlatformBanner.tsx
+++ b/apps/web/components/platform/PlatformBanner.tsx
@@ -18,6 +18,16 @@
  */
 
 import { useEffect, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Info,
+  RefreshCw,
+  X,
+} from "lucide-react";
 
 type BannerState =
   | { kind: "hidden" }
@@ -46,6 +56,7 @@ declare global {
 
 export function PlatformBanner(): React.ReactElement | null {
   const [state, setState] = useState<BannerState>({ kind: "hidden" });
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     const source = new EventSource("/api/agent/system-stream");
@@ -91,114 +102,129 @@ export function PlatformBanner(): React.ReactElement | null {
     };
   }, []);
 
+  useEffect(() => {
+    if (state.kind === "hidden") setCollapsed(false);
+  }, [state.kind]);
+
   if (state.kind === "hidden") return null;
 
-  // Theme tokens per AGENTS.md (CSS custom properties). Banner is rendered
-  // as a narrow strip at the top of the shell, above StatusBanner +
-  // UpdatePendingBanner.
-  const baseStyle: React.CSSProperties = {
-    width: "100%",
-    padding: "10px 16px",
-    fontSize: "14px",
-    fontWeight: 500,
-    display: "flex",
-    alignItems: "center",
-    gap: "12px",
-    borderBottom: "1px solid var(--dpf-border, rgba(0,0,0,0.08))",
-  };
+  const view = getPlatformBannerView(state);
+  const Icon = view.icon;
 
-  if (state.kind === "preparing") {
+  if (collapsed) {
     return (
-      <div
-        style={{
-          ...baseStyle,
-          background: "var(--dpf-surface-warning, #fff8e1)",
-          color: "var(--dpf-text, #3e2723)",
-        }}
-        role="status"
-        aria-live="polite"
-        data-quiescence-state="preparing"
-      >
-        <span aria-hidden>⏳</span>
-        <span>
-          Platform upgrade preparing. Your current work will finish — please don&apos;t start new actions.
-          {state.swapEtaSeconds != null ? ` (ETA ~${Math.ceil(state.swapEtaSeconds / 60)}min)` : ""}
-        </span>
-      </div>
-    );
-  }
-
-  if (state.kind === "swapping") {
-    return (
-      <div
-        style={{
-          ...baseStyle,
-          background: "var(--dpf-surface-warning, #fff3e0)",
-          color: "var(--dpf-text, #3e2723)",
-        }}
-        role="status"
-        aria-live="assertive"
-        data-quiescence-state="swapping"
-      >
-        <span aria-hidden>🔄</span>
-        <span>Platform upgrading. Please wait — should take about 30 seconds.</span>
-      </div>
-    );
-  }
-
-  if (state.kind === "reconnecting") {
-    return (
-      <div
-        style={{
-          ...baseStyle,
-          background: "var(--dpf-surface-info, #e3f2fd)",
-          color: "var(--dpf-text, #0d47a1)",
-        }}
-        role="status"
-        aria-live="assertive"
-        data-quiescence-state="reconnecting"
-      >
-        <span aria-hidden>✓</span>
-        <span>Upgrade complete. Reloading…</span>
-      </div>
-    );
-  }
-
-  // deferred
-  return (
-    <div
-      style={{
-        ...baseStyle,
-        background: "var(--dpf-surface-muted, #f5f5f5)",
-        color: "var(--dpf-text, #424242)",
-      }}
-      role="status"
-      aria-live="polite"
-      data-quiescence-state="deferred"
-    >
-      <span aria-hidden>ℹ️</span>
-      <span>
-        Upgrade postponed
-        {state.surface ? ` (blocker: ${state.surface})` : ""}
-        {state.reason ? `: ${state.reason}` : ""}. You can continue working.
-      </span>
       <button
         type="button"
-        onClick={() => setState({ kind: "hidden" })}
-        style={{
-          marginLeft: "auto",
-          background: "transparent",
-          border: "none",
-          cursor: "pointer",
-          color: "inherit",
-          fontSize: "14px",
-        }}
-        aria-label="Dismiss banner"
+        aria-expanded="false"
+        aria-label="Expand platform status banner"
+        data-quiescence-state={state.kind}
+        data-quiescence-collapsed="true"
+        onClick={() => setCollapsed(false)}
+        className="pointer-events-auto flex max-w-[calc(100vw-24px)] items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs font-medium text-[var(--dpf-text)] shadow-[0_10px_30px_color-mix(in_srgb,var(--dpf-text)_14%,transparent)]"
       >
-        ✕
+        <Icon aria-hidden="true" className={`h-3.5 w-3.5 ${view.iconClassName}`} />
+        <span className="max-w-[min(72vw,40rem)] truncate">{view.compactLabel}</span>
+        <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 text-[var(--dpf-muted)]" />
       </button>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live={view.assertive ? "assertive" : "polite"}
+      className={`pointer-events-auto w-[min(960px,calc(100vw-24px))] rounded-md border px-3 py-2 text-xs text-[var(--dpf-text)] shadow-[0_10px_30px_color-mix(in_srgb,var(--dpf-text)_14%,transparent)] ${view.frameClassName}`}
+      data-overlay-banner="true"
+      data-quiescence-state={state.kind}
+    >
+      <div className="flex items-center gap-2">
+        <Icon aria-hidden="true" className={`h-4 w-4 shrink-0 ${view.iconClassName}`} />
+        <span className="min-w-0 flex-1" style={{ overflowWrap: "anywhere" }}>{view.message}</span>
+        <button
+          type="button"
+          aria-expanded="true"
+          aria-label="Collapse platform status banner"
+          title="Collapse platform status banner"
+          onClick={() => setCollapsed(true)}
+          className="shrink-0 rounded p-1 text-[var(--dpf-muted)] transition hover:bg-[var(--dpf-surface-2)] hover:text-[var(--dpf-text)]"
+        >
+          <ChevronUp aria-hidden="true" className="h-4 w-4" />
+        </button>
+        {state.kind === "deferred" && (
+          <button
+            type="button"
+            onClick={() => setState({ kind: "hidden" })}
+            className="shrink-0 rounded p-1 text-[var(--dpf-muted)] transition hover:bg-[var(--dpf-surface-2)] hover:text-[var(--dpf-text)]"
+            aria-label="Dismiss platform status banner"
+            title="Dismiss platform status banner"
+          >
+            <X aria-hidden="true" className="h-4 w-4" />
+          </button>
+        )}
+      </div>
     </div>
   );
+}
+
+type PlatformBannerView = {
+  compactLabel: string;
+  message: string;
+  assertive: boolean;
+  frameClassName: string;
+  iconClassName: string;
+  icon: typeof Clock;
+};
+
+function getPlatformBannerView(state: Exclude<BannerState, { kind: "hidden" }>): PlatformBannerView {
+  const warningFrame =
+    "border-[color-mix(in_srgb,var(--dpf-warning)_34%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-warning)_12%,var(--dpf-surface-1))]";
+  const infoFrame =
+    "border-[color-mix(in_srgb,var(--dpf-accent)_34%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-accent)_10%,var(--dpf-surface-1))]";
+  const neutralFrame =
+    "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]";
+
+  switch (state.kind) {
+    case "preparing":
+      return {
+        compactLabel: "Platform upgrade preparing",
+        message: `Platform upgrade preparing. Current work will finish before the update${
+          state.swapEtaSeconds != null ? `, ETA about ${Math.ceil(state.swapEtaSeconds / 60)} min` : ""
+        }.`,
+        assertive: false,
+        frameClassName: warningFrame,
+        iconClassName: "text-[var(--dpf-warning)]",
+        icon: Clock,
+      };
+    case "swapping":
+      return {
+        compactLabel: "Platform upgrading",
+        message: "Platform upgrading. Please wait; this should take about 30 seconds.",
+        assertive: true,
+        frameClassName: warningFrame,
+        iconClassName: "text-[var(--dpf-warning)]",
+        icon: RefreshCw,
+      };
+    case "reconnecting":
+      return {
+        compactLabel: "Upgrade complete",
+        message: "Upgrade complete. Reloading.",
+        assertive: true,
+        frameClassName: infoFrame,
+        iconClassName: "text-[var(--dpf-accent)]",
+        icon: CheckCircle2,
+      };
+    case "deferred":
+      return {
+        compactLabel: "Upgrade postponed",
+        message: `Upgrade postponed${state.surface ? `, blocker: ${state.surface}` : ""}${
+          state.reason ? `, ${state.reason}` : ""
+        }. You can continue working.`,
+        assertive: false,
+        frameClassName: neutralFrame,
+        iconClassName: "text-[var(--dpf-muted)]",
+        icon: state.reason === "failed" ? AlertCircle : Info,
+      };
+  }
 }
 
 /**

--- a/apps/web/components/shell/ShellBannerOverlay.test.tsx
+++ b/apps/web/components/shell/ShellBannerOverlay.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ShellBannerOverlay } from "./ShellBannerOverlay";
+
+describe("ShellBannerOverlay", () => {
+  it("floats shell notices over the page instead of taking document flow space", () => {
+    const html = renderToStaticMarkup(
+      <ShellBannerOverlay>
+        <div>Notice</div>
+      </ShellBannerOverlay>,
+    );
+
+    expect(html).toContain("fixed");
+    expect(html).toContain("top-0");
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain('data-testid="shell-banner-overlay"');
+  });
+});

--- a/apps/web/components/shell/ShellBannerOverlay.tsx
+++ b/apps/web/components/shell/ShellBannerOverlay.tsx
@@ -1,0 +1,15 @@
+export function ShellBannerOverlay({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      aria-label="System notices"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[80] flex flex-col items-center gap-2 px-3 pt-3 sm:px-4"
+      data-testid="shell-banner-overlay"
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/shell/StatusBanner.tsx
+++ b/apps/web/components/shell/StatusBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { X } from "lucide-react";
 
 type BannerMessage = {
   id: string;
@@ -46,7 +47,10 @@ export function StatusBanner() {
   if (messages.length === 0) return null;
 
   return (
-    <div style={{ width: "100%" }}>
+    <div
+      className="pointer-events-auto w-[min(960px,calc(100vw-24px))] space-y-2"
+      data-overlay-banner="true"
+    >
       {messages.map((msg) => {
         const colors = BANNER_COLORS[msg.type];
         return (
@@ -56,20 +60,31 @@ export function StatusBanner() {
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
-              padding: "6px 16px",
+              gap: 12,
+              padding: "8px 12px",
               background: colors.bg,
-              borderBottom: `1px solid ${colors.border}`,
+              border: `1px solid ${colors.border}`,
+              borderRadius: 6,
+              boxShadow: "0 10px 30px color-mix(in srgb, var(--dpf-text) 14%, transparent)",
               fontSize: 12,
               color: colors.text,
             }}
           >
-            <span>{msg.text}</span>
+            <span style={{ minWidth: 0, overflowWrap: "anywhere" }}>{msg.text}</span>
             <button
               type="button"
+              aria-label="Dismiss status banner"
               onClick={() => setMessages((prev) => prev.filter((m) => m.id !== msg.id))}
-              style={{ background: "none", border: "none", color: colors.text, cursor: "pointer", fontSize: 14, padding: "0 4px", opacity: 0.7 }}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: colors.text,
+                cursor: "pointer",
+                padding: 4,
+                opacity: 0.8,
+              }}
             >
-              ✕
+              <X aria-hidden="true" size={14} />
             </button>
           </div>
         );

--- a/apps/web/components/shell/UpdatePendingBanner.tsx
+++ b/apps/web/components/shell/UpdatePendingBanner.tsx
@@ -1,7 +1,7 @@
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import Link from "next/link";
+import { UpdatePendingBannerClient } from "./UpdatePendingBannerClient";
 
 export async function UpdatePendingBanner() {
   const session = await auth();
@@ -20,32 +20,5 @@ export async function UpdatePendingBanner() {
 
   if (!config?.updatePending || !config.pendingVersion) return null;
 
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: 4,
-        padding: "6px 16px",
-        background: "color-mix(in srgb, var(--dpf-accent) 15%, transparent)",
-        borderBottom: "1px solid color-mix(in srgb, var(--dpf-accent) 30%, transparent)",
-        fontSize: 12,
-        lineHeight: 1.4,
-        color: "var(--dpf-accent)",
-        overflowWrap: "anywhere",
-      }}
-    >
-      <span style={{ minWidth: 0 }}>
-        Platform update v{config.pendingVersion} is ready. Your customisations are preserved.{" "}
-        <Link
-          href="/admin/platform-development"
-          style={{ color: "var(--dpf-accent)", textDecoration: "underline", overflowWrap: "anywhere" }}
-        >
-          Review in Admin &rarr; Platform Development
-        </Link>
-      </span>
-    </div>
-  );
+  return <UpdatePendingBannerClient pendingVersion={config.pendingVersion} />;
 }

--- a/apps/web/components/shell/UpdatePendingBannerClient.test.tsx
+++ b/apps/web/components/shell/UpdatePendingBannerClient.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import "@/components/build-studio/test-setup";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { UpdatePendingBannerClient } from "./UpdatePendingBannerClient";
+
+describe("UpdatePendingBannerClient", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders as an overlay-friendly banner with a collapse control", () => {
+    render(<UpdatePendingBannerClient pendingVersion="v1.2.3" />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("data-overlay-banner", "true");
+    expect(screen.getByRole("link", { name: /review in admin/i })).toHaveAttribute(
+      "href",
+      "/admin/platform-development",
+    );
+    expect(screen.getByRole("button", { name: /collapse platform update banner/i })).toBeInTheDocument();
+  });
+
+  it("collapses into a compact overlay pill and can expand again", () => {
+    render(<UpdatePendingBannerClient pendingVersion="v1.2.3" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /collapse platform update banner/i }));
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /expand platform update banner/i })).toHaveTextContent(
+      "Platform update v1.2.3",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /expand platform update banner/i }));
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/shell/UpdatePendingBannerClient.tsx
+++ b/apps/web/components/shell/UpdatePendingBannerClient.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
+
+type Props = {
+  pendingVersion: string;
+};
+
+const STORAGE_PREFIX = "dpf:update-pending-banner-collapsed:";
+
+export function UpdatePendingBannerClient({ pendingVersion }: Props) {
+  const versionLabel = formatPendingVersion(pendingVersion);
+  const storageKey = useMemo(() => `${STORAGE_PREFIX}${pendingVersion}`, [pendingVersion]);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      setCollapsed(window.localStorage.getItem(storageKey) === "true");
+    } catch {
+      setCollapsed(false);
+    }
+  }, [storageKey]);
+
+  function updateCollapsed(next: boolean) {
+    setCollapsed(next);
+    try {
+      window.localStorage.setItem(storageKey, String(next));
+    } catch {
+      /* localStorage may be unavailable in private contexts */
+    }
+  }
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        aria-expanded="false"
+        aria-label="Expand platform update banner"
+        onClick={() => updateCollapsed(false)}
+        className="pointer-events-auto flex max-w-[calc(100vw-24px)] items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs font-medium text-[var(--dpf-text)] shadow-[0_10px_30px_color-mix(in_srgb,var(--dpf-text)_14%,transparent)]"
+      >
+        <RefreshCw aria-hidden="true" className="h-3.5 w-3.5 text-[var(--dpf-accent)]" />
+        <span className="max-w-[min(72vw,40rem)] truncate">Platform update {versionLabel}</span>
+        <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 text-[var(--dpf-muted)]" />
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-overlay-banner="true"
+      className="pointer-events-auto w-[min(960px,calc(100vw-24px))] rounded-md border border-[color-mix(in_srgb,var(--dpf-accent)_34%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-accent)_12%,var(--dpf-surface-1))] px-3 py-2 text-xs text-[var(--dpf-text)] shadow-[0_10px_30px_color-mix(in_srgb,var(--dpf-text)_14%,transparent)]"
+    >
+      <div className="flex items-center gap-2">
+        <RefreshCw aria-hidden="true" className="h-4 w-4 shrink-0 text-[var(--dpf-accent)]" />
+        <div className="min-w-0 flex-1">
+          <span className="font-medium">Platform update {versionLabel} is ready.</span>{" "}
+          <span className="text-[var(--dpf-muted)]">Your customisations are preserved.</span>{" "}
+          <Link
+            href="/admin/platform-development"
+            className="font-medium text-[var(--dpf-accent)] underline underline-offset-2"
+          >
+            Review in Admin - Platform Development
+          </Link>
+        </div>
+        <button
+          type="button"
+          aria-expanded="true"
+          aria-label="Collapse platform update banner"
+          title="Collapse platform update banner"
+          onClick={() => updateCollapsed(true)}
+          className="shrink-0 rounded p-1 text-[var(--dpf-muted)] transition hover:bg-[var(--dpf-surface-2)] hover:text-[var(--dpf-text)]"
+        >
+          <ChevronUp aria-hidden="true" className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatPendingVersion(pendingVersion: string): string {
+  if (/^v\d+\.\d+\.\d+$/i.test(pendingVersion)) return pendingVersion;
+  if (/^[0-9a-f]{40}$/i.test(pendingVersion)) return pendingVersion;
+  return `v${pendingVersion}`;
+}

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -225,6 +225,49 @@ describe("applyPlatformUpdate", () => {
     expect(commands).not.toContain("git add -A");
   });
 
+  it("repairs and retries when checkout cannot resolve the managed upstream branch", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockReturnValue(false);
+
+    let upstreamCheckoutAttempts = 0;
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd === "git checkout dpf-upstream") {
+        upstreamCheckoutAttempts += 1;
+        if (upstreamCheckoutAttempts === 1) {
+          cb(new Error("pathspec 'dpf-upstream' did not match any file(s) known to git"), {
+            stdout: "",
+            stderr: "pathspec 'dpf-upstream' did not match any file(s) known to git",
+          });
+          return;
+        }
+      }
+      if (cmd === "git rev-parse --verify origin/main") {
+        cb(null, { stdout: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n", stderr: "" });
+        return;
+      }
+      if (cmd === "git diff --name-only origin/main...HEAD -- apps/web packages") {
+        cb(null, { stdout: "", stderr: "" });
+        return;
+      }
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 2 files changed, 5 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd);
+    expect(commands.filter((cmd) => cmd === "git checkout dpf-upstream")).toHaveLength(2);
+    expect(commands).toContain("git branch -f dpf-upstream HEAD");
+    expect(commands).toContain("git checkout my-changes");
+  });
+
   it("does not repair missing update branches over committed source changes", async () => {
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       updatePending: true,

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -763,6 +763,30 @@ async function gitBranchExists(
   }
 }
 
+function gitErrorText(err: unknown): string {
+  if (!err || typeof err !== "object") {
+    return err instanceof Error ? err.message : String(err);
+  }
+  const record = err as { message?: unknown; stderr?: unknown; stdout?: unknown };
+  return [record.message, record.stderr, record.stdout]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join("\n");
+}
+
+function isMissingGitReferenceError(err: unknown, ref: string): boolean {
+  const text = gitErrorText(err).toLowerCase();
+  const normalizedRef = ref.toLowerCase();
+  return (
+    text.includes(normalizedRef) &&
+    (text.includes("pathspec") ||
+      text.includes("did not match") ||
+      text.includes("not a commit") ||
+      text.includes("unknown revision") ||
+      text.includes("invalid reference") ||
+      text.includes("could not resolve"))
+  );
+}
+
 async function ensureManagedUpdateBranches(
   execUpdate: ExecUpdate,
   gitOpts: ExecUpdateOptions,
@@ -818,6 +842,25 @@ async function assertBranchRepairCanUseCurrentHead(
       "Workspace is missing managed update branches and has committed source changes in apps/web or packages. A safe upstream baseline cannot be reconstructed automatically.",
     );
   }
+}
+
+async function checkoutManagedUpdateBranch(
+  execUpdate: ExecUpdate,
+  gitOpts: ExecUpdateOptions,
+  branch: string,
+): Promise<void> {
+  try {
+    await execUpdate(`git checkout ${branch}`, gitOpts);
+    return;
+  } catch (err) {
+    if (!isMissingGitReferenceError(err, branch)) {
+      throw err;
+    }
+  }
+
+  await assertBranchRepairCanUseCurrentHead(execUpdate, gitOpts);
+  await execUpdate(`git branch -f ${branch} HEAD`, gitOpts);
+  await execUpdate(`git checkout ${branch}`, gitOpts);
 }
 
 async function collectPlatformUpdateConflicts(
@@ -907,7 +950,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     await ensureManagedUpdateBranches(execUpdate, gitOpts);
 
     // Step 1-3: Refresh dpf-upstream branch with new source
-    await execUpdate(`git checkout ${UPDATE_UPSTREAM_BRANCH}`, gitOpts);
+    await checkoutManagedUpdateBranch(execUpdate, gitOpts, UPDATE_UPSTREAM_BRANCH);
     await execUpdate("rm -rf apps/web packages", gitOpts);
     await execUpdate("cp -r /app/apps/web-src/. apps/web/", gitOpts);
     await execUpdate("cp -r /app/packages-src/. packages/", gitOpts);
@@ -926,7 +969,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     }
 
     // Step 4: Merge into my-changes
-    await execUpdate(`git checkout ${UPDATE_WORK_BRANCH}`, gitOpts);
+    await checkoutManagedUpdateBranch(execUpdate, gitOpts, UPDATE_WORK_BRANCH);
     try {
       await execUpdate(`git merge ${UPDATE_UPSTREAM_BRANCH} --no-commit --no-ff`, gitOpts);
     } catch {
@@ -990,7 +1033,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     // Best-effort: leave my-changes checked out so the operator's working
     // copy is in a known state even when the merge step itself crashes.
     try {
-      await execUpdate(`git checkout ${UPDATE_WORK_BRANCH}`, gitOpts);
+      await checkoutManagedUpdateBranch(execUpdate, gitOpts, UPDATE_WORK_BRANCH);
     } catch {
       /* best effort — original error is already captured below */
     }

--- a/services/edge-node/src/__tests__/sweep.test.ts
+++ b/services/edge-node/src/__tests__/sweep.test.ts
@@ -197,6 +197,32 @@ describe("runSweepLoop", () => {
     expect(submit.mock.calls[1]![0]).toBe("dpfedge_specifictoken");
   });
 
+  it("skips discovery submissions while the edge node is not trusted", async () => {
+    const submit = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(submit);
+    const logged: string[] = [];
+    let sleeps = 0;
+
+    await runSweepLoop({
+      config: makeConfig(),
+      api,
+      state: makeState({ trustState: "pending" }),
+      sleep: async () => { sleeps += 1; },
+      log: (_level, message) => logged.push(message),
+      maxIterations: 2,
+      hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
+      nmapAdapter: emptyNmapAdapter(),
+      snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
+    });
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(api.fetchAdapters).not.toHaveBeenCalled();
+    expect(logged.some((message) => message.includes("trustState=pending"))).toBe(true);
+    expect(sleeps).toBe(2);
+  });
+
   it("drops the envelope on 4xx client error (no retry)", async () => {
     const submit = vi
       .fn()

--- a/services/edge-node/src/sweep.ts
+++ b/services/edge-node/src/sweep.ts
@@ -160,6 +160,15 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
     // dedupes them anyway.
     await drainQueue({ queue, api, state, log });
 
+    if (state.trustState !== "trusted") {
+      log(
+        "warn",
+        `Discovery sweep skipped because trustState=${state.trustState}; heartbeat remains active while approval is pending.`,
+      );
+      await sleep(state.sweepIntervalSec * 1000);
+      continue;
+    }
+
     // Collect + submit a fresh sweep.
     let envelope: SubmissionEnvelope;
     try {

--- a/tests/release/dpf-release-remote-main.test.ps1
+++ b/tests/release/dpf-release-remote-main.test.ps1
@@ -16,6 +16,71 @@ function Get-PowerShellCommand {
     return $command.Source
 }
 
+function Invoke-ReleaseAndReject {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$PowerShell,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ScriptUnderTest,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Local,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Bump,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ExpectedVersion,
+
+        [Parameter(Mandatory=$true)]
+        [string]$LocalHead
+    )
+
+    $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $processInfo.FileName = $PowerShell
+    $processInfo.WorkingDirectory = $Local
+    $processInfo.UseShellExecute = $false
+    $processInfo.RedirectStandardInput = $true
+    $processInfo.RedirectStandardOutput = $true
+    $processInfo.RedirectStandardError = $true
+    $processInfo.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptUnderTest`" $Bump"
+
+    $process = [System.Diagnostics.Process]::Start($processInfo)
+    $process.StandardInput.WriteLine("n")
+    $process.StandardInput.Close()
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    $output = "$stdout`n$stderr"
+
+    if ($process.ExitCode -ne 0) {
+        throw "Expected release script to abort cleanly after confirmation for $Bump; got exit code $($process.ExitCode). Output: $output"
+    }
+    if ($output -match "Fast-forward pull failed") {
+        throw "Release script still tried to fast-forward local main for $Bump. Output: $output"
+    }
+    if ($output -notmatch "Release target:\s+origin/main") {
+        throw "Release script did not report origin/main as the release target for $Bump. Output: $output"
+    }
+    if ($output -notmatch "New version:\s+$([regex]::Escape($ExpectedVersion))\s+\($Bump bump\)") {
+        throw "Release script did not compute $ExpectedVersion for $Bump. Output: $output"
+    }
+    if ($output -notmatch "Aborted\.") {
+        throw "Release script did not abort at operator confirmation for $Bump. Output: $output"
+    }
+
+    $headAfter = (& git "-C" $Local rev-parse HEAD).Trim()
+    if ($headAfter -ne $LocalHead) {
+        throw "Release script changed local HEAD for $Bump. Before: $LocalHead After: $headAfter"
+    }
+
+    $createdTag = ((& git "-C" $Local tag --list $ExpectedVersion) | Out-String).Trim()
+    if ($createdTag) {
+        throw "Release script created $ExpectedVersion even though operator rejected confirmation."
+    }
+}
+
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $releaseScript = Join-Path $repoRoot "dpf-release.ps1"
 if (-not (Test-Path -LiteralPath $releaseScript)) {
@@ -58,47 +123,12 @@ try {
     Invoke-TestGit "-C" $seed push origin main
 
     $powerShell = Get-PowerShellCommand
-    $processInfo = New-Object System.Diagnostics.ProcessStartInfo
-    $processInfo.FileName = $powerShell
-    $processInfo.WorkingDirectory = $local
-    $processInfo.UseShellExecute = $false
-    $processInfo.RedirectStandardInput = $true
-    $processInfo.RedirectStandardOutput = $true
-    $processInfo.RedirectStandardError = $true
-    $processInfo.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptUnderTest`" minor"
 
-    $process = [System.Diagnostics.Process]::Start($processInfo)
-    $process.StandardInput.WriteLine("n")
-    $process.StandardInput.Close()
-    $stdout = $process.StandardOutput.ReadToEnd()
-    $stderr = $process.StandardError.ReadToEnd()
-    $process.WaitForExit()
-    $output = "$stdout`n$stderr"
+    Invoke-ReleaseAndReject -PowerShell $powerShell -ScriptUnderTest $scriptUnderTest -Local $local -Bump "minor" -ExpectedVersion "v1.1.0" -LocalHead $localHead
+    Invoke-ReleaseAndReject -PowerShell $powerShell -ScriptUnderTest $scriptUnderTest -Local $local -Bump "patch" -ExpectedVersion "v1.0.1" -LocalHead $localHead
+    Invoke-ReleaseAndReject -PowerShell $powerShell -ScriptUnderTest $scriptUnderTest -Local $local -Bump "major" -ExpectedVersion "v2.0.0" -LocalHead $localHead
 
-    if ($process.ExitCode -ne 0) {
-        throw "Expected release script to abort cleanly after confirmation; got exit code $($process.ExitCode). Output: $output"
-    }
-    if ($output -match "Fast-forward pull failed") {
-        throw "Release script still tried to fast-forward local main. Output: $output"
-    }
-    if ($output -notmatch "Release target:\s+origin/main") {
-        throw "Release script did not report origin/main as the release target. Output: $output"
-    }
-    if ($output -notmatch "Aborted\.") {
-        throw "Release script did not abort at operator confirmation. Output: $output"
-    }
-
-    $headAfter = (& git "-C" $local rev-parse HEAD).Trim()
-    if ($headAfter -ne $localHead) {
-        throw "Release script changed local HEAD. Before: $localHead After: $headAfter"
-    }
-
-    $createdTag = ((& git "-C" $local tag --list v1.1.0) | Out-String).Trim()
-    if ($createdTag) {
-        throw "Release script created v1.1.0 even though operator rejected confirmation."
-    }
-
-    Write-Host "PASS: dpf-release.ps1 uses origin/main without mutating divergent local main."
+    Write-Host "PASS: dpf-release.ps1 uses origin/main without mutating divergent local main, and computes minor/patch/major tags."
 }
 finally {
     if (Test-Path -LiteralPath $testRoot) {

--- a/tests/release/publish-image-workflow.test.ps1
+++ b/tests/release/publish-image-workflow.test.ps1
@@ -1,0 +1,42 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$workflowPath = Join-Path $repoRoot ".github\workflows\publish-image.yml"
+if (-not (Test-Path -LiteralPath $workflowPath)) {
+    throw "Missing publish-image workflow at $workflowPath"
+}
+
+$workflow = Get-Content -Raw -LiteralPath $workflowPath
+
+if ($workflow -notmatch 'tags:\s*\["v\*"\]') {
+    throw "publish-image.yml must run on v* tag pushes."
+}
+
+foreach ($image in @(
+    "dpf-portal",
+    "dpf-sandbox",
+    "dpf-promoter",
+    "dpf-browser-use",
+    "dpf-adp",
+    "dpf-edge-node"
+)) {
+    if ($workflow -notmatch [regex]::Escape("- name: $image") -and $workflow -notmatch [regex]::Escape("- $image")) {
+        throw "publish-image.yml is missing image matrix coverage for $image."
+    }
+}
+
+foreach ($needle in @(
+    "--tag `"`${IMAGE}:`${TAG}`"",
+    "--tag `"`${IMAGE}:latest`"",
+    '"architecture": "amd64"',
+    '"architecture": "arm64"',
+    "Run install-dpf.sh (release mode, --no-autostart for CI)",
+    "bash install-dpf.sh --headless --release --no-autostart"
+)) {
+    if ($workflow -notmatch [regex]::Escape($needle)) {
+        throw "publish-image.yml is missing release-image guard: $needle"
+    }
+}
+
+Write-Host "PASS: publish-image.yml covers v* tag pushes, release images, multi-arch manifests, and release-mode install verification."


### PR DESCRIPTION
## Summary
- repair managed updater checkout when `dpf-upstream` or `my-changes` is missing by safely recreating the branch from the current managed HEAD
- render shell/system banners as fixed top overlays with collapse controls instead of pushing the portal layout down
- stop pending edge nodes from submitting discovery sweeps while still allowing heartbeat
- add release guards for patch/minor/major version calculation and GHCR image workflow coverage

## Verification
- `pnpm --filter web exec vitest run lib/actions/platform-dev-config.apply.test.ts components/shell/ShellBannerOverlay.test.tsx components/shell/UpdatePendingBannerClient.test.tsx`
- `pnpm --filter dpf-edge-node exec vitest run src/__tests__/sweep.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter dpf-edge-node typecheck`
- `powershell -NoProfile -ExecutionPolicy Bypass -File tests\release\dpf-release-remote-main.test.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File tests\release\publish-image-workflow.test.ps1`
- `pnpm --filter web build`
- live Docker check: `dpf-portal-1` and `dpf-edge-node-1` healthy

## Notes
The production build still reports the existing Edge Runtime Node API warnings in platform version/discovery imports; the build exits 0.
