### PR TITLE
fix(contributor-inventory-sync): upsert ScheduledJob heartbeat

### DIFF
--- a/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   syncRunCreate: vi.fn(),
   syncRunUpdate: vi.fn(),
   snapshotCreateMany: vi.fn(),
-  scheduledJobUpdate: vi.fn(),
+  scheduledJobUpsert: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -35,9 +35,16 @@ vi.mock("@dpf/db", () => ({
       createMany: mocks.snapshotCreateMany,
     },
     scheduledJob: {
-      update: mocks.scheduledJobUpdate,
+      upsert: mocks.scheduledJobUpsert,
     },
   },
+  // Constants the runner imports from the @dpf/db barrel — the seed module
+  // re-exports them and the runner uses them to populate the upsert create
+  // branch. Mirror them here so the mocked module surface matches the real
+  // one. Values must match packages/db/src/seed-contributor-inventory.ts.
+  CONTRIBUTOR_INVENTORY_JOB_ID: "contributor-inventory-sync",
+  CONTRIBUTOR_INVENTORY_JOB_NAME: "Contributor inventory sync (platform-managed)",
+  CONTRIBUTOR_INVENTORY_SCHEDULE: "every-10-minutes",
 }));
 
 import { runContributorInventorySync, type SyncSourceReaders } from "./contributor-inventory-sync";
@@ -79,7 +86,7 @@ beforeEach(() => {
   mocks.snapshotCreateMany.mockImplementation(async ({ data }) => ({
     count: data.length,
   }));
-  mocks.scheduledJobUpdate.mockResolvedValue({});
+  mocks.scheduledJobUpsert.mockResolvedValue({});
 });
 
 describe("runContributorInventorySync", () => {
@@ -102,9 +109,17 @@ describe("runContributorInventorySync", () => {
         data: expect.objectContaining({ status: "completed" }),
       }),
     );
-    expect(mocks.scheduledJobUpdate).toHaveBeenCalledWith(
+    expect(mocks.scheduledJobUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
+        where: { jobId: "contributor-inventory-sync" },
+        create: expect.objectContaining({
+          jobId: "contributor-inventory-sync",
+          name: "Contributor inventory sync (platform-managed)",
+          schedule: "every-10-minutes",
+          lastStatus: "completed",
+          lastError: null,
+        }),
+        update: expect.objectContaining({
           lastStatus: "completed",
           lastError: null,
         }),
@@ -143,9 +158,13 @@ describe("runContributorInventorySync", () => {
     expect(result.status).toBe("failed");
     expect(result.insertedRows).toBe(0);
     expect(mocks.snapshotCreateMany).not.toHaveBeenCalled();
-    expect(mocks.scheduledJobUpdate).toHaveBeenCalledWith(
+    expect(mocks.scheduledJobUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
+        update: expect.objectContaining({
+          lastStatus: "failed",
+          lastError: expect.stringContaining("git not found"),
+        }),
+        create: expect.objectContaining({
           lastStatus: "failed",
           lastError: expect.stringContaining("git not found"),
         }),
@@ -237,9 +256,37 @@ describe("runContributorInventorySync", () => {
       readers: fakeReaders(),
     });
 
-    const updateCall = mocks.scheduledJobUpdate.mock.calls[0]?.[0];
-    expect(updateCall?.data.nextRunAt).toEqual(
-      new Date(FIXED_NOW.getTime() + 10 * 60_000),
-    );
+    const upsertCall = mocks.scheduledJobUpsert.mock.calls[0]?.[0];
+    const expectedNextRunAt = new Date(FIXED_NOW.getTime() + 10 * 60_000);
+    expect(upsertCall?.update.nextRunAt).toEqual(expectedNextRunAt);
+    expect(upsertCall?.create.nextRunAt).toEqual(expectedNextRunAt);
+  });
+
+  it("heartbeat is created if missing — upsert path populates create branch with seed-derived name + schedule", async () => {
+    // The seed helper (packages/db/src/seed-contributor-inventory.ts) is the
+    // only writer of the heartbeat row's jobId/name/schedule on fresh installs.
+    // On upgrade installs where `pnpm db seed` doesn't re-run, the row never
+    // gets created and the first cron tick used to throw P2025. The runner
+    // now uses upsert; this case locks in that the create branch carries the
+    // exact name + schedule strings the seed helper would have written, so
+    // the heartbeat row a missing-seed install ends up with is identical to
+    // a seeded one.
+    await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(mocks.scheduledJobUpsert).toHaveBeenCalledTimes(1);
+    const upsertCall = mocks.scheduledJobUpsert.mock.calls[0]?.[0];
+    expect(upsertCall?.where).toEqual({ jobId: "contributor-inventory-sync" });
+    expect(upsertCall?.create).toEqual({
+      jobId: "contributor-inventory-sync",
+      name: "Contributor inventory sync (platform-managed)",
+      schedule: "every-10-minutes",
+      lastRunAt: FIXED_NOW,
+      lastStatus: "completed",
+      lastError: null,
+      nextRunAt: new Date(FIXED_NOW.getTime() + 10 * 60_000),
+    });
   });
 });

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -25,11 +25,18 @@
 
 import { cron } from "inngest";
 
+import {
+  CONTRIBUTOR_INVENTORY_JOB_ID,
+  CONTRIBUTOR_INVENTORY_JOB_NAME,
+  CONTRIBUTOR_INVENTORY_SCHEDULE,
+} from "@dpf/db";
+
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
-// Re-exported for callers and tests; the actual implementation lives below.
-export const CONTRIBUTOR_INVENTORY_SYNC_JOB_ID = "contributor-inventory-sync";
+// Re-exported for callers and tests; mirrors the canonical seed-side constant
+// so the runner and seed cannot drift on the jobId string.
+export const CONTRIBUTOR_INVENTORY_SYNC_JOB_ID = CONTRIBUTOR_INVENTORY_JOB_ID;
 
 // Cron interval in minutes; reaper threshold is 2× this value.
 const CRON_INTERVAL_MIN = 10;
@@ -167,21 +174,37 @@ export async function runContributorInventorySync(
     },
   });
 
-  // Heartbeat update — runner-owned fields only (does not touch metadata,
-  // which is owned by Phase 4's GitHub etag persistence).
-  await prisma.scheduledJob.update({
-    where: { jobId: CONTRIBUTOR_INVENTORY_SYNC_JOB_ID },
-    data: {
+  // Heartbeat upsert — runner-owned fields only (does not touch metadata,
+  // which is owned by Phase 4's GitHub etag persistence). Upsert (not update)
+  // because upgrade installs that skip `pnpm db seed` leave the heartbeat row
+  // missing; a plain update would throw P2025 RecordNotFound on the first
+  // cron tick. Create + update branches set identical runner-owned fields;
+  // jobId/name/schedule come from the @dpf/db seed constants so the two
+  // sides cannot drift.
+  const lastError =
+    status === "failed"
+      ? Object.values(perSourceResult)
+          .map((r) => r.error)
+          .filter(Boolean)
+          .join("; ") || "all sources failed"
+      : null;
+  const nextRunAt = new Date(now.getTime() + CRON_INTERVAL_MIN * 60_000);
+  await prisma.scheduledJob.upsert({
+    where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+    create: {
+      jobId: CONTRIBUTOR_INVENTORY_JOB_ID,
+      name: CONTRIBUTOR_INVENTORY_JOB_NAME,
+      schedule: CONTRIBUTOR_INVENTORY_SCHEDULE,
       lastRunAt: now,
       lastStatus: status,
-      lastError:
-        status === "failed"
-          ? Object.values(perSourceResult)
-              .map((r) => r.error)
-              .filter(Boolean)
-              .join("; ") || "all sources failed"
-          : null,
-      nextRunAt: new Date(now.getTime() + CRON_INTERVAL_MIN * 60_000),
+      lastError,
+      nextRunAt,
+    },
+    update: {
+      lastRunAt: now,
+      lastStatus: status,
+      lastError,
+      nextRunAt,
     },
   });
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -248,3 +248,13 @@ export * from "./discovery-fingerprint-rules";
 // NFT pattern. The helper is test-only — import it directly from
 // `./discovery-fingerprint-catalog` in tests, not via the barrel.
 export * from "./discovery-fingerprint-store";
+
+// Contributor-inventory-sync ScheduledJob constants — shared between the
+// seed helper and the apps/web Inngest runner so the heartbeat row's name +
+// schedule strings cannot drift between create (seed) and create-on-miss
+// (runner upsert).
+export {
+  CONTRIBUTOR_INVENTORY_JOB_ID,
+  CONTRIBUTOR_INVENTORY_JOB_NAME,
+  CONTRIBUTOR_INVENTORY_SCHEDULE,
+} from "./seed-contributor-inventory";


### PR DESCRIPTION
## Summary

- Switch `runContributorInventorySync`'s heartbeat write from `prisma.scheduledJob.update` to `upsert`, so upgrade installs where `pnpm db seed` doesn't re-run no longer throw `P2025 RecordNotFound` on the first cron tick.
- Both branches (`create` and `update`) write identical runner-owned fields. `jobId` / `name` / `schedule` come from new `@dpf/db` re-exports of the canonical `seed-contributor-inventory.ts` constants, so the seed and runner cannot drift on those strings.
- Hotfix-class change discovered during Phase 7 functional verification of [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213).

## Why upsert, not findUnique + update

`mcp-catalog-sync.ts` (apps/web/lib/queue/functions/mcp-catalog-sync.ts:25-37) uses `findUnique` + `update`, which silently no-ops when the row is missing. That hides the same upgrade-install hole. Upsert is the correct pattern here: the runner is the only writer of the runner-owned fields, the seed helper is the only writer of `jobId/name/schedule`, and an empty heartbeat row should self-heal on the first tick rather than need a re-seed.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/queue/functions/contributor-inventory-sync.test.ts` — 10/10 pass
  - 9 existing cases rewritten to assert on `scheduledJob.upsert` (covering `create` + `update` branches)
  - New 10th case: "heartbeat is created if missing — upsert path populates create branch with seed-derived name + schedule" locks in that the create-branch payload matches the seed constants
- [x] `pnpm --filter @dpf/db exec vitest run src/seed-contributor-inventory.test.ts` — 5/5 still pass (seed helper unchanged)
- [x] Scoped typecheck (`pnpm --filter web exec tsc --noEmit` + `pnpm --filter @dpf/db exec tsc --noEmit`) — clean
- [x] DCO sign-off

## Out of scope

- `mcp-catalog-sync.ts` has the same fragility (silently no-ops vs. throwing) — leaving for a separate maintenance PR rather than expanding this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)