### PR TITLE
fix: repair platform update flow

### DIFF
--- a/apps/web/components/monitoring/prometheus-config.test.ts
+++ b/apps/web/components/monitoring/prometheus-config.test.ts
@@ -25,6 +25,13 @@ describe("Prometheus substrate configs", () => {
     expect(config).toContain('targets: ["node-exporter:9100"]');
   });
 
+  it("does not page optional Linux exporter jobs through the default ContainerDown rule", () => {
+    const config = readPrometheusConfig("alerts.yml");
+
+    expect(config).toContain('expr: up{job!~"cadvisor|node-exporter"} == 0');
+    expect(config).not.toContain("expr: up == 0");
+  });
+
   it("starts Linux exporter containers when the Linux scrape config is mounted", () => {
     const config = readRepoFile("docker-compose.linux.yml");
 

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -287,7 +287,7 @@ describe("applyPlatformUpdate", () => {
     const commands = mockExec.mock.calls.map(([cmd]) => cmd);
     expect(commands).toContain("git diff --quiet --ignore-cr-at-eol -- apps/web packages");
     expect(commands).toContain("git diff --cached --quiet --ignore-cr-at-eol -- apps/web packages");
-    expect(commands).toContain("git checkout -f dpf-upstream");
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f dpf-upstream");
     const diffCall = mockExec.mock.calls.find(
       ([cmd]) => cmd === "git diff --quiet --ignore-cr-at-eol -- apps/web packages",
     );
@@ -332,8 +332,38 @@ describe("applyPlatformUpdate", () => {
 
     expect(result.kind).toBe("clean-merge");
     const commands = mockExec.mock.calls.map(([cmd]) => cmd);
-    expect(commands).toContain("git checkout -f dpf-upstream");
-    expect(commands).toContain("git checkout -f my-changes");
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f dpf-upstream");
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f my-changes");
+  });
+
+  it("does not run host checkout hooks while switching managed update branches", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockReturnValue(false);
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd === "git checkout -f dpf-upstream") {
+        cb(new Error("git-lfs was not found on your path"), {
+          stdout: "Switched to branch 'dpf-upstream'",
+          stderr: "This repository is configured for Git LFS but 'git-lfs' was not found on your path.",
+        });
+        return;
+      }
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 4 files changed, 12 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd);
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f dpf-upstream");
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f my-changes");
   });
 
   it("repairs missing managed update branches before applying the update", async () => {
@@ -380,7 +410,7 @@ describe("applyPlatformUpdate", () => {
     let upstreamCheckoutAttempts = 0;
     mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
       if (!cb) return;
-      if (cmd === "git checkout -f dpf-upstream") {
+      if (cmd === "git -c core.hooksPath=/dev/null checkout -f dpf-upstream") {
         upstreamCheckoutAttempts += 1;
         if (upstreamCheckoutAttempts === 1) {
           cb(new Error("pathspec 'dpf-upstream' did not match any file(s) known to git"), {
@@ -407,9 +437,9 @@ describe("applyPlatformUpdate", () => {
 
     expect(result.kind).toBe("clean-merge");
     const commands = mockExec.mock.calls.map(([cmd]) => cmd);
-    expect(commands.filter((cmd) => cmd === "git checkout -f dpf-upstream")).toHaveLength(2);
+    expect(commands.filter((cmd) => cmd === "git -c core.hooksPath=/dev/null checkout -f dpf-upstream")).toHaveLength(2);
     expect(commands).toContain("git branch -f dpf-upstream HEAD");
-    expect(commands).toContain("git checkout -f my-changes");
+    expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f my-changes");
   });
 
   it("does not repair missing update branches over committed source changes", async () => {

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -188,7 +188,7 @@ describe("applyPlatformUpdate", () => {
       expect(result.filesUpdated).toBe(3);
     }
     const commands = mockExec.mock.calls.map(([cmd]) => cmd);
-    expect(commands.some((cmd) => String(cmd).startsWith('git commit -s -m "chore: merge dpf'))).toBe(true);
+    expect(commands.some((cmd) => String(cmd).startsWith('git -c core.hooksPath=/dev/null commit -s -m "chore: merge dpf'))).toBe(true);
     expect(commands).not.toContain("rm -rf apps/web packages");
     expect(mockWriteFileSync).toHaveBeenCalled();
     expect(mockPrisma.platformDevConfig.update).toHaveBeenCalledWith({
@@ -364,6 +364,36 @@ describe("applyPlatformUpdate", () => {
     const commands = mockExec.mock.calls.map(([cmd]) => cmd);
     expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f dpf-upstream");
     expect(commands).toContain("git -c core.hooksPath=/dev/null checkout -f my-changes");
+  });
+
+  it("does not run host commit hooks when recording managed update commits", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockReturnValue(false);
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.startsWith("git commit -s -m ")) {
+        cb(new Error("pre-commit hook did not finish inside the portal container"), {
+          stdout: "",
+          stderr: "pre-commit hook did not finish inside the portal container",
+        });
+        return;
+      }
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 4 files changed, 12 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd);
+    expect(commands).toContain('git -c core.hooksPath=/dev/null commit -s -m "chore: dpf-upstream vv1.2.3"');
+    expect(commands).toContain('git -c core.hooksPath=/dev/null commit -s -m "chore: merge dpf vv1.2.3"');
   });
 
   it("repairs missing managed update branches before applying the update", async () => {

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -733,6 +733,7 @@ type ExecUpdate = (
 
 const UPDATE_UPSTREAM_BRANCH = "dpf-upstream";
 const UPDATE_WORK_BRANCH = "my-changes";
+const HOOKLESS_GIT = "git -c core.hooksPath=/dev/null";
 const PLATFORM_UPDATE_SOURCE_PATHS = ["apps/web", "packages"] as const;
 
 function shellQuote(value: string): string {
@@ -885,7 +886,7 @@ async function checkoutManagedUpdateBranch(
   branch: string,
 ): Promise<void> {
   try {
-    await execUpdate(`git checkout -f ${branch}`, gitOpts);
+    await execUpdate(`${HOOKLESS_GIT} checkout -f ${branch}`, gitOpts);
     return;
   } catch (err) {
     if (!isMissingGitReferenceError(err, branch)) {
@@ -895,7 +896,7 @@ async function checkoutManagedUpdateBranch(
 
   await assertBranchRepairCanUseCurrentHead(execUpdate, gitOpts);
   await execUpdate(`git branch -f ${branch} HEAD`, gitOpts);
-  await execUpdate(`git checkout -f ${branch}`, gitOpts);
+  await execUpdate(`${HOOKLESS_GIT} checkout -f ${branch}`, gitOpts);
 }
 
 async function collectPlatformUpdateConflicts(

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -946,7 +946,7 @@ async function finishPlatformUpdateMerge(
     10,
   );
   await execUpdate(
-    `git commit -s -m "chore: merge dpf v${pendingVersion}"`,
+    `${HOOKLESS_GIT} commit -s -m "chore: merge dpf v${pendingVersion}"`,
     gitOpts,
   );
 
@@ -1051,7 +1051,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     );
     if (diffCheck.trim()) {
       await execUpdate(
-        `git commit -s -m "chore: ${UPDATE_UPSTREAM_BRANCH} v${pendingVersion}"`,
+        `${HOOKLESS_GIT} commit -s -m "chore: ${UPDATE_UPSTREAM_BRANCH} v${pendingVersion}"`,
         gitOpts,
       );
     }

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       # ─── Container Health ──────────────────────────────────
       - alert: ContainerDown
-        expr: up == 0
+        expr: up{job!~"cadvisor|node-exporter"} == 0
         for: 1m
         labels:
           severity: critical


### PR DESCRIPTION
Repairs the Admin > Platform Development Apply update flow on Windows installs and suppresses optional Linux exporter ContainerDown alerts from the default Prometheus rule. Verification: pnpm --filter web test -- --run lib/actions/platform-dev-config.apply.test.ts lib/self-upgrade/config.test.ts lib/self-upgrade/version.test.ts lib/actions/promotions.self-upgrade.test.ts lib/queue/functions/self-upgrade.test.ts components/monitoring/prometheus-config.test.ts components/monitoring/health-summary.test.ts; pnpm --filter web typecheck; pnpm --filter web exec next build; live UX completed Apply update, PlatformDevConfig updatePending=false, /api/platform/metrics/alerts returns [].