### PR TITLE
fix(admin): harden platform update conflict flow

### DIFF
--- a/apps/web/components/admin/PlatformUpdateApplyPanel.test.tsx
+++ b/apps/web/components/admin/PlatformUpdateApplyPanel.test.tsx
@@ -28,6 +28,7 @@ describe("PlatformUpdateApplyPanel", () => {
     );
 
     expect(html).toContain("managed source workspace");
+    expect(html).toContain("click Apply update again");
     expect(html).not.toMatch(/Build Studio/i);
   });
 });

--- a/apps/web/components/admin/PlatformUpdateApplyPanel.tsx
+++ b/apps/web/components/admin/PlatformUpdateApplyPanel.tsx
@@ -159,7 +159,7 @@ export function ApplyResult({ result }: { result: ApplyPlatformUpdateResult }) {
           {result.conflicts.length} file{result.conflicts.length === 1 ? "" : "s"} need
           resolution. The merge is paused in the managed source workspace on the{" "}
           <code>my-changes</code> branch. Resolve the listed files there, run the verification
-          gate, then finish the merge commit.
+          gate, then click Apply update again to finish the merge commit.
           <ul style={{ marginTop: 8, paddingLeft: 18 }}>
             {result.conflicts.map((c) => (
               <li key={c.file} style={{ marginBottom: 8 }}>

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -138,6 +138,65 @@ describe("applyPlatformUpdate", () => {
     }
   });
 
+  it("parses CRLF conflict markers from the managed Windows source volume", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockExistsSync.mockReturnValue(true);
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.includes("--diff-filter=U")) {
+        cb(null, { stdout: "apps/web/page.tsx\n", stderr: "" });
+        return;
+      }
+      cb(null, { stdout: "", stderr: "" });
+    });
+    mockReadFileSync.mockReturnValue(
+      "// header\r\n<<<<<<< HEAD\r\nlocal version\r\n=======\r\nupstream version\r\n>>>>>>> dpf-upstream\r\n",
+    );
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("conflicts");
+    if (result.kind === "conflicts") {
+      expect(result.conflicts[0]?.localChange).toBe("local version");
+      expect(result.conflicts[0]?.upstreamChange).toBe("upstream version");
+    }
+  });
+
+  it("finishes a resumed merge when all conflicts have already been resolved", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockReturnValue(true);
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 3 files changed, 9 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    if (result.kind === "clean-merge") {
+      expect(result.filesUpdated).toBe(3);
+    }
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd);
+    expect(commands.some((cmd) => String(cmd).startsWith('git commit -s -m "chore: merge dpf'))).toBe(true);
+    expect(commands).not.toContain("rm -rf apps/web packages");
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    expect(mockPrisma.platformDevConfig.update).toHaveBeenCalledWith({
+      where: { id: "singleton" },
+      data: { updatePending: false, pendingVersion: null },
+    });
+  });
+
   it("marks the workspace as a Git safe directory before reading merge state", async () => {
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       updatePending: true,
@@ -148,11 +207,14 @@ describe("applyPlatformUpdate", () => {
     mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
       if (!cb) return;
       if (cmd.includes("--diff-filter=U")) {
-        cb(null, { stdout: "", stderr: "" });
+        cb(null, { stdout: "apps/web/page.tsx\n", stderr: "" });
         return;
       }
       cb(null, { stdout: "", stderr: "" });
     });
+    mockReadFileSync.mockReturnValue(
+      "// header\n<<<<<<< HEAD\nlocal version\n=======\nupstream version\n>>>>>>> dpf-upstream\n",
+    );
 
     const result = await applyPlatformUpdate();
 

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -883,8 +883,8 @@ async function collectPlatformUpdateConflicts(
   const { readFileSync } = lazyFs();
   for (const file of conflicted.trim().split("\n").filter(Boolean)) {
     const content = readFileSync(resolvePath(workspace, file), "utf-8");
-    const localMatch = content.match(/<<<<<<< .+?\n([\s\S]*?)=======/);
-    const upstreamMatch = content.match(/=======\n([\s\S]*?)>>>>>>> .+/);
+    const localMatch = content.match(/<<<<<<<[^\r\n]*(?:\r?\n)([\s\S]*?)(?:\r?\n)=======/);
+    const upstreamMatch = content.match(/=======(?:\r?\n)([\s\S]*?)(?:\r?\n)>>>>>>>[^\r\n]*/);
     conflicts.push({
       file,
       upstreamChange: upstreamMatch?.[1]?.trim() ?? "(could not parse)",
@@ -892,6 +892,49 @@ async function collectPlatformUpdateConflicts(
     });
   }
   return conflicts;
+}
+
+async function finishPlatformUpdateMerge(
+  execUpdate: ExecUpdate,
+  gitOpts: ExecUpdateOptions,
+  workspace: string,
+  resolvePath: (...parts: string[]) => string,
+  pendingVersion: string,
+): Promise<Extract<ApplyPlatformUpdateResult, { kind: "clean-merge" }>> {
+  const { stdout: filesChanged } = await execUpdate(
+    "git diff --cached --stat",
+    gitOpts,
+  );
+  const fileCount = parseInt(
+    (filesChanged.match(/(\d+) files? changed/) || ["0", "0"])[1] ?? "0",
+    10,
+  );
+  await execUpdate(
+    `git commit -s -m "chore: merge dpf v${pendingVersion}"`,
+    gitOpts,
+  );
+
+  const { writeFileSync } = lazyFs();
+  writeFileSync(
+    resolvePath(workspace, ".dpf-version"),
+    pendingVersion,
+    "utf-8",
+  );
+
+  await prisma.platformDevConfig.update({
+    where: { id: "singleton" },
+    data: { updatePending: false, pendingVersion: null },
+  });
+
+  revalidatePath("/admin/platform-development");
+  revalidatePath("/", "layout"); // banner lives in shell layout
+
+  return {
+    kind: "clean-merge",
+    message: `Platform updated to v${pendingVersion}. ${fileCount} files updated. No conflicts.`,
+    version: pendingVersion,
+    filesUpdated: fileCount,
+  };
 }
 
 export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> {
@@ -937,6 +980,15 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
         workspace,
         resolvePath,
       );
+      if (conflicts.length === 0) {
+        return await finishPlatformUpdateMerge(
+          execUpdate,
+          gitOpts,
+          workspace,
+          resolvePath,
+          pendingVersion,
+        );
+      }
       return {
         kind: "conflicts",
         message: `A merge is already in progress. ${conflicts.length} conflict(s) remaining.`,
@@ -963,7 +1015,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     );
     if (diffCheck.trim()) {
       await execUpdate(
-        `git commit -m "chore: ${UPDATE_UPSTREAM_BRANCH} v${pendingVersion}"`,
+        `git commit -s -m "chore: ${UPDATE_UPSTREAM_BRANCH} v${pendingVersion}"`,
         gitOpts,
       );
     }
@@ -995,40 +1047,13 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     }
 
     // Clean merge — commit, write sentinel, clear pending flag
-    const { stdout: filesChanged } = await execUpdate(
-      "git diff --cached --stat",
+    return await finishPlatformUpdateMerge(
+      execUpdate,
       gitOpts,
-    );
-    const fileCount = parseInt(
-      (filesChanged.match(/(\d+) files? changed/) || ["0", "0"])[1] ?? "0",
-      10,
-    );
-    await execUpdate(
-      `git commit -m "chore: merge dpf v${pendingVersion}"`,
-      gitOpts,
-    );
-
-    const { writeFileSync } = lazyFs();
-    writeFileSync(
-      resolvePath(workspace, ".dpf-version"),
+      workspace,
+      resolvePath,
       pendingVersion,
-      "utf-8",
     );
-
-    await prisma.platformDevConfig.update({
-      where: { id: "singleton" },
-      data: { updatePending: false, pendingVersion: null },
-    });
-
-    revalidatePath("/admin/platform-development");
-    revalidatePath("/", "layout"); // banner lives in shell layout
-
-    return {
-      kind: "clean-merge",
-      message: `Platform updated to v${pendingVersion}. ${fileCount} files updated. No conflicts.`,
-      version: pendingVersion,
-      filesUpdated: fileCount,
-    };
   } catch (err) {
     // Best-effort: leave my-changes checked out so the operator's working
     // copy is in a known state even when the merge step itself crashes.

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,10 +2,10 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 import { config as loadEnv } from "dotenv";
+import { buildNodeModuleAliases } from "./vitest.path-aliases";
 
 const rootDir = resolve(__dirname, "../..");
 const webDir = resolve(__dirname);
-const rootNodeModulesDir = resolve(rootDir, "node_modules");
 
 loadEnv({ path: resolve(rootDir, ".env") });
 loadEnv({ path: resolve(webDir, ".env.local"), override: true });
@@ -61,12 +61,7 @@ export default defineConfig({
         replacement: resolve(rootDir, "packages/finance-templates/src/index.ts"),
       },
       { find: "server-only", replacement: resolve(webDir, "test-support/server-only.ts") },
-      { find: "next/server", replacement: resolve(rootDir, "node_modules/next/server.js") },
-      { find: "react/jsx-dev-runtime", replacement: resolve(rootNodeModulesDir, "react/jsx-dev-runtime.js") },
-      { find: "react/jsx-runtime", replacement: resolve(rootNodeModulesDir, "react/jsx-runtime.js") },
-      { find: "react-dom/server", replacement: resolve(rootNodeModulesDir, "react-dom/server.node.js") },
-      { find: "react-dom", replacement: resolve(rootNodeModulesDir, "react-dom/index.js") },
-      { find: "react", replacement: resolve(rootNodeModulesDir, "react/index.js") },
+      ...buildNodeModuleAliases({ webDir, rootDir }),
     ],
   },
 });

--- a/apps/web/vitest.path-aliases.test.ts
+++ b/apps/web/vitest.path-aliases.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { buildNodeModuleAliases } from "./vitest.path-aliases";
+
+describe("buildNodeModuleAliases", () => {
+  it("prefers app-local node_modules when root package links are absent", () => {
+    const aliases = buildNodeModuleAliases({
+      webDir: "/workspace/apps/web",
+      rootDir: "/workspace",
+      resolvePath: (...parts) => parts.join("/").replace(/\/+/g, "/"),
+      existsSync: (path) => path.startsWith("/workspace/apps/web/node_modules/"),
+    });
+
+    expect(aliases.find((alias) => alias.find === "react")?.replacement).toBe(
+      "/workspace/apps/web/node_modules/react/index.js",
+    );
+    expect(aliases.find((alias) => alias.find === "react-dom/server")?.replacement).toBe(
+      "/workspace/apps/web/node_modules/react-dom/server.node.js",
+    );
+    expect(aliases.find((alias) => alias.find === "react/jsx-runtime")?.replacement).toBe(
+      "/workspace/apps/web/node_modules/react/jsx-runtime.js",
+    );
+  });
+});

--- a/apps/web/vitest.path-aliases.ts
+++ b/apps/web/vitest.path-aliases.ts
@@ -1,0 +1,35 @@
+import { existsSync as nodeExistsSync } from "fs";
+import { resolve } from "path";
+
+type AliasEntry = {
+  find: string | RegExp;
+  replacement: string;
+};
+
+type BuildNodeModuleAliasesOptions = {
+  webDir: string;
+  rootDir: string;
+  existsSync?: (path: string) => boolean;
+  resolvePath?: (...parts: string[]) => string;
+};
+
+function packageFile(
+  { webDir, rootDir, existsSync = nodeExistsSync, resolvePath = resolve }: BuildNodeModuleAliasesOptions,
+  ...pathParts: string[]
+): string {
+  const webPath = resolvePath(webDir, "node_modules", ...pathParts);
+  if (existsSync(webPath)) return webPath;
+
+  return resolvePath(rootDir, "node_modules", ...pathParts);
+}
+
+export function buildNodeModuleAliases(options: BuildNodeModuleAliasesOptions): AliasEntry[] {
+  return [
+    { find: "next/server", replacement: packageFile(options, "next", "server.js") },
+    { find: "react/jsx-dev-runtime", replacement: packageFile(options, "react", "jsx-dev-runtime.js") },
+    { find: "react/jsx-runtime", replacement: packageFile(options, "react", "jsx-runtime.js") },
+    { find: "react-dom/server", replacement: packageFile(options, "react-dom", "server.node.js") },
+    { find: "react-dom", replacement: packageFile(options, "react-dom", "index.js") },
+    { find: "react", replacement: packageFile(options, "react", "index.js") },
+  ];
+}


### PR DESCRIPTION
## Summary
- Parse CRLF merge-conflict markers in platform update previews so Windows-managed workspaces show the actual local/upstream hunks.
- Allow a paused update merge to finish when all conflict files have already been resolved and staged.
- Prefer app-local node_modules aliases in Vitest so managed source volumes without root package links can still run React-based tests.
- Clarify the Admin copy: after resolving conflicts and running the gate, click Apply update again to finish the merge commit.

## Root Cause
The conflict preview parser only matched LF-only markers, so CRLF files from the Windows managed source volume fell through to `(could not parse)`. The apply flow also treated any existing `.git/MERGE_HEAD` as a conflict state even after `git diff --name-only --diff-filter=U` returned no unresolved files.

## Validation
- `pnpm --filter web exec vitest run components/admin/PlatformUpdateApplyPanel.test.tsx lib/actions/platform-dev-config.apply.test.ts vitest.path-aliases.test.ts components/build/EpicRollupListItem.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `git diff --cached --check`
- pre-commit hook: staged Gitleaks scan and scoped typecheck
