### PR TITLE
[codex] Fix ops hide done for epic items

### DIFF
--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -5,18 +5,18 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { deleteEpic } from "@/lib/actions/backlog";
 import {
-  EPIC_STATUS_COLOURS,
   type EpicWithRelations,
   type BacklogItemWithRelations,
 } from "@/lib/backlog";
 import { AGENT_NAME_MAP } from "@/lib/agent-routing";
 import { BacklogItemRow } from "./BacklogItemRow";
+import { isTerminalBacklogItemStatus } from "./backlogVisibility";
 
 // Must stay in sync with OpsClient SortField / SortState
 export type EpicSortField = "title" | "status" | "progress" | "stories";
 export type EpicSort = { field: EpicSortField; dir: "asc" | "desc" } | null;
 
-const ITEM_STATUS_ORDER: Record<string, number> = { open: 0, "in-progress": 1, done: 2 };
+const ITEM_STATUS_ORDER: Record<string, number> = { open: 0, "in-progress": 1, done: 2, deferred: 3 };
 
 function sortedItems(
   items: BacklogItemWithRelations[],
@@ -40,23 +40,27 @@ function sortedItems(
 type Props = {
   epic: EpicWithRelations;
   sort: EpicSort;
+  hideDoneItems: boolean;
   onEdit: (epic: EpicWithRelations) => void;
   onItemEdit: (item: BacklogItemWithRelations) => void;
   focusedItemId?: string;
 };
 
-export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Props) {
+export function EpicCard({ epic, sort, hideDoneItems, onEdit, onItemEdit, focusedItemId }: Props) {
   const router = useRouter();
   const hasFocusedItem = epic.items.some((item) => isFocusedBacklogItem(item, focusedItemId));
   const [expanded, setExpanded] = useState(hasFocusedItem);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isPending, startTransition] = useTransition();
 
+  const visibleItems = hideDoneItems
+    ? epic.items.filter((item) => !isTerminalBacklogItemStatus(item.status))
+    : epic.items;
+  const hiddenItemCount = epic.items.length - visibleItems.length;
   const doneCount = epic.items.filter((i) => i.status === "done").length;
   const totalCount = epic.items.length;
   const progressPct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
-  const statusColour = EPIC_STATUS_COLOURS[epic.status] ?? "#8888a0";
   const portfolioLabels = epic.portfolios.filter((p) => p.portfolio).map((p) => p.portfolio.name).join(" · ");
 
   function handleDelete() {
@@ -83,8 +87,7 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
         {/* col: status — w-14 */}
         <div className="w-14 shrink-0 flex items-center">
           <span
-            className="w-1.5 h-1.5 rounded-full"
-            style={{ background: statusColour }}
+            className={["w-1.5 h-1.5 rounded-full", epicStatusDotClassName(epic.status)].join(" ")}
             title={epic.status}
           />
         </div>
@@ -124,7 +127,7 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
           {confirmDelete ? (
             <>
               <button onClick={handleDelete} disabled={isPending}
-                className="text-[10px] text-red-400 hover:text-red-300 px-1">
+                className="text-[10px] text-[var(--dpf-error)] hover:opacity-80 px-1">
                 {isPending ? "…" : "confirm"}
               </button>
               <button onClick={() => setConfirmDelete(false)}
@@ -139,7 +142,7 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
                 edit
               </button>
               <button onClick={() => setConfirmDelete(true)}
-                className="text-[10px] text-[var(--dpf-muted)] hover:text-red-400 px-1">
+                className="text-[10px] text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] px-1">
                 del
               </button>
             </>
@@ -184,9 +187,13 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
           )}
           {epic.items.length === 0 ? (
             <p className="text-xs text-[var(--dpf-muted)]">No items in this epic yet.</p>
+          ) : visibleItems.length === 0 ? (
+            <p className="text-xs text-[var(--dpf-muted)]">
+              All {epic.items.length} items in this epic are done or deferred. Uncheck &quot;Hide done&quot; to see them.
+            </p>
           ) : (
             <div className="flex flex-col gap-1.5">
-              {sortedItems(epic.items, sort).map((item) => (
+              {sortedItems(visibleItems, sort).map((item) => (
                 <BacklogItemRow
                   key={item.id}
                   item={item}
@@ -196,6 +203,11 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
               ))}
             </div>
           )}
+          {hiddenItemCount > 0 && (
+            <p className="mt-1.5 text-[10px] text-[var(--dpf-muted)]">
+              {hiddenItemCount} completed item{hiddenItemCount !== 1 ? "s" : ""} hidden
+            </p>
+          )}
         </div>
       )}
     </div>
@@ -204,4 +216,14 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Prop
 
 function isFocusedBacklogItem(item: BacklogItemWithRelations, focusedItemId?: string): boolean {
   return Boolean(focusedItemId && (item.itemId === focusedItemId || item.id === focusedItemId));
+}
+
+function epicStatusDotClassName(status: string): string {
+  const classes: Record<string, string> = {
+    open: "bg-[var(--dpf-accent)]",
+    "in-progress": "bg-[var(--dpf-warning)]",
+    done: "bg-[var(--dpf-success)]",
+  };
+
+  return classes[status] ?? "bg-[var(--dpf-muted)]";
 }

--- a/apps/web/components/ops/OpsClient.test.tsx
+++ b/apps/web/components/ops/OpsClient.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { BacklogItemWithRelations, EpicWithRelations } from "@/lib/backlog";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    title,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    title?: string;
+  }) => (
+    <a href={href} className={className} title={title}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/actions/backlog", () => ({
+  deleteBacklogItem: vi.fn(),
+  deleteEpic: vi.fn(),
+  escalateBacklogItemUpstream: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/backlog-build", () => ({
+  startBacklogBuild: vi.fn(),
+}));
+
+import { OpsClient } from "./OpsClient";
+
+const now = new Date("2026-05-25T12:00:00Z");
+
+function item(overrides: Partial<BacklogItemWithRelations>): BacklogItemWithRelations {
+  return {
+    id: "item-id",
+    itemId: "BI-TEST",
+    title: "Backlog item",
+    status: "open",
+    type: "product",
+    body: null,
+    priority: 1,
+    epicId: "epic-id",
+    triageOutcome: null,
+    effortSize: null,
+    activeBuildId: null,
+    activeBuild: null,
+    digitalProduct: null,
+    taxonomyNode: null,
+    submittedBy: { email: "admin@dpf.local" },
+    completedAt: null,
+    agentId: null,
+    createdAt: now,
+    updatedAt: now,
+    upstreamIssueNumber: null,
+    upstreamIssueUrl: null,
+    ...overrides,
+  };
+}
+
+function epic(overrides: Partial<EpicWithRelations>): EpicWithRelations {
+  return {
+    id: "epic-id",
+    epicId: "EP-TEST",
+    title: "Test epic",
+    description: "A test epic",
+    status: "in-progress",
+    createdAt: now,
+    updatedAt: now,
+    submittedBy: { email: "admin@dpf.local" },
+    agentId: null,
+    completedAt: null,
+    portfolios: [],
+    items: [],
+    ...overrides,
+  };
+}
+
+describe("OpsClient", () => {
+  it("hides terminal backlog items inside expanded epics when Hide done is active", () => {
+    const openItem = item({
+      id: "open-item-id",
+      itemId: "BI-OPEN",
+      title: "Visible active child",
+      status: "in-progress",
+    });
+    const doneItem = item({
+      id: "done-item-id",
+      itemId: "BI-DONE",
+      title: "Hidden completed child",
+      status: "done",
+      completedAt: now,
+    });
+    const deferredItem = item({
+      id: "deferred-item-id",
+      itemId: "BI-DEFERRED",
+      title: "Hidden deferred child",
+      status: "deferred",
+    });
+
+    const html = renderToStaticMarkup(
+      <OpsClient
+        items={[openItem, doneItem, deferredItem]}
+        digitalProducts={[]}
+        taxonomyNodes={[]}
+        epics={[epic({ items: [openItem, doneItem, deferredItem] })]}
+        portfolios={[]}
+        focusedItemId="BI-OPEN"
+      />,
+    );
+
+    expect(html).toContain("Visible active child");
+    expect(html).not.toContain("Hidden completed child");
+    expect(html).not.toContain("Hidden deferred child");
+    expect(html).toContain("2 completed items hidden");
+  });
+});

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -6,6 +6,7 @@ import { BacklogPanel } from "./BacklogPanel";
 import { BacklogItemRow } from "./BacklogItemRow";
 import { EpicCard, type EpicSort } from "./EpicCard";
 import { EpicPanel } from "./EpicPanel";
+import { isTerminalBacklogItemStatus } from "./backlogVisibility";
 import type {
   BacklogItemWithRelations,
   DigitalProductSelect,
@@ -201,6 +202,7 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
                       key={epic.id}
                       epic={epic}
                       sort={epicSort}
+                      hideDoneItems={hideDone}
                       onEdit={openEditEpic}
                       onItemEdit={openEdit}
                       focusedItemId={focusedItemId}
@@ -227,7 +229,7 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
 
         {types.map((t) => {
           const typeItems = byType.get(t) ?? [];
-          const filteredItems = hideDone ? typeItems.filter((i) => i.status !== "done" && i.status !== "deferred") : typeItems;
+          const filteredItems = hideDone ? typeItems.filter((i) => !isTerminalBacklogItemStatus(i.status)) : typeItems;
           const hiddenItemCount = typeItems.length - filteredItems.length;
           const label = TYPE_LABELS[t] ?? t;
 

--- a/apps/web/components/ops/backlogVisibility.ts
+++ b/apps/web/components/ops/backlogVisibility.ts
@@ -1,0 +1,3 @@
+export function isTerminalBacklogItemStatus(status: string): boolean {
+  return status === "done" || status === "deferred";
+}


### PR DESCRIPTION
## Summary
- Hide terminal child backlog items inside expanded epics when the Ops backlog Hide done toggle is enabled.
- Share the done/deferred visibility rule with the unassigned backlog section and show a compact hidden-item notice.
- Add regression coverage for expanded epic child filtering.

## Root cause
The Ops backlog page filtered done epics and unassigned items, but `EpicCard` rendered `epic.items` directly, so done/deferred child backlog items still appeared under expanded epics.

## Validation
- `pnpm --filter web exec vitest run components/ops/OpsClient.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`
- Rebuilt the Docker portal image and browser-verified `/ops`: checked hides terminal epic children, unchecked shows them again.