### PR TITLE
fix: anchor update banner to viewport top

### DIFF
--- a/apps/web/components/shell/ShellBannerOverlay.test.tsx
+++ b/apps/web/components/shell/ShellBannerOverlay.test.tsx
@@ -12,7 +12,9 @@ describe("ShellBannerOverlay", () => {
     );
 
     expect(html).toContain("fixed");
-    expect(html).toContain("top-20");
+    expect(html).toContain("top-0");
+    expect(html).not.toContain("top-20");
+    expect(html).not.toMatch(/\b(?:[a-z]+:)?pt-/);
     expect(html).toContain("pointer-events-none");
     expect(html).toContain('data-testid="shell-banner-overlay"');
   });

--- a/apps/web/components/shell/ShellBannerOverlay.tsx
+++ b/apps/web/components/shell/ShellBannerOverlay.tsx
@@ -6,7 +6,7 @@ export function ShellBannerOverlay({
   return (
     <div
       aria-label="System notices"
-      className="pointer-events-none fixed inset-x-0 top-20 z-[80] flex flex-col items-center gap-2 px-3 pt-3 sm:px-4"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[80] flex flex-col items-center gap-2 px-3 sm:px-4"
       data-testid="shell-banner-overlay"
     >
       {children}


### PR DESCRIPTION
## Summary
- Anchor shell banner overlays to the viewport top edge instead of below the header.
- Add a regression assertion that shell notices do not use top padding or the old `top-20` offset.

## Verification
- `pnpm --filter web test -- --run components/shell/ShellBannerOverlay.test.tsx components/shell/UpdatePendingBannerClient.test.tsx`
- `pnpm --filter web typecheck`
- `docker build --target build -t dpf-update-banner-position-build-test .` (passed after rerun; first rerun hit the known native Next worker SIGTRAP)
- Live Docker-served UX check at `http://127.0.0.1:3000/platform/ai`: banner `y=0`, no tab intersections, Build Runtime and Operations Map links both navigated successfully.