### PR TITLE
fix(portal): derive system health from telemetry

### DIFF
--- a/apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx
@@ -1,6 +1,6 @@
 // apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx
 //
-// Health tab — product-specific health metrics.
+// Health tab - product-specific health metrics.
 // For the portal product (dpf-portal), renders the service-level health dashboard.
 // For other products, shows observation config and SLA compliance.
 
@@ -8,6 +8,7 @@ import { prisma } from "@dpf/db";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ServiceHealthDashboard } from "@/components/monitoring/ServiceHealthDashboard";
+import { TONE_COLOR, type Tone } from "@/components/monitoring/health-summary";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -64,20 +65,10 @@ export default async function ProductHealthPage({ params }: Props) {
 
 function PortalHealth({ openBugs, productId }: { openBugs: number; productId: string }) {
   return (
-    <div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
-        <HealthCard label="Platform Status" value="Operational" colour="#4ade80" />
-        <HealthCard
-          label="Open Backlog Items"
-          value={String(openBugs)}
-          colour={openBugs > 0 ? "#fbbf24" : "#4ade80"}
-          href={`/portfolio/product/${productId}/backlog`}
-          hint={openBugs > 0 ? "View list" : undefined}
-        />
-        <HealthCard label="Health Monitoring" value="Active" colour="#4ade80" />
-      </div>
-      <ServiceHealthDashboard />
-    </div>
+    <ServiceHealthDashboard
+      openBacklogItems={openBugs}
+      backlogHref={`/portfolio/product/${productId}/backlog`}
+    />
   );
 }
 
@@ -123,19 +114,19 @@ function ProductHealth({
         <HealthCard
           label="Open Backlog Items"
           value={String(openBugs)}
-          colour={openBugs > 0 ? "#fbbf24" : "#4ade80"}
+          tone={openBugs > 0 ? "warning" : "success"}
           href={`/portfolio/product/${productId}/backlog`}
           hint={openBugs > 0 ? "View list" : undefined}
         />
         <HealthCard
           label="SLA Targets"
           value={`${offerings.length} defined`}
-          colour={hasOfferings ? "#4ade80" : "#8888a0"}
+          tone={hasOfferings ? "success" : "neutral"}
         />
         <HealthCard
           label="Observation"
           value={hasObservation ? "Configured" : "Not set"}
-          colour={hasObservation ? "#4ade80" : "#8888a0"}
+          tone={hasObservation ? "success" : "neutral"}
         />
       </div>
 
@@ -174,24 +165,24 @@ function ProductHealth({
 function HealthCard({
   label,
   value,
-  colour,
+  tone,
   href,
   hint,
 }: {
   label: string;
   value: string;
-  colour: string;
+  tone: Tone;
   href?: string;
   hint?: string;
 }) {
   const body = (
     <div className="bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg p-4 transition-colors hover:border-[var(--dpf-accent)]">
-      <div className="text-lg font-bold" style={{ color: colour }}>
+      <div className="text-lg font-bold" style={{ color: TONE_COLOR[tone] }}>
         {value}
       </div>
       <div className="text-[11px] text-[var(--dpf-muted)] mt-1">{label}</div>
       {hint && (
-        <div className="text-[10px] text-[var(--dpf-accent)] mt-1">{hint} →</div>
+        <div className="text-[10px] text-[var(--dpf-accent)] mt-1">{hint} -&gt;</div>
       )}
     </div>
   );

--- a/apps/web/components/monitoring/AiCoworkerHealthPanel.tsx
+++ b/apps/web/components/monitoring/AiCoworkerHealthPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useMetricQuery } from "./useMetricQuery";
 import { MetricTimeSeries } from "./MetricTimeSeries";
+import { TONE_COLOR } from "./health-summary";
 
 export function AiCoworkerHealthPanel() {
   const { data: inferenceUp, offline } = useMetricQuery('up{job="model-runner"}');
@@ -24,7 +25,8 @@ export function AiCoworkerHealthPanel() {
     );
   }
 
-  const inferenceAvailable = parseFloat(inferenceUp?.[0]?.value?.[1] ?? "0") === 1;
+  const modelRunnerScraped = (inferenceUp?.length ?? 0) > 0;
+  const inferenceAvailable = !modelRunnerScraped || parseFloat(inferenceUp?.[0]?.value?.[1] ?? "0") === 1;
   const memoryAvailable = parseFloat(qdrantUp?.[0]?.value?.[1] ?? "0") === 1;
   const hasMemErrors = parseFloat(memErrors?.[0]?.value?.[1] ?? "0") > 0;
   const p95Value = parseFloat(inferenceP95?.[0]?.value?.[1] ?? "0");
@@ -40,7 +42,7 @@ export function AiCoworkerHealthPanel() {
           <StatusIndicator
             label="Inference"
             ok={inferenceAvailable}
-            okText="Available"
+            okText={modelRunnerScraped ? "Available" : "Portal metrics"}
             failText="Offline"
           />
           <StatusIndicator
@@ -59,7 +61,7 @@ export function AiCoworkerHealthPanel() {
             <span className="text-xs text-[var(--dpf-muted)]">Memory Errors (5m)</span>
             <span
               className={`text-sm font-mono ${
-                hasMemErrors ? "text-red-400 font-bold" : "text-[var(--dpf-text)]"
+                hasMemErrors ? "font-bold text-[var(--dpf-error)]" : "text-[var(--dpf-text)]"
               }`}
             >
               {hasMemErrors ? "FAILING" : "None"}
@@ -99,11 +101,16 @@ function StatusIndicator({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <span className={`w-2.5 h-2.5 rounded-full ${ok ? "bg-green-500" : "bg-red-500 animate-pulse"}`} />
+      <span
+        className={`h-2.5 w-2.5 rounded-full ${ok ? "" : "animate-pulse"}`}
+        style={{ backgroundColor: ok ? TONE_COLOR.success : TONE_COLOR.critical }}
+        aria-hidden="true"
+      />
       <div className="flex flex-col">
         <span className="text-xs text-[var(--dpf-muted)]">{label}</span>
         <span
-          className={`text-xs font-medium ${ok ? "text-green-500" : "text-red-400"}`}
+          className="text-xs font-medium"
+          style={{ color: ok ? TONE_COLOR.success : TONE_COLOR.critical }}
         >
           {ok ? okText : failText}
         </span>

--- a/apps/web/components/monitoring/AlertBanner.tsx
+++ b/apps/web/components/monitoring/AlertBanner.tsx
@@ -1,50 +1,19 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 
-type Alert = {
-  labels: Record<string, string>;
-  annotations: Record<string, string>;
-  state: "firing" | "pending" | "inactive";
-  activeAt: string;
-};
+import { TONE_COLOR, getActiveAlerts } from "./health-summary";
+import { useAlertQuery } from "./useAlertQuery";
 
 type Props = {
   className?: string;
 };
 
 export function AlertBanner({ className = "" }: Props) {
-  const [alerts, setAlerts] = useState<Alert[]>([]);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
-  const [offline, setOffline] = useState(false);
+  const { alerts, offline } = useAlertQuery();
 
-  const fetchAlerts = useCallback(async () => {
-    try {
-      const res = await fetch("/api/platform/metrics/alerts");
-      if (res.status === 503) {
-        setOffline(true);
-        setAlerts([]);
-        return;
-      }
-      const json = await res.json();
-      setOffline(false);
-      const firing = (json.data?.alerts ?? []).filter(
-        (a: Alert) => a.state === "firing" || a.state === "pending",
-      );
-      setAlerts(firing);
-    } catch {
-      setOffline(true);
-      setAlerts([]);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchAlerts();
-    const id = setInterval(fetchAlerts, 30_000);
-    return () => clearInterval(id);
-  }, [fetchAlerts]);
-
-  const visibleAlerts = alerts.filter(
+  const visibleAlerts = getActiveAlerts(alerts).filter(
     (a) => !dismissed.has(a.labels.alertname ?? ""),
   );
 
@@ -57,15 +26,18 @@ export function AlertBanner({ className = "" }: Props) {
         const severity = alert.labels.severity ?? "warning";
         const summary = alert.annotations.summary ?? name;
         const isCritical = severity === "critical";
+        const tone = isCritical ? "critical" : "warning";
+        const color = TONE_COLOR[tone];
 
         return (
           <div
             key={name}
-            className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${
-              isCritical
-                ? "bg-red-500/10 border border-red-500/30 text-red-400"
-                : "bg-yellow-500/10 border border-yellow-500/30 text-yellow-400"
-            }`}
+            className="flex items-center justify-between rounded-lg border px-3 py-2 text-xs"
+            style={{
+              backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+              borderColor: `color-mix(in srgb, ${color} 35%, var(--dpf-border))`,
+              color,
+            }}
           >
             <span>
               <span className="font-semibold uppercase mr-2">{severity}</span>

--- a/apps/web/components/monitoring/ContainerResourceTable.tsx
+++ b/apps/web/components/monitoring/ContainerResourceTable.tsx
@@ -111,7 +111,7 @@ export function ContainerResourceTable() {
                   </td>
                   <td
                     className={`px-3 py-1.5 text-right ${
-                      hasRestarts ? "text-yellow-500 font-semibold" : "text-[var(--dpf-text)]"
+                      hasRestarts ? "text-[var(--dpf-warning)] font-semibold" : "text-[var(--dpf-text)]"
                     }`}
                   >
                     {row.restarts !== null ? Math.round(row.restarts) : "--"}

--- a/apps/web/components/monitoring/CoworkerHealthStatus.tsx
+++ b/apps/web/components/monitoring/CoworkerHealthStatus.tsx
@@ -107,14 +107,14 @@ export function CoworkerHealthStatus() {
           textAlign: "center",
         }}
       >
-        AI Coworker unavailable — check System Health
+        AI Coworker unavailable - check System Health
       </div>
     );
   }
 
   const messages: string[] = [];
   if (!health.memoryUp) {
-    messages.push("Memory offline — responses won't recall prior context");
+    messages.push("Memory offline - responses won't recall prior context");
   }
   if (health.inferenceSlow) {
     messages.push("AI responses may be slower than usual");

--- a/apps/web/components/monitoring/MetricGauge.tsx
+++ b/apps/web/components/monitoring/MetricGauge.tsx
@@ -7,6 +7,7 @@ type Props = {
   label: string;
   unit?: string;
   thresholds?: { warning: number; critical: number };
+  hint?: string;
   className?: string;
 };
 
@@ -15,6 +16,7 @@ export function MetricGauge({
   label,
   unit = "%",
   thresholds = { warning: 70, critical: 85 },
+  hint,
   className = "",
 }: Props) {
   const { data, loading, offline } = useMetricQuery(query);
@@ -36,6 +38,7 @@ export function MetricGauge({
   const circumference = Math.PI * radius; // half circle
   const pct = numValue !== null ? Math.min(numValue / 100, 1) : 0;
   const offset = circumference * (1 - pct);
+  const displayValue = loading ? "..." : numValue !== null ? `${Math.round(numValue)}${unit}` : "No data";
 
   if (offline) {
     return (
@@ -73,14 +76,15 @@ export function MetricGauge({
           x="50"
           y="50"
           textAnchor="middle"
-          fontSize="14"
+          fontSize={displayValue === "No data" ? "11" : "14"}
           fontWeight="bold"
           fill={color}
         >
-          {loading ? "..." : numValue !== null ? `${Math.round(numValue)}${unit}` : "--"}
+          {displayValue}
         </text>
       </svg>
       <span className="text-xs font-medium text-[var(--dpf-text)]">{label}</span>
+      {hint && <span className="text-[10px] leading-3 text-[var(--dpf-muted)]">{hint}</span>}
     </div>
   );
 }

--- a/apps/web/components/monitoring/MetricTimeSeries.test.ts
+++ b/apps/web/components/monitoring/MetricTimeSeries.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMetricSeries } from "./MetricTimeSeries";
+
+describe("normalizeMetricSeries", () => {
+  it("drops non-finite samples so charts render no data instead of NaN labels", () => {
+    const series = normalizeMetricSeries(
+      [
+        {
+          metric: { job: "portal" },
+          values: [
+            [1, "NaN"],
+            [2, "+Inf"],
+            [3, "-Inf"],
+          ],
+        },
+      ],
+      "Latency",
+    );
+
+    expect(series).toEqual([]);
+  });
+});

--- a/apps/web/components/monitoring/MetricTimeSeries.tsx
+++ b/apps/web/components/monitoring/MetricTimeSeries.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMetricRangeQuery } from "./useMetricRangeQuery";
+import { useMetricRangeQuery, type RangeResult } from "./useMetricRangeQuery";
 
 type Props = {
   query: string;
@@ -37,11 +37,7 @@ export function MetricTimeSeries({
     );
   }
 
-  // Collect all series
-  const series = (data ?? []).map((d) => ({
-    label: d.metric.instance || d.metric.name || d.metric.job || label,
-    values: d.values.map(([ts, v]) => ({ ts, v: parseFloat(v) })),
-  }));
+  const series = normalizeMetricSeries(data ?? [], label);
 
   if (series.length === 0 || series[0]!.values.length === 0) {
     return (
@@ -153,6 +149,17 @@ function formatValue(v: number, unit: string): string {
   if (unit === "%") return `${Math.round(v)}%`;
   if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
   return Number.isInteger(v) ? v.toString() : v.toFixed(2);
+}
+
+export function normalizeMetricSeries(data: RangeResult[], fallbackLabel: string) {
+  return data
+    .map((d) => ({
+      label: d.metric.instance || d.metric.name || d.metric.job || fallbackLabel,
+      values: d.values
+        .map(([ts, value]) => ({ ts, v: parseFloat(value) }))
+        .filter((point) => Number.isFinite(point.v)),
+    }))
+    .filter((series) => series.values.length > 0);
 }
 
 function formatTime(ts: number): string {

--- a/apps/web/components/monitoring/PlatformHealthIndicator.tsx
+++ b/apps/web/components/monitoring/PlatformHealthIndicator.tsx
@@ -1,62 +1,19 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 
-type Alert = {
-  labels: Record<string, string>;
-  annotations: Record<string, string>;
-  state: string;
-};
+import { TONE_COLOR, getActiveAlerts, type MonitoringAlert, type Tone } from "./health-summary";
+import { useAlertQuery } from "./useAlertQuery";
 
 type HealthState = "healthy" | "warning" | "critical" | "offline";
 
 export function PlatformHealthIndicator() {
-  const [health, setHealth] = useState<HealthState>("offline");
-  const [alerts, setAlerts] = useState<Alert[]>([]);
   const [open, setOpen] = useState(false);
+  const { alerts: allAlerts, offline } = useAlertQuery();
+  const alerts = getActiveAlerts(allAlerts);
 
-  const fetchHealth = useCallback(async () => {
-    try {
-      const res = await fetch("/api/platform/metrics/alerts", {
-        signal: AbortSignal.timeout(3_000),
-        cache: "no-store",
-      });
-      if (res.status === 503) {
-        setHealth("offline");
-        setAlerts([]);
-        return;
-      }
-      const json = await res.json();
-      const firing: Alert[] = (json.data?.alerts ?? []).filter(
-        (a: Alert) => a.state === "firing",
-      );
-      setAlerts(firing);
-
-      if (firing.length === 0) {
-        setHealth("healthy");
-      } else if (firing.some((a) => a.labels.severity === "critical")) {
-        setHealth("critical");
-      } else {
-        setHealth("warning");
-      }
-    } catch {
-      setHealth("offline");
-      setAlerts([]);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchHealth();
-    const id = setInterval(fetchHealth, 30_000);
-    return () => clearInterval(id);
-  }, [fetchHealth]);
-
-  const dotColor = {
-    healthy: "bg-green-500",
-    warning: "bg-yellow-500",
-    critical: "bg-red-500 animate-pulse",
-    offline: "bg-gray-400",
-  }[health];
+  const health = deriveHealthState(offline, alerts);
+  const dotTone = healthToTone(health);
 
   const label = {
     healthy: "All systems healthy",
@@ -72,7 +29,11 @@ export function PlatformHealthIndicator() {
         className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-[var(--dpf-surface-2)] transition-colors"
         title={label}
       >
-        <span className={`w-2 h-2 rounded-full ${dotColor}`} />
+        <span
+          className={`h-2 w-2 rounded-full ${health === "critical" ? "animate-pulse" : ""}`}
+          style={{ backgroundColor: TONE_COLOR[dotTone] }}
+          aria-hidden="true"
+        />
         {health !== "healthy" && health !== "offline" && (
           <span className="text-[10px] text-[var(--dpf-muted)]">
             {alerts.length > 0 ? alerts.length : ""}
@@ -87,7 +48,11 @@ export function PlatformHealthIndicator() {
           <div className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] shadow-lg overflow-hidden">
             <div className="px-3 py-2 border-b border-[var(--dpf-border)] flex items-center justify-between">
               <span className="text-xs font-semibold text-[var(--dpf-text)]">Platform Health</span>
-              <span className={`w-2 h-2 rounded-full ${dotColor}`} />
+              <span
+                className={`h-2 w-2 rounded-full ${health === "critical" ? "animate-pulse" : ""}`}
+                style={{ backgroundColor: TONE_COLOR[dotTone] }}
+                aria-hidden="true"
+              />
             </div>
 
             {health === "offline" && (
@@ -101,7 +66,7 @@ export function PlatformHealthIndicator() {
             )}
 
             {health === "healthy" && (
-              <div className="px-3 py-4 text-xs text-green-500 text-center">
+              <div className="px-3 py-4 text-center text-xs text-[var(--dpf-success)]">
                 All systems operational
               </div>
             )}
@@ -110,6 +75,7 @@ export function PlatformHealthIndicator() {
               <div className="max-h-48 overflow-y-auto">
                 {alerts.map((alert, i) => {
                   const severity = alert.labels.severity ?? "warning";
+                  const tone = severity === "critical" ? "critical" : "warning";
                   return (
                     <div
                       key={i}
@@ -117,9 +83,8 @@ export function PlatformHealthIndicator() {
                     >
                       <div className="flex items-center gap-1.5">
                         <span
-                          className={`text-[10px] font-bold uppercase ${
-                            severity === "critical" ? "text-red-400" : "text-yellow-400"
-                          }`}
+                          className="text-[10px] font-bold uppercase"
+                          style={{ color: TONE_COLOR[tone] }}
                         >
                           {severity}
                         </span>
@@ -148,4 +113,17 @@ export function PlatformHealthIndicator() {
       )}
     </div>
   );
+}
+
+function deriveHealthState(offline: boolean, alerts: MonitoringAlert[]): HealthState {
+  if (offline) return "offline";
+  if (alerts.length === 0) return "healthy";
+  return alerts.some((alert) => alert.labels.severity === "critical") ? "critical" : "warning";
+}
+
+function healthToTone(health: HealthState): Tone {
+  if (health === "healthy") return "success";
+  if (health === "critical") return "critical";
+  if (health === "warning") return "warning";
+  return "neutral";
 }

--- a/apps/web/components/monitoring/PortalHealthSummary.tsx
+++ b/apps/web/components/monitoring/PortalHealthSummary.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+
+import {
+  TONE_COLOR,
+  deriveMonitoringSummary,
+  derivePlatformSummary,
+  type HealthSummary,
+  type Tone,
+} from "./health-summary";
+import { useAlertQuery } from "./useAlertQuery";
+import { useMetricQuery } from "./useMetricQuery";
+import { useMonitoringStatus } from "./MonitoringContext";
+
+type Props = {
+  openBacklogItems: number;
+  backlogHref: string;
+};
+
+export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
+  const { checked, online } = useMonitoringStatus();
+  const { data: upTargets, loading: upTargetsLoading } = useMetricQuery("up");
+  const { alerts } = useAlertQuery();
+
+  const platform = derivePlatformSummary({
+    checked,
+    online,
+    upTargets,
+    upTargetsLoading,
+    alerts,
+  });
+
+  const monitoring = deriveMonitoringSummary({
+    checked,
+    online,
+    upTargets,
+    upTargetsLoading,
+    alerts,
+  });
+
+  const backlogTone: Tone = openBacklogItems > 0 ? "warning" : "success";
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <HealthCard label="Platform Status" summary={platform} />
+      <HealthCard
+        label="Open Backlog Items"
+        summary={{
+          value: String(openBacklogItems),
+          tone: backlogTone,
+          detail: openBacklogItems > 0 ? "View list" : "No open backlog items",
+        }}
+        href={backlogHref}
+      />
+      <HealthCard label="Health Monitoring" summary={monitoring} />
+    </div>
+  );
+}
+
+function HealthCard({
+  label,
+  summary,
+  href,
+}: {
+  label: string;
+  summary: HealthSummary;
+  href?: string;
+}) {
+  const body = (
+    <div className="h-full rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:border-[var(--dpf-accent)]">
+      <div className="text-lg font-bold" style={{ color: TONE_COLOR[summary.tone] }}>
+        {summary.value}
+      </div>
+      <div className="mt-1 text-[11px] text-[var(--dpf-muted)]">{label}</div>
+      <div className="mt-1 text-[10px] leading-4 text-[var(--dpf-muted)]">
+        {summary.detail}
+        {href ? " ->" : ""}
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block">
+        {body}
+      </Link>
+    );
+  }
+
+  return body;
+}

--- a/apps/web/components/monitoring/RecentAlertsPanel.tsx
+++ b/apps/web/components/monitoring/RecentAlertsPanel.tsx
@@ -1,38 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-
-type Alert = {
-  labels: Record<string, string>;
-  annotations: Record<string, string>;
-  state: string;
-  activeAt: string;
-};
+import { TONE_COLOR, type MonitoringAlert, type Tone } from "./health-summary";
+import { useAlertQuery } from "./useAlertQuery";
 
 export function RecentAlertsPanel() {
-  const [alerts, setAlerts] = useState<Alert[]>([]);
-  const [offline, setOffline] = useState(false);
-
-  const fetchAlerts = useCallback(async () => {
-    try {
-      const res = await fetch("/api/platform/metrics/alerts");
-      if (res.status === 503) {
-        setOffline(true);
-        return;
-      }
-      const json = await res.json();
-      setOffline(false);
-      setAlerts(json.data?.alerts ?? []);
-    } catch {
-      setOffline(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchAlerts();
-    const id = setInterval(fetchAlerts, 30_000);
-    return () => clearInterval(id);
-  }, [fetchAlerts]);
+  const { alerts, offline } = useAlertQuery();
 
   return (
     <section>
@@ -45,7 +17,7 @@ export function RecentAlertsPanel() {
       )}
 
       {!offline && alerts.length === 0 && (
-        <p className="text-xs text-green-500">No alerts</p>
+        <p className="text-xs text-[var(--dpf-success)]">No alerts</p>
       )}
 
       {!offline && alerts.length > 0 && (
@@ -54,7 +26,7 @@ export function RecentAlertsPanel() {
             <tbody>
               {alerts.slice(0, 10).map((alert, i) => {
                 const severity = alert.labels.severity ?? "warning";
-                const isCritical = severity === "critical";
+                const tone = getAlertTone(alert);
                 const time = alert.activeAt
                   ? new Date(alert.activeAt).toLocaleTimeString([], {
                       hour: "2-digit",
@@ -72,9 +44,8 @@ export function RecentAlertsPanel() {
                     </td>
                     <td className="px-2 py-1.5 w-16">
                       <span
-                        className={`text-[10px] font-bold uppercase ${
-                          isCritical ? "text-red-400" : alert.state === "firing" ? "text-yellow-400" : "text-green-500"
-                        }`}
+                        className="text-[10px] font-bold uppercase"
+                        style={{ color: TONE_COLOR[tone] }}
                       >
                         {alert.state === "firing"
                           ? severity.toUpperCase()
@@ -96,4 +67,9 @@ export function RecentAlertsPanel() {
       )}
     </section>
   );
+}
+
+function getAlertTone(alert: MonitoringAlert): Tone {
+  if (alert.state === "inactive") return "success";
+  return alert.labels.severity === "critical" ? "critical" : "warning";
 }

--- a/apps/web/components/monitoring/ServiceHealthDashboard.tsx
+++ b/apps/web/components/monitoring/ServiceHealthDashboard.tsx
@@ -14,16 +14,26 @@ import { MetricTimeSeries } from "./MetricTimeSeries";
 import { MetricTable } from "./MetricTable";
 import { AiCoworkerHealthPanel } from "./AiCoworkerHealthPanel";
 import { RecentAlertsPanel } from "./RecentAlertsPanel";
+import { PortalHealthSummary } from "./PortalHealthSummary";
+import { HOST_RESOURCE_QUERIES } from "./health-summary";
 
-export function ServiceHealthDashboard() {
+type ServiceHealthDashboardProps = {
+  openBacklogItems?: number;
+  backlogHref?: string;
+};
+
+export function ServiceHealthDashboard(props: ServiceHealthDashboardProps = {}) {
   return (
     <MonitoringProvider>
-      <ServiceHealthContent />
+      <ServiceHealthContent {...props} />
     </MonitoringProvider>
   );
 }
 
-function ServiceHealthContent() {
+function ServiceHealthContent({
+  openBacklogItems,
+  backlogHref,
+}: ServiceHealthDashboardProps) {
   const { online, checked } = useMonitoringStatus();
 
   if (!checked) {
@@ -48,6 +58,10 @@ function ServiceHealthContent() {
 
   return (
     <div className="space-y-6">
+      {openBacklogItems !== undefined && backlogHref && (
+        <PortalHealthSummary openBacklogItems={openBacklogItems} backlogHref={backlogHref} />
+      )}
+
       {/* Active alerts */}
       <AlertBanner />
 
@@ -61,18 +75,19 @@ function ServiceHealthContent() {
         </h3>
         <div className="grid grid-cols-3 gap-3">
           <MetricGauge
-            query='100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)'
+            query={HOST_RESOURCE_QUERIES.compute}
             label="Compute"
             thresholds={{ warning: 70, critical: 85 }}
           />
           <MetricGauge
-            query="(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+            query={HOST_RESOURCE_QUERIES.memory}
             label="Memory"
             thresholds={{ warning: 70, critical: 85 }}
           />
           <MetricGauge
-            query='(1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100'
+            query={HOST_RESOURCE_QUERIES.storage}
             label="Storage"
+            hint="Highest drive usage"
             thresholds={{ warning: 70, critical: 90 }}
           />
         </div>

--- a/apps/web/components/monitoring/ServiceStatusGrid.tsx
+++ b/apps/web/components/monitoring/ServiceStatusGrid.tsx
@@ -1,30 +1,16 @@
 "use client";
 
 import { useMetricQuery } from "./useMetricQuery";
-
-type ServiceDef = {
-  name: string;
-  job: string;
-  detail?: string;
-};
+import { TONE_COLOR, deriveServiceStatuses, type ServiceDefinition } from "./health-summary";
 
 type Props = {
-  services: ServiceDef[];
+  services: ServiceDefinition[];
   className?: string;
 };
 
 export function ServiceStatusGrid({ services, className = "" }: Props) {
-  // Query all targets at once
   const { data, loading, offline } = useMetricQuery("up");
-
-  // Build a map: job → up/down
-  const statusMap = new Map<string, number>();
-  if (data) {
-    for (const result of data) {
-      const job = result.metric.job;
-      if (job) statusMap.set(job, parseFloat(result.value[1]));
-    }
-  }
+  const rows = deriveServiceStatuses({ services, upTargets: data, loading, offline });
 
   return (
     <div className={className}>
@@ -32,57 +18,31 @@ export function ServiceStatusGrid({ services, className = "" }: Props) {
         Platform Services
       </h3>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-        {services.map((svc) => {
-          const up = statusMap.get(svc.job);
-          const isUp = up === 1;
-          const isDown = up === 0;
-          const unknown = up === undefined;
-
-          const dotColor = offline || loading
-            ? "bg-gray-400"
-            : isUp
-              ? "bg-green-500"
-              : isDown
-                ? "bg-red-500"
-                : unknown
-                  ? "bg-gray-400"
-                  : "bg-yellow-500";
-
-          const statusText = offline
-            ? "Offline"
-            : loading
-              ? "..."
-              : isUp
-                ? "UP"
-                : isDown
-                  ? "DOWN"
-                  : "Unknown";
-
-          return (
-            <div
-              key={svc.job}
-              className="flex flex-col items-center gap-1 p-2 rounded-lg bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)]"
-            >
-              <span className={`w-3 h-3 rounded-full ${dotColor}`} />
-              <span className="text-xs font-medium text-[var(--dpf-text)]">{svc.name}</span>
-              <span className="text-[10px] text-[var(--dpf-muted)]">
-                {statusText}
-                {svc.detail && isUp ? ` ${svc.detail}` : ""}
-              </span>
-            </div>
-          );
-        })}
+        {rows.map((svc) => (
+          <div
+            key={svc.name}
+            className="flex min-h-20 flex-col items-center justify-center gap-1 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-center"
+          >
+            <span
+              className="h-3 w-3 rounded-full"
+              style={{ backgroundColor: TONE_COLOR[svc.tone] }}
+              aria-hidden="true"
+            />
+            <span className="text-xs font-medium text-[var(--dpf-text)]">{svc.name}</span>
+            <span className="text-[10px] leading-3 text-[var(--dpf-muted)]">{svc.label}</span>
+          </div>
+        ))}
       </div>
     </div>
   );
 }
 
-export const DPF_SERVICES: ServiceDef[] = [
+export const DPF_SERVICES: ServiceDefinition[] = [
   { name: "Portal", job: "portal" },
   { name: "PostgreSQL", job: "postgres" },
-  { name: "Neo4j", job: "neo4j" },
+  { name: "Neo4j", statusHint: "Not scraped" },
   { name: "Qdrant", job: "qdrant" },
-  { name: "AI Inference", job: "model-runner" },
+  { name: "AI Inference", statusHint: "Portal metrics" },
   { name: "Sandbox 1", job: "sandbox" },
   { name: "Sandbox 2", job: "sandbox" },
   { name: "Sandbox 3", job: "sandbox" },

--- a/apps/web/components/monitoring/SparkLine.tsx
+++ b/apps/web/components/monitoring/SparkLine.tsx
@@ -25,7 +25,9 @@ export function SparkLine({
     return <div className={`inline-block ${className}`} style={{ width, height }} />;
   }
 
-  const values = (data[0]?.values ?? []).map(([, v]) => parseFloat(v));
+  const values = (data[0]?.values ?? [])
+    .map(([, v]) => parseFloat(v))
+    .filter((value) => Number.isFinite(value));
   if (values.length === 0) return <div className={`inline-block ${className}`} style={{ width, height }} />;
 
   const min = Math.min(...values);

--- a/apps/web/components/monitoring/SystemHealthDashboard.tsx
+++ b/apps/web/components/monitoring/SystemHealthDashboard.tsx
@@ -10,6 +10,7 @@ import { MetricTable } from "./MetricTable";
 import { ContainerResourceTable } from "./ContainerResourceTable";
 import { AiCoworkerHealthPanel } from "./AiCoworkerHealthPanel";
 import { RecentAlertsPanel } from "./RecentAlertsPanel";
+import { HOST_RESOURCE_QUERIES } from "./health-summary";
 
 export function SystemHealthDashboard() {
   return (
@@ -71,18 +72,19 @@ function SystemHealthContent() {
         </h3>
         <div className="grid grid-cols-3 gap-3">
           <MetricGauge
-            query='100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)'
+            query={HOST_RESOURCE_QUERIES.compute}
             label="CPU"
             thresholds={{ warning: 70, critical: 85 }}
           />
           <MetricGauge
-            query="(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+            query={HOST_RESOURCE_QUERIES.memory}
             label="Memory"
             thresholds={{ warning: 70, critical: 85 }}
           />
           <MetricGauge
-            query='(1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100'
+            query={HOST_RESOURCE_QUERIES.storage}
             label="Disk"
+            hint="Highest drive usage"
             thresholds={{ warning: 70, critical: 90 }}
           />
         </div>

--- a/apps/web/components/monitoring/health-summary.test.ts
+++ b/apps/web/components/monitoring/health-summary.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOST_RESOURCE_QUERIES,
+  deriveMonitoringSummary,
+  derivePlatformSummary,
+  deriveServiceStatuses,
+  type MonitoringAlert,
+  type PrometheusInstantResult,
+  type ServiceDefinition,
+} from "./health-summary";
+
+function up(job: string, value: "0" | "1" = "1"): PrometheusInstantResult {
+  return {
+    metric: { job },
+    value: [1, value],
+  };
+}
+
+function alert(
+  severity: "critical" | "warning",
+  state: "firing" | "pending" | "inactive" = "firing",
+): MonitoringAlert {
+  return {
+    labels: { alertname: "ContainerDown", severity, job: "node-exporter" },
+    annotations: { summary: "Service node-exporter is down" },
+    state,
+    activeAt: "2026-05-25T15:29:00.000Z",
+  };
+}
+
+describe("derivePlatformSummary", () => {
+  it("reports critical instead of operational when critical alerts are firing", () => {
+    const summary = derivePlatformSummary({
+      checked: true,
+      online: true,
+      upTargets: [up("prometheus"), up("portal"), up("postgres"), up("qdrant")],
+      alerts: [alert("critical")],
+    });
+
+    expect(summary.value).toBe("Critical");
+    expect(summary.tone).toBe("critical");
+    expect(summary.detail).toContain("Service node-exporter is down");
+  });
+});
+
+describe("deriveMonitoringSummary", () => {
+  it("reports degraded telemetry when Prometheus is up but an exporter target is down", () => {
+    const summary = deriveMonitoringSummary({
+      checked: true,
+      online: true,
+      upTargets: [
+        up("prometheus"),
+        up("windows-host"),
+        up("node-exporter", "0"),
+        up("cadvisor", "0"),
+      ],
+      alerts: [alert("critical")],
+    });
+
+    expect(summary.value).toBe("Degraded");
+    expect(summary.tone).toBe("warning");
+    expect(summary.detail).toContain("2 telemetry targets down");
+  });
+
+  it("reports active when Prometheus and telemetry targets are healthy", () => {
+    const summary = deriveMonitoringSummary({
+      checked: true,
+      online: true,
+      upTargets: [up("prometheus"), up("windows-host"), up("cadvisor")],
+      alerts: [],
+    });
+
+    expect(summary.value).toBe("Active");
+    expect(summary.tone).toBe("success");
+  });
+});
+
+describe("deriveServiceStatuses", () => {
+  it("marks intentionally unmonitored services as not monitored instead of unknown", () => {
+    const services: ServiceDefinition[] = [
+      { name: "Portal", job: "portal" },
+      { name: "AI Inference", statusHint: "Tracked by portal metrics" },
+    ];
+
+    const rows = deriveServiceStatuses({
+      services,
+      upTargets: [up("portal")],
+      loading: false,
+      offline: false,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({ name: "Portal", state: "up", label: "UP" }),
+      expect.objectContaining({
+        name: "AI Inference",
+        state: "not-monitored",
+        label: "Tracked by portal metrics",
+      }),
+    ]);
+  });
+});
+
+describe("HOST_RESOURCE_QUERIES", () => {
+  it("uses Windows exporter fallback queries for local Windows installs", () => {
+    expect(HOST_RESOURCE_QUERIES.compute).toContain("windows_cpu_time_total");
+    expect(HOST_RESOURCE_QUERIES.memory).toContain("windows_os_physical_memory_free_bytes");
+    expect(HOST_RESOURCE_QUERIES.storage).toContain("windows_logical_disk_free_bytes");
+  });
+});

--- a/apps/web/components/monitoring/health-summary.ts
+++ b/apps/web/components/monitoring/health-summary.ts
@@ -1,0 +1,215 @@
+export type Tone = "success" | "warning" | "critical" | "neutral";
+
+export type PrometheusInstantResult = {
+  metric: Record<string, string | undefined>;
+  value: [number, string];
+};
+
+export type MonitoringAlert = {
+  labels: Record<string, string | undefined>;
+  annotations: Record<string, string | undefined>;
+  state: "firing" | "pending" | "inactive" | string;
+  activeAt: string;
+};
+
+export type HealthSummary = {
+  value: string;
+  tone: Tone;
+  detail: string;
+};
+
+export type ServiceDefinition = {
+  name: string;
+  job?: string;
+  detail?: string;
+  statusHint?: string;
+};
+
+export type ServiceStatus = ServiceDefinition & {
+  state: "up" | "down" | "unknown" | "loading" | "offline" | "not-monitored";
+  label: string;
+  tone: Tone;
+};
+
+type SummaryInput = {
+  checked: boolean;
+  online: boolean;
+  upTargets: PrometheusInstantResult[] | null | undefined;
+  alerts: MonitoringAlert[];
+  upTargetsLoading?: boolean;
+};
+
+type ServiceStatusInput = {
+  services: ServiceDefinition[];
+  upTargets: PrometheusInstantResult[] | null | undefined;
+  loading: boolean;
+  offline: boolean;
+};
+
+const PLATFORM_REQUIRED_JOBS = ["portal", "postgres", "qdrant", "sandbox"];
+const TELEMETRY_JOBS = ["node-exporter", "cadvisor"];
+
+export const HOST_RESOURCE_QUERIES = {
+  compute:
+    '(100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) or (100 - (avg(rate(windows_cpu_time_total{mode="idle"}[5m])) * 100))',
+  memory:
+    "((1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100) or ((1 - windows_os_physical_memory_free_bytes / windows_cs_physical_memory_bytes) * 100)",
+  storage:
+    'max((1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100) or max((1 - windows_logical_disk_free_bytes{volume=~"[A-Z]:"} / windows_logical_disk_size_bytes{volume=~"[A-Z]:"}) * 100)',
+};
+
+export const TONE_COLOR: Record<Tone, string> = {
+  success: "var(--dpf-success)",
+  warning: "var(--dpf-warning)",
+  critical: "var(--dpf-error)",
+  neutral: "var(--dpf-muted)",
+};
+
+export function derivePlatformSummary({
+  checked,
+  online,
+  upTargets,
+  alerts,
+  upTargetsLoading = false,
+}: SummaryInput): HealthSummary {
+  if (!checked || upTargetsLoading) {
+    return { value: "Checking", tone: "neutral", detail: "Collecting current health signals" };
+  }
+
+  if (!online) {
+    return { value: "Unavailable", tone: "critical", detail: "Monitoring stack is unreachable" };
+  }
+
+  const activeAlerts = getActiveAlerts(alerts);
+  const criticalAlerts = activeAlerts.filter((alert) => alert.labels.severity === "critical");
+  if (criticalAlerts.length > 0) {
+    return {
+      value: "Critical",
+      tone: "critical",
+      detail: alertSummary(criticalAlerts[0]) ?? `${criticalAlerts.length} critical alerts firing`,
+    };
+  }
+
+  const jobStatus = buildJobStatusMap(upTargets);
+  const downRequiredJobs = PLATFORM_REQUIRED_JOBS.filter((job) => jobStatus.get(job) === 0);
+  if (downRequiredJobs.length > 0) {
+    return {
+      value: "Critical",
+      tone: "critical",
+      detail: `${downRequiredJobs.join(", ")} down`,
+    };
+  }
+
+  const missingRequiredJobs = PLATFORM_REQUIRED_JOBS.filter((job) => !jobStatus.has(job));
+  if (missingRequiredJobs.length > 0) {
+    return {
+      value: "Degraded",
+      tone: "warning",
+      detail: `${missingRequiredJobs.join(", ")} status unknown`,
+    };
+  }
+
+  const warningAlerts = activeAlerts.filter((alert) => alert.labels.severity === "warning");
+  if (warningAlerts.length > 0) {
+    return {
+      value: "Degraded",
+      tone: "warning",
+      detail: alertSummary(warningAlerts[0]) ?? `${warningAlerts.length} warning alerts firing`,
+    };
+  }
+
+  return { value: "Operational", tone: "success", detail: "Required platform services are up" };
+}
+
+export function deriveMonitoringSummary({
+  checked,
+  online,
+  upTargets,
+  upTargetsLoading = false,
+}: SummaryInput): HealthSummary {
+  if (!checked || upTargetsLoading) {
+    return { value: "Checking", tone: "neutral", detail: "Checking monitoring targets" };
+  }
+
+  if (!online) {
+    return { value: "Offline", tone: "critical", detail: "Prometheus API is unreachable" };
+  }
+
+  const jobStatus = buildJobStatusMap(upTargets);
+  if (jobStatus.get("prometheus") === 0) {
+    return { value: "Offline", tone: "critical", detail: "Prometheus self-target is down" };
+  }
+
+  const telemetryDown = TELEMETRY_JOBS.filter((job) => jobStatus.get(job) === 0);
+  if (telemetryDown.length > 0) {
+    return {
+      value: "Degraded",
+      tone: "warning",
+      detail: `${telemetryDown.length} telemetry targets down: ${telemetryDown.join(", ")}`,
+    };
+  }
+
+  const hasHostTelemetry = jobStatus.get("windows-host") === 1 || jobStatus.get("node-exporter") === 1;
+  if (!hasHostTelemetry) {
+    return { value: "Degraded", tone: "warning", detail: "Host telemetry is not available" };
+  }
+
+  return { value: "Active", tone: "success", detail: "Prometheus and telemetry targets are healthy" };
+}
+
+export function deriveServiceStatuses({
+  services,
+  upTargets,
+  loading,
+  offline,
+}: ServiceStatusInput): ServiceStatus[] {
+  const jobStatus = buildJobStatusMap(upTargets);
+
+  return services.map((service) => {
+    if (offline) {
+      return { ...service, state: "offline", label: "Offline", tone: "neutral" };
+    }
+
+    if (loading) {
+      return { ...service, state: "loading", label: "...", tone: "neutral" };
+    }
+
+    if (!service.job) {
+      return {
+        ...service,
+        state: "not-monitored",
+        label: service.statusHint ?? "Not monitored",
+        tone: "neutral",
+      };
+    }
+
+    const status = jobStatus.get(service.job);
+    if (status === 1) {
+      return { ...service, state: "up", label: service.detail ? `UP ${service.detail}` : "UP", tone: "success" };
+    }
+
+    if (status === 0) {
+      return { ...service, state: "down", label: "DOWN", tone: "critical" };
+    }
+
+    return { ...service, state: "unknown", label: "Unknown", tone: "neutral" };
+  });
+}
+
+export function getActiveAlerts(alerts: MonitoringAlert[]): MonitoringAlert[] {
+  return alerts.filter((alert) => alert.state === "firing" || alert.state === "pending");
+}
+
+function buildJobStatusMap(results: PrometheusInstantResult[] | null | undefined): Map<string, number> {
+  const jobStatus = new Map<string, number>();
+  for (const result of results ?? []) {
+    const job = result.metric.job;
+    if (!job) continue;
+    jobStatus.set(job, parseFloat(result.value[1]));
+  }
+  return jobStatus;
+}
+
+function alertSummary(alert: MonitoringAlert): string | undefined {
+  return alert.annotations.summary ?? alert.labels.alertname;
+}

--- a/apps/web/components/monitoring/useAlertQuery.ts
+++ b/apps/web/components/monitoring/useAlertQuery.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { MonitoringAlert } from "./health-summary";
+
+type AlertQueryState = {
+  alerts: MonitoringAlert[];
+  loading: boolean;
+  offline: boolean;
+};
+
+export function useAlertQuery(intervalMs = 30_000): AlertQueryState {
+  const [state, setState] = useState<AlertQueryState>({
+    alerts: [],
+    loading: true,
+    offline: false,
+  });
+
+  const fetchAlerts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/platform/metrics/alerts", { cache: "no-store" });
+      if (res.status === 503) {
+        setState({ alerts: [], loading: false, offline: true });
+        return;
+      }
+
+      const json = await res.json();
+      setState({
+        alerts: json.data?.alerts ?? [],
+        loading: false,
+        offline: false,
+      });
+    } catch {
+      setState({ alerts: [], loading: false, offline: true });
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAlerts();
+    const id = setInterval(fetchAlerts, intervalMs);
+    return () => clearInterval(id);
+  }, [fetchAlerts, intervalMs]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- derive the portal health summary from live Prometheus targets and alerts instead of hardcoded green cards
- use Windows exporter fallback queries for compute, memory, and storage gauges so Windows installs show real resource data
- centralize alert polling/status tone mapping and remove hardcoded monitoring colors from the health surface
- filter non-finite time-series samples so empty Prometheus series render as no data instead of NaN labels

## Verification
- pnpm --filter web exec vitest run components/monitoring/health-summary.test.ts components/monitoring/MetricTimeSeries.test.ts components/monitoring/CoworkerHealthStatus.test.ts
- pnpm --filter web typecheck
- pnpm --filter web build
- docker compose --env-file D:\DPF\.env -p dpf build --no-cache portal
- docker compose --env-file D:\DPF\.env -p dpf up -d --no-deps --force-recreate portal
- Playwright login and health-screen verification against http://127.0.0.1:3000/portfolio/product/cmpims34t08xv6ymg1scwabhv/health