### PR TITLE
test(skills): mock seed warning action

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/lib/actions/skills-observatory", () => ({
   getSkillReviewDetail: vi.fn().mockResolvedValue(null),
   getLatestSkillCuratorReport: vi.fn().mockResolvedValue(null),
   getSkillLifecycleState: vi.fn().mockResolvedValue(null),
+  getSkillSeedWarnings: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/components/platform/SkillProposalsPanel", () => ({


### PR DESCRIPTION
## Summary
- Add the missing `getSkillSeedWarnings` mock to the skills observatory page test.
- Keeps the page test aligned with the data loader added in PR #1168.

## Root cause
PR #1168 added `getSkillSeedWarnings()` to `app/(shell)/platform/ai/skills/page.tsx`, but the page test mocked `@/lib/actions/skills-observatory` without that new export. CI unit tests failed with Vitest's missing mock export error.

## Verification
- `pnpm --filter web exec vitest run "app/(shell)/platform/ai/skills/page.test.tsx"`
- `pnpm --filter web typecheck`
- `pnpm security:secrets:staged`