### PR TITLE
docs(kernel): replace manual overlap estimates with mechanical principle_decide scan results

### DIFF
--- a/docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md
+++ b/docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md
@@ -22,17 +22,20 @@ principlePublic: false
 authoredAt: 2026-05-18
 authoredBy: mark-bodman
 principleOverlapScan:
-  highestAlignment: 0.60
-  highestAlignmentSlug: human-in-the-loop-at-phase-boundaries
+  highestAlignment: 0.74
+  highestAlignmentSlug: never-fabricate
+  scanRunAt: 2026-05-26
   rationale: |
-    Adjacent but orthogonal. human-in-the-loop-at-phase-boundaries defines WHERE gates fire
-    (the phase boundary, not per-call); this principle defines WHAT they evaluate (evidence,
-    not producer identity). The two compose — a gate fires at a boundary AND evaluates
-    evidence. structural-verification-is-not-functional is the narrower second-closest:
-    it names what counts as evidence at the ship gate specifically, while this principle is
-    the general rule across all gates. Mechanical scan via principle_decide could not be run
-    at promotion time (MCP endpoint unreachable); estimates above are based on reading of
-    nearby principles. Recommend re-running the scan post-merge for telemetry.
+    Crosses the §4.3 ship-freely threshold of 0.70; falls below the 0.85 reject line.
+    Body includes an additivity paragraph (see "Additivity to Never Fabricate" below)
+    explaining why this principle is additive rather than redundant. Mechanical scan via
+    principle_decide ran with ringScope=[ring-2-workflow, ring-4-sandbox-prod] and returned
+    10 commandment-tier principles. Highest dimension-vector alignment was 0.74 against
+    Never Fabricate; Build Gate Mandatory at 0.70, All Changes Land via PR at 0.69, DCO
+    Sign-Off at 0.65 followed. These are dimension-vector alignments (do the candidate's
+    features point the same way as the existing principle's vector?), not semantic-redundancy
+    scores — the alignment is driven by shared dimensions (governance_compliance high,
+    evidence_density high) rather than overlapping decision moments.
 ---
 
 # Governance approves evidence, not provenance
@@ -74,6 +77,19 @@ It can appear to conflict with [`destructive-actions-require-explicit-go`](destr
 - **"Mark complete and skip the gates" as a shortcut.** This is the standing operator-forbidden move, no matter how strong the external evidence appears. The principle is to *use* the gates with the available evidence, not bypass them.
 - **Gate logic that branches on `producer` / `dispatcher` / `sourceAgent` fields.** Audit log, yes. Gate input, no.
 - **Asymmetric trust by author identity** ("Mark's commits skip review; coworker commits get full review"). This compounds in two directions: the platform stops detecting Mark's mistakes, and the coworker can never accumulate trust. Both erode the autonomy ladder.
+
+## Additivity to Never Fabricate
+
+The 2026-05-26 mechanical overlap scan (`principle_decide`, ring scope `[ring-2-workflow, ring-4-sandbox-prod]`) returned a 0.74 dimension-vector alignment against [`never-fabricate`](never-fabricate.md), crossing the §4.3 ship-freely threshold of 0.70 and triggering the additivity-paragraph requirement.
+
+The alignment is dimension-driven, not decision-moment-driven. Both principles score high on `governance_compliance` and `evidence_density` because both protect the truth substrate the platform depends on. But they bind **different decision moments**:
+
+- **Never Fabricate** binds the *producer* moment: "do not invent facts, results, or capabilities you did not actually observe." It governs what a coworker is allowed to *say*.
+- **Governance-approves-evidence-not-provenance** binds the *gate-evaluator* moment: "when a phase gate fires, evaluate the evidence presented, not who or what produced it." It governs how a *gate* is allowed to *decide*.
+
+A coworker that fabricates evidence violates Never Fabricate (the producer rule). A gate that branches on `producer === "AGT-ORCH-300"` violates this principle (the evaluator rule). The two failures occur at different layers, are detected by different audits, and are repaired by different changes. They compose: a healthy system needs both — non-fabricated evidence reaching a gate that evaluates that evidence on quality alone. Removing either makes the other insufficient.
+
+Build Gate Mandatory (0.70 in the same scan) and All Changes Land via PR Against Main (0.69) sit at similar alignment for the same dimensional reason and the same additivity logic applies.
 
 ## Why one rule, not a per-case enumeration
 

--- a/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
+++ b/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
@@ -18,18 +18,22 @@ principlePublic: false
 authoredAt: 2026-05-22
 authoredBy: mark-bodman
 principleOverlapScan:
-  highestAlignment: 0.55
-  highestAlignmentSlug: worktree-per-session
+  highestAlignment: 0.60
+  highestAlignmentSlug: never-fabricate
+  scanRunAt: 2026-05-26
   rationale: |
-    Adjacent but not redundant. worktree-per-session is a concrete physical-isolation tactic
-    at the filesystem layer; PAR is the upstream protocol that explains why such tactics are
-    needed and generalises to operator/agent, agent/agent, and session/review-pass handoffs
-    that do not touch git at all. human-in-the-loop-at-phase-boundaries is the narrowest
-    second-closest (phase-boundary approval is the canonical operator-acknowledgement
-    surface, but PAR covers handoffs that have no phase to anchor on). Mechanical scan via
-    principle_decide could not be run at promotion time (MCP endpoint unreachable); estimates
-    above are based on reading of nearby principles. Recommend re-running the scan
-    post-merge for telemetry.
+    Below the §4.3 ship-freely threshold of 0.70 — no body-paragraph additivity argument
+    required. Mechanical scan via principle_decide ran with ringScope=universal-ring and
+    returned 10 commandment-tier principles (retrieval cap reached). Highest dimension-vector
+    alignment was 0.60 against Never Fabricate; All Changes Land via PR Against Main and
+    Build Gate Mandatory tied at the same level. These are dimension-vector alignments
+    (do the candidate's features point the same way as the existing principle's vector?),
+    not semantic-redundancy scores — PAR binds a different decision moment from any of
+    those commandments (ack-before-mutate vs PR-lands-on-main / build-gate / don't-invent).
+    Core-tier principles like worktree-per-session and human-in-the-loop-at-phase-boundaries
+    were not returned in the retrieval set (the cap was reached on commandments); the
+    qualitative argument that PAR is upstream of worktree-per-session and adjacent to HITL
+    still holds and is captured in the body's Related-Principles section.
 ---
 
 # Propose, Acknowledge, Reassign (PAR)


### PR DESCRIPTION
## Summary

Follow-up to [PR #1134](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1134) (merged). At promotion time MCP was unreachable, so both new kernel pages shipped with manual `principleOverlapScan` estimates and a \"recommend re-running post-merge\" note in their rationales. MCP is back; ran the mechanical scan and replacing the estimates with real numbers.

## Scan results

| Page | Manual estimate | Mechanical scan | Action |
|---|---|---|---|
| `propose-acknowledge-reassign` | 0.55 vs worktree-per-session | **0.60** vs Never Fabricate | Below §4.3 ship-freely threshold (0.70) — frontmatter rationale updated, no body change |
| `governance-approves-evidence-not-provenance` | 0.60 vs human-in-the-loop-at-phase-boundaries | **0.74** vs Never Fabricate | Crosses §4.3 0.70 threshold — added required additivity paragraph + updated frontmatter rationale |

Both scans ran 2026-05-26 via `mcp__dpf__principle_decide` with `callingPopulation=in_platform_coworker` and the appropriate `ringScope` for each page's binding.

## Interpretation note (also recorded in both rationales)

`principle_decide` returns **dimension-vector alignment** (do the candidate's feature scores point the same way as the existing principle's vector?), not semantic-redundancy. Two principles with high alignment can still bind different decision moments — which is the case here for governance-evidence vs Never Fabricate:

- Never Fabricate is the *producer* rule (\"don't invent facts you didn't observe\")
- Governance-evidence is the *gate-evaluator* rule (\"don't branch gate logic on producer identity\")

Same dimensional shape (both score high on `governance_compliance` + `evidence_density` because both protect truth substrate), different decision moments, additive in composition. That's exactly the case §4.3's additivity-paragraph requirement was designed for.

Also noted: scan retrieval capped at 10 commandment-tier principles. Core-tier principles that the manual estimates compared against (`worktree-per-session`, `human-in-the-loop-at-phase-boundaries`) were not in the retrieval set. Their qualitative arguments still hold and remain in each page's Related-Principles section.

## Class

Documentation / kernel governance — completing the test-plan item flagged in #1134.

## Related

- Parent: [PR #1134 (merged)](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1134) — original kernel-page promotion
- Governing spec: [PR #1081 (merged)](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1081) — founder kernel evolution discipline, §4.3
- BI: BI-0DF248B4 (linked from #1134); this PR completes its post-merge follow-up

## Test plan

- [ ] Manual review of the new \"Additivity to Never Fabricate\" section on governance-approves-evidence-not-provenance — does it land as a clean §4.3-compliant additivity argument?
- [ ] Confirm frontmatter `principleOverlapScan` updates parse cleanly (YAML with `scanRunAt` ISO date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)