### PR TITLE
feat: add contributor MCP readiness

### DIFF
--- a/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
@@ -44,7 +44,7 @@ export default async function BuildStudioPage() {
     getProviders(),
     getBuildStudioConfig(),
     user
-      ? getContributorMcpReadiness(user.id, { probe: false, baseUrl })
+      ? getContributorMcpReadiness(user.id, { probe: false })
       : Promise.resolve(unauthenticatedReadiness()),
   ]);
 

--- a/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
@@ -1,11 +1,31 @@
 // apps/web/app/(shell)/platform/ai/build-studio/page.tsx
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { headers } from "next/headers";
 import { getProviders } from "@/lib/inference/ai-provider-data";
 import { getBuildStudioConfig } from "@/lib/integrate/build-studio-config";
+import { getContributorMcpReadiness, type ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
+import {
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+  getMcpTokenTemplate,
+} from "@/lib/mcp-token-scopes";
 import { BuildStudioConfigForm } from "@/components/platform/BuildStudioConfigForm";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "@/components/platform/build-studio-route-copy";
 import Link from "next/link";
+
+function unauthenticatedReadiness(): ContributorMcpReadiness {
+  const requiredGrants = [...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS];
+  return {
+    status: "needs_authorization",
+    recommendedAction: "issue_development_token",
+    identityBinding: "not_available",
+    token: null,
+    missingGrants: [...requiredGrants],
+    requiredGrants,
+    recommendedScopes: [...(getMcpTokenTemplate("development")?.grants ?? requiredGrants)],
+    probe: { status: "not_run" },
+  };
+}
 
 export default async function BuildStudioPage() {
   const session = await auth();
@@ -15,9 +35,17 @@ export default async function BuildStudioPage() {
     "manage_provider_connections",
   );
 
-  const [allProviders, config] = await Promise.all([
+  const hdrs = await headers();
+  const proto = hdrs.get("x-forwarded-proto") ?? "http";
+  const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
+  const baseUrl = `${proto}://${host}`;
+
+  const [allProviders, config, contributorMcpReadiness] = await Promise.all([
     getProviders(),
     getBuildStudioConfig(),
+    user
+      ? getContributorMcpReadiness(user.id, { probe: false, baseUrl })
+      : Promise.resolve(unauthenticatedReadiness()),
   ]);
 
   // Dynamic: group providers by cliEngine field instead of hardcoded IDs
@@ -63,6 +91,8 @@ export default async function BuildStudioPage() {
           billingLabel: p.provider.billingLabel,
           costNotes: p.provider.costPerformanceNotes,
         }))}
+        contributorMcpReadiness={contributorMcpReadiness}
+        baseUrl={baseUrl}
         canWrite={canWrite}
       />
     </div>

--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -158,7 +158,6 @@ describe("McpTokenManager", () => {
     expect(await screen.findByText("Claude/Codex MCP readiness is satisfied.")).toBeTruthy();
     expect(readinessMock).toHaveBeenCalledWith({
       probe: false,
-      baseUrl: "http://localhost:3000",
     });
   });
 

--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/lib/actions/mcp-tokens", () => ({
   issueMyMcpToken: vi.fn(),
   issueMyTemplateMcpToken: vi.fn(),
   issueMyWriteMcpToken: vi.fn(),
+  getMyContributorMcpReadiness: vi.fn(),
   listAvailableMcpScopes: vi.fn(),
   listMcpTokenTemplates: vi.fn(),
   listMyMcpTokens: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/lib/actions/mcp-tokens", () => ({
 import {
   bulkRevokeMyMcpTokens,
   copyMyMcpToken,
+  getMyContributorMcpReadiness,
   issueMyTemplateMcpToken,
   listAvailableMcpScopes,
   listMcpTokenTemplates,
@@ -32,6 +34,7 @@ import { McpTokenManager } from "./McpTokenManager";
 
 const bulkRevokeMock = bulkRevokeMyMcpTokens as unknown as ReturnType<typeof vi.fn>;
 const copyMock = copyMyMcpToken as unknown as ReturnType<typeof vi.fn>;
+const readinessMock = getMyContributorMcpReadiness as unknown as ReturnType<typeof vi.fn>;
 const scopesMock = listAvailableMcpScopes as unknown as ReturnType<typeof vi.fn>;
 const templatesMock = listMcpTokenTemplates as unknown as ReturnType<typeof vi.fn>;
 const templateIssueMock = issueMyTemplateMcpToken as unknown as ReturnType<typeof vi.fn>;
@@ -39,8 +42,35 @@ const tokensMock = listMyMcpTokens as unknown as ReturnType<typeof vi.fn>;
 const rotateMock = rotateMyMcpToken as unknown as ReturnType<typeof vi.fn>;
 const rotateWithEditMock = rotateMyMcpTokenWithEdit as unknown as ReturnType<typeof vi.fn>;
 
+function contributorReadiness(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "ready",
+    recommendedAction: "test_connection",
+    identityBinding: "not_available",
+    token: {
+      id: "tok_active",
+      name: "Mark laptop",
+      prefix: "dpfmcp_MAR",
+      tokenSuffix: "A1B2",
+      scope: "write",
+      scopes: ["backlog_read", "backlog_write"],
+      lastUsedAt: "2026-05-18T12:00:00.000Z",
+      expiresAt: null,
+    },
+    missingGrants: [],
+    requiredGrants: ["backlog_read", "backlog_write"],
+    recommendedScopes: ["backlog_read", "backlog_write", "sandbox_execute"],
+    probe: { status: "not_run" },
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
+  readinessMock.mockResolvedValue({
+    ok: true,
+    readiness: contributorReadiness(),
+  });
   scopesMock.mockResolvedValue({
     scopes: ["backlog_read", "backlog_write", "spec_plan_read"],
   });
@@ -122,6 +152,100 @@ afterEach(() => {
 });
 
 describe("McpTokenManager", () => {
+  it("shows a compact ready banner for contributor MCP readiness", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    expect(await screen.findByText("Claude/Codex MCP readiness is satisfied.")).toBeTruthy();
+    expect(readinessMock).toHaveBeenCalledWith({
+      probe: false,
+      baseUrl: "http://localhost:3000",
+    });
+  });
+
+  it("points missing contributor grants to rotate-with-edit instead of duplicating setup controls", async () => {
+    readinessMock.mockResolvedValue({
+      ok: true,
+      readiness: contributorReadiness({
+        status: "needs_grants",
+        recommendedAction: "rotate_development_token",
+        missingGrants: ["sandbox_execute"],
+      }),
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    expect(await screen.findByText(/Development token needs attention: missing 1 grant/i)).toBeTruthy();
+    expect(screen.getByText(/Use Rotate with edit on the token row/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Test connection/i })).toBeNull();
+    expect(screen.queryByText("Required grants")).toBeNull();
+  });
+
+  it("labels read-only contributor tokens as read-only instead of missing zero grants", async () => {
+    readinessMock.mockResolvedValue({
+      ok: true,
+      readiness: contributorReadiness({
+        status: "needs_grants",
+        recommendedAction: "rotate_development_token",
+        missingGrants: [],
+        token: {
+          id: "tok_read_only",
+          name: "Read only laptop",
+          prefix: "dpfmcp_RD",
+          tokenSuffix: "R0",
+          scope: "read",
+          scopes: ["backlog_read", "backlog_write"],
+          lastUsedAt: "2026-05-18T12:00:00.000Z",
+          expiresAt: null,
+        },
+      }),
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    expect(await screen.findByText(/Development token needs attention: read-only token/i)).toBeTruthy();
+    expect(screen.queryByText(/missing 0 grants/i)).toBeNull();
+  });
+
+  it("keeps lifecycle-managed ephemeral tokens out of contributor readiness", async () => {
+    readinessMock.mockResolvedValue({
+      ok: true,
+      readiness: contributorReadiness({
+        status: "needs_authorization",
+        recommendedAction: "issue_development_token",
+        token: null,
+        missingGrants: ["backlog_write"],
+      }),
+    });
+    tokensMock.mockResolvedValue({
+      ok: true,
+      archivedCount: 0,
+      tokens: [
+        {
+          id: "tok_ship",
+          name: "Ship phase token",
+          prefix: "dpfmcp_SHIP",
+          tokenSuffix: "S1P",
+          canCopy: false,
+          capability: "write",
+          scope: "write",
+          scopes: ["backlog_write"],
+          lastUsedAt: "2026-05-18T12:00:00.000Z",
+          idleDays: 0,
+          kind: "ephemeral_ship",
+          buildId: "build_123456789",
+          expiresAt: null,
+          revokedAt: null,
+          createdAt: "2026-05-18T10:00:00.000Z",
+        },
+      ],
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    expect(await screen.findByText(/Development token needs attention: no usable development token/i)).toBeTruthy();
+    expect(screen.getByText("ephemeral")).toBeTruthy();
+  });
+
   it("shows active token suffix, scope, issued time, last-used time, and lifecycle actions", async () => {
     render(<McpTokenManager baseUrl="http://localhost:3000" />);
 

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -265,7 +265,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
         listMyMcpTokens(),
         listAvailableMcpScopes(),
         listMcpTokenTemplates(),
-        getMyContributorMcpReadiness({ probe: false, baseUrl: props.baseUrl }),
+        getMyContributorMcpReadiness({ probe: false }),
       ]);
       if (cancelled) return;
       if (tokensResult.ok) {
@@ -285,13 +285,13 @@ export function McpTokenManager(props: McpTokenManagerProps) {
     return () => {
       cancelled = true;
     };
-  }, [props.baseUrl]);
+  }, []);
 
   function refresh() {
     startTransition(async () => {
       const [tokensResult, readinessResult] = await Promise.all([
         listMyMcpTokens(),
-        getMyContributorMcpReadiness({ probe: false, baseUrl: props.baseUrl }),
+        getMyContributorMcpReadiness({ probe: false }),
       ]);
       if (tokensResult.ok) {
         setTokens(tokensResult.tokens);

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   AlertTriangle,
   Ban,
@@ -17,6 +18,7 @@ import { type ReactNode, useEffect, useMemo, useState, useTransition } from "rea
 import {
   bulkRevokeMyMcpTokens,
   copyMyMcpToken,
+  getMyContributorMcpReadiness,
   issueMyMcpToken,
   issueMyTemplateMcpToken,
   issueMyWriteMcpToken,
@@ -29,6 +31,7 @@ import {
   upgradeMyMcpTokenForCodingAgent,
   type McpTokenTemplateSummary,
 } from "@/lib/actions/mcp-tokens";
+import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import {
   defaultMcpTokenScopes,
   MCP_TOKEN_DEFAULT_STALE_DAYS,
@@ -144,8 +147,85 @@ async function writeClipboardText(value: string): Promise<boolean> {
   }
 }
 
+function contributorReadinessCopy(readiness: ContributorMcpReadiness): {
+  tone: "ready" | "attention";
+  message: string;
+  guidance: string;
+} {
+  switch (readiness.status) {
+    case "ready":
+      return {
+        tone: "ready",
+        message: "Claude/Codex MCP readiness is satisfied.",
+        guidance: "Build Studio can use the current development token.",
+      };
+    case "needs_grants":
+      if (readiness.missingGrants.length === 0) {
+        return {
+          tone: "attention",
+          message: "Development token needs attention: read-only token.",
+          guidance: "Use Rotate with edit on the token row to apply development write access.",
+        };
+      }
+      return {
+        tone: "attention",
+        message: `Development token needs attention: missing ${readiness.missingGrants.length} ${readiness.missingGrants.length === 1 ? "grant" : "grants"}.`,
+        guidance: "Use Rotate with edit on the token row to apply the development grant set.",
+      };
+    case "needs_reissue":
+      return {
+        tone: "attention",
+        message: "Development token needs attention: expired or revoked token.",
+        guidance: "Issue a development token to replace the unusable row.",
+      };
+    case "needs_identity_binding":
+      return {
+        tone: "attention",
+        message: "Development token needs attention: peer identity is not GAID-bound.",
+        guidance: "Token grants still gate MCP calls while the identity binding work lands.",
+      };
+    case "needs_authorization":
+      return {
+        tone: "attention",
+        message: "Development token needs attention: no usable development token.",
+        guidance: "Issue a development token above before connecting Claude Code or Codex.",
+      };
+  }
+}
+
+function ContributorReadinessBanner(props: { readiness: ContributorMcpReadiness | null }) {
+  if (!props.readiness) return null;
+
+  const copy = contributorReadinessCopy(props.readiness);
+  const ready = copy.tone === "ready";
+
+  return (
+    <div className="mb-4 flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm md:flex-row md:items-center md:justify-between">
+      <div className="flex min-w-0 items-start gap-2">
+        {ready ? (
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[var(--dpf-success)]" aria-hidden="true" />
+        ) : (
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--dpf-warning)]" aria-hidden="true" />
+        )}
+        <div className="min-w-0">
+          <p className="font-medium text-[var(--dpf-text)]">{copy.message}</p>
+          <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">{copy.guidance}</p>
+        </div>
+      </div>
+      <Link
+        href="/platform/ai/build-studio"
+        className="shrink-0 text-xs font-medium text-[var(--dpf-accent)] underline-offset-2 hover:underline"
+      >
+        Build Studio readiness
+      </Link>
+    </div>
+  );
+}
+
 export function McpTokenManager(props: McpTokenManagerProps) {
   const [tokens, setTokens] = useState<TokenRow[]>([]);
+  const [contributorReadiness, setContributorReadiness] =
+    useState<ContributorMcpReadiness | null>(null);
   const [scopes, setScopes] = useState<string[]>([]);
   const [templates, setTemplates] = useState<McpTokenTemplateSummary[]>([]);
   const [view, setView] = useState<View>({ kind: "idle" });
@@ -181,15 +261,19 @@ export function McpTokenManager(props: McpTokenManagerProps) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [tokensResult, scopesResult, templatesResult] = await Promise.all([
+      const [tokensResult, scopesResult, templatesResult, readinessResult] = await Promise.all([
         listMyMcpTokens(),
         listAvailableMcpScopes(),
         listMcpTokenTemplates(),
+        getMyContributorMcpReadiness({ probe: false, baseUrl: props.baseUrl }),
       ]);
       if (cancelled) return;
       if (tokensResult.ok) {
         setTokens(tokensResult.tokens);
         setArchivedCount(tokensResult.archivedCount);
+      }
+      if (readinessResult.ok) {
+        setContributorReadiness(readinessResult.readiness);
       }
       const availableScopes = scopesResult.scopes;
       setScopes(availableScopes);
@@ -201,14 +285,20 @@ export function McpTokenManager(props: McpTokenManagerProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [props.baseUrl]);
 
   function refresh() {
     startTransition(async () => {
-      const result = await listMyMcpTokens();
-      if (result.ok) {
-        setTokens(result.tokens);
-        setArchivedCount(result.archivedCount);
+      const [tokensResult, readinessResult] = await Promise.all([
+        listMyMcpTokens(),
+        getMyContributorMcpReadiness({ probe: false, baseUrl: props.baseUrl }),
+      ]);
+      if (tokensResult.ok) {
+        setTokens(tokensResult.tokens);
+        setArchivedCount(tokensResult.archivedCount);
+      }
+      if (readinessResult.ok) {
+        setContributorReadiness(readinessResult.readiness);
       }
     });
   }
@@ -514,6 +604,8 @@ export function McpTokenManager(props: McpTokenManagerProps) {
       </div>
 
       <div className="p-5">
+        <ContributorReadinessBanner readiness={contributorReadiness} />
+
         {inlineError && (
           <div className="mb-4 flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-error)]">
             <AlertTriangle className="h-4 w-4" aria-hidden="true" />

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -4,7 +4,9 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { saveBuildStudioConfig } from "@/lib/actions/build-studio";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
+import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
+import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
 
 type ProviderOption = {
   providerId: string;
@@ -18,6 +20,8 @@ type Props = {
   config: BuildStudioDispatchConfig;
   claudeProviders: ProviderOption[];
   codexProviders: ProviderOption[];
+  contributorMcpReadiness: ContributorMcpReadiness;
+  baseUrl: string;
   canWrite: boolean;
 };
 
@@ -55,7 +59,14 @@ function isConfigured(status: string): boolean {
   return status === "ok" || status === "configured" || status === "pending";
 }
 
-export function BuildStudioConfigForm({ config, claudeProviders, codexProviders, canWrite }: Props) {
+export function BuildStudioConfigForm({
+  config,
+  claudeProviders,
+  codexProviders,
+  contributorMcpReadiness,
+  baseUrl,
+  canWrite,
+}: Props) {
   const [provider, setProvider] = useState(config.provider);
   const [claudeProviderId, setClaudeProviderId] = useState(config.claudeProviderId);
   const [codexProviderId, setCodexProviderId] = useState(config.codexProviderId);
@@ -124,6 +135,12 @@ export function BuildStudioConfigForm({ config, claudeProviders, codexProviders,
           </Link>
         </div>
       </section>
+
+      <ContributorMcpReadinessCard
+        initialReadiness={contributorMcpReadiness}
+        baseUrl={baseUrl}
+        canWrite={canWrite}
+      />
 
       {/* Section 1: Active CLI Provider */}
       <section style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", borderRadius: 8, padding: 16 }}>

--- a/apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
+++ b/apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/actions/mcp-tokens", () => ({
+  getMyContributorMcpReadiness: vi.fn(),
+  issueMyWriteMcpToken: vi.fn(),
+  rotateMyMcpTokenWithEdit: vi.fn(),
+}));
+
+import {
+  getMyContributorMcpReadiness,
+  issueMyWriteMcpToken,
+  rotateMyMcpTokenWithEdit,
+} from "@/lib/actions/mcp-tokens";
+import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
+import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
+
+const getReadinessMock = getMyContributorMcpReadiness as unknown as ReturnType<typeof vi.fn>;
+const issueMock = issueMyWriteMcpToken as unknown as ReturnType<typeof vi.fn>;
+const rotateMock = rotateMyMcpTokenWithEdit as unknown as ReturnType<typeof vi.fn>;
+
+const setupSnippets = {
+  claudeCode: '{"mcpServers":{"dpf":{"headers":{"Authorization":"Bearer ${DPF_MCP_BEARER_TOKEN}"}}}}',
+  codex: '[mcp_servers.dpf]\nbearer_token_env_var = "DPF_MCP_BEARER_TOKEN"',
+  vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer ${env:DPF_MCP_BEARER_TOKEN}"}}}}',
+  syncCommand: ".\\scripts\\sync-mcp-worktrees.ps1",
+  envPowerShell:
+    "[System.Environment]::SetEnvironmentVariable('DPF_MCP_BEARER_TOKEN', 'dpfmcp_NEW', 'User')",
+  runtimeRefreshPowerShell:
+    "Invoke-RestMethod -Method Post -Uri 'http://localhost:3000/api/mcp/token/refresh'",
+};
+
+function readiness(overrides: Partial<ContributorMcpReadiness> = {}): ContributorMcpReadiness {
+  return {
+    status: "ready",
+    recommendedAction: "test_connection",
+    identityBinding: "not_available",
+    token: {
+      id: "tok_ready",
+      name: "Development token",
+      prefix: "dpfmcp_DEV",
+      tokenSuffix: "R3AD",
+      scope: "write",
+      scopes: ["backlog_write", "work_capsule_write"],
+      lastUsedAt: "2026-05-26T12:00:00.000Z",
+      expiresAt: "2026-08-24T12:00:00.000Z",
+    },
+    missingGrants: [],
+    requiredGrants: ["backlog_write", "work_capsule_write"],
+    recommendedScopes: ["backlog_write", "work_capsule_write", "sandbox_execute"],
+    probe: { status: "not_run" },
+    ...overrides,
+  };
+}
+
+function renderCard(initialReadiness: ContributorMcpReadiness, canWrite = true) {
+  return render(
+    <ContributorMcpReadinessCard
+      initialReadiness={initialReadiness}
+      baseUrl="http://localhost:3000"
+      canWrite={canWrite}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  issueMock.mockResolvedValue({
+    ok: true,
+    tokenId: "tok_new",
+    plaintext: "dpfmcp_NEW",
+    prefix: "dpfmcp_NEW",
+    tokenSuffix: "N3W",
+    expiresAt: "2026-08-24T12:00:00.000Z",
+    setupSnippets,
+  });
+  rotateMock.mockResolvedValue({
+    ok: true,
+    tokenId: "tok_rotated",
+    plaintext: "dpfmcp_ROTATED",
+    prefix: "dpfmcp_ROT",
+    tokenSuffix: "R0T",
+    expiresAt: "2026-08-24T12:00:00.000Z",
+    setupSnippets,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+describe("ContributorMcpReadinessCard", () => {
+  it("shows a quiet ready state with a test connection action", () => {
+    renderCard(readiness());
+
+    expect(screen.getByText(/Claude Code and Codex can use DPF MCP/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Test connection/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Issue development token/i })).toBeNull();
+  });
+
+  it("runs a live probe for ready tokens", async () => {
+    getReadinessMock.mockResolvedValue({
+      ok: true,
+      readiness: readiness({
+        probe: {
+          status: "success",
+          checkedAt: "2026-05-26T12:01:00.000Z",
+          toolCount: 12,
+        },
+      }),
+    });
+
+    renderCard(readiness());
+    fireEvent.click(screen.getByRole("button", { name: /Test connection/i }));
+
+    await waitFor(() => {
+      expect(getReadinessMock).toHaveBeenCalledWith({
+        probe: true,
+        baseUrl: "http://localhost:3000",
+      });
+    });
+    expect(await screen.findByText(/Probe returned 12 MCP tools/i)).toBeTruthy();
+  });
+
+  it("offers exactly one primary issue action when no contributor token is ready", () => {
+    renderCard(
+      readiness({
+        status: "needs_authorization",
+        recommendedAction: "issue_development_token",
+        token: null,
+      }),
+    );
+
+    expect(screen.getAllByRole("button", { name: /Issue development token/i })).toHaveLength(1);
+    expect(screen.getByText(/No usable development token yet/i)).toBeTruthy();
+  });
+
+  it("describes read-only tokens without claiming missing zero grants", () => {
+    renderCard(
+      readiness({
+        status: "needs_grants",
+        recommendedAction: "rotate_development_token",
+        missingGrants: [],
+        token: {
+          ...readiness().token!,
+          scope: "read",
+        },
+      }),
+    );
+
+    expect(screen.getByText(/Current token is read-only/i)).toBeTruthy();
+    expect(screen.queryByText(/missing 0 grants/i)).toBeNull();
+  });
+
+  it("uses the existing issue action for missing or unusable tokens and shows setup snippets", async () => {
+    renderCard(
+      readiness({
+        status: "needs_reissue",
+        recommendedAction: "issue_development_token",
+        token: null,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Issue development token/i }));
+
+    await waitFor(() => {
+      expect(issueMock).toHaveBeenCalledWith({ baseUrl: "http://localhost:3000" });
+    });
+    expect(await screen.findByText(/New token issued/i)).toBeTruthy();
+    expect(screen.getByText("Session refresh")).toBeTruthy();
+    expect(screen.getByText(setupSnippets.runtimeRefreshPowerShell)).toBeTruthy();
+  });
+
+  it("rotates an under-granted token with the recommended development grants", async () => {
+    renderCard(
+      readiness({
+        status: "needs_grants",
+        recommendedAction: "rotate_development_token",
+        missingGrants: ["sandbox_execute"],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Rotate development token/i }));
+
+    await waitFor(() => {
+      expect(rotateMock).toHaveBeenCalledWith({
+        tokenId: "tok_ready",
+        name: "Development token",
+        scope: "write",
+        scopes: ["backlog_write", "work_capsule_write", "sandbox_execute"],
+        expiresInDays: 90,
+        baseUrl: "http://localhost:3000",
+      });
+    });
+    expect(await screen.findByText(/New token issued/i)).toBeTruthy();
+    expect(screen.getByText("Codex config")).toBeTruthy();
+    expect(screen.getByText(/bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"/)).toBeTruthy();
+  });
+});

--- a/apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
+++ b/apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
@@ -119,7 +119,6 @@ describe("ContributorMcpReadinessCard", () => {
     await waitFor(() => {
       expect(getReadinessMock).toHaveBeenCalledWith({
         probe: true,
-        baseUrl: "http://localhost:3000",
       });
     });
     expect(await screen.findByText(/Probe returned 12 MCP tools/i)).toBeTruthy();

--- a/apps/web/components/platform/ContributorMcpReadinessCard.tsx
+++ b/apps/web/components/platform/ContributorMcpReadinessCard.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  Copy,
+  KeyRound,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
+import { useState, useTransition } from "react";
+
+import {
+  getMyContributorMcpReadiness,
+  issueMyWriteMcpToken,
+  rotateMyMcpTokenWithEdit,
+  type IssueTokenActionResult,
+} from "@/lib/actions/mcp-tokens";
+import type {
+  ContributorMcpProbe,
+  ContributorMcpReadiness,
+} from "@/lib/mcp/contributor-readiness";
+
+type Props = {
+  initialReadiness: ContributorMcpReadiness;
+  baseUrl: string;
+  canWrite: boolean;
+};
+
+type IssuedPayload = Extract<IssueTokenActionResult, { ok: true }>;
+
+type LocalNotice =
+  | { kind: "error"; message: string }
+  | { kind: "success"; message: string }
+  | null;
+
+function primaryButtonClass(): string {
+  return "inline-flex items-center gap-1.5 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-semibold text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50";
+}
+
+function secondaryButtonClass(): string {
+  return "inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:cursor-not-allowed disabled:opacity-50";
+}
+
+function iconClass(): string {
+  return "h-4 w-4";
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "never";
+  return new Date(value).toLocaleString();
+}
+
+function statusMessage(readiness: ContributorMcpReadiness): string {
+  switch (readiness.status) {
+    case "ready":
+      return "Claude Code and Codex can use DPF MCP for Build Studio work.";
+    case "needs_authorization":
+      return "No usable development token yet. Issue a development token to enable Build Studio MCP.";
+    case "needs_reissue":
+      return "Current token is expired or revoked. Issue a replacement development token.";
+    case "needs_grants":
+      if (readiness.missingGrants.length === 0) {
+        return "Current token is read-only. Rotate it with development write access for Build Studio MCP.";
+      }
+      return `Current token is missing ${readiness.missingGrants.length} grants needed for Build Studio work.`;
+    case "needs_identity_binding":
+      return "Token access is not GAID-bound yet. RBAC and token grants still gate the peer.";
+  }
+}
+
+function primaryActionLabel(readiness: ContributorMcpReadiness): string {
+  switch (readiness.recommendedAction) {
+    case "test_connection":
+      return "Test connection";
+    case "issue_development_token":
+      return "Issue development token";
+    case "rotate_development_token":
+      return "Rotate development token";
+    case "none":
+      return "View details";
+  }
+}
+
+function probeMessage(probe: ContributorMcpProbe): string | null {
+  switch (probe.status) {
+    case "success":
+      return `Probe returned ${probe.toolCount} MCP tools.`;
+    case "failed":
+      return `Probe failed: ${probe.message}`;
+    case "unavailable":
+      return `Probe unavailable: ${probe.message}`;
+    case "not_run":
+      return null;
+  }
+}
+
+async function writeClipboardText(value: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ContributorMcpReadinessCard({
+  initialReadiness,
+  baseUrl,
+  canWrite,
+}: Props) {
+  const [readiness, setReadiness] = useState(initialReadiness);
+  const [issued, setIssued] = useState<IssuedPayload | null>(null);
+  const [notice, setNotice] = useState<LocalNotice>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const ready = readiness.status === "ready";
+  const attention = readiness.status !== "ready";
+  const probeCopy = probeMessage(readiness.probe);
+  const actionLabel = primaryActionLabel(readiness);
+  const disablePrimary =
+    isPending ||
+    !canWrite ||
+    readiness.recommendedAction === "none" ||
+    (readiness.recommendedAction === "rotate_development_token" && !readiness.token);
+
+  function runPrimaryAction() {
+    setNotice(null);
+    setIssued(null);
+
+    if (readiness.recommendedAction === "test_connection") {
+      startTransition(async () => {
+        const result = await getMyContributorMcpReadiness({ probe: true, baseUrl });
+        if (!result.ok) {
+          setNotice({ kind: "error", message: "Sign in before testing MCP readiness." });
+          return;
+        }
+        setReadiness(result.readiness);
+      });
+      return;
+    }
+
+    if (readiness.recommendedAction === "issue_development_token") {
+      startTransition(async () => {
+        const result = await issueMyWriteMcpToken({ baseUrl });
+        if (!result.ok) {
+          setNotice({ kind: "error", message: result.message });
+          return;
+        }
+        setIssued(result);
+        setNotice({
+          kind: "success",
+          message: "Refresh the running Claude/Codex session before retrying.",
+        });
+      });
+      return;
+    }
+
+    if (readiness.recommendedAction === "rotate_development_token" && readiness.token) {
+      startTransition(async () => {
+        const result = await rotateMyMcpTokenWithEdit({
+          tokenId: readiness.token!.id,
+          name: readiness.token!.name,
+          scope: "write",
+          scopes: readiness.recommendedScopes,
+          expiresInDays: 90,
+          baseUrl,
+        });
+        if (!result.ok) {
+          setNotice({ kind: "error", message: result.message });
+          return;
+        }
+        setIssued(result);
+        setNotice({
+          kind: "success",
+          message: "Refresh the running Claude/Codex session before retrying.",
+        });
+      });
+    }
+  }
+
+  return (
+    <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            {ready ? (
+              <CheckCircle2 className="h-4 w-4 text-[var(--dpf-success)]" aria-hidden="true" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 text-[var(--dpf-warning)]" aria-hidden="true" />
+            )}
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+              Claude/Codex MCP readiness
+            </h2>
+          </div>
+          <p className="mt-1 text-sm leading-5 text-[var(--dpf-text)]">
+            {statusMessage(readiness)}
+          </p>
+          {readiness.token && (
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Last used: {formatDateTime(readiness.token.lastUsedAt)} · Expires:{" "}
+              {formatDateTime(readiness.token.expiresAt)}
+            </p>
+          )}
+          {probeCopy && (
+            <p
+              className={`mt-1 text-xs ${
+                readiness.probe.status === "success"
+                  ? "text-[var(--dpf-success)]"
+                  : "text-[var(--dpf-warning)]"
+              }`}
+            >
+              {probeCopy}
+            </p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={runPrimaryAction}
+            disabled={disablePrimary}
+            className={attention ? primaryButtonClass() : secondaryButtonClass()}
+          >
+            {readiness.recommendedAction === "test_connection" ? (
+              <RefreshCw className={iconClass()} aria-hidden="true" />
+            ) : (
+              <ShieldCheck className={iconClass()} aria-hidden="true" />
+            )}
+            {isPending ? "Working..." : actionLabel}
+          </button>
+          <Link
+            href="/admin/platform-development"
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+          >
+            <KeyRound className={iconClass()} aria-hidden="true" />
+            Manage tokens
+          </Link>
+        </div>
+      </div>
+
+      {!canWrite && (
+        <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-xs text-[var(--dpf-muted)]">
+          Token remediation requires provider-management permission.
+        </div>
+      )}
+
+      {notice && (
+        <div
+          className={`mt-3 flex items-start gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm ${
+            notice.kind === "success" ? "text-[var(--dpf-success)]" : "text-[var(--dpf-error)]"
+          }`}
+        >
+          {notice.kind === "success" ? (
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          ) : (
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          )}
+          <span>{notice.message}</span>
+        </div>
+      )}
+
+      <details className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+        <summary className="flex cursor-pointer list-none items-center gap-2 text-xs font-medium text-[var(--dpf-text)]">
+          <ChevronDown className="h-3.5 w-3.5 text-[var(--dpf-muted)]" aria-hidden="true" />
+          Details
+        </summary>
+        <div className="mt-3 grid gap-3 text-xs text-[var(--dpf-muted)] md:grid-cols-2">
+          <ReadinessList title="Required grants" items={readiness.requiredGrants} />
+          <ReadinessList
+            title="Missing grants"
+            items={readiness.missingGrants.length > 0 ? readiness.missingGrants : ["none"]}
+          />
+          <div>
+            <p className="font-medium text-[var(--dpf-text)]">Peer identity</p>
+            <p className="mt-1">
+              {readiness.identityBinding === "bound"
+                ? "GAID-bound"
+                : "GAID binding is not available in this slice."}
+            </p>
+          </div>
+          <div>
+            <p className="font-medium text-[var(--dpf-text)]">Endpoint</p>
+            <p className="mt-1 break-all">{baseUrl}/api/mcp/v1</p>
+          </div>
+        </div>
+      </details>
+
+      {issued && <IssuedTokenSetupPanel payload={issued} />}
+    </section>
+  );
+}
+
+function ReadinessList(props: { title: string; items: string[] }) {
+  return (
+    <div>
+      <p className="font-medium text-[var(--dpf-text)]">{props.title}</p>
+      <p className="mt-1 break-words">{props.items.join(", ")}</p>
+    </div>
+  );
+}
+
+function IssuedTokenSetupPanel(props: { payload: IssuedPayload }) {
+  return (
+    <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+      <div className="flex items-center gap-2">
+        <CheckCircle2 className="h-4 w-4 text-[var(--dpf-success)]" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)]">New token issued</h3>
+      </div>
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+        Bind this token to Claude Code and Codex, then refresh the running client session.
+      </p>
+      <div className="mt-3 space-y-3">
+        <SnippetBlock label="Client env" value={props.payload.setupSnippets.envPowerShell} />
+        <SnippetBlock
+          label="Session refresh"
+          value={props.payload.setupSnippets.runtimeRefreshPowerShell}
+        />
+        <SnippetBlock label="Claude config" value={props.payload.setupSnippets.claudeCode} />
+        <SnippetBlock label="Codex config" value={props.payload.setupSnippets.codex} />
+      </div>
+    </div>
+  );
+}
+
+function SnippetBlock(props: { label: string; value: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "blocked">("idle");
+
+  async function copy() {
+    const copied = await writeClipboardText(props.value);
+    setCopyState(copied ? "copied" : "blocked");
+  }
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-[var(--dpf-text)]">{props.label}</p>
+          {copyState !== "idle" && (
+            <p
+              className={`mt-0.5 text-xs ${
+                copyState === "copied" ? "text-[var(--dpf-success)]" : "text-[var(--dpf-warning)]"
+              }`}
+            >
+              {copyState === "copied" ? "Copied" : "Clipboard blocked"}
+            </p>
+          )}
+        </div>
+        <button type="button" onClick={copy} className={secondaryButtonClass()}>
+          <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+          Copy
+        </button>
+      </div>
+      <div className="max-h-28 overflow-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 font-mono text-xs text-[var(--dpf-text)]">
+        <code className="break-all whitespace-pre-wrap">{props.value}</code>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/ContributorMcpReadinessCard.tsx
+++ b/apps/web/components/platform/ContributorMcpReadinessCard.tsx
@@ -132,7 +132,7 @@ export function ContributorMcpReadinessCard({
 
     if (readiness.recommendedAction === "test_connection") {
       startTransition(async () => {
-        const result = await getMyContributorMcpReadiness({ probe: true, baseUrl });
+        const result = await getMyContributorMcpReadiness({ probe: true });
         if (!result.ok) {
           setNotice({ kind: "error", message: "Sign in before testing MCP readiness." });
           return;

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -180,15 +180,11 @@ describe("getMyContributorMcpReadiness", () => {
       probe: { status: "not_run" },
     });
 
-    const result = await getMyContributorMcpReadiness({
-      probe: true,
-      baseUrl: "http://localhost:3000",
-    });
+    const result = await getMyContributorMcpReadiness({ probe: true });
 
     expect(result.ok).toBe(true);
     expect(readinessMock).toHaveBeenCalledWith("u1", {
       probe: true,
-      baseUrl: "http://localhost:3000",
     });
     expect(JSON.stringify(result)).not.toContain("dpfmcp_SECRET");
   });

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -17,6 +17,10 @@ vi.mock("@/lib/tak/agent-grants", () => ({
   getToolGrantMapping: vi.fn(),
 }));
 
+vi.mock("@/lib/mcp/contributor-readiness", () => ({
+  getContributorMcpReadiness: vi.fn(),
+}));
+
 import { auth } from "@/lib/auth";
 import {
   addScopesToMcpApiToken,
@@ -27,9 +31,11 @@ import {
   rotateMcpApiToken,
 } from "@/lib/auth/mcp-api-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import { getContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import {
   bulkRevokeMyMcpTokens,
   copyMyMcpToken,
+  getMyContributorMcpReadiness,
   issueMyMcpToken,
   issueMyTemplateMcpToken,
   issueMyWriteMcpToken,
@@ -106,6 +112,7 @@ const revokeMock = revokeMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const listMock = listMcpApiTokens as unknown as ReturnType<typeof vi.fn>;
 const rotateMock = rotateMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const grantMapMock = getToolGrantMapping as unknown as ReturnType<typeof vi.fn>;
+const readinessMock = getContributorMcpReadiness as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -137,6 +144,53 @@ describe("listAvailableMcpScopes", () => {
       "code_graph_read",
       "spec_plan_read",
     ]);
+  });
+});
+
+describe("getMyContributorMcpReadiness", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+
+    const result = await getMyContributorMcpReadiness();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unauthorized");
+    expect(readinessMock).not.toHaveBeenCalled();
+  });
+
+  it("returns contributor readiness for the current operator without plaintext", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    readinessMock.mockResolvedValue({
+      status: "ready",
+      recommendedAction: "test_connection",
+      identityBinding: "not_available",
+      token: {
+        id: "tok_1",
+        name: "Development token",
+        prefix: "dpfmcp_DEV",
+        tokenSuffix: "DEV1",
+        scope: "write",
+        scopes: ["backlog_write"],
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+      missingGrants: [],
+      requiredGrants: ["backlog_write"],
+      recommendedScopes: ["backlog_write"],
+      probe: { status: "not_run" },
+    });
+
+    const result = await getMyContributorMcpReadiness({
+      probe: true,
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readinessMock).toHaveBeenCalledWith("u1", {
+      probe: true,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(JSON.stringify(result)).not.toContain("dpfmcp_SECRET");
   });
 });
 

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -107,7 +107,6 @@ export async function listMyMcpTokens() {
 
 export async function getMyContributorMcpReadiness(input?: {
   probe?: boolean;
-  baseUrl?: string;
 }) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -116,7 +115,6 @@ export async function getMyContributorMcpReadiness(input?: {
 
   const readiness = await getContributorMcpReadiness(session.user.id, {
     probe: input?.probe ?? false,
-    baseUrl: input?.baseUrl,
   });
   return { ok: true as const, readiness };
 }

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/auth/mcp-api-token";
 import { buildSetupSnippets } from "@/lib/auth/mcp-setup-snippets";
 import { writeMcpJsonToHost } from "@/lib/auth/mcp-host-writer";
+import { getContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
   deriveIdleDays,
@@ -102,6 +103,22 @@ export async function listMyMcpTokens() {
       createdAt: t.createdAt.toISOString(),
     })),
   };
+}
+
+export async function getMyContributorMcpReadiness(input?: {
+  probe?: boolean;
+  baseUrl?: string;
+}) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false as const, error: "unauthorized" };
+  }
+
+  const readiness = await getContributorMcpReadiness(session.user.id, {
+    probe: input?.probe ?? false,
+    baseUrl: input?.baseUrl,
+  });
+  return { ok: true as const, readiness };
 }
 
 export type IssueTokenActionResult =

--- a/apps/web/lib/mcp-token-scopes.test.ts
+++ b/apps/web/lib/mcp-token-scopes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   CODING_AGENT_MCP_TOKEN_SCOPES,
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
   MCP_TOKEN_REVOKED_ARCHIVE_DAYS,
   MCP_TOKEN_TEMPLATES,
   WRITE_MCP_TOKEN_SCOPES,
@@ -113,6 +114,14 @@ describe("MCP_TOKEN_TEMPLATES", () => {
 
   it("returns undefined for unknown template ids", () => {
     expect(getMcpTokenTemplate("does_not_exist")).toBeUndefined();
+  });
+
+  it("keeps the development template as a superset of contributor MCP readiness", () => {
+    const development = getMcpTokenTemplate("development");
+    expect(development).toBeDefined();
+    for (const grant of CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS) {
+      expect(development!.grants).toContain(grant);
+    }
   });
 });
 

--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -158,6 +158,20 @@ export type McpTokenTemplate = {
   grants: readonly string[];
 };
 
+export const CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS = [
+  "architecture_read",
+  "backlog_read",
+  "backlog_write",
+  "code_graph_read",
+  "file_read",
+  "spec_plan_read",
+  "work_capsule_read",
+  "work_capsule_write",
+  "work_capsule_adopt",
+  "sandbox_execute",
+  "iac_execute",
+] as const;
+
 const DEVELOPMENT_TEMPLATE_GRANTS = [
   // Reads needed to navigate the codebase, specs, backlog, and architecture
   "architecture_read",

--- a/apps/web/lib/mcp/contributor-readiness.test.ts
+++ b/apps/web/lib/mcp/contributor-readiness.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth/mcp-api-token", () => ({
   copyMcpApiTokenPlaintext: vi.fn(),
@@ -42,6 +42,11 @@ function token(overrides: Partial<ContributorMcpTokenRow> = {}): ContributorMcpT
 beforeEach(() => {
   vi.resetAllMocks();
   _resetContributorMcpReadinessProbeCacheForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe("getContributorMcpReadiness", () => {
@@ -149,12 +154,10 @@ describe("getContributorMcpReadiness", () => {
 
     const first = await getContributorMcpReadiness("user_1", {
       probe: true,
-      baseUrl: "http://localhost:3000",
       now: new Date("2026-05-26T12:00:00Z"),
     });
     const second = await getContributorMcpReadiness("user_1", {
       probe: true,
-      baseUrl: "http://localhost:3000",
       now: new Date("2026-05-26T12:00:30Z"),
     });
 
@@ -166,7 +169,31 @@ describe("getContributorMcpReadiness", () => {
     expect(second.probe).toEqual(first.probe);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(first)).not.toContain("dpfmcp_SECRET");
-    vi.unstubAllGlobals();
+  });
+
+  it("builds the live probe URL from server configuration only", async () => {
+    vi.stubEnv("APP_URL", "https://portal.example.test/custom/path?tenant=x#fragment");
+    listTokensMock.mockResolvedValue([token()]);
+    copyTokenMock.mockResolvedValue({
+      ok: true,
+      plaintext: "dpfmcp_SECRET",
+      prefix: "dpfmcp_SECR",
+      tokenSuffix: "CRET",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { tools: [{ name: "list_backlog_items" }] } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getContributorMcpReadiness("user_1", {
+      probe: true,
+      now: new Date("2026-05-26T12:00:00Z"),
+    });
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://portal.example.test/api/mcp/v1",
+    );
   });
 
   it("caches failed probe results inside the probe window", async () => {
@@ -186,12 +213,10 @@ describe("getContributorMcpReadiness", () => {
 
     const first = await getContributorMcpReadiness("user_1", {
       probe: true,
-      baseUrl: "http://localhost:3000",
       now: new Date("2026-05-26T12:00:00Z"),
     });
     const second = await getContributorMcpReadiness("user_1", {
       probe: true,
-      baseUrl: "http://localhost:3000",
       now: new Date("2026-05-26T12:00:30Z"),
     });
 
@@ -202,6 +227,5 @@ describe("getContributorMcpReadiness", () => {
     });
     expect(second.probe).toEqual(first.probe);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/lib/mcp/contributor-readiness.test.ts
+++ b/apps/web/lib/mcp/contributor-readiness.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/mcp-api-token", () => ({
+  copyMcpApiTokenPlaintext: vi.fn(),
+  listMcpApiTokens: vi.fn(),
+}));
+
+import {
+  copyMcpApiTokenPlaintext,
+  listMcpApiTokens,
+} from "@/lib/auth/mcp-api-token";
+import { CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS } from "@/lib/mcp-token-scopes";
+import {
+  _resetContributorMcpReadinessProbeCacheForTests,
+  getContributorMcpReadiness,
+  type ContributorMcpTokenRow,
+} from "./contributor-readiness";
+
+const listTokensMock = listMcpApiTokens as unknown as ReturnType<typeof vi.fn>;
+const copyTokenMock = copyMcpApiTokenPlaintext as unknown as ReturnType<typeof vi.fn>;
+
+function token(overrides: Partial<ContributorMcpTokenRow> = {}): ContributorMcpTokenRow {
+  return {
+    id: "tok_1",
+    name: "Development token",
+    prefix: "dpfmcp_DEV",
+    tokenSuffix: "DEV1",
+    canCopy: true,
+    capability: "write",
+    scope: "write",
+    scopes: [...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS],
+    kind: "operator",
+    buildId: null,
+    lastUsedAt: new Date("2026-05-26T12:00:00Z"),
+    expiresAt: null,
+    revokedAt: null,
+    createdAt: new Date("2026-05-20T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  _resetContributorMcpReadinessProbeCacheForTests();
+});
+
+describe("getContributorMcpReadiness", () => {
+  it("returns needs_authorization when the operator has no tokens", async () => {
+    listTokensMock.mockResolvedValue([]);
+
+    const result = await getContributorMcpReadiness("user_1");
+
+    expect(result.status).toBe("needs_authorization");
+    expect(result.recommendedAction).toBe("issue_development_token");
+    expect(result.token).toBeNull();
+    expect(result.missingGrants).toEqual([...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS]);
+  });
+
+  it("returns needs_reissue when every operator token is expired or revoked", async () => {
+    listTokensMock.mockResolvedValue([
+      token({
+        id: "tok_expired",
+        expiresAt: new Date("2026-05-01T00:00:00Z"),
+        lastUsedAt: new Date("2026-05-10T00:00:00Z"),
+      }),
+      token({
+        id: "tok_revoked",
+        revokedAt: new Date("2026-05-20T00:00:00Z"),
+        lastUsedAt: new Date("2026-05-25T00:00:00Z"),
+      }),
+    ]);
+
+    const result = await getContributorMcpReadiness("user_1", {
+      now: new Date("2026-05-26T12:00:00Z"),
+    });
+
+    expect(result.status).toBe("needs_reissue");
+    expect(result.recommendedAction).toBe("issue_development_token");
+    expect(result.token?.id).toBe("tok_revoked");
+  });
+
+  it("ignores lifecycle-managed ship tokens", async () => {
+    listTokensMock.mockResolvedValue([
+      token({ id: "tok_ship", kind: "ephemeral_ship", buildId: "FB-123" }),
+    ]);
+
+    const result = await getContributorMcpReadiness("user_1");
+
+    expect(result.status).toBe("needs_authorization");
+    expect(result.token).toBeNull();
+  });
+
+  it("returns needs_grants for read-tier or under-granted active tokens", async () => {
+    listTokensMock.mockResolvedValue([
+      token({
+        id: "tok_read",
+        capability: "read",
+        scope: "read",
+        scopes: ["architecture_read", "backlog_read"],
+      }),
+    ]);
+
+    const result = await getContributorMcpReadiness("user_1");
+
+    expect(result.status).toBe("needs_grants");
+    expect(result.recommendedAction).toBe("rotate_development_token");
+    expect(result.token?.id).toBe("tok_read");
+    expect(result.missingGrants).toContain("backlog_write");
+  });
+
+  it("returns ready for an active write token with every required grant", async () => {
+    listTokensMock.mockResolvedValue([token()]);
+
+    const result = await getContributorMcpReadiness("user_1");
+
+    expect(result.status).toBe("ready");
+    expect(result.recommendedAction).toBe("test_connection");
+    expect(result.identityBinding).toBe("not_available");
+    expect(result.missingGrants).toEqual([]);
+    expect(result.requiredGrants).toEqual([...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS]);
+    expect(result.token?.id).toBe("tok_1");
+  });
+
+  it("prefers the most recently used ready token", async () => {
+    listTokensMock.mockResolvedValue([
+      token({ id: "tok_old", lastUsedAt: new Date("2026-05-20T12:00:00Z") }),
+      token({ id: "tok_new", lastUsedAt: new Date("2026-05-26T12:00:00Z") }),
+    ]);
+
+    const result = await getContributorMcpReadiness("user_1");
+
+    expect(result.status).toBe("ready");
+    expect(result.token?.id).toBe("tok_new");
+  });
+
+  it("runs a cached read-only tools/list probe without exposing plaintext", async () => {
+    listTokensMock.mockResolvedValue([token()]);
+    copyTokenMock.mockResolvedValue({
+      ok: true,
+      plaintext: "dpfmcp_SECRET",
+      prefix: "dpfmcp_SECR",
+      tokenSuffix: "CRET",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { tools: [{ name: "list_backlog_items" }] } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await getContributorMcpReadiness("user_1", {
+      probe: true,
+      baseUrl: "http://localhost:3000",
+      now: new Date("2026-05-26T12:00:00Z"),
+    });
+    const second = await getContributorMcpReadiness("user_1", {
+      probe: true,
+      baseUrl: "http://localhost:3000",
+      now: new Date("2026-05-26T12:00:30Z"),
+    });
+
+    expect(first.probe).toEqual({
+      status: "success",
+      checkedAt: "2026-05-26T12:00:00.000Z",
+      toolCount: 1,
+    });
+    expect(second.probe).toEqual(first.probe);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(first)).not.toContain("dpfmcp_SECRET");
+    vi.unstubAllGlobals();
+  });
+
+  it("caches failed probe results inside the probe window", async () => {
+    listTokensMock.mockResolvedValue([token()]);
+    copyTokenMock.mockResolvedValue({
+      ok: true,
+      plaintext: "dpfmcp_SECRET",
+      prefix: "dpfmcp_SECR",
+      tokenSuffix: "CRET",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await getContributorMcpReadiness("user_1", {
+      probe: true,
+      baseUrl: "http://localhost:3000",
+      now: new Date("2026-05-26T12:00:00Z"),
+    });
+    const second = await getContributorMcpReadiness("user_1", {
+      probe: true,
+      baseUrl: "http://localhost:3000",
+      now: new Date("2026-05-26T12:00:30Z"),
+    });
+
+    expect(first.probe).toEqual({
+      status: "failed",
+      checkedAt: "2026-05-26T12:00:00.000Z",
+      message: "HTTP 403",
+    });
+    expect(second.probe).toEqual(first.probe);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/lib/mcp/contributor-readiness.ts
+++ b/apps/web/lib/mcp/contributor-readiness.ts
@@ -53,7 +53,6 @@ export type ContributorMcpReadiness = {
 
 export type ContributorMcpReadinessOptions = {
   probe?: boolean;
-  baseUrl?: string;
   now?: Date;
 };
 
@@ -133,7 +132,7 @@ function baseResult(
 
 async function runProbe(
   token: ContributorMcpTokenRow,
-  opts: Required<Pick<ContributorMcpReadinessOptions, "baseUrl" | "now">>,
+  opts: Required<Pick<ContributorMcpReadinessOptions, "now">>,
 ): Promise<ContributorMcpProbe> {
   const cached = probeCache.get(token.id);
   if (cached && opts.now.getTime() - cached.checkedAtMs < PROBE_TTL_MS) {
@@ -150,7 +149,7 @@ async function runProbe(
 
   const checkedAt = opts.now.toISOString();
   try {
-    const response = await fetch(`${opts.baseUrl}/api/mcp/v1`, {
+    const response = await fetch(new URL("/api/mcp/v1", resolveProbeBaseUrl()), {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -224,11 +223,22 @@ export async function getContributorMcpReadiness(
   const result = baseResult("ready", readyToken, []);
   if (opts.probe) {
     result.probe = await runProbe(readyToken, {
-      baseUrl: opts.baseUrl ?? process.env.APP_URL ?? process.env.AUTH_URL ?? "http://127.0.0.1:3000",
       now,
     });
   }
   return result;
+}
+
+function resolveProbeBaseUrl(): string {
+  const rawBaseUrl = process.env.APP_URL ?? process.env.AUTH_URL ?? "http://127.0.0.1:3000";
+  const url = new URL(rawBaseUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("MCP probe base URL must use http or https.");
+  }
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
 }
 
 export function _resetContributorMcpReadinessProbeCacheForTests(): void {

--- a/apps/web/lib/mcp/contributor-readiness.ts
+++ b/apps/web/lib/mcp/contributor-readiness.ts
@@ -1,0 +1,236 @@
+import {
+  copyMcpApiTokenPlaintext,
+  listMcpApiTokens,
+} from "@/lib/auth/mcp-api-token";
+import {
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+  getMcpTokenTemplate,
+  type McpTokenScopeTier,
+} from "@/lib/mcp-token-scopes";
+
+const PROBE_TTL_MS = 60_000;
+
+export type ContributorMcpReadinessStatus =
+  | "ready"
+  | "needs_authorization"
+  | "needs_reissue"
+  | "needs_grants"
+  | "needs_identity_binding";
+
+export type ContributorMcpRecommendedAction =
+  | "none"
+  | "issue_development_token"
+  | "rotate_development_token"
+  | "test_connection";
+
+export type ContributorMcpProbe =
+  | { status: "not_run" }
+  | { status: "success"; checkedAt: string; toolCount: number }
+  | { status: "failed"; checkedAt: string; message: string }
+  | { status: "unavailable"; message: string };
+
+export type ContributorMcpTokenRow = Awaited<ReturnType<typeof listMcpApiTokens>>[number];
+
+export type ContributorMcpReadiness = {
+  status: ContributorMcpReadinessStatus;
+  recommendedAction: ContributorMcpRecommendedAction;
+  identityBinding: "bound" | "not_available";
+  token: null | {
+    id: string;
+    name: string;
+    prefix: string;
+    tokenSuffix: string;
+    scope: McpTokenScopeTier;
+    scopes: string[];
+    lastUsedAt: string | null;
+    expiresAt: string | null;
+  };
+  missingGrants: string[];
+  requiredGrants: string[];
+  recommendedScopes: string[];
+  probe: ContributorMcpProbe;
+};
+
+export type ContributorMcpReadinessOptions = {
+  probe?: boolean;
+  baseUrl?: string;
+  now?: Date;
+};
+
+const probeCache = new Map<string, { checkedAtMs: number; probe: ContributorMcpProbe }>();
+
+function cacheProbe(
+  tokenId: string,
+  checkedAtMs: number,
+  probe: ContributorMcpProbe,
+): ContributorMcpProbe {
+  probeCache.set(tokenId, { checkedAtMs, probe });
+  return probe;
+}
+
+function isActive(token: ContributorMcpTokenRow, now: Date): boolean {
+  if (token.revokedAt != null) return false;
+  if (token.expiresAt != null && token.expiresAt.getTime() < now.getTime()) return false;
+  return true;
+}
+
+function scopeCanWrite(scope: string): boolean {
+  return scope === "write" || scope === "admin";
+}
+
+function missingRequiredGrants(token: ContributorMcpTokenRow): string[] {
+  const scopes = new Set(token.scopes);
+  return CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS.filter((grant) => !scopes.has(grant));
+}
+
+function sortByFreshness(a: ContributorMcpTokenRow, b: ContributorMcpTokenRow): number {
+  const aTime = (a.lastUsedAt ?? a.createdAt).getTime();
+  const bTime = (b.lastUsedAt ?? b.createdAt).getTime();
+  return bTime - aTime;
+}
+
+function projectToken(token: ContributorMcpTokenRow): ContributorMcpReadiness["token"] {
+  return {
+    id: token.id,
+    name: token.name,
+    prefix: token.prefix,
+    tokenSuffix: token.tokenSuffix,
+    scope: token.scope,
+    scopes: token.scopes,
+    lastUsedAt: token.lastUsedAt?.toISOString() ?? null,
+    expiresAt: token.expiresAt?.toISOString() ?? null,
+  };
+}
+
+function baseResult(
+  status: ContributorMcpReadinessStatus,
+  token: ContributorMcpTokenRow | null,
+  missingGrants: string[],
+): ContributorMcpReadiness {
+  const recommendedScopes = getMcpTokenTemplate("development")?.grants ?? [
+    ...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+  ];
+  const recommendedAction: ContributorMcpRecommendedAction =
+    status === "ready"
+      ? "test_connection"
+      : status === "needs_grants"
+        ? "rotate_development_token"
+        : status === "needs_identity_binding"
+          ? "none"
+          : "issue_development_token";
+
+  return {
+    status,
+    recommendedAction,
+    identityBinding: "not_available",
+    token: token ? projectToken(token) : null,
+    missingGrants,
+    requiredGrants: [...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS],
+    recommendedScopes: [...recommendedScopes],
+    probe: { status: "not_run" },
+  };
+}
+
+async function runProbe(
+  token: ContributorMcpTokenRow,
+  opts: Required<Pick<ContributorMcpReadinessOptions, "baseUrl" | "now">>,
+): Promise<ContributorMcpProbe> {
+  const cached = probeCache.get(token.id);
+  if (cached && opts.now.getTime() - cached.checkedAtMs < PROBE_TTL_MS) {
+    return cached.probe;
+  }
+
+  const copied = await copyMcpApiTokenPlaintext(token.id);
+  if (!copied.ok) {
+    return cacheProbe(token.id, opts.now.getTime(), {
+      status: "unavailable",
+      message: `Token plaintext unavailable: ${copied.error}`,
+    });
+  }
+
+  const checkedAt = opts.now.toISOString();
+  try {
+    const response = await fetch(`${opts.baseUrl}/api/mcp/v1`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${copied.plaintext}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    if (!response.ok) {
+      return cacheProbe(token.id, opts.now.getTime(), {
+        status: "failed",
+        checkedAt,
+        message: `HTTP ${response.status}`,
+      });
+    }
+    const payload = (await response.json()) as {
+      result?: { tools?: unknown[] };
+      error?: { message?: string };
+    };
+    const tools = payload.result?.tools;
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return cacheProbe(token.id, opts.now.getTime(), {
+        status: "failed",
+        checkedAt,
+        message: payload.error?.message ?? "tools/list returned no tools",
+      });
+    }
+    const probe: ContributorMcpProbe = {
+      status: "success",
+      checkedAt,
+      toolCount: tools.length,
+    };
+    return cacheProbe(token.id, opts.now.getTime(), probe);
+  } catch (err) {
+    return cacheProbe(token.id, opts.now.getTime(), {
+      status: "failed",
+      checkedAt,
+      message: err instanceof Error ? err.message : "Unknown probe failure",
+    });
+  }
+}
+
+export async function getContributorMcpReadiness(
+  userId: string,
+  opts: ContributorMcpReadinessOptions = {},
+): Promise<ContributorMcpReadiness> {
+  const now = opts.now ?? new Date();
+  const operatorTokens = (await listMcpApiTokens(userId))
+    .filter((token) => token.kind === "operator")
+    .sort(sortByFreshness);
+  const activeOperatorTokens = operatorTokens.filter((token) => isActive(token, now));
+
+  if (activeOperatorTokens.length === 0) {
+    if (operatorTokens.length > 0) {
+      return baseResult("needs_reissue", operatorTokens[0] ?? null, [
+        ...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+      ]);
+    }
+    return baseResult("needs_authorization", null, [
+      ...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+    ]);
+  }
+
+  const readyToken = activeOperatorTokens.find(
+    (token) => scopeCanWrite(token.scope) && missingRequiredGrants(token).length === 0,
+  );
+  if (!readyToken) {
+    const token = activeOperatorTokens[0]!;
+    return baseResult("needs_grants", token, missingRequiredGrants(token));
+  }
+
+  const result = baseResult("ready", readyToken, []);
+  if (opts.probe) {
+    result.probe = await runProbe(readyToken, {
+      baseUrl: opts.baseUrl ?? process.env.APP_URL ?? process.env.AUTH_URL ?? "http://127.0.0.1:3000",
+      now,
+    });
+  }
+  return result;
+}
+
+export function _resetContributorMcpReadinessProbeCacheForTests(): void {
+  probeCache.clear();
+}

--- a/docs/superpowers/plans/2026-05-26-contributor-client-mcp-readiness.md
+++ b/docs/superpowers/plans/2026-05-26-contributor-client-mcp-readiness.md
@@ -81,7 +81,7 @@ it("keeps the development template as a superset of contributor MCP readiness", 
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/lib/mcp-token-scopes.test.ts
+pnpm --filter web exec vitest run lib/mcp-token-scopes.test.ts
 ```
 
 Expected: fails because `CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS` is not exported.
@@ -111,7 +111,7 @@ export const CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS = [
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/lib/mcp-token-scopes.test.ts
+pnpm --filter web exec vitest run lib/mcp-token-scopes.test.ts
 ```
 
 Expected: all tests in `mcp-token-scopes.test.ts` pass.
@@ -173,7 +173,7 @@ function token(overrides: Partial<ContributorMcpTokenRow> = {}): ContributorMcpT
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/lib/mcp/contributor-readiness.test.ts
+pnpm --filter web exec vitest run lib/mcp/contributor-readiness.test.ts
 ```
 
 Expected: fails because the module does not exist.
@@ -274,7 +274,7 @@ non-empty `tools` array. Do not expose plaintext in the result.
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/lib/mcp/contributor-readiness.test.ts
+pnpm --filter web exec vitest run lib/mcp/contributor-readiness.test.ts
 ```
 
 Expected: all readiness tests pass.
@@ -321,7 +321,7 @@ export async function getMyContributorMcpReadiness(input?: {
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/lib/actions/mcp-tokens.test.ts
+pnpm --filter web exec vitest run lib/actions/mcp-tokens.test.ts
 ```
 
 Expected: action tests pass.
@@ -386,7 +386,7 @@ section.
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
+pnpm --filter web exec vitest run components/platform/ContributorMcpReadinessCard.test.tsx
 ```
 
 Expected: card tests pass.
@@ -423,7 +423,7 @@ Do not move or duplicate the existing issue/rotate/revoke controls.
 Run:
 
 ```powershell
-pnpm --filter web exec vitest run apps/web/components/admin/McpTokenManager.test.tsx
+pnpm --filter web exec vitest run components/admin/McpTokenManager.test.tsx
 ```
 
 Expected: token manager tests pass.
@@ -441,11 +441,11 @@ Run:
 
 ```powershell
 pnpm --filter web exec vitest run `
-  apps/web/lib/mcp-token-scopes.test.ts `
-  apps/web/lib/mcp/contributor-readiness.test.ts `
-  apps/web/lib/actions/mcp-tokens.test.ts `
-  apps/web/components/platform/ContributorMcpReadinessCard.test.tsx `
-  apps/web/components/admin/McpTokenManager.test.tsx
+  lib/mcp-token-scopes.test.ts `
+  lib/mcp/contributor-readiness.test.ts `
+  lib/actions/mcp-tokens.test.ts `
+  components/platform/ContributorMcpReadinessCard.test.tsx `
+  components/admin/McpTokenManager.test.tsx
 ```
 
 Expected: all focused tests pass.

--- a/docs/superpowers/plans/2026-05-26-contributor-client-mcp-readiness.md
+++ b/docs/superpowers/plans/2026-05-26-contributor-client-mcp-readiness.md
@@ -1,0 +1,505 @@
+# Contributor Client MCP Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Build Studio and Platform Development readiness surface that proves Claude Code and Codex can use the DPF MCP server with the right token access controls.
+
+**Architecture:** Implement a pure, non-mutating read model in `apps/web/lib/mcp/contributor-readiness.ts`, then consume it from a compact Build Studio card and a Platform Development banner. Existing MCP token actions remain the only write path for issue, rotate, revoke, copy, and setup snippets.
+
+**Tech Stack:** Next.js 16 server actions, React 19 client components, Vitest, DPF MCP token substrate, DPF theme CSS variables.
+
+---
+
+## Scope Notes
+
+This plan implements the first slice from
+`docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md`.
+It does not add a new schema migration. GAID binding is represented honestly as
+`identityBinding: "not_available"` until the TAK/GAID protocol-profile work
+lands a first-class external contributor principal binding.
+
+Do not create a parallel token issuance path. All write operations must continue
+through `apps/web/lib/actions/mcp-tokens.ts` and
+`apps/web/lib/auth/mcp-api-token.ts`.
+
+## File Structure
+
+- Modify: `apps/web/lib/mcp-token-scopes.ts`
+  - Export `CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`.
+- Modify: `apps/web/lib/mcp-token-scopes.test.ts`
+  - Assert the development template is a superset of the readiness threshold.
+- Create: `apps/web/lib/mcp/contributor-readiness.ts`
+  - Pure read model, token selection, missing grant diff, optional live probe.
+- Create: `apps/web/lib/mcp/contributor-readiness.test.ts`
+  - TDD coverage for readiness states and probe caching.
+- Modify: `apps/web/lib/actions/mcp-tokens.ts`
+  - Add `getMyContributorMcpReadiness`.
+- Modify: `apps/web/lib/actions/mcp-tokens.test.ts`
+  - Assert auth, delegation, and no plaintext exposure.
+- Create: `apps/web/components/platform/ContributorMcpReadinessCard.tsx`
+  - Compact card used by Build Studio.
+- Create: `apps/web/components/platform/ContributorMcpReadinessCard.test.tsx`
+  - Component states and primary actions.
+- Modify: `apps/web/components/platform/BuildStudioConfigForm.tsx`
+  - Render the card above Build Dispatch Engine.
+- Modify: `apps/web/app/(shell)/platform/ai/build-studio/page.tsx`
+  - Resolve base URL and initial readiness server-side.
+- Modify: `apps/web/components/admin/McpTokenManager.tsx`
+  - Add a small status banner that consumes the same read model.
+- Modify: `apps/web/components/admin/McpTokenManager.test.tsx`
+  - Banner behavior and no duplicate token semantics.
+
+## Chunk 1: Readiness Threshold Constant
+
+### Task 1: Export Required Grants
+
+**Files:**
+- Modify: `apps/web/lib/mcp-token-scopes.ts`
+- Modify: `apps/web/lib/mcp-token-scopes.test.ts`
+
+- [ ] **Step 1: Write the failing invariant test**
+
+Add to `apps/web/lib/mcp-token-scopes.test.ts`:
+
+```ts
+import {
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+  getMcpTokenTemplate,
+} from "./mcp-token-scopes";
+
+it("keeps the development template as a superset of contributor MCP readiness", () => {
+  const development = getMcpTokenTemplate("development");
+  expect(development).toBeDefined();
+  for (const grant of CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS) {
+    expect(development!.grants).toContain(grant);
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp-token-scopes.test.ts
+```
+
+Expected: fails because `CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS` is not exported.
+
+- [ ] **Step 3: Add the constant**
+
+Add to `apps/web/lib/mcp-token-scopes.ts`, near the template section:
+
+```ts
+export const CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS = [
+  "architecture_read",
+  "backlog_read",
+  "backlog_write",
+  "code_graph_read",
+  "file_read",
+  "spec_plan_read",
+  "work_capsule_read",
+  "work_capsule_write",
+  "work_capsule_adopt",
+  "sandbox_execute",
+  "iac_execute",
+] as const;
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp-token-scopes.test.ts
+```
+
+Expected: all tests in `mcp-token-scopes.test.ts` pass.
+
+## Chunk 2: Pure Readiness Model
+
+### Task 2: Implement Non-Mutating Readiness State
+
+**Files:**
+- Create: `apps/web/lib/mcp/contributor-readiness.ts`
+- Create: `apps/web/lib/mcp/contributor-readiness.test.ts`
+
+- [ ] **Step 1: Write failing tests for token selection and states**
+
+Create `apps/web/lib/mcp/contributor-readiness.test.ts` with cases for:
+
+- no owned tokens -> `needs_authorization`
+- only expired/revoked operator tokens -> `needs_reissue`
+- only `ephemeral_ship` tokens -> `needs_authorization`
+- active read-tier token -> `needs_grants`
+- active write token missing one required grant -> `needs_grants`
+- active write/admin token with every required grant -> `ready`
+- multiple ready tokens -> picks the most recently used token
+- GAID binding unavailable -> `identityBinding: "not_available"` without fabricated GAID
+
+Use dependency injection so tests do not touch Prisma:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import {
+  getContributorMcpReadiness,
+  type ContributorMcpTokenRow,
+} from "./contributor-readiness";
+import { CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS } from "../mcp-token-scopes";
+
+function token(overrides: Partial<ContributorMcpTokenRow> = {}): ContributorMcpTokenRow {
+  return {
+    id: "tok_1",
+    name: "Development token",
+    prefix: "dpfmcp_DEV",
+    tokenSuffix: "DEV1",
+    canCopy: true,
+    capability: "write",
+    scope: "write",
+    scopes: [...CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS],
+    kind: "operator",
+    buildId: null,
+    lastUsedAt: new Date("2026-05-26T12:00:00Z"),
+    expiresAt: null,
+    revokedAt: null,
+    createdAt: new Date("2026-05-20T12:00:00Z"),
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp/contributor-readiness.test.ts
+```
+
+Expected: fails because the module does not exist.
+
+- [ ] **Step 3: Implement the read model**
+
+Create `apps/web/lib/mcp/contributor-readiness.ts`:
+
+```ts
+import { copyMcpApiTokenPlaintext, listMcpApiTokens } from "@/lib/auth/mcp-api-token";
+import {
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS,
+  type McpTokenScopeTier,
+} from "@/lib/mcp-token-scopes";
+
+export type ContributorMcpReadinessStatus =
+  | "ready"
+  | "needs_authorization"
+  | "needs_reissue"
+  | "needs_grants"
+  | "needs_identity_binding";
+
+export type ContributorMcpRecommendedAction =
+  | "none"
+  | "issue_development_token"
+  | "rotate_development_token"
+  | "test_connection";
+
+export type ContributorMcpProbe =
+  | { status: "not_run" }
+  | { status: "success"; checkedAt: string; toolCount: number }
+  | { status: "failed"; checkedAt: string; message: string }
+  | { status: "unavailable"; message: string };
+
+export type ContributorMcpTokenRow = Awaited<ReturnType<typeof listMcpApiTokens>>[number];
+
+export type ContributorMcpReadiness = {
+  status: ContributorMcpReadinessStatus;
+  recommendedAction: ContributorMcpRecommendedAction;
+  identityBinding: "bound" | "not_available";
+  token: null | {
+    id: string;
+    name: string;
+    prefix: string;
+    tokenSuffix: string;
+    scope: McpTokenScopeTier;
+    scopes: string[];
+    lastUsedAt: string | null;
+    expiresAt: string | null;
+  };
+  missingGrants: string[];
+  requiredGrants: string[];
+  recommendedScopes: string[];
+  probe: ContributorMcpProbe;
+};
+```
+
+Implementation rules:
+
+- Filter out `kind !== "operator"`.
+- Treat revoked or expired operator tokens as `needs_reissue`.
+- Treat `scope === "read"` or missing grants as `needs_grants`.
+- Prefer the most recently used structurally ready token.
+- Set `requiredGrants` to `CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`.
+- Set `recommendedScopes` to the resolved development-template grants when
+  available, falling back to `CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`.
+- Return `identityBinding: "not_available"` in this slice.
+- Do not write to any token row.
+
+- [ ] **Step 4: Add optional live probe with one-minute cache**
+
+Add an internal cache keyed by token id:
+
+```ts
+const PROBE_TTL_MS = 60_000;
+const probeCache = new Map<string, { checkedAtMs: number; probe: ContributorMcpProbe }>();
+```
+
+When `opts.probe === true`, use `copyMcpApiTokenPlaintext(token.id)` to recover
+the plaintext server-side, then POST `tools/list` to `${baseUrl}/api/mcp/v1`:
+
+```ts
+const res = await fetch(`${baseUrl}/api/mcp/v1`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    authorization: `Bearer ${plaintext}`,
+  },
+  body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+});
+```
+
+Return `success` only when HTTP is ok and the JSON-RPC result contains a
+non-empty `tools` array. Do not expose plaintext in the result.
+
+- [ ] **Step 5: Run readiness tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp/contributor-readiness.test.ts
+```
+
+Expected: all readiness tests pass.
+
+## Chunk 3: Server Action and UI Integration
+
+### Task 3: Add Readiness Server Action
+
+**Files:**
+- Modify: `apps/web/lib/actions/mcp-tokens.ts`
+- Modify: `apps/web/lib/actions/mcp-tokens.test.ts`
+
+- [ ] **Step 1: Test unauthenticated and authenticated action behavior**
+
+Add tests that:
+
+- unauthenticated callers get `{ ok: false, error: "unauthorized" }`
+- authenticated callers delegate to `getContributorMcpReadiness`
+- the action response never includes `plaintext`
+
+- [ ] **Step 2: Implement the action**
+
+Add to `apps/web/lib/actions/mcp-tokens.ts`:
+
+```ts
+export async function getMyContributorMcpReadiness(input?: {
+  probe?: boolean;
+  baseUrl?: string;
+}) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false as const, error: "unauthorized" };
+  }
+  const readiness = await getContributorMcpReadiness(session.user.id, {
+    probe: input?.probe ?? false,
+    baseUrl: input?.baseUrl,
+  });
+  return { ok: true as const, readiness };
+}
+```
+
+- [ ] **Step 3: Run action tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/actions/mcp-tokens.test.ts
+```
+
+Expected: action tests pass.
+
+### Task 4: Build Studio Readiness Card
+
+**Files:**
+- Create: `apps/web/components/platform/ContributorMcpReadinessCard.tsx`
+- Create: `apps/web/components/platform/ContributorMcpReadinessCard.test.tsx`
+- Modify: `apps/web/components/platform/BuildStudioConfigForm.tsx`
+- Modify: `apps/web/app/(shell)/platform/ai/build-studio/page.tsx`
+
+- [ ] **Step 1: Write component tests first**
+
+Cover:
+
+- `ready` shows quiet success copy and `Test connection`
+- `needs_authorization` shows exactly one primary `Issue development token`
+- `needs_reissue` shows `Issue development token`
+- `needs_grants` shows `Rotate development token`
+- `Test connection` calls `getMyContributorMcpReadiness({ probe: true, baseUrl })`
+- issue/rotate actions show the existing setup snippets returned by token actions
+
+- [ ] **Step 2: Implement the card**
+
+Use `lucide-react` icons already present in the app, theme variables only, and
+no nested card layout. The card receives:
+
+```ts
+type Props = {
+  initialReadiness: ContributorMcpReadiness;
+  baseUrl: string;
+  canWrite: boolean;
+};
+```
+
+Primary actions:
+
+- `needs_authorization` / `needs_reissue`: call `issueMyWriteMcpToken({ baseUrl })`.
+- `needs_grants`: call `rotateMyMcpTokenWithEdit` with the selected token id,
+  `scope: "write"`, and `readiness.recommendedScopes`.
+- `ready`: call `getMyContributorMcpReadiness({ probe: true, baseUrl })`.
+
+`needs_client_refresh` is local component state after a successful issue or
+rotation action. The read model does not try to inspect Claude/Codex process
+environment variables.
+
+- [ ] **Step 3: Wire the card into Build Studio**
+
+In `apps/web/app/(shell)/platform/ai/build-studio/page.tsx`:
+
+- derive `baseUrl` using `headers()` the same way
+  `admin/platform-development/page.tsx` does
+- call `getContributorMcpReadiness(user.id, { probe: false, baseUrl })`
+- pass `baseUrl` and `contributorMcpReadiness` into `BuildStudioConfigForm`
+
+In `BuildStudioConfigForm.tsx`, render the card above the Build Dispatch Engine
+section.
+
+- [ ] **Step 4: Run UI tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/platform/ContributorMcpReadinessCard.test.tsx
+```
+
+Expected: card tests pass.
+
+## Chunk 4: Platform Development Banner
+
+### Task 5: Reuse Readiness in MCP Token Manager
+
+**Files:**
+- Modify: `apps/web/components/admin/McpTokenManager.tsx`
+- Modify: `apps/web/components/admin/McpTokenManager.test.tsx`
+
+- [ ] **Step 1: Add tests for the readiness banner**
+
+Cover:
+
+- ready banner appears when `getMyContributorMcpReadiness` returns `ready`
+- missing grants banner points to rotate-with-edit rather than custom setup
+- banner does not duplicate the full Build Studio card
+- lifecycle-managed `ephemeral_ship` rows do not count as contributor readiness
+
+- [ ] **Step 2: Implement a compact banner**
+
+Keep the full token list as-is. Add a small banner above the list:
+
+- Ready: "Claude/Codex MCP readiness is satisfied."
+- Attention: "Development token needs attention: <reason>."
+- Link to Build Studio only as a secondary text link.
+
+Do not move or duplicate the existing issue/rotate/revoke controls.
+
+- [ ] **Step 3: Run token manager tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/admin/McpTokenManager.test.tsx
+```
+
+Expected: token manager tests pass.
+
+## Chunk 5: Verification and Handoff
+
+### Task 6: Focused Verification
+
+**Files:**
+- All files touched above
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run `
+  apps/web/lib/mcp-token-scopes.test.ts `
+  apps/web/lib/mcp/contributor-readiness.test.ts `
+  apps/web/lib/actions/mcp-tokens.test.ts `
+  apps/web/components/platform/ContributorMcpReadinessCard.test.tsx `
+  apps/web/components/admin/McpTokenManager.test.tsx
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: zero TypeScript errors.
+
+- [ ] **Step 3: Run production build**
+
+Run:
+
+```powershell
+pnpm --filter web build
+```
+
+Expected: Next.js production build succeeds.
+
+- [ ] **Step 4: UX verify locally**
+
+Use the running local portal at the configured localhost URL. Verify:
+
+- Build Studio configuration page shows the readiness card above Build Dispatch Engine.
+- Ready state is quiet and compact.
+- Issue development token shows setup snippets and refresh command.
+- Rotate development token handles missing grants.
+- Test connection runs the live probe and reports success or failure inline.
+- Admin > Platform Development > MCP shows the matching compact readiness banner.
+
+Record a short dynamic-analysis summary in the implementation handoff.
+
+- [ ] **Step 5: Commit and push**
+
+Run:
+
+```powershell
+git status --short
+git add apps/web/lib/mcp-token-scopes.ts apps/web/lib/mcp-token-scopes.test.ts `
+  apps/web/lib/mcp/contributor-readiness.ts apps/web/lib/mcp/contributor-readiness.test.ts `
+  apps/web/lib/actions/mcp-tokens.ts apps/web/lib/actions/mcp-tokens.test.ts `
+  apps/web/components/platform/ContributorMcpReadinessCard.tsx `
+  apps/web/components/platform/ContributorMcpReadinessCard.test.tsx `
+  apps/web/components/platform/BuildStudioConfigForm.tsx `
+  'apps/web/app/(shell)/platform/ai/build-studio/page.tsx' `
+  apps/web/components/admin/McpTokenManager.tsx apps/web/components/admin/McpTokenManager.test.tsx
+git commit -s -m "feat: add contributor MCP readiness"
+git push
+```
+
+Expected: branch is pushed. Do not open a PR until the build gate and UX
+evidence are complete and the branch is believed ready to merge.

--- a/docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md
+++ b/docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md
@@ -1,7 +1,9 @@
 ---
 title: Contributor Client MCP Readiness for Build Studio
-status: draft-for-operator-review
+status: revised-for-implementation
 author: Codex
+reviewers:
+  - Claude (chief architect + UX review, 2026-05-26)
 date: 2026-05-26
 related:
   - docs/superpowers/specs/2026-05-18-mcp-governance-flow-token-scope-design.md
@@ -24,6 +26,38 @@ the current install is ready for external contributor clients to use
 governed fix. The target architecture is stricter: peer access is gated by the
 human operator's RBAC, the non-human peer identity's GAID posture, and the MCP
 token's enforced access controls.
+
+## Review summary (2026-05-26, chief architect + UX)
+
+The original draft is directionally right: a readiness projection over the
+existing token machinery, surfaced compactly in Build Studio, with all token
+issuance, rotation, and revocation remaining in Admin > Platform Development >
+MCP. The substrate already carries everything the read model needs — the
+`development` MCP token template, granular scopes, the `kind` lifecycle field,
+the `lastUsedAt` signal, and the `structuredContent.error =
+"insufficient_token_scope"` contract on `/api/mcp/v1`.
+
+This revision tightens the design in five places:
+
+1. **Probe vs refresh.** Replaces the `/api/mcp/token/refresh` acknowledgment
+   check with a live, **non-mutating** MCP probe (`tools/list` against
+   `/api/mcp/v1` with the operator's current token). `/api/mcp/token/refresh`
+   is a client-environment binding endpoint, not a server readiness signal —
+   they are not the same thing. Dynamic analysis is the evidence.
+2. **Readiness threshold vs issued grants.** Calls out that the development
+   template grants a broader superset than this readiness contract requires.
+   Readiness asserts the minimum grant subset Build Studio Claude/Codex work
+   actually needs; the token may legitimately carry more.
+3. **File location.** Moves the read model from `apps/web/lib/auth/` to
+   `apps/web/lib/mcp/contributor-readiness.ts`, next to `mcp-token-scopes.ts`
+   — `auth/` is already crowded with token-issue and host-writer machinery.
+4. **PrincipalAlias shape.** Recommends the natural
+   `(aliasType="mcp_client", aliasValue="claude-code" | "codex")` shape rather
+   than a colon-namespaced `mcp_client:claude-code` string crammed into
+   `aliasType`. Matches the existing `edge_node` precedent.
+5. **Explicit kernel principles enforced.** Adds a section binding this design
+   to the relevant founder-kernel principles so the reviewer gate has a
+   citation to score against.
 
 ## Problem
 
@@ -98,7 +132,9 @@ revocation, and setup snippets. Build Studio consumes a readiness projection so
 it can keep the human workflow simple:
 
 - Ready: Claude/Codex DPF MCP access is available for development work.
-- Needs authorization: issue or rotate a development token.
+- Needs authorization: issue a development token.
+- Needs reissue: the best candidate token is expired or revoked, so issue a
+  replacement development token rather than rotating the unusable row.
 - Needs client refresh: token exists, but the current client/env refresh has not
   been acknowledged.
 - Needs grants: token exists, but the enforced access controls do not cover the
@@ -108,25 +144,45 @@ it can keep the human workflow simple:
 
 ## Access Model
 
-The readiness check must evaluate the full chain:
+The readiness check must evaluate the full chain. **All checks are
+non-mutating**: the read model and the live probe issue no writes, advance no
+state, and never auto-issue or auto-rotate tokens behind the operator's back.
 
 1. **Human RBAC**: the signed-in operator can manage contributor MCP access.
 2. **Peer identity**: the Claude/Codex peer is represented as a governed
    non-human identity with GAID/AIDoc posture, or the readiness state explicitly
    reports that this binding is not yet available.
-3. **Token lifecycle**: the token is active, unexpired, not revoked, and not a
-   lifecycle-managed `ephemeral_ship` token.
+3. **Token lifecycle**: the operator owns at least one `kind = "operator"`
+   token that is active, unexpired, and not revoked. `kind =
+   "ephemeral_ship"` tokens (build-lifecycle managed; see
+   `apps/web/lib/auth/ephemeral-ship-tokens.ts`) are excluded from
+   contributor-client readiness — they are issued and revoked by the build
+   phase machinery, not by the operator.
 4. **Token authority tier**: the token has the required coarse `scope`
-   (`read`, `write`, or `admin`) for the intended workflow.
+   (`read`, `write`, or `admin`) for the intended workflow. For Build
+   Studio-oriented Claude/Codex work the required tier is `write` or higher,
+   because the workflow needs `backlog_write` and `work_capsule_write`.
 5. **Token grants**: the token `scopes[]` include the granular grants required
-   by the workflow, such as `backlog_write`, `work_capsule_write`,
-   `sandbox_execute`, `iac_execute`, `spec_plan_read`, and `code_graph_read`.
+   by the workflow (see *Required Grants for Development Readiness* below).
+   The development template legitimately bundles a broader superset of grants;
+   readiness asserts the minimum subset, not template-equivalence.
 6. **Client wiring**: Claude Code and Codex can both resolve the same
    `DPF_MCP_BEARER_TOKEN` contract and target the canonical `/api/mcp/v1`
-   endpoint.
-7. **Server acknowledgment**: `/api/mcp/token/refresh` has accepted the current
-   token or the platform can show the refresh action immediately after issue or
-   rotation.
+   endpoint. The skill pack's `claude.mcp.json` / `codex.mcp.json` descriptors
+   are the contract — the readiness check confirms they are present and
+   reference `${DPF_MCP_BEARER_TOKEN}`.
+7. **Live probe (when available)**: the read model can issue an authenticated,
+   read-only MCP request — `tools/list` against `/api/mcp/v1` with the
+   operator's current token — and confirm it returns `200` with a non-empty
+   tool catalog. This is the strongest ready signal: it proves the token is
+   actually accepted by the running MCP server end-to-end, not merely
+   structurally valid. The probe is rate-limited (one per minute per token)
+   and cached.
+
+`/api/mcp/token/refresh` is a separate mechanism: it binds a freshly-issued or
+rotated token to a running agent client's process environment. The readiness
+surface should expose it as the **post-issue** action on the same card, not
+conflate it with the live probe.
 
 This does not replace the MCP server's call-time enforcement. Readiness is a
 preflight and remediation surface; `/api/mcp/v1` remains authoritative on every
@@ -136,13 +192,36 @@ tool call.
 
 ### Build Studio surface
 
-Add a compact readiness row to the Build Studio configuration surface:
+Add a compact readiness row to the Build Studio configuration surface
+(`apps/web/components/platform/BuildStudioConfigForm.tsx`, above the Build
+Dispatch Engine section so the operator sees it before selecting a CLI
+provider):
 
-- **Ready**: show a quiet success state, last used time, and expiry.
-- **Action needed**: show one primary button with the best next action:
-  `Issue development token`, `Rotate development token`, or `Refresh client`.
-- **Details**: keep the exact token grants, client snippets, and raw token
-  mechanics behind disclosure.
+- **Ready** — quiet success state. One line: "Claude Code and Codex can use
+  DPF MCP for Build Studio work." Inline metadata: last used (relative time
+  from `lastUsedAt`), expiry (relative time), and an unobtrusive
+  `Test connection` button that runs the live probe and reports the result
+  in-line.
+- **Action needed** — single primary button with the smallest correct next
+  action, drawn from the table below. Never offer more than one primary
+  action; secondary affordances live in the disclosure panel.
+- **Details** — disclosure panel showing the granular grants, the missing
+  grants (if any), the client snippets, the runtime refresh snippet, and a
+  link to Admin > Platform Development > MCP for full management.
+
+| Readiness state            | Primary action            | One-line copy                                                                  |
+| -------------------------- | ------------------------- | ------------------------------------------------------------------------------ |
+| `ready`                    | `Test connection`         | "Ready. Last used <X> ago."                                                    |
+| `needs_authorization`      | `Issue development token` | "No usable token yet — issue a development token to enable Build Studio MCP."  |
+| `needs_reissue`            | `Issue development token` | "Current token is expired or revoked — issue a replacement development token." |
+| `needs_grants`             | `Rotate development token`| "Current token is missing <N> grants needed for Build Studio work."            |
+| `needs_client_refresh`     | `Refresh client`          | "New token issued — bind it to the running Claude/Codex session."              |
+| `needs_identity_binding`   | (disclosure only)         | "Token works, but the Claude/Codex peer identity is not GAID-bound yet."       |
+
+The `Test connection` affordance is the dynamic-analysis signal — it must
+actually call `/api/mcp/v1` (read-only `tools/list`) with the current token
+and report the response. Static field checks are necessary but not sufficient
+evidence per the kernel principle `structural-verification-is-not-functional`.
 
 The main Build Studio workspace should not become an access-management page. It
 may show a small status chip only when external contributor handoff is relevant.
@@ -165,35 +244,83 @@ the development-token path so it reads as a guided Claude/Codex setup:
 When `/api/mcp/v1` returns `structuredContent.error =
 "insufficient_token_scope"` with a `requiredScope`, the user-facing recovery
 should be the same readiness flow. The message should name the missing access
-briefly and offer the fix action. It should not tell the operator to use direct
-database access, patch config files manually, or bypass MCP.
+briefly and offer the fix action.
+
+It must **never** tell the operator to use `psql`, Prisma scripts, direct DB
+edits, hand-edited `.mcp.json` files, or any other path that bypasses the
+governed token machinery — per AGENTS.md §8 ("Scope escalation rule") and the
+kernel principle `never-ask-user-to-run-commands`. The correct recovery is
+always: issue or rotate a scoped token through this readiness surface (which
+delegates to the existing `mcp-tokens.ts` actions), then `Refresh client`.
+
+Note: the `requiredScope` value returned by `/api/mcp/v1` is the coarse tier
+(`"read"` / `"write"` / `"admin"`), not a granular grant key. The readiness
+read model computes the missing granular grants client-side by diffing the
+token's `scopes[]` against the required-grants list — that diff is what the
+disclosure panel shows.
 
 ## Data and Code Shape
 
 The first implementation should avoid schema churn unless GAID binding cannot be
-represented with existing `Principal` / `PrincipalAlias` records.
+represented with existing `Principal` / `PrincipalAlias` records. Inspection of
+the current schema confirms `PrincipalAlias` is a free-form
+`(aliasType, aliasValue, issuer)` triple — adequate for an MCP-client peer
+identity without migration.
 
 Recommended components:
 
-- `apps/web/lib/auth/contributor-mcp-readiness.ts`
-  - pure server read model over current user, `McpApiToken`, template grants,
-    and available grant catalog
-  - exports the readiness status, missing grants, recommended action, and
-    optional GAID binding state
+- `apps/web/lib/mcp/contributor-readiness.ts` *(new — colocated with
+  `mcp-token-scopes.ts`, not under `apps/web/lib/auth/` where token-issue,
+  ephemeral-ship, and host-writer machinery already live)*
+  - exports a pure async function
+    `getContributorMcpReadiness(userId: string, opts?: { probe?: boolean }): Promise<ContributorMcpReadiness>`
+  - composes over `listMcpApiTokens`, the `development` template grants,
+    `getToolGrantMapping`, and (when `probe: true` and within the rate-limit
+    window) a single `tools/list` MCP call
+  - exports `ContributorMcpReadiness` discriminated union: `ready`,
+    `needs_authorization`, `needs_reissue`, `needs_grants`,
+    `needs_client_refresh`, `needs_identity_binding`
+  - **never mutates** — no issue, rotate, revoke, or refresh side-effects
 - `apps/web/lib/actions/mcp-tokens.ts`
-  - add a server action that returns readiness for the current operator
-  - keep token issue/rotate behavior in the existing actions
-- `apps/web/components/platform/ContributorMcpReadinessCard.tsx`
-  - compact Build Studio card/row using theme-aware styling
-  - calls the existing issue/rotate/setup-snippet actions
+  - add a thin server action `getMyContributorMcpReadiness({ probe?: boolean
+    })` that resolves the session user and delegates to the pure function
+  - keep token issue/rotate/revoke behavior in the existing actions —
+    readiness *reads*, the existing actions *write*
+- `apps/web/components/platform/ContributorMcpReadinessCard.tsx` *(new)*
+  - compact Build Studio card/row using the existing theme tokens
+    (`var(--dpf-surface-1)`, `var(--dpf-border)`, `var(--dpf-text)`,
+    `var(--dpf-accent)`, `var(--dpf-success)`, `var(--dpf-warning)`,
+    `var(--dpf-error)`) — the sole exception of `color: "white"` on a
+    `bg-var(--dpf-accent)` primary button applies per AGENTS.md §12
+  - calls the existing issue/rotate/setup-snippet actions; never opens a new
+    token issuance path
 - `apps/web/components/admin/McpTokenManager.tsx`
-  - optionally reuse the readiness read model for a development-token status
-    banner
+  - reuse the readiness read model for a development-token status banner that
+    matches the Build Studio card's verdict — one source of truth across both
+    surfaces
 
 If the GAID identity binding is not yet implemented for external contributor
 clients, the read model should report `identityBinding: "not_available"` rather
 than fabricating a binding. That state is acceptable for an initial readiness
 slice if the token access controls still enforce the actual tool grants.
+
+### PrincipalAlias shape for MCP-client peer identity
+
+When the GAID binding is implemented, model each external contributor client
+as one `Principal` (`kind = "non_human"`) with `PrincipalAlias` rows of the
+form:
+
+| `aliasType`   | `aliasValue`   | `issuer`                                        |
+| ------------- | -------------- | ----------------------------------------------- |
+| `mcp_client`  | `claude-code`  | install identifier (e.g. `dpf://<install-id>`)  |
+| `mcp_client`  | `codex`        | install identifier                              |
+
+This mirrors the existing `edge_node` alias precedent (`aliasType="edge_node"`
+keyed by `aliasValue`) and stays inside the `PrincipalAlias.@@unique([aliasType,
+aliasValue, issuer])` constraint without introducing a colon-namespaced
+overload of `aliasType`. The MCP token's `agentId` (already nullable on
+`issueMcpApiToken`) is the candidate FK back to the Principal once the binding
+exists.
 
 ## Required Grants for Development Readiness
 
@@ -216,6 +343,32 @@ should at minimum require:
 The implementation should derive these from the development template when
 possible, then expose any missing grants in the readiness result.
 
+**Threshold vs template superset.** The `development` template in
+`apps/web/lib/mcp-token-scopes.ts` legitimately bundles a broader set
+(`build_promote`, `build_plan_write`, `deployment_plan_create`,
+`release_gate_create`, `release_plan_create`, `deliberation_create`,
+`thread_write`, `document_write`, `tool_evaluation_create`, etc.). The
+required-grants list above is the **minimum threshold** for the readiness
+contract — a token may legitimately carry more. The reverse is never true:
+issuing a development-template token must always satisfy this threshold.
+A regression test in `mcp-token-scopes.test.ts` should assert
+`DEVELOPMENT_TEMPLATE_GRANTS ⊇ CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`
+so future template edits cannot silently break readiness.
+
+**`sandbox_execute` and `iac_execute`.** These two grants exist primarily for
+Build Studio's in-portal sandbox loop, not for the external contributor
+client. They are nonetheless included in the readiness threshold because the
+"governed handoff back to Build Studio" path (`contribute_to_hive`, capsule
+adoption, build evidence recording) routes through tools that require them.
+If a later substrate change splits sandbox/iac execution from contributor
+write paths, this list must be revisited.
+
+**`lastUsedAt` as a freshness signal.** `McpApiToken.lastUsedAt` (already
+exposed by `listMyMcpTokens`) is the natural "is this token actually used
+right now" indicator. The Ready state surfaces it; the read model uses it to
+order tokens when the operator owns more than one development-tier token
+(prefer the most recently used).
+
 ## Acceptance Criteria
 
 1. Build Studio configuration shows contributor-client MCP readiness for
@@ -228,26 +381,77 @@ possible, then expose any missing grants in the readiness result.
    development-token actions and returns the same setup snippets used by Admin >
    Platform Development > MCP.
 5. The readiness model includes GAID/non-human peer binding state. If the
-   current substrate cannot resolve it, the state degrades explicitly.
+   current substrate cannot resolve it, the state degrades explicitly to
+   `identityBinding: "not_available"` and the readiness card surfaces this in
+   the disclosure panel — never asserts an unverified binding.
 6. `insufficient_token_scope` errors can be mapped to the same remediation
    contract.
 7. No new free-floating token issuance path is introduced.
-8. No UI hardcodes colors outside the DPF theme token system.
+8. No UI hardcodes colors outside the DPF theme token system (sole exception
+   per AGENTS.md §12: `text-white` on `bg-[var(--dpf-accent)]` buttons).
+9. The readiness read model performs no writes. It does not auto-issue,
+   auto-rotate, auto-revoke, or auto-refresh tokens. Every state transition
+   is explicit operator-initiated through the existing actions.
+10. When the live probe is enabled, the Ready state is backed by a successful
+    `tools/list` response from `/api/mcp/v1` within the probe-cache window.
+    A structural-only Ready state (no probe yet) is visually distinguishable
+    from a probe-confirmed Ready state.
+11. `kind = "ephemeral_ship"` tokens are ignored by the readiness model —
+    they neither satisfy nor invalidate contributor-client readiness.
+12. The required-grants threshold is exported as a named constant
+    (`CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`) and the
+    `DEVELOPMENT_TEMPLATE_GRANTS ⊇ CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS`
+    invariant is asserted by a unit test.
 
 ## Verification Plan
 
 - Unit test the readiness read model for ready, missing-token, expired,
-  revoked, read-only, missing-grant, lifecycle-managed, and GAID-unavailable
-  states.
+  revoked, read-only, missing-grant, lifecycle-managed (ephemeral_ship),
+  multiple-tokens (picks most recently used), and GAID-unavailable states.
+- Unit test the `DEVELOPMENT_TEMPLATE_GRANTS ⊇
+  CONTRIBUTOR_MCP_READINESS_REQUIRED_GRANTS` invariant.
 - Unit test the server action to prove it returns only current-operator token
   state and does not expose plaintext tokens.
-- Component test the readiness UI for the quiet ready state and the primary
-  remediation actions.
+- Integration test the live probe path: with a valid development token,
+  `getContributorMcpReadiness(userId, { probe: true })` issues exactly one
+  `tools/list` request to `/api/mcp/v1` and reports the probe outcome in the
+  result. The probe is rate-limited (one per minute per token) and the
+  cached probe result is returned on subsequent calls within the window.
+- Component test the readiness UI for the quiet ready state, the
+  probe-confirmed ready state, and each of the primary remediation actions.
 - Existing token action tests continue to cover issue/rotate/setup snippets.
-- UX verify the Build Studio configuration page against the local portal.
+- UX verify the Build Studio configuration page against the local portal —
+  drive each readiness state by manipulating the underlying token (issue,
+  let expire by setting `expiresInDays: 0`, revoke, rotate to a smaller
+  grant set) and confirm the card transitions correctly. Report findings
+  as a dynamic-analysis prose summary, not a screenshot pile (per the
+  memory `feedback_dynamic_analysis_is_evidence`).
 - Run affected Vitest tests and `pnpm --filter web typecheck`.
 - For a final implementation slice, run the production build gate per
-  `AGENTS.md`.
+  `AGENTS.md` §5 (unit + `next build` + UX + migrations if any).
+
+## Kernel Principles Enforced
+
+This design intentionally satisfies the following kernel principles
+(`docs/founder-kernel/wiki/principles/`):
+
+- `structural-verification-is-not-functional` — Ready is backed by a live
+  MCP probe, not field-level checks alone.
+- `never-ask-user-to-run-commands` — Every remediation is one button click;
+  no copy-paste shell, no `psql`, no hand-edited config.
+- `architecture-over-shortcuts` — Readiness is a read projection over the
+  existing token machinery; no parallel token-issue surface, no DB-bypass
+  fallback when scope is missing.
+- `single-source-of-truth` — One required-grants constant, one read model,
+  consumed by both the Build Studio card and the Admin token manager banner.
+- `verify-substrate-before-proposing-new` — Confirms `PrincipalAlias`,
+  `McpApiToken.kind`, `lastUsedAt`, and the `insufficient_token_scope`
+  contract already exist before designing on top.
+- `evidence-before-diagnosis` — `Test connection` returns the live probe
+  result, so the operator sees the actual server response when something
+  is wrong, not a guess derived from token fields.
+- `live-state-over-seed-data` — The read model queries `McpApiToken` and
+  `TOOL_TO_GRANTS` at runtime; no seed-time snapshot of grants.
 
 ## Open Follow-Ups
 
@@ -255,10 +459,27 @@ possible, then expose any missing grants in the readiness result.
   questions like this one. The tool selected the right direction during this
   discussion, but returned zero-valued low-confidence contributions because the
   feature dimensions did not map cleanly to the kernel registry.
-- Decide whether external contributor clients should get a first-class
-  `PrincipalAlias` type such as `mcp_client:claude-code` /
-  `mcp_client:codex`, or whether the first slice should expose the current
-  GAID-unavailable state until the TAK/GAID protocol-profile work lands.
+- Confirm the recommended `PrincipalAlias` shape
+  (`aliasType="mcp_client"`, `aliasValue="claude-code" | "codex"`,
+  `issuer=<install-id>`) when the TAK/GAID protocol-profile work lands. Until
+  then, the readiness model reports `identityBinding: "not_available"` as the
+  honest state.
 - Decide whether stale-but-capable tokens should remain `ready` with a warning
   or become `attention_needed`. This spec recommends warning-only because idle
-  is not the same as revoked or expired.
+  is not the same as revoked or expired (consistent with
+  `MCP_TOKEN_DEFAULT_STALE_DAYS = 7` and the kernel-stated
+  `idle-is-not-abandoned` posture).
+- Per-PR Build Studio readiness: ephemeral_ship tokens are excluded from
+  contributor readiness today. When Build Studio cloud runners adopt their
+  own readiness surface, decide whether the same read model is reused with a
+  `kind: "ephemeral_ship"` filter flip, or whether ephemeral-ship readiness
+  is a separate projection.
+- Headless / cloud contributor case: the current design assumes a local
+  Claude Code or Codex install with `DPF_MCP_BEARER_TOKEN` in the user
+  environment. When external CI agents (cloud Claude, hosted Codex) become
+  contributor peers, the readiness card needs a second mode that targets
+  the agent's environment rather than the operator's machine.
+- Probe rate-limiting and caching policy: the spec calls for one probe per
+  minute per token. Confirm this against `/api/mcp/v1` throughput targets
+  and whether the probe cache should be in-memory per-process or backed by
+  the existing audit substrate so multiple admin tabs share one probe.

--- a/docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md
+++ b/docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md
@@ -1,0 +1,264 @@
+---
+title: Contributor Client MCP Readiness for Build Studio
+status: draft-for-operator-review
+author: Codex
+date: 2026-05-26
+related:
+  - docs/superpowers/specs/2026-05-18-mcp-governance-flow-token-scope-design.md
+  - docs/superpowers/specs/2026-05-21-tak-gaid-protocol-profiles-supervisor-control-design.md
+  - docs/superpowers/specs/2026-04-11-platform-mcp-tool-server-design.md
+  - packages/dpf-skill-pack/README.md
+  - AGENTS.md
+---
+
+# Contributor Client MCP Readiness for Build Studio
+
+## Purpose
+
+Make Claude Code and Codex feel seamlessly connected to DPF through the DPF MCP
+server without hiding the authority model that keeps the platform safe.
+
+The target user experience is simple: Build Studio should be able to say whether
+the current install is ready for external contributor clients to use
+`/api/mcp/v1`, and when it is not ready, guide the operator through the smallest
+governed fix. The target architecture is stricter: peer access is gated by the
+human operator's RBAC, the non-human peer identity's GAID posture, and the MCP
+token's enforced access controls.
+
+## Problem
+
+DPF now has the right pieces, but the operator still has to mentally stitch them
+together:
+
+- Claude Code and Codex plugins can carry skills and MCP server configuration.
+- The DPF skill pack ships Claude and Codex MCP descriptors that point at the
+  DPF MCP endpoint and read `DPF_MCP_BEARER_TOKEN`.
+- Admin > Platform Development > MCP can issue scoped MCP tokens from role
+  templates, including the development template.
+- The MCP server enforces token scope and granular grants at call time.
+- Build Studio increasingly expects external contributor work to flow back
+  through governed records rather than chat memory.
+
+The missing product layer is readiness. The platform should answer, in one
+place, whether Claude/Codex can use the DPF MCP server for the Build Studio work
+at hand. A token list is necessary but not sufficient; it exposes the parts
+without explaining whether the whole connection is usable.
+
+## Research and Benchmarking
+
+### External patterns
+
+- Claude Code plugins are the shareable packaging unit for skills, agents,
+  hooks, MCP servers, LSP servers, and monitors. The docs explicitly position
+  plugins as the team/project distribution path, while standalone config is for
+  personal or one-off workflows. See
+  [Claude Code: Create plugins](https://code.claude.com/docs/en/plugins) and
+  [Claude Code: Plugins reference](https://code.claude.com/docs/en/plugins-reference).
+- OpenAI's Codex plugin guidance describes plugins as a way to connect Codex to
+  external tools and sources of information, while skills teach repeatable
+  workflows. See
+  [OpenAI Academy: Plugins and skills](https://openai.com/academy/codex-plugins-and-skills/).
+- The MCP authorization specification treats HTTP MCP servers as protected
+  resources accessed with bearer access tokens on behalf of resource owners. It
+  makes authorization transport-level and token-mediated, which matches DPF's
+  choice to enforce access inside `/api/mcp/v1`. See
+  [Model Context Protocol Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).
+
+### DPF patterns to adopt
+
+- `packages/dpf-skill-pack/README.md` already makes the plugin the project
+  default for Claude Code and Codex. It correctly keeps plugin wiring in git and
+  token issuance outside git.
+- `apps/web/lib/mcp-token-scopes.ts` already defines the development token
+  template as a write-tier grant bundle for coding-agent and Build Studio loops.
+- `apps/web/lib/actions/mcp-tokens.ts` already centralizes token issue, rotate,
+  copy, and setup-snippet behavior. Readiness must reuse these actions rather
+  than minting a new token path.
+- `docs/superpowers/specs/2026-05-21-tak-gaid-protocol-profiles-supervisor-control-design.md`
+  frames MCP as the tool/data carrier while TAK governs runtime authority and
+  GAID preserves identity and receipts.
+
+### Anti-patterns to reject
+
+- Do not add token issuance UI to every AI agent or coworker.
+- Do not silently auto-upgrade tokens when a call needs broader access.
+- Do not treat a bearer token as merely a local setup detail. In DPF, the token
+  carries enforced access control: coarse scope plus granular grants.
+- Do not ask the operator to repair Claude/Codex setup by copying scattered
+  commands from docs when the platform already knows the correct token template
+  and setup snippets.
+
+## Decision
+
+Build Studio and Platform Development should share a **Contributor Client MCP
+Readiness** read model and remediation flow.
+
+Platform Development remains the system of record for token issuance, rotation,
+revocation, and setup snippets. Build Studio consumes a readiness projection so
+it can keep the human workflow simple:
+
+- Ready: Claude/Codex DPF MCP access is available for development work.
+- Needs authorization: issue or rotate a development token.
+- Needs client refresh: token exists, but the current client/env refresh has not
+  been acknowledged.
+- Needs grants: token exists, but the enforced access controls do not cover the
+  workflow.
+- Needs identity binding: token access is not tied to the expected non-human
+  peer identity/GAID posture.
+
+## Access Model
+
+The readiness check must evaluate the full chain:
+
+1. **Human RBAC**: the signed-in operator can manage contributor MCP access.
+2. **Peer identity**: the Claude/Codex peer is represented as a governed
+   non-human identity with GAID/AIDoc posture, or the readiness state explicitly
+   reports that this binding is not yet available.
+3. **Token lifecycle**: the token is active, unexpired, not revoked, and not a
+   lifecycle-managed `ephemeral_ship` token.
+4. **Token authority tier**: the token has the required coarse `scope`
+   (`read`, `write`, or `admin`) for the intended workflow.
+5. **Token grants**: the token `scopes[]` include the granular grants required
+   by the workflow, such as `backlog_write`, `work_capsule_write`,
+   `sandbox_execute`, `iac_execute`, `spec_plan_read`, and `code_graph_read`.
+6. **Client wiring**: Claude Code and Codex can both resolve the same
+   `DPF_MCP_BEARER_TOKEN` contract and target the canonical `/api/mcp/v1`
+   endpoint.
+7. **Server acknowledgment**: `/api/mcp/token/refresh` has accepted the current
+   token or the platform can show the refresh action immediately after issue or
+   rotation.
+
+This does not replace the MCP server's call-time enforcement. Readiness is a
+preflight and remediation surface; `/api/mcp/v1` remains authoritative on every
+tool call.
+
+## User Experience
+
+### Build Studio surface
+
+Add a compact readiness row to the Build Studio configuration surface:
+
+- **Ready**: show a quiet success state, last used time, and expiry.
+- **Action needed**: show one primary button with the best next action:
+  `Issue development token`, `Rotate development token`, or `Refresh client`.
+- **Details**: keep the exact token grants, client snippets, and raw token
+  mechanics behind disclosure.
+
+The main Build Studio workspace should not become an access-management page. It
+may show a small status chip only when external contributor handoff is relevant.
+
+### Platform Development surface
+
+Keep Admin > Platform Development > MCP as the full management surface. Improve
+the development-token path so it reads as a guided Claude/Codex setup:
+
+- one-click development token issue/rotation,
+- existing Claude Code and Codex snippets,
+- session refresh snippet,
+- clear status for active, stale, expired, revoked, and lifecycle-managed
+  tokens,
+- explicit warning when a token does not satisfy the contributor-client
+  readiness contract.
+
+### Error handling
+
+When `/api/mcp/v1` returns `structuredContent.error =
+"insufficient_token_scope"` with a `requiredScope`, the user-facing recovery
+should be the same readiness flow. The message should name the missing access
+briefly and offer the fix action. It should not tell the operator to use direct
+database access, patch config files manually, or bypass MCP.
+
+## Data and Code Shape
+
+The first implementation should avoid schema churn unless GAID binding cannot be
+represented with existing `Principal` / `PrincipalAlias` records.
+
+Recommended components:
+
+- `apps/web/lib/auth/contributor-mcp-readiness.ts`
+  - pure server read model over current user, `McpApiToken`, template grants,
+    and available grant catalog
+  - exports the readiness status, missing grants, recommended action, and
+    optional GAID binding state
+- `apps/web/lib/actions/mcp-tokens.ts`
+  - add a server action that returns readiness for the current operator
+  - keep token issue/rotate behavior in the existing actions
+- `apps/web/components/platform/ContributorMcpReadinessCard.tsx`
+  - compact Build Studio card/row using theme-aware styling
+  - calls the existing issue/rotate/setup-snippet actions
+- `apps/web/components/admin/McpTokenManager.tsx`
+  - optionally reuse the readiness read model for a development-token status
+    banner
+
+If the GAID identity binding is not yet implemented for external contributor
+clients, the read model should report `identityBinding: "not_available"` rather
+than fabricating a binding. That state is acceptable for an initial readiness
+slice if the token access controls still enforce the actual tool grants.
+
+## Required Grants for Development Readiness
+
+The baseline should use the existing `development` MCP token template instead
+of a new grant bundle. For Build Studio-oriented Claude/Codex work, readiness
+should at minimum require:
+
+- `architecture_read`
+- `backlog_read`
+- `backlog_write`
+- `code_graph_read`
+- `file_read`
+- `spec_plan_read`
+- `work_capsule_read`
+- `work_capsule_write`
+- `work_capsule_adopt`
+- `sandbox_execute`
+- `iac_execute`
+
+The implementation should derive these from the development template when
+possible, then expose any missing grants in the readiness result.
+
+## Acceptance Criteria
+
+1. Build Studio configuration shows contributor-client MCP readiness for
+   Claude/Codex without requiring the operator to inspect the full token list.
+2. A current active development token produces a ready state when it has the
+   required coarse scope and granular grants.
+3. Missing, expired, revoked, stale, read-only, or under-granted tokens produce
+   a clear next action.
+4. Issuing or rotating through the readiness surface reuses the existing
+   development-token actions and returns the same setup snippets used by Admin >
+   Platform Development > MCP.
+5. The readiness model includes GAID/non-human peer binding state. If the
+   current substrate cannot resolve it, the state degrades explicitly.
+6. `insufficient_token_scope` errors can be mapped to the same remediation
+   contract.
+7. No new free-floating token issuance path is introduced.
+8. No UI hardcodes colors outside the DPF theme token system.
+
+## Verification Plan
+
+- Unit test the readiness read model for ready, missing-token, expired,
+  revoked, read-only, missing-grant, lifecycle-managed, and GAID-unavailable
+  states.
+- Unit test the server action to prove it returns only current-operator token
+  state and does not expose plaintext tokens.
+- Component test the readiness UI for the quiet ready state and the primary
+  remediation actions.
+- Existing token action tests continue to cover issue/rotate/setup snippets.
+- UX verify the Build Studio configuration page against the local portal.
+- Run affected Vitest tests and `pnpm --filter web typecheck`.
+- For a final implementation slice, run the production build gate per
+  `AGENTS.md`.
+
+## Open Follow-Ups
+
+- Improve `principle_decide` / WWMD scoring for responsibility-placement
+  questions like this one. The tool selected the right direction during this
+  discussion, but returned zero-valued low-confidence contributions because the
+  feature dimensions did not map cleanly to the kernel registry.
+- Decide whether external contributor clients should get a first-class
+  `PrincipalAlias` type such as `mcp_client:claude-code` /
+  `mcp_client:codex`, or whether the first slice should expose the current
+  GAID-unavailable state until the TAK/GAID protocol-profile work lands.
+- Decide whether stale-but-capable tokens should remain `ready` with a warning
+  or become `attention_needed`. This spec recommends warning-only because idle
+  is not the same as revoked or expired.


### PR DESCRIPTION
## Summary
- Adds a non-mutating contributor MCP readiness model for Claude Code and Codex access to the DPF MCP server.
- Adds a compact Build Studio readiness card for issue, rotate, test connection, and setup snippets through existing governed token actions.
- Adds a Platform Development readiness banner that guides operators to existing token controls without duplicating the full UX.

## Verification completed before PR
- pnpm --filter web exec vitest run lib/mcp-token-scopes.test.ts lib/mcp/contributor-readiness.test.ts lib/actions/mcp-tokens.test.ts components/platform/ContributorMcpReadinessCard.test.tsx components/admin/McpTokenManager.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web build
- git diff --check
- confirmed no temporary worktree servers listening on 3001 or 53602

## Post-merge portal verification required
Verification must run against the merged portal at http://localhost:3000 after the branch is deployed there. The current 3000 portal was checked on 2026-05-26 and still reported git SHA a34196cfb4274c64fe8342d7c9f21e3ed15e7d36, so it does not yet contain this PR's readiness card.

Exercise:
- /platform/ai/build-studio
- /admin/platform-development
- no token, read-only token, under-granted token, ready token
- issue/rotate snippets
- Test connection probe

## Notes
- Production build exits 0 but still prints the existing Edge-runtime Node API warnings from platform/version and discovery collectors.
- GAID binding is represented honestly as not_available in this slice; token scope, granular grants, and RBAC remain the active gates.