### PR TITLE
feat(customer): add pipeline stage inspector

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
@@ -3,6 +3,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { PipelineStageInspector } from "@/components/customer/PipelineStageInspector";
+import { updateOpportunityStageFromForm } from "@/lib/actions/crm";
+import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
 import { getOpportunityStageMeta, getQuoteStatusMeta } from "@/lib/crm/presentation";
 
 const ACTIVITY_ICONS: Record<string, string> = {
@@ -17,7 +20,7 @@ export default async function OpportunityDetailPage({
 }) {
   const { id } = await params;
 
-  const [opportunity, quotes] = await Promise.all([
+  const [opportunity, quotes, inspector] = await Promise.all([
     prisma.opportunity.findUnique({
       where: { id },
       include: {
@@ -38,9 +41,10 @@ export default async function OpportunityDetailPage({
         totalAmount: true, currency: true, sentAt: true, acceptedAt: true,
       },
     }),
+    getPipelineInspectorView(id),
   ]);
 
-  if (!opportunity) notFound();
+  if (!opportunity || !inspector) notFound();
 
   const stageMeta = getOpportunityStageMeta(opportunity.stage);
   const isClosed = opportunity.stage === "closed_won" || opportunity.stage === "closed_lost";
@@ -69,6 +73,13 @@ export default async function OpportunityDetailPage({
           {opportunity.opportunityId}
         </p>
       </div>
+
+      <PipelineStageInspector
+        inspector={inspector}
+        showFullDetailLink={false}
+        stageFormAction={updateOpportunityStageFromForm}
+        className="mb-6"
+      />
 
       {/* Metadata */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
@@ -2,14 +2,23 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { PipelineStageInspector } from "@/components/customer/PipelineStageInspector";
+import { updateOpportunityStageFromForm } from "@/lib/actions/crm";
 import {
   CRM_TONE_CLASSES,
   getOpportunityStageMeta,
   OPEN_OPPORTUNITY_STAGES,
 } from "@/lib/crm/presentation";
+import { getStageAgeDays } from "@/lib/crm/pipeline-inspector";
+import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 
-export default async function OpportunitiesPage() {
+type OpportunitiesPageProps = {
+  searchParams?: Promise<{ opportunity?: string }>;
+};
+
+export default async function OpportunitiesPage({ searchParams }: OpportunitiesPageProps) {
+  const requestedOpportunityId = (await searchParams)?.opportunity;
   const opportunities = await prisma.opportunity.findMany({
     orderBy: { createdAt: "desc" },
     include: {
@@ -19,7 +28,6 @@ export default async function OpportunitiesPage() {
     },
   });
 
-  // Group by stage for Kanban
   const byStage: Record<string, typeof opportunities> = {};
   for (const stage of OPEN_OPPORTUNITY_STAGES) {
     byStage[stage] = [];
@@ -29,10 +37,14 @@ export default async function OpportunitiesPage() {
     byStage[opp.stage]!.push(opp);
   }
 
-  // Pipeline metrics
   const openOpps = opportunities.filter((o) =>
     OPEN_OPPORTUNITY_STAGES.includes(o.stage as (typeof OPEN_OPPORTUNITY_STAGES)[number]),
   );
+  const selectedOpportunityId =
+    requestedOpportunityId && opportunities.some((opp) => opp.id === requestedOpportunityId)
+      ? requestedOpportunityId
+      : openOpps[0]?.id ?? opportunities[0]?.id ?? null;
+  const inspector = await getPipelineInspectorView(selectedOpportunityId);
   const totalPipelineValue = openOpps.reduce(
     (s, o) => s + Number(o.expectedValue ?? 0),
     0,
@@ -47,7 +59,7 @@ export default async function OpportunitiesPage() {
     <div>
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Pipeline</h1>
-        <div className="flex gap-4 mt-1 text-[10px]">
+        <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[10px]">
           <span className="text-[var(--dpf-muted)]">
             {openOpps.length} open opportunit{openOpps.length !== 1 ? "ies" : "y"}
           </span>
@@ -65,105 +77,131 @@ export default async function OpportunitiesPage() {
         </div>
       </div>
 
-      {/* Kanban board — open stages */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-8">
-        {OPEN_OPPORTUNITY_STAGES.map((stage) => {
-          const meta = getOpportunityStageMeta(stage);
-          const toneClasses = CRM_TONE_CLASSES[meta.tone];
-          const opps = byStage[stage] ?? [];
-          const stageValue = opps.reduce(
-            (s, o) => s + Number(o.expectedValue ?? 0),
-            0,
-          );
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
+        <div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {OPEN_OPPORTUNITY_STAGES.map((stage) => {
+              const meta = getOpportunityStageMeta(stage);
+              const toneClasses = CRM_TONE_CLASSES[meta.tone];
+              const opps = byStage[stage] ?? [];
+              const stageValue = opps.reduce(
+                (s, o) => s + Number(o.expectedValue ?? 0),
+                0,
+              );
 
-          return (
-            <div key={stage}>
-              <div
-                className={[
-                  "flex items-center justify-between mb-2 pb-1 border-b-2",
-                  toneClasses.border,
-                ].join(" ")}
-              >
-                <span className="text-xs font-semibold text-[var(--dpf-text)]">
-                  {meta.label}
-                </span>
-                <span className="text-[9px] text-[var(--dpf-muted)]">
-                  {opps.length} · {formatRevenueAmount(stageValue)}
-                </span>
-              </div>
-
-              <div className="space-y-2">
-                {opps.map((opp) => (
-                  <Link
-                    key={opp.id}
-                    href={`/customer/opportunities/${opp.id}`}
-                    className="block p-3 rounded-lg bg-[var(--dpf-surface-1)] hover:bg-[var(--dpf-surface-2)] transition-colors"
+              return (
+                <section key={stage} className="min-w-0">
+                  <div
+                    className={[
+                      "mb-2 flex items-center justify-between border-b-2 pb-1",
+                      toneClasses.border,
+                    ].join(" ")}
                   >
-                    <div className="flex items-start justify-between gap-2 mb-1">
-                      <p className="text-xs font-semibold text-[var(--dpf-text)] leading-tight truncate">
-                        {opp.title}
-                      </p>
-                      {opp.isDormant && (
-                        <CustomerStatusBadge label="Dormant" tone="warning" />
-                      )}
-                    </div>
-                    <p className="text-[9px] text-[var(--dpf-muted)] truncate">
-                      {opp.account.name}
-                    </p>
-                    <div className="flex items-center justify-between mt-1.5">
-                      {opp.expectedValue && (
-                        <span className="text-[10px] font-mono text-[var(--dpf-text)]">
-                          {formatRevenueAmount(Number(opp.expectedValue))}
-                        </span>
-                      )}
-                      <span className="text-[9px] text-[var(--dpf-muted)]">
-                        {opp.probability}%
-                      </span>
-                    </div>
-                  </Link>
-                ))}
+                    <span className="text-xs font-semibold text-[var(--dpf-text)]">
+                      {meta.label}
+                    </span>
+                    <span className="text-[9px] text-[var(--dpf-muted)]">
+                      {opps.length} / {formatRevenueAmount(stageValue)}
+                    </span>
+                  </div>
 
-                {opps.length === 0 && (
-                  <p className="text-[10px] text-[var(--dpf-muted)] text-center py-4">
-                    Empty
-                  </p>
+                  <div className="space-y-2">
+                    {opps.map((opp) => {
+                      const selected = opp.id === selectedOpportunityId;
+                      const stageAgeDays = getStageAgeDays(opp.stageChangedAt);
+                      return (
+                        <Link
+                          key={opp.id}
+                          href={`/customer/opportunities?opportunity=${opp.id}`}
+                          aria-current={selected ? "true" : undefined}
+                          className={[
+                            "block rounded-lg border bg-[var(--dpf-surface-1)] p-3 transition-colors hover:bg-[var(--dpf-surface-2)]",
+                            selected ? "border-[var(--dpf-accent)]" : "border-[var(--dpf-border)]",
+                          ].join(" ")}
+                        >
+                          <div className="mb-1 flex items-start justify-between gap-2">
+                            <p className="min-w-0 truncate text-xs font-semibold leading-tight text-[var(--dpf-text)]">
+                              {opp.title}
+                            </p>
+                            {opp.isDormant && (
+                              <CustomerStatusBadge label="Dormant" tone="warning" />
+                            )}
+                          </div>
+                          <p className="truncate text-[9px] text-[var(--dpf-muted)]">
+                            {opp.account.name}
+                          </p>
+                          <div className="mt-1.5 flex items-center justify-between gap-2">
+                            {opp.expectedValue && (
+                              <span className="truncate text-[10px] font-mono text-[var(--dpf-text)]">
+                                {formatRevenueAmount(Number(opp.expectedValue), opp.currency)}
+                              </span>
+                            )}
+                            <span className="shrink-0 text-[9px] text-[var(--dpf-muted)]">
+                              {opp.probability}% / {stageAgeDays}d
+                            </span>
+                          </div>
+                        </Link>
+                      );
+                    })}
+
+                    {opps.length === 0 && (
+                      <p className="py-4 text-center text-[10px] text-[var(--dpf-muted)]">
+                        Empty
+                      </p>
+                    )}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          {((byStage["closed_won"]?.length ?? 0) > 0 || (byStage["closed_lost"]?.length ?? 0) > 0) && (
+            <section className="mt-8">
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+                Closed
+              </h2>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {[...(byStage["closed_won"] ?? []), ...(byStage["closed_lost"] ?? [])].map(
+                  (opp) => {
+                    const meta = getOpportunityStageMeta(opp.stage);
+                    return (
+                      <Link
+                        key={opp.id}
+                        href={`/customer/opportunities?opportunity=${opp.id}`}
+                        className="flex items-center justify-between rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 transition-colors hover:bg-[var(--dpf-surface-2)]"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate text-xs text-[var(--dpf-text)]">{opp.title}</p>
+                          <p className="truncate text-[9px] text-[var(--dpf-muted)]">
+                            {opp.account.name}
+                          </p>
+                        </div>
+                        <CustomerStatusBadge label={meta.label} tone={meta.tone} />
+                      </Link>
+                    );
+                  },
                 )}
               </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Closed deals */}
-      {((byStage["closed_won"]?.length ?? 0) > 0 || (byStage["closed_lost"]?.length ?? 0) > 0) && (
-        <div>
-          <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-3">
-            Closed
-          </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {[...(byStage["closed_won"] ?? []), ...(byStage["closed_lost"] ?? [])].map(
-              (opp) => {
-                const meta = getOpportunityStageMeta(opp.stage);
-                return (
-                  <Link
-                    key={opp.id}
-                    href={`/customer/opportunities/${opp.id}`}
-                    className="p-3 rounded-lg bg-[var(--dpf-surface-1)] hover:bg-[var(--dpf-surface-2)] transition-colors flex items-center justify-between"
-                  >
-                    <div>
-                      <p className="text-xs text-[var(--dpf-text)]">{opp.title}</p>
-                      <p className="text-[9px] text-[var(--dpf-muted)]">
-                        {opp.account.name}
-                      </p>
-                    </div>
-                    <CustomerStatusBadge label={meta.label} tone={meta.tone} />
-                  </Link>
-                );
-              },
-            )}
-          </div>
+            </section>
+          )}
         </div>
-      )}
+
+        <aside className="xl:sticky xl:top-6 xl:self-start">
+          {inspector ? (
+            <PipelineStageInspector
+              inspector={inspector}
+              stageFormAction={updateOpportunityStageFromForm}
+            />
+          ) : (
+            <section className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+              <p className="text-sm font-medium text-[var(--dpf-text)]">No opportunities yet</p>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                Qualified engagements will appear here when they become pipeline work.
+              </p>
+            </section>
+          )}
+        </aside>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/customer/PipelineStageInspector.test.tsx
+++ b/apps/web/components/customer/PipelineStageInspector.test.tsx
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PipelineStageInspector } from "./PipelineStageInspector";
+import type { PipelineInspectorView } from "@/lib/crm/pipeline-inspector";
+
+const inspector: PipelineInspectorView = {
+  id: "opp-1",
+  opportunityId: "OPP-CODEX-001",
+  title: "Modernize revenue workflow",
+  account: { id: "acct-1", name: "Acme Ops" },
+  contactLabel: "Bea Buyer",
+  stage: "proposal",
+  stageLabel: "Proposal",
+  stageTone: "info",
+  stageAgeDays: 20,
+  stageAgeLabel: "20 days in stage",
+  isStale: true,
+  staleLabel: "Stale stage",
+  probabilityLabel: "70%",
+  expectedValueLabel: "£15,000",
+  expectedCloseLabel: "10 Jun 2026",
+  sourceEngagement: {
+    id: "eng-1",
+    label: "Website pricing inquiry",
+    detail: "Qualified from web inquiry",
+  },
+  latestQuote: {
+    id: "quote-1",
+    quoteNumber: "QUO-2026-0004",
+    statusLabel: "Sent",
+    statusTone: "info",
+    totalLabel: "£15,000",
+  },
+  recentActivities: [
+    {
+      id: "act-1",
+      label: "Sent proposal",
+      detail: "Email / 22 May 2026",
+      body: "Proposal and pricing sent.",
+    },
+  ],
+  stageExitCriteria: [
+    "Quote or proposal sent",
+    "Commercial owner identified",
+    "Budget and timeline confirmed",
+  ],
+  suggestedNextAction: "Follow up on the sent quote and confirm the next buyer commitment.",
+  aiTopics: [
+    {
+      id: "deal-summary",
+      label: "Summarize deal",
+      description: "Review account, activity, quote, and stage context.",
+      prompt: "Summarize this deal.",
+      contextSummary: "OPP-CODEX-001 at Proposal.",
+      expectedNextStep: "A concise deal summary.",
+    },
+    {
+      id: "follow-up-draft",
+      label: "Draft follow-up",
+      description: "Draft the next buyer-facing follow-up for approval.",
+      prompt: "Draft a follow-up.",
+      contextSummary: "Sent quote and latest activity.",
+      expectedNextStep: "A draft that must be reviewed before sending.",
+    },
+  ],
+};
+
+describe("PipelineStageInspector", () => {
+  it("renders the stage health, next action, source engagement, quote, and guided AI topics", () => {
+    const html = renderToStaticMarkup(<PipelineStageInspector inspector={inspector} />);
+
+    expect(html).toContain("Modernize revenue workflow");
+    expect(html).toContain("20 days in stage");
+    expect(html).toContain("Stale stage");
+    expect(html).toContain("Follow up on the sent quote");
+    expect(html).toContain("Website pricing inquiry");
+    expect(html).toContain("QUO-2026-0004");
+    expect(html).toContain("Stage exit criteria");
+    expect(html).toContain("Summarize deal");
+    expect(html).toContain("Draft follow-up");
+  });
+
+  it("uses theme-aware classes instead of raw colors", () => {
+    const html = renderToStaticMarkup(<PipelineStageInspector inspector={inspector} />);
+
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/customer/PipelineStageInspector.tsx
+++ b/apps/web/components/customer/PipelineStageInspector.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import { AgentWorkLauncher } from "@/components/agent/AgentWorkLauncher";
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import {
+  PIPELINE_STAGE_UPDATE_OPTIONS,
+  type PipelineInspectorView,
+} from "@/lib/crm/pipeline-inspector";
+
+type PipelineStageInspectorProps = {
+  inspector: PipelineInspectorView;
+  className?: string;
+  showFullDetailLink?: boolean;
+  stageFormAction?: (formData: FormData) => void | Promise<void>;
+};
+
+function InfoStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  if (!value) return null;
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">{label}</dt>
+      <dd className="mt-1 text-sm font-semibold text-[var(--dpf-text)]">{value}</dd>
+    </div>
+  );
+}
+
+function StageUpdateForm({
+  inspector,
+  action,
+}: {
+  inspector: PipelineInspectorView;
+  action?: PipelineStageInspectorProps["stageFormAction"];
+}) {
+  if (!action) return null;
+  return (
+    <form action={action} className="mt-3 flex gap-2">
+      <input type="hidden" name="opportunityId" value={inspector.id} />
+      <select
+        name="stage"
+        defaultValue={inspector.stage}
+        className="min-w-0 flex-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs text-[var(--dpf-text)]"
+      >
+        {PIPELINE_STAGE_UPDATE_OPTIONS.map((stage) => (
+          <option
+            key={stage.value}
+            value={stage.value}
+            className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+          >
+            {stage.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="shrink-0 rounded bg-[var(--dpf-accent)] px-3 py-2 text-xs font-medium text-white"
+      >
+        Update stage
+      </button>
+    </form>
+  );
+}
+
+export function PipelineStageInspector({
+  inspector,
+  className = "",
+  showFullDetailLink = true,
+  stageFormAction,
+}: PipelineStageInspectorProps) {
+  return (
+    <section
+      className={[
+        "rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Stage inspector
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-[var(--dpf-text)]">
+            {inspector.title}
+          </h2>
+          <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]">
+            {inspector.account.name}
+            {inspector.contactLabel ? ` / ${inspector.contactLabel}` : ""}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <CustomerStatusBadge label={inspector.stageLabel} tone={inspector.stageTone} />
+          {inspector.staleLabel ? (
+            <CustomerStatusBadge label={inspector.staleLabel} tone="warning" />
+          ) : null}
+        </div>
+      </div>
+
+      <dl className="mt-4 grid grid-cols-2 gap-3">
+        <InfoStat label="Stage age" value={inspector.stageAgeLabel} />
+        <InfoStat label="Probability" value={inspector.probabilityLabel} />
+        <InfoStat label="Expected value" value={inspector.expectedValueLabel} />
+        <InfoStat label="Expected close" value={inspector.expectedCloseLabel} />
+      </dl>
+
+      <StageUpdateForm inspector={inspector} action={stageFormAction} />
+
+      <div className="mt-4 border-t border-[var(--dpf-border)] pt-4">
+        <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+          Suggested next action
+        </p>
+        <p className="mt-1 text-sm text-[var(--dpf-text)]">{inspector.suggestedNextAction}</p>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-1">
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Source engagement
+          </p>
+          {inspector.sourceEngagement ? (
+            <>
+              <p className="mt-1 text-sm font-medium text-[var(--dpf-text)]">
+                {inspector.sourceEngagement.label}
+              </p>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                {inspector.sourceEngagement.detail}
+              </p>
+            </>
+          ) : (
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              No source engagement is linked yet.
+            </p>
+          )}
+        </div>
+
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Linked quote
+          </p>
+          {inspector.latestQuote ? (
+            <>
+              <div className="mt-1 flex items-center justify-between gap-2">
+                <Link
+                  href={`/customer/quotes/${inspector.latestQuote.id}`}
+                  className="text-sm font-mono text-[var(--dpf-text)] hover:text-[var(--dpf-accent)]"
+                >
+                  {inspector.latestQuote.quoteNumber}
+                </Link>
+                <CustomerStatusBadge
+                  label={inspector.latestQuote.statusLabel}
+                  tone={inspector.latestQuote.statusTone}
+                />
+              </div>
+              {inspector.latestQuote.totalLabel ? (
+                <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                  {inspector.latestQuote.totalLabel}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              No quote is linked yet.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+          Stage exit criteria
+        </p>
+        <ul className="mt-2 space-y-1">
+          {inspector.stageExitCriteria.map((criterion) => (
+            <li key={criterion} className="text-xs text-[var(--dpf-text)]">
+              {criterion}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+          Recent activity
+        </p>
+        {inspector.recentActivities.length === 0 ? (
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">No activity recorded yet.</p>
+        ) : (
+          <div className="mt-2 space-y-2">
+            {inspector.recentActivities.map((activity) => (
+              <div key={activity.id} className="border-l border-[var(--dpf-border)] pl-3">
+                <p className="text-xs font-medium text-[var(--dpf-text)]">{activity.label}</p>
+                <p className="text-[10px] text-[var(--dpf-muted)]">{activity.detail}</p>
+                {activity.body ? (
+                  <p className="mt-1 line-clamp-2 text-xs text-[var(--dpf-muted)]">
+                    {activity.body}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showFullDetailLink ? (
+        <Link
+          href={`/customer/opportunities/${inspector.id}`}
+          className="mt-4 inline-flex rounded border border-[var(--dpf-border)] px-3 py-2 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          Open full detail
+        </Link>
+      ) : null}
+
+      <div className="mt-4">
+        <AgentWorkLauncher
+          agentName="Customer Advisor"
+          primaryActionLabel="Ask Customer Advisor"
+          topics={inspector.aiTopics}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -28,6 +28,10 @@ vi.mock("@dpf/db", () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    opportunity: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
     activity: {
       create: vi.fn(),
     },
@@ -58,6 +62,8 @@ import {
   searchCustomerSiteAddresses,
   createCustomerSite,
   createCustomerSiteNode,
+  advanceOpportunityStage,
+  updateOpportunityStageFromForm,
   updateCustomerConfigurationItem,
 } from "./crm";
 
@@ -310,6 +316,89 @@ describe("createCustomerConfigurationItem", () => {
     });
     expect(revalidatePath).toHaveBeenCalledWith("/customer");
     expect(revalidatePath).toHaveBeenCalledWith("/customer/acct-1");
+  });
+});
+
+describe("advanceOpportunityStage", () => {
+  it("updates stage, records a status-change activity, and revalidates opportunity routes", async () => {
+    vi.mocked(prisma.opportunity.findUnique).mockResolvedValue({
+      id: "opp-1",
+      title: "Modernize revenue workflow",
+      stage: "proposal",
+      probability: 70,
+      accountId: "acct-1",
+      contactId: "contact-1",
+    } as never);
+    vi.mocked(prisma.opportunity.update).mockResolvedValue({
+      id: "opp-1",
+      title: "Modernize revenue workflow",
+      stage: "negotiation",
+      probability: 80,
+      accountId: "acct-1",
+      contactId: "contact-1",
+      activities: [],
+    } as never);
+    vi.mocked(prisma.activity.create).mockResolvedValue({ id: "act-1" } as never);
+
+    const updated = await advanceOpportunityStage("opp-1", "negotiation", {
+      probability: 80,
+    });
+
+    expect(updated.stage).toBe("negotiation");
+    expect(prisma.opportunity.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "opp-1" },
+        data: expect.objectContaining({
+          stage: "negotiation",
+          stageChangedAt: expect.any(Date),
+          isDormant: false,
+        }),
+      }),
+    );
+    expect(prisma.activity.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        type: "status_change",
+        subject: "Opportunity stage: proposal -> negotiation (80%)",
+        accountId: "acct-1",
+        contactId: "contact-1",
+        opportunityId: "opp-1",
+      }),
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/customer/opportunities");
+    expect(revalidatePath).toHaveBeenCalledWith("/customer/opportunities/opp-1");
+  });
+
+  it("supports stage updates from an explicit form action", async () => {
+    vi.mocked(prisma.opportunity.findUnique).mockResolvedValue({
+      id: "opp-1",
+      title: "Modernize revenue workflow",
+      stage: "discovery",
+      probability: 40,
+      accountId: "acct-1",
+      contactId: null,
+    } as never);
+    vi.mocked(prisma.opportunity.update).mockResolvedValue({
+      id: "opp-1",
+      title: "Modernize revenue workflow",
+      stage: "proposal",
+      probability: 70,
+      accountId: "acct-1",
+      contactId: null,
+      activities: [],
+    } as never);
+
+    const formData = new FormData();
+    formData.set("opportunityId", "opp-1");
+    formData.set("stage", "proposal");
+
+    await updateOpportunityStageFromForm(formData);
+
+    expect(prisma.opportunity.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "opp-1" },
+        data: expect.objectContaining({ stage: "proposal" }),
+      }),
+    );
   });
 });
 

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -798,7 +798,7 @@ export async function advanceOpportunityStage(
   });
 
   await logSystemActivity(
-    `Opportunity stage: ${oldStage} → ${newStage} (${probability}%)`,
+    `Opportunity stage: ${oldStage} -> ${newStage} (${probability}%)`,
     {
       type: "status_change",
       accountId: updated.accountId,
@@ -807,7 +807,25 @@ export async function advanceOpportunityStage(
     },
   );
 
+  revalidatePath("/customer/opportunities");
+  revalidatePath(`/customer/opportunities/${updated.id}`);
+  revalidatePath(`/customer/${updated.accountId}`);
+
   return updated;
+}
+
+export async function updateOpportunityStageFromForm(formData: FormData) {
+  const opportunityId = String(formData.get("opportunityId") ?? "").trim();
+  const stage = String(formData.get("stage") ?? "").trim();
+
+  if (!opportunityId) {
+    throw new Error("Opportunity id is required");
+  }
+  if (!stage) {
+    throw new Error("Stage is required");
+  }
+
+  await advanceOpportunityStage(opportunityId, stage);
 }
 
 export async function closeOpportunity(

--- a/apps/web/lib/crm/pipeline-inspector-data.ts
+++ b/apps/web/lib/crm/pipeline-inspector-data.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+import {
+  buildPipelineInspectorView,
+  type PipelineInspectorView,
+} from "./pipeline-inspector";
+
+export async function getPipelineInspectorView(
+  opportunityId: string | null | undefined,
+): Promise<PipelineInspectorView | null> {
+  if (!opportunityId) return null;
+
+  const opportunity = await prisma.opportunity.findUnique({
+    where: { id: opportunityId },
+    include: {
+      account: { select: { id: true, name: true } },
+      contact: { select: { email: true, firstName: true, lastName: true } },
+      activities: {
+        orderBy: { createdAt: "desc" },
+        select: { id: true, type: true, subject: true, body: true, createdAt: true },
+      },
+      quotes: {
+        orderBy: [{ version: "desc" }, { createdAt: "desc" }],
+        select: {
+          id: true,
+          quoteNumber: true,
+          status: true,
+          totalAmount: true,
+          currency: true,
+          sentAt: true,
+          acceptedAt: true,
+        },
+      },
+    },
+  });
+
+  if (!opportunity) return null;
+
+  const engagement = opportunity.engagementId
+    ? await prisma.engagement.findUnique({
+        where: { id: opportunity.engagementId },
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          source: true,
+          sourceRefId: true,
+        },
+      })
+    : null;
+
+  return buildPipelineInspectorView({
+    opportunity: {
+      id: opportunity.id,
+      opportunityId: opportunity.opportunityId,
+      title: opportunity.title,
+      stage: opportunity.stage,
+      isDormant: opportunity.isDormant,
+      probability: opportunity.probability,
+      expectedValue: opportunity.expectedValue,
+      currency: opportunity.currency,
+      expectedClose: opportunity.expectedClose,
+      stageChangedAt: opportunity.stageChangedAt,
+      notes: opportunity.notes,
+      account: opportunity.account,
+      contact: opportunity.contact,
+      engagement,
+      quotes: opportunity.quotes,
+      activities: opportunity.activities,
+    },
+  });
+}

--- a/apps/web/lib/crm/pipeline-inspector.test.ts
+++ b/apps/web/lib/crm/pipeline-inspector.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPipelineInspectorView,
+  getStageAgeDays,
+  getStageExitCriteria,
+  isStageStale,
+} from "./pipeline-inspector";
+
+const now = new Date("2026-05-26T12:00:00.000Z");
+
+describe("pipeline inspector view model", () => {
+  it("calculates stage age in whole days", () => {
+    expect(getStageAgeDays(new Date("2026-05-20T11:00:00.000Z"), now)).toBe(6);
+    expect(getStageAgeDays(new Date("2026-05-26T11:00:00.000Z"), now)).toBe(0);
+  });
+
+  it("flags stale open stages using stage-specific thresholds or dormant state", () => {
+    expect(isStageStale({ stage: "proposal", stageAgeDays: 15, isDormant: false })).toBe(true);
+    expect(isStageStale({ stage: "proposal", stageAgeDays: 3, isDormant: false })).toBe(false);
+    expect(isStageStale({ stage: "discovery", stageAgeDays: 1, isDormant: true })).toBe(true);
+    expect(isStageStale({ stage: "closed_won", stageAgeDays: 90, isDormant: false })).toBe(false);
+  });
+
+  it("returns stage exit criteria for buyer-progress stages", () => {
+    expect(getStageExitCriteria("proposal")).toEqual([
+      "Quote or proposal sent",
+      "Commercial owner identified",
+      "Budget and timeline confirmed",
+    ]);
+    expect(getStageExitCriteria("custom_stage")).toEqual([
+      "Confirm the next buyer commitment",
+      "Record the evidence needed to leave this stage",
+    ]);
+  });
+
+  it("builds a scan-first inspector with quote, engagement, next action, and AI topics", () => {
+    const view = buildPipelineInspectorView({
+      now,
+      opportunity: {
+        id: "opp-1",
+        opportunityId: "OPP-CODEX-001",
+        title: "Modernize revenue workflow",
+        stage: "proposal",
+        isDormant: false,
+        probability: 70,
+        expectedValue: 15000,
+        currency: "GBP",
+        expectedClose: new Date("2026-06-10T00:00:00.000Z"),
+        stageChangedAt: new Date("2026-05-06T12:00:00.000Z"),
+        notes: "Proposal sent after discovery.",
+        account: { id: "acct-1", name: "Acme Ops" },
+        contact: { email: "buyer@example.com", firstName: "Bea", lastName: "Buyer" },
+        engagement: {
+          id: "eng-1",
+          title: "Website pricing inquiry",
+          status: "qualified",
+          source: "web_inquiry",
+          sourceRefId: "inq-1",
+        },
+        quotes: [
+          {
+            id: "quote-1",
+            quoteNumber: "QUO-2026-0004",
+            status: "sent",
+            totalAmount: 15000,
+            currency: "GBP",
+            sentAt: new Date("2026-05-22T00:00:00.000Z"),
+            acceptedAt: null,
+          },
+        ],
+        activities: [
+          {
+            id: "act-1",
+            type: "email",
+            subject: "Sent proposal",
+            body: "Proposal and pricing sent.",
+            createdAt: new Date("2026-05-22T09:00:00.000Z"),
+          },
+        ],
+      },
+    });
+
+    expect(view.stageAgeLabel).toBe("20 days in stage");
+    expect(view.staleLabel).toBe("Stale stage");
+    expect(view.stageExitCriteria).toContain("Quote or proposal sent");
+    expect(view.suggestedNextAction).toBe("Follow up on the sent quote and confirm the next buyer commitment.");
+    expect(view.sourceEngagement?.label).toBe("Website pricing inquiry");
+    expect(view.latestQuote?.statusLabel).toBe("Sent");
+    expect(view.aiTopics.map((topic) => topic.id)).toEqual([
+      "deal-summary",
+      "stale-stage-diagnosis",
+      "follow-up-draft",
+    ]);
+  });
+});

--- a/apps/web/lib/crm/pipeline-inspector.ts
+++ b/apps/web/lib/crm/pipeline-inspector.ts
@@ -1,0 +1,391 @@
+import type { CrmTone } from "./presentation";
+import {
+  formatCrmStatusLabel,
+  getOpportunityStageMeta,
+  getQuoteStatusMeta,
+  isOpenOpportunityStage,
+  OPEN_OPPORTUNITY_STAGES,
+} from "./presentation";
+import { formatRevenueAmount } from "./revenue-cockpit";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const STAGE_STALE_THRESHOLDS_DAYS: Record<string, number> = {
+  qualification: 7,
+  discovery: 10,
+  proposal: 14,
+  negotiation: 10,
+};
+
+const STAGE_EXIT_CRITERIA: Record<string, string[]> = {
+  qualification: [
+    "Buyer problem is clear",
+    "Account and primary contact are known",
+    "Value hypothesis is recorded",
+  ],
+  discovery: [
+    "Needs and success criteria captured",
+    "Stakeholders and blockers identified",
+    "Commercial fit is plausible",
+  ],
+  proposal: [
+    "Quote or proposal sent",
+    "Commercial owner identified",
+    "Budget and timeline confirmed",
+  ],
+  negotiation: [
+    "Decision process confirmed",
+    "Commercial objections resolved",
+    "Signature or close step scheduled",
+  ],
+  closed_won: [
+    "Order or onboarding path confirmed",
+    "Handoff owner recorded",
+  ],
+  closed_lost: [
+    "Lost reason recorded",
+    "Reusable learning captured",
+  ],
+};
+
+export const PIPELINE_STAGE_UPDATE_OPTIONS = OPEN_OPPORTUNITY_STAGES.map((stage) => ({
+  value: stage,
+  label: getOpportunityStageMeta(stage).label,
+}));
+
+export type PipelineInspectorActivityInput = {
+  id: string;
+  type: string;
+  subject: string;
+  body?: string | null;
+  createdAt: Date;
+};
+
+export type PipelineInspectorQuoteInput = {
+  id: string;
+  quoteNumber: string;
+  status: string;
+  totalAmount?: number | string | { toString(): string } | null;
+  currency?: string | null;
+  sentAt?: Date | null;
+  acceptedAt?: Date | null;
+};
+
+export type PipelineInspectorEngagementInput = {
+  id: string;
+  title: string;
+  status: string;
+  source?: string | null;
+  sourceRefId?: string | null;
+} | null;
+
+export type PipelineInspectorOpportunityInput = {
+  id: string;
+  opportunityId: string;
+  title: string;
+  stage: string;
+  isDormant: boolean;
+  probability: number;
+  expectedValue?: number | string | { toString(): string } | null;
+  currency?: string | null;
+  expectedClose?: Date | null;
+  stageChangedAt: Date;
+  notes?: string | null;
+  account: {
+    id: string;
+    name: string;
+  };
+  contact?: {
+    email?: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null;
+  engagement?: PipelineInspectorEngagementInput;
+  quotes: PipelineInspectorQuoteInput[];
+  activities: PipelineInspectorActivityInput[];
+};
+
+export type PipelineInspectorTopic = {
+  id: string;
+  label: string;
+  description: string;
+  prompt: string;
+  contextSummary: string;
+  expectedNextStep: string;
+};
+
+export type PipelineInspectorView = {
+  id: string;
+  opportunityId: string;
+  title: string;
+  account: {
+    id: string;
+    name: string;
+  };
+  contactLabel: string | null;
+  stage: string;
+  stageLabel: string;
+  stageTone: CrmTone;
+  stageAgeDays: number;
+  stageAgeLabel: string;
+  isStale: boolean;
+  staleLabel: string | null;
+  probabilityLabel: string;
+  expectedValueLabel: string | null;
+  expectedCloseLabel: string | null;
+  sourceEngagement: {
+    id: string;
+    label: string;
+    detail: string;
+  } | null;
+  latestQuote: {
+    id: string;
+    quoteNumber: string;
+    statusLabel: string;
+    statusTone: CrmTone;
+    totalLabel: string | null;
+  } | null;
+  recentActivities: {
+    id: string;
+    label: string;
+    detail: string;
+    body: string | null;
+  }[];
+  stageExitCriteria: string[];
+  suggestedNextAction: string;
+  aiTopics: PipelineInspectorTopic[];
+};
+
+export function getStageAgeDays(stageChangedAt: Date, now: Date = new Date()): number {
+  return Math.max(0, Math.floor((now.getTime() - stageChangedAt.getTime()) / DAY_MS));
+}
+
+export function isStageStale(input: {
+  stage: string;
+  stageAgeDays: number;
+  isDormant: boolean;
+}): boolean {
+  if (!isOpenOpportunityStage(input.stage)) {
+    return false;
+  }
+  if (input.isDormant) {
+    return true;
+  }
+  const threshold = STAGE_STALE_THRESHOLDS_DAYS[input.stage] ?? 14;
+  return input.stageAgeDays >= threshold;
+}
+
+export function getStageExitCriteria(stage: string): string[] {
+  return STAGE_EXIT_CRITERIA[stage] ?? [
+    "Confirm the next buyer commitment",
+    "Record the evidence needed to leave this stage",
+  ];
+}
+
+function toNumber(value: number | string | { toString(): string } | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const numberValue = typeof value === "number" ? value : Number(value.toString());
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function formatDateLabel(value: Date | null | undefined): string | null {
+  if (!value) return null;
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(value);
+}
+
+function formatStageAgeLabel(days: number): string {
+  if (days === 0) return "New in stage";
+  return `${days} day${days === 1 ? "" : "s"} in stage`;
+}
+
+function formatSourceLabel(source: string | null | undefined): string {
+  if (!source) return "unknown source";
+  return source.replace(/[_-]+/g, " ");
+}
+
+function buildContactLabel(contact: PipelineInspectorOpportunityInput["contact"]): string | null {
+  if (!contact) return null;
+  const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim();
+  return name || contact.email || null;
+}
+
+function selectLatestQuote(quotes: PipelineInspectorQuoteInput[]): PipelineInspectorQuoteInput | null {
+  return quotes[0] ?? null;
+}
+
+function buildSuggestedNextAction(input: {
+  stage: string;
+  isStale: boolean;
+  latestQuote: PipelineInspectorQuoteInput | null;
+  activityCount: number;
+}): string {
+  if (input.latestQuote?.status === "sent") {
+    return "Follow up on the sent quote and confirm the next buyer commitment.";
+  }
+  if (input.stage === "proposal" && !input.latestQuote) {
+    return "Prepare the proposal or quote evidence needed to leave this stage.";
+  }
+  if (input.stage === "negotiation") {
+    return "Confirm the decision process, blockers, and signature step.";
+  }
+  if (input.activityCount === 0) {
+    return "Log the first buyer activity and confirm the next commitment.";
+  }
+  if (input.isStale) {
+    return "Review why this stage is stale and schedule the next buyer action.";
+  }
+  if (input.stage === "qualification") {
+    return "Confirm the buyer problem, owner, and value hypothesis.";
+  }
+  if (input.stage === "discovery") {
+    return "Capture needs, stakeholders, and success criteria from the buyer.";
+  }
+  return "Confirm the next buyer commitment and keep the timeline current.";
+}
+
+function buildAiTopics(input: {
+  opportunityId: string;
+  title: string;
+  accountName: string;
+  stageLabel: string;
+  stageAgeLabel: string;
+  suggestedNextAction: string;
+  latestQuote: PipelineInspectorView["latestQuote"];
+  isStale: boolean;
+}): PipelineInspectorTopic[] {
+  const quoteContext = input.latestQuote
+    ? `Latest quote: ${input.latestQuote.quoteNumber} (${input.latestQuote.statusLabel}).`
+    : "No quote is linked yet.";
+  const baseContext =
+    `${input.opportunityId} "${input.title}" for ${input.accountName} is in ${input.stageLabel}. ` +
+    `${input.stageAgeLabel}. ${quoteContext}`;
+
+  return [
+    {
+      id: "deal-summary",
+      label: "Summarize deal",
+      description: "Review account, activity, quote, and stage context.",
+      prompt:
+        `Summarize opportunity ${input.opportunityId}: ${input.title}. ` +
+        `${baseContext} Highlight current stage evidence, blockers, and the next best internal action.`,
+      contextSummary: baseContext,
+      expectedNextStep:
+        "Customer Advisor should return a concise stage-aware deal summary without taking external action.",
+    },
+    {
+      id: "stale-stage-diagnosis",
+      label: input.isStale ? "Explain stale stage" : "Check stage health",
+      description: "Inspect stage age, missing evidence, and what must happen next.",
+      prompt:
+        `Diagnose stage health for opportunity ${input.opportunityId}. ` +
+        `${baseContext} Suggested next action: ${input.suggestedNextAction}`,
+      contextSummary: `${input.stageLabel}; ${input.stageAgeLabel}; next action: ${input.suggestedNextAction}`,
+      expectedNextStep:
+        "Customer Advisor should explain the stage posture and propose a governed follow-up task if needed.",
+    },
+    {
+      id: "follow-up-draft",
+      label: "Draft follow-up",
+      description: "Draft the next buyer-facing follow-up for review.",
+      prompt:
+        `Draft a buyer follow-up for opportunity ${input.opportunityId}. ` +
+        `${baseContext} Do not send or schedule anything; provide a draft for operator approval.`,
+      contextSummary: baseContext,
+      expectedNextStep:
+        "Customer Advisor should produce draft copy only; the operator decides whether to send it.",
+    },
+  ];
+}
+
+export function buildPipelineInspectorView(input: {
+  opportunity: PipelineInspectorOpportunityInput;
+  now?: Date;
+}): PipelineInspectorView {
+  const now = input.now ?? new Date();
+  const opportunity = input.opportunity;
+  const stageMeta = getOpportunityStageMeta(opportunity.stage);
+  const stageAgeDays = getStageAgeDays(opportunity.stageChangedAt, now);
+  const stale = isStageStale({
+    stage: opportunity.stage,
+    stageAgeDays,
+    isDormant: opportunity.isDormant,
+  });
+  const latestQuoteInput = selectLatestQuote(opportunity.quotes);
+  const latestQuoteMeta = latestQuoteInput ? getQuoteStatusMeta(latestQuoteInput.status) : null;
+  const latestQuoteTotal = toNumber(latestQuoteInput?.totalAmount);
+  const latestQuote = latestQuoteInput && latestQuoteMeta
+    ? {
+        id: latestQuoteInput.id,
+        quoteNumber: latestQuoteInput.quoteNumber,
+        statusLabel: latestQuoteMeta.label,
+        statusTone: latestQuoteMeta.tone,
+        totalLabel: latestQuoteTotal !== null
+          ? formatRevenueAmount(latestQuoteTotal, latestQuoteInput.currency ?? "GBP")
+          : null,
+      }
+    : null;
+  const expectedValue = toNumber(opportunity.expectedValue);
+  const suggestedNextAction = buildSuggestedNextAction({
+    stage: opportunity.stage,
+    isStale: stale,
+    latestQuote: latestQuoteInput,
+    activityCount: opportunity.activities.length,
+  });
+
+  const view: PipelineInspectorView = {
+    id: opportunity.id,
+    opportunityId: opportunity.opportunityId,
+    title: opportunity.title,
+    account: opportunity.account,
+    contactLabel: buildContactLabel(opportunity.contact),
+    stage: opportunity.stage,
+    stageLabel: stageMeta.label,
+    stageTone: stageMeta.tone,
+    stageAgeDays,
+    stageAgeLabel: formatStageAgeLabel(stageAgeDays),
+    isStale: stale,
+    staleLabel: stale ? "Stale stage" : null,
+    probabilityLabel: `${opportunity.probability}%`,
+    expectedValueLabel: expectedValue !== null
+      ? formatRevenueAmount(expectedValue, opportunity.currency ?? "GBP")
+      : null,
+    expectedCloseLabel: formatDateLabel(opportunity.expectedClose),
+    sourceEngagement: opportunity.engagement
+      ? {
+          id: opportunity.engagement.id,
+          label: opportunity.engagement.title,
+          detail:
+            `${formatCrmStatusLabel(opportunity.engagement.status)} from ` +
+            formatSourceLabel(opportunity.engagement.source),
+        }
+      : null,
+    latestQuote,
+    recentActivities: opportunity.activities.slice(0, 3).map((activity) => ({
+      id: activity.id,
+      label: activity.subject,
+      detail: `${formatCrmStatusLabel(activity.type)} / ${formatDateLabel(activity.createdAt)}`,
+      body: activity.body ?? null,
+    })),
+    stageExitCriteria: getStageExitCriteria(opportunity.stage),
+    suggestedNextAction,
+    aiTopics: [],
+  };
+
+  return {
+    ...view,
+    aiTopics: buildAiTopics({
+      opportunityId: view.opportunityId,
+      title: view.title,
+      accountName: view.account.name,
+      stageLabel: view.stageLabel,
+      stageAgeLabel: view.stageAgeLabel,
+      suggestedNextAction: view.suggestedNextAction,
+      latestQuote: view.latestQuote,
+      isStale: view.isStale,
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the CRM pipeline stage inspector for Slice 2 under `BI-09ECF363` / `EP-CRM-MKT-OPS`.
- Adds a reusable inspector view model, server data loader, and customer-facing inspector component with stage age, stale-stage state, expected value, linked quote, exit criteria, recent activity, and Customer Advisor guided work starts.
- Wires the inspector into `/customer/opportunities` and `/customer/opportunities/[id]`, including selected-opportunity deep linking and stage updates that record activity and revalidate affected CRM routes.

## Verification
- `pnpm --filter web exec vitest run lib/crm/pipeline-inspector.test.ts components/customer/PipelineStageInspector.test.tsx lib/actions/crm.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec vitest run lib/crm/presentation.test.ts lib/crm/revenue-cockpit.test.ts lib/crm/pipeline-inspector.test.ts components/customer/CustomerStatusBadge.test.tsx components/customer/RevenueCockpit.test.tsx components/customer/PipelineStageInspector.test.tsx lib/actions/crm.test.ts`
- `pnpm --filter web build` (passes; existing Edge Runtime warnings remain in platform version/discovery imports)
- Built-app UX pass on `http://127.0.0.1:3001/customer/opportunities?opportunity=cmpn16jo40002h4u4cbb1qa7i` and `/customer/opportunities/cmpn16jo40002h4u4cbb1qa7i` for desktop and mobile: inspector, suggested next action, exit criteria, Customer Advisor launcher, linked quote, and no horizontal overflow.
- No migration added.