### PR TITLE
fix(compose): pass Inngest env cluster to dev-portal override

### DIFF
--- a/docker-compose.dev-against-live-db.yml
+++ b/docker-compose.dev-against-live-db.yml
@@ -30,6 +30,15 @@
 #   could corrupt production-style data. Use knowingly. Same risk profile as
 #   any local-dev-against-shared-DB workflow — keep the prod portal on :3000
 #   as the stable reference and treat :3001 as the verification surface.
+#
+# What this override injects
+#   - Live DB connection strings (postgres / neo4j / qdrant).
+#   - AUTH_SECRET / CREDENTIAL_ENCRYPTION_KEY from the live install so
+#     encrypted secrets decrypt correctly.
+#   - AUTH_URL / APP_URL / NEXT_PUBLIC_APP_URL pointed at :3001.
+#   - The Inngest event/serve cluster (INNGEST_DEV, INNGEST_EVENT_KEY,
+#     INNGEST_BASE_URL, INNGEST_SERVE_ORIGIN, INNGEST_SIGNING_KEY) so the
+#     dev-portal can register and serve scheduled / event-driven functions.
 
 services:
   dev-portal:
@@ -58,6 +67,22 @@ services:
       DPF_ENVIRONMENT: dev
       INSTANCE_TYPE: dev
       PROJECT_ROOT: /workspace
+      # ─── Inngest event/serve cluster ──────────────────────────────────────
+      # Without these, GET /api/inngest 500s with
+      #   "In cloud mode but no signing key found"
+      # and the dev-portal cannot register or serve scheduled / event-driven
+      # functions. The Live portal on :3000 already has these — match its
+      # values so the single in-cluster Inngest dev server (dpf-inngest-1)
+      # treats both apps consistently. INNGEST_SERVE_ORIGIN points at the
+      # dev-portal hostname inside the compose network so Inngest can call
+      # back to /api/inngest. Discovered during Phase 7 verification of
+      # BI-063BDF1B — the cron in PR #1213 cannot be functionally verified
+      # through :3001 until these env vars are set.
+      INNGEST_DEV: ${INNGEST_DEV:-0}
+      INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-deadbeefcafebabe}
+      INNGEST_BASE_URL: ${INNGEST_BASE_URL:-http://inngest:8288}
+      INNGEST_SERVE_ORIGIN: http://dev-portal:3001
+      INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-abcdef0123456789}
     # Compose merges depends_on by default, so a plain block here would APPEND
     # to the base file's `dev-init` dep instead of replacing it. We don't want
     # dev-init (it's the sanitized-clone of prod→dev DB, irrelevant when we


### PR DESCRIPTION
## Summary

Adds the Inngest event/serve cluster env vars to `docker-compose.dev-against-live-db.yml` so the Contributor preview at `:3001` can register and serve Inngest functions.

## Why

Phase 7 functional verification of [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213) surfaced this gap. The override that points dev-portal at the live DB doesn't pass through the Inngest cluster the Live portal uses. Result: `GET http://localhost:3001/api/inngest` returns 500 with `"In cloud mode but no signing key found"`, and any feature with a scheduled or event-triggered Inngest function is undriveable through `:3001`.

## What changed

`docker-compose.dev-against-live-db.yml` gains five new env vars under `dev-portal.environment`:

```yaml
INNGEST_DEV: ${INNGEST_DEV:-0}
INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-deadbeefcafebabe}
INNGEST_BASE_URL: ${INNGEST_BASE_URL:-http://inngest:8288}
INNGEST_SERVE_ORIGIN: http://dev-portal:3001
INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-abcdef0123456789}
```

The Live portal already has these (`docker exec dpf-portal-1 env | grep INNGEST` returns the same values). The only deliberate divergence is `INNGEST_SERVE_ORIGIN: http://dev-portal:3001` — Inngest needs to call back to the dev-portal's handler at that hostname inside the compose network. The header comment is expanded with a new "What this override injects" section that names the five categories of state passed to dev-portal.

## Verification

Locally restarted `dev-portal` with the override applied and confirmed:

- `GET http://localhost:3001/api/inngest` returns **401 "Unauthorized"** (was **500 "In cloud mode but no signing key found"**). 401 is correct — Inngest expects a signed request from the cluster, not an unsigned curl probe.
- `docker logs dpf-dev-portal-1` shows the Inngest serve handler responding instead of the cloud-mode crash trace.
- Live portal continues to register and serve under `INNGEST_SERVE_ORIGIN: http://portal:3000` — no cross-contamination.
- Inngest container (`dpf-inngest-1`) uses `dev_mode=false` and signs requests to both apps; routing by function id, no collision.

Local pre-commit typecheck was skipped because the diff is YAML-only.

## Related

- Surfaced by Phase 7 verification of [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213#issuecomment-4550671238) "finding (A)".
- Unblocks functional verification of Phase 5 (refresh button + MCP trigger), Phase 6 (notifications), and any future Inngest-cron feature on the Contributor preview.
- Independent of [#1219](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1219) (heartbeat upsert) — disjoint files, can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)