### PR TITLE
fix(release): refresh STT image digest guard

### DIFF
--- a/.github/workflows/install-verification.yml
+++ b/.github/workflows/install-verification.yml
@@ -74,6 +74,10 @@ jobs:
       - name: Install pnpm
         run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
+      - name: Verify digest-pinned release compose image manifests
+        if: ${{ (github.event.inputs.mode || 'dev') == 'release' }}
+        run: node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned
+
       - name: Run install-dpf.sh (real install, --no-autostart for CI)
         # Skips the autostart unit step (no user session on a GHA runner).
         # The install path itself — preflight, state, compose chain,
@@ -119,8 +123,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: doctor-bundle-${{ github.event.inputs.mode || 'dev' }}-${{ github.run_id }}
-          path: ~/.dpf/doctor-*.tar.gz
+          path: /home/runner/.dpf/doctor-*.tar.gz
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Tear down (uninstall --purge)

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -310,6 +310,9 @@ jobs:
       - name: Install pnpm
         run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
+      - name: Verify digest-pinned release compose image manifests
+        run: node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned
+
       - name: Run install-dpf.sh (release mode, --no-autostart for CI)
         run: bash install-dpf.sh --headless --release --no-autostart
 
@@ -339,8 +342,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: doctor-bundle-release-${{ github.run_id }}
-          path: ~/.dpf/doctor-*.tar.gz
+          path: /home/runner/.dpf/doctor-*.tar.gz
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Tear down (uninstall --purge)

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -4,13 +4,16 @@ name: Installer Release Gates
 permissions:
   contents: read
 
-# Per the installer-parity roadmap Phase 9b (CI release gates). Three
+# Per the installer-parity roadmap Phase 9b (CI release gates). Four
 # fast gates plus one paid macos-14 gate, all path-filtered so they
-# only run when installer-touching files change. Image-manifests
-# verification lives in publish-image.yml (Phase 1) and runs on tag
-# push, not here.
+# only run when installer-touching files change. Full image-manifest
+# verification still lives in publish-image.yml (Phase 1) and runs on
+# tag push; this workflow checks digest-pinned compose images early so
+# deleted upstream manifests fail before release day.
 #
 # Gates:
+#   - release-contract Static release workflow + artifact contract tests.
+#   - image-manifests  Checks digest-pinned compose images resolve.
 #   - compose-render   Asserts docker-compose.{yml,macos.yml,linux.yml,release.yml}
 #                      render cleanly for every (mode × platform) combo.
 #                      Catches overlay merge regressions before they
@@ -39,7 +42,11 @@ on:
       - "docker-compose*.yml"
       - ".env.docker.example"
       - "docker-entrypoint.sh"
+      - "scripts/release/**"
+      - "tests/release/**"
       - ".github/workflows/release-gates.yml"
+      - ".github/workflows/publish-image.yml"
+      - ".github/workflows/install-verification.yml"
   push:
     branches: [main]
     paths:
@@ -52,13 +59,45 @@ on:
       - "docker-compose*.yml"
       - ".env.docker.example"
       - "docker-entrypoint.sh"
+      - "scripts/release/**"
+      - "tests/release/**"
       - ".github/workflows/release-gates.yml"
+      - ".github/workflows/publish-image.yml"
+      - ".github/workflows/install-verification.yml"
 
 concurrency:
   group: release-gates-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  release-contract:
+    name: Release Contract Guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Run release contract tests
+        run: node tests/release/installer-release-contract.test.mjs
+
+  image-manifests:
+    name: Release Image Manifest Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify digest-pinned release compose image manifests
+        run: node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned
+
   compose-render:
     name: Compose Render Policy (${{ matrix.mode }} / ${{ matrix.platform }})
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -632,10 +632,10 @@ services:
   #
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
-    # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest at
-    # commit time. Bump deliberately; never reach for `:latest` in shipped
-    # compose because it makes the install non-reproducible.
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:4b4f3747242bc4be9c7a0a6d2160fef0a957813cf08574e0058841aba630dbd7}
+    # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
+    # resolved on 2026-05-26. Bump deliberately; never reach for `:latest`
+    # in shipped compose because it makes the install non-reproducible.
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:de379f0727e4c6b64bfb1be5c0c1c66bda215beb6a3e8e0c5d63061c73e9ec3b}
     restart: unless-stopped
     environment:
       # `base` (~145 MB) is the smallest model with usable accuracy on English.

--- a/scripts/release/verify-compose-image-manifests.mjs
+++ b/scripts/release/verify-compose-image-manifests.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const VALID_MODES = new Set(["dev", "release"]);
+const VALID_PLATFORMS = new Set(["linux", "macos"]);
+const VALID_ONLY = new Set(["all", "digest-pinned"]);
+
+function parseArgs(argv) {
+  const options = {
+    mode: "release",
+    platform: "linux",
+    only: "digest-pinned",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--mode" && next) {
+      options.mode = next;
+      i += 1;
+    } else if (arg === "--platform" && next) {
+      options.platform = next;
+      i += 1;
+    } else if (arg === "--only" && next) {
+      options.only = next;
+      i += 1;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
+    }
+  }
+
+  if (!VALID_MODES.has(options.mode)) {
+    throw new Error(`--mode must be one of: ${Array.from(VALID_MODES).join(", ")}`);
+  }
+  if (!VALID_PLATFORMS.has(options.platform)) {
+    throw new Error(`--platform must be one of: ${Array.from(VALID_PLATFORMS).join(", ")}`);
+  }
+  if (!VALID_ONLY.has(options.only)) {
+    throw new Error(`--only must be one of: ${Array.from(VALID_ONLY).join(", ")}`);
+  }
+
+  return options;
+}
+
+function repoRoot() {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`git rev-parse failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function composeFiles(root, { mode, platform }) {
+  const files = [join(root, "docker-compose.yml")];
+  if (mode === "release") {
+    files.push(join(root, "docker-compose.release.yml"));
+  }
+  files.push(join(root, `docker-compose.${platform}.yml`));
+
+  for (const file of files) {
+    if (!existsSync(file)) {
+      throw new Error(`Missing compose file: ${file}`);
+    }
+  }
+  return files;
+}
+
+function composeEnv() {
+  return {
+    ...process.env,
+    DPF_HOST_INSTALL_PATH: process.env.DPF_HOST_INSTALL_PATH ?? "/tmp/dpf",
+    AUTH_SECRET: process.env.AUTH_SECRET ?? "ci-placeholder",
+    CREDENTIAL_ENCRYPTION_KEY:
+      process.env.CREDENTIAL_ENCRYPTION_KEY ??
+      "0000000000000000000000000000000000000000000000000000000000000000",
+    ADMIN_PASSWORD: process.env.ADMIN_PASSWORD ?? "ci-placeholder",
+    POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD ?? "ci-placeholder",
+    NEO4J_AUTH: process.env.NEO4J_AUTH ?? "neo4j/ci-placeholder",
+    DATABASE_URL:
+      process.env.DATABASE_URL ??
+      "postgresql://dpf:ci-placeholder@postgres:5432/dpf",
+  };
+}
+
+function listImages(root, files) {
+  const args = ["compose"];
+  for (const file of files) {
+    args.push("-f", file);
+  }
+  args.push("config", "--images");
+
+  const result = spawnSync("docker", args, {
+    cwd: root,
+    env: composeEnv(),
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`docker compose config --images failed:\n${result.stderr.trim()}`);
+  }
+
+  return Array.from(
+    new Set(
+      result.stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  ).sort();
+}
+
+function verifyManifest(image) {
+  const result = spawnSync("docker", ["manifest", "inspect", image], {
+    encoding: "utf8",
+  });
+  return {
+    ok: result.status === 0,
+    stderr: result.stderr.trim(),
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const root = repoRoot();
+  const files = composeFiles(root, options);
+  const renderedImages = listImages(root, files);
+  const images =
+    options.only === "digest-pinned"
+      ? renderedImages.filter((image) => image.includes("@sha256:"))
+      : renderedImages;
+
+  if (images.length === 0) {
+    throw new Error(`No ${options.only} compose images found for ${options.mode}/${options.platform}.`);
+  }
+
+  console.log(
+    `[compose-image-manifests] Checking ${images.length} ${options.only} image(s) for ${options.mode}/${options.platform}`,
+  );
+
+  const failures = [];
+  for (const image of images) {
+    const result = verifyManifest(image);
+    if (result.ok) {
+      console.log(`[ok] ${image}`);
+    } else {
+      console.error(`[missing] ${image}`);
+      if (result.stderr) {
+        console.error(result.stderr);
+      }
+      failures.push(image);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Missing or unreachable image manifests:\n${failures.join("\n")}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const RETIRED_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:4b4f3747242bc4be9c7a0a6d2160fef0a957813cf08574e0058841aba630dbd7";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:de379f0727e4c6b64bfb1be5c0c1c66bda215beb6a3e8e0c5d63061c73e9ec3b";
+const MANIFEST_GUARD =
+  "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
+
+function read(path) {
+  return readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+test("default STT sidecar uses the current reachable multi-arch image digest", () => {
+  const compose = read("docker-compose.yml");
+
+  assert.match(compose, new RegExp(CURRENT_STT_DIGEST.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(compose, new RegExp(RETIRED_STT_DIGEST.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("release gates verify digest-pinned compose images before release install reaches compose up", () => {
+  const releaseGates = read(".github/workflows/release-gates.yml");
+  const publishImage = read(".github/workflows/publish-image.yml");
+
+  assert.match(releaseGates, new RegExp(MANIFEST_GUARD.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(publishImage, new RegExp(MANIFEST_GUARD.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("CI doctor bundle uploads include the hidden .dpf directory", () => {
+  for (const path of [".github/workflows/install-verification.yml", ".github/workflows/publish-image.yml"]) {
+    const workflow = read(path);
+
+    assert.match(workflow, /path:\s+\/home\/runner\/\.dpf\/doctor-\*\.tar\.gz/);
+    assert.match(workflow, /include-hidden-files:\s+true/);
+  }
+});


### PR DESCRIPTION
## Summary
- refresh the default `dpf-stt` image pin to the currently reachable multi-arch `hwdsl2/whisper-server` digest
- add a release compose image-manifest guard before release install verification reaches `docker compose up`
- fix CI doctor bundle artifact uploads from `/home/runner/.dpf` by allowing hidden-file upload

## Verification
- `node tests/release/installer-release-contract.test.mjs`
- `node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned`
- `node scripts/release/verify-compose-image-manifests.mjs --mode release --platform macos --only digest-pinned`
- `pnpm typecheck`
- `pnpm --filter web build`

## Notes
The failed `v5.3.0` release job was a new failure mode: Docker Hub no longer serves the previously pinned `hwdsl2/whisper-server@sha256:4b4f...` manifest, so the release install stopped before any DPF container could boot.