### PR TITLE
fix: use root prisma generate in source bootstrap

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,7 +93,7 @@ install_workspace_dependencies() {
   cd "$WORKSPACE"
   pnpm install --frozen-lockfile --config.confirmModulesPurge=false --ignore-scripts 2>&1 || pnpm install --config.confirmModulesPurge=false --ignore-scripts 2>&1
   echo "  Dependencies installed"
-  pnpm --filter @dpf/db exec prisma generate 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
+  pnpm exec prisma generate --schema packages/db/prisma/schema.prisma 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
 }
 
 is_workspace_housekeeping_status() {

--- a/docs/superpowers/plans/2026-05-26-source-bootstrap-root-prisma-generate.md
+++ b/docs/superpowers/plans/2026-05-26-source-bootstrap-root-prisma-generate.md
@@ -1,0 +1,64 @@
+# Source Bootstrap Root Prisma Generate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the non-fatal Prisma CLI stack trace from source-volume bootstrap after production dependency installs.
+
+**Architecture:** The Docker entrypoint already skips lifecycle scripts during source-volume dependency install and then runs Prisma generation explicitly. Under `NODE_ENV=production`, the Prisma CLI is present at the workspace root, so the explicit generation step should use `pnpm exec prisma generate --schema packages/db/prisma/schema.prisma` instead of the package-filtered command that expects package-local CLI links.
+
+**Tech Stack:** Docker entrypoint shell, pnpm 10, Prisma 7, Node test runner.
+
+---
+
+### Task 1: Source-Volume Prisma Generation Command
+
+**Files:**
+- Modify: `docker-entrypoint.sh`
+- Test: `scripts/lib/docker-entrypoint-source-volume.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Update `scripts/lib/docker-entrypoint-source-volume.test.mjs` so `install_workspace_dependencies` must call:
+
+```sh
+pnpm exec prisma generate --schema packages/db/prisma/schema.prisma
+```
+
+and must not call:
+
+```sh
+pnpm --filter @dpf/db exec prisma generate
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+node scripts/lib/docker-entrypoint-source-volume.test.mjs
+```
+
+Expected: the Prisma-generation assertion fails while the current entrypoint still uses the package-filtered command.
+
+- [ ] **Step 3: Implement the minimal entrypoint change**
+
+Change the explicit generation command in `docker-entrypoint.sh` to:
+
+```sh
+pnpm exec prisma generate --schema packages/db/prisma/schema.prisma 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
+```
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```powershell
+node scripts/lib/docker-entrypoint-source-volume.test.mjs
+sh -n docker-entrypoint.sh
+```
+
+Expected: the test passes and shell syntax validation exits 0.
+
+- [ ] **Step 5: Deploy verification after merge**
+
+Build the runner image, tag the same image as `dpf-portal-init:latest`, recreate `portal-init` and `portal`, then confirm the init logs no longer include `Cannot find module '/workspace/packages/db/node_modules/prisma/build/index.js'`.

--- a/scripts/lib/docker-entrypoint-source-volume.test.mjs
+++ b/scripts/lib/docker-entrypoint-source-volume.test.mjs
@@ -59,7 +59,12 @@ test("workspace dependency install skips lifecycle scripts before explicit Prism
   );
   assert.match(
     body,
+    /pnpm exec prisma generate --schema packages\/db\/prisma\/schema\.prisma/,
+    "Prisma generation should use the workspace-root CLI with an explicit schema path",
+  );
+  assert.doesNotMatch(
+    body,
     /pnpm --filter @dpf\/db exec prisma generate/,
-    "Prisma generation should remain an explicit ordered step after dependency installation",
+    "Prisma generation should not rely on package-local CLI links in the production source volume",
   );
 });


### PR DESCRIPTION
## Summary
- switch source-volume Prisma generation to the workspace-root CLI with an explicit schema path
- keep lifecycle scripts skipped during dependency install while preserving explicit Prisma generation afterward
- add a regression test and install-path plan for the bootstrap warning

## Root cause
`portal-init` runs the source-volume install under `NODE_ENV=production`, so `pnpm --filter @dpf/db exec prisma generate` can look for package-local Prisma CLI links that are not present after the production dependency install. The workspace root CLI is present and works with `--schema packages/db/prisma/schema.prisma`.

## Verification
- `node scripts/lib/docker-entrypoint-source-volume.test.mjs`
- `docker run --rm -v "D:/DPF-source-bootstrap-root-prisma:/src" -w /src alpine:3.20 sh -n docker-entrypoint.sh`
- `git diff --check HEAD~1 HEAD`