### PR TITLE
fix: skip lifecycle scripts during source bootstrap install

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,7 +91,7 @@ sync_image_source_to_workspace() {
 install_workspace_dependencies() {
   echo "  Installing dependencies (this takes 1-2 minutes on first run)..."
   cd "$WORKSPACE"
-  pnpm install --frozen-lockfile --config.confirmModulesPurge=false 2>&1 || pnpm install --config.confirmModulesPurge=false 2>&1
+  pnpm install --frozen-lockfile --config.confirmModulesPurge=false --ignore-scripts 2>&1 || pnpm install --config.confirmModulesPurge=false --ignore-scripts 2>&1
   echo "  Dependencies installed"
   pnpm --filter @dpf/db exec prisma generate 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
 }

--- a/docs/superpowers/plans/2026-05-26-source-bootstrap-ignore-lifecycle-scripts.md
+++ b/docs/superpowers/plans/2026-05-26-source-bootstrap-ignore-lifecycle-scripts.md
@@ -1,0 +1,39 @@
+# Source Bootstrap Ignore Lifecycle Scripts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make managed `/workspace` dependency refresh finish even when pnpm recreates `node_modules` and package lifecycle scripts would run before the dependency tree is stable.
+
+**Architecture:** Keep dependency installation in `docker-entrypoint.sh`, but install workspace dependencies with lifecycle scripts disabled. The entrypoint already runs Prisma generation immediately after install, so the only required postinstall side effect remains explicit and ordered.
+
+**Tech Stack:** POSIX shell, pnpm 10, Node's built-in test runner.
+
+---
+
+### Task 1: Skip Lifecycle Scripts During Source-Volume Install
+
+**Files:**
+- Modify: `docker-entrypoint.sh`
+- Modify: `scripts/lib/docker-entrypoint-source-volume.test.mjs`
+
+- [x] **Step 1: Write the failing test**
+
+Add a regression test asserting that both `pnpm install` commands in `install_workspace_dependencies` include `--ignore-scripts`.
+
+- [x] **Step 2: Run the focused test**
+
+Run: `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
+Expected before implementation: FAIL, because the install commands do not yet disable lifecycle scripts.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Add `--ignore-scripts` to both dependency-install commands in `install_workspace_dependencies`.
+
+- [x] **Step 4: Verify locally and in Docker shell syntax**
+
+Run: `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
+Run: `docker run --rm -v "${PWD}/docker-entrypoint.sh:/tmp/docker-entrypoint.sh:ro" alpine:3.20 sh -n /tmp/docker-entrypoint.sh`
+
+- [ ] **Step 5: Ship and redeploy**
+
+Run required CI, merge the PR, tag both Compose service images from the clean release build, force-recreate `portal-init` and `portal`, and verify health plus the Admin update UI.

--- a/scripts/lib/docker-entrypoint-source-volume.test.mjs
+++ b/scripts/lib/docker-entrypoint-source-volume.test.mjs
@@ -47,3 +47,19 @@ test("workspace dependency install disables pnpm's interactive modules purge pro
     "both frozen and fallback pnpm install commands should disable the non-TTY modules purge prompt",
   );
 });
+
+test("workspace dependency install skips lifecycle scripts before explicit Prisma generation", () => {
+  const body = functionBody("install_workspace_dependencies");
+  const installMatches = [...body.matchAll(/pnpm install(?: --frozen-lockfile)? --config\.confirmModulesPurge=false --ignore-scripts/g)];
+
+  assert.equal(
+    installMatches.length,
+    2,
+    "both install commands should skip lifecycle scripts while the node_modules tree is being recreated",
+  );
+  assert.match(
+    body,
+    /pnpm --filter @dpf\/db exec prisma generate/,
+    "Prisma generation should remain an explicit ordered step after dependency installation",
+  );
+});


### PR DESCRIPTION
## Summary
- run managed `/workspace` dependency installs with lifecycle scripts disabled while `node_modules` is being recreated
- keep Prisma generation as the explicit ordered step after dependency install
- add a regression test and install-path plan for the source-volume bootstrap behavior

## Verification
- `node --test scripts/lib/docker-entrypoint-source-volume.test.mjs`
- `docker run --rm -v "${PWD}/docker-entrypoint.sh:/tmp/docker-entrypoint.sh:ro" alpine:3.20 sh -n /tmp/docker-entrypoint.sh`
- `pnpm security:secrets:staged`