### PR TITLE
feat(build): group decomposed builds by epic

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -1,7 +1,7 @@
 // apps/web/app/(shell)/build/page.tsx
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
-import { getFeatureBuilds } from "@/lib/feature-build-data";
+import { getExecutionEpicRollups, getFeatureBuildById, getFeatureBuilds } from "@/lib/feature-build-data";
 import { getPortfoliosForSelect } from "@/lib/backlog-data";
 import { businessBuildBriefFromRecord } from "@/lib/build/business-build-brief";
 import { BuildStudio } from "@/components/build/BuildStudio";
@@ -173,10 +173,14 @@ export default async function BuildPage({ searchParams }: PageProps) {
     );
   }
 
-  const [builds, portfolios] = await Promise.all([
+  const [builds, epicRollups, portfolios] = await Promise.all([
     getFeatureBuilds(session.user.id),
+    getExecutionEpicRollups(session.user.id),
     getPortfoliosForSelect(),
   ]);
+  const initialActiveBuild = buildId && !builds.some((build) => build.buildId === buildId)
+    ? await getFeatureBuildById(buildId)
+    : null;
   const portalContext = await resolvePortalContextEnvelope(
     {
       pathname: "/build",
@@ -199,6 +203,7 @@ export default async function BuildPage({ searchParams }: PageProps) {
     <section className="min-h-full">
       <BuildStudio
         builds={builds}
+        epicRollups={epicRollups}
         portfolios={portfolios}
         governedBacklogEnabled={devConfig.governedBacklogEnabled}
         dpfEnvironment={process.env.DPF_ENVIRONMENT ?? "production"}
@@ -206,6 +211,7 @@ export default async function BuildPage({ searchParams }: PageProps) {
         submissionBranchShortId={submissionBranchShortId}
         initialBuildId={buildId}
         portalContext={portalContext}
+        initialActiveBuild={initialActiveBuild}
       />
     </section>
   );

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -21,6 +21,7 @@ import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
 import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
+import { EpicRollupListItem } from "./EpicRollupListItem";
 import { deriveFleetCounts, deriveNeedsAttention, deriveQueueState } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
@@ -35,6 +36,7 @@ import type { ActiveAssuranceFindingRow } from "@/lib/assurance/finding-read";
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import type { BuildFlowState } from "@/lib/build-flow-state";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import type { EpicRollupView } from "@/lib/build/epic-rollup";
 import type { BomSummary } from "@/lib/assurance/bom-read";
 import type { CodeGraphFreshness } from "@/lib/integrate/code-graph-access";
 import type { BuildExecutionState } from "@/lib/integrate/build-exec-types";
@@ -52,6 +54,7 @@ import {
 
 type Props = {
   builds: FeatureBuildRow[];
+  epicRollups?: EpicRollupView[];
   portfolios: PortfolioForSelect[];
   governedBacklogEnabled: boolean;
   dpfEnvironment?: string;
@@ -59,6 +62,7 @@ type Props = {
   submissionBranchShortId?: string | null;
   initialBuildId?: string | null;
   portalContext?: PortalContextEnvelope | null;
+  initialActiveBuild?: FeatureBuildRow | null;
 };
 
 const MISSING_BOM_SUMMARY: BomSummary = {
@@ -81,6 +85,7 @@ const MISSING_BOM_SUMMARY: BomSummary = {
 
 export function BuildStudio({
   builds,
+  epicRollups = [],
   portfolios,
   governedBacklogEnabled,
   dpfEnvironment,
@@ -88,12 +93,14 @@ export function BuildStudio({
   submissionBranchShortId,
   initialBuildId,
   portalContext,
+  initialActiveBuild,
 }: Props) {
   const router = useRouter();
   const buildRows = Array.isArray(builds) ? builds : [];
+  const rollupRows = Array.isArray(epicRollups) ? epicRollups : [];
   const portfolioRows = Array.isArray(portfolios) ? portfolios : [];
   const [activeBuild, setActiveBuild] = useState<FeatureBuildRow | null>(
-    resolveInitialActiveBuild(buildRows, initialBuildId),
+    () => initialActiveBuild ?? resolveInitialActiveBuild(buildRows, initialBuildId),
   );
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState("");
@@ -123,6 +130,10 @@ export function BuildStudio({
     setSelectedNodeClick(null);
   }, [activeBuild?.buildId]);
   const isDevEnvironment = dpfEnvironment === "dev";
+  const supervisedBuildRows =
+    activeBuild && !buildRows.some((build) => build.buildId === activeBuild.buildId)
+      ? [activeBuild, ...buildRows]
+      : buildRows;
   const branchBadge = resolveBuildStudioBranchBadge({
     submissionBranchShortId,
     buildTitle: activeBuild?.title ?? null,
@@ -183,6 +194,20 @@ export function BuildStudio({
     setBomSummary(nextBomSummary);
     setAssuranceFindings(nextFindings);
   }, []);
+  const selectBuildById = useCallback(async (buildId: string) => {
+    const existing = buildRows.find((build) => build.buildId === buildId);
+    if (existing) {
+      setActiveBuild(existing);
+      setSidebarOpen(true);
+      return;
+    }
+
+    const fresh = await getFeatureBuild(buildId);
+    if (fresh) {
+      setActiveBuild(fresh);
+      setSidebarOpen(true);
+    }
+  }, [buildRows]);
   const debouncedRefetch = useCallback(async () => {
     if (!activeBuild) return;
     const now = Date.now();
@@ -503,6 +528,7 @@ export function BuildStudio({
               ascending for same-kind tie-break. */}
           <FleetRailZone
             buildRows={buildRows}
+            epicRollups={rollupRows}
             activeBuildId={activeBuild?.buildId ?? null}
             governedBacklogEnabled={governedBacklogEnabled}
             isDevEnvironment={isDevEnvironment}
@@ -510,6 +536,7 @@ export function BuildStudio({
               setActiveBuild(build);
               setSidebarOpen(true);
             }}
+            onSelectBuildById={selectBuildById}
             onDeleteBuild={(build) => {
               if (isDevEnvironment) return;
               if (!confirm(`Delete "${build.title}"?`)) return;
@@ -694,7 +721,7 @@ export function BuildStudio({
                       activeBuild,
                       progressVisibility,
                       drawerInitialSectionId,
-                      buildRows,
+                      supervisedBuildRows,
                     )}
                   />
                 </div>
@@ -738,7 +765,7 @@ export function BuildStudio({
       {/* Footer — single shared OpenSandboxButton (sandbox is shared across
           all in-flight builds; surfacing one link labeled with the current
           driver replaces the dishonest per-build Preview tab). */}
-      <BuildStudioFooter builds={buildRows} />
+      <BuildStudioFooter builds={supervisedBuildRows} />
     </div>
   );
 }
@@ -1135,21 +1162,27 @@ function BuildFailedBanner({ execState }: { execState: BuildExecutionState | nul
 
 function FleetRailZone({
   buildRows,
+  epicRollups,
   activeBuildId,
   governedBacklogEnabled,
   isDevEnvironment,
   onSelectBuild,
+  onSelectBuildById,
   onDeleteBuild,
   onOpenQueueDrawer,
 }: {
   buildRows: FeatureBuildRow[];
+  epicRollups: EpicRollupView[];
   activeBuildId: string | null;
   governedBacklogEnabled: boolean;
   isDevEnvironment: boolean;
   onSelectBuild: (build: FeatureBuildRow) => void;
+  onSelectBuildById: (buildId: string) => void | Promise<void>;
   onDeleteBuild: (build: FeatureBuildRow) => void;
   onOpenQueueDrawer: () => void;
 }) {
+  const [expandedEpicIds, setExpandedEpicIds] = useState<Set<string>>(() => new Set());
+
   // Derive per-row fleet entries: queueState + needsAttention + lifecycle.
   // queueState falls back to phase-based heuristics until the concurrency
   // dispatcher exposes real values (its thread owns that surface).
@@ -1189,11 +1222,37 @@ function FleetRailZone({
   // header semantic — the list should only show inflight work by default.
   const activeEntries = sorted.filter((e) => e.build.phase !== "complete");
   const completedEntries = sorted.filter((e) => e.build.phase === "complete");
+  const activeEpicRollups = epicRollups.filter((rollup) => rollup.status !== "complete");
+  const completedEpicRollups = epicRollups.filter((rollup) => rollup.status === "complete");
+  const completedItemCount = completedEntries.length + completedEpicRollups.length;
   const [showCompleted, setShowCompleted] = useState(false);
 
   const counts = deriveFleetCounts(entries.map((e) => e.queueState));
 
-  if (buildRows.length === 0) {
+  useEffect(() => {
+    if (!activeBuildId) return;
+    const activeEpic = epicRollups.find((rollup) =>
+      rollup.children.some((child) => child.buildId === activeBuildId),
+    );
+    if (!activeEpic) return;
+    setExpandedEpicIds((previous) => {
+      if (previous.has(activeEpic.epicId)) return previous;
+      const next = new Set(previous);
+      next.add(activeEpic.epicId);
+      return next;
+    });
+  }, [activeBuildId, epicRollups]);
+
+  const toggleEpic = useCallback((epicId: string) => {
+    setExpandedEpicIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(epicId)) next.delete(epicId);
+      else next.add(epicId);
+      return next;
+    });
+  }, []);
+
+  if (buildRows.length === 0 && epicRollups.length === 0) {
     return (
       <div className="flex-1 overflow-auto p-2">
         <div className="p-6 text-center">
@@ -1233,12 +1292,24 @@ function FleetRailZone({
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
       </button>
       <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
+        {activeEpicRollups.map((rollup, idx) => (
+          <li key={rollup.epicId}>
+            <EpicRollupListItem
+              rollup={rollup}
+              activeBuildId={activeBuildId}
+              expanded={expandedEpicIds.has(rollup.epicId)}
+              index={idx}
+              onToggle={() => toggleEpic(rollup.epicId)}
+              onSelectBuild={onSelectBuildById}
+            />
+          </li>
+        ))}
         {activeEntries.map((entry, idx) => (
           <li key={entry.build.buildId}>
             <BuildListItem
               build={entry.build}
               active={activeBuildId === entry.build.buildId}
-              index={idx}
+              index={activeEpicRollups.length + idx}
               lifecycleLabel={entry.lifecycleLabel}
               isDevEnvironment={isDevEnvironment}
               density="fleet"
@@ -1249,12 +1320,12 @@ function FleetRailZone({
             />
           </li>
         ))}
-        {activeEntries.length === 0 && (
+        {activeEpicRollups.length === 0 && activeEntries.length === 0 && (
           <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
             No active builds. Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
           </li>
         )}
-        {completedEntries.length > 0 && (
+        {completedItemCount > 0 && (
           <>
             <li>
               <button
@@ -1266,7 +1337,7 @@ function FleetRailZone({
                 className="mt-2 flex w-full items-center justify-between rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-muted)] transition-colors hover:bg-[var(--dpf-surface-3)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
               >
                 <span>
-                  {completedEntries.length} completed build{completedEntries.length === 1 ? "" : "s"}
+                  {completedItemCount} completed build{completedItemCount === 1 ? "" : "s"}
                 </span>
                 <span aria-hidden="true" className="text-[var(--dpf-muted)]">
                   {showCompleted ? "▾" : "▸"}
@@ -1276,12 +1347,24 @@ function FleetRailZone({
             {showCompleted && (
               <li id="fleet-rail-completed-list" className="contents">
                 <ul className="flex flex-col gap-0.5">
+                  {completedEpicRollups.map((rollup, idx) => (
+                    <li key={rollup.epicId}>
+                      <EpicRollupListItem
+                        rollup={rollup}
+                        activeBuildId={activeBuildId}
+                        expanded={expandedEpicIds.has(rollup.epicId)}
+                        index={activeEpicRollups.length + activeEntries.length + idx}
+                        onToggle={() => toggleEpic(rollup.epicId)}
+                        onSelectBuild={onSelectBuildById}
+                      />
+                    </li>
+                  ))}
                   {completedEntries.map((entry, idx) => (
                     <li key={entry.build.buildId}>
                       <BuildListItem
                         build={entry.build}
                         active={activeBuildId === entry.build.buildId}
-                        index={activeEntries.length + idx}
+                        index={activeEpicRollups.length + activeEntries.length + completedEpicRollups.length + idx}
                         lifecycleLabel={entry.lifecycleLabel}
                         isDevEnvironment={isDevEnvironment}
                         density="fleet"

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -8,6 +8,7 @@ import {
   normalizeHappyPathState,
   type FeatureBuildRow,
 } from "@/lib/feature-build-types";
+import type { EpicRollupView } from "@/lib/build/epic-rollup";
 import type { PortalContextEnvelope } from "@/lib/portal-context";
 
 afterEach(cleanup);
@@ -162,6 +163,53 @@ function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
   };
 }
 
+function makeEpicRollup(overrides: Partial<EpicRollupView> = {}): EpicRollupView {
+  return {
+    epicId: "EP-TRUCK-STOCK",
+    title: "Truck stock tracker",
+    updatedAt: new Date("2026-05-25T12:00:00Z"),
+    status: "in-progress",
+    backlogItems: [
+      { itemId: "BI-ORIGIN", title: "Track truck parts", status: "in-progress", isOriginating: true },
+      { itemId: "BI-RESTOCK", title: "Surface restock needs", status: "open", isOriginating: false },
+    ],
+    backlogSummary: "2 backlog items",
+    childPhases: [
+      { phase: "complete", count: 1 },
+      { phase: "build", count: 1 },
+      { phase: "plan", count: 1 },
+    ],
+    children: [
+      {
+        buildId: "FB-READ",
+        title: "Truck and parts read",
+        phase: "complete",
+        childOrder: 1,
+        waitingOn: [],
+        updatedAt: new Date("2026-05-25T10:00:00Z"),
+      },
+      {
+        buildId: "FB-USAGE",
+        title: "Record usage",
+        phase: "build",
+        childOrder: 2,
+        waitingOn: [],
+        updatedAt: new Date("2026-05-25T11:00:00Z"),
+      },
+      {
+        buildId: "FB-LOW",
+        title: "Low-stock surfacing",
+        phase: "plan",
+        childOrder: 3,
+        waitingOn: ["Record usage"],
+        updatedAt: new Date("2026-05-25T11:30:00Z"),
+      },
+    ],
+    rollupSummary: "1 of 3 done \u00b7 1 in build \u00b7 1 waiting",
+    ...overrides,
+  };
+}
+
 describe("BuildStudio active-build header layout", () => {
   it("renders the empty state instead of crashing when server data arrays are missing", () => {
     const html = renderToStaticMarkup(
@@ -176,6 +224,25 @@ describe("BuildStudio active-build header layout", () => {
 
     expect(html).toContain("Product Development Studio");
     expect(html).toContain("No builds yet");
+  });
+
+  it("renders execution epics as fleet rows even when their child builds are no longer flat rows", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[]}
+        epicRollups={[makeEpicRollup()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain("Truck stock tracker");
+    expect(html).toContain("1 of 3 done");
+    expect(html).toContain("2 backlog items");
+    expect(html).not.toContain("No builds yet");
+    expect(html).not.toContain("Low-stock surfacing");
   });
 
   it("keeps the active-build title and metadata lane shrinkable for long submission branches", () => {

--- a/apps/web/components/build/EpicRollupListItem.test.tsx
+++ b/apps/web/components/build/EpicRollupListItem.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { EpicRollupListItem } from "./EpicRollupListItem";
+import type { EpicRollupView } from "@/lib/build/epic-rollup";
+
+function makeRollup(overrides: Partial<EpicRollupView> = {}): EpicRollupView {
+  return {
+    epicId: "EP-TRUCK-STOCK",
+    title: "Truck stock tracker",
+    updatedAt: new Date("2026-05-25T12:00:00Z"),
+    status: "in-progress",
+    backlogItems: [
+      { itemId: "BI-ORIGIN", title: "Track truck parts", status: "in-progress", isOriginating: true },
+      { itemId: "BI-RESTOCK", title: "Surface restock needs", status: "open", isOriginating: false },
+    ],
+    backlogSummary: "2 backlog items",
+    childPhases: [
+      { phase: "complete", count: 1 },
+      { phase: "build", count: 1 },
+      { phase: "plan", count: 1 },
+    ],
+    children: [
+      {
+        buildId: "FB-READ",
+        title: "Truck and parts read",
+        phase: "complete",
+        childOrder: 1,
+        waitingOn: [],
+        updatedAt: new Date("2026-05-25T10:00:00Z"),
+      },
+      {
+        buildId: "FB-USAGE",
+        title: "Record usage",
+        phase: "build",
+        childOrder: 2,
+        waitingOn: [],
+        updatedAt: new Date("2026-05-25T11:00:00Z"),
+      },
+      {
+        buildId: "FB-LOW",
+        title: "Low-stock surfacing",
+        phase: "plan",
+        childOrder: 3,
+        waitingOn: ["Record usage"],
+        updatedAt: new Date("2026-05-25T11:30:00Z"),
+      },
+    ],
+    rollupSummary: "1 of 3 done \u00b7 1 in build \u00b7 1 waiting",
+    ...overrides,
+  };
+}
+
+describe("EpicRollupListItem", () => {
+  it("renders a collapsed epic bridge row with backlog and child-build rollup", () => {
+    const html = renderToStaticMarkup(
+      <EpicRollupListItem
+        rollup={makeRollup()}
+        activeBuildId={null}
+        expanded={false}
+        index={0}
+        onToggle={vi.fn()}
+        onSelectBuild={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Truck stock tracker");
+    expect(html).toContain("1 of 3 done");
+    expect(html).toContain("2 backlog items");
+    expect(html).toContain("Updated May 25");
+    expect(html).not.toContain("Low-stock surfacing");
+  });
+
+  it("renders expanded child rows with phase badges and waiting-on titles", () => {
+    const html = renderToStaticMarkup(
+      <EpicRollupListItem
+        rollup={makeRollup()}
+        activeBuildId="FB-LOW"
+        expanded
+        index={0}
+        onToggle={vi.fn()}
+        onSelectBuild={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Truck and parts read");
+    expect(html).toContain("Record usage");
+    expect(html).toContain("Low-stock surfacing");
+    expect(html).toContain("Waiting on: Record usage");
+    expect(html).toContain("data-active-child=\"true\"");
+    expect(html).toContain("Plan");
+  });
+});

--- a/apps/web/components/build/EpicRollupListItem.tsx
+++ b/apps/web/components/build/EpicRollupListItem.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { EpicRollupView } from "@/lib/build/epic-rollup";
+import { PHASE_LABELS, type BuildPhase } from "@/lib/feature-build-types";
+
+type EpicRollupListItemProps = {
+  rollup: EpicRollupView;
+  activeBuildId: string | null;
+  expanded: boolean;
+  index: number;
+  onToggle: () => void;
+  onSelectBuild: (buildId: string) => void;
+};
+
+export function EpicRollupListItem({
+  rollup,
+  activeBuildId,
+  expanded,
+  index,
+  onToggle,
+  onSelectBuild,
+}: EpicRollupListItemProps) {
+  const Icon = expanded ? ChevronDown : ChevronRight;
+  const activeChildCount = rollup.children.filter((child) => child.buildId === activeBuildId).length;
+
+  return (
+    <div
+      data-testid="build-studio-epic-rollup"
+      data-active-epic={activeChildCount > 0 ? "true" : "false"}
+      className="animate-slide-up"
+      style={{
+        animationDelay: `${index * 30}ms`,
+        animationFillMode: "backwards",
+      }}
+    >
+      <div
+        className={[
+          "group",
+          "relative",
+          "flex",
+          "items-center",
+          "gap-2",
+          "rounded-md",
+          "border-l-4",
+          activeChildCount > 0 ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]" : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]",
+          "px-2",
+          "py-1",
+          "min-h-11",
+          "hover:bg-[var(--dpf-surface-2)]",
+        ].join(" ")}
+      >
+        <button
+          type="button"
+          aria-label={`${expanded ? "Collapse" : "Expand"} epic ${rollup.title}`}
+          aria-expanded={expanded}
+          onClick={onToggle}
+          className="grid h-5 w-5 shrink-0 cursor-pointer place-items-center rounded text-[var(--dpf-muted)] transition-colors hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
+        >
+          <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 flex-col gap-0.5 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 font-mono text-[11px] text-[var(--dpf-text)]">
+              {rollup.epicId}
+            </span>
+            <span className="min-w-0 truncate text-[11px] font-semibold text-[var(--dpf-text)]">
+              {rollup.title}
+            </span>
+          </span>
+          <span className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-[var(--dpf-muted)]">
+            <span className="min-w-0 truncate">{rollup.rollupSummary}</span>
+            <span className="shrink-0">{rollup.backlogSummary}</span>
+            <span className="shrink-0">Updated {formatUpdatedAt(rollup.updatedAt)}</span>
+          </span>
+        </button>
+      </div>
+
+      {expanded && (
+        <ul className="ml-5 mt-0.5 flex flex-col gap-0.5 border-l border-[var(--dpf-border)] pl-2">
+          {rollup.children.map((child, childIndex) => {
+            const activeChild = activeBuildId === child.buildId;
+            return (
+              <li key={child.buildId}>
+                <button
+                  type="button"
+                  aria-label={`Open build ${child.title}`}
+                  aria-pressed={activeChild}
+                  data-active-child={activeChild ? "true" : "false"}
+                  onClick={() => onSelectBuild(child.buildId)}
+                  className={[
+                    "flex",
+                    "min-h-8",
+                    "w-full",
+                    "cursor-pointer",
+                    "items-center",
+                    "gap-2",
+                    "rounded-md",
+                    "border-l-4",
+                    activeChild ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]" : "border-transparent bg-transparent",
+                    "px-2",
+                    "py-1",
+                    "text-left",
+                    "hover:bg-[var(--dpf-surface-2)]",
+                    "focus-visible:outline-2",
+                    "focus-visible:outline-[var(--dpf-accent)]",
+                    "focus-visible:outline-offset-2",
+                  ].join(" ")}
+                >
+                  <span className="w-4 shrink-0 text-right font-mono text-[10px] text-[var(--dpf-muted)]">
+                    {child.childOrder ?? childIndex + 1}
+                  </span>
+                  <PhaseBadge phase={child.phase} />
+                  <span className="min-w-0 flex-1 truncate text-[11px] text-[var(--dpf-text)]">
+                    {child.title}
+                  </span>
+                  {child.waitingOn.length > 0 && (
+                    <span className="hidden max-w-[45%] shrink truncate text-[11px] text-[var(--dpf-muted)] xl:inline">
+                      Waiting on: {child.waitingOn.join(", ")}
+                    </span>
+                  )}
+                </button>
+                {child.waitingOn.length > 0 && (
+                  <p className="ml-[4.75rem] mt-0.5 truncate text-[10px] text-[var(--dpf-muted)] xl:hidden">
+                    Waiting on: {child.waitingOn.join(", ")}
+                  </p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function PhaseBadge({ phase }: { phase: BuildPhase }) {
+  return (
+    <span className="inline-flex h-5 shrink-0 items-center rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-1.5 text-[10px] font-semibold text-[var(--dpf-muted)]">
+      {PHASE_LABELS[phase] ?? phase}
+    </span>
+  );
+}
+
+function formatUpdatedAt(value: Date | string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}

--- a/apps/web/lib/build/epic-rollup.test.ts
+++ b/apps/web/lib/build/epic-rollup.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveEpicRollup } from "./epic-rollup";
+
+describe("deriveEpicRollup", () => {
+  it("bridges backlog items to ordered child builds and derives waiting-on titles", () => {
+    const rollup = deriveEpicRollup({
+      epic: {
+        id: "epic-row-1",
+        epicId: "EP-TRUCK-STOCK",
+        title: "Truck stock tracker",
+        updatedAt: new Date("2026-05-25T12:00:00Z"),
+        originatingBacklogItemId: "bi-row-origin",
+        items: [
+          { id: "bi-row-origin", itemId: "BI-ORIGIN", title: "Track truck parts", status: "in-progress" },
+          { id: "bi-row-restock", itemId: "BI-RESTOCK", title: "Surface restock needs", status: "open" },
+        ],
+        featureBuilds: [
+          {
+            id: "fb-low-stock-row",
+            buildId: "FB-LOW",
+            title: "Low-stock surfacing",
+            phase: "plan",
+            childOrder: 3,
+            updatedAt: new Date("2026-05-25T11:30:00Z"),
+          },
+          {
+            id: "fb-read-row",
+            buildId: "FB-READ",
+            title: "Truck and parts read",
+            phase: "complete",
+            childOrder: 1,
+            updatedAt: new Date("2026-05-25T10:00:00Z"),
+          },
+          {
+            id: "fb-usage-row",
+            buildId: "FB-USAGE",
+            title: "Record usage",
+            phase: "build",
+            childOrder: 2,
+            updatedAt: new Date("2026-05-25T11:00:00Z"),
+          },
+        ],
+        dependencies: [
+          {
+            dependentBuildId: "fb-low-stock-row",
+            dependsOnBuildId: "fb-read-row",
+          },
+          {
+            dependentBuildId: "fb-low-stock-row",
+            dependsOnBuildId: "fb-usage-row",
+          },
+        ],
+      },
+    });
+
+    expect(rollup.backlogItems).toEqual([
+      {
+        itemId: "BI-ORIGIN",
+        title: "Track truck parts",
+        status: "in-progress",
+        isOriginating: true,
+      },
+      {
+        itemId: "BI-RESTOCK",
+        title: "Surface restock needs",
+        status: "open",
+        isOriginating: false,
+      },
+    ]);
+    expect(rollup.backlogSummary).toBe("2 backlog items");
+    expect(rollup.children.map((child) => child.buildId)).toEqual(["FB-READ", "FB-USAGE", "FB-LOW"]);
+    expect(rollup.children[2]?.waitingOn).toEqual(["Record usage"]);
+    expect(rollup.rollupSummary).toBe("1 of 3 done \u00b7 1 in build \u00b7 1 waiting");
+    expect(rollup.status).toBe("in-progress");
+    expect(rollup.updatedAt).toEqual(new Date("2026-05-25T12:00:00Z"));
+  });
+
+  it("marks an epic complete when every child build is complete", () => {
+    const rollup = deriveEpicRollup({
+      epic: {
+        id: "epic-row-2",
+        epicId: "EP-COMPLETE",
+        title: "Done work",
+        updatedAt: new Date("2026-05-25T12:00:00Z"),
+        originatingBacklogItemId: null,
+        items: [],
+        featureBuilds: [
+          {
+            id: "fb-a-row",
+            buildId: "FB-A",
+            title: "First child",
+            phase: "complete",
+            childOrder: 1,
+            updatedAt: new Date("2026-05-25T12:00:00Z"),
+          },
+          {
+            id: "fb-b-row",
+            buildId: "FB-B",
+            title: "Second child",
+            phase: "complete",
+            childOrder: 2,
+            updatedAt: new Date("2026-05-25T12:00:00Z"),
+          },
+        ],
+        dependencies: [],
+      },
+    });
+
+    expect(rollup.status).toBe("complete");
+    expect(rollup.rollupSummary).toBe("2 of 2 done");
+  });
+});

--- a/apps/web/lib/build/epic-rollup.ts
+++ b/apps/web/lib/build/epic-rollup.ts
@@ -1,0 +1,178 @@
+import type { BuildPhase } from "@/lib/feature-build-types";
+
+export type EpicRollupBacklogItemInput = {
+  id: string;
+  itemId: string;
+  title: string;
+  status: string;
+};
+
+export type EpicRollupBuildInput = {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: BuildPhase;
+  childOrder: number | null;
+  updatedAt: Date | string;
+};
+
+export type EpicRollupDependencyInput = {
+  dependentBuildId: string;
+  dependsOnBuildId: string;
+};
+
+export type EpicRollupInput = {
+  epic: {
+    id: string;
+    epicId: string;
+    title: string;
+    updatedAt: Date | string;
+    originatingBacklogItemId: string | null;
+    items: EpicRollupBacklogItemInput[];
+    featureBuilds: EpicRollupBuildInput[];
+    dependencies: EpicRollupDependencyInput[];
+  };
+};
+
+export type EpicRollupView = {
+  epicId: string;
+  title: string;
+  updatedAt: Date;
+  status: "ready" | "in-progress" | "complete" | "blocked" | "needs-attention";
+  backlogItems: Array<{
+    itemId: string;
+    title: string;
+    status: string;
+    isOriginating: boolean;
+  }>;
+  backlogSummary: string;
+  childPhases: Array<{ phase: BuildPhase; count: number }>;
+  children: Array<{
+    buildId: string;
+    title: string;
+    phase: BuildPhase;
+    childOrder: number | null;
+    waitingOn: string[];
+    updatedAt: Date;
+  }>;
+  rollupSummary: string;
+};
+
+const PHASE_LABELS: Partial<Record<BuildPhase, string>> = {
+  ideate: "in ideate",
+  plan: "planning",
+  build: "in build",
+  review: "in review",
+  ship: "ready to ship",
+  failed: "failed",
+};
+
+const PHASE_ORDER: BuildPhase[] = ["ideate", "plan", "build", "review", "ship", "complete", "failed"];
+
+export function deriveEpicRollup({ epic }: EpicRollupInput): EpicRollupView {
+  const buildsById = new Map(epic.featureBuilds.map((build) => [build.id, build]));
+  const sortedChildren = [...epic.featureBuilds].sort((a, b) => {
+    const orderA = a.childOrder ?? Number.MAX_SAFE_INTEGER;
+    const orderB = b.childOrder ?? Number.MAX_SAFE_INTEGER;
+    if (orderA !== orderB) return orderA - orderB;
+    return a.buildId.localeCompare(b.buildId);
+  });
+
+  const dependenciesByDependent = new Map<string, EpicRollupDependencyInput[]>();
+  for (const dependency of epic.dependencies) {
+    const existing = dependenciesByDependent.get(dependency.dependentBuildId) ?? [];
+    existing.push(dependency);
+    dependenciesByDependent.set(dependency.dependentBuildId, existing);
+  }
+
+  const children = sortedChildren.map((build) => {
+    const waitingOn = build.phase === "complete"
+      ? []
+      : (dependenciesByDependent.get(build.id) ?? [])
+        .flatMap((dependency) => {
+          const dependencyBuild = buildsById.get(dependency.dependsOnBuildId);
+          return dependencyBuild && dependencyBuild.phase !== "complete"
+            ? [dependencyBuild.title]
+            : [];
+        });
+
+    return {
+      buildId: build.buildId,
+      title: build.title,
+      phase: build.phase,
+      childOrder: build.childOrder,
+      waitingOn,
+      updatedAt: new Date(build.updatedAt),
+    };
+  });
+
+  const childPhases = PHASE_ORDER.flatMap((phase) => {
+    const count = children.filter((child) => child.phase === phase).length;
+    return count === 0 ? [] : [{ phase, count }];
+  });
+
+  const waitingCount = children.filter((child) => child.waitingOn.length > 0).length;
+  const doneCount = children.filter((child) => child.phase === "complete").length;
+  const rollupSummary = formatRollupSummary({ children, doneCount, waitingCount });
+
+  return {
+    epicId: epic.epicId,
+    title: epic.title,
+    updatedAt: new Date(epic.updatedAt),
+    status: deriveEpicStatus(children, waitingCount),
+    backlogItems: epic.items.map((item) => ({
+      itemId: item.itemId,
+      title: item.title,
+      status: item.status,
+      isOriginating: item.id === epic.originatingBacklogItemId,
+    })),
+    backlogSummary: formatBacklogSummary(epic.items.length),
+    childPhases,
+    children,
+    rollupSummary,
+  };
+}
+
+function deriveEpicStatus(
+  children: EpicRollupView["children"],
+  waitingCount: number,
+): EpicRollupView["status"] {
+  if (children.length === 0) return "ready";
+  if (children.some((child) => child.phase === "failed")) return "needs-attention";
+  if (children.every((child) => child.phase === "complete")) return "complete";
+  if (waitingCount > 0 && children.every((child) => child.phase === "complete" || child.waitingOn.length > 0)) {
+    return "blocked";
+  }
+  return "in-progress";
+}
+
+function formatRollupSummary({
+  children,
+  doneCount,
+  waitingCount,
+}: {
+  children: EpicRollupView["children"];
+  doneCount: number;
+  waitingCount: number;
+}): string {
+  const total = children.length;
+  if (total === 0) return "No child builds";
+
+  const parts = [`${doneCount} of ${total} done`];
+  for (const phase of PHASE_ORDER) {
+    if (phase === "complete") continue;
+    const count = children.filter((child) => child.phase === phase && child.waitingOn.length === 0).length;
+    if (count === 0) continue;
+    const label = PHASE_LABELS[phase] ?? phase;
+    parts.push(`${count} ${label}`);
+  }
+  if (waitingCount > 0) {
+    parts.push(`${waitingCount} waiting`);
+  }
+  return parts.join(" \u00b7 ");
+}
+
+function formatBacklogSummary(count: number): string {
+  if (count === 0) return "No backlog items";
+  return `${count} backlog item${count === 1 ? "" : "s"}`;
+}

--- a/apps/web/lib/explore/feature-build-data.test.ts
+++ b/apps/web/lib/explore/feature-build-data.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  Prisma: {
+    DbNull: { kind: "DbNull" },
+  },
   prisma: {
     featureBuild: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    epic: {
       findMany: vi.fn(),
     },
     platformDevConfig: {
@@ -26,6 +32,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dpf/db", () => ({
   prisma: mocks.prisma,
+  Prisma: mocks.Prisma,
 }));
 
 vi.mock("@/lib/decision-perspective/types", () => ({
@@ -45,8 +52,93 @@ vi.mock("@/lib/design-intelligence", () => ({
   generateDesignSystem: vi.fn(() => "Generated design system"),
 }));
 
-import { prisma } from "@dpf/db";
-import { getFeatureBuildForContext } from "./feature-build-data";
+import { Prisma, prisma } from "@dpf/db";
+import {
+  getExecutionEpicRollups,
+  getFeatureBuildForContext,
+  getFeatureBuilds,
+} from "./feature-build-data";
+
+describe("getFeatureBuilds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.featureBuild.findMany).mockResolvedValue([] as never);
+  });
+
+  it("loads only undecomposed top-level builds for the flat fleet rows", async () => {
+    await getFeatureBuilds("user-phase5-flat-builds");
+
+    expect(prisma.featureBuild.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          phase: { not: "failed" },
+          parentEpicId: null,
+          supersededByEpicId: null,
+        },
+      }),
+    );
+  });
+});
+
+describe("getExecutionEpicRollups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads execution epics as the bridge across backlog items, child builds, and dependencies", async () => {
+    vi.mocked(prisma.epic.findMany).mockResolvedValue([
+      {
+        id: "epic-row-1",
+        epicId: "EP-TRUCK-STOCK",
+        title: "Truck stock tracker",
+        updatedAt: new Date("2026-05-25T12:00:00Z"),
+        originatingBacklogItemId: "bi-row-origin",
+        items: [
+          { id: "bi-row-origin", itemId: "BI-ORIGIN", title: "Track truck parts", status: "in-progress" },
+        ],
+        featureBuilds: [
+          {
+            id: "fb-read-row",
+            buildId: "FB-READ",
+            title: "Truck and parts read",
+            phase: "complete",
+            childOrder: 1,
+            updatedAt: new Date("2026-05-25T10:00:00Z"),
+          },
+          {
+            id: "fb-usage-row",
+            buildId: "FB-USAGE",
+            title: "Record usage",
+            phase: "plan",
+            childOrder: 2,
+            updatedAt: new Date("2026-05-25T11:00:00Z"),
+          },
+        ],
+        dependencies: [
+          {
+            dependentBuildId: "fb-usage-row",
+            dependsOnBuildId: "fb-read-row",
+          },
+        ],
+      },
+    ] as never);
+
+    const rollups = await getExecutionEpicRollups("user-phase5-epics");
+
+    expect(prisma.epic.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          designDoc: { not: Prisma.DbNull },
+          featureBuilds: { some: {} },
+        },
+        orderBy: { updatedAt: "desc" },
+      }),
+    );
+    expect(rollups[0]?.epicId).toBe("EP-TRUCK-STOCK");
+    expect(rollups[0]?.backlogItems[0]?.itemId).toBe("BI-ORIGIN");
+    expect(rollups[0]?.children.map((child) => child.buildId)).toEqual(["FB-READ", "FB-USAGE"]);
+  });
+});
 
 describe("getFeatureBuildForContext taxonomy context", () => {
   beforeEach(() => {

--- a/apps/web/lib/explore/feature-build-data.ts
+++ b/apps/web/lib/explore/feature-build-data.ts
@@ -1,15 +1,62 @@
 // apps/web/lib/feature-build-data.ts
 import { cache } from "react";
-import { prisma } from "@dpf/db";
+import { Prisma, prisma } from "@dpf/db";
 import type { FeatureBuildRow, FeatureBrief, BuildPhase, BuildDesignDoc, ReviewResult, BuildPlanDoc, TaskResult, VerificationOutput, AcceptanceCriterion, BuildDeliberationSummary } from "./feature-build-types";
 import { normalizeHappyPathState } from "./feature-build-types";
 import type { BuildContext } from "@/lib/build-agent-prompts";
 import type { AttachmentInfo } from "@/lib/agent-coworker-types";
+import { deriveEpicRollup, type EpicRollupView } from "@/lib/build/epic-rollup";
 import { PLAN_READINESS_DOMAIN_CLASS } from "@/lib/decision-perspective/types";
 import {
   DECISION_INTERACTION_GATE_SELECT,
   decisionInteractionRowToGateView,
 } from "@/lib/decision-perspective/view-model";
+
+const EXECUTION_EPIC_ROLLUP_SELECT = {
+  id: true,
+  epicId: true,
+  title: true,
+  updatedAt: true,
+  originatingBacklogItemId: true,
+  items: {
+    orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
+    select: {
+      id: true,
+      itemId: true,
+      title: true,
+      status: true,
+    },
+  },
+  originatingBacklogItem: {
+    select: {
+      id: true,
+      itemId: true,
+      title: true,
+      status: true,
+    },
+  },
+  featureBuilds: {
+    orderBy: [{ childOrder: "asc" }, { updatedAt: "desc" }],
+    select: {
+      id: true,
+      buildId: true,
+      title: true,
+      phase: true,
+      childOrder: true,
+      updatedAt: true,
+    },
+  },
+  dependencies: {
+    select: {
+      dependentBuildId: true,
+      dependsOnBuildId: true,
+    },
+  },
+} satisfies Prisma.EpicSelect;
+
+type ExecutionEpicRollupRow = Prisma.EpicGetPayload<{
+  select: typeof EXECUTION_EPIC_ROLLUP_SELECT;
+}>;
 
 export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBuildRow[]> => {
   // Build Studio is internal-cockpit-only and DPF is single-org-per-install
@@ -25,7 +72,11 @@ export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBui
   // PR for the same reason.
   void userId;
   const rows = await prisma.featureBuild.findMany({
-    where: { phase: { not: "failed" } },
+    where: {
+      phase: { not: "failed" },
+      parentEpicId: null,
+      supersededByEpicId: null,
+    },
     orderBy: { updatedAt: "desc" },
     select: {
       id: true,
@@ -126,6 +177,41 @@ export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBui
     phaseHandoffs: null,
     decisionInteraction: decisionInteractionRowToGateView(r.decisionInteractions[0] ?? null),
   }));
+});
+
+export const getExecutionEpicRollups = cache(async (userId: string): Promise<EpicRollupView[]> => {
+  void userId;
+  const rows = await prisma.epic.findMany({
+    where: {
+      designDoc: { not: Prisma.DbNull },
+      featureBuilds: { some: {} },
+    },
+    orderBy: { updatedAt: "desc" },
+    select: EXECUTION_EPIC_ROLLUP_SELECT,
+  }) as ExecutionEpicRollupRow[];
+
+  return rows.map((row) => {
+    const items = [...row.items];
+    if (row.originatingBacklogItem && !items.some((item) => item.id === row.originatingBacklogItem?.id)) {
+      items.unshift(row.originatingBacklogItem);
+    }
+
+    return deriveEpicRollup({
+      epic: {
+        id: row.id,
+        epicId: row.epicId,
+        title: row.title,
+        updatedAt: row.updatedAt,
+        originatingBacklogItemId: row.originatingBacklogItemId,
+        items,
+        featureBuilds: row.featureBuilds.map((build) => ({
+          ...build,
+          phase: build.phase as BuildPhase,
+        })),
+        dependencies: row.dependencies,
+      },
+    });
+  });
 });
 
 export const getFeatureBuildById = cache(async (buildId: string): Promise<FeatureBuildRow | null> => {


### PR DESCRIPTION
## Summary

- Adds a pure Epic rollup model for execution-organizational Epics, including child phase counts and waiting-on dependency titles.
- Updates `/build` data loading so superseded originals and child builds are no longer flat top-level rows, while execution Epics render as grouped fleet rows.
- Adds an expandable Epic rollup row with inline child FeatureBuild rows and preserves direct child-build selection from deep links.

## Verification

- `pnpm --filter web exec vitest run lib/build/ components/build/`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`
- Authenticated Playwright smoke against worktree production server at `http://127.0.0.1:3015/build` rendered `build-studio-shell=1` and `fleet-rail-body=1`. The live install had no execution Epic rows, so expanded Epic-row behavior is covered by unit/render tests.

## Notes

- Build completed with existing Edge-runtime warnings around platform version/discovery imports; no Phase 5 build errors.
- BI: BI-2E6CC391. Epics: EP-BUILD-STUDIO, EP-9FC5D2FD, EP-REDUCTION-GEAR-ARCH.
