### PR TITLE
fix: load install env in portal redeploy helper

### DIFF
--- a/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
+++ b/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add one local redeploy helper per shell that builds and recreates `portal-init` and `portal` together so manual rebuilds cannot leave the init image behind the app image.
 
-**Architecture:** Keep `scripts/build-images.{ps1,sh}` as the build-only primitive. Add `scripts/redeploy-portal.{ps1,sh}` as the operator-safe workflow: resolve repo root, stamp `DPF_VERSION` from `git rev-parse HEAD`, build `portal` and `portal-init` together, recreate both services with `--no-build --force-recreate`, and fail if the resulting containers do not reference the same image ID. Update version-check drift guidance to point to the new helper.
+**Architecture:** Keep `scripts/build-images.{ps1,sh}` as the build-only primitive. Add `scripts/redeploy-portal.{ps1,sh}` as the operator-safe workflow: resolve repo root, resolve the Docker Compose env file from an explicit argument or conventional install root, stamp `DPF_VERSION` from `git rev-parse HEAD`, build `portal` and `portal-init` together, recreate both services with `--no-build --force-recreate`, and fail if the resulting containers do not reference the same image ID. Update version-check drift guidance to point to the new helper.
 
 **Tech Stack:** PowerShell 5.1, POSIX shell, Docker Compose, Node built-in test runner.
 
@@ -25,10 +25,11 @@ Create `scripts/lib/redeploy-portal.test.mjs` that asserts both helper scripts:
 
 ```text
 1. stamp DPF_VERSION from git HEAD
-2. build portal and portal-init together
-3. recreate portal-init and portal with --no-build --force-recreate
-4. inspect both containers' .Image values
-5. fail when those image values differ
+2. resolve a Compose env file from `DPF_COMPOSE_ENV_FILE`, the checkout `.env`, or the conventional install `.env`
+3. build portal and portal-init together
+4. recreate portal-init and portal with --no-build --force-recreate
+5. inspect both containers' .Image values
+6. fail when those image values differ
 ```
 
 Also assert `portal-version-check` drift messages mention the new redeploy helper for the matching shell.

--- a/scripts/lib/redeploy-portal.test.mjs
+++ b/scripts/lib/redeploy-portal.test.mjs
@@ -9,8 +9,11 @@ function read(path) {
 test("PowerShell redeploy helper builds and recreates portal services together", () => {
   const body = read("scripts/redeploy-portal.ps1");
 
+  assert.match(body, /DPF_COMPOSE_ENV_FILE/);
+  assert.match(body, /D:\\DPF\\\.env/);
+  assert.match(body, /\$composeArgs\s*\+=\s*@\("--env-file", \$composeEnvFile\)/);
   assert.match(body, /\$env:DPF_VERSION\s*=\s*\$sha/);
-  assert.match(body, /\$buildArgs\s*=\s*@\("compose", "build"\)/);
+  assert.match(body, /\$buildArgs\s*=\s*\$composeArgs\s*\+\s*@\("build"\)/);
   assert.match(body, /\$buildArgs\s*\+=\s*@\("portal", "portal-init"\)/);
   assert.match(body, /"up", "-d", "--no-build", "--force-recreate", "portal-init", "portal"/);
   assert.match(body, /docker inspect -f '{{\.Image}}'/);
@@ -20,9 +23,12 @@ test("PowerShell redeploy helper builds and recreates portal services together",
 test("shell redeploy helper builds and recreates portal services together", () => {
   const body = read("scripts/redeploy-portal.sh");
 
+  assert.match(body, /DPF_COMPOSE_ENV_FILE/);
+  assert.match(body, /\$HOME\/dpf\/\.env/);
+  assert.match(body, /compose_args\+=\(--env-file "\$compose_env_file"\)/);
   assert.match(body, /export DPF_VERSION="\$sha"/);
-  assert.match(body, /docker compose build "\$\{build_flags\[@\]\}" portal portal-init/);
-  assert.match(body, /docker compose up -d --no-build --force-recreate portal-init portal/);
+  assert.match(body, /docker compose "\$\{compose_args\[@\]\}" build "\$\{build_flags\[@\]\}" portal portal-init/);
+  assert.match(body, /docker compose "\$\{compose_args\[@\]\}" up -d --no-build --force-recreate portal-init portal/);
   assert.match(body, /docker inspect -f '{{\.Image}}'/);
   assert.match(body, /\[ "\$portal_image" != "\$portal_init_image" \]/);
 });

--- a/scripts/redeploy-portal.ps1
+++ b/scripts/redeploy-portal.ps1
@@ -11,13 +11,19 @@
 .PARAMETER NoCache
   Pass --no-cache to docker compose build.
 
+.PARAMETER ComposeEnvFile
+  Optional Docker Compose env file. Defaults to $env:DPF_COMPOSE_ENV_FILE,
+  then this checkout's .env, then D:\DPF\.env when present.
+
 .EXAMPLE
   scripts\redeploy-portal.ps1
   scripts\redeploy-portal.ps1 -NoCache
+  scripts\redeploy-portal.ps1 -ComposeEnvFile D:\DPF\.env
 #>
 [CmdletBinding()]
 param(
-  [switch]$NoCache
+  [switch]$NoCache,
+  [string]$ComposeEnvFile = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -29,6 +35,48 @@ if (-not $repoRoot) {
 }
 Set-Location $repoRoot
 
+function Resolve-ComposeEnvFile {
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [string]$RequestedPath
+  )
+
+  if ($RequestedPath) {
+    if (-not (Test-Path -LiteralPath $RequestedPath)) {
+      Write-Error "Compose env file not found: $RequestedPath"
+      exit 1
+    }
+    return (Resolve-Path -LiteralPath $RequestedPath).Path
+  }
+
+  if ($env:DPF_COMPOSE_ENV_FILE) {
+    if (-not (Test-Path -LiteralPath $env:DPF_COMPOSE_ENV_FILE)) {
+      Write-Error "DPF_COMPOSE_ENV_FILE points to a missing file: $env:DPF_COMPOSE_ENV_FILE"
+      exit 1
+    }
+    return (Resolve-Path -LiteralPath $env:DPF_COMPOSE_ENV_FILE).Path
+  }
+
+  $repoEnv = Join-Path $Root ".env"
+  if (Test-Path -LiteralPath $repoEnv) {
+    return (Resolve-Path -LiteralPath $repoEnv).Path
+  }
+
+  $defaultWindowsInstallEnv = "D:\DPF\.env"
+  if (Test-Path -LiteralPath $defaultWindowsInstallEnv) {
+    return (Resolve-Path -LiteralPath $defaultWindowsInstallEnv).Path
+  }
+
+  return $null
+}
+
+$composeEnvFile = Resolve-ComposeEnvFile -Root $repoRoot -RequestedPath $ComposeEnvFile
+$composeArgs = @("compose")
+if ($composeEnvFile) {
+  Write-Host "[redeploy-portal] Using Compose env file: $composeEnvFile"
+  $composeArgs += @("--env-file", $composeEnvFile)
+}
+
 $sha = git rev-parse HEAD
 if (-not $sha) {
   Write-Error "Failed to resolve git HEAD."
@@ -38,7 +86,7 @@ if (-not $sha) {
 $env:DPF_VERSION = $sha
 Write-Host "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
 
-$buildArgs = @("compose", "build")
+$buildArgs = $composeArgs + @("build")
 if ($NoCache) { $buildArgs += "--no-cache" }
 $buildArgs += @("portal", "portal-init")
 
@@ -46,14 +94,15 @@ $buildArgs += @("portal", "portal-init")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "[redeploy-portal] Recreating portal-init and portal from the built images"
-$upArgs = @("compose", "up", "-d", "--no-build", "--force-recreate", "portal-init", "portal")
+$upArgs = $composeArgs + @("up", "-d", "--no-build", "--force-recreate", "portal-init", "portal")
 & docker @upArgs
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 function Get-ComposeContainerImage {
   param([Parameter(Mandatory = $true)][string]$Service)
 
-  $containerId = (& docker compose ps -q $Service).Trim()
+  $psArgs = $composeArgs + @("ps", "-q", $Service)
+  $containerId = (& docker @psArgs).Trim()
   if (-not $containerId) {
     Write-Error "No container found for compose service '$Service'."
     exit 1

--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -11,6 +11,9 @@ Usage:
 Builds portal and portal-init with DPF_VERSION set to the current git HEAD,
 recreates both services without rebuilding again, and verifies both containers
 reference the same image ID.
+
+Set DPF_COMPOSE_ENV_FILE to override the Docker Compose env file. By default,
+the helper uses this checkout's .env, then $HOME/dpf/.env when present.
 EOF
 }
 
@@ -36,17 +39,36 @@ done
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+compose_env_file="${DPF_COMPOSE_ENV_FILE:-}"
+if [ -z "$compose_env_file" ]; then
+  if [ -f "$repo_root/.env" ]; then
+    compose_env_file="$repo_root/.env"
+  elif [ -f "$HOME/dpf/.env" ]; then
+    compose_env_file="$HOME/dpf/.env"
+  fi
+fi
+
+declare -a compose_args=()
+if [ -n "$compose_env_file" ]; then
+  if [ ! -f "$compose_env_file" ]; then
+    echo "[redeploy-portal] Compose env file not found: $compose_env_file" >&2
+    exit 1
+  fi
+  echo "[redeploy-portal] Using Compose env file: $compose_env_file"
+  compose_args+=(--env-file "$compose_env_file")
+fi
+
 sha="$(git rev-parse HEAD)"
 export DPF_VERSION="$sha"
 echo "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
 
-docker compose build "${build_flags[@]}" portal portal-init
+docker compose "${compose_args[@]}" build "${build_flags[@]}" portal portal-init
 
 echo "[redeploy-portal] Recreating portal-init and portal from the built images"
-docker compose up -d --no-build --force-recreate portal-init portal
+docker compose "${compose_args[@]}" up -d --no-build --force-recreate portal-init portal
 
-portal_container="$(docker compose ps -q portal)"
-portal_init_container="$(docker compose ps -q portal-init)"
+portal_container="$(docker compose "${compose_args[@]}" ps -q portal)"
+portal_init_container="$(docker compose "${compose_args[@]}" ps -q portal-init)"
 
 if [ -z "$portal_container" ] || [ -z "$portal_init_container" ]; then
   echo "[redeploy-portal] Missing portal or portal-init container after recreate." >&2


### PR DESCRIPTION
## Summary
- resolves the Docker Compose env file for the local portal redeploy helper from an explicit argument, `DPF_COMPOSE_ENV_FILE`, the checkout `.env`, or the conventional install `.env`
- passes the resolved env file through build, up, and container lookup calls so release worktrees can redeploy the installed portal without copying secrets
- expands the helper regression assertions and plan note for the env-file contract

## Verification
- `node scripts/lib/redeploy-portal.test.mjs`
- `docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n scripts/redeploy-portal.sh`
- `$null = [scriptblock]::Create((Get-Content -Raw -LiteralPath 'scripts\redeploy-portal.ps1'))`
- `git diff --check`