### PR TITLE
fix: add local portal redeploy helper

### DIFF
--- a/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
+++ b/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
@@ -1,0 +1,63 @@
+# Local Redeploy Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one local redeploy helper per shell that builds and recreates `portal-init` and `portal` together so manual rebuilds cannot leave the init image behind the app image.
+
+**Architecture:** Keep `scripts/build-images.{ps1,sh}` as the build-only primitive. Add `scripts/redeploy-portal.{ps1,sh}` as the operator-safe workflow: resolve repo root, stamp `DPF_VERSION` from `git rev-parse HEAD`, build `portal` and `portal-init` together, recreate both services with `--no-build --force-recreate`, and fail if the resulting containers do not reference the same image ID. Update version-check drift guidance to point to the new helper.
+
+**Tech Stack:** PowerShell 5.1, POSIX shell, Docker Compose, Node built-in test runner.
+
+---
+
+### Task 1: Redeploy Helper Contract
+
+**Files:**
+- Create: `scripts/lib/redeploy-portal.test.mjs`
+- Create: `scripts/redeploy-portal.ps1`
+- Create: `scripts/redeploy-portal.sh`
+- Modify: `scripts/portal-version-check.ps1`
+- Modify: `scripts/portal-version-check.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/lib/redeploy-portal.test.mjs` that asserts both helper scripts:
+
+```text
+1. stamp DPF_VERSION from git HEAD
+2. build portal and portal-init together
+3. recreate portal-init and portal with --no-build --force-recreate
+4. inspect both containers' .Image values
+5. fail when those image values differ
+```
+
+Also assert `portal-version-check` drift messages mention the new redeploy helper for the matching shell.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+node scripts/lib/redeploy-portal.test.mjs
+```
+
+Expected: fail because `scripts/redeploy-portal.ps1` and `scripts/redeploy-portal.sh` do not exist yet.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add `scripts/redeploy-portal.ps1` and `scripts/redeploy-portal.sh` with the workflow above. Keep output concise and use only ASCII.
+
+- [ ] **Step 4: Update drift guidance**
+
+Change `scripts/portal-version-check.ps1` and `scripts/portal-version-check.sh` so drift guidance points to `scripts/redeploy-portal.ps1` and `scripts/redeploy-portal.sh`.
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```powershell
+node scripts/lib/redeploy-portal.test.mjs
+docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n scripts/redeploy-portal.sh
+```
+
+Expected: tests pass and shell syntax validation exits 0.

--- a/scripts/lib/redeploy-portal.test.mjs
+++ b/scripts/lib/redeploy-portal.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+function read(path) {
+  return readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+test("PowerShell redeploy helper builds and recreates portal services together", () => {
+  const body = read("scripts/redeploy-portal.ps1");
+
+  assert.match(body, /\$env:DPF_VERSION\s*=\s*\$sha/);
+  assert.match(body, /\$buildArgs\s*=\s*@\("compose", "build"\)/);
+  assert.match(body, /\$buildArgs\s*\+=\s*@\("portal", "portal-init"\)/);
+  assert.match(body, /"up", "-d", "--no-build", "--force-recreate", "portal-init", "portal"/);
+  assert.match(body, /docker inspect -f '{{\.Image}}'/);
+  assert.match(body, /\$portalImage\s*-ne\s*\$portalInitImage/);
+});
+
+test("shell redeploy helper builds and recreates portal services together", () => {
+  const body = read("scripts/redeploy-portal.sh");
+
+  assert.match(body, /export DPF_VERSION="\$sha"/);
+  assert.match(body, /docker compose build "\$\{build_flags\[@\]\}" portal portal-init/);
+  assert.match(body, /docker compose up -d --no-build --force-recreate portal-init portal/);
+  assert.match(body, /docker inspect -f '{{\.Image}}'/);
+  assert.match(body, /\[ "\$portal_image" != "\$portal_init_image" \]/);
+});
+
+test("version-check drift guidance points to redeploy helper", () => {
+  assert.match(read("scripts/portal-version-check.ps1"), /scripts\\redeploy-portal\.ps1/);
+  assert.match(read("scripts/portal-version-check.sh"), /scripts\/redeploy-portal\.sh/);
+});

--- a/scripts/portal-version-check.ps1
+++ b/scripts/portal-version-check.ps1
@@ -61,7 +61,7 @@ Write-Host "[version-check] Portal image version: $($response.version)"
 Write-Host "[version-check] Local origin/main   : $expected"
 
 if ($response.source -ne "git-sha") {
-  Write-Host "[version-check] Image was built without DPF_VERSION (content-hash fallback) - cannot compare to a SHA. Rebuild with scripts/build-images.ps1 to stamp a git SHA."
+  Write-Host "[version-check] Image was built without DPF_VERSION (content-hash fallback) - cannot compare to a SHA. Rebuild/redeploy with scripts\redeploy-portal.ps1 to stamp a git SHA."
   exit 2
 }
 
@@ -71,5 +71,5 @@ if ($response.version.ToLower() -eq $expected.ToLower()) {
 }
 
 Write-Host "[version-check] DRIFT - portal is NOT serving origin/main."
-Write-Host "[version-check] Rebuild with: scripts\build-images.ps1 (then docker compose up -d portal portal-init)"
+Write-Host "[version-check] Rebuild/redeploy with: scripts\redeploy-portal.ps1"
 exit 1

--- a/scripts/portal-version-check.sh
+++ b/scripts/portal-version-check.sh
@@ -45,7 +45,7 @@ echo "[version-check] Portal image version: $image_version"
 echo "[version-check] Local origin/main   : $expected"
 
 if [ "$image_source" != "git-sha" ]; then
-  echo "[version-check] Image was built without DPF_VERSION (content-hash fallback) - cannot compare to a SHA. Rebuild with scripts/build-images.sh to stamp a git SHA."
+  echo "[version-check] Image was built without DPF_VERSION (content-hash fallback) - cannot compare to a SHA. Rebuild/redeploy with scripts/redeploy-portal.sh to stamp a git SHA."
   exit 2
 fi
 
@@ -55,5 +55,5 @@ if [ "$(printf '%s' "$image_version" | tr 'A-F' 'a-f')" = "$(printf '%s' "$expec
 fi
 
 echo "[version-check] DRIFT - portal is NOT serving origin/main."
-echo "[version-check] Rebuild with: scripts/build-images.sh (then docker compose up -d portal portal-init)"
+echo "[version-check] Rebuild/redeploy with: scripts/redeploy-portal.sh"
 exit 1

--- a/scripts/redeploy-portal.ps1
+++ b/scripts/redeploy-portal.ps1
@@ -1,0 +1,79 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Build and recreate the local portal-init and portal services together.
+
+.DESCRIPTION
+  Stamps the current git HEAD into DPF_VERSION, builds portal-init and portal
+  from the same checkout, recreates both containers without rebuilding again,
+  and verifies the resulting containers reference the same image ID.
+
+.PARAMETER NoCache
+  Pass --no-cache to docker compose build.
+
+.EXAMPLE
+  scripts\redeploy-portal.ps1
+  scripts\redeploy-portal.ps1 -NoCache
+#>
+[CmdletBinding()]
+param(
+  [switch]$NoCache
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = git rev-parse --show-toplevel
+if (-not $repoRoot) {
+  Write-Error "Not inside a git working tree."
+  exit 1
+}
+Set-Location $repoRoot
+
+$sha = git rev-parse HEAD
+if (-not $sha) {
+  Write-Error "Failed to resolve git HEAD."
+  exit 1
+}
+
+$env:DPF_VERSION = $sha
+Write-Host "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
+
+$buildArgs = @("compose", "build")
+if ($NoCache) { $buildArgs += "--no-cache" }
+$buildArgs += @("portal", "portal-init")
+
+& docker @buildArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "[redeploy-portal] Recreating portal-init and portal from the built images"
+$upArgs = @("compose", "up", "-d", "--no-build", "--force-recreate", "portal-init", "portal")
+& docker @upArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+function Get-ComposeContainerImage {
+  param([Parameter(Mandatory = $true)][string]$Service)
+
+  $containerId = (& docker compose ps -q $Service).Trim()
+  if (-not $containerId) {
+    Write-Error "No container found for compose service '$Service'."
+    exit 1
+  }
+
+  $imageId = (& docker inspect -f '{{.Image}}' $containerId).Trim()
+  if (-not $imageId) {
+    Write-Error "Could not inspect image ID for compose service '$Service'."
+    exit 1
+  }
+
+  return $imageId
+}
+
+$portalImage = Get-ComposeContainerImage -Service "portal"
+$portalInitImage = Get-ComposeContainerImage -Service "portal-init"
+
+if ($portalImage -ne $portalInitImage) {
+  Write-Error "portal and portal-init image IDs differ. portal=$portalImage portal-init=$portalInitImage"
+  exit 1
+}
+
+Write-Host "[redeploy-portal] portal and portal-init image IDs match: $portalImage"

--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build and recreate the local portal-init and portal services together.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/redeploy-portal.sh [--no-cache]
+
+Builds portal and portal-init with DPF_VERSION set to the current git HEAD,
+recreates both services without rebuilding again, and verifies both containers
+reference the same image ID.
+EOF
+}
+
+declare -a build_flags=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-cache)
+      build_flags+=("--no-cache")
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[redeploy-portal] Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+sha="$(git rev-parse HEAD)"
+export DPF_VERSION="$sha"
+echo "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
+
+docker compose build "${build_flags[@]}" portal portal-init
+
+echo "[redeploy-portal] Recreating portal-init and portal from the built images"
+docker compose up -d --no-build --force-recreate portal-init portal
+
+portal_container="$(docker compose ps -q portal)"
+portal_init_container="$(docker compose ps -q portal-init)"
+
+if [ -z "$portal_container" ] || [ -z "$portal_init_container" ]; then
+  echo "[redeploy-portal] Missing portal or portal-init container after recreate." >&2
+  exit 1
+fi
+
+portal_image="$(docker inspect -f '{{.Image}}' "$portal_container")"
+portal_init_image="$(docker inspect -f '{{.Image}}' "$portal_init_container")"
+
+if [ "$portal_image" != "$portal_init_image" ]; then
+  echo "[redeploy-portal] portal and portal-init image IDs differ." >&2
+  echo "[redeploy-portal] portal=$portal_image" >&2
+  echo "[redeploy-portal] portal-init=$portal_init_image" >&2
+  exit 1
+fi
+
+echo "[redeploy-portal] portal and portal-init image IDs match: $portal_image"


### PR DESCRIPTION
## Summary
- add `scripts/redeploy-portal.ps1` and `scripts/redeploy-portal.sh` for one-command local rebuild/recreate of `portal-init` and `portal`
- verify the recreated containers reference the same Docker image ID so init/app image drift is caught immediately
- update `portal-version-check` drift guidance to point operators at the redeploy helper
- add a focused Node regression test plus an install-path plan artifact

## Why
During the platform update repair, a manual `docker build -t dpf-portal:latest .` updated the app image but left `dpf-portal-init:latest` stale. The existing `build-images` wrapper already builds both services, but the operator-safe path needed to bundle build, recreate, and image-alignment verification.

## Verification
- `node scripts/lib/redeploy-portal.test.mjs`
- `docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n scripts/redeploy-portal.sh`
- PowerShell parse check: `[scriptblock]::Create((Get-Content -Raw -LiteralPath 'scripts\\redeploy-portal.ps1'))`
- `git diff --check --cached`