### PR TITLE
fix(marketing): let advise-mode strategist save its recommendation

### DIFF
--- a/apps/web/lib/actions/agent-coworker-tool-filter.test.ts
+++ b/apps/web/lib/actions/agent-coworker-tool-filter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
+import type { ToolDefinition } from "../mcp-tools";
+
+function tool(name: string, overrides: Partial<ToolDefinition> = {}): ToolDefinition {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    requiredCapability: null,
+    ...overrides,
+  };
+}
+
+describe("filterToolsForCoworkerRuntime", () => {
+  it("keeps read-only tools in advise mode", () => {
+    const tools = [tool("get_marketing_summary", { sideEffect: false })];
+    const out = filterToolsForCoworkerRuntime(tools, { coworkerMode: "advise", activeBuildPhase: null });
+    expect(out.map((t) => t.name)).toEqual(["get_marketing_summary"]);
+  });
+
+  it("strips side-effect tools in advise mode", () => {
+    const tools = [tool("publish_landing_page", { sideEffect: true })];
+    const out = filterToolsForCoworkerRuntime(tools, { coworkerMode: "advise", activeBuildPhase: null });
+    expect(out).toEqual([]);
+  });
+
+  it("keeps coworkerArtifact tools in advise mode even when side-effect", () => {
+    const tools = [
+      tool("save_marketing_review", { sideEffect: true, coworkerArtifact: true }),
+      tool("create_marketing_campaign_brief", { sideEffect: true, coworkerArtifact: true }),
+      tool("create_marketing_asset_task", { sideEffect: true, coworkerArtifact: true }),
+      tool("record_marketing_kpi_checkpoint", { sideEffect: true, coworkerArtifact: true }),
+      tool("create_marketing_automation_candidate", { sideEffect: true, coworkerArtifact: true }),
+      tool("publish_landing_page", { sideEffect: true }),
+    ];
+    const out = filterToolsForCoworkerRuntime(tools, { coworkerMode: "advise", activeBuildPhase: null });
+    expect(out.map((t) => t.name).sort()).toEqual([
+      "create_marketing_asset_task",
+      "create_marketing_automation_candidate",
+      "create_marketing_campaign_brief",
+      "record_marketing_kpi_checkpoint",
+      "save_marketing_review",
+    ]);
+  });
+
+  it("keeps side-effect tools in act mode", () => {
+    const tools = [
+      tool("save_marketing_review", { sideEffect: true, coworkerArtifact: true }),
+      tool("publish_landing_page", { sideEffect: true }),
+    ];
+    const out = filterToolsForCoworkerRuntime(tools, { coworkerMode: "act", activeBuildPhase: null });
+    expect(out.map((t) => t.name).sort()).toEqual(["publish_landing_page", "save_marketing_review"]);
+  });
+
+  it("filters by build phase when active phase is set", () => {
+    const tools = [
+      tool("ideate_only", { sideEffect: false, buildPhases: ["ideate"] }),
+      tool("plan_only", { sideEffect: false, buildPhases: ["plan"] }),
+      tool("no_phase_tool", { sideEffect: false }),
+    ];
+    const out = filterToolsForCoworkerRuntime(tools, { coworkerMode: "act", activeBuildPhase: "ideate" });
+    expect(out.map((t) => t.name)).toEqual(["ideate_only"]);
+  });
+});

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -21,8 +21,9 @@ import {
   extractFormAssistResult,
   type AgentFormAssistContext,
 } from "@/lib/agent-form-assist";
-// mcp-tools is imported dynamically at call sites to avoid NFT whole-project tracing
-import type { BuildPhaseTag, ToolDefinition } from "@/lib/mcp-tools";
+// mcp-tools is imported dynamically at call sites to avoid NFT whole-project tracing;
+// type-only imports are erased at build time and safe.
+import type { ToolDefinition } from "@/lib/mcp-tools";
 import { getActionsForRoute } from "@/lib/agent-action-registry";
 import { getBuildContextSection } from "@/lib/build-agent-prompts";
 import { getFeatureBuildForContext } from "@/lib/feature-build-data";
@@ -66,19 +67,8 @@ import {
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
-function filterToolsForCoworkerRuntime(
-  tools: ToolDefinition[],
-  input: { coworkerMode?: "advise" | "act"; activeBuildPhase: string | null },
-): ToolDefinition[] {
-  return tools.filter((tool) => {
-    if (input.coworkerMode === "advise" && tool.sideEffect) return false;
-    if (input.activeBuildPhase) {
-      if (!tool.buildPhases) return false;
-      return tool.buildPhases.includes(input.activeBuildPhase as BuildPhaseTag);
-    }
-    return true;
-  });
-}
+import { filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
+export { filterToolsForCoworkerRuntime };
 
 async function requireAuthUser() {
   const session = await auth();

--- a/apps/web/lib/actions/coworker-tool-filter.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.ts
@@ -1,0 +1,33 @@
+import type { BuildPhaseTag, ToolDefinition } from "@/lib/mcp-tools";
+
+/**
+ * Filter the merged tool set (platform tools + page actions) down to what
+ * the in-portal coworker is allowed to use right now.
+ *
+ * Advise mode is the default for non-/build routes. It strips side-effect
+ * tools so the coworker cannot act on the outside world without explicit
+ * "act" intent. Tools flagged as `coworkerArtifact` persist the coworker's
+ * own recommendation as an internal artifact (e.g. `save_marketing_review`)
+ * and stay available — saving the advice the user explicitly asked for is
+ * part of the advisory workflow, not an external action.
+ *
+ * Build-phase filtering only applies inside an active build: when
+ * `activeBuildPhase` is set, only tools whose `buildPhases` includes that
+ * phase are kept.
+ *
+ * Extracted to its own module so the filter is unit-testable without
+ * dragging in next-auth and the rest of the agent-coworker action surface.
+ */
+export function filterToolsForCoworkerRuntime(
+  tools: ToolDefinition[],
+  input: { coworkerMode?: "advise" | "act"; activeBuildPhase: string | null },
+): ToolDefinition[] {
+  return tools.filter((tool) => {
+    if (input.coworkerMode === "advise" && tool.sideEffect && !tool.coworkerArtifact) return false;
+    if (input.activeBuildPhase) {
+      if (!tool.buildPhases) return false;
+      return tool.buildPhases.includes(input.activeBuildPhase as BuildPhaseTag);
+    }
+    return true;
+  });
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -119,6 +119,17 @@ export type ToolDefinition = {
   requiresExternalAccess?: boolean;
   executionMode?: "proposal" | "immediate";
   sideEffect?: boolean;
+  /**
+   * Tool captures the coworker's own recommendation or work product as a
+   * structured artifact (e.g. save_marketing_review). Persistence-only; no
+   * external action. Coworkers running in `advise` mode are still permitted
+   * to call these tools because the recommendation IS the deliverable — the
+   * advise/act distinction guards against acting on the outside world, not
+   * against recording the advice the user explicitly asked for. The tool
+   * remains `sideEffect: true` for MCP annotations and tool-execution
+   * memory; this flag only exempts it from the advise-mode runtime filter.
+   */
+  coworkerArtifact?: boolean;
   /** When set, tool is only available during these build phases.
    *  Null/undefined = available in all phases (non-build tools). */
   buildPhases?: BuildPhaseTag[] | null;
@@ -1339,6 +1350,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    coworkerArtifact: true,
   },
   {
     name: "create_marketing_campaign_brief",
@@ -1359,6 +1371,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    coworkerArtifact: true,
   },
   {
     name: "create_marketing_asset_task",
@@ -1376,6 +1389,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    coworkerArtifact: true,
   },
   {
     name: "record_marketing_kpi_checkpoint",
@@ -1392,6 +1406,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    coworkerArtifact: true,
   },
   {
     name: "create_marketing_automation_candidate",
@@ -1409,6 +1424,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    coworkerArtifact: true,
   },
   {
     name: "analyze_seo_opportunity",


### PR DESCRIPTION
## Summary

- Marketing Strategist's system prompt tells it to call `save_marketing_review` (and the campaign brief / asset task / KPI / automation candidate tools) whenever it gives a concrete recommendation, but the advise-mode tool filter strips every `sideEffect: true` tool — so it never can.
- The Marketing dashboard's empty state explicitly asks the user to "Ask the Marketing Strategist for a plan and it should persist the recommendation here." Driving the page as the CEO surfaced the gap: the coworker said "I can't save this to the marketing dashboard from the tools currently available on this screen."
- Introduce `coworkerArtifact: true` on the five marketing artifact tools so the advise filter keeps them, while the broader `sideEffect` semantics (MCP annotations, tool-execution memory, audit) stay intact — these tools capture the coworker's own recommendation, not an external action.
- Filter extracted to its own module so the rule is unit-testable without dragging in next-auth.

## Test plan

- [x] `apps/web/lib/actions/agent-coworker-tool-filter.test.ts` (new) — 5 cases covering read-only kept, side-effect stripped, `coworkerArtifact` exempted, act mode keeps everything, build-phase filter preserved
- [x] `pnpm --filter web exec vitest run` for the new test + neighboring suites — 63 passed
- [x] `pnpm --filter web typecheck` — clean
- [x] `npx next build` in `apps/web` — exit 0 (existing Edge-Runtime warnings unrelated)
- [ ] Post-merge: rebuild portal image, drive `/customer/marketing` as CEO, confirm `save_marketing_review` fires and the dashboard's "Latest strategist recommendation" populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)