### PR TITLE
fix(db): resolve catalog path by runtime style

### DIFF
--- a/packages/db/scripts/reconcile-catalog-capabilities.test.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.test.ts
@@ -84,6 +84,20 @@ describe("resolveKnownProviderModelsPath", () => {
 
     expect(resolved).toBe(packagedCatalog);
   });
+
+  it("resolves Linux-style packaged app source paths independent of the test host OS", () => {
+    const scriptDir = "/app/packages/db/scripts";
+    const packagedRoot = "/app/apps/web-src";
+    const packagedCatalog = "/app/apps/web-src/lib/routing/known-provider-models.ts";
+
+    const resolved = resolveKnownProviderModelsPath({
+      scriptDir,
+      packagedWebSourceRoot: packagedRoot,
+      exists: (candidate) => candidate === packagedCatalog,
+    });
+
+    expect(resolved).toBe(packagedCatalog);
+  });
 });
 
 describe("admin row-level protection", () => {

--- a/packages/db/scripts/reconcile-catalog-capabilities.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.ts
@@ -13,7 +13,7 @@
  */
 import { createHash } from "crypto";
 import { existsSync } from "fs";
-import { dirname, resolve } from "path";
+import { dirname, posix, resolve as nativeResolve, win32 } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { prisma } from "../src/client";
 import type { KnownModel } from "../../../apps/web/lib/routing/known-provider-models";
@@ -52,13 +52,27 @@ export type ProfileUpdateShape = {
   metadataConfidence: string;
 };
 
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value) || /^\\\\/.test(value);
+}
+
+function resolveForPathStyle(basePath: string, ...segments: string[]): string {
+  if (isWindowsAbsolutePath(basePath)) {
+    return win32.resolve(basePath, ...segments);
+  }
+  if (basePath.startsWith("/")) {
+    return posix.resolve(basePath, ...segments);
+  }
+  return nativeResolve(basePath, ...segments);
+}
+
 export function resolveKnownProviderModelsPath(
   options: CatalogPathResolutionOptions = {},
 ): string {
   const scriptDir = options.scriptDir ?? dirname(fileURLToPath(import.meta.url));
   const exists = options.exists ?? existsSync;
-  const repoCatalog = resolve(scriptDir, "../../../apps/web/lib/routing/known-provider-models.ts");
-  const packagedCatalog = resolve(
+  const repoCatalog = resolveForPathStyle(scriptDir, "../../../apps/web/lib/routing/known-provider-models.ts");
+  const packagedCatalog = resolveForPathStyle(
     options.packagedWebSourceRoot ?? "/app/apps/web-src",
     "lib/routing/known-provider-models.ts",
   );


### PR DESCRIPTION
## Summary
- resolve catalog reconciliation paths with the path style supplied by the caller, so Windows-style installer paths and POSIX container paths do not depend on the test host OS
- add a Linux-style packaged source regression test alongside the existing Windows-style packaged source case

## Verification
- `pnpm --filter @dpf/db exec vitest run scripts/reconcile-catalog-capabilities.test.ts` (red before fix, green after)
- Linux container: `pnpm --filter @dpf/db exec vitest run scripts/reconcile-catalog-capabilities.test.ts`
- CI-style DB: `pnpm --filter @dpf/db exec prisma migrate deploy`
- CI-style DB: `pnpm --filter @dpf/db exec vitest run` (92 files, 628 tests)
- `pnpm typecheck`
- `pnpm --filter web build` (exit 0; existing Edge Runtime Node API warnings only)