### PR TITLE
Phase 8: Build decomposition amendment flow

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -19,6 +19,7 @@ import { BuildProgressOperationalPanel } from "./BuildProgressOperationalPanel";
 import { ReleaseDecisionPanel } from "./ReleaseDecisionPanel";
 import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
 import { DecompositionCoordinator } from "./DecompositionCoordinator";
+import { ParentDesignAmendmentCoordinator } from "./ParentDesignAmendmentCoordinator";
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
 import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
@@ -672,6 +673,9 @@ export function BuildStudio({
                         existingOverride={activeBuild.designReview?.decompositionOverride ?? null}
                         planOscillationEntry
                       />
+                    )}
+                    {workflowAction.kind === "amend-parent-design" && (
+                      <ParentDesignAmendmentCoordinator buildId={activeBuild.buildId} />
                     )}
                   </div>
                 )}

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -305,8 +305,12 @@ describe("BuildStudioWorkflowActionCard decomposition affordances", () => {
     }
   });
 
-  it("opens the coworker with parent-amendment copy for child builds", async () => {
-    const dispatchSpy = vi.spyOn(document, "dispatchEvent");
+  it("emits the open-parent-design-amendment event for child builds", async () => {
+    const received: unknown[] = [];
+    const handler = (event: Event) => {
+      received.push((event as CustomEvent).detail);
+    };
+    document.addEventListener("open-parent-design-amendment", handler);
     const action: BuildStudioWorkflowAction = {
       kind: "amend-parent-design",
       title: "Amend Parent Design",
@@ -318,26 +322,22 @@ describe("BuildStudioWorkflowActionCard decomposition affordances", () => {
       coworkerPrompt: "Help me amend the parent design instead of decomposing this child.",
     };
 
-    render(
-      <BuildStudioWorkflowActionCard
-        build={makeBuild({ buildId: "FB-CHILD", parentEpicId: "epic-row-1", decisionInteraction: null })}
-        action={action}
-      />,
-    );
+    try {
+      render(
+        <BuildStudioWorkflowActionCard
+          build={makeBuild({ buildId: "FB-CHILD", parentEpicId: "epic-row-1", decisionInteraction: null })}
+          action={action}
+        />,
+      );
 
-    fireEvent.click(screen.getByRole("button", { name: "Amend parent design" }));
+      fireEvent.click(screen.getByRole("button", { name: "Amend parent design" }));
 
-    await waitFor(() => {
-      expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({
-        type: "open-agent-panel",
-      }));
-    });
-    const event = dispatchSpy.mock.calls
-      .map((call) => call[0])
-      .find((candidate) => candidate.type === "open-agent-panel") as CustomEvent;
-    expect(event.detail.autoMessage).toContain("parent design");
-    expect(event.detail.targetBuildId).toBe("FB-CHILD");
-    dispatchSpy.mockRestore();
+      await waitFor(() => {
+        expect(received).toEqual([{ buildId: "FB-CHILD" }]);
+      });
+    } finally {
+      document.removeEventListener("open-parent-design-amendment", handler);
+    }
   });
 });
 

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -177,7 +177,11 @@ export function BuildStudioWorkflowActionCard({
           }),
         );
       } else if (action.kind === "amend-parent-design") {
-        handleCoworkerAction();
+        document.dispatchEvent(
+          new CustomEvent("open-parent-design-amendment", {
+            detail: { buildId: build.buildId },
+          }),
+        );
       }
 
       window.dispatchEvent(

--- a/apps/web/components/build/ParentDesignAmendmentCoordinator.test.tsx
+++ b/apps/web/components/build/ParentDesignAmendmentCoordinator.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BuildDesignDoc } from "@/lib/feature-build-types";
+
+const contextMock = vi.fn();
+const amendMock = vi.fn();
+
+vi.mock("@/lib/actions/decomposition-actions", () => ({
+  getParentDesignAmendmentContextAction: (...args: unknown[]) => contextMock(...args),
+  amendParentDesignAction: (...args: unknown[]) => amendMock(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  contextMock.mockReset();
+  amendMock.mockReset();
+});
+
+import { ParentDesignAmendmentCoordinator } from "./ParentDesignAmendmentCoordinator";
+
+const parentDesignDoc: BuildDesignDoc = {
+  problemStatement: "Dale needs the right truck parts without return trips.",
+  reusePlan: "Reuse Build Studio child builds.",
+  proposedApproach: "Build read, usage, and restock flows.",
+  acceptanceCriteria: ["Find truck parts", "Record a used part", "Review low stock"],
+};
+
+function contextResult() {
+  return {
+    ok: true,
+    parentEpic: {
+      epicId: "EP-TRUCK",
+      title: "Truck inventory",
+      designDoc: parentDesignDoc,
+    },
+    currentChildBuildId: "FB-CHILD2",
+    children: [
+      { buildId: "FB-CHILD1", title: "Read parts", phase: "complete", childOrder: 1 },
+      { buildId: "FB-CHILD2", title: "Use parts", phase: "plan", childOrder: 2 },
+      { buildId: "FB-CHILD3", title: "Restock", phase: "plan", childOrder: 3 },
+    ],
+  };
+}
+
+describe("ParentDesignAmendmentCoordinator", () => {
+  it("opens from the parent-amendment event and submits a proposed parent design", async () => {
+    contextMock.mockResolvedValue(contextResult());
+    amendMock.mockResolvedValue({
+      ok: true,
+      quiescenceRunId: "QR-2026-05-24-amend",
+      updatedChildBuildIds: ["FB-CHILD2", "FB-CHILD3"],
+      skippedCompletedChildBuildIds: ["FB-CHILD1"],
+    });
+
+    render(<ParentDesignAmendmentCoordinator buildId="FB-CHILD2" />);
+    expect(screen.queryByRole("dialog", { name: "Amend parent design" })).not.toBeInTheDocument();
+
+    fireEvent(
+      document,
+      new CustomEvent("open-parent-design-amendment", {
+        detail: { buildId: "FB-CHILD2" },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(contextMock).toHaveBeenCalledWith({ childBuildId: "FB-CHILD2" });
+    });
+    expect(screen.getByRole("dialog", { name: "Amend parent design" })).toBeInTheDocument();
+    expect(screen.getByText("Truck inventory")).toBeInTheDocument();
+    expect(screen.getByText("Read parts")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Proposed approach"), {
+      target: { value: "Keep lookup and usage now; defer supplier automation." },
+    });
+    fireEvent.change(screen.getByLabelText("Acceptance criteria"), {
+      target: { value: "Find truck parts fast\nRecord a used part\nReview low stock" },
+    });
+    fireEvent.change(screen.getByLabelText("Amendment rationale"), {
+      target: { value: "Dale needs lookup speed before supplier automation." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply parent amendment" }));
+
+    await waitFor(() => {
+      expect(amendMock).toHaveBeenCalledWith({
+        childBuildId: "FB-CHILD2",
+        proposedDesignDoc: {
+          ...parentDesignDoc,
+          proposedApproach: "Keep lookup and usage now; defer supplier automation.",
+          acceptanceCriteria: [
+            "Find truck parts fast",
+            "Record a used part",
+            "Review low stock",
+          ],
+        },
+        rationale: "Dale needs lookup speed before supplier automation.",
+      });
+    });
+    expect(screen.getByText(/Updated 2 child build/)).toBeInTheDocument();
+  });
+
+  it("surfaces server-side execution-child blocks without closing the panel", async () => {
+    contextMock.mockResolvedValue({
+      ...contextResult(),
+      children: [
+        { buildId: "FB-CHILD1", title: "Read parts", phase: "complete", childOrder: 1 },
+        { buildId: "FB-CHILD2", title: "Use parts", phase: "review", childOrder: 2 },
+        { buildId: "FB-CHILD3", title: "Restock", phase: "plan", childOrder: 3 },
+      ],
+    });
+    amendMock.mockResolvedValue({
+      ok: false,
+      code: "execution-child-requires-operator-review",
+      error: "One or more affected children has already entered build/review/ship.",
+      blockedChildBuildIds: ["FB-CHILD2"],
+    });
+
+    render(<ParentDesignAmendmentCoordinator buildId="FB-CHILD2" />);
+    fireEvent(
+      document,
+      new CustomEvent("open-parent-design-amendment", {
+        detail: { buildId: "FB-CHILD2" },
+      }),
+    );
+    await screen.findByRole("dialog", { name: "Amend parent design" });
+
+    fireEvent.change(screen.getByLabelText("Amendment rationale"), {
+      target: { value: "Adjust parent contract safely." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply parent amendment" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("parent-amendment-error")).toHaveTextContent(
+        "already entered build/review/ship",
+      );
+    });
+    expect(screen.getByRole("dialog", { name: "Amend parent design" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/build/ParentDesignAmendmentCoordinator.tsx
+++ b/apps/web/components/build/ParentDesignAmendmentCoordinator.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+
+import {
+  amendParentDesignAction,
+  getParentDesignAmendmentContextAction,
+  type ParentDesignAmendmentContextResult,
+} from "@/lib/actions/decomposition-actions";
+import type { BuildDesignDoc, BuildPhase } from "@/lib/feature-build-types";
+
+type Props = {
+  buildId: string;
+};
+
+type FlightState = "idle" | "loading" | "submitting";
+
+type LoadedContext = Extract<ParentDesignAmendmentContextResult, { ok: true }>;
+
+export function ParentDesignAmendmentCoordinator({ buildId }: Props) {
+  const [_isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [flight, setFlight] = useState<FlightState>("idle");
+  const [context, setContext] = useState<LoadedContext | null>(null);
+  const [proposedApproach, setProposedApproach] = useState("");
+  const [acceptanceCriteriaText, setAcceptanceCriteriaText] = useState("");
+  const [rationale, setRationale] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const loadContext = useCallback((targetBuildId: string) => {
+    setOpen(true);
+    setFlight("loading");
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    startTransition(async () => {
+      try {
+        const result = await getParentDesignAmendmentContextAction({
+          childBuildId: targetBuildId,
+        });
+        if (!result.ok) {
+          setErrorMessage(result.error);
+          setFlight("idle");
+          return;
+        }
+        setContext(result);
+        setProposedApproach(result.parentEpic.designDoc.proposedApproach);
+        setAcceptanceCriteriaText(result.parentEpic.designDoc.acceptanceCriteria.join("\n"));
+        setRationale("");
+        setFlight("idle");
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : "Could not load parent design.");
+        setFlight("idle");
+      }
+    });
+  }, [startTransition]);
+
+  useEffect(() => {
+    const handleOpen = (event: Event) => {
+      const detail = (event as CustomEvent<{ buildId?: unknown }>).detail;
+      if (detail?.buildId !== buildId) return;
+      loadContext(buildId);
+    };
+
+    document.addEventListener("open-parent-design-amendment", handleOpen);
+    return () => document.removeEventListener("open-parent-design-amendment", handleOpen);
+  }, [buildId, loadContext]);
+
+  const proposedDesignDoc = useMemo(() => {
+    if (!context) return null;
+    return {
+      ...context.parentEpic.designDoc,
+      proposedApproach,
+      acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteriaText),
+    };
+  }, [acceptanceCriteriaText, context, proposedApproach]);
+
+  const diff = useMemo(() => {
+    if (!context || !proposedDesignDoc) return [];
+    return describeDiff(context.parentEpic.designDoc, proposedDesignDoc);
+  }, [context, proposedDesignDoc]);
+
+  const rationaleReady = rationale.trim().length > 0;
+  const canSubmit = context != null && proposedDesignDoc != null && rationaleReady && flight === "idle";
+
+  const submit = () => {
+    if (!context || !proposedDesignDoc || !canSubmit) return;
+    setFlight("submitting");
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    startTransition(async () => {
+      try {
+        const result = await amendParentDesignAction({
+          childBuildId: context.currentChildBuildId,
+          proposedDesignDoc,
+          rationale: rationale.trim(),
+        });
+        if (!result.ok) {
+          setErrorMessage(result.error);
+          setFlight("idle");
+          return;
+        }
+        setSuccessMessage(
+          `Updated ${result.updatedChildBuildIds.length} child build${result.updatedChildBuildIds.length === 1 ? "" : "s"}; skipped ${result.skippedCompletedChildBuildIds.length} completed child build${result.skippedCompletedChildBuildIds.length === 1 ? "" : "s"}.`,
+        );
+        setFlight("idle");
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : "Parent design amendment failed.");
+        setFlight("idle");
+      }
+    });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="parent-design-amendment-coordinator"
+      className="fixed inset-0 z-40 flex"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Amend parent design"
+    >
+      <button
+        type="button"
+        aria-label="Close parent design amendment"
+        onClick={() => setOpen(false)}
+        className="absolute inset-0 bg-[color-mix(in_srgb,var(--dpf-text)_35%,transparent)]"
+      />
+      <aside className="relative ml-auto flex h-full w-full max-w-4xl flex-col border-l border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] shadow-2xl">
+        <header className="flex items-start justify-between border-b border-[var(--dpf-border)] px-4 py-3">
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase text-[var(--dpf-muted)]">
+              Parent Design Amendment
+            </p>
+            <h2 className="mt-1 text-base font-semibold">
+              {context?.parentEpic.title ?? "Loading parent design"}
+            </h2>
+            {context && (
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                {context.parentEpic.epicId}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-semibold text-[var(--dpf-text)]"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {flight === "loading" && (
+            <p className="text-sm text-[var(--dpf-muted)]">Loading parent design...</p>
+          )}
+
+          {context && proposedDesignDoc && (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <section className="min-w-0">
+                <h3 className="text-sm font-semibold">Current parent contract</h3>
+                <DesignDocSummary designDoc={context.parentEpic.designDoc} />
+                <ChildPhaseList children={context.children} />
+              </section>
+
+              <section className="min-w-0">
+                <h3 className="text-sm font-semibold">Proposed parent contract</h3>
+                <div className="mt-3 space-y-3">
+                  <label className="block">
+                    <span className="text-xs font-semibold text-[var(--dpf-text)]">
+                      Proposed approach
+                    </span>
+                    <textarea
+                      aria-label="Proposed approach"
+                      value={proposedApproach}
+                      onChange={(event) => setProposedApproach(event.target.value)}
+                      rows={5}
+                      className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-xs font-semibold text-[var(--dpf-text)]">
+                      Acceptance criteria
+                    </span>
+                    <textarea
+                      aria-label="Acceptance criteria"
+                      value={acceptanceCriteriaText}
+                      onChange={(event) => setAcceptanceCriteriaText(event.target.value)}
+                      rows={6}
+                      className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-xs font-semibold text-[var(--dpf-text)]">
+                      Amendment rationale
+                    </span>
+                    <input
+                      aria-label="Amendment rationale"
+                      value={rationale}
+                      onChange={(event) => setRationale(event.target.value)}
+                      className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]"
+                    />
+                  </label>
+                </div>
+
+                <DiffSummary diff={diff} />
+              </section>
+            </div>
+          )}
+
+          {errorMessage && (
+            <div
+              data-testid="parent-amendment-error"
+              role="alert"
+              className="mt-4 rounded-md border border-[var(--dpf-error)] bg-[color-mix(in_srgb,var(--dpf-error)_8%,var(--dpf-surface-1))] px-3 py-2 text-sm text-[var(--dpf-error)]"
+            >
+              {errorMessage}
+            </div>
+          )}
+          {successMessage && (
+            <div
+              role="status"
+              className="mt-4 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]"
+            >
+              {successMessage}
+            </div>
+          )}
+        </div>
+
+        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--dpf-border)] px-4 py-3">
+          <div className="text-xs text-[var(--dpf-muted)]">
+            {diff.length === 0 ? "No design changes yet." : `${diff.length} changed field${diff.length === 1 ? "" : "s"}.`}
+          </div>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!canSubmit}
+            className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {flight === "submitting" ? "Applying amendment..." : "Apply parent amendment"}
+          </button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+function DesignDocSummary({ designDoc }: { designDoc: BuildDesignDoc }) {
+  return (
+    <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+      <p className="text-xs font-semibold text-[var(--dpf-text)]">Problem</p>
+      <p className="mt-1 text-sm text-[var(--dpf-muted)]">{designDoc.problemStatement}</p>
+      <p className="mt-3 text-xs font-semibold text-[var(--dpf-text)]">Approach</p>
+      <p className="mt-1 text-sm text-[var(--dpf-muted)]">{designDoc.proposedApproach}</p>
+      <p className="mt-3 text-xs font-semibold text-[var(--dpf-text)]">Acceptance criteria</p>
+      <ol className="mt-1 space-y-1 text-sm text-[var(--dpf-muted)]">
+        {designDoc.acceptanceCriteria.map((criterion, index) => (
+          <li key={`${index}-${criterion}`} className="flex gap-2">
+            <span className="font-mono text-[var(--dpf-text)]">{index + 1}.</span>
+            <span>{criterion}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function ChildPhaseList({
+  children,
+}: {
+  children: Array<{ buildId: string; title: string; phase: BuildPhase | string; childOrder: number | null }>;
+}) {
+  return (
+    <div className="mt-4">
+      <h3 className="text-sm font-semibold">Child build impact</h3>
+      <ul className="mt-2 space-y-2">
+        {children
+          .slice()
+          .sort((a, b) => (a.childOrder ?? 99) - (b.childOrder ?? 99))
+          .map((child) => (
+            <li
+              key={child.buildId}
+              className="flex items-center justify-between gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-[var(--dpf-text)]">
+                  {child.title}
+                </p>
+                <p className="text-[11px] text-[var(--dpf-muted)]">{child.buildId}</p>
+              </div>
+              <span className="shrink-0 rounded-full border border-[var(--dpf-border)] px-2 py-1 text-[10px] font-semibold uppercase text-[var(--dpf-text)]">
+                {child.phase}
+              </span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}
+
+function DiffSummary({ diff }: { diff: string[] }) {
+  return (
+    <div className="mt-4 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+      <p className="text-xs font-semibold text-[var(--dpf-text)]">Diff summary</p>
+      {diff.length === 0 ? (
+        <p className="mt-1 text-sm text-[var(--dpf-muted)]">No changed fields.</p>
+      ) : (
+        <ul className="mt-2 flex flex-wrap gap-2">
+          {diff.map((field) => (
+            <li
+              key={field}
+              className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[11px] text-[var(--dpf-text)]"
+            >
+              {field}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function parseAcceptanceCriteria(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function describeDiff(before: BuildDesignDoc, after: BuildDesignDoc): string[] {
+  const fields: string[] = [];
+  if (before.proposedApproach !== after.proposedApproach) {
+    fields.push("proposedApproach");
+  }
+  if (
+    before.acceptanceCriteria.length !== after.acceptanceCriteria.length
+    || before.acceptanceCriteria.some((criterion, index) => criterion !== after.acceptanceCriteria[index])
+  ) {
+    fields.push("acceptanceCriteria");
+  }
+  return fields;
+}

--- a/apps/web/lib/actions/decomposition-actions.ts
+++ b/apps/web/lib/actions/decomposition-actions.ts
@@ -2,11 +2,11 @@
 
 // apps/web/lib/actions/decomposition-actions.ts
 //
-// Phase 4c — operator-facing server actions for the design-time
-// decomposition flow. The slide-over UI and banner CTAs call these instead
-// of the MCP layer directly, so the human path has the same business-logic
-// surface as the agent path but with `can(... "manage_backlog")` instead of
-// the AgentGrant capability check.
+// Phase 4c/8 — operator-facing server actions for the design-time
+// decomposition flow. The slide-over UI, amendment panel, and banner CTAs
+// call these instead of the MCP layer directly, so the human path has the
+// same business-logic surface as the agent path but with
+// `can(... "manage_backlog")` instead of the AgentGrant capability check.
 //
 // Spec: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
 // BI: BI-2E6CC391.
@@ -15,12 +15,14 @@
 //   - proposeBuildDecompositionAction → proposeDecomposition (4b)
 //   - approveDecompositionAction      → approveDecomposition (4a)
 //   - recordDecompositionOverrideAction → recordDecompositionOverride (4a)
+//   - amendParentDesignAction → amendEpicDecomposition (8)
 //
 // Result shape mirrors the lib module's discriminated union so the client
 // component can pattern-match on ok + code.
 
 import { revalidatePath } from "next/cache";
 
+import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 
@@ -28,6 +30,11 @@ import {
   approveDecomposition,
   type ApproveDecompositionResult,
 } from "@/lib/build/approve-decomposition";
+import {
+  amendEpicDecomposition,
+  coerceBuildDesignDoc,
+  type AmendEpicDecompositionResult,
+} from "@/lib/build/amend-epic-decomposition";
 import type { DecompositionCandidate } from "@/lib/build/decomposition-candidates";
 import {
   proposeDecomposition,
@@ -37,6 +44,7 @@ import {
   recordDecompositionOverride,
   type RecordDecompositionOverrideResult,
 } from "@/lib/build/decomposition-override";
+import type { BuildDesignDoc, BuildPhase } from "@/lib/explore/feature-build-types";
 
 // ─── Auth helper ─────────────────────────────────────────────────────────────
 
@@ -106,6 +114,154 @@ export async function recordDecompositionOverrideAction(args: {
   });
   if (result.ok) {
     revalidatePath(`/build/${args.buildId}`);
+  }
+  return result;
+}
+
+export type ParentDesignAmendmentContextResult =
+  | {
+      ok: true;
+      currentChildBuildId: string;
+      parentEpic: {
+        epicId: string;
+        title: string;
+        designDoc: BuildDesignDoc;
+      };
+      children: Array<{
+        buildId: string;
+        title: string;
+        phase: BuildPhase;
+        childOrder: number | null;
+      }>;
+    }
+  | {
+      ok: false;
+      code:
+        | "child-build-not-found"
+        | "build-has-no-parent-epic"
+        | "parent-epic-missing-design-doc";
+      error: string;
+    };
+
+export type AmendParentDesignActionResult =
+  | AmendEpicDecompositionResult
+  | {
+      ok: false;
+      code: "child-build-not-found" | "build-has-no-parent-epic";
+      error: string;
+    };
+
+export async function getParentDesignAmendmentContextAction(args: {
+  childBuildId: string;
+}): Promise<ParentDesignAmendmentContextResult> {
+  await requireManageBacklog();
+  const child = await prisma.featureBuild.findUnique({
+    where: { buildId: args.childBuildId },
+    select: {
+      buildId: true,
+      parentEpic: {
+        select: {
+          epicId: true,
+          title: true,
+          designDoc: true,
+          featureBuilds: {
+            orderBy: [{ childOrder: "asc" }, { buildId: "asc" }],
+            select: {
+              buildId: true,
+              title: true,
+              phase: true,
+              childOrder: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!child) {
+    return {
+      ok: false,
+      code: "child-build-not-found",
+      error: `FeatureBuild ${args.childBuildId} was not found.`,
+    };
+  }
+  if (!child.parentEpic) {
+    return {
+      ok: false,
+      code: "build-has-no-parent-epic",
+      error: "Only child builds can amend an execution-organizational parent Epic.",
+    };
+  }
+
+  const designDoc = coerceBuildDesignDoc(child.parentEpic.designDoc);
+  if (!designDoc) {
+    return {
+      ok: false,
+      code: "parent-epic-missing-design-doc",
+      error: `Parent Epic ${child.parentEpic.epicId} does not have a designDoc to amend.`,
+    };
+  }
+
+  return {
+    ok: true,
+    currentChildBuildId: child.buildId,
+    parentEpic: {
+      epicId: child.parentEpic.epicId,
+      title: child.parentEpic.title,
+      designDoc,
+    },
+    children: child.parentEpic.featureBuilds.map((build) => ({
+      buildId: build.buildId,
+      title: build.title,
+      phase: build.phase as BuildPhase,
+      childOrder: build.childOrder,
+    })),
+  };
+}
+
+export async function amendParentDesignAction(args: {
+  childBuildId: string;
+  proposedDesignDoc: BuildDesignDoc;
+  rationale: string;
+}): Promise<AmendParentDesignActionResult> {
+  const { userId } = await requireManageBacklog();
+  const child = await prisma.featureBuild.findUnique({
+    where: { buildId: args.childBuildId },
+    select: {
+      buildId: true,
+      parentEpic: {
+        select: {
+          epicId: true,
+        },
+      },
+    },
+  });
+
+  if (!child) {
+    return {
+      ok: false,
+      code: "child-build-not-found",
+      error: `FeatureBuild ${args.childBuildId} was not found.`,
+    };
+  }
+  if (!child.parentEpic) {
+    return {
+      ok: false,
+      code: "build-has-no-parent-epic",
+      error: "Only child builds can amend an execution-organizational parent Epic.",
+    };
+  }
+
+  const result = await amendEpicDecomposition({
+    epicId: child.parentEpic.epicId,
+    proposedDesignDoc: args.proposedDesignDoc,
+    rationale: args.rationale,
+    userId,
+  });
+
+  if (result.ok) {
+    revalidatePath(`/build/${args.childBuildId}`);
+    revalidatePath("/build");
   }
   return result;
 }

--- a/apps/web/lib/build/amend-epic-decomposition.test.ts
+++ b/apps/web/lib/build/amend-epic-decomposition.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BuildDesignDoc, BuildPhase } from "@/lib/feature-build-types";
+import type {
+  AmendEpicDecompositionDb,
+  AmendEpicDecompositionStartQuiescence,
+  DecompositionAmendmentChild,
+  DecompositionAmendmentTx,
+} from "./amend-epic-decomposition";
+import {
+  amendEpicDecomposition,
+  deriveDecompositionAmendmentImpact,
+} from "./amend-epic-decomposition";
+
+type FakeChild = DecompositionAmendmentChild & {
+  designDoc: BuildDesignDoc;
+};
+
+type FakeEpic = {
+  id: string;
+  epicId: string;
+  title: string;
+  designDoc: BuildDesignDoc | null;
+  decompositionState: unknown;
+  featureBuilds: FakeChild[];
+};
+
+type RecordedWrites = {
+  epicUpdates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>;
+  buildUpdates: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>;
+  activities: Array<Record<string, unknown>>;
+};
+
+const currentParentDoc: BuildDesignDoc = {
+  problemStatement: "Dale needs truck parts on hand without return trips.",
+  reusePlan: "Reuse Build Studio FeatureBuild flow.",
+  proposedApproach: "Create truck inventory read, use, and restock slices.",
+  acceptanceCriteria: ["read parts", "mark part used", "see usage audit", "see low stock"],
+};
+
+const amendedParentDoc: BuildDesignDoc = {
+  ...currentParentDoc,
+  proposedApproach: "Prioritize in-truck part lookup and defer supplier automation.",
+  acceptanceCriteria: ["read parts fast", "mark part used", "see usage audit", "see low stock"],
+};
+
+function makeChild(overrides: Partial<FakeChild>): FakeChild {
+  const childOrder = overrides.childOrder ?? 1;
+  return {
+    id: `child-row-${childOrder}`,
+    buildId: `FB-CHILD${childOrder}`,
+    title: `Child ${childOrder}`,
+    phase: "plan",
+    childOrder,
+    designDoc: {
+      ...currentParentDoc,
+      proposedApproach: `Child ${childOrder}`,
+      acceptanceCriteria: [currentParentDoc.acceptanceCriteria[childOrder - 1] ?? "fallback"],
+    },
+    phaseRuns: [],
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    sourceBuildId: "FB-PARENT",
+    candidateId: "cand-approved",
+    candidateRationale: "Split read, usage, and restock.",
+    approvedAt: "2026-05-24T20:00:00.000Z",
+    approvedByUserId: "user-1",
+    approvedByAgentId: "agent-1",
+    partition: [
+      {
+        childOrder: 1,
+        title: "Read parts",
+        summary: "Show parts on a truck.",
+        acceptanceCriteriaIndices: [0],
+        dependsOn: [],
+      },
+      {
+        childOrder: 2,
+        title: "Use parts",
+        summary: "Record parts used on a job.",
+        acceptanceCriteriaIndices: [1, 2],
+        dependsOn: [1],
+      },
+      {
+        childOrder: 3,
+        title: "Restock",
+        summary: "Show low-stock items for follow-up.",
+        acceptanceCriteriaIndices: [3],
+        dependsOn: [1, 2],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeEpic(overrides: Partial<FakeEpic> = {}): FakeEpic {
+  return {
+    id: "epic-row-1",
+    epicId: "EP-TRUCK-PARTS",
+    title: "Truck inventory",
+    designDoc: currentParentDoc,
+    decompositionState: makeState(),
+    featureBuilds: [
+      makeChild({ childOrder: 1, phase: "complete" }),
+      makeChild({
+        childOrder: 2,
+        phase: "plan",
+        phaseRuns: [{ phase: "plan", completedAt: null }],
+      }),
+      makeChild({ childOrder: 3, phase: "plan" }),
+    ],
+    ...overrides,
+  };
+}
+
+function makeFakeDb(epic: FakeEpic | null): {
+  db: AmendEpicDecompositionDb;
+  writes: RecordedWrites;
+} {
+  const writes: RecordedWrites = {
+    epicUpdates: [],
+    buildUpdates: [],
+    activities: [],
+  };
+
+  const tx: DecompositionAmendmentTx = {
+    epic: {
+      update: vi.fn(async (args) => {
+        writes.epicUpdates.push(args);
+        return null;
+      }),
+    },
+    featureBuild: {
+      update: vi.fn(async (args) => {
+        writes.buildUpdates.push(args);
+        return null;
+      }),
+    },
+    buildActivity: {
+      create: vi.fn(async ({ data }) => {
+        writes.activities.push(data);
+        return null;
+      }),
+    },
+  };
+
+  return {
+    writes,
+    db: {
+      epic: {
+        findUnique: vi.fn(async () => epic) as AmendEpicDecompositionDb["epic"]["findUnique"],
+      },
+      $transaction: vi.fn(async (fn) => fn(tx)) as AmendEpicDecompositionDb["$transaction"],
+    },
+  };
+}
+
+function fakeQuiescence(runId = "QR-2026-05-24-amend"): AmendEpicDecompositionStartQuiescence {
+  return vi.fn(async () => ({
+    runId,
+    awaitReady: vi.fn(async () => ({
+      ok: true,
+      outcome: "ready-to-swap",
+      runId,
+      finalSnapshot: {
+        capturedAt: "2026-05-24T20:05:00.000Z",
+        thresholdMs: 300000,
+        totalBlockers: 0,
+        hardBlockers: 0,
+        softBlockers: 0,
+        unobservableSurfaces: [],
+        surfaces: [],
+      },
+    })),
+  }));
+}
+
+describe("deriveDecompositionAmendmentImpact", () => {
+  it("keeps completed children immutable, rederives planning children, and requires quiescence for in-flight Plan work", () => {
+    const impact = deriveDecompositionAmendmentImpact({
+      parentDesignDoc: amendedParentDoc,
+      decompositionState: makeState(),
+      children: makeEpic().featureBuilds,
+    });
+
+    expect(impact.ok).toBe(true);
+    if (!impact.ok) throw new Error("unreachable");
+    expect(impact.requiresQuiescence).toBe(true);
+    expect(impact.completedChildBuildIds).toEqual(["FB-CHILD1"]);
+    expect(impact.updatedChildren.map((child) => child.buildId)).toEqual(["FB-CHILD2", "FB-CHILD3"]);
+    expect(impact.updatedChildren[0]!.designDoc.acceptanceCriteria).toEqual([
+      "mark part used",
+      "see usage audit",
+    ]);
+    expect(impact.updatedChildren[1]!.designDoc.acceptanceCriteria).toEqual(["see low stock"]);
+  });
+
+  it("blocks automatic amendment when an affected child has entered build, review, or ship", () => {
+    const impact = deriveDecompositionAmendmentImpact({
+      parentDesignDoc: amendedParentDoc,
+      decompositionState: makeState(),
+      children: makeEpic({
+        featureBuilds: [
+          makeChild({ childOrder: 1, phase: "complete" }),
+          makeChild({ childOrder: 2, phase: "build" }),
+          makeChild({ childOrder: 3, phase: "plan" }),
+        ],
+      }).featureBuilds,
+    });
+
+    expect(impact.ok).toBe(false);
+    if (impact.ok) throw new Error("unreachable");
+    expect(impact.code).toBe("execution-child-requires-operator-review");
+    expect(impact.blockedChildBuildIds).toEqual(["FB-CHILD2"]);
+  });
+
+  it("rejects parent design amendments that change acceptance-criteria shape before a new partition is chosen", () => {
+    const impact = deriveDecompositionAmendmentImpact({
+      parentDesignDoc: {
+        ...amendedParentDoc,
+        acceptanceCriteria: [...amendedParentDoc.acceptanceCriteria, "new supplier automation"],
+      },
+      decompositionState: makeState(),
+      children: makeEpic().featureBuilds,
+    });
+
+    expect(impact.ok).toBe(false);
+    if (impact.ok) throw new Error("unreachable");
+    expect(impact.code).toBe("acceptance-criteria-shape-changed");
+  });
+});
+
+describe("amendEpicDecomposition", () => {
+  it("drains in-flight Plan work, updates the parent Epic, rederives planning children, and leaves completed children untouched", async () => {
+    const { db, writes } = makeFakeDb(makeEpic());
+    const startQuiescence = fakeQuiescence();
+
+    const result = await amendEpicDecomposition({
+      epicId: "EP-TRUCK-PARTS",
+      proposedDesignDoc: amendedParentDoc,
+      rationale: "Dale needs lookup speed before supplier automation.",
+      userId: "user-1",
+      db,
+      startQuiescence,
+      now: () => new Date("2026-05-24T21:00:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.quiescenceRunId).toBe("QR-2026-05-24-amend");
+    expect(result.updatedChildBuildIds).toEqual(["FB-CHILD2", "FB-CHILD3"]);
+    expect(result.skippedCompletedChildBuildIds).toEqual(["FB-CHILD1"]);
+
+    expect(startQuiescence).toHaveBeenCalledWith({
+      trigger: "manual",
+      triggerRefId: "decomposition-amendment:EP-TRUCK-PARTS",
+      budgetMs: 300000,
+    });
+
+    expect(writes.epicUpdates).toHaveLength(1);
+    expect(writes.epicUpdates[0]!.where).toEqual({ id: "epic-row-1" });
+    expect(writes.epicUpdates[0]!.data.designDoc).toEqual(amendedParentDoc);
+    const nextState = writes.epicUpdates[0]!.data.decompositionState as { amendments: Array<Record<string, unknown>> };
+    expect(nextState.amendments).toHaveLength(1);
+    expect(nextState.amendments[0]).toMatchObject({
+      amendedByUserId: "user-1",
+      amendedAt: "2026-05-24T21:00:00.000Z",
+      rationale: "Dale needs lookup speed before supplier automation.",
+      quiescenceRunId: "QR-2026-05-24-amend",
+      affectedChildBuildIds: ["FB-CHILD2", "FB-CHILD3"],
+      skippedCompletedChildBuildIds: ["FB-CHILD1"],
+    });
+
+    expect(writes.buildUpdates.map((write) => write.where)).toEqual([
+      { buildId: "FB-CHILD2" },
+      { buildId: "FB-CHILD3" },
+    ]);
+    expect(writes.buildUpdates[0]!.data.designDoc).toMatchObject({
+      proposedApproach: "Record parts used on a job.",
+      acceptanceCriteria: ["mark part used", "see usage audit"],
+    });
+    expect(writes.activities.map((activity) => activity.buildId)).toEqual(["FB-CHILD2", "FB-CHILD3"]);
+  });
+
+  it("does not start quiescence or write when an execution child would be mutated silently", async () => {
+    const { db, writes } = makeFakeDb(makeEpic({
+      featureBuilds: [
+        makeChild({ childOrder: 1, phase: "complete" }),
+        makeChild({ childOrder: 2, phase: "review" }),
+        makeChild({ childOrder: 3, phase: "plan" }),
+      ],
+    }));
+    const startQuiescence = fakeQuiescence();
+
+    const result = await amendEpicDecomposition({
+      epicId: "EP-TRUCK-PARTS",
+      proposedDesignDoc: amendedParentDoc,
+      rationale: "Dale needs lookup speed before supplier automation.",
+      userId: "user-1",
+      db,
+      startQuiescence,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("execution-child-requires-operator-review");
+    expect(startQuiescence).not.toHaveBeenCalled();
+    expect(writes.epicUpdates).toHaveLength(0);
+    expect(writes.buildUpdates).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/build/amend-epic-decomposition.ts
+++ b/apps/web/lib/build/amend-epic-decomposition.ts
@@ -1,0 +1,496 @@
+import { prisma } from "@dpf/db";
+
+import type { BuildDesignDoc, BuildPhase } from "@/lib/feature-build-types";
+import {
+  failQuiescenceSwap,
+  signalSwapComplete,
+  signalSwapStarting,
+  startQuiescence,
+  type ActiveSessionBlockers,
+  type QuiescenceOutcome,
+} from "@/lib/self-upgrade/quiescence";
+import {
+  candidateToChildDesignDocs,
+  validateCandidate,
+  type DecompositionCandidate,
+  type DecompositionChildScope,
+} from "./decomposition-candidates";
+
+// Phase 8 amendment substrate for execution-organizational Epics.
+// Future reduction-gear instrumentation should emit a Ring 2 -> Ring 3
+// GearInterface event whenever an amendment changes the child projections.
+
+export type DecompositionAmendmentChild = {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: BuildPhase;
+  childOrder: number | null;
+  designDoc: unknown;
+  phaseRuns?: Array<{ phase: string; completedAt: Date | string | null }>;
+};
+
+type DecompositionAmendmentEpic = {
+  id: string;
+  epicId: string;
+  title: string;
+  designDoc: unknown;
+  decompositionState: unknown;
+  featureBuilds: DecompositionAmendmentChild[];
+};
+
+export type DecompositionAmendmentTx = {
+  epic: {
+    update: (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => Promise<unknown>;
+  };
+  featureBuild: {
+    update: (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => Promise<unknown>;
+  };
+  buildActivity: {
+    create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+  };
+};
+
+export type AmendEpicDecompositionDb = {
+  epic: {
+    findUnique: (args: unknown) => Promise<DecompositionAmendmentEpic | null>;
+  };
+  $transaction: <T>(fn: (tx: DecompositionAmendmentTx) => Promise<T>) => Promise<T>;
+};
+
+export type AmendEpicDecompositionStartQuiescence = (args: {
+  trigger: "manual";
+  triggerRefId: string;
+  budgetMs: number;
+}) => Promise<{
+  runId: string;
+  awaitReady: () => Promise<QuiescenceOutcome | {
+    ok: boolean;
+    outcome: string;
+    runId: string;
+    finalSnapshot?: ActiveSessionBlockers | null;
+    reason?: string;
+    deferSurface?: string | null;
+  }>;
+}>;
+
+export type DecompositionAmendmentImpact =
+  | {
+      ok: true;
+      requiresQuiescence: boolean;
+      completedChildBuildIds: string[];
+      updatedChildren: Array<{
+        id: string;
+        buildId: string;
+        childOrder: number;
+        designDoc: BuildDesignDoc;
+      }>;
+    }
+  | {
+      ok: false;
+      code:
+        | "acceptance-criteria-shape-changed"
+        | "execution-child-requires-operator-review"
+        | "invalid-decomposition-state";
+      error: string;
+      blockedChildBuildIds?: string[];
+    };
+
+export function deriveDecompositionAmendmentImpact(args: {
+  parentDesignDoc: BuildDesignDoc;
+  decompositionState: unknown;
+  children: DecompositionAmendmentChild[];
+}): DecompositionAmendmentImpact {
+  const candidate = candidateFromDecompositionState(args.decompositionState);
+  if (!candidate) {
+    return {
+      ok: false,
+      code: "invalid-decomposition-state",
+      error: "Epic decompositionState is missing the approved child partition.",
+    };
+  }
+
+  const expectedAcCount = expectedAcceptanceCriteriaCount(candidate.childScopes);
+  if (args.parentDesignDoc.acceptanceCriteria.length !== expectedAcCount) {
+    return {
+      ok: false,
+      code: "acceptance-criteria-shape-changed",
+      error:
+        `The amendment changes the parent acceptance-criteria count from ${expectedAcCount} to ${args.parentDesignDoc.acceptanceCriteria.length}. Choose a new decomposition partition before updating child designs.`,
+    };
+  }
+
+  const validation = validateCandidate(candidate, args.parentDesignDoc);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      code: "invalid-decomposition-state",
+      error: `Stored decomposition partition is no longer valid: ${validation.failures.map((f) => f.code).join(", ")}`,
+    };
+  }
+
+  const childrenByOrder = new Map<number, DecompositionAmendmentChild>();
+  for (const child of args.children) {
+    if (child.childOrder != null) {
+      childrenByOrder.set(child.childOrder, child);
+    }
+  }
+
+  const affectedChildren = args.children.filter((child) => child.phase !== "complete");
+  const executionChildren = affectedChildren.filter((child) => isExecutionPhase(child.phase));
+  if (executionChildren.length > 0) {
+    return {
+      ok: false,
+      code: "execution-child-requires-operator-review",
+      error:
+        "One or more affected children has already entered build/review/ship. Narrow the amendment or file follow-up work instead of silently rewriting execution scope.",
+      blockedChildBuildIds: executionChildren.map((child) => child.buildId),
+    };
+  }
+
+  const childDocs = candidateToChildDesignDocs(candidate, args.parentDesignDoc);
+  const updatedChildren = childDocs.flatMap((childDoc) => {
+    const child = childrenByOrder.get(childDoc.childOrder);
+    if (!child || child.phase === "complete") return [];
+    return [{
+      id: child.id,
+      buildId: child.buildId,
+      childOrder: childDoc.childOrder,
+      designDoc: childDoc.designDoc,
+    }];
+  });
+
+  const completedChildBuildIds = args.children
+    .filter((child) => child.phase === "complete")
+    .map((child) => child.buildId);
+  const requiresQuiescence = affectedChildren.some((child) => hasInFlightPlanRun(child));
+
+  return {
+    ok: true,
+    requiresQuiescence,
+    completedChildBuildIds,
+    updatedChildren,
+  };
+}
+
+export type AmendEpicDecompositionResult =
+  | {
+      ok: true;
+      quiescenceRunId: string | null;
+      updatedChildBuildIds: string[];
+      skippedCompletedChildBuildIds: string[];
+    }
+  | {
+      ok: false;
+      code:
+        | "epic-not-found"
+        | "epic-missing-design-doc"
+        | "acceptance-criteria-shape-changed"
+        | "execution-child-requires-operator-review"
+        | "invalid-decomposition-state"
+        | "quiescence-not-ready";
+      error: string;
+      blockedChildBuildIds?: string[];
+    };
+
+export async function amendEpicDecomposition(args: {
+  epicId: string;
+  proposedDesignDoc: BuildDesignDoc;
+  rationale: string;
+  userId: string;
+  db?: AmendEpicDecompositionDb;
+  startQuiescence?: AmendEpicDecompositionStartQuiescence;
+  now?: () => Date;
+}): Promise<AmendEpicDecompositionResult> {
+  const now = args.now ?? (() => new Date());
+  const db = args.db ?? defaultDb();
+  const epic = await db.epic.findUnique({
+    where: { epicId: args.epicId },
+    select: {
+      id: true,
+      epicId: true,
+      title: true,
+      designDoc: true,
+      decompositionState: true,
+      featureBuilds: {
+        select: {
+          id: true,
+          buildId: true,
+          title: true,
+          phase: true,
+          childOrder: true,
+          designDoc: true,
+          phaseRuns: {
+            where: { completedAt: null },
+            select: { phase: true, completedAt: true },
+          },
+        },
+        orderBy: [{ childOrder: "asc" }, { buildId: "asc" }],
+      },
+    },
+  });
+
+  if (!epic) {
+    return { ok: false, code: "epic-not-found", error: `Epic ${args.epicId} not found.` };
+  }
+  const currentDesignDoc = coerceBuildDesignDoc(epic.designDoc);
+  if (!currentDesignDoc) {
+    return {
+      ok: false,
+      code: "epic-missing-design-doc",
+      error: `Epic ${epic.epicId} does not have a designDoc to amend.`,
+    };
+  }
+
+  const impact = deriveDecompositionAmendmentImpact({
+    parentDesignDoc: args.proposedDesignDoc,
+    decompositionState: epic.decompositionState,
+    children: epic.featureBuilds,
+  });
+  if (!impact.ok) {
+    return impact;
+  }
+
+  let quiescenceRunId: string | null = null;
+  const injectedQuiescence = args.startQuiescence != null;
+  const startQuiescenceFn = args.startQuiescence ?? startQuiescence;
+  if (impact.requiresQuiescence) {
+    const started = await startQuiescenceFn({
+      trigger: "manual",
+      triggerRefId: `decomposition-amendment:${epic.epicId}`,
+      budgetMs: 5 * 60 * 1000,
+    });
+    quiescenceRunId = started.runId;
+    const ready = await started.awaitReady();
+    if (!ready.ok) {
+      return {
+        ok: false,
+        code: "quiescence-not-ready",
+        error: formatQuiescenceFailure(ready),
+      };
+    }
+    if (!injectedQuiescence) {
+      await signalSwapStarting(quiescenceRunId);
+    }
+  }
+
+  try {
+    const amendedAt = now().toISOString();
+    const nextState = appendAmendmentRecord({
+      state: epic.decompositionState,
+      amendment: {
+        amendedAt,
+        amendedByUserId: args.userId,
+        rationale: args.rationale.trim(),
+        quiescenceRunId,
+        affectedChildBuildIds: impact.updatedChildren.map((child) => child.buildId),
+        skippedCompletedChildBuildIds: impact.completedChildBuildIds,
+        designDocDiff: summarizeDesignDocDiff(currentDesignDoc, args.proposedDesignDoc),
+        gearInterfaceAlignment:
+          "Future reduction-gear instrumentation emits a Ring 2 -> Ring 3 GearInterface event for this amendment.",
+      },
+    });
+
+    await db.$transaction(async (tx) => {
+      await tx.epic.update({
+        where: { id: epic.id },
+        data: {
+          designDoc: args.proposedDesignDoc as unknown as Record<string, unknown>,
+          decompositionState: nextState as Record<string, unknown>,
+        },
+      });
+
+      for (const child of impact.updatedChildren) {
+        await tx.featureBuild.update({
+          where: { buildId: child.buildId },
+          data: { designDoc: child.designDoc as unknown as Record<string, unknown> },
+        });
+        await tx.buildActivity.create({
+          data: {
+            buildId: child.buildId,
+            tool: "amendEpicDecomposition",
+            summary: `Parent Epic ${epic.epicId} design amended; child #${child.childOrder} design projection re-derived.`,
+          },
+        });
+      }
+    });
+  } catch (err) {
+    if (quiescenceRunId && !injectedQuiescence) {
+      await failQuiescenceSwap(
+        quiescenceRunId,
+        err instanceof Error ? err.message : "Epic decomposition amendment failed.",
+      );
+    }
+    throw err;
+  }
+
+  if (quiescenceRunId && !injectedQuiescence) {
+    await signalSwapComplete(quiescenceRunId);
+  }
+
+  return {
+    ok: true,
+    quiescenceRunId,
+    updatedChildBuildIds: impact.updatedChildren.map((child) => child.buildId),
+    skippedCompletedChildBuildIds: impact.completedChildBuildIds,
+  };
+}
+
+function defaultDb(): AmendEpicDecompositionDb {
+  return {
+    epic: {
+      findUnique: prisma.epic.findUnique.bind(prisma.epic) as AmendEpicDecompositionDb["epic"]["findUnique"],
+    },
+    $transaction: ((fn) => prisma.$transaction(fn as never)) as AmendEpicDecompositionDb["$transaction"],
+  };
+}
+
+function candidateFromDecompositionState(state: unknown): DecompositionCandidate | null {
+  if (!isRecord(state) || !Array.isArray(state.partition)) return null;
+  const childScopes: DecompositionChildScope[] = [];
+  for (const rawScope of state.partition) {
+    if (!isRecord(rawScope)) return null;
+    const childOrder = numberValue(rawScope.childOrder);
+    const title = stringValue(rawScope.title);
+    const summary = stringValue(rawScope.summary);
+    const acceptanceCriteriaIndices = numberArray(rawScope.acceptanceCriteriaIndices);
+    const dependsOn = numberArray(rawScope.dependsOn);
+    if (
+      childOrder == null
+      || title == null
+      || summary == null
+      || acceptanceCriteriaIndices == null
+      || dependsOn == null
+    ) {
+      return null;
+    }
+    childScopes.push({
+      childOrder,
+      title,
+      summary,
+      acceptanceCriteriaIndices,
+      dependsOn,
+    });
+  }
+
+  return {
+    candidateId: stringValue(state.candidateId) ?? "approved-partition",
+    rationale: stringValue(state.candidateRationale) ?? "Approved decomposition partition.",
+    childScopes,
+  };
+}
+
+function expectedAcceptanceCriteriaCount(childScopes: DecompositionChildScope[]): number {
+  const indices = new Set<number>();
+  for (const scope of childScopes) {
+    for (const index of scope.acceptanceCriteriaIndices) {
+      indices.add(index);
+    }
+  }
+  return indices.size;
+}
+
+function isExecutionPhase(phase: BuildPhase): boolean {
+  return phase === "build" || phase === "review" || phase === "ship";
+}
+
+function hasInFlightPlanRun(child: DecompositionAmendmentChild): boolean {
+  return (child.phaseRuns ?? []).some((run) => run.phase === "plan" && run.completedAt == null);
+}
+
+export function coerceBuildDesignDoc(value: unknown): BuildDesignDoc | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.problemStatement !== "string"
+    || typeof value.reusePlan !== "string"
+    || typeof value.proposedApproach !== "string"
+    || !Array.isArray(value.acceptanceCriteria)
+    || !value.acceptanceCriteria.every((item) => typeof item === "string")
+  ) {
+    return null;
+  }
+  return value as BuildDesignDoc;
+}
+
+function appendAmendmentRecord(args: {
+  state: unknown;
+  amendment: Record<string, unknown>;
+}): Record<string, unknown> {
+  const state = isRecord(args.state) ? args.state : {};
+  const prior = Array.isArray(state.amendments) ? state.amendments : [];
+  return {
+    ...state,
+    amendments: [...prior, args.amendment],
+  };
+}
+
+function summarizeDesignDocDiff(
+  before: BuildDesignDoc,
+  after: BuildDesignDoc,
+): Record<string, unknown> {
+  const changedFields: string[] = [];
+  const scalarFields = [
+    "problemStatement",
+    "dataModel",
+    "existingCodeAudit",
+    "existingFunctionalityAudit",
+    "reusePlan",
+    "proposedApproach",
+    "accessibility",
+  ] as const;
+  for (const field of scalarFields) {
+    if (before[field] !== after[field]) {
+      changedFields.push(field);
+    }
+  }
+  const acceptanceCriteria = after.acceptanceCriteria.flatMap((afterText, index) => {
+    const beforeText = before.acceptanceCriteria[index];
+    return beforeText === afterText
+      ? []
+      : [{ index, before: beforeText ?? null, after: afterText }];
+  });
+  if (acceptanceCriteria.length > 0) {
+    changedFields.push("acceptanceCriteria");
+  }
+
+  return {
+    changedFields,
+    acceptanceCriteria,
+  };
+}
+
+type AmendmentQuiescenceReadyOutcome = Awaited<
+  ReturnType<Awaited<ReturnType<AmendEpicDecompositionStartQuiescence>>["awaitReady"]>
+>;
+
+function formatQuiescenceFailure(outcome: AmendmentQuiescenceReadyOutcome): string {
+  if (outcome.outcome === "deferred") {
+    return `Quiescence deferred amendment for ${"deferSurface" in outcome ? outcome.deferSurface ?? "unknown surface" : "unknown surface"}.`;
+  }
+  if ("reason" in outcome && outcome.reason) {
+    return `Quiescence ${outcome.outcome}: ${outcome.reason}`;
+  }
+  return `Quiescence ${outcome.outcome}; parent design was not amended.`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function numberArray(value: unknown): number[] | null {
+  if (!Array.isArray(value)) return null;
+  const out: number[] = [];
+  for (const item of value) {
+    if (typeof item !== "number" || !Number.isInteger(item)) return null;
+    out.push(item);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Phase 8 for BI-2E6CC391: parent Epic amendment flow for decomposed Build Studio work.

- Adds a tested amendment substrate that updates `Epic.designDoc`, appends `Epic.decompositionState.amendments[]`, re-derives mutable child `designDoc`s, and preserves completed children.
- Integrates Activity Quiescence for in-flight Plan work using `trigger="manual"` plus `triggerRefId="decomposition-amendment:<epicId>"`, keeping QuiescenceRun trigger taxonomy stable while preserving audit linkage.
- Blocks silent mutation of children already in build/review/ship so execution work is not rewritten without explicit operator follow-up.
- Adds an operator parent-design amendment panel wired from the Phase 7 `amend-parent-design` action.

## Verification

- `pnpm --filter web exec vitest run lib/build/ components/build/` — 68 files, 678 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web build` — passed; Turbopack still reports the existing Edge-runtime warnings around platform version/discovery imports.
- `git diff --check` — passed, with existing Windows LF-to-CRLF checkout warnings.

## UX Evidence

The live Docker database currently has zero `FeatureBuild` rows with `parentEpicId IS NOT NULL`, so the real `/build` child-amendment affordance cannot be exercised against production data without manufacturing live state. The amendment panel is covered with jsdom interaction tests that open the panel, edit the proposed parent design, submit the server action contract, and keep the panel open on execution-child blocks.

## Notes

The reduction-gear alignment is captured in the amendment substrate: future instrumentation should emit a Ring 2 -> Ring 3 `GearInterface` event for each accepted parent-design amendment.
