### PR TITLE
feat(marketing): execution loop Phase 1 — drafter + approval queue

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/actions.ts
+++ b/apps/web/app/(shell)/customer/marketing/actions.ts
@@ -1,0 +1,123 @@
+"use server";
+
+// Server actions for the marketing approval queue.
+// Reference plan: docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  assertDraftTransition,
+  draftStatusForDecision,
+  type OutboundApprovalDecisionValue,
+  type OutboundDraftStatus,
+} from "@/lib/marketing/execution";
+
+type ActionResult =
+  | { ok: true; draftId: string; status: OutboundDraftStatus }
+  | { ok: false; error: string };
+
+async function requireOperator(): Promise<{ userId: string } | { error: string }> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) return { error: "Unauthorized" };
+  const ctx = { platformRole: user.platformRole ?? null, isSuperuser: user.isSuperuser ?? false };
+  if (!can(ctx, "operate_marketing")) return { error: "Insufficient capability: operate_marketing" };
+  return { userId: user.id };
+}
+
+async function decideOnDraft(
+  draftId: string,
+  decision: OutboundApprovalDecisionValue,
+  editedBody: string | null,
+  notes: string | null,
+  reviewerUserId: string,
+): Promise<ActionResult> {
+  const draft = await prisma.outboundDraft.findUnique({
+    where: { draftId },
+    select: { draftId: true, status: true },
+  });
+  if (!draft) return { ok: false, error: "Draft not found" };
+
+  const currentStatus = draft.status as OutboundDraftStatus;
+  const nextStatus = draftStatusForDecision(decision);
+  try {
+    assertDraftTransition(currentStatus, nextStatus);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  await prisma.$transaction([
+    prisma.outboundApprovalDecision.create({
+      data: {
+        draftId,
+        reviewerUserId,
+        decision,
+        editedBody: editedBody && editedBody.trim().length > 0 ? editedBody : null,
+        notes: notes && notes.trim().length > 0 ? notes : null,
+      },
+    }),
+    prisma.outboundDraft.update({
+      where: { draftId },
+      data: { status: nextStatus },
+    }),
+  ]);
+
+  revalidatePath("/customer/marketing");
+  return { ok: true, draftId, status: nextStatus };
+}
+
+export async function approveOutboundDraftAction(
+  draftId: string,
+  editedBody?: string,
+  notes?: string,
+): Promise<ActionResult> {
+  const auth = await requireOperator();
+  if ("error" in auth) return { ok: false, error: auth.error };
+  return decideOnDraft(draftId, "approved", editedBody ?? null, notes ?? null, auth.userId);
+}
+
+export async function requestChangesOnDraftAction(
+  draftId: string,
+  notes: string,
+): Promise<ActionResult> {
+  const auth = await requireOperator();
+  if ("error" in auth) return { ok: false, error: auth.error };
+  if (!notes || notes.trim().length === 0) {
+    return { ok: false, error: "Notes are required when requesting changes" };
+  }
+  return decideOnDraft(draftId, "needs-changes", null, notes, auth.userId);
+}
+
+export async function rejectOutboundDraftAction(
+  draftId: string,
+  notes?: string,
+): Promise<ActionResult> {
+  const auth = await requireOperator();
+  if ("error" in auth) return { ok: false, error: auth.error };
+  return decideOnDraft(draftId, "rejected", null, notes ?? null, auth.userId);
+}
+
+export async function draftMarketingAssetAction(
+  assetTaskId: string,
+  toneNotes?: string,
+): Promise<
+  | { ok: true; draftId: string; wordCount: number }
+  | { ok: false; error: string }
+> {
+  const auth = await requireOperator();
+  if ("error" in auth) return { ok: false, error: auth.error };
+
+  const { draftMarketingAsset } = await import("@/lib/marketing/draft-builder");
+  const result = await draftMarketingAsset({
+    assetTaskId,
+    toneNotes,
+    createdByAgentId: "marketing-specialist",
+  });
+
+  if (!result.success) return { ok: false, error: result.error };
+
+  revalidatePath("/customer/marketing");
+  return { ok: true, draftId: result.draftId, wordCount: result.wordCount };
+}

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -5,6 +5,7 @@ import {
   getMarketingWorkspaceSnapshot,
 } from "@/lib/marketing";
 import { AgentWorkLauncher } from "@/components/agent/AgentWorkLauncher";
+import { ApprovalQueuePanel } from "@/components/customer-marketing/ApprovalQueuePanel";
 import { MarketingStrategyOverview } from "@/components/customer-marketing/MarketingStrategyOverview";
 
 export default async function CustomerMarketingPage() {
@@ -240,6 +241,8 @@ export default async function CustomerMarketingPage() {
       </section>
 
       <MarketingStrategyOverview snapshot={snapshot} />
+
+      <ApprovalQueuePanel drafts={snapshot.pendingDrafts} />
     </div>
   );
 }

--- a/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
@@ -1,0 +1,99 @@
+import type { OutboundDraftRow } from "@/lib/marketing";
+import { formatMarketingLabel } from "@/lib/marketing";
+import { ApprovalQueueReview } from "./ApprovalQueueReview";
+
+type Props = {
+  drafts: OutboundDraftRow[];
+};
+
+function timeAgo(date: Date | string): string {
+  const ms = Date.now() - new Date(date).getTime();
+  const m = Math.round(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+function statusLabel(status: OutboundDraftRow["status"]): string {
+  if (status === "needs-changes") return "Needs changes";
+  if (status === "pending-review") return "Pending review";
+  return status[0]!.toUpperCase() + status.slice(1);
+}
+
+export function ApprovalQueuePanel({ drafts }: Props) {
+  return (
+    <section
+      data-testid="marketing-approval-queue"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
+    >
+      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+            Awaiting your review
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+            Drafts the Marketing Strategist produced from your saved asset tasks. Approve, edit, request changes, or reject — no external posting until you say so.
+          </p>
+        </div>
+        <p className="text-sm font-medium text-[var(--dpf-accent)]">
+          {drafts.length} {drafts.length === 1 ? "draft" : "drafts"}
+        </p>
+      </div>
+
+      {drafts.length === 0 ? (
+        <p className="mt-4 rounded-lg bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-muted)]">
+          No drafts awaiting your review. Ask the Marketing Strategist to draft an asset, or click <span className="font-medium text-[var(--dpf-text)]">Draft</span> next to an asset task above.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {drafts.map((draft) => (
+            <li
+              key={draft.draftId}
+              data-draft-id={draft.draftId}
+              className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--dpf-muted)]">
+                    <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-[var(--dpf-text)]">
+                      {formatMarketingLabel(draft.channelId)}
+                    </span>
+                    <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-[var(--dpf-text)]">
+                      {draft.assetType}
+                    </span>
+                    <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-[var(--dpf-text)]">
+                      {statusLabel(draft.status)}
+                    </span>
+                    <span>
+                      Drafted by {draft.createdByAgentId ?? "unknown"} · {timeAgo(draft.createdAt)}
+                    </span>
+                  </div>
+                  {draft.assetTaskTitle ? (
+                    <p className="mt-2 truncate text-sm font-medium text-[var(--dpf-text)]">
+                      {draft.assetTaskTitle}
+                    </p>
+                  ) : null}
+                  <p className="mt-1 line-clamp-3 text-sm text-[var(--dpf-text)]">
+                    {draft.body}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3">
+                <ApprovalQueueReview
+                  draftId={draft.draftId}
+                  initialBody={draft.body}
+                  assetTaskTitle={draft.assetTaskTitle}
+                  channelId={draft.channelId}
+                  assetType={draft.assetType}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  approveOutboundDraftAction,
+  requestChangesOnDraftAction,
+  rejectOutboundDraftAction,
+} from "@/app/(shell)/customer/marketing/actions";
+
+type Props = {
+  draftId: string;
+  initialBody: string;
+  assetTaskTitle: string | null;
+  channelId: string;
+  assetType: string;
+};
+
+type FlashState = { kind: "ok" | "err"; message: string } | null;
+
+export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, channelId, assetType }: Props) {
+  const [open, setOpen] = useState(false);
+  const [body, setBody] = useState(initialBody);
+  const [notes, setNotes] = useState("");
+  const [flash, setFlash] = useState<FlashState>(null);
+  const [pending, startTransition] = useTransition();
+
+  function showError(err: string) {
+    setFlash({ kind: "err", message: err });
+  }
+
+  function approve(withEdits: boolean) {
+    startTransition(async () => {
+      const editedBody = withEdits && body !== initialBody ? body : undefined;
+      const result = await approveOutboundDraftAction(draftId, editedBody, notes || undefined);
+      if (result.ok) {
+        setFlash({ kind: "ok", message: withEdits ? "Approved with your edits" : "Approved" });
+        setOpen(false);
+      } else {
+        showError(result.error);
+      }
+    });
+  }
+
+  function requestChanges() {
+    if (!notes.trim()) {
+      showError("Add a note explaining what to change.");
+      return;
+    }
+    startTransition(async () => {
+      const result = await requestChangesOnDraftAction(draftId, notes);
+      if (result.ok) {
+        setFlash({ kind: "ok", message: "Changes requested" });
+        setOpen(false);
+      } else {
+        showError(result.error);
+      }
+    });
+  }
+
+  function reject() {
+    startTransition(async () => {
+      const result = await rejectOutboundDraftAction(draftId, notes || undefined);
+      if (result.ok) {
+        setFlash({ kind: "ok", message: "Rejected" });
+        setOpen(false);
+      } else {
+        showError(result.error);
+      }
+    });
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          {open ? "Close" : "Review"}
+        </button>
+        {flash ? (
+          <span
+            data-testid="approval-flash"
+            className={
+              flash.kind === "ok"
+                ? "text-sm text-[var(--dpf-accent)]"
+                : "text-sm text-[var(--dpf-text)]"
+            }
+            role="status"
+          >
+            {flash.message}
+          </span>
+        ) : null}
+      </div>
+
+      {open ? (
+        <div className="mt-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <div className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                Source
+              </p>
+              <p className="mt-1 text-sm text-[var(--dpf-text)]">
+                {assetTaskTitle ?? "Manual draft"}
+              </p>
+              <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                Channel
+              </p>
+              <p className="mt-1 text-sm text-[var(--dpf-text)]">
+                {channelId} · {assetType}
+              </p>
+            </div>
+
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                Body (markdown)
+              </label>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={12}
+                className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
+              />
+
+              <label className="mt-3 block text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                Notes (optional, required for "Request changes")
+              </label>
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={2}
+                placeholder="What should the drafter change?"
+                className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
+              />
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={pending}
+                  onClick={() => approve(false)}
+                  className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  disabled={pending || body === initialBody}
+                  onClick={() => approve(true)}
+                  className="rounded-full border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-4 py-1.5 text-sm font-medium text-[var(--dpf-accent)] disabled:opacity-50"
+                >
+                  Approve with edits
+                </button>
+                <button
+                  type="button"
+                  disabled={pending}
+                  onClick={requestChanges}
+                  className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
+                >
+                  Request changes
+                </button>
+                <button
+                  type="button"
+                  disabled={pending}
+                  onClick={reject}
+                  className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/customer-marketing/DraftAssetButton.tsx
+++ b/apps/web/components/customer-marketing/DraftAssetButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { draftMarketingAssetAction } from "@/app/(shell)/customer/marketing/actions";
+
+type Props = {
+  assetTaskId: string;
+  assetTaskTitle: string;
+};
+
+export function DraftAssetButton({ assetTaskId, assetTaskTitle }: Props) {
+  const [status, setStatus] = useState<"idle" | "drafting" | "done" | "error">("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function onClick() {
+    setStatus("drafting");
+    setMessage(null);
+    startTransition(async () => {
+      const result = await draftMarketingAssetAction(assetTaskId);
+      if (result.ok) {
+        setStatus("done");
+        setMessage(`Drafted ${result.wordCount} words — review below`);
+      } else {
+        setStatus("error");
+        setMessage(result.error);
+      }
+    });
+  }
+
+  const label =
+    status === "drafting" || pending
+      ? "Drafting…"
+      : status === "done"
+        ? "Drafted"
+        : status === "error"
+          ? "Retry draft"
+          : "Draft";
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        aria-label={`Draft ${assetTaskTitle}`}
+        className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+      >
+        {label}
+      </button>
+      {message ? (
+        <span
+          data-testid="draft-flash"
+          className={
+            status === "error" ? "text-xs text-[var(--dpf-text)]" : "text-xs text-[var(--dpf-accent)]"
+          }
+          role="status"
+        >
+          {message}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
+++ b/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
@@ -3,6 +3,7 @@ import {
   formatMarketingLabel,
   type MarketingWorkspaceSnapshot,
 } from "@/lib/marketing";
+import { DraftAssetButton } from "./DraftAssetButton";
 
 type Props = {
   snapshot: MarketingWorkspaceSnapshot;
@@ -278,6 +279,7 @@ export function MarketingStrategyOverview({
                       {task.dueWindow ? ` - ${task.dueWindow}` : ""}
                     </p>
                     {task.brief && <p className="mt-1 text-[var(--dpf-text)]">{task.brief}</p>}
+                    <DraftAssetButton assetTaskId={task.taskId} assetTaskTitle={task.title} />
                   </li>
                 ))}
               </ul>

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -268,7 +268,22 @@ export type MarketingWorkspaceSnapshot = {
       createdAt: Date;
     }>;
   };
+  pendingDrafts: OutboundDraftRow[];
   staleAreas: string[];
+};
+
+export type OutboundDraftRow = {
+  draftId: string;
+  sourceType: "marketing-asset-task" | "marketing-campaign-brief" | "inbound-channel-message" | "manual";
+  sourceId: string | null;
+  assetTaskTitle: string | null;
+  channelId: string;
+  assetType: string;
+  status: "draft" | "pending-review" | "approved" | "rejected" | "needs-changes" | "stale";
+  body: string;
+  bodyFormat: "markdown" | "html" | "plain";
+  createdByAgentId: string | null;
+  createdAt: Date;
 };
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -1129,6 +1144,7 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
     assetTasks,
     kpiCheckpoints,
     automationCandidates,
+    pendingDraftsRaw,
   ] = await Promise.all([
     prisma.marketingCampaignBrief.findMany({
       where: { strategyId: strategy.strategyId },
@@ -1150,7 +1166,35 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
       orderBy: { createdAt: "desc" },
       take: 5,
     }),
+    prisma.outboundDraft.findMany({
+      where: {
+        organizationId: organization.id,
+        domain: "marketing",
+        status: { in: ["pending-review", "needs-changes"] },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }),
   ]);
+
+  // Map asset task ids to titles for the queue panel
+  const taskIdToTitle = new Map(assetTasks.map((t) => [t.taskId, t.title]));
+  const pendingDrafts: OutboundDraftRow[] = pendingDraftsRaw.map((draft) => ({
+    draftId: draft.draftId,
+    sourceType: draft.sourceType as OutboundDraftRow["sourceType"],
+    sourceId: draft.sourceId,
+    assetTaskTitle:
+      draft.sourceType === "marketing-asset-task" && draft.sourceId
+        ? taskIdToTitle.get(draft.sourceId) ?? null
+        : null,
+    channelId: draft.channelId,
+    assetType: draft.assetType,
+    status: draft.status as OutboundDraftRow["status"],
+    body: draft.body,
+    bodyFormat: draft.bodyFormat as OutboundDraftRow["bodyFormat"],
+    createdByAgentId: draft.createdByAgentId,
+    createdAt: draft.createdAt,
+  }));
 
   const normalizedSnapshot: MarketingWorkspaceSnapshot = {
     organization: {
@@ -1248,6 +1292,7 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
         createdAt: candidate.createdAt,
       })),
     },
+    pendingDrafts,
     staleAreas: [],
   };
 

--- a/apps/web/lib/marketing/draft-builder.ts
+++ b/apps/web/lib/marketing/draft-builder.ts
@@ -1,0 +1,187 @@
+// Marketing execution loop — content drafter.
+//
+// Turns a saved MarketingAssetTask brief into a channel-shaped,
+// human-reviewable OutboundDraft. Phase 1: LinkedIn posts and email assets
+// only. Other asset types (ads, carousel, video script) ship in later
+// phases and add their own shaping helpers here.
+//
+// Reference spec:
+//   docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md
+// Reference plan:
+//   docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md
+
+import { prisma } from "@dpf/db";
+import {
+  type OutboundBodyFormat,
+  type OutboundDraftStatus,
+} from "./execution";
+import { getMarketingWorkspaceSnapshot } from "../marketing";
+
+export type DraftMarketingAssetResult =
+  | {
+      success: true;
+      draftId: string;
+      status: OutboundDraftStatus;
+      bodyFormat: OutboundBodyFormat;
+      wordCount: number;
+      channelId: string;
+      assetType: string;
+      message: string;
+    }
+  | { success: false; error: string; message: string };
+
+const LINKEDIN_POST_GUIDE = `LinkedIn post shape:
+- Hook in line 1 — pain-led, specific, no generic openers like "I've been thinking…".
+- Target 180–280 words. Concrete examples beat abstractions.
+- Use short paragraphs (1–3 lines). Whitespace makes mobile readable.
+- 0–3 hashtags max, only ones a technical-founder audience would actually search.
+- Exactly one call to action at the end. Comment-trigger CTAs ("comment 'X' for the checklist") perform well for inquiry.
+- No emoji-flood, no "🚀". Confident founder voice, not corporate marketing voice.`;
+
+const EMAIL_GUIDE = `Email shape:
+- First line: subject (prefix with "Subject: "). Concise, curiosity-led, no clickbait.
+- Body: short paragraphs. 100–220 words total.
+- Personalize the opener if PAGE DATA includes a recipient signal; otherwise lead with the recipient's likely problem.
+- One ask in the body. One link or one reply prompt — never both.
+- Sign-off with a name placeholder ({{senderName}}) so the sender substitutes it before send.`;
+
+const AD_CREATIVE_GUIDE = `Ad creative shape (placeholder for Phase 4 — Phase 1 should not draft ad creatives yet, return a needs-changes diagnostic instead).`;
+
+function shapingGuide(assetType: string): string {
+  const normalized = assetType.toLowerCase();
+  if (normalized.includes("linkedin")) return LINKEDIN_POST_GUIDE;
+  if (normalized.includes("email")) return EMAIL_GUIDE;
+  if (normalized.includes("ad")) return AD_CREATIVE_GUIDE;
+  return LINKEDIN_POST_GUIDE;
+}
+
+function isSupportedAssetType(assetType: string): boolean {
+  const normalized = assetType.toLowerCase();
+  return normalized.includes("linkedin") || normalized.includes("email");
+}
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export async function draftMarketingAsset(input: {
+  assetTaskId: string;
+  channelOverride?: string;
+  toneNotes?: string;
+  createdByAgentId: string | null;
+}): Promise<DraftMarketingAssetResult> {
+  const task = await prisma.marketingAssetTask.findUnique({
+    where: { taskId: input.assetTaskId },
+  });
+  if (!task) {
+    return {
+      success: false,
+      error: "Asset task not found",
+      message: `MarketingAssetTask ${input.assetTaskId} does not exist; cannot draft.`,
+    };
+  }
+
+  if (!isSupportedAssetType(task.assetType)) {
+    return {
+      success: false,
+      error: "Unsupported asset type for Phase 1",
+      message: `assetType=${JSON.stringify(task.assetType)} is not yet drafted by Phase 1 (LinkedIn posts and emails only). Ads and other shapes land in later phases.`,
+    };
+  }
+
+  const snapshot = await getMarketingWorkspaceSnapshot();
+  if (!snapshot) {
+    return {
+      success: false,
+      error: "No marketing workspace",
+      message: "Cannot draft without a configured marketing workspace.",
+    };
+  }
+
+  const channelId = input.channelOverride ?? task.channel ?? "linkedin";
+  const positioning = snapshot.latestReview?.summary
+    ?? "No saved strategist review — drafter is operating without a positioning anchor.";
+  const audience =
+    snapshot.strategy.targetSegments[0]?.name
+    ?? snapshot.strategy.idealCustomerProfiles[0]?.name
+    ?? "the strategist's chosen buyer segment";
+  const proof =
+    snapshot.strategy.proofAssets[0]?.label ?? null;
+
+  const systemPrompt = `You are a senior marketing copywriter producing channel-shaped, ready-to-publish copy from a marketing brief.
+
+You produce the body the human will review next. Do NOT produce meta-commentary, options, or "here are three variants" — produce ONE draft, the one you'd publish if you had the authority. The human reviews and edits before any external publish.
+
+${shapingGuide(task.assetType)}
+
+Constraints:
+- Stay grounded in the brief and the positioning. Do not invent product features that aren't in the brief.
+- Use the strategist's stakeholder language. If the audience term is "technical founders", do not say "SMB owners".
+- No placeholders like [Insert X] except the explicit signer placeholder in email sign-offs.`;
+
+  const userPrompt = `Brief title: ${task.title}
+Asset type: ${task.assetType}
+Channel: ${channelId}
+Due window: ${task.dueWindow ?? "not specified"}
+
+Brief instructions:
+${task.brief ?? "(no brief — use the positioning + audience anchors)"}
+
+Positioning anchor (latest strategist review):
+${positioning}
+
+Audience anchor: ${audience}
+${proof ? `Proof asset anchor: ${proof}` : ""}
+${input.toneNotes ? `Tone notes: ${input.toneNotes}` : ""}
+
+Produce the ${task.assetType} now. Output the body only — no preamble, no commentary.`;
+
+  const { routeAndCall } = await import("../routed-inference");
+  const result = await routeAndCall(
+    [{ role: "user", content: userPrompt }],
+    systemPrompt,
+    "internal",
+  );
+
+  const body = (result?.content ?? "").trim();
+  if (!body) {
+    return {
+      success: false,
+      error: "Drafter returned empty body",
+      message: "The drafter produced an empty response; retry with a more specific brief or tone note.",
+    };
+  }
+
+  const draft = await prisma.outboundDraft.create({
+    data: {
+      organizationId: snapshot.organization.id,
+      domain: "marketing",
+      sourceType: "marketing-asset-task",
+      sourceId: task.taskId,
+      strategyId: snapshot.strategy.strategyId,
+      status: "pending-review",
+      channelId,
+      assetType: task.assetType,
+      body,
+      bodyFormat: "markdown",
+      metadata: {
+        assetTaskTitle: task.title,
+        assetTaskDueWindow: task.dueWindow,
+      },
+      createdByAgentId: input.createdByAgentId,
+    },
+    select: { draftId: true, status: true, bodyFormat: true, body: true, channelId: true, assetType: true },
+  });
+
+  const wordCount = countWords(draft.body);
+  return {
+    success: true,
+    draftId: draft.draftId,
+    status: draft.status as OutboundDraftStatus,
+    bodyFormat: draft.bodyFormat as OutboundBodyFormat,
+    wordCount,
+    channelId: draft.channelId,
+    assetType: draft.assetType,
+    message: `Drafted ${wordCount}-word ${draft.assetType} for review on /customer/marketing.`,
+  };
+}

--- a/apps/web/lib/marketing/execution.test.ts
+++ b/apps/web/lib/marketing/execution.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  OUTBOUND_DRAFT_STATUS,
+  OUTBOUND_APPROVAL_DECISION,
+  OUTBOUND_DOMAIN,
+  OUTBOUND_SOURCE_TYPE,
+  OUTBOUND_BODY_FORMAT,
+  isAllowedDraftTransition,
+  assertDraftTransition,
+  draftStatusForDecision,
+} from "./execution";
+
+describe("OUTBOUND_DRAFT_STATUS catalog", () => {
+  it("contains the six expected states", () => {
+    expect([...OUTBOUND_DRAFT_STATUS].sort()).toEqual(
+      ["approved", "draft", "needs-changes", "pending-review", "rejected", "stale"],
+    );
+  });
+});
+
+describe("OUTBOUND_APPROVAL_DECISION catalog", () => {
+  it("matches draft status transitions", () => {
+    expect([...OUTBOUND_APPROVAL_DECISION].sort()).toEqual(
+      ["approved", "needs-changes", "rejected"],
+    );
+  });
+});
+
+describe("OUTBOUND_DOMAIN catalog", () => {
+  it("starts with marketing as the first adopter", () => {
+    expect(OUTBOUND_DOMAIN).toContain("marketing");
+  });
+});
+
+describe("OUTBOUND_SOURCE_TYPE catalog", () => {
+  it("includes marketing-asset-task for Phase 1 + future inbound source", () => {
+    expect([...OUTBOUND_SOURCE_TYPE].sort()).toEqual(
+      ["inbound-channel-message", "manual", "marketing-asset-task", "marketing-campaign-brief"],
+    );
+  });
+});
+
+describe("OUTBOUND_BODY_FORMAT catalog", () => {
+  it("supports markdown / html / plain", () => {
+    expect([...OUTBOUND_BODY_FORMAT].sort()).toEqual(["html", "markdown", "plain"]);
+  });
+});
+
+describe("draft state machine", () => {
+  it("allows pending-review → approved", () => {
+    expect(isAllowedDraftTransition("pending-review", "approved")).toBe(true);
+  });
+
+  it("allows pending-review → rejected", () => {
+    expect(isAllowedDraftTransition("pending-review", "rejected")).toBe(true);
+  });
+
+  it("allows pending-review → needs-changes", () => {
+    expect(isAllowedDraftTransition("pending-review", "needs-changes")).toBe(true);
+  });
+
+  it("allows needs-changes → pending-review (drafter produces a new revision)", () => {
+    expect(isAllowedDraftTransition("needs-changes", "pending-review")).toBe(true);
+  });
+
+  it("rejects approved → approved (idempotency boundary)", () => {
+    expect(isAllowedDraftTransition("approved", "approved")).toBe(false);
+  });
+
+  it("rejects rejected → approved (no resurrection without a new draft)", () => {
+    expect(isAllowedDraftTransition("rejected", "approved")).toBe(false);
+  });
+
+  it("rejects approved → rejected (terminal)", () => {
+    expect(isAllowedDraftTransition("approved", "rejected")).toBe(false);
+  });
+
+  it("assertDraftTransition throws with a clear message on illegal transition", () => {
+    expect(() => assertDraftTransition("approved", "approved")).toThrow(/Illegal/);
+  });
+
+  it("assertDraftTransition does not throw on legal transition", () => {
+    expect(() => assertDraftTransition("pending-review", "approved")).not.toThrow();
+  });
+});
+
+describe("draftStatusForDecision", () => {
+  it("maps approved decision to approved status", () => {
+    expect(draftStatusForDecision("approved")).toBe("approved");
+  });
+
+  it("maps rejected decision to rejected status", () => {
+    expect(draftStatusForDecision("rejected")).toBe("rejected");
+  });
+
+  it("maps needs-changes decision to needs-changes status", () => {
+    expect(draftStatusForDecision("needs-changes")).toBe("needs-changes");
+  });
+});

--- a/apps/web/lib/marketing/execution.ts
+++ b/apps/web/lib/marketing/execution.ts
@@ -1,0 +1,92 @@
+// Typed catalogs for the marketing execution loop substrate.
+//
+// All status / domain / source-type / format strings used by the outbound
+// draft + approval queue MUST come from here. Pages, tools, server actions,
+// and tests import the typed constants — string literals scattered across
+// call sites violate the strongly-typed-string-enums kernel principle.
+//
+// Reference spec:
+//   docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md §6.
+
+export const OUTBOUND_DRAFT_STATUS = [
+  "draft",
+  "pending-review",
+  "approved",
+  "rejected",
+  "needs-changes",
+  "stale",
+] as const;
+export type OutboundDraftStatus = (typeof OUTBOUND_DRAFT_STATUS)[number];
+
+export const OUTBOUND_APPROVAL_DECISION = [
+  "approved",
+  "rejected",
+  "needs-changes",
+] as const;
+export type OutboundApprovalDecisionValue = (typeof OUTBOUND_APPROVAL_DECISION)[number];
+
+/**
+ * Domains that share the outbound execution substrate. Marketing is the
+ * first; customer-advisor outbound, ops-coordinator status comms, and
+ * build-specialist contributor recruitment join here when they adopt
+ * the substrate, without a rename migration.
+ */
+export const OUTBOUND_DOMAIN = ["marketing"] as const;
+export type OutboundDomain = (typeof OUTBOUND_DOMAIN)[number];
+
+export const OUTBOUND_SOURCE_TYPE = [
+  "marketing-asset-task",
+  "marketing-campaign-brief",
+  "inbound-channel-message",
+  "manual",
+] as const;
+export type OutboundSourceType = (typeof OUTBOUND_SOURCE_TYPE)[number];
+
+export const OUTBOUND_BODY_FORMAT = ["markdown", "html", "plain"] as const;
+export type OutboundBodyFormat = (typeof OUTBOUND_BODY_FORMAT)[number];
+
+// ─── State machine ──────────────────────────────────────────────────────────
+//
+// Strict transitions, enforced by `assertDraftTransition` below.
+// `pending-review` is the only state that accepts a decision.
+// `approved` and `rejected` are terminal for this draft revision — a new
+// revision requires a fresh draft row, not an in-place status flip.
+
+const ALLOWED_TRANSITIONS: Readonly<Record<OutboundDraftStatus, ReadonlyArray<OutboundDraftStatus>>> = {
+  draft: ["pending-review", "stale"],
+  "pending-review": ["approved", "rejected", "needs-changes", "stale"],
+  "needs-changes": ["pending-review", "stale"],
+  approved: [],
+  rejected: [],
+  stale: [],
+};
+
+export function isAllowedDraftTransition(from: OutboundDraftStatus, to: OutboundDraftStatus): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+export function assertDraftTransition(from: OutboundDraftStatus, to: OutboundDraftStatus): void {
+  if (!isAllowedDraftTransition(from, to)) {
+    throw new Error(
+      `Illegal OutboundDraft transition: ${JSON.stringify(from)} -> ${JSON.stringify(to)}. ` +
+        `Approved and rejected drafts are terminal; create a new draft revision instead.`,
+    );
+  }
+}
+
+/**
+ * Map an approval-decision value to the resulting draft status.
+ *   approved      -> approved (terminal)
+ *   rejected      -> rejected (terminal)
+ *   needs-changes -> needs-changes (drafter can produce a new revision)
+ */
+export function draftStatusForDecision(decision: OutboundApprovalDecisionValue): OutboundDraftStatus {
+  switch (decision) {
+    case "approved":
+      return "approved";
+    case "rejected":
+      return "rejected";
+    case "needs-changes":
+      return "needs-changes";
+  }
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1392,6 +1392,22 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     coworkerArtifact: true,
   },
   {
+    name: "draft_marketing_asset",
+    description: "Turn a saved MarketingAssetTask brief into a channel-shaped, human-reviewable draft. Creates an OutboundDraft with status='pending-review' that appears in the marketing approval queue on /customer/marketing. Phase 1: LinkedIn posts and emails only. No external API call — the draft is internal until a human approves and a publish tool fires.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        assetTaskId: { type: "string", description: "MarketingAssetTask.taskId to draft from" },
+        channelOverride: { type: "string", enum: [...MARKETING_CHANNELS], description: "Override the asset task's channel if drafting a variant" },
+        toneNotes: { type: "string", description: "Optional one-line guidance the drafter should respect (e.g. 'first person, technical, no emojis')" },
+      },
+      required: ["assetTaskId"],
+    },
+    requiredCapability: "operate_marketing",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+  {
     name: "record_marketing_kpi_checkpoint",
     description: "Record a KPI checkpoint or target for the active marketing plan so the workspace can show what will be measured.",
     inputSchema: {
@@ -13180,6 +13196,31 @@ export async function executeTool(
         success: true,
         entityId: result.taskId,
         message: `${result.message}. The marketing workspace now has a saved proof/content task.`,
+        data: result,
+      };
+    }
+
+    case "draft_marketing_asset": {
+      const { draftMarketingAsset } = await import("./marketing/draft-builder");
+      const result = await draftMarketingAsset({
+        assetTaskId: String(params["assetTaskId"] ?? ""),
+        channelOverride: typeof params["channelOverride"] === "string" ? params["channelOverride"] : undefined,
+        toneNotes: typeof params["toneNotes"] === "string" ? params["toneNotes"] : undefined,
+        createdByAgentId: context?.agentId ?? null,
+      });
+
+      if (!result.success) {
+        return {
+          success: false,
+          message: result.message,
+          error: result.error,
+        };
+      }
+
+      return {
+        success: true,
+        entityId: result.draftId,
+        message: result.message,
         data: result,
       };
     }

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -256,6 +256,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_marketing_asset_task:   ["marketing_write"],
   record_marketing_kpi_checkpoint: ["marketing_write"],
   create_marketing_automation_candidate: ["marketing_write"],
+  draft_marketing_asset:         ["marketing_write"],
   analyze_seo_opportunity:      ["marketing_read"],
   generate_custom_archetype:    ["marketing_write"],
   assess_archetype_refinement:  ["marketing_read"],

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -213,6 +213,7 @@ HEURISTICS:
 - Channel fit: recommend channels appropriate to the business model, not generic SMB marketing lists
 - Burden reduction: reduce user effort by drafting, sequencing, and structuring the work wherever possible
 - Persistence: when you give a concrete channel, cadence, KPI, or campaign recommendation, call save_marketing_review so the page shows what you recommended and what changed
+- Drafting: after saving a campaign brief and asset task, call draft_marketing_asset(assetTaskId) to turn the brief into channel-shaped, human-reviewable copy. The draft lands in the approval queue on /customer/marketing. Phase 1 stops at human approval; never claim a draft has been published
 
 ACTIVE MARKETING WORK:
 - Treat concrete recommendations as durable work product, not chat-only advice. A recommendation is concrete when it names a channel, cadence, audience, KPI, campaign, proof asset, SEO page, forum/community motion, or next execution step.

--- a/docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md
+++ b/docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md
@@ -1,0 +1,308 @@
+# Marketing Execution Loop — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the immediate strategy→publish gap on `/customer/marketing` by giving the platform the ability to turn a saved `MarketingAssetTask` into a channel-shaped, human-reviewable draft — gated by an explicit approval queue, with a full audit trail. No external API integration in this phase.
+
+**Architecture:** Add the substrate-named outbound execution layer (`OutboundDraft` + `OutboundApprovalDecision`) with a `domain="marketing"` discriminator so it generalizes to other coworker domains later without a rename migration. Add a typed status catalog at `apps/web/lib/marketing/execution.ts` to keep enum strings out of pages, tools, and tests. Expose one new MCP tool — `draft_marketing_asset(assetTaskId)` — that the marketing-specialist (and a one-click UI affordance next to each asset task) can call to produce a draft. Render a new "Awaiting your review" panel on `/customer/marketing` with inline edit + Approve / Approve-with-edits / Request changes / Reject actions, writing one `OutboundApprovalDecision` per decision.
+
+**Tech Stack:** Next.js app router, React server components + light client edit panel, Prisma 7 migration, Vitest, existing DPF MCP/tool surface, existing theme variables only.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md`](../specs/2026-05-26-marketing-execution-loop-design.md) (Phase 1 = §6.1 + §7 Phase 1 + §9).
+
+---
+
+## UX Architecture Fit Gate
+
+Per the spec §8, every phase plan must answer this gate before implementation starts:
+
+- **Feature:** Outbound draft + approval queue for marketing assets.
+- **Owning area:** Business > Customer > Marketing.
+- **Primary route family:** `/customer/marketing`.
+- **Primary persona:** Mark Bodman as CEO / marketing operator using the Marketing Strategist coworker.
+- **Job the first viewport helps complete:** "Review and approve content the strategist drafted for me to publish this week."
+- **Navigation layer touched:** local route + contextual action only. No AppRail, Workspace, or Platform navigation additions.
+- **Existing component or pattern reused:** `MarketingStrategyOverview` panel composition; `Section` + `Pill` helpers already in `apps/web/components/customer-marketing/`. Action buttons reuse the existing accent-button class. Side drawer / focused panel for the long-copy editor uses the existing inline-detail pattern (no new modal stack).
+- **New component justified because:** none of the existing review surfaces (`AgentMessageInput`, `BuildReviewPanel`, `ReleaseDecisionPanel`) target a marketing-asset shape with inline copy editing + four-button decision. A new `ApprovalQueuePanel` keyed by domain="marketing" is the minimum surface; it lives next to other marketing components.
+- **Source-of-truth model or service:** `OutboundDraft` (new) and `OutboundApprovalDecision` (new). Reads composed through `getMarketingWorkspaceSnapshot()` so the page stays one query path.
+- **Empty state behavior:** "No drafts awaiting your review. Ask the Marketing Strategist to draft an asset, or click 'Draft' next to an asset task above." One concrete next action — not a wall of zeros.
+- **Failure / unavailable behavior:** if the drafter tool fails, the asset task row surfaces "Draft failed — see chat for details" with a Retry button. The approval queue still renders empty (does not crash).
+- **AI or coworker action boundary:** drafter writes to `OutboundDraft` (internal artifact). Approval is a button on the queue row — never an inferred outcome of chat. Per the kernel principle, approval cannot be auto-fired by the agent.
+- **Theme and layout checks:** all colors via `var(--dpf-*)` tokens. No `text-white` except on accent buttons. Pills reuse existing badge class.
+- **Routes to verify:** `/customer/marketing` desktop + mobile; light mode + dark mode.
+- **Evidence required before merge:** screenshot + dynamic-analysis log of (a) draft created from existing Week 1 LinkedIn Post asset task, (b) edit-then-approve writing an `OutboundApprovalDecision` row with `editedBody`, (c) reject writing decision row with `decision=rejected`.
+
+---
+
+## Phase 0: Branch and Substrate Guard
+
+- [ ] Confirm work is on an isolated branch/worktree off `origin/main`, not on `main` and not on a dirty worktree.
+
+  ```powershell
+  git status --short --branch
+  git branch --show-current
+  ```
+
+- [ ] Re-read the governing docs before implementation:
+  - [`AGENTS.md`](../../../AGENTS.md)
+  - [`docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md`](../specs/2026-05-26-marketing-execution-loop-design.md)
+  - [`docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md`](../specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md)
+  - [`docs/platform-usability-standards.md`](../../platform-usability-standards.md)
+
+- [ ] Substrate sweep — verify the proposed table names don't already exist on `origin/main` or in an open BS sandbox:
+
+  ```bash
+  grep -rn "model OutboundDraft\|model OutboundApprovalDecision" packages/db/prisma/schema.prisma
+  ```
+
+  Expected: zero matches. If anything matches, stop and align with the existing model first.
+
+## Phase 1: Status Catalog + Prisma Models
+
+- [ ] Add `apps/web/lib/marketing/execution.ts` with strongly-typed catalogs:
+
+  ```typescript
+  export const OUTBOUND_DRAFT_STATUS = [
+    "draft",
+    "pending-review",
+    "approved",
+    "rejected",
+    "needs-changes",
+    "stale",
+  ] as const;
+  export type OutboundDraftStatus = (typeof OUTBOUND_DRAFT_STATUS)[number];
+
+  export const OUTBOUND_APPROVAL_DECISION = [
+    "approved",
+    "rejected",
+    "needs-changes",
+  ] as const;
+  export type OutboundApprovalDecisionValue = (typeof OUTBOUND_APPROVAL_DECISION)[number];
+
+  export const OUTBOUND_DOMAIN = ["marketing"] as const; // grows as other domains adopt
+  export type OutboundDomain = (typeof OUTBOUND_DOMAIN)[number];
+
+  export const OUTBOUND_SOURCE_TYPE = [
+    "marketing-asset-task",
+    "marketing-campaign-brief",
+    "inbound-channel-message",
+    "manual",
+  ] as const;
+  export type OutboundSourceType = (typeof OUTBOUND_SOURCE_TYPE)[number];
+
+  export const OUTBOUND_BODY_FORMAT = ["markdown", "html", "plain"] as const;
+  export type OutboundBodyFormat = (typeof OUTBOUND_BODY_FORMAT)[number];
+  ```
+
+- [ ] Add Prisma models to `packages/db/prisma/schema.prisma`:
+
+  ```prisma
+  model OutboundDraft {
+    draftId          String   @id @default(cuid())
+    organizationId   String
+    domain           String
+    sourceType       String
+    sourceId         String?
+    strategyId       String?
+    status           String
+    channelId        String
+    assetType        String
+    body             String   @db.Text
+    bodyFormat       String
+    metadata         Json?
+    createdByAgentId String?
+    originalPromptId String?
+    createdAt        DateTime @default(now())
+    updatedAt        DateTime @updatedAt
+
+    approvals        OutboundApprovalDecision[]
+
+    @@index([organizationId, domain, status])
+    @@index([sourceType, sourceId])
+    @@index([channelId, status])
+  }
+
+  model OutboundApprovalDecision {
+    decisionId       String   @id @default(cuid())
+    draftId          String
+    reviewerUserId   String
+    decision         String
+    editedBody       String?  @db.Text
+    notes            String?  @db.Text
+    decidedAt        DateTime @default(now())
+
+    draft            OutboundDraft @relation(fields: [draftId], references: [draftId], onDelete: Cascade)
+
+    @@index([draftId])
+    @@index([reviewerUserId, decidedAt])
+  }
+  ```
+
+- [ ] Create migration: `pnpm --filter @dpf/db exec prisma migrate dev --name marketing_execution_outbound_draft`. Migration body is empty SQL (Prisma generates `CREATE TABLE` for both models).
+
+- [ ] Regenerate the Prisma client.
+
+- [ ] Verify migration applies cleanly on a fresh DB:
+  - Run the migration against a scratch container or use the existing prisma migrate workflow.
+  - Confirm `\d "OutboundDraft"` and `\d "OutboundApprovalDecision"` show the expected columns + indexes in `psql`.
+
+## Phase 2: Data Access Helpers
+
+- [ ] Extend `apps/web/lib/marketing.ts` with snapshot helpers (or add `apps/web/lib/marketing-execution.ts` if marketing.ts is already heavy — keep one source of truth per route data path):
+
+  ```typescript
+  export type OutboundDraftRow = {
+    draftId: string;
+    sourceType: OutboundSourceType;
+    sourceId: string | null;
+    assetTaskTitle?: string | null; // joined when sourceType=marketing-asset-task
+    channelId: string;
+    assetType: string;
+    status: OutboundDraftStatus;
+    body: string;
+    bodyFormat: OutboundBodyFormat;
+    createdByAgentId: string | null;
+    createdAt: Date;
+  };
+
+  export async function listPendingOutboundDrafts(organizationId: string): Promise<OutboundDraftRow[]>;
+  export async function getOutboundDraft(draftId: string): Promise<OutboundDraftRow | null>;
+  ```
+
+- [ ] Extend `getMarketingWorkspaceSnapshot()` to include `pendingDrafts: OutboundDraftRow[]`. Existing `workProducts` map stays untouched.
+
+- [ ] Server actions in `apps/web/app/(shell)/customer/marketing/actions.ts` (new file if not present):
+  - `approveOutboundDraftAction(draftId: string, editedBody?: string, notes?: string)` — writes `OutboundApprovalDecision(decision="approved", editedBody, notes)` + flips draft to `approved`.
+  - `requestChangesOnDraftAction(draftId: string, notes: string)` — writes decision + flips draft to `needs-changes`.
+  - `rejectOutboundDraftAction(draftId: string, notes?: string)` — writes decision + flips draft to `rejected`.
+
+  All three:
+  - Require `operate_marketing` capability via the existing `can()` helper.
+  - Use a single Prisma transaction.
+  - Revalidate `/customer/marketing` on success.
+
+## Phase 3: MCP Tool — `draft_marketing_asset`
+
+- [ ] Add tool definition in `apps/web/lib/mcp-tools.ts` after `create_marketing_asset_task`:
+
+  ```typescript
+  {
+    name: "draft_marketing_asset",
+    description: "Turn a saved MarketingAssetTask brief into a channel-shaped, human-reviewable draft. Outputs an OutboundDraft with status='pending-review' that appears in the marketing approval queue. No external API call — the draft is internal until a human approves and publishes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        assetTaskId: { type: "string", description: "MarketingAssetTask.taskId to draft from" },
+        channelOverride: { type: "string", enum: [...MARKETING_CHANNELS], description: "Override the asset task's channel if drafting a variant" },
+        toneNotes: { type: "string", description: "Optional one-line guidance the drafter should respect (e.g. 'first person, technical, no emojis')" },
+      },
+      required: ["assetTaskId"],
+    },
+    requiredCapability: "operate_marketing",
+    sideEffect: true,
+    coworkerArtifact: true,
+  },
+  ```
+
+- [ ] Add `TOOL_TO_GRANTS["draft_marketing_asset"] = ["marketing_write"]` in `apps/web/lib/tak/agent-grants.ts`.
+
+- [ ] Implement the tool handler in the `executeTool` switch:
+  - Load the `MarketingAssetTask` by id; reject with `{ success: false, error: "Asset task not found" }` if missing.
+  - Build a channel-shaped drafter prompt that consumes: `task.title`, `task.brief`, `task.assetType`, `task.channel`, `task.dueWindow`, the current `MarketingStrategy` snapshot (positioning, channels, KPIs), and the latest `MarketingReview.summary`.
+  - Channel-aware shaping: for `assetType=LinkedIn post`, target 180–280 words, 0–3 hashtags, one CTA. For `assetType=email`, include subject line. For `assetType=ad-creative`, include 1 headline + 2 description variants. (Phase 1 covers LinkedIn post + email; other types ship later phases.)
+  - Call the platform LLM via the existing `routeAndCall` path with the `marketing-specialist` agent context.
+  - Persist the result as `OutboundDraft(status="pending-review", domain="marketing", sourceType="marketing-asset-task", sourceId=assetTaskId, channelId=task.channel, assetType=task.assetType, body=output, bodyFormat="markdown", createdByAgentId=agentId)`.
+  - Return `{ success: true, draftId, message: "Draft N words queued for review on /customer/marketing" }`.
+
+- [ ] Update the marketing-specialist agent prompt to mention the new tool:
+  - In `apps/web/lib/tak/agent-routing.ts` line ~215, add: "When a campaign brief and asset task are saved, call `draft_marketing_asset(assetTaskId)` to produce the human-reviewable copy. The draft lands in the approval queue on the marketing page; do not claim it has been published."
+
+## Phase 4: Approval Queue UI
+
+- [ ] New component `apps/web/components/customer-marketing/ApprovalQueuePanel.tsx`:
+  - Server component reads `snapshot.pendingDrafts`.
+  - Empty state: "No drafts awaiting your review. Ask the Marketing Strategist to draft an asset, or click 'Draft' next to an asset task above."
+  - Each row: channel + asset type pill, source asset task title, agent + timestamp, preview of first ~120 chars, "Review" button.
+  - Click "Review" opens a focused detail panel (drawer pattern from `MarketingStrategyOverview` — no modal stack) with:
+    - Left: the brief from the asset task (read-only).
+    - Right: editable `<textarea>` pre-filled with `draft.body`.
+    - Buttons: **Approve**, **Approve with edits**, **Request changes**, **Reject**.
+    - Each action calls the corresponding server action.
+
+- [ ] New client component `apps/web/components/customer-marketing/ApprovalQueueReview.tsx` for the edit surface (small client island; rest stays server-rendered).
+
+- [ ] Wire `ApprovalQueuePanel` into `apps/web/app/(shell)/customer/marketing/page.tsx` immediately below the existing "Strategist work products" section.
+
+- [ ] Add a one-click "Draft" affordance to each `MarketingAssetTask` row in `MarketingStrategyOverview` that calls the new tool via a server action; show inline "Drafting…" state and surface the new draft in the queue panel on success.
+
+## Phase 5: Tests
+
+- [ ] Unit tests in `apps/web/lib/marketing/execution.test.ts`:
+  - Status enum invariants (each catalog value present, no rogue strings).
+  - `OUTBOUND_DRAFT_STATUS` type assignability sanity checks.
+
+- [ ] Unit tests in `apps/web/lib/marketing/draft-state-machine.test.ts` (small pure-function state transition module if extracted, otherwise inline):
+  - `pending-review → approved` valid via approve decision.
+  - `pending-review → needs-changes` valid via request-changes decision.
+  - `pending-review → rejected` valid via reject decision.
+  - `approved → approved` rejected (idempotency boundary).
+  - `rejected → approved` rejected (no resurrection without a new draft revision).
+
+- [ ] Integration test in `apps/web/app/(shell)/customer/marketing/actions.test.ts`:
+  - Approve writes an `OutboundApprovalDecision` row with `decision="approved"`, no `editedBody`.
+  - Approve-with-edits writes a row with `editedBody` populated.
+  - Request changes writes a row with `decision="needs-changes"` and a non-null `notes`.
+  - Reject writes a row with `decision="rejected"`.
+  - User without `operate_marketing` is rejected.
+
+- [ ] MCP tool test in `apps/web/lib/mcp-tools.test.ts` (or a new `mcp-tools-marketing-execution.test.ts`):
+  - `draft_marketing_asset` with a missing `assetTaskId` returns success=false.
+  - With a valid `assetTaskId`, it writes an `OutboundDraft` with `status="pending-review"` and a non-empty body.
+
+## Phase 6: Build Gate
+
+- [ ] `pnpm --filter web exec vitest run lib/marketing lib/actions lib/mcp-tools` — all passing.
+- [ ] `pnpm --filter web typecheck` — clean.
+- [ ] `pnpm --filter web exec next build` — exit 0.
+- [ ] Migration applies cleanly when portal is rebuilt (no manual SQL needed).
+
+## Phase 7: UX Verification on Live Install
+
+- [ ] Drive the flow as Mark on `http://localhost:3000/customer/marketing`:
+  1. Confirm the Week 1 LinkedIn Post asset task already exists (it does — `cmpnaj574008z01s2hcwomedy`).
+  2. Click "Draft" next to it. Observe inline "Drafting…" → success.
+  3. Confirm a new row appears in the "Awaiting your review" panel.
+  4. Click "Review". Drawer opens with brief on left, editable body on right.
+  5. Approve as-is. Confirm row leaves queue. Confirm `OutboundApprovalDecision` row in DB.
+  6. Trigger a second draft (different asset task). Edit the body. Click "Approve with edits". Confirm `editedBody` written.
+  7. Trigger a third draft. Click "Reject". Confirm `decision="rejected"` row.
+  8. Take screenshots of (a) populated queue, (b) drawer with side-by-side, (c) audit-trail surfacing.
+
+- [ ] Mobile width verification: queue rows do not overlap badges/buttons. Touch targets ≥ 44px.
+- [ ] Light mode + dark mode + a brand-token override: drawer + buttons render correctly.
+
+## Phase 8: Ship
+
+- [ ] DCO-signed commit per concern (separate commits for migration, helpers + tool, UI, tests).
+- [ ] Push branch `feat/marketing-execution-loop-phase-1`.
+- [ ] Open PR titled "feat: marketing execution loop Phase 1 — drafter + approval queue".
+- [ ] PR body links the spec and this plan, includes UX verification screenshots, lists which acceptance criteria pass.
+- [ ] CI green → squash-merge → delete branch.
+- [ ] Rebuild portal at `D:/DPF/.claude/worktrees/portal-latest-main` (fast-forward main, `docker compose build --no-cache portal portal-init sandbox`, `docker compose up -d`).
+- [ ] Re-drive the flow on the rebuilt portal to confirm behavior survives the rebuild.
+
+## Phase 9: Cleanup and Follow-on
+
+- [ ] Mark `BI-7A152AED` (Phase 1 backlog item) `done` once the rebuilt portal verifies.
+- [ ] File a tiny follow-up BI to update the `customer-marketing.prompt.md` content (point users at the approval queue in plain-language UX copy) if any prompt copy needs adjustment after seeing the live flow.
+- [ ] Confirm the next phase (Phase 2 LinkedIn publish vs. Phase 3 email — see spec §15 Q2) before opening the next plan.
+
+---
+
+## Definition of Done
+
+- All Phase 1 build-gate steps pass.
+- Live install demonstrates: existing asset task → drafted LinkedIn-shaped body → reviewed in queue → approved (with and without edits) → audit row visible.
+- No external API calls fire from this PR.
+- All theme tokens used per platform-usability-standards.
+- `EP-MARKETING-EXEC` epic has `BI-7A152AED` flipped to `done` post-merge.

--- a/packages/db/prisma/migrations/20260527000000_marketing_execution_outbound_draft/migration.sql
+++ b/packages/db/prisma/migrations/20260527000000_marketing_execution_outbound_draft/migration.sql
@@ -1,0 +1,59 @@
+-- EP-MARKETING-EXEC Phase 1: outbound execution substrate.
+-- Generic outbound-draft + approval-decision tables with a domain
+-- discriminator. Marketing is the first domain; future coworker domains
+-- (customer-advisor, ops-coordinator, build-specialist) join without a
+-- rename migration. Typed status catalog lives at
+-- apps/web/lib/marketing/execution.ts.
+
+CREATE TABLE IF NOT EXISTS "OutboundDraft" (
+    "draftId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "domain" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT,
+    "strategyId" TEXT,
+    "status" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "assetType" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "bodyFormat" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdByAgentId" TEXT,
+    "originalPromptId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OutboundDraft_pkey" PRIMARY KEY ("draftId")
+);
+
+CREATE INDEX IF NOT EXISTS "OutboundDraft_organizationId_domain_status_idx"
+    ON "OutboundDraft"("organizationId", "domain", "status");
+
+CREATE INDEX IF NOT EXISTS "OutboundDraft_sourceType_sourceId_idx"
+    ON "OutboundDraft"("sourceType", "sourceId");
+
+CREATE INDEX IF NOT EXISTS "OutboundDraft_channelId_status_idx"
+    ON "OutboundDraft"("channelId", "status");
+
+CREATE TABLE IF NOT EXISTS "OutboundApprovalDecision" (
+    "decisionId" TEXT NOT NULL,
+    "draftId" TEXT NOT NULL,
+    "reviewerUserId" TEXT NOT NULL,
+    "decision" TEXT NOT NULL,
+    "editedBody" TEXT,
+    "notes" TEXT,
+    "decidedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OutboundApprovalDecision_pkey" PRIMARY KEY ("decisionId")
+);
+
+CREATE INDEX IF NOT EXISTS "OutboundApprovalDecision_draftId_idx"
+    ON "OutboundApprovalDecision"("draftId");
+
+CREATE INDEX IF NOT EXISTS "OutboundApprovalDecision_reviewerUserId_decidedAt_idx"
+    ON "OutboundApprovalDecision"("reviewerUserId", "decidedAt");
+
+ALTER TABLE "OutboundApprovalDecision"
+    ADD CONSTRAINT "OutboundApprovalDecision_draftId_fkey"
+    FOREIGN KEY ("draftId") REFERENCES "OutboundDraft"("draftId")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -545,60 +545,60 @@ model TerminationRecord {
 }
 
 model Portfolio {
-  id                     String                      @id @default(cuid())
-  slug                   String                      @unique
-  name                   String
-  description            String?
-  rootNodeId             String?
-  createdAt              DateTime                    @default(now())
-  updatedAt              DateTime                    @updatedAt
-  budgetKUsd             Int?
-  agents                 Agent[]
-  products               DigitalProduct[]
-  eaElements             EaElement[]
-  epicPortfolios         EpicPortfolio[]
-  inventoryEntities      InventoryEntity[]
-  portfolioQualityIssues PortfolioQualityIssue[]
+  id                            String                         @id @default(cuid())
+  slug                          String                         @unique
+  name                          String
+  description                   String?
+  rootNodeId                    String?
+  createdAt                     DateTime                       @default(now())
+  updatedAt                     DateTime                       @updatedAt
+  budgetKUsd                    Int?
+  agents                        Agent[]
+  products                      DigitalProduct[]
+  eaElements                    EaElement[]
+  epicPortfolios                EpicPortfolio[]
+  inventoryEntities             InventoryEntity[]
+  portfolioQualityIssues        PortfolioQualityIssue[]
   capabilityMaturityAssessments CapabilityMaturityAssessment[]
-  knowledgeArticles      KnowledgeArticlePortfolio[]
-  valueStreamTeams       ValueStreamTeam[]
-  workQueues             WorkQueue[]
+  knowledgeArticles             KnowledgeArticlePortfolio[]
+  valueStreamTeams              ValueStreamTeam[]
+  workQueues                    WorkQueue[]
 }
 
 model DigitalProduct {
-  id                           String                        @id @default(cuid())
-  productId                    String                        @unique
-  name                         String
-  portfolioId                  String?
-  createdAt                    DateTime                      @default(now())
-  updatedAt                    DateTime                      @updatedAt
-  taxonomyNodeId               String?
-  lifecycleStage               String                        @default("plan")
-  lifecycleStatus              String                        @default("draft")
-  version                      String                        @default("1.0.0")
-  description                  String?
-  observationConfig            Json?
-  backlogItems                 BacklogItem[]
-  manifests                    CodebaseManifest[]
-  assuranceFindings            AssuranceFinding[]
-  assuranceRuns                AssuranceRun[]
-  bomDocuments                 BomDocument[]
-  portfolio                    Portfolio?                    @relation(fields: [portfolioId], references: [id])
-  taxonomyNode                 TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
-  eaElements                   EaElement[]
-  featureBuilds                FeatureBuild[]
-  inventoryEntities            InventoryEntity[]
-  portfolioQualityIssues       PortfolioQualityIssue[]
+  id                            String                         @id @default(cuid())
+  productId                     String                         @unique
+  name                          String
+  portfolioId                   String?
+  createdAt                     DateTime                       @default(now())
+  updatedAt                     DateTime                       @updatedAt
+  taxonomyNodeId                String?
+  lifecycleStage                String                         @default("plan")
+  lifecycleStatus               String                         @default("draft")
+  version                       String                         @default("1.0.0")
+  description                   String?
+  observationConfig             Json?
+  backlogItems                  BacklogItem[]
+  manifests                     CodebaseManifest[]
+  assuranceFindings             AssuranceFinding[]
+  assuranceRuns                 AssuranceRun[]
+  bomDocuments                  BomDocument[]
+  portfolio                     Portfolio?                     @relation(fields: [portfolioId], references: [id])
+  taxonomyNode                  TaxonomyNode?                  @relation(fields: [taxonomyNodeId], references: [id])
+  eaElements                    EaElement[]
+  featureBuilds                 FeatureBuild[]
+  inventoryEntities             InventoryEntity[]
+  portfolioQualityIssues        PortfolioQualityIssue[]
   capabilityMaturityAssessments CapabilityMaturityAssessment[]
-  versions                     ProductVersion[]
-  serviceOfferings             ServiceOffering[]
-  quoteLineItems               QuoteLineItem[]
-  changeItems                  ChangeItem[]                  @relation("ChangeItemProduct")
-  businessModels               ProductBusinessModel[]
-  businessModelRoleAssignments BusinessModelRoleAssignment[]
-  knowledgeArticles            KnowledgeArticleProduct[]
-  workQueues                   WorkQueue[]
-  businessCapabilityLinks      BusinessCapabilityTraceLink[] @relation("BusinessCapabilityProductLinks")
+  versions                      ProductVersion[]
+  serviceOfferings              ServiceOffering[]
+  quoteLineItems                QuoteLineItem[]
+  changeItems                   ChangeItem[]                   @relation("ChangeItemProduct")
+  businessModels                ProductBusinessModel[]
+  businessModelRoleAssignments  BusinessModelRoleAssignment[]
+  knowledgeArticles             KnowledgeArticleProduct[]
+  workQueues                    WorkQueue[]
+  businessCapabilityLinks       BusinessCapabilityTraceLink[]  @relation("BusinessCapabilityProductLinks")
 }
 
 model BusinessModel {
@@ -899,28 +899,28 @@ model ServiceOffering {
 }
 
 model TaxonomyNode {
-  id                       String                        @id @default(cuid())
-  nodeId                   String                        @unique
-  name                     String
-  portfolioId              String?
-  parentId                 String?
-  status                   String                        @default("active")
-  governance               Json?
-  description              String?
-  enrichment               Json?
-  backlogItems             BacklogItem[]
-  products                 DigitalProduct[]
-  eaElements               EaElement[]
-  businessCapabilityLinks  BusinessCapabilityTraceLink[] @relation("BusinessCapabilityTaxonomyLinks")
-  fingerprintRules         DiscoveryFingerprintRule[]
-  inventoryEntities        InventoryEntity[]
-  portfolioQualityIssues   PortfolioQualityIssue[]
+  id                            String                         @id @default(cuid())
+  nodeId                        String                         @unique
+  name                          String
+  portfolioId                   String?
+  parentId                      String?
+  status                        String                         @default("active")
+  governance                    Json?
+  description                   String?
+  enrichment                    Json?
+  backlogItems                  BacklogItem[]
+  products                      DigitalProduct[]
+  eaElements                    EaElement[]
+  businessCapabilityLinks       BusinessCapabilityTraceLink[]  @relation("BusinessCapabilityTaxonomyLinks")
+  fingerprintRules              DiscoveryFingerprintRule[]
+  inventoryEntities             InventoryEntity[]
+  portfolioQualityIssues        PortfolioQualityIssue[]
   capabilityMaturityAssessments CapabilityMaturityAssessment[]
-  triageSelectionDecisions DiscoveryTriageDecision[]     @relation("DiscoveryTriageDecisionSelectedTaxonomy")
-  taxonomyProposalParents  TaxonomyProposal[]            @relation("TaxonomyProposalParent")
-  createdTaxonomyProposals TaxonomyProposal[]            @relation("TaxonomyProposalCreatedNode")
-  parent                   TaxonomyNode?                 @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children                 TaxonomyNode[]                @relation("TaxonomyTree")
+  triageSelectionDecisions      DiscoveryTriageDecision[]      @relation("DiscoveryTriageDecisionSelectedTaxonomy")
+  taxonomyProposalParents       TaxonomyProposal[]             @relation("TaxonomyProposalParent")
+  createdTaxonomyProposals      TaxonomyProposal[]             @relation("TaxonomyProposalCreatedNode")
+  parent                        TaxonomyNode?                  @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children                      TaxonomyNode[]                 @relation("TaxonomyTree")
 }
 
 model TaxonomyProposal {
@@ -4312,10 +4312,10 @@ model PlatformIssueReport {
   reportedBy          User?         @relation(fields: [reportedById], references: [id])
   featureBuild        FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
 
+  @@unique([reportedById, supportSessionId])
   @@index([featureBuildId])
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId])
-  @@unique([reportedById, supportSessionId])
   @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }
 
@@ -4402,15 +4402,15 @@ model NonProductionEnvironmentLease {
 }
 
 model FeatureBuild {
-  id                       String                  @id @default(cuid())
-  buildId                  String                  @unique
+  id                       String                   @id @default(cuid())
+  buildId                  String                   @unique
   title                    String
   description              String?
   portfolioId              String?
   originatingBacklogItemId String?
   brief                    Json?
   plan                     Json?
-  phase                    String                  @default("ideate")
+  phase                    String                   @default("ideate")
   sandboxId                String?
   sandboxPort              Int?
   buildBranch              String? // git branch in sandbox: "build/<buildId>"
@@ -4419,15 +4419,15 @@ model FeatureBuild {
   codingProvider           String?
   threadId                 String?
   createdById              String
-  createdAt                DateTime                @default(now())
-  updatedAt                DateTime                @updatedAt
+  createdAt                DateTime                 @default(now())
+  updatedAt                DateTime                 @updatedAt
   digitalProductId         String?
   designDoc                Json?
   designReview             Json?
   buildPlan                Json?
   planReview               Json?
   taskResults              Json?
-  taskResultsVersion       Int                     @default(0)
+  taskResultsVersion       Int                      @default(0)
   verificationOut          Json?
   acceptanceMet            Json?
   scoutFindings            Json?
@@ -4435,7 +4435,7 @@ model FeatureBuild {
   claimedByAgentId         String?
   claimedAt                DateTime?
   claimStatus              String?
-  gitCommitHashes          String[]                @default([])
+  gitCommitHashes          String[]                 @default([])
   uxTestResults            Json?
   uxVerificationStatus     String? // null | "running" | "complete" | "failed" | "skipped"
   deliberationSummary      Json? // compact BuildDeliberationSummary (see apps/web/lib/feature-build-types.ts)
@@ -4466,14 +4466,14 @@ model FeatureBuild {
   taxonomyProposals        TaxonomyProposal[]
   dependenciesOut          FeatureBuildDependency[] @relation("DependentBuild")
   dependenciesIn           FeatureBuildDependency[] @relation("DependsOnBuild")
-  activeForBacklogItem     BacklogItem?            @relation("BacklogItemActiveBuild")
-  accountableEmployee      EmployeeProfile?        @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
-  createdBy                User                    @relation(fields: [createdById], references: [id])
-  digitalProduct           DigitalProduct?         @relation(fields: [digitalProductId], references: [id])
-  originator               BacklogItem?            @relation("BacklogItemOriginator", fields: [originatingBacklogItemId], references: [id])
-  parentEpic               Epic?                   @relation("EpicFeatureBuilds", fields: [parentEpicId], references: [id])
-  supersededByEpic         Epic?                   @relation("EpicSupersededBuilds", fields: [supersededByEpicId], references: [id])
-  releaseBundle            ReleaseBundle?          @relation(fields: [releaseBundleId], references: [id])
+  activeForBacklogItem     BacklogItem?             @relation("BacklogItemActiveBuild")
+  accountableEmployee      EmployeeProfile?         @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
+  createdBy                User                     @relation(fields: [createdById], references: [id])
+  digitalProduct           DigitalProduct?          @relation(fields: [digitalProductId], references: [id])
+  originator               BacklogItem?             @relation("BacklogItemOriginator", fields: [originatingBacklogItemId], references: [id])
+  parentEpic               Epic?                    @relation("EpicFeatureBuilds", fields: [parentEpicId], references: [id])
+  supersededByEpic         Epic?                    @relation("EpicSupersededBuilds", fields: [supersededByEpicId], references: [id])
+  releaseBundle            ReleaseBundle?           @relation(fields: [releaseBundleId], references: [id])
   productVersions          ProductVersion[]
   promotionBackups         PromotionBackup[]
   issueReports             PlatformIssueReport[]
@@ -5041,16 +5041,16 @@ model StallEvent {
 //
 // Spec: docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md §5.1
 model QuiescenceRun {
-  id              String    @id @default(cuid())
+  id           String  @id @default(cuid())
   // Public/human-readable id (e.g., "QR-2026-05-24-abc123"). Used in event
   // payloads + URLs + log lines; the cuid `id` is internal FK substrate only.
-  runId           String    @unique
+  runId        String  @unique
   // Caller category: "self-upgrade" | "manual" | "sandbox-recovery"
-  trigger         String
+  trigger      String
   // Caller's external reference (e.g., SelfUpgradeRun.runId). Echoed back
   // on platform.quiescence-cleared so caller's step.waitForEvent can filter
   // when multiple non-self-upgrade callers emit in close sequence (spec §5.3).
-  triggerRefId    String?
+  triggerRefId String?
 
   // State machine value (see model comment above). String not enum so future
   // additions don't require a schema migration — application-layer validation
@@ -5086,25 +5086,25 @@ model QuiescenceRun {
   // Operator-promised wait budget (ms). Coordinator chooses regime at
   // preparing time and may extend per spec §5.5 max(regimeBudget, phaseBudget)
   // rule when a BuildPhaseRun blocker is present.
-  budgetMs        Int
+  budgetMs     Int
   // Actual wait time at terminal transition. Populated for success/defer paths.
-  actualWaitMs    Int?
+  actualWaitMs Int?
 
   // Defer audit (populated when status='deferred').
-  deferReason     String?
-  deferSurface    String?
+  deferReason    String?
+  deferSurface   String?
   // List of surfaces force-cancelled past budget (e.g., ship-force override).
   // JSON array of { surface, reason, forcedAt } objects.
-  forcedSurfaces  Json      @default("[]")
+  forcedSurfaces Json    @default("[]")
 
   // Terminal outcome label: succeeded | deferred-by-surface |
   // aborted-by-operator | failed. Set together with status transition.
-  outcome         String?
+  outcome          String?
   // Where the terminal transition came from: caller | boot-reconciler | watchdog.
   // Distinguishes "caller signaled swap-complete cleanly" from "post-swap boot
   // reconciler had to close out a pending run" from "watchdog forced cleanup".
   completionSource String?
-  outcomeNotes    String?   @db.Text
+  outcomeNotes     String? @db.Text
 
   @@index([trigger, startedAt])
   // Stuck-coordinator query: status NOT IN (terminal) AND lastHeartbeatAt < cutoff.
@@ -5475,33 +5475,33 @@ model EaDqRule {
 }
 
 model EaElement {
-  id                      String                        @id @default(cuid())
-  elementTypeId           String
-  name                    String
-  description             String?
-  properties              Json                          @default("{}")
-  lifecycleStage          String                        @default("plan")
-  lifecycleStatus         String                        @default("draft")
-  createdById             String?
-  digitalProductId        String?
-  infraCiKey              String?
-  portfolioId             String?
-  taxonomyNodeId          String?
-  syncedAt                DateTime?
-  refinementLevel         String?
-  itValueStream           String?
-  ontologyRole            String?
-  createdAt               DateTime                      @default(now())
-  updatedAt               DateTime                      @updatedAt
-  conformanceIssues       EaConformanceIssue[]
-  digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
-  elementType             EaElementType                 @relation(fields: [elementTypeId], references: [id])
-  portfolio               Portfolio?                    @relation(fields: [portfolioId], references: [id])
-  taxonomyNode            TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
-  fromRelationships       EaRelationship[]              @relation("FromElement")
-  toRelationships         EaRelationship[]              @relation("ToElement")
-  viewElements            EaViewElement[]
-  businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityEaElementLinks")
+  id                            String                         @id @default(cuid())
+  elementTypeId                 String
+  name                          String
+  description                   String?
+  properties                    Json                           @default("{}")
+  lifecycleStage                String                         @default("plan")
+  lifecycleStatus               String                         @default("draft")
+  createdById                   String?
+  digitalProductId              String?
+  infraCiKey                    String?
+  portfolioId                   String?
+  taxonomyNodeId                String?
+  syncedAt                      DateTime?
+  refinementLevel               String?
+  itValueStream                 String?
+  ontologyRole                  String?
+  createdAt                     DateTime                       @default(now())
+  updatedAt                     DateTime                       @updatedAt
+  conformanceIssues             EaConformanceIssue[]
+  digitalProduct                DigitalProduct?                @relation(fields: [digitalProductId], references: [id])
+  elementType                   EaElementType                  @relation(fields: [elementTypeId], references: [id])
+  portfolio                     Portfolio?                     @relation(fields: [portfolioId], references: [id])
+  taxonomyNode                  TaxonomyNode?                  @relation(fields: [taxonomyNodeId], references: [id])
+  fromRelationships             EaRelationship[]               @relation("FromElement")
+  toRelationships               EaRelationship[]               @relation("ToElement")
+  viewElements                  EaViewElement[]
+  businessCapabilityLinks       BusinessCapabilityTraceLink[]  @relation("BusinessCapabilityEaElementLinks")
   capabilityMaturityAssessments CapabilityMaturityAssessment[]
 
   @@index([portfolioId])
@@ -6937,6 +6937,54 @@ model MarketingAutomationCandidate {
   @@index([status])
 }
 
+// ─── Outbound execution substrate (EP-MARKETING-EXEC Phase 1) ────────────────
+//
+// Generic outbound-execution tables with a `domain` discriminator. Marketing
+// is the first domain; customer-advisor outbound, ops-coordinator status
+// comms, and build-specialist contributor recruitment join later without a
+// rename migration. Typed status catalog lives at
+// apps/web/lib/marketing/execution.ts.
+
+model OutboundDraft {
+  draftId          String   @id @default(cuid())
+  organizationId   String
+  domain           String // "marketing" today; see OUTBOUND_DOMAIN catalog
+  sourceType       String // "marketing-asset-task" | "marketing-campaign-brief" | "inbound-channel-message" | "manual"
+  sourceId         String?
+  strategyId       String?
+  status           String // "draft" | "pending-review" | "approved" | "rejected" | "needs-changes" | "stale"
+  channelId        String // "linkedin" | "email" | "linkedin-ads" | ...
+  assetType        String // "linkedin-post" | "email" | "ad-creative" | "reply" | ...
+  body             String
+  bodyFormat       String // "markdown" | "html" | "plain"
+  metadata         Json?
+  createdByAgentId String?
+  originalPromptId String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  approvals OutboundApprovalDecision[]
+
+  @@index([organizationId, domain, status])
+  @@index([sourceType, sourceId])
+  @@index([channelId, status])
+}
+
+model OutboundApprovalDecision {
+  decisionId     String   @id @default(cuid())
+  draftId        String
+  reviewerUserId String
+  decision       String // "approved" | "rejected" | "needs-changes"
+  editedBody     String?
+  notes          String?
+  decidedAt      DateTime @default(now())
+
+  draft OutboundDraft @relation(fields: [draftId], references: [draftId], onDelete: Cascade)
+
+  @@index([draftId])
+  @@index([reviewerUserId, decidedAt])
+}
+
 model StorefrontSection {
   id           String           @id @default(cuid())
   storefrontId String
@@ -8092,18 +8140,18 @@ model SkillDefinition {
 }
 
 model SkillSeedWarning {
-  id          String   @id @default(cuid())
-  warningId   String   @unique
+  id          String    @id @default(cuid())
+  warningId   String    @unique
   skillId     String
   warningType String
   message     String
   legacyPath  String?
   pluginPath  String?
-  sourceType  String   @default("dpf-platform-plugin")
-  metadata    Json     @default("{}")
+  sourceType  String    @default("dpf-platform-plugin")
+  metadata    Json      @default("{}")
   resolvedAt  DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@index([skillId])
   @@index([warningType])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4312,10 +4312,10 @@ model PlatformIssueReport {
   reportedBy          User?         @relation(fields: [reportedById], references: [id])
   featureBuild        FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
 
-  @@unique([reportedById, supportSessionId])
   @@index([featureBuildId])
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId])
+  @@unique([reportedById, supportSessionId])
   @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }
 


### PR DESCRIPTION
## Summary

Implements **EP-MARKETING-EXEC Phase 1** per the operator-reviewed spec at [`docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md`](docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md) and the plan at [`docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md`](docs/superpowers/plans/2026-05-26-marketing-execution-loop-phase-1.md).

Before this PR the Marketing Strategist could save a plan but no substrate existed to turn an asset task into reviewable copy — the strategist's brief sat on the dashboard and nothing got drafted. This PR closes that gap inside the platform (no external publishing — that's Phase 2).

## What ships

- **Substrate.** `OutboundDraft` + `OutboundApprovalDecision` Prisma models with a `domain` discriminator (= `marketing` today). Generalizes when customer-advisor / ops-coordinator / build-specialist hit the same outbound gap without a rename migration. Typed catalogs at `apps/web/lib/marketing/execution.ts` — no string literals scattered across pages, tools, and tests.
- **Strict state machine.** `pending-review` is the only state that accepts a decision; `approved` and `rejected` are terminal; resurrection requires a new draft row.
- **`draft_marketing_asset` MCP tool.** Takes a saved `MarketingAssetTask`, composes a channel-shaped prompt with audience + positioning + proof anchors from the current strategy/review, routes through the platform LLM, persists `OutboundDraft(status=pending-review)`. Phase 1 shapes LinkedIn posts + emails; unsupported types return a clear diagnostic. `marketing_write` grant + `coworkerArtifact: true` (callable in advise mode).
- **Strategist prompt update.** Mentions the drafter delegation path and explicitly forbids claiming a draft has been published.
- **Approval queue UX.** New "Awaiting your review" panel on `/customer/marketing`. Each row: channel + asset type + status pills, source asset task, drafter + timestamp. **Review** button opens side-by-side editor (brief context left, editable markdown body right). **Approve / Approve with edits / Request changes / Reject** — each writes one `OutboundApprovalDecision`; edits land in `editedBody` and become the effective published body when later phases publish.
- **Draft affordance.** Every `MarketingAssetTask` row in `MarketingStrategyOverview` gets a one-click **Draft** button that fires the tool via a server action.

## Test plan

- [x] 17 unit tests for catalog invariants, every state-machine transition (legal + illegal), decision→status mapping, and assertDraftTransition error path — passing
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web exec next build` — exit 0
- [x] Migration `20260527000000_marketing_execution_outbound_draft` applies against `dpf-postgres-1` (verified locally with `\d "OutboundDraft"` showing expected columns + indexes)
- [ ] Post-merge UX verification on rebuilt portal: drive the flow as CEO — Draft button → drafted body → review → approve as-is → approve with edits → reject → check audit rows in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)