### PR TITLE
feat: add CRM revenue cockpit

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
@@ -1,14 +1,7 @@
 // apps/web/app/(shell)/customer/engagements/page.tsx
-import Link from "next/link";
 import { prisma } from "@dpf/db";
-
-const STATUS_COLOURS: Record<string, string> = {
-  new: "#fbbf24",
-  contacted: "#38bdf8",
-  qualified: "#4ade80",
-  unqualified: "#8888a0",
-  converted: "#a78bfa",
-};
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { getEngagementStatusMeta } from "@/lib/crm/presentation";
 
 const SOURCE_LABELS: Record<string, string> = {
   web_inquiry: "Web",
@@ -44,15 +37,14 @@ export default async function EngagementsPage() {
       {/* Status summary chips */}
       <div className="flex flex-wrap gap-2 mb-4">
         {Object.entries(statusCounts).map(([status, count]) => {
-          const color = STATUS_COLOURS[status] ?? "#8888a0";
+          const meta = getEngagementStatusMeta(status);
           return (
-            <span
+            <CustomerStatusBadge
               key={status}
-              className="text-[10px] px-2 py-1 rounded-full"
-              style={{ background: `${color}20`, color }}
-            >
-              {status} ({count})
-            </span>
+              label={`${meta.label} (${count})`}
+              tone={meta.tone}
+              className="px-2 py-1 text-[10px]"
+            />
           );
         })}
       </div>
@@ -60,7 +52,7 @@ export default async function EngagementsPage() {
       {/* Engagement list */}
       <div className="space-y-2">
         {engagements.map((e) => {
-          const color = STATUS_COLOURS[e.status] ?? "#8888a0";
+          const statusMeta = getEngagementStatusMeta(e.status);
           const contactName = [e.contact.firstName, e.contact.lastName]
             .filter(Boolean)
             .join(" ") || e.contact.email;
@@ -68,20 +60,17 @@ export default async function EngagementsPage() {
           return (
             <div
               key={e.id}
-              className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 flex items-start justify-between gap-3"
-              style={{ borderLeftColor: color }}
+              className="flex items-start justify-between gap-3 rounded-lg border-l-4 border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-4"
             >
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
                   <p className="text-sm font-semibold text-[var(--dpf-text)] truncate">
                     {e.title}
                   </p>
-                  <span
-                    className="text-[9px] px-1.5 py-0.5 rounded-full shrink-0"
-                    style={{ background: `${color}20`, color }}
-                  >
-                    {e.status}
-                  </span>
+                  <CustomerStatusBadge
+                    label={statusMeta.label}
+                    tone={statusMeta.tone}
+                  />
                   {e.source && (
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] shrink-0">
                       {SOURCE_LABELS[e.source] ?? e.source}

--- a/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
@@ -1,14 +1,21 @@
 // apps/web/app/(shell)/customer/funnel/page.tsx
 import { prisma } from "@dpf/db";
+import {
+  CRM_TONE_CLASSES,
+  getOpportunityStageMeta,
+  OPEN_OPPORTUNITY_STAGES,
+  type CrmTone,
+} from "@/lib/crm/presentation";
+import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 
-const STAGE_COLOURS: Record<string, string> = {
-  qualification: "#fbbf24",
-  discovery: "#fb923c",
-  proposal: "#38bdf8",
-  negotiation: "#a78bfa",
-  closed_won: "#4ade80",
-  closed_lost: "#ef4444",
-};
+function getFunnelWidthClass(width: number) {
+  if (width >= 90) return "w-full";
+  if (width >= 75) return "w-4/5";
+  if (width >= 60) return "w-3/5";
+  if (width >= 40) return "w-2/5";
+  if (width >= 25) return "w-1/3";
+  return "w-1/4";
+}
 
 export default async function FunnelPage() {
   const thirtyDaysAgo = new Date();
@@ -35,8 +42,9 @@ export default async function FunnelPage() {
 
   const totalInteractions = bookings + inquiries + orders + donations;
   const totalEngagements = engagements.reduce((s, e) => s + e._count, 0);
-  const openStages = ["qualification", "discovery", "proposal", "negotiation"];
-  const openOpps = opportunities.filter((o) => openStages.includes(o.stage));
+  const openOpps = opportunities.filter((o) =>
+    OPEN_OPPORTUNITY_STAGES.includes(o.stage as (typeof OPEN_OPPORTUNITY_STAGES)[number]),
+  );
   const totalOpenOpps = openOpps.reduce((s, o) => s + o._count, 0);
   const closedWon = opportunities.find((o) => o.stage === "closed_won")?._count ?? 0;
   const closedLost = opportunities.find((o) => o.stage === "closed_lost")?._count ?? 0;
@@ -66,7 +74,7 @@ export default async function FunnelPage() {
       count: totalInteractions,
       detail: `${ctaLabel}: ${primaryCount}`,
       convLabel: null as string | null,
-      color: "#f472b6",
+      tone: "accent" as CrmTone,
       width: 100,
     },
     {
@@ -74,7 +82,7 @@ export default async function FunnelPage() {
       count: totalEngagements,
       detail: engagements.map((e) => `${e.status}: ${e._count}`).join(", ") || "none",
       convLabel: convToEngagement ? `${convToEngagement}% conversion` : null,
-      color: "#fb923c",
+      tone: "attention" as CrmTone,
       width: totalInteractions > 0 ? Math.max(15, (totalEngagements / totalInteractions) * 100) : 15,
     },
     {
@@ -82,15 +90,15 @@ export default async function FunnelPage() {
       count: totalOpenOpps + closedWon + closedLost,
       detail: openOpps.map((o) => `${o.stage}: ${o._count}`).join(", ") || "none",
       convLabel: convToOpp ? `${convToOpp}% conversion` : null,
-      color: "var(--dpf-accent)",
+      tone: "info" as CrmTone,
       width: totalInteractions > 0 ? Math.max(10, ((totalOpenOpps + closedWon + closedLost) / Math.max(totalInteractions, 1)) * 100) : 10,
     },
     {
       label: "Closed Won",
       count: closedWon,
-      detail: wonValue > 0 ? `Value: $${wonValue.toLocaleString()}` : "no revenue yet",
+      detail: wonValue > 0 ? `Value: ${formatRevenueAmount(wonValue)}` : "no revenue yet",
       convLabel: winRate ? `${winRate}% win rate` : null,
-      color: "#4ade80",
+      tone: "success" as CrmTone,
       width: totalInteractions > 0 ? Math.max(5, (closedWon / Math.max(totalInteractions, 1)) * 100) : 5,
     },
   ];
@@ -117,41 +125,37 @@ export default async function FunnelPage() {
 
       {/* Funnel visualisation */}
       <div className="space-y-3 mb-6">
-        {funnelStages.map((stage) => (
-          <div key={stage.label}>
-            <div className="flex items-center justify-between mb-1">
-              <span className="text-xs font-medium text-[var(--dpf-text)]">{stage.label}</span>
-              {stage.convLabel && (
-                <span className="text-[10px] text-[var(--dpf-muted)]">{stage.convLabel}</span>
-              )}
-            </div>
-            <div className="relative">
-              <div
-                className="h-10 rounded-md flex items-center px-3 transition-all"
-                style={{
-                  width: `${stage.width}%`,
-                  background: `${stage.color}20`,
-                  borderLeft: `3px solid ${stage.color}`,
-                  minWidth: 120,
-                }}
-              >
-                <span className="text-sm font-bold text-[var(--dpf-text)] mr-2">{stage.count}</span>
-                <span className="text-[10px] text-[var(--dpf-muted)] truncate">{stage.detail}</span>
+        {funnelStages.map((stage) => {
+          const toneClasses = CRM_TONE_CLASSES[stage.tone];
+          return (
+            <div key={stage.label}>
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs font-medium text-[var(--dpf-text)]">{stage.label}</span>
+                {stage.convLabel && (
+                  <span className="text-[10px] text-[var(--dpf-muted)]">{stage.convLabel}</span>
+                )}
+              </div>
+              <div className="relative">
+                <div
+                  className={[
+                    "flex h-10 min-w-[120px] items-center rounded-md border-l-4 px-3 transition-all",
+                    getFunnelWidthClass(stage.width),
+                    toneClasses.border,
+                    toneClasses.surface,
+                  ].join(" ")}
+                >
+                  <span className="text-sm font-bold text-[var(--dpf-text)] mr-2">{stage.count}</span>
+                  <span className="text-[10px] text-[var(--dpf-muted)] truncate">{stage.detail}</span>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Weakest point callout */}
       {weakest && Number(weakest.rate) < 50 && (
-        <div
-          className="p-3 rounded-lg border-l-2 mb-6"
-          style={{
-            background: "var(--dpf-surface-1)",
-            borderLeftColor: "#ef4444",
-          }}
-        >
+        <div className="p-3 rounded-lg border-l-2 border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] mb-6">
           <p className="text-xs font-medium text-[var(--dpf-text)]">
             Weakest conversion point
           </p>
@@ -166,21 +170,24 @@ export default async function FunnelPage() {
         <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">Pipeline by Stage</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           {opportunities.map((o) => {
-            const colour = STAGE_COLOURS[o.stage] ?? "#8888a0";
+            const meta = getOpportunityStageMeta(o.stage);
+            const toneClasses = CRM_TONE_CLASSES[meta.tone];
             const value = Number(o._sum?.expectedValue ?? 0);
             return (
               <div
                 key={o.stage}
-                className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-2"
-                style={{ borderLeftColor: colour }}
+                className={[
+                  "p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-2",
+                  toneClasses.border,
+                ].join(" ")}
               >
                 <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-wider">
-                  {o.stage.replace(/_/g, " ")}
+                  {meta.label}
                 </p>
                 <p className="text-lg font-bold text-[var(--dpf-text)]">{o._count}</p>
                 {value > 0 && (
-                  <p className="text-[10px]" style={{ color: colour }}>
-                    ${value.toLocaleString()}
+                  <p className={["text-[10px]", toneClasses.text].join(" ")}>
+                    {formatRevenueAmount(value)}
                   </p>
                 )}
               </div>
@@ -194,22 +201,27 @@ export default async function FunnelPage() {
         <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">Storefront Inbox (30d)</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {[
-            { label: "Bookings", count: bookings, color: "#a78bfa" },
-            { label: "Inquiries", count: inquiries, color: "#fb923c" },
-            { label: "Orders", count: orders, color: "#4ade80" },
-            { label: "Donations", count: donations, color: "#f472b6" },
-          ].map((item) => (
-            <div
-              key={item.label}
-              className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-2"
-              style={{ borderLeftColor: item.color }}
-            >
-              <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-wider">
-                {item.label}
-              </p>
-              <p className="text-lg font-bold text-[var(--dpf-text)]">{item.count}</p>
-            </div>
-          ))}
+            { label: "Bookings", count: bookings, tone: "accent" as CrmTone },
+            { label: "Inquiries", count: inquiries, tone: "attention" as CrmTone },
+            { label: "Orders", count: orders, tone: "success" as CrmTone },
+            { label: "Donations", count: donations, tone: "info" as CrmTone },
+          ].map((item) => {
+            const toneClasses = CRM_TONE_CLASSES[item.tone];
+            return (
+              <div
+                key={item.label}
+                className={[
+                  "p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-2",
+                  toneClasses.border,
+                ].join(" ")}
+              >
+                <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-wider">
+                  {item.label}
+                </p>
+                <p className="text-lg font-bold text-[var(--dpf-text)]">{item.count}</p>
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
@@ -1,17 +1,13 @@
 // apps/web/app/(shell)/customer/opportunities/page.tsx
 import Link from "next/link";
 import { prisma } from "@dpf/db";
-
-const STAGE_META: Record<string, { label: string; color: string }> = {
-  qualification: { label: "Qualification", color: "#fbbf24" },
-  discovery: { label: "Discovery", color: "#fb923c" },
-  proposal: { label: "Proposal", color: "#38bdf8" },
-  negotiation: { label: "Negotiation", color: "#a78bfa" },
-  closed_won: { label: "Won", color: "#4ade80" },
-  closed_lost: { label: "Lost", color: "#ef4444" },
-};
-
-const OPEN_STAGES = ["qualification", "discovery", "proposal", "negotiation"];
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import {
+  CRM_TONE_CLASSES,
+  getOpportunityStageMeta,
+  OPEN_OPPORTUNITY_STAGES,
+} from "@/lib/crm/presentation";
+import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 
 export default async function OpportunitiesPage() {
   const opportunities = await prisma.opportunity.findMany({
@@ -25,7 +21,7 @@ export default async function OpportunitiesPage() {
 
   // Group by stage for Kanban
   const byStage: Record<string, typeof opportunities> = {};
-  for (const stage of OPEN_STAGES) {
+  for (const stage of OPEN_OPPORTUNITY_STAGES) {
     byStage[stage] = [];
   }
   for (const opp of opportunities) {
@@ -34,7 +30,9 @@ export default async function OpportunitiesPage() {
   }
 
   // Pipeline metrics
-  const openOpps = opportunities.filter((o) => OPEN_STAGES.includes(o.stage));
+  const openOpps = opportunities.filter((o) =>
+    OPEN_OPPORTUNITY_STAGES.includes(o.stage as (typeof OPEN_OPPORTUNITY_STAGES)[number]),
+  );
   const totalPipelineValue = openOpps.reduce(
     (s, o) => s + Number(o.expectedValue ?? 0),
     0,
@@ -53,14 +51,14 @@ export default async function OpportunitiesPage() {
           <span className="text-[var(--dpf-muted)]">
             {openOpps.length} open opportunit{openOpps.length !== 1 ? "ies" : "y"}
           </span>
-          <span style={{ color: "var(--dpf-accent)" }}>
-            £{totalPipelineValue.toLocaleString()} total
+          <span className="text-[var(--dpf-accent)]">
+            {formatRevenueAmount(totalPipelineValue)} total
           </span>
-          <span style={{ color: "#4ade80" }}>
-            £{Math.round(weightedValue).toLocaleString()} weighted
+          <span className="text-[var(--dpf-text)]">
+            {formatRevenueAmount(Math.round(weightedValue))} weighted
           </span>
           {dormantCount > 0 && (
-            <span style={{ color: "#ef4444" }}>
+            <span className="text-[var(--dpf-text)]">
               {dormantCount} dormant
             </span>
           )}
@@ -69,8 +67,9 @@ export default async function OpportunitiesPage() {
 
       {/* Kanban board — open stages */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-8">
-        {OPEN_STAGES.map((stage) => {
-          const meta = STAGE_META[stage]!;
+        {OPEN_OPPORTUNITY_STAGES.map((stage) => {
+          const meta = getOpportunityStageMeta(stage);
+          const toneClasses = CRM_TONE_CLASSES[meta.tone];
           const opps = byStage[stage] ?? [];
           const stageValue = opps.reduce(
             (s, o) => s + Number(o.expectedValue ?? 0),
@@ -80,14 +79,16 @@ export default async function OpportunitiesPage() {
           return (
             <div key={stage}>
               <div
-                className="flex items-center justify-between mb-2 pb-1 border-b-2"
-                style={{ borderBottomColor: meta.color }}
+                className={[
+                  "flex items-center justify-between mb-2 pb-1 border-b-2",
+                  toneClasses.border,
+                ].join(" ")}
               >
                 <span className="text-xs font-semibold text-[var(--dpf-text)]">
                   {meta.label}
                 </span>
                 <span className="text-[9px] text-[var(--dpf-muted)]">
-                  {opps.length} · £{stageValue.toLocaleString()}
+                  {opps.length} · {formatRevenueAmount(stageValue)}
                 </span>
               </div>
 
@@ -103,9 +104,7 @@ export default async function OpportunitiesPage() {
                         {opp.title}
                       </p>
                       {opp.isDormant && (
-                        <span className="text-[8px] px-1 py-0.5 rounded-full bg-red-900/30 text-red-400 shrink-0">
-                          dormant
-                        </span>
+                        <CustomerStatusBadge label="Dormant" tone="warning" />
                       )}
                     </div>
                     <p className="text-[9px] text-[var(--dpf-muted)] truncate">
@@ -114,7 +113,7 @@ export default async function OpportunitiesPage() {
                     <div className="flex items-center justify-between mt-1.5">
                       {opp.expectedValue && (
                         <span className="text-[10px] font-mono text-[var(--dpf-text)]">
-                          £{Number(opp.expectedValue).toLocaleString()}
+                          {formatRevenueAmount(Number(opp.expectedValue))}
                         </span>
                       )}
                       <span className="text-[9px] text-[var(--dpf-muted)]">
@@ -144,7 +143,7 @@ export default async function OpportunitiesPage() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {[...(byStage["closed_won"] ?? []), ...(byStage["closed_lost"] ?? [])].map(
               (opp) => {
-                const meta = STAGE_META[opp.stage]!;
+                const meta = getOpportunityStageMeta(opp.stage);
                 return (
                   <Link
                     key={opp.id}
@@ -157,12 +156,7 @@ export default async function OpportunitiesPage() {
                         {opp.account.name}
                       </p>
                     </div>
-                    <span
-                      className="text-[9px] px-1.5 py-0.5 rounded-full shrink-0"
-                      style={{ background: `${meta.color}20`, color: meta.color }}
-                    >
-                      {meta.label}
-                    </span>
+                    <CustomerStatusBadge label={meta.label} tone={meta.tone} />
                   </Link>
                 );
               },

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -2,74 +2,93 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { NewCustomerButton } from "@/components/customer/NewCustomerButton";
-
-const STATUS_COLOURS: Record<string, string> = {
-  prospect: "#fbbf24",
-  qualified: "#fb923c",
-  onboarding: "#38bdf8",
-  active: "#4ade80",
-  at_risk: "#ef4444",
-  suspended: "#8888a0",
-  closed: "#555566",
-};
+import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { buildRevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
+import { getAccountStatusMeta } from "@/lib/crm/presentation";
 
 export default async function CustomerPage() {
-  const [accounts, engagementCounts, opportunityCounts, quoteCounts, orderCounts] =
-    await Promise.all([
-      prisma.customerAccount.findMany({
-        orderBy: { name: "asc" },
-        select: {
-          id: true,
-          accountId: true,
-          name: true,
-          status: true,
-          industry: true,
-          _count: { select: { contacts: true, opportunities: true } },
-        },
-      }),
-      prisma.engagement.groupBy({
-        by: ["status"],
-        _count: true,
-      }),
-      prisma.opportunity.groupBy({
-        by: ["stage"],
-        _count: true,
-        _sum: { expectedValue: true },
-      }),
-      prisma.quote.groupBy({
-        by: ["status"],
-        _count: true,
-      }),
-      prisma.salesOrder.groupBy({
-        by: ["status"],
-        _count: true,
-      }),
-    ]);
+  const [
+    accounts,
+    engagementCounts,
+    opportunityCounts,
+    quoteCounts,
+    orderCounts,
+    staleOpportunityCount,
+    campaignBriefsOpen,
+    assetTasksOpen,
+    automationCandidatesOpen,
+  ] = await Promise.all([
+    prisma.customerAccount.findMany({
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        accountId: true,
+        name: true,
+        status: true,
+        industry: true,
+        _count: { select: { contacts: true, opportunities: true } },
+      },
+    }),
+    prisma.engagement.groupBy({
+      by: ["status"],
+      _count: true,
+    }),
+    prisma.opportunity.groupBy({
+      by: ["stage"],
+      _count: true,
+      _sum: { expectedValue: true },
+    }),
+    prisma.quote.groupBy({
+      by: ["status"],
+      _count: true,
+    }),
+    prisma.salesOrder.groupBy({
+      by: ["status"],
+      _count: true,
+    }),
+    prisma.opportunity.count({
+      where: {
+        isDormant: true,
+        stage: { in: ["qualification", "discovery", "proposal", "negotiation"] },
+      },
+    }),
+    prisma.marketingCampaignBrief.count({
+      where: { status: "draft" },
+    }),
+    prisma.marketingAssetTask.count({
+      where: { status: "draft" },
+    }),
+    prisma.marketingAutomationCandidate.count({
+      where: { status: "draft" },
+    }),
+  ]);
 
-  const engTotal = engagementCounts.reduce((s, e) => s + e._count, 0);
-  const engNew = engagementCounts.find((e) => e.status === "new")?._count ?? 0;
-
-  const openStages = ["qualification", "discovery", "proposal", "negotiation"];
-  const openOpps = opportunityCounts.filter((o) => openStages.includes(o.stage));
-  const pipelineCount = openOpps.reduce((s, o) => s + o._count, 0);
-  const pipelineValue = openOpps.reduce(
-    (s, o) => s + Number(o._sum.expectedValue ?? 0),
-    0,
-  );
-
-  const quoteDraft = quoteCounts.find((q) => q.status === "draft")?._count ?? 0;
-  const quoteSent = quoteCounts.find((q) => q.status === "sent")?._count ?? 0;
-
-  const ordersActive = orderCounts
-    .filter((o) => o.status === "confirmed" || o.status === "in_progress")
-    .reduce((s, o) => s + o._count, 0);
-
-  const summaryCards = [
-    { label: "Engagements", value: engTotal, sub: `${engNew} new`, color: "#fb923c", href: "/customer/engagements" },
-    { label: "Pipeline", value: pipelineCount, sub: `$${pipelineValue.toLocaleString()}`, color: "var(--dpf-accent)", href: "/customer/opportunities" },
-    { label: "Quotes", value: quoteDraft + quoteSent, sub: `${quoteSent} sent`, color: "#38bdf8", href: "/customer/quotes" },
-    { label: "Orders", value: ordersActive, sub: "active", color: "#4ade80", href: "/customer/sales-orders" },
-  ];
+  const revenueSummary = buildRevenueCockpitSummary({
+    engagementCounts: engagementCounts.map((item) => ({
+      status: item.status,
+      count: item._count,
+    })),
+    opportunityCounts: opportunityCounts.map((item) => ({
+      stage: item.stage,
+      count: item._count,
+      expectedValue: Number(item._sum.expectedValue ?? 0),
+    })),
+    quoteCounts: quoteCounts.map((item) => ({
+      status: item.status,
+      count: item._count,
+    })),
+    orderCounts: orderCounts.map((item) => ({
+      status: item.status,
+      count: item._count,
+    })),
+    staleOpportunityCount,
+    marketingWork: {
+      campaignBriefsOpen,
+      assetTasksOpen,
+      automationCandidatesOpen,
+    },
+  });
 
   return (
     <div>
@@ -83,36 +102,17 @@ export default async function CustomerPage() {
         <NewCustomerButton />
       </div>
 
-      {/* Pipeline summary cards */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-        {summaryCards.map((c) => (
-          <Link
-            key={c.label}
-            href={c.href}
-            className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-2 hover:bg-[var(--dpf-surface-2)] transition-colors"
-            style={{ borderLeftColor: c.color }}
-          >
-            <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-wider">
-              {c.label}
-            </p>
-            <p className="text-lg font-bold text-[var(--dpf-text)]">{c.value}</p>
-            <p className="text-[10px]" style={{ color: c.color }}>
-              {c.sub}
-            </p>
-          </Link>
-        ))}
-      </div>
+      <RevenueCockpit summary={revenueSummary} />
 
       {/* Account list */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {accounts.map((a) => {
-          const statusColour = STATUS_COLOURS[a.status] ?? "#8888a0";
+          const statusMeta = getAccountStatusMeta(a.status);
           return (
             <Link
               key={a.id}
               href={`/customer/${a.id}`}
-              className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 hover:bg-[var(--dpf-surface-2)] transition-colors"
-              style={{ borderLeftColor: "#f472b6" }}
+              className="rounded-lg border-l-4 border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]"
             >
               <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">
                 {a.accountId}
@@ -121,12 +121,10 @@ export default async function CustomerPage() {
                 <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight">
                   {a.name}
                 </p>
-                <span
-                  className="text-[9px] px-1.5 py-0.5 rounded-full shrink-0"
-                  style={{ background: `${statusColour}20`, color: statusColour }}
-                >
-                  {a.status}
-                </span>
+                <CustomerStatusBadge
+                  label={statusMeta.label}
+                  tone={statusMeta.tone}
+                />
               </div>
               <div className="flex gap-3 text-[9px] text-[var(--dpf-muted)]">
                 <span>{a._count.contacts} contact{a._count.contacts !== 1 ? "s" : ""}</span>

--- a/apps/web/components/customer-marketing/MarketingTabNav.test.tsx
+++ b/apps/web/components/customer-marketing/MarketingTabNav.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+let pathname = "/customer/marketing";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { MarketingTabNav } from "./MarketingTabNav";
+
+describe("MarketingTabNav", () => {
+  it("renders only implemented marketing routes", () => {
+    pathname = "/customer/marketing";
+    const html = renderToStaticMarkup(<MarketingTabNav />);
+
+    expect(html).toContain('href="/customer/marketing"');
+    expect(html).toContain('href="/customer/marketing/strategy"');
+    expect(html).not.toContain("Campaigns");
+    expect(html).not.toContain("Funnel");
+    expect(html).not.toContain("Automation");
+    expect(html).not.toContain("Phase 2");
+    expect(html).not.toContain("Phase 3");
+  });
+
+  it("keeps Strategy active for nested strategy routes", () => {
+    pathname = "/customer/marketing/strategy";
+    const html = renderToStaticMarkup(<MarketingTabNav />);
+
+    expect(html).toContain("border-[var(--dpf-accent)]");
+  });
+});

--- a/apps/web/components/customer-marketing/MarketingTabNav.tsx
+++ b/apps/web/components/customer-marketing/MarketingTabNav.tsx
@@ -4,11 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const TABS = [
-  { label: "Overview", href: "/customer/marketing", enabled: true },
-  { label: "Strategy", href: "/customer/marketing/strategy", enabled: true },
-  { label: "Campaigns", href: "/customer/marketing/campaigns", enabled: false, reason: "Phase 2" },
-  { label: "Funnel", href: "/customer/marketing/funnel", enabled: false, reason: "Phase 3" },
-  { label: "Automation", href: "/customer/marketing/automation", enabled: false, reason: "Phase 2" },
+  { label: "Overview", href: "/customer/marketing" },
+  { label: "Strategy", href: "/customer/marketing/strategy" },
 ] as const;
 
 export function MarketingTabNav() {
@@ -23,32 +20,20 @@ export function MarketingTabNav() {
 
   return (
     <nav className="mb-6 flex flex-wrap gap-2 border-b border-[var(--dpf-border)] pb-3">
-      {TABS.map((tab) =>
-        tab.enabled ? (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            className={[
-              "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
-              isActive(tab.href)
-                ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
-                : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-            ].join(" ")}
-          >
-            {tab.label}
-          </Link>
-        ) : (
-          <span
-            key={tab.href}
-            className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs text-[var(--dpf-muted)] opacity-80"
-          >
-            {tab.label}
-            <span className="ml-2 text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
-              {tab.reason}
-            </span>
-          </span>
-        ),
-      )}
+      {TABS.map((tab) => (
+        <Link
+          key={tab.href}
+          href={tab.href}
+          className={[
+            "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+            isActive(tab.href)
+              ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+              : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+          ].join(" ")}
+        >
+          {tab.label}
+        </Link>
+      ))}
     </nav>
   );
 }

--- a/apps/web/components/customer/CustomerMetricTile.test.tsx
+++ b/apps/web/components/customer/CustomerMetricTile.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CustomerMetricTile } from "./CustomerMetricTile";
+
+describe("CustomerMetricTile", () => {
+  it("renders a linked metric with DPF theme classes", () => {
+    const html = renderToStaticMarkup(
+      <CustomerMetricTile
+        href="/customer/opportunities"
+        label="Pipeline"
+        value="3"
+        detail="£6,000 open"
+        tone="accent"
+      />,
+    );
+
+    expect(html).toContain('href="/customer/opportunities"');
+    expect(html).toContain(">Pipeline<");
+    expect(html).toContain(">3<");
+    expect(html).toContain("£6,000 open");
+    expect(html).toContain("border-[var(--dpf-accent)]");
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+});

--- a/apps/web/components/customer/CustomerMetricTile.tsx
+++ b/apps/web/components/customer/CustomerMetricTile.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { CrmTone } from "@/lib/crm/presentation";
+import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+
+type CustomerMetricTileProps = {
+  href: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: CrmTone;
+};
+
+export function CustomerMetricTile({
+  href,
+  label,
+  value,
+  detail,
+  tone,
+}: CustomerMetricTileProps) {
+  const toneClasses = CRM_TONE_CLASSES[tone];
+
+  return (
+    <Link
+      href={href}
+      className={[
+        "block rounded-lg border-l-2 bg-[var(--dpf-surface-1)] p-3 transition-colors hover:bg-[var(--dpf-surface-2)]",
+        toneClasses.border,
+      ].join(" ")}
+    >
+      <p className="text-[10px] uppercase tracking-wider text-[var(--dpf-muted)]">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-bold text-[var(--dpf-text)]">{value}</p>
+      <p className={["mt-1 text-[10px]", toneClasses.text].join(" ")}>
+        {detail}
+      </p>
+    </Link>
+  );
+}

--- a/apps/web/components/customer/CustomerStatusBadge.test.tsx
+++ b/apps/web/components/customer/CustomerStatusBadge.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CustomerStatusBadge } from "./CustomerStatusBadge";
+
+describe("CustomerStatusBadge", () => {
+  it("renders the label and theme-aware tone classes", () => {
+    const html = renderToStaticMarkup(
+      <CustomerStatusBadge label="Dormant" tone="warning" />,
+    );
+
+    expect(html).toContain(">Dormant<");
+    expect(html).toContain("border-[var(--dpf-border)]");
+    expect(html).toContain("text-[var(--dpf-text)]");
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+});

--- a/apps/web/components/customer/CustomerStatusBadge.tsx
+++ b/apps/web/components/customer/CustomerStatusBadge.tsx
@@ -1,0 +1,28 @@
+import type { CrmTone } from "@/lib/crm/presentation";
+import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+
+type CustomerStatusBadgeProps = {
+  label: string;
+  tone: CrmTone;
+  className?: string;
+};
+
+export function CustomerStatusBadge({
+  label,
+  tone,
+  className = "",
+}: CustomerStatusBadgeProps) {
+  return (
+    <span
+      className={[
+        "shrink-0 rounded-full border px-1.5 py-0.5 text-[9px]",
+        CRM_TONE_CLASSES[tone].badge,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/components/customer/EditCustomerConfigurationItemButton.tsx
+++ b/apps/web/components/customer/EditCustomerConfigurationItemButton.tsx
@@ -383,7 +383,7 @@ export function EditCustomerConfigurationItemButton({
                 </div>
               </div>
 
-              {error ? <p className="text-xs text-red-500">{error}</p> : null}
+              {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
 
               <div className="flex justify-end gap-2">
                 <button

--- a/apps/web/components/customer/NewCustomerButton.tsx
+++ b/apps/web/components/customer/NewCustomerButton.tsx
@@ -118,7 +118,7 @@ export function NewCustomerButton() {
               className={inputClasses}
             />
           </div>
-          {error && <p className="text-xs text-red-400">{error}</p>}
+          {error && <p className="text-xs text-[var(--dpf-text)]">{error}</p>}
           <div className="flex gap-2 justify-end">
             <button
               type="button"

--- a/apps/web/components/customer/NewCustomerConfigurationItemButton.tsx
+++ b/apps/web/components/customer/NewCustomerConfigurationItemButton.tsx
@@ -299,7 +299,7 @@ export function NewCustomerConfigurationItemButton({
                 </p>
               ) : null}
 
-              {error ? <p className="text-xs text-red-500">{error}</p> : null}
+              {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
 
               <div className="flex justify-end gap-2">
                 <button

--- a/apps/web/components/customer/NewCustomerSiteButton.tsx
+++ b/apps/web/components/customer/NewCustomerSiteButton.tsx
@@ -181,7 +181,7 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
             />
           </div>
 
-          {error ? <p className="text-xs text-red-500">{error}</p> : null}
+          {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
 
           <div className="flex justify-end gap-2">
             <button

--- a/apps/web/components/customer/NewCustomerSiteNodeButton.tsx
+++ b/apps/web/components/customer/NewCustomerSiteNodeButton.tsx
@@ -133,7 +133,7 @@ export function NewCustomerSiteNodeButton({
                 />
               </div>
 
-              {error ? <p className="text-xs text-red-500">{error}</p> : null}
+              {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
 
               <div className="flex justify-end gap-2">
                 <button

--- a/apps/web/components/customer/RevenueCockpit.test.tsx
+++ b/apps/web/components/customer/RevenueCockpit.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RevenueCockpit } from "./RevenueCockpit";
+
+describe("RevenueCockpit", () => {
+  it("renders metrics and attention items", () => {
+    const html = renderToStaticMarkup(
+      <RevenueCockpit
+        summary={{
+          metrics: [
+            {
+              id: "pipeline",
+              label: "Pipeline",
+              value: "3",
+              detail: "£6,000 open",
+              href: "/customer/opportunities",
+              tone: "accent",
+            },
+          ],
+          attentionItems: [
+            {
+              id: "stale-opportunities",
+              label: "2 stale opportunities need a next action",
+              href: "/customer/opportunities",
+              tone: "warning",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Today in revenue");
+    expect(html).toContain("Pipeline");
+    expect(html).toContain("2 stale opportunities need a next action");
+    expect(html).toContain('href="/customer/opportunities"');
+  });
+
+  it("renders a calm empty attention state", () => {
+    const html = renderToStaticMarkup(
+      <RevenueCockpit
+        summary={{
+          metrics: [],
+          attentionItems: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain("No urgent revenue actions right now.");
+  });
+});

--- a/apps/web/components/customer/RevenueCockpit.tsx
+++ b/apps/web/components/customer/RevenueCockpit.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { CustomerMetricTile } from "./CustomerMetricTile";
+import type { RevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
+import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+
+type RevenueCockpitProps = {
+  summary: RevenueCockpitSummary;
+};
+
+export function RevenueCockpit({ summary }: RevenueCockpitProps) {
+  return (
+    <section className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-[10px] uppercase tracking-wider text-[var(--dpf-muted)]">
+            Today in revenue
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-[var(--dpf-text)]">
+            Pipeline, signals, and work that need attention
+          </h2>
+        </div>
+        <Link
+          href="/customer/marketing"
+          className="text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+        >
+          Open marketing workspace
+        </Link>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {summary.metrics.map((metric) => (
+          <CustomerMetricTile
+            key={metric.id}
+            href={metric.href}
+            label={metric.label}
+            value={metric.value}
+            detail={metric.detail}
+            tone={metric.tone}
+          />
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {summary.attentionItems.length > 0 ? (
+          summary.attentionItems.map((item) => (
+            <Link
+              key={item.id}
+              href={item.href}
+              className={[
+                "rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-[var(--dpf-surface-2)]",
+                CRM_TONE_CLASSES[item.tone].badge,
+              ].join(" ")}
+            >
+              {item.label}
+            </Link>
+          ))
+        ) : (
+          <p className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs text-[var(--dpf-muted)]">
+            No urgent revenue actions right now.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/crm/presentation.test.ts
+++ b/apps/web/lib/crm/presentation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  CRM_TONE_CLASSES,
+  formatCrmStatusLabel,
+  getAccountStatusMeta,
+  getEngagementStatusMeta,
+  getOpportunityStageMeta,
+  isOpenOpportunityStage,
+  OPEN_OPPORTUNITY_STAGES,
+} from "./presentation";
+
+describe("CRM presentation metadata", () => {
+  it("defines open opportunity stages in buyer-progress order", () => {
+    expect(OPEN_OPPORTUNITY_STAGES).toEqual([
+      "qualification",
+      "discovery",
+      "proposal",
+      "negotiation",
+    ]);
+  });
+
+  it("identifies only active pipeline stages as open", () => {
+    expect(isOpenOpportunityStage("qualification")).toBe(true);
+    expect(isOpenOpportunityStage("closed_won")).toBe(false);
+    expect(isOpenOpportunityStage("unknown")).toBe(false);
+  });
+
+  it("formats CRM status values for display", () => {
+    expect(formatCrmStatusLabel("closed_won")).toBe("Closed won");
+    expect(formatCrmStatusLabel("in_progress")).toBe("In progress");
+    expect(formatCrmStatusLabel("new")).toBe("New");
+  });
+
+  it("returns specific metadata for known statuses and fallback metadata otherwise", () => {
+    expect(getAccountStatusMeta("active")).toMatchObject({
+      label: "Active",
+      tone: "success",
+    });
+    expect(getEngagementStatusMeta("converted")).toMatchObject({
+      label: "Converted",
+      tone: "accent",
+    });
+    expect(getOpportunityStageMeta("proposal")).toMatchObject({
+      label: "Proposal",
+      tone: "info",
+    });
+    expect(getOpportunityStageMeta("custom_stage")).toMatchObject({
+      label: "Custom stage",
+      tone: "neutral",
+    });
+  });
+
+  it("uses theme-aware classes instead of raw hex colors", () => {
+    const serialized = JSON.stringify(CRM_TONE_CLASSES);
+    expect(serialized).not.toMatch(/#[0-9a-f]{3,6}/i);
+    expect(serialized).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/lib/crm/presentation.ts
+++ b/apps/web/lib/crm/presentation.ts
@@ -1,0 +1,133 @@
+export const OPEN_OPPORTUNITY_STAGES = [
+  "qualification",
+  "discovery",
+  "proposal",
+  "negotiation",
+] as const;
+
+export type OpenOpportunityStage = typeof OPEN_OPPORTUNITY_STAGES[number];
+
+export type CrmTone =
+  | "accent"
+  | "attention"
+  | "danger"
+  | "info"
+  | "neutral"
+  | "success"
+  | "warning";
+
+export type CrmPresentationMeta = {
+  label: string;
+  tone: CrmTone;
+};
+
+export const CRM_TONE_CLASSES: Record<
+  CrmTone,
+  {
+    border: string;
+    badge: string;
+    text: string;
+    surface: string;
+  }
+> = {
+  accent: {
+    border: "border-[var(--dpf-accent)]",
+    badge: "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-accent)]",
+    text: "text-[var(--dpf-accent)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+  attention: {
+    border: "border-[var(--dpf-accent)]",
+    badge: "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+    text: "text-[var(--dpf-text)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+  danger: {
+    border: "border-[var(--dpf-border)]",
+    badge: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+    text: "text-[var(--dpf-text)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+  info: {
+    border: "border-[var(--dpf-border)]",
+    badge: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+    text: "text-[var(--dpf-text)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+  neutral: {
+    border: "border-[var(--dpf-border)]",
+    badge: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+    text: "text-[var(--dpf-muted)]",
+    surface: "bg-[var(--dpf-surface-1)]",
+  },
+  success: {
+    border: "border-[var(--dpf-accent)]",
+    badge: "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+    text: "text-[var(--dpf-text)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+  warning: {
+    border: "border-[var(--dpf-border)]",
+    badge: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+    text: "text-[var(--dpf-text)]",
+    surface: "bg-[var(--dpf-surface-2)]",
+  },
+};
+
+const ACCOUNT_STATUS_META: Record<string, CrmPresentationMeta> = {
+  prospect: { label: "Prospect", tone: "warning" },
+  qualified: { label: "Qualified", tone: "attention" },
+  onboarding: { label: "Onboarding", tone: "info" },
+  active: { label: "Active", tone: "success" },
+  at_risk: { label: "At risk", tone: "danger" },
+  suspended: { label: "Suspended", tone: "neutral" },
+  closed: { label: "Closed", tone: "neutral" },
+};
+
+const ENGAGEMENT_STATUS_META: Record<string, CrmPresentationMeta> = {
+  new: { label: "New", tone: "warning" },
+  contacted: { label: "Contacted", tone: "info" },
+  qualified: { label: "Qualified", tone: "success" },
+  unqualified: { label: "Unqualified", tone: "neutral" },
+  converted: { label: "Converted", tone: "accent" },
+};
+
+const OPPORTUNITY_STAGE_META: Record<string, CrmPresentationMeta> = {
+  qualification: { label: "Qualification", tone: "warning" },
+  discovery: { label: "Discovery", tone: "attention" },
+  proposal: { label: "Proposal", tone: "info" },
+  negotiation: { label: "Negotiation", tone: "accent" },
+  closed_won: { label: "Won", tone: "success" },
+  closed_lost: { label: "Lost", tone: "danger" },
+};
+
+export function formatCrmStatusLabel(value: string): string {
+  const normalized = value.replace(/[_-]+/g, " ").trim();
+  if (!normalized) {
+    return "Unknown";
+  }
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function fallbackMeta(value: string): CrmPresentationMeta {
+  return {
+    label: formatCrmStatusLabel(value),
+    tone: "neutral",
+  };
+}
+
+export function getAccountStatusMeta(status: string): CrmPresentationMeta {
+  return ACCOUNT_STATUS_META[status] ?? fallbackMeta(status);
+}
+
+export function getEngagementStatusMeta(status: string): CrmPresentationMeta {
+  return ENGAGEMENT_STATUS_META[status] ?? fallbackMeta(status);
+}
+
+export function getOpportunityStageMeta(stage: string): CrmPresentationMeta {
+  return OPPORTUNITY_STAGE_META[stage] ?? fallbackMeta(stage);
+}
+
+export function isOpenOpportunityStage(stage: string): stage is OpenOpportunityStage {
+  return OPEN_OPPORTUNITY_STAGES.includes(stage as OpenOpportunityStage);
+}

--- a/apps/web/lib/crm/revenue-cockpit.test.ts
+++ b/apps/web/lib/crm/revenue-cockpit.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { buildRevenueCockpitSummary, formatRevenueAmount } from "./revenue-cockpit";
+
+describe("revenue cockpit summary", () => {
+  it("formats revenue in GBP by default (matches Opportunity.currency default)", () => {
+    expect(formatRevenueAmount(12500)).toBe("£12,500");
+  });
+
+  it("respects a passed currency code", () => {
+    expect(formatRevenueAmount(12500, "USD")).toBe("$12,500");
+    expect(formatRevenueAmount(12500, "EUR")).toBe("€12,500");
+  });
+
+  it("summarizes pipeline, engagements, quotes, and active orders", () => {
+    const summary = buildRevenueCockpitSummary({
+      engagementCounts: [
+        { status: "new", count: 3 },
+        { status: "contacted", count: 2 },
+      ],
+      opportunityCounts: [
+        { stage: "qualification", count: 2, expectedValue: 1000 },
+        { stage: "proposal", count: 1, expectedValue: 5000 },
+        { stage: "closed_won", count: 1, expectedValue: 7500 },
+      ],
+      quoteCounts: [
+        { status: "draft", count: 2 },
+        { status: "sent", count: 1 },
+      ],
+      orderCounts: [
+        { status: "confirmed", count: 1 },
+        { status: "in_progress", count: 2 },
+        { status: "fulfilled", count: 5 },
+      ],
+      staleOpportunityCount: 0,
+      marketingWork: {
+        campaignBriefsOpen: 0,
+        assetTasksOpen: 0,
+        automationCandidatesOpen: 0,
+      },
+    });
+
+    expect(summary.metrics).toEqual([
+      {
+        id: "engagements",
+        label: "Engagements",
+        value: "5",
+        detail: "3 new",
+        href: "/customer/engagements",
+        tone: "attention",
+      },
+      {
+        id: "pipeline",
+        label: "Pipeline",
+        value: "3",
+        detail: "£6,000 open",
+        href: "/customer/opportunities",
+        tone: "accent",
+      },
+      {
+        id: "quotes",
+        label: "Quotes",
+        value: "3",
+        detail: "1 sent",
+        href: "/customer/quotes",
+        tone: "info",
+      },
+      {
+        id: "orders",
+        label: "Orders",
+        value: "3",
+        detail: "active",
+        href: "/customer/sales-orders",
+        tone: "success",
+      },
+    ]);
+    expect(summary.attentionItems).toEqual([]);
+  });
+
+  it("surfaces stale opportunities and marketing work as attention items", () => {
+    const summary = buildRevenueCockpitSummary({
+      engagementCounts: [],
+      opportunityCounts: [],
+      quoteCounts: [],
+      orderCounts: [],
+      staleOpportunityCount: 2,
+      marketingWork: {
+        campaignBriefsOpen: 1,
+        assetTasksOpen: 3,
+        automationCandidatesOpen: 1,
+      },
+    });
+
+    expect(summary.attentionItems).toEqual([
+      {
+        id: "stale-opportunities",
+        label: "2 stale opportunities need a next action",
+        href: "/customer/opportunities",
+        tone: "warning",
+      },
+      {
+        id: "marketing-work",
+        label: "5 marketing work products are waiting",
+        href: "/customer/marketing",
+        tone: "accent",
+      },
+    ]);
+  });
+
+  it("uses singular phrasing for a single stale opportunity and a single waiting work product", () => {
+    const summary = buildRevenueCockpitSummary({
+      engagementCounts: [],
+      opportunityCounts: [],
+      quoteCounts: [],
+      orderCounts: [],
+      staleOpportunityCount: 1,
+      marketingWork: {
+        campaignBriefsOpen: 1,
+        assetTasksOpen: 0,
+        automationCandidatesOpen: 0,
+      },
+    });
+
+    expect(summary.attentionItems).toEqual([
+      {
+        id: "stale-opportunities",
+        label: "1 stale opportunity needs a next action",
+        href: "/customer/opportunities",
+        tone: "warning",
+      },
+      {
+        id: "marketing-work",
+        label: "1 marketing work product is waiting",
+        href: "/customer/marketing",
+        tone: "accent",
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/crm/revenue-cockpit.ts
+++ b/apps/web/lib/crm/revenue-cockpit.ts
@@ -1,0 +1,137 @@
+import type { CrmTone } from "./presentation";
+import { isOpenOpportunityStage } from "./presentation";
+
+export type CountByStatus = {
+  status: string;
+  count: number;
+};
+
+export type CountByStage = {
+  stage: string;
+  count: number;
+  expectedValue: number;
+};
+
+export type RevenueCockpitMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  href: string;
+  tone: CrmTone;
+};
+
+export type RevenueCockpitAttentionItem = {
+  id: string;
+  label: string;
+  href: string;
+  tone: CrmTone;
+};
+
+export type RevenueCockpitSummary = {
+  metrics: RevenueCockpitMetric[];
+  attentionItems: RevenueCockpitAttentionItem[];
+};
+
+export type RevenueCockpitInput = {
+  engagementCounts: CountByStatus[];
+  opportunityCounts: CountByStage[];
+  quoteCounts: CountByStatus[];
+  orderCounts: CountByStatus[];
+  staleOpportunityCount: number;
+  marketingWork: {
+    campaignBriefsOpen: number;
+    assetTasksOpen: number;
+    automationCandidatesOpen: number;
+  };
+};
+
+// Default currency mirrors Opportunity.currency and Quote.currency Prisma defaults.
+export function formatRevenueAmount(value: number, currency: string = "GBP"): string {
+  const locale = currency === "GBP" ? "en-GB" : "en-US";
+
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function countWhere(items: CountByStatus[], statuses: string[]): number {
+  return items
+    .filter((item) => statuses.includes(item.status))
+    .reduce((sum, item) => sum + item.count, 0);
+}
+
+export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueCockpitSummary {
+  const engagementTotal = input.engagementCounts.reduce((sum, item) => sum + item.count, 0);
+  const newEngagements = countWhere(input.engagementCounts, ["new"]);
+  const openOpportunities = input.opportunityCounts.filter((item) => isOpenOpportunityStage(item.stage));
+  const pipelineCount = openOpportunities.reduce((sum, item) => sum + item.count, 0);
+  const pipelineValue = openOpportunities.reduce((sum, item) => sum + item.expectedValue, 0);
+  const quoteCount = countWhere(input.quoteCounts, ["draft", "sent"]);
+  const sentQuotes = countWhere(input.quoteCounts, ["sent"]);
+  const activeOrders = countWhere(input.orderCounts, ["confirmed", "in_progress"]);
+  const marketingWorkCount =
+    input.marketingWork.campaignBriefsOpen +
+    input.marketingWork.assetTasksOpen +
+    input.marketingWork.automationCandidatesOpen;
+
+  const attentionItems: RevenueCockpitAttentionItem[] = [];
+
+  if (input.staleOpportunityCount > 0) {
+    attentionItems.push({
+      id: "stale-opportunities",
+      label: `${input.staleOpportunityCount} stale opportunit${input.staleOpportunityCount === 1 ? "y needs" : "ies need"} a next action`,
+      href: "/customer/opportunities",
+      tone: "warning",
+    });
+  }
+
+  if (marketingWorkCount > 0) {
+    attentionItems.push({
+      id: "marketing-work",
+      label: `${marketingWorkCount} marketing work product${marketingWorkCount === 1 ? " is" : "s are"} waiting`,
+      href: "/customer/marketing",
+      tone: "accent",
+    });
+  }
+
+  return {
+    metrics: [
+      {
+        id: "engagements",
+        label: "Engagements",
+        value: String(engagementTotal),
+        detail: `${newEngagements} new`,
+        href: "/customer/engagements",
+        tone: "attention",
+      },
+      {
+        id: "pipeline",
+        label: "Pipeline",
+        value: String(pipelineCount),
+        detail: `${formatRevenueAmount(pipelineValue)} open`,
+        href: "/customer/opportunities",
+        tone: "accent",
+      },
+      {
+        id: "quotes",
+        label: "Quotes",
+        value: String(quoteCount),
+        detail: `${sentQuotes} sent`,
+        href: "/customer/quotes",
+        tone: "info",
+      },
+      {
+        id: "orders",
+        label: "Orders",
+        value: String(activeOrders),
+        detail: "active",
+        href: "/customer/sales-orders",
+        tone: "success",
+      },
+    ],
+    attentionItems,
+  };
+}

--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -5,7 +5,34 @@ const BASH_AVAILABLE = _probe("bash", ["--version"], { encoding: "utf8" }).statu
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 
-const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
+function quoteForBash(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function resolveBashPath(path: string) {
+  if (process.platform !== "win32") {
+    return path;
+  }
+
+  const normalized = path.replace(/\\/g, "/");
+  const driveMatch = /^([A-Za-z]):\/(.*)$/.exec(normalized);
+  if (!driveMatch) {
+    return normalized;
+  }
+
+  const [, drive, rest] = driveMatch;
+  const candidates = [`/mnt/${drive.toLowerCase()}/${rest}`, `/${drive.toLowerCase()}/${rest}`, normalized];
+  return (
+    candidates.find((candidate) => {
+      const probe = _probe("bash", ["-lc", `test -f ${quoteForBash(candidate)}`], {
+        encoding: "utf8",
+      });
+      return probe.status === 0;
+    }) ?? normalized
+  );
+}
+
+const SCRIPT = resolveBashPath(resolve(__dirname, "../../../../scripts/promote.sh"));
 
 const BASE_ENV: Record<string, string> = {
   PROMOTE_SOURCE: "/opt/app/release",
@@ -15,8 +42,21 @@ const BASE_ENV: Record<string, string> = {
 };
 
 function runScript(env: Record<string, string | undefined>, extraArgs: string[] = []) {
-  return spawnSync("bash", [SCRIPT, "--self-upgrade", ...extraArgs], {
-    env: { PATH: process.env.PATH ?? "/usr/bin:/bin", NODE_ENV: process.env.NODE_ENV ?? "test", ...env } as NodeJS.ProcessEnv,
+  const envSource: Record<string, string | undefined> = { NODE_ENV: process.env.NODE_ENV ?? "test", ...env };
+  const envAssignments = Object.entries(envSource).flatMap(([key, value]) =>
+    value === undefined ? [] : [`${key}=${quoteForBash(value)}`],
+  );
+  const command = [
+    "env",
+    "-i",
+    'PATH="$PATH"',
+    ...envAssignments,
+    quoteForBash(SCRIPT),
+    "--self-upgrade",
+    ...extraArgs.map(quoteForBash),
+  ].join(" ");
+
+  return spawnSync("bash", ["-lc", command], {
     encoding: "utf8",
   });
 }


### PR DESCRIPTION
## Summary
- add shared CRM presentation metadata and revenue cockpit summary helpers with tests
- surface a Pipedrive-inspired customer revenue cockpit on `/customer`
- refactor CRM opportunities, engagements, and funnel surfaces to reuse theme-aware presentation metadata
- hide unimplemented customer marketing phase tabs so only Overview and Strategy remain selectable
- clean up customer UI hardcoded error colors in the touched customer surface
- fix the self-upgrade contract test harness so Windows/WSL bash can run the full web test gate

## Verification
- `pnpm --filter web exec vitest run lib/crm/presentation.test.ts lib/crm/revenue-cockpit.test.ts components/customer/CustomerMetricTile.test.tsx components/customer/CustomerStatusBadge.test.tsx components/customer/RevenueCockpit.test.tsx components/customer-marketing/MarketingTabNav.test.tsx components/customer/CustomerTabNav.test.tsx`
- `pnpm --filter web exec vitest run lib/self-upgrade/promote-script-contract.test.ts`
- `pnpm --filter web test` — 994 passed, 4 skipped; 8303 tests passed, 15 skipped, 18 todo
- `pnpm --filter web typecheck`
- `pnpm --filter web build` — exits 0; existing Edge-runtime warnings remain
- hardcoded-style scan on touched customer/marketing surfaces returned no matches
- browser preview on `http://localhost:3001`: verified `/customer`, `/customer/opportunities`, `/customer/funnel`, and `/customer/marketing`; marketing sub-tabs expose only Overview and Strategy; checked pages had no browser console errors
- overlap sweep: no open PRs matching `customer marketing OR crm OR pipeline`