### PR TITLE
docs: explain platform update detection

### DIFF
--- a/docs/install/cloud-single-vm.md
+++ b/docs/install/cloud-single-vm.md
@@ -358,28 +358,35 @@ Same lifecycle commands as bare-metal Linux:
 
 ### Portal self-upgrade (cloud VM operators)
 
-The platform ships a governed **portal self-upgrade** runtime that
-detects when the running portal is behind `origin/main` and runs an
-in-place upgrade through the same promoter, backup, swap, health, and
-rollback path used for Build Studio ship-phase promotions. For a
-single cloud VM this removes the SSH-and-`git pull` cycle from your
-weekly maintenance.
+The platform ships a governed **portal self-upgrade** runtime for
+operators who want the portal to upgrade itself through the same
+quiescence, promoter, backup, swap, health, and rollback controls used
+for Build Studio ship-phase promotions.
+
+This is separate from the shared-workspace update banner described in
+the [Development Workspace guide](../user-guide/development-workspace.md#platform-updates-and-notifications).
+The banner tells an operator that a newer image is already present and
+the install's shared source workspace needs to merge that source. The
+self-upgrade runner is the operations path that can check a configured
+target and perform the upgrade cycle when enabled.
 
 | Surface | What it does |
 |---------|--------------|
 | `/ops/self-upgrade` | Operations dashboard panel — current SHA, target SHA, recent run history, manual trigger. Read access is gated by the `view_operations` capability; manual triggers require `manage_provider_connections`. |
-| **Daily cron** | `portal/self-upgrade-scheduled` runs at `0 8 * * *` (`SelfUpgradeRun` row written for each cycle; runs that find no new commits exit with `status: "skipped"`). |
-| **Manual trigger** | The dashboard's manual-trigger button fires the `portal/self-upgrade.requested` event, which runs the same cycle on demand. |
-| **Completion sweep** | A separate `*/15 * * * *` cron reconciles runs in the `completing` state — important when the swap succeeded but the post-build verification needs to confirm the running SHA before the run flips to `succeeded`. |
+| **Hourly scheduled runner** | `ops/self-upgrade-scheduled` is registered with cron `0 * * * *` when scheduled Inngest functions are enabled for the runtime. It calls the same runner as manual requests; checks that do not proceed return a skip reason, while upgrade attempts create `SelfUpgradeRun` records. |
+| **Manual trigger** | The dashboard's manual-trigger button fires the `ops/self-upgrade.run` event, which runs the same cycle on demand. |
+| **Skip states** | Scheduled runs skip cleanly when self-upgrade is disabled, outside the configured maintenance window, already up to date, missing a target, or already running another upgrade. |
 
 Canonical status enum: `queued | running | succeeded | failed | rolled_back | completing | skipped`. On health-check failure during the swap the promoter rolls back to the previous image and the run lands in `rolled_back`; the operator can investigate from the dashboard without losing the running portal.
 
-To **disable** scheduled self-upgrade on a particular install, set the
-relevant `PlatformConfig.selfUpgrade.*` flag from the admin surface —
-the manual trigger remains available for operators who want to run
-the cycle on their own schedule.
+Scheduled self-upgrade is opt-in. The runtime must include scheduled
+Inngest functions, and `PlatformConfig["self_upgrade"]` must set
+`enabled: true` with the desired channel, target source path, branch,
+maintenance windows, and health URL. The legacy
+`PlatformConfig["portal.selfUpgrade"]` key is read only as a fallback
+for older installs.
 
-Implementation reference: [`docs/superpowers/plans/2026-05-20-portal-self-upgrade-local.md`](../superpowers/plans/2026-05-20-portal-self-upgrade-local.md).
+Implementation reference: [`docs/superpowers/plans/2026-05-23-governed-platform-upgrade-phase-0-and-1.md`](../superpowers/plans/2026-05-23-governed-platform-upgrade-phase-0-and-1.md).
 
 ## What Phase 0 does NOT cover
 

--- a/docs/user-guide/development-workspace.md
+++ b/docs/user-guide/development-workspace.md
@@ -2,7 +2,7 @@
 title: "Development Workspace"
 area: getting-started
 order: 6
-lastUpdated: 2026-04-05
+lastUpdated: 2026-05-26
 updatedBy: Codex
 ---
 
@@ -74,6 +74,35 @@ The recommended branch pattern is:
 
 - one durable branch per install, such as `install/<install-slug>`
 - short-lived export branches only when preparing an upstream PR
+
+## Platform Updates And Notifications
+
+The portal has two related update paths, and they answer different questions.
+
+### Shared-workspace update banner
+
+The banner at the top of the portal is the operator-facing signal that a newer platform image is present but the install's shared workspace still needs attention.
+
+On portal bootstrap, the runtime compares:
+
+- the running image version from `/app/.dpf-image-version`
+- the shared workspace version from `/workspace/.dpf-version`
+
+If the versions match, nothing is shown. If the image is newer and the shared workspace has no user changes, the bootstrap refreshes the managed source workspace from the image and clears the pending-update flag.
+
+If the image is newer and the shared workspace has local/source changes, the bootstrap does not overwrite them. Instead it writes `PlatformDevConfig.updatePending = true` and stores the image version in `PlatformDevConfig.pendingVersion`. Users with `manage_platform` see a portal banner that links to **Admin > Platform Development**, where the **Apply update** panel merges the new platform source into the install's `my-changes` branch.
+
+The apply action preserves customisations. A clean merge writes the new `.dpf-version` value and clears the banner. If Git reports conflicts, the merge pauses in the shared workspace and the panel lists the conflicted files for review instead of guessing a resolution.
+
+This banner is not a browser polling loop. It reflects the latest server-side platform-development state whenever the shell renders. The state is normally changed by bootstrap/redeploy work, or by the apply action clearing a completed update.
+
+### Governed self-upgrade runner
+
+The operations self-upgrade path is separate from the shared-workspace banner. It lives at `/ops/self-upgrade` and records `SelfUpgradeRun` history for governed portal upgrades.
+
+When scheduled Inngest functions are enabled for the install and `PlatformConfig["self_upgrade"].enabled` is true, the `ops/self-upgrade-scheduled` function runs hourly. Each run checks the configured target branch, skips when the install is disabled, outside its maintenance window, already up to date, missing a target, or already running an upgrade, and otherwise runs the same quiescence, promotion, health, and rollback path used by manual self-upgrade requests.
+
+The manual operation uses the `ops/self-upgrade.run` event and the same runner. This path answers "can the running portal upgrade itself under governed operations controls?" The shared-workspace banner answers "does the local install workspace need to merge newer platform source?"
 
 ## Production, Development, And Validation Data
 


### PR DESCRIPTION
## Summary
- document how the shared-workspace update banner is set and cleared
- clarify that the banner is separate from the governed `/ops/self-upgrade` runner
- update the cloud Single VM guide from legacy `portal/self-upgrade-*` names to the current `ops/self-upgrade-*` flow

## Verification
- `git diff --check`
- `pnpm --filter web test -- --run lib/queue/functions/self-upgrade.test.ts lib/queue/functions/index.test.ts` (38 passed)
- `pnpm --filter web build` (exit 0; existing Edge Runtime warnings remain)