### PR TITLE
fix: recover stale platform update git lock

### DIFF
--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -16,7 +16,14 @@ const { mockPrisma, mockCan, mockAuth } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
 }));
 
-const { mockExec, mockExistsSync, mockReadFileSync, mockWriteFileSync } = vi.hoisted(() => ({
+const {
+  mockExec,
+  mockExistsSync,
+  mockReadFileSync,
+  mockStatSync,
+  mockUnlinkSync,
+  mockWriteFileSync,
+} = vi.hoisted(() => ({
   // exec returns { stdout, stderr } when promisified; child_process.exec API
   // dispatches via a callback, but lazy-node lets us shape it as a function
   // that promisify() turns into a thenable. We expose a callback-shape mock.
@@ -25,6 +32,8 @@ const { mockExec, mockExistsSync, mockReadFileSync, mockWriteFileSync } = vi.hoi
   }),
   mockExistsSync: vi.fn().mockReturnValue(false),
   mockReadFileSync: vi.fn().mockReturnValue(""),
+  mockStatSync: vi.fn().mockReturnValue({ mtimeMs: Date.now() - 60_000 }),
+  mockUnlinkSync: vi.fn(),
   mockWriteFileSync: vi.fn(),
 }));
 
@@ -55,6 +64,8 @@ vi.mock("@/lib/shared/lazy-node", () => ({
   lazyFs: () => ({
     existsSync: mockExistsSync,
     readFileSync: mockReadFileSync,
+    statSync: mockStatSync,
+    unlinkSync: mockUnlinkSync,
     writeFileSync: mockWriteFileSync,
   }),
   lazyFsPromises: () => ({}),
@@ -71,6 +82,7 @@ describe("applyPlatformUpdate", () => {
     mockAuth.mockResolvedValue({ user: { id: "u-1", platformRole: "admin", isSuperuser: false } });
     mockCan.mockReturnValue(true);
     mockExistsSync.mockReturnValue(false);
+    mockStatSync.mockReturnValue({ mtimeMs: Date.now() - 60_000 });
     mockExec.mockImplementation((_cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
       if (cb) cb(null, { stdout: "", stderr: "" });
     });
@@ -254,6 +266,46 @@ describe("applyPlatformUpdate", () => {
       data: { updatePending: false, pendingVersion: null },
     });
     expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it("clears a stale Git index lock before applying the queued update", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockImplementation((path: string) => path.endsWith("/.git/index.lock"));
+    mockStatSync.mockReturnValue({ mtimeMs: Date.now() - 60_000 });
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 2 files changed, 5 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    expect(mockUnlinkSync).toHaveBeenCalledWith("/workspace/.git/index.lock");
+  });
+
+  it("returns a friendly retry message while a Git index lock is still fresh", async () => {
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockExistsSync.mockImplementation((path: string) => path.endsWith("/.git/index.lock"));
+    mockStatSync.mockReturnValue({ mtimeMs: Date.now() });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/another platform update appears to be running/i);
+      expect(result.message).not.toMatch(/index\.lock/i);
+    }
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
   });
 
   it("allows Windows CRLF-only source differences before applying the update", async () => {

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -735,6 +735,7 @@ const UPDATE_UPSTREAM_BRANCH = "dpf-upstream";
 const UPDATE_WORK_BRANCH = "my-changes";
 const HOOKLESS_GIT = "git -c core.hooksPath=/dev/null";
 const PLATFORM_UPDATE_SOURCE_PATHS = ["apps/web", "packages"] as const;
+const STALE_GIT_INDEX_LOCK_MS = 30_000;
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -749,6 +750,24 @@ async function ensureWorkspaceSafeDirectory(
     `git config --global --add safe.directory ${shellQuote(workspace)} >/dev/null 2>&1 || true`,
     gitOpts,
   );
+}
+
+function recoverStaleGitIndexLock(
+  workspace: string,
+  resolvePath: (...parts: string[]) => string,
+): void {
+  const { existsSync, statSync, unlinkSync } = lazyFs();
+  const lockPath = resolvePath(workspace, ".git", "index.lock");
+  if (!existsSync(lockPath)) return;
+
+  const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+  if (ageMs < STALE_GIT_INDEX_LOCK_MS) {
+    throw new Error(
+      "Another platform update appears to be running. Wait a minute, then click Apply update again.",
+    );
+  }
+
+  unlinkSync(lockPath);
 }
 
 async function gitBranchExists(
@@ -1012,6 +1031,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     const { resolve: resolvePath } = lazyPath();
 
     await ensureWorkspaceSafeDirectory(execUpdate, gitOpts, workspace);
+    recoverStaleGitIndexLock(workspace, resolvePath);
 
     if (existsSync(resolvePath(workspace, ".git", "MERGE_HEAD"))) {
       const conflicts = await collectPlatformUpdateConflicts(

--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -51,6 +51,7 @@ function runScript(env: Record<string, string | undefined>, extraArgs: string[] 
     "-i",
     'PATH="$PATH"',
     ...envAssignments,
+    "bash",
     quoteForBash(SCRIPT),
     "--self-upgrade",
     ...extraArgs.map(quoteForBash),


### PR DESCRIPTION
## Summary
- Recover a stale `/workspace/.git/index.lock` before applying a queued platform update.
- Return a friendly retry message when the lock is still fresh, instead of surfacing raw Git internals to normal users.
- Add regression coverage for stale-lock recovery and active-lock retry behavior.

## Verification
- `pnpm --filter web test -- --run lib/actions/platform-dev-config.apply.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `git diff --check`
- Docker Desktop comparison: `docker build --target build -t dpf-main-build-compare .` passed on current main. Branch Docker build attempts failed in Docker's native build runtime after source compile/typecheck boundaries (`SIGTRAP` in Next worker, then `SIGSEGV` in Prisma generate on no-cache), while the branch's local production build passed.