### PR TITLE
chore(dev-portal): forward Inngest cluster env to live-DB override

### DIFF
--- a/docker-compose.dev-against-live-db.yml
+++ b/docker-compose.dev-against-live-db.yml
@@ -30,6 +30,18 @@
 #   could corrupt production-style data. Use knowingly. Same risk profile as
 #   any local-dev-against-shared-DB workflow — keep the prod portal on :3000
 #   as the stable reference and treat :3001 as the verification surface.
+#
+# Inngest env
+#   The base dev-portal service ships with zero Inngest env vars, so
+#   `GET /api/inngest` 500s with "no signing key found" the moment any
+#   feature that registers Inngest functions is exercised (e.g. the cron
+#   that drives contributor inventory sync). We forward the same Inngest
+#   cluster the live portal uses — INNGEST_EVENT_KEY, INNGEST_BASE_URL
+#   (the shared inngest:8288 container), and INNGEST_SIGNING_KEY — plus a
+#   dev-portal-specific INNGEST_SERVE_ORIGIN so sync registrations announce
+#   `http://dev-portal:3000` (Docker-DNS + internal port) instead of the
+#   live portal's hostname. INNGEST_DEV stays `0`: the Inngest container
+#   itself is the dev-mode signal; the apps just need creds to talk to it.
 
 services:
   dev-portal:
@@ -58,6 +70,15 @@ services:
       DPF_ENVIRONMENT: dev
       INSTANCE_TYPE: dev
       PROJECT_ROOT: /workspace
+      # Inngest — same cluster as the live portal (shared inngest:8288), with a
+      # dev-portal-specific serve origin so step-execution callbacks resolve
+      # via Docker DNS (`dev-portal:3000` — internal port, not the :3001 host
+      # mapping). Without these, /api/inngest 500s on every register attempt.
+      INNGEST_BASE_URL: http://inngest:8288
+      INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-deadbeefcafebabe}
+      INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-abcdef0123456789}
+      INNGEST_DEV: ${INNGEST_DEV:-0}
+      INNGEST_SERVE_ORIGIN: http://dev-portal:3000
     # Compose merges depends_on by default, so a plain block here would APPEND
     # to the base file's `dev-init` dep instead of replacing it. We don't want
     # dev-init (it's the sanitized-clone of prod→dev DB, irrelevant when we


### PR DESCRIPTION
## Summary

- The `docker-compose.dev-against-live-db.yml` override (Contributor preview on :3001 pointed at the live postgres/neo4j/qdrant stack) was missing the entire Inngest env block. `GET http://localhost:3001/api/inngest` 500s with *"no signing key found"* the moment any feature that registers Inngest functions is exercised — surfaced during Phase 7 functional verification of [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213) (contributor inventory sync).
- Forward the same Inngest cluster the live portal uses (`INNGEST_BASE_URL=http://inngest:8288`, `INNGEST_EVENT_KEY`, `INNGEST_SIGNING_KEY`, `INNGEST_DEV=0`), plus a dev-portal-specific `INNGEST_SERVE_ORIGIN=http://dev-portal:3000` — Docker-DNS hostname + the container's **internal** port (not the `:3001` host-side mapping, which nothing listens on inside the network).
- Header comment updated with a new "Inngest env" section explaining the requirement.

## Why `:3000` not `:3001` for `INNGEST_SERVE_ORIGIN`

The dev-portal container's port mapping is `3001:3000` (host:container). Next.js inside the container listens on `3000`; `3001` is only the host-side publish. Inngest's `serve()` records the origin so the Inngest worker can POST step-execution callbacks via Docker DNS — that path resolves on the container network, where the port is `3000`. Pointing it at `:3001` would announce a port nothing listens on inside the bridge.

## Verification

- **Structural (done):** `docker compose -p dpf -f docker-compose.yml -f docker-compose.dev-against-live-db.yml --profile dev config dev-portal` resolves all five Inngest vars onto the dev-portal env block.
- **Functional (deferred):** the current dev-portal container is bind-mounted to a sibling worktree's source; recreating it from here would yank the bind. The fix lands at the next natural `up -d dev-portal` from this override.

## Test plan

- [ ] Re-create dev-portal: `docker compose -p dpf -f docker-compose.yml -f docker-compose.dev-against-live-db.yml --profile dev up -d dev-portal`
- [ ] `curl http://localhost:3001/api/inngest` returns 200 (was 500).
- [ ] Inngest UI at http://localhost:8288 lists both `dpf-portal-1` and `dpf-dev-portal-1` as registered apps.
- [ ] Live portal :3000 still functions normally (no shared-state regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)