### PR TITLE
fix: keep platform update sentinel out of source status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ docker-compose.override.yml
 .install-progress
 .selected-model
 .tmp-codex-config.toml*
+/data/uploads/
 
 # Test artifacts
 e2e-report/

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -247,6 +247,8 @@ describe("applyPlatformUpdate", () => {
       expect(result.version).toBe("v1.2.3");
       expect(result.filesUpdated).toBe(42);
     }
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd);
+    expect(commands).toContain("git update-index --skip-worktree .dpf-version 2>/dev/null || true");
     expect(mockPrisma.platformDevConfig.update).toHaveBeenCalledWith({
       where: { id: "singleton" },
       data: { updatePending: false, pendingVersion: null },

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -956,6 +956,10 @@ async function finishPlatformUpdateMerge(
     pendingVersion,
     "utf-8",
   );
+  await execUpdate(
+    "git update-index --skip-worktree .dpf-version 2>/dev/null || true",
+    gitOpts,
+  );
 
   await prisma.platformDevConfig.update({
     where: { id: "singleton" },


### PR DESCRIPTION
Keeps the platform update version sentinel from surfacing as source work after a successful Apply update, and ignores local runtime upload data.\n\nVerification:\n- pnpm --filter web test -- --run lib/actions/platform-dev-config.apply.test.ts components/monitoring/prometheus-config.test.ts components/monitoring/health-summary.test.ts\n- pnpm --filter web typecheck\n- pnpm --filter web exec next build