### PR TITLE
fix: verify one-shot portal init redeploy

### DIFF
--- a/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
+++ b/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
@@ -28,7 +28,7 @@ Create `scripts/lib/redeploy-portal.test.mjs` that asserts both helper scripts:
 2. resolve a Compose env file from `DPF_COMPOSE_ENV_FILE`, the checkout `.env`, or the conventional install `.env`
 3. build portal and portal-init together
 4. recreate portal-init and portal with --no-build --force-recreate
-5. inspect both containers' .Image values
+5. inspect both containers' .Image values, including the exited `portal-init` one-shot container
 6. fail when those image values differ
 ```
 

--- a/scripts/lib/redeploy-portal.test.mjs
+++ b/scripts/lib/redeploy-portal.test.mjs
@@ -16,6 +16,7 @@ test("PowerShell redeploy helper builds and recreates portal services together",
   assert.match(body, /\$buildArgs\s*=\s*\$composeArgs\s*\+\s*@\("build"\)/);
   assert.match(body, /\$buildArgs\s*\+=\s*@\("portal", "portal-init"\)/);
   assert.match(body, /"up", "-d", "--no-build", "--force-recreate", "portal-init", "portal"/);
+  assert.match(body, /\$composeArgs\s*\+\s*@\("ps", "-a", "-q", \$Service\)/);
   assert.match(body, /docker inspect -f '{{\.Image}}'/);
   assert.match(body, /\$portalImage\s*-ne\s*\$portalInitImage/);
 });
@@ -29,6 +30,7 @@ test("shell redeploy helper builds and recreates portal services together", () =
   assert.match(body, /export DPF_VERSION="\$sha"/);
   assert.match(body, /docker compose "\$\{compose_args\[@\]\}" build "\$\{build_flags\[@\]\}" portal portal-init/);
   assert.match(body, /docker compose "\$\{compose_args\[@\]\}" up -d --no-build --force-recreate portal-init portal/);
+  assert.match(body, /docker compose "\$\{compose_args\[@\]\}" ps -a -q portal-init/);
   assert.match(body, /docker inspect -f '{{\.Image}}'/);
   assert.match(body, /\[ "\$portal_image" != "\$portal_init_image" \]/);
 });

--- a/scripts/redeploy-portal.ps1
+++ b/scripts/redeploy-portal.ps1
@@ -101,14 +101,24 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 function Get-ComposeContainerImage {
   param([Parameter(Mandatory = $true)][string]$Service)
 
-  $psArgs = $composeArgs + @("ps", "-q", $Service)
-  $containerId = (& docker @psArgs).Trim()
+  $psArgs = $composeArgs + @("ps", "-a", "-q", $Service)
+  $containerId = (& docker @psArgs | Select-Object -First 1)
+  if ($null -eq $containerId) {
+    $containerId = ""
+  } else {
+    $containerId = $containerId.Trim()
+  }
   if (-not $containerId) {
     Write-Error "No container found for compose service '$Service'."
     exit 1
   }
 
-  $imageId = (& docker inspect -f '{{.Image}}' $containerId).Trim()
+  $imageId = (& docker inspect -f '{{.Image}}' $containerId | Select-Object -First 1)
+  if ($null -eq $imageId) {
+    $imageId = ""
+  } else {
+    $imageId = $imageId.Trim()
+  }
   if (-not $imageId) {
     Write-Error "Could not inspect image ID for compose service '$Service'."
     exit 1

--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -67,8 +67,8 @@ docker compose "${compose_args[@]}" build "${build_flags[@]}" portal portal-init
 echo "[redeploy-portal] Recreating portal-init and portal from the built images"
 docker compose "${compose_args[@]}" up -d --no-build --force-recreate portal-init portal
 
-portal_container="$(docker compose "${compose_args[@]}" ps -q portal)"
-portal_init_container="$(docker compose "${compose_args[@]}" ps -q portal-init)"
+portal_container="$(docker compose "${compose_args[@]}" ps -a -q portal | head -n 1)"
+portal_init_container="$(docker compose "${compose_args[@]}" ps -a -q portal-init | head -n 1)"
 
 if [ -z "$portal_container" ] || [ -z "$portal_init_container" ]; then
   echo "[redeploy-portal] Missing portal or portal-init container after recreate." >&2


### PR DESCRIPTION
## Summary
- updates the local redeploy helper image verification to include exited Compose containers, which is required because `portal-init` is a successful one-shot service
- avoids null-trim crashes in the PowerShell helper when Compose cannot resolve a container
- expands the helper regression assertions and plan note for the one-shot verification contract

## Verification
- red: `node scripts/lib/redeploy-portal.test.mjs` failed before the helper change because both scripts used `docker compose ps -q`
- green: `node scripts/lib/redeploy-portal.test.mjs`
- `docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n scripts/redeploy-portal.sh`
- `$null = [scriptblock]::Create((Get-Content -Raw -LiteralPath 'scripts\redeploy-portal.ps1'))`
- `git diff --check`