### PR TITLE
feat: add trust vectors for data responses

### DIFF
--- a/apps/web/components/build/BuildAssuranceGateCard.test.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.test.tsx
@@ -21,6 +21,7 @@ import {
   requestBuildAssuranceScan,
   requestBuildBomGeneration,
 } from "@/lib/actions/assurance";
+import { buildAssuranceSummaryTrust } from "@/lib/trust-vector/adapters/assurance";
 
 afterEach(cleanup);
 
@@ -36,6 +37,13 @@ const noScanner = {
   approvedScannerCount: 0,
   scannerNames: [],
   reason: "no-approved-scanner" as const,
+};
+
+const readyScanner = {
+  state: "ready" as const,
+  approvedScannerCount: 1,
+  scannerNames: ["pnpm-audit"],
+  reason: "platform-native-scanner-available" as const,
 };
 
 describe("BuildAssuranceGateCard", () => {
@@ -202,6 +210,39 @@ describe("BuildAssuranceGateCard", () => {
 
     expect(screen.getByText("Active findings")).toBeInTheDocument();
     expect(screen.getByText("Generate a BOM, then run a scan.")).toBeInTheDocument();
+  });
+
+  it("qualifies empty findings when the latest scan is stale", () => {
+    const summary = {
+      state: "current" as const,
+      document: {
+        documentId: "bom_abc",
+        digest: "abc123",
+        generatedAt: new Date("2026-05-22T00:00:00.000Z"),
+        componentCount: 12,
+        sourceKind: "pnpm-lock",
+      },
+      latestAssuranceRunCompletedAt: new Date("2026-04-11T12:00:00.000Z"),
+      counts: { components: 12, models: 2 },
+      findings: emptyFindings,
+      scanner: readyScanner,
+    };
+
+    render(
+      <BuildAssuranceGateCard
+        buildId="BUILD-1"
+        summary={{
+          ...summary,
+          trust: buildAssuranceSummaryTrust(summary, {
+            asOf: new Date("2026-05-26T12:00:00.000Z"),
+          }),
+        }}
+        findings={[]}
+      />,
+    );
+
+    expect(screen.getByText("Medium trust")).toBeInTheDocument();
+    expect(screen.getByText("No active findings in the latest scan. Latest assurance scan completed 45 days ago.")).toBeInTheDocument();
   });
 
   it("renders supplied findings inside the gate card", () => {

--- a/apps/web/components/build/BuildAssuranceGateCard.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/lib/actions/assurance";
 import type { BomSummary } from "@/lib/assurance/bom-read";
 import type { ActiveAssuranceFindingRow } from "@/lib/assurance/finding-read";
+import { buildTrustMessage } from "@/lib/trust-vector";
+import { TrustBadge } from "@/components/ui/TrustBadge";
 import { AssuranceFindingsList } from "./AssuranceFindingsList";
 
 type RequestState = "idle" | "queued" | "failed";
@@ -44,6 +46,20 @@ function scannerDetail(summary: BomSummary): string {
   return "No approved vulnerability scanner";
 }
 
+function emptyFindingsLabel(summary: BomSummary, hasBom: boolean): string {
+  if (!hasBom) return "Generate a BOM, then run a scan.";
+
+  if (summary.trust && summary.findings.total === 0) {
+    return buildTrustMessage(summary.trust, {
+      currentFact: "No active findings.",
+      lastKnownFact: "No active findings in the latest scan.",
+      lowConfidenceResult: "No active findings in the latest scan.",
+    });
+  }
+
+  return "No active findings.";
+}
+
 export function BuildAssuranceGateCard({
   buildId,
   summary,
@@ -57,7 +73,7 @@ export function BuildAssuranceGateCard({
   const [scanPending, startScanTransition] = useTransition();
   const [requestState, setRequestState] = useState<RequestState>("idle");
   const [scanRequestState, setScanRequestState] = useState<RequestState>("idle");
-  const hasBom = summary.state !== "missing" && summary.document;
+  const hasBom = Boolean(summary.state !== "missing" && summary.document);
   const StatusIcon = summary.findings.blocking > 0
     ? ShieldAlert
     : hasBom && summary.scanner.state === "ready"
@@ -87,7 +103,10 @@ export function BuildAssuranceGateCard({
             <StatusIcon className={`h-4 w-4 ${statusColor}`} aria-hidden="true" />
             <h2>Assurance Gate</h2>
           </div>
-          <p className={`mt-1 text-xs font-medium ${statusColor}`}>{statusLabel(summary)}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <p className={`text-xs font-medium ${statusColor}`}>{statusLabel(summary)}</p>
+            {summary.trust && <TrustBadge trust={summary.trust} compact />}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -170,7 +189,7 @@ export function BuildAssuranceGateCard({
         <div className="mt-2">
           <AssuranceFindingsList
             findings={findings}
-            emptyLabel={hasBom ? "No active findings." : "Generate a BOM, then run a scan."}
+            emptyLabel={emptyFindingsLabel(summary, hasBom)}
           />
         </div>
       </div>

--- a/apps/web/components/build/CodeIntelligenceStatusCard.test.tsx
+++ b/apps/web/components/build/CodeIntelligenceStatusCard.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
 import type { CodeGraphFreshness } from "@/lib/integrate/code-graph-access";
+import { buildCodeGraphFreshnessTrust } from "@/lib/trust-vector/adapters/code-graph";
 
 function freshness(overrides: Partial<CodeGraphFreshness> = {}): CodeGraphFreshness {
   return {
@@ -63,5 +64,26 @@ describe("CodeIntelligenceStatusCard", () => {
     );
 
     expect(html).toContain("Uncommitted local changes");
+  });
+
+  it("renders trust tier and stale rationale when graph freshness is low", () => {
+    const trust = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      workspaceDirty: false,
+      indexedFileCount: 2756,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    const html = renderToStaticMarkup(
+      <CodeIntelligenceStatusCard freshness={freshness({ trust })} />,
+    );
+
+    expect(html).toContain('data-trust-tier="low"');
+    expect(html).toContain("Low trust");
+    expect(html).toContain("Code graph index is 16 days old.");
   });
 });

--- a/apps/web/components/build/CodeIntelligenceStatusCard.tsx
+++ b/apps/web/components/build/CodeIntelligenceStatusCard.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, CheckCircle2, GitBranch, Network } from "lucide-react";
 
 import type { CodeGraphFreshness } from "@/lib/integrate/code-graph-access";
+import { TrustBadge } from "@/components/ui/TrustBadge";
 
 type Props = {
   freshness: CodeGraphFreshness | null;
@@ -38,6 +39,10 @@ export function CodeIntelligenceStatusCard({ freshness }: Props) {
   const ready = freshness.available && freshness.indexStatus === "ready";
   const StatusIcon = ready ? CheckCircle2 : AlertTriangle;
   const statusColor = ready ? "text-[var(--dpf-success)]" : "text-[var(--dpf-warning)]";
+  const trust = freshness.trust;
+  const showTrustRationale = Boolean(
+    trust && (trust.tier !== "high" || trust.action !== "present"),
+  );
 
   return (
     <section
@@ -54,9 +59,12 @@ export function CodeIntelligenceStatusCard({ freshness }: Props) {
             {freshness.indexedFileCount.toLocaleString()} files indexed at {formatIndexedAt(freshness.lastIndexedAt)}
           </p>
         </div>
-        <div className={`inline-flex items-center gap-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-medium ${statusColor}`}>
-          <StatusIcon className="h-3.5 w-3.5" aria-hidden="true" />
-          {freshness.indexStatus}
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {trust && <TrustBadge trust={trust} compact />}
+          <div className={`inline-flex items-center gap-1 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-medium ${statusColor}`}>
+            <StatusIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            {freshness.indexStatus}
+          </div>
         </div>
       </div>
 
@@ -69,6 +77,12 @@ export function CodeIntelligenceStatusCard({ freshness }: Props) {
           {shortSha(freshness.lastIndexedHeadSha)}
         </code>
       </div>
+
+      {showTrustRationale && trust && (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          {trust.primaryRationale}
+        </p>
+      )}
 
       {freshness.warnings.length > 0 && (
         <ul className="mt-3 space-y-1">

--- a/apps/web/components/ui/TrustBadge.test.tsx
+++ b/apps/web/components/ui/TrustBadge.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TrustBadge } from "@/components/ui/TrustBadge";
+import { scoreTrustVector } from "@/lib/trust-vector";
+
+function trust(score: number, rationale = "Latest scan completed today.") {
+  return scoreTrustVector({
+    subject: {
+      type: "assurance-scan",
+      id: "scan-1",
+      label: "Build assurance scan",
+    },
+    asOf: "2026-05-26T12:00:00.000Z",
+    dimensions: [
+      {
+        key: "freshness",
+        label: "Freshness",
+        score,
+        rationale,
+        evidenceRefs: [],
+      },
+      {
+        key: "sourceAuthority",
+        label: "Source authority",
+        score: 1,
+        rationale: "AssuranceRun is authoritative.",
+        evidenceRefs: [],
+      },
+    ],
+  });
+}
+
+describe("TrustBadge", () => {
+  it("renders compact high-trust state with accessible rationale", () => {
+    const html = renderToStaticMarkup(<TrustBadge trust={trust(1)} compact />);
+
+    expect(html).toContain('data-trust-tier="high"');
+    expect(html).toContain("High trust");
+    expect(html).toContain("All trust dimensions are strong.");
+    expect(html).toContain("aria-label=");
+  });
+
+  it("renders expandable dimension detail", () => {
+    const html = renderToStaticMarkup(
+      <TrustBadge
+        trust={trust(0.2, "Latest scan completed 45 days ago.")}
+        disclosureLabel="Trust details"
+      />,
+    );
+
+    expect(html).toContain("<details");
+    expect(html).toContain("Trust details");
+    expect(html).toContain("Freshness");
+    expect(html).toContain("Latest scan completed 45 days ago.");
+  });
+
+  it("uses DPF theme tokens rather than hardcoded colors", () => {
+    const html = renderToStaticMarkup(<TrustBadge trust={trust(0.2)} />);
+
+    expect(html).toContain("var(--dpf-");
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}|text-gray|bg-white|border-gray/);
+  });
+});

--- a/apps/web/components/ui/TrustBadge.tsx
+++ b/apps/web/components/ui/TrustBadge.tsx
@@ -1,0 +1,106 @@
+import { AlertTriangle, CheckCircle2, HelpCircle, Info } from "lucide-react";
+
+import type { TrustAssessment, TrustTier } from "@/lib/trust-vector";
+
+type Props = {
+  trust: TrustAssessment;
+  compact?: boolean;
+  disclosureLabel?: string;
+  className?: string;
+};
+
+const TIER_LABELS: Record<TrustTier, string> = {
+  high: "High trust",
+  medium: "Medium trust",
+  low: "Low trust",
+  unknown: "Trust unknown",
+};
+
+const TIER_TONES: Record<TrustTier, { className: string; dotClassName: string }> = {
+  high: {
+    className:
+      "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-success)]",
+    dotClassName: "bg-[var(--dpf-success)]",
+  },
+  medium: {
+    className:
+      "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-warning)]",
+    dotClassName: "bg-[var(--dpf-warning)]",
+  },
+  low: {
+    className:
+      "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-error)]",
+    dotClassName: "bg-[var(--dpf-error)]",
+  },
+  unknown: {
+    className:
+      "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+    dotClassName: "bg-[var(--dpf-muted)]",
+  },
+};
+
+const TIER_ICONS = {
+  high: CheckCircle2,
+  medium: Info,
+  low: AlertTriangle,
+  unknown: HelpCircle,
+} satisfies Record<TrustTier, typeof CheckCircle2>;
+
+export function TrustBadge({
+  trust,
+  compact = false,
+  disclosureLabel = "Trust details",
+  className = "",
+}: Props) {
+  const label = TIER_LABELS[trust.tier];
+  const tone = TIER_TONES[trust.tier];
+  const Icon = TIER_ICONS[trust.tier];
+  const badge = (
+    <span
+      data-trust-tier={trust.tier}
+      aria-label={`Trust: ${label}. ${trust.primaryRationale}`}
+      title={trust.primaryRationale}
+      className={[
+        "inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-0.5",
+        "text-[10px] font-medium leading-4",
+        tone.className,
+        className,
+      ].join(" ")}
+    >
+      <span
+        aria-hidden="true"
+        className={["h-1.5 w-1.5 shrink-0 rounded-full", tone.dotClassName].join(" ")}
+      />
+      <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <span className="truncate">{label}</span>
+      <span className="sr-only">: {trust.primaryRationale}</span>
+    </span>
+  );
+
+  if (compact) {
+    return badge;
+  }
+
+  return (
+    <div className="space-y-2 text-xs">
+      {badge}
+      <p className="text-[var(--dpf-muted)]">{trust.primaryRationale}</p>
+      <details className="group">
+        <summary className="cursor-pointer text-[var(--dpf-accent)] hover:text-[var(--dpf-text)]">
+          {disclosureLabel}
+        </summary>
+        <dl className="mt-2 space-y-2 border-l border-[var(--dpf-border)] pl-3">
+          {trust.dimensions.map((dimension) => (
+            <div key={dimension.key} className="min-w-0">
+              <dt className="font-medium text-[var(--dpf-text)]">
+                {dimension.label}
+                <span className="ml-1 text-[var(--dpf-muted)]">({TIER_LABELS[dimension.tier]})</span>
+              </dt>
+              <dd className="mt-0.5 text-[var(--dpf-muted)]">{dimension.rationale}</dd>
+            </div>
+          ))}
+        </dl>
+      </details>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/assurance.test.ts
+++ b/apps/web/lib/actions/assurance.test.ts
@@ -97,13 +97,18 @@ describe("assurance actions", () => {
   it("normalizes build summary read failures to a missing state", async () => {
     vi.mocked(prisma.bomDocument.findFirst).mockRejectedValue(new Error("db down"));
 
-    await expect(getBuildBomSummary("BUILD-1")).resolves.toEqual({
+    const summary = await getBuildBomSummary("BUILD-1");
+
+    expect(summary).toMatchObject({
       state: "missing",
       document: null,
       counts: { components: 0, models: 0 },
       findings: emptyFindings,
       scanner: noScanner,
     });
+    expect(summary.latestAssuranceRunCompletedAt).toBeNull();
+    expect(summary.trust?.tier).toBe("low");
+    expect(summary.trust?.action).toBe("refresh-required");
   });
 
   it("forwards finding status updates with the authenticated user id", async () => {

--- a/apps/web/lib/assurance/bom-read.test.ts
+++ b/apps/web/lib/assurance/bom-read.test.ts
@@ -23,12 +23,17 @@ describe("getLatestBomSummaryForBuild", () => {
   it("returns a missing state when no BOM exists", async () => {
     const db = { bomDocument: { findFirst: vi.fn(async () => null) } };
 
-    await expect(getLatestBomSummaryForBuild(db, "BUILD-1")).resolves.toEqual({
+    await expect(getLatestBomSummaryForBuild(db, "BUILD-1", {
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toMatchObject({
       state: "missing",
       document: null,
       counts: { components: 0, models: 0 },
       findings: emptyFindings,
       scanner: platformNativeScanner,
+      trust: expect.objectContaining({
+        action: "refresh-required",
+      }),
     });
   });
 
@@ -51,7 +56,9 @@ describe("getLatestBomSummaryForBuild", () => {
       },
     };
 
-    await expect(getLatestBomSummaryForBuild(db, "BUILD-1")).resolves.toEqual({
+    await expect(getLatestBomSummaryForBuild(db, "BUILD-1", {
+      now: new Date("2026-05-22T01:00:00.000Z"),
+    })).resolves.toMatchObject({
       state: "current",
       document: {
         documentId: "bom_1",
@@ -63,10 +70,46 @@ describe("getLatestBomSummaryForBuild", () => {
       counts: { components: 3, models: 1 },
       findings: emptyFindings,
       scanner: platformNativeScanner,
+      trust: expect.objectContaining({
+        statementKind: "current-fact",
+      }),
     });
     expect(db.bomDocument.findFirst).toHaveBeenCalledWith(expect.objectContaining({
       where: { buildId: "BUILD-1" },
       orderBy: { generatedAt: "desc" },
+    }));
+  });
+
+  it("adds stale scan trust metadata from the latest assurance run", async () => {
+    const generatedAt = new Date("2026-05-22T00:00:00.000Z");
+    const db = {
+      bomDocument: {
+        findFirst: vi.fn(async () => ({
+          documentId: "bom_1",
+          digest: "abc",
+          generatedAt,
+          componentCount: 3,
+          sourceKind: "pnpm-lock",
+          status: "current",
+          occurrences: [],
+        })),
+      },
+      assuranceRun: {
+        findFirst: vi.fn(async () => ({
+          completedAt: new Date("2026-04-11T12:00:00.000Z"),
+        })),
+      },
+    };
+
+    const summary = await getLatestBomSummaryForBuild(db, "BUILD-1", {
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(summary.latestAssuranceRunCompletedAt).toEqual(new Date("2026-04-11T12:00:00.000Z"));
+    expect(summary.trust?.action).toBe("refresh-required");
+    expect(summary.trust?.primaryRationale).toContain("45 days");
+    expect(db.assuranceRun.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { buildId: "BUILD-1", status: "completed" },
     }));
   });
 });
@@ -87,11 +130,14 @@ describe("getLatestBomSummaryForProduct", () => {
       },
     };
 
-    const summary = await getLatestBomSummaryForProduct(db, "product-1");
+    const summary = await getLatestBomSummaryForProduct(db, "product-1", {
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
 
     expect(summary.state).toBe("stale");
     expect(summary.findings).toEqual(emptyFindings);
     expect(summary.scanner).toEqual(platformNativeScanner);
+    expect(summary.trust?.statementKind).toBe("last-known-fact");
     expect(db.bomDocument.findFirst).toHaveBeenCalledWith(expect.objectContaining({
       where: { digitalProductId: "product-1" },
     }));

--- a/apps/web/lib/assurance/bom-read.ts
+++ b/apps/web/lib/assurance/bom-read.ts
@@ -9,6 +9,8 @@ import {
   noApprovedScannerReadiness,
   type AssuranceScannerReadiness,
 } from "./scanner-catalog";
+import type { TrustAssessment } from "@/lib/trust-vector";
+import { buildAssuranceSummaryTrust } from "@/lib/trust-vector/adapters/assurance";
 
 export interface BomSummary {
   state: "missing" | "current" | "stale";
@@ -19,12 +21,14 @@ export interface BomSummary {
     componentCount: number;
     sourceKind: string;
   };
+  latestAssuranceRunCompletedAt?: Date | null;
   counts: {
     components: number;
     models: number;
   };
   findings: AssuranceFindingSummary;
   scanner: AssuranceScannerReadiness;
+  trust?: TrustAssessment;
 }
 
 export interface ProductSupplyChainComponentRow {
@@ -71,6 +75,9 @@ type BomReadDb = {
   bomDocument: {
     findFirst(args: unknown): Promise<null | BomSummaryRow>;
   };
+  assuranceRun?: {
+    findFirst(args: unknown): Promise<null | { completedAt: Date | null }>;
+  };
   assuranceFinding?: {
     findMany(args: unknown): Promise<Array<{
       policySeverity: string;
@@ -91,6 +98,10 @@ type BomReadDb = {
   };
 };
 
+type BomReadOptions = {
+  now?: Date;
+};
+
 type ProductBomReadDb = {
   bomDocument: {
     findFirst(args: unknown): Promise<null | ProductBomRows>;
@@ -99,13 +110,20 @@ type ProductBomReadDb = {
   toolEvaluation?: BomReadDb["toolEvaluation"];
 };
 
-export function missingBomSummary(): BomSummary {
-  return {
+export function missingBomSummary(options: BomReadOptions & {
+  latestAssuranceRunCompletedAt?: Date | null;
+} = {}): BomSummary {
+  const summary: BomSummary = {
     state: "missing",
     document: null,
+    latestAssuranceRunCompletedAt: options.latestAssuranceRunCompletedAt ?? null,
     counts: { components: 0, models: 0 },
     findings: emptyFindingSummary(),
     scanner: noApprovedScannerReadiness(),
+  };
+  return {
+    ...summary,
+    trust: buildAssuranceSummaryTrust(summary, { asOf: options.now }),
   };
 }
 
@@ -113,12 +131,21 @@ function summarizeBomDocument(
   document: BomSummaryRow | null,
   findings: AssuranceFindingSummary,
   scanner: AssuranceScannerReadiness,
+  latestAssuranceRunCompletedAt: Date | null,
+  options: BomReadOptions = {},
 ): BomSummary {
   if (!document) {
-    return {
-      ...missingBomSummary(),
+    const summary: BomSummary = {
+      state: "missing",
+      document: null,
+      latestAssuranceRunCompletedAt,
+      counts: { components: 0, models: 0 },
       findings,
       scanner,
+    };
+    return {
+      ...summary,
+      trust: buildAssuranceSummaryTrust(summary, { asOf: options.now }),
     };
   }
 
@@ -126,7 +153,7 @@ function summarizeBomDocument(
     entry.component?.componentType === "model"
   )).length;
 
-  return {
+  const summary: BomSummary = {
     state: document.status && document.status !== "current" ? "stale" : "current",
     document: {
       documentId: document.documentId,
@@ -135,12 +162,18 @@ function summarizeBomDocument(
       componentCount: document.componentCount,
       sourceKind: document.sourceKind,
     },
+    latestAssuranceRunCompletedAt,
     counts: {
       components: document.componentCount,
       models: modelCount,
     },
     findings,
     scanner,
+  };
+
+  return {
+    ...summary,
+    trust: buildAssuranceSummaryTrust(summary, { asOf: options.now }),
   };
 }
 
@@ -167,8 +200,9 @@ function latestBomSummarySelect() {
 export async function getLatestBomSummaryForBuild(
   db: BomReadDb,
   buildId: string,
+  options: BomReadOptions = {},
 ): Promise<BomSummary> {
-  const [document, findings, scanner] = await Promise.all([
+  const [document, findings, scanner, latestRun] = await Promise.all([
     db.bomDocument.findFirst({
       where: { buildId },
       orderBy: { generatedAt: "desc" },
@@ -176,16 +210,18 @@ export async function getLatestBomSummaryForBuild(
     }),
     getActiveFindingSummaryForBuild(db, buildId),
     getAssuranceScannerReadiness(db),
+    getLatestAssuranceRun(db, { buildId }),
   ]);
 
-  return summarizeBomDocument(document, findings, scanner);
+  return summarizeBomDocument(document, findings, scanner, latestRun?.completedAt ?? null, options);
 }
 
 export async function getLatestBomSummaryForProduct(
   db: BomReadDb,
   digitalProductId: string,
+  options: BomReadOptions = {},
 ): Promise<BomSummary> {
-  const [document, findings, scanner] = await Promise.all([
+  const [document, findings, scanner, latestRun] = await Promise.all([
     db.bomDocument.findFirst({
       where: { digitalProductId },
       orderBy: { generatedAt: "desc" },
@@ -193,9 +229,10 @@ export async function getLatestBomSummaryForProduct(
     }),
     getActiveFindingSummaryForProduct(db, digitalProductId),
     getAssuranceScannerReadiness(db),
+    getLatestAssuranceRun(db, { digitalProductId }),
   ]);
 
-  return summarizeBomDocument(document, findings, scanner);
+  return summarizeBomDocument(document, findings, scanner, latestRun?.completedAt ?? null, options);
 }
 
 export async function getLatestBomComponentsForProduct(
@@ -247,4 +284,20 @@ export async function getLatestBomComponentsForProduct(
     findingSummary,
     scanner,
   };
+}
+
+function getLatestAssuranceRun(
+  db: BomReadDb,
+  where: { buildId?: string; digitalProductId?: string },
+): Promise<null | { completedAt: Date | null }> {
+  if (!db.assuranceRun) return Promise.resolve(null);
+
+  return db.assuranceRun.findFirst({
+    where: {
+      ...where,
+      status: "completed",
+    },
+    orderBy: { completedAt: "desc" },
+    select: { completedAt: true },
+  });
 }

--- a/apps/web/lib/integrate/change-impact.test.ts
+++ b/apps/web/lib/integrate/change-impact.test.ts
@@ -20,6 +20,7 @@ import { prisma } from "@dpf/db";
 import { summarizeCodeGraphCoverage } from "./code-graph-access";
 import { findRelatedTests } from "./code-graph/graph-queries";
 import { analyzeChangeImpact, formatImpactForChat } from "./change-impact";
+import { buildCodeGraphFreshnessTrust } from "@/lib/trust-vector/adapters/code-graph";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -147,5 +148,47 @@ describe("formatImpactForChat", () => {
     expect(chat).toContain("1/2 changed files");
     expect(chat).toContain("Uncommitted local changes");
     expect(chat).toContain("change-impact.test.ts");
+  });
+
+  it("qualifies code-graph summaries with trust wording when trust metadata is present", () => {
+    const trust = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      workspaceDirty: false,
+      indexedFileCount: 42,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    const chat = formatImpactForChat({
+      routes: { new: [], modified: [], deleted: [] },
+      schemaChanges: [],
+      impactedRoles: [],
+      blastRadius: {
+        newRoutes: 0,
+        modifiedRoutes: 0,
+        deletedRoutes: 0,
+        schemaChanges: 0,
+        totalFilesChanged: 1,
+      },
+      riskLevel: "low",
+      rollbackComplexity: "simple",
+      summary: "Code-only changes",
+      codeGraph: {
+        graphKey: "source-code",
+        available: true,
+        indexStatus: "ready",
+        indexedFiles: ["apps/web/lib/integrate/change-impact.ts"],
+        unindexedFiles: [],
+        warnings: [],
+        summary: "Code graph covers 1/1 changed files at the current indexed commit.",
+        trust,
+      },
+    });
+
+    expect(chat).toContain("Code graph trust: **Low trust**");
+    expect(chat).toContain("Code graph index is 16 days old.");
   });
 });

--- a/apps/web/lib/integrate/change-impact.ts
+++ b/apps/web/lib/integrate/change-impact.ts
@@ -400,6 +400,9 @@ export function formatImpactForChat(report: ChangeImpactReport): string {
 
   if (report.codeGraph) {
     lines.push(`- Code graph: ${report.codeGraph.indexStatus} | ${report.codeGraph.summary}`);
+    if (report.codeGraph.trust) {
+      lines.push(`- Code graph trust: **${report.codeGraph.trust.summary}** | ${report.codeGraph.trust.primaryRationale}`);
+    }
     if (report.codeGraph.warnings.length > 0) {
       lines.push(`- Code graph warnings: ${report.codeGraph.warnings.join(" ")}`);
     }

--- a/apps/web/lib/integrate/code-graph-access.test.ts
+++ b/apps/web/lib/integrate/code-graph-access.test.ts
@@ -31,11 +31,14 @@ describe("getCodeGraphFreshness", () => {
   it("returns missing state when no graph index exists", async () => {
     vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
 
-    const result = await getCodeGraphFreshness();
+    const result = await getCodeGraphFreshness("source-code", {
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
 
     expect(result.available).toBe(false);
     expect(result.indexStatus).toBe("missing");
     expect(result.summary).toContain("not been built yet");
+    expect(result.trust?.action).toBe("refresh-required");
   });
 
   it("surfaces warnings for dirty or non-ready workspaces", async () => {
@@ -53,11 +56,37 @@ describe("getCodeGraphFreshness", () => {
       lastError: null,
     } as never);
 
-    const result = await getCodeGraphFreshness();
+    const result = await getCodeGraphFreshness("source-code", {
+      now: new Date("2026-04-20T01:00:00.000Z"),
+    });
 
     expect(result.available).toBe(true);
     expect(result.indexStatus).toBe("ready");
     expect(result.warnings).toContain("Uncommitted local changes may not be reflected in graph-backed analysis.");
+    expect(result.trust?.primaryRationale).toContain("Uncommitted local changes");
+  });
+
+  it("adds stale trust metadata when the ready graph is older than seven days", async () => {
+    vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue({
+      graphKey: "source-code",
+      graphVersion: 1,
+      indexStatus: "ready",
+      workspaceRoot: "/workspace",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      lastIndexedBranch: "main",
+      lastIndexedHeadSha: "abc123",
+      workspaceDirty: false,
+      workspaceDirtyObservedAt: null,
+      indexedFileCount: 42,
+      lastError: null,
+    } as never);
+
+    const result = await getCodeGraphFreshness("source-code", {
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(result.trust?.statementKind).toBe("last-known-fact");
+    expect(result.trust?.primaryRationale).toContain("16 days");
   });
 
   it("can inspect structural relationship health for realistic benchmark readiness", async () => {
@@ -81,6 +110,7 @@ describe("getCodeGraphFreshness", () => {
 
     const result = await getCodeGraphFreshness("source-code", {
       inspectStructuralHealth: true,
+      now: new Date("2026-05-13T01:00:00.000Z"),
     });
 
     expect(result.relationshipCounts).toEqual({
@@ -118,10 +148,13 @@ describe("summarizeCodeGraphCoverage", () => {
     const result = await summarizeCodeGraphCoverage([
       "apps/web/lib/integrate/change-impact.ts",
       "apps/web/lib/integrate/new-file.ts",
-    ]);
+    ], "source-code", {
+      now: new Date("2026-04-20T01:00:00.000Z"),
+    });
 
     expect(result.indexedFiles).toEqual(["apps/web/lib/integrate/change-impact.ts"]);
     expect(result.unindexedFiles).toEqual(["apps/web/lib/integrate/new-file.ts"]);
     expect(result.summary).toContain("1/2 changed files");
+    expect(result.trust?.action).toBe("qualify");
   });
 });

--- a/apps/web/lib/integrate/code-graph-access.ts
+++ b/apps/web/lib/integrate/code-graph-access.ts
@@ -1,6 +1,11 @@
 import { prisma, runCypher } from "@dpf/db";
 import type { CodeGraphEdgeKind } from "./code-graph/types";
 import { CODE_GRAPH_GRAPH_KEY } from "./code-graph/constants";
+import type { TrustAssessment } from "@/lib/trust-vector";
+import {
+  buildCodeGraphCoverageTrust,
+  buildCodeGraphFreshnessTrust,
+} from "@/lib/trust-vector/adapters/code-graph";
 
 const BENCHMARK_REQUIRED_RELATIONSHIPS = [
   "DEFINES",
@@ -25,6 +30,7 @@ export type CodeGraphFreshness = {
   relationshipCounts?: Record<BenchmarkRelationship, number>;
   warnings: string[];
   summary: string;
+  trust?: TrustAssessment;
 };
 
 export type CodeGraphCoverageSummary = {
@@ -35,6 +41,7 @@ export type CodeGraphCoverageSummary = {
   unindexedFiles: string[];
   warnings: string[];
   summary: string;
+  trust?: TrustAssessment;
 };
 
 function buildFreshnessWarnings(input: {
@@ -127,13 +134,24 @@ async function inspectStructuralRelationshipHealth(graphKey: string): Promise<{
 
 export async function getCodeGraphFreshness(
   graphKey = CODE_GRAPH_GRAPH_KEY,
-  options: { inspectStructuralHealth?: boolean } = {},
+  options: { inspectStructuralHealth?: boolean; now?: Date } = {},
 ): Promise<CodeGraphFreshness> {
   const state = await prisma.codeGraphIndexState.findUnique({
     where: { graphKey },
   });
 
   if (!state) {
+    const trust = buildCodeGraphFreshnessTrust({
+      graphKey,
+      available: false,
+      indexStatus: "missing",
+      lastIndexedAt: null,
+      workspaceDirty: false,
+      indexedFileCount: 0,
+      lastError: null,
+      asOf: options.now,
+    });
+
     return {
       graphKey,
       available: false,
@@ -146,6 +164,7 @@ export async function getCodeGraphFreshness(
       lastError: null,
       warnings: ["The code graph has not been built yet."],
       summary: "Code graph has not been built yet for this workspace.",
+      trust,
     };
   }
 
@@ -170,6 +189,17 @@ export async function getCodeGraphFreshness(
       : "No indexed commit recorded yet.",
     ...warnings,
   ].join(" ");
+  const trust = buildCodeGraphFreshnessTrust({
+    graphKey,
+    available: true,
+    indexStatus: state.indexStatus,
+    lastIndexedAt: state.lastIndexedAt,
+    workspaceDirty: state.workspaceDirty,
+    indexedFileCount: state.indexedFileCount,
+    lastError: state.lastError,
+    ...(relationshipHealth ? { relationshipCounts: relationshipHealth.counts } : {}),
+    asOf: options.now,
+  });
 
   return {
     graphKey,
@@ -184,17 +214,29 @@ export async function getCodeGraphFreshness(
     ...(relationshipHealth ? { relationshipCounts: relationshipHealth.counts } : {}),
     warnings,
     summary,
+    trust,
   };
 }
 
 export async function summarizeCodeGraphCoverage(
   filePaths: string[],
   graphKey = CODE_GRAPH_GRAPH_KEY,
+  options: { now?: Date } = {},
 ): Promise<CodeGraphCoverageSummary> {
-  const freshness = await getCodeGraphFreshness(graphKey);
+  const freshness = await getCodeGraphFreshness(graphKey, { now: options.now });
   const uniquePaths = [...new Set(filePaths.filter(Boolean))];
 
   if (!freshness.available || uniquePaths.length === 0) {
+    const trust = buildCodeGraphCoverageTrust({
+      graphKey,
+      available: freshness.available,
+      indexStatus: freshness.indexStatus,
+      indexedFileCount: 0,
+      totalFileCount: uniquePaths.length,
+      warnings: freshness.warnings,
+      asOf: options.now,
+    });
+
     return {
       graphKey,
       available: freshness.available,
@@ -205,6 +247,7 @@ export async function summarizeCodeGraphCoverage(
       summary: uniquePaths.length === 0
         ? "No changed files were available for code-graph coverage analysis."
         : freshness.summary,
+      trust,
     };
   }
 
@@ -230,5 +273,14 @@ export async function summarizeCodeGraphCoverage(
     unindexedFiles,
     warnings: freshness.warnings,
     summary: `Code graph covers ${indexedFiles.length}/${uniquePaths.length} changed files at the current indexed commit.`,
+    trust: buildCodeGraphCoverageTrust({
+      graphKey,
+      available: true,
+      indexStatus: freshness.indexStatus,
+      indexedFileCount: indexedFiles.length,
+      totalFileCount: uniquePaths.length,
+      warnings: freshness.warnings,
+      asOf: options.now,
+    }),
   };
 }

--- a/apps/web/lib/mcp-tools-code-graph.test.ts
+++ b/apps/web/lib/mcp-tools-code-graph.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockFindRelatedTests,
+  mockGetCodeGraphFreshness,
   mockSearchCodeGraph,
   mockTraceCodeSurface,
 } = vi.hoisted(() => ({
   mockFindRelatedTests: vi.fn(),
+  mockGetCodeGraphFreshness: vi.fn(),
   mockSearchCodeGraph: vi.fn(),
   mockTraceCodeSurface: vi.fn(),
 }));
@@ -16,7 +18,12 @@ vi.mock("@/lib/integrate/code-graph/graph-queries", () => ({
   traceCodeSurface: mockTraceCodeSurface,
 }));
 
+vi.mock("@/lib/integrate/code-graph-access", () => ({
+  getCodeGraphFreshness: mockGetCodeGraphFreshness,
+}));
+
 import { executeTool } from "./mcp-tools";
+import { buildCodeGraphFreshnessTrust } from "@/lib/trust-vector/adapters/code-graph";
 
 const unavailableResult = {
   graphKey: "dpf-source",
@@ -31,6 +38,41 @@ beforeEach(() => {
 });
 
 describe("code graph MCP handlers", () => {
+  it("returns trust metadata and stale wording for code graph freshness", async () => {
+    const trust = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      workspaceDirty: false,
+      indexedFileCount: 42,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    mockGetCodeGraphFreshness.mockResolvedValueOnce({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      lastIndexedBranch: "main",
+      lastIndexedHeadSha: "abc123",
+      workspaceDirty: false,
+      indexedFileCount: 42,
+      lastError: null,
+      warnings: [],
+      summary: "Code graph is ready for 42 indexed files.",
+      trust,
+    });
+
+    const result = await executeTool("get_code_graph_freshness", {}, "user-1");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Code graph index is 16 days old.");
+    expect(result.data).toEqual(expect.objectContaining({
+      trust: expect.objectContaining({ tier: "low" }),
+    }));
+  });
+
   it("returns failure when graph search cannot read the graph", async () => {
     mockSearchCodeGraph.mockResolvedValueOnce({
       ...unavailableResult,

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7713,10 +7713,18 @@ export async function executeTool(
 
     case "get_code_graph_freshness": {
       const { getCodeGraphFreshness } = await import("@/lib/integrate/code-graph-access");
+      const { buildTrustMessage } = await import("@/lib/trust-vector");
       const freshness = await getCodeGraphFreshness(undefined, { inspectStructuralHealth: true });
       return {
         success: true,
-        message: freshness.summary,
+        message: freshness.trust
+          ? buildTrustMessage(freshness.trust, {
+              currentFact: freshness.summary,
+              lastKnownFact: freshness.summary,
+              lowConfidenceResult: freshness.summary,
+              inferredResult: freshness.summary,
+            })
+          : freshness.summary,
         data: freshness,
       };
     }

--- a/apps/web/lib/surface-data-provenance.ts
+++ b/apps/web/lib/surface-data-provenance.ts
@@ -1,3 +1,5 @@
+import type { TrustAssessment } from "@/lib/trust-vector";
+
 export type DataSourceKind =
   | "live-db"
   | "connected-account"
@@ -15,6 +17,7 @@ export type DataSourceProvenance = {
   sourceRoute?: string;
   lastVerifiedAt?: string;
   actionHref?: string;
+  trust?: TrustAssessment;
 };
 
 export type ProvenancedMetric<T = string | number> = {

--- a/apps/web/lib/trust-vector/adapters/assurance.test.ts
+++ b/apps/web/lib/trust-vector/adapters/assurance.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAssuranceSummaryTrust } from "./assurance";
+
+const emptyFindings = {
+  total: 0,
+  blocking: 0,
+  bySeverity: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+  byKind: {},
+};
+
+const readyScanner = {
+  state: "ready" as const,
+  approvedScannerCount: 1,
+  scannerNames: ["pnpm-audit"],
+  reason: "platform-native-scanner-available" as const,
+};
+
+function currentSummary(overrides = {}) {
+  return {
+    state: "current" as const,
+    document: {
+      documentId: "bom_1",
+      digest: "abc",
+      generatedAt: new Date("2026-05-26T10:00:00.000Z"),
+      componentCount: 10,
+      sourceKind: "pnpm-lock",
+    },
+    latestAssuranceRunCompletedAt: new Date("2026-05-26T10:30:00.000Z"),
+    counts: { components: 10, models: 1 },
+    findings: emptyFindings,
+    scanner: readyScanner,
+    ...overrides,
+  };
+}
+
+describe("buildAssuranceSummaryTrust", () => {
+  it("scores a current BOM and current scan as a high-trust current fact", () => {
+    const assessment = buildAssuranceSummaryTrust(currentSummary(), {
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).toBe("high");
+    expect(assessment.statementKind).toBe("current-fact");
+    expect(assessment.action).toBe("present");
+  });
+
+  it("requires refresh for no-finding claims when the latest scan is 45 days old", () => {
+    const assessment = buildAssuranceSummaryTrust(currentSummary({
+      latestAssuranceRunCompletedAt: new Date("2026-04-11T12:00:00.000Z"),
+    }), {
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.statementKind).toBe("last-known-fact");
+    expect(assessment.action).toBe("refresh-required");
+    expect(assessment.primaryRationale).toContain("45 days");
+  });
+
+  it("marks missing BOMs as requiring refresh", () => {
+    const assessment = buildAssuranceSummaryTrust({
+      state: "missing",
+      document: null,
+      latestAssuranceRunCompletedAt: null,
+      counts: { components: 0, models: 0 },
+      findings: emptyFindings,
+      scanner: readyScanner,
+    }, {
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).toBe("low");
+    expect(assessment.action).toBe("refresh-required");
+    expect(assessment.primaryRationale).toContain("No assurance scan");
+  });
+
+  it("lowers trust when no approved scanner is available", () => {
+    const assessment = buildAssuranceSummaryTrust(currentSummary({
+      scanner: {
+        state: "needs-evaluation" as const,
+        approvedScannerCount: 0,
+        scannerNames: [],
+        reason: "no-approved-scanner" as const,
+      },
+    }), {
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).not.toBe("high");
+    expect(assessment.dimensions.find((dimension) => dimension.key === "toolReliability")?.tier).toBe("low");
+  });
+});

--- a/apps/web/lib/trust-vector/adapters/assurance.ts
+++ b/apps/web/lib/trust-vector/adapters/assurance.ts
@@ -1,0 +1,225 @@
+import { scoreTrustVector } from "@/lib/trust-vector/score";
+import type { TrustAssessment, TrustDimensionInput } from "@/lib/trust-vector/types";
+import type { BomSummary } from "@/lib/assurance/bom-read";
+
+type AssuranceTrustOptions = {
+  asOf?: Date | string;
+};
+
+export function buildAssuranceSummaryTrust(
+  summary: BomSummary,
+  options: AssuranceTrustOptions = {},
+): TrustAssessment {
+  const asOf = toDate(options.asOf) ?? new Date();
+  const dimensions: TrustDimensionInput[] = [
+    buildScanFreshnessDimension(summary, asOf),
+    buildBomLineageDimension(summary, asOf),
+    buildToolReliabilityDimension(summary),
+    buildSourceAuthorityDimension(summary),
+    buildCoverageDimension(summary),
+  ];
+
+  if (summary.findings.blocking > 0) {
+    dimensions.push({
+      key: "riskImpact",
+      label: "Risk impact",
+      score: 0.4,
+      rationale: `${summary.findings.blocking} blocking assurance finding${summary.findings.blocking === 1 ? "" : "s"} require review.`,
+      evidenceRefs: [],
+    });
+  }
+
+  return scoreTrustVector({
+    subject: {
+      type: "assurance-summary",
+      id: summary.document?.documentId ?? "missing-bom",
+      label: "Assurance summary",
+    },
+    asOf: asOf.toISOString(),
+    dimensions,
+    riskLevel: "high",
+    sourceSummary: "Assurance trust is derived from BOM freshness, scan recency, finding evidence, and scanner readiness.",
+  });
+}
+
+function buildScanFreshnessDimension(summary: BomSummary, asOf: Date): TrustDimensionInput {
+  if (summary.state === "stale") {
+    return {
+      key: "freshness",
+      label: "Scan freshness",
+      score: 0.2,
+      weight: 2,
+      rationale: "The latest BOM document is marked stale.",
+      evidenceRefs: [],
+    };
+  }
+
+  const completedAt = summary.latestAssuranceRunCompletedAt ?? summary.document?.generatedAt ?? null;
+
+  if (!completedAt) {
+    return {
+      key: "freshness",
+      label: "Scan freshness",
+      score: 0.1,
+      weight: 2,
+      rationale: "No assurance scan has completed for this scope.",
+      evidenceRefs: [],
+    };
+  }
+
+  const completedDate = toDate(completedAt);
+  if (!completedDate) {
+    return {
+      key: "freshness",
+      label: "Scan freshness",
+      score: 0.1,
+      weight: 2,
+      rationale: "Latest assurance scan completion time is invalid.",
+      evidenceRefs: [],
+    };
+  }
+
+  const ageDays = ageInDays(completedDate, asOf);
+  if (ageDays <= 7) {
+    return {
+      key: "freshness",
+      label: "Scan freshness",
+      score: 1,
+      weight: 2,
+      rationale: "Latest assurance scan completed within the last 7 days.",
+      measuredAt: completedDate.toISOString(),
+      evidenceRefs: [],
+    };
+  }
+
+  if (ageDays <= 30) {
+    return {
+      key: "freshness",
+      label: "Scan freshness",
+      score: 0.7,
+      weight: 2,
+      rationale: `Latest assurance scan completed ${ageDays} ${ageDays === 1 ? "day" : "days"} ago.`,
+      measuredAt: completedDate.toISOString(),
+      evidenceRefs: [],
+    };
+  }
+
+  return {
+    key: "freshness",
+    label: "Scan freshness",
+    score: 0.2,
+    weight: 2,
+    rationale: `Latest assurance scan completed ${ageDays} ${ageDays === 1 ? "day" : "days"} ago.`,
+    measuredAt: completedDate.toISOString(),
+    evidenceRefs: [],
+  };
+}
+
+function buildBomLineageDimension(summary: BomSummary, asOf: Date): TrustDimensionInput {
+  if (!summary.document) {
+    return {
+      key: "dataLineage",
+      label: "BOM lineage",
+      score: 0.1,
+      rationale: "No BOM document is available for this scope.",
+      evidenceRefs: [],
+    };
+  }
+
+  if (summary.state === "stale") {
+    return {
+      key: "dataLineage",
+      label: "BOM lineage",
+      score: 0.2,
+      rationale: "The latest BOM document is marked stale.",
+      evidenceRefs: [{
+        kind: "bom-document",
+        label: "BomDocument",
+        ref: summary.document.documentId,
+        sourceTable: "BomDocument",
+      }],
+    };
+  }
+
+  const ageDays = ageInDays(summary.document.generatedAt, asOf);
+  const score = ageDays <= 14 ? 1 : ageDays <= 45 ? 0.7 : 0.2;
+
+  return {
+    key: "dataLineage",
+    label: "BOM lineage",
+    score,
+    rationale: `Latest BOM document was generated ${ageDays} ${ageDays === 1 ? "day" : "days"} ago.`,
+    measuredAt: summary.document.generatedAt.toISOString(),
+    evidenceRefs: [{
+      kind: "bom-document",
+      label: "BomDocument",
+      ref: summary.document.documentId,
+      sourceTable: "BomDocument",
+    }],
+  };
+}
+
+function buildToolReliabilityDimension(summary: BomSummary): TrustDimensionInput {
+  const ready = summary.scanner.state === "ready";
+  return {
+    key: "toolReliability",
+    label: "Scanner readiness",
+    score: ready ? 1 : 0.2,
+    weight: 2,
+    rationale: ready
+      ? `Approved scanner available: ${summary.scanner.scannerNames.join(", ")}.`
+      : "No approved assurance scanner is available.",
+    evidenceRefs: [],
+  };
+}
+
+function buildSourceAuthorityDimension(summary: BomSummary): TrustDimensionInput {
+  return {
+    key: "sourceAuthority",
+    label: "Source authority",
+    score: summary.document ? 0.9 : 0.4,
+    rationale: summary.document
+      ? "BomDocument and AssuranceFinding are authoritative for persisted assurance results."
+      : "No authoritative BOM document is available yet.",
+    evidenceRefs: summary.document
+      ? [{
+          kind: "bom-document",
+          label: "BomDocument",
+          ref: summary.document.documentId,
+          sourceTable: "BomDocument",
+        }]
+      : [],
+  };
+}
+
+function buildCoverageDimension(summary: BomSummary): TrustDimensionInput {
+  if (!summary.document) {
+    return {
+      key: "coverageCompleteness",
+      label: "Coverage",
+      score: 0.1,
+      rationale: "No BOM components are available for coverage assessment.",
+      evidenceRefs: [],
+    };
+  }
+
+  const score = summary.counts.components > 0 ? 0.85 : 0.4;
+  return {
+    key: "coverageCompleteness",
+    label: "Coverage",
+    score,
+    rationale: `${summary.counts.components} component${summary.counts.components === 1 ? "" : "s"} captured in the latest BOM.`,
+    evidenceRefs: [],
+  };
+}
+
+function ageInDays(from: Date, asOf: Date): number {
+  const ageMs = Math.max(0, asOf.getTime() - from.getTime());
+  return Math.floor(ageMs / (1000 * 60 * 60 * 24));
+}
+
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/apps/web/lib/trust-vector/adapters/code-graph.test.ts
+++ b/apps/web/lib/trust-vector/adapters/code-graph.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCodeGraphCoverageTrust,
+  buildCodeGraphFreshnessTrust,
+} from "./code-graph";
+
+describe("code graph trust adapter", () => {
+  it("scores a current ready graph as high-trust current fact", () => {
+    const assessment = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-26T10:00:00.000Z"),
+      workspaceDirty: false,
+      indexedFileCount: 42,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).toBe("high");
+    expect(assessment.statementKind).toBe("current-fact");
+    expect(assessment.action).toBe("present");
+  });
+
+  it("marks a graph older than seven days as a last-known fact", () => {
+    const assessment = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      lastIndexedAt: new Date("2026-05-10T12:00:00.000Z"),
+      workspaceDirty: false,
+      indexedFileCount: 42,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.statementKind).toBe("last-known-fact");
+    expect(assessment.action).toBe("warn-stale");
+    expect(assessment.primaryRationale).toContain("16 days");
+  });
+
+  it("requires refresh when the graph is missing", () => {
+    const assessment = buildCodeGraphFreshnessTrust({
+      graphKey: "source-code",
+      available: false,
+      indexStatus: "missing",
+      lastIndexedAt: null,
+      workspaceDirty: false,
+      indexedFileCount: 0,
+      lastError: null,
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).toBe("low");
+    expect(assessment.action).toBe("refresh-required");
+    expect(assessment.primaryRationale).toContain("not been built");
+  });
+
+  it("qualifies impact analysis when only part of the changed-file set is indexed", () => {
+    const assessment = buildCodeGraphCoverageTrust({
+      graphKey: "source-code",
+      available: true,
+      indexStatus: "ready",
+      indexedFileCount: 1,
+      totalFileCount: 2,
+      warnings: [],
+      asOf: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(assessment.tier).toBe("medium");
+    expect(assessment.action).toBe("qualify");
+    expect(assessment.primaryRationale).toContain("covers 1/2 changed files");
+  });
+});

--- a/apps/web/lib/trust-vector/adapters/code-graph.ts
+++ b/apps/web/lib/trust-vector/adapters/code-graph.ts
@@ -1,0 +1,259 @@
+import { scoreTrustVector } from "@/lib/trust-vector/score";
+import type { TrustAssessment, TrustDimensionInput } from "@/lib/trust-vector/types";
+
+type CodeGraphFreshnessTrustInput = {
+  graphKey: string;
+  available: boolean;
+  indexStatus: string;
+  lastIndexedAt: Date | string | null;
+  workspaceDirty: boolean;
+  indexedFileCount: number;
+  lastError: string | null;
+  relationshipCounts?: Record<string, number>;
+  asOf?: Date | string;
+};
+
+type CodeGraphCoverageTrustInput = {
+  graphKey: string;
+  available: boolean;
+  indexStatus: string;
+  indexedFileCount: number;
+  totalFileCount: number;
+  warnings: string[];
+  asOf?: Date | string;
+};
+
+export function buildCodeGraphFreshnessTrust(
+  input: CodeGraphFreshnessTrustInput,
+): TrustAssessment {
+  const asOf = toDate(input.asOf) ?? new Date();
+  const dimensions: TrustDimensionInput[] = [
+    buildFreshnessDimension(input, asOf),
+    buildRuntimeDimension(input),
+    {
+      key: "sourceAuthority",
+      label: "Source authority",
+      score: input.available && input.indexedFileCount > 0 ? 0.9 : 0.6,
+      rationale: input.available
+        ? "CodeGraphIndexState is the authoritative source for graph index freshness."
+        : "No CodeGraphIndexState row exists for this graph.",
+      evidenceRefs: [{
+        kind: "prisma-row",
+        label: "CodeGraphIndexState",
+        ref: input.graphKey,
+        sourceTable: "CodeGraphIndexState",
+      }],
+    },
+  ];
+
+  if (input.relationshipCounts) {
+    dimensions.push(buildStructuralHealthDimension(input.relationshipCounts));
+  }
+
+  return scoreTrustVector({
+    subject: {
+      type: "code-graph",
+      id: input.graphKey,
+      label: "Code graph",
+    },
+    asOf: asOf.toISOString(),
+    dimensions,
+    riskLevel: input.available ? "medium" : "high",
+    sourceSummary: "Code graph trust is derived from index state, runtime health, and optional relationship coverage.",
+  });
+}
+
+export function buildCodeGraphCoverageTrust(
+  input: CodeGraphCoverageTrustInput,
+): TrustAssessment {
+  const asOf = toDate(input.asOf) ?? new Date();
+  const coverageScore = input.totalFileCount === 0
+    ? null
+    : input.indexedFileCount / input.totalFileCount;
+  const dimensions: TrustDimensionInput[] = [
+    {
+      key: "coverageCompleteness",
+      label: "Changed-file coverage",
+      score: coverageScore,
+      weight: 2,
+      rationale: input.totalFileCount === 0
+        ? "No changed files were available for code-graph coverage analysis."
+        : `Code graph covers ${input.indexedFileCount}/${input.totalFileCount} changed files.`,
+      evidenceRefs: [{
+        kind: "prisma-row",
+        label: "CodeGraphFileHash",
+        ref: input.graphKey,
+        sourceTable: "CodeGraphFileHash",
+      }],
+    },
+    {
+      key: "runtimeAvailability",
+      label: "Runtime availability",
+      score: input.available && input.indexStatus === "ready" ? 1 : 0.3,
+      rationale: input.available
+        ? `Code graph index status is ${input.indexStatus}.`
+        : "The code graph has not been built yet.",
+      evidenceRefs: [],
+    },
+    {
+      key: "sourceAuthority",
+      label: "Source authority",
+      score: input.available ? 0.85 : 0.4,
+      rationale: "CodeGraphFileHash is the committed-file coverage source for changed files.",
+      evidenceRefs: [],
+    },
+  ];
+
+  return scoreTrustVector({
+    subject: {
+      type: "code-graph-coverage",
+      id: input.graphKey,
+      label: "Code graph coverage",
+    },
+    asOf: asOf.toISOString(),
+    dimensions,
+    sourceSummary: "Coverage trust is derived from changed files present in CodeGraphFileHash.",
+  });
+}
+
+function buildFreshnessDimension(
+  input: CodeGraphFreshnessTrustInput,
+  asOf: Date,
+): TrustDimensionInput {
+  if (!input.available) {
+    return {
+      key: "freshness",
+      label: "Freshness",
+      score: 0.1,
+      weight: 2,
+      rationale: "The code graph has not been built yet.",
+      evidenceRefs: [],
+    };
+  }
+
+  if (input.workspaceDirty) {
+    return {
+      key: "freshness",
+      label: "Freshness",
+      score: 0.2,
+      weight: 2,
+      rationale: "Uncommitted local changes may not be reflected in graph-backed analysis.",
+      evidenceRefs: [],
+    };
+  }
+
+  const indexedAt = toDate(input.lastIndexedAt);
+  if (!indexedAt) {
+    return {
+      key: "freshness",
+      label: "Freshness",
+      score: 0.2,
+      weight: 2,
+      rationale: "No indexed commit timestamp is recorded for the code graph.",
+      evidenceRefs: [],
+    };
+  }
+
+  const ageMs = Math.max(0, asOf.getTime() - indexedAt.getTime());
+  const ageHours = ageMs / (1000 * 60 * 60);
+  const ageDays = Math.floor(ageHours / 24);
+
+  if (ageHours <= 24) {
+    return {
+      key: "freshness",
+      label: "Freshness",
+      score: 1,
+      weight: 2,
+      rationale: "Code graph was indexed within the last 24 hours.",
+      measuredAt: indexedAt.toISOString(),
+      evidenceRefs: [],
+    };
+  }
+
+  if (ageDays <= 7) {
+    return {
+      key: "freshness",
+      label: "Freshness",
+      score: 0.7,
+      weight: 2,
+      rationale: `Code graph index is ${ageDays} ${ageDays === 1 ? "day" : "days"} old.`,
+      measuredAt: indexedAt.toISOString(),
+      evidenceRefs: [],
+    };
+  }
+
+  return {
+    key: "freshness",
+    label: "Freshness",
+    score: 0.2,
+    weight: 2,
+    rationale: `Code graph index is ${ageDays} ${ageDays === 1 ? "day" : "days"} old.`,
+    measuredAt: indexedAt.toISOString(),
+    evidenceRefs: [],
+  };
+}
+
+function buildRuntimeDimension(input: CodeGraphFreshnessTrustInput): TrustDimensionInput {
+  if (!input.available) {
+    return {
+      key: "runtimeAvailability",
+      label: "Runtime availability",
+      score: 0.7,
+      rationale: "Code graph runtime responded, but no index state exists yet.",
+      evidenceRefs: [],
+    };
+  }
+
+  if (input.lastError) {
+    return {
+      key: "runtimeAvailability",
+      label: "Runtime availability",
+      score: 0.3,
+      rationale: `Last code-graph error: ${input.lastError}`,
+      evidenceRefs: [],
+    };
+  }
+
+  if (input.indexStatus !== "ready") {
+    return {
+      key: "runtimeAvailability",
+      label: "Runtime availability",
+      score: 0.3,
+      rationale: `The code graph is currently ${input.indexStatus}.`,
+      evidenceRefs: [],
+    };
+  }
+
+  return {
+    key: "runtimeAvailability",
+    label: "Runtime availability",
+    score: 1,
+    rationale: "The code graph index is ready.",
+    evidenceRefs: [],
+  };
+}
+
+function buildStructuralHealthDimension(
+  relationshipCounts: Record<string, number>,
+): TrustDimensionInput {
+  const values = Object.values(relationshipCounts);
+  const presentCount = values.filter((count) => count > 0).length;
+  const totalCount = values.length;
+  const score = totalCount === 0 ? null : presentCount / totalCount;
+
+  return {
+    key: "toolReliability",
+    label: "Structural relationship health",
+    score,
+    rationale: totalCount === 0
+      ? "No structural relationship benchmark was available."
+      : `Code graph has ${presentCount}/${totalCount} benchmark relationship types populated.`,
+    evidenceRefs: [],
+  };
+}
+
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/apps/web/lib/trust-vector/index.ts
+++ b/apps/web/lib/trust-vector/index.ts
@@ -1,0 +1,3 @@
+export * from "./score";
+export * from "./types";
+export * from "./wording";

--- a/apps/web/lib/trust-vector/score.test.ts
+++ b/apps/web/lib/trust-vector/score.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  scoreTrustVector,
+  type TrustDimensionInput,
+} from "@/lib/trust-vector";
+
+const subject = {
+  type: "assurance-scan",
+  id: "scan-1",
+  label: "Build assurance scan",
+};
+
+function dimension(
+  key: TrustDimensionInput["key"],
+  score: number | null,
+  rationale: string,
+  weight = 1,
+): TrustDimensionInput {
+  return {
+    key,
+    label: key,
+    score,
+    weight,
+    rationale,
+    evidenceRefs: [],
+  };
+}
+
+describe("scoreTrustVector", () => {
+  it("presents high-trust current facts when freshness, authority, coverage, and runtime are strong", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Latest scan completed today."),
+        dimension("sourceAuthority", 1, "AssuranceRun is the authoritative scan source."),
+        dimension("coverageCompleteness", 0.95, "Scan covered the whole build."),
+        dimension("runtimeAvailability", 1, "Scanner was available."),
+      ],
+    });
+
+    expect(assessment.statementKind).toBe("current-fact");
+    expect(assessment.tier).toBe("high");
+    expect(assessment.action).toBe("present");
+    expect(assessment.overallScore).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("turns stale high-risk scan findings into last-known facts that require refresh", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      riskLevel: "high",
+      dimensions: [
+        dimension("freshness", 0.2, "Latest scan completed 45 days ago.", 2),
+        dimension("sourceAuthority", 1, "AssuranceFinding is authoritative for persisted findings."),
+        dimension("evidenceGrade", 1, "The scan has a receipt."),
+        dimension("runtimeAvailability", 1, "Scanner is currently available."),
+      ],
+    });
+
+    expect(assessment.statementKind).toBe("last-known-fact");
+    expect(assessment.action).toBe("refresh-required");
+    expect(assessment.primaryRationale).toContain("45 days");
+  });
+
+  it("caps runtime-unavailable results at low trust and prevents present action", () => {
+    const assessment = scoreTrustVector({
+      subject: {
+        type: "graph-view",
+        id: "portfolio-map",
+        label: "Portfolio graph",
+      },
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Postgres records were read now."),
+        dimension("sourceAuthority", 1, "Postgres is authoritative for products."),
+        dimension("runtimeAvailability", 0.1, "Neo4j was unavailable."),
+      ],
+    });
+
+    expect(assessment.tier).toBe("low");
+    expect(assessment.statementKind).toBe("low-confidence-result");
+    expect(assessment.action).not.toBe("present");
+    expect(assessment.primaryRationale).toContain("Neo4j");
+  });
+
+  it("escalates contradicted source claims", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Both sources were current."),
+        dimension("sourceAuthority", 0.8, "Both sources are operational."),
+        dimension("conflictContradiction", 0.1, "Inventory and scanner evidence disagree."),
+      ],
+    });
+
+    expect(assessment.tier).toBe("low");
+    expect(assessment.action).toBe("escalate");
+    expect(assessment.statementKind).toBe("low-confidence-result");
+  });
+
+  it("does not penalize not-applicable dimensions", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Latest scan completed today."),
+        dimension("sourceAuthority", 1, "AssuranceRun is authoritative."),
+        dimension("humanValidation", null, "No human review is required for this read-only summary.", 10),
+      ],
+    });
+
+    expect(assessment.tier).toBe("high");
+    expect(assessment.overallScore).toBe(1);
+  });
+});

--- a/apps/web/lib/trust-vector/score.ts
+++ b/apps/web/lib/trust-vector/score.ts
@@ -1,0 +1,196 @@
+import type {
+  ScoreTrustVectorInput,
+  TrustAction,
+  TrustAssessment,
+  TrustDimension,
+  TrustDimensionKey,
+  TrustStatementKind,
+  TrustTier,
+} from "./types";
+
+const LOW_DIMENSION_THRESHOLD = 0.4;
+
+const CAP_ORDER: TrustDimensionKey[] = [
+  "conflictContradiction",
+  "runtimeAvailability",
+  "freshness",
+  "evidenceGrade",
+  "coverageCompleteness",
+];
+
+export function scoreTrustVector(input: ScoreTrustVectorInput): TrustAssessment {
+  const dimensions = input.dimensions.map(toScoredDimension);
+  const applicable = dimensions.filter((dimension) => dimension.score !== null);
+  const overallScore = calculateOverallScore(applicable);
+  const baseTier = tierFromScore(overallScore);
+  const capDimension = findCapDimension(dimensions);
+  const freshnessLow = isDimensionLow(dimensions, "freshness");
+  const graphTraversalLow = isDimensionLow(dimensions, "graphTraversalDepth");
+  const highRisk = input.riskLevel === "high" || input.riskLevel === "critical";
+
+  const cappedTier = applyTierCaps(baseTier, capDimension);
+  const statementKind = determineStatementKind({
+    tier: cappedTier,
+    capKey: capDimension?.key,
+    freshnessLow,
+    graphTraversalLow,
+  });
+  const action = determineAction({
+    tier: cappedTier,
+    capKey: capDimension?.key,
+    statementKind,
+    highRisk,
+  });
+  const primaryRationale = choosePrimaryRationale(dimensions, capDimension, cappedTier);
+
+  return {
+    kind: "data-trust-vector",
+    schemaVersion: 1,
+    subject: input.subject,
+    statementKind,
+    tier: cappedTier,
+    overallScore,
+    action,
+    asOf: input.asOf,
+    summary: `${capitalize(cappedTier)} trust`,
+    primaryRationale,
+    dimensions,
+    sourceSummary: input.sourceSummary ?? `${input.subject.label} assessed from ${applicable.length} trust dimensions.`,
+    ...(input.auditRef ? { auditRef: input.auditRef } : {}),
+  };
+}
+
+function toScoredDimension(input: ScoreTrustVectorInput["dimensions"][number]): TrustDimension {
+  const score = input.score === null ? null : clampScore(input.score);
+
+  return {
+    key: input.key,
+    label: input.label,
+    score,
+    weight: input.weight ?? 1,
+    rationale: input.rationale,
+    tier: tierFromScore(score),
+    ...(input.measuredAt ? { measuredAt: input.measuredAt } : {}),
+    ...(input.expiresAt ? { expiresAt: input.expiresAt } : {}),
+    evidenceRefs: input.evidenceRefs ?? [],
+  };
+}
+
+function calculateOverallScore(dimensions: TrustDimension[]): number | null {
+  if (dimensions.length === 0) return null;
+
+  let weightedScore = 0;
+  let totalWeight = 0;
+  for (const dimension of dimensions) {
+    if (dimension.score === null) continue;
+    const weight = Math.max(0, dimension.weight);
+    weightedScore += dimension.score * weight;
+    totalWeight += weight;
+  }
+
+  if (totalWeight === 0) return null;
+
+  return Number((weightedScore / totalWeight).toFixed(2));
+}
+
+function tierFromScore(score: number | null): TrustTier {
+  if (score === null) return "unknown";
+  if (score >= 0.8) return "high";
+  if (score >= 0.6) return "medium";
+  return "low";
+}
+
+function findCapDimension(dimensions: TrustDimension[]): TrustDimension | null {
+  for (const key of CAP_ORDER) {
+    const dimension = dimensions.find((entry) => entry.key === key && entry.score !== null);
+    if (dimension && (dimension.score ?? 1) < LOW_DIMENSION_THRESHOLD) {
+      return dimension;
+    }
+  }
+
+  return null;
+}
+
+function isDimensionLow(dimensions: TrustDimension[], key: TrustDimensionKey): boolean {
+  const dimension = dimensions.find((entry) => entry.key === key);
+  return dimension?.score !== null && (dimension?.score ?? 1) < LOW_DIMENSION_THRESHOLD;
+}
+
+function applyTierCaps(baseTier: TrustTier, capDimension: TrustDimension | null): TrustTier {
+  if (!capDimension) return baseTier;
+
+  if (capDimension.key === "freshness") {
+    return baseTier === "high" ? "medium" : baseTier;
+  }
+
+  return "low";
+}
+
+function determineStatementKind(input: {
+  tier: TrustTier;
+  capKey?: TrustDimensionKey;
+  freshnessLow: boolean;
+  graphTraversalLow: boolean;
+}): TrustStatementKind {
+  if (input.capKey === "conflictContradiction" || input.capKey === "runtimeAvailability") {
+    return "low-confidence-result";
+  }
+
+  if (input.freshnessLow) {
+    return "last-known-fact";
+  }
+
+  if (input.graphTraversalLow) {
+    return "inferred-result";
+  }
+
+  if (input.tier === "low" || input.tier === "unknown") {
+    return "low-confidence-result";
+  }
+
+  return "current-fact";
+}
+
+function determineAction(input: {
+  tier: TrustTier;
+  capKey?: TrustDimensionKey;
+  statementKind: TrustStatementKind;
+  highRisk: boolean;
+}): TrustAction {
+  if (input.capKey === "conflictContradiction") return "escalate";
+  if (input.capKey === "runtimeAvailability") return "defer";
+  if (input.capKey === "evidenceGrade") return "defer";
+  if (input.capKey === "freshness") {
+    return input.highRisk ? "refresh-required" : "warn-stale";
+  }
+  if (input.capKey === "coverageCompleteness") return "qualify";
+  if (input.tier === "unknown") return "defer";
+  if (input.tier === "low") return "qualify";
+  if (input.statementKind === "inferred-result") return "qualify";
+
+  return input.tier === "high" ? "present" : "qualify";
+}
+
+function choosePrimaryRationale(
+  dimensions: TrustDimension[],
+  capDimension: TrustDimension | null,
+  tier: TrustTier,
+): string {
+  if (capDimension) return capDimension.rationale;
+  if (tier === "high") return "All trust dimensions are strong.";
+
+  const lowest = [...dimensions]
+    .filter((dimension) => dimension.score !== null)
+    .sort((a, b) => (a.score ?? 0) - (b.score ?? 0))[0];
+
+  return lowest?.rationale ?? "No applicable trust dimensions were available.";
+}
+
+function clampScore(score: number): number {
+  if (Number.isNaN(score)) return 0;
+  return Math.min(1, Math.max(0, score));
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}

--- a/apps/web/lib/trust-vector/types.ts
+++ b/apps/web/lib/trust-vector/types.ts
@@ -1,0 +1,101 @@
+export type TrustStatementKind =
+  | "current-fact"
+  | "last-known-fact"
+  | "inferred-result"
+  | "low-confidence-result";
+
+export type TrustTier = "high" | "medium" | "low" | "unknown";
+
+export type TrustAction =
+  | "present"
+  | "qualify"
+  | "warn-stale"
+  | "refresh-required"
+  | "escalate"
+  | "defer";
+
+export type TrustRiskLevel = "low" | "medium" | "high" | "critical";
+
+export type TrustDimensionKey =
+  | "freshness"
+  | "sourceAuthority"
+  | "evidenceGrade"
+  | "coverageCompleteness"
+  | "toolRecency"
+  | "toolReliability"
+  | "graphTraversalDepth"
+  | "dataLineage"
+  | "humanValidation"
+  | "conflictContradiction"
+  | "runtimeAvailability"
+  | "sampleSize"
+  | "riskImpact";
+
+export type TrustEvidenceRef = {
+  kind:
+    | "prisma-row"
+    | "neo4j-node"
+    | "neo4j-relationship"
+    | "tool-execution"
+    | "assurance-run"
+    | "bom-document"
+    | "assurance-finding"
+    | "wiki-page"
+    | "decision-interaction"
+    | "gear-interface"
+    | "external-provider";
+  label: string;
+  ref: string;
+  sourceTable?: string;
+  sourceRoute?: string;
+};
+
+export type TrustSubject = {
+  type: string;
+  id: string;
+  label: string;
+};
+
+export type TrustDimensionInput = {
+  key: TrustDimensionKey;
+  label: string;
+  score: number | null;
+  weight?: number;
+  rationale: string;
+  measuredAt?: string;
+  expiresAt?: string;
+  evidenceRefs?: TrustEvidenceRef[];
+};
+
+export type TrustDimension = Required<Pick<TrustDimensionInput, "key" | "label" | "score" | "rationale">> & {
+  tier: TrustTier;
+  weight: number;
+  measuredAt?: string;
+  expiresAt?: string;
+  evidenceRefs: TrustEvidenceRef[];
+};
+
+export type TrustAssessment = {
+  kind: "data-trust-vector";
+  schemaVersion: 1;
+  subject: TrustSubject;
+  statementKind: TrustStatementKind;
+  tier: TrustTier;
+  overallScore: number | null;
+  action: TrustAction;
+  asOf: string;
+  summary: string;
+  primaryRationale: string;
+  dimensions: TrustDimension[];
+  sourceSummary: string;
+  auditRef?: TrustEvidenceRef;
+};
+
+export type ScoreTrustVectorInput = {
+  subject: TrustSubject;
+  asOf: string;
+  dimensions: TrustDimensionInput[];
+  riskLevel?: TrustRiskLevel;
+  sourceSummary?: string;
+  auditRef?: TrustEvidenceRef;
+};

--- a/apps/web/lib/trust-vector/wording.test.ts
+++ b/apps/web/lib/trust-vector/wording.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTrustMessage,
+  scoreTrustVector,
+  type TrustDimensionInput,
+} from "@/lib/trust-vector";
+
+const subject = {
+  type: "assurance-scan",
+  id: "scan-1",
+  label: "Build assurance scan",
+};
+
+function dimension(
+  key: TrustDimensionInput["key"],
+  score: number,
+  rationale: string,
+  weight = 1,
+): TrustDimensionInput {
+  return {
+    key,
+    label: key,
+    score,
+    weight,
+    rationale,
+    evidenceRefs: [],
+  };
+}
+
+describe("buildTrustMessage", () => {
+  it("uses current-fact wording when the assessment can be presented", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Latest scan completed today."),
+        dimension("sourceAuthority", 1, "AssuranceRun is authoritative."),
+      ],
+    });
+
+    expect(buildTrustMessage(assessment, {
+      currentFact: "No active findings.",
+      lastKnownFact: "No active findings in the latest scan.",
+    })).toBe("No active findings.");
+  });
+
+  it("qualifies stale scan claims as last-known facts", () => {
+    const assessment = scoreTrustVector({
+      subject,
+      asOf: "2026-05-26T12:00:00.000Z",
+      riskLevel: "high",
+      dimensions: [
+        dimension("freshness", 0.2, "Latest scan completed 45 days ago.", 2),
+        dimension("sourceAuthority", 1, "AssuranceFinding is authoritative."),
+        dimension("runtimeAvailability", 1, "Scanner is available."),
+      ],
+    });
+
+    expect(buildTrustMessage(assessment, {
+      currentFact: "No active findings.",
+      lastKnownFact: "No active findings in the latest scan.",
+    })).toBe(
+      "No active findings in the latest scan. Latest scan completed 45 days ago.",
+    );
+  });
+
+  it("explains low-confidence results without raw math", () => {
+    const assessment = scoreTrustVector({
+      subject: {
+        type: "graph-view",
+        id: "portfolio-map",
+        label: "Portfolio graph",
+      },
+      asOf: "2026-05-26T12:00:00.000Z",
+      dimensions: [
+        dimension("freshness", 1, "Postgres records were read now."),
+        dimension("runtimeAvailability", 0.1, "Neo4j was unavailable."),
+      ],
+    });
+
+    const message = buildTrustMessage(assessment, {
+      lowConfidenceResult: "This graph result is incomplete.",
+    });
+
+    expect(message).toBe("This graph result is incomplete. Neo4j was unavailable.");
+    expect(message).not.toMatch(/\d+\.\d+/);
+  });
+});

--- a/apps/web/lib/trust-vector/wording.ts
+++ b/apps/web/lib/trust-vector/wording.ts
@@ -1,0 +1,49 @@
+import type { TrustAssessment } from "./types";
+
+export type TrustMessageOptions = {
+  currentFact?: string;
+  lastKnownFact?: string;
+  inferredResult?: string;
+  lowConfidenceResult?: string;
+  fallback?: string;
+};
+
+export function buildTrustMessage(
+  assessment: TrustAssessment,
+  options: TrustMessageOptions = {},
+): string {
+  if (assessment.statementKind === "current-fact" && assessment.action === "present") {
+    return normalizeSentence(options.currentFact ?? options.fallback ?? assessment.summary);
+  }
+
+  const base = normalizeSentence(baseMessageForAssessment(assessment, options));
+  const rationale = normalizeSentence(assessment.primaryRationale);
+
+  if (base === rationale || base.includes(rationale)) {
+    return base;
+  }
+
+  return `${base} ${rationale}`;
+}
+
+function baseMessageForAssessment(
+  assessment: TrustAssessment,
+  options: TrustMessageOptions,
+): string {
+  switch (assessment.statementKind) {
+    case "current-fact":
+      return options.currentFact ?? options.fallback ?? assessment.summary;
+    case "last-known-fact":
+      return options.lastKnownFact ?? options.currentFact ?? options.fallback ?? `${assessment.subject.label} is a last-known fact.`;
+    case "inferred-result":
+      return options.inferredResult ?? options.fallback ?? `${assessment.subject.label} is inferred.`;
+    case "low-confidence-result":
+      return options.lowConfidenceResult ?? options.fallback ?? `${assessment.subject.label} is low confidence.`;
+  }
+}
+
+function normalizeSentence(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}

--- a/docs/superpowers/plans/2026-05-26-graph-data-trust-vector.md
+++ b/docs/superpowers/plans/2026-05-26-graph-data-trust-vector.md
@@ -1,0 +1,399 @@
+# Graph/Data Trust Vector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first reusable trust-vector slice for graph/data responses so Build Studio code intelligence and assurance results can distinguish current facts, last-known facts, inferred results, and low-confidence results.
+
+**Architecture:** Add a shared `TrustAssessment` read-model contract, scorer, wording helpers, and UI badge. Adapt existing authoritative source models (`CodeGraphIndexState`, `CodeGraphFileHash`, `BomDocument`, `AssuranceRun`, `AssuranceFinding`, `ToolExecution`) into trust vectors. Do not add a new persistence table in this slice; trust metadata travels with read models and MCP/tool results, and existing tool/evidence ledgers capture it when calls are executed.
+
+**Tech Stack:** Next.js 16, TypeScript, React, Prisma 7, PostgreSQL, Neo4j, Vitest, Testing Library, DPF MCP JSON-RPC at `/api/mcp/v1`.
+
+**Source spec:** `docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md`
+
+**Capacity split:** Reserve at least 20% of the implementation for refactoring existing stale/freshness/provenance wording into shared helpers. Do not spend the whole slice adding local page badges.
+
+---
+
+## Implementation Guardrails
+
+- Work in an isolated branch/worktree off `origin/main`.
+- Do not implement until the spec and plan are approved in the thread.
+- Keep current source tables authoritative.
+- Do not add a `TrustAssessment` table or migration in this slice.
+- Use `pnpm --filter web exec vitest run ...`, not `npx`.
+- UI must use DPF theme tokens only.
+- If a touched UI surface has nearby hardcoded colors, clean them up in the same surface.
+- For any coworker/MCP result carrying trust, assert both `data.trust` and stale/low-confidence `message` wording in tests.
+
+---
+
+## Task 0: Approval Gate
+
+- [ ] Confirm the spec is approved for implementation.
+- [ ] If the approved first slice changes, update both spec and plan before editing code.
+- [ ] Run `git status --short --branch` and confirm the branch is not `main` and not detached.
+
+Expected branch pattern:
+
+```powershell
+git status --short --branch
+```
+
+Expected result:
+
+- Branch is `doc/trust-vector-data-responses` or a follow-on implementation branch.
+- No unrelated dirty files are present except approved docs/code changes.
+
+---
+
+## Task 1: Create Shared Trust-Vector Primitives
+
+### Files
+
+- Add `apps/web/lib/trust-vector/types.ts`
+- Add `apps/web/lib/trust-vector/score.ts`
+- Add `apps/web/lib/trust-vector/wording.ts`
+- Add `apps/web/lib/trust-vector/index.ts`
+- Add `apps/web/lib/trust-vector/score.test.ts`
+- Add `apps/web/lib/trust-vector/wording.test.ts`
+- Modify `apps/web/lib/surface-data-provenance.ts`
+- Modify `apps/web/lib/surface-data-provenance.test.ts`
+
+### Steps
+
+- [ ] Define the contract from the spec:
+
+```ts
+export type TrustStatementKind =
+  | "current-fact"
+  | "last-known-fact"
+  | "inferred-result"
+  | "low-confidence-result";
+
+export type TrustTier = "high" | "medium" | "low" | "unknown";
+
+export type TrustAction =
+  | "present"
+  | "qualify"
+  | "warn-stale"
+  | "refresh-required"
+  | "escalate"
+  | "defer";
+```
+
+- [ ] Define `TrustDimensionKey`, `TrustDimension`, `TrustEvidenceRef`, and `TrustAssessment`.
+- [ ] Add a pure `scoreTrustVector(input)` helper that:
+  - computes a weighted average over applicable dimensions,
+  - applies hard caps for contradiction, runtime availability, stale freshness, low evidence grade, low coverage, and high risk,
+  - returns `tier`, `statementKind`, `action`, `overallScore`, `summary`, and `primaryRationale`.
+- [ ] Add a pure `buildTrustMessage(assessment, options?)` helper for UI/coworker wording.
+- [ ] Extend `DataSourceProvenance` with optional `trust?: TrustAssessment`.
+- [ ] Keep all primitives client/server safe: no Prisma imports, no server-only imports, no DB calls.
+
+### Tests
+
+- [ ] High freshness + authoritative source + full coverage returns `current-fact`, `high`, `present`.
+- [ ] A 45-day security scan returns `last-known-fact`, low/medium depending policy, and `refresh-required`.
+- [ ] Runtime unavailable caps the result at `low` and prevents `present`.
+- [ ] Contradiction caps the result at `low` and returns `escalate` or `defer`.
+- [ ] Missing non-applicable dimensions do not lower the score.
+- [ ] `DataSourceProvenance` still works for source-only badges.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/trust-vector/score.test.ts apps/web/lib/trust-vector/wording.test.ts apps/web/lib/surface-data-provenance.test.ts
+```
+
+---
+
+## Task 2: Code Graph Trust Adapter
+
+### Files
+
+- Add `apps/web/lib/trust-vector/adapters/code-graph.ts`
+- Add `apps/web/lib/trust-vector/adapters/code-graph.test.ts`
+- Modify `apps/web/lib/integrate/code-graph-access.ts`
+- Modify `apps/web/lib/integrate/code-graph-access.test.ts`
+
+### Steps
+
+- [ ] Add `buildCodeGraphFreshnessTrust(input)` that accepts the current `CodeGraphFreshness` source fields plus optional policy settings.
+- [ ] Add `buildCodeGraphCoverageTrust(input)` for changed-file coverage.
+- [ ] Add optional `trust?: TrustAssessment` to `CodeGraphFreshness`.
+- [ ] Add optional `trust?: TrustAssessment` to `CodeGraphCoverageSummary`.
+- [ ] Convert existing freshness warnings where possible to trust-vector wording, while preserving the current warning strings until all callers migrate.
+- [ ] Add age-based freshness:
+  - current: `0-24h` or indexed head matches active head when available,
+  - watch: `1-7d`,
+  - low: `>7d`, missing index, dirty workspace, non-ready index, or last error.
+- [ ] Keep structural relationship health as a tool-reliability/coverage signal, not a proof of semantic completeness.
+
+### Tests
+
+- [ ] Existing missing-state test still passes and now includes `trust.action` of `refresh-required` or `defer`.
+- [ ] Dirty workspace test includes low/medium trust and a visible rationale.
+- [ ] Index older than 7 days produces stale/low freshness.
+- [ ] Coverage `1/2 changed files` lowers `coverageCompleteness` and qualifies broad impact claims.
+- [ ] Structural relationship gaps affect `toolReliability` or `coverageCompleteness`.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/trust-vector/adapters/code-graph.test.ts apps/web/lib/integrate/code-graph-access.test.ts
+```
+
+---
+
+## Task 3: Code Intelligence UI Pattern
+
+### Files
+
+- Add `apps/web/components/ui/TrustBadge.tsx`
+- Add `apps/web/components/ui/TrustBadge.test.tsx`
+- Modify `apps/web/components/build/CodeIntelligenceStatusCard.tsx`
+- Modify `apps/web/components/build/CodeIntelligenceStatusCard.test.tsx`
+
+### Steps
+
+- [ ] Build `TrustBadge` with compact and disclosure modes.
+- [ ] Use semantic DPF tokens only:
+  - `var(--dpf-success)`
+  - `var(--dpf-warning)`
+  - `var(--dpf-error)`
+  - `var(--dpf-accent)`
+  - `var(--dpf-muted)`
+  - `var(--dpf-border)`
+  - `var(--dpf-surface-1)`
+  - `var(--dpf-surface-2)`
+  - `var(--dpf-text)`
+- [ ] Do not show raw floats in the compact badge.
+- [ ] Render one concise rationale inline.
+- [ ] Put dimension detail behind a native `details` disclosure or existing local disclosure pattern.
+- [ ] Integrate `TrustBadge` into `CodeIntelligenceStatusCard`.
+- [ ] Preserve existing warnings while making trust the primary visible confidence cue.
+
+### Tests
+
+- [ ] `TrustBadge` renders high/medium/low/unknown labels.
+- [ ] `TrustBadge` exposes rationale to screen readers.
+- [ ] Code intelligence card renders stale trust rationale when graph age is low.
+- [ ] Existing missing graph warning test still passes.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/ui/TrustBadge.test.tsx apps/web/components/build/CodeIntelligenceStatusCard.test.tsx
+```
+
+---
+
+## Task 4: Code Graph Coworker / MCP Behavior
+
+### Files
+
+- Modify `apps/web/lib/integrate/change-impact.ts`
+- Modify `apps/web/lib/integrate/change-impact.test.ts`
+- Modify `apps/web/lib/mcp-tools.ts`
+- Modify `apps/web/lib/mcp-tools-code-graph.test.ts`
+
+### Steps
+
+- [ ] Update `formatImpactReport()` so code graph summary includes trust wording when `report.codeGraph.trust` exists.
+- [ ] Update `get_code_graph_freshness` handler so:
+  - `data.trust` is returned,
+  - top-level `message` uses trust-aware stale/low-confidence wording.
+- [ ] Update `inspect_build_code_impact` so:
+  - `data.codeGraph.trust` is returned,
+  - stale/low confidence prevents unqualified broad claims.
+- [ ] Keep MCP results read-only and side-effect-free.
+
+### Tests
+
+- [ ] `get_code_graph_freshness` returns structured `data.trust`.
+- [ ] stale graph result top-level `message` contains the stale rationale.
+- [ ] `inspect_build_code_impact` qualifies coverage gaps.
+- [ ] Existing unavailable graph failures remain explicit.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/integrate/change-impact.test.ts apps/web/lib/mcp-tools-code-graph.test.ts
+```
+
+---
+
+## Task 5: Assurance Trust Adapter
+
+### Files
+
+- Add `apps/web/lib/trust-vector/adapters/assurance.ts`
+- Add `apps/web/lib/trust-vector/adapters/assurance.test.ts`
+- Modify `apps/web/lib/assurance/bom-read.ts`
+- Modify `apps/web/lib/assurance/bom-read.test.ts`
+
+### Steps
+
+- [ ] Add `buildAssuranceSummaryTrust(summary, options)` that evaluates:
+  - BOM freshness from `BomDocument.generatedAt`,
+  - scan freshness from latest relevant `AssuranceRun.completedAt` when available,
+  - scanner readiness/tool approval,
+  - active finding count and severity,
+  - component count / model count as coverage clues,
+  - risk impact for security/compliance claims.
+- [ ] Extend `BomSummary` with optional `trust?: TrustAssessment`.
+- [ ] If scan freshness cannot be derived from current `BomSummary`, add the smallest read-model field needed, preferably `latestAssuranceRunCompletedAt?: Date | null`.
+- [ ] Do not add schema fields unless the current tables cannot express the read model.
+- [ ] Keep scan freshness distinct from BOM freshness in dimension rationales.
+
+### Tests
+
+- [ ] Missing BOM returns `unknown` or `refresh-required` trust.
+- [ ] Current BOM + current scan + no findings returns high trust current fact.
+- [ ] No active findings with latest scan 45 days old returns last-known fact and stale rationale.
+- [ ] Scanner not approved lowers tool reliability and prevents high trust.
+- [ ] Blocking findings influence risk/action but do not hide freshness.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/trust-vector/adapters/assurance.test.ts apps/web/lib/assurance/bom-read.test.ts
+```
+
+---
+
+## Task 6: Assurance Gate UI
+
+### Files
+
+- Modify `apps/web/components/build/BuildAssuranceGateCard.tsx`
+- Modify `apps/web/components/build/BuildAssuranceGateCard.test.tsx`
+
+### Steps
+
+- [ ] Add `TrustBadge` next to the Assurance Gate status.
+- [ ] Replace static empty findings label with trust-aware wording:
+  - current: `No active findings.`
+  - stale: `No active findings in the latest scan. Scan freshness is low because the latest scan completed 45 days ago.`
+  - missing scan/BOM: retain `Generate a BOM, then run a scan.`
+- [ ] Keep the card compact and scannable.
+- [ ] Keep Run scan as the primary refresh affordance.
+- [ ] Avoid nested cards and keep border radius consistent with existing `rounded-md`.
+
+### Tests
+
+- [ ] Assurance Gate renders trust badge.
+- [ ] Stale 45-day scan renders last-known wording.
+- [ ] Missing BOM still asks the user to generate BOM/run scan.
+- [ ] Run scan button behavior remains unchanged.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/build/BuildAssuranceGateCard.test.tsx
+```
+
+---
+
+## Task 7: Evidence / Audit Trail Check
+
+### Files
+
+- Modify only if needed:
+  - `apps/web/lib/assurance/scan-job.ts`
+  - `apps/web/lib/assurance/bom-job.ts`
+  - `apps/web/lib/mcp-tools.ts`
+  - existing tests around `ToolExecution.result`
+
+### Steps
+
+- [ ] Confirm MCP/tool results with `data.trust` are persisted through existing `ToolExecution.result`.
+- [ ] Confirm assurance facts remain persisted in `AssuranceRun`, `BomDocument`, `AssuranceFinding`, and `ToolExecutionReceipt`.
+- [ ] Do not persist trust in a new table.
+- [ ] If a side-effecting assurance run already writes a summary payload, optionally include trust input facts there, not a duplicate assessment table.
+
+### Tests
+
+- [ ] Existing scan/BOM job tests still pass.
+- [ ] If summary payload changes, tests assert the new trust inputs without weakening receipt assertions.
+
+Verification:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/assurance/scan-job.test.ts apps/web/lib/assurance/bom-job.test.ts
+```
+
+---
+
+## Task 8: Full Slice Verification
+
+### Targeted Tests
+
+Run all changed-unit tests:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/trust-vector/score.test.ts apps/web/lib/trust-vector/wording.test.ts apps/web/lib/trust-vector/adapters/code-graph.test.ts apps/web/lib/trust-vector/adapters/assurance.test.ts apps/web/lib/integrate/code-graph-access.test.ts apps/web/lib/integrate/change-impact.test.ts apps/web/lib/mcp-tools-code-graph.test.ts apps/web/components/ui/TrustBadge.test.tsx apps/web/components/build/CodeIntelligenceStatusCard.test.tsx apps/web/components/build/BuildAssuranceGateCard.test.tsx apps/web/lib/assurance/bom-read.test.ts
+```
+
+### Typecheck
+
+```powershell
+pnpm --filter web typecheck
+```
+
+### Production Build
+
+```powershell
+Set-Location apps/web
+pnpm exec next build
+```
+
+### UX Verification
+
+Use the Docker-served app, not stale `next dev`, after code changes:
+
+```powershell
+docker compose build --no-cache portal portal-init sandbox
+docker compose up -d
+```
+
+Then verify:
+
+- Build Studio header shows Code Intelligence trust badge and rationale.
+- Assurance Gate shows trust badge and freshness-aware empty findings text.
+- Low/stale states are visible without hover-only disclosure.
+- Theme tokens render correctly in light/dark branding modes.
+- No text overflow or incoherent overlap at desktop and mobile widths.
+
+Capture screenshots/evidence before declaring complete.
+
+---
+
+## Task 9: Final Branch Hygiene
+
+- [ ] Run `git diff --check`.
+- [ ] Run `git status --short --branch`.
+- [ ] Review changed files and ensure scope is only trust-vector first slice.
+- [ ] Commit with DCO signoff:
+
+```powershell
+git add docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md docs/superpowers/plans/2026-05-26-graph-data-trust-vector.md apps/web/lib/trust-vector apps/web/lib/surface-data-provenance.ts apps/web/lib/surface-data-provenance.test.ts apps/web/lib/integrate/code-graph-access.ts apps/web/lib/integrate/code-graph-access.test.ts apps/web/lib/integrate/change-impact.ts apps/web/lib/integrate/change-impact.test.ts apps/web/lib/mcp-tools.ts apps/web/lib/mcp-tools-code-graph.test.ts apps/web/components/ui/TrustBadge.tsx apps/web/components/ui/TrustBadge.test.tsx apps/web/components/build/CodeIntelligenceStatusCard.tsx apps/web/components/build/CodeIntelligenceStatusCard.test.tsx apps/web/lib/assurance/bom-read.ts apps/web/lib/assurance/bom-read.test.ts apps/web/components/build/BuildAssuranceGateCard.tsx apps/web/components/build/BuildAssuranceGateCard.test.tsx
+git commit -s -m "Add graph data trust vector first slice"
+git push
+```
+
+- [ ] Open PR only after targeted tests, typecheck, production build, and UX verification pass, unless the operator explicitly asks for a draft recovery PR.
+
+---
+
+## Definition of Done
+
+- Spec and plan are approved.
+- Shared trust-vector primitives exist and are tested.
+- Code graph responses include trust metadata and stale/coverage wording.
+- Assurance Gate qualifies stale "no active findings" claims.
+- UI uses compact badge + concise rationale + expandable detail.
+- Coworker/MCP responses include `data.trust` and top-level qualified messages.
+- Existing evidence ledgers remain authoritative.
+- No new trust table or migration exists.
+- Targeted tests, typecheck, production build, and UX verification pass or documented pre-existing failures are captured.

--- a/docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md
+++ b/docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md
@@ -1,0 +1,552 @@
+---
+title: Graph/Data Trust Vector Design
+authoredAt: 2026-05-26
+authoredBy: codex
+status: draft
+specKind: design
+epic: EP-REDUCTION-GEAR-ARCH
+relatedEpics:
+  - EP-ASSURANCE-LEDGER
+  - EP-WWMD-MCP
+  - EP-BUILD-STUDIO
+  - EP-AI-OPSMAP
+  - EP-TAK-3F9A21
+relatedSpecs:
+  - docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md
+  - docs/superpowers/specs/2026-05-19-wwmd-mcp-exposure-design.md
+  - docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md
+  - docs/superpowers/specs/2026-05-13-code-intelligence-graph-adoption-design.md
+  - docs/superpowers/specs/2026-05-21-supply-chain-and-desired-state-assurance-design.md
+relatedPlans:
+  - docs/superpowers/plans/2026-05-13-portal-ux-data-source-trust-repair.md
+  - docs/superpowers/plans/2026-05-13-code-intelligence-graph-adoption.md
+  - docs/superpowers/plans/2026-05-21-assurance-ledger-phase-0.md
+relatedPrinciples:
+  - docs/founder-kernel/wiki/principles/never-fabricate.md
+  - docs/founder-kernel/wiki/principles/never-assume-verify.md
+  - docs/founder-kernel/wiki/principles/trust-the-data-spine.md
+  - docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+  - docs/founder-kernel/wiki/principles/no-hardcoded-colors.md
+externalReferences:
+  - https://www.w3.org/TR/prov-dm/
+  - https://openlineage.io/docs/spec/facets/
+  - https://openlineage.io/docs/1.38.0/spec/facets/dataset-facets/data_quality_metrics/
+  - https://openlineage.io/docs/next/spec/facets/dataset-facets/data_quality_assertions/
+  - https://docs.greatexpectations.io/docs/reference/api/core/expectationvalidationresult_class/
+  - https://docs.greatexpectations.io/docs/core/trigger_actions_based_on_results/choose_a_result_format/
+  - https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/quality
+  - https://www.servicenow.com/docs/r/zurich/servicenow-platform/configuration-management-database-cmdb/r_CMDBHealthMetrics.html
+  - https://www.servicenow.com/docs/r/zurich/servicenow-platform/configuration-management-database-cmdb/c_MonitorCMDBHealth.html
+  - https://learn.microsoft.com/en-us/purview/concepts-data-quality-rules
+  - https://learn.microsoft.com/en-us/purview/unified-catalog-data-quality-scores
+  - https://productresources.collibra.com/docs/collibra/latest/Content/UnifiedDataQuality/co_about-data-quality-scores.htm
+  - https://productresources.collibra.com/docs/collibra/latest/Content/Settings/OperatingModel/QualityScoreAggregations/co_asset-data-quality.htm
+---
+
+# Graph/Data Trust Vector Design
+
+## 1. Purpose
+
+DPF already treats WWMD decisions as vectorized, explainable evaluations: retrieved principles, evidence grade, freshness, risk, confidence, and a ledger combine into an outcome such as `recommend`, `escalate`, or `defer`. Graph-backed and data-centric interfaces need the same discipline.
+
+When a page, coworker, MCP tool, graph traversal, code analysis, estate discovery view, portfolio health result, compliance answer, or assurance result presents a claim, the claim must carry structured trust metadata alongside the result. A single hardcoded score is not enough. Users and coworkers need the reason a result is trusted, stale, inferred, partially covered, contradicted, or unavailable.
+
+The first user-visible problem is simple:
+
+> "No critical findings" is only a current fact if the scan is current enough. If the latest scan is 45 days old, DPF should say: "No critical findings in the latest scan, but scan freshness is low because the latest code analysis is 45 days old."
+
+This spec defines the reusable substrate for that behavior.
+
+## 2. Current Runtime Truth
+
+This section separates what exists today from the future-state design.
+
+### 2.1 Live Backlog / Epic State
+
+DPF MCP was available during this research pass on 2026-05-26. Live backlog/epic lookup was performed through `list_epics` and `list_backlog_items`; no DB fallback was used.
+
+Relevant live epics:
+
+| Epic | Current state | Why it shapes this design |
+| --- | --- | --- |
+| `EP-REDUCTION-GEAR-ARCH` | Open; 77 total items, 58 open, 7 in progress, 10 done | Home for reusable observation/evidence/calibration substrate. |
+| `EP-ASSURANCE-LEDGER` | Open; 5 total items, 2 open, 3 done | Home for SBOM, scan, finding, and compliance evidence. |
+| `EP-WWMD-MCP` | Open; 13 total items, 12 open, 1 in progress | WWMD pattern to mirror for explainable trust and advisory output. |
+| `EP-BUILD-STUDIO` | Open; 51 total items, 18 open, 11 in progress, 16 done | First user-facing surface for code intelligence and assurance gates. |
+| `EP-AI-OPSMAP` | Open; 9 total items, 3 open, 1 in progress, 5 done | Future data-centric operator surface with stale/runtime-state risks. |
+| `EP-TAK-3F9A21` | Open; 5 total items, 3 open, 2 done | Memory/evidence freshness, identity, and receipt observability overlap. |
+
+Relevant live backlog items:
+
+| Item | Current state | Design implication |
+| --- | --- | --- |
+| `BI-REFACTOR-CC46703A` | Open, priority 2 | Do not add another finding-shaped model. Trust vector must normalize around existing findings/evidence first. |
+| `BI-B1C0F266` | Open | Principle-vector work is adjacent; graph/data trust should interoperate but not overload WWMD tables. |
+| `BI-MEM-5A41C7` | Open | Freshness rules and effectiveness checks are cross-cutting. |
+| `BI-OBS-4B63F2` | Open | Supervisor-facing receipts and observability are needed for AI trust. |
+| `BI-F499EBBA` | Open | Coworker memory shape contracts are a future consumer of trust metadata. |
+| `BI-5B8FE5C1` | Open under `EP-REDUCTION-GEAR-ARCH` | Workspace primitives should consume trust without each board inventing labels. |
+
+MCP `wiki_query` did not return principle results for the trust-vector search phrases in this session, so local founder-kernel principle files and repo specs were used for grounding.
+
+### 2.2 Existing Substrates
+
+DPF has enough substrate to avoid a parallel trust island:
+
+- WWMD / decision perspective:
+  - The WWMD spec requires unsupported claims to carry less confidence than source-backed facts and uses `PerspectiveMaterial.evidenceGrade`, `freshness`, confidence weighting, and ledgered `DecisionInteraction` records.
+  - `PerspectiveMaterial` already stores `freshness`, `evidenceGrade`, `stalenessPolicy`, `lastValidatedAt`, and `confidenceWeight`.
+  - `DecisionInteraction` already stores evidence bundles, sources, risk tier, confidence before/after, outcome type, and conflict state.
+- Source provenance:
+  - `apps/web/lib/surface-data-provenance.ts` defines `DataSourceProvenance` and `ProvenancedMetric<T>`.
+  - The portal UX data-source plan intentionally put provenance on read models first, not in a new table.
+- Code graph:
+  - `CodeGraphIndexState` stores `indexStatus`, `lastIndexedAt`, branch/head SHA, dirty workspace state, indexed file count, and last error.
+  - `CodeGraphFileHash` stores per-file coverage with source `authority`.
+  - `getCodeGraphFreshness()` and `summarizeCodeGraphCoverage()` already return warnings, but no trust vector or age-based freshness decay.
+  - `CodeIntelligenceStatusCard` displays index state and warnings.
+  - MCP tools `get_code_graph_freshness` and `inspect_build_code_impact` already expose code graph data to coworkers/external clients.
+- Assurance ledger:
+  - `AssuranceRun`, `BomDocument`, `AssuranceFinding`, `ToolExecution`, and `ToolExecutionReceipt` already record scan/BOM/finding facts and receipts.
+  - `BomSummary` returns `state: "missing" | "current" | "stale"`, document metadata, counts, finding summary, and scanner readiness.
+  - `BuildAssuranceGateCard` shows BOM current/stale, findings, generated time, and scanner detail, but "No active findings" is not qualified by scan freshness.
+- Estate / discovery:
+  - `InventoryEntity` and `InventoryRelationship` already carry confidence and first/last seen timestamps.
+  - `PortfolioQualityIssue` already records stale entity/relationship and attribution/quality problems.
+  - `EstateItem` derives identity confidence, version confidence, freshness, and blast radius labels.
+  - Estate MCP tools already explain posture, version confidence, and blast radius, but return labels rather than structured trust metadata.
+- Portfolio health:
+  - `computePortfolioCompleteness()` returns orthogonal scores for required fields, enrichment, open quality issues, and product count.
+  - Existing provenance badges distinguish live, connected, computed, catalog, seed-default, demo-placeholder, and not-connected sources.
+- Graph-backed portfolio/infrastructure view:
+  - `getFullGraphData()` enriches Postgres graph data with Neo4j infrastructure topology, then silently falls back to Postgres-only data if Neo4j fails.
+  - That fallback needs to become visible trust metadata before users rely on missing graph edges as "no dependencies."
+- Reduction Gear:
+  - `GearInterface` is already the canonical observation/decision envelope for interface events while source tables remain authoritative write models.
+  - It is a good audit/calibration stream when a trusted result crosses a workflow/autonomy boundary, not the mandatory storage place for every page read.
+
+### 2.3 Architecture Decision via `principle_decide`
+
+`principle_decide` was run for three options:
+
+1. Extend only `DataSourceProvenance` with one-off page freshness labels.
+2. Create a persisted `TrustAssessment` table immediately and force all surfaces to persist before display.
+3. Create a reusable shared trust-vector contract, scorer, wording rules, UI primitive, and adapters that attach metadata to read models and tool results first; persist through existing evidence ledgers only when those surfaces already write evidence.
+
+The live tool recommended option 3 with high confidence:
+
+| Option | Composite | Result |
+| --- | ---: | --- |
+| `shared-contract-read-model-first` | 6.03 | Recommended |
+| `persist-new-trust-assessment-table` | 4.98 | Not first slice |
+| `extend-provenance-only` | 3.64 | Too narrow |
+
+This spec adopts that recommendation.
+
+## 3. Research & Benchmarking
+
+This is not a generic analytics score. The benchmark pattern is "structured quality/provenance metadata travels with the thing being asserted, while UI shows a compact summary and allows inspection."
+
+### 3.1 Standards and Open-Source Systems
+
+| Reference | Relevant pattern | DPF adoption |
+| --- | --- | --- |
+| [W3C PROV-DM](https://www.w3.org/TR/prov-dm/) | Provenance models entities, activities, agents, responsibility, derivation, and time so consumers can assess quality/reliability/trustworthiness. | Trust evidence references should identify subject, producer/activity, source, timestamps, and lineage without forcing every response into a full PROV graph. |
+| [OpenLineage facets](https://openlineage.io/docs/spec/facets/) | Facets attach atomic metadata to runs, jobs, and datasets. Data-quality facets include metrics like row/file counts and last-updated timestamps; assertion facets preserve individual assertion success. | Treat `trust` as a response facet: structured metadata attached to the result, not detached prose. Preserve dimensions instead of collapsing everything into one score. |
+| [Great Expectations validation results](https://docs.greatexpectations.io/docs/reference/api/core/expectationvalidationresult_class/) and [result formats](https://docs.greatexpectations.io/docs/core/trigger_actions_based_on_results/choose_a_result_format/) | Validation results expose success, result details, metadata, exception info, and configurable verbosity from boolean-only to complete debug output. | UI defaults to compact trust tier + rationale, with expandable details for dimensions and evidence. Coworkers receive structured detail in tool results. |
+| [OpenMetadata data quality](https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/quality) | Data trust is built through freshness, completeness, accuracy tests, alerts, dashboards, and resolution workflow. | DPF dimensions include freshness, coverage/completeness, evidence grade, runtime availability, and conflict/resolution state. |
+
+### 3.2 Commercial Systems
+
+| Reference | Relevant pattern | DPF adoption |
+| --- | --- | --- |
+| [ServiceNow CMDB Health KPIs](https://www.servicenow.com/docs/r/zurich/servicenow-platform/configuration-management-database-cmdb/r_CMDBHealthMetrics.html) and [dashboard](https://www.servicenow.com/docs/r/zurich/servicenow-platform/configuration-management-database-cmdb/c_MonitorCMDBHealth.html) | CMDB health aggregates correctness, completeness, compliance, staleness, duplicate/orphan/relationship health, and drill-down detail. | Estate and graph surfaces should show compact health/trust signals plus drill-down dimensions. Staleness is first-class, not a footnote. |
+| [Microsoft Purview data quality rules](https://learn.microsoft.com/en-us/purview/concepts-data-quality-rules) and [scores](https://learn.microsoft.com/en-us/purview/unified-catalog-data-quality-scores) | Data quality rules include freshness, uniqueness, conformity, consistency, completeness, and sample-size-aware score derivation. | DPF trust scoring should account for sample size/coverage and should avoid presenting a tiny sample as high-confidence global truth. |
+| [Collibra data quality scores](https://productresources.collibra.com/docs/collibra/latest/Content/UnifiedDataQuality/co_about-data-quality-scores.htm) and [asset quality views](https://productresources.collibra.com/docs/collibra/latest/Content/Settings/OperatingModel/QualityScoreAggregations/co_asset-data-quality.htm) | Quality scores can be calculated through knowledge-graph traversal and aggregation paths; UI separates internal and external quality sources and shows dimension rings/history. | DPF graph traversal depth/aggregation path must influence trust. External provider/tool scores should remain source-separated rather than mixed into a single unqualified platform score. |
+
+## 4. Design Goals
+
+- Model trust as a vector of dimensions, not a single page-specific score.
+- Preserve dimensional reasons so UI and coworkers can explain trust without raw math.
+- Attach trust metadata to data responses, read models, and tool outputs.
+- Reuse existing provenance/evidence/assurance/graph/WWMD/GearInterface substrate.
+- Keep first-slice implementation small enough to prove value in current user-visible surfaces.
+- Make stale/low-confidence results visible without turning every card into a dashboard.
+- Use DPF theme tokens only.
+- Distinguish:
+  - current fact
+  - last-known fact
+  - inferred result
+  - low-confidence result
+- Reserve at least 20% implementation capacity for refactoring existing evidence seams rather than adding new wrappers everywhere.
+
+## 5. Non-Goals
+
+- No new canonical trust table in the first slice.
+- No ML/LLM trust classifier in v1.
+- No attempt to convert every DPF response to PROV, OpenLineage, or Great Expectations format.
+- No full estate/portfolio/compliance migration in the first slice.
+- No raw numeric trust score as the primary UI. Numeric score may exist in structured metadata and audit payloads.
+- No page-specific "trust math" hidden in React components.
+
+## 6. Trust Vector Contract
+
+Trust travels with the response as a structured property:
+
+```ts
+export type TrustStatementKind =
+  | "current-fact"
+  | "last-known-fact"
+  | "inferred-result"
+  | "low-confidence-result";
+
+export type TrustTier = "high" | "medium" | "low" | "unknown";
+
+export type TrustAction =
+  | "present"
+  | "qualify"
+  | "warn-stale"
+  | "refresh-required"
+  | "escalate"
+  | "defer";
+
+export type TrustDimensionKey =
+  | "freshness"
+  | "sourceAuthority"
+  | "evidenceGrade"
+  | "coverageCompleteness"
+  | "toolRecency"
+  | "toolReliability"
+  | "graphTraversalDepth"
+  | "dataLineage"
+  | "humanValidation"
+  | "conflictContradiction"
+  | "runtimeAvailability"
+  | "sampleSize"
+  | "riskImpact";
+
+export type TrustDimension = {
+  key: TrustDimensionKey;
+  label: string;
+  score: number | null; // 0..1 when applicable; null means not applicable.
+  tier: TrustTier;
+  weight: number;
+  rationale: string;
+  measuredAt?: string;
+  expiresAt?: string;
+  evidenceRefs: TrustEvidenceRef[];
+};
+
+export type TrustEvidenceRef = {
+  kind:
+    | "prisma-row"
+    | "neo4j-node"
+    | "neo4j-relationship"
+    | "tool-execution"
+    | "assurance-run"
+    | "bom-document"
+    | "assurance-finding"
+    | "wiki-page"
+    | "decision-interaction"
+    | "gear-interface"
+    | "external-provider";
+  label: string;
+  ref: string;
+  sourceTable?: string;
+  sourceRoute?: string;
+};
+
+export type TrustAssessment = {
+  kind: "data-trust-vector";
+  schemaVersion: 1;
+  subject: {
+    type: string;
+    id: string;
+    label: string;
+  };
+  statementKind: TrustStatementKind;
+  tier: TrustTier;
+  overallScore: number | null;
+  action: TrustAction;
+  asOf: string;
+  summary: string;
+  primaryRationale: string;
+  dimensions: TrustDimension[];
+  sourceSummary: string;
+  auditRef?: TrustEvidenceRef;
+};
+```
+
+`DataSourceProvenance` should gain an optional `trust?: TrustAssessment` when a metric has structured trust. Existing components can still show source-only provenance while new trust-aware surfaces render richer detail.
+
+## 7. Dimension Semantics
+
+| Dimension | Measures | Examples |
+| --- | --- | --- |
+| `freshness` | Age of the underlying data vs the surface's freshness policy. | Scan completed 45 days ago; graph indexed 2 hours ago. |
+| `sourceAuthority` | Whether the source is canonical for this claim. | `AssuranceFinding` for vulnerability state; `CodeGraphIndexState` for graph freshness; provider API for connected-account data. |
+| `evidenceGrade` | Evidence strength using WWMD-compatible A/B/C/D semantics. | Scan receipt = A; inferred label from raw package string = C; contradicted claim = D. |
+| `coverageCompleteness` | Whether the result covers the whole subject. | Code graph covers 6/8 changed files; BOM has 312 components; portfolio score has only 2 products. |
+| `toolRecency` | Whether the tool producing the answer ran recently enough. | Latest scanner run was 45 days ago. |
+| `toolReliability` | Whether the producing tool is approved, healthy, and error-free. | Scanner approved; last code graph run failed; external provider degraded. |
+| `graphTraversalDepth` | How indirect the graph inference is. | Direct edge has high trust; 4-hop dependency inference has lower trust unless backed by evidence. |
+| `dataLineage` | Whether the path from source to answer is known. | BOM source digest, file hash authority, provider run id, derivation path. |
+| `humanValidation` | Whether a human accepted, corrected, or reviewed the fact. | HITL acceptance, triage decision, compliance approval. |
+| `conflictContradiction` | Whether sources disagree. | Inventory says active, discovery marks stale; findings contradict "clean" summary. |
+| `runtimeAvailability` | Whether dependencies needed to answer were available. | Neo4j unavailable, so graph view is Postgres-only. |
+| `sampleSize` | Whether the denominator is meaningful. | Portfolio health from 1 product vs 200 products. |
+| `riskImpact` | How much trust is required before presenting the result as current. | Compliance/security claims need higher thresholds than decorative summary counts. |
+
+Not every surface needs every dimension. The scorer excludes `null` dimensions from the denominator but includes "unknown" dimensions when the missing dimension itself should reduce trust.
+
+## 8. Score Derivation
+
+The shared scorer produces:
+
+- per-dimension tier and rationale
+- weighted overall score
+- statement kind
+- action
+- user/coworker wording
+
+Baseline tiers:
+
+| Overall score | Tier | Default action |
+| ---: | --- | --- |
+| `>= 0.80` | `high` | `present` |
+| `>= 0.60` and `< 0.80` | `medium` | `qualify` |
+| `< 0.60` | `low` | `warn-stale`, `refresh-required`, `escalate`, or `defer` depending on dimension caps |
+| `null` | `unknown` | `defer` or `refresh-required` |
+
+Hard caps:
+
+- `conflictContradiction` low caps overall tier at `low` and action at `escalate` or `defer`.
+- `runtimeAvailability` low caps overall tier at `low` for graph/data claims that require that runtime.
+- `freshness` low caps current-fact claims at `last-known-fact`; high-risk claims become `refresh-required`.
+- `evidenceGrade` D or contradicted zeroes the contributing evidence and prevents `present`.
+- `riskImpact` high does not lower truth by itself, but it raises the minimum tier required for `present`.
+- `coverageCompleteness` low prevents broad universal claims; the surface must qualify the scope.
+
+Freshness policies are per surface and explicit. Initial defaults:
+
+| Surface | Current | Watch | Low |
+| --- | ---: | ---: | ---: |
+| Assurance scan / critical finding claim | 0-7 days | 8-30 days | >30 days |
+| BOM component inventory | 0-14 days | 15-45 days | >45 days |
+| Code graph index for active build impact | Same commit/head when known, or 0-24 hours | 1-7 days | >7 days or dirty/missing index |
+| Estate discovery evidence | 0-7 days | 8-30 days | >30 days |
+| Portfolio completeness scores | Live DB read with current quality issues | Missing denominator or partial product scope | stale source/import or no denominator |
+
+The 45-day scan example therefore becomes low freshness, last-known fact, and usually `refresh-required` for security/compliance wording.
+
+## 9. Wording Rules
+
+Trust wording is generated centrally so UI and coworkers do not drift.
+
+| Statement kind | Allowed wording pattern |
+| --- | --- |
+| `current-fact` | "No active critical findings are present in the current scan." |
+| `last-known-fact` | "No active critical findings were present in the latest scan, but scan freshness is low because it completed 45 days ago." |
+| `inferred-result` | "This dependency appears impacted based on a 2-hop graph traversal; direct ownership evidence is not available." |
+| `low-confidence-result` | "This result is low confidence because Neo4j was unavailable and the view fell back to Postgres-only relationships." |
+
+UI rules:
+
+- Show a compact `TrustBadge` near the result title or metric, not a separate trust dashboard.
+- Show one short rationale inline.
+- Use an expandable detail panel for dimensions and evidence refs.
+- Do not require users to interpret raw math.
+- Use DPF theme tokens only.
+- Do not hide stale/not-connected warnings behind hover-only UI.
+
+Coworker/tool rules:
+
+- Tool responses include `data.trust`.
+- The top-level `message` must qualify stale/low-confidence claims.
+- If action is `refresh-required`, the coworker should recommend or invoke the governed refresh path if it has the grant.
+- If action is `escalate` or `defer`, the coworker must not present the data as decisive.
+
+## 10. First Slice
+
+The smallest useful implementation should prove trust calculation, score derivation, stale wording, UI display, coworker behavior, tests, and evidence/audit handling in current surfaces.
+
+### 10.1 Slice A: Build Studio Code Intelligence
+
+Affected current surfaces:
+
+- `apps/web/lib/integrate/code-graph-access.ts`
+- `apps/web/lib/integrate/change-impact.ts`
+- `apps/web/components/build/CodeIntelligenceStatusCard.tsx`
+- `apps/web/lib/mcp-tools.ts` handlers for `get_code_graph_freshness` and `inspect_build_code_impact`
+- tests under `apps/web/lib/integrate/*code-graph*`, `apps/web/components/build/CodeIntelligenceStatusCard.test.tsx`, and `apps/web/lib/mcp-tools-code-graph.test.ts`
+
+Trust dimensions:
+
+- `freshness`: `CodeGraphIndexState.lastIndexedAt`, dirty flag, and head SHA when comparable.
+- `runtimeAvailability`: `available`, `indexStatus`, `lastError`, Neo4j query health.
+- `coverageCompleteness`: changed files covered by `CodeGraphFileHash`.
+- `sourceAuthority`: `CodeGraphFileHash.authority` and graph key.
+- `graphTraversalDepth`: direct graph freshness is depth 0; future impact traces include hop count.
+- `toolReliability`: last error / structural relationship health.
+
+Behavior:
+
+- `getCodeGraphFreshness()` returns `trust`.
+- `summarizeCodeGraphCoverage()` returns coverage trust.
+- `CodeIntelligenceStatusCard` renders `TrustBadge` and stale/dirty warning.
+- `inspect_build_code_impact` includes trust metadata and qualified message.
+- Existing warnings remain but are generated from trust dimensions where possible.
+
+### 10.2 Slice B: Build Assurance Gate
+
+Affected current surfaces:
+
+- `apps/web/lib/assurance/bom-read.ts`
+- `apps/web/components/build/BuildAssuranceGateCard.tsx`
+- `apps/web/lib/assurance/finding-read.ts` if scan recency must be selected directly
+- existing assurance tests under `apps/web/lib/assurance/*` and `apps/web/components/build/BuildAssuranceGateCard.test.tsx`
+
+Trust dimensions:
+
+- `freshness`: latest `BomDocument.generatedAt` and latest relevant `AssuranceRun.completedAt`.
+- `sourceAuthority`: `AssuranceRun`, `AssuranceFinding`, `BomDocument`.
+- `evidenceGrade`: scanner run receipt and persisted finding evidence.
+- `coverageCompleteness`: BOM component count and selected scope.
+- `toolRecency`: latest scan age.
+- `toolReliability`: scanner approval/readiness.
+- `runtimeAvailability`: scanner readiness and queue/worker availability if known.
+- `riskImpact`: security/compliance finding claims require current scan to present as current fact.
+
+Behavior:
+
+- `BomSummary` gains optional `trust`.
+- `BuildAssuranceGateCard` shows compact trust badge and one concise rationale.
+- Empty findings text becomes freshness-aware:
+  - Current: "No active findings."
+  - Stale: "No active findings in the latest scan. Scan freshness is low because the latest scan completed 45 days ago."
+- The Run scan action remains the primary refresh affordance.
+
+### 10.3 Deferred Surfaces
+
+The first slice should not touch these unless implementation discovers a shared helper must be broadened:
+
+- Estate discovery item cards and MCP tools: adopt after Build Studio proves the contract.
+- Portfolio completeness/health: adopt after `ProvenancedMetric` can carry `trust`.
+- Graph-backed infrastructure view: adopt once the Neo4j fallback can return structured availability metadata rather than a silent catch.
+- Wiki retrieval / WWMD: consume trust vector output later; do not merge data-response trust into `PerspectiveMaterial`.
+
+## 11. Persistence and Audit
+
+First slice persistence rule:
+
+- Trust metadata travels in read models and tool results.
+- MCP/tool calls already persist `ToolExecution.result`, so trust metadata is audit-visible there when a coworker/tool invokes it.
+- Assurance scan/BOM jobs continue to persist facts in `AssuranceRun`, `BomDocument`, `AssuranceFinding`, and `ToolExecutionReceipt`.
+- GearInterface receives trust-related observations only when the result crosses an autonomy/workflow boundary already covered by Reduction Gear emission.
+- No new `TrustAssessment` table until at least two user-visible surfaces prove read-model metadata is insufficient.
+
+Future persisted projection trigger:
+
+Add a projection table only if operators need to query historical trust assessments independently of source executions, or if multiple surfaces need to compare trust trends over time without re-reading source ledgers.
+
+## 12. UI Pattern
+
+New UI primitive:
+
+```tsx
+<TrustBadge
+  trust={assessment}
+  compact
+  disclosureLabel="Trust details"
+/>
+```
+
+Rendering:
+
+- high: compact badge with "High trust" and success token.
+- medium: compact badge with "Medium trust" and accent/warning token depending on action.
+- low: compact badge with "Low trust" and warning/error token.
+- unknown: compact badge with "Trust unknown" and muted/warning token.
+
+Detail disclosure:
+
+- primary rationale
+- source summary
+- dimensions as rows with tier label and rationale
+- evidence references as concise links/labels when available
+
+Accessibility:
+
+- Badge has descriptive `aria-label`.
+- Details can be expanded with keyboard.
+- Warnings use visible text, not color alone.
+
+## 13. Coworker Response Contract
+
+Any MCP/coworker tool returning data-centric assertions should eventually conform:
+
+```json
+{
+  "success": true,
+  "message": "No active findings in the latest scan, but scan freshness is low because the latest scan completed 45 days ago.",
+  "data": {
+    "result": {
+      "activeCriticalFindings": 0
+    },
+    "trust": {
+      "kind": "data-trust-vector",
+      "schemaVersion": 1,
+      "statementKind": "last-known-fact",
+      "tier": "low",
+      "action": "refresh-required",
+      "summary": "Low trust",
+      "primaryRationale": "Latest scan completed 45 days ago; current policy requires security finding claims to be refreshed after 30 days."
+    }
+  }
+}
+```
+
+The top-level `message` cannot contradict `data.trust`. Low trust means the coworker qualifies or refreshes; it does not make an unqualified claim.
+
+## 14. Refactoring Allocation
+
+At least 20% of first-slice implementation time should remove fragmentation:
+
+- Extract shared trust-vector types, scoring, and wording under `apps/web/lib/trust-vector/`.
+- Avoid duplicating stale wording in `CodeIntelligenceStatusCard`, `BuildAssuranceGateCard`, and MCP handlers.
+- Extend `DataSourceProvenance` instead of inventing a competing provenance type.
+- Keep component styling token-based and reuse `DataSourceBadge` design language where possible.
+- Keep source tables authoritative; adapters convert source facts into trust dimensions.
+
+## 15. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Trust becomes another generic score that hides reasons. | Preserve dimensions, rationale, evidence refs, and statement kind. UI hides raw math but not reasons. |
+| Surfaces hand-roll trust differently. | Shared scorer/wording helpers and tests are required in the first slice. |
+| Trust metadata becomes stale itself. | Every assessment has `asOf`; dimensions can have `measuredAt`/`expiresAt`. |
+| A new table duplicates existing ledgers. | First slice is read-model/tool-result metadata only; persistence uses existing ledgers. |
+| Low-confidence UI becomes noisy. | Compact badge + one rationale + expandable details. |
+| Coworker messages ignore structured trust. | MCP handler tests assert stale/low-confidence wording in `message` and `data.trust`. |
+| Graph fallback hides partial truth. | Runtime availability dimension marks Postgres-only fallback as low/partial. |
+
+## 16. Open Questions
+
+1. Should code graph freshness compare `lastIndexedHeadSha` to the active build's diff head when available, or is age/dirty state enough for v1?
+2. Should `BomSummary` select latest `AssuranceRun.completedAt` separately from BOM generation time so "scan freshness" is distinct from "BOM freshness"?
+3. Should `TrustAssessment.overallScore` be stored in `ToolExecution.summary` for search/filtering, or only in JSON result for v1?
+4. How should trust vector dimensions map into Reduction Gear's `torqueConfidence` once Ring 1 to Ring 2 telemetry is broad enough?
+
+## 17. Acceptance Criteria
+
+The first implementation slice is complete when:
+
+- Shared trust-vector types, scoring, and wording helpers exist with unit tests.
+- Code graph freshness and coverage responses include `trust`.
+- Build Studio code intelligence UI shows trust tier and stale/dirty rationale.
+- Assurance Gate UI qualifies stale "no active findings" states.
+- MCP/coworker code graph messages include stale/low-confidence wording and structured `data.trust`.
+- Tests cover the 45-day stale scan example or equivalent assurance freshness case.
+- UI uses theme tokens only.
+- No new trust table or migration is added.
+- The implementation plan's verification commands pass, or pre-existing failures are documented.


### PR DESCRIPTION
## Summary

Adds a reusable trust-vector substrate for graph and data-centric responses, then applies the first slice to Build Studio code intelligence and assurance evidence.

## What changed

- Added `apps/web/lib/trust-vector/*` for dimensional trust scoring, tiers, actions, and wording.
- Attached trust metadata to code graph freshness/coverage and assurance BOM summaries.
- Added a compact `TrustBadge` UI component.
- Surfaced trust badges and concise rationale in Build Studio code intelligence and assurance cards.
- Updated code graph MCP/change-impact wording so stale or low-trust results are not presented as fully current.
- Added the repo-grounded design spec and implementation plan under `docs/superpowers/`.

## Verification

After rebasing onto current `origin/main` (`89104cf66fff4c207a85f90ff8dad8697554cf10`), local head is `c727ffa97ea7c7ef06199326298cb1e93aa756c7`.

- `pnpm --filter web exec vitest run lib/trust-vector/score.test.ts lib/trust-vector/wording.test.ts lib/trust-vector/adapters/code-graph.test.ts lib/trust-vector/adapters/assurance.test.ts lib/integrate/code-graph-access.test.ts lib/integrate/change-impact.test.ts lib/mcp-tools-code-graph.test.ts components/ui/TrustBadge.test.tsx components/build/CodeIntelligenceStatusCard.test.tsx components/build/BuildAssuranceGateCard.test.tsx lib/assurance/bom-read.test.ts lib/actions/assurance.test.ts lib/surface-data-provenance.test.ts`
  - 13 files, 60 tests passed.
- `pnpm --filter web typecheck`
  - Passed.
- `cd apps/web; pnpm exec next build`
  - Passed.
  - Existing Edge Runtime warnings remain around platform version/discovery/Prisma imports.
- `git merge-base --is-ancestor origin/main HEAD`
  - Passed; current `origin/main` is an ancestor of PR head `c727ffa9`.

## Governed local verification lane

Verified on the registered Contributor preview lane, not a rogue portal:

- Runtime target: `RT-DEV-PORTAL`
- URL: `http://localhost:3001/build?buildId=FB-77DED2A4`
- Compose service/container: `dpf` / `dev-portal` / `dpf-dev-portal-1`
- Served branch/head: `doc/trust-vector-data-responses` / `c727ffa97ea7c7ef06199326298cb1e93aa756c7`
- DPF verification event: `VR-TRUST-VECTOR-3001-C727FFA9-20260527-0136`
- Local screenshot evidence: `C:\Users\Mark Bodman\.codex\artifacts\trust-vector-build-studio-3001-rebased-expanded.png`

Visual check on `/build` -> `Code intel & assurance` confirmed:

- Code intelligence shows `Low trust` with the rationale `Uncommitted local changes may not be reflected in graph-backed analysis.`
- Assurance Gate shows `Low trust` with the rationale `No assurance scan has completed for this scope.`
- The page distinguishes current scan state from last-known or missing evidence; it does not present missing/stale assurance as a fully current no-finding result.
- Browser console logs for the checked tab had no errors or warnings.

Lane notes:

- `3000` remains the root portal lane and was not overwritten.
- `3035` remains the Build Studio sandbox lane and was not overwritten.
- No `3016` or `15432` listener was started for this PR.
