### PR TITLE
fix(customer): centralize CRM status presentation

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { EditCustomerConfigurationItemButton } from "@/components/customer/EditCustomerConfigurationItemButton";
 import { NewCustomerConfigurationItemButton } from "@/components/customer/NewCustomerConfigurationItemButton";
 import { CustomerLifecycleReviewQueues } from "@/components/customer/CustomerLifecycleReviewQueues";
@@ -13,16 +14,7 @@ import {
   deriveCustomerConfigurationItemDefaults,
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
-
-const STATUS_COLOURS: Record<string, string> = {
-  prospect: "#fbbf24",
-  qualified: "#fb923c",
-  onboarding: "#38bdf8",
-  active: "#4ade80",
-  at_risk: "#ef4444",
-  suspended: "#8888a0",
-  closed: "#555566",
-};
+import { getAccountStatusMeta } from "@/lib/crm/presentation";
 
 const ACTIVITY_ICONS: Record<string, string> = {
   note: "📝",
@@ -171,7 +163,7 @@ export default async function AccountDetailPage({
 
   if (!account) notFound();
 
-  const statusColour = STATUS_COLOURS[account.status] ?? "#8888a0";
+  const statusMeta = getAccountStatusMeta(account.status);
   const managedItemDefaults = deriveCustomerConfigurationItemDefaults(
     readActivationProfile(storefrontConfig?.archetype?.activationProfile),
   );
@@ -205,12 +197,7 @@ export default async function AccountDetailPage({
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{account.name}</h1>
-          <span
-            className="text-[9px] px-1.5 py-0.5 rounded-full"
-            style={{ background: `${statusColour}20`, color: statusColour }}
-          >
-            {account.status}
-          </span>
+          <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
         </div>
         <p className="text-[10px] font-mono text-[var(--dpf-muted)]">
           {account.accountId}
@@ -333,14 +320,18 @@ export default async function AccountDetailPage({
                   )}
                   <div className="flex gap-1 mt-1">
                     {!c.isActive && (
-                      <span className="text-[8px] px-1 py-0.5 rounded-full bg-red-900/30 text-red-400">
-                        inactive
-                      </span>
+                      <CustomerStatusBadge
+                        label="Inactive"
+                        tone="warning"
+                        className="text-[8px]"
+                      />
                     )}
                     {c.doNotContact && (
-                      <span className="text-[8px] px-1 py-0.5 rounded-full bg-yellow-900/30 text-yellow-400">
-                        do not contact
-                      </span>
+                      <CustomerStatusBadge
+                        label="Do not contact"
+                        tone="danger"
+                        className="text-[8px]"
+                      />
                     )}
                   </div>
                 </div>

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
@@ -2,15 +2,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
-
-const STAGE_COLOURS: Record<string, string> = {
-  qualification: "#fbbf24",
-  discovery: "#fb923c",
-  proposal: "#38bdf8",
-  negotiation: "#a78bfa",
-  closed_won: "#4ade80",
-  closed_lost: "#ef4444",
-};
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { getOpportunityStageMeta, getQuoteStatusMeta } from "@/lib/crm/presentation";
 
 const ACTIVITY_ICONS: Record<string, string> = {
   note: "📝", call: "📞", email: "📧", meeting: "📅", task: "☑️",
@@ -49,7 +42,7 @@ export default async function OpportunityDetailPage({
 
   if (!opportunity) notFound();
 
-  const stageColour = STAGE_COLOURS[opportunity.stage] ?? "#8888a0";
+  const stageMeta = getOpportunityStageMeta(opportunity.stage);
   const isClosed = opportunity.stage === "closed_won" || opportunity.stage === "closed_lost";
 
   return (
@@ -67,16 +60,9 @@ export default async function OpportunityDetailPage({
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{opportunity.title}</h1>
-          <span
-            className="text-[9px] px-1.5 py-0.5 rounded-full"
-            style={{ background: `${stageColour}20`, color: stageColour }}
-          >
-            {opportunity.stage.replace("_", " ")}
-          </span>
+          <CustomerStatusBadge label={stageMeta.label} tone={stageMeta.tone} />
           {opportunity.isDormant && (
-            <span className="text-[8px] px-1 py-0.5 rounded-full bg-red-900/30 text-red-400">
-              dormant
-            </span>
+            <CustomerStatusBadge label="Dormant" tone="warning" className="text-[8px]" />
           )}
         </div>
         <p className="text-[10px] font-mono text-[var(--dpf-muted)]">
@@ -164,7 +150,7 @@ export default async function OpportunityDetailPage({
             ) : (
               <div className="space-y-2">
                 {quotes.map((q) => {
-                  const qColor = q.status === "accepted" ? "#4ade80" : q.status === "sent" ? "#38bdf8" : "#8888a0";
+                  const quoteMeta = getQuoteStatusMeta(q.status);
                   return (
                     <Link
                       key={q.id}
@@ -173,12 +159,7 @@ export default async function OpportunityDetailPage({
                     >
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-mono text-[var(--dpf-text)]">{q.quoteNumber}</span>
-                        <span
-                          className="text-[9px] px-1.5 py-0.5 rounded-full"
-                          style={{ background: `${qColor}20`, color: qColor }}
-                        >
-                          {q.status}
-                        </span>
+                        <CustomerStatusBadge label={quoteMeta.label} tone={quoteMeta.tone} />
                       </div>
                       <p className="text-[10px] font-mono text-[var(--dpf-text)] mt-1">
                         {q.currency} {Number(q.totalAmount).toLocaleString()}
@@ -214,7 +195,7 @@ export default async function OpportunityDetailPage({
               <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-2">
                 Lost Reason
               </h2>
-              <p className="text-xs text-red-400">{opportunity.lostReason}</p>
+              <p className="text-xs text-[var(--dpf-text)]">{opportunity.lostReason}</p>
             </div>
           )}
 

--- a/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
@@ -1,15 +1,8 @@
 // apps/web/app/(shell)/customer/quotes/page.tsx
 import Link from "next/link";
 import { prisma } from "@dpf/db";
-
-const STATUS_COLOURS: Record<string, string> = {
-  draft: "#8888a0",
-  sent: "#38bdf8",
-  accepted: "#4ade80",
-  rejected: "#ef4444",
-  expired: "#fbbf24",
-  superseded: "#555566",
-};
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { CRM_TONE_CLASSES, getQuoteStatusMeta } from "@/lib/crm/presentation";
 
 export default async function QuotesPage() {
   const quotes = await prisma.quote.findMany({
@@ -33,13 +26,16 @@ export default async function QuotesPage() {
 
       <div className="space-y-2">
         {quotes.map((q) => {
-          const color = STATUS_COLOURS[q.status] ?? "#8888a0";
+          const statusMeta = getQuoteStatusMeta(q.status);
+          const toneClasses = CRM_TONE_CLASSES[statusMeta.tone];
           return (
             <Link
               key={q.id}
               href={`/customer/quotes/${q.id}`}
-              className="block p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 hover:bg-[var(--dpf-surface-2)] transition-colors"
-              style={{ borderLeftColor: color }}
+              className={[
+                "block rounded-lg border-l-4 bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]",
+                toneClasses.border,
+              ].join(" ")}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
@@ -48,12 +44,7 @@ export default async function QuotesPage() {
                       {q.quoteNumber}
                     </p>
                     <span className="text-[9px] text-[var(--dpf-muted)]">v{q.version}</span>
-                    <span
-                      className="text-[9px] px-1.5 py-0.5 rounded-full"
-                      style={{ background: `${color}20`, color }}
-                    >
-                      {q.status}
-                    </span>
+                    <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
                   </div>
                   <p className="text-xs text-[var(--dpf-muted)]">
                     {q.account.name} · {q.opportunity.title}

--- a/apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx
@@ -1,13 +1,8 @@
 // apps/web/app/(shell)/customer/sales-orders/page.tsx
 import Link from "next/link";
 import { prisma } from "@dpf/db";
-
-const STATUS_COLOURS: Record<string, string> = {
-  confirmed: "#38bdf8",
-  in_progress: "#fbbf24",
-  fulfilled: "#4ade80",
-  cancelled: "#ef4444",
-};
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { CRM_TONE_CLASSES, getSalesOrderStatusMeta } from "@/lib/crm/presentation";
 
 export default async function SalesOrdersPage() {
   const orders = await prisma.salesOrder.findMany({
@@ -29,24 +24,22 @@ export default async function SalesOrdersPage() {
 
       <div className="space-y-2">
         {orders.map((o) => {
-          const color = STATUS_COLOURS[o.status] ?? "#8888a0";
+          const statusMeta = getSalesOrderStatusMeta(o.status);
+          const toneClasses = CRM_TONE_CLASSES[statusMeta.tone];
           return (
             <div
               key={o.id}
-              className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 flex items-center justify-between"
-              style={{ borderLeftColor: color }}
+              className={[
+                "flex items-center justify-between rounded-lg border-l-4 bg-[var(--dpf-surface-1)] p-4",
+                toneClasses.border,
+              ].join(" ")}
             >
               <div>
                 <div className="flex items-center gap-2 mb-1">
                   <p className="text-xs font-mono font-semibold text-[var(--dpf-text)]">
                     {o.orderRef}
                   </p>
-                  <span
-                    className="text-[9px] px-1.5 py-0.5 rounded-full"
-                    style={{ background: `${color}20`, color }}
-                  >
-                    {o.status.replace("_", " ")}
-                  </span>
+                  <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
                 </div>
                 <p className="text-xs text-[var(--dpf-muted)]">
                   <Link href={`/customer/${o.account.id}`} className="hover:text-[var(--dpf-text)]">

--- a/apps/web/lib/crm/presentation.test.ts
+++ b/apps/web/lib/crm/presentation.test.ts
@@ -5,6 +5,8 @@ import {
   getAccountStatusMeta,
   getEngagementStatusMeta,
   getOpportunityStageMeta,
+  getQuoteStatusMeta,
+  getSalesOrderStatusMeta,
   isOpenOpportunityStage,
   OPEN_OPPORTUNITY_STAGES,
 } from "./presentation";
@@ -46,6 +48,44 @@ describe("CRM presentation metadata", () => {
     });
     expect(getOpportunityStageMeta("custom_stage")).toMatchObject({
       label: "Custom stage",
+      tone: "neutral",
+    });
+  });
+
+  it("returns quote status metadata for quote list and opportunity detail badges", () => {
+    expect(getQuoteStatusMeta("sent")).toMatchObject({
+      label: "Sent",
+      tone: "info",
+    });
+    expect(getQuoteStatusMeta("accepted")).toMatchObject({
+      label: "Accepted",
+      tone: "success",
+    });
+    expect(getQuoteStatusMeta("rejected")).toMatchObject({
+      label: "Rejected",
+      tone: "danger",
+    });
+    expect(getQuoteStatusMeta("custom_quote_state")).toMatchObject({
+      label: "Custom quote state",
+      tone: "neutral",
+    });
+  });
+
+  it("returns sales order status metadata for order badges", () => {
+    expect(getSalesOrderStatusMeta("confirmed")).toMatchObject({
+      label: "Confirmed",
+      tone: "info",
+    });
+    expect(getSalesOrderStatusMeta("in_progress")).toMatchObject({
+      label: "In progress",
+      tone: "warning",
+    });
+    expect(getSalesOrderStatusMeta("fulfilled")).toMatchObject({
+      label: "Fulfilled",
+      tone: "success",
+    });
+    expect(getSalesOrderStatusMeta("unknown_order_state")).toMatchObject({
+      label: "Unknown order state",
       tone: "neutral",
     });
   });

--- a/apps/web/lib/crm/presentation.ts
+++ b/apps/web/lib/crm/presentation.ts
@@ -101,6 +101,22 @@ const OPPORTUNITY_STAGE_META: Record<string, CrmPresentationMeta> = {
   closed_lost: { label: "Lost", tone: "danger" },
 };
 
+const QUOTE_STATUS_META: Record<string, CrmPresentationMeta> = {
+  draft: { label: "Draft", tone: "neutral" },
+  sent: { label: "Sent", tone: "info" },
+  accepted: { label: "Accepted", tone: "success" },
+  rejected: { label: "Rejected", tone: "danger" },
+  expired: { label: "Expired", tone: "warning" },
+  superseded: { label: "Superseded", tone: "neutral" },
+};
+
+const SALES_ORDER_STATUS_META: Record<string, CrmPresentationMeta> = {
+  confirmed: { label: "Confirmed", tone: "info" },
+  in_progress: { label: "In progress", tone: "warning" },
+  fulfilled: { label: "Fulfilled", tone: "success" },
+  cancelled: { label: "Cancelled", tone: "danger" },
+};
+
 export function formatCrmStatusLabel(value: string): string {
   const normalized = value.replace(/[_-]+/g, " ").trim();
   if (!normalized) {
@@ -126,6 +142,14 @@ export function getEngagementStatusMeta(status: string): CrmPresentationMeta {
 
 export function getOpportunityStageMeta(stage: string): CrmPresentationMeta {
   return OPPORTUNITY_STAGE_META[stage] ?? fallbackMeta(stage);
+}
+
+export function getQuoteStatusMeta(status: string): CrmPresentationMeta {
+  return QUOTE_STATUS_META[status] ?? fallbackMeta(status);
+}
+
+export function getSalesOrderStatusMeta(status: string): CrmPresentationMeta {
+  return SALES_ORDER_STATUS_META[status] ?? fallbackMeta(status);
 }
 
 export function isOpenOpportunityStage(stage: string): stage is OpenOpportunityStage {

--- a/packages/db/prisma/migrations/20260526193000_drop_stale_customer_search_triggers/migration.sql
+++ b/packages/db/prisma/migrations/20260526193000_drop_stale_customer_search_triggers/migration.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS trg_customer_contact_search ON "CustomerContact";
+DROP TRIGGER IF EXISTS trg_customer_account_search ON "CustomerAccount";
+
+DROP FUNCTION IF EXISTS customer_contact_search_update();
+DROP FUNCTION IF EXISTS customer_account_search_update();


### PR DESCRIPTION
## Summary
- Link CRM and marketing operations Slice 1b to `EP-CRM-MKT-OPS` / `BI-6B2F4CB2`.
- Refactor account, opportunity, quote, and sales-order status badges onto shared CRM presentation metadata and `CustomerStatusBadge`.
- Add quote and sales-order status metadata coverage.
- Add a migration that drops stale customer `searchVector` triggers/functions left behind by the earlier CRM migration.

## Verification
- `pnpm --filter web exec vitest run lib/crm/presentation.test.ts components/customer/CustomerStatusBadge.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passes; existing Edge Runtime warnings remain unrelated)
- `pnpm --filter @dpf/db exec prisma migrate deploy` against dev Postgres
- Playwright UX refresh against built app on `http://127.0.0.1:3001` for `/customer`, account detail, quotes, sales orders, and opportunity detail routes