### PR TITLE
fix: make source bootstrap pnpm install noninteractive

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,7 +91,7 @@ sync_image_source_to_workspace() {
 install_workspace_dependencies() {
   echo "  Installing dependencies (this takes 1-2 minutes on first run)..."
   cd "$WORKSPACE"
-  pnpm install --frozen-lockfile 2>&1 || pnpm install 2>&1
+  pnpm install --frozen-lockfile --config.confirmModulesPurge=false 2>&1 || pnpm install --config.confirmModulesPurge=false 2>&1
   echo "  Dependencies installed"
   pnpm --filter @dpf/db exec prisma generate 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
 }

--- a/docs/superpowers/plans/2026-05-26-source-bootstrap-pnpm-noninteractive.md
+++ b/docs/superpowers/plans/2026-05-26-source-bootstrap-pnpm-noninteractive.md
@@ -1,0 +1,39 @@
+# Source Bootstrap pnpm Noninteractive Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the portal init container from failing when it refreshes a managed `/workspace` that already has a `node_modules` tree.
+
+**Architecture:** The source-volume bootstrap remains in `docker-entrypoint.sh`; dependency installation is the only behavior that changes. The fix makes the existing `pnpm install` commands explicitly non-interactive instead of relying on a TTY or manual cleanup.
+
+**Tech Stack:** POSIX shell, pnpm 10, Node's built-in test runner.
+
+---
+
+### Task 1: Make Workspace Dependency Install Noninteractive
+
+**Files:**
+- Modify: `docker-entrypoint.sh`
+- Modify: `scripts/lib/docker-entrypoint-source-volume.test.mjs`
+
+- [x] **Step 1: Write the failing test**
+
+Add a regression test asserting that `install_workspace_dependencies` passes `--config.confirmModulesPurge=false` to both the frozen install and fallback install.
+
+- [x] **Step 2: Run the focused test**
+
+Run: `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
+Expected before implementation: FAIL, because the install commands do not yet include the pnpm noninteractive purge config.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Update both `pnpm install` calls in `install_workspace_dependencies` to include `--config.confirmModulesPurge=false`.
+
+- [x] **Step 4: Verify locally**
+
+Run: `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
+Run: `docker run --rm -v "${PWD}/docker-entrypoint.sh:/tmp/docker-entrypoint.sh:ro" alpine:3.20 sh -n /tmp/docker-entrypoint.sh`
+
+- [ ] **Step 5: Ship and redeploy**
+
+Run the affected CI gates, open the PR, merge after green checks, rebuild the portal image, restart the portal service, and verify the live update flow.

--- a/scripts/lib/docker-entrypoint-source-volume.test.mjs
+++ b/scripts/lib/docker-entrypoint-source-volume.test.mjs
@@ -36,3 +36,14 @@ test("source-volume snapshot commits add the safe-directory allowance before loc
     /git init -b dpf-upstream\s+ensure_workspace_safe_directory\s+git config user\.email/,
   );
 });
+
+test("workspace dependency install disables pnpm's interactive modules purge prompt", () => {
+  const body = functionBody("install_workspace_dependencies");
+  const matches = [...body.matchAll(/pnpm install(?: --frozen-lockfile)? --config\.confirmModulesPurge=false/g)];
+
+  assert.equal(
+    matches.length,
+    2,
+    "both frozen and fallback pnpm install commands should disable the non-TTY modules purge prompt",
+  );
+});


### PR DESCRIPTION
## Summary
- make managed `/workspace` dependency installs disable pnpm's non-TTY modules purge prompt
- add a regression test for the source-volume bootstrap install commands
- capture the install-path plan required for shared bootstrap changes

## Verification
- `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
- `docker run --rm -v "${PWD}/docker-entrypoint.sh:/tmp/docker-entrypoint.sh:ro" alpine:3.20 sh -n /tmp/docker-entrypoint.sh`
- `pnpm security:secrets:staged`