### PR TITLE
feat(build): gate decomposed child dependencies

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -105,7 +105,7 @@ vi.mock("next/cache", () => ({
 }));
 
 import { revalidatePath } from "next/cache";
-import { approveBuildStart, advanceBuildPhase, createFeatureBuild, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
+import { approveBuildStart, advanceBuildPhase, completeBuild, createFeatureBuild, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
 
 describe("governed build start approvals", () => {
   beforeEach(() => {
@@ -655,6 +655,69 @@ describe("governed build start approvals", () => {
     );
   });
 
+  it("advanceBuildPhase blocks child implementation while an upstream sibling is unfinished", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      id: "build-row-usage",
+      buildId: "FB-USAGE",
+      title: "Record usage",
+      phase: "plan",
+      parentEpicId: "epic-row-1",
+      dependenciesOut: [
+        {
+          dependsOn: {
+            id: "build-row-read",
+            buildId: "FB-READ",
+            title: "Truck and parts read",
+            phase: "build",
+          },
+        },
+      ],
+      createdById: "user-1",
+      originatingBacklogItemId: "backlog-row-1",
+      draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+      designDoc: { problemStatement: "Record parts usage" },
+      designReview: { decision: "pass", summary: "ok", issues: [] },
+      plan: {
+        happyPathState: {
+          intake: {
+            status: "ready",
+            taxonomyNodeId: "taxonomy-1",
+            backlogItemId: "BI-USAGE",
+            epicId: "EP-TRUCK",
+            constrainedGoal: "Record usage",
+            failureReason: null,
+          },
+        },
+      },
+      brief: { acceptanceCriteria: ["A technician can mark a part used."] },
+      buildPlan: {
+        fileStructure: [{ path: "apps/web/components/build/BuildStudio.tsx", action: "modify", purpose: "Record usage" }],
+        tasks: [{ title: "Usage", testFirst: "Add test", implement: "Patch UI", verify: "Run checks" }],
+      },
+      planReview: { decision: "pass", summary: "ready", issues: [] },
+      taskResults: null,
+      verificationOut: null,
+      acceptanceMet: null,
+      uxTestResults: null,
+      uxVerificationStatus: null,
+      sandboxId: null,
+      deliberationSummary: null,
+    });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({ governedBacklogEnabled: true });
+
+    await expect(advanceBuildPhase("FB-USAGE", "build")).rejects.toThrow(
+      "Waiting on: Truck and parts read",
+    );
+
+    expect(mockEvaluateBuildStudioPlanAdvancementGate).not.toHaveBeenCalled();
+    expect(mockPrisma.featureBuild.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { buildId: "FB-USAGE" },
+        data: expect.objectContaining({ phase: "build" }),
+      }),
+    );
+  });
+
   it("advanceBuildPhase blocks plan to build when WWMD escalates or defers", async () => {
     mockPrisma.featureBuild.findUnique.mockResolvedValue({
       id: "build-row-1",
@@ -731,6 +794,62 @@ describe("governed build start approvals", () => {
       }),
     );
     expect(mockQueueBuildReviewVerification).toHaveBeenCalledWith("FB-789");
+  });
+
+  it("completeBuild records ready dependent children after their upstream blockers clear", async () => {
+    mockPrisma.featureBuild.findUnique.mockImplementation(async (args) => {
+      if ((args as { select?: { dependenciesIn?: unknown } }).select?.dependenciesIn) {
+        return {
+          id: "build-row-read",
+          buildId: "FB-READ",
+          title: "Truck and parts read",
+          parentEpicId: "epic-row-1",
+          phase: "complete",
+          dependenciesIn: [
+            {
+              dependent: {
+                id: "build-row-usage",
+                buildId: "FB-USAGE",
+                title: "Record usage",
+                parentEpicId: "epic-row-1",
+                phase: "plan",
+                dependenciesOut: [
+                  {
+                    dependsOn: {
+                      id: "build-row-read",
+                      buildId: "FB-READ",
+                      title: "Truck and parts read",
+                      phase: "complete",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }
+
+      return {
+        createdById: "user-1",
+      };
+    });
+    mockPrisma.featureBuild.update.mockResolvedValue({});
+
+    await completeBuild("FB-READ");
+
+    expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith({
+      where: { buildId: "FB-READ" },
+      data: { phase: "complete" },
+    });
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          buildId: "FB-USAGE",
+          tool: "dependency:ready",
+          summary: expect.stringContaining("Ready to plan"),
+        }),
+      }),
+    );
   });
 
   it("recordBuildAcceptance persists met acceptance evidence once review checks are complete", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -22,6 +22,11 @@ import {
 import { buildDesignReviewPrompt, buildPlanReviewPrompt, parseReviewResponse } from "@/lib/build-reviewers";
 import { queueBuildReviewVerification } from "@/lib/build-review-verification-trigger";
 import { saveBuildArtifactRevision, type BuildArtifactField } from "@/lib/build/build-artifact-provenance";
+import {
+  assertFeatureBuildDependencyGate,
+  FEATURE_BUILD_DEPENDENCY_GATE_SELECT,
+  recordReadyDependentsAfterCompletion,
+} from "@/lib/build/feature-build-dependencies";
 import { evaluateBuildStudioPlanAdvancementGate } from "@/lib/decision-perspective/build-studio-gate";
 import type { ResumeBuildImplementationOutcome, ResumeImplementationMode } from "@/lib/build/progress-visibility-types";
 import {
@@ -363,6 +368,8 @@ export async function advanceBuildPhase(
       uxVerificationStatus: true,
       sandboxId: true,
       deliberationSummary: true,
+      parentEpicId: true,
+      dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
     },
   });
   if (!build) throw new Error("Build not found");
@@ -442,6 +449,15 @@ export async function advanceBuildPhase(
   }
 
   if (currentPhase === "plan" && targetPhase === "build") {
+    assertFeatureBuildDependencyGate({
+      id: build.id,
+      buildId: build.buildId,
+      title: build.title,
+      parentEpicId: build.parentEpicId,
+      phase: build.phase,
+      dependenciesOut: build.dependenciesOut,
+    });
+
     const decisionGate = await evaluateBuildStudioPlanAdvancementGate({
       db: prisma,
       build: {
@@ -1459,6 +1475,10 @@ export async function completeBuild(buildId: string): Promise<void> {
     data: { phase: "complete" },
   });
   revalidatePortalContextForBuild(buildId);
+  await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
+    console.error("[completeBuild] dependency readiness check failed:", err);
+  });
+  revalidatePath("/build");
 }
 
 // ─── Create Epic + Backlog Items for a Build ────────────────────────────────

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -14,6 +14,7 @@ import { prisma } from "@dpf/db";
 import type { BuildPhase } from "@/lib/feature-build-types";
 import { PHASE_LABELS } from "@/lib/feature-build-types";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
+import { recordReadyDependentsAfterCompletion } from "@/lib/build/feature-build-dependencies";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -442,6 +443,9 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
   await prisma.featureBuild.update({
     where: { buildId },
     data: { phase: "complete" },
+  });
+  await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
+    console.error("[reconcileBuildCompletion] dependency readiness check failed:", err);
   });
 
   // Emit phase:change so the UI updates without a full refresh. Dynamic

--- a/apps/web/lib/build/feature-build-dependencies.test.ts
+++ b/apps/web/lib/build/feature-build-dependencies.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveFeatureBuildDependencyGate,
+  deriveReadyDependentsAfterCompletion,
+} from "./feature-build-dependencies";
+
+describe("deriveFeatureBuildDependencyGate", () => {
+  it("allows top-level builds because dependency gates only apply inside execution Epics", () => {
+    const gate = deriveFeatureBuildDependencyGate({
+      id: "build-row-top",
+      buildId: "FB-TOP",
+      title: "Top-level feature",
+      parentEpicId: null,
+      phase: "plan",
+      dependenciesOut: [],
+    });
+
+    expect(gate.allowed).toBe(true);
+  });
+
+  it("blocks child builds whose upstream sibling is not complete", () => {
+    const gate = deriveFeatureBuildDependencyGate({
+      id: "build-row-dependent",
+      buildId: "FB-DEPENDENT",
+      title: "Record usage",
+      parentEpicId: "epic-row-1",
+      phase: "plan",
+      dependenciesOut: [
+        {
+          dependsOn: {
+            id: "build-row-upstream",
+            buildId: "FB-UPSTREAM",
+            title: "Truck and parts read",
+            phase: "build",
+          },
+        },
+      ],
+    });
+
+    expect(gate.allowed).toBe(false);
+    if (gate.allowed) throw new Error("unreachable");
+    expect(gate.waitingOn).toEqual([
+      {
+        buildId: "FB-UPSTREAM",
+        title: "Truck and parts read",
+        phase: "build",
+      },
+    ]);
+    expect(gate.message).toContain("Waiting on: Truck and parts read");
+    expect(gate.message).not.toContain("build-row-upstream");
+  });
+
+  it("allows child builds when every upstream sibling is complete", () => {
+    const gate = deriveFeatureBuildDependencyGate({
+      id: "build-row-dependent",
+      buildId: "FB-DEPENDENT",
+      title: "Record usage",
+      parentEpicId: "epic-row-1",
+      phase: "plan",
+      dependenciesOut: [
+        {
+          dependsOn: {
+            id: "build-row-upstream",
+            buildId: "FB-UPSTREAM",
+            title: "Truck and parts read",
+            phase: "complete",
+          },
+        },
+      ],
+    });
+
+    expect(gate.allowed).toBe(true);
+  });
+});
+
+describe("deriveReadyDependentsAfterCompletion", () => {
+  it("returns only incomplete dependents whose full dependency set is complete", () => {
+    const ready = deriveReadyDependentsAfterCompletion({
+      completedBuild: {
+        id: "build-row-read",
+        buildId: "FB-READ",
+        title: "Truck and parts read",
+        parentEpicId: "epic-row-1",
+        phase: "complete",
+      },
+      dependents: [
+        {
+          id: "build-row-usage",
+          buildId: "FB-USAGE",
+          title: "Record usage",
+          parentEpicId: "epic-row-1",
+          phase: "plan",
+          dependenciesOut: [
+            {
+              dependsOn: {
+                id: "build-row-read",
+                buildId: "FB-READ",
+                title: "Truck and parts read",
+                phase: "complete",
+              },
+            },
+          ],
+        },
+        {
+          id: "build-row-low-stock",
+          buildId: "FB-LOW",
+          title: "Low-stock surfacing",
+          parentEpicId: "epic-row-1",
+          phase: "plan",
+          dependenciesOut: [
+            {
+              dependsOn: {
+                id: "build-row-read",
+                buildId: "FB-READ",
+                title: "Truck and parts read",
+                phase: "complete",
+              },
+            },
+            {
+              dependsOn: {
+                id: "build-row-usage",
+                buildId: "FB-USAGE",
+                title: "Record usage",
+                phase: "build",
+              },
+            },
+          ],
+        },
+        {
+          id: "build-row-done",
+          buildId: "FB-DONE",
+          title: "Already shipped child",
+          parentEpicId: "epic-row-1",
+          phase: "complete",
+          dependenciesOut: [
+            {
+              dependsOn: {
+                id: "build-row-read",
+                buildId: "FB-READ",
+                title: "Truck and parts read",
+                phase: "complete",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(ready).toEqual([
+      {
+        buildId: "FB-USAGE",
+        title: "Record usage",
+        phase: "plan",
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/build/feature-build-dependencies.ts
+++ b/apps/web/lib/build/feature-build-dependencies.ts
@@ -1,0 +1,231 @@
+export type DependencyBuildPhase = string;
+
+export type FeatureBuildDependencyBuild = {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: DependencyBuildPhase;
+};
+
+export type FeatureBuildDependencyGateBuild = {
+  id: string;
+  buildId: string;
+  title: string;
+  parentEpicId: string | null;
+  phase: DependencyBuildPhase;
+  dependenciesOut: ReadonlyArray<{
+    dependsOn: FeatureBuildDependencyBuild;
+  }>;
+};
+
+export type WaitingOnDependency = {
+  buildId: string;
+  title: string;
+  phase: DependencyBuildPhase;
+};
+
+export type FeatureBuildDependencyGateResult =
+  | { allowed: true; waitingOn: [] }
+  | { allowed: false; waitingOn: WaitingOnDependency[]; message: string };
+
+export type ReadyDependentBuild = {
+  buildId: string;
+  title: string;
+  phase: DependencyBuildPhase;
+};
+
+export const FEATURE_BUILD_DEPENDENCY_READY_TOOL = "dependency:ready";
+
+export const FEATURE_BUILD_DEPENDENCY_GATE_SELECT = {
+  id: true,
+  buildId: true,
+  title: true,
+  parentEpicId: true,
+  phase: true,
+  dependenciesOut: {
+    select: {
+      dependsOn: {
+        select: {
+          id: true,
+          buildId: true,
+          title: true,
+          phase: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export const FEATURE_BUILD_DEPENDENCY_COMPLETION_SELECT = {
+  id: true,
+  buildId: true,
+  title: true,
+  parentEpicId: true,
+  phase: true,
+  dependenciesIn: {
+    select: {
+      dependent: {
+        select: {
+          id: true,
+          buildId: true,
+          title: true,
+          parentEpicId: true,
+          phase: true,
+          dependenciesOut: {
+            select: {
+              dependsOn: {
+                select: {
+                  id: true,
+                  buildId: true,
+                  title: true,
+                  phase: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+type CompletionSourceBuild = FeatureBuildDependencyBuild & {
+  parentEpicId: string | null;
+  dependenciesIn: ReadonlyArray<{
+    dependent: FeatureBuildDependencyGateBuild;
+  }>;
+};
+
+type FeatureBuildDependencyDb = {
+  featureBuild: {
+    findUnique(args: {
+      where: { buildId: string };
+      select: typeof FEATURE_BUILD_DEPENDENCY_COMPLETION_SELECT;
+    }): Promise<CompletionSourceBuild | null>;
+  };
+  buildActivity: {
+    create(args: {
+      data: {
+        buildId: string;
+        tool: string;
+        summary: string;
+      };
+    }): Promise<unknown>;
+  };
+};
+
+export function deriveFeatureBuildDependencyGate(
+  build: FeatureBuildDependencyGateBuild,
+): FeatureBuildDependencyGateResult {
+  if (build.parentEpicId == null) {
+    return { allowed: true, waitingOn: [] };
+  }
+
+  const waitingOn = build.dependenciesOut
+    .flatMap((edge) => (
+      edge.dependsOn.phase === "complete"
+        ? []
+        : [{
+            buildId: edge.dependsOn.buildId,
+            title: edge.dependsOn.title,
+            phase: edge.dependsOn.phase,
+          }]
+    ))
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  if (waitingOn.length === 0) {
+    return { allowed: true, waitingOn: [] };
+  }
+
+  const titleList = waitingOn.map((dependency) => dependency.title).join(", ");
+  return {
+    allowed: false,
+    waitingOn,
+    message: `Waiting on: ${titleList}. Complete those sibling builds before starting implementation for ${build.title}.`,
+  };
+}
+
+export function assertFeatureBuildDependencyGate(
+  build: FeatureBuildDependencyGateBuild,
+): void {
+  const gate = deriveFeatureBuildDependencyGate(build);
+  if (!gate.allowed) {
+    throw new Error(gate.message);
+  }
+}
+
+export async function assertFeatureBuildDependenciesSatisfied(args: {
+  db: {
+    featureBuild: {
+      findUnique(query: {
+        where: { buildId: string };
+        select: typeof FEATURE_BUILD_DEPENDENCY_GATE_SELECT;
+      }): Promise<FeatureBuildDependencyGateBuild | null>;
+    };
+  };
+  buildId: string;
+}): Promise<FeatureBuildDependencyGateResult> {
+  const build = await args.db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: FEATURE_BUILD_DEPENDENCY_GATE_SELECT,
+  });
+  if (!build) throw new Error("Build not found");
+
+  const gate = deriveFeatureBuildDependencyGate(build);
+  if (!gate.allowed) {
+    throw new Error(gate.message);
+  }
+  return gate;
+}
+
+export function deriveReadyDependentsAfterCompletion(args: {
+  completedBuild: FeatureBuildDependencyBuild & { parentEpicId: string | null };
+  dependents: ReadonlyArray<FeatureBuildDependencyGateBuild>;
+}): ReadyDependentBuild[] {
+  if (args.completedBuild.parentEpicId == null || args.completedBuild.phase !== "complete") {
+    return [];
+  }
+
+  return args.dependents
+    .filter((dependent) => {
+      if (dependent.parentEpicId !== args.completedBuild.parentEpicId) return false;
+      if (dependent.phase === "complete" || dependent.phase === "failed") return false;
+      return dependent.dependenciesOut.every((edge) => edge.dependsOn.phase === "complete");
+    })
+    .sort((a, b) => a.title.localeCompare(b.title))
+    .map((dependent) => ({
+      buildId: dependent.buildId,
+      title: dependent.title,
+      phase: dependent.phase,
+    }));
+}
+
+export async function recordReadyDependentsAfterCompletion(args: {
+  db: FeatureBuildDependencyDb;
+  buildId: string;
+}): Promise<ReadyDependentBuild[]> {
+  const completedBuild = await args.db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: FEATURE_BUILD_DEPENDENCY_COMPLETION_SELECT,
+  });
+  if (!completedBuild) return [];
+
+  const readyDependents = deriveReadyDependentsAfterCompletion({
+    completedBuild,
+    dependents: completedBuild.dependenciesIn.map((edge) => edge.dependent),
+  });
+
+  await Promise.all(
+    readyDependents.map((dependent) =>
+      args.db.buildActivity.create({
+        data: {
+          buildId: dependent.buildId,
+          tool: FEATURE_BUILD_DEPENDENCY_READY_TOOL,
+          summary: `Ready to plan: all upstream dependency builds are complete for ${dependent.title}.`,
+        },
+      }).catch(() => {}),
+    ),
+  );
+
+  return readyDependents;
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7299,7 +7299,21 @@ export async function executeTool(
       // see the fix in reviewDesignDoc for the backstory.
       try {
         const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import("@/lib/feature-build-types");
-        const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId } });
+        const { deriveFeatureBuildDependencyGate, FEATURE_BUILD_DEPENDENCY_GATE_SELECT } = await import("@/lib/build/feature-build-dependencies");
+        const updatedBuild = await prisma.featureBuild.findUnique({
+          where: { buildId },
+          select: {
+            phase: true,
+            plan: true,
+            buildPlan: true,
+            planReview: true,
+            id: true,
+            buildId: true,
+            title: true,
+            parentEpicId: true,
+            dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
+          },
+        });
         if (updatedBuild && updatedBuild.phase === "plan" && canTransitionPhase("plan", "build")) {
           const plan = (updatedBuild.plan as Record<string, unknown> | null) ?? {};
           const happyPathState = normalizeHappyPathState(plan.happyPathState);
@@ -7309,33 +7323,38 @@ export async function executeTool(
             happyPathState,
           });
           if (gate.allowed) {
-            // Initialize the build branch BEFORE flipping the phase. If the
-            // phase flip lands without buildBranch set, deploy_feature runs
-            // on whatever the current sandbox HEAD is — picking up leftover
-            // work from earlier builds. Gate the transition on the branch
-            // actually being ready so the "phase: build" record is always
-            // paired with a valid buildBranch on the FeatureBuild row.
-            try {
-              const { isSandboxAvailable, startBuildBranch } = await import("@/lib/integrate/sandbox/build-branch");
-              const sandboxUp = await isSandboxAvailable();
-              if (!sandboxUp) {
-                logBuildActivity(buildId, "phase:gate-blocked", "Auto-advance to build blocked: sandbox not running. Start the sandbox, then call start_build.");
-              } else {
-                await startBuildBranch(buildId);
-                // EP-COST Phase 3: record plan-phase cost rollup, start build tracking, and compact thread
-                const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
-                void completeBuildPhaseRun(buildId, "plan");
-                void startBuildPhaseRun(buildId, "build");
-                if (context?.threadId) {
-                  const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
-                  void persistPhaseHandoffSummary(context.threadId, "plan");
+            const dependencyGate = deriveFeatureBuildDependencyGate(updatedBuild);
+            if (!dependencyGate.allowed) {
+              logBuildActivity(buildId, "phase:gate-blocked", dependencyGate.message);
+            } else {
+              // Initialize the build branch BEFORE flipping the phase. If the
+              // phase flip lands without buildBranch set, deploy_feature runs
+              // on whatever the current sandbox HEAD is — picking up leftover
+              // work from earlier builds. Gate the transition on the branch
+              // actually being ready so the "phase: build" record is always
+              // paired with a valid buildBranch on the FeatureBuild row.
+              try {
+                const { isSandboxAvailable, startBuildBranch } = await import("@/lib/integrate/sandbox/build-branch");
+                const sandboxUp = await isSandboxAvailable();
+                if (!sandboxUp) {
+                  logBuildActivity(buildId, "phase:gate-blocked", "Auto-advance to build blocked: sandbox not running. Start the sandbox, then call start_build.");
+                } else {
+                  await startBuildBranch(buildId);
+                  // EP-COST Phase 3: record plan-phase cost rollup, start build tracking, and compact thread
+                  const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
+                  void completeBuildPhaseRun(buildId, "plan");
+                  void startBuildPhaseRun(buildId, "build");
+                  if (context?.threadId) {
+                    const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+                    void persistPhaseHandoffSummary(context.threadId, "plan");
+                  }
+                  await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
+                  if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "build" });
+                  logBuildActivity(buildId, "phase:advance", "Phase advanced: plan → build (buildBranch initialized)");
                 }
-                await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
-                if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "build" });
-                logBuildActivity(buildId, "phase:advance", "Phase advanced: plan → build (buildBranch initialized)");
+              } catch (branchErr) {
+                logBuildActivity(buildId, "phase:gate-blocked", `startBuildBranch failed: ${(branchErr as Error).message?.slice(0, 200)}`);
               }
-            } catch (branchErr) {
-              logBuildActivity(buildId, "phase:gate-blocked", `startBuildBranch failed: ${(branchErr as Error).message?.slice(0, 200)}`);
             }
           } else {
             logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "unknown");
@@ -7560,6 +7579,17 @@ export async function executeTool(
     case "start_build": {
       const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
+
+      try {
+        const { assertFeatureBuildDependenciesSatisfied } = await import("@/lib/build/feature-build-dependencies");
+        await assertFeatureBuildDependenciesSatisfied({ db: prisma, buildId });
+      } catch (err) {
+        return {
+          success: false,
+          error: "Dependency gate blocked.",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
 
       const { isSandboxAvailable, startBuildBranch } = await import("@/lib/integrate/sandbox/build-branch");
 
@@ -8609,6 +8639,10 @@ export async function executeTool(
           await prisma.featureBuild.update({
             where: { buildId },
             data: { phase: "complete" },
+          });
+          const { recordReadyDependentsAfterCompletion } = await import("@/lib/build/feature-build-dependencies");
+          await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
+            console.warn("[create_portal_pr] dependency readiness check failed:", err);
           });
 
           const promotion = build.productVersions[0]?.promotions[0];


### PR DESCRIPTION
## Summary
- Add a pure FeatureBuild dependency gate/readiness helper for execution-organizational Epics.
- Block child plan-to-build advancement and MCP `start_build` dispatch when upstream sibling dependencies are not yet complete.
- Record `dependency:ready` BuildActivity rows when a completed child clears the last blockers for dependent children.

## Verification
- `pnpm --filter web exec vitest run lib/build/ lib/actions/build-governed.test.ts lib/build-flow-state.test.ts lib/mcp-tools.test.ts lib/mcp-tools-save-build-evidence.test.ts lib/mcp-tools-build-observer.test.ts lib/mcp-tools-resolve-build-id.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passes with existing Edge-runtime warnings for Node APIs in middleware/instrumentation import paths)