### PR TITLE
feat(platform): contributor change lanes — Phase 1-4 read-only dashboard

### DIFF
--- a/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
+++ b/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
@@ -1,0 +1,29 @@
+import path from "node:path";
+
+import { ChangeLanesDashboard } from "@/components/platform/development/change-lanes/ChangeLanesDashboard";
+import { loadContributorChangeLaneReadModel } from "@/lib/contributor-change-lanes/read-model";
+import { createNodeInventoryRunners } from "@/lib/contributor-change-lanes/runners-node";
+
+export const dynamic = "force-dynamic";
+
+export default async function ChangeLanesPage() {
+  const repoCwd = process.cwd();
+  const worktreeRoot = path.join(repoCwd, ".claude", "worktrees");
+  const runners = createNodeInventoryRunners({ repoCwd, worktreeRoot });
+
+  const now = new Date();
+  const { lanes, freshness } = await loadContributorChangeLaneReadModel({
+    runners,
+    now,
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-[1600px] px-4 py-6">
+      <ChangeLanesDashboard
+        lanes={lanes}
+        freshness={freshness}
+        generatedAt={now.toISOString()}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneBlockers.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneBlockers.tsx
@@ -1,0 +1,17 @@
+export function ChangeLaneBlockers({ blockers }: { blockers: string[] }) {
+  if (blockers.length === 0) {
+    return <span className="text-[var(--dpf-muted)]">—</span>;
+  }
+  return (
+    <ul className="space-y-0.5">
+      {blockers.map((b, i) => (
+        <li
+          key={`${i}-${b}`}
+          className="text-[var(--dpf-error)] text-xs leading-snug"
+        >
+          {b}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
@@ -1,0 +1,43 @@
+import type { LaneReadModelFreshness } from "@/lib/contributor-change-lanes/read-model";
+
+const SOURCE_LABEL: Record<LaneReadModelFreshness["source"], string> = {
+  "work-capsule": "Work Capsules",
+  "runtime-target": "Runtime Targets",
+  "runtime-verification": "Runtime Verifications",
+  "nonprod-lease": "Non-prod Leases",
+  "git-worktree": "Git Worktrees",
+  "git-branch": "Git Branches",
+  "github-pr": "GitHub PRs",
+};
+
+export function ChangeLaneSourceSummary({ freshness }: { freshness: LaneReadModelFreshness[] }) {
+  return (
+    <div
+      className="rounded border p-3 text-xs"
+      style={{
+        borderColor: "var(--dpf-border)",
+        backgroundColor: "var(--dpf-surface-2)",
+      }}
+    >
+      <div className="mb-2 text-[var(--dpf-muted)] uppercase tracking-wide text-[10px]">
+        Source freshness
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 md:grid-cols-4">
+        {freshness.map((f) => (
+          <div key={f.source} className="flex items-center gap-2">
+            <span
+              className={`inline-block h-1.5 w-1.5 rounded-full ${
+                f.ok ? "bg-[var(--dpf-success)]" : "bg-[var(--dpf-error)]"
+              }`}
+              aria-hidden
+            />
+            <span className="text-[var(--dpf-text)]">{SOURCE_LABEL[f.source]}</span>
+            <span className="text-[var(--dpf-muted)]">
+              {f.ok ? f.count : f.error ?? "error"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
@@ -1,0 +1,24 @@
+import type { ContributorLaneStatus } from "@/lib/contributor-change-lanes/types";
+
+const STATUS_COLOR_CLASSES: Record<ContributorLaneStatus, string> = {
+  blocked: "border-[var(--dpf-error)] text-[var(--dpf-error)]",
+  starting: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
+  verifying: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
+  running: "border-[var(--dpf-accent)] text-[var(--dpf-accent)]",
+  "ready-for-review": "border-[var(--dpf-success)] text-[var(--dpf-success)]",
+  claimed: "border-[var(--dpf-muted)] text-[var(--dpf-text)]",
+  available: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
+  released: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
+  stale: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
+};
+
+export function ChangeLaneStatusBadge({ status }: { status: ContributorLaneStatus }) {
+  const classes = STATUS_COLOR_CLASSES[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${classes}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
@@ -1,0 +1,160 @@
+import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types";
+
+import { ChangeLaneBlockers } from "./ChangeLaneBlockers";
+import { ChangeLaneStatusBadge } from "./ChangeLaneStatusBadge";
+
+export function ChangeLaneTable({ lanes }: { lanes: ContributorChangeLane[] }) {
+  if (lanes.length === 0) {
+    return (
+      <div
+        className="rounded border p-6 text-center text-sm text-[var(--dpf-muted)]"
+        style={{ borderColor: "var(--dpf-border)" }}
+      >
+        No lanes in this view.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-x-auto rounded border"
+      style={{ borderColor: "var(--dpf-border)" }}
+    >
+      <table className="w-full min-w-[1200px] text-xs">
+        <thead
+          className="text-left text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]"
+          style={{ backgroundColor: "var(--dpf-surface-2)" }}
+        >
+          <tr>
+            <Th>Lane</Th>
+            <Th>Status</Th>
+            <Th>Owner</Th>
+            <Th>Branch</Th>
+            <Th>Commit</Th>
+            <Th>Served</Th>
+            <Th>PR</Th>
+            <Th>Runtime</Th>
+            <Th>Verification</Th>
+            <Th>TTL</Th>
+            <Th className="w-[20%]">Blockers</Th>
+            <Th className="w-[18%]">Next action</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {lanes.map((lane) => (
+            <tr
+              key={lane.id}
+              className="align-top border-t text-[var(--dpf-text)]"
+              style={{ borderColor: "var(--dpf-border)" }}
+            >
+              <Td>
+                <div className="font-medium">{lane.laneKind}</div>
+                <div className="text-[var(--dpf-muted)] text-[10px]">{lane.id}</div>
+                <div className="text-[var(--dpf-muted)] text-[10px]">{lane.source}</div>
+              </Td>
+              <Td>
+                <ChangeLaneStatusBadge status={lane.status} />
+              </Td>
+              <Td>{lane.owner ?? <Em>—</Em>}</Td>
+              <Td>
+                {lane.branch ? (
+                  <span className="font-mono text-[11px]">{lane.branch}</span>
+                ) : (
+                  <Em>—</Em>
+                )}
+              </Td>
+              <Td>{shortenSha(lane.commitSha)}</Td>
+              <Td>{shortenSha(lane.servedCommitSha)}</Td>
+              <Td>
+                {lane.pullRequestUrl ? (
+                  <a
+                    href={lane.pullRequestUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--dpf-accent)] underline decoration-dotted"
+                  >
+                    {prNumberFromUrl(lane.pullRequestUrl)}
+                  </a>
+                ) : (
+                  <Em>—</Em>
+                )}
+              </Td>
+              <Td>
+                {lane.runtimeUrl ? (
+                  <a
+                    href={lane.runtimeUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--dpf-accent)] underline decoration-dotted"
+                  >
+                    {hostnameFromUrl(lane.runtimeUrl)}
+                  </a>
+                ) : (
+                  <Em>—</Em>
+                )}
+              </Td>
+              <Td>
+                <div>{lane.latestVerification.status}</div>
+                {lane.latestVerification.checkedAt && (
+                  <div className="text-[var(--dpf-muted)] text-[10px]">
+                    {formatRelative(lane.latestVerification.checkedAt)}
+                  </div>
+                )}
+              </Td>
+              <Td>{lane.expiresAt ? formatRelative(lane.expiresAt) : <Em>—</Em>}</Td>
+              <Td>
+                <ChangeLaneBlockers blockers={lane.blockers} />
+              </Td>
+              <Td>
+                <span className="text-[var(--dpf-text)]">{lane.nextAction}</span>
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Th({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <th className={`px-2 py-1.5 ${className ?? ""}`}>{children}</th>;
+}
+
+function Td({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <td className={`px-2 py-1.5 ${className ?? ""}`}>{children}</td>;
+}
+
+function Em({ children }: { children: React.ReactNode }) {
+  return <span className="text-[var(--dpf-muted)]">{children}</span>;
+}
+
+function shortenSha(sha: string | null): React.ReactNode {
+  if (!sha) return <Em>—</Em>;
+  return <span className="font-mono text-[11px]">{sha.slice(0, 7)}</span>;
+}
+
+function prNumberFromUrl(url: string): string {
+  const m = url.match(/\/pull\/(\d+)/);
+  return m ? `#${m[1]}` : url;
+}
+
+function hostnameFromUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.host;
+  } catch {
+    return url;
+  }
+}
+
+function formatRelative(date: Date): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const abs = Math.abs(diff);
+  const mins = Math.round(abs / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${diff < 0 ? "in " : ""}${mins}m${diff < 0 ? "" : " ago"}`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${diff < 0 ? "in " : ""}${hours}h${diff < 0 ? "" : " ago"}`;
+  const days = Math.round(hours / 24);
+  return `${diff < 0 ? "in " : ""}${days}d${diff < 0 ? "" : " ago"}`;
+}

--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { LaneReadModelFreshness } from "@/lib/contributor-change-lanes/read-model";
+import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types";
+
+import { ChangeLaneSourceSummary } from "./ChangeLaneSourceSummary";
+import { ChangeLaneTable } from "./ChangeLaneTable";
+
+const TABS = [
+  { id: "active", label: "Active lanes" },
+  { id: "handoff", label: "Branches needing handoff" },
+  { id: "worktrees", label: "Orphan worktrees" },
+  { id: "leases", label: "Stale leases" },
+  { id: "cleanup", label: "Merged branches safe to delete" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+const ACTIVE_STATUSES = new Set([
+  "running",
+  "verifying",
+  "starting",
+  "ready-for-review",
+  "blocked",
+  "claimed",
+  "available",
+]);
+
+const STALE_STATUSES = new Set(["stale", "released"]);
+
+export function ChangeLanesDashboard({
+  lanes,
+  freshness,
+  generatedAt,
+}: {
+  lanes: ContributorChangeLane[];
+  freshness: LaneReadModelFreshness[];
+  generatedAt: string;
+}) {
+  const [tab, setTab] = useState<TabId>("active");
+
+  const filteredLanes = useMemo(() => filterLanes(lanes, tab), [lanes, tab]);
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold text-[var(--dpf-text)]">
+          Contributor change lanes
+        </h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Branches, worktrees, runtimes, and PRs joined into one view so contributor
+          handoff state is visible — read-only for this slice.
+        </p>
+        <p className="text-[10px] text-[var(--dpf-muted)]">
+          Snapshot at {generatedAt}
+        </p>
+      </header>
+
+      <ChangeLaneSourceSummary freshness={freshness} />
+
+      <div
+        className="flex flex-wrap gap-1 border-b text-xs"
+        style={{ borderColor: "var(--dpf-border)" }}
+      >
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={[
+              "rounded-t px-3 py-1.5 font-medium transition-colors",
+              tab === t.id
+                ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+            ].join(" ")}
+          >
+            {t.label}
+            <span className="ml-1 text-[10px] text-[var(--dpf-muted)]">
+              {countLanes(lanes, t.id)}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <ChangeLaneTable lanes={filteredLanes} />
+    </div>
+  );
+}
+
+function filterLanes(
+  lanes: ContributorChangeLane[],
+  tab: TabId,
+): ContributorChangeLane[] {
+  switch (tab) {
+    case "active":
+      return lanes.filter((l) => ACTIVE_STATUSES.has(l.status));
+    case "handoff":
+      return lanes.filter(
+        (l) =>
+          l.source === "git-branch" ||
+          (l.source === "work-capsule" &&
+            !l.pullRequestUrl &&
+            l.blockers.some((b) => /WIP TTL|expired|no branch/i.test(b))),
+      );
+    case "worktrees":
+      return lanes.filter((l) => l.source === "worktree");
+    case "leases":
+      return lanes.filter(
+        (l) =>
+          l.source === "nonprod-lease" ||
+          (STALE_STATUSES.has(l.status) && l.source === "runtime-target"),
+      );
+    case "cleanup":
+      return lanes.filter(
+        (l) =>
+          l.source === "git-branch" &&
+          l.blockers.some((b) => /no Work Capsule/i.test(b)),
+      );
+    default:
+      return lanes;
+  }
+}
+
+function countLanes(lanes: ContributorChangeLane[], tab: TabId): number {
+  return filterLanes(lanes, tab).length;
+}

--- a/apps/web/lib/contributor-change-lanes/git-inventory.test.ts
+++ b/apps/web/lib/contributor-change-lanes/git-inventory.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mergeFilesystemAndRegisteredWorktrees,
+  parseGitBranchList,
+  parseGitWorktreeList,
+} from "./git-inventory";
+
+const PORCELAIN_SAMPLE = `worktree D:/DPF
+HEAD 5dbe23b0aaaa
+branch refs/heads/main
+
+worktree D:/DPF/.claude/worktrees/ccl-phase-1
+HEAD 1234567890abcdef
+branch refs/heads/feat/contributor-change-lanes-phase-1
+
+worktree D:/DPF/.claude/worktrees/detached
+HEAD deadbeef
+detached
+
+worktree D:/DPF/.claude/worktrees/bare
+bare
+`;
+
+const FOR_EACH_REF_SAMPLE = [
+  "refs/remotes/origin/main\t5dbe23b0\t2026-05-26T20:00:00Z\tmerged",
+  "refs/remotes/origin/feat/ccl\t1234abcd\t2026-05-26T21:00:00Z\t",
+  "refs/remotes/origin/HEAD\t\t\t",
+  "refs/remotes/origin/feat/orphan\tabcd1234\t2026-04-01T00:00:00Z\t",
+].join("\n");
+
+describe("parseGitWorktreeList", () => {
+  it("parses each non-bare block into a worktree snapshot, normalizing paths to forward slashes", () => {
+    const result = parseGitWorktreeList(PORCELAIN_SAMPLE);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      path: "D:/DPF",
+      branch: "main",
+      headSha: "5dbe23b0aaaa",
+      isRegistered: true,
+    });
+    expect(result[1]!.branch).toBe("feat/contributor-change-lanes-phase-1");
+    expect(result[2]!.branch).toBeNull();
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseGitWorktreeList("")).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const crlf = PORCELAIN_SAMPLE.replace(/\n/g, "\r\n");
+    const result = parseGitWorktreeList(crlf);
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe("parseGitBranchList", () => {
+  it("strips the refs/remotes/origin/ prefix and parses the lastCommit date + merged flag", () => {
+    const result = parseGitBranchList(FOR_EACH_REF_SAMPLE);
+    const main = result.find((b) => b.name === "main");
+    const ccl = result.find((b) => b.name === "feat/ccl");
+    const orphan = result.find((b) => b.name === "feat/orphan");
+
+    expect(main).toBeDefined();
+    expect(main!.isMerged).toBe(true);
+    expect(main!.headSha).toBe("5dbe23b0");
+    expect(main!.lastCommitAt).toEqual(new Date("2026-05-26T20:00:00Z"));
+
+    expect(ccl).toBeDefined();
+    expect(ccl!.isMerged).toBe(false);
+
+    expect(orphan).toBeDefined();
+    expect(orphan!.lastCommitAt).toEqual(new Date("2026-04-01T00:00:00Z"));
+  });
+
+  it("skips the HEAD symbolic ref", () => {
+    const result = parseGitBranchList(FOR_EACH_REF_SAMPLE);
+    expect(result.find((b) => b.name === "HEAD")).toBeUndefined();
+  });
+
+  it("returns an empty array on empty input", () => {
+    expect(parseGitBranchList("")).toEqual([]);
+  });
+});
+
+describe("mergeFilesystemAndRegisteredWorktrees", () => {
+  it("adds filesystem paths that are not registered git worktrees", () => {
+    const registered = parseGitWorktreeList(PORCELAIN_SAMPLE);
+    const merged = mergeFilesystemAndRegisteredWorktrees(registered, [
+      "D:/DPF/.claude/worktrees/orphan-dir",
+      "D:\\DPF\\.claude\\worktrees\\ccl-phase-1",
+    ]);
+    expect(merged.length).toBe(registered.length + 1);
+    const additions = merged.filter((wt) => !wt.isRegistered);
+    expect(additions).toHaveLength(1);
+    expect(additions[0]!.path).toBe("D:/DPF/.claude/worktrees/orphan-dir");
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/git-inventory.ts
+++ b/apps/web/lib/contributor-change-lanes/git-inventory.ts
@@ -1,0 +1,121 @@
+import type { GitBranchSnapshot, GitWorktreeSnapshot } from "./types";
+
+const ORIGIN_PREFIX = "refs/remotes/origin/";
+const SHORT_ORIGIN_PREFIX = "origin/";
+
+export type GitInventoryError = {
+  source: "worktree" | "branch";
+  message: string;
+};
+
+export type GitInventoryResult = {
+  worktrees: GitWorktreeSnapshot[];
+  branches: GitBranchSnapshot[];
+  errors: GitInventoryError[];
+};
+
+export function parseGitWorktreeList(porcelain: string): GitWorktreeSnapshot[] {
+  if (!porcelain.trim()) return [];
+
+  const blocks = porcelain.split(/\r?\n\r?\n/);
+  const out: GitWorktreeSnapshot[] = [];
+
+  for (const block of blocks) {
+    if (!block.trim()) continue;
+    let path: string | null = null;
+    let head: string | null = null;
+    let branch: string | null = null;
+    let detached = false;
+    let bare = false;
+
+    for (const line of block.split(/\r?\n/)) {
+      if (line.startsWith("worktree ")) path = line.slice("worktree ".length).trim();
+      else if (line.startsWith("HEAD ")) head = line.slice("HEAD ".length).trim();
+      else if (line.startsWith("branch ")) {
+        const raw = line.slice("branch ".length).trim();
+        branch = raw.startsWith("refs/heads/") ? raw.slice("refs/heads/".length) : raw;
+      } else if (line === "detached") detached = true;
+      else if (line === "bare") bare = true;
+    }
+
+    if (!path || bare) continue;
+    out.push({
+      path: normalizePath(path),
+      branch: detached ? null : branch,
+      headSha: head,
+      isRegistered: true,
+    });
+  }
+
+  return out;
+}
+
+export function parseGitBranchList(
+  forEachRefOutput: string,
+  options?: { remote?: "origin" | "local"; now?: Date },
+): GitBranchSnapshot[] {
+  if (!forEachRefOutput.trim()) return [];
+  const remote = options?.remote ?? "origin";
+  const out: GitBranchSnapshot[] = [];
+
+  for (const line of forEachRefOutput.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    if (parts.length < 2) continue;
+    const [refname, sha, lastCommitRaw, mergedRaw] = parts;
+    const name = normalizeBranchName(refname ?? "");
+    if (!name) continue;
+    if (name === "HEAD") continue;
+
+    const lastCommitAt = lastCommitRaw ? parseGitDate(lastCommitRaw) : null;
+    const isMerged = (mergedRaw ?? "").trim() === "merged";
+
+    out.push({
+      name,
+      headSha: sha ?? null,
+      remote,
+      isMerged,
+      lastCommitAt,
+    });
+  }
+
+  return out;
+}
+
+export function mergeFilesystemAndRegisteredWorktrees(
+  registered: GitWorktreeSnapshot[],
+  filesystemPaths: string[],
+): GitWorktreeSnapshot[] {
+  const known = new Set(registered.map((wt) => normalizePath(wt.path)));
+  const additions: GitWorktreeSnapshot[] = [];
+  for (const raw of filesystemPaths) {
+    const path = normalizePath(raw);
+    if (known.has(path)) continue;
+    additions.push({
+      path,
+      branch: null,
+      headSha: null,
+      isRegistered: false,
+    });
+  }
+  return [...registered, ...additions];
+}
+
+function normalizeBranchName(refname: string): string {
+  if (refname.startsWith(ORIGIN_PREFIX)) return refname.slice(ORIGIN_PREFIX.length);
+  if (refname.startsWith(SHORT_ORIGIN_PREFIX)) return refname.slice(SHORT_ORIGIN_PREFIX.length);
+  if (refname.startsWith("refs/heads/")) return refname.slice("refs/heads/".length);
+  return refname;
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function parseGitDate(raw: string): Date | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const d = new Date(trimmed);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}

--- a/apps/web/lib/contributor-change-lanes/github-inventory.test.ts
+++ b/apps/web/lib/contributor-change-lanes/github-inventory.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGhPrListJson } from "./github-inventory";
+
+const VALID_JSON = JSON.stringify([
+  {
+    number: 1205,
+    url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1205",
+    title: "docs: specify contributor change lanes",
+    headRefName: "doc/contributor-change-lanes",
+    baseRefName: "main",
+    isDraft: true,
+    state: "OPEN",
+    mergeStateStatus: "BLOCKED",
+  },
+  {
+    number: 1206,
+    url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1206",
+    title: "feat: route acquisition signals",
+    headRefName: "feat/acquisition",
+    state: "MERGED",
+    isDraft: false,
+  },
+  {
+    number: 999,
+    url: "https://example.com/pr/999",
+    title: "closed pr",
+    headRefName: "feat/closed",
+    state: "CLOSED",
+  },
+]);
+
+describe("parseGhPrListJson", () => {
+  it("parses each PR object into a snapshot, preserving the URL, branch, draft, and merge-state", () => {
+    const result = parseGhPrListJson(VALID_JSON);
+    expect(result.errors).toEqual([]);
+    expect(result.pullRequests).toHaveLength(3);
+
+    const ccl = result.pullRequests.find((p) => p.number === 1205);
+    expect(ccl).toBeDefined();
+    expect(ccl!.headBranch).toBe("doc/contributor-change-lanes");
+    expect(ccl!.state).toBe("open");
+    expect(ccl!.isDraft).toBe(true);
+    expect(ccl!.mergeStateStatus).toBe("BLOCKED");
+
+    expect(result.pullRequests.find((p) => p.number === 1206)!.state).toBe("merged");
+    expect(result.pullRequests.find((p) => p.number === 999)!.state).toBe("closed");
+  });
+
+  it("returns an error and empty list for malformed JSON", () => {
+    const result = parseGhPrListJson("not json");
+    expect(result.pullRequests).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.source).toBe("pr-list");
+  });
+
+  it("returns an error when gh output is not a JSON array", () => {
+    const result = parseGhPrListJson('{"foo": "bar"}');
+    expect(result.pullRequests).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it("skips entries missing required fields rather than throwing", () => {
+    const json = JSON.stringify([
+      { number: "not-a-number", url: "x", headRefName: "x" },
+      { number: 1, url: 2, headRefName: "x" },
+      { number: 5, url: "ok", headRefName: "feat/x", state: "OPEN" },
+    ]);
+    const result = parseGhPrListJson(json);
+    expect(result.pullRequests).toHaveLength(1);
+    expect(result.pullRequests[0]!.number).toBe(5);
+  });
+
+  it("handles empty input as no errors and no PRs", () => {
+    const result = parseGhPrListJson("");
+    expect(result.pullRequests).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/github-inventory.ts
+++ b/apps/web/lib/contributor-change-lanes/github-inventory.ts
@@ -1,0 +1,71 @@
+import type { PullRequestSnapshot } from "./types";
+
+export type GitHubInventoryError = {
+  source: "pr-list";
+  message: string;
+};
+
+export type GitHubInventoryResult = {
+  pullRequests: PullRequestSnapshot[];
+  errors: GitHubInventoryError[];
+};
+
+type RawPr = {
+  number: number;
+  url: string;
+  title: string;
+  headRefName?: string;
+  state?: string;
+  isDraft?: boolean;
+  mergeStateStatus?: string | null;
+};
+
+export function parseGhPrListJson(json: string): GitHubInventoryResult {
+  if (!json.trim()) {
+    return { pullRequests: [], errors: [] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    return {
+      pullRequests: [],
+      errors: [{ source: "pr-list", message: `Failed to parse gh JSON: ${(err as Error).message}` }],
+    };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return {
+      pullRequests: [],
+      errors: [{ source: "pr-list", message: "gh output is not a JSON array" }],
+    };
+  }
+
+  const pullRequests: PullRequestSnapshot[] = [];
+  for (const raw of parsed as RawPr[]) {
+    if (!raw || typeof raw !== "object") continue;
+    if (typeof raw.number !== "number") continue;
+    if (typeof raw.url !== "string") continue;
+    if (typeof raw.headRefName !== "string") continue;
+    pullRequests.push({
+      number: raw.number,
+      url: raw.url,
+      title: typeof raw.title === "string" ? raw.title : "",
+      headBranch: raw.headRefName,
+      state: normalizeState(raw.state),
+      isDraft: Boolean(raw.isDraft),
+      mergeStateStatus: typeof raw.mergeStateStatus === "string" ? raw.mergeStateStatus : null,
+    });
+  }
+
+  return { pullRequests, errors: [] };
+}
+
+function normalizeState(s: unknown): PullRequestSnapshot["state"] {
+  if (typeof s !== "string") return "open";
+  const lower = s.toLowerCase();
+  if (lower === "merged") return "merged";
+  if (lower === "closed") return "closed";
+  return "open";
+}

--- a/apps/web/lib/contributor-change-lanes/lane-projection.test.ts
+++ b/apps/web/lib/contributor-change-lanes/lane-projection.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+
+import { projectContributorChangeLanes } from "./lane-projection";
+import type {
+  GitBranchSnapshot,
+  GitWorktreeSnapshot,
+  LaneProjectionInput,
+  NonprodEnvironmentLeaseSnapshot,
+  PullRequestSnapshot,
+  RuntimeTargetSnapshot,
+  RuntimeVerificationSnapshot,
+  WorkCapsuleSnapshot,
+} from "./types";
+
+const NOW = new Date("2026-05-26T22:00:00.000Z");
+const FRESH = new Date("2026-05-26T21:58:00.000Z");
+const STALE = new Date("2026-05-26T20:00:00.000Z");
+
+function emptyInput(overrides: Partial<LaneProjectionInput> = {}): LaneProjectionInput {
+  return {
+    workCapsules: [],
+    runtimeTargets: [],
+    runtimeVerifications: [],
+    leases: [],
+    worktrees: [],
+    branches: [],
+    pullRequests: [],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function capsule(overrides: Partial<WorkCapsuleSnapshot> = {}): WorkCapsuleSnapshot {
+  return {
+    capsuleId: "WC-TEST",
+    title: "Test capsule",
+    status: "working",
+    executorKind: "claude-desktop",
+    executorRef: "session-abc",
+    headBranch: "feat/test",
+    headSha: "aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1",
+    worktreePath: "D:/DPF/.claude/worktrees/test",
+    pullRequestUrl: null,
+    backlogItemId: "BI-TEST",
+    featureBuildId: null,
+    leaseHolderPrincipalId: "principal-1",
+    leaseExpiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+    updatedAt: FRESH,
+    purpose: "Test purpose",
+    nextAction: null,
+    ...overrides,
+  };
+}
+
+function target(overrides: Partial<RuntimeTargetSnapshot> = {}): RuntimeTargetSnapshot {
+  return {
+    targetId: "RT-TEST",
+    kind: "dev-portal",
+    status: "running",
+    hostUrl: "http://localhost:3001",
+    serviceVersion: null,
+    servedCommitSha: "aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1",
+    workCapsuleId: null,
+    featureBuildId: null,
+    branchName: null,
+    acceptanceRole: "non-prod-verification",
+    lastHeartbeatAt: FRESH,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+function lease(overrides: Partial<NonprodEnvironmentLeaseSnapshot> = {}): NonprodEnvironmentLeaseSnapshot {
+  return {
+    leaseId: "NPEL-TEST",
+    environmentKey: "active-candidate",
+    status: "active",
+    ownerProvider: "claude",
+    ownerSessionId: "session-abc",
+    purpose: "verify branch",
+    url: "http://localhost:3001",
+    worktreePath: null,
+    branchName: null,
+    expiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+function pr(overrides: Partial<PullRequestSnapshot> = {}): PullRequestSnapshot {
+  return {
+    number: 1234,
+    url: "https://example.com/pr/1234",
+    title: "feat: test",
+    headBranch: "feat/test",
+    state: "open",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    ...overrides,
+  };
+}
+
+function branch(overrides: Partial<GitBranchSnapshot> = {}): GitBranchSnapshot {
+  return {
+    name: "feat/test",
+    headSha: "aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1",
+    remote: "origin",
+    isMerged: false,
+    lastCommitAt: FRESH,
+    ...overrides,
+  };
+}
+
+function worktree(overrides: Partial<GitWorktreeSnapshot> = {}): GitWorktreeSnapshot {
+  return {
+    path: "D:/DPF/.claude/worktrees/test",
+    branch: "feat/test",
+    headSha: "aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1",
+    isRegistered: true,
+    ...overrides,
+  };
+}
+
+describe("projectContributorChangeLanes", () => {
+  it("joins a work capsule, runtime target, and open PR into one lane row with ready-for-review status when SHAs match and verification passed", () => {
+    const wc = capsule();
+    const rt = target({
+      workCapsuleId: wc.capsuleId,
+      branchName: wc.headBranch,
+      servedCommitSha: wc.headSha,
+    });
+    const verification: RuntimeVerificationSnapshot = {
+      verificationId: "RV-1",
+      runtimeTargetId: rt.targetId,
+      workCapsuleId: wc.capsuleId,
+      kind: "ux",
+      status: "passed",
+      summary: "Dashboard loads",
+      completedAt: FRESH,
+    };
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        runtimeTargets: [rt],
+        runtimeVerifications: [verification],
+        pullRequests: [pr({ headBranch: wc.headBranch! })],
+      }),
+    );
+
+    expect(result.lanes).toHaveLength(1);
+    const lane = result.lanes[0]!;
+    expect(lane.id).toBe(rt.targetId);
+    expect(lane.source).toBe("runtime-target");
+    expect(lane.status).toBe("ready-for-review");
+    expect(lane.branch).toBe(wc.headBranch);
+    expect(lane.servedCommitSha).toBe(wc.headSha);
+    expect(lane.pullRequestUrl).toBe("https://example.com/pr/1234");
+    expect(lane.workCapsuleId).toBe(wc.capsuleId);
+    expect(lane.blockers).toEqual([]);
+    expect(lane.latestVerification.status).toBe("passed");
+  });
+
+  it("flags a branch with an open PR but no work capsule with a missing-capsule blocker", () => {
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        branches: [branch({ name: "feat/orphan-pr" })],
+        pullRequests: [pr({ headBranch: "feat/orphan-pr", number: 7777 })],
+      }),
+    );
+
+    expect(result.lanes).toHaveLength(1);
+    const lane = result.lanes[0]!;
+    expect(lane.source).toBe("git-branch");
+    expect(lane.branch).toBe("feat/orphan-pr");
+    expect(lane.pullRequestUrl).toBe("https://example.com/pr/1234");
+    expect(lane.blockers).toContain("PR exists but no Work Capsule attached");
+    expect(lane.status).toBe("claimed");
+  });
+
+  it("flags a branch with no PR and no active WIP TTL as orphaned", () => {
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        branches: [branch({ name: "feat/orphan-branch" })],
+      }),
+    );
+
+    expect(result.lanes).toHaveLength(1);
+    const lane = result.lanes[0]!;
+    expect(lane.source).toBe("git-branch");
+    expect(lane.branch).toBe("feat/orphan-branch");
+    expect(lane.pullRequestUrl).toBeNull();
+    expect(lane.blockers).toContain("No open PR and no active WIP record");
+    expect(lane.status).toBe("stale");
+  });
+
+  it("flags a worktree with no branch or capsule linkage as orphaned", () => {
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        worktrees: [
+          worktree({
+            path: "D:/DPF/.claude/worktrees/orphan",
+            branch: null,
+            headSha: null,
+          }),
+        ],
+      }),
+    );
+
+    expect(result.lanes).toHaveLength(1);
+    const lane = result.lanes[0]!;
+    expect(lane.source).toBe("worktree");
+    expect(lane.worktreePath).toBe("D:/DPF/.claude/worktrees/orphan");
+    expect(lane.blockers).toContain("Worktree has no active Work Capsule");
+    expect(lane.status).toBe("stale");
+  });
+
+  it("treats a stopped registered dev-portal without lease as available", () => {
+    const rt = target({
+      targetId: "RT-DEV-PORTAL",
+      status: "planned",
+      hostUrl: "http://localhost:3001",
+      servedCommitSha: null,
+      lastHeartbeatAt: null,
+      branchName: null,
+      workCapsuleId: null,
+    });
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        runtimeTargets: [rt],
+      }),
+    );
+
+    const lane = result.lanes.find((l) => l.runtimeTargetId === "RT-DEV-PORTAL");
+    expect(lane).toBeDefined();
+    expect(lane!.status).toBe("available");
+    expect(lane!.blockers).toEqual([]);
+    expect(lane!.nextAction).toMatch(/claim/i);
+  });
+
+  it("treats a claimed stopped dev-portal with active lease as starting", () => {
+    const wc = capsule({
+      capsuleId: "WC-DEV-CLAIM",
+      worktreePath: "D:/DPF/.claude/worktrees/dev-claim",
+      headBranch: "feat/dev-claim",
+    });
+    const rt = target({
+      targetId: "RT-DEV-PORTAL",
+      status: "planned",
+      hostUrl: "http://localhost:3001",
+      servedCommitSha: null,
+      lastHeartbeatAt: null,
+      workCapsuleId: wc.capsuleId,
+      branchName: wc.headBranch,
+    });
+    const lse = lease({
+      leaseId: "NPEL-DEV-1",
+      worktreePath: wc.worktreePath,
+      branchName: wc.headBranch,
+    });
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        runtimeTargets: [rt],
+        leases: [lse],
+      }),
+    );
+
+    const lane = result.lanes.find((l) => l.runtimeTargetId === "RT-DEV-PORTAL");
+    expect(lane).toBeDefined();
+    expect(lane!.status).toBe("starting");
+    expect(lane!.expiresAt).toEqual(lse.expiresAt);
+  });
+
+  it("marks the lane blocked when the latest verification failed", () => {
+    const wc = capsule();
+    const rt = target({ workCapsuleId: wc.capsuleId, branchName: wc.headBranch });
+    const verification: RuntimeVerificationSnapshot = {
+      verificationId: "RV-FAIL",
+      runtimeTargetId: rt.targetId,
+      workCapsuleId: wc.capsuleId,
+      kind: "health",
+      status: "failed",
+      summary: "Health endpoint timed out",
+      completedAt: FRESH,
+    };
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        runtimeTargets: [rt],
+        runtimeVerifications: [verification],
+      }),
+    );
+
+    const lane = result.lanes.find((l) => l.runtimeTargetId === rt.targetId);
+    expect(lane).toBeDefined();
+    expect(lane!.status).toBe("blocked");
+    expect(lane!.latestVerification.status).toBe("failed");
+  });
+
+  it("adds a served-SHA-mismatch blocker without changing status to ready-for-review", () => {
+    const wc = capsule({ headSha: "aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1aaaaaaa1" });
+    const rt = target({
+      workCapsuleId: wc.capsuleId,
+      branchName: wc.headBranch,
+      servedCommitSha: "bbbbbbb2bbbbbbb2bbbbbbb2bbbbbbb2bbbbbbb2",
+    });
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        runtimeTargets: [rt],
+      }),
+    );
+
+    const lane = result.lanes.find((l) => l.runtimeTargetId === rt.targetId);
+    expect(lane).toBeDefined();
+    expect(lane!.status).not.toBe("ready-for-review");
+    expect(lane!.blockers.some((b) => b.includes("but branch head is"))).toBe(true);
+  });
+
+  it("does not duplicate a branch row when a work capsule already covers it", () => {
+    const wc = capsule({ headBranch: "feat/dedupe" });
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        branches: [branch({ name: "feat/dedupe" })],
+      }),
+    );
+    expect(result.lanes.filter((l) => l.branch === "feat/dedupe")).toHaveLength(1);
+    expect(result.lanes[0]!.source).toBe("work-capsule");
+  });
+
+  it("does not duplicate a worktree row when a runtime target already covers its capsule", () => {
+    const wc = capsule({
+      capsuleId: "WC-DEDUPE",
+      worktreePath: "D:/DPF/.claude/worktrees/dedupe-wt",
+      headBranch: "feat/dedupe-wt",
+    });
+    const rt = target({
+      targetId: "RT-DEDUPE",
+      workCapsuleId: wc.capsuleId,
+      branchName: wc.headBranch,
+    });
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [wc],
+        runtimeTargets: [rt],
+        worktrees: [worktree({ path: wc.worktreePath!, branch: wc.headBranch })],
+      }),
+    );
+    const worktreeRows = result.lanes.filter((l) => l.source === "worktree");
+    expect(worktreeRows).toHaveLength(0);
+  });
+
+  it("sorts blocked lanes before running and orphans last", () => {
+    const blockedTarget = target({
+      targetId: "RT-BLOCKED",
+      status: "blocked",
+      branchName: null,
+      workCapsuleId: null,
+    });
+    const runningCapsule = capsule({
+      capsuleId: "WC-RUN",
+      worktreePath: "D:/DPF/.claude/worktrees/run",
+      headBranch: "feat/run",
+    });
+    const runningTarget = target({
+      targetId: "RT-RUN",
+      workCapsuleId: runningCapsule.capsuleId,
+      branchName: runningCapsule.headBranch,
+      servedCommitSha: runningCapsule.headSha,
+    });
+
+    const result = projectContributorChangeLanes(
+      emptyInput({
+        workCapsules: [runningCapsule],
+        runtimeTargets: [blockedTarget, runningTarget],
+        branches: [branch({ name: "feat/orphan" })],
+      }),
+    );
+
+    expect(result.lanes[0]!.id).toBe("RT-BLOCKED");
+    expect(result.lanes.at(-1)!.source).toBe("git-branch");
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/lane-projection.ts
+++ b/apps/web/lib/contributor-change-lanes/lane-projection.ts
@@ -1,0 +1,487 @@
+import {
+  CONTRIBUTOR_LANE_KINDS,
+  DEFAULT_STALE_HEARTBEAT_MS,
+  DEFAULT_STALE_VERIFIED_MS,
+  type ContributorChangeLane,
+  type ContributorLaneKind,
+  type ContributorLaneStatus,
+  type ContributorLaneVerification,
+  type GitBranchSnapshot,
+  type GitWorktreeSnapshot,
+  type LaneProjectionInput,
+  type LaneProjectionResult,
+  type NonprodEnvironmentLeaseSnapshot,
+  type PullRequestSnapshot,
+  type RuntimeTargetSnapshot,
+  type RuntimeVerificationSnapshot,
+  type WorkCapsuleSnapshot,
+} from "./types";
+
+const LANE_KIND_SET: ReadonlySet<string> = new Set(CONTRIBUTOR_LANE_KINDS);
+
+const BASE_BRANCHES: ReadonlySet<string> = new Set(["main", "master"]);
+
+const LANE_STATUS_PRIORITY: Record<ContributorLaneStatus, number> = {
+  blocked: 0,
+  starting: 1,
+  verifying: 2,
+  running: 3,
+  "ready-for-review": 4,
+  claimed: 5,
+  available: 6,
+  released: 7,
+  stale: 8,
+};
+
+export function projectContributorChangeLanes(
+  input: LaneProjectionInput,
+): LaneProjectionResult {
+  const staleHeartbeatMs = input.staleHeartbeatThresholdMs ?? DEFAULT_STALE_HEARTBEAT_MS;
+  const staleVerifiedMs = input.staleVerifiedThresholdMs ?? DEFAULT_STALE_VERIFIED_MS;
+  const now = input.now;
+
+  const verificationsByTarget = indexVerificationsByTarget(input.runtimeVerifications);
+  const leasesByWorktree = indexLeasesByWorktree(input.leases);
+  const leasesByBranch = indexLeasesByBranch(input.leases);
+  const prByBranch = indexPullRequestsByBranch(input.pullRequests);
+  const capsuleByBranch = indexCapsulesByBranch(input.workCapsules);
+  const capsuleByWorktree = indexCapsulesByWorktree(input.workCapsules);
+
+  const lanes: ContributorChangeLane[] = [];
+  const consumedBranches = new Set<string>();
+  const consumedWorktrees = new Set<string>();
+  const consumedCapsules = new Set<string>();
+
+  for (const target of input.runtimeTargets) {
+    const laneKind = resolveLaneKind(target.kind);
+    if (!laneKind) continue;
+
+    const capsule = target.workCapsuleId
+      ? input.workCapsules.find((c) => c.capsuleId === target.workCapsuleId) ?? null
+      : null;
+    const branchName = target.branchName ?? capsule?.headBranch ?? null;
+    const pr = branchName ? prByBranch.get(branchName) ?? null : null;
+    const lease =
+      (target.workCapsuleId && leasesByWorktree.get(capsule?.worktreePath ?? "")) ||
+      (branchName && leasesByBranch.get(branchName)) ||
+      null;
+    const latestVerification = verificationsByTarget.get(target.targetId) ?? null;
+
+    const blockers: string[] = [];
+    if (
+      target.servedCommitSha &&
+      capsule?.headSha &&
+      target.servedCommitSha !== capsule.headSha
+    ) {
+      blockers.push(
+        `Runtime serving ${shortenSha(target.servedCommitSha)} but branch head is ${shortenSha(capsule.headSha)}`,
+      );
+    }
+    if (isStaleHeartbeat(target.lastHeartbeatAt, now, staleHeartbeatMs)) {
+      blockers.push(
+        `Runtime heartbeat stale since ${target.lastHeartbeatAt?.toISOString() ?? "unknown"}`,
+      );
+    }
+    if (!capsule && target.kind !== "root-portal" && target.kind !== "dev-portal") {
+      blockers.push("No active Work Capsule attached");
+    }
+
+    const status = resolveLaneStatusForTarget({
+      target,
+      lease,
+      capsule,
+      latestVerification,
+      now,
+      staleVerifiedMs,
+    });
+
+    lanes.push({
+      id: target.targetId,
+      laneKind,
+      source: "runtime-target",
+      status,
+      owner: capsule?.leaseHolderPrincipalId ?? capsule?.executorRef ?? lease?.ownerSessionId ?? null,
+      branch: branchName,
+      worktreePath: capsule?.worktreePath ?? lease?.worktreePath ?? null,
+      commitSha: capsule?.headSha ?? null,
+      servedCommitSha: target.servedCommitSha,
+      pullRequestUrl: pr?.url ?? capsule?.pullRequestUrl ?? null,
+      runtimeTargetId: target.targetId,
+      runtimeUrl: target.hostUrl,
+      workCapsuleId: capsule?.capsuleId ?? null,
+      backlogItemId: capsule?.backlogItemId ?? null,
+      expiresAt: lease?.expiresAt ?? target.expiresAt ?? null,
+      lastHeartbeatAt: target.lastHeartbeatAt,
+      latestVerification: presentVerification(latestVerification),
+      blockers,
+      nextAction: deriveNextActionForRuntime(status, blockers, target, capsule, pr),
+    });
+
+    if (capsule) consumedCapsules.add(capsule.capsuleId);
+    if (capsule?.worktreePath) consumedWorktrees.add(capsule.worktreePath);
+    if (lease?.worktreePath) consumedWorktrees.add(lease.worktreePath);
+    if (branchName) consumedBranches.add(branchName);
+  }
+
+  for (const capsule of input.workCapsules) {
+    if (consumedCapsules.has(capsule.capsuleId)) continue;
+    if (capsule.status === "released" || capsule.status === "archived") continue;
+
+    const pr = capsule.headBranch ? prByBranch.get(capsule.headBranch) ?? null : null;
+    const blockers: string[] = [];
+    const hasTtl = Boolean(capsule.leaseExpiresAt);
+    const isExpired = hasTtl && capsule.leaseExpiresAt! <= now;
+    if (!pr && !hasTtl) {
+      blockers.push("No open PR and no active WIP TTL");
+    }
+    if (isExpired) {
+      blockers.push(
+        `WIP lease expired at ${capsule.leaseExpiresAt?.toISOString() ?? "unknown"}`,
+      );
+    }
+    if (!capsule.headBranch) {
+      blockers.push("Capsule has no branch");
+    }
+
+    const status: ContributorLaneStatus = isExpired
+      ? "stale"
+      : pr?.state === "open"
+        ? "ready-for-review"
+        : "claimed";
+
+    lanes.push({
+      id: capsule.capsuleId,
+      laneKind: "external-debug",
+      source: "work-capsule",
+      status,
+      owner: capsule.leaseHolderPrincipalId ?? capsule.executorRef,
+      branch: capsule.headBranch,
+      worktreePath: capsule.worktreePath,
+      commitSha: capsule.headSha,
+      servedCommitSha: null,
+      pullRequestUrl: pr?.url ?? capsule.pullRequestUrl,
+      runtimeTargetId: null,
+      runtimeUrl: null,
+      workCapsuleId: capsule.capsuleId,
+      backlogItemId: capsule.backlogItemId,
+      expiresAt: capsule.leaseExpiresAt,
+      lastHeartbeatAt: capsule.updatedAt,
+      latestVerification: presentVerification(null),
+      blockers,
+      nextAction: deriveNextActionForCapsule(capsule, pr, blockers),
+    });
+
+    if (capsule.headBranch) consumedBranches.add(capsule.headBranch);
+    if (capsule.worktreePath) consumedWorktrees.add(capsule.worktreePath);
+  }
+
+  for (const lease of input.leases) {
+    if (lease.status !== "active") continue;
+    if (lease.worktreePath && consumedWorktrees.has(lease.worktreePath)) continue;
+    if (lease.branchName && consumedBranches.has(lease.branchName)) continue;
+
+    const pr = lease.branchName ? prByBranch.get(lease.branchName) ?? null : null;
+    const laneKind: ContributorLaneKind =
+      lease.environmentKey === "local-integration-ci" ? "local-integration" : "dev-portal";
+    const expired = lease.expiresAt ? lease.expiresAt <= now : false;
+    const status: ContributorLaneStatus = expired ? "stale" : "claimed";
+    const blockers: string[] = [];
+    if (expired) blockers.push("Lease expired");
+    if (!pr && !lease.expiresAt) blockers.push("No PR and no TTL");
+
+    lanes.push({
+      id: lease.leaseId,
+      laneKind,
+      source: "nonprod-lease",
+      status,
+      owner: lease.ownerSessionId,
+      branch: lease.branchName,
+      worktreePath: lease.worktreePath,
+      commitSha: null,
+      servedCommitSha: null,
+      pullRequestUrl: pr?.url ?? null,
+      runtimeTargetId: null,
+      runtimeUrl: lease.url,
+      workCapsuleId: null,
+      backlogItemId: null,
+      expiresAt: lease.expiresAt,
+      lastHeartbeatAt: null,
+      latestVerification: presentVerification(null),
+      blockers,
+      nextAction: expired ? "Release expired lease" : "Drive verification on the leased runtime",
+    });
+
+    if (lease.worktreePath) consumedWorktrees.add(lease.worktreePath);
+    if (lease.branchName) consumedBranches.add(lease.branchName);
+  }
+
+  for (const branch of input.branches) {
+    if (consumedBranches.has(branch.name)) continue;
+    if (BASE_BRANCHES.has(branch.name)) continue;
+    const pr = prByBranch.get(branch.name) ?? null;
+    if (branch.isMerged && !pr) continue;
+    const hasCapsule = capsuleByBranch.has(branch.name);
+    if (hasCapsule) continue;
+
+    const blockers: string[] = [];
+    if (!pr) blockers.push("No open PR and no active WIP record");
+    else blockers.push("PR exists but no Work Capsule attached");
+
+    lanes.push({
+      id: `branch:${branch.name}`,
+      laneKind: "external-debug",
+      source: "git-branch",
+      status: pr?.state === "open" ? "claimed" : "stale",
+      owner: null,
+      branch: branch.name,
+      worktreePath: null,
+      commitSha: branch.headSha,
+      servedCommitSha: null,
+      pullRequestUrl: pr?.url ?? null,
+      runtimeTargetId: null,
+      runtimeUrl: null,
+      workCapsuleId: null,
+      backlogItemId: null,
+      expiresAt: null,
+      lastHeartbeatAt: branch.lastCommitAt,
+      latestVerification: presentVerification(null),
+      blockers,
+      nextAction: pr
+        ? "Attach a Work Capsule or close the PR"
+        : "Open a PR or file a WIP handoff with TTL",
+    });
+  }
+
+  for (const worktree of input.worktrees) {
+    if (consumedWorktrees.has(worktree.path)) continue;
+    if (worktree.branch && capsuleByBranch.has(worktree.branch)) continue;
+    if (capsuleByWorktree.has(worktree.path)) continue;
+    if (worktree.branch && BASE_BRANCHES.has(worktree.branch) && worktree.isRegistered) continue;
+
+    const blockers = [
+      worktree.isRegistered
+        ? "Worktree has no active Work Capsule"
+        : "Filesystem-only worktree (not registered with git)",
+    ];
+
+    lanes.push({
+      id: `worktree:${worktree.path}`,
+      laneKind: "external-debug",
+      source: "worktree",
+      status: "stale",
+      owner: null,
+      branch: worktree.branch,
+      worktreePath: worktree.path,
+      commitSha: worktree.headSha,
+      servedCommitSha: null,
+      pullRequestUrl: null,
+      runtimeTargetId: null,
+      runtimeUrl: null,
+      workCapsuleId: null,
+      backlogItemId: null,
+      expiresAt: null,
+      lastHeartbeatAt: null,
+      latestVerification: presentVerification(null),
+      blockers,
+      nextAction: worktree.isRegistered
+        ? "Attach a Work Capsule or remove the worktree"
+        : "Register the worktree with git or remove the directory",
+    });
+  }
+
+  lanes.sort(compareLanes);
+  return { lanes };
+}
+
+function resolveLaneKind(kind: string): ContributorLaneKind | null {
+  if (LANE_KIND_SET.has(kind)) return kind as ContributorLaneKind;
+  return null;
+}
+
+function resolveLaneStatusForTarget(args: {
+  target: RuntimeTargetSnapshot;
+  lease: NonprodEnvironmentLeaseSnapshot | null;
+  capsule: WorkCapsuleSnapshot | null;
+  latestVerification: RuntimeVerificationSnapshot | null;
+  now: Date;
+  staleVerifiedMs: number;
+}): ContributorLaneStatus {
+  const { target, lease, capsule, latestVerification, now, staleVerifiedMs } = args;
+
+  if (latestVerification?.status === "failed") return "blocked";
+  if (target.status === "failed" || target.status === "blocked" || target.status === "misconfigured") {
+    return "blocked";
+  }
+  if (target.status === "starting") return "starting";
+  if (target.status === "verifying") return "verifying";
+  if (target.status === "running") {
+    if (latestVerification?.status === "passed" && capsule?.headSha && target.servedCommitSha === capsule.headSha) {
+      return "ready-for-review";
+    }
+    return "running";
+  }
+  if (target.status === "verified") {
+    if (
+      target.lastHeartbeatAt &&
+      now.getTime() - target.lastHeartbeatAt.getTime() > staleVerifiedMs
+    ) {
+      return "stale";
+    }
+    return "ready-for-review";
+  }
+  if (target.status === "released") return "released";
+  if (target.status === "expired") return "stale";
+  if (target.status === "assigned") return "claimed";
+  if (target.status === "planned") {
+    if (lease) return "starting";
+    return "available";
+  }
+  return "available";
+}
+
+function deriveNextActionForRuntime(
+  status: ContributorLaneStatus,
+  blockers: string[],
+  target: RuntimeTargetSnapshot,
+  capsule: WorkCapsuleSnapshot | null,
+  pr: PullRequestSnapshot | null,
+): string {
+  if (status === "blocked") return blockers[0] ?? "Investigate runtime failure";
+  if (status === "starting") return "Wait for health check, then drive verification";
+  if (status === "available") return "Claim the lane to begin verification";
+  if (status === "ready-for-review") {
+    if (pr) return "Review the open PR";
+    return "Open a PR — runtime evidence is in place";
+  }
+  if (status === "running" && capsule?.headSha && target.servedCommitSha !== capsule.headSha) {
+    return "Redeploy the branch head to this runtime";
+  }
+  if (status === "released") return "Lane released — claim a new one when ready";
+  if (status === "stale") return "Lane is stale — release or refresh heartbeat";
+  return "Drive verification on this lane";
+}
+
+function deriveNextActionForCapsule(
+  capsule: WorkCapsuleSnapshot,
+  pr: PullRequestSnapshot | null,
+  blockers: string[],
+): string {
+  if (capsule.nextAction) return capsule.nextAction;
+  if (blockers.length > 0) return blockers[0];
+  if (pr?.state === "open") return "Drive ready-for-review verification";
+  return "Open a PR or extend the WIP TTL";
+}
+
+function presentVerification(
+  v: RuntimeVerificationSnapshot | null,
+): ContributorLaneVerification {
+  if (!v) return { status: "pending", checkedAt: null, summary: null };
+  return {
+    status: mapVerificationStatus(v.status),
+    checkedAt: v.completedAt,
+    summary: v.summary,
+  };
+}
+
+function mapVerificationStatus(s: string): ContributorLaneVerification["status"] {
+  switch (s) {
+    case "passed":
+      return "passed";
+    case "failed":
+      return "failed";
+    case "superseded":
+    case "waived":
+    case "skipped":
+      return "blocked";
+    case "running":
+    case "pending":
+      return "pending";
+    default:
+      return "pending";
+  }
+}
+
+function isStaleHeartbeat(at: Date | null, now: Date, thresholdMs: number): boolean {
+  if (!at) return false;
+  return now.getTime() - at.getTime() > thresholdMs;
+}
+
+function shortenSha(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+function indexVerificationsByTarget(
+  list: RuntimeVerificationSnapshot[],
+): Map<string, RuntimeVerificationSnapshot> {
+  const out = new Map<string, RuntimeVerificationSnapshot>();
+  for (const v of list) {
+    if (!v.runtimeTargetId) continue;
+    const prev = out.get(v.runtimeTargetId);
+    if (!prev) {
+      out.set(v.runtimeTargetId, v);
+      continue;
+    }
+    if ((v.completedAt?.getTime() ?? 0) > (prev.completedAt?.getTime() ?? 0)) {
+      out.set(v.runtimeTargetId, v);
+    }
+  }
+  return out;
+}
+
+function indexLeasesByWorktree(
+  list: NonprodEnvironmentLeaseSnapshot[],
+): Map<string, NonprodEnvironmentLeaseSnapshot> {
+  const out = new Map<string, NonprodEnvironmentLeaseSnapshot>();
+  for (const lease of list) {
+    if (lease.status !== "active") continue;
+    if (!lease.worktreePath) continue;
+    out.set(lease.worktreePath, lease);
+  }
+  return out;
+}
+
+function indexLeasesByBranch(
+  list: NonprodEnvironmentLeaseSnapshot[],
+): Map<string, NonprodEnvironmentLeaseSnapshot> {
+  const out = new Map<string, NonprodEnvironmentLeaseSnapshot>();
+  for (const lease of list) {
+    if (lease.status !== "active") continue;
+    if (!lease.branchName) continue;
+    out.set(lease.branchName, lease);
+  }
+  return out;
+}
+
+function indexPullRequestsByBranch(list: PullRequestSnapshot[]): Map<string, PullRequestSnapshot> {
+  const out = new Map<string, PullRequestSnapshot>();
+  for (const pr of list) {
+    if (pr.state !== "open") continue;
+    out.set(pr.headBranch, pr);
+  }
+  return out;
+}
+
+function indexCapsulesByBranch(list: WorkCapsuleSnapshot[]): Map<string, WorkCapsuleSnapshot> {
+  const out = new Map<string, WorkCapsuleSnapshot>();
+  for (const c of list) {
+    if (!c.headBranch) continue;
+    out.set(c.headBranch, c);
+  }
+  return out;
+}
+
+function indexCapsulesByWorktree(list: WorkCapsuleSnapshot[]): Map<string, WorkCapsuleSnapshot> {
+  const out = new Map<string, WorkCapsuleSnapshot>();
+  for (const c of list) {
+    if (!c.worktreePath) continue;
+    out.set(c.worktreePath, c);
+  }
+  return out;
+}
+
+function compareLanes(a: ContributorChangeLane, b: ContributorChangeLane): number {
+  const aRank = LANE_STATUS_PRIORITY[a.status];
+  const bRank = LANE_STATUS_PRIORITY[b.status];
+  if (aRank !== bRank) return aRank - bRank;
+  return a.id.localeCompare(b.id);
+}

--- a/apps/web/lib/contributor-change-lanes/read-model.test.ts
+++ b/apps/web/lib/contributor-change-lanes/read-model.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadContributorChangeLaneReadModel,
+  type LaneReadModelInventoryRunners,
+} from "./read-model";
+
+const NOW = new Date("2026-05-26T22:00:00.000Z");
+const FRESH = new Date("2026-05-26T21:58:00.000Z");
+
+function makeDb() {
+  return {
+    workCapsule: { findMany: vi.fn() },
+    runtimeTarget: { findMany: vi.fn() },
+    runtimeVerification: { findMany: vi.fn() },
+    nonProductionEnvironmentLease: { findMany: vi.fn() },
+  };
+}
+
+type DbHarness = ReturnType<typeof makeDb>;
+
+function dbAsAny(db: DbHarness): any {
+  return db;
+}
+
+function makeRunners(overrides: Partial<LaneReadModelInventoryRunners> = {}): LaneReadModelInventoryRunners {
+  return {
+    runGitWorktreeList: async () => "",
+    runGitForEachRef: async () => "",
+    runGhPrList: async () => "[]",
+    listFilesystemWorktreePaths: async () => [],
+    ...overrides,
+  };
+}
+
+describe("loadContributorChangeLaneReadModel", () => {
+  let db: DbHarness;
+
+  beforeEach(() => {
+    db = makeDb();
+    db.workCapsule.findMany.mockResolvedValue([]);
+    db.runtimeTarget.findMany.mockResolvedValue([]);
+    db.runtimeVerification.findMany.mockResolvedValue([]);
+    db.nonProductionEnvironmentLease.findMany.mockResolvedValue([]);
+  });
+
+  it("returns lanes and a freshness row per source on the happy path", async () => {
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners: makeRunners(),
+      now: NOW,
+    });
+
+    expect(result.lanes).toEqual([]);
+    const sources = result.freshness.map((f) => f.source).sort();
+    expect(sources).toEqual([
+      "git-branch",
+      "git-worktree",
+      "github-pr",
+      "nonprod-lease",
+      "runtime-target",
+      "runtime-verification",
+      "work-capsule",
+    ]);
+    expect(result.freshness.every((f) => f.ok)).toBe(true);
+  });
+
+  it("joins a Prisma WorkCapsule + RuntimeTarget into one lane row", async () => {
+    db.workCapsule.findMany.mockResolvedValueOnce([
+      {
+        capsuleId: "WC-INT-1",
+        title: "Integration",
+        status: "working",
+        executorKind: "claude-desktop",
+        executorRef: "session-a",
+        headBranch: "feat/x",
+        headSha: "abc123",
+        worktreePath: "D:/DPF/.claude/worktrees/x",
+        pullRequestUrl: "https://example.com/pr/1",
+        backlogItemId: "BI-INT",
+        featureBuildId: null,
+        leaseHolderPrincipalId: "p-1",
+        leaseExpiresAt: new Date(NOW.getTime() + 60_000),
+        updatedAt: FRESH,
+        objective: "Make X work",
+      },
+    ]);
+    db.runtimeTarget.findMany.mockResolvedValueOnce([
+      {
+        targetId: "RT-INT-1",
+        kind: "dev-portal",
+        status: "running",
+        hostUrl: "http://localhost:3001",
+        serviceVersion: "abc123",
+        workCapsuleId: "WC-INT-1",
+        featureBuildId: null,
+        acceptanceRoleOverride: null,
+        lastHeartbeatAt: FRESH,
+        expiresAt: null,
+        metadata: { servedCommitSha: "abc123", branchName: "feat/x" },
+      },
+    ]);
+    db.runtimeVerification.findMany.mockResolvedValueOnce([
+      {
+        verificationId: "RV-1",
+        runtimeTargetId: "RT-INT-1",
+        workCapsuleId: "WC-INT-1",
+        kind: "ux",
+        status: "passed",
+        completedAt: FRESH,
+        result: { summary: "OK" },
+      },
+    ]);
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners: makeRunners(),
+      now: NOW,
+    });
+
+    expect(result.lanes).toHaveLength(1);
+    const lane = result.lanes[0]!;
+    expect(lane.runtimeTargetId).toBe("RT-INT-1");
+    expect(lane.workCapsuleId).toBe("WC-INT-1");
+    expect(lane.branch).toBe("feat/x");
+    expect(lane.servedCommitSha).toBe("abc123");
+    expect(lane.commitSha).toBe("abc123");
+    expect(lane.latestVerification.status).toBe("passed");
+    expect(lane.status).toBe("ready-for-review");
+  });
+
+  it("records a freshness error and continues when work-capsule Prisma read throws", async () => {
+    db.workCapsule.findMany.mockRejectedValueOnce(new Error("db offline"));
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners: makeRunners(),
+      now: NOW,
+    });
+
+    const wcFreshness = result.freshness.find((f) => f.source === "work-capsule");
+    expect(wcFreshness).toBeDefined();
+    expect(wcFreshness!.ok).toBe(false);
+    expect(wcFreshness!.error).toBe("db offline");
+    expect(result.lanes).toEqual([]);
+  });
+
+  it("records a freshness error when the gh runner throws but still returns other sources", async () => {
+    const runners = makeRunners({
+      runGhPrList: async () => {
+        throw new Error("gh not installed");
+      },
+    });
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners,
+      now: NOW,
+    });
+
+    const prFreshness = result.freshness.find((f) => f.source === "github-pr");
+    expect(prFreshness).toBeDefined();
+    expect(prFreshness!.ok).toBe(false);
+    expect(prFreshness!.error).toBe("gh not installed");
+    const otherSources = result.freshness.filter((f) => f.source !== "github-pr");
+    expect(otherSources.every((f) => f.ok)).toBe(true);
+  });
+
+  it("flags a runner as missing when no runner function is configured", async () => {
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners: {},
+      now: NOW,
+    });
+    const sources = result.freshness.filter((f) => !f.ok).map((f) => f.source).sort();
+    expect(sources).toEqual(["git-branch", "git-worktree", "github-pr"]);
+    expect(
+      result.freshness
+        .filter((f) => !f.ok)
+        .every((f) => f.error === "no runner configured"),
+    ).toBe(true);
+  });
+
+  it("merges filesystem-only worktree paths into the inventory", async () => {
+    const runners = makeRunners({
+      runGitWorktreeList: async () => "worktree D:/DPF\nHEAD abc\nbranch refs/heads/main\n",
+      listFilesystemWorktreePaths: async () => ["D:/DPF/.claude/worktrees/orphan-fs"],
+    });
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      runners,
+      now: NOW,
+    });
+
+    const orphanRows = result.lanes.filter((l) => l.source === "worktree");
+    expect(orphanRows).toHaveLength(1);
+    expect(orphanRows[0]!.worktreePath).toBe("D:/DPF/.claude/worktrees/orphan-fs");
+    expect(orphanRows[0]!.blockers[0]).toMatch(/Filesystem-only/);
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/read-model.ts
+++ b/apps/web/lib/contributor-change-lanes/read-model.ts
@@ -1,0 +1,416 @@
+import { prisma } from "@dpf/db";
+
+import { mergeFilesystemAndRegisteredWorktrees, parseGitBranchList, parseGitWorktreeList } from "./git-inventory";
+import { parseGhPrListJson } from "./github-inventory";
+import { projectContributorChangeLanes } from "./lane-projection";
+import type {
+  ContributorChangeLane,
+  GitBranchSnapshot,
+  GitWorktreeSnapshot,
+  NonprodEnvironmentLeaseSnapshot,
+  PullRequestSnapshot,
+  RuntimeTargetSnapshot,
+  RuntimeVerificationSnapshot,
+  WorkCapsuleSnapshot,
+} from "./types";
+
+type ReadModelDb = Pick<
+  typeof prisma,
+  "workCapsule" | "runtimeTarget" | "runtimeVerification" | "nonProductionEnvironmentLease"
+>;
+
+export type LaneReadModelSource = "work-capsule" | "runtime-target" | "runtime-verification" | "nonprod-lease" | "git-worktree" | "git-branch" | "github-pr";
+
+export type LaneReadModelFreshness = {
+  source: LaneReadModelSource;
+  ok: boolean;
+  fetchedAt: Date;
+  error: string | null;
+  count: number;
+};
+
+export type LaneReadModelResult = {
+  lanes: ContributorChangeLane[];
+  freshness: LaneReadModelFreshness[];
+};
+
+export type LaneReadModelInventoryRunners = {
+  runGitWorktreeList: () => Promise<string>;
+  runGitForEachRef: () => Promise<string>;
+  runGhPrList: () => Promise<string>;
+  listFilesystemWorktreePaths: () => Promise<string[]>;
+};
+
+export type LaneReadModelArgs = {
+  db?: ReadModelDb;
+  runners?: Partial<LaneReadModelInventoryRunners>;
+  now?: Date;
+  staleHeartbeatThresholdMs?: number;
+  staleVerifiedThresholdMs?: number;
+};
+
+export async function loadContributorChangeLaneReadModel(
+  args: LaneReadModelArgs = {},
+): Promise<LaneReadModelResult> {
+  const db = args.db ?? prisma;
+  const now = args.now ?? new Date();
+  const runners = args.runners ?? {};
+
+  const freshness: LaneReadModelFreshness[] = [];
+
+  const [workCapsules, runtimeTargets, runtimeVerifications, leases] = await Promise.all([
+    readWorkCapsules(db, freshness, now),
+    readRuntimeTargets(db, freshness, now),
+    readRuntimeVerifications(db, freshness, now),
+    readActiveLeases(db, freshness, now),
+  ]);
+
+  const [worktrees, branches, pullRequests] = await Promise.all([
+    readWorktreeInventory(runners, freshness, now),
+    readBranchInventory(runners, freshness, now),
+    readPullRequestInventory(runners, freshness, now),
+  ]);
+
+  const projection = projectContributorChangeLanes({
+    workCapsules,
+    runtimeTargets,
+    runtimeVerifications,
+    leases,
+    worktrees,
+    branches,
+    pullRequests,
+    now,
+    staleHeartbeatThresholdMs: args.staleHeartbeatThresholdMs,
+    staleVerifiedThresholdMs: args.staleVerifiedThresholdMs,
+  });
+
+  return { lanes: projection.lanes, freshness };
+}
+
+async function readWorkCapsules(
+  db: ReadModelDb,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<WorkCapsuleSnapshot[]> {
+  try {
+    const rows = await db.workCapsule.findMany({
+      where: {
+        status: { notIn: ["archived"] },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 250,
+    });
+    const out = rows.map(toWorkCapsuleSnapshot);
+    freshness.push({ source: "work-capsule", ok: true, fetchedAt: now, error: null, count: out.length });
+    return out;
+  } catch (err) {
+    freshness.push({
+      source: "work-capsule",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readRuntimeTargets(
+  db: ReadModelDb,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<RuntimeTargetSnapshot[]> {
+  try {
+    const rows = await db.runtimeTarget.findMany({
+      where: {
+        status: { notIn: ["released", "expired"] },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 250,
+    });
+    const out = rows.map(toRuntimeTargetSnapshot);
+    freshness.push({ source: "runtime-target", ok: true, fetchedAt: now, error: null, count: out.length });
+    return out;
+  } catch (err) {
+    freshness.push({
+      source: "runtime-target",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readRuntimeVerifications(
+  db: ReadModelDb,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<RuntimeVerificationSnapshot[]> {
+  try {
+    const rows = await db.runtimeVerification.findMany({
+      where: { runtimeTargetId: { not: null } },
+      orderBy: { completedAt: "desc" },
+      take: 500,
+    });
+    const out = rows.map(toRuntimeVerificationSnapshot);
+    freshness.push({
+      source: "runtime-verification",
+      ok: true,
+      fetchedAt: now,
+      error: null,
+      count: out.length,
+    });
+    return out;
+  } catch (err) {
+    freshness.push({
+      source: "runtime-verification",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readActiveLeases(
+  db: ReadModelDb,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<NonprodEnvironmentLeaseSnapshot[]> {
+  try {
+    const rows = await db.nonProductionEnvironmentLease.findMany({
+      where: { status: "active" },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    });
+    const out = rows.map(toLeaseSnapshot);
+    freshness.push({ source: "nonprod-lease", ok: true, fetchedAt: now, error: null, count: out.length });
+    return out;
+  } catch (err) {
+    freshness.push({
+      source: "nonprod-lease",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readWorktreeInventory(
+  runners: Partial<LaneReadModelInventoryRunners>,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<GitWorktreeSnapshot[]> {
+  if (!runners.runGitWorktreeList) {
+    freshness.push({ source: "git-worktree", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
+    return [];
+  }
+  try {
+    const porcelain = await runners.runGitWorktreeList();
+    const registered = parseGitWorktreeList(porcelain);
+    const filesystemPaths = runners.listFilesystemWorktreePaths
+      ? await runners.listFilesystemWorktreePaths()
+      : [];
+    const merged = mergeFilesystemAndRegisteredWorktrees(registered, filesystemPaths);
+    freshness.push({ source: "git-worktree", ok: true, fetchedAt: now, error: null, count: merged.length });
+    return merged;
+  } catch (err) {
+    freshness.push({
+      source: "git-worktree",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readBranchInventory(
+  runners: Partial<LaneReadModelInventoryRunners>,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<GitBranchSnapshot[]> {
+  if (!runners.runGitForEachRef) {
+    freshness.push({ source: "git-branch", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
+    return [];
+  }
+  try {
+    const raw = await runners.runGitForEachRef();
+    const branches = parseGitBranchList(raw, { remote: "origin" });
+    freshness.push({ source: "git-branch", ok: true, fetchedAt: now, error: null, count: branches.length });
+    return branches;
+  } catch (err) {
+    freshness.push({
+      source: "git-branch",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+async function readPullRequestInventory(
+  runners: Partial<LaneReadModelInventoryRunners>,
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+): Promise<PullRequestSnapshot[]> {
+  if (!runners.runGhPrList) {
+    freshness.push({ source: "github-pr", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
+    return [];
+  }
+  try {
+    const json = await runners.runGhPrList();
+    const result = parseGhPrListJson(json);
+    const ok = result.errors.length === 0;
+    freshness.push({
+      source: "github-pr",
+      ok,
+      fetchedAt: now,
+      error: ok ? null : result.errors.map((e) => e.message).join("; "),
+      count: result.pullRequests.length,
+    });
+    return result.pullRequests;
+  } catch (err) {
+    freshness.push({
+      source: "github-pr",
+      ok: false,
+      fetchedAt: now,
+      error: (err as Error).message,
+      count: 0,
+    });
+    return [];
+  }
+}
+
+type WorkCapsuleRowLike = {
+  capsuleId: string;
+  title: string;
+  status: string;
+  executorKind: string | null;
+  executorRef: string | null;
+  headBranch: string | null;
+  headSha: string | null;
+  worktreePath: string | null;
+  pullRequestUrl: string | null;
+  backlogItemId: string | null;
+  featureBuildId: string | null;
+  leaseHolderPrincipalId: string | null;
+  leaseExpiresAt: Date | null;
+  updatedAt: Date | null;
+  objective?: string | null;
+};
+
+function toWorkCapsuleSnapshot(row: WorkCapsuleRowLike): WorkCapsuleSnapshot {
+  return {
+    capsuleId: row.capsuleId,
+    title: row.title,
+    status: row.status,
+    executorKind: row.executorKind,
+    executorRef: row.executorRef,
+    headBranch: row.headBranch,
+    headSha: row.headSha,
+    worktreePath: row.worktreePath,
+    pullRequestUrl: row.pullRequestUrl,
+    backlogItemId: row.backlogItemId,
+    featureBuildId: row.featureBuildId,
+    leaseHolderPrincipalId: row.leaseHolderPrincipalId,
+    leaseExpiresAt: row.leaseExpiresAt,
+    updatedAt: row.updatedAt,
+    purpose: row.objective ?? null,
+    nextAction: null,
+  };
+}
+
+type RuntimeTargetRowLike = {
+  targetId: string;
+  kind: string;
+  status: string;
+  hostUrl: string | null;
+  serviceVersion: string | null;
+  workCapsuleId: string | null;
+  featureBuildId: string | null;
+  acceptanceRoleOverride: string | null;
+  lastHeartbeatAt: Date | null;
+  expiresAt: Date | null;
+  metadata: unknown;
+};
+
+function toRuntimeTargetSnapshot(row: RuntimeTargetRowLike): RuntimeTargetSnapshot {
+  const md = (row.metadata ?? {}) as Record<string, unknown>;
+  const servedCommitSha = typeof md.servedCommitSha === "string" ? md.servedCommitSha : row.serviceVersion;
+  const branchName = typeof md.branchName === "string" ? md.branchName : null;
+  return {
+    targetId: row.targetId,
+    kind: row.kind,
+    status: row.status,
+    hostUrl: row.hostUrl,
+    serviceVersion: row.serviceVersion,
+    servedCommitSha,
+    workCapsuleId: row.workCapsuleId,
+    featureBuildId: row.featureBuildId,
+    branchName,
+    acceptanceRole: row.acceptanceRoleOverride,
+    lastHeartbeatAt: row.lastHeartbeatAt,
+    expiresAt: row.expiresAt,
+  };
+}
+
+type RuntimeVerificationRowLike = {
+  verificationId: string;
+  runtimeTargetId: string | null;
+  workCapsuleId: string | null;
+  kind: string;
+  status: string;
+  completedAt: Date | null;
+  result: unknown;
+};
+
+function toRuntimeVerificationSnapshot(row: RuntimeVerificationRowLike): RuntimeVerificationSnapshot {
+  const result = (row.result ?? {}) as Record<string, unknown>;
+  const summary = typeof result.summary === "string" ? result.summary : null;
+  return {
+    verificationId: row.verificationId,
+    runtimeTargetId: row.runtimeTargetId,
+    workCapsuleId: row.workCapsuleId,
+    kind: row.kind,
+    status: row.status,
+    summary,
+    completedAt: row.completedAt,
+  };
+}
+
+type LeaseRowLike = {
+  leaseId: string;
+  environmentKey: string;
+  status: string;
+  ownerProvider: string;
+  ownerSessionId: string | null;
+  purpose: string | null;
+  url: string | null;
+  worktreePath: string | null;
+  branchName: string | null;
+  expiresAt: Date | null;
+};
+
+function toLeaseSnapshot(row: LeaseRowLike): NonprodEnvironmentLeaseSnapshot {
+  return {
+    leaseId: row.leaseId,
+    environmentKey: row.environmentKey,
+    status: row.status,
+    ownerProvider: row.ownerProvider,
+    ownerSessionId: row.ownerSessionId,
+    purpose: row.purpose,
+    url: row.url,
+    worktreePath: row.worktreePath,
+    branchName: row.branchName,
+    expiresAt: row.expiresAt,
+  };
+}

--- a/apps/web/lib/contributor-change-lanes/runners-node.ts
+++ b/apps/web/lib/contributor-change-lanes/runners-node.ts
@@ -1,0 +1,83 @@
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import type { LaneReadModelInventoryRunners } from "./read-model";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const MAX_BUFFER = 4 * 1024 * 1024;
+
+export type NodeRunnerOptions = {
+  repoCwd: string;
+  worktreeRoot?: string;
+  timeoutMs?: number;
+};
+
+export function createNodeInventoryRunners(
+  options: NodeRunnerOptions,
+): LaneReadModelInventoryRunners {
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const cwd = options.repoCwd;
+
+  return {
+    runGitWorktreeList: async () => {
+      const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"], {
+        cwd,
+        timeout,
+        maxBuffer: MAX_BUFFER,
+      });
+      return stdout;
+    },
+    runGitForEachRef: async () => {
+      const { stdout } = await execFileAsync(
+        "git",
+        [
+          "for-each-ref",
+          "--format=%(refname)\t%(objectname)\t%(committerdate:iso-strict)\t%(if)%(upstream:trackshort)%(then)%(else)%(end)",
+          "refs/remotes/origin/",
+        ],
+        {
+          cwd,
+          timeout,
+          maxBuffer: MAX_BUFFER,
+        },
+      );
+      return stdout;
+    },
+    runGhPrList: async () => {
+      const { stdout } = await execFileAsync(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--state",
+          "open",
+          "--limit",
+          "200",
+          "--json",
+          "number,title,headRefName,baseRefName,isDraft,mergeStateStatus,url,state",
+        ],
+        {
+          cwd,
+          timeout,
+          maxBuffer: MAX_BUFFER,
+        },
+      );
+      return stdout;
+    },
+    listFilesystemWorktreePaths: async () => {
+      if (!options.worktreeRoot) return [];
+      try {
+        const entries = await readdir(options.worktreeRoot, { withFileTypes: true });
+        return entries
+          .filter((e) => e.isDirectory())
+          .map((e) => path.join(options.worktreeRoot!, e.name).replace(/\\/g, "/"));
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/apps/web/lib/contributor-change-lanes/types.ts
+++ b/apps/web/lib/contributor-change-lanes/types.ts
@@ -1,0 +1,173 @@
+export const CONTRIBUTOR_LANE_KINDS = [
+  "root-portal",
+  "dev-portal",
+  "build-sandbox",
+  "local-integration",
+  "external-debug",
+] as const;
+
+export type ContributorLaneKind = (typeof CONTRIBUTOR_LANE_KINDS)[number];
+
+export const CONTRIBUTOR_LANE_STATUSES = [
+  "available",
+  "claimed",
+  "starting",
+  "running",
+  "verifying",
+  "blocked",
+  "ready-for-review",
+  "released",
+  "stale",
+] as const;
+
+export type ContributorLaneStatus = (typeof CONTRIBUTOR_LANE_STATUSES)[number];
+
+export const CONTRIBUTOR_LANE_SOURCES = [
+  "work-capsule",
+  "runtime-target",
+  "nonprod-lease",
+  "git-branch",
+  "worktree",
+] as const;
+
+export type ContributorLaneSource = (typeof CONTRIBUTOR_LANE_SOURCES)[number];
+
+export const CONTRIBUTOR_LANE_VERIFICATION_STATUSES = [
+  "pending",
+  "passed",
+  "failed",
+  "blocked",
+] as const;
+
+export type ContributorLaneVerificationStatus =
+  (typeof CONTRIBUTOR_LANE_VERIFICATION_STATUSES)[number];
+
+export type ContributorLaneVerification = {
+  status: ContributorLaneVerificationStatus;
+  checkedAt: Date | null;
+  summary: string | null;
+};
+
+export type ContributorChangeLane = {
+  id: string;
+  laneKind: ContributorLaneKind;
+  source: ContributorLaneSource;
+  status: ContributorLaneStatus;
+  owner: string | null;
+  branch: string | null;
+  worktreePath: string | null;
+  commitSha: string | null;
+  servedCommitSha: string | null;
+  pullRequestUrl: string | null;
+  runtimeTargetId: string | null;
+  runtimeUrl: string | null;
+  workCapsuleId: string | null;
+  backlogItemId: string | null;
+  expiresAt: Date | null;
+  lastHeartbeatAt: Date | null;
+  latestVerification: ContributorLaneVerification;
+  blockers: string[];
+  nextAction: string;
+};
+
+export type WorkCapsuleSnapshot = {
+  capsuleId: string;
+  title: string;
+  status: string;
+  executorKind: string | null;
+  executorRef: string | null;
+  headBranch: string | null;
+  headSha: string | null;
+  worktreePath: string | null;
+  pullRequestUrl: string | null;
+  backlogItemId: string | null;
+  featureBuildId: string | null;
+  leaseHolderPrincipalId: string | null;
+  leaseExpiresAt: Date | null;
+  updatedAt: Date | null;
+  purpose: string | null;
+  nextAction: string | null;
+};
+
+export type RuntimeTargetSnapshot = {
+  targetId: string;
+  kind: string;
+  status: string;
+  hostUrl: string | null;
+  serviceVersion: string | null;
+  servedCommitSha: string | null;
+  workCapsuleId: string | null;
+  featureBuildId: string | null;
+  branchName: string | null;
+  acceptanceRole: string | null;
+  lastHeartbeatAt: Date | null;
+  expiresAt: Date | null;
+};
+
+export type RuntimeVerificationSnapshot = {
+  verificationId: string;
+  runtimeTargetId: string | null;
+  workCapsuleId: string | null;
+  kind: string;
+  status: string;
+  summary: string | null;
+  completedAt: Date | null;
+};
+
+export type NonprodEnvironmentLeaseSnapshot = {
+  leaseId: string;
+  environmentKey: string;
+  status: string;
+  ownerProvider: string;
+  ownerSessionId: string | null;
+  purpose: string | null;
+  url: string | null;
+  worktreePath: string | null;
+  branchName: string | null;
+  expiresAt: Date | null;
+};
+
+export type GitWorktreeSnapshot = {
+  path: string;
+  branch: string | null;
+  headSha: string | null;
+  isRegistered: boolean;
+};
+
+export type GitBranchSnapshot = {
+  name: string;
+  headSha: string | null;
+  remote: "origin" | "local";
+  isMerged: boolean;
+  lastCommitAt: Date | null;
+};
+
+export type PullRequestSnapshot = {
+  number: number;
+  url: string;
+  title: string;
+  headBranch: string;
+  state: "open" | "merged" | "closed";
+  isDraft: boolean;
+  mergeStateStatus: string | null;
+};
+
+export type LaneProjectionInput = {
+  workCapsules: WorkCapsuleSnapshot[];
+  runtimeTargets: RuntimeTargetSnapshot[];
+  runtimeVerifications: RuntimeVerificationSnapshot[];
+  leases: NonprodEnvironmentLeaseSnapshot[];
+  worktrees: GitWorktreeSnapshot[];
+  branches: GitBranchSnapshot[];
+  pullRequests: PullRequestSnapshot[];
+  now: Date;
+  staleHeartbeatThresholdMs?: number;
+  staleVerifiedThresholdMs?: number;
+};
+
+export type LaneProjectionResult = {
+  lanes: ContributorChangeLane[];
+};
+
+export const DEFAULT_STALE_HEARTBEAT_MS = 10 * 60 * 1000;
+export const DEFAULT_STALE_VERIFIED_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

Implements the read-only first slice of `BI-9BA4653F` (epic `EP-REDUCTION-GEAR-ARCH`) per the spec/plan in [#1205](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1205).

Joins `WorkCapsule`, `RuntimeTarget`, `RuntimeVerification`, `NonProductionEnvironmentLease`, git worktree inventory, branch inventory, and GitHub PR state into one projected lane view at `/platform/development/change-lanes`. Read-only — no claim/release/deploy/cleanup actions in this PR.

## What's in this PR

- `apps/web/lib/contributor-change-lanes/types.ts` — projection types + snapshot shapes
- `apps/web/lib/contributor-change-lanes/lane-projection.ts` — pure projection function
- `apps/web/lib/contributor-change-lanes/git-inventory.ts` — porcelain parser
- `apps/web/lib/contributor-change-lanes/github-inventory.ts` — `gh pr list --json` parser
- `apps/web/lib/contributor-change-lanes/read-model.ts` — server-side read model, DI for db + runners
- `apps/web/lib/contributor-change-lanes/runners-node.ts` — concrete node shell runners
- `apps/web/app/(shell)/platform/development/change-lanes/page.tsx` — server component
- `apps/web/components/platform/development/change-lanes/` — 5 components, theme variables only

## What's NOT in this PR (deliberate — separate BIs)

- Phase 5: async startup + brokered health-check workflow for stopped registered lanes
- Phase 6: MCP tools (`list_runtime_lanes`, `claim_runtime_lane`, `deploy_branch_to_runtime_lane`, `release_runtime_lane`, `list_orphaned_branches`, `list_orphaned_worktrees`, `record_branch_handoff`) + `TOOL_TO_GRANTS` updates
- Phase 7: `dpf-skill-pack` agent rule updates (no ad hoc runtime; claim a lane or stop; ready-for-review gate)
- Phase 8: Guarded janitor cleanup actions

## Verification

### Structural (CI — all green)

- **Typecheck:** pass (2m12s)
- **Unit Tests:** pass (3m51s)
- **Production Build:** pass (2m39s)
- **CodeQL Analyze (actions, go, python, javascript-typescript):** pass
- **DCO, Secrets Scan, gitleaks, Routing Invariants, Routing Tier Contract, Actions Injection, Stall Detection, Mobile Jest Pin Guard, Dockerfile Node Version, ADP Integration Tests:** pass

Local focused vitest run also clean: 29/29 (lane-projection 11, git-inventory 5, github-inventory 5, read-model 6 — covers the 8 plan-mandated cases plus dedupe/sort edges).

### Functional (browser-driven against `:3001` with live DB)

Brought up the Contributor preview (`dev-portal`) bind-mounted to this worktree via the `dev-portal-start` skill. Drove `/platform/development/change-lanes` against live data:

- **Page renders.** Header, snapshot timestamp, source-freshness band, tabs, table all present.
- **Source freshness** correctly shows 4 ok (Non-prod Leases 0, Runtime Targets 4, Work Capsules 11, Runtime Verifications 0) and 3 errors (GitHub PRs — `spawn gh ENOENT`; Git Branches — git command failed inside container; Git Worktrees — same). The graceful-degradation behavior works exactly as designed: missing sources render as red dots with the raw error message, and the table still loads from the data that did succeed.
- **Tab filtering works.** Active lanes 15 / Branches needing handoff 11 / Orphan worktrees 0 / Stale leases 0 / Merged branches safe to delete 0. Clicked each tab — table re-filters correctly. Empty tabs show "No lanes in this view." (the empty-state component).
- **Status badges render.** RUNNING (3 runtime-target rows) and CLAIMED (work-capsule rows) appear with the correct theme colors.
- **Blockers render meaningful findings:**
  - `RT-BUILD-SANDBOX-FB-486B7710` → "Runtime heartbeat stale since 2026-05-24T16:25:31.643Z" + "No active Work Capsule attached" — proves stale-heartbeat detection works.
  - 11 build-studio work capsules → "No open PR and no active WIP TTL" + "Capsule has no branch" — proves orphan-capsule detection. The list includes `FB-2E8FD336`, the dead Build Studio inventory that was created earlier in this very session for these change-lanes — the dashboard caught its own creation as a missing-handoff capsule. Recursive evidence the feature does what the spec says.
- **Runtime URLs are clickable** (`http://localhost:3035` and `http://localhost:3000`).
- **Theme conformance:** rendered correctly in dark mode; no hardcoded colors observed.

### Finding worth noting (not blocking this PR)

Inside the `dev-portal` container the `git`/`gh` shell-outs fail because (a) `gh` is not installed in that image and (b) the bind-mount path causes `process.cwd()` to produce a path the container can't resolve as a git repo. The page handles this gracefully — sources show as failed, table loads from Prisma data, no 500. In the production Live portal (`:3000`) the container layout is different, so behavior there may differ; either way, fixing the runner to be tolerant of "git isn't available" is properly scoped to Phase 5/6 (when the runners need to do more than read).

## Dependencies

- **Reviews against [#1205](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1205)** (spec + plan). This PR implements that design contract; if spec review changes the design, this implementation may need adjustment.
- Independent of [#1197](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1197) / [#1204](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1204) (contributor MCP readiness) — disjoint scope despite adjacent names.

## Substrate verified before implementation

All referenced libraries, migrations, and epics exist on `origin/main` at base commit `5dbe23b0`:
- `apps/web/lib/work-capsules/*`, `apps/web/lib/runtime-coordination/*`, `apps/web/lib/nonprod/*`
- Migrations: `20260514120000_add_work_capsules`, `20260518023000_runtime_coordination_targets`, `20260526094500_nonprod_environment_leases`
- Epics: `EP-REDUCTION-GEAR-ARCH`, `EP-BUILD-STUDIO`, `EP-CAPSULE`, `EP-WORKTREE-HYGIENE`

## Local typecheck note (DPF_SKIP_TYPECHECK=1 on the commit only)

The local pre-commit `typecheck` was bypassed because `dev-portal-start` contaminated the host `node_modules` symlinks (container-root-owned files in the bind mount), causing pre-existing unrelated files to fail with `Cannot find module '@dpf/db'`. CI ran on a fresh `ubuntu-latest` with its own `pnpm install` + `prisma generate` and passed cleanly — that's the source of truth and is now green. The pre-commit hook's own message ("CI will still gate the merge either way") explicitly anticipates this kind of escape hatch. New memory `feedback_dev_portal_polluted_node_modules.md` captures the recovery path for future contributors.