### PR TITLE
fix: verify portal redeploy version markers

### DIFF
--- a/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
+++ b/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add one local redeploy helper per shell that builds and recreates `portal-init` and `portal` together so manual rebuilds cannot leave the init image behind the app image.
 
-**Architecture:** Keep `scripts/build-images.{ps1,sh}` as the build-only primitive. Add `scripts/redeploy-portal.{ps1,sh}` as the operator-safe workflow: resolve repo root, resolve the Docker Compose env file from an explicit argument or conventional install root, stamp `DPF_VERSION` from `git rev-parse HEAD`, build `portal` and `portal-init` together, recreate both services with `--no-build --force-recreate`, and fail if the resulting containers do not reference the same image ID. Update version-check drift guidance to point to the new helper.
+**Architecture:** Keep `scripts/build-images.{ps1,sh}` as the build-only primitive. Add `scripts/redeploy-portal.{ps1,sh}` as the operator-safe workflow: resolve repo root, resolve the Docker Compose env file from an explicit argument or conventional install root, stamp `DPF_VERSION` from `git rev-parse HEAD`, build `portal` and `portal-init` together, recreate both services with `--no-build --force-recreate`, and fail if either resulting container does not carry the expected `/app/.dpf-image-version` marker. Update version-check drift guidance to point to the new helper.
 
 **Tech Stack:** PowerShell 5.1, POSIX shell, Docker Compose, Node built-in test runner.
 
@@ -28,8 +28,8 @@ Create `scripts/lib/redeploy-portal.test.mjs` that asserts both helper scripts:
 2. resolve a Compose env file from `DPF_COMPOSE_ENV_FILE`, the checkout `.env`, or the conventional install `.env`
 3. build portal and portal-init together
 4. recreate portal-init and portal with --no-build --force-recreate
-5. inspect both containers' .Image values, including the exited `portal-init` one-shot container
-6. fail when those image values differ
+5. inspect both containers' `/app/.dpf-image-version` values, including the exited `portal-init` one-shot container
+6. fail when either value differs from the build SHA
 ```
 
 Also assert `portal-version-check` drift messages mention the new redeploy helper for the matching shell.

--- a/scripts/lib/redeploy-portal.test.mjs
+++ b/scripts/lib/redeploy-portal.test.mjs
@@ -17,8 +17,10 @@ test("PowerShell redeploy helper builds and recreates portal services together",
   assert.match(body, /\$buildArgs\s*\+=\s*@\("portal", "portal-init"\)/);
   assert.match(body, /"up", "-d", "--no-build", "--force-recreate", "portal-init", "portal"/);
   assert.match(body, /\$composeArgs\s*\+\s*@\("ps", "-a", "-q", \$Service\)/);
-  assert.match(body, /docker inspect -f '{{\.Image}}'/);
-  assert.match(body, /\$portalImage\s*-ne\s*\$portalInitImage/);
+  assert.match(body, /\/app\/\.dpf-image-version/);
+  assert.match(body, /docker cp/);
+  assert.match(body, /\$portalVersion\s*-ne\s*\$sha/);
+  assert.match(body, /\$portalInitVersion\s*-ne\s*\$sha/);
 });
 
 test("shell redeploy helper builds and recreates portal services together", () => {
@@ -31,8 +33,10 @@ test("shell redeploy helper builds and recreates portal services together", () =
   assert.match(body, /docker compose "\$\{compose_args\[@\]\}" build "\$\{build_flags\[@\]\}" portal portal-init/);
   assert.match(body, /docker compose "\$\{compose_args\[@\]\}" up -d --no-build --force-recreate portal-init portal/);
   assert.match(body, /docker compose "\$\{compose_args\[@\]\}" ps -a -q portal-init/);
-  assert.match(body, /docker inspect -f '{{\.Image}}'/);
-  assert.match(body, /\[ "\$portal_image" != "\$portal_init_image" \]/);
+  assert.match(body, /\/app\/\.dpf-image-version/);
+  assert.match(body, /docker cp/);
+  assert.match(body, /\[ "\$portal_version" != "\$sha" \]/);
+  assert.match(body, /\[ "\$portal_init_version" != "\$sha" \]/);
 });
 
 test("version-check drift guidance points to redeploy helper", () => {

--- a/scripts/redeploy-portal.ps1
+++ b/scripts/redeploy-portal.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
   Stamps the current git HEAD into DPF_VERSION, builds portal-init and portal
   from the same checkout, recreates both containers without rebuilding again,
-  and verifies the resulting containers reference the same image ID.
+  and verifies the resulting containers carry the same DPF version marker.
 
 .PARAMETER NoCache
   Pass --no-cache to docker compose build.
@@ -98,7 +98,7 @@ $upArgs = $composeArgs + @("up", "-d", "--no-build", "--force-recreate", "portal
 & docker @upArgs
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-function Get-ComposeContainerImage {
+function Get-ComposeContainerId {
   param([Parameter(Mandatory = $true)][string]$Service)
 
   $psArgs = $composeArgs + @("ps", "-a", "-q", $Service)
@@ -113,26 +113,45 @@ function Get-ComposeContainerImage {
     exit 1
   }
 
-  $imageId = (& docker inspect -f '{{.Image}}' $containerId | Select-Object -First 1)
-  if ($null -eq $imageId) {
-    $imageId = ""
-  } else {
-    $imageId = $imageId.Trim()
+  return $containerId
+}
+
+function Get-ComposeContainerVersion {
+  param([Parameter(Mandatory = $true)][string]$Service)
+
+  $containerId = Get-ComposeContainerId -Service $Service
+  $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "dpf-redeploy-$([guid]::NewGuid().ToString('N'))"
+  $versionPath = Join-Path $tempDir "$Service.dpf-image-version"
+
+  New-Item -ItemType Directory -Path $tempDir | Out-Null
+  try {
+    & docker cp "$containerId`:/app/.dpf-image-version" $versionPath
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    $version = (Get-Content -Raw -LiteralPath $versionPath).Trim()
+  } finally {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
   }
-  if (-not $imageId) {
-    Write-Error "Could not inspect image ID for compose service '$Service'."
+
+  if (-not $version) {
+    Write-Error "Could not read .dpf-image-version for compose service '$Service'."
     exit 1
   }
 
-  return $imageId
+  return $version
 }
 
-$portalImage = Get-ComposeContainerImage -Service "portal"
-$portalInitImage = Get-ComposeContainerImage -Service "portal-init"
+$portalVersion = Get-ComposeContainerVersion -Service "portal"
+$portalInitVersion = Get-ComposeContainerVersion -Service "portal-init"
 
-if ($portalImage -ne $portalInitImage) {
-  Write-Error "portal and portal-init image IDs differ. portal=$portalImage portal-init=$portalInitImage"
+if ($portalVersion -ne $sha) {
+  Write-Error "portal image version differs from build SHA. portal=$portalVersion expected=$sha"
   exit 1
 }
 
-Write-Host "[redeploy-portal] portal and portal-init image IDs match: $portalImage"
+if ($portalInitVersion -ne $sha) {
+  Write-Error "portal-init image version differs from build SHA. portal-init=$portalInitVersion expected=$sha"
+  exit 1
+}
+
+Write-Host "[redeploy-portal] portal and portal-init image versions match DPF_VERSION=$sha"

--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -10,7 +10,7 @@ Usage:
 
 Builds portal and portal-init with DPF_VERSION set to the current git HEAD,
 recreates both services without rebuilding again, and verifies both containers
-reference the same image ID.
+carry the same DPF version marker.
 
 Set DPF_COMPOSE_ENV_FILE to override the Docker Compose env file. By default,
 the helper uses this checkout's .env, then $HOME/dpf/.env when present.
@@ -75,14 +75,31 @@ if [ -z "$portal_container" ] || [ -z "$portal_init_container" ]; then
   exit 1
 fi
 
-portal_image="$(docker inspect -f '{{.Image}}' "$portal_container")"
-portal_init_image="$(docker inspect -f '{{.Image}}' "$portal_init_container")"
+version_tmp="$(mktemp -d)"
+trap 'rm -rf "$version_tmp"' EXIT
 
-if [ "$portal_image" != "$portal_init_image" ]; then
-  echo "[redeploy-portal] portal and portal-init image IDs differ." >&2
-  echo "[redeploy-portal] portal=$portal_image" >&2
-  echo "[redeploy-portal] portal-init=$portal_init_image" >&2
+read_container_version() {
+  local service="$1"
+  local container="$2"
+  local version_file="$version_tmp/$service.dpf-image-version"
+
+  docker cp "$container:/app/.dpf-image-version" "$version_file"
+  tr -d '\r\n' < "$version_file"
+}
+
+portal_version="$(read_container_version portal "$portal_container")"
+portal_init_version="$(read_container_version portal-init "$portal_init_container")"
+
+if [ "$portal_version" != "$sha" ]; then
+  echo "[redeploy-portal] portal image version differs from build SHA." >&2
+  echo "[redeploy-portal] portal=$portal_version expected=$sha" >&2
   exit 1
 fi
 
-echo "[redeploy-portal] portal and portal-init image IDs match: $portal_image"
+if [ "$portal_init_version" != "$sha" ]; then
+  echo "[redeploy-portal] portal-init image version differs from build SHA." >&2
+  echo "[redeploy-portal] portal-init=$portal_init_version expected=$sha" >&2
+  exit 1
+fi
+
+echo "[redeploy-portal] portal and portal-init image versions match DPF_VERSION=$sha"


### PR DESCRIPTION
## Summary
- replaces the redeploy helper's image-ID equality check with the platform's canonical `/app/.dpf-image-version` marker check
- verifies both the running `portal` container and the exited `portal-init` one-shot container carry the build SHA
- updates regression assertions and the plan note to describe the version-marker invariant

## Evidence
- live redeploy showed `portal` and `portal-init` image IDs differ even when both containers carry the same `/app/.dpf-image-version`
- direct container check showed both services stamped `d08af59c7a351f846c84b22179a88a01cfc97583`

## Verification
- red: `node scripts/lib/redeploy-portal.test.mjs` failed before the helper change because both scripts still asserted image-ID inspection
- green: `node scripts/lib/redeploy-portal.test.mjs`
- `docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n scripts/redeploy-portal.sh`
- `$null = [scriptblock]::Create((Get-Content -Raw -LiteralPath 'scripts\redeploy-portal.ps1'))`
- `git diff --check`