### PR TITLE
fix(build-studio): activate linked Codex OAuth provider

### DIFF
--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -160,7 +160,11 @@ describe("testProviderAuth", () => {
     );
     expect(mockActivateProvider).toHaveBeenCalledWith(
       "codex",
-      expect.objectContaining({ trigger: "test_auth" }),
+      expect.objectContaining({
+        trigger: "test_auth",
+        authMethod: "oauth2_authorization_code",
+        activateLinked: true,
+      }),
     );
   });
 
@@ -196,7 +200,11 @@ describe("testProviderAuth", () => {
     );
     expect(mockActivateProvider).toHaveBeenCalledWith(
       "chatgpt",
-      expect.objectContaining({ trigger: "test_auth" }),
+      expect.objectContaining({
+        trigger: "test_auth",
+        authMethod: "oauth2_authorization_code",
+        activateLinked: true,
+      }),
     );
   });
 
@@ -365,6 +373,38 @@ describe("configureProvider", () => {
     expect(mockSeedAiProviderFinanceBridge).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: "openai",
+      }),
+    );
+  });
+
+  it("activates the paired OpenAI provider when configuring ChatGPT OAuth", async () => {
+    mockPrisma.modelProvider.findUnique.mockImplementation(({ select }: { select?: Record<string, boolean> }) => {
+      if (select?.cliEngine) {
+        return Promise.resolve({ providerId: "chatgpt", cliEngine: "codex" });
+      }
+      return Promise.resolve({
+        providerId: "chatgpt",
+        name: "ChatGPT",
+        consoleUrl: "https://chatgpt.com",
+        docsUrl: "https://platform.openai.com/docs",
+        inputPricePerMToken: 0,
+        outputPricePerMToken: 0,
+      });
+    });
+
+    const result = await configureProvider({
+      providerId: "chatgpt",
+      enabledFamilies: ["gpt-5.4"],
+      authMethod: "oauth2_authorization_code",
+    });
+
+    expect(result).toEqual({});
+    expect(mockActivateProvider).toHaveBeenCalledWith(
+      "chatgpt",
+      expect.objectContaining({
+        trigger: "api_key_configure",
+        authMethod: "oauth2_authorization_code",
+        activateLinked: true,
       }),
     );
   });

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -30,6 +30,18 @@ import {
 import { activateProvider } from "@/lib/govern/activate-provider";
 import { seedAiProviderFinanceBridge } from "@/lib/finance/ai-provider-finance";
 
+const OPENAI_OAUTH_LINKED_PROVIDERS = new Set(["codex", "chatgpt"]);
+
+function getOpenAiLinkedActivationOptions(
+  providerId: string,
+  authMethod: string | null | undefined,
+): { authMethod: string; activateLinked: true } | Record<string, never> {
+  if (authMethod === "oauth2_authorization_code" && OPENAI_OAUTH_LINKED_PROVIDERS.has(providerId)) {
+    return { authMethod, activateLinked: true };
+  }
+  return {};
+}
+
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
 async function requireManageProviders(): Promise<string> {
@@ -276,6 +288,7 @@ export async function configureProvider(input: {
   await activateProvider(input.providerId, {
     trigger: "api_key_configure",
     authMethod: input.authMethod,
+    ...getOpenAiLinkedActivationOptions(input.providerId, input.authMethod),
   });
 
   const providerForFinance = await prisma.modelProvider.findUnique({
@@ -479,7 +492,10 @@ export async function testProviderAuth(providerId: string): Promise<{ ok: boolea
       });
 
       if (res.ok || res.status === 400) {
-        await activateProvider(providerId, { trigger: "test_auth" });
+        await activateProvider(providerId, {
+          trigger: "test_auth",
+          ...getOpenAiLinkedActivationOptions(providerId, provider.authMethod),
+        });
         return { ok: true, message: "Connected via OAuth — Responses API verified" };
       }
 


### PR DESCRIPTION
## Summary
- Link ChatGPT/Codex OAuth activation from provider configuration and Test Auth flows.
- Preserve the existing OpenAI OAuth pairing so Build Studio can see the active Codex tool-capable profiles instead of only the ChatGPT profile.
- Add regression coverage for both OAuth auth-test paths and ChatGPT OAuth configuration.

## Root Cause
The live install had valid OAuth credentials and active Codex model profiles, but `ModelProvider.codex.status` was still `disabled`. Build Studio filters model profiles through active providers, so it ignored the Codex rows and only saw ChatGPT's non-tool profile. The OAuth exchange path already linked the sibling provider, but the configure/Test Auth paths did not pass `activateLinked: true`.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter web exec vitest run lib/actions/ai-providers.test.ts`
- `pnpm --filter web exec vitest run lib/actions/ai-providers.test.ts lib/govern/activate-provider.test.ts lib/build/build-studio-capability.test.ts lib/build/build-studio-capability-db.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passes; existing Edge-runtime warnings remain for unrelated `node:*` imports)
