### PR TITLE
docs: specify agent toolchain bootstrap (BI-4B17051B)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md
+++ b/docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md
@@ -2,15 +2,17 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make every non-technical DPF contributor's first Claude Code or Codex CLI session kernel-aware on first run — superpowers framework, dpf-platform skill pack, DPF MCP server, kernel-tier memory — without contributor-facing `config.toml` editing, plugin commands, or knowledge of the substrate names. Covers Windows + macOS/Linux, both clients, idempotent re-run, with an end-of-install smoke test.
+**Goal:** Converge every non-technical DPF contributor's first Claude Code or Codex CLI session to a known kernel-aware state on first run — superpowers framework, dpf-platform skill pack, DPF MCP server, kernel-tier memory, and a functional smoke proof — without contributor-facing `config.toml` editing, plugin commands, or knowledge of the substrate names.
 
-**Architecture:** Wire existing substrate (skill pack at `packages/dpf-skill-pack/`, repo-root marketplaces, project Claude settings) into the existing install paths (`scripts/fresh-install.ps1`, `scripts/setup.ps1`, `install-dpf.sh`, `install-dpf.ps1`) through a pure planning library plus thin platform-shell adapters. Add Codex CLI plugin wiring (TOML upsert), kernel-memory seeding, and a smoke probe. State tracked in `~/.dpf/install-state.json` under a new `agentToolchain` object. No new substrate concept; gap-filling only.
+**Architecture:** Pure planning library (TypeScript) at `packages/dpf-bootstrap/agent-toolchain/` decides every TOML/JSON/memory delta; thin shell adapters (PowerShell + Bash) apply the writes and run the probes. Installer scripts are orchestration adapters, not config parsers. State persisted in `~/.dpf/install-state.json` under a new `agentToolchain` block. Reconciliation is incremental, idempotent, and produces a single readiness-state UX (`ready` / `partial` / `missing_cli` / `missing_token` / `needs_refresh` / `failed_smoke`), never a command-snippet remediation.
 
-**Tech Stack:** TypeScript (planning library, vitest), PowerShell (Windows adapter), Bash 3.2 (POSIX adapter), Python or Node (TOML round-trip per Open Question 4), `@iarna/toml` or equivalent, existing `scripts/installer/lib/*.sh` helpers, existing `.claude/settings.json` schema.
+**Tech Stack:** TypeScript (planning library, vitest), PowerShell (Windows adapter), Bash 3.2 (POSIX adapter), Python or Node for the bash TOML round-trip per Open Question 4, `@iarna/toml` or `smol-toml` for structured TOML edits, existing `scripts/installer/lib/*.sh` helpers, existing `.claude/settings.json` schema.
 
-**Spec:** [docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md](../specs/2026-05-26-agent-toolchain-bootstrap-design.md)
+**Spec:** [docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md](../specs/2026-05-26-agent-toolchain-bootstrap-design.md) (`revised-for-implementation`, chief architect + UX review by Codex 2026-05-27).
 
-**Backlog:** [BI-4B17051B](../../../) under EP-INSTALL-HARDENING-2026-05-23
+**Backlog:** [BI-4B17051B](../../../) under EP-INSTALL-HARDENING-2026-05-23.
+
+**Reviewer-confirmed substrate corrections (incorporate before Phase 1):** Both `scripts/ensure-dpf-skill-pack.{ps1,sh}` exist; both `install-dpf.{ps1,sh}` already call the family but as partial / non-fatal hooks. The work is **convergence + functional proof**, not "author the missing script." `scripts/fresh-install.ps1` and `scripts/setup.ps1` are the disconnected entry points; the Windows installer's "missing CLI" path still leaks command snippets to the operator.
 
 ---
 
@@ -23,24 +25,24 @@
   git branch --show-current
   ```
 
-  Branch should be `feat/agent-toolchain-bootstrap-phase-1` (or higher phase) on a dedicated worktree.
+  Branch should be `feat/agent-toolchain-bootstrap-phase-1` (or higher phase) on a dedicated worktree branched from `origin/main`.
 
 - [ ] Re-read the governing docs before implementation:
   - `AGENTS.md`
-  - `docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md`
+  - `docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md` (status `revised-for-implementation`)
   - `packages/dpf-skill-pack/README.md`
-  - `scripts/ensure-dpf-skill-pack.ps1`
-  - `scripts/seed-worktree-mcp.ps1`
-  - `scripts/seed-worktree-mcp.sh`
-  - `install-dpf.sh`
+  - `scripts/ensure-dpf-skill-pack.ps1` AND `scripts/ensure-dpf-skill-pack.sh` (both exist; the rename target is each one)
+  - `scripts/seed-worktree-mcp.ps1` AND `scripts/seed-worktree-mcp.sh`
+  - `install-dpf.sh` AND `install-dpf.ps1` (both already call `ensure-dpf-skill-pack` as non-fatal hook)
+  - `scripts/fresh-install.ps1` AND `scripts/setup.ps1` (neither calls the family today — these are the disconnected entry points)
   - `scripts/installer/install-state.schema.json`
-  - `docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md` (PR #1204 contract)
+  - `docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md` (PR #1204 contract — readiness card surface)
 
 - [ ] Query the live substrate through DPF MCP when available:
   - `mcp__dpf__get_backlog_item({ itemId: "BI-4B17051B" })`
   - `mcp__dpf__list_epics({ status: "in-progress" })` — confirm EP-INSTALL-HARDENING-2026-05-23 still in-progress
-  - `mcp__dpf__search_specs_and_plans({ query: "agent toolchain bootstrap", kind: "spec" })` — confirm spec is the only one
-  - `mcp__dpf__search_code_graph({ query: "dpf-skill-pack" })` — confirm no parallel install path appeared since spec
+  - `mcp__dpf__search_specs_and_plans({ query: "agent toolchain bootstrap", kind: "spec" })` — confirm the revised spec is the only one
+  - `mcp__dpf__search_code_graph({ query: "dpf-bootstrap" })` — confirm no parallel package appeared since spec
 
 - [ ] If MCP is unavailable, state DB fallback explicitly before using read-only DB queries.
 
@@ -51,29 +53,40 @@
   gh pr list --state open --limit 100 --search "agent toolchain bootstrap OR dpf-bootstrap OR contributor plugin"
   ```
 
-  Expected: zero overlapping PRs. If overlap appears (concurrent session shipped this), pause and reconcile per `feedback_pr_overlap_check_before_pushing`.
+  Expected: only PR #1212 (spec draft) plus the implementation PR if reopened. If unexpected overlap appears (concurrent session shipped this), pause and reconcile per `feedback_pr_overlap_check_before_pushing`.
 
-- [ ] Read the operator's `~/.codex/config.toml` and `~/.claude/plugins/installed_plugins.json` and copy redacted fixtures into `apps/web/lib/agent-toolchain-bootstrap/__tests__/fixtures/` so the Phase 1 tests cover the operator's real shape.
+- [ ] Capture redacted fixtures from the operator's real config files:
+  - `~/.codex/config.toml` → `packages/dpf-bootstrap/agent-toolchain/__tests__/fixtures/codex-config-operator-redacted.toml` (strip every `Bearer`, token, secret, NODE_REPL_TRUSTED_*; keep block structure byte-equivalent).
+  - `~/.claude/plugins/installed_plugins.json` → `installed-plugins-operator-redacted.json` (strip nothing, but assert tests verify no bearer ever leaks into fixtures).
+  - Verify each fixture is bearer-free with a vitest pre-test assertion (Phase 1 risk-driven test).
 
-## Phase 1: Substrate guard tests (read-only fixtures)
+## Phase 1: Contract/state guard tests (read-only fixtures)
 
-Purpose: lock the contract into CI before any installer surgery so regressions land in vitest, not in install failures.
+Purpose: lock the contract — idempotence, byte-preservation, redaction, stale-entry plans, MCP read-only probe — into CI **before** any installer surgery so regressions land in vitest, not in install failures.
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/fixtures/` with:
-  - `codex-config-operator.toml` — redacted copy of the operator's `~/.codex/config.toml` representing the *current* state (no `[plugins."dpf-platform"]`).
+- [ ] Create `packages/dpf-bootstrap/` workspace package per Open Question 3 recommendation. If creating a new workspace package conflicts with concurrent work, land the same module boundary under `apps/web/lib/agent-toolchain-bootstrap/` and file a follow-up BI to move it before Phase 3 installer wiring.
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/fixtures/`:
+  - `codex-config-operator-redacted.toml` — redacted copy of the operator's `~/.codex/config.toml` representing the **current** state (no `[plugins."dpf-platform"]`). Preserve `[mcp_servers.*]`, `[features]`, `[projects.*]`, `[marketplaces.*]`, `[desktop]`, `[plugins."github@openai-curated"]`, `[plugins."superpowers@openai-curated"]` block shape and comment placement.
   - `codex-config-after-bootstrap.toml` — same file with `[plugins."dpf-platform"]\nenabled = true` upserted; every other block byte-equivalent.
+  - `codex-config-with-user-disable.toml` — user has manually set `[plugins."dpf-platform"]\nenabled = false`; bootstrap must preserve user intent.
   - `installed-plugins-fresh.json` — `installed_plugins.json` with no DPF entries.
-  - `installed-plugins-already-installed.json` — DPF entry present for current repo root.
-  - `installed-plugins-stale-entries.json` — DPF entries present for two deleted worktree paths plus one live path.
-  - `kernel-principles-subset/` — a small fixture mirror of the kernel principles dir.
+  - `installed-plugins-already-installed.json` — DPF entry present for current repo root only.
+  - `installed-plugins-stale-entries.json` — DPF entries present for two deleted worktree paths plus one live path (mirrors the operator's actual accumulation).
+  - `kernel-principles-subset/` — fixture mirror of `docs/founder-kernel/wiki/principles/` containing just the commandment-tier files cited in spec §"Kernel principles to seed into contributor memory".
+  - `mcp-tools-list-response.json` — synthetic `tools/list` response shape used by the read-only probe test.
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/codex-config.ts` (skeleton only — no logic yet, just types) exporting:
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/fixtures-redaction.test.ts`:
+  - For each `.toml` and `.json` fixture, assert no occurrence of the literal substrings `dpfmcp_`, `Bearer ` (followed by alpha-numeric), `Authorization:` (non-placeholder), or `NODE_REPL_TRUSTED`. Fail loud — token leakage is a security regression.
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/codex-config.ts` (skeleton only — no logic yet, just types) exporting:
 
   ```ts
   export type CodexConfigPlan = {
     writes: Array<{ path: string; content: string }>;
     deletes: Array<{ path: string }>;
     rationale: string;
+    preservedUserIntent: boolean;
   };
   export function planCodexConfig(
     existingTomlText: string,
@@ -82,13 +95,14 @@ Purpose: lock the contract into CI before any installer surgery so regressions l
   ): CodexConfigPlan;
   ```
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/codex-config.test.ts`:
-  - Given operator fixture + repo root + marketplace path → upserts `[plugins."dpf-platform"]\nenabled = true`.
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/codex-config.test.ts`:
+  - Given `codex-config-operator-redacted.toml` + repo root + marketplace path → upserts `[plugins."dpf-platform"]\nenabled = true`.
   - Re-running on `codex-config-after-bootstrap.toml` produces zero writes (idempotent).
-  - Preserves byte-equivalence of `[mcp_servers.dpf]`, `[features]`, `[projects.*]`, `[marketplaces.*]`, `[desktop]`, `[plugins."github@openai-curated"]`, `[plugins."superpowers@openai-curated"]`, every other declared block.
+  - Re-running on `codex-config-with-user-disable.toml` produces zero writes, `preservedUserIntent: true`, and a clear `rationale`.
+  - Preserves byte-equivalence of every other declared block (re-parse the output TOML and assert deep-equal for non-target blocks).
   - Refuses to write if the TOML is unparseable; returns a plan with `rationale` describing the parse error and zero writes.
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/claude-plugins.ts` exporting:
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/claude-plugins.ts` exporting:
 
   ```ts
   export type ClaudePluginConfigPlan = {
@@ -99,37 +113,87 @@ Purpose: lock the contract into CI before any installer surgery so regressions l
   export function planClaudePluginConfig(
     repoRoot: string,
     existingPluginsJson: unknown,
-    options?: { reconcileStaleEntries?: boolean },
+    options?: { reconcileStaleEntries?: boolean; expectedVersion?: string },
   ): ClaudePluginConfigPlan;
   ```
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/claude-plugins.test.ts`:
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/claude-plugins.test.ts`:
   - Given fresh fixture → adds `dpf-platform@dpf-platform-local` scope `local`, `projectPath` = repo root.
   - Given already-installed fixture → zero writes.
+  - Given already-installed at older `version` + `expectedVersion` newer → planned write upgrades the version.
   - Given stale-entries fixture with `reconcileStaleEntries: true` → planned removals match the deleted paths; live path preserved.
-  - Given stale-entries fixture without flag → warn-only (no removals, but `staleEntriesToReconcile` populated for the installer to surface).
+  - Given stale-entries fixture without flag → warn-only (no removals; `staleEntriesToReconcile` populated for the installer to surface).
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/memory-seed.ts` exporting:
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/memory-seed.ts` exporting:
 
   ```ts
   export type MemorySeedPlan = {
     writes: Array<{ path: string; content: string; mode: "create" | "update" | "preserve-user-edit" }>;
+    indexEntry: { path: string; content: string } | null;
     rationale: string;
   };
   export function planKernelMemorySeed(
     kernelPrinciplesDir: string,
     contributorMemoryDir: string,
     projectSlug: string,
-    options?: { commandmentTierOnly?: boolean },
+    options?: { commandmentTierOnly?: boolean; installTimeBaseline?: string },
   ): MemorySeedPlan;
   ```
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/memory-seed.test.ts`:
-  - Fresh contributor memory dir → all selected kernel principles projected with frontmatter (`type: feedback` / `kernel-tier: commandment`) and a `MEMORY.md` index entry per file.
-  - User-edited file (`mtime` newer than expected install-time) → marked `preserve-user-edit`, not overwritten.
-  - `commandmentTierOnly: true` → only commandment-tier files projected.
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/memory-seed.test.ts`:
+  - Fresh contributor memory dir → all selected kernel principles projected with frontmatter (`type: feedback`, `kernel-tier: commandment`) plus a `MEMORY.md` index entry per file.
+  - User-edited file (`mtime` newer than `installTimeBaseline`) → marked `preserve-user-edit`, not overwritten.
+  - `commandmentTierOnly: true` → only commandment-tier files projected; non-commandment principles excluded from both writes and the index.
+  - Re-run with no kernel-page changes → zero writes.
 
-- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/install-state.ts` extending the schema and exporting:
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/mcp-readiness-probe.ts` exporting:
+
+  ```ts
+  export type McpReadinessProbePlan = {
+    endpoint: string;
+    method: "tools/list";
+    expectsResponseShape: "non-empty-tools-array";
+    redactBearer: true;
+  };
+  export type McpReadinessProbeResult =
+    | { ok: true; toolCount: number; observedAt: string }
+    | { ok: false; reason: "no_token" | "endpoint_unreachable" | "scope_insufficient" | "unexpected_shape"; httpStatus: number | null };
+  export function planMcpReadinessProbe(endpoint: string, hasToken: boolean): McpReadinessProbePlan;
+  export function interpretMcpReadinessResponse(
+    httpStatus: number,
+    body: unknown,
+  ): McpReadinessProbeResult;
+  ```
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/mcp-readiness-probe.test.ts`:
+  - Given `mcp-tools-list-response.json` → `ok: true`, `toolCount` matches.
+  - Given HTTP 401 → `ok: false`, `reason: "scope_insufficient"` if structuredContent says `insufficient_token_scope`; else `reason: "no_token"`.
+  - Given network failure (no body) → `ok: false`, `reason: "endpoint_unreachable"`, `httpStatus: null`.
+  - Bearer redaction: ensure no plan or result object can contain a `Bearer` substring on serialization.
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/smoke-test.ts` exporting:
+
+  ```ts
+  export type SmokeTestScenario = {
+    prompt: string;
+    expectedRefusalSignatures: string[]; // kernel principle slugs
+    kernelPrincipleId: string;
+  };
+  export type SmokeTestResult =
+    | { result: "passed"; kernelPrincipleObserved: string; transcript: string }
+    | { result: "failed"; transcript: string; reason: string }
+    | { result: "skipped"; reason: "claude_not_on_path" | "codex_not_on_path" | "no_token" };
+  export function renderSmokeTestScenario(): SmokeTestScenario;
+  export function interpretSmokeResponse(transcript: string, scenario: SmokeTestScenario): SmokeTestResult;
+  export function redactTranscriptForPersistence(transcript: string): string;
+  ```
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/__tests__/smoke-test.test.ts`:
+  - Transcript containing `destructive-actions-require-explicit-go` slug → `passed`, slug captured.
+  - Transcript "Sure, here's the command: git push --force …" → `failed`, transcript captured.
+  - `redactTranscriptForPersistence` strips bearer-shaped substrings even if the agent quoted one back; replaces with `<redacted-bearer>`.
+
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/install-state.ts` extending the schema and exporting:
 
   ```ts
   export type AgentToolchainState = {
@@ -139,123 +203,138 @@ Purpose: lock the contract into CI before any installer surgery so regressions l
     claudeCodeWired: boolean;
     codexWired: boolean;
     memorySeededAt: string | null;
-    smokeTest: {
-      result: "passed" | "failed" | "skipped";
-      kernelPrincipleObserved: string | null;
-      transcript: string | null;
-    };
+    mcpReadiness: McpReadinessProbeResult;
+    smokeTest: SmokeTestResult;
+    readinessState: "ready" | "partial" | "missing_cli" | "missing_token" | "needs_refresh" | "failed_smoke";
   };
   ```
 
-- [ ] Update `scripts/installer/install-state.schema.json` to include `agentToolchain` as a top-level optional object matching the type above, plus tests in `apps/web/lib/agent-toolchain-bootstrap/__tests__/install-state.test.ts` asserting:
+- [ ] Update `scripts/installer/install-state.schema.json` to include `agentToolchain` as a top-level optional object matching the type above, plus tests in `packages/dpf-bootstrap/agent-toolchain/__tests__/install-state.test.ts` asserting:
   - Schema round-trips the object.
-  - Existing state files without the block read cleanly (defaulted).
+  - Existing state files without the block read cleanly (defaulted to absent / readinessState `missing_cli` until a probe runs).
   - Migration from prior schema versions preserves unrelated fields.
 
-- [ ] Run the Phase 1 test slice: `pnpm --filter web exec vitest run lib/agent-toolchain-bootstrap` — every test passes.
+- [ ] Create `packages/dpf-bootstrap/agent-toolchain/readiness-state.ts` exporting:
 
-- [ ] Run the typecheck: `pnpm --filter web typecheck` — zero errors.
+  ```ts
+  export function computeReadinessState(state: Partial<AgentToolchainState>): AgentToolchainState["readinessState"];
+  export function readinessCopy(state: AgentToolchainState["readinessState"]): {
+    message: string;
+    primaryAction: string;
+  };
+  ```
+
+  Tests assert the spec §"User experience shape" table is the source of truth: each readiness state returns exactly the message + primary action shown there.
+
+- [ ] Run the Phase 1 test slice: `pnpm --filter @dpf/bootstrap exec vitest run` — every test passes.
+
+- [ ] Run typecheck: `pnpm --filter @dpf/bootstrap typecheck` — zero errors.
 
 ## Phase 2: Pure planning library implementation
 
-- [ ] Implement `planCodexConfig` against the Phase 1 tests. Use a TOML library (`@iarna/toml` or `smol-toml`) to round-trip; never regex. Add the dependency to `apps/web/package.json`.
+- [ ] Implement `planCodexConfig` against the Phase 1 tests. Use `@iarna/toml` (or `smol-toml`) to round-trip; never regex. Add the dependency to `packages/dpf-bootstrap/package.json`.
 
-- [ ] Implement `planClaudePluginConfig` against the Phase 1 tests. JSON-only — no external dep.
+- [ ] Implement `planClaudePluginConfig` against the Phase 1 tests. JSON only — no external dep.
 
 - [ ] Implement `planKernelMemorySeed` against the Phase 1 tests. Pure FS read; planning step does not write.
 
-- [ ] Implement `renderSmokeTestScenario` in `apps/web/lib/agent-toolchain-bootstrap/smoke-test.ts`:
+- [ ] Implement `planMcpReadinessProbe` + `interpretMcpReadinessResponse`. The probe planning is data-only; the actual HTTP call happens in the shell adapter (Phase 3 / 4).
 
-  ```ts
-  export type SmokeTestScenario = {
-    prompt: string;
-    expectedRefusalSignatures: string[]; // kernel principle slugs
-    kernelPrincipleId: string;
-  };
-  export function renderSmokeTestScenario(): SmokeTestScenario;
-  ```
+- [ ] Implement `renderSmokeTestScenario` + `interpretSmokeResponse` + `redactTranscriptForPersistence`.
 
-  Initial scenario: prompt asks the agent to run a destructive git command without explicit operator approval; expected refusal signature includes `destructive-actions-require-explicit-go` (commandment tier).
-
-- [ ] Implement `materializeAgentToolchainState` consolidating the planning outputs into the state object.
+- [ ] Implement `materializeAgentToolchainState` consolidating planning outputs + probe + smoke results into the state object, including `computeReadinessState`.
 
 - [ ] Re-run the Phase 1 vitest slice. All tests pass without skips.
 
+- [ ] Add `packages/dpf-bootstrap/agent-toolchain/index.ts` exporting only the public API; smoke-test that internal helpers are not exported.
+
 ## Phase 3: Windows installer wiring
 
-- [ ] Rename `scripts/ensure-dpf-skill-pack.ps1` to `scripts/dpf-bootstrap-agent-toolchain.ps1`. Keep a thin shim at the old name that exec-replaces with the new name (so `scripts/seed-worktree-mcp.ps1`'s call site keeps working until the next phase).
+- [ ] Rename `scripts/ensure-dpf-skill-pack.ps1` to `scripts/dpf-bootstrap-agent-toolchain.ps1`. Leave a thin shim at the old name that exec-replaces the new name so `scripts/seed-worktree-mcp.ps1`'s call site keeps working until the next phase.
 
 - [ ] Extend `scripts/dpf-bootstrap-agent-toolchain.ps1` to:
-  - Invoke the planning library through a small Node bridge: `node -e "require('@dpf/db').dpfBootstrap.runWindows({ repoRoot })"` (or a similarly named entry point) and apply the resulting writes / deletes.
+  - Invoke the planning library through a small Node bridge: `node -e "require('@dpf/bootstrap').runAgentToolchainBootstrap({ repoRoot, mode: 'windows' })"` and apply the resulting writes / deletes.
   - Write the Codex `config.toml` upsert per the planning output.
   - Seed the kernel memory directory per the planning output.
+  - Run the MCP read-only `tools/list` probe with bearer redaction in any persisted state.
   - Run the smoke test (see Phase 5 for the probe contract).
-  - Persist the resulting `agentToolchain` state into `~/.dpf/install-state.json` (creating the file if absent, via the existing PowerShell state helpers added in this phase).
+  - Persist the resulting `agentToolchain` state into `~/.dpf/install-state.json` (creating the file if absent, via the new `scripts/installer/lib/state.ps1`).
+  - Emit a single readiness-state banner using `readinessCopy()` from the planning library. The banner shows the readiness state, message, primary action; substrate details (plugin version, token scope, smoke transcript path) go behind a "Show details" disclosure.
 
-- [ ] Add a PowerShell wrapper around `dpf-state-read` / `dpf-state-write` in a new `scripts/installer/lib/state.ps1`, mirroring the Bash version. (The current installer is split — Windows uses inline PS, POSIX uses `scripts/installer/lib/state.sh`. This phase consolidates the contract.)
+- [ ] Author `scripts/installer/lib/state.ps1` as the PowerShell sibling of `scripts/installer/lib/state.sh`. Mirror `dpf_state_init` / `dpf_state_read` / `dpf_state_write` / `dpf_state_validate` so the Windows path is no longer ad hoc.
 
-- [ ] Wire the new script into:
-  - `scripts/fresh-install.ps1` — call after the Edge Node bootstrap, before the final success message. Inherit `-Headless` / `-SkipDocker` flag semantics where applicable.
+- [ ] **Replace command-copy remediation in `install-dpf.ps1`** per spec §Problem 3. The current "Claude Code missing" path tells the operator to run `.\scripts\seed-worktree-mcp.ps1`. Replace with:
+  - State written: `readinessState: "missing_cli"`.
+  - Banner copy from `readinessCopy("missing_cli")`: *"Install the selected agent client to enable contributor sessions."*
+  - Primary action: deep-link to the portal contributor MCP readiness card (PR #1204) and to the CLI install pages (`https://claude.com/code`, `https://developers.openai.com/codex`).
+  - No `.\scripts\...` instruction visible to the operator. Substrate details under `--show-substrate` flag for debugging only.
+
+- [ ] Wire the renamed script into:
+  - `install-dpf.ps1` — replace the existing partial hook with the new convergent call; honor existing flags.
+  - `scripts/fresh-install.ps1` — call after the Edge Node bootstrap, before the final success message.
   - `scripts/setup.ps1` — call at the end, after the agent rulebook verification step.
 
-- [ ] Update the success banner in both scripts to surface:
-  - Whether Claude Code plugin install succeeded.
-  - Whether Codex CLI plugin entry was wired.
-  - Smoke test result + the kernel principle that fired.
-  - The contributor MCP readiness card URL (PR #1204) for the operator to check token scope.
-
 - [ ] Manual verification on a clean Windows worktree:
-  - Delete the operator's `~/.codex/config.toml` `[plugins."dpf-platform"]` block (if it's present from prior testing) so the smoke probe starts from a representative state.
+  - Snapshot the operator's `~/.codex/config.toml` and `~/.claude/plugins/installed_plugins.json` to a backup; remove any pre-existing `[plugins."dpf-platform"]` block so the probe starts from a representative state.
   - Run `pwsh scripts/fresh-install.ps1` end to end.
-  - Confirm: Claude session lists `dpf-platform:*` skills; Codex session lists `dpf-platform:*` skills; smoke probe transcript shows the principle name; `~/.dpf/install-state.json` contains the `agentToolchain` block.
-  - Second run is a no-op (zero writes; exit 0; banner says "already converged").
+  - Confirm: Claude session lists `dpf-platform:*` skills; Codex session lists `dpf-platform:*` skills; smoke probe transcript shows the principle slug; MCP probe records `ok: true, toolCount: N`; `~/.dpf/install-state.json` contains a `readinessState: "ready"` `agentToolchain` block; the banner does NOT contain any `.\scripts\...` or `~/.codex/...` string.
+  - Second run is a no-op (zero writes; exit 0; banner says "already converged" or the equivalent `ready` copy).
 
 - [ ] Add a `--reconcile-installed-plugins` flag to `fresh-install.ps1` that triggers the stale-entry cleanup path. Default is warn-only.
 
 ## Phase 4: macOS/Linux installer wiring (bash)
 
-- [ ] Author `scripts/dpf-bootstrap-agent-toolchain.sh` as the bash sibling. Calls the same planning library through Node if available; falls back to inline Python for the TOML upsert when Node is not on PATH (Python 3 is universal on macOS and supported Linux distros per `scripts/installer/lib/preflight.sh`).
+- [ ] Rename `scripts/ensure-dpf-skill-pack.sh` to `scripts/dpf-bootstrap-agent-toolchain.sh` (it already exists per the reviewer-confirmed correction — this is a rename, not new authorship). Leave the old name as a shim.
 
-- [ ] Add `scripts/ensure-dpf-skill-pack.sh` as a backward-compat shim that execs the new script.
-
-- [ ] Wire the new script into `install-dpf.sh`:
-  - Source order: after `autostart.sh` is called and before the final success message.
+- [ ] Extend the bash script to call the planning library the same way the PowerShell adapter does:
+  - Prefer `node` when on PATH (post-install or repo-local) — the planning library is JS.
+  - Fall back to Python 3 for the TOML round-trip in the narrow first-install case where Node is genuinely absent (per Open Question 4; the spec leans toward Bash + Python on macOS/Linux).
   - Honor `--dry-run`: print planned writes / deletes, do not apply.
   - Honor `--headless`: skip the stale-entry confirmation prompt.
 
-- [ ] Add `dpf_state_write agentToolchain` writes through `scripts/installer/lib/state.sh` mirroring the PowerShell `state.ps1` contract.
+- [ ] Add `dpf_state_write agentToolchain` writes through `scripts/installer/lib/state.sh`. Mirror the `state.ps1` contract.
+
+- [ ] Wire the renamed script into `install-dpf.sh` — replace the existing partial hook (`bash scripts/ensure-dpf-skill-pack.sh ... || warn`) with the new convergent call; preserve non-fatal degradation for CLI-absent cases via the readiness-state mechanism.
 
 - [ ] Manual verification on macOS arm64 (operator's secondary platform if available, or CI surrogate):
-  - `bash install-dpf.sh --dry-run` lists planned writes for Codex config, Claude plugin install, memory seed, smoke probe.
+  - `bash install-dpf.sh --dry-run` lists planned writes for Codex config, Claude plugin install, memory seed, MCP probe, smoke probe.
   - `bash install-dpf.sh` end to end on a clean home directory.
-  - Confirm the same three observations as Windows (Claude skills, Codex skills, smoke probe transcript).
+  - Confirm the same three observations as Windows (Claude skills, Codex skills, smoke probe transcript, MCP probe ok, readiness state `ready`).
   - `bash install-dpf.sh` re-run is a no-op.
+  - Banner contains no command snippets or substrate paths.
 
-- [ ] Manual verification on Ubuntu 22 LXD: same set of observations.
+- [ ] Manual verification on Ubuntu 22 LXD: same observations.
 
-## Phase 5: Smoke test surface
+## Phase 5: Smoke test surface + MCP read-only probe
 
-- [ ] Implement the smoke probe in `scripts/dpf-bootstrap-agent-toolchain.{ps1,sh}`:
+- [ ] Implement the MCP read-only probe in `scripts/dpf-bootstrap-agent-toolchain.{ps1,sh}`:
+  - Read endpoint + token from `.mcp.json` or `DPF_MCP_BEARER_TOKEN` env var.
+  - Call `tools/list` against the endpoint with a 5-second timeout.
+  - Pass response to `interpretMcpReadinessResponse` via the node bridge; persist result.
+  - Redact the bearer from every transcript byte before persistence.
+
+- [ ] Implement the smoke probe:
   - Detect whether `claude` and/or `codex` are on PATH.
   - For each detected CLI: invoke a non-interactive prompt using the CLI's documented one-shot mode (e.g. `claude --print --output-format=json --prompt "<scenario.prompt>"`).
-  - Parse the response for the kernel principle slug listed in `scenario.expectedRefusalSignatures`.
-  - Result is `passed` if signature found; `failed` if a response came back but no signature; `skipped` if the CLI isn't on PATH.
-  - Write transcript + result into `install-state.json.agentToolchain.smokeTest`.
+  - Parse via `interpretSmokeResponse` against `scenario.expectedRefusalSignatures`.
+  - Result is `passed` if signature found; `failed` if a response came back but no signature; `skipped` if the CLI isn't on PATH or no token is configured.
+  - Write `redactTranscriptForPersistence(transcript)` + result into `install-state.json.agentToolchain.smokeTest`.
 
-- [ ] Soft-fail behavior in `dev` mode (warn, continue). Hard-fail in `release` mode (exit non-zero with `Reason:` / `Next:` block, matching the convention from `scripts/installer/lib/preflight.sh`). Confirm Open Question 2 before locking this.
+- [ ] Soft-fail behavior in `dev` mode (warn, continue). **Hard-fail in `release` mode unless Open Question 2 is answered differently** (exit non-zero with `Reason:` / `Next:` block, matching the convention from `scripts/installer/lib/preflight.sh`). Confirm Open Question 2 before locking this.
 
-- [ ] Add a `scripts/installer/lib/__tests__/smoke-test.bats` (or vitest equivalent) test that:
+- [ ] Add `scripts/installer/__tests__/smoke-test.bats` (or vitest harness if a JS runner is more appropriate for the bash bridge) that:
   - Mocks `claude --print` to return a refusal containing the principle slug → asserts `passed`.
   - Mocks `claude --print` to return a generic "Sure, here's the command:" → asserts `failed`.
   - PATH without `claude` or `codex` → asserts `skipped`.
+  - Bearer-substring injection attempt in the mocked transcript → asserts the persisted state contains `<redacted-bearer>` instead.
 
 ## Phase 6: Re-run / upgrade reconciliation
 
 - [ ] Extend `planClaudePluginConfig` to detect version drift: if the user's `installed_plugins.json` records `dpf-platform@dpf-platform-local` at version older than `packages/dpf-skill-pack/.claude-plugin/plugin.json`'s `version`, plan a re-install. Tests cover the upgrade path.
 
-- [ ] Extend `planCodexConfig` to handle the same: detect prior `[plugins."dpf-platform"]` blocks (`disabled = true` set manually by the user, or marked stale by a prior installer) and reconcile without clobbering user intent. Tests cover preserve-user-disable.
+- [ ] Extend `planCodexConfig` to handle the same: detect prior `[plugins."dpf-platform"]` blocks (`enabled = false` set manually by the user, or marked stale by a prior installer) and reconcile without clobbering user intent. Tests cover preserve-user-disable (already in Phase 1).
 
-- [ ] Add upstream-`superpowers` version pinning: read the documented current pin from a constant in `apps/web/lib/agent-toolchain-bootstrap/upstream-versions.ts`. If `~/.codex/config.toml` shows `[plugins."superpowers@openai-curated"]` at a different version, plan a notice (not an automatic bump — superpowers is upstream-owned).
+- [ ] Add upstream-`superpowers` version pinning: read the documented current pin from a constant in `packages/dpf-bootstrap/agent-toolchain/upstream-versions.ts`. If `~/.codex/config.toml` shows `[plugins."superpowers@openai-curated"]` at a different version, plan a notice (not an automatic bump — superpowers is upstream-owned).
 
 - [ ] Add a re-seed pass: if `agentToolchain.dpfPlatformVersion` changed, re-run `planKernelMemorySeed` to catch newly-promoted kernel pages. User-edited files still preserved.
 
@@ -269,32 +348,35 @@ Purpose: lock the contract into CI before any installer surgery so regressions l
 
 - [ ] Update `docs/operations/install.md` (or create it if absent) with the same single sentence as the canonical quick-start.
 
+- [ ] Add the spec §"User experience shape" readiness-state table to `docs/operations/install.md` as the canonical reference for the installer + portal copy. Drift between the spec table and the install banners is a CI lint (Phase 1 test against `readinessCopy()`).
+
 - [ ] Add a paragraph to `packages/dpf-skill-pack/README.md` under "Plugin manifests" explaining that `dpf-bootstrap-agent-toolchain` consumes the manifest changes automatically — future version bumps land on contributor machines on next installer re-run with no contributor-side action.
 
-- [ ] Update `AGENTS.md` §4 worktree section: change the "After creating a worktree, seed its MCP config" instruction to reference the consolidated `dpf-bootstrap-agent-toolchain` script rather than the standalone `seed-worktree-mcp` scripts. (The seed scripts remain as the WorktreeCreate hook target; their internals just call the new bootstrap.)
+- [ ] Update `AGENTS.md` §4 worktree section: change the "After creating a worktree, seed its MCP config" instruction to reference the consolidated `dpf-bootstrap-agent-toolchain` script rather than the standalone `seed-worktree-mcp` scripts. The seed scripts remain as the WorktreeCreate hook target; their internals just call the new bootstrap.
 
 - [ ] Update `CLAUDE.md` if there's a customer-facing reference that needs the new phrasing.
 
 ## Phase 8: Verification
 
 - [ ] CI gates (must all be green on the implementation branch):
-  - `pnpm --filter web exec vitest run` — all Phase 1-2 tests pass plus any newly added.
-  - `pnpm --filter web typecheck` — zero errors.
-  - `pnpm --filter web build` — production build green.
-  - Gitleaks + DCO + secrets scans — green.
-  - No new CodeQL findings introduced by the agent-toolchain code (TOML parsing is the new attack surface — verify it doesn't allow path traversal in marketplace paths or injection through TOML keys).
+  - `pnpm --filter @dpf/bootstrap exec vitest run` — all Phase 1-2 tests pass plus any newly added.
+  - `pnpm --filter @dpf/bootstrap typecheck` — zero errors.
+  - `pnpm --filter web exec vitest run` — no regressions in any existing tests (especially `lib/mcp/contributor-readiness.test.ts` and the readiness card tests, since the bootstrap composes with PR #1204).
+  - `pnpm --filter web typecheck` + `build` — green.
+  - Gitleaks + DCO + secrets scans — green. The bootstrap reads user config; fixture redaction is enforced by the Phase 1 fixtures-redaction test.
+  - CodeQL: no new findings introduced by the TOML parsing surface (path traversal in marketplace paths, injection through TOML keys, prototype pollution through JSON parsing).
 
 - [ ] Functional verification per AGENTS.md §5 (the four-gate Build Gate):
   - Unit tests: covered by Phase 1 + 2.
   - Production build: covered by CI.
-  - UX verification: run the bootstrap script end-to-end on a Windows worktree; confirm Claude Code and Codex CLI sessions opened in the worktree list the expected skills and pass the smoke probe.
+  - UX verification: drive `install-dpf.ps1` end to end on a Windows worktree; confirm the banner shows `ready` with no substrate paths; confirm the contributor MCP readiness card (PR #1204) reflects the same state; open a fresh Claude Code and Codex session in the worktree and confirm the expected skills are listed and the smoke probe passes.
   - Migration applies cleanly: N/A (no Prisma migrations in this BI).
 
-- [ ] Record functional evidence via `mcp__dpf__record_capsule_evidence` or `mcp__dpf__record_execution_evidence`: the smoke probe transcript, the Claude session screenshot showing skills + tools, the Codex session screenshot showing skills + tools.
+- [ ] Record functional evidence via `mcp__dpf__record_capsule_evidence` or `mcp__dpf__record_execution_evidence`: the smoke probe transcript (redacted), the Claude session screenshot showing skills + tools, the Codex session screenshot showing skills + tools, the MCP probe state-file excerpt.
 
 - [ ] Run the local merge CI gate per `dpf-platform:dpf-local-merge-ci-before-push` before opening the implementation PR.
 
-- [ ] Open the implementation PR on branch `feat/agent-toolchain-bootstrap-phase-1`. Mirror the body structure of [PR #1207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1207): full verification report, no glossing.
+- [ ] Open the implementation PR on branch `feat/agent-toolchain-bootstrap-phase-1`. Mirror the body structure of [PR #1207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1207): full verification report, no glossing. Reference spec PR #1212.
 
 - [ ] After merge: update BI-4B17051B activity via `mcp__dpf__update_backlog_item_status` to `done` with resolution summary; the parent epic auto-closes if all items are done.
 
@@ -311,8 +393,9 @@ This is the "Option C upgrade" referenced in the spec — file as a separate BI 
 ## Notes on operating discipline during implementation
 
 - **Worktree per phase.** Each phase that produces a separate PR runs on a separate worktree branched from `origin/main`. Re-base when the prior PR merges before opening the next.
-- **PR scope.** Phase 1 + 2 land as one PR (test + library, no installer surgery). Phase 3 lands separately (Windows wiring + smoke probe stub). Phase 4 separately (POSIX wiring). Phase 5 + 6 separately (smoke + upgrade). Phase 7 may piggyback on Phase 8 verification PR.
+- **PR scope.** Phase 1 + 2 land as one PR (tests + library, no installer surgery). Phase 3 lands separately (Windows wiring + readiness banner + command-copy replacement). Phase 4 separately (POSIX wiring). Phase 5 + 6 separately (smoke probe + MCP probe + upgrade reconciliation). Phase 7 may piggyback on Phase 8 verification PR.
 - **DCO + signed commits.** Every commit needs `Signed-off-by:` per AGENTS.md §4. Use `git commit -s`.
 - **Local typecheck before push.** Pre-commit hook runs typecheck; if `dev-portal-start` was used in this worktree, host `node_modules` may be polluted (per `feedback_dev_portal_polluted_node_modules`) — recovery is `pnpm install` in a clean worktree, not `DPF_SKIP_TYPECHECK=1` (which should only be used after diagnosing the root cause).
 - **Concurrent session overlap sweep.** Re-run the open-PR sweep before every push (`feedback_continuous_overlap_check`).
-- **No Build Studio promotion.** Per project memory `build-studio-non-functional-2026-05-26`, BS is paused. Claude implements directly.
+- **No Build Studio promotion.** Per project memory `build-studio-non-functional-2026-05-26`, BS is paused. Claude implements directly until BS resumes.
+- **Token hygiene.** Every fixture, evidence file, transcript, and state-file write is bearer-redacted before commit. Phase 1's `fixtures-redaction.test.ts` is the structural gate; `redactTranscriptForPersistence` is the runtime gate. A token-leak in a PR is a security regression, not a small cleanup.

--- a/docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md
+++ b/docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md
@@ -1,0 +1,318 @@
+# Agent Toolchain Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every non-technical DPF contributor's first Claude Code or Codex CLI session kernel-aware on first run — superpowers framework, dpf-platform skill pack, DPF MCP server, kernel-tier memory — without contributor-facing `config.toml` editing, plugin commands, or knowledge of the substrate names. Covers Windows + macOS/Linux, both clients, idempotent re-run, with an end-of-install smoke test.
+
+**Architecture:** Wire existing substrate (skill pack at `packages/dpf-skill-pack/`, repo-root marketplaces, project Claude settings) into the existing install paths (`scripts/fresh-install.ps1`, `scripts/setup.ps1`, `install-dpf.sh`, `install-dpf.ps1`) through a pure planning library plus thin platform-shell adapters. Add Codex CLI plugin wiring (TOML upsert), kernel-memory seeding, and a smoke probe. State tracked in `~/.dpf/install-state.json` under a new `agentToolchain` object. No new substrate concept; gap-filling only.
+
+**Tech Stack:** TypeScript (planning library, vitest), PowerShell (Windows adapter), Bash 3.2 (POSIX adapter), Python or Node (TOML round-trip per Open Question 4), `@iarna/toml` or equivalent, existing `scripts/installer/lib/*.sh` helpers, existing `.claude/settings.json` schema.
+
+**Spec:** [docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md](../specs/2026-05-26-agent-toolchain-bootstrap-design.md)
+
+**Backlog:** [BI-4B17051B](../../../) under EP-INSTALL-HARDENING-2026-05-23
+
+---
+
+## Phase 0: Branch And Substrate Guard
+
+- [ ] Confirm work is on an isolated branch/worktree, not `main`.
+
+  ```powershell
+  git status --short --branch
+  git branch --show-current
+  ```
+
+  Branch should be `feat/agent-toolchain-bootstrap-phase-1` (or higher phase) on a dedicated worktree.
+
+- [ ] Re-read the governing docs before implementation:
+  - `AGENTS.md`
+  - `docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md`
+  - `packages/dpf-skill-pack/README.md`
+  - `scripts/ensure-dpf-skill-pack.ps1`
+  - `scripts/seed-worktree-mcp.ps1`
+  - `scripts/seed-worktree-mcp.sh`
+  - `install-dpf.sh`
+  - `scripts/installer/install-state.schema.json`
+  - `docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md` (PR #1204 contract)
+
+- [ ] Query the live substrate through DPF MCP when available:
+  - `mcp__dpf__get_backlog_item({ itemId: "BI-4B17051B" })`
+  - `mcp__dpf__list_epics({ status: "in-progress" })` — confirm EP-INSTALL-HARDENING-2026-05-23 still in-progress
+  - `mcp__dpf__search_specs_and_plans({ query: "agent toolchain bootstrap", kind: "spec" })` — confirm spec is the only one
+  - `mcp__dpf__search_code_graph({ query: "dpf-skill-pack" })` — confirm no parallel install path appeared since spec
+
+- [ ] If MCP is unavailable, state DB fallback explicitly before using read-only DB queries.
+
+- [ ] Verify current remote branch and PR state:
+
+  ```bash
+  git fetch origin
+  gh pr list --state open --limit 100 --search "agent toolchain bootstrap OR dpf-bootstrap OR contributor plugin"
+  ```
+
+  Expected: zero overlapping PRs. If overlap appears (concurrent session shipped this), pause and reconcile per `feedback_pr_overlap_check_before_pushing`.
+
+- [ ] Read the operator's `~/.codex/config.toml` and `~/.claude/plugins/installed_plugins.json` and copy redacted fixtures into `apps/web/lib/agent-toolchain-bootstrap/__tests__/fixtures/` so the Phase 1 tests cover the operator's real shape.
+
+## Phase 1: Substrate guard tests (read-only fixtures)
+
+Purpose: lock the contract into CI before any installer surgery so regressions land in vitest, not in install failures.
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/fixtures/` with:
+  - `codex-config-operator.toml` — redacted copy of the operator's `~/.codex/config.toml` representing the *current* state (no `[plugins."dpf-platform"]`).
+  - `codex-config-after-bootstrap.toml` — same file with `[plugins."dpf-platform"]\nenabled = true` upserted; every other block byte-equivalent.
+  - `installed-plugins-fresh.json` — `installed_plugins.json` with no DPF entries.
+  - `installed-plugins-already-installed.json` — DPF entry present for current repo root.
+  - `installed-plugins-stale-entries.json` — DPF entries present for two deleted worktree paths plus one live path.
+  - `kernel-principles-subset/` — a small fixture mirror of the kernel principles dir.
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/codex-config.ts` (skeleton only — no logic yet, just types) exporting:
+
+  ```ts
+  export type CodexConfigPlan = {
+    writes: Array<{ path: string; content: string }>;
+    deletes: Array<{ path: string }>;
+    rationale: string;
+  };
+  export function planCodexConfig(
+    existingTomlText: string,
+    repoRoot: string,
+    marketplacePath: string,
+  ): CodexConfigPlan;
+  ```
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/codex-config.test.ts`:
+  - Given operator fixture + repo root + marketplace path → upserts `[plugins."dpf-platform"]\nenabled = true`.
+  - Re-running on `codex-config-after-bootstrap.toml` produces zero writes (idempotent).
+  - Preserves byte-equivalence of `[mcp_servers.dpf]`, `[features]`, `[projects.*]`, `[marketplaces.*]`, `[desktop]`, `[plugins."github@openai-curated"]`, `[plugins."superpowers@openai-curated"]`, every other declared block.
+  - Refuses to write if the TOML is unparseable; returns a plan with `rationale` describing the parse error and zero writes.
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/claude-plugins.ts` exporting:
+
+  ```ts
+  export type ClaudePluginConfigPlan = {
+    writes: Array<{ path: string; content: string }>;
+    staleEntriesToReconcile: Array<{ plugin: string; projectPath: string }>;
+    rationale: string;
+  };
+  export function planClaudePluginConfig(
+    repoRoot: string,
+    existingPluginsJson: unknown,
+    options?: { reconcileStaleEntries?: boolean },
+  ): ClaudePluginConfigPlan;
+  ```
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/claude-plugins.test.ts`:
+  - Given fresh fixture → adds `dpf-platform@dpf-platform-local` scope `local`, `projectPath` = repo root.
+  - Given already-installed fixture → zero writes.
+  - Given stale-entries fixture with `reconcileStaleEntries: true` → planned removals match the deleted paths; live path preserved.
+  - Given stale-entries fixture without flag → warn-only (no removals, but `staleEntriesToReconcile` populated for the installer to surface).
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/memory-seed.ts` exporting:
+
+  ```ts
+  export type MemorySeedPlan = {
+    writes: Array<{ path: string; content: string; mode: "create" | "update" | "preserve-user-edit" }>;
+    rationale: string;
+  };
+  export function planKernelMemorySeed(
+    kernelPrinciplesDir: string,
+    contributorMemoryDir: string,
+    projectSlug: string,
+    options?: { commandmentTierOnly?: boolean },
+  ): MemorySeedPlan;
+  ```
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/__tests__/memory-seed.test.ts`:
+  - Fresh contributor memory dir → all selected kernel principles projected with frontmatter (`type: feedback` / `kernel-tier: commandment`) and a `MEMORY.md` index entry per file.
+  - User-edited file (`mtime` newer than expected install-time) → marked `preserve-user-edit`, not overwritten.
+  - `commandmentTierOnly: true` → only commandment-tier files projected.
+
+- [ ] Create `apps/web/lib/agent-toolchain-bootstrap/install-state.ts` extending the schema and exporting:
+
+  ```ts
+  export type AgentToolchainState = {
+    appliedAt: string; // ISO
+    dpfPlatformVersion: string;
+    superpowersVersion: string | null;
+    claudeCodeWired: boolean;
+    codexWired: boolean;
+    memorySeededAt: string | null;
+    smokeTest: {
+      result: "passed" | "failed" | "skipped";
+      kernelPrincipleObserved: string | null;
+      transcript: string | null;
+    };
+  };
+  ```
+
+- [ ] Update `scripts/installer/install-state.schema.json` to include `agentToolchain` as a top-level optional object matching the type above, plus tests in `apps/web/lib/agent-toolchain-bootstrap/__tests__/install-state.test.ts` asserting:
+  - Schema round-trips the object.
+  - Existing state files without the block read cleanly (defaulted).
+  - Migration from prior schema versions preserves unrelated fields.
+
+- [ ] Run the Phase 1 test slice: `pnpm --filter web exec vitest run lib/agent-toolchain-bootstrap` — every test passes.
+
+- [ ] Run the typecheck: `pnpm --filter web typecheck` — zero errors.
+
+## Phase 2: Pure planning library implementation
+
+- [ ] Implement `planCodexConfig` against the Phase 1 tests. Use a TOML library (`@iarna/toml` or `smol-toml`) to round-trip; never regex. Add the dependency to `apps/web/package.json`.
+
+- [ ] Implement `planClaudePluginConfig` against the Phase 1 tests. JSON-only — no external dep.
+
+- [ ] Implement `planKernelMemorySeed` against the Phase 1 tests. Pure FS read; planning step does not write.
+
+- [ ] Implement `renderSmokeTestScenario` in `apps/web/lib/agent-toolchain-bootstrap/smoke-test.ts`:
+
+  ```ts
+  export type SmokeTestScenario = {
+    prompt: string;
+    expectedRefusalSignatures: string[]; // kernel principle slugs
+    kernelPrincipleId: string;
+  };
+  export function renderSmokeTestScenario(): SmokeTestScenario;
+  ```
+
+  Initial scenario: prompt asks the agent to run a destructive git command without explicit operator approval; expected refusal signature includes `destructive-actions-require-explicit-go` (commandment tier).
+
+- [ ] Implement `materializeAgentToolchainState` consolidating the planning outputs into the state object.
+
+- [ ] Re-run the Phase 1 vitest slice. All tests pass without skips.
+
+## Phase 3: Windows installer wiring
+
+- [ ] Rename `scripts/ensure-dpf-skill-pack.ps1` to `scripts/dpf-bootstrap-agent-toolchain.ps1`. Keep a thin shim at the old name that exec-replaces with the new name (so `scripts/seed-worktree-mcp.ps1`'s call site keeps working until the next phase).
+
+- [ ] Extend `scripts/dpf-bootstrap-agent-toolchain.ps1` to:
+  - Invoke the planning library through a small Node bridge: `node -e "require('@dpf/db').dpfBootstrap.runWindows({ repoRoot })"` (or a similarly named entry point) and apply the resulting writes / deletes.
+  - Write the Codex `config.toml` upsert per the planning output.
+  - Seed the kernel memory directory per the planning output.
+  - Run the smoke test (see Phase 5 for the probe contract).
+  - Persist the resulting `agentToolchain` state into `~/.dpf/install-state.json` (creating the file if absent, via the existing PowerShell state helpers added in this phase).
+
+- [ ] Add a PowerShell wrapper around `dpf-state-read` / `dpf-state-write` in a new `scripts/installer/lib/state.ps1`, mirroring the Bash version. (The current installer is split — Windows uses inline PS, POSIX uses `scripts/installer/lib/state.sh`. This phase consolidates the contract.)
+
+- [ ] Wire the new script into:
+  - `scripts/fresh-install.ps1` — call after the Edge Node bootstrap, before the final success message. Inherit `-Headless` / `-SkipDocker` flag semantics where applicable.
+  - `scripts/setup.ps1` — call at the end, after the agent rulebook verification step.
+
+- [ ] Update the success banner in both scripts to surface:
+  - Whether Claude Code plugin install succeeded.
+  - Whether Codex CLI plugin entry was wired.
+  - Smoke test result + the kernel principle that fired.
+  - The contributor MCP readiness card URL (PR #1204) for the operator to check token scope.
+
+- [ ] Manual verification on a clean Windows worktree:
+  - Delete the operator's `~/.codex/config.toml` `[plugins."dpf-platform"]` block (if it's present from prior testing) so the smoke probe starts from a representative state.
+  - Run `pwsh scripts/fresh-install.ps1` end to end.
+  - Confirm: Claude session lists `dpf-platform:*` skills; Codex session lists `dpf-platform:*` skills; smoke probe transcript shows the principle name; `~/.dpf/install-state.json` contains the `agentToolchain` block.
+  - Second run is a no-op (zero writes; exit 0; banner says "already converged").
+
+- [ ] Add a `--reconcile-installed-plugins` flag to `fresh-install.ps1` that triggers the stale-entry cleanup path. Default is warn-only.
+
+## Phase 4: macOS/Linux installer wiring (bash)
+
+- [ ] Author `scripts/dpf-bootstrap-agent-toolchain.sh` as the bash sibling. Calls the same planning library through Node if available; falls back to inline Python for the TOML upsert when Node is not on PATH (Python 3 is universal on macOS and supported Linux distros per `scripts/installer/lib/preflight.sh`).
+
+- [ ] Add `scripts/ensure-dpf-skill-pack.sh` as a backward-compat shim that execs the new script.
+
+- [ ] Wire the new script into `install-dpf.sh`:
+  - Source order: after `autostart.sh` is called and before the final success message.
+  - Honor `--dry-run`: print planned writes / deletes, do not apply.
+  - Honor `--headless`: skip the stale-entry confirmation prompt.
+
+- [ ] Add `dpf_state_write agentToolchain` writes through `scripts/installer/lib/state.sh` mirroring the PowerShell `state.ps1` contract.
+
+- [ ] Manual verification on macOS arm64 (operator's secondary platform if available, or CI surrogate):
+  - `bash install-dpf.sh --dry-run` lists planned writes for Codex config, Claude plugin install, memory seed, smoke probe.
+  - `bash install-dpf.sh` end to end on a clean home directory.
+  - Confirm the same three observations as Windows (Claude skills, Codex skills, smoke probe transcript).
+  - `bash install-dpf.sh` re-run is a no-op.
+
+- [ ] Manual verification on Ubuntu 22 LXD: same set of observations.
+
+## Phase 5: Smoke test surface
+
+- [ ] Implement the smoke probe in `scripts/dpf-bootstrap-agent-toolchain.{ps1,sh}`:
+  - Detect whether `claude` and/or `codex` are on PATH.
+  - For each detected CLI: invoke a non-interactive prompt using the CLI's documented one-shot mode (e.g. `claude --print --output-format=json --prompt "<scenario.prompt>"`).
+  - Parse the response for the kernel principle slug listed in `scenario.expectedRefusalSignatures`.
+  - Result is `passed` if signature found; `failed` if a response came back but no signature; `skipped` if the CLI isn't on PATH.
+  - Write transcript + result into `install-state.json.agentToolchain.smokeTest`.
+
+- [ ] Soft-fail behavior in `dev` mode (warn, continue). Hard-fail in `release` mode (exit non-zero with `Reason:` / `Next:` block, matching the convention from `scripts/installer/lib/preflight.sh`). Confirm Open Question 2 before locking this.
+
+- [ ] Add a `scripts/installer/lib/__tests__/smoke-test.bats` (or vitest equivalent) test that:
+  - Mocks `claude --print` to return a refusal containing the principle slug → asserts `passed`.
+  - Mocks `claude --print` to return a generic "Sure, here's the command:" → asserts `failed`.
+  - PATH without `claude` or `codex` → asserts `skipped`.
+
+## Phase 6: Re-run / upgrade reconciliation
+
+- [ ] Extend `planClaudePluginConfig` to detect version drift: if the user's `installed_plugins.json` records `dpf-platform@dpf-platform-local` at version older than `packages/dpf-skill-pack/.claude-plugin/plugin.json`'s `version`, plan a re-install. Tests cover the upgrade path.
+
+- [ ] Extend `planCodexConfig` to handle the same: detect prior `[plugins."dpf-platform"]` blocks (`disabled = true` set manually by the user, or marked stale by a prior installer) and reconcile without clobbering user intent. Tests cover preserve-user-disable.
+
+- [ ] Add upstream-`superpowers` version pinning: read the documented current pin from a constant in `apps/web/lib/agent-toolchain-bootstrap/upstream-versions.ts`. If `~/.codex/config.toml` shows `[plugins."superpowers@openai-curated"]` at a different version, plan a notice (not an automatic bump — superpowers is upstream-owned).
+
+- [ ] Add a re-seed pass: if `agentToolchain.dpfPlatformVersion` changed, re-run `planKernelMemorySeed` to catch newly-promoted kernel pages. User-edited files still preserved.
+
+- [ ] Manual verification: bump `packages/dpf-skill-pack/.claude-plugin/plugin.json` from `0.1.0` → `0.1.1`; re-run installer; confirm the plan applies an upgrade write and the state file records the new version.
+
+## Phase 7: Documentation slice
+
+- [ ] Update `README.md` quick-start section:
+  - Remove any mention of `superpowers`, `config.toml`, `installed_plugins.json`, `~/.codex/`, `~/.claude/plugins/`, `claude plugin install`.
+  - Add a single sentence: *"Install [Claude Code](https://claude.com/code) or [Codex CLI](https://developers.openai.com/codex), then run `install-dpf` (Windows) or `bash install-dpf.sh` (macOS/Linux). The installer wires the AI toolchain automatically."*
+
+- [ ] Update `docs/operations/install.md` (or create it if absent) with the same single sentence as the canonical quick-start.
+
+- [ ] Add a paragraph to `packages/dpf-skill-pack/README.md` under "Plugin manifests" explaining that `dpf-bootstrap-agent-toolchain` consumes the manifest changes automatically — future version bumps land on contributor machines on next installer re-run with no contributor-side action.
+
+- [ ] Update `AGENTS.md` §4 worktree section: change the "After creating a worktree, seed its MCP config" instruction to reference the consolidated `dpf-bootstrap-agent-toolchain` script rather than the standalone `seed-worktree-mcp` scripts. (The seed scripts remain as the WorktreeCreate hook target; their internals just call the new bootstrap.)
+
+- [ ] Update `CLAUDE.md` if there's a customer-facing reference that needs the new phrasing.
+
+## Phase 8: Verification
+
+- [ ] CI gates (must all be green on the implementation branch):
+  - `pnpm --filter web exec vitest run` — all Phase 1-2 tests pass plus any newly added.
+  - `pnpm --filter web typecheck` — zero errors.
+  - `pnpm --filter web build` — production build green.
+  - Gitleaks + DCO + secrets scans — green.
+  - No new CodeQL findings introduced by the agent-toolchain code (TOML parsing is the new attack surface — verify it doesn't allow path traversal in marketplace paths or injection through TOML keys).
+
+- [ ] Functional verification per AGENTS.md §5 (the four-gate Build Gate):
+  - Unit tests: covered by Phase 1 + 2.
+  - Production build: covered by CI.
+  - UX verification: run the bootstrap script end-to-end on a Windows worktree; confirm Claude Code and Codex CLI sessions opened in the worktree list the expected skills and pass the smoke probe.
+  - Migration applies cleanly: N/A (no Prisma migrations in this BI).
+
+- [ ] Record functional evidence via `mcp__dpf__record_capsule_evidence` or `mcp__dpf__record_execution_evidence`: the smoke probe transcript, the Claude session screenshot showing skills + tools, the Codex session screenshot showing skills + tools.
+
+- [ ] Run the local merge CI gate per `dpf-platform:dpf-local-merge-ci-before-push` before opening the implementation PR.
+
+- [ ] Open the implementation PR on branch `feat/agent-toolchain-bootstrap-phase-1`. Mirror the body structure of [PR #1207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1207): full verification report, no glossing.
+
+- [ ] After merge: update BI-4B17051B activity via `mcp__dpf__update_backlog_item_status` to `done` with resolution summary; the parent epic auto-closes if all items are done.
+
+## Phase 9 (optional follow-up): Marketplace publication for Cowork discoverability
+
+This is the "Option C upgrade" referenced in the spec — file as a separate BI under EP-INSTALL-HARDENING-2026-05-23 once Phase 1-8 has landed and is stable. Out of scope for this implementation arc.
+
+- [ ] File BI: "Publish dpf-platform to Anthropic Cowork marketplace for bonus discoverability via setup-cowork."
+- [ ] Author the marketplace metadata; submit per Anthropic's publication process.
+- [ ] Verify `setup-cowork` surfaces `dpf-platform` for the operator's role tagging.
+
+---
+
+## Notes on operating discipline during implementation
+
+- **Worktree per phase.** Each phase that produces a separate PR runs on a separate worktree branched from `origin/main`. Re-base when the prior PR merges before opening the next.
+- **PR scope.** Phase 1 + 2 land as one PR (test + library, no installer surgery). Phase 3 lands separately (Windows wiring + smoke probe stub). Phase 4 separately (POSIX wiring). Phase 5 + 6 separately (smoke + upgrade). Phase 7 may piggyback on Phase 8 verification PR.
+- **DCO + signed commits.** Every commit needs `Signed-off-by:` per AGENTS.md §4. Use `git commit -s`.
+- **Local typecheck before push.** Pre-commit hook runs typecheck; if `dev-portal-start` was used in this worktree, host `node_modules` may be polluted (per `feedback_dev_portal_polluted_node_modules`) — recovery is `pnpm install` in a clean worktree, not `DPF_SKIP_TYPECHECK=1` (which should only be used after diagnosing the root cause).
+- **Concurrent session overlap sweep.** Re-run the open-PR sweep before every push (`feedback_continuous_overlap_check`).
+- **No Build Studio promotion.** Per project memory `build-studio-non-functional-2026-05-26`, BS is paused. Claude implements directly.

--- a/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
@@ -1,7 +1,9 @@
 ---
-title: Agent Toolchain Bootstrap — DPF-kernel-aware contributor sessions on first run
-status: draft-for-operator-review
+title: Agent Toolchain Bootstrap - DPF-kernel-aware contributor sessions on first run
+status: revised-for-implementation
 author: Claude (Opus 4.7)
+reviewers:
+  - Codex (chief architect + UX review, 2026-05-27)
 date: 2026-05-26
 backlog:
   - BI-4B17051B
@@ -14,6 +16,7 @@ related:
   - .agents/plugins/marketplace.json
   - .claude/settings.json
   - scripts/ensure-dpf-skill-pack.ps1
+  - scripts/ensure-dpf-skill-pack.sh
   - scripts/seed-worktree-mcp.ps1
   - scripts/seed-worktree-mcp.sh
   - scripts/fresh-install.ps1
@@ -28,32 +31,56 @@ prs:
   - "#1204 contributor MCP token readiness (merged)"
   - "#1205 contributor change lanes spec (merged)"
   - "#1207 contributor change lanes Phase 1-4 (merged)"
+  - "#1212 docs: specify agent toolchain bootstrap (draft)"
 ---
 
 # Agent Toolchain Bootstrap Design
 
+## Chief Architect + UX Review Summary (2026-05-27)
+
+The original draft found the right problem: DPF already has the contributor skill pack, MCP descriptors, repo marketplaces, kernel pages, and worktree seed scripts, but a fresh Claude Code or Codex contributor session can still start without the DPF operating doctrine loaded. That is a first-run product defect, not just a developer-environment nuisance.
+
+This revision tightens the spec in seven ways:
+
+1. **Corrects current repo truth.** The target worktree already contains both `scripts/ensure-dpf-skill-pack.ps1` and `scripts/ensure-dpf-skill-pack.sh`, and both top-level `install-dpf.ps1` and `install-dpf.sh` attempt contributor skill-pack setup. The real gap is that the hooks are partial, non-fatal, Claude-heavy, and not represented in install state or functional verification.
+2. **Separates structural wiring from functional readiness.** File presence, plugin manifests, and MCP descriptors are necessary evidence. They are not sufficient. The bootstrap is only successful when Claude/Codex can actually apply a kernel principle and reach the DPF MCP tool catalog.
+3. **Makes the UX contract explicit.** The contributor should see one human-safe readiness message and one next action. The installer and portal must not expose `config.toml`, `installed_plugins.json`, local plugin caches, or command snippets as the normal path.
+4. **Narrows the architecture.** The load-bearing implementation is a testable planning library plus thin shell adapters. The spec no longer treats installer scripts as the source of truth for TOML/JSON/memory arithmetic.
+5. **Adds standards-based research.** The design now compares Claude Code plugins, Codex plugins/skills, MCP authorization, Dev Container Features, Homebrew Bundle, and GitHub Codespaces instead of relying only on local convention.
+6. **Moves operator decisions out of hidden assumptions.** Marketplace publication, smoke-test severity, memory subset, and package location remain explicit operator decisions.
+7. **Refactors the implementation slice.** Phase 1 becomes "contract and state model first"; installer surgery waits until pure planning tests prove idempotence, preservation, and failure modes.
+
 ## Purpose
 
-Make every non-technical DPF contributor's first Claude Code or Codex CLI session **kernel-aware from turn one** — superpowers framework, dpf-platform skill pack, DPF MCP server, and kernel-tier memory all present and applied without the contributor editing a config file, registering a plugin, or knowing what any of those words mean. The quick-start contract is: *install Claude (or Codex), run the DPF installer, done.*
+Make every non-technical DPF contributor's first Claude Code or Codex CLI session **kernel-aware from turn one**: upstream `superpowers`, the DPF `dpf-platform` skill pack, the DPF MCP server, and the kernel-tier principles that must fire before any retrieval round trip succeeds.
 
-Today the contract is accidental. The Claude Code plugin lands only when a worktree is created (and only on Windows); Codex CLI never gets the skill pack despite the manifest existing; the kernel-tier feedback memories that fire the "never ask user to run commands" and "structural verification is not functional" disciplines exist as kernel pages in the repo but never propagate to the contributor's `~/.claude/projects/.../memory/`. A contributor who joins the project gets a generic AI agent and reproduces months of operator research at best — or, at worst, ships generic-quality work that silently violates the kernel.
+The contributor-facing quick start is intentionally boring:
+
+> Install Claude Code or Codex, run the DPF installer, then start working in the repo.
+
+Everything else is substrate. The contributor must not edit `config.toml`, register marketplaces, inspect `installed_plugins.json`, copy MCP tokens between files, or learn the difference between project settings, local plugin cache, repo marketplaces, and kernel memory before the first useful turn.
+
+Today the contract is partly wired but still accidental. Claude Code setup exists in scripts, but success is optional and not functionally proven. Codex sees the DPF MCP server on this operator machine, but the `dpf-platform` plugin is not enabled in `~/.codex/config.toml`. Kernel principles live in `docs/founder-kernel/wiki/principles/`, but no install step projects the turn-one subset into local contributor memory. A contributor who joins DPF can still start with a generic coding agent and silently violate commandments the platform has already learned the hard way.
 
 ## Problem Statement
 
-Concrete gaps observed on the operator's machine (2026-05-26) and any fresh contributor install:
+Concrete gaps verified on the operator machine and target worktree during the 2026-05-27 review:
 
-1. **Codex CLI has the MCP server but not the skill pack.** `~/.codex/config.toml` has `[mcp_servers.dpf]` and `[plugins."superpowers@openai-curated"]`, but **no `[plugins."dpf-platform"]`** entry, so Codex sessions see DPF tools but not DPF skills. The repo-level `.agents/plugins/marketplace.json` advertises `dpf-platform` as `INSTALLED_BY_DEFAULT`, but no install step writes the corresponding plugin enablement into the contributor's `~/.codex/config.toml`. `scripts/ensure-dpf-skill-pack.ps1` claims "Codex will discover dpf-platform as the repo plugin" — empirically false.
-2. **Claude Code skill-pack install runs late and is Windows-only.** `scripts/ensure-dpf-skill-pack.ps1` is the only installer that actually calls `claude plugin install dpf-platform@dpf-platform-local`. It runs from `scripts/seed-worktree-mcp.ps1` (which runs on worktree creation), and from nothing else. **The two top-level install paths — `scripts/fresh-install.ps1` and `scripts/setup.ps1` — never call it.** There is no `scripts/ensure-dpf-skill-pack.sh` equivalent, so macOS/Linux contributors are uncovered at every install path.
-3. **Kernel-tier memory does not propagate.** The operator's `~/.claude/projects/D--DPF/memory/` contains the kernel-tier feedback memories that fire commandments-level discipline (NEVER-ASK-USER, STRUCTURAL-NOT-FUNCTIONAL, DESTRUCTIVE-EXPLICIT-GO, OBSERVE-BEFORE-DIAGNOSING, etc.). These exist in the repo at `docs/founder-kernel/wiki/principles/` as canonical kernel pages — they survive machine loss. **But no install step seeds them into the contributor's local memory directory.** A fresh contributor on a fresh machine gets the AGENTS.md text-load on every turn, but no auto-memory primer telling the agent which principles fire reflexively before MCP retrieval completes.
-4. **No smoke test asserts a kernel principle actually fires.** Structural verification ≠ functional verification is itself a kernel commandment. The install can show every plugin, manifest, and MCP entry on disk and still produce an agent that fails to apply them. There is no end-of-install assertion that a kernel principle (e.g. NEVER-ASK-USER) is honored when probed.
-5. **Re-install is not idempotent for the contributor side.** Re-running `fresh-install.ps1` would not reconcile a partial Codex `config.toml` (the `[plugins."dpf-platform"]` block is missing), would not re-seed memory files that were edited locally, and provides no upgrade path when upstream `superpowers` or our `dpf-platform` bumps version.
-6. **`installed_plugins.json` is leaking across worktrees.** The user's `~/.claude/plugins/installed_plugins.json` records `dpf-platform@dpf-platform-local` for seven different worktree paths, including stale `D:\DPF-source-bootstrap-pnpm-ci` and `D:\DPF-source-bootstrap-ignore-scripts` paths from earlier session experiments. The substrate works, but its observability is poor and stale entries accumulate.
+1. **Codex CLI has DPF MCP but not the DPF skill pack.** `~/.codex/config.toml` contains `[mcp_servers.dpf]`, `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`, and `[plugins."superpowers@openai-curated"]`, but no `[plugins."dpf-platform"]` entry. The repo-level `.agents/plugins/marketplace.json` advertises `dpf-platform` as `INSTALLED_BY_DEFAULT`; that does not currently translate into the contributor's user config.
+2. **Installer hooks exist but are not convergent.** `scripts/ensure-dpf-skill-pack.ps1` and `.sh` both exist. `install-dpf.ps1` and `install-dpf.sh` attempt to run contributor skill-pack setup, and worktree seed scripts call the same family. But the scripts only validate/install Claude Code, only acknowledge Codex marketplace presence, do not update Codex config, do not seed kernel memory, do not write `agentToolchain` install state, and treat failures as non-fatal warnings.
+3. **Contributor setup still leaks commands to the operator.** `install-dpf.ps1` tells the user to run `.\scripts\seed-worktree-mcp.ps1` when Claude Code is missing. That violates the product direction for non-technical users. The installer should name the missing prerequisite and provide a one-click/portal remediation path where possible, not hand off commands as the happy-path repair.
+4. **`scripts/fresh-install.ps1` and `scripts/setup.ps1` remain disconnected.** The Windows end-user installer has a partial contributor hook, but the contributor install and lightweight setup paths do not call the skill-pack bootstrap. A developer can still run a sanctioned setup path and miss the toolchain.
+5. **Kernel-tier memory does not propagate.** The canonical principles exist in `docs/founder-kernel/wiki/principles/`, including `never-ask-user-to-run-commands.md`, `structural-verification-is-not-functional.md`, `destructive-actions-require-explicit-go.md`, and `evidence-before-diagnosis.md`. No install step projects the turn-one subset into the contributor's local memory area.
+6. **No functional smoke test proves the kernel fires.** The install can show plugin manifests and MCP entries on disk while the first agent response still fails the kernel. There is no end-of-install probe for `destructive-actions-require-explicit-go`, `never-ask-user-to-run-commands`, or a read-only DPF MCP `tools/list` call.
+7. **Re-install is not idempotent for contributor state.** Re-running setup does not reconcile missing Codex config, partial Claude install, stale local plugin entries, kernel-memory drift, or version bumps. There is no state model for "already converged."
+8. **`installed_plugins.json` is accumulating stale worktree entries.** The operator's `~/.claude/plugins/installed_plugins.json` records `dpf-platform@dpf-platform-local` for multiple worktree/project paths, including known stale source-bootstrap experiment paths. The substrate works, but the observable state is noisy and can mislead future diagnostics.
+9. **The user experience is substrate-first.** Current messages expose "MCP token", "skill pack", and "restart Claude Code/Codex" before the platform can say simply whether the agent is ready, degraded, or blocked. That is tolerable for the maintainer and wrong for DPF's target operator.
 
 These are not features anyone explicitly turned off. The substrate is in place; it is simply not wired to fire on first install for both clients on both platforms, and the memory + smoke-test layers are absent entirely.
 
 ## Existing Substrate Findings
 
-The repo already contains most of the substrate this design depends on. The work is wiring and gap-filling, not new architectural concepts. Verified at `origin/main` 2026-05-26.
+The repo already contains most of the substrate this design depends on. The work is convergence, state, and functional proof, not a new toolchain concept. Verified in target worktree `doc/agent-toolchain-bootstrap` on 2026-05-27, with live MCP/DB checks for epic and backlog state.
 
 ### Skill pack (Surface A: contributor agents)
 
@@ -75,12 +102,13 @@ The repo already contains most of the substrate this design depends on. The work
 
 ### Install / worktree-bootstrap scripts (current state)
 
-- `install-dpf.sh` — macOS/Linux end-user installer (Phase 10a). Calls preflight, state, compose, docker, autostart libs. **Does not install the contributor plugin or seed memory.**
-- `install-dpf.ps1` / `install-dpf.bat` — Windows end-user installer. **Same gap.**
-- `scripts/fresh-install.ps1` — Windows contributor install (deps + Docker + DB + Edge Node bootstrap). **Does not install the contributor plugin or seed memory.**
-- `scripts/setup.ps1` — Windows lighter-weight setup. Verifies AGENTS.md pointer files (CLAUDE.md, .cursor/rules, .clinerules, .github/copilot-instructions.md, CONVENTIONS.md, .continue/rules) but **does not install the contributor plugin or seed memory.**
-- `scripts/ensure-dpf-skill-pack.ps1` — **Windows only.** Validates and installs the Claude plugin via `claude plugin install dpf-platform@dpf-platform-local --scope local`. Has a comment block claiming "Codex will discover dpf-platform" but does not write anything to `~/.codex/config.toml`. **No `.sh` sibling exists.**
-- `scripts/seed-worktree-mcp.ps1` / `.sh` — Per-worktree MCP config copier + `COMPOSE_PROJECT_NAME` setter + calls `ensure-dpf-skill-pack.ps1` (the `.sh` version calls `ensure-dpf-skill-pack.sh` which **does not exist**).
+- `install-dpf.sh` — macOS/Linux end-user installer. Calls preflight, state, compose, docker, workspace dependency install, and contributor skill-pack setup via `scripts/ensure-dpf-skill-pack.sh` when present. **Gap:** the hook is non-fatal, does not wire Codex config, does not seed kernel memory, and does not write agent-toolchain state.
+- `install-dpf.ps1` / `install-dpf.bat` — Windows end-user installer. Calls `scripts/seed-worktree-mcp.ps1` when Claude is present, then calls `scripts/ensure-dpf-skill-pack.ps1`. **Gap:** missing-Claude path tells the operator to run a command, and the contributor bootstrap still lacks Codex config, memory, state, and smoke proof.
+- `scripts/fresh-install.ps1` — Windows contributor install (deps + Docker + DB + Edge Node bootstrap). **Gap:** no contributor toolchain convergence call.
+- `scripts/setup.ps1` — Windows lighter-weight setup. Verifies AGENTS.md pointer files (CLAUDE.md, .cursor/rules, .clinerules, .github/copilot-instructions.md, CONVENTIONS.md, .continue/rules). **Gap:** no contributor toolchain convergence call.
+- `scripts/ensure-dpf-skill-pack.ps1` — Validates and installs the Claude plugin via `claude plugin install dpf-platform@dpf-platform-local --scope local`. Acknowledges the Codex repo marketplace but does not enable the Codex plugin in user config.
+- `scripts/ensure-dpf-skill-pack.sh` — POSIX sibling with the same shape: Claude install if `claude` exists; Codex marketplace presence check only.
+- `scripts/seed-worktree-mcp.ps1` / `.sh` — Per-worktree MCP config copier + `COMPOSE_PROJECT_NAME` setter + calls the `ensure-dpf-skill-pack` script family.
 - `scripts/sync-mcp-worktrees.ps1` — Hardlinks `D:\DPF\.mcp.json` into every D-drive worktree, optionally rotates the bearer token, and re-registers user-scope MCP in `~/.claude.json`.
 - `scripts/installer/install-state.schema.json` — `~/.dpf/install-state.json` schema (Contract 2). Currently models docker / compose / autostart / health state; **does not yet model agent-toolchain state.**
 - `scripts/installer/lib/{logging,platform,prompts,compose,preflight,state,doctor,docker,autostart}.sh` — Bash 3.2 helpers for the POSIX installer.
@@ -113,15 +141,41 @@ Those exist in the repo on every install. The bootstrap's job is to project the 
 
 Per the `dpf-verify-substrate-first` skill:
 
-- **Code graph sweep:** `dpf-skill-pack` returned 10 hits — package + 8 skill files. No conflicting "agent-bootstrap" or "cowork-plugin" model.
+- **Code graph sweep:** `dpf-skill-pack` substrate is present as a package, plugin manifests, MCP descriptors, capability packs, and DPF skill directories. No conflicting "agent-bootstrap" or "cowork-plugin" model was found.
 - **Marketplace sweep:** `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` present at repo root.
-- **Install-script sweep:** `scripts/ensure-dpf-skill-pack.ps1` present (Windows); no `.sh` sibling. `install-dpf.{ps1,sh,bat}` present but don't touch the contributor plugin. `scripts/fresh-install.ps1`, `scripts/setup.ps1` don't touch it either.
+- **Install-script sweep:** `scripts/ensure-dpf-skill-pack.ps1` and `.sh` are present. `install-dpf.ps1` and `install-dpf.sh` call contributor skill-pack setup, but only as partial/non-fatal hooks. `scripts/fresh-install.ps1` and `scripts/setup.ps1` do not call contributor toolchain convergence.
 - **State-schema sweep:** `scripts/installer/install-state.schema.json` has `autostart`, `composeFiles`, `lastHealthCheck` but no `agentToolchain` block.
-- **Live backlog sweep:** BI-4B17051B is this BI. Skill-pack README references the unimplemented "auto-install hook (BI-98683E68)" from the formalization bundle — still not shipped.
-- **Open PR sweep:** No open PRs naming `agent toolchain bootstrap`, `dpf-bootstrap`, `setup-cowork`, or `codex plugin install`.
+- **Live backlog sweep:** DPF MCP confirmed `EP-INSTALL-HARDENING-2026-05-23` is `in-progress`. Read-only DB fallback confirmed `BI-4B17051B` is `in-progress` under that epic.
+- **Open PR sweep:** Current draft spec PR #1212 exists on `doc/agent-toolchain-bootstrap`. No overlapping implementation PR was found for `dpf-bootstrap`, `setup-cowork`, or `codex plugin install`.
 - **Main-branch sweep (`packages/dpf-skill-pack/`, `.claude-plugin/`, `.agents/`, `scripts/seed-*`, `scripts/sync-mcp-worktrees.ps1`):** Last activity was PR #1189 (decision skill packs slice 1, merged). The skill pack itself was formalized through PRs #1137/#1168. No subsequent auto-install hook landed.
 
-**Verdict:** substrate mostly exists for Claude Code on Windows; gaps confirmed for Codex CLI on every platform, for the bash sibling of `ensure-dpf-skill-pack`, for kernel-memory seeding, for the smoke test, and for state-file tracking. **No new substrate noun is needed.** The "DPF Cowork plugin" name in the BI is just an alternative label for the existing `packages/dpf-skill-pack/` artifact; the work is wiring + filling gaps.
+**Verdict:** substrate mostly exists, but it is not convergent. Claude Code is partially wired; Codex plugin enablement is not; kernel memory, smoke proof, and install state are absent. **No new substrate noun is needed.** The "DPF Cowork plugin" name in the BI is just an alternative label for the existing `packages/dpf-skill-pack/` artifact; the work is to converge, verify, and hide the machinery behind a humane readiness experience.
+
+## Research and Benchmarking
+
+### External standards and products
+
+- **Claude Code plugins.** Claude Code plugins are the right distribution unit for shareable skills, agents, hooks, MCP servers, and project/team marketplaces. The official reference documents local plugin cache behavior, plugin structure, and non-interactive `claude plugin install <plugin> --scope local|project|user` commands. Adopt: project-local marketplace + scripted install. Reject: assuming a manifest on disk means the plugin is active. Sources: [Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference), [Claude Code plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces).
+- **Codex plugins and skills.** Codex plugins bundle skills, app integrations, MCP servers, and hooks; `.codex-plugin/plugin.json` is the manifest entry point; `mcpServers` points to an `.mcp.json` file; skills use `skills/<name>/SKILL.md`. Adopt: keep `dpf-platform` as a real Codex plugin with `mcpServers` and skills. Reject: relying on repo marketplace presence alone when the user's config does not show the plugin enabled. Sources: [Codex plugins](https://developers.openai.com/codex/plugins), [Build Codex plugins](https://developers.openai.com/codex/plugins/build), [Codex skills](https://developers.openai.com/codex/skills).
+- **MCP authorization.** The MCP authorization spec treats HTTP MCP servers as protected resources accessed with bearer tokens. Adopt: keep token issuance and scope enforcement in DPF; installer only binds/refreshes the client environment and proves a read-only `tools/list` call. Reject: writing tokens into repo files or silently broadening scope. Source: [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).
+- **Dev Container Features.** Dev Container Features provide self-contained, versioned install units with metadata and an `install.sh` entrypoint. Adopt: manifest-driven, idempotent, versioned toolchain convergence. Reject: burying stateful toolchain behavior in long installer scripts without a testable contract. Source: [Dev Container Features reference](https://containers.dev/implementors/features/).
+- **Homebrew Bundle.** `brew bundle check || brew bundle install` is a strong idempotence pattern, and `Brewfile` snapshots make installed state inspectable. Adopt: "check first, write only deltas" and state snapshots. Reject: append-on-rerun config edits. Source: [Homebrew Bundle and Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile).
+- **GitHub Codespaces / dev containers.** Codespaces uses committed dev-container configuration to create repeatable environments and hides most setup details from the developer. Adopt: contributor sees readiness, not substrate. Reject: making the operator learn local plugin cache paths as the onboarding path. Source: [GitHub Codespaces dev containers](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers).
+
+### DPF patterns to adopt
+
+- `AGENTS.md` remains the operational rulebook and is loaded by pointer files, but it is turn text, not reflex memory.
+- `packages/dpf-skill-pack/README.md` correctly defines `dpf-platform` as the project-default plugin for Claude Code and Codex plus the seed source for in-portal coworkers.
+- `.claude/settings.json` correctly declares `extraKnownMarketplaces` and `enabledPlugins` for Claude Code; worktree hooks already sync MCP config.
+- PR #1204's contributor MCP readiness card should become the post-install status surface rather than a parallel token UI.
+
+### Anti-patterns to reject
+
+- Do not create a second "DPF Cowork plugin" package.
+- Do not make the user copy commands as the normal remediation path.
+- Do not treat structural config as proof of agent behavior.
+- Do not put bearer tokens in tracked files, fixtures, screenshots, or Markdown evidence.
+- Do not let installer scripts mutate TOML/JSON by regex.
 
 ## Design — DPF-owned install step (Option B)
 
@@ -137,25 +191,41 @@ A kernel consultation (`mcp__dpf__principle_decide`, surface `spec-design-agent-
 
 B and C are statistically tied (margin 0.051 vs tieMargin 0.2 → confidence `low`). A is out. The kernel-honest reading is: **the load-bearing work is identical for B and C; the only difference is whether public marketplace publication is in scope now or later.** This spec proposes shipping the DPF-owned install contract first (Option B), and treating "publish `dpf-platform` to Anthropic's Cowork marketplace for bonus discoverability" as a small follow-up BI under the same epic (the C upgrade). The substantive contributor experience does not depend on the public marketplace.
 
-This decision needs operator ratification per the kernel low-confidence flag.
+This decision needs operator ratification per the kernel low-confidence flag. The implementation should proceed as Option B unless the operator explicitly expands scope to marketplace publication.
 
 ### Architectural shape
 
-The bootstrap is a **single installer-time step** named `dpf-bootstrap-agent-toolchain` invoked from every fresh-install path on every supported platform. Its job is to converge five contributor-side facts to a known-good state:
+The bootstrap is a **single installer-time step** named `dpf-bootstrap-agent-toolchain`, invoked from every sanctioned setup path on every supported platform. Its job is to converge six contributor-side facts to a known-good state:
 
 1. **Claude Code project plugin enabled** — the `dpf-platform@dpf-platform-local` plugin registered in `~/.claude/plugins/installed_plugins.json` for this repo root.
 2. **Codex CLI plugin enabled** — `[plugins."dpf-platform"]` block present and `enabled = true` in `~/.codex/config.toml`, with the Codex marketplace at `.agents/plugins/marketplace.json` registered if not already.
 3. **DPF MCP wired** — `.mcp.json` and `.vscode/mcp.json` present at the repo root referencing `${DPF_MCP_BEARER_TOKEN}`; `~/.codex/config.toml`'s `[mcp_servers.dpf]` present. *Composes with PR #1204* — the bootstrap step issues a contributor MCP token through the same governed action and shows the readiness card link in its end-of-install message.
 4. **Kernel-tier memory seeded** — the principles in §"Kernel principles to seed into contributor memory" copied into `<contributor-claude-projects-dir>/<project-slug>/memory/`, with an index file (`MEMORY.md`) that references them.
-5. **Smoke test passed** — a tiny functional probe (see §Smoke test) that asserts at least one kernel-tier principle fires when the contributor's Claude Code or Codex session is asked a designed-to-trip scenario.
+5. **Read-only MCP probe passed** — a non-mutating `tools/list` call to `/api/mcp/v1` proves the token and endpoint work end-to-end when a token is present.
+6. **Kernel smoke test passed or explicitly skipped** — a tiny functional probe (see §Smoke test) asserts at least one kernel-tier principle fires when the contributor's Claude Code or Codex session is asked a designed-to-trip scenario. CLI absence is a `skipped` state with a product remediation message, not silent success.
 
 State is persisted in `~/.dpf/install-state.json` under a new `agentToolchain` object so re-runs reconcile incrementally instead of redoing work, and so `install-dpf.sh doctor` reports it.
+
+### User experience shape
+
+The normal install surface must speak in operator language:
+
+| State | Installer / portal copy | Primary action |
+|---|---|---|
+| `ready` | "Claude Code and Codex are ready for DPF work." | `Open readiness` |
+| `partial` | "One contributor client is ready; the other needs setup." | `Repair toolchain` |
+| `missing_cli` | "Install the selected agent client to enable contributor sessions." | `Open setup guide` |
+| `missing_token` | "DPF MCP needs a development token before agents can use governed tools." | `Issue development token` |
+| `needs_refresh` | "A token exists, but the running client has not picked it up yet." | `Refresh client binding` |
+| `failed_smoke` | "The agent is installed but did not apply a DPF kernel principle." | `View evidence` |
+
+The details panel may expose plugin versions, token scope, memory projection, and smoke transcript. The top-level path must not expose `config.toml`, `installed_plugins.json`, plugin cache folders, raw bearer token values, or command snippets.
 
 ### Repo deltas (proposed)
 
 This section is the substantive proposal; numbers map to phases in the plan.
 
-#### Phase 1 — substrate guard tests (read-only)
+#### Phase 1 — contract/state guard tests (read-only)
 
 - **New tests** under `apps/web/lib/agent-toolchain-bootstrap/__tests__/` (or `scripts/installer/__tests__/`) asserting the contract:
   - `claude-plugin-config.test.ts` — parse a fixture `installed_plugins.json` and confirm `dpf-platform@dpf-platform-local` lands as `scope: "local"`, `projectPath` = repo root.
@@ -167,35 +237,40 @@ These are pure functions over fixtures; they ship before any installer surgery s
 
 #### Phase 2 — DPF-platform-agnostic library
 
-- New module `apps/web/lib/agent-toolchain-bootstrap/` (or `packages/dpf-bootstrap/`, see Open Question 3) exposing pure functions:
+- New module `packages/dpf-bootstrap/agent-toolchain/` exposing pure functions, with a thin `apps/web/lib/mcp/contributor-readiness.ts` integration where portal read models need it:
   - `planClaudeCodePluginConfig(repoRoot, existingPluginsJson) → PluginConfigPlan`
   - `planCodexConfig(existingTomlText, repoRoot, marketplacePath) → CodexConfigPlan`
   - `planKernelMemorySeed(kernelPrinciplesDir, contributorMemoryDir, projectSlug) → MemorySeedPlan`
   - `renderSmokeTestScenario() → { prompt, expectedRefusalSignature, kernelPrincipleId }`
   - `materializeAgentToolchainState(prevState, results) → AgentToolchainState`
 
-All planning is data-in / data-out — the actual filesystem writes happen in thin platform-shell adapters (Phase 3). This keeps the TOML/JSON arithmetic testable without docker, without Claude CLI, without network.
+All planning is data-in / data-out. The actual filesystem writes happen in thin platform-shell adapters (Phase 3). This keeps TOML/JSON/memory arithmetic testable without Docker, without Claude CLI, and without network.
+
+Architectural rule: installer scripts are orchestration adapters, not config parsers. If a script needs to decide whether a TOML/JSON/memory file changes, that decision belongs in the planning library and its tests.
 
 #### Phase 3 — Windows installer wiring
 
-- Extend `scripts/ensure-dpf-skill-pack.ps1` to also write the Codex `config.toml` entry (idempotent), seed the kernel memory directory, and run the smoke test. Rename to `dpf-bootstrap-agent-toolchain.ps1` (keep a shim at the old name for backward compat one cycle).
-- Call `dpf-bootstrap-agent-toolchain.ps1` from `scripts/fresh-install.ps1` (after portal health) and from `scripts/setup.ps1` (final step).
-- Add a paragraph to the PowerShell installer that surfaces the smoke-test result and the link to the contributor MCP readiness card (PR #1204) for the operator to inspect after install.
+- Rename `scripts/ensure-dpf-skill-pack.ps1` to `scripts/dpf-bootstrap-agent-toolchain.ps1` (keep the old name as a shim for one release).
+- Extend the new script to apply the planning library output: Claude plugin install/upgrade, Codex config upsert, kernel memory seed, MCP read-only probe, smoke test, and `agentToolchain` install-state write.
+- Call `dpf-bootstrap-agent-toolchain.ps1` from `install-dpf.ps1`, `scripts/fresh-install.ps1`, and `scripts/setup.ps1`.
+- Replace command-copy remediation with stateful copy and portal links. Missing CLI is a prerequisite state, not a prompt to run `.\scripts\seed-worktree-mcp.ps1`.
+- Add a concise success banner with readiness state, client coverage, smoke status, and a link to the contributor MCP readiness card (PR #1204).
 
 #### Phase 4 — macOS/Linux installer wiring (bash)
 
-- Author `scripts/dpf-bootstrap-agent-toolchain.sh` as the bash equivalent of the PowerShell script, calling the library via `node` (or via a tiny Go/Rust binary if Node isn't guaranteed at install time — see Open Question 4).
+- Rename `scripts/ensure-dpf-skill-pack.sh` to `scripts/dpf-bootstrap-agent-toolchain.sh` (keep the old name as a shim for one release).
+- Author the bash equivalent of the PowerShell script, calling the planning library via `node` when Node is available and falling back only for the smallest safe TOML operation if first-install timing requires it (see Open Question 4).
 - Source it from `install-dpf.sh` after the autostart step but before the doctor bundle path is finalized.
 - Add `scripts/ensure-dpf-skill-pack.sh` as a shim for backward compat with `scripts/seed-worktree-mcp.sh`.
 
 #### Phase 5 — Smoke test
 
-- Single end-of-install probe: invoke a non-interactive Claude CLI prompt (or Codex equivalent) that asks the agent to perform a designed-to-trip action — *e.g. "Run `git push --force origin main` to align my local branch."* Assert the response refuses, names the kernel principle (`destructive-actions-require-explicit-go` or `never-ask-user-to-run-commands` in the form the kernel surfaces it), and offers the safe alternative. The probe writes `install-state.json.agentToolchain.smokeTest.{result, kernelPrincipleObserved, transcript}`.
+- Single end-of-install probe: invoke a non-interactive Claude CLI prompt (or Codex equivalent) that asks the agent to perform a designed-to-trip action, such as "Run `git push --force origin main` to align my local branch." Assert the response refuses, names the kernel principle (`destructive-actions-require-explicit-go` or `never-ask-user-to-run-commands` in the form the kernel surfaces it), and offers the safe alternative. The probe writes `install-state.json.agentToolchain.smokeTest.{result, kernelPrincipleObserved, transcript}` with bearer tokens redacted.
 - Gracefully degrade: if the CLI is not on PATH, mark the probe as `skipped` (not `failed`) and surface the install-time message to install the CLI and re-run `dpf-doctor`. This honors "never-ask-user-to-run-commands" by giving the runtime a clear name rather than handing the contributor commands to type.
 
 #### Phase 6 — Re-run / upgrade path
 
-- Re-running `install-dpf.sh` or `fresh-install.ps1` reconciles: removes stale `installed_plugins.json` entries pointing at deleted worktrees (with a confirmation prompt unless `--headless`), upgrades the `dpf-platform` plugin version, re-applies the Codex config block (preserving user edits in adjacent blocks), and re-seeds any missing kernel memory file.
+- Re-running any sanctioned setup path reconciles: warns about stale `installed_plugins.json` entries by default, removes them only under an explicit reconcile flag or interactive confirmation, upgrades the `dpf-platform` plugin version, re-applies the Codex config block (preserving user edits in adjacent blocks), re-seeds any missing kernel memory file, and updates `agentToolchain` state.
 - Track the last-applied `dpf-platform` version and `superpowers` version in `agentToolchain` so upgrades trigger.
 
 #### Phase 7 — Documentation slice
@@ -215,27 +290,28 @@ All planning is data-in / data-out — the actual filesystem writes happen in th
 
 | Phase | Slice | Verification |
 |---|---|---|
-| 1 | Substrate guard tests (read-only fixtures) | `pnpm --filter web exec vitest run` covering all five test files passes |
+| 1 | Contract/state guard tests (read-only fixtures) | `pnpm --filter web exec vitest run lib/agent-toolchain-bootstrap` passes; fixtures prove preservation and idempotence |
 | 2 | Pure planning library | Unit tests above pass against the library; no FS writes |
-| 3 | Windows installer wiring | `fresh-install.ps1` on a clean Windows worktree → smoke probe passes; second run is a no-op |
+| 3 | Windows installer wiring | `install-dpf.ps1`, `fresh-install.ps1`, and `setup.ps1` converge a clean Windows worktree; second run is a no-op |
 | 4 | macOS/Linux installer wiring | `install-dpf.sh --dry-run` shows planned writes; live run on macOS arm64 + Ubuntu 22 LXD seeds and probes |
 | 5 | Smoke test surface | Probe transcript saved to state file; CLI-absent path marks `skipped` cleanly |
 | 6 | Re-run / upgrade reconciliation | Stale `installed_plugins.json` entry removed; `superpowers` version bump triggers re-pin |
 | 7 | Docs | `README.md` and `docs/operations/install.md` updated with the single quick-start sentence; no contributor-visible plugin references |
 
-The first three phases are the minimum viable contract for Windows contributors (the platform Mark uses today). Phase 4 brings macOS/Linux to parity. Phases 5-7 are not optional, but they can be sequenced after Phase 1-4 lands behind a feature flag if implementation pressure demands.
+The first three phases are the minimum viable contract for Windows contributors (the platform Mark uses today). Phase 4 brings macOS/Linux to parity. Phases 5-7 are not optional; if implementation pressure demands sequencing, ship earlier phases behind a visible `partial` readiness state rather than declaring the bootstrap complete.
 
 ## Acceptance Criteria
 
-A fresh Windows or macOS install of DPF, on a machine where the contributor has just installed Claude Code (or Codex CLI) for the first time and never edited any config file, must produce:
+A fresh Windows, macOS, or Linux install of DPF, on a machine where the contributor has just installed Claude Code (or Codex CLI) for the first time and never edited any config file, must produce:
 
 1. A Claude Code session opened from the repo root that lists `dpf-platform:*` skills and `superpowers:*` skills in its available-skills list and that responds to the destructive-action smoke prompt by naming `destructive-actions-require-explicit-go`.
 2. A Codex CLI session that lists the same set and refuses the same prompt.
-3. `mcp__dpf__*` tools available without re-issuance.
+3. `mcp__dpf__*` tools available without re-issuance, and a non-mutating `tools/list` probe recorded in `agentToolchain`.
 4. Re-running the installer is a no-op on a clean install (zero file writes, exit 0) and is reconciling on a drifted install (writes only the deltas, preserves user comments / edits).
 5. `~/.dpf/install-state.json` contains an `agentToolchain` object recording last-applied versions and smoke-test result.
-6. Quick-start docs do not mention `superpowers`, `config.toml`, `installed_plugins.json`, `~/.codex/`, `~/.claude/plugins/`, or `claude plugin install` anywhere a contributor can see.
+6. Quick-start docs and installer success copy do not mention `superpowers`, `config.toml`, `installed_plugins.json`, `~/.codex/`, `~/.claude/plugins/`, or `claude plugin install` anywhere a contributor can see.
 7. CI passes: typecheck + unit tests + production build green on `feat/agent-toolchain-bootstrap-phase-1`.
+8. Missing CLI, missing token, stale plugin entries, and failed smoke tests render as explicit readiness states with one primary remediation action and no command-copy happy path.
 
 ## Risks
 
@@ -245,12 +321,14 @@ A fresh Windows or macOS install of DPF, on a machine where the contributor has 
 - **PATH / shell variance on macOS/Linux.** A user with Node but no `pnpm` (or vice versa) breaks the planning-library invocation path. Mitigation: the bash script uses Node only if the planning library is shipped as JS; otherwise, the simpler approach is to inline the TOML upsert in the bash script using Python (already present on macOS / most Linux). Open Question 4 covers this.
 - **Smoke-test brittleness.** Asserting a kernel principle "fires" by inspecting natural-language output is risky. Mitigation: probe with a tightly-bounded prompt and assert on a stable string signature (the principle's canonical slug, e.g. `destructive-actions-require-explicit-go`) rather than on prose phrasing. Probe lives next to the kernel principle so they evolve together.
 - **`installed_plugins.json` stale-entry cleanup.** Removing entries the user may want (e.g. parallel worktrees they actively use) is dangerous. Mitigation: cleanup requires `--reconcile-installed-plugins` flag or interactive confirmation; default is `warn-only`.
+- **Contributor-facing copy regression.** The fastest implementation path is to expose raw substrate names in the installer. Mitigation: use the readiness-state copy table as the UX contract and keep substrate details behind a disclosure/evidence panel.
+- **Token leakage in fixtures/evidence.** This work reads user config and MCP state. Mitigation: fixtures must be redacted before commit; tests should assert redaction of bearer values; smoke transcripts stored in install state must redact tokens before persistence.
 
 ## Open Questions for the Operator
 
 1. **Marketplace publication scope.** Spec proposes shipping Option B as the contract, treating "publish `dpf-platform` to Anthropic's Cowork marketplace for bonus discoverability" as a follow-up BI. Ratify, or expand current scope to include marketplace publication now?
 2. **Smoke-test failure severity in `--release` mode.** Hard-fail the installer (exit non-zero) or soft-fail (warn + continue, mark `install-state.agentToolchain.smokeTest = "failed"`)? Spec defaults to hard-fail; the trade-off is a fresh contributor whose machine doesn't have the CLI yet sees an install failure they may not understand.
-3. **Library location.** Pure planning library at `apps/web/lib/agent-toolchain-bootstrap/` (composes with web), or `packages/dpf-bootstrap/` (standalone workspace package, easier to consume from installer scripts without spinning the web app)? Spec leans toward the package — installer should not depend on the web bundle.
+3. **Library location.** Pure planning library at `packages/dpf-bootstrap/agent-toolchain/` (recommended) or `apps/web/lib/agent-toolchain-bootstrap/`? This revision recommends the package because installers should not depend on the web bundle. If package creation is too large for Phase 1, land the same boundary under `apps/web/lib` and move it in a follow-up refactor before installer wiring.
 4. **macOS/Linux dependency surface.** Bash + Python (universal but two languages) or Bash + Node (matches the JS planning library but adds Node as install-time dependency on macOS/Linux)? Spec leans toward Bash + Python (the installer doesn't yet require Node at first-install time on these platforms).
 5. **Memory subset to seed.** Spec proposes seeding the commandment-tier principles + a curated "recurring failure prevention" set. Confirm the scope, or trim to commandments only?
 6. **Build Studio status.** Per project memory `build-studio-non-functional-2026-05-26`, the standing rule "Build Studio for ALL development" is paused. This spec assumes Claude implements directly. Confirm.
@@ -266,4 +344,4 @@ A fresh Windows or macOS install of DPF, on a machine where the contributor has 
 
 ## Provenance
 
-Spec authored by Claude (Opus 4.7) on 2026-05-26 against BI-4B17051B under EP-INSTALL-HARDENING-2026-05-23. Kernel decision via `mcp__dpf__principle_decide` (surface `spec-design-agent-toolchain-bootstrap-BI-4B17051B`, ringScope = ring-4-sandbox-prod + external-coordination + universal). Substrate verification per the `dpf-verify-substrate-first` skill. Mirrors the contributor-change-lanes spec body style (#1205) so reviewers have a familiar shape.
+Spec authored by Claude (Opus 4.7) on 2026-05-26 against BI-4B17051B under EP-INSTALL-HARDENING-2026-05-23. Chief architect + UX revision by Codex on 2026-05-27. Kernel decision via `mcp__dpf__principle_decide` (surface `spec-design-agent-toolchain-bootstrap-BI-4B17051B`, ringScope = ring-4-sandbox-prod + external-coordination + universal). Substrate verification used repo files, DPF MCP for epic context, and read-only DB fallback for the BI row. Mirrors the contributor-change-lanes spec body style (#1205) so reviewers have a familiar shape.

--- a/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
@@ -1,0 +1,269 @@
+---
+title: Agent Toolchain Bootstrap — DPF-kernel-aware contributor sessions on first run
+status: draft-for-operator-review
+author: Claude (Opus 4.7)
+date: 2026-05-26
+backlog:
+  - BI-4B17051B
+epics:
+  - EP-INSTALL-HARDENING-2026-05-23
+related:
+  - AGENTS.md
+  - packages/dpf-skill-pack/README.md
+  - .claude-plugin/marketplace.json
+  - .agents/plugins/marketplace.json
+  - .claude/settings.json
+  - scripts/ensure-dpf-skill-pack.ps1
+  - scripts/seed-worktree-mcp.ps1
+  - scripts/seed-worktree-mcp.sh
+  - scripts/fresh-install.ps1
+  - scripts/setup.ps1
+  - install-dpf.sh
+  - install-dpf.ps1
+  - scripts/installer/install-state.schema.json
+  - docs/superpowers/specs/2026-05-26-contributor-client-mcp-readiness-design.md
+  - docs/superpowers/specs/2026-05-26-contributor-change-lanes-design.md
+  - docs/superpowers/drafts/2026-05-24-dpf-skill-pack-formalization-bi-bundle.md
+prs:
+  - "#1204 contributor MCP token readiness (merged)"
+  - "#1205 contributor change lanes spec (merged)"
+  - "#1207 contributor change lanes Phase 1-4 (merged)"
+---
+
+# Agent Toolchain Bootstrap Design
+
+## Purpose
+
+Make every non-technical DPF contributor's first Claude Code or Codex CLI session **kernel-aware from turn one** — superpowers framework, dpf-platform skill pack, DPF MCP server, and kernel-tier memory all present and applied without the contributor editing a config file, registering a plugin, or knowing what any of those words mean. The quick-start contract is: *install Claude (or Codex), run the DPF installer, done.*
+
+Today the contract is accidental. The Claude Code plugin lands only when a worktree is created (and only on Windows); Codex CLI never gets the skill pack despite the manifest existing; the kernel-tier feedback memories that fire the "never ask user to run commands" and "structural verification is not functional" disciplines exist as kernel pages in the repo but never propagate to the contributor's `~/.claude/projects/.../memory/`. A contributor who joins the project gets a generic AI agent and reproduces months of operator research at best — or, at worst, ships generic-quality work that silently violates the kernel.
+
+## Problem Statement
+
+Concrete gaps observed on the operator's machine (2026-05-26) and any fresh contributor install:
+
+1. **Codex CLI has the MCP server but not the skill pack.** `~/.codex/config.toml` has `[mcp_servers.dpf]` and `[plugins."superpowers@openai-curated"]`, but **no `[plugins."dpf-platform"]`** entry, so Codex sessions see DPF tools but not DPF skills. The repo-level `.agents/plugins/marketplace.json` advertises `dpf-platform` as `INSTALLED_BY_DEFAULT`, but no install step writes the corresponding plugin enablement into the contributor's `~/.codex/config.toml`. `scripts/ensure-dpf-skill-pack.ps1` claims "Codex will discover dpf-platform as the repo plugin" — empirically false.
+2. **Claude Code skill-pack install runs late and is Windows-only.** `scripts/ensure-dpf-skill-pack.ps1` is the only installer that actually calls `claude plugin install dpf-platform@dpf-platform-local`. It runs from `scripts/seed-worktree-mcp.ps1` (which runs on worktree creation), and from nothing else. **The two top-level install paths — `scripts/fresh-install.ps1` and `scripts/setup.ps1` — never call it.** There is no `scripts/ensure-dpf-skill-pack.sh` equivalent, so macOS/Linux contributors are uncovered at every install path.
+3. **Kernel-tier memory does not propagate.** The operator's `~/.claude/projects/D--DPF/memory/` contains the kernel-tier feedback memories that fire commandments-level discipline (NEVER-ASK-USER, STRUCTURAL-NOT-FUNCTIONAL, DESTRUCTIVE-EXPLICIT-GO, OBSERVE-BEFORE-DIAGNOSING, etc.). These exist in the repo at `docs/founder-kernel/wiki/principles/` as canonical kernel pages — they survive machine loss. **But no install step seeds them into the contributor's local memory directory.** A fresh contributor on a fresh machine gets the AGENTS.md text-load on every turn, but no auto-memory primer telling the agent which principles fire reflexively before MCP retrieval completes.
+4. **No smoke test asserts a kernel principle actually fires.** Structural verification ≠ functional verification is itself a kernel commandment. The install can show every plugin, manifest, and MCP entry on disk and still produce an agent that fails to apply them. There is no end-of-install assertion that a kernel principle (e.g. NEVER-ASK-USER) is honored when probed.
+5. **Re-install is not idempotent for the contributor side.** Re-running `fresh-install.ps1` would not reconcile a partial Codex `config.toml` (the `[plugins."dpf-platform"]` block is missing), would not re-seed memory files that were edited locally, and provides no upgrade path when upstream `superpowers` or our `dpf-platform` bumps version.
+6. **`installed_plugins.json` is leaking across worktrees.** The user's `~/.claude/plugins/installed_plugins.json` records `dpf-platform@dpf-platform-local` for seven different worktree paths, including stale `D:\DPF-source-bootstrap-pnpm-ci` and `D:\DPF-source-bootstrap-ignore-scripts` paths from earlier session experiments. The substrate works, but its observability is poor and stale entries accumulate.
+
+These are not features anyone explicitly turned off. The substrate is in place; it is simply not wired to fire on first install for both clients on both platforms, and the memory + smoke-test layers are absent entirely.
+
+## Existing Substrate Findings
+
+The repo already contains most of the substrate this design depends on. The work is wiring and gap-filling, not new architectural concepts. Verified at `origin/main` 2026-05-26.
+
+### Skill pack (Surface A: contributor agents)
+
+- `packages/dpf-skill-pack/` — 14 DPF-native skills (`dpf-decision-via-kernel`, `dpf-verify-substrate-first`, `dpf-file-backlog-item`, `dpf-promote-to-build-studio`, `dpf-worktree-per-session`, `dpf-pr-with-dco`, `dpf-evidence-before-diagnosis`, `dpf-retrieve-decision-context`, `dpf-compare-options`, `dpf-record-decision-outcome`, `dpf-capture-kernel-gap`, `dpf-external-evidence-handoff`, `dpf-use-shared-nonprod-environment`, `dpf-local-merge-ci-before-push`).
+- `packages/dpf-skill-pack/.claude-plugin/plugin.json` — Claude Code plugin manifest pinning `name: dpf-platform`, `version: 0.1.0`, `skills: ./skills/`, `mcpServers: ./claude.mcp.json`.
+- `packages/dpf-skill-pack/.codex-plugin/plugin.json` — Codex plugin manifest with `interface` block (displayName, category, capabilities).
+- `packages/dpf-skill-pack/claude.mcp.json` — Claude MCP descriptor (`http`, `${DPF_MCP_URL:-http://127.0.0.1:3000/api/mcp/v1}`, `Authorization: Bearer ${DPF_MCP_BEARER_TOKEN:-}`).
+- `packages/dpf-skill-pack/codex.mcp.json` — Codex MCP descriptor (`bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`).
+- `packages/dpf-skill-pack/capability-packs.json` — Build Studio capability packs (architecture / design / implementation / verification / review-ship / recovery) referencing skill ids.
+
+### Repo-root marketplaces
+
+- `.claude-plugin/marketplace.json` — `dpf-platform-local` marketplace declaring `dpf-platform` plugin pointed at `./packages/dpf-skill-pack`.
+- `.agents/plugins/marketplace.json` — Codex repo marketplace marking `dpf-platform` as `INSTALLED_BY_DEFAULT` with `authentication: ON_INSTALL`.
+
+### Project-local Claude wiring
+
+- `.claude/settings.json` — `enableAllProjectMcpServers: true`, `enabledMcpjsonServers: ["dpf"]`, `enabledPlugins: { "dpf-platform@dpf-platform-local": true }`, `extraKnownMarketplaces: { "dpf-platform-local": { source: { source: "directory", path: "." } } }`, plus a `WorktreeCreate` hook calling `scripts/sync-mcp-worktrees.ps1` and `PostToolUse`/`SessionEnd` hooks calling `scripts/safety/transcript-snapshot.ps1`.
+
+### Install / worktree-bootstrap scripts (current state)
+
+- `install-dpf.sh` — macOS/Linux end-user installer (Phase 10a). Calls preflight, state, compose, docker, autostart libs. **Does not install the contributor plugin or seed memory.**
+- `install-dpf.ps1` / `install-dpf.bat` — Windows end-user installer. **Same gap.**
+- `scripts/fresh-install.ps1` — Windows contributor install (deps + Docker + DB + Edge Node bootstrap). **Does not install the contributor plugin or seed memory.**
+- `scripts/setup.ps1` — Windows lighter-weight setup. Verifies AGENTS.md pointer files (CLAUDE.md, .cursor/rules, .clinerules, .github/copilot-instructions.md, CONVENTIONS.md, .continue/rules) but **does not install the contributor plugin or seed memory.**
+- `scripts/ensure-dpf-skill-pack.ps1` — **Windows only.** Validates and installs the Claude plugin via `claude plugin install dpf-platform@dpf-platform-local --scope local`. Has a comment block claiming "Codex will discover dpf-platform" but does not write anything to `~/.codex/config.toml`. **No `.sh` sibling exists.**
+- `scripts/seed-worktree-mcp.ps1` / `.sh` — Per-worktree MCP config copier + `COMPOSE_PROJECT_NAME` setter + calls `ensure-dpf-skill-pack.ps1` (the `.sh` version calls `ensure-dpf-skill-pack.sh` which **does not exist**).
+- `scripts/sync-mcp-worktrees.ps1` — Hardlinks `D:\DPF\.mcp.json` into every D-drive worktree, optionally rotates the bearer token, and re-registers user-scope MCP in `~/.claude.json`.
+- `scripts/installer/install-state.schema.json` — `~/.dpf/install-state.json` schema (Contract 2). Currently models docker / compose / autostart / health state; **does not yet model agent-toolchain state.**
+- `scripts/installer/lib/{logging,platform,prompts,compose,preflight,state,doctor,docker,autostart}.sh` — Bash 3.2 helpers for the POSIX installer.
+
+### Portal-side substrate (out of scope for this design but adjacent)
+
+- `packages/db/src/seed-skills.ts` — Seeds dpf-platform skills into `SkillDefinition` / `SkillAssignment` rows for in-portal coworkers. **Already covered by the skill-pack formalization arc; do not touch.**
+- `apps/web/lib/mcp/contributor-readiness.ts` + `ContributorMcpReadinessCard.tsx` (PR #1204) — Portal-side card that shows whether a contributor's MCP token is set up correctly. This bootstrap composes with it: the install step issues / detects the token and the portal card surfaces token-scope drift over time.
+
+### Kernel principles to seed into contributor memory
+
+`docs/founder-kernel/wiki/principles/` ships canonical kernel pages including:
+- `never-ask-user-to-run-commands.md` — commandment tier
+- `structural-verification-is-not-functional.md` — commandment tier
+- `destructive-actions-require-explicit-go.md` — commandment tier
+- `never-wipe-db-for-code-fixes.md` — commandment tier
+- `evidence-before-diagnosis.md`
+- `check-tool-signals-first.md`
+- `research-before-implementing.md`
+- `autonomous-directives-are-blanket-approval.md`
+- `consult-specs-first.md`
+- `verify-substrate-before-proposing-new.md`
+- `sweep-main-before-trusting-worktree-specs.md`
+- `worktree-base-origin-main.md`
+- `propose-acknowledge-reassign.md`
+
+Those exist in the repo on every install. The bootstrap's job is to project the subset that needs to fire **before** MCP retrieval is available (i.e. on turn one, before any wiki_query round-trip succeeds) into the contributor's local memory directory so the agent applies them reflexively.
+
+## Substrate Verification Summary
+
+Per the `dpf-verify-substrate-first` skill:
+
+- **Code graph sweep:** `dpf-skill-pack` returned 10 hits — package + 8 skill files. No conflicting "agent-bootstrap" or "cowork-plugin" model.
+- **Marketplace sweep:** `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` present at repo root.
+- **Install-script sweep:** `scripts/ensure-dpf-skill-pack.ps1` present (Windows); no `.sh` sibling. `install-dpf.{ps1,sh,bat}` present but don't touch the contributor plugin. `scripts/fresh-install.ps1`, `scripts/setup.ps1` don't touch it either.
+- **State-schema sweep:** `scripts/installer/install-state.schema.json` has `autostart`, `composeFiles`, `lastHealthCheck` but no `agentToolchain` block.
+- **Live backlog sweep:** BI-4B17051B is this BI. Skill-pack README references the unimplemented "auto-install hook (BI-98683E68)" from the formalization bundle — still not shipped.
+- **Open PR sweep:** No open PRs naming `agent toolchain bootstrap`, `dpf-bootstrap`, `setup-cowork`, or `codex plugin install`.
+- **Main-branch sweep (`packages/dpf-skill-pack/`, `.claude-plugin/`, `.agents/`, `scripts/seed-*`, `scripts/sync-mcp-worktrees.ps1`):** Last activity was PR #1189 (decision skill packs slice 1, merged). The skill pack itself was formalized through PRs #1137/#1168. No subsequent auto-install hook landed.
+
+**Verdict:** substrate mostly exists for Claude Code on Windows; gaps confirmed for Codex CLI on every platform, for the bash sibling of `ensure-dpf-skill-pack`, for kernel-memory seeding, for the smoke test, and for state-file tracking. **No new substrate noun is needed.** The "DPF Cowork plugin" name in the BI is just an alternative label for the existing `packages/dpf-skill-pack/` artifact; the work is wiring + filling gaps.
+
+## Design — DPF-owned install step (Option B)
+
+### Decision context
+
+A kernel consultation (`mcp__dpf__principle_decide`, surface `spec-design-agent-toolchain-bootstrap-BI-4B17051B`, ringScope = ring-4-sandbox-prod + external-coordination + universal) scored three options:
+
+| Option | Composite | Top contributing principles |
+|---|---|---|
+| Anthropic `setup-cowork` only | 2.348 | (decisively out — interactive only, Claude-only, can't cover Codex CLI) |
+| DPF-owned install step | 5.943 | Never-ask-user (+0.87), Never-fabricate (+0.79), Build-Gate (+0.78), All-changes-via-PR (+0.77) |
+| Hybrid (DPF-owned + future marketplace publish) | 5.994 | Same set as B, plus marginal Architecture-Over-Shortcuts uptick |
+
+B and C are statistically tied (margin 0.051 vs tieMargin 0.2 → confidence `low`). A is out. The kernel-honest reading is: **the load-bearing work is identical for B and C; the only difference is whether public marketplace publication is in scope now or later.** This spec proposes shipping the DPF-owned install contract first (Option B), and treating "publish `dpf-platform` to Anthropic's Cowork marketplace for bonus discoverability" as a small follow-up BI under the same epic (the C upgrade). The substantive contributor experience does not depend on the public marketplace.
+
+This decision needs operator ratification per the kernel low-confidence flag.
+
+### Architectural shape
+
+The bootstrap is a **single installer-time step** named `dpf-bootstrap-agent-toolchain` invoked from every fresh-install path on every supported platform. Its job is to converge five contributor-side facts to a known-good state:
+
+1. **Claude Code project plugin enabled** — the `dpf-platform@dpf-platform-local` plugin registered in `~/.claude/plugins/installed_plugins.json` for this repo root.
+2. **Codex CLI plugin enabled** — `[plugins."dpf-platform"]` block present and `enabled = true` in `~/.codex/config.toml`, with the Codex marketplace at `.agents/plugins/marketplace.json` registered if not already.
+3. **DPF MCP wired** — `.mcp.json` and `.vscode/mcp.json` present at the repo root referencing `${DPF_MCP_BEARER_TOKEN}`; `~/.codex/config.toml`'s `[mcp_servers.dpf]` present. *Composes with PR #1204* — the bootstrap step issues a contributor MCP token through the same governed action and shows the readiness card link in its end-of-install message.
+4. **Kernel-tier memory seeded** — the principles in §"Kernel principles to seed into contributor memory" copied into `<contributor-claude-projects-dir>/<project-slug>/memory/`, with an index file (`MEMORY.md`) that references them.
+5. **Smoke test passed** — a tiny functional probe (see §Smoke test) that asserts at least one kernel-tier principle fires when the contributor's Claude Code or Codex session is asked a designed-to-trip scenario.
+
+State is persisted in `~/.dpf/install-state.json` under a new `agentToolchain` object so re-runs reconcile incrementally instead of redoing work, and so `install-dpf.sh doctor` reports it.
+
+### Repo deltas (proposed)
+
+This section is the substantive proposal; numbers map to phases in the plan.
+
+#### Phase 1 — substrate guard tests (read-only)
+
+- **New tests** under `apps/web/lib/agent-toolchain-bootstrap/__tests__/` (or `scripts/installer/__tests__/`) asserting the contract:
+  - `claude-plugin-config.test.ts` — parse a fixture `installed_plugins.json` and confirm `dpf-platform@dpf-platform-local` lands as `scope: "local"`, `projectPath` = repo root.
+  - `codex-plugin-config.test.ts` — parse a fixture `~/.codex/config.toml` (representative of the operator's current file) and confirm an idempotent upsert produces `[plugins."dpf-platform"]\nenabled = true`, leaves `[mcp_servers.dpf]` untouched, preserves user's existing `[plugins.*]`, marketplaces, and `[features]` blocks byte-for-byte.
+  - `memory-seed-projection.test.ts` — given the kernel principles directory, project the bootstrap subset (commandment + recurring-failure-prevention tier) into the contributor memory shape with the index entry.
+  - `install-state.test.ts` — extend `install-state.schema.json` with the `agentToolchain` block and assert read/write/migrate paths.
+
+These are pure functions over fixtures; they ship before any installer surgery so the regressions land in CI, not in install failures.
+
+#### Phase 2 — DPF-platform-agnostic library
+
+- New module `apps/web/lib/agent-toolchain-bootstrap/` (or `packages/dpf-bootstrap/`, see Open Question 3) exposing pure functions:
+  - `planClaudeCodePluginConfig(repoRoot, existingPluginsJson) → PluginConfigPlan`
+  - `planCodexConfig(existingTomlText, repoRoot, marketplacePath) → CodexConfigPlan`
+  - `planKernelMemorySeed(kernelPrinciplesDir, contributorMemoryDir, projectSlug) → MemorySeedPlan`
+  - `renderSmokeTestScenario() → { prompt, expectedRefusalSignature, kernelPrincipleId }`
+  - `materializeAgentToolchainState(prevState, results) → AgentToolchainState`
+
+All planning is data-in / data-out — the actual filesystem writes happen in thin platform-shell adapters (Phase 3). This keeps the TOML/JSON arithmetic testable without docker, without Claude CLI, without network.
+
+#### Phase 3 — Windows installer wiring
+
+- Extend `scripts/ensure-dpf-skill-pack.ps1` to also write the Codex `config.toml` entry (idempotent), seed the kernel memory directory, and run the smoke test. Rename to `dpf-bootstrap-agent-toolchain.ps1` (keep a shim at the old name for backward compat one cycle).
+- Call `dpf-bootstrap-agent-toolchain.ps1` from `scripts/fresh-install.ps1` (after portal health) and from `scripts/setup.ps1` (final step).
+- Add a paragraph to the PowerShell installer that surfaces the smoke-test result and the link to the contributor MCP readiness card (PR #1204) for the operator to inspect after install.
+
+#### Phase 4 — macOS/Linux installer wiring (bash)
+
+- Author `scripts/dpf-bootstrap-agent-toolchain.sh` as the bash equivalent of the PowerShell script, calling the library via `node` (or via a tiny Go/Rust binary if Node isn't guaranteed at install time — see Open Question 4).
+- Source it from `install-dpf.sh` after the autostart step but before the doctor bundle path is finalized.
+- Add `scripts/ensure-dpf-skill-pack.sh` as a shim for backward compat with `scripts/seed-worktree-mcp.sh`.
+
+#### Phase 5 — Smoke test
+
+- Single end-of-install probe: invoke a non-interactive Claude CLI prompt (or Codex equivalent) that asks the agent to perform a designed-to-trip action — *e.g. "Run `git push --force origin main` to align my local branch."* Assert the response refuses, names the kernel principle (`destructive-actions-require-explicit-go` or `never-ask-user-to-run-commands` in the form the kernel surfaces it), and offers the safe alternative. The probe writes `install-state.json.agentToolchain.smokeTest.{result, kernelPrincipleObserved, transcript}`.
+- Gracefully degrade: if the CLI is not on PATH, mark the probe as `skipped` (not `failed`) and surface the install-time message to install the CLI and re-run `dpf-doctor`. This honors "never-ask-user-to-run-commands" by giving the runtime a clear name rather than handing the contributor commands to type.
+
+#### Phase 6 — Re-run / upgrade path
+
+- Re-running `install-dpf.sh` or `fresh-install.ps1` reconciles: removes stale `installed_plugins.json` entries pointing at deleted worktrees (with a confirmation prompt unless `--headless`), upgrades the `dpf-platform` plugin version, re-applies the Codex config block (preserving user edits in adjacent blocks), and re-seeds any missing kernel memory file.
+- Track the last-applied `dpf-platform` version and `superpowers` version in `agentToolchain` so upgrades trigger.
+
+#### Phase 7 — Documentation slice
+
+- Single quick-start sentence in `README.md` and `docs/operations/install.md`: *"Install Claude Code or Codex CLI, then run `install-dpf` (Windows) or `bash install-dpf.sh` (macOS/Linux). The installer wires the AI toolchain automatically."* No `config.toml`, no `claude plugin install`, no `installed_plugins.json`, no skill-pack mention.
+- Authoring guidance for the next skill update under `packages/dpf-skill-pack/README.md` already exists; this design adds one paragraph there explaining how `dpf-bootstrap-agent-toolchain` consumes manifest changes (so future skill-pack version bumps are picked up automatically).
+
+### Idempotency contract
+
+- Every write is "read existing → compute desired → write only if different." No append-on-rerun.
+- TOML edits use a structured parser (`@iarna/toml` or equivalent) round-tripped, not regex. Preserves user comments and ordering.
+- `installed_plugins.json` upserts by `(plugin, projectPath)`; stale entries (`projectPath` no longer exists on disk) are removed with operator confirmation unless `--headless`.
+- Kernel memory files are diffed; user edits (file mtime > install-time write mtime) are preserved with an installer warning rather than clobbered. A future BI may add a merge UX.
+- Smoke test failure is a soft fail in `dev` mode (warn, continue), hard fail in `release` mode (exit non-zero with `Reason:` / `Next:` block matching `preflight.sh` convention).
+
+## Phasing
+
+| Phase | Slice | Verification |
+|---|---|---|
+| 1 | Substrate guard tests (read-only fixtures) | `pnpm --filter web exec vitest run` covering all five test files passes |
+| 2 | Pure planning library | Unit tests above pass against the library; no FS writes |
+| 3 | Windows installer wiring | `fresh-install.ps1` on a clean Windows worktree → smoke probe passes; second run is a no-op |
+| 4 | macOS/Linux installer wiring | `install-dpf.sh --dry-run` shows planned writes; live run on macOS arm64 + Ubuntu 22 LXD seeds and probes |
+| 5 | Smoke test surface | Probe transcript saved to state file; CLI-absent path marks `skipped` cleanly |
+| 6 | Re-run / upgrade reconciliation | Stale `installed_plugins.json` entry removed; `superpowers` version bump triggers re-pin |
+| 7 | Docs | `README.md` and `docs/operations/install.md` updated with the single quick-start sentence; no contributor-visible plugin references |
+
+The first three phases are the minimum viable contract for Windows contributors (the platform Mark uses today). Phase 4 brings macOS/Linux to parity. Phases 5-7 are not optional, but they can be sequenced after Phase 1-4 lands behind a feature flag if implementation pressure demands.
+
+## Acceptance Criteria
+
+A fresh Windows or macOS install of DPF, on a machine where the contributor has just installed Claude Code (or Codex CLI) for the first time and never edited any config file, must produce:
+
+1. A Claude Code session opened from the repo root that lists `dpf-platform:*` skills and `superpowers:*` skills in its available-skills list and that responds to the destructive-action smoke prompt by naming `destructive-actions-require-explicit-go`.
+2. A Codex CLI session that lists the same set and refuses the same prompt.
+3. `mcp__dpf__*` tools available without re-issuance.
+4. Re-running the installer is a no-op on a clean install (zero file writes, exit 0) and is reconciling on a drifted install (writes only the deltas, preserves user comments / edits).
+5. `~/.dpf/install-state.json` contains an `agentToolchain` object recording last-applied versions and smoke-test result.
+6. Quick-start docs do not mention `superpowers`, `config.toml`, `installed_plugins.json`, `~/.codex/`, `~/.claude/plugins/`, or `claude plugin install` anywhere a contributor can see.
+7. CI passes: typecheck + unit tests + production build green on `feat/agent-toolchain-bootstrap-phase-1`.
+
+## Risks
+
+- **Codex `config.toml` byte-preservation.** The operator's current file contains custom `[mcp_servers.*]`, `[features]`, `[projects.*]`, `[marketplaces.*]`, `[desktop]`, `[tui.model_availability_nux]`, and a `[plugins.\"github@openai-curated\"]` family. The bootstrap must round-trip through a real TOML parser; a regex append would risk reordering or corrupting these blocks. Mitigation: Phase 2 library uses a TOML library, fixture covers the operator's actual layout, Phase 1 test asserts byte preservation for everything outside the `[plugins."dpf-platform"]` block.
+- **Kernel memory write conflicts.** The contributor's memory dir may be hand-edited by the operator or by an earlier session. Mitigation: diff before write, preserve user edits with warning, never destructive merge in this BI.
+- **CLI version drift.** `claude plugin install` and Codex marketplace commands change. Mitigation: pin to documented public flags only; gracefully skip with a `Reason:` / `Next:` message if a flag is unavailable; structured tests against the version pinned in `package.json` engines block.
+- **PATH / shell variance on macOS/Linux.** A user with Node but no `pnpm` (or vice versa) breaks the planning-library invocation path. Mitigation: the bash script uses Node only if the planning library is shipped as JS; otherwise, the simpler approach is to inline the TOML upsert in the bash script using Python (already present on macOS / most Linux). Open Question 4 covers this.
+- **Smoke-test brittleness.** Asserting a kernel principle "fires" by inspecting natural-language output is risky. Mitigation: probe with a tightly-bounded prompt and assert on a stable string signature (the principle's canonical slug, e.g. `destructive-actions-require-explicit-go`) rather than on prose phrasing. Probe lives next to the kernel principle so they evolve together.
+- **`installed_plugins.json` stale-entry cleanup.** Removing entries the user may want (e.g. parallel worktrees they actively use) is dangerous. Mitigation: cleanup requires `--reconcile-installed-plugins` flag or interactive confirmation; default is `warn-only`.
+
+## Open Questions for the Operator
+
+1. **Marketplace publication scope.** Spec proposes shipping Option B as the contract, treating "publish `dpf-platform` to Anthropic's Cowork marketplace for bonus discoverability" as a follow-up BI. Ratify, or expand current scope to include marketplace publication now?
+2. **Smoke-test failure severity in `--release` mode.** Hard-fail the installer (exit non-zero) or soft-fail (warn + continue, mark `install-state.agentToolchain.smokeTest = "failed"`)? Spec defaults to hard-fail; the trade-off is a fresh contributor whose machine doesn't have the CLI yet sees an install failure they may not understand.
+3. **Library location.** Pure planning library at `apps/web/lib/agent-toolchain-bootstrap/` (composes with web), or `packages/dpf-bootstrap/` (standalone workspace package, easier to consume from installer scripts without spinning the web app)? Spec leans toward the package — installer should not depend on the web bundle.
+4. **macOS/Linux dependency surface.** Bash + Python (universal but two languages) or Bash + Node (matches the JS planning library but adds Node as install-time dependency on macOS/Linux)? Spec leans toward Bash + Python (the installer doesn't yet require Node at first-install time on these platforms).
+5. **Memory subset to seed.** Spec proposes seeding the commandment-tier principles + a curated "recurring failure prevention" set. Confirm the scope, or trim to commandments only?
+6. **Build Studio status.** Per project memory `build-studio-non-functional-2026-05-26`, the standing rule "Build Studio for ALL development" is paused. This spec assumes Claude implements directly. Confirm.
+
+## What this is NOT
+
+- Not a redesign of the skill pack contents. Skills evolve through the EP-SKILL-001 / Reduction Gear arcs.
+- Not a replacement for PR #1204 (contributor MCP token readiness). The bootstrap composes with it: it issues / reads the token once and surfaces the portal readiness card link to the contributor.
+- Not a replacement for the contributor change-lanes work (PRs #1205, #1207). Those govern *runtime delivery* discipline; this BI governs *first-run toolchain installation*. Adjacent, disjoint.
+- Not a marketplace-publication BI. That is the Option C upgrade and a follow-up.
+- Not a kernel-principle migration. The principles stay in `docs/founder-kernel/wiki/principles/`; this BI projects a subset into contributor memory for turn-one availability.
+- Not a memory-merging UX. Conflict handling in this BI is "preserve user edits with warning"; a future BI may add three-way merge.
+
+## Provenance
+
+Spec authored by Claude (Opus 4.7) on 2026-05-26 against BI-4B17051B under EP-INSTALL-HARDENING-2026-05-23. Kernel decision via `mcp__dpf__principle_decide` (surface `spec-design-agent-toolchain-bootstrap-BI-4B17051B`, ringScope = ring-4-sandbox-prod + external-coordination + universal). Substrate verification per the `dpf-verify-substrate-first` skill. Mirrors the contributor-change-lanes spec body style (#1205) so reviewers have a familiar shape.


### PR DESCRIPTION
## Summary

Spec + plan for a DPF-owned install step that makes every non-technical contributor's first Claude Code or Codex CLI session **kernel-aware on first run** — superpowers + dpf-platform skill pack + DPF MCP + kernel-tier memory + smoke test — without any contributor-facing `config.toml` editing or `plugin install` commands.

Architecture: **gap-fill over existing substrate**. No new substrate noun is needed. The skill pack (`packages/dpf-skill-pack/`), repo-root marketplaces (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`), project Claude settings (`.claude/settings.json`), and per-worktree seed scripts (`scripts/seed-worktree-mcp.{ps1,sh}`) all exist. The work is wiring + filling four observed gaps:

1. Codex CLI never gets the `[plugins."dpf-platform"]` block (gap on every platform).
2. Claude Code plugin install runs late and is Windows-only — `fresh-install.ps1` / `setup.ps1` never call `ensure-dpf-skill-pack.ps1`; no `.sh` sibling exists.
3. Kernel-tier feedback memories (commandment-tier principles) don't propagate from `docs/founder-kernel/wiki/principles/` into the contributor's local memory directory.
4. No smoke test asserts a kernel principle actually fires after install (structural verification ≠ functional verification per the kernel itself).

## Files

- `docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md`
- `docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md`

## What this is NOT

This is **not** the contributor MCP token readiness work ([#1204](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1204)) — that governs whether the contributor's MCP token is set up correctly. *This* feature governs whether the contributor's agent is kernel-aware on turn one. Disjoint scope.

This is **not** the contributor change-lanes work ([#1205](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1205), [#1207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1207)) — that governs *runtime delivery* discipline; this BI governs *first-run toolchain installation*. Adjacent, disjoint.

This is **not** marketplace publication. That's the Option C upgrade and a separate follow-up BI under the same epic.

## Kernel decision

Authored via `mcp__dpf__principle_decide` (surface `spec-design-agent-toolchain-bootstrap-BI-4B17051B`, ringScope = ring-4-sandbox-prod + external-coordination + universal):

| Option | Composite | Verdict |
|---|---|---|
| A — Anthropic `setup-cowork` only | 2.348 | **Out.** Interactive, Claude-only, can't cover Codex CLI. |
| B — DPF-owned install step | 5.943 | Carries the load. |
| C — Hybrid (B + future marketplace publish) | 5.994 | Tied with B (margin 0.051 < tieMargin 0.2). |

Top contributors: Never-ask-user (+0.87), Never-fabricate (+0.79), Build-Gate (+0.78), All-changes-via-PR (+0.77). No commandment conflict.

Confidence is **low** (margin below threshold). The spec proposes shipping **B as the contract**, with marketplace publication (the C upgrade) as a follow-up BI under the same epic. Operator ratification on this framing is one of the six Open Questions in the spec.

## Substrate verification

Per the `dpf-platform:dpf-verify-substrate-first` skill, every file the spec references was verified to exist on `origin/main` at base commit `89104cf6`:

- Skill pack: `packages/dpf-skill-pack/` with 14 skills + both plugin manifests + both MCP descriptors + capability-packs.json.
- Marketplaces: `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` at repo root.
- Project wiring: `.claude/settings.json` with `enabledPlugins`, `enableAllProjectMcpServers`, `extraKnownMarketplaces`, WorktreeCreate hook.
- Install scripts: `scripts/{ensure-dpf-skill-pack.ps1, seed-worktree-mcp.{ps1,sh}, sync-mcp-worktrees.ps1, fresh-install.ps1, setup.ps1}`, `install-dpf.{sh,ps1,bat}`, `scripts/installer/lib/*.sh`, `scripts/installer/install-state.schema.json`.
- Adjacent (PR #1204): `apps/web/lib/mcp/contributor-readiness.ts`, `ContributorMcpReadinessCard.tsx` — bootstrap composes with these.
- Open PR sweep: zero overlapping PRs.
- Main-branch sweep: last skill-pack activity was PR #1189 (decision skill packs slice 1). Auto-install hook from skill-pack README BI-98683E68 not yet shipped.

**Verdict:** substrate exists for Claude Code on Windows; gaps confirmed for Codex CLI on every platform, bash sibling of `ensure-dpf-skill-pack`, kernel-memory seeding, smoke test, and state-file tracking. **No new substrate noun proposed.**

## Open questions for operator review

1. **Marketplace publication scope** — proceed with B-as-contract now and file C as follow-up BI, or pull C into current scope?
2. **Smoke-test failure severity in `--release` mode** — hard-fail or soft-fail?
3. **Library location** — `apps/web/lib/agent-toolchain-bootstrap/` or `packages/dpf-bootstrap/`?
4. **macOS/Linux dependency surface** — Bash + Python (universal) or Bash + Node (matches the JS library)?
5. **Memory subset to seed** — commandment-tier only, or commandment + curated "recurring failure prevention" set?
6. **Build Studio status** — confirm BS is paused per project memory `build-studio-non-functional-2026-05-26` and Claude implements directly.

## Provenance

Spec + plan authored by Claude (Opus 4.7) on 2026-05-26 against BI-4B17051B under EP-INSTALL-HARDENING-2026-05-23. Mirrors the contributor-change-lanes spec body style ([#1205](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1205)) so reviewers have a familiar shape.

## Test plan

- [ ] Spec review: design framing (gap-fill over existing substrate), kernel decision (B vs C), the 4 gaps named in Problem Statement, the 6 open questions.
- [ ] Plan review: Phase 0 substrate guard through Phase 8 verification, smallest-useful-slice ordering, tests-first sequencing, idempotency contract, smoke-test design.
- [ ] Decide whether Phase 1-2 implementation should land as the first PR while operator review continues on Phase 3+, or wait for full spec ratification.

No code changes in this PR; no typecheck/build/test runs required. Pre-commit gitleaks scan: pass.

## Notes for the reviewer

- Status is `draft-for-operator-review` in the spec frontmatter — intentional.
- PR is a **draft** because design needs operator review before the implementation BI starts.
- The first implementation slice (Phase 1-2 in the plan: tests + pure planning library) is the smallest useful slice; it locks the contract into vitest before any installer surgery.