### PR TITLE
feat(feedback): add support-mode entry

### DIFF
--- a/apps/web/app/api/quality/report/route.ts
+++ b/apps/web/app/api/quality/report/route.ts
@@ -1,4 +1,5 @@
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
 
 export async function POST(request: Request): Promise<Response> {
   try {
@@ -8,6 +9,7 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     const body = (await request.json()) as Record<string, unknown>;
+    const supportSessionId = typeof body.supportSessionId === "string" ? body.supportSessionId : null;
 
     const { reportId } = await createPlatformIssueReport({
       type: String(body.type ?? "user_report"),
@@ -18,9 +20,15 @@ export async function POST(request: Request): Promise<Response> {
       routeContext: typeof body.routeContext === "string" ? body.routeContext : null,
       errorStack: typeof body.errorStack === "string" ? body.errorStack : null,
       userAgent: typeof body.userAgent === "string" ? body.userAgent : null,
+      triggerKind: typeof body.triggerKind === "string" ? body.triggerKind : null,
+      supportSessionId,
       reportedById: typeof body.userId === "string" ? body.userId : null,
+      threadId: typeof body.threadId === "string" ? body.threadId : null,
+      taskRunId: typeof body.taskRunId === "string" ? body.taskRunId : null,
+      featureBuildId: typeof body.featureBuildId === "string" ? body.featureBuildId : null,
       portfolioId: typeof body.portfolioId === "string" ? body.portfolioId : null,
       digitalProductId: typeof body.digitalProductId === "string" ? body.digitalProductId : null,
+      ...(supportSessionId ? { status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE } : {}),
     });
 
     return Response.json({ ok: true, reportId });

--- a/apps/web/components/agent/AgentCoworkerShell.test.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.test.tsx
@@ -1,0 +1,368 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FeedbackEventDetail } from "@/lib/feedback/feedback-event";
+import { AgentCoworkerShell } from "./AgentCoworkerShell";
+
+let pathname = "/build";
+
+const {
+  agentCoworkerPanelMock,
+  getOrCreateThreadSnapshotMock,
+  startFeedbackSupportMock,
+} = vi.hoisted(() => ({
+  agentCoworkerPanelMock: vi.fn(),
+  getOrCreateThreadSnapshotMock: vi.fn(),
+  startFeedbackSupportMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+vi.mock("@/lib/actions/agent-coworker", () => ({
+  getOrCreateThreadSnapshot: getOrCreateThreadSnapshotMock,
+}));
+
+vi.mock("@/lib/actions/feedback-support", () => ({
+  startFeedbackSupport: startFeedbackSupportMock,
+}));
+
+vi.mock("./AgentFAB", () => ({
+  AgentFAB: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" data-agent-fab="true" onClick={onClick}>
+      Open coworker
+    </button>
+  ),
+}));
+
+vi.mock("./AgentCoworkerPanel", () => ({
+  AgentCoworkerPanel: (props: Record<string, unknown>) => {
+    agentCoworkerPanelMock(props);
+
+    const initialMessages =
+      (props.initialMessages as Array<{ id: string; content: string }> | undefined) ?? [];
+    const supportCopy =
+      typeof props.supportCopy === "string" ? props.supportCopy : null;
+
+    return (
+      <section data-testid="coworker-panel">
+        <div data-testid="panel-thread-id">{String(props.threadId ?? "")}</div>
+        <button type="button" onClick={props.onClose as () => void}>
+          Close
+        </button>
+        {supportCopy && <p>{supportCopy}</p>}
+        {initialMessages.map((message) => (
+          <p key={message.id}>{message.content}</p>
+        ))}
+        {props.pendingAutoMessage ? (
+          <p data-testid="pending-auto-message">{String(props.pendingAutoMessage)}</p>
+        ) : null}
+      </section>
+    );
+  },
+}));
+
+vi.mock("./agent-auto-message", () => ({
+  shouldDispatchAutoMessageImmediately: () => true,
+  shouldSuppressAutoMessage: () => false,
+}));
+
+vi.mock("./agent-panel-layout", () => ({
+  clampPanelPosition: (position: { x: number; y: number }) => position,
+  clampPanelSize: (size: { width: number; height: number }) => size,
+  getDockedPanelFrame: () => null,
+  getReservedPanelWidth: () => 0,
+  isDockedPanelViewport: () => false,
+}));
+
+vi.mock("./agent-panel-prefs", () => ({
+  loadPanelOpen: () => false,
+  loadPanelPosition: () => ({ x: 32, y: 48 }),
+  loadPanelSize: () => ({ width: 380, height: 480 }),
+  savePanelOpen: vi.fn(),
+  savePanelPosition: vi.fn(),
+  savePanelSize: vi.fn(),
+}));
+
+function renderShell() {
+  return render(
+    <AgentCoworkerShell
+      userContext={{
+        userId: "user-1",
+        platformRole: "OPS-100",
+        isSuperuser: false,
+      }}
+      useUnifiedCoworker={true}
+    />,
+  );
+}
+
+function supportDetail(
+  supportSessionId = "dpf_support_1234567890abcdef1234567890abcdef",
+): FeedbackEventDetail {
+  return {
+    routeContext: "/build",
+    triggerKind: "manual",
+    supportSessionId,
+    autoFilePolicy: "ask",
+  };
+}
+
+function activeBuild(buildId = "FB-9E4FA6DE") {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("build-studio-active-build", { detail: buildId }),
+    );
+  });
+}
+
+async function settleShellThread() {
+  await waitFor(() => {
+    expect(getOrCreateThreadSnapshotMock).toHaveBeenCalled();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("AgentCoworkerShell support entry", () => {
+  beforeEach(() => {
+    pathname = "/build";
+    getOrCreateThreadSnapshotMock.mockResolvedValue({
+      threadId: "thread-1",
+      messages: [],
+    });
+    startFeedbackSupportMock.mockResolvedValue({
+      ok: true,
+      status: "created",
+      reportId: "PIR-1",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("handles a valid open-agent-feedback event in the existing panel", async () => {
+    renderShell();
+    activeBuild();
+    await settleShellThread();
+
+    const event = new CustomEvent("open-agent-feedback", {
+      cancelable: true,
+      detail: supportDetail(),
+    });
+
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(await screen.findByTestId("coworker-panel")).toBeInTheDocument();
+    expect(screen.getByText(/support mode/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/capture route\/build\/thread context/i),
+    ).toBeVisible();
+    expect(screen.queryByText(/category/i)).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(startFeedbackSupportMock).toHaveBeenCalledTimes(1);
+    });
+    expect(startFeedbackSupportMock).toHaveBeenCalledWith({
+      detail: supportDetail(),
+      featureBuildId: "FB-9E4FA6DE",
+      threadId: "thread-1",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("opens support in a focusable panel and returns focus to the launcher on close", async () => {
+    renderShell();
+    await settleShellThread();
+
+    const launcher = screen.getByRole("button", { name: "Open coworker" });
+    launcher.focus();
+    fireEvent.click(launcher);
+
+    const panel = await screen.findByRole("dialog", {
+      name: /coworker panel/i,
+    });
+    expect(panel).toHaveAttribute("tabindex", "-1");
+    await waitFor(() => {
+      expect(panel).toHaveFocus();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    const restoredLauncher = await screen.findByRole("button", {
+      name: "Open coworker",
+    });
+    await waitFor(() => {
+      expect(restoredLauncher).toHaveFocus();
+    });
+  });
+
+  it("shows text feedback when support report start is rate limited", async () => {
+    startFeedbackSupportMock.mockRejectedValueOnce(
+      new Error("Too many support sessions started. Try again in a minute."),
+    );
+
+    renderShell();
+    activeBuild();
+    await settleShellThread();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("open-agent-feedback", {
+          cancelable: true,
+          detail: supportDetail(),
+        }),
+      );
+    });
+
+    expect(
+      await screen.findByText(/too many support sessions started/i),
+    ).toBeVisible();
+  });
+
+  it("shows text feedback when support report start fails", async () => {
+    startFeedbackSupportMock.mockRejectedValueOnce(new Error("Report start failed"));
+
+    renderShell();
+    activeBuild();
+    await settleShellThread();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("open-agent-feedback", {
+          cancelable: true,
+          detail: supportDetail(),
+        }),
+      );
+    });
+
+    expect(await screen.findByText(/couldn't start support triage/i)).toBeVisible();
+  });
+
+  it("calls support start once per supportSessionId", async () => {
+    renderShell();
+    activeBuild();
+    await settleShellThread();
+
+    const detail = supportDetail();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("open-agent-feedback", { cancelable: true, detail }),
+      );
+      document.dispatchEvent(
+        new CustomEvent("open-agent-feedback", { cancelable: true, detail }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(startFeedbackSupportMock).toHaveBeenCalledTimes(1);
+    });
+
+    const nextDetail = supportDetail("dpf_support_fedcba0987654321fedcba0987654321");
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("open-agent-feedback", {
+          cancelable: true,
+          detail: nextDetail,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(startFeedbackSupportMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("reconciles a support entry when the thread arrives after the event", async () => {
+    let resolveSnapshot:
+      | ((value: { threadId: string; messages: [] }) => void)
+      | undefined;
+    getOrCreateThreadSnapshotMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSnapshot = resolve;
+      }),
+    );
+
+    renderShell();
+
+    const detail = supportDetail();
+    const event = new CustomEvent("open-agent-feedback", {
+      cancelable: true,
+      detail,
+    });
+
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(startFeedbackSupportMock).not.toHaveBeenCalled();
+    expect(await screen.findByTestId("coworker-panel")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSnapshot?.({ threadId: "thread-late", messages: [] });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(startFeedbackSupportMock).toHaveBeenCalledTimes(1);
+    });
+    expect(startFeedbackSupportMock).toHaveBeenCalledWith({
+      detail,
+      featureBuildId: null,
+      threadId: "thread-late",
+    });
+  });
+
+  it("preserves legacy open-agent-panel behavior", async () => {
+    pathname = "/setup";
+    renderShell();
+    await settleShellThread();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("open-agent-panel", {
+          detail: {
+            welcomeMessage: "Setup helper",
+            autoMessage: "Continue setup",
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByTestId("coworker-panel")).toBeInTheDocument();
+    expect(screen.getByText("Setup helper")).toBeInTheDocument();
+    expect(screen.getByTestId("pending-auto-message")).toHaveTextContent(
+      "Continue setup",
+    );
+    expect(startFeedbackSupportMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -5,6 +5,11 @@ import { usePathname } from "next/navigation";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { getOrCreateThreadSnapshot } from "@/lib/actions/agent-coworker";
+import { startFeedbackSupport } from "@/lib/actions/feedback-support";
+import {
+  isFeedbackEventDetail,
+  type FeedbackEventDetail,
+} from "@/lib/feedback/feedback-event";
 import { AgentFAB } from "./AgentFAB";
 import { AgentCoworkerPanel } from "./AgentCoworkerPanel";
 import {
@@ -29,10 +34,19 @@ import {
   savePanelPosition,
   savePanelSize,
 } from "./agent-panel-prefs";
+import {
+  OPEN_AGENT_FEEDBACK_EVENT,
+  SUPPORT_WELCOME_MESSAGE,
+} from "@/components/feedback/support-entry";
 
 type Props = {
   userContext: UserContext;
   useUnifiedCoworker: boolean;
+};
+
+type PendingSupportSession = {
+  detail: FeedbackEventDetail;
+  featureBuildId: string | null;
 };
 
 function getViewport() {
@@ -45,6 +59,40 @@ function getViewport() {
 function getShellContentTop(): number {
   const shellContent = document.querySelector<HTMLElement>("[data-shell-content='true']");
   return shellContent?.getBoundingClientRect().top ?? 16;
+}
+
+function withSupportWelcomeMessage(messages: AgentMessageRow[]): AgentMessageRow[] {
+  if (messages.some((message) => message.content === SUPPORT_WELCOME_MESSAGE)) {
+    return messages;
+  }
+
+  return [
+    ...messages,
+    {
+      id: "support-mode-welcome",
+      role: "assistant",
+      content: SUPPORT_WELCOME_MESSAGE,
+      createdAt: new Date().toISOString(),
+      agentId: "dale",
+      routeContext: null,
+    },
+  ];
+}
+
+function supportStartFailureMessage(error: unknown): AgentMessageRow {
+  const message = error instanceof Error ? error.message : "";
+  const content = /too many support sessions/i.test(message)
+    ? message
+    : "Couldn't start support triage. You can still describe the issue here.";
+
+  return {
+    id: `support-mode-start-failed-${Date.now()}`,
+    role: "assistant",
+    content,
+    createdAt: new Date().toISOString(),
+    agentId: "dale",
+    routeContext: null,
+  };
 }
 
 export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
@@ -66,11 +114,39 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
     message: string;
     targetBuildId: string | null;
   } | null>(null);
+  const pendingSupportSessionsRef = useRef<Map<string, PendingSupportSession>>(new Map());
+  const startedSupportSessionsRef = useRef<Set<string>>(new Set());
+  const lastFocusRef = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const positionRef = useRef(position);
   const sizeRef = useRef(size);
   const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
   const resizeRef = useRef<{ startX: number; startY: number; startWidth: number; startHeight: number } | null>(null);
   const userKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
+
+  function beginFeedbackSupport(session: PendingSupportSession, resolvedThreadId: string | null) {
+    if (!resolvedThreadId) {
+      pendingSupportSessionsRef.current.set(session.detail.supportSessionId, session);
+      return;
+    }
+
+    if (startedSupportSessionsRef.current.has(session.detail.supportSessionId)) {
+      pendingSupportSessionsRef.current.delete(session.detail.supportSessionId);
+      return;
+    }
+
+    startedSupportSessionsRef.current.add(session.detail.supportSessionId);
+    pendingSupportSessionsRef.current.delete(session.detail.supportSessionId);
+
+    void startFeedbackSupport({
+      detail: session.detail,
+      featureBuildId: session.featureBuildId,
+      threadId: resolvedThreadId,
+    }).catch((error) => {
+      console.warn("startFeedbackSupport error:", error);
+      setInitialMessages((prev) => [...prev, supportStartFailureMessage(error)]);
+    });
+  }
 
   useEffect(() => {
     const viewport = getViewport();
@@ -142,7 +218,18 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
       const snapshot = await getOrCreateThreadSnapshot({ routeContext: threadContext });
       if (!active) return;
       setThreadId(snapshot?.threadId ?? null);
-      setInitialMessages(snapshot?.messages ?? []);
+      const hasPendingSupport = pendingSupportSessionsRef.current.size > 0;
+      setInitialMessages(
+        hasPendingSupport
+          ? withSupportWelcomeMessage(snapshot?.messages ?? [])
+          : snapshot?.messages ?? [],
+      );
+
+      if (snapshot?.threadId) {
+        for (const session of Array.from(pendingSupportSessionsRef.current.values())) {
+          beginFeedbackSupport(session, snapshot.threadId);
+        }
+      }
 
       // Release a queued auto-message targeted at THIS build now that its
       // thread is loaded. Draining inside the load callback avoids the race
@@ -168,6 +255,9 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
   }, [threadContext]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleOpen() {
+    lastFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
     setIsOpen(true);
     savePanelOpen(userKey, true);
   }
@@ -175,14 +265,56 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
   function handleClose() {
     setIsOpen(false);
     savePanelOpen(userKey, false);
+    window.setTimeout(() => {
+      const previousFocus = lastFocusRef.current;
+      if (previousFocus?.isConnected) {
+        previousFocus.focus();
+        return;
+      }
+
+      document.querySelector<HTMLElement>("[data-agent-fab='true']")?.focus();
+    }, 0);
   }
+
+  useEffect(() => {
+    if (!isOpen) return;
+    panelRef.current?.focus();
+  }, [isOpen]);
 
   // Listen for panel open requests (feedback button, build creation, etc.)
   useEffect(() => {
     function handleOpenPanel(e: Event) {
+      const detail = (e as CustomEvent<{ autoMessage?: string; welcomeMessage?: string; targetBuildId?: string } | undefined>).detail;
+      if (e.type === OPEN_AGENT_FEEDBACK_EVENT) {
+        if (!isFeedbackEventDetail((e as CustomEvent<unknown>).detail)) {
+          console.warn("Invalid open-agent-feedback detail");
+          return;
+        }
+
+        e.preventDefault();
+        lastFocusRef.current = document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+        setIsOpen(true);
+        savePanelOpen(userKey, true);
+
+        const supportDetail = (e as CustomEvent<FeedbackEventDetail>).detail;
+        const supportSession = {
+          detail: supportDetail,
+          featureBuildId: pathname === "/build" ? activeBuildId : null,
+        };
+
+        setInitialMessages((prev) => withSupportWelcomeMessage(prev));
+        beginFeedbackSupport(supportSession, threadId);
+        return;
+      }
+
+      lastFocusRef.current = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
       setIsOpen(true);
       savePanelOpen(userKey, true);
-      const detail = (e as CustomEvent<{ autoMessage?: string; welcomeMessage?: string; targetBuildId?: string } | undefined>).detail;
+
       if (detail?.autoMessage) {
         const signature = `${detail.autoMessage}::${detail.targetBuildId ?? ""}`;
         const now = Date.now();
@@ -231,13 +363,13 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
         });
       }
     }
-    document.addEventListener("open-agent-feedback", handleOpenPanel);
+    document.addEventListener(OPEN_AGENT_FEEDBACK_EVENT, handleOpenPanel);
     document.addEventListener("open-agent-panel", handleOpenPanel);
     return () => {
-      document.removeEventListener("open-agent-feedback", handleOpenPanel);
+      document.removeEventListener(OPEN_AGENT_FEEDBACK_EVENT, handleOpenPanel);
       document.removeEventListener("open-agent-panel", handleOpenPanel);
     };
-  }, [activeBuildId, threadId, userKey]);
+  }, [activeBuildId, pathname, threadId, userContext.userId, userKey]);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     if (dockedFrame) return;
@@ -391,7 +523,11 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
 
       {isOpen && (
         <div
+          ref={panelRef}
           data-agent-panel="true"
+          role="dialog"
+          aria-label="AI coworker panel"
+          tabIndex={-1}
           style={panelStyle}
         >
           <AgentCoworkerPanel

--- a/apps/web/components/agent/AgentFAB.tsx
+++ b/apps/web/components/agent/AgentFAB.tsx
@@ -81,6 +81,7 @@ export function AgentFAB({ onClick }: Props) {
   return (
     <button
       type="button"
+      data-agent-fab="true"
       onMouseDown={handleMouseDown}
       onClick={handleClick}
       title="Open AI Co-worker"

--- a/apps/web/components/feedback/FeedbackButton.test.tsx
+++ b/apps/web/components/feedback/FeedbackButton.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackButton } from "./FeedbackButton";
+
+let pathname = "/build";
+
+const feedbackFormMock = vi.hoisted(() => ({
+  props: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+vi.mock("./FeedbackForm", () => ({
+  FeedbackForm: (props: Record<string, unknown>) => {
+    feedbackFormMock.props.push(props);
+
+    return <div data-testid="feedback-form">Feedback fallback</div>;
+  },
+}));
+
+describe("FeedbackButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pathname = "/build";
+    feedbackFormMock.props = [];
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("dispatches a cancelable manual support event for the build route", () => {
+    const received: CustomEvent[] = [];
+    const handler = ((event: Event) => {
+      received.push(event as CustomEvent);
+    }) as EventListener;
+    document.addEventListener("open-agent-feedback", handler);
+
+    try {
+      render(<FeedbackButton userId="user-1" />);
+      const trigger = screen.getByRole("button", {
+        name: /^feedback$/i,
+      });
+
+      expect(trigger).toHaveAccessibleName("Feedback");
+
+      fireEvent.click(trigger);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].cancelable).toBe(true);
+      expect(received[0].detail).toEqual(
+        expect.objectContaining({
+          routeContext: "/build",
+          triggerKind: "manual",
+          autoFilePolicy: "ask",
+        }),
+      );
+      expect(received[0].detail.supportSessionId).toMatch(
+        /^dpf_support_[a-f0-9]{32}$/,
+      );
+    } finally {
+      document.removeEventListener("open-agent-feedback", handler);
+    }
+  });
+
+  it("keeps the fallback form closed when the support event is handled", () => {
+    const handler = ((event: Event) => {
+      event.preventDefault();
+    }) as EventListener;
+    document.addEventListener("open-agent-feedback", handler);
+
+    try {
+      render(<FeedbackButton userId="user-1" />);
+      fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
+      expect(feedbackFormMock.props).toHaveLength(0);
+    } finally {
+      document.removeEventListener("open-agent-feedback", handler);
+    }
+  });
+
+  it("keeps the fallback form closed when the coworker panel opens", () => {
+    render(<FeedbackButton userId="user-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
+
+    const panel = document.createElement("div");
+    panel.setAttribute("data-agent-panel", "true");
+    document.body.appendChild(panel);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
+    expect(feedbackFormMock.props).toHaveLength(0);
+    panel.remove();
+  });
+
+  it("opens the fallback form with the same support context when the event is unhandled", () => {
+    render(<FeedbackButton userId="user-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /^feedback$/i }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId("feedback-form")).toBeInTheDocument();
+    expect(screen.getByText("Feedback fallback")).toBeVisible();
+    expect(feedbackFormMock.props).toHaveLength(1);
+    expect(feedbackFormMock.props[0]).toEqual(
+      expect.objectContaining({
+        routeContext: "/build",
+        userId: "user-1",
+        source: "manual",
+        triggerKind: "manual",
+        autoFilePolicy: "ask",
+      }),
+    );
+    expect(feedbackFormMock.props[0].supportSessionId).toMatch(
+      /^dpf_support_[a-f0-9]{32}$/,
+    );
+  });
+});

--- a/apps/web/components/feedback/FeedbackButton.tsx
+++ b/apps/web/components/feedback/FeedbackButton.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import { FeedbackForm } from "./FeedbackForm";
+import {
+  createManualFeedbackEventDetail,
+  type FeedbackEventDetail,
+} from "@/lib/feedback/feedback-event";
 
 type Props = {
   userId?: string | null;
@@ -11,14 +15,25 @@ type Props = {
 export function FeedbackButton({ userId }: Props) {
   const pathname = usePathname();
   const [showForm, setShowForm] = useState(false);
+  const [fallbackDetail, setFallbackDetail] = useState<FeedbackEventDetail | null>(null);
 
   function handleClick() {
-    const event = new CustomEvent("open-agent-feedback");
-    document.dispatchEvent(event);
+    const detail = createManualFeedbackEventDetail(pathname);
+    const handled = !document.dispatchEvent(
+      new CustomEvent("open-agent-feedback", {
+        cancelable: true,
+        detail,
+      }),
+    );
+
+    if (handled) {
+      return;
+    }
 
     setTimeout(() => {
       const panel = document.querySelector("[data-agent-panel]");
       if (!panel) {
+        setFallbackDetail(detail);
         setShowForm(true);
       }
     }, 500);
@@ -43,9 +58,14 @@ export function FeedbackButton({ userId }: Props) {
             Send Feedback
           </div>
           <FeedbackForm
-            routeContext={pathname}
+            routeContext={fallbackDetail?.routeContext ?? pathname}
             {...(userId != null && { userId })}
             source="manual"
+            {...(fallbackDetail && {
+              triggerKind: fallbackDetail.triggerKind,
+              supportSessionId: fallbackDetail.supportSessionId,
+              autoFilePolicy: fallbackDetail.autoFilePolicy,
+            })}
             onClose={() => setShowForm(false)}
           />
         </div>

--- a/apps/web/components/feedback/FeedbackForm.tsx
+++ b/apps/web/components/feedback/FeedbackForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { FeedbackAutoFilePolicy, FeedbackTriggerKind } from "@/lib/feedback/feedback-event";
 import { submitReport } from "@/lib/quality-queue";
 
 type Props = {
@@ -9,6 +10,9 @@ type Props = {
   errorMessage?: string;
   errorStack?: string;
   source?: string;
+  triggerKind?: FeedbackTriggerKind;
+  supportSessionId?: string;
+  autoFilePolicy?: FeedbackAutoFilePolicy;
   onClose?: () => void;
 };
 
@@ -18,6 +22,9 @@ export function FeedbackForm({
   errorMessage,
   errorStack,
   source,
+  triggerKind,
+  supportSessionId,
+  autoFilePolicy,
   onClose,
 }: Props) {
   const [type, setType] = useState<string>(errorMessage ? "runtime_error" : "user_report");
@@ -36,6 +43,9 @@ export function FeedbackForm({
       ...(errorStack !== undefined && { errorStack }),
       source: source ?? "manual",
       ...(userId != null && { userId }),
+      ...(triggerKind !== undefined && { triggerKind }),
+      ...(supportSessionId !== undefined && { supportSessionId }),
+      ...(autoFilePolicy !== undefined && { autoFilePolicy }),
     });
     if (result.ok && result.reportId) {
       setReportId(result.reportId);

--- a/apps/web/components/feedback/HeaderFeedbackButton.test.tsx
+++ b/apps/web/components/feedback/HeaderFeedbackButton.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HeaderFeedbackButton } from "./HeaderFeedbackButton";
+
+let pathname = "/build";
+
+const feedbackFormMock = vi.hoisted(() => ({
+  props: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+vi.mock("./FeedbackForm", () => ({
+  FeedbackForm: (props: Record<string, unknown>) => {
+    feedbackFormMock.props.push(props);
+
+    return <div data-testid="feedback-form">Feedback fallback</div>;
+  },
+}));
+
+describe("HeaderFeedbackButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pathname = "/build";
+    feedbackFormMock.props = [];
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("dispatches a cancelable manual support event for the build route", () => {
+    const received: CustomEvent[] = [];
+    const handler = ((event: Event) => {
+      received.push(event as CustomEvent);
+    }) as EventListener;
+    document.addEventListener("open-agent-feedback", handler);
+
+    try {
+      render(<HeaderFeedbackButton userId="user-1" />);
+      const trigger = screen.getByRole("button", {
+        name: /^feedback$/i,
+      });
+
+      expect(trigger).toHaveAccessibleName("Feedback");
+
+      fireEvent.click(trigger);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].cancelable).toBe(true);
+      expect(received[0].detail).toEqual(
+        expect.objectContaining({
+          routeContext: "/build",
+          triggerKind: "manual",
+          autoFilePolicy: "ask",
+        }),
+      );
+      expect(received[0].detail.supportSessionId).toMatch(
+        /^dpf_support_[a-f0-9]{32}$/,
+      );
+    } finally {
+      document.removeEventListener("open-agent-feedback", handler);
+    }
+  });
+
+  it("keeps the fallback form closed when the support event is handled", () => {
+    const handler = ((event: Event) => {
+      event.preventDefault();
+    }) as EventListener;
+    document.addEventListener("open-agent-feedback", handler);
+
+    try {
+      render(<HeaderFeedbackButton userId="user-1" />);
+      fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
+      expect(feedbackFormMock.props).toHaveLength(0);
+    } finally {
+      document.removeEventListener("open-agent-feedback", handler);
+    }
+  });
+
+  it("keeps the fallback form closed when the coworker panel opens", () => {
+    render(<HeaderFeedbackButton userId="user-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
+
+    const panel = document.createElement("div");
+    panel.setAttribute("data-agent-panel", "true");
+    document.body.appendChild(panel);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
+    expect(feedbackFormMock.props).toHaveLength(0);
+    panel.remove();
+  });
+
+  it("opens the fallback form with the same support context when the event is unhandled", () => {
+    render(<HeaderFeedbackButton userId="user-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /^feedback$/i }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId("feedback-form")).toBeInTheDocument();
+    expect(screen.getByText("Feedback fallback")).toBeVisible();
+    expect(feedbackFormMock.props).toHaveLength(1);
+    expect(feedbackFormMock.props[0]).toEqual(
+      expect.objectContaining({
+        routeContext: "/build",
+        userId: "user-1",
+        source: "manual",
+        triggerKind: "manual",
+        autoFilePolicy: "ask",
+      }),
+    );
+    expect(feedbackFormMock.props[0].supportSessionId).toMatch(
+      /^dpf_support_[a-f0-9]{32}$/,
+    );
+  });
+});

--- a/apps/web/components/feedback/HeaderFeedbackButton.tsx
+++ b/apps/web/components/feedback/HeaderFeedbackButton.tsx
@@ -3,6 +3,10 @@
 import { useState, useRef, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { FeedbackForm } from "./FeedbackForm";
+import {
+  createManualFeedbackEventDetail,
+  type FeedbackEventDetail,
+} from "@/lib/feedback/feedback-event";
 
 type Props = {
   userId?: string | null;
@@ -11,6 +15,7 @@ type Props = {
 export function HeaderFeedbackButton({ userId }: Props) {
   const pathname = usePathname();
   const [showForm, setShowForm] = useState(false);
+  const [fallbackDetail, setFallbackDetail] = useState<FeedbackEventDetail | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -25,14 +30,23 @@ export function HeaderFeedbackButton({ userId }: Props) {
   }, [showForm]);
 
   function handleClick() {
-    // Try to open AI co-worker with feedback prompt
-    const event = new CustomEvent("open-agent-feedback");
-    document.dispatchEvent(event);
+    const detail = createManualFeedbackEventDetail(pathname);
+    const handled = !document.dispatchEvent(
+      new CustomEvent("open-agent-feedback", {
+        cancelable: true,
+        detail,
+      }),
+    );
+
+    if (handled) {
+      return;
+    }
 
     // Fallback: if panel doesn't open, show the simple form
     setTimeout(() => {
       const panel = document.querySelector("[data-agent-panel]");
       if (!panel) {
+        setFallbackDetail(detail);
         setShowForm(true);
       }
     }, 500);
@@ -54,9 +68,14 @@ export function HeaderFeedbackButton({ userId }: Props) {
             Send Feedback
           </div>
           <FeedbackForm
-            routeContext={pathname}
+            routeContext={fallbackDetail?.routeContext ?? pathname}
             {...(userId != null && { userId })}
             source="manual"
+            {...(fallbackDetail && {
+              triggerKind: fallbackDetail.triggerKind,
+              supportSessionId: fallbackDetail.supportSessionId,
+              autoFilePolicy: fallbackDetail.autoFilePolicy,
+            })}
             onClose={() => setShowForm(false)}
           />
         </div>

--- a/apps/web/components/feedback/support-entry.ts
+++ b/apps/web/components/feedback/support-entry.ts
@@ -1,0 +1,4 @@
+export const SUPPORT_WELCOME_MESSAGE =
+  "You're in support mode. Share what blocked you, and I'll capture route/build/thread context for platform triage.";
+
+export const OPEN_AGENT_FEEDBACK_EVENT = "open-agent-feedback";

--- a/apps/web/lib/actions/feedback-support.test.ts
+++ b/apps/web/lib/actions/feedback-support.test.ts
@@ -1,0 +1,444 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FeedbackEventDetail } from "@/lib/feedback/feedback-event";
+
+const { mockAuth, mockCreatePlatformIssueReport, mockPrisma } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCreatePlatformIssueReport: vi.fn(),
+  mockPrisma: {
+    featureBuild: {
+      findUnique: vi.fn(),
+    },
+    platformIssueReport: {
+      count: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/quality/platform-issue-reports", () => ({
+  createPlatformIssueReport: mockCreatePlatformIssueReport,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+}));
+
+type StartFeedbackSupportInput = {
+  detail: FeedbackEventDetail;
+  featureBuildId?: string | null;
+  threadId?: string | null;
+  text?: string | null;
+};
+
+type ReconcileFeedbackSupportFallbackInput = {
+  detail: FeedbackEventDetail;
+  threadId: string;
+};
+
+type FeedbackSupportActions = {
+  startFeedbackSupport: (input: StartFeedbackSupportInput) => Promise<unknown>;
+  reconcileFeedbackSupportFallback: (
+    input: ReconcileFeedbackSupportFallbackInput,
+  ) => Promise<unknown>;
+};
+
+async function loadActions(): Promise<FeedbackSupportActions> {
+  return import("./feedback-support") as Promise<FeedbackSupportActions>;
+}
+
+const userSession = {
+  user: {
+    id: "user-1",
+    platformRole: "HR-300",
+    isSuperuser: false,
+  },
+};
+
+function supportDetail(
+  overrides: Partial<FeedbackEventDetail> = {},
+): FeedbackEventDetail {
+  return {
+    routeContext: "/build",
+    triggerKind: "manual",
+    supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    autoFilePolicy: "ask",
+    ...overrides,
+  };
+}
+
+describe("startFeedbackSupport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(userSession);
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({ id: "feature-build-1" });
+    mockPrisma.platformIssueReport.count.mockResolvedValue(0);
+    mockPrisma.platformIssueReport.findUnique.mockResolvedValue(null);
+    mockPrisma.platformIssueReport.findFirst.mockResolvedValue(null);
+    mockPrisma.platformIssueReport.update.mockResolvedValue({ reportId: "PIR-SUPPORT" });
+    mockCreatePlatformIssueReport.mockResolvedValue({ reportId: "PIR-SUPPORT" });
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockAuth.mockResolvedValue(null);
+
+    await expect(
+      startFeedbackSupport({
+        detail: supportDetail(),
+        featureBuildId: "FB-9E4FA6DE",
+        threadId: "thread-1",
+      }),
+    ).rejects.toThrow(/unauthorized/i);
+
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed support event details", async () => {
+    const { startFeedbackSupport } = await loadActions();
+
+    await expect(
+      startFeedbackSupport({
+        detail: {
+          ...supportDetail(),
+          supportSessionId: "not-a-support-session",
+        },
+      }),
+    ).rejects.toThrow(/invalid feedback support detail/i);
+
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("resolves public FB-* build ids before writing", async () => {
+    const { startFeedbackSupport } = await loadActions();
+
+    await startFeedbackSupport({
+      detail: supportDetail(),
+      featureBuildId: "FB-9E4FA6DE",
+      threadId: "thread-1",
+    });
+
+    expect(mockPrisma.featureBuild.findUnique).toHaveBeenCalledWith({
+      where: { buildId: "FB-9E4FA6DE" },
+      select: { id: true },
+    });
+    expect(mockCreatePlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        featureBuildId: "feature-build-1",
+      }),
+    );
+  });
+
+  it("tolerates missing build resolution and still creates support context", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.featureBuild.findUnique.mockResolvedValue(null);
+
+    const result = await startFeedbackSupport({
+      detail: supportDetail(),
+      featureBuildId: "FB-MISSING",
+      threadId: "thread-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "created",
+      reportId: "PIR-SUPPORT",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(mockCreatePlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        featureBuildId: null,
+      }),
+    );
+  });
+
+  it("writes the support entry payload with user, trigger, route, thread, and supportSessionId", async () => {
+    const { startFeedbackSupport } = await loadActions();
+
+    await startFeedbackSupport({
+      detail: supportDetail({
+        routeContext: "/build",
+        sourceId: "header-feedback",
+        triggerKind: "manual",
+      }),
+      featureBuildId: "feature-build-direct",
+      threadId: "thread-1",
+    });
+
+    expect(mockCreatePlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "user_report",
+        severity: "medium",
+        status: "support_triage",
+        title: "Support session started",
+        description: expect.stringMatching(/opened coworker support mode/i),
+        routeContext: "/build",
+        source: "support_mode",
+        reportedById: "user-1",
+        triggerKind: "manual",
+        supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+        featureBuildId: "feature-build-direct",
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("dedupes repeated starts with the same supportSessionId for the user", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.platformIssueReport.findUnique.mockResolvedValue({
+      reportId: "PIR-EXISTING",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+
+    const result = await startFeedbackSupport({
+      detail: supportDetail(),
+      threadId: "thread-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "existing",
+      reportId: "PIR-EXISTING",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(mockPrisma.platformIssueReport.findUnique).toHaveBeenCalledWith({
+      where: {
+        reportedById_supportSessionId: {
+          reportedById: "user-1",
+          supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+        },
+      },
+      select: expect.objectContaining({
+        reportId: true,
+        supportSessionId: true,
+      }),
+    });
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an existing fallback row with an empty threadId instead of creating a duplicate", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.platformIssueReport.findUnique.mockResolvedValue({
+      id: "issue-row-1",
+      reportId: "PIR-FALLBACK",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+      threadId: null,
+    });
+    mockPrisma.platformIssueReport.update.mockResolvedValue({
+      reportId: "PIR-FALLBACK",
+      threadId: "thread-1",
+    });
+
+    const result = await startFeedbackSupport({
+      detail: supportDetail(),
+      threadId: "thread-1",
+      text: "Fallback form details",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "reconciled",
+      reportId: "PIR-FALLBACK",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(mockPrisma.platformIssueReport.update).toHaveBeenCalledWith({
+      where: { id: "issue-row-1" },
+      data: {
+        status: "support_triage",
+        threadId: "thread-1",
+      },
+    });
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips an existing support row with a conflicting threadId", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockPrisma.platformIssueReport.findUnique.mockResolvedValue({
+      id: "issue-row-1",
+      reportId: "PIR-EXISTING",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+      threadId: "thread-existing",
+    });
+
+    const result = await startFeedbackSupport({
+      detail: supportDetail(),
+      threadId: "thread-new",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "skipped",
+      reportId: "PIR-EXISTING",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Feedback support session threadId conflict",
+      expect.objectContaining({
+        reportId: "PIR-EXISTING",
+        supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+      }),
+    );
+    expect(mockPrisma.platformIssueReport.update).not.toHaveBeenCalled();
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("handles unique races by returning the existing user-owned support report", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.platformIssueReport.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "issue-row-1",
+        reportId: "PIR-RACED",
+        supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+        threadId: "thread-1",
+      });
+    mockCreatePlatformIssueReport.mockRejectedValue(Object.assign(new Error("Unique constraint failed"), { code: "P2002" }));
+
+    const result = await startFeedbackSupport({
+      detail: supportDetail(),
+      threadId: "thread-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "existing",
+      reportId: "PIR-RACED",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(mockPrisma.platformIssueReport.findUnique).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects the fourth support start in one minute", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.platformIssueReport.count.mockResolvedValue(3);
+
+    await expect(
+      startFeedbackSupport({
+        detail: supportDetail({
+          supportSessionId: "dpf_support_fedcba0987654321fedcba0987654321",
+        }),
+      }),
+    ).rejects.toThrow(/too many support sessions/i);
+
+    expect(mockPrisma.platformIssueReport.count).toHaveBeenCalledWith({
+      where: {
+        reportedById: "user-1",
+        status: "support_triage",
+        createdAt: { gte: expect.any(Date) },
+      },
+    });
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+
+  it("rejects the eleventh support start in one hour", async () => {
+    const { startFeedbackSupport } = await loadActions();
+    mockPrisma.platformIssueReport.count.mockResolvedValueOnce(2).mockResolvedValueOnce(10);
+
+    await expect(
+      startFeedbackSupport({
+        detail: supportDetail({
+          supportSessionId: "dpf_support_fedcba0987654321fedcba0987654321",
+        }),
+      }),
+    ).rejects.toThrow(/too many support sessions/i);
+
+    expect(mockPrisma.platformIssueReport.count).toHaveBeenCalledWith({
+      where: {
+        reportedById: "user-1",
+        status: "support_triage",
+        createdAt: { gte: expect.any(Date) },
+      },
+    });
+    expect(mockCreatePlatformIssueReport).not.toHaveBeenCalled();
+  });
+});
+
+describe("reconcileFeedbackSupportFallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(userSession);
+    mockPrisma.platformIssueReport.findFirst.mockResolvedValue({
+      id: "issue-row-1",
+      reportId: "PIR-FALLBACK",
+      threadId: null,
+    });
+    mockPrisma.platformIssueReport.update.mockResolvedValue({
+      reportId: "PIR-FALLBACK",
+      threadId: "thread-1",
+    });
+  });
+
+  it("reconciles a fallback report with the opened support thread", async () => {
+    const { reconcileFeedbackSupportFallback } = await loadActions();
+
+    const result = await reconcileFeedbackSupportFallback({
+      detail: supportDetail(),
+      threadId: "thread-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "reconciled",
+      reportId: "PIR-FALLBACK",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(mockPrisma.platformIssueReport.findFirst).toHaveBeenCalledWith({
+      where: {
+        reportedById: "user-1",
+        supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+      },
+      select: expect.objectContaining({
+        id: true,
+        reportId: true,
+        threadId: true,
+      }),
+      orderBy: { createdAt: "desc" },
+    });
+    expect(mockPrisma.platformIssueReport.update).toHaveBeenCalledWith({
+      where: { id: "issue-row-1" },
+      data: expect.objectContaining({
+        status: "support_triage",
+        threadId: "thread-1",
+      }),
+    });
+  });
+
+  it("does not overwrite an existing conflicting threadId during reconciliation", async () => {
+    const { reconcileFeedbackSupportFallback } = await loadActions();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockPrisma.platformIssueReport.findFirst.mockResolvedValue({
+      id: "issue-row-1",
+      reportId: "PIR-FALLBACK",
+      threadId: "thread-existing",
+    });
+
+    const result = await reconcileFeedbackSupportFallback({
+      detail: supportDetail(),
+      threadId: "thread-new",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "skipped",
+      reportId: "PIR-FALLBACK",
+      supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Feedback support fallback threadId conflict",
+      expect.objectContaining({
+        reportId: "PIR-FALLBACK",
+        supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+      }),
+    );
+    expect(mockPrisma.platformIssueReport.update).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/web/lib/actions/feedback-support.ts
+++ b/apps/web/lib/actions/feedback-support.ts
@@ -1,0 +1,359 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { isFeedbackEventDetail, type FeedbackEventDetail } from "@/lib/feedback/feedback-event";
+import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
+import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import { prisma } from "@dpf/db";
+
+type StartFeedbackSupportInput = {
+  detail: FeedbackEventDetail;
+  featureBuildId?: string | null;
+  threadId?: string | null;
+  text?: string | null;
+};
+
+type ReconcileFeedbackSupportFallbackInput = {
+  detail: FeedbackEventDetail;
+  threadId: string;
+};
+
+type FeedbackSupportResult = {
+  ok: true;
+  status: "created" | "existing" | "reconciled" | "skipped";
+  reportId: string;
+  supportSessionId: string;
+};
+
+type AgentThreadDelegate = {
+  findUnique: (args: {
+    where: { id: string };
+    select: { userId: true };
+  }) => Promise<{ userId: string } | null>;
+};
+
+const SUPPORT_RATE_LIMIT_MINUTE_WINDOW_MS = 60 * 1000;
+const SUPPORT_RATE_LIMIT_HOUR_WINDOW_MS = 60 * 60 * 1000;
+const SUPPORT_RATE_LIMIT_PER_MINUTE = 3;
+const SUPPORT_RATE_LIMIT_PER_HOUR = 10;
+const MAX_SUPPORT_TEXT_LENGTH = 10_000;
+
+type ExistingSupportReport = {
+  id: string;
+  reportId: string;
+  supportSessionId: string | null;
+  threadId: string | null;
+};
+
+function requireValidDetail(detail: unknown): FeedbackEventDetail {
+  if (!isFeedbackEventDetail(detail)) {
+    throw new Error("Invalid feedback support detail");
+  }
+
+  return detail;
+}
+
+async function requireAuthUserId(): Promise<string> {
+  const session = await auth();
+  const userId = session?.user?.id;
+
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
+
+  return userId;
+}
+
+function normalizeOptionalId(value: string | null | undefined, label: string): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.length > 191) {
+    throw new Error(`Invalid ${label}`);
+  }
+
+  return trimmed;
+}
+
+function normalizeSupportText(value: string | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.length > MAX_SUPPORT_TEXT_LENGTH) {
+    throw new Error("Invalid support text");
+  }
+
+  return trimmed;
+}
+
+async function resolveFeatureBuildId(featureBuildId: string | null): Promise<string | null> {
+  if (!featureBuildId) {
+    return null;
+  }
+
+  if (!featureBuildId.startsWith("FB-")) {
+    return featureBuildId;
+  }
+
+  const featureBuild = await prisma.featureBuild.findUnique({
+    where: { buildId: featureBuildId },
+    select: { id: true },
+  });
+
+  return featureBuild?.id ?? null;
+}
+
+async function assertThreadOwnership(threadId: string | null, userId: string): Promise<void> {
+  if (!threadId) {
+    return;
+  }
+
+  const agentThread = (prisma as unknown as { agentThread?: AgentThreadDelegate }).agentThread;
+  if (!agentThread) {
+    return;
+  }
+
+  const thread = await agentThread.findUnique({
+    where: { id: threadId },
+    select: { userId: true },
+  });
+
+  if (!thread || thread.userId !== userId) {
+    throw new Error("Unauthorized");
+  }
+}
+
+function supportDescription(text: string | null): string {
+  if (!text) {
+    return "User opened coworker support mode from Feedback.";
+  }
+
+  return `User opened coworker support mode from Feedback.\n\n${text}`;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "P2002";
+}
+
+async function findExistingSupportReport(
+  reportedById: string,
+  supportSessionId: string,
+): Promise<ExistingSupportReport | null> {
+  return prisma.platformIssueReport.findUnique({
+    where: {
+      reportedById_supportSessionId: {
+        reportedById,
+        supportSessionId,
+      },
+    },
+    select: {
+      id: true,
+      reportId: true,
+      supportSessionId: true,
+      threadId: true,
+    },
+  });
+}
+
+async function returnOrReconcileExistingSupportReport(
+  existing: ExistingSupportReport,
+  supportSessionId: string,
+  threadId: string | null,
+): Promise<FeedbackSupportResult> {
+  if (existing.threadId && threadId && existing.threadId !== threadId) {
+    console.warn("Feedback support session threadId conflict", {
+      reportId: existing.reportId,
+      supportSessionId,
+    });
+
+    return {
+      ok: true,
+      status: "skipped",
+      reportId: existing.reportId,
+      supportSessionId,
+    };
+  }
+
+  if (existing.threadId === null && threadId) {
+    const updated = await prisma.platformIssueReport.update({
+      where: { id: existing.id },
+      data: {
+        status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+        threadId,
+      },
+    });
+
+    return {
+      ok: true,
+      status: "reconciled",
+      reportId: updated.reportId,
+      supportSessionId,
+    };
+  }
+
+  return {
+    ok: true,
+    status: "existing",
+    reportId: existing.reportId,
+    supportSessionId,
+  };
+}
+
+async function enforceSupportStartRateLimit(userId: string): Promise<void> {
+  const now = Date.now();
+  const minuteSince = new Date(now - SUPPORT_RATE_LIMIT_MINUTE_WINDOW_MS);
+  const hourSince = new Date(now - SUPPORT_RATE_LIMIT_HOUR_WINDOW_MS);
+
+  const [startsInMinute, startsInHour] = await Promise.all([
+    prisma.platformIssueReport.count({
+      where: {
+        reportedById: userId,
+        status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+        createdAt: { gte: minuteSince },
+      },
+    }),
+    prisma.platformIssueReport.count({
+      where: {
+        reportedById: userId,
+        status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+        createdAt: { gte: hourSince },
+      },
+    }),
+  ]);
+
+  if (startsInMinute >= SUPPORT_RATE_LIMIT_PER_MINUTE) {
+    throw new Error("Too many support sessions started. Try again in a minute.");
+  }
+
+  if (startsInHour >= SUPPORT_RATE_LIMIT_PER_HOUR) {
+    throw new Error("Too many support sessions started. Try again in an hour.");
+  }
+}
+
+export async function startFeedbackSupport(input: StartFeedbackSupportInput): Promise<FeedbackSupportResult> {
+  const userId = await requireAuthUserId();
+  const detail = requireValidDetail(input.detail);
+  const threadId = normalizeOptionalId(input.threadId, "threadId");
+  const requestedFeatureBuildId = normalizeOptionalId(input.featureBuildId, "featureBuildId");
+  const text = normalizeSupportText(input.text);
+
+  await assertThreadOwnership(threadId, userId);
+
+  const existing = await findExistingSupportReport(userId, detail.supportSessionId);
+
+  if (existing?.reportId && existing.supportSessionId) {
+    return returnOrReconcileExistingSupportReport(existing, detail.supportSessionId, threadId);
+  }
+
+  await enforceSupportStartRateLimit(userId);
+
+  const featureBuildId = await resolveFeatureBuildId(requestedFeatureBuildId);
+  let report: { reportId: string };
+
+  try {
+    report = await createPlatformIssueReport({
+      type: "user_report",
+      severity: "medium",
+      status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+      title: "Support session started",
+      description: supportDescription(text),
+      routeContext: detail.routeContext,
+      source: "support_mode",
+      reportedById: userId,
+      triggerKind: detail.triggerKind,
+      supportSessionId: detail.supportSessionId,
+      threadId,
+      featureBuildId,
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) {
+      throw error;
+    }
+
+    const racedExisting = await findExistingSupportReport(userId, detail.supportSessionId);
+    if (!racedExisting?.reportId || !racedExisting.supportSessionId) {
+      throw error;
+    }
+
+    return returnOrReconcileExistingSupportReport(racedExisting, detail.supportSessionId, threadId);
+  }
+
+  return {
+    ok: true,
+    status: "created",
+    reportId: report.reportId,
+    supportSessionId: detail.supportSessionId,
+  };
+}
+
+export async function reconcileFeedbackSupportFallback(
+  input: ReconcileFeedbackSupportFallbackInput,
+): Promise<FeedbackSupportResult> {
+  const userId = await requireAuthUserId();
+  const detail = requireValidDetail(input.detail);
+  const threadId = normalizeOptionalId(input.threadId, "threadId");
+
+  if (!threadId) {
+    throw new Error("Invalid threadId");
+  }
+
+  await assertThreadOwnership(threadId, userId);
+
+  const existing = await prisma.platformIssueReport.findFirst({
+    where: {
+      reportedById: userId,
+      supportSessionId: detail.supportSessionId,
+    },
+    select: {
+      id: true,
+      reportId: true,
+      threadId: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!existing) {
+    throw new Error("Support report not found");
+  }
+
+  if (existing.threadId && existing.threadId !== threadId) {
+    console.warn("Feedback support fallback threadId conflict", {
+      reportId: existing.reportId,
+      supportSessionId: detail.supportSessionId,
+    });
+
+    return {
+      ok: true,
+      status: "skipped",
+      reportId: existing.reportId,
+      supportSessionId: detail.supportSessionId,
+    };
+  }
+
+  const updated = await prisma.platformIssueReport.update({
+    where: { id: existing.id },
+    data: {
+      status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
+      threadId,
+    },
+  });
+
+  return {
+    ok: true,
+    status: "reconciled",
+    reportId: updated.reportId,
+    supportSessionId: detail.supportSessionId,
+  };
+}

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -17,6 +17,11 @@ export async function reportQualityIssue(input: {
   routeContext: string;
   errorStack?: string;
   source?: string;
+  triggerKind?: string;
+  supportSessionId?: string;
+  featureBuildId?: string;
+  threadId?: string;
+  taskRunId?: string;
 }): Promise<{ reportId: string } | { error: string }> {
   const session = await auth();
   const userId = session?.user?.id ?? null;
@@ -30,7 +35,13 @@ export async function reportQualityIssue(input: {
       description: input.description ?? null,
       routeContext: input.routeContext,
       errorStack: input.errorStack ?? null,
+      triggerKind: input.triggerKind ?? null,
+      supportSessionId: input.supportSessionId ?? null,
       reportedById: userId,
+      featureBuildId: input.featureBuildId ?? null,
+      threadId: input.threadId ?? null,
+      taskRunId: input.taskRunId ?? null,
+      ...(input.supportSessionId ? { status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE } : {}),
     });
     return { reportId };
   } catch {

--- a/apps/web/lib/feedback/feedback-event.test.ts
+++ b/apps/web/lib/feedback/feedback-event.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type FeedbackEventDetail,
+  FEEDBACK_TRIGGER_KINDS,
+  createManualFeedbackEventDetail,
+  isFeedbackEventDetail,
+  normalizeFeedbackRoute,
+} from "./feedback-event";
+
+const validFeedbackEventDetail: FeedbackEventDetail = {
+  routeContext: "/build",
+  triggerKind: "manual",
+  supportSessionId: "dpf_support_1234567890abcdef1234567890abcdef",
+  autoFilePolicy: "ask",
+};
+
+describe("feedback event contract", () => {
+  it("publishes the supported feedback trigger vocabulary", () => {
+    expect(FEEDBACK_TRIGGER_KINDS).toEqual([
+      "manual",
+      "runtime-error",
+      "grant-denied",
+      "structural-verification-fail",
+      "coworker-stall",
+      "issue-spike",
+    ]);
+  });
+
+  it("builds a manual support event detail for the build route", () => {
+    expect(createManualFeedbackEventDetail("/build")).toMatchObject({
+      routeContext: "/build",
+      triggerKind: "manual",
+      autoFilePolicy: "ask",
+    });
+  });
+
+  it("generates a dpf support session id", () => {
+    const detail = createManualFeedbackEventDetail("/build");
+
+    expect(detail.supportSessionId).toMatch(/^dpf_support_[a-f0-9]{32}$/);
+  });
+
+  it("normalizes route context to a stable path without query, hash, origin, or trailing slash", () => {
+    expect(normalizeFeedbackRoute("https://app.example.com/build/?tab=tasks#top")).toBe("/build");
+    expect(normalizeFeedbackRoute("/build/")).toBe("/build");
+    expect(normalizeFeedbackRoute("build")).toBe("/build");
+  });
+
+  it("accepts optional trigger metadata from the phase 1 contract", () => {
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        title: "Build blocked",
+        description: "The coworker stopped.",
+        errorStack: "Error: stopped",
+        userAgent: "Vitest",
+        featureBuildId: "FB-9E4FA6DE",
+        threadId: "thread-1",
+        taskRunId: "task-run-1",
+        sourceId: "feedback-button",
+        autoFilePolicy: "auto-hard-failure",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed event payloads", () => {
+    expect(isFeedbackEventDetail(null)).toBe(false);
+    expect(isFeedbackEventDetail({ ...validFeedbackEventDetail, autoFilePolicy: "auto" })).toBe(false);
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        triggerKind: "unexpected",
+      }),
+    ).toBe(false);
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        triggerKind: "feedback-button",
+      }),
+    ).toBe(false);
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        triggerKind: "header-feedback",
+      }),
+    ).toBe(false);
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        routeContext: "javascript:alert(1)",
+      }),
+    ).toBe(false);
+    expect(
+      isFeedbackEventDetail({
+        ...validFeedbackEventDetail,
+        supportSessionId: "support_test",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/feedback/feedback-event.ts
+++ b/apps/web/lib/feedback/feedback-event.ts
@@ -1,0 +1,136 @@
+export const FEEDBACK_TRIGGER_KINDS = [
+  "manual",
+  "runtime-error",
+  "grant-denied",
+  "structural-verification-fail",
+  "coworker-stall",
+  "issue-spike",
+] as const;
+
+export type FeedbackTriggerKind = (typeof FEEDBACK_TRIGGER_KINDS)[number];
+
+export type FeedbackAutoFilePolicy = "ask" | "auto-hard-failure";
+
+export type FeedbackEventDetail = {
+  triggerKind: FeedbackTriggerKind;
+  routeContext: string;
+  title?: string;
+  description?: string;
+  errorStack?: string;
+  userAgent?: string;
+  featureBuildId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  sourceId?: string;
+  autoFilePolicy?: FeedbackAutoFilePolicy;
+  supportSessionId: string;
+};
+
+const SUPPORT_SESSION_ID_PREFIX = "dpf_support_";
+const SUPPORT_SESSION_ID_RANDOM_BYTES = 16;
+const SUPPORT_SESSION_ID_PATTERN = /^dpf_support_[a-f0-9]{32}$/;
+const MAX_ROUTE_CONTEXT_LENGTH = 512;
+const ROUTE_CONTEXT_PATTERN = /^\/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*$/;
+const OPTIONAL_STRING_KEYS = [
+  "title",
+  "description",
+  "errorStack",
+  "userAgent",
+  "featureBuildId",
+  "threadId",
+  "taskRunId",
+  "sourceId",
+] as const;
+
+function isFeedbackTriggerKind(value: unknown): value is FeedbackTriggerKind {
+  return typeof value === "string" && FEEDBACK_TRIGGER_KINDS.includes(value as FeedbackTriggerKind);
+}
+
+function isFeedbackAutoFilePolicy(value: unknown): value is FeedbackAutoFilePolicy | undefined {
+  return value === undefined || value === "ask" || value === "auto-hard-failure";
+}
+
+function generateSupportSessionId(): string {
+  const bytes = new Uint8Array(SUPPORT_SESSION_ID_RANDOM_BYTES);
+  const crypto = globalThis.crypto;
+
+  if (!crypto?.getRandomValues) {
+    throw new Error("Web Crypto getRandomValues is required to create support feedback events");
+  }
+
+  crypto.getRandomValues(bytes);
+
+  return `${SUPPORT_SESSION_ID_PREFIX}${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+export function normalizeFeedbackRoute(routeContext: string): string {
+  const rawRoute = routeContext.trim();
+
+  if (!rawRoute) {
+    throw new Error("Invalid feedback route context");
+  }
+
+  const schemeMatch = rawRoute.match(/^([a-z][a-z0-9+.-]*):/i);
+  const routeWithoutOrigin = schemeMatch
+    ? normalizeAbsoluteFeedbackRoute(rawRoute, schemeMatch[1])
+    : rawRoute.split(/[?#]/, 1)[0];
+  const routeWithLeadingSlash = routeWithoutOrigin.startsWith("/") ? routeWithoutOrigin : `/${routeWithoutOrigin}`;
+  const normalizedRoute = routeWithLeadingSlash.replace(/\/{2,}/g, "/").replace(/\/+$/, "") || "/";
+
+  if (!isValidFeedbackRoute(normalizedRoute)) {
+    throw new Error("Invalid feedback route context");
+  }
+
+  return normalizedRoute;
+}
+
+function normalizeAbsoluteFeedbackRoute(routeContext: string, scheme: string): string {
+  if (scheme !== "http" && scheme !== "https") {
+    throw new Error("Invalid feedback route context");
+  }
+
+  return new URL(routeContext).pathname;
+}
+
+export function createManualFeedbackEventDetail(routeContext: string): FeedbackEventDetail {
+  return {
+    routeContext: normalizeFeedbackRoute(routeContext),
+    triggerKind: "manual",
+    supportSessionId: generateSupportSessionId(),
+    autoFilePolicy: "ask",
+  };
+}
+
+export function isFeedbackEventDetail(value: unknown): value is FeedbackEventDetail {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const detail = value as Partial<FeedbackEventDetail>;
+
+  return (
+    isFeedbackTriggerKind(detail.triggerKind) &&
+    typeof detail.routeContext === "string" &&
+    isValidFeedbackRoute(detail.routeContext) &&
+    typeof detail.supportSessionId === "string" &&
+    SUPPORT_SESSION_ID_PATTERN.test(detail.supportSessionId) &&
+    isFeedbackAutoFilePolicy(detail.autoFilePolicy) &&
+    OPTIONAL_STRING_KEYS.every((key) => detail[key] === undefined || typeof detail[key] === "string")
+  );
+}
+
+function isValidFeedbackRoute(routeContext: string): boolean {
+  if (routeContext.length === 0 || routeContext.length > MAX_ROUTE_CONTEXT_LENGTH) {
+    return false;
+  }
+
+  if (routeContext.includes("?") || routeContext.includes("#")) {
+    return false;
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(routeContext)) {
+    return false;
+  }
+
+  return ROUTE_CONTEXT_PATTERN.test(routeContext);
+}

--- a/apps/web/lib/operate/quality-queue.ts
+++ b/apps/web/lib/operate/quality-queue.ts
@@ -10,6 +10,12 @@ type QueuedReport = {
   source?: string;
   userAgent?: string;
   userId?: string;
+  triggerKind?: string;
+  supportSessionId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  featureBuildId?: string;
+  autoFilePolicy?: string;
   queuedAt: string;
 };
 

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -11,6 +11,8 @@ const LIMITS = {
   routeContext: 500,
   errorStack: 20_000,
   userAgent: 500,
+  triggerKind: 100,
+  supportSessionId: 191,
 } as const;
 
 // Same route → portfolio slug map used today by reportQualityIssue().
@@ -57,6 +59,8 @@ export interface CreatePlatformIssueReportInput {
   routeContext?: string | null;
   errorStack?: string | null;
   userAgent?: string | null;
+  triggerKind?: string | null;
+  supportSessionId?: string | null;
 
   // Identity / linkage
   reportedById?: string | null;
@@ -129,6 +133,8 @@ export async function createPlatformIssueReport(
       routeContext: trimTo(input.routeContext ?? null, LIMITS.routeContext),
       errorStack: trimTo(input.errorStack ?? null, LIMITS.errorStack),
       userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
+      triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
+      supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
       reportedById: input.reportedById ?? null,
       threadId: input.threadId ?? null,
       taskRunId: input.taskRunId ?? null,

--- a/docs/superpowers/evidence/2026-05-26-feedback-support-mode-entry-verification.md
+++ b/docs/superpowers/evidence/2026-05-26-feedback-support-mode-entry-verification.md
@@ -1,0 +1,142 @@
+# Feedback Support Mode Entry Verification
+
+Date: 2026-05-26
+
+## Automated checks
+
+Prisma client generation:
+
+```sh
+pnpm install
+```
+
+Result: passed. The worktree had no `node_modules`; install reused the pnpm
+store and ran `packages/db postinstall: prisma generate` successfully.
+
+Focused Phase 1 regression suite:
+
+```sh
+pnpm --filter web exec vitest run lib/feedback/feedback-event.test.ts components/feedback/FeedbackButton.test.tsx components/feedback/HeaderFeedbackButton.test.tsx components/agent/AgentCoworkerShell.test.tsx lib/actions/feedback-support.test.ts lib/quality/platform-issue-reports.test.ts app/api/quality/report/route.test.ts lib/actions/quality.test.ts
+```
+
+Result: passed.
+
+- Test files: 8 passed.
+- Tests: 55 passed.
+
+TypeScript:
+
+```sh
+pnpm --filter web exec tsc --noEmit
+```
+
+Result: passed after regenerating the Prisma client for the rebased `main`
+schema.
+
+Full web Vitest gate:
+
+```sh
+cd apps/web && pnpm test
+```
+
+Result: passed on the rebased branch.
+
+- Test files: 999 passed, 4 skipped.
+- Tests: 8339 passed, 15 skipped, 18 todo.
+
+Production build:
+
+```sh
+cd apps/web && pnpm exec next build
+```
+
+Result: passed. Build completed with pre-existing Edge Runtime warnings about
+Node APIs imported by platform version/discovery paths.
+
+Prisma schema validation:
+
+```sh
+pnpm --filter @dpf/db exec prisma validate
+```
+
+Result: passed.
+
+## Migration check
+
+Applied to the local live Postgres container:
+
+```sh
+pnpm --filter @dpf/db exec prisma migrate deploy
+```
+
+Result: passed.
+
+- Datasource: PostgreSQL database `dpf`, schema `public`, at `127.0.0.1:5432`.
+- Applied migration: `20260526000000_add_issue_report_support_context`.
+- Prisma reported all migrations successfully applied.
+
+## Production-path runtime
+
+Rebuilt the Docker-served live portal from this worktree and recreated the live
+portal services without dropping volumes:
+
+```sh
+docker compose --env-file D:\DPF\.env build --no-cache portal-init portal
+docker compose --env-file D:\DPF\.env up -d --force-recreate portal-init portal
+```
+
+Result: passed. `dpf-portal-1` and `dpf-postgres-1` were healthy before browser
+verification.
+
+## Live UX verification
+
+Browser route: `http://localhost:3000/build`.
+
+Steps:
+
+1. Logged in as `admin@dpf.local`.
+2. Opened `/build`.
+3. Clicked visible `Feedback`.
+4. Waited for `[data-agent-panel="true"]`.
+5. Verified support-mode copy was visible.
+6. Verified no category form was visible.
+
+Result: passed.
+
+Observed browser state after click:
+
+```json
+{
+  "url": "http://localhost:3000/build",
+  "feedbackCountAfterLogin": 2,
+  "supportVisibleAfterLogin": true,
+  "categoryCountAfterLogin": 0,
+  "fallbackSelectAfterLogin": 0
+}
+```
+
+Postgres proof:
+
+```sql
+select "reportId", status, "routeContext", "triggerKind", "threadId",
+       "supportSessionId", "featureBuildId", "createdAt"
+from "PlatformIssueReport"
+where status = 'support_triage'
+order by "createdAt" desc
+limit 1;
+```
+
+Result:
+
+```text
+PIR-5XDEW | support_triage | /build | manual | cmpiqce8s04g901o6tvepvzjc | dpf_support_be2e0d6d5dea9e097a3baa1cf4767dd9 | null | 2026-05-26 08:00:15.162
+```
+
+Notes:
+
+- The live `/build` route rendered its existing error boundary with
+  `Cannot read properties of undefined (reading 'toLowerCase')` before the
+  Feedback click. The Phase 1 support entry still satisfied the acceptance path:
+  support copy opened in the existing coworker shell, no category form appeared,
+  and the local report captured route, trigger, thread, support session, and
+  `support_triage` status.

--- a/docs/superpowers/plans/2026-05-26-feedback-support-mode-entry.md
+++ b/docs/superpowers/plans/2026-05-26-feedback-support-mode-entry.md
@@ -27,6 +27,7 @@
 - **Support mode is an entry mode, not a new backend `CoworkerMode`.** Existing runtime `CoworkerMode` is `"advise" | "act"`. Phase 1 should add support copy and support report creation without widening that runtime enum.
 - **Do not write public build IDs into relation fields.** The browser has the public Build Studio `buildId` such as `FB-12345678`. `PlatformIssueReport.featureBuildId` is a relation to internal `FeatureBuild.id`. The server action must resolve public `buildId` to internal `id` before calling the writer.
 - **Manual click should not force category selection.** Healthy installs open the coworker with support copy. The fallback `FeedbackForm` remains only for shell-unavailable cases and continues to post through the existing fallback path, but it must carry the same `supportSessionId`, `routeContext`, and `triggerKind` so a fallback race cannot create a duplicate report.
+- **Explicit Feedback buttons are `manual` triggers.** Per spec section 6.1, `triggerKind` describes why feedback was raised (`manual`, `runtime-error`, `grant-denied`, etc.), not which UI control was clicked. `FeedbackButton` and `HeaderFeedbackButton` should both emit `triggerKind: "manual"` for Phase 1. Do not invent button-specific trigger kinds such as `"feedback-button"` or `"header-feedback"`.
 - **Thread reconciliation is monotonic.** A support report with no `threadId` may be updated with a validated user-owned thread. A report with the same `threadId` is already reconciled. A report with a different `threadId` must not be relinked.
 - **Abuse limits are server-side.** Do not rely on client throttling. Enforce 3 support starts per user per minute and 10 per user per hour, with user-visible text feedback and audit logging on repeated burst violations.
 
@@ -51,7 +52,7 @@
 - Modify `apps/web/components/feedback/FeedbackButton.tsx`
   - Dispatch typed event detail with route and `triggerKind: "manual"`.
 - Modify `apps/web/components/feedback/HeaderFeedbackButton.tsx`
-  - Same event detail and session-aware fallback behavior.
+  - Same event detail (`triggerKind: "manual"`) and session-aware fallback behavior.
 - Create or modify feedback button tests:
   - `apps/web/components/feedback/FeedbackButton.test.tsx`
   - `apps/web/components/feedback/HeaderFeedbackButton.test.tsx`
@@ -558,7 +559,7 @@ In `AgentCoworkerShell.tsx`:
 - import `isFeedbackEventDetail`, `FeedbackEventDetail`, and `startFeedbackSupport`;
 - keep legacy panel detail support unchanged;
 - when event name is `open-agent-feedback` and detail is valid:
-  - call `preventDefault()` immediately so the feedback button knows the shell handled the event;
+  - validate `isFeedbackEventDetail()` first, then call `preventDefault()` only after accepting a valid support event so malformed or unhandled events can still fall through to the existing fallback path;
   - set panel open and save preference;
   - inject a support welcome message, not a category form;
   - store pending support detail in state or ref;

--- a/docs/superpowers/plans/2026-05-26-feedback-support-mode-entry.md
+++ b/docs/superpowers/plans/2026-05-26-feedback-support-mode-entry.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development if available, or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking. This is product behavior and MUST run through Build Studio; do not implement this feature directly from a human chat thread.
 
-**Goal:** Feedback clicks open the existing AI coworker shell in support-entry mode, carry typed context, and create a local `PlatformIssueReport` in `support_triage` with route, trigger, thread, and build context where available.
+**Goal:** Feedback clicks open the existing AI coworker shell in support-entry mode, carry typed context, and create or reconcile one local `PlatformIssueReport` in `support_triage` with route, trigger, support-session, thread, and build context where available.
 
-**Architecture:** Define one typed feedback event contract that both feedback buttons and the coworker shell consume. The shell remains the only panel surface; it enriches the clicked event with the currently loaded thread and active Build Studio build, then calls a server action that uses Phase 0's `createPlatformIssueReport()` writer. Persist `triggerKind` in Phase 1 because acceptance requires it on the created report; defer routing decisions, upstream bridge work, coalescing, implicit triggers, reverse notifications, and STT to later phases.
+**Architecture:** Define one typed feedback event contract that both feedback buttons and the coworker shell consume. The shell remains the only panel surface; it synchronously claims handled events, enriches the clicked event with the currently loaded thread and active Build Studio build, then calls a server action that uses Phase 0's `createPlatformIssueReport()` writer. Persist `triggerKind` and a per-user `supportSessionId` in Phase 1 because acceptance requires durable trigger context and review identified double-click/fallback races as a ship blocker; defer routing decisions, upstream bridge work, coalescing, implicit triggers, reverse notifications, and STT to later phases.
 
 **Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Prisma 7, Vitest, React Testing Library, DPF MCP, Docker-served portal verification.
 
@@ -22,11 +22,13 @@
 
 ## Key Decisions
 
-- **Persist `triggerKind` now.** Phase 1 acceptance says the created report has `triggerKind`; the current schema has no such field. Add only `PlatformIssueReport.triggerKind String?` in this phase. Do not add coalescing, capacity decision, support summary, acknowledgement, or resolved fields.
+- **Persist `triggerKind` and `supportSessionId` now.** Phase 1 acceptance says the created report has `triggerKind`; the current schema has no such field. The support-session key is the minimal additional persistence needed to make support start idempotent across double-clicks, remounts, late thread creation, and shell/fallback races. Do not add coalescing, capacity decision, support summary, acknowledgement, or resolved fields.
 - **Use the existing shell.** Do not create a new support chat surface. `AgentCoworkerShell` already listens for `open-agent-feedback` and `open-agent-panel`; extend that listener.
 - **Support mode is an entry mode, not a new backend `CoworkerMode`.** Existing runtime `CoworkerMode` is `"advise" | "act"`. Phase 1 should add support copy and support report creation without widening that runtime enum.
 - **Do not write public build IDs into relation fields.** The browser has the public Build Studio `buildId` such as `FB-12345678`. `PlatformIssueReport.featureBuildId` is a relation to internal `FeatureBuild.id`. The server action must resolve public `buildId` to internal `id` before calling the writer.
-- **Manual click should not force category selection.** Healthy installs open the coworker with support copy. The fallback `FeedbackForm` remains only for shell-unavailable cases and continues to post through `/api/quality/report`.
+- **Manual click should not force category selection.** Healthy installs open the coworker with support copy. The fallback `FeedbackForm` remains only for shell-unavailable cases and continues to post through the existing fallback path, but it must carry the same `supportSessionId`, `routeContext`, and `triggerKind` so a fallback race cannot create a duplicate report.
+- **Thread reconciliation is monotonic.** A support report with no `threadId` may be updated with a validated user-owned thread. A report with the same `threadId` is already reconciled. A report with a different `threadId` must not be relinked.
+- **Abuse limits are server-side.** Do not rely on client throttling. Enforce 3 support starts per user per minute and 10 per user per hour, with user-visible text feedback and audit logging on repeated burst violations.
 
 ## File Map
 
@@ -35,21 +37,21 @@
 - Create `apps/web/lib/feedback/feedback-event.test.ts`
   - Protects the event vocabulary and manual payload shape.
 - Modify `packages/db/prisma/schema.prisma`
-  - Add `triggerKind String?` to `PlatformIssueReport`.
-- Create migration under `packages/db/prisma/migrations/<timestamp>_add_issue_report_trigger_kind/migration.sql`
-  - Add nullable `triggerKind`; no backfill.
+  - Add `triggerKind String?`, `supportSessionId String?`, and a user-scoped unique constraint on `[reportedById, supportSessionId]` to `PlatformIssueReport`.
+- Create migration under `packages/db/prisma/migrations/<timestamp>_add_issue_report_support_context/migration.sql`
+  - Add nullable `triggerKind` and `supportSessionId`, plus the user-scoped unique index; no backfill.
 - Modify `apps/web/lib/quality/platform-issue-reports.ts`
-  - Accept and persist `triggerKind`.
+  - Accept and persist `triggerKind` and `supportSessionId`.
 - Modify `apps/web/lib/quality/platform-issue-reports.test.ts`
-  - Prove writer persists `triggerKind`.
+  - Prove writer persists `triggerKind` and `supportSessionId`.
 - Create `apps/web/lib/actions/feedback-support.ts`
-  - Server action for support-triage report creation.
+  - Server action for support-triage report creation, idempotent reconciliation, build ID resolution, thread ownership validation, and rate limiting.
 - Create `apps/web/lib/actions/feedback-support.test.ts`
-  - Proves auth, build ID resolution, thread pass-through, status, source, and trigger persistence.
+  - Proves auth, build ID resolution, thread pass-through, status, source, trigger persistence, support-session dedupe, monotonic thread reconciliation, and rate limits.
 - Modify `apps/web/components/feedback/FeedbackButton.tsx`
   - Dispatch typed event detail with route and `triggerKind: "manual"`.
 - Modify `apps/web/components/feedback/HeaderFeedbackButton.tsx`
-  - Same event detail and unchanged fallback behavior.
+  - Same event detail and session-aware fallback behavior.
 - Create or modify feedback button tests:
   - `apps/web/components/feedback/FeedbackButton.test.tsx`
   - `apps/web/components/feedback/HeaderFeedbackButton.test.tsx`
@@ -88,11 +90,11 @@ pnpm --filter web exec vitest run lib/quality/issue-report-status.test.ts lib/qu
 
 Expected: all pass. If they fail, stop and reconcile before changing Phase 1 code.
 
-### Task 2: Add `triggerKind` to `PlatformIssueReport`
+### Task 2: Add support context to `PlatformIssueReport`
 
 **Files:**
 - Modify: `packages/db/prisma/schema.prisma`
-- Create: `packages/db/prisma/migrations/<timestamp>_add_issue_report_trigger_kind/migration.sql`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_issue_report_support_context/migration.sql`
 - Modify: `apps/web/lib/quality/platform-issue-reports.ts`
 - Modify: `apps/web/lib/quality/platform-issue-reports.test.ts`
 
@@ -101,17 +103,19 @@ Expected: all pass. If they fail, stop and reconcile before changing Phase 1 cod
 Add a test to `platform-issue-reports.test.ts`:
 
 ```ts
-it("persists triggerKind when provided", async () => {
+it("persists support context when provided", async () => {
   await createPlatformIssueReport({
     type: "user_report",
     title: "Build help",
     source: "support_mode",
     status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
     triggerKind: "manual",
+    supportSessionId: "dpf_support_test",
   });
 
   const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
   expect(args?.data.triggerKind).toBe("manual");
+  expect(args?.data.supportSessionId).toBe("dpf_support_test");
 });
 ```
 
@@ -123,26 +127,31 @@ Run:
 pnpm --filter web exec vitest run lib/quality/platform-issue-reports.test.ts
 ```
 
-Expected: fail because `triggerKind` is not in `CreatePlatformIssueReportInput` or writer data.
+Expected: fail because support context is not in `CreatePlatformIssueReportInput` or writer data.
 
-- [ ] **Step 3: Add schema field and migration**
+- [ ] **Step 3: Add schema fields, index, and migration**
 
 Modify `PlatformIssueReport`:
 
 ```prisma
   triggerKind         String?
+  supportSessionId    String?
+
+  @@unique([reportedById, supportSessionId])
+  @@index([reportedById, source, status, createdAt])
 ```
 
 Create migration:
 
 ```powershell
-pnpm --filter @dpf/db exec prisma migrate dev --name add_issue_report_trigger_kind
+pnpm --filter @dpf/db exec prisma migrate dev --name add_issue_report_support_context
 ```
 
-Expected migration SQL:
+Expected migration SQL includes:
 
 ```sql
 ALTER TABLE "PlatformIssueReport" ADD COLUMN "triggerKind" TEXT;
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "supportSessionId" TEXT;
 ```
 
 Do not backfill existing reports.
@@ -153,15 +162,17 @@ Add to `CreatePlatformIssueReportInput`:
 
 ```ts
   triggerKind?: string | null;
+  supportSessionId?: string | null;
 ```
 
 Add to the `create` data:
 
 ```ts
       triggerKind: trimTo(input.triggerKind ?? null, LIMITS.source),
+      supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.source),
 ```
 
-Use the existing short string limit style; if a dedicated `triggerKind` limit is added, keep it near the Phase 0 `LIMITS` object.
+Use the existing short string limit style; if dedicated `triggerKind` or `supportSessionId` limits are added, keep them near the Phase 0 `LIMITS` object.
 
 - [ ] **Step 5: Run focused tests**
 
@@ -179,7 +190,7 @@ Run:
 
 ```powershell
 git add packages/db/prisma/schema.prisma packages/db/prisma/migrations apps/web/lib/quality/platform-issue-reports.ts apps/web/lib/quality/platform-issue-reports.test.ts
-git commit -s -m "feat(feedback): persist issue report trigger kind"
+git commit -s -m "feat(feedback): persist issue report support context"
 ```
 
 ---
@@ -220,12 +231,13 @@ describe("feedback-event", () => {
     expect(createManualFeedbackEventDetail("/build")).toMatchObject({
       triggerKind: "manual",
       routeContext: "/build",
+      supportSessionId: expect.stringMatching(/^dpf_support_/),
       autoFilePolicy: "ask",
     });
   });
 
   it("rejects malformed event details", () => {
-    expect(isFeedbackEventDetail({ triggerKind: "manual", routeContext: "/build" })).toBe(true);
+    expect(isFeedbackEventDetail({ triggerKind: "manual", routeContext: "/build", supportSessionId: "dpf_support_test" })).toBe(true);
     expect(isFeedbackEventDetail({ triggerKind: "unknown", routeContext: "/build" })).toBe(false);
     expect(isFeedbackEventDetail({ triggerKind: "manual" })).toBe(false);
   });
@@ -261,6 +273,7 @@ export type FeedbackTriggerKind = (typeof FEEDBACK_TRIGGER_KINDS)[number];
 export type FeedbackEventDetail = {
   triggerKind: FeedbackTriggerKind;
   routeContext: string;
+  supportSessionId: string;
   title?: string;
   description?: string;
   errorStack?: string;
@@ -273,7 +286,7 @@ export type FeedbackEventDetail = {
 };
 ```
 
-Also add `createManualFeedbackEventDetail(routeContext: string)` and `isFeedbackEventDetail(value: unknown)`.
+Also add `createManualFeedbackEventDetail(routeContext: string)` and `isFeedbackEventDetail(value: unknown)`. Generate `supportSessionId` with at least 128 bits of entropy. Validate `routeContext` as a normalized path string with a conservative length cap; reject malformed trigger details.
 
 - [ ] **Step 4: Run the contract test**
 
@@ -301,6 +314,7 @@ Test both components with `next/navigation` mocked to return `/build`. Capture `
 expect(detail).toMatchObject({
   triggerKind: "manual",
   routeContext: "/build",
+  supportSessionId: expect.stringMatching(/^dpf_support_/),
   autoFilePolicy: "ask",
 });
 ```
@@ -335,16 +349,19 @@ In both button files:
 import { createManualFeedbackEventDetail } from "@/lib/feedback/feedback-event";
 
 const event = new CustomEvent("open-agent-feedback", {
+  cancelable: true,
   detail: createManualFeedbackEventDetail(pathname),
 });
-document.dispatchEvent(event);
+const handled = !document.dispatchEvent(event);
 ```
 
 Leave fallback `FeedbackForm` behavior intact:
 
 ```tsx
-<FeedbackForm routeContext={pathname} source="manual" ... />
+<FeedbackForm routeContext={pathname} source="manual" triggerKind={detail.triggerKind} supportSessionId={detail.supportSessionId} ... />
 ```
+
+Only open the fallback form if `handled` is false after the existing shell-detection grace period.
 
 - [ ] **Step 4: Run feedback component tests**
 
@@ -384,6 +401,9 @@ Mock `auth`, `prisma`, and `createPlatformIssueReport`. Cover:
 - public `activeBuildId: "FB-12345678"` resolves to internal `FeatureBuild.id`;
 - `threadId` is passed when available;
 - `triggerKind` is passed as `"manual"`;
+- `supportSessionId` is passed and dedupes repeated calls for the same user action;
+- a conflicting existing `threadId` is not overwritten;
+- rate limits reject the fourth support start inside one minute;
 - if no active build is found, the action still writes route/thread/trigger with `featureBuildId: null`.
 
 Expected writer call:
@@ -397,6 +417,7 @@ expect(createPlatformIssueReportMock).toHaveBeenCalledWith(
     status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
     routeContext: "/build",
     triggerKind: "manual",
+    supportSessionId: "dpf_support_test",
     reportedById: "user-1",
     threadId: "thread-1",
     featureBuildId: "internal-feature-build-id",
@@ -438,6 +459,8 @@ type StartFeedbackSupportInput = {
 };
 ```
 
+Require `detail.supportSessionId`, normalize route/trigger values, and reject oversized optional text fields. Look up existing reports by authenticated `reportedById` plus `supportSessionId` before creating. If an existing row has no `threadId`, update it with the validated user-owned thread. If it has a different `threadId`, return a conflict without overwriting.
+
 Resolve public build ID:
 
 ```ts
@@ -463,6 +486,7 @@ const { reportId } = await createPlatformIssueReport({
   source: "support_mode",
   status: ISSUE_REPORT_STATUS.SUPPORT_TRIAGE,
   triggerKind: input.detail.triggerKind,
+  supportSessionId: input.detail.supportSessionId,
   reportedById: session.user.id,
   threadId: input.threadId ?? input.detail.threadId ?? featureBuild?.threadId ?? null,
   taskRunId: input.detail.taskRunId ?? null,
@@ -470,7 +494,7 @@ const { reportId } = await createPlatformIssueReport({
 });
 ```
 
-Return `{ ok: true, reportId }` or `{ ok: false, error: "..." }`. Do not throw into the client shell for normal failures.
+Return `{ ok: true, reportId }` or `{ ok: false, error: "..." }`. Do not throw into the client shell for normal failures. Enforce 3 support starts per user per minute and 10 per user per hour at this server boundary.
 
 - [ ] **Step 4: Run action tests**
 
@@ -534,10 +558,11 @@ In `AgentCoworkerShell.tsx`:
 - import `isFeedbackEventDetail`, `FeedbackEventDetail`, and `startFeedbackSupport`;
 - keep legacy panel detail support unchanged;
 - when event name is `open-agent-feedback` and detail is valid:
+  - call `preventDefault()` immediately so the feedback button knows the shell handled the event;
   - set panel open and save preference;
   - inject a support welcome message, not a category form;
   - store pending support detail in state or ref;
-  - create the support report once when `threadId` is available.
+  - create or reconcile the support report once per `supportSessionId`, updating the same report when `threadId` becomes available.
 
 Recommended visible support copy:
 
@@ -672,16 +697,16 @@ Expected UI:
 Run:
 
 ```powershell
-docker exec dpf-postgres-1 psql -U dpf -d dpf -c "SELECT \"reportId\", status, source, \"triggerKind\", \"routeContext\", \"threadId\" IS NOT NULL AS has_thread, \"featureBuildId\" IS NOT NULL AS has_build FROM \"PlatformIssueReport\" WHERE status='support_triage' ORDER BY \"createdAt\" DESC LIMIT 3;"
+docker exec dpf-postgres-1 psql -U dpf -d dpf -c "SELECT \"reportId\", status, source, \"triggerKind\", \"supportSessionId\" IS NOT NULL AS has_support_session, \"routeContext\", \"threadId\" IS NOT NULL AS has_thread, \"featureBuildId\" IS NOT NULL AS has_build FROM \"PlatformIssueReport\" WHERE status='support_triage' ORDER BY \"createdAt\" DESC LIMIT 3;"
 ```
 
-Expected: newest row has `status=support_triage`, `source=support_mode`, `triggerKind=manual`, `routeContext=/build`, and `has_thread=true` when the coworker thread loaded. `has_build=true` only when a Build Studio active build exists.
+Expected: newest row has `status=support_triage`, `source=support_mode`, `triggerKind=manual`, `has_support_session=true`, `routeContext=/build`, and `has_thread=true` when the coworker thread loaded. `has_build=true` only when a Build Studio active build exists.
 
 - [ ] **Step 4: Verify fallback still posts**
 
 Temporarily test a shell-unavailable path without source edits if possible: use a route/layout state where `AgentCoworkerShell` is not mounted, or in a browser devtools test remove the panel listener before click. Submit fallback form.
 
-Expected DB row: `source=manual`, ordinary `status=open`, and no `support_triage` unless the shell handled the event.
+Expected DB row: `source=manual`, ordinary `status=open`, and the same `supportSessionId`/`triggerKind` carried from the click. No duplicate `support_triage` row should appear for the same user action unless the shell genuinely handled and reconciled that same support session.
 
 - [ ] **Step 5: Verify non-build route**
 
@@ -696,7 +721,7 @@ Evidence doc must include:
 - commands run and pass/fail result;
 - Chrome MCP path driven;
 - screenshots or text observations for `/build` and non-build support entry;
-- SQL query output proving `routeContext`, `triggerKind`, `threadId` when available, and `status=support_triage`;
+- SQL query output proving `routeContext`, `triggerKind`, `supportSessionId`, `threadId` when available, and `status=support_triage`;
 - fallback-form result;
 - explicit statement that Phase 2+ out-of-scope items were not implemented.
 

--- a/packages/db/prisma/migrations/20260526000000_add_issue_report_support_context/migration.sql
+++ b/packages/db/prisma/migrations/20260526000000_add_issue_report_support_context/migration.sql
@@ -1,0 +1,10 @@
+-- Add manual support-mode context for feedback triage reports.
+ALTER TABLE "PlatformIssueReport"
+  ADD COLUMN IF NOT EXISTS "triggerKind" TEXT,
+  ADD COLUMN IF NOT EXISTS "supportSessionId" TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PlatformIssueReport_reportedById_supportSessionId_key"
+  ON "PlatformIssueReport"("reportedById", "supportSessionId");
+
+CREATE INDEX IF NOT EXISTS "PlatformIssueReport_reportedById_supportSessionId_createdAt_idx"
+  ON "PlatformIssueReport"("reportedById", "supportSessionId", "createdAt" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4229,6 +4229,8 @@ model PlatformIssueReport {
   portfolioId         String?
   agentId             String?
   featureBuildId      String?
+  triggerKind         String?
+  supportSessionId    String?
   source              String        @default("manual")
   // Governed Hermes learning Slice 1: link runtime issues to the thread/run
   // that produced them so reflection can avoid route/time-window heuristics.
@@ -4245,6 +4247,8 @@ model PlatformIssueReport {
   @@index([featureBuildId])
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId])
+  @@unique([reportedById, supportSessionId])
+  @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }
 
 model ImprovementSignal {


### PR DESCRIPTION
## Summary
- Adds the typed `open-agent-feedback` detail contract and wires both Feedback buttons to dispatch manual support events with route/support-session context.
- Extends the existing coworker shell into support mode, with support welcome copy, active `/build` feature-build/thread context when available, and idempotent local `PlatformIssueReport` creation through the Phase 0 writer.
- Adds support-triage persistence fields/migration and keeps fallback `FeedbackForm` posting support context when the shell is unavailable.

## Verification
- `pnpm --filter web exec vitest run lib/feedback/feedback-event.test.ts components/feedback/FeedbackButton.test.tsx components/feedback/HeaderFeedbackButton.test.tsx components/agent/AgentCoworkerShell.test.tsx lib/actions/feedback-support.test.ts lib/quality/platform-issue-reports.test.ts app/api/quality/report/route.test.ts lib/actions/quality.test.ts` — 8 files passed, 55 tests passed
- `pnpm --filter @dpf/db exec prisma generate`
- `pnpm --filter web exec tsc --noEmit`
- `cd apps/web && pnpm test` — 999 files passed, 8339 tests passed
- `cd apps/web && pnpm exec next build`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter @dpf/db exec prisma migrate deploy` against local `dpf-postgres-1`
- Rebuilt/recreated Docker-served `dpf-portal-1` from this branch and verified `http://localhost:3000/build` Feedback click opens support mode with no category form.
- SQL proof: latest support row had `status=support_triage`, `routeContext=/build`, `triggerKind=manual`, and a non-null `threadId`/`supportSessionId`.

## Notes
- During live verification, `/build` rendered its existing error boundary (`Cannot read properties of undefined (reading 'toLowerCase')`) before the Feedback click. Phase 1 acceptance still passed; the error is recorded in the evidence doc for follow-up.