### PR TITLE
fix: tolerate legacy build plan graph entries

### DIFF
--- a/apps/web/lib/integrate/task-dependency-graph.test.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.test.ts
@@ -123,4 +123,29 @@ describe("buildDependencyGraph", () => {
     // QA phase is always appended last.
     expect(phases[phases.length - 1]?.tasks[0]?.specialist).toBe("qa-engineer");
   });
+
+  it("does not throw when legacy file entries omit purpose", () => {
+    // Regression: PR-generated buildPlan JSON can store fileStructure entries
+    // as `{ path, change }`. The graph should tolerate that legacy shape
+    // instead of crashing /build while matching task keywords.
+    const files = [
+      {
+        path: "apps/web/lib/feedback/feedback-event.ts",
+        change: "Restrict trigger vocabulary to spec section 6.1.",
+      },
+    ] as unknown as PlanFileEntry[];
+    const tasks: PlanTask[] = [
+      {
+        title: "Align feedback event contract",
+        testFirst: "",
+        implement: "",
+        verify: "",
+      },
+    ];
+
+    expect(() => buildDependencyGraph(files, tasks)).not.toThrow();
+
+    const phases = buildDependencyGraph(files, tasks);
+    expect(phases[0]?.tasks[0]?.files[0]?.path).toBe("apps/web/lib/feedback/feedback-event.ts");
+  });
 });

--- a/apps/web/lib/integrate/task-dependency-graph.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.ts
@@ -31,6 +31,37 @@ export type ExecutionPhase = {
   tasks: AssignedTask[];
 };
 
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizePlanFileEntry(value: unknown): PlanFileEntry | null {
+  if (value === null || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const path = stringField(row.path).trim();
+  if (!path) return null;
+
+  const action = row.action === "create" || row.action === "modify"
+    ? row.action
+    : "modify";
+  const purpose = stringField(row.purpose).trim() || stringField(row.change).trim();
+
+  return { path, action, purpose };
+}
+
+function normalizePlanTask(value: unknown, index: number): PlanTask | null {
+  if (value === null || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const title = stringField(row.title).trim() || `Task ${index + 1}`;
+
+  return {
+    title,
+    testFirst: stringField(row.testFirst),
+    implement: stringField(row.implement) || stringField(row.change),
+    verify: stringField(row.verify) || stringField(row.acceptanceCriterion),
+  };
+}
+
 // --- Specialist Assignment ---------------------------------------------------
 
 const SCHEMA_PATTERNS = [/packages\/db\/prisma\//i, /\.prisma$/i, /migration/i];
@@ -116,15 +147,24 @@ export function buildDependencyGraph(
   files: PlanFileEntry[] | null | undefined,
   tasks: PlanTask[],
 ): ExecutionPhase[] {
-  // Tolerate missing fileStructure — the BuildPlanDoc type says required,
-  // but the Prisma JSON column does not enforce shape and some legacy /
-  // partially-written plans store only `tasks`. Without this guard the
-  // client-side process graph crashes the entire /build page when a user
-  // selects a build whose stored buildPlan lacks `fileStructure`.
-  const safeFiles = Array.isArray(files) ? files : [];
+  // Tolerate partial/legacy JSON shapes. BuildPlanDoc is stricter than the
+  // Prisma JSON column, and stored plans can contain `{ path, change }` file
+  // entries or task rows without every optional planning field.
+  const safeFiles = Array.isArray(files)
+    ? files.flatMap((file) => {
+        const normalized = normalizePlanFileEntry(file);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  const safeTasks = Array.isArray(tasks)
+    ? tasks.flatMap((task, index) => {
+        const normalized = normalizePlanTask(task, index);
+        return normalized ? [normalized] : [];
+      })
+    : [];
 
   // Assign specialists to tasks
-  const assigned = tasks.map((task, i) => assignSpecialist(task, i, safeFiles));
+  const assigned = safeTasks.map((task, i) => assignSpecialist(task, i, safeFiles));
 
   // Group by priority level
   const byPriority = new Map<number, AssignedTask[]>();


### PR DESCRIPTION
## Summary
- Normalize legacy Build Studio plan graph JSON before assigning task dependencies.
- Accept stored `fileStructure` entries shaped as `{ path, change }` by falling back from missing `purpose` to `change`.
- Add a regression test for legacy file entries so `/build` does not crash when existing FeatureBuild rows contain older plan shapes.

## Root Cause
The installed portal was already serving the latest `origin/main`, but `/build` crashed in the client process graph when a stored `buildPlan.fileStructure` row omitted `purpose`. Live data includes PR-generated entries with `path` and `change`; the graph called `toLowerCase()` on the missing `purpose` field while matching task keywords.

## Verification
- `pnpm --filter web exec vitest run lib/integrate/task-dependency-graph.test.ts` — 8 passed.
- `pnpm --filter web typecheck` — passed.
- `scripts/redeploy-portal.ps1 -ComposeEnvFile D:\DPF\.env` — production Docker build and portal redeploy passed from commit `406fb3b29fc55aaa3acf4d4971c7afb6d6ccf04f`.
- Browser check: `http://127.0.0.1:3000/build` renders Build Studio, with no `Cannot read properties of undefined (reading 'toLowerCase')` error.
- Fresh `docker logs dpf-portal-1 --since 3m` check found no matching `toLowerCase`, `Cannot read properties`, or `TypeError` entries after the `/build` visit.
