### PR TITLE
Show business capability provenance

### DIFF
--- a/apps/web/app/(shell)/portfolio/architecture/page.tsx
+++ b/apps/web/app/(shell)/portfolio/architecture/page.tsx
@@ -32,7 +32,7 @@ export default async function PortfolioArchitecturePage() {
         </div>
       </header>
 
-      <BusinessCapabilityMap mapRows={data.mapRows} summary={data.summary} />
+      <BusinessCapabilityMap mapRows={data.mapRows} summary={data.summary} provenance={data.provenance} />
 
       <details className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
         <summary className="cursor-pointer text-sm font-semibold text-[var(--dpf-text)]">

--- a/apps/web/components/portfolio/architecture/BusinessCapabilityMap.test.tsx
+++ b/apps/web/components/portfolio/architecture/BusinessCapabilityMap.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BusinessCapabilityMap } from "./BusinessCapabilityMap";
+
+const summary = {
+  totalCapabilities: 0,
+  l1Count: 0,
+  l2Count: 0,
+  l3Count: 0,
+  gapCount: 0,
+  watchCount: 0,
+  alignedCount: 0,
+};
+
+describe("BusinessCapabilityMap", () => {
+  it("renders the read-only archetype capability perspective provenance", () => {
+    render(
+      <BusinessCapabilityMap
+        mapRows={[]}
+        summary={summary}
+        provenance={{
+          activePerspectiveLabel: "Common Small Business + IT Managed Services",
+          archetypeId: "it-managed-services",
+          archetypeLabel: "IT Managed Services",
+          category: "professional-services",
+          projectionStatus: "seed-projected",
+          seedCapabilityCount: 27,
+          sourcePerspectiveIds: ["common-small-business", "it-managed-services"],
+          sources: [
+            {
+              perspectiveId: "common-small-business",
+              label: "Common Small Business",
+              source: "DPF baseline informed by APQC-style process families",
+            },
+            {
+              perspectiveId: "it-managed-services",
+              label: "IT Managed Services",
+              source: "DPF MSP overlay informed by managed services",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Capability perspective")).toBeVisible();
+    expect(screen.getByText("Common Small Business + IT Managed Services")).toBeVisible();
+    expect(screen.getByText(/IT Managed Services archetype/i)).toBeVisible();
+    expect(screen.getByText(/27 projected capabilities/i)).toBeVisible();
+    expect(screen.queryByRole("button", { name: /perspective/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/portfolio/architecture/BusinessCapabilityMap.tsx
+++ b/apps/web/components/portfolio/architecture/BusinessCapabilityMap.tsx
@@ -1,23 +1,82 @@
 import { BusinessCapabilityMapClient } from "@/components/portfolio/architecture/BusinessCapabilityMapClient";
 import type { BusinessCapabilitySummary } from "@/lib/business-capabilities/data";
-import type { BusinessCapabilityMapRow } from "@/lib/business-capabilities/view-model";
+import type { BusinessCapabilityProvenance } from "@/lib/business-capabilities/provenance";
+import type {
+  BusinessCapabilityMapRow,
+} from "@/lib/business-capabilities/view-model";
 
 type Props = {
   mapRows: BusinessCapabilityMapRow[];
   summary: BusinessCapabilitySummary;
+  provenance: BusinessCapabilityProvenance;
 };
 
-export function BusinessCapabilityMap({ mapRows, summary }: Props) {
-  if (mapRows.length === 0) {
-    return (
-      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
-        <p className="text-sm font-medium text-[var(--dpf-text)]">No business capabilities yet.</p>
-        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-          Add an L1 family, then add L2 capabilities beneath it.
-        </p>
-      </section>
-    );
-  }
+export function BusinessCapabilityMap({ mapRows, summary, provenance }: Props) {
+  return (
+    <section className="space-y-4">
+      <CapabilityPerspectiveBadge provenance={provenance} />
 
-  return <BusinessCapabilityMapClient mapRows={mapRows} summary={summary} />;
+      {mapRows.length === 0 ? (
+        <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
+          <p className="text-sm font-medium text-[var(--dpf-text)]">No business capabilities yet.</p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Add an L1 family, then add L2 capabilities beneath it.
+          </p>
+        </section>
+      ) : (
+        <BusinessCapabilityMapClient mapRows={mapRows} summary={summary} />
+      )}
+    </section>
+  );
+}
+
+function CapabilityPerspectiveBadge({ provenance }: { provenance: BusinessCapabilityProvenance }) {
+  const archetypeText = provenance.archetypeLabel
+    ? `${provenance.archetypeLabel} archetype`
+    : "No selected archetype";
+  const countText =
+    provenance.seedCapabilityCount === 1
+      ? "1 projected capability"
+      : `${provenance.seedCapabilityCount} projected capabilities`;
+
+  return (
+    <section
+      aria-label="Capability perspective provenance"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-[var(--dpf-muted)]">
+            Capability perspective
+          </p>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+            {provenance.activePerspectiveLabel}
+          </h2>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            {archetypeText}
+            {provenance.category ? ` · ${provenance.category}` : ""}
+            {" · "}
+            {countText}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {provenance.sources.map((source) => (
+            <span
+              key={source.perspectiveId}
+              title={source.source}
+              className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1 text-xs text-[var(--dpf-text)]"
+            >
+              {source.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {provenance.projectionStatus === "manual-or-empty" ? (
+        <p className="mt-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-xs text-[var(--dpf-muted)]">
+          No seed-projected capabilities are active yet; existing manual capability rows remain visible.
+        </p>
+      ) : null}
+    </section>
+  );
 }

--- a/apps/web/lib/business-capabilities/data.test.ts
+++ b/apps/web/lib/business-capabilities/data.test.ts
@@ -12,6 +12,7 @@ import {
   buildCapabilityMapRows,
   deriveCapabilityOverlayState,
 } from "./view-model";
+import { buildCapabilityProvenance } from "./provenance";
 
 const rows: BusinessCapabilityRecord[] = [
   {
@@ -189,5 +190,29 @@ describe("business capability map data helpers", () => {
 
     expect(buildCapabilityMapRows(tree)).toEqual([{ id: "row-1", families: tree }]);
     expect(buildCapabilityMapRows([])).toEqual([]);
+  });
+
+  it("describes the active archetype capability perspective provenance", () => {
+    const seededRows = rows.map((row, index) => ({
+      ...row,
+      capabilityId: index === 0 ? "BCAP-SEED-setup" : row.capabilityId,
+    }));
+
+    const provenance = buildCapabilityProvenance({
+      archetype: {
+        archetypeId: "it-managed-services",
+        category: "professional-services",
+        name: "IT Managed Services",
+      },
+      records: seededRows,
+    });
+
+    expect(provenance.activePerspectiveLabel).toBe("Common Small Business + IT Managed Services");
+    expect(provenance.seedCapabilityCount).toBe(1);
+    expect(provenance.projectionStatus).toBe("seed-projected");
+    expect(provenance.sources.map((source) => source.perspectiveId)).toEqual([
+      "common-small-business",
+      "it-managed-services",
+    ]);
   });
 });

--- a/apps/web/lib/business-capabilities/data.ts
+++ b/apps/web/lib/business-capabilities/data.ts
@@ -7,6 +7,7 @@ import {
   type CapabilityMaturityBand,
   type TraceTargetType,
 } from "./types";
+import { buildCapabilityProvenance } from "./provenance";
 import { buildCapabilityMapRows } from "./view-model";
 
 export type BusinessCapabilityTraceRecord = {
@@ -222,7 +223,7 @@ function toTraceRecord(link: {
 }
 
 export async function getBusinessCapabilityMapData() {
-  const [capabilities, taxonomyNodes, digitalProducts, backlogItems, eaElements] = await Promise.all([
+  const [capabilities, taxonomyNodes, digitalProducts, backlogItems, eaElements, storefront] = await Promise.all([
     prisma.businessCapability.findMany({
       where: { status: "active" },
       orderBy: [{ level: "asc" }, { sortOrder: "asc" }, { name: "asc" }],
@@ -259,6 +260,14 @@ export async function getBusinessCapabilityMapData() {
       take: 200,
       select: { id: true, name: true, elementType: { select: { name: true } } },
     }),
+    prisma.storefrontConfig.findFirst({
+      select: {
+        archetype: {
+          select: { archetypeId: true, category: true, name: true },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    }),
   ]);
 
   const records: BusinessCapabilityRecord[] = capabilities.map((capability) => ({
@@ -284,6 +293,10 @@ export async function getBusinessCapabilityMapData() {
     tree,
     mapRows: buildCapabilityMapRows(tree),
     summary: summarizeCapabilityMap(records),
+    provenance: buildCapabilityProvenance({
+      archetype: storefront?.archetype ?? null,
+      records,
+    }),
     targetOptions: {
       taxonomyNodes: taxonomyNodes.map((node) => ({ id: node.id, label: `${node.name} (${node.nodeId})` })),
       digitalProducts: digitalProducts.map((product) => ({ id: product.id, label: `${product.name} (${product.productId})` })),

--- a/apps/web/lib/business-capabilities/provenance.ts
+++ b/apps/web/lib/business-capabilities/provenance.ts
@@ -1,0 +1,51 @@
+import {
+  BUSINESS_CAPABILITY_SEED_PREFIX,
+  resolveBusinessCapabilityPerspective,
+  type BusinessCapabilityPerspectiveSource,
+} from "@dpf/db/business-capability-perspectives";
+
+import type { BusinessCapabilityRecord } from "./data";
+
+export type BusinessCapabilityArchetypeContext = {
+  archetypeId: string;
+  category: string;
+  name: string;
+};
+
+export type BusinessCapabilityProvenance = {
+  activePerspectiveLabel: string;
+  sourcePerspectiveIds: string[];
+  sources: BusinessCapabilityPerspectiveSource[];
+  archetypeId: string | null;
+  archetypeLabel: string | null;
+  category: string | null;
+  projectionStatus: "seed-projected" | "manual-or-empty";
+  seedCapabilityCount: number;
+};
+
+export function buildCapabilityProvenance({
+  archetype,
+  records,
+}: {
+  archetype: BusinessCapabilityArchetypeContext | null;
+  records: BusinessCapabilityRecord[];
+}): BusinessCapabilityProvenance {
+  const resolved = resolveBusinessCapabilityPerspective({
+    archetypeId: archetype?.archetypeId ?? null,
+    category: archetype?.category ?? null,
+  });
+  const seedCapabilityCount = records.filter((record) =>
+    record.capabilityId.startsWith(BUSINESS_CAPABILITY_SEED_PREFIX),
+  ).length;
+
+  return {
+    activePerspectiveLabel: resolved.sources.map((source) => source.label).join(" + "),
+    sourcePerspectiveIds: resolved.sourcePerspectiveIds,
+    sources: resolved.sources,
+    archetypeId: archetype?.archetypeId ?? null,
+    archetypeLabel: archetype?.name ?? null,
+    category: archetype?.category ?? null,
+    projectionStatus: seedCapabilityCount > 0 ? "seed-projected" : "manual-or-empty",
+    seedCapabilityCount,
+  };
+}

--- a/packages/db/src/business-capability-perspectives.ts
+++ b/packages/db/src/business-capability-perspectives.ts
@@ -84,8 +84,14 @@ type BusinessCapabilityPerspective = {
   capabilities: BusinessCapabilitySeedDefinition[];
 };
 
+export type BusinessCapabilityPerspectiveSource = Pick<
+  BusinessCapabilityPerspective,
+  "perspectiveId" | "label" | "source"
+>;
+
 export type ResolvedBusinessCapabilityPerspective = {
   sourcePerspectiveIds: string[];
+  sources: BusinessCapabilityPerspectiveSource[];
   capabilities: BusinessCapabilitySeedDefinition[];
 };
 
@@ -211,6 +217,11 @@ export function resolveBusinessCapabilityPerspective(
 
   return {
     sourcePerspectiveIds: perspectives.map((perspective) => perspective.perspectiveId),
+    sources: perspectives.map((perspective) => ({
+      perspectiveId: perspective.perspectiveId,
+      label: perspective.label,
+      source: perspective.source,
+    })),
     capabilities: dedupeCapabilities(perspectives.flatMap((perspective) => perspective.capabilities)),
   };
 }

--- a/packages/db/test/business-capability-perspectives.test.ts
+++ b/packages/db/test/business-capability-perspectives.test.ts
@@ -17,9 +17,15 @@ describe("business capability perspectives", () => {
     });
 
     expect(msp.sourcePerspectiveIds).toEqual(["common-small-business", "it-managed-services"]);
+    expect(msp.sources.map((source) => source.label)).toEqual(["Common Small Business", "IT Managed Services"]);
+    expect(msp.sources.map((source) => source.source)).toEqual([
+      "DPF baseline informed by APQC-style process families",
+      "DPF MSP overlay informed by managed services, customer estate, NIST CSF, and service-agreement operating patterns",
+    ]);
     expect(msp.capabilities.some((capability) => capability.key === "msp-managed-customer-estate")).toBe(true);
     expect(msp.capabilities.some((capability) => capability.key === "finance")).toBe(true);
     expect(salon.sourcePerspectiveIds).toEqual(["common-small-business"]);
+    expect(salon.sources.map((source) => source.label)).toEqual(["Common Small Business"]);
     expect(salon.capabilities.some((capability) => capability.key === "msp-managed-customer-estate")).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- add readable source metadata to the archetype business capability perspective resolver
- derive `/portfolio/architecture` provenance from the selected storefront archetype and active seed-projected capability rows
- render a read-only capability perspective badge above the Business Capability Map, including tests for resolver metadata, provenance, and the UI badge

## Validation
- `pnpm --filter @dpf/db test -- business-capability-perspectives`
- `pnpm --filter web test -- business-capabilities/data BusinessCapabilityMap`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passed on rerun; one prior Windows build worker exit `3221225477` was not reproducible, existing Edge-runtime warnings remain)

## UX note
- Verified the visible badge through jsdom component coverage rather than starting another local server/worktree runtime.