### PR TITLE
Harden admin issue report triage

### DIFF
--- a/apps/web/components/admin/IssueReportPanel.test.tsx
+++ b/apps/web/components/admin/IssueReportPanel.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/quality", () => ({
+  updateIssueReportStatus: vi.fn(),
+}));
+
+import { IssueReportPanel } from "./IssueReportPanel";
+
+const reports = [
+  {
+    id: "db-1",
+    reportId: "coworker-process-1-zero-tool-call",
+    type: "runtime_error",
+    severity: "high",
+    status: "open",
+    title: "[coworker-process] zero-tool-call on phase=review",
+    description: "Agent closed the review phase without tool calls.",
+    routeContext: "/build",
+    errorStack: null,
+    source: "agentic-loop-guard",
+    createdAt: "2026-05-25T21:34:43.000Z",
+    reportedBy: null,
+  },
+  {
+    id: "db-2",
+    reportId: "PIR-WARM",
+    type: "feedback",
+    severity: "medium",
+    status: "acknowledged",
+    title: "Model warmup ping",
+    description: "Warmup probe.",
+    routeContext: null,
+    errorStack: null,
+    source: "warmup",
+    createdAt: "2026-05-25T19:58:01.000Z",
+    reportedBy: null,
+  },
+];
+
+const stats = {
+  byStatus: { open: 1, acknowledged: 1 },
+  bySeverity: { high: 1, medium: 1 },
+  bySource: { "agentic-loop-guard": 1, warmup: 1 },
+  last24h: 2,
+  last7d: 2,
+  topRoutes: [{ route: "/build", count: 1 }],
+  queueSummary: {
+    actionable: 1,
+    processGuard: 1,
+    warmupNoise: 1,
+    triaged: 1,
+    resolved: 0,
+    suppressed: 0,
+  },
+};
+
+describe("IssueReportPanel", () => {
+  it("renders an action-oriented queue instead of a flat warmup-heavy list", () => {
+    const html = renderToStaticMarkup(
+      <IssueReportPanel items={reports} total={2} stats={stats} />,
+    );
+
+    expect(html).toContain("Needs action");
+    expect(html).toContain("Process guard");
+    expect(html).toContain("Warmup noise");
+    expect(html).toContain("Ask System Admin");
+    expect(html).toContain("Suppress");
+    expect(html).not.toContain("Acknowledge");
+  });
+});

--- a/apps/web/components/admin/IssueReportPanel.tsx
+++ b/apps/web/components/admin/IssueReportPanel.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
+import { Archive, Bot, CheckCircle2, Filter, ShieldAlert } from "lucide-react";
 import { updateIssueReportStatus } from "@/lib/actions/quality";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "@/lib/quality/issue-report-status";
+import {
+  classifyIssueReport,
+  normalizeIssueReportStatus,
+  summarizeIssueReportQueue,
+  type IssueReportCategory,
+  type IssueReportQueueSummary,
+} from "@/lib/quality/issue-report-queue";
 
 interface ReportRow {
   id: string;
@@ -25,31 +30,21 @@ interface ReportRow {
 interface Stats {
   byStatus: Record<string, number>;
   bySeverity: Record<string, number>;
+  bySource?: Record<string, number>;
   last24h: number;
   last7d: number;
   topRoutes: Array<{ route: string | null; count: number }>;
+  queueSummary?: IssueReportQueueSummary;
 }
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
+type QueueFilter = "needs_action" | "process_guard" | "warmup_noise" | "all";
 
-const SEVERITY_COLOURS: Record<string, string> = {
-  critical: "var(--dpf-error, #ef4444)",
-  high: "#fb923c",
-  medium: "var(--dpf-warning, #fbbf24)",
-  low: "var(--dpf-muted, #9ca3af)",
-};
-
-const STATUS_COLOURS: Record<string, string> = {
-  open: "#f87171",
-  acknowledged: "#fbbf24",
-  resolved: "#4ade80",
-};
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+const FILTERS: Array<{ id: QueueFilter; label: string }> = [
+  { id: "needs_action", label: "Needs action" },
+  { id: "process_guard", label: "Process guard" },
+  { id: "warmup_noise", label: "Warmup noise" },
+  { id: "all", label: "All reports" },
+];
 
 export function IssueReportPanel({
   items: initialItems,
@@ -61,222 +56,351 @@ export function IssueReportPanel({
   stats: Stats;
 }) {
   const [items, setItems] = useState(initialItems);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(items[0]?.id ?? null);
+  const [activeFilter, setActiveFilter] = useState<QueueFilter>("needs_action");
   const [isPending, startTransition] = useTransition();
 
-  function handleStatusChange(reportId: string, newStatus: "acknowledged" | "resolved") {
+  const classifiedItems = useMemo(
+    () =>
+      items.map((item) => ({
+        item,
+        classification: classifyIssueReport(item),
+      })),
+    [items],
+  );
+  const localSummary = useMemo(() => summarizeIssueReportQueue(items), [items]);
+  const queueSummary = stats.queueSummary ?? localSummary;
+
+  const visibleItems = classifiedItems.filter(({ classification }) => {
+    if (activeFilter === "all") return true;
+    if (activeFilter === "needs_action") return classification.isActionable;
+    return classification.category === activeFilter;
+  });
+
+  function handleStatusChange(reportId: string, newStatus: IssueReportStatus) {
     startTransition(async () => {
       await updateIssueReportStatus(reportId, newStatus);
       setItems((prev) =>
-        prev.map((r) => (r.reportId === reportId ? { ...r, status: newStatus } : r)),
+        prev.map((report) => (report.reportId === reportId ? { ...report, status: newStatus } : report)),
       );
     });
   }
 
-  const openCount = stats.byStatus["open"] ?? 0;
-  const ackCount = stats.byStatus["acknowledged"] ?? 0;
-  const resolvedCount = stats.byStatus["resolved"] ?? 0;
+  function handleAskAdmin(report: ReportRow) {
+    const classification = classifyIssueReport(report);
+    document.dispatchEvent(
+      new CustomEvent("open-agent-panel", {
+        detail: {
+          autoMessage: buildAdminPrompt(report, classification.category),
+        },
+      }),
+    );
+  }
 
   return (
-    <div>
-      {/* ── Summary Cards ────────────────────────────────────────── */}
-      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
-        <StatCard label="Open" value={openCount} color={STATUS_COLOURS.open} />
-        <StatCard label="Acknowledged" value={ackCount} color={STATUS_COLOURS.acknowledged} />
-        <StatCard label="Resolved" value={resolvedCount} color={STATUS_COLOURS.resolved} />
-        <StatCard label="Last 24h" value={stats.last24h} />
-        <StatCard label="Last 7d" value={stats.last7d} />
+    <div className="space-y-5">
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+        <StatCard label="Needs action" value={queueSummary.actionable} tone="var(--dpf-error)" />
+        <StatCard label="Process guard" value={queueSummary.processGuard} tone="var(--dpf-accent)" />
+        <StatCard label="Warmup noise" value={queueSummary.warmupNoise} tone="var(--dpf-warning)" />
+        <StatCard label="Triaged" value={queueSummary.triaged} tone="var(--dpf-warning)" />
+        <StatCard label="Resolved" value={queueSummary.resolved} tone="var(--dpf-success)" />
         <StatCard label="Total" value={total} />
-      </div>
+      </section>
 
-      {/* ── Top Routes ───────────────────────────────────────────── */}
-      {stats.topRoutes.length > 0 && (
-        <div className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[rgba(26,26,46,0.6)] p-4">
-          <h3 className="mb-2 text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-wider">
-            Top Error Routes
-          </h3>
-          <div className="flex flex-wrap gap-3">
-            {stats.topRoutes.map((r) => (
-              <span
-                key={r.route}
-                className="rounded bg-[rgba(15,15,26,0.8)] px-2 py-1 text-xs text-[var(--dpf-text)]"
-              >
-                {r.route ?? "(unknown)"}{" "}
-                <span className="text-[var(--dpf-muted)]">({r.count})</span>
-              </span>
-            ))}
+      <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase text-[var(--dpf-muted)]">
+            <ShieldAlert className="h-4 w-4" aria-hidden="true" />
+            Queue posture
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <PostureBlock
+              label="Action queue"
+              value={queueSummary.actionable}
+              detail="Open reports that need an admin investigation."
+            />
+            <PostureBlock
+              label="Suppress candidates"
+              value={queueSummary.warmupNoise}
+              detail="Suppress warmup probes and health pings so they do not dominate triage."
+            />
+            <PostureBlock
+              label="Recent volume"
+              value={stats.last24h}
+              detail={`${stats.last7d} reports in the last 7 days.`}
+            />
           </div>
         </div>
-      )}
 
-      {/* ── Severity Distribution ────────────────────────────────── */}
-      {Object.keys(stats.bySeverity).length > 0 && (
-        <div className="mb-6 flex gap-3">
-          {Object.entries(stats.bySeverity).map(([sev, count]) => (
-            <span
-              key={sev}
-              className="rounded px-2 py-1 text-xs"
-              style={{
-                color: SEVERITY_COLOURS[sev] ?? "var(--dpf-text)",
-                border: `1px solid ${SEVERITY_COLOURS[sev] ?? "var(--dpf-border)"}`,
-              }}
-            >
-              {sev}: {count}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {/* ── Report List ──────────────────────────────────────────── */}
-      {items.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No issue reports found.</p>
-      ) : (
-        <div className="space-y-2">
-          {items.map((r) => {
-            const isExpanded = expandedId === r.id;
-            return (
-              <div
-                key={r.id}
-                className="rounded-lg border border-[var(--dpf-border)] bg-[rgba(26,26,46,0.6)]"
-              >
-                {/* Row header */}
-                <button
-                  type="button"
-                  onClick={() => setExpandedId(isExpanded ? null : r.id)}
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left"
+        {stats.topRoutes.length > 0 && (
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h3 className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Top routes</h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {stats.topRoutes.map((route) => (
+                <span
+                  key={route.route ?? "unknown"}
+                  className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)]"
                 >
-                  {/* Severity dot */}
-                  <span
-                    className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-                    style={{ background: SEVERITY_COLOURS[r.severity] ?? "var(--dpf-muted)" }}
-                    title={r.severity}
-                  />
+                  {route.route ?? "(unknown)"}{" "}
+                  <span className="text-[var(--dpf-muted)]">({route.count})</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
 
-                  {/* Report ID */}
-                  <span className="shrink-0 text-xs font-mono text-[var(--dpf-muted)]">
-                    {r.reportId}
-                  </span>
-
-                  {/* Title */}
-                  <span className="flex-1 truncate text-sm text-[var(--dpf-text)]">
-                    {r.title}
-                  </span>
-
-                  {/* Status badge */}
-                  <span
-                    className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
-                    style={{
-                      color: STATUS_COLOURS[r.status] ?? "var(--dpf-muted)",
-                      border: `1px solid ${STATUS_COLOURS[r.status] ?? "var(--dpf-border)"}`,
-                    }}
-                  >
-                    {r.status}
-                  </span>
-
-                  {/* Source badge */}
-                  <span className="shrink-0 text-[10px] text-[var(--dpf-muted)]">
-                    {r.source}
-                  </span>
-
-                  {/* Route */}
-                  {r.routeContext && (
-                    <span className="shrink-0 text-[10px] font-mono text-[var(--dpf-muted)]">
-                      {r.routeContext}
-                    </span>
-                  )}
-
-                  {/* Time */}
-                  <span className="shrink-0 text-[10px] text-[var(--dpf-muted)]">
-                    {new Date(r.createdAt).toLocaleString()}
-                  </span>
-                </button>
-
-                {/* Expanded details */}
-                {isExpanded && (
-                  <div className="border-t border-[var(--dpf-border)] px-4 py-3 space-y-3">
-                    {r.description && (
-                      <div>
-                        <h4 className="text-[10px] font-semibold text-[var(--dpf-muted)] uppercase mb-1">
-                          Description
-                        </h4>
-                        <p className="text-xs text-[var(--dpf-text)] whitespace-pre-wrap">
-                          {r.description}
-                        </p>
-                      </div>
-                    )}
-
-                    {r.errorStack && (
-                      <div>
-                        <h4 className="text-[10px] font-semibold text-[var(--dpf-muted)] uppercase mb-1">
-                          Stack Trace
-                        </h4>
-                        <pre className="max-h-48 overflow-auto rounded bg-[rgba(15,15,26,0.8)] p-2 text-[10px] text-[var(--dpf-muted)] leading-relaxed">
-                          {r.errorStack}
-                        </pre>
-                      </div>
-                    )}
-
-                    {r.reportedBy && (
-                      <p className="text-[10px] text-[var(--dpf-muted)]">
-                        Reported by: {r.reportedBy.name ?? r.reportedBy.email ?? r.reportedBy.id}
-                      </p>
-                    )}
-
-                    {/* Actions */}
-                    <div className="flex gap-2 pt-1">
-                      {r.status === "open" && (
-                        <button
-                          type="button"
-                          disabled={isPending}
-                          onClick={() => handleStatusChange(r.reportId, "acknowledged")}
-                          className="rounded bg-[rgba(251,191,36,0.15)] px-3 py-1 text-xs text-[#fbbf24] hover:bg-[rgba(251,191,36,0.25)] disabled:opacity-50"
-                        >
-                          Acknowledge
-                        </button>
-                      )}
-                      {(r.status === "open" || r.status === "acknowledged") && (
-                        <button
-                          type="button"
-                          disabled={isPending}
-                          onClick={() => handleStatusChange(r.reportId, "resolved")}
-                          className="rounded bg-[rgba(74,222,128,0.15)] px-3 py-1 text-xs text-[#4ade80] hover:bg-[rgba(74,222,128,0.25)] disabled:opacity-50"
-                        >
-                          Resolve
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
+      {Object.keys(stats.bySeverity).length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(stats.bySeverity).map(([severity, count]) => {
+            const tone = toneForSeverity(severity);
+            return (
+              <span
+                key={severity}
+                className="rounded-md border px-2 py-1 text-xs"
+                style={{ color: tone, borderColor: tone }}
+              >
+                {severity}: {count}
+              </span>
             );
           })}
         </div>
       )}
+
+      <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <div className="flex flex-col gap-3 border-b border-[var(--dpf-border)] p-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-[var(--dpf-muted)]" aria-hidden="true" />
+            <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Issue queue</h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {FILTERS.map((filter) => (
+              <button
+                key={filter.id}
+                type="button"
+                onClick={() => setActiveFilter(filter.id)}
+                className={[
+                  "rounded-md border px-3 py-1.5 text-xs font-medium transition",
+                  activeFilter === filter.id
+                    ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent)] text-white"
+                    : "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]",
+                ].join(" ")}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {visibleItems.length === 0 ? (
+          <p className="p-4 text-sm text-[var(--dpf-muted)]">No reports match this queue view.</p>
+        ) : (
+          <div className="divide-y divide-[var(--dpf-border)]">
+            {visibleItems.map(({ item }) => (
+              <IssueReportRow
+                key={item.id}
+                report={item}
+                expanded={expandedId === item.id}
+                onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                onAskAdmin={() => handleAskAdmin(item)}
+                onStatusChange={handleStatusChange}
+                isPending={isPending}
+              />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function StatCard({
-  label,
-  value,
-  color,
+function IssueReportRow({
+  report,
+  expanded,
+  onToggle,
+  onAskAdmin,
+  onStatusChange,
+  isPending,
 }: {
-  label: string;
-  value: number;
-  color?: string;
+  report: ReportRow;
+  expanded: boolean;
+  onToggle: () => void;
+  onAskAdmin: () => void;
+  onStatusChange: (reportId: string, status: IssueReportStatus) => void;
+  isPending: boolean;
 }) {
+  const classification = classifyIssueReport(report);
+  const status = normalizeIssueReportStatus(report.status);
+  const severityTone = toneForSeverity(report.severity);
+  const statusTone = toneForStatusBucket(status.bucket);
+
   return (
-    <div className="rounded-lg border border-[var(--dpf-border)] bg-[rgba(26,26,46,0.6)] p-3">
-      <p className="text-[10px] font-semibold text-[var(--dpf-muted)] uppercase tracking-wider">
-        {label}
-      </p>
-      <p className="text-xl font-bold" style={{ color: color ?? "var(--dpf-text)" }}>
+    <article className="bg-[var(--dpf-surface-1)]">
+      <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+        <button type="button" onClick={onToggle} className="min-w-0 text-left">
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: severityTone }}
+              title={report.severity}
+            />
+            <span className="truncate font-mono text-xs text-[var(--dpf-muted)]">{report.reportId}</span>
+            <span className="truncate text-sm font-medium text-[var(--dpf-text)]">{report.title}</span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--dpf-muted)]">
+            <Badge label={classification.categoryLabel} />
+            <Badge label={status.label} tone={statusTone} />
+            <span>{report.source}</span>
+            {report.routeContext && <span className="font-mono">{report.routeContext}</span>}
+            <span>{new Date(report.createdAt).toLocaleString()}</span>
+          </div>
+        </button>
+
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          <button
+            type="button"
+            onClick={onAskAdmin}
+            className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+          >
+            <Bot className="h-3.5 w-3.5" aria-hidden="true" />
+            Ask System Admin
+          </button>
+          {classification.category === "warmup_noise" && status.bucket !== "suppressed" && (
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() => onStatusChange(report.reportId, ISSUE_REPORT_STATUS.SUPPRESSED)}
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-warning)] disabled:opacity-50"
+            >
+              <Archive className="h-3.5 w-3.5" aria-hidden="true" />
+              Suppress
+            </button>
+          )}
+          {status.isActive && (
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() => onStatusChange(report.reportId, ISSUE_REPORT_STATUS.TRIAGED_LOCAL)}
+              className="inline-flex items-center gap-1 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Triaged
+            </button>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="space-y-3 border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+          {report.description && (
+            <div>
+              <h4 className="mb-1 text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">Description</h4>
+              <p className="whitespace-pre-wrap text-xs leading-5 text-[var(--dpf-text)]">{report.description}</p>
+            </div>
+          )}
+
+          {report.errorStack && (
+            <div>
+              <h4 className="mb-1 text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">Stack trace</h4>
+              <pre className="max-h-48 overflow-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] leading-relaxed text-[var(--dpf-muted)]">
+                {report.errorStack}
+              </pre>
+            </div>
+          )}
+
+          {report.reportedBy && (
+            <p className="text-[10px] text-[var(--dpf-muted)]">
+              Reported by: {report.reportedBy.name ?? report.reportedBy.email ?? report.reportedBy.id}
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            {status.bucket !== "resolved" && (
+              <button
+                type="button"
+                disabled={isPending}
+                onClick={() => onStatusChange(report.reportId, ISSUE_REPORT_STATUS.RESOLVED_LOCALLY)}
+                className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-success)] disabled:opacity-50"
+              >
+                Resolve
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function StatCard({ label, value, tone }: { label: string; value: number; tone?: string }) {
+  return (
+    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+      <p className="text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">{label}</p>
+      <p className="text-xl font-bold text-[var(--dpf-text)]" style={tone ? { color: tone } : undefined}>
         {value}
       </p>
     </div>
   );
+}
+
+function PostureBlock({ label, value, detail }: { label: string; value: number; detail: string }) {
+  return (
+    <div>
+      <p className="text-2xl font-semibold text-[var(--dpf-text)]">{value}</p>
+      <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">{label}</p>
+      <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{detail}</p>
+    </div>
+  );
+}
+
+function Badge({ label, tone }: { label: string; tone?: string }) {
+  return (
+    <span
+      className="rounded-md border border-[var(--dpf-border)] px-1.5 py-0.5 font-semibold uppercase"
+      style={tone ? { color: tone, borderColor: tone } : undefined}
+    >
+      {label}
+    </span>
+  );
+}
+
+function toneForSeverity(severity: string): string {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "var(--dpf-error)";
+    case "medium":
+      return "var(--dpf-warning)";
+    default:
+      return "var(--dpf-muted)";
+  }
+}
+
+function toneForStatusBucket(bucket: string): string {
+  switch (bucket) {
+    case "needs_action":
+      return "var(--dpf-error)";
+    case "resolved":
+      return "var(--dpf-success)";
+    case "suppressed":
+      return "var(--dpf-muted)";
+    default:
+      return "var(--dpf-warning)";
+  }
+}
+
+function buildAdminPrompt(report: ReportRow, category: IssueReportCategory): string {
+  return [
+    "Triage this admin issue report using backend evidence. Do not use Build Studio.",
+    `Report: ${report.reportId}`,
+    `Title: ${report.title}`,
+    `Category: ${category}`,
+    `Status: ${report.status}`,
+    `Severity: ${report.severity}`,
+    `Source: ${report.source}`,
+    report.routeContext ? `Route: ${report.routeContext}` : "Route: unknown",
+    report.description ? `Description: ${report.description.slice(0, 1200)}` : "Description: none",
+    "Use admin_query_db for PlatformIssueReport and ToolExecution evidence, admin_view_logs for portal logs when relevant, and admin_read_file for source inspection. Return the actionable cause, recommended status, and whether this needs a PR.",
+  ].join("\n");
 }

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -3,6 +3,11 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import {
+  ISSUE_REPORT_STATUS,
+  type IssueReportStatus,
+} from "@/lib/quality/issue-report-status";
+import { LEGACY_ISSUE_REPORT_STATUS, type LegacyIssueReportStatus } from "@/lib/quality/issue-report-queue";
 
 export async function reportQualityIssue(input: {
   type: "runtime_error" | "user_report" | "feedback";
@@ -63,7 +68,7 @@ export async function getIssueReports(filters?: {
 
 export async function updateIssueReportStatus(
   reportId: string,
-  status: "acknowledged" | "resolved",
+  status: IssueReportStatus | LegacyIssueReportStatus,
 ) {
   return prisma.platformIssueReport.update({
     where: { reportId },
@@ -75,10 +80,41 @@ export async function getIssueReportStats() {
   const now = new Date();
   const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const warmupNoiseWhere = {
+    OR: [
+      { source: "warmup" },
+      { title: { in: ["Model warmup ping", "System warmup check"] } },
+    ],
+  };
+  const activeStatusWhere = {
+    status: {
+      in: [
+        ISSUE_REPORT_STATUS.OPEN,
+        ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+        ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK,
+        ISSUE_REPORT_STATUS.UPSTREAM_PENDING,
+        ISSUE_REPORT_STATUS.UPSTREAM_FILED,
+      ],
+    },
+  };
 
-  const [byStatus, bySeverity, last24h, last7d, topRoutes] = await Promise.all([
+  const [
+    byStatus,
+    bySeverity,
+    bySource,
+    last24h,
+    last7d,
+    topRoutes,
+    actionable,
+    processGuard,
+    warmupNoise,
+    triaged,
+    resolved,
+    suppressed,
+  ] = await Promise.all([
     prisma.platformIssueReport.groupBy({ by: ["status"], _count: { _all: true } }),
     prisma.platformIssueReport.groupBy({ by: ["severity"], _count: { _all: true } }),
+    prisma.platformIssueReport.groupBy({ by: ["source"], _count: { _all: true } }),
     prisma.platformIssueReport.count({ where: { createdAt: { gte: oneDayAgo } } }),
     prisma.platformIssueReport.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
     prisma.platformIssueReport.groupBy({
@@ -88,13 +124,49 @@ export async function getIssueReportStats() {
       take: 5,
       where: { routeContext: { not: null } },
     }),
+    prisma.platformIssueReport.count({
+      where: {
+        ...activeStatusWhere,
+        NOT: warmupNoiseWhere,
+      },
+    }),
+    prisma.platformIssueReport.count({ where: { source: "agentic-loop-guard" } }),
+    prisma.platformIssueReport.count({ where: warmupNoiseWhere }),
+    prisma.platformIssueReport.count({
+      where: {
+        status: {
+          in: [ISSUE_REPORT_STATUS.TRIAGED_LOCAL, LEGACY_ISSUE_REPORT_STATUS.ACKNOWLEDGED],
+        },
+      },
+    }),
+    prisma.platformIssueReport.count({
+      where: {
+        status: {
+          in: [
+            ISSUE_REPORT_STATUS.RESOLVED_LOCALLY,
+            ISSUE_REPORT_STATUS.RESOLVED_UPSTREAM,
+            LEGACY_ISSUE_REPORT_STATUS.RESOLVED,
+          ],
+        },
+      },
+    }),
+    prisma.platformIssueReport.count({ where: { status: ISSUE_REPORT_STATUS.SUPPRESSED } }),
   ]);
 
   return {
     byStatus: Object.fromEntries(byStatus.map((r) => [r.status, r._count._all])),
     bySeverity: Object.fromEntries(bySeverity.map((r) => [r.severity, r._count._all])),
+    bySource: Object.fromEntries(bySource.map((r) => [r.source, r._count._all])),
     last24h,
     last7d,
     topRoutes: topRoutes.map((r) => ({ route: r.routeContext, count: r._count._all })),
+    queueSummary: {
+      actionable,
+      processGuard,
+      warmupNoise,
+      triaged,
+      resolved,
+      suppressed,
+    },
   };
 }

--- a/apps/web/lib/quality/issue-report-queue.test.ts
+++ b/apps/web/lib/quality/issue-report-queue.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyIssueReport,
+  normalizeIssueReportStatus,
+  summarizeIssueReportQueue,
+} from "./issue-report-queue";
+
+const baseReport = {
+  reportId: "PIR-1",
+  title: "Something broke",
+  status: "open",
+  severity: "medium",
+  source: "ai_assisted",
+  routeContext: null,
+};
+
+describe("issue-report queue helpers", () => {
+  it("treats legacy acknowledged reports as triaged but not active", () => {
+    expect(normalizeIssueReportStatus("acknowledged")).toEqual(
+      expect.objectContaining({
+        canonical: "triaged_local",
+        label: "Triaged",
+        bucket: "triaged",
+        isActive: false,
+        isLegacy: true,
+      }),
+    );
+  });
+
+  it("classifies warmup reports as suppressible operational noise", () => {
+    const classification = classifyIssueReport({
+      ...baseReport,
+      reportId: "PIR-WARM",
+      title: "Model warmup ping",
+      source: "warmup",
+    });
+
+    expect(classification.category).toBe("warmup_noise");
+    expect(classification.isActionable).toBe(false);
+    expect(classification.recommendedStatus).toBe("suppressed");
+  });
+
+  it("keeps open agentic-loop reports in the action queue", () => {
+    const classification = classifyIssueReport({
+      ...baseReport,
+      reportId: "coworker-process-1-zero-tool-call",
+      title: "[coworker-process] zero-tool-call on phase=review",
+      severity: "high",
+      source: "agentic-loop-guard",
+      routeContext: "/build",
+    });
+
+    expect(classification.category).toBe("process_guard");
+    expect(classification.isActionable).toBe(true);
+    expect(classification.recommendedStatus).toBe("triaged_local");
+  });
+
+  it("summarizes action, process, and warmup counts for the admin queue", () => {
+    const summary = summarizeIssueReportQueue([
+      {
+        ...baseReport,
+        reportId: "coworker-process-1-zero-tool-call",
+        title: "[coworker-process] zero-tool-call on phase=review",
+        source: "agentic-loop-guard",
+        severity: "high",
+        routeContext: "/build",
+      },
+      {
+        ...baseReport,
+        reportId: "PIR-WARM",
+        title: "System warmup check",
+        source: "ai_assisted",
+        status: "acknowledged",
+      },
+      {
+        ...baseReport,
+        reportId: "PIR-RES",
+        title: "Resolved issue",
+        status: "resolved_locally",
+      },
+    ]);
+
+    expect(summary.actionable).toBe(1);
+    expect(summary.processGuard).toBe(1);
+    expect(summary.warmupNoise).toBe(1);
+    expect(summary.resolved).toBe(1);
+  });
+});

--- a/apps/web/lib/quality/issue-report-queue.ts
+++ b/apps/web/lib/quality/issue-report-queue.ts
@@ -1,0 +1,201 @@
+import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "./issue-report-status";
+
+export const LEGACY_ISSUE_REPORT_STATUS = {
+  ACKNOWLEDGED: "acknowledged",
+  RESOLVED: "resolved",
+} as const;
+
+export type LegacyIssueReportStatus =
+  (typeof LEGACY_ISSUE_REPORT_STATUS)[keyof typeof LEGACY_ISSUE_REPORT_STATUS];
+
+export type IssueReportStatusBucket =
+  | "needs_action"
+  | "support_flow"
+  | "triaged"
+  | "resolved"
+  | "suppressed"
+  | "unknown";
+
+export type IssueReportCategory =
+  | "process_guard"
+  | "warmup_noise"
+  | "user_feedback"
+  | "runtime"
+  | "other";
+
+export type IssueReportQueueInput = {
+  reportId: string;
+  type?: string;
+  title: string;
+  status: string;
+  severity: string;
+  source: string;
+  routeContext: string | null;
+};
+
+export type NormalizedIssueReportStatus = {
+  raw: string;
+  canonical: IssueReportStatus | string;
+  label: string;
+  bucket: IssueReportStatusBucket;
+  isActive: boolean;
+  isTerminal: boolean;
+  isLegacy: boolean;
+};
+
+export type IssueReportClassification = {
+  category: IssueReportCategory;
+  categoryLabel: string;
+  actionLabel: string;
+  recommendedStatus: IssueReportStatus;
+  status: NormalizedIssueReportStatus;
+  isActionable: boolean;
+};
+
+export type IssueReportQueueSummary = {
+  actionable: number;
+  processGuard: number;
+  warmupNoise: number;
+  triaged: number;
+  resolved: number;
+  suppressed: number;
+};
+
+export function normalizeIssueReportStatus(status: string): NormalizedIssueReportStatus {
+  switch (status) {
+    case ISSUE_REPORT_STATUS.OPEN:
+      return normalized(status, ISSUE_REPORT_STATUS.OPEN, "Open", "needs_action", true, false);
+    case ISSUE_REPORT_STATUS.SUPPORT_TRIAGE:
+      return normalized(status, ISSUE_REPORT_STATUS.SUPPORT_TRIAGE, "Support triage", "support_flow", true, false);
+    case ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK:
+      return normalized(status, ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK, "Awaiting escalation", "support_flow", true, false);
+    case ISSUE_REPORT_STATUS.UPSTREAM_PENDING:
+      return normalized(status, ISSUE_REPORT_STATUS.UPSTREAM_PENDING, "Upstream pending", "support_flow", true, false);
+    case ISSUE_REPORT_STATUS.UPSTREAM_FILED:
+      return normalized(status, ISSUE_REPORT_STATUS.UPSTREAM_FILED, "Upstream filed", "support_flow", true, false);
+    case ISSUE_REPORT_STATUS.TRIAGED_LOCAL:
+      return normalized(status, ISSUE_REPORT_STATUS.TRIAGED_LOCAL, "Triaged", "triaged", false, false);
+    case LEGACY_ISSUE_REPORT_STATUS.ACKNOWLEDGED:
+      return normalized(status, ISSUE_REPORT_STATUS.TRIAGED_LOCAL, "Triaged", "triaged", false, false, true);
+    case ISSUE_REPORT_STATUS.RESOLVED_LOCALLY:
+      return normalized(status, ISSUE_REPORT_STATUS.RESOLVED_LOCALLY, "Resolved locally", "resolved", false, true);
+    case ISSUE_REPORT_STATUS.RESOLVED_UPSTREAM:
+      return normalized(status, ISSUE_REPORT_STATUS.RESOLVED_UPSTREAM, "Resolved upstream", "resolved", false, true);
+    case LEGACY_ISSUE_REPORT_STATUS.RESOLVED:
+      return normalized(status, ISSUE_REPORT_STATUS.RESOLVED_LOCALLY, "Resolved", "resolved", false, true, true);
+    case ISSUE_REPORT_STATUS.SUPPRESSED:
+      return normalized(status, ISSUE_REPORT_STATUS.SUPPRESSED, "Suppressed", "suppressed", false, true);
+    default:
+      return normalized(status, status, humanizeStatus(status), "unknown", status === ISSUE_REPORT_STATUS.OPEN, false);
+  }
+}
+
+export function classifyIssueReport(report: IssueReportQueueInput): IssueReportClassification {
+  const status = normalizeIssueReportStatus(report.status);
+  const category = detectCategory(report);
+  const recommendedStatus =
+    category === "warmup_noise" ? ISSUE_REPORT_STATUS.SUPPRESSED : ISSUE_REPORT_STATUS.TRIAGED_LOCAL;
+
+  return {
+    category,
+    categoryLabel: categoryLabel(category),
+    actionLabel: actionLabel(category),
+    recommendedStatus,
+    status,
+    isActionable: status.isActive && category !== "warmup_noise",
+  };
+}
+
+export function summarizeIssueReportQueue(reports: IssueReportQueueInput[]): IssueReportQueueSummary {
+  return reports.reduce<IssueReportQueueSummary>((summary, report) => {
+    const classification = classifyIssueReport(report);
+    if (classification.isActionable) summary.actionable += 1;
+    if (classification.category === "process_guard") summary.processGuard += 1;
+    if (classification.category === "warmup_noise") summary.warmupNoise += 1;
+    if (classification.status.bucket === "triaged") summary.triaged += 1;
+    if (classification.status.bucket === "resolved") summary.resolved += 1;
+    if (classification.status.bucket === "suppressed") summary.suppressed += 1;
+    return summary;
+  }, {
+    actionable: 0,
+    processGuard: 0,
+    warmupNoise: 0,
+    triaged: 0,
+    resolved: 0,
+    suppressed: 0,
+  });
+}
+
+function normalized(
+  raw: string,
+  canonical: IssueReportStatus | string,
+  label: string,
+  bucket: IssueReportStatusBucket,
+  isActive: boolean,
+  isTerminal: boolean,
+  isLegacy = false,
+): NormalizedIssueReportStatus {
+  return { raw, canonical, label, bucket, isActive, isTerminal, isLegacy };
+}
+
+function detectCategory(report: IssueReportQueueInput): IssueReportCategory {
+  const title = report.title.toLowerCase();
+  const source = report.source.toLowerCase();
+  const reportId = report.reportId.toLowerCase();
+
+  if (
+    source === "warmup" ||
+    title.includes("model warmup ping") ||
+    title.includes("system warmup check")
+  ) {
+    return "warmup_noise";
+  }
+  if (source === "agentic-loop-guard" || reportId.startsWith("coworker-process-")) {
+    return "process_guard";
+  }
+  if (report.type === "user_report" || report.type === "feedback") {
+    return "user_feedback";
+  }
+  if (report.type === "runtime_error") {
+    return "runtime";
+  }
+  return "other";
+}
+
+function categoryLabel(category: IssueReportCategory): string {
+  switch (category) {
+    case "process_guard":
+      return "Process guard";
+    case "warmup_noise":
+      return "Warmup noise";
+    case "user_feedback":
+      return "User feedback";
+    case "runtime":
+      return "Runtime";
+    default:
+      return "Other";
+  }
+}
+
+function actionLabel(category: IssueReportCategory): string {
+  switch (category) {
+    case "process_guard":
+      return "Investigate";
+    case "warmup_noise":
+      return "Suppress";
+    case "user_feedback":
+      return "Review";
+    case "runtime":
+      return "Diagnose";
+    default:
+      return "Review";
+  }
+}
+
+function humanizeStatus(status: string): string {
+  return status
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ") || "Unknown";
+}

--- a/apps/web/lib/queue/functions/issue-report-triage.ts
+++ b/apps/web/lib/queue/functions/issue-report-triage.ts
@@ -89,7 +89,7 @@ export const issueReportTriage = inngest.createFunction(
         acknowledgeReport: async (id) => {
           await prisma.platformIssueReport.update({
             where: { id },
-            data: { status: "acknowledged" },
+            data: { status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL },
           });
         },
 

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -482,4 +482,13 @@ describe("agent registry grant lookup", () => {
     expect(isToolAllowedByGrants("trace_code_surface", bySlug ?? [])).toBe(true);
     expect(isToolAllowedByGrants("find_related_tests", bySlug ?? [])).toBe(true);
   });
+
+  it("lets the admin assistant use read-only admin and backlog tools from the registry seed", () => {
+    const grants = getAgentToolGrants("admin-assistant");
+
+    expect(grants).toEqual(expect.arrayContaining(["admin_read", "admin_write", "backlog_read", "backlog_write"]));
+    expect(isToolAllowedByGrants("admin_query_db", grants ?? [])).toBe(true);
+    expect(isToolAllowedByGrants("admin_read_file", grants ?? [])).toBe(true);
+    expect(isToolAllowedByGrants("create_backlog_item", grants ?? [])).toBe(true);
+  });
 });

--- a/apps/web/lib/tak/agent-routing.test.ts
+++ b/apps/web/lib/tak/agent-routing.test.ts
@@ -143,6 +143,18 @@ describe("resolveAgentForRoute", () => {
     expect(result.systemPrompt).toContain("branding");
   });
 
+  it("keeps admin issue triage operational and out of Build Studio", () => {
+    const result = resolveAgentForRoute("/admin/issue-reports", superuser);
+
+    expect(result.agentId).toBe("admin-assistant");
+    expect(result.systemPrompt).toContain("issue reports");
+    expect(result.systemPrompt).toContain("Do not redirect issue-report triage to Build Studio");
+    expect(result.systemPrompt).not.toContain("tell the user to run it manually");
+    expect(result.systemPrompt).not.toContain("give the user the exact SQL to run manually");
+    expect(result.skills.some((skill) => skill.label === "Triage issue reports")).toBe(true);
+    expect(result.skills.some((skill) => skill.label === "Investigate open report")).toBe(true);
+  });
+
   it("returns a non-empty systemPrompt", () => {
     const result = resolveAgentForRoute("/portfolio", superuser);
     expect(result.systemPrompt).toBeTruthy();

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -441,16 +441,17 @@ YOU HAVE ADMIN TOOLS:
 
 RULES:
 1. Use tools to investigate before answering. Do not guess — check logs, query the DB, read files.
-2. When asked to do something destructive (delete data, stop services), explain what you would do and ask for confirmation BEFORE acting. If the tool blocks it, tell the user to run it manually in the terminal.
+2. When asked to do something destructive (delete data, stop services), explain what you would do and ask for confirmation BEFORE acting. If a tool blocks an unsafe action, say it is blocked and record or recommend governed follow-up inside the platform.
 3. Every tool call is audit-logged. You cannot hide your actions.
 4. You can only read/write within the project directory. No access to the host OS.
-5. SQL is read-only. For writes, give the user the exact SQL to run manually.
+5. SQL is read-only. For writes, use available admin or backlog tools; if no governed tool exists, explain the limitation and create tracked follow-up.
 6. Keep responses concise. Lead with the answer, then the evidence.
-7. You do NOT manage the sandbox or build workspace — that is Build Studio scope. Never reference sandbox containers, build commands, or code deployment.
+7. You do NOT manage the sandbox or build workspace. Never reference sandbox containers, build commands, or code deployment.
+8. Issue reports are an admin operations queue. Investigate PlatformIssueReport and ToolExecution evidence, separate actionable defects from warmup noise, and create or update backlog work when a report needs a code change. Do not redirect issue-report triage to Build Studio.
 
 PERSPECTIVE: You see the platform as configuration and operations. Your job is to help with user management, branding, settings, and platform health — not code development or builds.
 
-ON THIS PAGE: User management, role assignments, branding configuration, and platform settings.
+ON THIS PAGE: User management, role assignments, branding configuration, issue reports, diagnostics, backups, and platform settings.
 
 BRANDING CONTEXT: Theme tokens (palette colors, surfaces, typography) are in BrandingConfig, applied as CSS variables. Field names use camelCase (paletteAccent, surfacesSidebar, typographyFontFamily, radiusMd). You can also analyze a public website when the user wants to import branding cues or compare branding against the public website.`,
     skills: [
@@ -462,6 +463,9 @@ BRANDING CONTEXT: Theme tokens (palette colors, surfaces, typography) are in Bra
       { label: "Check system health", description: "Container status and logs", capability: "view_admin", prompt: "Check the health of all services — are any containers down or erroring?" },
       { label: "Run migrations", description: "Apply pending database migrations", capability: "view_admin", prompt: "Check for and apply any pending database migrations" },
       { label: "Inspect database", description: "Query tables and check data", capability: "view_admin", prompt: "I need to inspect some data in the database" },
+      { label: "Triage issue reports", description: "Classify actionable reports and operational noise", capability: "view_admin", prompt: "Triage the issue reports on this page using admin tools and backend evidence. Do not redirect issue-report triage to Build Studio." },
+      { label: "Investigate open report", description: "Find the backend cause of the top open issue", capability: "view_admin", prompt: "Investigate the top open issue report using logs, read-only database evidence, and source inspection. Tell me the cause, recommended status, and whether a PR is needed." },
+      { label: "Suppress warmup noise", description: "Move safe health-check reports out of active triage", capability: "view_admin", prompt: "Identify warmup or health-check reports that are safe to suppress, and explain why they are not actionable defects." },
       { label: "Report an issue", description: "Report a bug or give feedback", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
     modelRequirements: {

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -396,6 +396,42 @@ describe("runAgenticLoop", () => {
     threadId: "thread-1",
   };
 
+  it("explains missing tool-use capacity instead of masking it as a temporary outage", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockRejectedValueOnce(new Error(
+      "No eligible endpoints for task 'unknown': No endpoint satisfies agent capability floor (EP-AGENT-CAP-002). Missing: toolUse.",
+    ));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/admin/issue-reports",
+      agentId: "admin-assistant",
+    });
+
+    expect(result.content).toContain("No tool-use-capable AI provider is available");
+    expect(result.content).toContain("Platform > AI > Model Assignment");
+    expect(result.providerId).toBe("unknown");
+    expect(result.modelId).toBe("unknown");
+  });
+
+  it("explains exhausted tool-using endpoint failures instead of masking them as temporary", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockRejectedValueOnce(new Error(
+      'All endpoints failed for onboarding. Attempts: [{"endpointId":"local","error":"Network error calling local: fetch failed"},{"endpointId":"local","error":"skipped local fallback: 58 tools exceeds threshold for small local models"}]',
+    ));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/admin/issue-reports",
+      agentId: "admin-assistant",
+    });
+
+    expect(result.content).toContain("No tool-use-capable AI provider is available");
+    expect(result.content).toContain("Platform > AI > Model Assignment");
+    expect(result.providerId).toBe("unknown");
+    expect(result.modelId).toBe("unknown");
+  });
+
   it("executes tools through the governed lifecycle path", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     const mockExecuteTool = vi.mocked(executeTool);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1082,9 +1082,16 @@ export async function runAgenticLoop(params: {
       const msg = routeErr instanceof Error ? routeErr.message : String(routeErr);
       console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
       const isTooLarge = msg.startsWith("REQUEST_TOO_LARGE:");
+      const isMissingToolUseCapacity =
+        /No eligible endpoints/i.test(msg) && /toolUse/i.test(msg);
+      const isToolUsingEndpointFailure =
+        Boolean(routeOptions.tools && routeOptions.tools.length > 0) &&
+        (/All endpoints failed/i.test(msg) || /tools exceeds threshold/i.test(msg));
       return {
         content: isTooLarge
           ? "Your conversation is too long for this AI provider. Please start a new thread to continue."
+          : isMissingToolUseCapacity || isToolUsingEndpointFailure
+            ? "No tool-use-capable AI provider is available for this coworker. Configure an active model that supports tools in Platform > AI > Model Assignment, then retry this task."
           : "The AI provider is temporarily unavailable. Please try again in about 30 seconds.",
         providerId: "unknown",
         modelId: "unknown",

--- a/apps/web/lib/tak/route-context-map.test.ts
+++ b/apps/web/lib/tak/route-context-map.test.ts
@@ -55,6 +55,23 @@ describe("resolveRouteContext", () => {
     expect(ctx.sensitivity).toBe("restricted");
   });
 
+  it("uses a specialist context for admin issue reports", () => {
+    const ctx = resolveRouteContext("/admin/issue-reports");
+
+    expect(ctx.domain).toBe("Admin Issue Triage");
+    expect(ctx.routePrefix).toBe("/admin/issue-reports");
+    expect(ctx.sensitivity).toBe("restricted");
+    expect(ctx.domainTools).toEqual(expect.arrayContaining([
+      "admin_view_logs",
+      "admin_query_db",
+      "admin_read_file",
+      "create_backlog_item",
+      "update_backlog_item",
+    ]));
+    expect(ctx.skills.some((skill) => skill.label === "Triage issue reports")).toBe(true);
+    expect(ctx.skills.some((skill) => skill.label === "Suppress warmup noise")).toBe(true);
+  });
+
   it("returns correct sensitivity for /employee (confidential)", () => {
     const ctx = resolveRouteContext("/employee");
     expect(ctx.sensitivity).toBe("confidential");
@@ -137,6 +154,7 @@ describe("ROUTE_CONTEXT_MAP", () => {
       "/build",
       "/platform",
       "/admin",
+      "/admin/issue-reports",
       "/workspace",
     ];
     for (const route of expected) {

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -732,6 +732,57 @@ When generating or reviewing UI code, enforce these rules:
     ],
   },
 
+  "/admin/issue-reports": {
+    routePrefix: "/admin/issue-reports",
+    domain: "Admin Issue Triage",
+    sensitivity: "restricted",
+    domainContext:
+      "This page is the restricted administration queue for PlatformIssueReport records. The admin coworker should separate actionable process defects from automated warmup noise, inspect logs and read-only database evidence, create or update backlog work when a report needs code changes, and suppress or locally triage non-actionable operational noise. Do not redirect issue-report triage to Build Studio; use admin and backlog tools from this route.",
+    domainTools: [
+      "admin_view_logs",
+      "admin_query_db",
+      "admin_read_file",
+      "create_backlog_item",
+      "update_backlog_item",
+      "report_quality_issue",
+      "wiki_query",
+      "search_knowledge",
+      "search_knowledge_base",
+    ],
+    docsPath: "/docs/admin/index",
+    skills: [
+      {
+        label: "Triage issue reports",
+        description: "Group reports into actionable defects, warmup noise, and resolved items",
+        capability: "view_admin",
+        taskType: "analysis",
+        prompt:
+          "Triage the issue reports on this page. Use the visible queue first, then use admin_query_db for PlatformIssueReport and ToolExecution evidence and admin_view_logs when logs are relevant. Do not use Build Studio. Return the actionable cause, recommended status, and whether a backlog item or PR is needed.",
+      },
+      {
+        label: "Investigate open report",
+        description: "Inspect backend evidence for the selected or top open report",
+        capability: "view_admin",
+        taskType: "analysis",
+        prompt:
+          "Investigate the top open issue report. Use admin_query_db, admin_view_logs, and admin_read_file as needed. Explain the backend cause, whether it is a product defect or operational noise, and the next admin action. Do not redirect this to Build Studio.",
+      },
+      {
+        label: "Suppress warmup noise",
+        description: "Identify warmup probes that should not dominate issue triage",
+        capability: "view_admin",
+        prompt:
+          "Find warmup and health-check reports that are safe to suppress. Use backend evidence, avoid hiding genuine failures, and summarize which reports should move to suppressed status.",
+      },
+      {
+        label: "Report an issue",
+        description: "Report a bug or give feedback",
+        capability: null,
+        prompt: "I'd like to report an issue or give feedback about this page.",
+      },
+    ],
+  },
+
   "/admin": {
     routePrefix: "/admin",
     domain: "Administration",

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2502,8 +2502,10 @@
         },
         "concurrency_limit": 2,
         "tool_grants": [
+          "admin_read",
           "admin_write",
           "backlog_read",
+          "backlog_write",
           "file_read",
           "registry_read",
           "web_search"


### PR DESCRIPTION
## Summary

- Refactors Admin > Issue Reports into an action-oriented queue with explicit Needs action, Process guard, Warmup noise, Triaged, Resolved, and Total posture.
- Adds reusable issue-report queue classification helpers so legacy `acknowledged` records normalize to `triaged_local` and warmup reports are suppressible operational noise.
- Gives the System Admin route issue-triage skills, admin/backlog grants, and a dedicated `/admin/issue-reports` route context so triage stays in Admin instead of Build Studio.
- Improves agentic-loop provider failure copy for tool-using coworkers so missing or exhausted tool-use capacity points operators to Platform > AI > Model Assignment instead of a generic temporary outage.

## Root Cause

The portal had 311 issue reports, but most were warmup/health-check noise, while the one open actionable process report was buried in the same flat list. The System Admin coworker exposed admin tools in the UI, but its registry grants and route contract did not give it the complete governed admin/backlog surface, and provider-routing failures were masked as transient provider outages.

## Validation

- `pnpm --filter web exec vitest run lib/quality/issue-report-queue.test.ts components/admin/IssueReportPanel.test.tsx lib/tak/agent-routing.test.ts lib/tak/route-context-map.test.ts lib/tak/agent-grants.test.ts lib/tak/agentic-loop.test.ts` -> 204 passed.
- `pnpm --filter web typecheck` -> passed.
- `pnpm --filter web exec next build` -> passed. Existing Edge-runtime warnings remain around version/discovery/Prisma import paths.
- UX verified on `http://127.0.0.1:3036/admin/issue-reports`: queue posture displayed 1 actionable report, 23 process-guard reports, 288 warmup-noise reports; `Ask System Admin` opened the admin coworker with the backend-triage prompt; the newest provider failure rendered the specific tool-use-capability message.
