### PR TITLE
feat: contributor inventory sync — Phases 1-4 (move git/GitHub off request path)

### DIFF
--- a/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
+++ b/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
@@ -1,21 +1,12 @@
-import path from "node:path";
-
 import { ChangeLanesDashboard } from "@/components/platform/development/change-lanes/ChangeLanesDashboard";
 import { loadContributorChangeLaneReadModel } from "@/lib/contributor-change-lanes/read-model";
-import { createNodeInventoryRunners } from "@/lib/contributor-change-lanes/runners-node";
 
 export const dynamic = "force-dynamic";
 
 export default async function ChangeLanesPage() {
-  const repoCwd = process.cwd();
-  const worktreeRoot = path.join(repoCwd, ".claude", "worktrees");
-  const runners = createNodeInventoryRunners({ repoCwd, worktreeRoot });
-
   const now = new Date();
-  const { lanes, freshness } = await loadContributorChangeLaneReadModel({
-    runners,
-    now,
-  });
+  const { lanes, freshness, anySourceWarmingUp, anySnapshotSourceDegraded } =
+    await loadContributorChangeLaneReadModel({ now });
 
   return (
     <div className="mx-auto w-full max-w-[1600px] px-4 py-6">
@@ -23,6 +14,8 @@ export default async function ChangeLanesPage() {
         lanes={lanes}
         freshness={freshness}
         generatedAt={now.toISOString()}
+        anySourceWarmingUp={anySourceWarmingUp}
+        anySnapshotSourceDegraded={anySnapshotSourceDegraded}
       />
     </div>
   );

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
@@ -1,4 +1,7 @@
-import type { LaneReadModelFreshness } from "@/lib/contributor-change-lanes/read-model";
+import type {
+  LaneReadModelFreshness,
+  LaneReadModelFreshnessState,
+} from "@/lib/contributor-change-lanes/read-model";
 
 const SOURCE_LABEL: Record<LaneReadModelFreshness["source"], string> = {
   "work-capsule": "Work Capsules",
@@ -10,7 +13,32 @@ const SOURCE_LABEL: Record<LaneReadModelFreshness["source"], string> = {
   "github-pr": "GitHub PRs",
 };
 
-export function ChangeLaneSourceSummary({ freshness }: { freshness: LaneReadModelFreshness[] }) {
+const LIVE_SOURCES: LaneReadModelFreshness["source"][] = [
+  "work-capsule",
+  "runtime-target",
+  "runtime-verification",
+  "nonprod-lease",
+];
+
+const SNAPSHOT_SOURCES: LaneReadModelFreshness["source"][] = [
+  "git-worktree",
+  "git-branch",
+  "github-pr",
+];
+
+export function ChangeLaneSourceSummary({
+  freshness,
+}: {
+  freshness: LaneReadModelFreshness[];
+}) {
+  const byName = new Map(freshness.map((f) => [f.source, f]));
+  const live = LIVE_SOURCES.map((s) => byName.get(s)).filter(
+    (x): x is LaneReadModelFreshness => Boolean(x),
+  );
+  const snapshot = SNAPSHOT_SOURCES.map((s) => byName.get(s)).filter(
+    (x): x is LaneReadModelFreshness => Boolean(x),
+  );
+
   return (
     <div
       className="rounded border p-3 text-xs"
@@ -22,22 +50,92 @@ export function ChangeLaneSourceSummary({ freshness }: { freshness: LaneReadMode
       <div className="mb-2 text-[var(--dpf-muted)] uppercase tracking-wide text-[10px]">
         Source freshness
       </div>
+      <SubGroup label="Live data" rows={live} />
+      {live.length > 0 && snapshot.length > 0 ? (
+        <div
+          className="my-2 h-px"
+          style={{ backgroundColor: "var(--dpf-border)" }}
+          aria-hidden
+        />
+      ) : null}
+      <SubGroup label="Inventory snapshot" rows={snapshot} />
+    </div>
+  );
+}
+
+function SubGroup({
+  label,
+  rows,
+}: {
+  label: string;
+  rows: LaneReadModelFreshness[];
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <div className="mb-1 text-[10px] text-[var(--dpf-muted)] uppercase tracking-wide">
+        {label}
+      </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 md:grid-cols-4">
-        {freshness.map((f) => (
-          <div key={f.source} className="flex items-center gap-2">
-            <span
-              className={`inline-block h-1.5 w-1.5 rounded-full ${
-                f.ok ? "bg-[var(--dpf-success)]" : "bg-[var(--dpf-error)]"
-              }`}
-              aria-hidden
-            />
-            <span className="text-[var(--dpf-text)]">{SOURCE_LABEL[f.source]}</span>
-            <span className="text-[var(--dpf-muted)]">
-              {f.ok ? f.count : f.error ?? "error"}
-            </span>
-          </div>
+        {rows.map((row) => (
+          <FreshnessDot key={row.source} row={row} />
         ))}
       </div>
     </div>
   );
+}
+
+function FreshnessDot({ row }: { row: LaneReadModelFreshness }) {
+  const dotColor = colorForState(row.state);
+  const label = labelForRow(row);
+  return (
+    <div
+      className="flex items-center gap-2"
+      aria-label={`${SOURCE_LABEL[row.source]} — ${row.state} (${label})`}
+    >
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${
+          row.state === "warming-up" ? "animate-pulse" : ""
+        }`}
+        style={{ backgroundColor: `var(${dotColor})` }}
+        aria-hidden
+      />
+      <span className="text-[var(--dpf-text)]">{SOURCE_LABEL[row.source]}</span>
+      <span
+        className="text-[var(--dpf-muted)]"
+        title={row.message ?? undefined}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function colorForState(state: LaneReadModelFreshnessState): string {
+  switch (state) {
+    case "ok":
+      return "--dpf-success";
+    case "stale":
+      return "--dpf-warning";
+    case "error":
+      return "--dpf-error";
+    case "not-configured":
+    case "warming-up":
+      return "--dpf-muted";
+  }
+}
+
+function labelForRow(row: LaneReadModelFreshness): string {
+  switch (row.state) {
+    case "ok":
+      return String(row.count);
+    case "stale":
+      return row.message ?? `${row.count} (stale)`;
+    case "error":
+      return row.message ?? "error";
+    case "not-configured":
+      return "not configured";
+    case "warming-up":
+      return "syncing…";
+  }
 }

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
@@ -3,14 +3,22 @@ import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types
 import { ChangeLaneBlockers } from "./ChangeLaneBlockers";
 import { ChangeLaneStatusBadge } from "./ChangeLaneStatusBadge";
 
-export function ChangeLaneTable({ lanes }: { lanes: ContributorChangeLane[] }) {
+export function ChangeLaneTable({
+  lanes,
+  anySourceWarmingUp = false,
+}: {
+  lanes: ContributorChangeLane[];
+  anySourceWarmingUp?: boolean;
+}) {
   if (lanes.length === 0) {
     return (
       <div
         className="rounded border p-6 text-center text-sm text-[var(--dpf-muted)]"
         style={{ borderColor: "var(--dpf-border)" }}
       >
-        No lanes in this view.
+        {anySourceWarmingUp
+          ? "Inventory is still syncing — first results will appear within ~10 minutes. Refresh the page once the freshness dots turn green."
+          : "No lanes in this view."}
       </div>
     );
   }

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx
@@ -6,9 +6,11 @@ import { ChangeLaneStatusBadge } from "./ChangeLaneStatusBadge";
 export function ChangeLaneTable({
   lanes,
   anySourceWarmingUp = false,
+  githubNotConfigured = false,
 }: {
   lanes: ContributorChangeLane[];
   anySourceWarmingUp?: boolean;
+  githubNotConfigured?: boolean;
 }) {
   if (lanes.length === 0) {
     return (
@@ -40,7 +42,17 @@ export function ChangeLaneTable({
             <Th>Branch</Th>
             <Th>Commit</Th>
             <Th>Served</Th>
-            <Th>PR</Th>
+            <Th>
+              <div>PR</div>
+              {githubNotConfigured ? (
+                <div
+                  className="mt-0.5 text-[9px] normal-case font-normal text-[var(--dpf-warning)]"
+                  title="GitHub source is not configured; PR cells reflect only locally-known links."
+                >
+                  GitHub not connected
+                </div>
+              ) : null}
+            </Th>
             <Th>Runtime</Th>
             <Th>Verification</Th>
             <Th>TTL</Th>

--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -47,6 +47,9 @@ export function ChangeLanesDashboard({
 
   const filteredLanes = useMemo(() => filterLanes(lanes, tab), [lanes, tab]);
 
+  const githubFresh = freshness.find((f) => f.source === "github-pr");
+  const githubNotConfigured = githubFresh?.state === "not-configured";
+
   return (
     <div className="space-y-4">
       <header className="space-y-1">
@@ -100,6 +103,7 @@ export function ChangeLanesDashboard({
       <ChangeLaneTable
         lanes={filteredLanes}
         anySourceWarmingUp={anySourceWarmingUp}
+        githubNotConfigured={githubNotConfigured}
       />
     </div>
   );

--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -34,10 +34,14 @@ export function ChangeLanesDashboard({
   lanes,
   freshness,
   generatedAt,
+  anySourceWarmingUp = false,
+  anySnapshotSourceDegraded = false,
 }: {
   lanes: ContributorChangeLane[];
   freshness: LaneReadModelFreshness[];
   generatedAt: string;
+  anySourceWarmingUp?: boolean;
+  anySnapshotSourceDegraded?: boolean;
 }) {
   const [tab, setTab] = useState<TabId>("active");
 
@@ -80,11 +84,23 @@ export function ChangeLanesDashboard({
             <span className="ml-1 text-[10px] text-[var(--dpf-muted)]">
               {countLanes(lanes, t.id)}
             </span>
+            {anySnapshotSourceDegraded ? (
+              <span
+                className="ml-1 cursor-help text-[10px] text-[var(--dpf-warning)]"
+                title="Counts may be incomplete — some inventory sources are not synced."
+                aria-label="counts may be incomplete"
+              >
+                (?)
+              </span>
+            ) : null}
           </button>
         ))}
       </div>
 
-      <ChangeLaneTable lanes={filteredLanes} />
+      <ChangeLaneTable
+        lanes={filteredLanes}
+        anySourceWarmingUp={anySourceWarmingUp}
+      />
     </div>
   );
 }

--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
@@ -1,0 +1,247 @@
+// apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
+// Phase 4 of BI-063BDF1B — GitHub REST reader.
+//
+// Test fakes drive `fetch` so no real network call is made. Covers:
+//   - no credential row → state: not-configured, no fetch attempted
+//   - happy path: paginated response → all rows parsed, etag written
+//   - 304 Not Modified → ok with unchanged: true, no rows
+//   - 401 → state: error with actionable message
+//   - rate-limit headers captured
+//   - parseRepoFromUrl covers https + ssh URL shapes
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  credentialFindUnique: vi.fn(),
+  platformDevConfigFindUnique: vi.fn(),
+  scheduledJobFindUnique: vi.fn(),
+  scheduledJobUpdate: vi.fn(),
+  decryptSecret: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    credentialEntry: { findUnique: mocks.credentialFindUnique },
+    platformDevConfig: { findUnique: mocks.platformDevConfigFindUnique },
+    scheduledJob: {
+      findUnique: mocks.scheduledJobFindUnique,
+      update: mocks.scheduledJobUpdate,
+    },
+  },
+}));
+
+vi.mock("@/lib/credential-crypto", () => ({
+  decryptSecret: mocks.decryptSecret,
+}));
+
+import { parseRepoFromUrl, readGithubPullRequests } from "./github-rest-reader";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.credentialFindUnique.mockResolvedValue(null);
+  mocks.platformDevConfigFindUnique.mockResolvedValue({
+    upstreamRemoteUrl: "https://github.com/o/r.git",
+  });
+  mocks.scheduledJobFindUnique.mockResolvedValue({ metadata: {} });
+  mocks.scheduledJobUpdate.mockResolvedValue({});
+  mocks.decryptSecret.mockReturnValue("ghp_decrypted_xxxxxxxxx");
+});
+
+function makeResponse(
+  body: unknown,
+  init?: { status?: number; etag?: string; rateLimitRemaining?: string; rateLimitReset?: string },
+): Response {
+  const headers = new Headers();
+  if (init?.etag) headers.set("etag", init.etag);
+  if (init?.rateLimitRemaining) headers.set("x-ratelimit-remaining", init.rateLimitRemaining);
+  if (init?.rateLimitReset) headers.set("x-ratelimit-reset", init.rateLimitReset);
+  const status = init?.status ?? 200;
+  // 304 is a null-body status per the Fetch spec — Response constructor rejects a body.
+  if (status === 304) {
+    return new Response(null, { status, headers });
+  }
+  return new Response(JSON.stringify(body ?? null), { status, headers });
+}
+
+describe("readGithubPullRequests", () => {
+  it("returns state: not-configured when no credential row exists", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce(null);
+    const fetchImpl = vi.fn();
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.state).toBe("not-configured");
+      expect(result.error).toContain("contributor MCP readiness card");
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns state: not-configured when the row exists but status is not active", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "revoked",
+    });
+    const fetchImpl = vi.fn();
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.state).toBe("not-configured");
+  });
+
+  it("happy path: paginated response parsed, etag persisted to ScheduledJob.metadata", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:encrypted-token-value",
+      status: "active",
+    });
+    mocks.scheduledJobFindUnique.mockResolvedValue({ metadata: { other: "preserved" } });
+
+    const page1Rows = Array.from({ length: 100 }, (_, i) => makeRawPr(i + 1));
+    const page2Rows = [makeRawPr(101)];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResponse(page1Rows, { status: 200, etag: '"new-etag-abc"', rateLimitRemaining: "4998", rateLimitReset: "1748295000" }),
+      )
+      .mockResolvedValueOnce(makeResponse(page2Rows, { status: 200 }));
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rows).toHaveLength(101);
+      expect(result.unchanged).toBe(false);
+      expect(result.rateLimitRemaining).toBe(4998);
+      expect(result.rateLimitResetAt).toBeInstanceOf(Date);
+    }
+    // First fetch carried no If-None-Match (initial etag from prior run is empty {})
+    const firstCallHeaders = fetchImpl.mock.calls[0]?.[1].headers as Record<string, string>;
+    expect(firstCallHeaders["If-None-Match"]).toBeUndefined();
+    expect(firstCallHeaders.Authorization).toBe("Bearer ghp_decrypted_xxxxxxxxx");
+    // Etag persisted to metadata, preserving sibling keys
+    expect(mocks.scheduledJobUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { metadata: { other: "preserved", githubPrEtag: '"new-etag-abc"' } },
+      }),
+    );
+  });
+
+  it("sends If-None-Match from ScheduledJob.metadata.githubPrEtag on the first page", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    mocks.scheduledJobFindUnique.mockResolvedValue({
+      metadata: { githubPrEtag: '"prior-etag"' },
+    });
+    const fetchImpl = vi.fn().mockResolvedValueOnce(makeResponse([]));
+
+    await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    const headers = fetchImpl.mock.calls[0]?.[1].headers as Record<string, string>;
+    expect(headers["If-None-Match"]).toBe('"prior-etag"');
+  });
+
+  it("304 Not Modified → ok with unchanged: true, no rows, no etag write", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    mocks.scheduledJobFindUnique.mockResolvedValue({
+      metadata: { githubPrEtag: '"prior"' },
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(null, { status: 304, rateLimitRemaining: "5000" }));
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.unchanged).toBe(true);
+      expect(result.rows).toHaveLength(0);
+      expect(result.rateLimitRemaining).toBe(5000);
+    }
+    expect(mocks.scheduledJobUpdate).not.toHaveBeenCalled();
+  });
+
+  it("401 unauthorized → state: error with actionable message", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ message: "Bad credentials" }, { status: 401 }));
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.state).toBe("error");
+      expect(result.error).toContain("401");
+      expect(result.error.toLowerCase()).toMatch(/revoked|scope/);
+    }
+  });
+
+  it("network error caught and returned as state: error", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    const fetchImpl = vi.fn().mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.state).toBe("error");
+      expect(result.error).toContain("ECONNREFUSED");
+    }
+  });
+});
+
+describe("parseRepoFromUrl", () => {
+  it("parses https URLs with .git suffix", () => {
+    expect(parseRepoFromUrl("https://github.com/owner/repo.git")).toEqual({
+      owner: "owner",
+      name: "repo",
+    });
+  });
+
+  it("parses https URLs without .git suffix", () => {
+    expect(parseRepoFromUrl("https://github.com/owner/repo")).toEqual({
+      owner: "owner",
+      name: "repo",
+    });
+  });
+
+  it("parses ssh-style URLs", () => {
+    expect(parseRepoFromUrl("git@github.com:owner/repo.git")).toEqual({
+      owner: "owner",
+      name: "repo",
+    });
+  });
+
+  it("returns null for non-github URLs", () => {
+    expect(parseRepoFromUrl("https://gitlab.com/owner/repo")).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseRepoFromUrl("garbage")).toBeNull();
+  });
+});
+
+function makeRawPr(n: number) {
+  return {
+    number: n,
+    html_url: `https://github.com/o/r/pull/${n}`,
+    title: `PR ${n}`,
+    head: { ref: `feat/branch-${n}` },
+    state: "open",
+    draft: false,
+    mergeable_state: "CLEAN",
+  };
+}

--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
@@ -1,0 +1,304 @@
+// apps/web/lib/contributor-change-lanes/github-rest-reader.ts
+// Phase 4 of BI-063BDF1B — real GitHub REST reader.
+//
+// Replaces the Phase 2 stub. Authenticates via the CredentialEntry row
+// with providerId "github-pr-sync" (created by the Contributor MCP card
+// from PR #1204; disjoint from the "git-backup" / "hive-contribution"
+// rows used by the contribution pipeline). Etag persistence uses
+// ScheduledJob.metadata.githubPrEtag so the rate-budget protection
+// survives the ContributorInventorySnapshot 7-day retention sweep.
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+//   §"Per-source work" item 3, §"Etag persistence".
+
+import type { PullRequestSnapshot } from "./types";
+
+const GITHUB_PR_CREDENTIAL_PROVIDER_ID = "github-pr-sync";
+const CONTRIBUTOR_INVENTORY_SYNC_JOB_ID = "contributor-inventory-sync";
+const FALLBACK_REPO_OWNER = "OpenDigitalProductFactory";
+const FALLBACK_REPO_NAME = "opendigitalproductfactory";
+const DEFAULT_MAX_PAGES = 10;
+const DEFAULT_PER_PAGE = 100;
+
+export type SnapshotRowPayload = {
+  sourceKey: string;
+  payload: unknown;
+};
+
+export type GithubReaderResult =
+  | {
+      ok: true;
+      rows: SnapshotRowPayload[];
+      unchanged?: boolean;
+      rateLimitRemaining?: number;
+      rateLimitResetAt?: Date | null;
+    }
+  | {
+      ok: false;
+      error: string;
+      state: "not-configured" | "error";
+    };
+
+export type GithubReaderDeps = {
+  /** Injection point so tests don't fetch real URLs. */
+  fetchImpl?: typeof fetch;
+};
+
+/** Resolved repo coordinates `{owner}/{repo}`. */
+type RepoIdentity = { owner: string; name: string };
+
+/**
+ * Production GitHub PR reader. Returns the rows for the open-PR list,
+ * tagged with sourceKey = PR number as string. The pure runner in
+ * contributor-inventory-sync.ts wraps this into a SyncSourceResult.
+ */
+export async function readGithubPullRequests(
+  deps: GithubReaderDeps = {},
+): Promise<GithubReaderResult> {
+  const { prisma } = await import("@dpf/db");
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  const token = await resolveGithubToken(prisma);
+  if (!token) {
+    return {
+      ok: false,
+      error:
+        "no GitHub credential bound — connect GitHub on the contributor MCP readiness card to populate PR data",
+      state: "not-configured",
+    };
+  }
+
+  const repo = await resolveRepoIdentity(prisma);
+  const previousEtag = await loadEtag(prisma);
+
+  try {
+    const result = await fetchOpenPullRequests(fetchImpl, repo, token, previousEtag);
+    if (result.kind === "not-modified") {
+      return {
+        ok: true,
+        rows: [],
+        unchanged: true,
+        rateLimitRemaining: result.rateLimitRemaining,
+        rateLimitResetAt: result.rateLimitResetAt,
+      };
+    }
+    if (result.kind === "rows") {
+      // Persist new etag if one was returned.
+      if (result.etag) {
+        await persistEtag(prisma, result.etag);
+      }
+      return {
+        ok: true,
+        rows: result.rows,
+        unchanged: false,
+        rateLimitRemaining: result.rateLimitRemaining,
+        rateLimitResetAt: result.rateLimitResetAt,
+      };
+    }
+    return {
+      ok: false,
+      error: result.error,
+      state: "error",
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: (err as Error).message ?? "fetch failed",
+      state: "error",
+    };
+  }
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+import type { prisma } from "@dpf/db";
+
+type PrismaLike = Pick<
+  typeof prisma,
+  "credentialEntry" | "platformDevConfig" | "scheduledJob"
+>;
+
+async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
+  const cred = await prisma.credentialEntry.findUnique({
+    where: { providerId: GITHUB_PR_CREDENTIAL_PROVIDER_ID },
+    select: { secretRef: true, status: true },
+  });
+  if (!cred || cred.status !== "active" || !cred.secretRef) return null;
+
+  const stored = cred.secretRef;
+  try {
+    const { decryptSecret } = await import("@/lib/credential-crypto");
+    if (stored.startsWith("enc:")) {
+      return decryptSecret(stored);
+    }
+    return stored;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveRepoIdentity(prisma: PrismaLike): Promise<RepoIdentity> {
+  const cfg = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { upstreamRemoteUrl: true },
+  });
+  if (cfg?.upstreamRemoteUrl) {
+    const parsed = parseRepoFromUrl(cfg.upstreamRemoteUrl);
+    if (parsed) return parsed;
+  }
+  return { owner: FALLBACK_REPO_OWNER, name: FALLBACK_REPO_NAME };
+}
+
+export function parseRepoFromUrl(url: string): RepoIdentity | null {
+  // Accepts both https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git).
+  const https = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+  if (!https) return null;
+  return { owner: https[1]!, name: https[2]! };
+}
+
+async function loadEtag(prisma: PrismaLike): Promise<string | null> {
+  const row = await prisma.scheduledJob.findUnique({
+    where: { jobId: CONTRIBUTOR_INVENTORY_SYNC_JOB_ID },
+    select: { metadata: true },
+  });
+  const md = (row?.metadata ?? null) as { githubPrEtag?: string } | null;
+  return md?.githubPrEtag ?? null;
+}
+
+async function persistEtag(prisma: PrismaLike, etag: string): Promise<void> {
+  const row = await prisma.scheduledJob.findUnique({
+    where: { jobId: CONTRIBUTOR_INVENTORY_SYNC_JOB_ID },
+    select: { metadata: true },
+  });
+  const md = (row?.metadata ?? {}) as Record<string, unknown>;
+  await prisma.scheduledJob.update({
+    where: { jobId: CONTRIBUTOR_INVENTORY_SYNC_JOB_ID },
+    data: {
+      metadata: { ...md, githubPrEtag: etag },
+    },
+  });
+}
+
+type FetchOutcome =
+  | { kind: "rows"; rows: SnapshotRowPayload[]; etag: string | null; rateLimitRemaining?: number; rateLimitResetAt?: Date | null }
+  | { kind: "not-modified"; rateLimitRemaining?: number; rateLimitResetAt?: Date | null }
+  | { kind: "error"; error: string };
+
+async function fetchOpenPullRequests(
+  fetchImpl: typeof fetch,
+  repo: RepoIdentity,
+  token: string,
+  ifNoneMatch: string | null,
+): Promise<FetchOutcome> {
+  const rows: SnapshotRowPayload[] = [];
+  let etag: string | null = null;
+  let rateLimitRemaining: number | undefined;
+  let rateLimitResetAt: Date | null | undefined;
+
+  for (let page = 1; page <= DEFAULT_MAX_PAGES; page++) {
+    const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls?state=open&per_page=${DEFAULT_PER_PAGE}&page=${page}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "dpf-contributor-inventory-sync",
+    };
+    // Only send If-None-Match on the first page — subsequent pages are
+    // tied to that page's own etag (which the GitHub API does support but
+    // we don't store), so we just refetch them on each run.
+    if (page === 1 && ifNoneMatch) {
+      headers["If-None-Match"] = ifNoneMatch;
+    }
+
+    const res = await fetchImpl(url, { method: "GET", headers });
+
+    captureRateLimit(res, (rem, reset) => {
+      rateLimitRemaining = rem;
+      rateLimitResetAt = reset;
+    });
+
+    if (res.status === 304 && page === 1) {
+      return { kind: "not-modified", rateLimitRemaining, rateLimitResetAt };
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      return {
+        kind: "error",
+        error: `GitHub auth failed (${res.status}) — token may be revoked or lack required scopes`,
+      };
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        kind: "error",
+        error: `GitHub PR list failed: HTTP ${res.status} ${body.slice(0, 200)}`,
+      };
+    }
+
+    if (page === 1) {
+      etag = res.headers.get("etag");
+    }
+
+    const json = (await res.json()) as RawPullRequest[];
+    for (const pr of json) {
+      const parsed = parsePullRequest(pr);
+      if (parsed) {
+        rows.push({ sourceKey: String(parsed.number), payload: parsed });
+      }
+    }
+    if (json.length < DEFAULT_PER_PAGE) {
+      break;
+    }
+  }
+
+  return { kind: "rows", rows, etag, rateLimitRemaining, rateLimitResetAt };
+}
+
+function captureRateLimit(
+  res: Response,
+  setter: (remaining: number | undefined, reset: Date | null) => void,
+): void {
+  const remainingStr = res.headers.get("x-ratelimit-remaining");
+  const resetStr = res.headers.get("x-ratelimit-reset");
+  // Only update when the header is actually present — otherwise a paginated
+  // run would clobber the page-1 capture with the page-N response (which may
+  // omit headers entirely, depending on the proxy).
+  if (remainingStr === null && resetStr === null) return;
+  const remaining = remainingStr !== null ? Number.parseInt(remainingStr, 10) : undefined;
+  const reset =
+    resetStr !== null && !Number.isNaN(Number.parseInt(resetStr, 10))
+      ? new Date(Number.parseInt(resetStr, 10) * 1000)
+      : null;
+  setter(Number.isNaN(remaining as number) ? undefined : remaining, reset);
+}
+
+type RawPullRequest = {
+  number?: number;
+  url?: string;
+  html_url?: string;
+  title?: string;
+  head?: { ref?: string };
+  state?: string;
+  draft?: boolean;
+  mergeable_state?: string;
+};
+
+function parsePullRequest(pr: RawPullRequest): PullRequestSnapshot | null {
+  if (typeof pr.number !== "number" || !pr.head?.ref || !pr.html_url) return null;
+  return {
+    number: pr.number,
+    url: pr.html_url,
+    title: pr.title ?? "",
+    headBranch: pr.head.ref,
+    state: normalizeState(pr.state),
+    isDraft: pr.draft === true,
+    mergeStateStatus: pr.mergeable_state ?? null,
+  };
+}
+
+function normalizeState(s: string | undefined): PullRequestSnapshot["state"] {
+  if (s === "open") return "open";
+  if (s === "closed") return "closed";
+  return "open";
+}

--- a/apps/web/lib/contributor-change-lanes/read-model.test.ts
+++ b/apps/web/lib/contributor-change-lanes/read-model.test.ts
@@ -1,12 +1,17 @@
+// apps/web/lib/contributor-change-lanes/read-model.test.ts
+// Phase 3 rewrite for BI-063BDF1B — DB-only read model.
+//
+// Verifies latest-successful-per-source semantics, five-state freshness
+// discriminator (ok / stale / error / not-configured / warming-up), and the
+// cold-start affordances (anySourceWarmingUp + anySnapshotSourceDegraded).
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  loadContributorChangeLaneReadModel,
-  type LaneReadModelInventoryRunners,
-} from "./read-model";
+import { loadContributorChangeLaneReadModel } from "./read-model";
 
 const NOW = new Date("2026-05-26T22:00:00.000Z");
-const FRESH = new Date("2026-05-26T21:58:00.000Z");
+const RECENT = new Date("2026-05-26T21:58:00.000Z"); // 2 min ago — fresh
+const STALE = new Date("2026-05-26T21:30:00.000Z"); // 30 min ago — past 20-min threshold
 
 function makeDb() {
   return {
@@ -14,26 +19,34 @@ function makeDb() {
     runtimeTarget: { findMany: vi.fn() },
     runtimeVerification: { findMany: vi.fn() },
     nonProductionEnvironmentLease: { findMany: vi.fn() },
+    contributorInventorySyncRun: { findFirst: vi.fn() },
+    credentialEntry: { findFirst: vi.fn() },
   };
 }
 
 type DbHarness = ReturnType<typeof makeDb>;
-
 function dbAsAny(db: DbHarness): any {
   return db;
 }
 
-function makeRunners(overrides: Partial<LaneReadModelInventoryRunners> = {}): LaneReadModelInventoryRunners {
+function syncRunRow(opts: {
+  syncRunId: string;
+  completedAt: Date;
+  snapshots: { payload: unknown }[];
+}) {
   return {
-    runGitWorktreeList: async () => "",
-    runGitForEachRef: async () => "",
-    runGhPrList: async () => "[]",
-    listFilesystemWorktreePaths: async () => [],
-    ...overrides,
+    syncRunId: opts.syncRunId,
+    startedAt: new Date(opts.completedAt.getTime() - 1_000),
+    completedAt: opts.completedAt,
+    status: "completed",
+    perSourceResult: {},
+    snapshots: opts.snapshots,
   };
 }
 
-describe("loadContributorChangeLaneReadModel", () => {
+beforeEach(() => {});
+
+describe("loadContributorChangeLaneReadModel — Phase 3", () => {
   let db: DbHarness;
 
   beforeEach(() => {
@@ -42,160 +55,277 @@ describe("loadContributorChangeLaneReadModel", () => {
     db.runtimeTarget.findMany.mockResolvedValue([]);
     db.runtimeVerification.findMany.mockResolvedValue([]);
     db.nonProductionEnvironmentLease.findMany.mockResolvedValue([]);
+    // Default: no successful run for any snapshot source → warming-up.
+    db.contributorInventorySyncRun.findFirst.mockResolvedValue(null);
+    // Default: no GitHub credential bound → github-pr is not-configured.
+    db.credentialEntry.findFirst.mockResolvedValue(null);
   });
 
-  it("returns lanes and a freshness row per source on the happy path", async () => {
+  it("warming-up: no successful run yet for any snapshot source, no GitHub credential bound", async () => {
     const result = await loadContributorChangeLaneReadModel({
       db: dbAsAny(db),
-      runners: makeRunners(),
       now: NOW,
     });
 
     expect(result.lanes).toEqual([]);
-    const sources = result.freshness.map((f) => f.source).sort();
-    expect(sources).toEqual([
-      "git-branch",
-      "git-worktree",
-      "github-pr",
-      "nonprod-lease",
-      "runtime-target",
-      "runtime-verification",
-      "work-capsule",
-    ]);
-    expect(result.freshness.every((f) => f.ok)).toBe(true);
+    expect(result.anySourceWarmingUp).toBe(true);
+    expect(result.anySnapshotSourceDegraded).toBe(true);
+
+    const byName = new Map(result.freshness.map((f) => [f.source, f]));
+    expect(byName.get("git-worktree")?.state).toBe("warming-up");
+    expect(byName.get("git-branch")?.state).toBe("warming-up");
+    // No credential → github-pr is "not-configured", not "warming-up".
+    expect(byName.get("github-pr")?.state).toBe("not-configured");
+    expect(byName.get("github-pr")?.message).toContain("Contributor MCP card");
   });
 
-  it("joins a Prisma WorkCapsule + RuntimeTarget into one lane row", async () => {
-    db.workCapsule.findMany.mockResolvedValueOnce([
-      {
-        capsuleId: "WC-INT-1",
-        title: "Integration",
-        status: "working",
-        executorKind: "claude-desktop",
-        executorRef: "session-a",
-        headBranch: "feat/x",
-        headSha: "abc123",
-        worktreePath: "D:/DPF/.claude/worktrees/x",
-        pullRequestUrl: "https://example.com/pr/1",
-        backlogItemId: "BI-INT",
-        featureBuildId: null,
-        leaseHolderPrincipalId: "p-1",
-        leaseExpiresAt: new Date(NOW.getTime() + 60_000),
-        updatedAt: FRESH,
-        objective: "Make X work",
-      },
-    ]);
-    db.runtimeTarget.findMany.mockResolvedValueOnce([
-      {
-        targetId: "RT-INT-1",
-        kind: "dev-portal",
-        status: "running",
-        hostUrl: "http://localhost:3001",
-        serviceVersion: "abc123",
-        workCapsuleId: "WC-INT-1",
-        featureBuildId: null,
-        acceptanceRoleOverride: null,
-        lastHeartbeatAt: FRESH,
-        expiresAt: null,
-        metadata: { servedCommitSha: "abc123", branchName: "feat/x" },
-      },
-    ]);
-    db.runtimeVerification.findMany.mockResolvedValueOnce([
-      {
-        verificationId: "RV-1",
-        runtimeTargetId: "RT-INT-1",
-        workCapsuleId: "WC-INT-1",
-        kind: "ux",
-        status: "passed",
-        completedAt: FRESH,
-        result: { summary: "OK" },
-      },
-    ]);
+  it("ok: each source resolves to its latest-successful row independently", async () => {
+    const worktreePayload = {
+      path: "/repo/wt-a",
+      branch: "feat/a",
+      headSha: "abc",
+      isRegistered: true,
+    };
+    const branchPayload = {
+      name: "feat/a",
+      headSha: "abc",
+      remote: "origin",
+      isMerged: false,
+      lastCommitAt: null,
+    };
+    const prPayload = {
+      number: 42,
+      url: "https://github.com/o/r/pull/42",
+      title: "feat: a",
+      headBranch: "feat/a",
+      state: "open",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+    };
+
+    db.contributorInventorySyncRun.findFirst.mockImplementation(async ({ where }) => {
+      const path = (where.perSourceResult.path as string[])[0];
+      if (path === "git-worktree") {
+        return syncRunRow({
+          syncRunId: "run-a",
+          completedAt: RECENT,
+          snapshots: [{ payload: worktreePayload }],
+        });
+      }
+      if (path === "git-branch") {
+        return syncRunRow({
+          syncRunId: "run-a",
+          completedAt: RECENT,
+          snapshots: [{ payload: branchPayload }],
+        });
+      }
+      if (path === "github-pr") {
+        return syncRunRow({
+          syncRunId: "run-a",
+          completedAt: RECENT,
+          snapshots: [{ payload: prPayload }],
+        });
+      }
+      return null;
+    });
+    db.credentialEntry.findFirst.mockResolvedValue({ id: "cred-1" });
 
     const result = await loadContributorChangeLaneReadModel({
       db: dbAsAny(db),
-      runners: makeRunners(),
       now: NOW,
     });
 
-    expect(result.lanes).toHaveLength(1);
-    const lane = result.lanes[0]!;
-    expect(lane.runtimeTargetId).toBe("RT-INT-1");
-    expect(lane.workCapsuleId).toBe("WC-INT-1");
-    expect(lane.branch).toBe("feat/x");
-    expect(lane.servedCommitSha).toBe("abc123");
-    expect(lane.commitSha).toBe("abc123");
-    expect(lane.latestVerification.status).toBe("passed");
-    expect(lane.status).toBe("ready-for-review");
+    expect(result.anySourceWarmingUp).toBe(false);
+    expect(result.anySnapshotSourceDegraded).toBe(false);
+    const byName = new Map(result.freshness.map((f) => [f.source, f]));
+    expect(byName.get("git-worktree")?.state).toBe("ok");
+    expect(byName.get("git-worktree")?.count).toBe(1);
+    expect(byName.get("git-branch")?.state).toBe("ok");
+    expect(byName.get("github-pr")?.state).toBe("ok");
   });
 
-  it("records a freshness error and continues when work-capsule Prisma read throws", async () => {
+  it("latest-successful-per-source: GitHub failed in newest run but had succeeded in an older run → the older row drives the projection (the resolver is queried per source, not globally)", async () => {
+    const worktreePayload = { path: "/wt", branch: null, headSha: null, isRegistered: true };
+    const branchPayload = {
+      name: "main",
+      headSha: "z",
+      remote: "origin",
+      isMerged: false,
+      lastCommitAt: null,
+    };
+    const olderPrPayload = {
+      number: 7,
+      url: "https://example.com/pr/7",
+      title: "PR 7",
+      headBranch: "main",
+      state: "open",
+      isDraft: false,
+      mergeStateStatus: null,
+    };
+
+    db.contributorInventorySyncRun.findFirst.mockImplementation(async ({ where }) => {
+      const source = (where.perSourceResult.path as string[])[0];
+      // Each source returns ITS latest-successful row. The runner's actual
+      // SQL uses `orderBy startedAt DESC` against the `ok: true` filter so
+      // this test models that contract: when GitHub failed in the newest
+      // run, the resolver still returns the OLDER successful GitHub run.
+      if (source === "git-worktree") {
+        return syncRunRow({
+          syncRunId: "run-new",
+          completedAt: RECENT,
+          snapshots: [{ payload: worktreePayload }],
+        });
+      }
+      if (source === "git-branch") {
+        return syncRunRow({
+          syncRunId: "run-new",
+          completedAt: RECENT,
+          snapshots: [{ payload: branchPayload }],
+        });
+      }
+      if (source === "github-pr") {
+        return syncRunRow({
+          syncRunId: "run-old",
+          completedAt: RECENT,
+          snapshots: [{ payload: olderPrPayload }],
+        });
+      }
+      return null;
+    });
+    db.credentialEntry.findFirst.mockResolvedValue({ id: "cred-1" });
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      now: NOW,
+    });
+
+    expect(result.anySourceWarmingUp).toBe(false);
+    const byName = new Map(result.freshness.map((f) => [f.source, f]));
+    // All three sources resolve to "ok" — older GitHub data is the
+    // latest-successful for that source even though it's a different run.
+    expect(byName.get("github-pr")?.state).toBe("ok");
+    expect(byName.get("github-pr")?.count).toBe(1);
+  });
+
+  it("stale: latest-successful run older than 20-minute threshold → state stale, anySnapshotSourceDegraded true", async () => {
+    db.contributorInventorySyncRun.findFirst.mockResolvedValue(
+      syncRunRow({
+        syncRunId: "run-stale",
+        completedAt: STALE,
+        snapshots: [
+          {
+            payload: {
+              path: "/repo/wt",
+              branch: null,
+              headSha: null,
+              isRegistered: true,
+            },
+          },
+        ],
+      }),
+    );
+    db.credentialEntry.findFirst.mockResolvedValue({ id: "cred-1" });
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      now: NOW,
+    });
+
+    const byName = new Map(result.freshness.map((f) => [f.source, f]));
+    expect(byName.get("git-worktree")?.state).toBe("stale");
+    expect(byName.get("git-worktree")?.message).toMatch(/Last successful sync \d+ min ago/);
+    expect(result.anySnapshotSourceDegraded).toBe(true);
+  });
+
+  it("not-configured: no GitHub credential row → github-pr state is not-configured, message points to Contributor MCP card", async () => {
+    db.contributorInventorySyncRun.findFirst.mockResolvedValue(
+      syncRunRow({
+        syncRunId: "run-a",
+        completedAt: RECENT,
+        snapshots: [
+          { payload: { path: "/x", branch: null, headSha: null, isRegistered: true } },
+        ],
+      }),
+    );
+    db.credentialEntry.findFirst.mockResolvedValue(null);
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      now: NOW,
+    });
+
+    const github = result.freshness.find((f) => f.source === "github-pr");
+    expect(github?.state).toBe("not-configured");
+    expect(github?.message).toContain("Contributor MCP");
+    expect(github?.count).toBe(0);
+  });
+
+  it("error: ContributorInventorySyncRun read throws → state error for that source, other sources unaffected", async () => {
+    db.contributorInventorySyncRun.findFirst.mockImplementation(async ({ where }) => {
+      const source = (where.perSourceResult.path as string[])[0];
+      if (source === "git-worktree") {
+        throw new Error("snapshot read failed");
+      }
+      return null;
+    });
+
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      now: NOW,
+    });
+
+    const byName = new Map(result.freshness.map((f) => [f.source, f]));
+    expect(byName.get("git-worktree")?.state).toBe("error");
+    expect(byName.get("git-worktree")?.message).toContain("snapshot read failed");
+    expect(byName.get("git-branch")?.state).toBe("warming-up");
+  });
+
+  it("live Prisma sources are always state ok when their reads succeed", async () => {
+    const result = await loadContributorChangeLaneReadModel({
+      db: dbAsAny(db),
+      now: NOW,
+    });
+
+    const liveSources = result.freshness.filter((f) =>
+      ["work-capsule", "runtime-target", "runtime-verification", "nonprod-lease"].includes(
+        f.source,
+      ),
+    );
+    expect(liveSources.every((f) => f.state === "ok")).toBe(true);
+  });
+
+  it("live Prisma source error: workCapsule read throws → state error for work-capsule only", async () => {
     db.workCapsule.findMany.mockRejectedValueOnce(new Error("db offline"));
 
     const result = await loadContributorChangeLaneReadModel({
       db: dbAsAny(db),
-      runners: makeRunners(),
       now: NOW,
     });
 
-    const wcFreshness = result.freshness.find((f) => f.source === "work-capsule");
-    expect(wcFreshness).toBeDefined();
-    expect(wcFreshness!.ok).toBe(false);
-    expect(wcFreshness!.error).toBe("db offline");
-    expect(result.lanes).toEqual([]);
+    const wc = result.freshness.find((f) => f.source === "work-capsule");
+    expect(wc?.state).toBe("error");
+    expect(wc?.message).toBe("db offline");
   });
 
-  it("records a freshness error when the gh runner throws but still returns other sources", async () => {
-    const runners = makeRunners({
-      runGhPrList: async () => {
-        throw new Error("gh not installed");
-      },
-    });
+  it("custom staleHeartbeatThresholdMs overrides the default 20-minute threshold", async () => {
+    db.contributorInventorySyncRun.findFirst.mockResolvedValue(
+      syncRunRow({
+        syncRunId: "run-x",
+        completedAt: new Date(NOW.getTime() - 60_000), // 1 min ago
+        snapshots: [
+          { payload: { path: "/x", branch: null, headSha: null, isRegistered: true } },
+        ],
+      }),
+    );
+    db.credentialEntry.findFirst.mockResolvedValue({ id: "cred" });
 
     const result = await loadContributorChangeLaneReadModel({
       db: dbAsAny(db),
-      runners,
       now: NOW,
+      staleHeartbeatThresholdMs: 30_000, // 30s — 1-min-old data is stale by this rule
     });
 
-    const prFreshness = result.freshness.find((f) => f.source === "github-pr");
-    expect(prFreshness).toBeDefined();
-    expect(prFreshness!.ok).toBe(false);
-    expect(prFreshness!.error).toBe("gh not installed");
-    const otherSources = result.freshness.filter((f) => f.source !== "github-pr");
-    expect(otherSources.every((f) => f.ok)).toBe(true);
-  });
-
-  it("flags a runner as missing when no runner function is configured", async () => {
-    const result = await loadContributorChangeLaneReadModel({
-      db: dbAsAny(db),
-      runners: {},
-      now: NOW,
-    });
-    const sources = result.freshness.filter((f) => !f.ok).map((f) => f.source).sort();
-    expect(sources).toEqual(["git-branch", "git-worktree", "github-pr"]);
-    expect(
-      result.freshness
-        .filter((f) => !f.ok)
-        .every((f) => f.error === "no runner configured"),
-    ).toBe(true);
-  });
-
-  it("merges filesystem-only worktree paths into the inventory", async () => {
-    const runners = makeRunners({
-      runGitWorktreeList: async () => "worktree D:/DPF\nHEAD abc\nbranch refs/heads/main\n",
-      listFilesystemWorktreePaths: async () => ["D:/DPF/.claude/worktrees/orphan-fs"],
-    });
-
-    const result = await loadContributorChangeLaneReadModel({
-      db: dbAsAny(db),
-      runners,
-      now: NOW,
-    });
-
-    const orphanRows = result.lanes.filter((l) => l.source === "worktree");
-    expect(orphanRows).toHaveLength(1);
-    expect(orphanRows[0]!.worktreePath).toBe("D:/DPF/.claude/worktrees/orphan-fs");
-    expect(orphanRows[0]!.blockers[0]).toMatch(/Filesystem-only/);
+    const worktree = result.freshness.find((f) => f.source === "git-worktree");
+    expect(worktree?.state).toBe("stale");
   });
 });

--- a/apps/web/lib/contributor-change-lanes/read-model.ts
+++ b/apps/web/lib/contributor-change-lanes/read-model.ts
@@ -1,7 +1,21 @@
+// apps/web/lib/contributor-change-lanes/read-model.ts
+// Phase 3 of BI-063BDF1B — DB-only read model.
+//
+// The read model no longer accepts inventory runners. Snapshot sources
+// (git-worktree, git-branch, github-pr) come from ContributorInventorySnapshot
+// rows resolved via latest-successful-per-source semantics, so a partial sync
+// preserves prior good data for each source independently. Live Prisma sources
+// (work-capsule, runtime-target, runtime-verification, nonprod-lease) are read
+// at request time as today.
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+//   §"Read Model"
+//
+// The deprecated `runners-node.ts` is left on disk through Phase 7 for
+// rollback safety; it is unreferenced from this file or from page.tsx.
+
 import { prisma } from "@dpf/db";
 
-import { mergeFilesystemAndRegisteredWorktrees, parseGitBranchList, parseGitWorktreeList } from "./git-inventory";
-import { parseGhPrListJson } from "./github-inventory";
 import { projectContributorChangeLanes } from "./lane-projection";
 import type {
   ContributorChangeLane,
@@ -16,37 +30,76 @@ import type {
 
 type ReadModelDb = Pick<
   typeof prisma,
-  "workCapsule" | "runtimeTarget" | "runtimeVerification" | "nonProductionEnvironmentLease"
+  | "workCapsule"
+  | "runtimeTarget"
+  | "runtimeVerification"
+  | "nonProductionEnvironmentLease"
+  | "contributorInventorySyncRun"
+  | "credentialEntry"
 >;
 
-export type LaneReadModelSource = "work-capsule" | "runtime-target" | "runtime-verification" | "nonprod-lease" | "git-worktree" | "git-branch" | "github-pr";
+export type LaneReadModelSource =
+  | "work-capsule"
+  | "runtime-target"
+  | "runtime-verification"
+  | "nonprod-lease"
+  | "git-worktree"
+  | "git-branch"
+  | "github-pr";
+
+/** Distinct states the freshness band can render — see spec §"Freshness display". */
+export type LaneReadModelFreshnessState =
+  | "ok"
+  | "stale"
+  | "error"
+  | "not-configured"
+  | "warming-up";
 
 export type LaneReadModelFreshness = {
   source: LaneReadModelSource;
-  ok: boolean;
+  state: LaneReadModelFreshnessState;
   fetchedAt: Date;
-  error: string | null;
+  message: string | null;
   count: number;
 };
 
 export type LaneReadModelResult = {
   lanes: ContributorChangeLane[];
   freshness: LaneReadModelFreshness[];
-};
-
-export type LaneReadModelInventoryRunners = {
-  runGitWorktreeList: () => Promise<string>;
-  runGitForEachRef: () => Promise<string>;
-  runGhPrList: () => Promise<string>;
-  listFilesystemWorktreePaths: () => Promise<string[]>;
+  /** True iff at least one snapshot source has state === "warming-up". */
+  anySourceWarmingUp: boolean;
+  /** True iff any snapshot source has a non-"ok" state (used by tab-count warning). */
+  anySnapshotSourceDegraded: boolean;
 };
 
 export type LaneReadModelArgs = {
   db?: ReadModelDb;
-  runners?: Partial<LaneReadModelInventoryRunners>;
   now?: Date;
+  /** Threshold (ms) past which a snapshot's fetchedAt flips to state "stale". */
   staleHeartbeatThresholdMs?: number;
   staleVerifiedThresholdMs?: number;
+};
+
+const DEFAULT_STALE_THRESHOLD_MS = 20 * 60 * 1000;
+const GITHUB_PR_CREDENTIAL_PROVIDER_ID = "github-pr-sync";
+
+const SNAPSHOT_SOURCES: ("git-worktree" | "git-branch" | "github-pr")[] = [
+  "git-worktree",
+  "git-branch",
+  "github-pr",
+];
+
+type SnapshotRowLike = {
+  payload: unknown;
+};
+
+type SyncRunRowLike = {
+  syncRunId: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  status: string;
+  perSourceResult: unknown;
+  snapshots: SnapshotRowLike[];
 };
 
 export async function loadContributorChangeLaneReadModel(
@@ -54,7 +107,7 @@ export async function loadContributorChangeLaneReadModel(
 ): Promise<LaneReadModelResult> {
   const db = args.db ?? prisma;
   const now = args.now ?? new Date();
-  const runners = args.runners ?? {};
+  const staleThresholdMs = args.staleHeartbeatThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
 
   const freshness: LaneReadModelFreshness[] = [];
 
@@ -65,11 +118,27 @@ export async function loadContributorChangeLaneReadModel(
     readActiveLeases(db, freshness, now),
   ]);
 
-  const [worktrees, branches, pullRequests] = await Promise.all([
-    readWorktreeInventory(runners, freshness, now),
-    readBranchInventory(runners, freshness, now),
-    readPullRequestInventory(runners, freshness, now),
+  const [worktrees, branches, pullRequests, githubCredentialBound] = await Promise.all([
+    readSnapshotSource<GitWorktreeSnapshot>(db, "git-worktree", freshness, now, staleThresholdMs, null),
+    readSnapshotSource<GitBranchSnapshot>(db, "git-branch", freshness, now, staleThresholdMs, null),
+    Promise.resolve([] as PullRequestSnapshot[]).then(() => null), // placeholder, see below
+    isGithubPrCredentialBound(db),
   ]);
+
+  // We deferred the github-pr read so we know whether the credential is
+  // bound before deciding whether absence-of-data means "not-configured"
+  // (no credential) or "warming-up" (no run yet).
+  const githubPrRows = await readSnapshotSource<PullRequestSnapshot>(
+    db,
+    "github-pr",
+    freshness,
+    now,
+    staleThresholdMs,
+    githubCredentialBound ? null : "not-configured",
+  );
+
+  // (PR snapshot read above; we drop the placeholder value.)
+  void pullRequests;
 
   const projection = projectContributorChangeLanes({
     workCapsules,
@@ -78,14 +147,126 @@ export async function loadContributorChangeLaneReadModel(
     leases,
     worktrees,
     branches,
-    pullRequests,
+    pullRequests: githubPrRows,
     now,
     staleHeartbeatThresholdMs: args.staleHeartbeatThresholdMs,
     staleVerifiedThresholdMs: args.staleVerifiedThresholdMs,
   });
 
-  return { lanes: projection.lanes, freshness };
+  const snapshotStates = freshness
+    .filter((f) => SNAPSHOT_SOURCES.includes(f.source as (typeof SNAPSHOT_SOURCES)[number]))
+    .map((f) => f.state);
+
+  return {
+    lanes: projection.lanes,
+    freshness,
+    anySourceWarmingUp: snapshotStates.includes("warming-up"),
+    anySnapshotSourceDegraded: snapshotStates.some((s) => s !== "ok"),
+  };
 }
+
+// ─── Snapshot source resolver (latest-successful-per-source) ────────────────
+
+async function readSnapshotSource<T>(
+  db: ReadModelDb,
+  source: "git-worktree" | "git-branch" | "github-pr",
+  freshness: LaneReadModelFreshness[],
+  now: Date,
+  staleThresholdMs: number,
+  forcedNotConfiguredReason: "not-configured" | null,
+): Promise<T[]> {
+  if (forcedNotConfiguredReason === "not-configured") {
+    freshness.push({
+      source,
+      state: "not-configured",
+      fetchedAt: now,
+      message:
+        "GitHub not connected — connect on the Contributor MCP card to populate PR data",
+      count: 0,
+    });
+    return [];
+  }
+
+  let row: SyncRunRowLike | null = null;
+  try {
+    row = (await db.contributorInventorySyncRun.findFirst({
+      where: {
+        // Latest run where this source was OK. Status is not the filter —
+        // the audit-only status field can be "partial" even when this
+        // specific source succeeded; the source's `ok: true` in
+        // perSourceResult is the truth.
+        perSourceResult: { path: [source, "ok"], equals: true },
+      },
+      orderBy: { startedAt: "desc" },
+      select: {
+        syncRunId: true,
+        startedAt: true,
+        completedAt: true,
+        status: true,
+        perSourceResult: true,
+        snapshots: {
+          where: { source },
+          select: { payload: true },
+        },
+      },
+    })) as SyncRunRowLike | null;
+  } catch (err) {
+    freshness.push({
+      source,
+      state: "error",
+      fetchedAt: now,
+      message: (err as Error).message ?? "snapshot read failed",
+      count: 0,
+    });
+    return [];
+  }
+
+  if (!row) {
+    // No successful run for this source yet — warming up.
+    freshness.push({
+      source,
+      state: "warming-up",
+      fetchedAt: now,
+      message: "Syncing — first results within ~10 min",
+      count: 0,
+    });
+    return [];
+  }
+
+  const rows = row.snapshots.map((s) => s.payload as T);
+  const fetchedAt = row.completedAt ?? row.startedAt;
+  const ageMs = now.getTime() - fetchedAt.getTime();
+  const state: LaneReadModelFreshnessState = ageMs > staleThresholdMs ? "stale" : "ok";
+
+  freshness.push({
+    source,
+    state,
+    fetchedAt,
+    message:
+      state === "stale"
+        ? `Last successful sync ${Math.floor(ageMs / 60_000)} min ago`
+        : null,
+    count: rows.length,
+  });
+  return rows;
+}
+
+async function isGithubPrCredentialBound(db: ReadModelDb): Promise<boolean> {
+  try {
+    const cred = await db.credentialEntry.findFirst({
+      where: { providerId: GITHUB_PR_CREDENTIAL_PROVIDER_ID, status: "active" },
+      select: { id: true },
+    });
+    return cred !== null;
+  } catch {
+    // If the credential check itself fails, treat as not-bound — the
+    // surfaced state will be "not-configured" which is the safer message
+    // than "error" for an unconfigured customer install.
+    return false;
+  }
+}
+
+// ─── Live Prisma source readers (unchanged shape from Phase 1) ──────────────
 
 async function readWorkCapsules(
   db: ReadModelDb,
@@ -94,21 +275,25 @@ async function readWorkCapsules(
 ): Promise<WorkCapsuleSnapshot[]> {
   try {
     const rows = await db.workCapsule.findMany({
-      where: {
-        status: { notIn: ["archived"] },
-      },
+      where: { status: { notIn: ["archived"] } },
       orderBy: { updatedAt: "desc" },
       take: 250,
     });
     const out = rows.map(toWorkCapsuleSnapshot);
-    freshness.push({ source: "work-capsule", ok: true, fetchedAt: now, error: null, count: out.length });
+    freshness.push({
+      source: "work-capsule",
+      state: "ok",
+      fetchedAt: now,
+      message: null,
+      count: out.length,
+    });
     return out;
   } catch (err) {
     freshness.push({
       source: "work-capsule",
-      ok: false,
+      state: "error",
       fetchedAt: now,
-      error: (err as Error).message,
+      message: (err as Error).message ?? "read failed",
       count: 0,
     });
     return [];
@@ -122,21 +307,25 @@ async function readRuntimeTargets(
 ): Promise<RuntimeTargetSnapshot[]> {
   try {
     const rows = await db.runtimeTarget.findMany({
-      where: {
-        status: { notIn: ["released", "expired"] },
-      },
+      where: { status: { notIn: ["released", "expired"] } },
       orderBy: { updatedAt: "desc" },
       take: 250,
     });
     const out = rows.map(toRuntimeTargetSnapshot);
-    freshness.push({ source: "runtime-target", ok: true, fetchedAt: now, error: null, count: out.length });
+    freshness.push({
+      source: "runtime-target",
+      state: "ok",
+      fetchedAt: now,
+      message: null,
+      count: out.length,
+    });
     return out;
   } catch (err) {
     freshness.push({
       source: "runtime-target",
-      ok: false,
+      state: "error",
       fetchedAt: now,
-      error: (err as Error).message,
+      message: (err as Error).message ?? "read failed",
       count: 0,
     });
     return [];
@@ -157,18 +346,18 @@ async function readRuntimeVerifications(
     const out = rows.map(toRuntimeVerificationSnapshot);
     freshness.push({
       source: "runtime-verification",
-      ok: true,
+      state: "ok",
       fetchedAt: now,
-      error: null,
+      message: null,
       count: out.length,
     });
     return out;
   } catch (err) {
     freshness.push({
       source: "runtime-verification",
-      ok: false,
+      state: "error",
       fetchedAt: now,
-      error: (err as Error).message,
+      message: (err as Error).message ?? "read failed",
       count: 0,
     });
     return [];
@@ -187,108 +376,27 @@ async function readActiveLeases(
       take: 100,
     });
     const out = rows.map(toLeaseSnapshot);
-    freshness.push({ source: "nonprod-lease", ok: true, fetchedAt: now, error: null, count: out.length });
+    freshness.push({
+      source: "nonprod-lease",
+      state: "ok",
+      fetchedAt: now,
+      message: null,
+      count: out.length,
+    });
     return out;
   } catch (err) {
     freshness.push({
       source: "nonprod-lease",
-      ok: false,
+      state: "error",
       fetchedAt: now,
-      error: (err as Error).message,
+      message: (err as Error).message ?? "read failed",
       count: 0,
     });
     return [];
   }
 }
 
-async function readWorktreeInventory(
-  runners: Partial<LaneReadModelInventoryRunners>,
-  freshness: LaneReadModelFreshness[],
-  now: Date,
-): Promise<GitWorktreeSnapshot[]> {
-  if (!runners.runGitWorktreeList) {
-    freshness.push({ source: "git-worktree", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
-    return [];
-  }
-  try {
-    const porcelain = await runners.runGitWorktreeList();
-    const registered = parseGitWorktreeList(porcelain);
-    const filesystemPaths = runners.listFilesystemWorktreePaths
-      ? await runners.listFilesystemWorktreePaths()
-      : [];
-    const merged = mergeFilesystemAndRegisteredWorktrees(registered, filesystemPaths);
-    freshness.push({ source: "git-worktree", ok: true, fetchedAt: now, error: null, count: merged.length });
-    return merged;
-  } catch (err) {
-    freshness.push({
-      source: "git-worktree",
-      ok: false,
-      fetchedAt: now,
-      error: (err as Error).message,
-      count: 0,
-    });
-    return [];
-  }
-}
-
-async function readBranchInventory(
-  runners: Partial<LaneReadModelInventoryRunners>,
-  freshness: LaneReadModelFreshness[],
-  now: Date,
-): Promise<GitBranchSnapshot[]> {
-  if (!runners.runGitForEachRef) {
-    freshness.push({ source: "git-branch", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
-    return [];
-  }
-  try {
-    const raw = await runners.runGitForEachRef();
-    const branches = parseGitBranchList(raw, { remote: "origin" });
-    freshness.push({ source: "git-branch", ok: true, fetchedAt: now, error: null, count: branches.length });
-    return branches;
-  } catch (err) {
-    freshness.push({
-      source: "git-branch",
-      ok: false,
-      fetchedAt: now,
-      error: (err as Error).message,
-      count: 0,
-    });
-    return [];
-  }
-}
-
-async function readPullRequestInventory(
-  runners: Partial<LaneReadModelInventoryRunners>,
-  freshness: LaneReadModelFreshness[],
-  now: Date,
-): Promise<PullRequestSnapshot[]> {
-  if (!runners.runGhPrList) {
-    freshness.push({ source: "github-pr", ok: false, fetchedAt: now, error: "no runner configured", count: 0 });
-    return [];
-  }
-  try {
-    const json = await runners.runGhPrList();
-    const result = parseGhPrListJson(json);
-    const ok = result.errors.length === 0;
-    freshness.push({
-      source: "github-pr",
-      ok,
-      fetchedAt: now,
-      error: ok ? null : result.errors.map((e) => e.message).join("; "),
-      count: result.pullRequests.length,
-    });
-    return result.pullRequests;
-  } catch (err) {
-    freshness.push({
-      source: "github-pr",
-      ok: false,
-      fetchedAt: now,
-      error: (err as Error).message,
-      count: 0,
-    });
-    return [];
-  }
-}
+// ─── Prisma row → snapshot type shims (unchanged from prior implementation) ──
 
 type WorkCapsuleRowLike = {
   capsuleId: string;
@@ -345,7 +453,8 @@ type RuntimeTargetRowLike = {
 
 function toRuntimeTargetSnapshot(row: RuntimeTargetRowLike): RuntimeTargetSnapshot {
   const md = (row.metadata ?? {}) as Record<string, unknown>;
-  const servedCommitSha = typeof md.servedCommitSha === "string" ? md.servedCommitSha : row.serviceVersion;
+  const servedCommitSha =
+    typeof md.servedCommitSha === "string" ? md.servedCommitSha : row.serviceVersion;
   const branchName = typeof md.branchName === "string" ? md.branchName : null;
   return {
     targetId: row.targetId,
@@ -373,7 +482,9 @@ type RuntimeVerificationRowLike = {
   result: unknown;
 };
 
-function toRuntimeVerificationSnapshot(row: RuntimeVerificationRowLike): RuntimeVerificationSnapshot {
+function toRuntimeVerificationSnapshot(
+  row: RuntimeVerificationRowLike,
+): RuntimeVerificationSnapshot {
   const result = (row.result ?? {}) as Record<string, unknown>;
   const summary = typeof result.summary === "string" ? result.summary : null;
   return {

--- a/apps/web/lib/contributor-change-lanes/runners-node.ts
+++ b/apps/web/lib/contributor-change-lanes/runners-node.ts
@@ -1,14 +1,31 @@
+// DEPRECATED — Phase 3 of BI-063BDF1B replaced the per-request runner shape
+// with DB-backed snapshot reads in read-model.ts. This file is left on disk
+// for one rollback window; deletion ships in Phase 8 of
+// docs/superpowers/plans/2026-05-26-contributor-inventory-sync.md.
+//
+// No caller imports this module today. The local `LegacyInventoryRunners`
+// type is the contract the page server-component used pre-Phase 3.
+
 import { execFile } from "node:child_process";
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import type { LaneReadModelInventoryRunners } from "./read-model";
-
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_TIMEOUT_MS = 8_000;
 const MAX_BUFFER = 4 * 1024 * 1024;
+
+/**
+ * @deprecated Removed from active read-model in Phase 3. The new read-model
+ * resolves snapshot sources from ContributorInventorySnapshot rows.
+ */
+export type LegacyInventoryRunners = {
+  runGitWorktreeList: () => Promise<string>;
+  runGitForEachRef: () => Promise<string>;
+  runGhPrList: () => Promise<string>;
+  listFilesystemWorktreePaths: () => Promise<string[]>;
+};
 
 export type NodeRunnerOptions = {
   repoCwd: string;
@@ -16,9 +33,10 @@ export type NodeRunnerOptions = {
   timeoutMs?: number;
 };
 
+/** @deprecated See file-header note. */
 export function createNodeInventoryRunners(
   options: NodeRunnerOptions,
-): LaneReadModelInventoryRunners {
+): LegacyInventoryRunners {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const cwd = options.repoCwd;
 

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
@@ -1,0 +1,245 @@
+// apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+// Phase 2 of BI-063BDF1B.
+//
+// Covers the pure `runContributorInventorySync` runner:
+//   - happy path: all three sources return rows → status "completed",
+//     snapshot rows inserted, run row + ScheduledJob heartbeat updated
+//   - partial: one source fails → status "partial", other rows still
+//     inserted, error recorded in perSourceResult
+//   - failed: all sources fail → status "failed", no rows inserted,
+//     heartbeat lastStatus="failed"
+//   - stuck-run reaper: pre-existing running rows older than the
+//     threshold are marked failed BEFORE the new run is created; on-demand
+//     runs (reapStuckRuns: false) do NOT reap
+//   - thrown reader: caught and recorded as a per-source error; does not
+//     poison other sources
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  syncRunUpdateMany: vi.fn(),
+  syncRunCreate: vi.fn(),
+  syncRunUpdate: vi.fn(),
+  snapshotCreateMany: vi.fn(),
+  scheduledJobUpdate: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    contributorInventorySyncRun: {
+      updateMany: mocks.syncRunUpdateMany,
+      create: mocks.syncRunCreate,
+      update: mocks.syncRunUpdate,
+    },
+    contributorInventorySnapshot: {
+      createMany: mocks.snapshotCreateMany,
+    },
+    scheduledJob: {
+      update: mocks.scheduledJobUpdate,
+    },
+  },
+}));
+
+import { runContributorInventorySync, type SyncSourceReaders } from "./contributor-inventory-sync";
+
+const FIXED_NOW = new Date("2026-05-26T20:00:00.000Z");
+
+function fakeReaders(
+  overrides: Partial<SyncSourceReaders> = {},
+): SyncSourceReaders {
+  const okWorktree = async () => ({
+    ok: true as const,
+    rows: [
+      { sourceKey: "/repo/wt-a", payload: { path: "/repo/wt-a", branch: "feat/a" } },
+      { sourceKey: "/repo/wt-b", payload: { path: "/repo/wt-b", branch: "feat/b" } },
+    ],
+  });
+  const okBranch = async () => ({
+    ok: true as const,
+    rows: [{ sourceKey: "feat/a", payload: { name: "feat/a", remote: "origin" } }],
+  });
+  const okGithub = async () => ({
+    ok: true as const,
+    rows: [{ sourceKey: "1234", payload: { number: 1234, title: "feat: x" } }],
+  });
+  return {
+    worktree: overrides.worktree ?? okWorktree,
+    branch: overrides.branch ?? okBranch,
+    githubPr: overrides.githubPr ?? okGithub,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.syncRunUpdateMany.mockResolvedValue({ count: 0 });
+  mocks.syncRunCreate.mockImplementation(async ({ data }) => ({
+    syncRunId: data.syncRunId,
+  }));
+  mocks.syncRunUpdate.mockResolvedValue({});
+  mocks.snapshotCreateMany.mockImplementation(async ({ data }) => ({
+    count: data.length,
+  }));
+  mocks.scheduledJobUpdate.mockResolvedValue({});
+});
+
+describe("runContributorInventorySync", () => {
+  it("happy path: all three sources succeed → status completed, all rows inserted, heartbeat updated", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.insertedRows).toBe(4); // 2 worktrees + 1 branch + 1 PR
+    expect(result.perSourceResult["git-worktree"].ok).toBe(true);
+    expect(result.perSourceResult["git-branch"].ok).toBe(true);
+    expect(result.perSourceResult["github-pr"].ok).toBe(true);
+
+    expect(mocks.syncRunCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.snapshotCreateMany).toHaveBeenCalledTimes(3);
+    expect(mocks.syncRunUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "completed" }),
+      }),
+    );
+    expect(mocks.scheduledJobUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastStatus: "completed",
+          lastError: null,
+        }),
+      }),
+    );
+  });
+
+  it("partial: GitHub fails → status partial, local rows still inserted, error recorded in perSourceResult", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders({
+        githubPr: async () => ({ ok: false, error: "401 unauthorized" }),
+      }),
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.insertedRows).toBe(3); // worktree + branch, no PR rows
+    expect(result.perSourceResult["github-pr"].ok).toBe(false);
+    expect(result.perSourceResult["github-pr"].error).toBe("401 unauthorized");
+    expect(result.perSourceResult["git-worktree"].ok).toBe(true);
+    expect(result.perSourceResult["git-branch"].ok).toBe(true);
+    // snapshotCreateMany called for the two successful sources only
+    expect(mocks.snapshotCreateMany).toHaveBeenCalledTimes(2);
+  });
+
+  it("all sources fail → status failed, no rows inserted, heartbeat lastStatus=failed", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders({
+        worktree: async () => ({ ok: false, error: "git not found" }),
+        branch: async () => ({ ok: false, error: "git not found" }),
+        githubPr: async () => ({ ok: false, error: "no credential", state: "not-configured" }),
+      }),
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.insertedRows).toBe(0);
+    expect(mocks.snapshotCreateMany).not.toHaveBeenCalled();
+    expect(mocks.scheduledJobUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastStatus: "failed",
+          lastError: expect.stringContaining("git not found"),
+        }),
+      }),
+    );
+  });
+
+  it("preserves the not-configured state discriminator from the github reader", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders({
+        githubPr: async () => ({
+          ok: false,
+          error: "no credential bound",
+          state: "not-configured",
+        }),
+      }),
+    });
+
+    expect(result.perSourceResult["github-pr"].state).toBe("not-configured");
+  });
+
+  it("stuck-run reaper: when reapStuckRuns=true, marks pre-existing running rows older than the threshold as failed before the new run", async () => {
+    mocks.syncRunUpdateMany.mockResolvedValue({ count: 2 });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      reapStuckRuns: true,
+      readers: fakeReaders(),
+    });
+
+    expect(result.reaped).toBe(2);
+    expect(mocks.syncRunUpdateMany).toHaveBeenCalledWith({
+      where: {
+        status: "running",
+        startedAt: { lt: new Date(FIXED_NOW.getTime() - 20 * 60_000) },
+      },
+      data: { status: "failed", completedAt: FIXED_NOW },
+    });
+    // Reaper fires BEFORE the create
+    const reapCallOrder = mocks.syncRunUpdateMany.mock.invocationCallOrder[0];
+    const createCallOrder = mocks.syncRunCreate.mock.invocationCallOrder[0];
+    expect(reapCallOrder).toBeLessThan(createCallOrder);
+  });
+
+  it("stuck-run reaper: when reapStuckRuns=false (on-demand), does NOT reap", async () => {
+    await runContributorInventorySync({
+      now: FIXED_NOW,
+      reapStuckRuns: false,
+      readers: fakeReaders(),
+    });
+
+    expect(mocks.syncRunUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("thrown reader: caught as a per-source error and does not poison other sources", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders({
+        worktree: async () => {
+          throw new Error("execFile timeout");
+        },
+      }),
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.perSourceResult["git-worktree"].ok).toBe(false);
+    expect(result.perSourceResult["git-worktree"].error).toBe("execFile timeout");
+    expect(result.perSourceResult["git-branch"].ok).toBe(true);
+    expect(result.perSourceResult["github-pr"].ok).toBe(true);
+  });
+
+  it("triggeredBy is propagated to the run row", async () => {
+    await runContributorInventorySync({
+      now: FIXED_NOW,
+      triggeredBy: "ui",
+      readers: fakeReaders(),
+    });
+
+    expect(mocks.syncRunCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ triggeredBy: "ui" }),
+      select: { syncRunId: true },
+    });
+  });
+
+  it("scheduledJob nextRunAt is set to now + 10 minutes", async () => {
+    await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    const updateCall = mocks.scheduledJobUpdate.mock.calls[0]?.[0];
+    expect(updateCall?.data.nextRunAt).toEqual(
+      new Date(FIXED_NOW.getTime() + 10 * 60_000),
+    );
+  });
+});

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -262,12 +262,14 @@ async function createDefaultReaders(): Promise<SyncSourceReaders> {
       };
     },
     githubPr: async () => {
-      // Phase 2 stub — replaced in Phase 4 by github-rest-reader.ts.
-      return {
-        ok: false,
-        error: "github source not implemented yet (Phase 4)",
-        state: "not-configured",
-      };
+      const { readGithubPullRequests } = await import(
+        "@/lib/contributor-change-lanes/github-rest-reader"
+      );
+      const result = await readGithubPullRequests();
+      if (!result.ok) {
+        return { ok: false, error: result.error, state: result.state };
+      }
+      return { ok: true, rows: result.rows };
     },
   };
 }

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -1,0 +1,321 @@
+/**
+ * Contributor inventory sync — Phase 2 + Phase 4 of
+ * docs/superpowers/plans/2026-05-26-contributor-inventory-sync.md.
+ * Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+ *
+ * Two Inngest functions share one `runContributorInventorySync` runner:
+ *   - contributorInventorySyncCron     — triggers: [cron("*\/10 * * * *")]
+ *   - contributorInventorySyncOnDemand — triggers: [{ event: "ops/contributor-inventory-sync.run" }]
+ *
+ * Both use `concurrency: { limit: 1, scope: "fn" }` (matching every other
+ * function in this directory). Cross-function collision is safe because:
+ *
+ *   - Each run generates its own `syncRunId`.
+ *   - `ContributorInventorySnapshot` rows are uniquely keyed on
+ *     `(source, sourceKey, syncRunId)` — no row corruption on overlap.
+ *   - The read model resolves per-source from the latest successful run,
+ *     not from a single "most recent run."
+ *
+ * Stuck-run reaping runs from the cron function ONLY. On-demand runs do
+ * not reap because they can race with an in-flight cron run.
+ *
+ * GitHub source is stubbed in Phase 2 and replaced by the real
+ * `github-rest-reader.ts` in Phase 4.
+ */
+
+import { cron } from "inngest";
+
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+// Re-exported for callers and tests; the actual implementation lives below.
+export const CONTRIBUTOR_INVENTORY_SYNC_JOB_ID = "contributor-inventory-sync";
+
+// Cron interval in minutes; reaper threshold is 2× this value.
+const CRON_INTERVAL_MIN = 10;
+const STUCK_THRESHOLD_MS = 2 * CRON_INTERVAL_MIN * 60_000;
+
+export type SyncSourceKey = "git-worktree" | "git-branch" | "github-pr";
+
+export type SyncSourceResult =
+  | { ok: true; rows: SnapshotRowPayload[] }
+  | { ok: false; error: string; state?: "not-configured" | "error" };
+
+export type SnapshotRowPayload = {
+  sourceKey: string;
+  payload: unknown;
+};
+
+export type SyncSourceReaders = {
+  worktree: () => Promise<SyncSourceResult>;
+  branch: () => Promise<SyncSourceResult>;
+  githubPr: () => Promise<SyncSourceResult>;
+};
+
+export type RunSyncOptions = {
+  triggeredBy?: "cron" | "mcp" | "ui" | string;
+  reapStuckRuns?: boolean;
+  now?: Date;
+  readers?: SyncSourceReaders;
+};
+
+export type RunSyncResult = {
+  syncRunId: string;
+  status: "completed" | "partial" | "failed";
+  perSourceResult: Record<SyncSourceKey, PerSourceSummary>;
+  insertedRows: number;
+  reaped?: number;
+  durationMs: number;
+};
+
+export type PerSourceSummary = {
+  ok: boolean;
+  count: number;
+  error: string | null;
+  state?: "ok" | "not-configured" | "error";
+};
+
+/**
+ * Pure runner — no Inngest dependency, no shell-out unless the default
+ * reader factory is used. Tests inject fake `readers`.
+ */
+export async function runContributorInventorySync(
+  options: RunSyncOptions = {},
+): Promise<RunSyncResult> {
+  const { prisma } = await import("@dpf/db");
+  const now = options.now ?? new Date();
+  const triggeredBy = options.triggeredBy ?? "cron";
+  const reapStuckRuns = options.reapStuckRuns ?? false;
+  const readers = options.readers ?? (await createDefaultReaders());
+
+  let reaped = 0;
+  if (reapStuckRuns) {
+    const cutoff = new Date(now.getTime() - STUCK_THRESHOLD_MS);
+    const result = await prisma.contributorInventorySyncRun.updateMany({
+      where: {
+        status: "running",
+        startedAt: { lt: cutoff },
+      },
+      data: {
+        status: "failed",
+        completedAt: now,
+      },
+    });
+    reaped = result.count;
+  }
+
+  // Generate the run id and write the audit row. `syncRunId` is the
+  // string the snapshot rows FK to via ON DELETE CASCADE.
+  const runRow = await prisma.contributorInventorySyncRun.create({
+    data: {
+      syncRunId: cuid(),
+      status: "running",
+      triggeredBy,
+      startedAt: now,
+    },
+    select: { syncRunId: true },
+  });
+  const syncRunId = runRow.syncRunId;
+
+  // Run three readers in parallel — failure is per-source, not global.
+  const [worktreeRes, branchRes, githubRes] = await Promise.all([
+    safeRead(readers.worktree),
+    safeRead(readers.branch),
+    safeRead(readers.githubPr),
+  ]);
+
+  const perSourceResult: Record<SyncSourceKey, PerSourceSummary> = {
+    "git-worktree": summarize(worktreeRes),
+    "git-branch": summarize(branchRes),
+    "github-pr": summarize(githubRes),
+  };
+
+  const successful: { source: SyncSourceKey; rows: SnapshotRowPayload[] }[] = [];
+  if (worktreeRes.ok) successful.push({ source: "git-worktree", rows: worktreeRes.rows });
+  if (branchRes.ok) successful.push({ source: "git-branch", rows: branchRes.rows });
+  if (githubRes.ok) successful.push({ source: "github-pr", rows: githubRes.rows });
+
+  let insertedRows = 0;
+  for (const bucket of successful) {
+    if (bucket.rows.length === 0) continue;
+    const created = await prisma.contributorInventorySnapshot.createMany({
+      data: bucket.rows.map((row) => ({
+        source: bucket.source,
+        sourceKey: row.sourceKey,
+        payload: row.payload as never,
+        syncRunId,
+        fetchedAt: now,
+      })),
+      skipDuplicates: true,
+    });
+    insertedRows += created.count;
+  }
+
+  const okCount = [worktreeRes, branchRes, githubRes].filter((r) => r.ok).length;
+  const status: "completed" | "partial" | "failed" =
+    okCount === 3 ? "completed" : okCount === 0 ? "failed" : "partial";
+
+  const durationMs = Date.now() - now.getTime();
+
+  await prisma.contributorInventorySyncRun.update({
+    where: { syncRunId },
+    data: {
+      status,
+      completedAt: new Date(),
+      durationMs,
+      perSourceResult: perSourceResult as never,
+    },
+  });
+
+  // Heartbeat update — runner-owned fields only (does not touch metadata,
+  // which is owned by Phase 4's GitHub etag persistence).
+  await prisma.scheduledJob.update({
+    where: { jobId: CONTRIBUTOR_INVENTORY_SYNC_JOB_ID },
+    data: {
+      lastRunAt: now,
+      lastStatus: status,
+      lastError:
+        status === "failed"
+          ? Object.values(perSourceResult)
+              .map((r) => r.error)
+              .filter(Boolean)
+              .join("; ") || "all sources failed"
+          : null,
+      nextRunAt: new Date(now.getTime() + CRON_INTERVAL_MIN * 60_000),
+    },
+  });
+
+  return {
+    syncRunId,
+    status,
+    perSourceResult,
+    insertedRows,
+    reaped: reapStuckRuns ? reaped : undefined,
+    durationMs,
+  };
+}
+
+function summarize(res: SyncSourceResult): PerSourceSummary {
+  if (res.ok) {
+    return { ok: true, count: res.rows.length, error: null, state: "ok" };
+  }
+  return {
+    ok: false,
+    count: 0,
+    error: res.error,
+    state: res.state ?? "error",
+  };
+}
+
+async function safeRead(
+  reader: () => Promise<SyncSourceResult>,
+): Promise<SyncSourceResult> {
+  try {
+    return await reader();
+  } catch (err) {
+    return { ok: false, error: (err as Error).message ?? "reader threw" };
+  }
+}
+
+// ─── Default readers (production wiring) ────────────────────────────────────
+
+async function createDefaultReaders(): Promise<SyncSourceReaders> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execFileAsync = promisify(execFile);
+  const {
+    parseGitWorktreeList,
+    parseGitBranchList,
+  } = await import("@/lib/contributor-change-lanes/git-inventory");
+
+  const cwd = process.cwd();
+  const TIMEOUT_MS = 8_000;
+  const MAX_BUFFER = 4 * 1024 * 1024;
+
+  return {
+    worktree: async () => {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["worktree", "list", "--porcelain"],
+        { cwd, timeout: TIMEOUT_MS, maxBuffer: MAX_BUFFER },
+      );
+      const parsed = parseGitWorktreeList(stdout);
+      return {
+        ok: true,
+        rows: parsed.map((p) => ({ sourceKey: p.path, payload: p })),
+      };
+    },
+    branch: async () => {
+      const { stdout } = await execFileAsync(
+        "git",
+        [
+          "for-each-ref",
+          "--format=%(refname)\t%(objectname)\t%(committerdate:iso-strict)\t%(if)%(upstream:trackshort)%(then)%(else)%(end)",
+          "refs/remotes/origin/",
+        ],
+        { cwd, timeout: TIMEOUT_MS, maxBuffer: MAX_BUFFER },
+      );
+      const parsed = parseGitBranchList(stdout, { remote: "origin" });
+      return {
+        ok: true,
+        rows: parsed.map((p) => ({ sourceKey: p.name, payload: p })),
+      };
+    },
+    githubPr: async () => {
+      // Phase 2 stub — replaced in Phase 4 by github-rest-reader.ts.
+      return {
+        ok: false,
+        error: "github source not implemented yet (Phase 4)",
+        state: "not-configured",
+      };
+    },
+  };
+}
+
+// Minimal cuid generator. We avoid pulling in the @paralleldrive/cuid2 module
+// because Prisma's runtime generates the default-cuid id field for us; this
+// is the user-facing `syncRunId` string that needs to be unique and stable.
+function cuid(): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).slice(2, 12);
+  return `civs_${t}_${r}`;
+}
+
+// ─── Inngest function wrappers ──────────────────────────────────────────────
+
+export const contributorInventorySyncCron = inngest.createFunction(
+  {
+    id: "ops/contributor-inventory-sync-cron",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("*/10 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return await step.run("run-sync-cron", () =>
+      runContributorInventorySync({ triggeredBy: "cron", reapStuckRuns: true }),
+    );
+  },
+);
+
+export const contributorInventorySyncOnDemand = inngest.createFunction(
+  {
+    id: "ops/contributor-inventory-sync-on-demand",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [{ event: "ops/contributor-inventory-sync.run" }],
+  },
+  async ({ event, step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    const triggeredBy =
+      (event.data as { triggeredBy?: string } | undefined)?.triggeredBy ?? "mcp";
+
+    return await step.run("run-sync-on-demand", () =>
+      runContributorInventorySync({ triggeredBy, reapStuckRuns: false }),
+    );
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -19,6 +19,10 @@ import {
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
+import {
+  contributorInventorySyncCron,
+  contributorInventorySyncOnDemand,
+} from "./contributor-inventory-sync";
 import { selfUpgradeScheduled, selfUpgradeManual } from "./self-upgrade";
 import { quiescenceRun } from "./quiescence-run";
 import { wikiLint } from "./wiki-lint";
@@ -46,6 +50,7 @@ export const scheduledFunctions = [
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,
   tokenExpiryMonitor,
+  contributorInventorySyncCron,
   wikiLint,
   skillMetricsAggregator,
   skillCurator,
@@ -67,6 +72,7 @@ export const eventFunctions = [
   assuranceScanRun,
   deliberationRun,
   governedBacklogTeeUpRequested,
+  contributorInventorySyncOnDemand,
   gitPromotionSandboxVerification,
   postgresBackupRequested,
   postgresTrialRestoreRequested,

--- a/packages/db/prisma/migrations/20260526200000_contributor_inventory_snapshot/migration.sql
+++ b/packages/db/prisma/migrations/20260526200000_contributor_inventory_snapshot/migration.sql
@@ -1,0 +1,63 @@
+-- BI-063BDF1B (EP-REDUCTION-GEAR-ARCH): Contributor inventory sync substrate.
+-- Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+--
+-- Adds:
+--   - metadata column on ScheduledJob for per-job durable scratch state
+--     (used by jobId="contributor-inventory-sync" for GitHub etag persistence)
+--   - ContributorInventorySyncRun: per-run audit (mirrors BackupRun)
+--   - ContributorInventorySnapshot: per-source inventory rows (FK to sync run,
+--     ON DELETE CASCADE so the retention sweep deletes the run row and its
+--     snapshot rows atomically)
+
+-- 1. metadata column on ScheduledJob.
+ALTER TABLE "ScheduledJob"
+  ADD COLUMN "metadata" JSONB;
+
+-- 2. ContributorInventorySyncRun — per-run audit row.
+CREATE TABLE "ContributorInventorySyncRun" (
+  "id"              TEXT NOT NULL,
+  "syncRunId"       TEXT NOT NULL,
+  "startedAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "completedAt"     TIMESTAMP(3),
+  "status"          TEXT NOT NULL DEFAULT 'running',
+  "perSourceResult" JSONB NOT NULL DEFAULT '{}',
+  "triggeredBy"     TEXT NOT NULL DEFAULT 'cron',
+  "durationMs"      INTEGER,
+
+  CONSTRAINT "ContributorInventorySyncRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ContributorInventorySyncRun_syncRunId_key"
+  ON "ContributorInventorySyncRun"("syncRunId");
+CREATE INDEX "ContributorInventorySyncRun_startedAt_idx"
+  ON "ContributorInventorySyncRun"("startedAt");
+CREATE INDEX "ContributorInventorySyncRun_status_startedAt_idx"
+  ON "ContributorInventorySyncRun"("status", "startedAt");
+
+-- 3. ContributorInventorySnapshot — one row per inventory item per sync run.
+CREATE TABLE "ContributorInventorySnapshot" (
+  "id"        TEXT NOT NULL,
+  "source"    TEXT NOT NULL,
+  "sourceKey" TEXT NOT NULL,
+  "payload"   JSONB NOT NULL,
+  "syncRunId" TEXT NOT NULL,
+  "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "ContributorInventorySnapshot_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ContributorInventorySnapshot_source_sourceKey_syncRunId_key"
+  ON "ContributorInventorySnapshot"("source", "sourceKey", "syncRunId");
+CREATE INDEX "ContributorInventorySnapshot_source_syncRunId_idx"
+  ON "ContributorInventorySnapshot"("source", "syncRunId");
+CREATE INDEX "ContributorInventorySnapshot_source_fetchedAt_idx"
+  ON "ContributorInventorySnapshot"("source", "fetchedAt");
+
+-- 4. FK with ON DELETE CASCADE: deleting a sync run deletes its rows.
+ALTER TABLE "ContributorInventorySnapshot"
+  ADD CONSTRAINT "ContributorInventorySnapshot_syncRunId_fkey"
+    FOREIGN KEY ("syncRunId")
+    REFERENCES "ContributorInventorySyncRun"("syncRunId")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1697,6 +1697,12 @@ model ScheduledJob {
   nextRunAt  DateTime?
   lastStatus String?
   lastError  String?
+  // Per-job durable scratch state owned by the runner. Used today by
+  // jobId="contributor-inventory-sync" to store the GitHub etag
+  // (`githubPrEtag`) so conditional requests survive the retention
+  // sweep that prunes ContributorInventorySyncRun history.
+  // Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md §Etag persistence.
+  metadata   Json?
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 }
@@ -1761,6 +1767,68 @@ model BackupRestore {
   @@index([startedAt])
   @@index([status])
   @@index([trigger])
+}
+
+// Per-run audit row for the contributor-inventory-sync Inngest cron. Mirrors
+// BackupRun's role for the postgres-daily-backup cron: the ScheduledJob row
+// with jobId "contributor-inventory-sync" is the live heartbeat surfaced in
+// /platform/development/change-lanes; ContributorInventorySyncRun rows are
+// the durable per-run audit referenced by latest-successful-per-source
+// resolution in the read model.
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+model ContributorInventorySyncRun {
+  id              String    @id @default(cuid())
+  syncRunId       String    @unique
+  startedAt       DateTime  @default(now())
+  completedAt     DateTime?
+  // "running" | "completed" | "partial" | "failed"
+  // status is audit-only; the read model resolves per-source from
+  // perSourceResult.<source>.ok, not from this rollup.
+  status          String    @default("running")
+  // Per-source result map written by the runner:
+  //   { "git-worktree": { ok, count, error?, ... }, "git-branch": {...}, "github-pr": {...} }
+  perSourceResult Json      @default("{}")
+  // "cron" | "mcp" | "ui" — for audit only.
+  triggeredBy     String    @default("cron")
+  durationMs      Int?
+
+  snapshots ContributorInventorySnapshot[]
+
+  @@index([startedAt])
+  @@index([status, startedAt])
+}
+
+// One row per inventory item, partitioned by source. Rows are written in
+// bulk by the contributor-inventory-sync cron and read by latest-successful-
+// per-source resolution in apps/web/lib/contributor-change-lanes/read-model.ts.
+// The retention sweep deletes rows whose syncRunId belongs to a
+// ContributorInventorySyncRun older than 7 days AND whose syncRunId is not
+// the latest successful for any of the three sources (preservation guard).
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+model ContributorInventorySnapshot {
+  id        String   @id @default(cuid())
+  // One of: "git-worktree" | "git-branch" | "github-pr"
+  source    String
+  // Stable identity within a source — branch name, worktree path, PR
+  // number as string. Combined with syncRunId for the dedupe unique key.
+  sourceKey String
+  // The snapshot row payload, shape-compatible with
+  // GitWorktreeSnapshot / GitBranchSnapshot / PullRequestSnapshot from
+  // apps/web/lib/contributor-change-lanes/types.ts. JSON so the projection
+  // layer can evolve its shapes without a migration per shape change —
+  // same pattern as EaSnapshot.graphJson.
+  payload   Json
+  syncRunId String
+  fetchedAt DateTime @default(now())
+  createdAt DateTime @default(now())
+
+  syncRun ContributorInventorySyncRun @relation(fields: [syncRunId], references: [syncRunId], onDelete: Cascade)
+
+  @@unique([source, sourceKey, syncRunId])
+  @@index([source, syncRunId])
+  @@index([source, fetchedAt])
 }
 
 model CodeGraphIndexState {

--- a/packages/db/src/seed-contributor-inventory.test.ts
+++ b/packages/db/src/seed-contributor-inventory.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  CONTRIBUTOR_INVENTORY_JOB_ID,
+  CONTRIBUTOR_INVENTORY_JOB_NAME,
+  CONTRIBUTOR_INVENTORY_SCHEDULE,
+  ensureContributorInventoryScheduledJob,
+} from "./seed-contributor-inventory";
+
+describe("contributor inventory seed helper", () => {
+  const scheduledJob = {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+
+  beforeEach(() => {
+    scheduledJob.findUnique.mockReset();
+    scheduledJob.create.mockReset();
+    scheduledJob.update.mockReset();
+  });
+
+  it("creates the scheduled job on a fresh install", async () => {
+    scheduledJob.findUnique.mockResolvedValue(null);
+
+    const result = await ensureContributorInventoryScheduledJob(
+      { scheduledJob } as never,
+      // 14:23:45 — the next 10-minute boundary is 14:30:00.
+      new Date("2026-05-26T14:23:45Z"),
+    );
+
+    expect(result).toEqual({ created: true });
+    expect(scheduledJob.findUnique).toHaveBeenCalledWith({
+      where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+      select: { jobId: true, nextRunAt: true },
+    });
+    expect(scheduledJob.create).toHaveBeenCalledWith({
+      data: {
+        jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+        name: CONTRIBUTOR_INVENTORY_JOB_NAME,
+        schedule: CONTRIBUTOR_INVENTORY_SCHEDULE,
+        nextRunAt: new Date("2026-05-26T14:30:00Z"),
+      },
+    });
+    expect(scheduledJob.update).not.toHaveBeenCalled();
+  });
+
+  it("rounds 14:30:00 forward to the next boundary at 14:40:00", async () => {
+    scheduledJob.findUnique.mockResolvedValue(null);
+
+    await ensureContributorInventoryScheduledJob(
+      { scheduledJob } as never,
+      new Date("2026-05-26T14:30:00Z"),
+    );
+
+    expect(scheduledJob.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        nextRunAt: new Date("2026-05-26T14:40:00Z"),
+      }),
+    });
+  });
+
+  it("updates name and schedule on an existing row and preserves nextRunAt", async () => {
+    const preservedNextRun = new Date("2026-05-27T10:00:00Z");
+    scheduledJob.findUnique.mockResolvedValue({
+      jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+      nextRunAt: preservedNextRun,
+    });
+
+    const result = await ensureContributorInventoryScheduledJob(
+      { scheduledJob } as never,
+      new Date("2026-05-26T14:23:45Z"),
+    );
+
+    expect(result).toEqual({ created: false });
+    expect(scheduledJob.create).not.toHaveBeenCalled();
+    expect(scheduledJob.update).toHaveBeenCalledWith({
+      where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+      data: {
+        name: CONTRIBUTOR_INVENTORY_JOB_NAME,
+        schedule: CONTRIBUTOR_INVENTORY_SCHEDULE,
+        nextRunAt: preservedNextRun,
+      },
+    });
+  });
+
+  it("backfills nextRunAt on an existing row that was missing it", async () => {
+    scheduledJob.findUnique.mockResolvedValue({
+      jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+      nextRunAt: null,
+    });
+
+    await ensureContributorInventoryScheduledJob(
+      { scheduledJob } as never,
+      new Date("2026-05-26T14:23:45Z"),
+    );
+
+    expect(scheduledJob.update).toHaveBeenCalledWith({
+      where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+      data: expect.objectContaining({
+        nextRunAt: new Date("2026-05-26T14:30:00Z"),
+      }),
+    });
+  });
+
+  it("does not touch lastRunAt / lastStatus / lastError / metadata fields", async () => {
+    scheduledJob.findUnique.mockResolvedValue({
+      jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+      nextRunAt: new Date("2026-05-27T10:00:00Z"),
+    });
+
+    await ensureContributorInventoryScheduledJob(
+      { scheduledJob } as never,
+      new Date("2026-05-26T14:23:45Z"),
+    );
+
+    const updateCall = scheduledJob.update.mock.calls[0]?.[0];
+    expect(updateCall?.data).not.toHaveProperty("lastRunAt");
+    expect(updateCall?.data).not.toHaveProperty("lastStatus");
+    expect(updateCall?.data).not.toHaveProperty("lastError");
+    expect(updateCall?.data).not.toHaveProperty("metadata");
+  });
+});

--- a/packages/db/src/seed-contributor-inventory.ts
+++ b/packages/db/src/seed-contributor-inventory.ts
@@ -1,0 +1,78 @@
+import type { PrismaClient } from "../generated/client/client";
+
+/**
+ * Schedule + identifier constants for the contributor-inventory-sync cron.
+ *
+ * Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+ *
+ * The ScheduledJob row with this jobId is the live heartbeat surfaced in
+ * /platform/development/change-lanes. The cron writes its `metadata` field
+ * with `{ githubPrEtag: "..." }` so GitHub conditional requests survive the
+ * ContributorInventorySyncRun retention sweep.
+ *
+ * The same jobId is referenced from
+ * apps/web/lib/queue/functions/contributor-inventory-sync.ts (heartbeat
+ * upsert) and apps/web/lib/contributor-change-lanes/read-model.ts
+ * (etag read on the GitHub source). If you change this constant, change
+ * the apps/web references in the same PR or the heartbeat row will be
+ * orphaned.
+ */
+export const CONTRIBUTOR_INVENTORY_JOB_ID = "contributor-inventory-sync";
+export const CONTRIBUTOR_INVENTORY_JOB_NAME =
+  "Contributor inventory sync (platform-managed)";
+// 10-minute cadence; the value is recorded for display only — the
+// authoritative trigger is the cron expression on the Inngest function.
+export const CONTRIBUTOR_INVENTORY_SCHEDULE = "every-10-minutes";
+
+type ScheduledJobSeedClient = Pick<PrismaClient, "scheduledJob">;
+
+/** Returns the next 10-minute boundary strictly after `from`. */
+function nextTenMinuteBoundary(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  const minutes = next.getUTCMinutes();
+  const remainder = minutes % 10;
+  const advanceBy = remainder === 0 ? 10 : 10 - remainder;
+  next.setUTCMinutes(minutes + advanceBy);
+  return next;
+}
+
+/**
+ * Idempotent: create the contributor-inventory-sync ScheduledJob heartbeat
+ * row if missing; update name/schedule/nextRunAt on every seed run. Does
+ * not clobber lastRunAt / lastStatus / lastError / metadata — those are
+ * owned by the runner.
+ */
+export async function ensureContributorInventoryScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const nextRunAt = nextTenMinuteBoundary(now);
+
+  const existing = await prisma.scheduledJob.findUnique({
+    where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+    select: { jobId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledJob.update({
+      where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+      data: {
+        name: CONTRIBUTOR_INVENTORY_JOB_NAME,
+        schedule: CONTRIBUTOR_INVENTORY_SCHEDULE,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+    return { created: false };
+  }
+
+  await prisma.scheduledJob.create({
+    data: {
+      jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+      name: CONTRIBUTOR_INVENTORY_JOB_NAME,
+      schedule: CONTRIBUTOR_INVENTORY_SCHEDULE,
+      nextRunAt,
+    },
+  });
+  return { created: true };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -32,6 +32,7 @@ import { seedStallThresholds } from "./seed-stall-thresholds.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
 import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
+import { ensureContributorInventoryScheduledJob } from "./seed-contributor-inventory.js";
 import { seedAgentControlPlaneMaturity } from "./seed-agent-control-plane-maturity.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
@@ -2422,6 +2423,7 @@ async function main(): Promise<void> {
   await ensureDiscoveryTriageScheduledTask(prisma);
   await ensureHiveScoutScheduledTask(prisma);
   await ensureAllBackupScheduledJobs(prisma);
+  await ensureContributorInventoryScheduledJob(prisma);
   await seedMcpServers();
   await seedSandboxPool();
   await seedRuntimeTargets();


### PR DESCRIPTION
## Summary

Implements Phases 1-4 of [`BI-063BDF1B`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1210) (epic `EP-REDUCTION-GEAR-ARCH`) per the spec/plan in [#1210](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1210).

Moves contributor inventory (local git worktrees, remote branches, GitHub PR state) off the per-request shell-out path that PR #1207 shipped. Adds a scheduled Inngest cron (`*/10 * * * *`) that writes a `ContributorInventorySnapshot` Prisma table; the read-model becomes a pure DB query with latest-successful-per-source semantics. The Live portal at `:3000` now renders the dashboard meaningfully with no GitHub credential bound — local-git data populates from the same sync, PR cells show `—` with a "GitHub not connected" header annotation.

## What's in this PR

- **`packages/db/prisma/schema.prisma`** — `ContributorInventorySnapshot` + `ContributorInventorySyncRun` models with FK + ON DELETE CASCADE; `ScheduledJob.metadata` JSON column for durable etag persistence.
- **`packages/db/prisma/migrations/20260526200000_contributor_inventory_snapshot/`** — handwritten reversible SQL.
- **`packages/db/src/seed-contributor-inventory.ts`** — idempotent `ScheduledJob` heartbeat seed for `jobId: "contributor-inventory-sync"`, wired into `seed.ts`.
- **`apps/web/lib/queue/functions/contributor-inventory-sync.ts`** — pure `runContributorInventorySync` runner plus two Inngest function wrappers (`contributorInventorySyncCron` + `contributorInventorySyncOnDemand`) sharing the runner; matches the established pattern from `code-graph-reconcile.ts` and `governed-backlog-tee-up.ts`.
- **`apps/web/lib/contributor-change-lanes/read-model.ts`** — rewritten to read snapshot rows via latest-successful-per-source; `LaneReadModelFreshness` now carries a five-state discriminator (`ok` / `stale` / `error` / `not-configured` / `warming-up`).
- **`apps/web/lib/contributor-change-lanes/github-rest-reader.ts`** — REST reader against `api.github.com` using `CredentialEntry` with `providerId: "github-pr-sync"`; etag stored on `ScheduledJob.metadata.githubPrEtag`; rate-limit headers captured; 304 Not Modified honored.
- **`apps/web/lib/contributor-change-lanes/runners-node.ts`** — kept on disk but unreferenced (deletion deferred to Phase 8 in a follow-up PR for rollback safety; self-typechecks via a local `LegacyInventoryRunners` type).
- **`apps/web/app/(shell)/platform/development/change-lanes/page.tsx`** — drops the `runners` argument; pure DB read.
- **`apps/web/components/platform/development/change-lanes/`** — five-state freshness band with "Live data" / "Inventory snapshot" sub-groups; cold-start empty-state copy; `(?)` warning glyph on tab counts; PR column "GitHub not connected" header annotation.

## What's NOT in this PR (deliberate — separate slices)

- **Phase 5: Refresh button + MCP tool.** Per-page admin-gated refresh button on `ChangeLaneSourceSummary.tsx` (server action + polling + toast) and the `trigger_contributor_inventory_sync` MCP tool. Filed as a follow-up; current dashboard waits for the next cron tick.
- **Phase 6: Cleanup + notifications + tab-count warning.** Retention sweep with the latest-successful-per-source preservation guard, `PlatformNotification` writes for prolonged GitHub failure and stale heartbeat. The `(?)` glyph already lands in this PR (Phase 3); the notification side is Phase 6.
- **Phase 7: Functional verification** against live `dev-portal` + Live portal will be driven and reported separately once this PR's CI lands and Mark reviews.
- **Phase 8: Delete `runners-node.ts`.** Separate PR after one rollback window.

## Substrate verified before implementation

All references checked against `origin/main` at base commit `89104cf6`:

- Inngest scheduler: `apps/web/lib/queue/functions/{token-expiry-monitor,mcp-catalog-sync,discovery-poll,governed-backlog-tee-up,code-graph-reconcile}.ts`; `lib/queue/quiescence-gates.ts` for `gateAtEntry`.
- Snapshot precedents: `EaSnapshot` (line 5674; the only existing JSON-payload precedent, cited honestly in the spec) and `BackupRun` (line 1709, per-run audit pattern).
- GitHub credential substrate: `CredentialEntry` already used by `apps/web/lib/integrate/contribution-review.ts` (`providerId: "git-backup"` and `"hive-contribution"`); this PR uses a third, disjoint `providerId: "github-pr-sync"`. No `octokit` dependency added.
- Repo identity: `PlatformDevConfig.upstreamRemoteUrl`.

## Verification

### Structural (local)

- **Scoped typecheck (`apps/web` + `packages/db`):** pass
- **Vitest (contributor scope):** 55/55 pass (`lib/contributor-change-lanes/` + `lib/queue/functions/contributor-inventory-sync.test.ts` + `lib/queue/functions/index.test.ts` + `packages/db/src/seed-contributor-inventory.test.ts`)
- **Pre-commit `gitleaks`:** clean on every commit

### Functional (deferred)

Functional verification against the Contributor preview is scheduled as Phase 7. The proof points in the spec §"Acceptance Criteria":
- Cold-start UX (`warming-up` dots + table copy) on a freshly-migrated install.
- Latest-successful-per-source preservation (kill GitHub mid-run, prior PR data should remain visible).
- Stuck-run recovery (SIGKILL worker, next cron tick should mark the orphan `failed`).
- Etag durability across deletion of prior `ContributorInventorySyncRun` rows.
- Customer-install rendering: no credential = grey dot + "GitHub not connected" header annotation, NOT a `PlatformNotification`.

## Composition

- **Builds on [#1207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1207)** (change-lanes Phase 1-4 read-only dashboard). `lane-projection.ts` and `types.ts` are explicitly **not modified** by this PR.
- **Spec/plan: [#1210](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1210)** (merged 2026-05-26).
- **Composes with [#1204](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1204)** (contributor MCP readiness): the `github-pr-sync` `CredentialEntry` row is created by the same card.
- BI-063BDF1B filed for tracking only; Build Studio non-functional per project memory (`build-studio-non-functional-2026-05-26`). Claude implements directly per operator approval on PR #1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)