### PR TITLE
fix(routing): preserve CLI adapters on fallback

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -20,6 +20,7 @@ import {
   ANTHROPIC_OAUTH_BETA_HEADERS,
 } from "@/lib/ai-provider-internals";
 import type { RoutedExecutionPlan } from "../routing/recipe-types";
+import { resolveDefaultExecutionAdapter } from "../routing/execution-plan";
 import { getExecutionAdapter } from "../routing/execution-adapter-registry";
 import { resolveExecutionAdapter } from "../routing/resolve-execution-adapter";
 import {
@@ -427,10 +428,10 @@ export async function callProvider(
     modelId,
     recipeId: null,
     contractFamily: "unknown",
-    executionAdapter: "chat",
+    executionAdapter: resolveDefaultExecutionAdapter(providerId),
     maxTokens: 4096,
     providerSettings: {},
-    toolPolicy: {},
+    toolPolicy: (tools?.length ?? 0) > 0 ? { toolChoice: "auto" } : {},
     responsePolicy: {},
   };
 

--- a/apps/web/lib/routing/execution-plan.test.ts
+++ b/apps/web/lib/routing/execution-plan.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildPlanFromRecipe, buildDefaultPlan } from "./execution-plan";
+import {
+  buildPlanFromRecipe,
+  buildDefaultPlan,
+  resolveDefaultExecutionAdapter,
+} from "./execution-plan";
 import type { RecipeRow } from "./recipe-types";
 import type { RequestContract } from "./request-contract";
 import type { EndpointManifest } from "./types";
@@ -343,5 +347,23 @@ describe("buildDefaultPlan", () => {
       makeContract(),
     );
     expect(plan.executionAdapter).toBe("claude-cli");
+  });
+});
+
+describe("resolveDefaultExecutionAdapter", () => {
+  it("keeps Codex on the CLI adapter even without a full endpoint manifest", () => {
+    expect(resolveDefaultExecutionAdapter("codex")).toBe("codex-cli");
+  });
+
+  it("keeps ChatGPT subscription calls on the responses adapter", () => {
+    expect(resolveDefaultExecutionAdapter("chatgpt")).toBe("responses");
+  });
+
+  it("keeps Claude subscription calls on the Claude CLI adapter", () => {
+    expect(resolveDefaultExecutionAdapter("anthropic-sub")).toBe("claude-cli");
+  });
+
+  it("falls back to required model-class adapters for generic providers", () => {
+    expect(resolveDefaultExecutionAdapter("openai", "embedding")).toBe("embedding");
   });
 });

--- a/apps/web/lib/routing/execution-plan.ts
+++ b/apps/web/lib/routing/execution-plan.ts
@@ -22,6 +22,23 @@ const MODEL_CLASS_ADAPTER: Record<string, string> = {
   code: "chat",
 };
 
+export function resolveProviderExecutionAdapter(providerId: string): string | null {
+  if (usesCodexCli(providerId)) return "codex-cli";
+  if (usesResponsesApi(providerId)) return "responses";
+  if (usesCliAdapter(providerId)) return "claude-cli";
+  return null;
+}
+
+export function resolveDefaultExecutionAdapter(
+  providerId: string,
+  requiredModelClass?: string,
+): string {
+  const providerAdapter = resolveProviderExecutionAdapter(providerId);
+  if (providerAdapter) return providerAdapter;
+  if (requiredModelClass) return MODEL_CLASS_ADAPTER[requiredModelClass] ?? "chat";
+  return "chat";
+}
+
 // ── buildPlanFromRecipe ──────────────────────────────────────────────────────
 
 /**
@@ -67,13 +84,10 @@ export function buildPlanFromRecipe(
   // anthropic-sub uses OAuth tokens which only work with Claude CLI, not the
   // direct Messages API. Always route through CLI adapter for this provider.
   // MCP tool execution happens via the agentic loop, not the adapter itself.
-  const executionAdapter = usesCodexCli(recipe.providerId)
-    ? "codex-cli"
-    : usesResponsesApi(recipe.providerId)
-      ? "responses"
-      : usesCliAdapter(recipe.providerId)
-        ? "claude-cli"
-        : (recipe.executionAdapter ?? "chat");
+  const executionAdapter =
+    resolveProviderExecutionAdapter(recipe.providerId) ??
+    recipe.executionAdapter ??
+    "chat";
 
   const plan: RoutedExecutionPlan = {
     providerId: recipe.providerId,
@@ -122,15 +136,10 @@ export function buildDefaultPlan(
   };
 
   // EP-INF-009c: Select adapter based on required model class
-  const adapterType = usesCodexCli(endpoint.providerId)
-    ? "codex-cli"
-    : usesResponsesApi(endpoint.providerId)
-      ? "responses"
-      : usesCliAdapter(endpoint.providerId)
-        ? "claude-cli"
-        : contract.requiredModelClass
-          ? (MODEL_CLASS_ADAPTER[contract.requiredModelClass] ?? "chat")
-        : "chat";
+  const adapterType = resolveDefaultExecutionAdapter(
+    endpoint.providerId,
+    contract.requiredModelClass,
+  );
 
   return {
     providerId: endpoint.providerId,

--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -84,6 +84,21 @@ const makeDecision = (providerId: string, modelId: string): RouteDecision => ({
   timestamp: new Date(),
 });
 
+const makeCandidate = (
+  endpointId: string,
+  providerId: string,
+  modelId: string,
+): RouteDecision["candidates"][number] => ({
+  endpointId,
+  providerId,
+  modelId,
+  endpointName: modelId,
+  fitnessScore: 1,
+  dimensionScores: {},
+  costPerOutputMToken: null,
+  excluded: false,
+});
+
 const mockPrisma = prisma as unknown as {
   modelProvider: {
     findUnique: ReturnType<typeof vi.fn>;
@@ -180,6 +195,60 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
           fallbackOccurred: false,
         }),
       );
+    });
+
+    it("uses provider-specific execution plans for fallback endpoints", async () => {
+      mockCallProvider
+        .mockRejectedValueOnce(new Error("primary unavailable"))
+        .mockResolvedValueOnce({
+          content: "fallback ok",
+          inputTokens: 10,
+          outputTokens: 5,
+          inferenceMs: 100,
+        });
+
+      const tools = [
+        {
+          type: "function",
+          function: {
+            name: "read_project_file",
+            description: "Read a project file",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ];
+      const decision: RouteDecision = {
+        ...makeDecision("openai", "gpt-4.1"),
+        selectedEndpoint: "openai-ep",
+        selectedModelId: "gpt-4.1",
+        fallbackChain: ["codex-ep"],
+        candidates: [
+          makeCandidate("openai-ep", "openai", "gpt-4.1"),
+          makeCandidate("codex-ep", "codex", "gpt-5.4"),
+        ],
+      };
+
+      const pending = callWithFallbackChain(
+        decision,
+        [{ role: "user", content: "hi" }],
+        "system",
+        tools,
+      );
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toMatchObject({
+        providerId: "codex",
+        modelId: "gpt-5.4",
+        content: "fallback ok",
+        downgraded: true,
+      });
+
+      const fallbackPlan = mockCallProvider.mock.calls[1]?.[5];
+      expect(fallbackPlan).toMatchObject({
+        providerId: "codex",
+        modelId: "gpt-5.4",
+        executionAdapter: "codex-cli",
+        toolPolicy: { toolChoice: "auto" },
+      });
     });
   });
 

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -7,6 +7,7 @@ import type { ChatMessage } from "@/lib/ai-inference";
 import { prisma } from "@dpf/db";
 import type { RouteDecision } from "./types";
 import type { RoutedExecutionPlan } from "./recipe-types";
+import { resolveDefaultExecutionAdapter } from "./execution-plan";
 import { recordRequest, learnFromRateLimitResponse, extractRetryAfterMs } from "./rate-tracker";
 import { scheduleRecovery } from "./rate-recovery";
 import { recordRouteOutcome } from "./route-outcome";
@@ -27,6 +28,41 @@ type RouteOutcomeAttribution = {
    */
   agentMessageId?: string | null;
 };
+
+function buildFallbackProviderSettings(
+  sourcePlan?: RoutedExecutionPlan,
+): RoutedExecutionPlan["providerSettings"] {
+  const settings = sourcePlan?.providerSettings ?? {};
+  const effort = (settings as Record<string, unknown>).effort;
+  return effort ? { effort } : {};
+}
+
+function buildFallbackPlan(
+  entry: { providerId: string; modelId: string },
+  decision: RouteDecision,
+  tools?: Array<Record<string, unknown>>,
+  sourcePlan?: RoutedExecutionPlan,
+): RoutedExecutionPlan {
+  const toolPolicy: RoutedExecutionPlan["toolPolicy"] = {
+    ...(sourcePlan?.toolPolicy ?? {}),
+  };
+  if ((tools?.length ?? 0) > 0 && toolPolicy.toolChoice === undefined) {
+    toolPolicy.toolChoice = "auto";
+  }
+
+  return {
+    providerId: entry.providerId,
+    modelId: entry.modelId,
+    recipeId: null,
+    contractFamily: sourcePlan?.contractFamily ?? decision.taskType,
+    executionAdapter: resolveDefaultExecutionAdapter(entry.providerId),
+    maxTokens: sourcePlan?.maxTokens ?? 4096,
+    providerSettings: buildFallbackProviderSettings(sourcePlan),
+    toolPolicy,
+    responsePolicy: sourcePlan?.responsePolicy ?? {},
+    ...(sourcePlan?.temperature !== undefined ? { temperature: sourcePlan.temperature } : {}),
+  };
+}
 
 export interface FallbackResult {
   providerId: string;
@@ -157,13 +193,18 @@ export async function callWithFallbackChain(
     }
 
     try {
+      const entryPlan =
+        i === 0 && plan
+          ? plan
+          : buildFallbackPlan(entry, decision, tools, plan);
+
       const result = await callProvider(
         entry.providerId,
         entry.modelId,
         messages,
         systemPrompt,
         tools,
-        i === 0 ? plan : undefined,
+        entryPlan,
         i === 0 ? previousResponseId : undefined,
         mcpSession,
         { agentId, agentMessageId },


### PR DESCRIPTION
## Summary

Fixes a Build Studio regression where Codex could be selected as a fallback endpoint but then invoked through the generic chat/HTTP adapter instead of the Codex CLI adapter. That false path returned ChatGPT HTML auth content, caused Codex to be marked auth-failed, and pushed subsequent Build Studio routing toward local models.

## Changes

- Centralize provider-specific default adapter resolution for Codex, ChatGPT subscription, and Claude subscription providers.
- Build an entry-specific routed execution plan for every fallback endpoint instead of passing `undefined` after the first attempt.
- Preserve generic fallback settings while avoiding source-provider-specific adapter leakage.
- Add regression coverage proving Codex fallback receives `executionAdapter: "codex-cli"` and tool-capable fallbacks get `toolChoice: "auto"`.

## Verification

- `pnpm --filter web exec vitest run lib/routing/execution-plan.test.ts lib/routing/fallback.test.ts lib/inference/ai-inference.test.ts` - 64 passed.
- `pnpm --filter web typecheck` - passed.
- `pnpm --filter web build` - passed; existing Edge-runtime warnings remain.
- `docker compose build --no-cache portal portal-init sandbox` then retry for portal after transient Docker `SIGSEGV`; final portal, portal-init, and sandbox images built.
- `docker compose up -d` - portal healthy.
- Authenticated `/api/diagnostics/probe?routes=build&includeTools=true` - `/build` and `/build (with tools)` both passed on `providerId: codex`, `modelId: gpt-5.3-codex`.
- Fresh portal logs since rebuild: 4 Codex CLI adapter lines, 0 auth failures, 0 local-provider fallback lines, 0 route throws.
