### PR TITLE
fix(edge-node): share heartbeat state updates

### DIFF
--- a/services/edge-node/src/__tests__/heartbeat.test.ts
+++ b/services/edge-node/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuthorityApiClient } from "../api-client";
+import type { EdgeNodeConfig } from "../config";
+import { runHeartbeatLoop } from "../heartbeat";
+import type { EdgeNodeState } from "../state";
+
+function makeConfig(stateDir: string): EdgeNodeConfig {
+  return {
+    authorityUrl: "http://test-authority",
+    edgeNodeName: "test-edge",
+    platform: "linux",
+    installMode: "container-host",
+    version: "0.1.0-test",
+    stateDir,
+    bootstrapToken: undefined,
+  };
+}
+
+function makeState(overrides: Partial<EdgeNodeState> = {}): EdgeNodeState {
+  return {
+    nodeId: "edge_test",
+    nodeToken: "dpfedge_TESTTOKEN",
+    enrolledAt: "2026-05-12T00:00:00.000Z",
+    heartbeatIntervalSec: 60,
+    sweepIntervalSec: 300,
+    acceptedCapabilities: ["discovery.network"],
+    trustState: "pending",
+    ...overrides,
+  };
+}
+
+function makeApi(heartbeat: AuthorityApiClient["heartbeat"]): AuthorityApiClient {
+  return {
+    heartbeat,
+    enroll: vi.fn(),
+    submitDiscoveryRun: vi.fn(),
+    fetchAdapters: vi.fn(),
+  } as unknown as AuthorityApiClient;
+}
+
+describe("runHeartbeatLoop", () => {
+  it("mutates the shared state object when Authority approves the node", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "dpf-edge-heartbeat-"));
+    const state = makeState({ trustState: "pending" });
+    const api = makeApi(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        heartbeatIntervalSec: 30,
+        sweepIntervalSec: 45,
+        metricsIntervalSec: 10,
+        acceptedCapabilities: ["discovery.network", "metrics.network"],
+        trustState: "trusted",
+      }),
+    );
+
+    await runHeartbeatLoop({
+      config: makeConfig(stateDir),
+      api,
+      state,
+      sleep: async () => {},
+      maxIterations: 1,
+    });
+
+    expect(state.trustState).toBe("trusted");
+    expect(state.heartbeatIntervalSec).toBe(30);
+    expect(state.sweepIntervalSec).toBe(45);
+    expect(state.metricsIntervalSec).toBe(10);
+    expect(state.acceptedCapabilities).toEqual([
+      "discovery.network",
+      "metrics.network",
+    ]);
+  });
+});

--- a/services/edge-node/src/heartbeat.ts
+++ b/services/edge-node/src/heartbeat.ts
@@ -68,7 +68,7 @@ export async function runHeartbeatLoop(
         await saveState(config.stateDir, updated);
         log("info", `Heartbeat: state changed (trustState=${updated.trustState}).`);
       }
-      state = updated;
+      Object.assign(state, updated);
 
       // If Authority revoked us mid-loop, clear local state and
       // exit. Operator must re-enroll explicitly.


### PR DESCRIPTION
## Summary
- keep the Edge Node heartbeat loop mutating the shared state object instead of replacing its local reference
- add a regression test for pending -> trusted Authority approval so sweep/metrics loops observe the approval without a restart

## Verification
- pnpm --filter dpf-edge-node exec vitest run src/__tests__/heartbeat.test.ts
- pnpm --filter dpf-edge-node test
- pnpm --filter dpf-edge-node typecheck
- pnpm --filter dpf-edge-node build
- pnpm --filter web build
- git diff --check
- docker compose --env-file D:\DPF\.env -p dpf -f D:\DPF-edge-node-state-sync\docker-compose.yml -f D:\DPF-edge-node-state-sync\docker-compose.edge.yml build edge-node
- docker compose --env-file D:\DPF\.env -p dpf -f D:\DPF-edge-node-state-sync\docker-compose.yml -f D:\DPF-edge-node-state-sync\docker-compose.edge.yml up -d --no-deps --force-recreate edge-node
- verified dpf-edge-node-1 is running/healthy and submitted completed DiscoveryRun 517cb9d7-a029-4468-bd40-2797f56cb953