### PR TITLE
fix: generate prisma from db package in source bootstrap

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,7 +93,7 @@ install_workspace_dependencies() {
   cd "$WORKSPACE"
   pnpm install --frozen-lockfile --config.confirmModulesPurge=false --ignore-scripts 2>&1 || pnpm install --config.confirmModulesPurge=false --ignore-scripts 2>&1
   echo "  Dependencies installed"
-  pnpm exec prisma generate --schema packages/db/prisma/schema.prisma 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
+  pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma 2>&1 || echo "  WARN prisma generate failed (non-fatal)"
 }
 
 is_workspace_housekeeping_status() {

--- a/scripts/lib/docker-entrypoint-source-volume.test.mjs
+++ b/scripts/lib/docker-entrypoint-source-volume.test.mjs
@@ -59,12 +59,12 @@ test("workspace dependency install skips lifecycle scripts before explicit Prism
   );
   assert.match(
     body,
-    /pnpm exec prisma generate --schema packages\/db\/prisma\/schema\.prisma/,
-    "Prisma generation should use the workspace-root CLI with an explicit schema path",
+    /pnpm --filter @dpf\/db exec prisma generate --schema prisma\/schema\.prisma/,
+    "Prisma generation should use the db package CLI with the package-relative schema path",
   );
   assert.doesNotMatch(
     body,
-    /pnpm --filter @dpf\/db exec prisma generate/,
-    "Prisma generation should not rely on package-local CLI links in the production source volume",
+    /pnpm exec prisma generate --schema packages\/db\/prisma\/schema\.prisma/,
+    "Prisma generation should not rely on the workspace-root CLI link in the production source volume",
   );
 });


### PR DESCRIPTION
## Summary
- changes managed source-volume bootstrap to run Prisma generation through the `@dpf/db` package CLI
- updates the source-volume regression test to prevent returning to the workspace-root Prisma invocation

## Evidence
- init logs showed `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "prisma" not found` from root `pnpm exec prisma generate`
- inside the running portal container, `cd /workspace && pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma` succeeds

## Verification
- red: `node scripts/lib/docker-entrypoint-source-volume.test.mjs` failed after updating the expected Prisma command
- green: `node scripts/lib/docker-entrypoint-source-volume.test.mjs`
- `docker run --rm -v "D:/DPF-local-redeploy-helper:/src" -w /src bash:5.2 bash -n docker-entrypoint.sh`
- `git diff --check`