### PR TITLE
CRM marketing Slice 3: signal-to-engagement routing

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
@@ -1,24 +1,30 @@
 // apps/web/app/(shell)/customer/engagements/page.tsx
 import { prisma } from "@dpf/db";
+import { AcquisitionSignalRouter } from "@/components/customer/AcquisitionSignalRouter";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { createEngagementFromSignalForm } from "@/lib/actions/crm";
+import { getAcquisitionSignalWorkspace } from "@/lib/crm/acquisition-signal-data";
+import { formatAcquisitionSourceLabel } from "@/lib/crm/acquisition-signals";
 import { getEngagementStatusMeta } from "@/lib/crm/presentation";
 
-const SOURCE_LABELS: Record<string, string> = {
-  web_inquiry: "Web",
-  manual: "Manual",
-  referral: "Referral",
-  import: "Import",
-};
+async function routeSignalToEngagement(formData: FormData) {
+  "use server";
+
+  await createEngagementFromSignalForm(formData);
+}
 
 export default async function EngagementsPage() {
-  const engagements = await prisma.engagement.findMany({
-    orderBy: { createdAt: "desc" },
-    include: {
-      contact: { select: { id: true, email: true, firstName: true, lastName: true } },
-      account: { select: { id: true, accountId: true, name: true } },
-      assignedTo: { select: { id: true, email: true } },
-    },
-  });
+  const [engagements, signalWorkspace] = await Promise.all([
+    prisma.engagement.findMany({
+      orderBy: { createdAt: "desc" },
+      include: {
+        contact: { select: { id: true, email: true, firstName: true, lastName: true } },
+        account: { select: { id: true, accountId: true, name: true } },
+        assignedTo: { select: { id: true, email: true } },
+      },
+    }),
+    getAcquisitionSignalWorkspace(),
+  ]);
 
   const statusCounts = engagements.reduce<Record<string, number>>((acc, e) => {
     acc[e.status] = (acc[e.status] ?? 0) + 1;
@@ -26,13 +32,18 @@ export default async function EngagementsPage() {
   }, {});
 
   return (
-    <div>
+    <div className="space-y-6">
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Engagements</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
           {engagements.length} engagement{engagements.length !== 1 ? "s" : ""}
         </p>
       </div>
+
+      <AcquisitionSignalRouter
+        workspace={signalWorkspace}
+        formAction={routeSignalToEngagement}
+      />
 
       {/* Status summary chips */}
       <div className="flex flex-wrap gap-2 mb-4">
@@ -73,7 +84,7 @@ export default async function EngagementsPage() {
                   />
                   {e.source && (
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] shrink-0">
-                      {SOURCE_LABELS[e.source] ?? e.source}
+                      {formatAcquisitionSourceLabel(e.source)}
                     </span>
                   )}
                 </div>
@@ -81,7 +92,13 @@ export default async function EngagementsPage() {
                   <span>{contactName}</span>
                   {e.account && <span>{e.account.name}</span>}
                   {e.assignedTo && <span>→ {e.assignedTo.email}</span>}
+                  {e.sourceRefId && <span>Evidence {e.sourceRefId}</span>}
                 </div>
+                {e.notes ? (
+                  <p className="mt-2 line-clamp-2 text-xs text-[var(--dpf-muted)]">
+                    {e.notes}
+                  </p>
+                ) : null}
               </div>
               <p className="text-[9px] text-[var(--dpf-muted)] shrink-0">
                 {new Date(e.createdAt).toLocaleDateString()}

--- a/apps/web/components/customer/AcquisitionSignalRouter.test.tsx
+++ b/apps/web/components/customer/AcquisitionSignalRouter.test.tsx
@@ -1,0 +1,109 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AcquisitionSignalRouter } from "./AcquisitionSignalRouter";
+import type { AcquisitionSignalWorkspace } from "@/lib/crm/acquisition-signals";
+
+const workspace: AcquisitionSignalWorkspace = {
+  summary: {
+    observedCount: 2,
+    routeReadyCount: 1,
+    linkedCount: 1,
+    needsContactCount: 0,
+  },
+  signals: [
+    {
+      id: "inq-1",
+      kind: "storefront_inquiry",
+      source: "web_inquiry",
+      sourceRefId: "inq-1",
+      title: "Website inquiry from Bea Buyer",
+      summary: "Can you help with managed IT onboarding?",
+      buyerLabel: "Bea Buyer",
+      channelLabel: "Storefront inquiry",
+      observedAtLabel: "26 May 2026",
+      routingState: "route_ready",
+      routingLabel: "Ready to create engagement",
+      routingTone: "accent",
+      evidence: ["Ref INQ-1001", "bea@example.com"],
+      contactLabel: "Bea Buyer",
+      accountLabel: "Acme Ops",
+      linkedEngagement: null,
+      routeAction: {
+        title: "Website inquiry from Bea Buyer",
+        contactId: "contact-1",
+        accountId: "acct-1",
+        source: "web_inquiry",
+        sourceRefId: "inq-1",
+        notes: "Source: storefront inquiry",
+      },
+      integrationHref: null,
+      aiTopics: [
+        {
+          id: "signal-summary",
+          label: "Summarize signal",
+          description: "Review source evidence and recommend the next internal action.",
+          prompt: "Summarize this signal.",
+          contextSummary: "Storefront inquiry",
+          expectedNextStep: "Return a short signal summary.",
+        },
+      ],
+    },
+    {
+      id: "inq-2",
+      kind: "storefront_inquiry",
+      source: "web_inquiry",
+      sourceRefId: "inq-2",
+      title: "Website inquiry from Cam Contact",
+      summary: "Pricing question",
+      buyerLabel: "Cam Contact",
+      channelLabel: "Storefront inquiry",
+      observedAtLabel: "25 May 2026",
+      routingState: "linked",
+      routingLabel: "Engagement exists",
+      routingTone: "success",
+      evidence: ["Ref INQ-1002"],
+      contactLabel: "Cam Contact",
+      accountLabel: "Beta Ops",
+      linkedEngagement: {
+        id: "eng-2",
+        title: "Website inquiry from Cam Contact",
+        statusLabel: "New",
+      },
+      routeAction: null,
+      integrationHref: null,
+      aiTopics: [],
+    },
+  ],
+};
+
+describe("AcquisitionSignalRouter", () => {
+  it("distinguishes observed signals from linked engagements and renders the explicit route action", () => {
+    const html = renderToStaticMarkup(
+      <AcquisitionSignalRouter
+        workspace={workspace}
+        formAction={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Acquisition signals");
+    expect(html).toContain("2 observed");
+    expect(html).toContain("1 ready");
+    expect(html).toContain("Website inquiry from Bea Buyer");
+    expect(html).toContain("Ready to create engagement");
+    expect(html).toContain("Create engagement");
+    expect(html).toContain('name="sourceRefId" value="inq-1"');
+    expect(html).toContain("Engagement exists");
+  });
+
+  it("uses theme-aware classes rather than raw color values", () => {
+    const html = renderToStaticMarkup(
+      <AcquisitionSignalRouter
+        workspace={workspace}
+        formAction={() => undefined}
+      />,
+    );
+
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/customer/AcquisitionSignalRouter.tsx
+++ b/apps/web/components/customer/AcquisitionSignalRouter.tsx
@@ -1,0 +1,193 @@
+import Link from "next/link";
+import { ArrowRightCircle, ExternalLink, Link2, Sparkles } from "lucide-react";
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import type {
+  AcquisitionSignalView,
+  AcquisitionSignalWorkspace,
+} from "@/lib/crm/acquisition-signals";
+
+type AcquisitionSignalRouterProps = {
+  workspace: AcquisitionSignalWorkspace;
+  formAction: (formData: FormData) => void | Promise<void>;
+};
+
+function SummaryPill({ label }: { label: string }) {
+  return (
+    <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1 text-xs text-[var(--dpf-muted)]">
+      {label}
+    </span>
+  );
+}
+
+function RouteSignalForm({
+  signal,
+  formAction,
+}: {
+  signal: AcquisitionSignalView;
+  formAction: AcquisitionSignalRouterProps["formAction"];
+}) {
+  if (!signal.routeAction) return null;
+
+  return (
+    <form action={formAction} className="mt-4">
+      <input type="hidden" name="title" value={signal.routeAction.title} />
+      <input type="hidden" name="contactId" value={signal.routeAction.contactId} />
+      <input type="hidden" name="accountId" value={signal.routeAction.accountId} />
+      <input type="hidden" name="source" value={signal.routeAction.source} />
+      <input type="hidden" name="sourceRefId" value={signal.routeAction.sourceRefId} />
+      <input type="hidden" name="notes" value={signal.routeAction.notes} />
+      <button
+        type="submit"
+        className="inline-flex items-center gap-2 rounded bg-[var(--dpf-accent)] px-3 py-2 text-xs font-medium text-white"
+      >
+        <ArrowRightCircle className="h-4 w-4" aria-hidden="true" />
+        Create engagement
+      </button>
+    </form>
+  );
+}
+
+function SignalCard({
+  signal,
+  formAction,
+}: {
+  signal: AcquisitionSignalView;
+  formAction: AcquisitionSignalRouterProps["formAction"];
+}) {
+  return (
+    <article className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            {signal.channelLabel} / {signal.observedAtLabel}
+          </p>
+          <h3 className="mt-1 text-sm font-semibold text-[var(--dpf-text)]">{signal.title}</h3>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">{signal.summary}</p>
+        </div>
+        <CustomerStatusBadge
+          label={signal.routingLabel}
+          tone={signal.routingTone}
+          className="px-2 py-1 text-[10px]"
+        />
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2">
+        <div>
+          <dt className="text-[var(--dpf-muted)]">Buyer/source</dt>
+          <dd className="mt-1 text-[var(--dpf-text)]">{signal.buyerLabel}</dd>
+        </div>
+        <div>
+          <dt className="text-[var(--dpf-muted)]">CRM anchor</dt>
+          <dd className="mt-1 text-[var(--dpf-text)]">
+            {signal.contactLabel ?? "Contact not confirmed"}
+            {signal.accountLabel ? ` / ${signal.accountLabel}` : ""}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-4">
+        <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+          Source evidence
+        </p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {signal.evidence.map((item) => (
+            <span
+              key={item}
+              className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-2 py-1 text-[10px] text-[var(--dpf-muted)]"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {signal.linkedEngagement ? (
+        <div className="mt-4 flex items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 text-xs text-[var(--dpf-text)]">
+          <Link2 className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+          <span>
+            {signal.linkedEngagement.title} / {signal.linkedEngagement.statusLabel}
+          </span>
+        </div>
+      ) : null}
+
+      {signal.integrationHref && signal.routingState === "needs_contact" ? (
+        <Link
+          href={signal.integrationHref}
+          className="mt-4 inline-flex items-center gap-2 rounded border border-[var(--dpf-border)] px-3 py-2 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          Review source
+        </Link>
+      ) : null}
+
+      {signal.aiTopics.length > 0 ? (
+        <div className="mt-4">
+          <div className="flex items-center gap-2 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            AI handoff ideas
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {signal.aiTopics.map((topic) => (
+              <span
+                key={topic.id}
+                className="rounded-full border border-[var(--dpf-border)] px-2 py-1 text-[10px] text-[var(--dpf-muted)]"
+                title={topic.description}
+              >
+                {topic.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <RouteSignalForm signal={signal} formAction={formAction} />
+    </article>
+  );
+}
+
+export function AcquisitionSignalRouter({
+  workspace,
+  formAction,
+}: AcquisitionSignalRouterProps) {
+  return (
+    <section className="mb-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Signal routing
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-[var(--dpf-text)]">
+            Acquisition signals
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+            New storefront and connection evidence stays observed until someone explicitly turns it into CRM engagement.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <SummaryPill label={`${workspace.summary.observedCount} observed`} />
+          <SummaryPill label={`${workspace.summary.routeReadyCount} ready`} />
+          <SummaryPill label={`${workspace.summary.linkedCount} linked`} />
+          {workspace.summary.needsContactCount > 0 ? (
+            <SummaryPill label={`${workspace.summary.needsContactCount} need contact`} />
+          ) : null}
+        </div>
+      </div>
+
+      {workspace.signals.length > 0 ? (
+        <div className="mt-5 grid gap-3 xl:grid-cols-2">
+          {workspace.signals.map((signal) => (
+            <SignalCard
+              key={signal.id}
+              signal={signal}
+              formAction={formAction}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-[var(--dpf-muted)]">
+          No acquisition signals are waiting for review.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -23,10 +23,17 @@ vi.mock("@dpf/db", () => ({
     customerSiteNode: {
       create: vi.fn(),
     },
+    customerContact: {
+      findUnique: vi.fn(),
+    },
     customerConfigurationItem: {
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+    },
+    engagement: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
     },
     opportunity: {
       findUnique: vi.fn(),
@@ -65,6 +72,8 @@ import {
   advanceOpportunityStage,
   updateOpportunityStageFromForm,
   updateCustomerConfigurationItem,
+  routeAcquisitionSignalToEngagement,
+  createEngagementFromSignalForm,
 } from "./crm";
 
 beforeEach(() => {
@@ -316,6 +325,113 @@ describe("createCustomerConfigurationItem", () => {
     });
     expect(revalidatePath).toHaveBeenCalledWith("/customer");
     expect(revalidatePath).toHaveBeenCalledWith("/customer/acct-1");
+  });
+});
+
+describe("routeAcquisitionSignalToEngagement", () => {
+  it("returns the existing engagement when source evidence was already routed", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue({
+      id: "contact-1",
+      accountId: "acct-1",
+      email: "bea@example.com",
+      firstName: "Bea",
+      lastName: "Buyer",
+    } as never);
+    vi.mocked(prisma.engagement.findFirst).mockResolvedValue({
+      id: "eng-1",
+      engagementId: "ENG-1",
+      title: "Website inquiry from Bea Buyer",
+      status: "new",
+      source: "web_inquiry",
+      sourceRefId: "inq-1",
+    } as never);
+
+    const result = await routeAcquisitionSignalToEngagement({
+      title: "Website inquiry from Bea Buyer",
+      contactId: "contact-1",
+      accountId: "acct-1",
+      source: "web_inquiry",
+      sourceRefId: "inq-1",
+      notes: "Source: storefront inquiry",
+    });
+
+    expect(result).toEqual({
+      status: "linked",
+      engagementId: "eng-1",
+      engagementTitle: "Website inquiry from Bea Buyer",
+    });
+    expect(prisma.engagement.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { source: "web_inquiry", sourceRefId: "inq-1" },
+          {
+            accountId: "acct-1",
+            contactId: "contact-1",
+            source: "web_inquiry",
+            title: "Website inquiry from Bea Buyer",
+          },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+      },
+    });
+    expect(prisma.engagement.create).not.toHaveBeenCalled();
+  });
+
+  it("creates an engagement from an explicit signal routing form and revalidates CRM surfaces", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue({
+      id: "contact-1",
+      accountId: "acct-1",
+      email: "bea@example.com",
+      firstName: "Bea",
+      lastName: "Buyer",
+    } as never);
+    vi.mocked(prisma.engagement.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.engagement.create).mockResolvedValue({
+      id: "eng-1",
+      engagementId: "ENG-1",
+      title: "Website inquiry from Bea Buyer",
+      status: "new",
+      source: "web_inquiry",
+      sourceRefId: "inq-1",
+      accountId: "acct-1",
+      contactId: "contact-1",
+    } as never);
+    vi.mocked(prisma.activity.create).mockResolvedValue({ id: "act-1" } as never);
+
+    const formData = new FormData();
+    formData.set("title", " Website inquiry from Bea Buyer ");
+    formData.set("contactId", "contact-1");
+    formData.set("accountId", "acct-1");
+    formData.set("source", "web_inquiry");
+    formData.set("sourceRefId", "inq-1");
+    formData.set("notes", " Source: storefront inquiry ");
+
+    const result = await createEngagementFromSignalForm(formData);
+
+    expect(result.status).toBe("created");
+    expect(prisma.engagement.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        title: "Website inquiry from Bea Buyer",
+        status: "new",
+        accountId: "acct-1",
+        contactId: "contact-1",
+        source: "web_inquiry",
+        sourceRefId: "inq-1",
+        notes: "Source: storefront inquiry",
+      }),
+      include: {
+        contact: true,
+        account: true,
+        assignedTo: { select: { id: true, email: true } },
+      },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/customer");
+    expect(revalidatePath).toHaveBeenCalledWith("/customer/engagements");
+    expect(revalidatePath).toHaveBeenCalledWith("/customer/marketing");
   });
 });
 

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -630,6 +630,120 @@ export async function createEngagement(input: {
   return engagement;
 }
 
+export type RouteAcquisitionSignalToEngagementInput = {
+  title: string;
+  contactId: string;
+  accountId?: string | null;
+  source: string;
+  sourceRefId: string;
+  assignedToId?: string | null;
+  notes?: string | null;
+  userId?: string;
+};
+
+export type RouteAcquisitionSignalToEngagementResult = {
+  status: "created" | "linked";
+  engagementId: string;
+  engagementTitle: string;
+};
+
+function requiredTrimmed(value: string | null | undefined, label: string): string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    throw new Error(`${label} is required`);
+  }
+  return trimmed;
+}
+
+export async function routeAcquisitionSignalToEngagement(
+  input: RouteAcquisitionSignalToEngagementInput,
+): Promise<RouteAcquisitionSignalToEngagementResult> {
+  const title = requiredTrimmed(input.title, "Engagement title");
+  const contactId = requiredTrimmed(input.contactId, "Contact id");
+  const source = requiredTrimmed(input.source, "Signal source");
+  const sourceRefId = requiredTrimmed(input.sourceRefId, "Signal source reference");
+  const requestedAccountId = trimOrNull(input.accountId);
+
+  const contact = await prisma.customerContact.findUnique({
+    where: { id: contactId },
+    select: {
+      id: true,
+      accountId: true,
+    },
+  });
+
+  if (!contact) {
+    throw new Error("Signal contact was not found");
+  }
+
+  const accountId = requestedAccountId ?? contact.accountId;
+  if (requestedAccountId && requestedAccountId !== contact.accountId) {
+    throw new Error("Signal contact does not belong to the selected account");
+  }
+
+  const existing = await prisma.engagement.findFirst({
+    where: {
+      OR: [
+        { source, sourceRefId },
+        {
+          accountId,
+          contactId,
+          source,
+          title,
+        },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+    },
+  });
+
+  if (existing) {
+    return {
+      status: "linked",
+      engagementId: existing.id,
+      engagementTitle: existing.title,
+    };
+  }
+
+  const engagement = await createEngagement({
+    title,
+    contactId,
+    accountId,
+    source,
+    sourceRefId,
+    assignedToId: trimOrNull(input.assignedToId) ?? undefined,
+    notes: trimOrNull(input.notes) ?? undefined,
+    userId: input.userId,
+  });
+
+  return {
+    status: "created",
+    engagementId: engagement.id,
+    engagementTitle: engagement.title,
+  };
+}
+
+export async function createEngagementFromSignalForm(formData: FormData) {
+  const result = await routeAcquisitionSignalToEngagement({
+    title: String(formData.get("title") ?? ""),
+    contactId: String(formData.get("contactId") ?? ""),
+    accountId: String(formData.get("accountId") ?? ""),
+    source: String(formData.get("source") ?? ""),
+    sourceRefId: String(formData.get("sourceRefId") ?? ""),
+    assignedToId: String(formData.get("assignedToId") ?? ""),
+    notes: String(formData.get("notes") ?? ""),
+  });
+
+  revalidatePath("/customer");
+  revalidatePath("/customer/engagements");
+  revalidatePath("/customer/marketing");
+
+  return result;
+}
+
 export async function qualifyEngagement(
   engagementId: string,
   opts: {

--- a/apps/web/lib/crm/acquisition-signal-data.ts
+++ b/apps/web/lib/crm/acquisition-signal-data.ts
@@ -1,0 +1,162 @@
+import { prisma } from "@dpf/db";
+import { getFacebookLeadAdsAcquisitionSignal } from "@/lib/integrate/facebook-lead-ads/signal";
+import {
+  buildAcquisitionSignalWorkspace,
+  type AcquisitionSignalInput,
+  type AcquisitionSignalWorkspace,
+} from "./acquisition-signals";
+
+type ContactRow = {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  accountId: string;
+  account: {
+    id: string;
+    name: string;
+  };
+};
+
+function compact<T>(values: Array<T | null | undefined>): T[] {
+  return values.filter((value): value is T => value !== null && value !== undefined);
+}
+
+function buildContactLabel(contact: ContactRow): string {
+  return [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim() || contact.email;
+}
+
+export async function getAcquisitionSignalWorkspace(): Promise<AcquisitionSignalWorkspace> {
+  const [inquiries, facebookSignal] = await Promise.all([
+    prisma.storefrontInquiry.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        inquiryRef: true,
+        customerContactId: true,
+        customerEmail: true,
+        customerName: true,
+        customerPhone: true,
+        message: true,
+        status: true,
+        createdAt: true,
+      },
+    }),
+    getFacebookLeadAdsAcquisitionSignal(),
+  ]);
+
+  const contactIds = compact(inquiries.map((inquiry) => inquiry.customerContactId));
+  const emails = inquiries.map((inquiry) => inquiry.customerEmail).filter(Boolean);
+  const contactWhere =
+    contactIds.length > 0 || emails.length > 0
+      ? {
+          OR: [
+            ...(contactIds.length > 0 ? [{ id: { in: contactIds } }] : []),
+            ...(emails.length > 0 ? [{ email: { in: emails } }] : []),
+          ],
+        }
+      : null;
+  const contacts: ContactRow[] = contactWhere
+    ? await prisma.customerContact.findMany({
+        where: contactWhere,
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          accountId: true,
+          account: { select: { id: true, name: true } },
+        },
+      })
+    : [];
+  const contactsById = new Map(contacts.map((contact) => [contact.id, contact]));
+  const contactsByEmail = new Map(contacts.map((contact) => [contact.email, contact]));
+  const sourcePairs = [
+    ...inquiries.map((inquiry) => ({ source: "web_inquiry", sourceRefId: inquiry.id })),
+    ...(facebookSignal
+      ? [{ source: facebookSignal.source, sourceRefId: facebookSignal.sourceRefId }]
+      : []),
+  ];
+  const linkedEngagements =
+    sourcePairs.length > 0
+      ? await prisma.engagement.findMany({
+          where: {
+            OR: sourcePairs,
+          },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            source: true,
+            sourceRefId: true,
+          },
+        })
+      : [];
+  const engagementBySourceRef = new Map(
+    linkedEngagements.map((engagement) => [
+      `${engagement.source ?? ""}:${engagement.sourceRefId ?? ""}`,
+      engagement,
+    ]),
+  );
+
+  const storefrontSignals: AcquisitionSignalInput[] = inquiries.map((inquiry) => {
+    const contact =
+      (inquiry.customerContactId ? contactsById.get(inquiry.customerContactId) : null) ??
+      contactsByEmail.get(inquiry.customerEmail) ??
+      null;
+    const buyerLabel = inquiry.customerName || inquiry.customerEmail;
+    const linkedEngagement = engagementBySourceRef.get(`web_inquiry:${inquiry.id}`) ?? null;
+
+    return {
+      id: inquiry.id,
+      kind: "storefront_inquiry",
+      source: "web_inquiry",
+      sourceRefId: inquiry.id,
+      observedAt: inquiry.createdAt,
+      title: `Storefront inquiry from ${buyerLabel}`,
+      summary: inquiry.message || `Storefront inquiry status: ${inquiry.status}`,
+      buyerLabel,
+      channelLabel: "Storefront inquiry",
+      evidence: [
+        `Ref ${inquiry.inquiryRef}`,
+        inquiry.customerEmail,
+        ...(inquiry.customerPhone ? [inquiry.customerPhone] : []),
+        `Status ${inquiry.status}`,
+      ],
+      contact: contact
+        ? {
+            id: contact.id,
+            accountId: contact.accountId,
+            label: buildContactLabel(contact),
+            email: contact.email,
+            accountLabel: contact.account.name,
+          }
+        : null,
+      accountLabel: contact?.account.name ?? null,
+      linkedEngagement: linkedEngagement
+        ? {
+            id: linkedEngagement.id,
+            title: linkedEngagement.title,
+            status: linkedEngagement.status,
+          }
+        : null,
+    };
+  });
+
+  const signals = [
+    ...storefrontSignals,
+    ...(facebookSignal
+      ? [
+          {
+            ...facebookSignal,
+            linkedEngagement:
+              engagementBySourceRef.get(`${facebookSignal.source}:${facebookSignal.sourceRefId}`) ??
+              null,
+          },
+        ]
+      : []),
+  ];
+
+  return buildAcquisitionSignalWorkspace({ signals });
+}

--- a/apps/web/lib/crm/acquisition-signals.test.ts
+++ b/apps/web/lib/crm/acquisition-signals.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAcquisitionSignalWorkspace,
+  formatAcquisitionSourceLabel,
+  type AcquisitionSignalInput,
+} from "./acquisition-signals";
+
+const now = new Date("2026-05-26T12:00:00.000Z");
+
+describe("acquisition signal workspace", () => {
+  it("normalizes routable storefront inquiries and preserves source evidence", () => {
+    const workspace = buildAcquisitionSignalWorkspace({
+      now,
+      signals: [
+        {
+          kind: "storefront_inquiry",
+          id: "inq-1",
+          source: "web_inquiry",
+          sourceRefId: "inq-1",
+          observedAt: new Date("2026-05-26T10:30:00.000Z"),
+          title: "Website inquiry from Bea Buyer",
+          summary: "Can you help with managed IT onboarding?",
+          buyerLabel: "Bea Buyer",
+          channelLabel: "Storefront inquiry",
+          evidence: ["Ref INQ-1001", "bea@example.com"],
+          contact: {
+            id: "contact-1",
+            accountId: "acct-1",
+            label: "Bea Buyer",
+            email: "bea@example.com",
+          },
+        },
+      ],
+    });
+
+    expect(workspace.summary).toEqual({
+      observedCount: 1,
+      routeReadyCount: 1,
+      linkedCount: 0,
+      needsContactCount: 0,
+    });
+    expect(workspace.signals[0]).toMatchObject({
+      source: "web_inquiry",
+      sourceRefId: "inq-1",
+      routingState: "route_ready",
+      routingLabel: "Ready to create engagement",
+      routeAction: {
+        contactId: "contact-1",
+        accountId: "acct-1",
+        source: "web_inquiry",
+        sourceRefId: "inq-1",
+      },
+    });
+    expect(workspace.signals[0]?.evidence).toContain("Ref INQ-1001");
+  });
+
+  it("marks duplicate source evidence as already linked", () => {
+    const workspace = buildAcquisitionSignalWorkspace({
+      now,
+      signals: [
+        {
+          kind: "storefront_inquiry",
+          id: "inq-1",
+          source: "web_inquiry",
+          sourceRefId: "inq-1",
+          observedAt: new Date("2026-05-26T10:30:00.000Z"),
+          title: "Website inquiry from Bea Buyer",
+          summary: "Can you help with managed IT onboarding?",
+          buyerLabel: "Bea Buyer",
+          channelLabel: "Storefront inquiry",
+          evidence: ["Ref INQ-1001"],
+          contact: {
+            id: "contact-1",
+            accountId: "acct-1",
+            label: "Bea Buyer",
+            email: "bea@example.com",
+          },
+          linkedEngagement: {
+            id: "eng-1",
+            title: "Website inquiry from Bea Buyer",
+            status: "new",
+          },
+        },
+      ],
+    });
+
+    expect(workspace.summary.linkedCount).toBe(1);
+    expect(workspace.signals[0]).toMatchObject({
+      routingState: "linked",
+      routingLabel: "Engagement exists",
+      linkedEngagement: {
+        id: "eng-1",
+        statusLabel: "New",
+      },
+      routeAction: null,
+    });
+  });
+
+  it("shows native integration signals as observed when contact evidence is not present", () => {
+    const signal: AcquisitionSignalInput = {
+      kind: "facebook_lead_ads",
+      id: "facebook-lead-ads:page-123",
+      source: "facebook_lead_ads",
+      sourceRefId: "page-123",
+      observedAt: new Date("2026-05-26T09:00:00.000Z"),
+      title: "Facebook Lead Ads connected for Acme Local",
+      summary: "Recent lead-form preview is available for review.",
+      buyerLabel: "Acme Local",
+      channelLabel: "Facebook Lead Ads",
+      evidence: ["Page page-123", "Last tested 26 May 2026"],
+      integrationHref: "/platform/tools/integrations/facebook-lead-ads",
+    };
+
+    const workspace = buildAcquisitionSignalWorkspace({ now, signals: [signal] });
+
+    expect(workspace.summary).toEqual({
+      observedCount: 1,
+      routeReadyCount: 0,
+      linkedCount: 0,
+      needsContactCount: 1,
+    });
+    expect(workspace.signals[0]).toMatchObject({
+      routingState: "needs_contact",
+      routingLabel: "Needs contact",
+      routeAction: null,
+      integrationHref: "/platform/tools/integrations/facebook-lead-ads",
+    });
+    expect(workspace.signals[0]?.aiTopics.map((topic) => topic.id)).toEqual([
+      "signal-summary",
+      "campaign-brief",
+    ]);
+  });
+
+  it("formats acquisition source labels consistently", () => {
+    expect(formatAcquisitionSourceLabel("web_inquiry")).toBe("Storefront inquiry");
+    expect(formatAcquisitionSourceLabel("facebook_lead_ads")).toBe("Facebook Lead Ads");
+    expect(formatAcquisitionSourceLabel("unknown_source")).toBe("Unknown source");
+  });
+});

--- a/apps/web/lib/crm/acquisition-signals.ts
+++ b/apps/web/lib/crm/acquisition-signals.ts
@@ -1,0 +1,253 @@
+import { formatCrmStatusLabel, getEngagementStatusMeta, type CrmTone } from "./presentation";
+
+export type AcquisitionSignalKind =
+  | "storefront_inquiry"
+  | "facebook_lead_ads"
+  | "google_business_profile";
+
+export type AcquisitionSignalSource =
+  | "web_inquiry"
+  | "facebook_lead_ads"
+  | "google_business_profile"
+  | string;
+
+export type AcquisitionSignalRoutingState =
+  | "route_ready"
+  | "linked"
+  | "needs_contact";
+
+export type AcquisitionSignalTopic = {
+  id: string;
+  label: string;
+  description: string;
+  prompt: string;
+  contextSummary: string;
+  expectedNextStep: string;
+};
+
+export type AcquisitionSignalContactInput = {
+  id: string;
+  accountId: string;
+  label: string;
+  email?: string | null;
+  accountLabel?: string | null;
+};
+
+export type AcquisitionSignalInput = {
+  id: string;
+  kind: AcquisitionSignalKind;
+  source: AcquisitionSignalSource;
+  sourceRefId: string;
+  title: string;
+  summary: string;
+  buyerLabel: string;
+  channelLabel: string;
+  observedAt: Date;
+  evidence: string[];
+  contact?: AcquisitionSignalContactInput | null;
+  accountLabel?: string | null;
+  linkedEngagement?: {
+    id: string;
+    title: string;
+    status: string;
+  } | null;
+  integrationHref?: string | null;
+};
+
+export type AcquisitionSignalRouteAction = {
+  title: string;
+  contactId: string;
+  accountId: string;
+  source: AcquisitionSignalSource;
+  sourceRefId: string;
+  notes: string;
+};
+
+export type AcquisitionSignalView = {
+  id: string;
+  kind: AcquisitionSignalKind;
+  source: AcquisitionSignalSource;
+  sourceRefId: string;
+  title: string;
+  summary: string;
+  buyerLabel: string;
+  channelLabel: string;
+  observedAtLabel: string;
+  routingState: AcquisitionSignalRoutingState;
+  routingLabel: string;
+  routingTone: CrmTone;
+  evidence: string[];
+  contactLabel: string | null;
+  accountLabel: string | null;
+  linkedEngagement: {
+    id: string;
+    title: string;
+    statusLabel: string;
+  } | null;
+  routeAction: AcquisitionSignalRouteAction | null;
+  integrationHref: string | null;
+  aiTopics: AcquisitionSignalTopic[];
+};
+
+export type AcquisitionSignalWorkspace = {
+  summary: {
+    observedCount: number;
+    routeReadyCount: number;
+    linkedCount: number;
+    needsContactCount: number;
+  };
+  signals: AcquisitionSignalView[];
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  facebook_lead_ads: "Facebook Lead Ads",
+  google_business_profile: "Google Business Profile",
+  import: "Import",
+  manual: "Manual",
+  referral: "Referral",
+  web_inquiry: "Storefront inquiry",
+};
+
+export function formatAcquisitionSourceLabel(source: string | null | undefined): string {
+  if (!source) return "Unknown source";
+  return SOURCE_LABELS[source] ?? formatCrmStatusLabel(source);
+}
+
+function formatDateLabel(value: Date): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(value);
+}
+
+function buildNotes(input: AcquisitionSignalInput): string {
+  return [
+    `Source: ${formatAcquisitionSourceLabel(input.source)}`,
+    `Source ref: ${input.sourceRefId}`,
+    `Observed: ${formatDateLabel(input.observedAt)}`,
+    ...input.evidence,
+    input.summary,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildAiTopics(input: AcquisitionSignalInput): AcquisitionSignalTopic[] {
+  const sourceLabel = formatAcquisitionSourceLabel(input.source);
+  const context = `${sourceLabel}: ${input.title}. Buyer/source: ${input.buyerLabel}. Evidence: ${input.evidence.join("; ") || "none"}.`;
+
+  return [
+    {
+      id: "signal-summary",
+      label: "Summarize signal",
+      description: "Review the source evidence and recommend the next internal action.",
+      prompt:
+        `Summarize this CRM acquisition signal without taking external action. ${context} ` +
+        `Call out whether it should become an engagement, what evidence is missing, and who should own follow-up.`,
+      contextSummary: context,
+      expectedNextStep:
+        "Customer Advisor or Marketing Strategist returns a short signal summary for operator review.",
+    },
+    {
+      id: "campaign-brief",
+      label: "Campaign brief",
+      description: "Turn the signal into a campaign or proof-asset idea for review.",
+      prompt:
+        `Create a draft campaign-brief idea from this acquisition signal without publishing or scheduling anything. ${context} ` +
+        `Tie it to a target segment, channel, proof asset, and expected CRM stage movement.`,
+      contextSummary: context,
+      expectedNextStep:
+        "Marketing Strategist proposes an internal campaign brief only; the operator decides what to save or launch.",
+    },
+  ];
+}
+
+function buildSignalView(input: AcquisitionSignalInput): AcquisitionSignalView {
+  const linkedEngagement = input.linkedEngagement
+    ? {
+        id: input.linkedEngagement.id,
+        title: input.linkedEngagement.title,
+        statusLabel: getEngagementStatusMeta(input.linkedEngagement.status).label,
+      }
+    : null;
+  const routeAction =
+    !linkedEngagement && input.contact
+      ? {
+          title: input.title,
+          contactId: input.contact.id,
+          accountId: input.contact.accountId,
+          source: input.source,
+          sourceRefId: input.sourceRefId,
+          notes: buildNotes(input),
+        }
+      : null;
+  const routingState: AcquisitionSignalRoutingState = linkedEngagement
+    ? "linked"
+    : routeAction
+      ? "route_ready"
+      : "needs_contact";
+  const routingLabel =
+    routingState === "linked"
+      ? "Engagement exists"
+      : routingState === "route_ready"
+        ? "Ready to create engagement"
+        : "Needs contact";
+  const routingTone: CrmTone =
+    routingState === "linked"
+      ? "success"
+      : routingState === "route_ready"
+        ? "accent"
+        : "warning";
+
+  return {
+    id: input.id,
+    kind: input.kind,
+    source: input.source,
+    sourceRefId: input.sourceRefId,
+    title: input.title,
+    summary: input.summary,
+    buyerLabel: input.buyerLabel,
+    channelLabel: input.channelLabel,
+    observedAtLabel: formatDateLabel(input.observedAt),
+    routingState,
+    routingLabel,
+    routingTone,
+    evidence: input.evidence,
+    contactLabel: input.contact?.label ?? null,
+    accountLabel: input.contact?.accountLabel ?? input.accountLabel ?? null,
+    linkedEngagement,
+    routeAction,
+    integrationHref: input.integrationHref ?? null,
+    aiTopics: buildAiTopics(input),
+  };
+}
+
+export function buildAcquisitionSignalWorkspace(input: {
+  signals: AcquisitionSignalInput[];
+  now?: Date;
+}): AcquisitionSignalWorkspace {
+  const signals = input.signals
+    .map(buildSignalView)
+    .sort((a, b) => {
+      if (a.routingState !== b.routingState) {
+        const order: Record<AcquisitionSignalRoutingState, number> = {
+          route_ready: 0,
+          needs_contact: 1,
+          linked: 2,
+        };
+        return order[a.routingState] - order[b.routingState];
+      }
+      return a.title.localeCompare(b.title);
+    });
+
+  return {
+    summary: {
+      observedCount: signals.length,
+      routeReadyCount: signals.filter((signal) => signal.routingState === "route_ready").length,
+      linkedCount: signals.filter((signal) => signal.routingState === "linked").length,
+      needsContactCount: signals.filter((signal) => signal.routingState === "needs_contact").length,
+    },
+    signals,
+  };
+}

--- a/apps/web/lib/integrate/facebook-lead-ads/signal.test.ts
+++ b/apps/web/lib/integrate/facebook-lead-ads/signal.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindUnique } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    integrationCredential: {
+      findUnique: mockFindUnique,
+    },
+  },
+}));
+
+import { encryptJson } from "@/lib/govern/credential-crypto";
+import { getFacebookLeadAdsAcquisitionSignal } from "./signal";
+
+describe("getFacebookLeadAdsAcquisitionSignal", () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+  });
+
+  it("returns a sanitized CRM signal for a connected Facebook Lead Ads credential", async () => {
+    mockFindUnique.mockResolvedValue({
+      integrationId: "facebook-lead-ads",
+      provider: "facebook",
+      status: "connected",
+      fieldsEnc: encryptJson({
+        accessToken: "meta-token",
+        pageId: "page-123",
+        pageName: "Acme Local",
+        pageCategory: "Business Service",
+      }),
+      lastTestedAt: new Date("2026-05-26T09:30:00.000Z"),
+      updatedAt: new Date("2026-05-26T09:35:00.000Z"),
+    });
+
+    const signal = await getFacebookLeadAdsAcquisitionSignal();
+
+    expect(signal).toMatchObject({
+      id: "facebook-lead-ads:page-123",
+      kind: "facebook_lead_ads",
+      source: "facebook_lead_ads",
+      sourceRefId: "page-123",
+      title: "Facebook Lead Ads connected for Acme Local",
+      buyerLabel: "Acme Local",
+      integrationHref: "/platform/tools/integrations/facebook-lead-ads",
+    });
+    expect(signal?.evidence.join(" ")).toContain("Business Service");
+    expect(JSON.stringify(signal)).not.toContain("meta-token");
+  });
+
+  it("does not surface unconfigured credentials as acquisition signals", async () => {
+    mockFindUnique.mockResolvedValue({
+      integrationId: "facebook-lead-ads",
+      provider: "facebook",
+      status: "unconfigured",
+      fieldsEnc: encryptJson({ pageId: "page-123" }),
+      lastTestedAt: null,
+      updatedAt: new Date("2026-05-26T09:35:00.000Z"),
+    });
+
+    await expect(getFacebookLeadAdsAcquisitionSignal()).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/integrate/facebook-lead-ads/signal.ts
+++ b/apps/web/lib/integrate/facebook-lead-ads/signal.ts
@@ -1,0 +1,64 @@
+import { prisma } from "@dpf/db";
+import { decryptJson } from "@/lib/govern/credential-crypto";
+import type { AcquisitionSignalInput } from "@/lib/crm/acquisition-signals";
+
+const INTEGRATION_ID = "facebook-lead-ads";
+const INTEGRATION_HREF = "/platform/tools/integrations/facebook-lead-ads";
+
+type StoredFacebookLeadAdsFields = {
+  pageId?: string;
+  pageName?: string;
+  pageCategory?: string;
+};
+
+export async function getFacebookLeadAdsAcquisitionSignal(): Promise<AcquisitionSignalInput | null> {
+  const record = await prisma.integrationCredential.findUnique({
+    where: { integrationId: INTEGRATION_ID },
+  });
+
+  if (!record?.fieldsEnc || record.status !== "connected") {
+    return null;
+  }
+
+  const fields = decryptJson<StoredFacebookLeadAdsFields>(record.fieldsEnc);
+  if (typeof fields?.pageId !== "string" || fields.pageId.length === 0) {
+    return null;
+  }
+
+  const pageLabel =
+    typeof fields.pageName === "string" && fields.pageName.length > 0
+      ? fields.pageName
+      : `Page ${fields.pageId}`;
+  const observedAt = record.lastTestedAt ?? record.updatedAt;
+  const evidence = [
+    `Page ${fields.pageId}`,
+    record.lastTestedAt ? `Last tested ${formatDateLabel(record.lastTestedAt)}` : "Connection stored",
+  ];
+
+  if (typeof fields.pageCategory === "string" && fields.pageCategory.length > 0) {
+    evidence.push(fields.pageCategory);
+  }
+
+  return {
+    id: `${INTEGRATION_ID}:${fields.pageId}`,
+    kind: "facebook_lead_ads",
+    source: "facebook_lead_ads",
+    sourceRefId: fields.pageId,
+    observedAt,
+    title: `Facebook Lead Ads connected for ${pageLabel}`,
+    summary:
+      "Read-first lead form context is available. Route a specific lead only after contact evidence is confirmed.",
+    buyerLabel: pageLabel,
+    channelLabel: "Facebook Lead Ads",
+    evidence,
+    integrationHref: INTEGRATION_HREF,
+  };
+}
+
+function formatDateLabel(value: Date): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(value);
+}


### PR DESCRIPTION
## Summary
- Adds a CRM acquisition-signal read model over storefront inquiries and the native Facebook Lead Ads connection signal, without introducing a Lead table.
- Adds an explicit signal-to-engagement routing action with duplicate guards on source evidence and contact/account context.
- Adds the engagement-page signal router UI with source evidence, linked-state distinction, and AI handoff topic cues.

## Validation
- `pnpm --filter web exec vitest run lib/crm/acquisition-signals.test.ts components/customer/AcquisitionSignalRouter.test.tsx lib/actions/crm.test.ts lib/integrate/facebook-lead-ads/signal.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- Docker-served UX check at `http://localhost:3001/customer/engagements`; screenshot captured at `output/playwright/crm-signal-routing-engagements.png`

## Backlog
- BI-63F427A7: CRM marketing Slice 3: signal-to-engagement routing