### PR TITLE
feat(build-studio): quiet-agent link opens the last action (BI-9A7DA4AC)

### DIFF
--- a/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
@@ -104,3 +104,46 @@ describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => 
     expect(html).toMatch(/<summary[^>]*>[^<]*Raw[^<]*<\/summary>/i);
   });
 });
+
+describe("BuildDispatchHistoryCard — open-last-attempt event (BI-9A7DA4AC)", () => {
+  it("stamps data-most-recent='true' only on the last attempt", () => {
+    const older = attempt({ id: "att-older", taskTitle: "Older task" });
+    const newer = attempt({ id: "att-newer", taskTitle: "Newer task" });
+    const { container } = render(<BuildDispatchHistoryCard attempts={[older, newer]} />);
+    const flagged = container.querySelectorAll("[data-most-recent='true']");
+    expect(flagged.length).toBe(1);
+    // The flagged row corresponds to the newer (last) attempt.
+    expect(flagged[0].textContent).toContain("Newer task");
+  });
+
+  it("opens the most-recent attempt's <details> when the open-last event fires", () => {
+    const { container } = render(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const detailsBefore = container.querySelector<HTMLDetailsElement>("[data-most-recent='true'] details");
+    expect(detailsBefore).not.toBeNull();
+    expect(detailsBefore!.open).toBe(false);
+
+    document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"));
+
+    const detailsAfter = container.querySelector<HTMLDetailsElement>("[data-most-recent='true'] details");
+    expect(detailsAfter!.open).toBe(true);
+  });
+
+  it("sets data-just-opened on the most-recent row when the event fires", () => {
+    const { container } = render(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const row = container.querySelector<HTMLElement>("[data-most-recent='true']");
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute("data-just-opened")).toBeNull();
+
+    document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"));
+
+    expect(row!.getAttribute("data-just-opened")).toBe("true");
+  });
+
+  it("is a no-op when there are zero attempts", () => {
+    const { container } = render(<BuildDispatchHistoryCard attempts={[]} />);
+    expect(() => {
+      document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"));
+    }).not.toThrow();
+    expect(container.querySelector("[data-most-recent='true']")).toBeNull();
+  });
+});

--- a/apps/web/components/build/BuildDispatchHistoryCard.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { BuildDispatchAttemptView } from "@/lib/build/dispatch-attempts";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 
@@ -7,11 +8,50 @@ type Props = {
   attempts: BuildDispatchAttemptView[];
 };
 
+/**
+ * Custom event name shared with BuildProgressOperationalPanel's quiet-agent
+ * link. Kept as a module-level string so both ends agree without a context
+ * or shared store. Per BI-9A7DA4AC + 2026-05-24 spec §6.
+ */
+const OPEN_LAST_DISPATCH_ATTEMPT_EVENT = "dpf:open-last-dispatch-attempt";
+
 export function BuildDispatchHistoryCard({ attempts }: Props) {
   const latest = attempts.at(-1) ?? null;
+  const sectionRef = useRef<HTMLElement>(null);
+
+  // Listen for the quiet-agent banner's "view last action" link. On fire, open
+  // the most-recent attempt's <details> and apply a 2s highlight via
+  // data-just-opened. No-op when the card has zero attempts. See BI-9A7DA4AC.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+    function handler() {
+      const root = sectionRef.current;
+      if (!root) return;
+      const row = root.querySelector<HTMLElement>('[data-most-recent="true"]');
+      if (!row) return;
+      const details = row.querySelector<HTMLDetailsElement>("details");
+      if (details) details.open = true;
+      row.setAttribute("data-just-opened", "true");
+      if (highlightTimer) clearTimeout(highlightTimer);
+      highlightTimer = setTimeout(() => {
+        row.removeAttribute("data-just-opened");
+        highlightTimer = null;
+      }, 2000);
+    }
+    document.addEventListener(OPEN_LAST_DISPATCH_ATTEMPT_EVENT, handler);
+    return () => {
+      document.removeEventListener(OPEN_LAST_DISPATCH_ATTEMPT_EVENT, handler);
+      if (highlightTimer) clearTimeout(highlightTimer);
+    };
+  }, []);
 
   return (
-    <section id="build-dispatch-history" className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+    <section
+      ref={sectionRef}
+      id="build-dispatch-history"
+      className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Dispatch attempts</h3>
         <TruthSourceBadge source="dispatch-history" observedAt={latest?.completedAt ?? latest?.startedAt ?? null} />
@@ -19,11 +59,16 @@ export function BuildDispatchHistoryCard({ attempts }: Props) {
       <div className="mt-3 space-y-2">
         {attempts.length === 0 ? (
           <p className="text-xs text-[var(--dpf-muted)]">No dispatch attempts recorded yet.</p>
-        ) : attempts.map((attempt) => {
+        ) : attempts.map((attempt, idx) => {
           const diagnosis = attempt.rootCauseSummary ?? attempt.failureAxis;
           const rawOutput = attempt.stdoutExcerpt ?? attempt.stderrExcerpt;
+          const isMostRecent = idx === attempts.length - 1;
           return (
-            <div key={attempt.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs">
+            <div
+              key={attempt.id}
+              data-most-recent={isMostRecent ? "true" : undefined}
+              className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-2 text-xs transition-shadow data-[just-opened=true]:ring-2 data-[just-opened=true]:ring-[var(--dpf-accent)] data-[just-opened=true]:ring-offset-2 data-[just-opened=true]:ring-offset-[var(--dpf-surface-1)]"
+            >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="font-medium text-[var(--dpf-text)]">{attempt.taskTitle}</span>
                 <span className="text-[var(--dpf-muted)]">exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}</span>

--- a/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BuildProgressOperationalPanel } from "./BuildProgressOperationalPanel";
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 
@@ -151,5 +151,38 @@ describe("BuildProgressOperationalPanel", () => {
     expect(screen.getByText("Verification")).toBeInTheDocument();
     expect(screen.getByText("Agent has been quiet for 7m")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "view last action" })).toHaveAttribute("href", "#build-dispatch-history");
+  });
+});
+
+describe("BuildProgressOperationalPanel — quiet-agent link dispatches open-last event (BI-9A7DA4AC)", () => {
+  afterEach(() => {
+    // Auto-cleanup is unreliable in this file (sibling describe leaves a
+    // rendered tree behind). Clean explicitly so getByRole sees one match.
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches dpf:open-last-dispatch-attempt and preserves anchor + scroll behavior", () => {
+    cleanup();
+    const projection = makeProjection();
+    const dispatchSpy = vi.spyOn(document, "dispatchEvent");
+    render(<BuildProgressOperationalPanel projection={projection} />);
+
+    const link = screen.getByRole("link", { name: "view last action" });
+    // Anchor href must stay so the no-JS fallback still scrolls.
+    expect(link).toHaveAttribute("href", "#build-dispatch-history");
+
+    // Click via a real MouseEvent so we can inspect defaultPrevented afterwards.
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(event);
+
+    // The click handler must NOT preventDefault — anchor scroll proceeds.
+    expect(event.defaultPrevented).toBe(false);
+
+    // The custom event must have been dispatched on document with the right name.
+    const customEvents = dispatchSpy.mock.calls
+      .map(([dispatched]) => dispatched)
+      .filter((dispatched): dispatched is CustomEvent => dispatched instanceof CustomEvent);
+    expect(customEvents.some((dispatched) => dispatched.type === "dpf:open-last-dispatch-attempt")).toBe(true);
   });
 });

--- a/apps/web/components/build/BuildProgressOperationalPanel.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.tsx
@@ -75,7 +75,21 @@ export function BuildProgressOperationalPanel({ projection }: Props) {
             <div className="mt-3 rounded border border-[var(--dpf-warning)] bg-[var(--dpf-surface-2)] px-3 py-2 text-xs text-[var(--dpf-text)]">
               Agent has been quiet for {projection.quietAgent.minutesQuiet}m
               <span className="text-[var(--dpf-muted)]"> - </span>
-              <a className="font-semibold text-[var(--dpf-accent)] underline-offset-2 hover:underline" href="#build-dispatch-history">
+              <a
+                className="font-semibold text-[var(--dpf-accent)] underline-offset-2 hover:underline"
+                href="#build-dispatch-history"
+                onClick={() => {
+                  // Layered enhancement: fire a custom event that the
+                  // BuildDispatchHistoryCard listens for and uses to open
+                  // the most-recent attempt's collapsed <details> + briefly
+                  // highlight that row. The anchor scroll behavior is
+                  // preserved — we DO NOT call preventDefault. See spec
+                  // docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md
+                  // and BI-9A7DA4AC.
+                  if (typeof document === "undefined") return;
+                  document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"));
+                }}
+              >
                 view last action
               </a>
             </div>

--- a/docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md
+++ b/docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md
@@ -1,0 +1,176 @@
+# Build Studio quiet-agent link — implementation plan (BI-9A7DA4AC)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make the "view last action" link in the Build Studio quiet-agent banner auto-open the most-recent dispatch attempt's collapsed `<details>` (added in #1097) plus briefly highlight that row, while preserving the existing anchor-scroll behavior so the no-JS fallback still works.
+
+**Architecture:** Two small component touches connected by a custom DOM event (`dpf:open-last-dispatch-attempt`). `BuildProgressOperationalPanel` dispatches the event on link click; `BuildDispatchHistoryCard` listens via a `useEffect` and reacts by opening its `<details>` for the row marked `data-most-recent="true"` and toggling a `data-just-opened="true"` attribute (auto-removed after 2 seconds) that drives a highlight ring. No projection change, no API change, no schema change.
+
+**Tech Stack:** Next.js 15 / React / TypeScript / Vitest / jsdom / pnpm.
+
+**Spec:** [`docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md`](../specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md) (BI-9A7DA4AC, EP-BUILD-STUDIO).
+
+---
+
+## Hard constraints (carried from spec §7)
+
+- No projection change in `apps/web/lib/build/progress-visibility.ts`.
+- No new API route, no Docker-log tailing (Design C is filed as a follow-on BI if Mark still wants it).
+- No schema change.
+- No new "recent activity" drawer (Design B rejected — duplicates the dispatch card).
+- The anchor scroll behavior MUST be preserved (no `preventDefault`).
+- The custom event MUST only fire from the quiet-agent link, not from anywhere else in the panel.
+- Auto-open MUST only happen on explicit user click — never on render. Older attempts stay collapsed.
+
+Scope-violation check (before push): `git diff origin/main --stat` should touch only:
+- `apps/web/components/build/BuildProgressOperationalPanel.tsx`
+- `apps/web/components/build/BuildProgressOperationalPanel.test.tsx`
+- `apps/web/components/build/BuildDispatchHistoryCard.tsx`
+- `apps/web/components/build/BuildDispatchHistoryCard.test.tsx`
+- `docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md` (already committed)
+- `docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md` (this file)
+
+---
+
+## Task 1 — Make the dispatch card listen + react
+
+**Files:**
+- Modify: `apps/web/components/build/BuildDispatchHistoryCard.tsx`
+
+**Step 1: Add `data-most-recent` flag inline.**
+
+Inside the `attempts.map((attempt, idx) => …)` block (line 22), add an `isMostRecent` const and pass it through `data-most-recent`. The row div also gains the highlight-driven attribute selector classes.
+
+**Step 2: Add the listener.**
+
+A small `useEffect` subscribed to `document.addEventListener("dpf:open-last-dispatch-attempt", …)`. On fire:
+- Use a `useRef` on the `<section>` so the query scope is the card, not the whole document (so a panel that renders two cards — unlikely, but cheap to guard — doesn't double-open).
+- Query `[data-most-recent="true"]` inside that ref. If found, set `details.open = true` on the contained `<details>` element. Also set `data-just-opened="true"` on the row, and call `setTimeout` to remove it after 2000ms. Capture the timeout id and clear it in the effect's cleanup.
+
+**Step 3: Add the highlight class.**
+
+Use Tailwind's arbitrary-attribute selector on the row div:
+`data-[just-opened=true]:ring-2 data-[just-opened=true]:ring-[var(--dpf-accent)] data-[just-opened=true]:ring-offset-2 data-[just-opened=true]:ring-offset-[var(--dpf-surface-1)]`
+
+**Step 4: Component imports.**
+
+Add `useEffect, useRef` to the React import line (`import { useEffect, useRef } from "react";` — separate line since the file currently has no React import at all).
+
+**Step 5: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+---
+
+## Task 2 — Make the quiet-agent link dispatch the event
+
+**Files:**
+- Modify: `apps/web/components/build/BuildProgressOperationalPanel.tsx` (lines 78-80)
+
+**Step 1: Add the onClick handler.**
+
+Promote the `<a>` to include `onClick={() => { … }`. The handler dispatches a `CustomEvent("dpf:open-last-dispatch-attempt")` on `document`. We do NOT call `preventDefault` — the browser anchor scroll continues.
+
+Guard with `if (typeof window === "undefined") return;` so the (server-rendered) build does not blow up if React ever calls the handler during hydration with the document undefined.
+
+**Step 2: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: clean.
+
+---
+
+## Task 3 — Tests (TDD pair — written after impl since both halves are tiny)
+
+**Files:**
+- Modify: `apps/web/components/build/BuildDispatchHistoryCard.test.tsx`
+- Modify: `apps/web/components/build/BuildProgressOperationalPanel.test.tsx`
+
+**Step 1: Card tests.**
+
+Append to the existing `describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", …)` block, OR a new sibling block `describe("BuildDispatchHistoryCard — open-last-attempt event (BI-9A7DA4AC)", …)`:
+
+- Test A: rendering the card stamps `data-most-recent="true"` on the row of the LAST attempt and not on earlier attempts.
+- Test B: dispatching `dpf:open-last-dispatch-attempt` on `document` flips the most-recent row's `<details>` `open` property to `true`.
+- Test C: dispatching the event sets `data-just-opened="true"` on the most-recent row. (Don't try to time-travel for the 2s removal — that's a setTimeout side effect and jsdom's fake timer support is overkill for this scope.)
+- Test D: dispatching the event with zero attempts in the card is a no-op (no error, no crash).
+
+Use `render` from `@testing-library/react` (already imported in this file) + the existing `attempt()` factory. Dispatch events via `document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"))`.
+
+**Step 2: Panel tests.**
+
+Inspect `BuildProgressOperationalPanel.test.tsx` to find its existing pattern, then add:
+
+- Test E: when `projection.quietAgent.quiet === true`, clicking the "view last action" link dispatches a `dpf:open-last-dispatch-attempt` event on `document` and does NOT call `preventDefault`. Use `vi.spyOn(document, "dispatchEvent")` to capture, and assert the link's default action wasn't suppressed (assert via `MouseEvent.defaultPrevented === false` after the click, or simply assert the spy was called with a `CustomEvent` of the right type).
+
+**Step 3: Run touched tests.**
+
+```bash
+pnpm --filter web exec vitest run components/build/BuildDispatchHistoryCard.test.tsx components/build/BuildProgressOperationalPanel.test.tsx
+```
+
+Expected: all new assertions pass; no existing assertions regress.
+
+**Step 4: Broader test slice.**
+
+```bash
+pnpm --filter web exec vitest run lib/build components/build
+```
+
+Expected: green.
+
+---
+
+## Task 4 — Final verification + push + PR
+
+**Step 1: Typecheck.**
+
+```bash
+pnpm --filter web typecheck
+```
+
+**Step 2: Scope-violation diff.**
+
+```bash
+git diff origin/main --stat
+```
+
+Confirm only the 6 expected files (4 code/test + 2 spec/plan docs).
+
+**Step 3: Overlap sweep.**
+
+```bash
+git fetch origin main --quiet
+git log origin/main --oneline -10 --grep="quiet.agent|BI-9A7DA4AC|view.last.action" -i
+gh pr list --state open --limit 30 --json number,title --jq '.[] | select(.title | test("quiet.agent|9A7DA4AC|view.last.action"; "i")) | .title'
+```
+
+Expected: no overlap.
+
+**Step 4: Push.**
+
+```bash
+git push -u origin claude/quiet-agent-link-last-action
+```
+
+**Step 5: Open PR.**
+
+Title: `feat(build-studio): quiet-agent link opens the last action (BI-9A7DA4AC)`
+
+Body includes spec + plan links, what changes, what stays unchanged, the two-line summary of the operator-visible behavior, the in-merge test counts, and the post-merge UX check ("trigger a quiet-agent state on a real build; click 'view last action'; the most recent dispatch attempt's Raw stdout/stderr is already expanded and the row is briefly ringed").
+
+---
+
+## Done-criteria
+
+- Single PR landing 4 file changes + spec + plan.
+- All new tests pass; no regressions.
+- Anchor-scroll fallback still works without JS (no `preventDefault` was added).
+- BI-9A7DA4AC closes on merge + post-merge UX confirmation.

--- a/docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md
+++ b/docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md
@@ -1,0 +1,171 @@
+---
+title: Build Studio quiet-agent link should open the last action, not just scroll
+date: 2026-05-24
+status: proposal — awaiting operator review
+owner: Mark Bodman (CEO) — proposed by agent
+backlog-item: BI-9A7DA4AC
+epic: EP-BUILD-STUDIO
+relates-to:
+  - docs/superpowers/plans/2026-05-18-build-studio-progress-visibility-overhaul.md (Task 6 Step 4 — original "view last action" requirement)
+  - docs/superpowers/specs/2026-05-24-build-studio-dispatch-history-root-cause-display.md (the prior slice that overhauled the dispatch history card — PR #1097)
+  - apps/web/components/build/BuildProgressOperationalPanel.tsx (renders the quiet-agent banner + link)
+  - apps/web/components/build/BuildDispatchHistoryCard.tsx (the link target — now has expandable per-attempt raw stdout/stderr after PR #1097)
+  - apps/web/lib/build/progress-visibility.ts (`quietAgent` projection)
+---
+
+# Build Studio quiet-agent link should open the last action
+
+## 1. Problem (from BI-9A7DA4AC)
+
+Live verification on 2026-05-20 against the running portal showed:
+
+- The quiet-agent banner correctly appeared on `/build?buildId=FB-71FB3A53` ("Agent has been quiet for Nm").
+- Clicking the **view last action** link inside the banner only anchor-scrolled to `#build-dispatch-history`. It did not open evidence — the operator had to manually expand any raw stdout/stderr to see what the agent last did, AND the most recent attempt was not visually distinguished from older ones.
+- The BI describes this as "did not open the last 50 [codex-cli-adapter] / [codex-dispatch] / [agentic-loop] lines retrieved from the server as required by the progress-visibility overhaul brief."
+
+## 2. Source-brief intent
+
+The 2026-05-18 progress-visibility overhaul plan (Task 6 Step 4, line 768) is explicit about what the link should do:
+
+> "The link opens the build's dispatch/activity evidence drawer, **not Docker logs**."
+
+So the brief intends *server-derived evidence already projected into the build's progress visibility view* — not portal-container-process logs. The `[codex-cli-adapter]` / `[codex-dispatch]` / `[agentic-loop]` prefixes in BI-9A7DA4AC's body are how those log lines look in the portal container's stdout, but the brief's resolution is the dispatch/activity data the build already exposes.
+
+## 3. Repo truth (verified 2026-05-24 in this worktree)
+
+- `BuildProgressOperationalPanel.tsx` lines 74-82 render the quiet-agent banner with `<a href="#build-dispatch-history">view last action</a>`. The anchor scrolls to the section but does not expand or highlight anything.
+- `BuildDispatchHistoryCard.tsx` (after PR #1097) renders each `BuildDispatchAttempt` as: header, classified-diagnosis line, model, and a collapsed `<details>` containing raw stdout/stderr. The "most recent" attempt is not visually flagged — it just sits last in the list.
+- `BuildProgressVisibility.dispatchHistory` (the projection that backs the card) is already ordered `startedAt asc`. The last item is the most recent.
+- No `BuildActivity` panel exists in the operational view yet; activity is consumed by other surfaces (chat, audit logs). It is **not** required to satisfy the brief — dispatch attempts alone carry the agent's most recent observable action.
+- There is no existing API route that tails container stdout/stderr. Reading `[codex-cli-adapter]` / `[codex-dispatch]` / `[agentic-loop]` lines literally would require Docker socket access + a stream-filter implementation — out of scope for a "small" item.
+
+## 4. Designs evaluated
+
+### Design A — Auto-expand + scroll to the most recent attempt
+
+The `view last action` link becomes a JS-handled link (still progressively enhanced — anchor-scroll fallback if JS off) that:
+
+1. Scrolls to the dispatch history card.
+2. Programmatically opens the `<details>` element of the most recent attempt's raw stdout/stderr.
+3. Briefly highlights that attempt's row so the operator sees which one was singled out.
+
+- **Pro:** Tiny diff. No new data, no new endpoints, no schema change.
+- **Pro:** Leverages the post-#1097 dispatch card directly. The operator sees the diagnosis line first and the raw output is one-click-already-open.
+- **Pro:** Falls back cleanly without JS (still scrolls).
+- **Pro:** Server-derived evidence — matches the brief's "NOT Docker logs" line.
+- **Con:** Doesn't show portal-process logs (the `[codex-cli-adapter]` literal). The BI body names those, but the source brief explicitly excludes them.
+- **Verdict:** Recommended.
+
+### Design B — New activity drawer with last 50 events
+
+Add a new "Recent activity" inline drawer beneath the quiet-agent banner that lists the last N entries from `BuildActivity` + `BuildDispatchAttempt` interleaved by timestamp. Link opens the drawer.
+
+- **Pro:** Visually richer.
+- **Con:** Requires a new component + a new projection field + new tests. "Small" item turns medium.
+- **Con:** The dispatch history card already shows the same data; a drawer is redundant.
+- **Verdict:** Reject — duplicates the dispatch history card, scope creep.
+
+### Design C — Server-process log tailing
+
+Add `/api/build/[buildId]/server-logs` that uses the Docker socket to read the portal container's stdout/stderr, filtered by build-id-tagged lines from `[codex-cli-adapter]` / `[codex-dispatch]` / `[agentic-loop]`. Render the last 50 in a panel.
+
+- **Pro:** Literal interpretation of BI body.
+- **Con:** The source brief explicitly says "NOT Docker logs."
+- **Con:** Requires reading the portal's own logs from inside the portal, which is fragile (recursive container access) and non-portable (Docker-specific).
+- **Con:** Log capture isn't structured for filter-by-build-id today; lines tagged `[codex-cli-adapter]` carry the build context only when the build is named in the line.
+- **Verdict:** Defer to a separate BI if Mark decides the literal portal-log view is worth the infrastructure cost.
+
+## 5. Recommendation
+
+Ship **Design A**. The operator-visible win is: clicking *view last action* takes you straight to the most-recent attempt's raw output with one motion, the classified diagnosis (added in PR #1097) leads, and the previous attempts stay accessible just below.
+
+If the literal portal-process-log view is still wanted after Design A ships, file a separate BI for Design C with explicit scope around the Docker-socket access and the build-tagging of log lines. Do not bundle it into this slice.
+
+## 6. Specification (Design A)
+
+### 6.1 Make the quiet-agent link interactive
+
+Modify `apps/web/components/build/BuildProgressOperationalPanel.tsx` (lines 74-82):
+
+- Promote the anchor to a clickable element that, in addition to scrolling, dispatches a custom DOM event (`dpf:open-last-dispatch-attempt`) on the document. Keep the `href="#build-dispatch-history"` so behavior with JS disabled is unchanged: the browser handles the anchor scroll natively, and the JS handler runs as a layered enhancement. We never call `preventDefault` — both the scroll and the custom event proceed.
+
+Concrete shape:
+
+```tsx
+<a
+  className="font-semibold text-[var(--dpf-accent)] underline-offset-2 hover:underline"
+  href="#build-dispatch-history"
+  onClick={() => {
+    if (typeof window === "undefined") return;
+    // Fire the custom event; the dispatch history card listens.
+    // Anchor scroll behavior is preserved (we do NOT preventDefault).
+    document.dispatchEvent(new CustomEvent("dpf:open-last-dispatch-attempt"));
+  }}
+>
+  view last action
+</a>
+```
+
+### 6.2 Make the dispatch history card listen + react
+
+Modify `apps/web/components/build/BuildDispatchHistoryCard.tsx`:
+
+**Ordering invariant (carry into the implementation):** `BuildProgressVisibility.dispatchHistory` is ordered `startedAt asc` by `getDispatchHistoryForBuild`. The last element is the most recent. The card today already encodes this assumption at line 11 (`const latest = attempts.at(-1) ?? null`). The implementation reuses the same convention — if a future change re-sorts the projection, both the card's existing `latest` lookup and this slice's "most-recent" marker must be revisited together.
+
+- Tag the most-recent attempt's row with `data-most-recent="true"` (no per-row index attribute — there is only one most-recent row, and the card already singles it out at line 11). The flag is set inline during the `attempts.map` by comparing `idx === attempts.length - 1`.
+- Add a small `useEffect` (the component is already `"use client"`) that subscribes to `dpf:open-last-dispatch-attempt` on the document and, when fired:
+  - Queries the card's DOM subtree for the `[data-most-recent="true"]` row.
+  - Finds the `<details>` element inside that row and sets its `open` property to `true`.
+  - Sets a `data-just-opened="true"` attribute on the row, and uses `setTimeout(2000)` to remove it. While present, that attribute drives a brief highlight ring via Tailwind's arbitrary-attribute selector (e.g. `data-[just-opened=true]:ring-2 data-[just-opened=true]:ring-[var(--dpf-accent)]`) so the operator can see which attempt was singled out.
+
+The component remains thin — no state machine, just a one-shot effect + a one-shot timeout. Render still works deterministically for SSR (the `data-most-recent` attribute is rendered server-side; the listener and highlight class run client-side only).
+
+### 6.3 Tests
+
+- `BuildProgressOperationalPanel.test.tsx` — assert that clicking the link does NOT call `preventDefault` (so the anchor scroll still works) AND that a `dpf:open-last-dispatch-attempt` event is dispatched on document. Use a `vi.spyOn(document, 'dispatchEvent')` style spy.
+- `BuildDispatchHistoryCard.test.tsx` — render the card, dispatch the custom event, assert the most recent attempt's `<details>` element now has `open` set to `true` (jsdom supports the open property on HTMLDetailsElement).
+- Both tests live in existing test files; no new test files needed.
+
+### 6.4 What stays unchanged
+
+- The quiet-agent threshold logic in `progress-visibility.ts`.
+- The `BuildProgressVisibility` projection shape.
+- The `BuildDispatchAttempt` schema, projection, or any API contract.
+- Dispatch history card rendering of older attempts (they remain collapsed by default).
+- The anchor scroll behavior — the URL hash still updates so the browser back/forward keeps the anchor.
+
+## 7. Non-goals (carry to follow-on BIs if surfaced during review)
+
+- Portal-process log tailing (the literal BI body ask — Design C). File a separate BI if wanted.
+- Adding a separate "Recent activity" drawer (Design B).
+- Surfacing the same `dpf:open-last-dispatch-attempt` event from anywhere else (only the quiet-agent link uses it today).
+- Streaming live attempt updates.
+- Auto-opening on render-time (only the explicit user click should open the most recent attempt; otherwise the operator's prior collapse/expand state for older attempts is preserved).
+
+## 8. Verification
+
+Per `feedback_structural_not_functional`:
+
+- Vitest on `BuildProgressOperationalPanel.test.tsx` + `BuildDispatchHistoryCard.test.tsx` — new assertions pass.
+- `pnpm --filter web typecheck` — clean.
+- On the running Live portal, with a build in a known quiet-agent state: clicking *view last action* scrolls to the dispatch history card AND the most recent attempt's raw stdout/stderr is already expanded.
+
+## 9. Migration / rollback
+
+- No schema change. No data migration.
+- Rollback is `git revert` on the two component changes.
+- No customer install impact at boot.
+
+## 10. Open decisions
+
+1. **Approve Design A?** Recommendation: yes.
+2. **File a follow-on BI for Design C (portal-process-log view)?** Recommendation: yes, but only if you (Mark) still want it after seeing Design A in action.
+3. **Use a CustomEvent vs. lift to a shared client state hook?** Recommendation: CustomEvent — simpler, decoupled, no new state library needed. The two components are siblings and not parent/child, so prop drilling isn't an option.
+
+## 11. Definition of done
+
+- Spec reviewed and accepted or revised.
+- Plan file under `docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md`.
+- Single PR landing: panel link change + card listener + tests.
+- After merge, operator triggers a quiet-agent state on a real build, clicks *view last action*, and confirms the most recent attempt's raw section auto-expands.
+- BI-9A7DA4AC closes on merge + post-merge UX confirmation.


### PR DESCRIPTION
## Summary

Closes BI-9A7DA4AC. When Build Studio's quiet-agent banner appears ("Agent has been quiet for Nm — view last action"), clicking *view last action* now:

1. Scrolls to `#build-dispatch-history` (unchanged native anchor behavior).
2. Auto-opens the most-recent dispatch attempt's collapsed `<details>` (the raw stdout/stderr drawer added in #1097).
3. Briefly highlights that row with a 2-second accent ring so the operator sees which attempt the link singled out.

Implementation is a two-component touch wired through a single custom DOM event (`dpf:open-last-dispatch-attempt`). No projection, schema, MCP, or API change.

**Spec:** [`docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md`](../blob/claude/quiet-agent-link-last-action/docs/superpowers/specs/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md)
**Plan:** [`docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md`](../blob/claude/quiet-agent-link-last-action/docs/superpowers/plans/2026-05-24-build-studio-quiet-agent-link-shows-last-action.md)

## Why not portal-process log tailing?

The BI body mentions `[codex-cli-adapter]` / `[codex-dispatch]` / `[agentic-loop]` log line prefixes (which are portal container stdout). But the 2026-05-18 progress-visibility overhaul brief that the BI cites is explicit: *"The link opens the build's dispatch/activity evidence drawer, **not Docker logs**."* This PR follows the brief. If the literal portal-process-log view is still wanted after this lands, file it as a separate BI — spec §4 (Design C) documents the cost.

## Out of scope (per spec §7)

- No projection change in `progress-visibility.ts`.
- No new API route or Docker-log tailing.
- No schema change.
- Auto-open only on explicit user click — never on render. Older attempts stay collapsed.

## Verification

- [x] `pnpm --filter web exec vitest run components/build/BuildDispatchHistoryCard.test.tsx components/build/BuildProgressOperationalPanel.test.tsx` — 12/12 green
- [x] `pnpm --filter web exec vitest run lib/build components/build` — 768/768 green
- [x] `pnpm --filter web typecheck` — clean (pre-commit hook ran on the impl commit)
- [x] `git diff origin/main --stat` — 6 expected files (4 code/test + 2 spec/plan)
- [x] Rebased onto fresh `origin/main` (picked up #1212 + #1217 cleanly)
- [x] No-JS fallback preserved (anchor scroll proceeds; click handler does NOT call preventDefault)

## Test plan (post-merge)

- [ ] Trigger a quiet-agent state on a real build (or wait for one to appear naturally). Click *view last action* in the banner. Confirm the page scrolls to the dispatch attempts card, the most recent attempt's "Raw stdout/stderr" disclosure is already open, and the row is briefly ringed with the accent color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)