### PR TITLE
feat(platform): Phase 5 — Refresh button + trigger MCP tool for contributor inventory sync

### DIFF
--- a/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
+++ b/apps/web/app/(shell)/platform/development/change-lanes/page.tsx
@@ -1,12 +1,30 @@
 import { ChangeLanesDashboard } from "@/components/platform/development/change-lanes/ChangeLanesDashboard";
+import { auth } from "@/lib/auth";
 import { loadContributorChangeLaneReadModel } from "@/lib/contributor-change-lanes/read-model";
+import { can } from "@/lib/permissions";
 
 export const dynamic = "force-dynamic";
 
 export default async function ChangeLanesPage() {
   const now = new Date();
-  const { lanes, freshness, anySourceWarmingUp, anySnapshotSourceDegraded } =
-    await loadContributorChangeLaneReadModel({ now });
+  const [session, readModel] = await Promise.all([
+    auth(),
+    loadContributorChangeLaneReadModel({ now }),
+  ]);
+  const { lanes, freshness, anySourceWarmingUp, anySnapshotSourceDegraded } = readModel;
+
+  // Admin-gating for the Refresh button mirrors `triggerBackupNowAction`'s
+  // permission check — same authority bracket. Non-admin sessions still see
+  // the dashboard (it's read-only); they just don't get the Refresh button.
+  const isAdmin =
+    session?.user != null &&
+    can(
+      {
+        platformRole: session.user.platformRole,
+        isSuperuser: session.user.isSuperuser,
+      },
+      "manage_provider_connections",
+    );
 
   return (
     <div className="mx-auto w-full max-w-[1600px] px-4 py-6">
@@ -16,6 +34,7 @@ export default async function ChangeLanesPage() {
         generatedAt={now.toISOString()}
         anySourceWarmingUp={anySourceWarmingUp}
         anySnapshotSourceDegraded={anySnapshotSourceDegraded}
+        isAdmin={isAdmin}
       />
     </div>
   );

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx
@@ -3,6 +3,8 @@ import type {
   LaneReadModelFreshnessState,
 } from "@/lib/contributor-change-lanes/read-model";
 
+import { RefreshContributorInventoryButton } from "./RefreshContributorInventoryButton";
+
 const SOURCE_LABEL: Record<LaneReadModelFreshness["source"], string> = {
   "work-capsule": "Work Capsules",
   "runtime-target": "Runtime Targets",
@@ -28,8 +30,10 @@ const SNAPSHOT_SOURCES: LaneReadModelFreshness["source"][] = [
 
 export function ChangeLaneSourceSummary({
   freshness,
+  isAdmin = false,
 }: {
   freshness: LaneReadModelFreshness[];
+  isAdmin?: boolean;
 }) {
   const byName = new Map(freshness.map((f) => [f.source, f]));
   const live = LIVE_SOURCES.map((s) => byName.get(s)).filter(
@@ -47,8 +51,9 @@ export function ChangeLaneSourceSummary({
         backgroundColor: "var(--dpf-surface-2)",
       }}
     >
-      <div className="mb-2 text-[var(--dpf-muted)] uppercase tracking-wide text-[10px]">
-        Source freshness
+      <div className="mb-2 flex items-center text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+        <span>Source freshness</span>
+        <RefreshContributorInventoryButton isAdmin={isAdmin} />
       </div>
       <SubGroup label="Live data" rows={live} />
       {live.length > 0 && snapshot.length > 0 ? (

--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -36,12 +36,14 @@ export function ChangeLanesDashboard({
   generatedAt,
   anySourceWarmingUp = false,
   anySnapshotSourceDegraded = false,
+  isAdmin = false,
 }: {
   lanes: ContributorChangeLane[];
   freshness: LaneReadModelFreshness[];
   generatedAt: string;
   anySourceWarmingUp?: boolean;
   anySnapshotSourceDegraded?: boolean;
+  isAdmin?: boolean;
 }) {
   const [tab, setTab] = useState<TabId>("active");
 
@@ -65,7 +67,7 @@ export function ChangeLanesDashboard({
         </p>
       </header>
 
-      <ChangeLaneSourceSummary freshness={freshness} />
+      <ChangeLaneSourceSummary freshness={freshness} isAdmin={isAdmin} />
 
       <div
         className="flex flex-wrap gap-1 border-b text-xs"

--- a/apps/web/components/platform/development/change-lanes/RefreshContributorInventoryButton.tsx
+++ b/apps/web/components/platform/development/change-lanes/RefreshContributorInventoryButton.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+// Phase 5 of BI-063BDF1B — admin-gated refresh button in the freshness
+// header. Server-component parent passes `isAdmin: boolean`; this returns
+// null for non-admin sessions so the surface is truly hidden, not just
+// disabled.
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+//   §"Manual refresh affordance"
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  getContributorInventorySyncStatusAction,
+  triggerContributorInventorySyncAction,
+  type ContributorInventorySyncStatus,
+} from "@/lib/actions/contributor-inventory";
+
+type ButtonState =
+  | { kind: "idle" }
+  | { kind: "dispatching" }
+  | { kind: "polling"; startedAtMs: number }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string };
+
+const POLL_INTERVAL_MS = 3_000;
+const MAX_POLL_MS = 5 * 60_000; // give up after 5 minutes — sync should complete well under this
+
+export function RefreshContributorInventoryButton({
+  isAdmin,
+}: {
+  isAdmin: boolean;
+}) {
+  const router = useRouter();
+  const [state, setState] = useState<ButtonState>({ kind: "idle" });
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearPolling = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Auto-dismiss success/error toasts after 3.5s, mirroring PromptManager's
+  // useState-only toast pattern.
+  useEffect(() => {
+    if (state.kind !== "success" && state.kind !== "error") return;
+    const timer = setTimeout(() => setState({ kind: "idle" }), 3500);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  // Cleanup polling interval on unmount.
+  useEffect(() => clearPolling, [clearPolling]);
+
+  const onClick = useCallback(async () => {
+    if (state.kind !== "idle" && state.kind !== "success" && state.kind !== "error") {
+      // Spam-click guard: ignore clicks while in-flight. The server-side
+      // concurrency: { limit: 1 } collapses repeated dispatches anyway,
+      // but the UX is clearer if the button visibly refuses.
+      return;
+    }
+    setState({ kind: "dispatching" });
+    const dispatch = await triggerContributorInventorySyncAction("refresh-button");
+    if (!dispatch.ok) {
+      setState({ kind: "error", message: dispatch.error });
+      return;
+    }
+    const startedAtMs = Date.now();
+    setState({ kind: "polling", startedAtMs });
+
+    intervalRef.current = setInterval(async () => {
+      try {
+        const status = await getContributorInventorySyncStatusAction();
+        if (!status) return; // runner hasn't created the row yet — keep polling
+        if (status.startedAt.getTime() < startedAtMs - 1_000) {
+          // The latest run is OLDER than our dispatch — the new run hasn't
+          // started yet (queued behind an in-flight cron run). Keep polling.
+          return;
+        }
+        if (isTerminal(status.status)) {
+          clearPolling();
+          if (status.status === "failed") {
+            const errMsg = extractTerminalError(status);
+            setState({ kind: "error", message: errMsg ?? "Sync failed" });
+          } else {
+            setState({ kind: "success", message: terminalSummary(status) });
+            router.refresh();
+          }
+        }
+      } catch (err) {
+        clearPolling();
+        setState({
+          kind: "error",
+          message: (err as Error).message ?? "Status check failed",
+        });
+      }
+      if (Date.now() - startedAtMs > MAX_POLL_MS) {
+        clearPolling();
+        setState({
+          kind: "error",
+          message: "Sync timed out — check the platform notifications panel",
+        });
+      }
+    }, POLL_INTERVAL_MS);
+  }, [state.kind, router, clearPolling]);
+
+  if (!isAdmin) return null;
+
+  const disabled = state.kind === "dispatching" || state.kind === "polling";
+
+  return (
+    <div className="ml-auto flex items-center gap-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label="Refresh contributor inventory now"
+        className="rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide transition-colors disabled:opacity-50"
+        style={{
+          borderColor: "var(--dpf-border)",
+          color: "var(--dpf-text)",
+          backgroundColor: "var(--dpf-surface-1)",
+        }}
+      >
+        {state.kind === "dispatching" || state.kind === "polling" ? (
+          <>
+            <span aria-hidden className="mr-1 inline-block animate-spin">
+              ⟳
+            </span>
+            Syncing…
+          </>
+        ) : (
+          "Refresh now"
+        )}
+      </button>
+      {state.kind === "success" ? (
+        <span className="text-[10px] text-[var(--dpf-success)]" role="status">
+          {state.message}
+        </span>
+      ) : null}
+      {state.kind === "error" ? (
+        <span className="text-[10px] text-[var(--dpf-error)]" role="status">
+          {state.message}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function isTerminal(s: string): boolean {
+  return s === "completed" || s === "partial" || s === "failed";
+}
+
+function terminalSummary(status: ContributorInventorySyncStatus): string {
+  const psr = (status.perSourceResult ?? {}) as Record<
+    string,
+    { ok?: boolean; count?: number }
+  >;
+  const oks = Object.values(psr).filter((s) => s?.ok).length;
+  const total = Object.keys(psr).length || 3;
+  return `Synced ${oks}/${total} sources`;
+}
+
+function extractTerminalError(
+  status: ContributorInventorySyncStatus,
+): string | null {
+  const psr = (status.perSourceResult ?? {}) as Record<
+    string,
+    { ok?: boolean; error?: string | null }
+  >;
+  const errors = Object.entries(psr)
+    .filter(([, s]) => s && s.ok === false && s.error)
+    .map(([k, s]) => `${k}: ${s.error}`);
+  return errors.length > 0 ? errors.join("; ") : null;
+}

--- a/apps/web/lib/actions/contributor-inventory.test.ts
+++ b/apps/web/lib/actions/contributor-inventory.test.ts
@@ -1,0 +1,168 @@
+// apps/web/lib/actions/contributor-inventory.test.ts
+// Phase 5 of BI-063BDF1B — server action tests.
+//
+// Cover the trigger and status actions through their permission gate,
+// Inngest dispatch, and Prisma read.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  can: vi.fn(),
+  inngestSend: vi.fn(),
+  findUnique: vi.fn(),
+  findFirst: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/lib/permissions", () => ({ can: mocks.can }));
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: { send: mocks.inngestSend },
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    contributorInventorySyncRun: {
+      findUnique: mocks.findUnique,
+      findFirst: mocks.findFirst,
+    },
+  },
+}));
+
+import {
+  getContributorInventorySyncStatusAction,
+  triggerContributorInventorySyncAction,
+} from "./contributor-inventory";
+
+const ADMIN_SESSION = {
+  user: { id: "u-admin", platformRole: "owner", isSuperuser: true },
+};
+const NON_ADMIN_SESSION = {
+  user: { id: "u-user", platformRole: "member", isSuperuser: false },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.inngestSend.mockResolvedValue({ ids: ["evt-1", "evt-2"] });
+  mocks.findUnique.mockResolvedValue(null);
+  mocks.findFirst.mockResolvedValue(null);
+});
+
+describe("triggerContributorInventorySyncAction", () => {
+  it("non-admin returns { ok: false, error: 'Unauthorized' } without dispatching", async () => {
+    mocks.auth.mockResolvedValue(NON_ADMIN_SESSION);
+    mocks.can.mockReturnValue(false);
+
+    const result = await triggerContributorInventorySyncAction();
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
+  });
+
+  it("unauthenticated session returns Unauthorized", async () => {
+    mocks.auth.mockResolvedValue(null);
+    const result = await triggerContributorInventorySyncAction();
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
+  });
+
+  it("admin dispatches the on-demand event and returns the event ids", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+
+    const result = await triggerContributorInventorySyncAction();
+
+    expect(result).toEqual({ ok: true, eventIds: ["evt-1", "evt-2"] });
+    expect(mocks.inngestSend).toHaveBeenCalledWith({
+      name: "ops/contributor-inventory-sync.run",
+      data: { triggeredBy: "ui" },
+    });
+  });
+
+  it("propagates the reason tag into triggeredBy", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+
+    await triggerContributorInventorySyncAction("refresh-button");
+
+    expect(mocks.inngestSend).toHaveBeenCalledWith({
+      name: "ops/contributor-inventory-sync.run",
+      data: { triggeredBy: "ui:refresh-button" },
+    });
+  });
+
+  it("returns ok: false with the error message when Inngest send throws", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+    mocks.inngestSend.mockRejectedValue(new Error("inngest unreachable"));
+
+    const result = await triggerContributorInventorySyncAction();
+
+    expect(result).toEqual({ ok: false, error: "inngest unreachable" });
+  });
+});
+
+describe("getContributorInventorySyncStatusAction", () => {
+  it("non-admin throws Unauthorized", async () => {
+    mocks.auth.mockResolvedValue(NON_ADMIN_SESSION);
+    mocks.can.mockReturnValue(false);
+
+    await expect(getContributorInventorySyncStatusAction()).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+
+  it("looks up by syncRunId when provided", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+    const startedAt = new Date("2026-05-27T03:00:00Z");
+    mocks.findUnique.mockResolvedValue({
+      syncRunId: "civs-1",
+      status: "completed",
+      startedAt,
+      completedAt: new Date("2026-05-27T03:00:01Z"),
+      perSourceResult: { "git-worktree": { ok: true } },
+    });
+
+    const result = await getContributorInventorySyncStatusAction("civs-1");
+
+    expect(mocks.findUnique).toHaveBeenCalledWith({ where: { syncRunId: "civs-1" } });
+    expect(mocks.findFirst).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      syncRunId: "civs-1",
+      status: "completed",
+      startedAt,
+      completedAt: new Date("2026-05-27T03:00:01Z"),
+      perSourceResult: { "git-worktree": { ok: true } },
+    });
+  });
+
+  it("falls back to most-recent run when no syncRunId given", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+    mocks.findFirst.mockResolvedValue({
+      syncRunId: "civs-latest",
+      status: "running",
+      startedAt: new Date(),
+      completedAt: null,
+      perSourceResult: {},
+    });
+
+    const result = await getContributorInventorySyncStatusAction();
+
+    expect(mocks.findFirst).toHaveBeenCalledWith({
+      orderBy: { startedAt: "desc" },
+    });
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+    expect(result?.syncRunId).toBe("civs-latest");
+    expect(result?.status).toBe("running");
+  });
+
+  it("returns null when no row matches", async () => {
+    mocks.auth.mockResolvedValue(ADMIN_SESSION);
+    mocks.can.mockReturnValue(true);
+    mocks.findUnique.mockResolvedValue(null);
+
+    const result = await getContributorInventorySyncStatusAction("does-not-exist");
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/lib/actions/contributor-inventory.ts
+++ b/apps/web/lib/actions/contributor-inventory.ts
@@ -1,0 +1,108 @@
+"use server";
+
+// apps/web/lib/actions/contributor-inventory.ts
+// Phase 5 of BI-063BDF1B — server actions backing the Refresh button
+// on /platform/development/change-lanes.
+//
+// Spec: docs/superpowers/specs/2026-05-26-contributor-inventory-sync-design.md
+//   §"Manual refresh affordance"
+//
+// Both actions are admin-gated. The trigger action sends the
+// `ops/contributor-inventory-sync.run` Inngest event, which the
+// `contributorInventorySyncOnDemand` function in
+// apps/web/lib/queue/functions/contributor-inventory-sync.ts consumes.
+// The status action is read-only and used by the client's polling loop
+// to flip the button out of in-flight state.
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { inngest } from "@/lib/queue/inngest-client";
+
+const TRIGGER_EVENT = "ops/contributor-inventory-sync.run";
+// Permission reuse: refreshing the inventory cron is a platform-admin
+// surface; same authority as the backup-trigger action.
+const REQUIRED_CAPABILITY = "manage_provider_connections" as const;
+
+async function requireContributorInventoryAdmin(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      REQUIRED_CAPABILITY,
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+}
+
+/**
+ * Refresh affordance — dispatches the on-demand Inngest event so the cron
+ * runs out-of-band. The actual `ContributorInventorySyncRun` row is created
+ * by the runner once Inngest invokes the handler; this action returns the
+ * Inngest event id so the caller can poll until the row appears.
+ */
+export async function triggerContributorInventorySyncAction(
+  reason?: string,
+): Promise<{ ok: true; eventIds: string[] } | { ok: false; error: string }> {
+  try {
+    await requireContributorInventoryAdmin();
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+  try {
+    const result = await inngest.send({
+      name: TRIGGER_EVENT,
+      data: { triggeredBy: reason ? `ui:${reason}` : "ui" },
+    });
+    return { ok: true, eventIds: result.ids };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export type ContributorInventorySyncStatus = {
+  syncRunId: string;
+  status: "running" | "completed" | "partial" | "failed";
+  startedAt: Date;
+  completedAt: Date | null;
+  perSourceResult: unknown;
+};
+
+/**
+ * Read-only status snapshot — used by the client poller to decide whether
+ * to keep the spinner spinning or flip to a terminal state. Admin-gated
+ * because exposing inventory-cron status outside admin scope leaks
+ * platform-internal state. Returns `null` if the run isn't visible yet
+ * (event was sent but the runner hasn't created the row).
+ */
+export async function getContributorInventorySyncStatusAction(
+  syncRunIdOrNull?: string,
+): Promise<ContributorInventorySyncStatus | null> {
+  await requireContributorInventoryAdmin();
+
+  // If the caller doesn't yet have a syncRunId (event just dispatched, the
+  // runner hasn't started), look up the most recent run instead.
+  const row = syncRunIdOrNull
+    ? await prisma.contributorInventorySyncRun.findUnique({
+        where: { syncRunId: syncRunIdOrNull },
+      })
+    : await prisma.contributorInventorySyncRun.findFirst({
+        orderBy: { startedAt: "desc" },
+      });
+
+  if (!row) return null;
+  return {
+    syncRunId: row.syncRunId,
+    status: row.status as ContributorInventorySyncStatus["status"],
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    perSourceResult: row.perSourceResult,
+  };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4159,6 +4159,23 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
   },
+  {
+    name: "trigger_contributor_inventory_sync",
+    description:
+      "Dispatch an on-demand contributor inventory sync (git worktrees, branches, GitHub PRs) without waiting for the 10-minute cron. Used by agents that just made an external change (pushed a branch, opened a PR) and want the /platform/development/change-lanes dashboard to reflect it on the next refresh. Returns the Inngest event id immediately; the runner creates the ContributorInventorySyncRun row asynchronously.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        reason: {
+          type: "string",
+          description: "Optional short tag propagated to the run row's triggeredBy field for audit.",
+        },
+      },
+    },
+    requiredCapability: "manage_provider_connections",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
 ];
 
 // ─── Capability Filtering ────────────────────────────────────────────────────
@@ -13804,6 +13821,32 @@ export async function executeTool(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return { success: false, error: msg, message: `get_deliberation_outcome failed: ${msg}` };
+      }
+    }
+
+    case "trigger_contributor_inventory_sync": {
+      // BI-063BDF1B Phase 5 — admin-scope handle for agents to dispatch the
+      // on-demand Inngest event. The runner is contributorInventorySyncOnDemand
+      // in apps/web/lib/queue/functions/contributor-inventory-sync.ts.
+      const reason = typeof params["reason"] === "string" ? params["reason"] : null;
+      try {
+        const { inngest } = await import("@/lib/queue/inngest-client");
+        const result = await inngest.send({
+          name: "ops/contributor-inventory-sync.run",
+          data: { triggeredBy: reason ? `mcp:${reason}` : "mcp" },
+        });
+        return {
+          success: true,
+          message: "Queued an on-demand contributor inventory sync.",
+          data: { eventIds: result.ids, status: "queued" },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          error: msg,
+          message: `trigger_contributor_inventory_sync failed: ${msg}`,
+        };
       }
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -287,6 +287,11 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   contribute_to_hive:     ["backlog_write"],
   apply_platform_update:  ["admin_write"],
 
+  // Contributor inventory sync — admin-scope on-demand trigger so agents
+  // that just pushed a branch / opened a PR can force the cron to run
+  // out-of-band rather than waiting up to 10 minutes (BI-063BDF1B Phase 5).
+  trigger_contributor_inventory_sync: ["admin_write"],
+
   // Design intelligence (read-only references)
   search_design_intelligence: ["file_read"],
   generate_design_system:     ["file_read"],


### PR DESCRIPTION
## Summary

Implements Phase 5 of [`BI-063BDF1B`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-063BDF1B) (epic `EP-REDUCTION-GEAR-ARCH`) per the spec in [#1210](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1210). Adds operator and agent affordances to refresh the contributor inventory dashboard on demand without waiting for the 10-minute cron.

Builds on [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213) (Phases 1-4) and Phase 7 functional verification ([comment on #1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213#issuecomment-4550671238)).

## What's in this PR

**User-facing — Refresh button** (rendered only for admin sessions):

- `apps/web/components/platform/development/change-lanes/RefreshContributorInventoryButton.tsx` — client component. Click flow: `dispatching` → `polling` (3s interval, 5-min cap) → on terminal `status` renders inline success toast + `router.refresh()`, or inline error with the failing source name. Spam-click guard refuses dispatches while in-flight (server-side `concurrency: { limit: 1 }` collapses anyway).
- `ChangeLaneSourceSummary.tsx` — inlines the button in the "Source freshness" header; gains `isAdmin: boolean` prop.
- `ChangeLanesDashboard.tsx` — threads `isAdmin` through.
- `page.tsx` — looks up the session, computes `isAdmin` via `can(user, "manage_provider_connections")` (same authority bracket as `triggerBackupNowAction`), and passes it to the dashboard. Non-admin sessions still see the read-only dashboard; they just don't get the Refresh button.

**Server actions** (`apps/web/lib/actions/contributor-inventory.ts`):

- `triggerContributorInventorySyncAction(reason?)` — admin-gated, dispatches `ops/contributor-inventory-sync.run` Inngest event with `triggeredBy: "ui"` or `"ui:<reason>"`.
- `getContributorInventorySyncStatusAction(syncRunId?)` — admin-gated, read-only. Looks up by syncRunId if provided; falls back to most-recent run if not (covers the race where the event was sent but the runner hasn't yet created the row).

**Agent-facing — MCP tool** (`apps/web/lib/mcp-tools.ts` + `apps/web/lib/tak/agent-grants.ts`):

- New `trigger_contributor_inventory_sync` tool — same event dispatch, optional `reason` propagated to `triggeredBy: "mcp:<reason>"`. `requiredCapability: "manage_provider_connections"`, `sideEffect: true`, grant `["admin_write"]`.

## Verification

- **Vitest (local)**: 9 new server-action cases — non-admin denial, unauth, admin happy path, reason propagation, Inngest send error, status by syncRunId, status fallback to most-recent, null fallback. **9/9 pass.** Full contributor-related suite: **62/62 pass** (7 files).
- **Pre-commit gitleaks**: clean. Pre-commit typecheck skipped locally because dev-portal-start polluted host `node_modules` workspace symlinks during Phase 7 verification (memory `dev_portal_polluted_node_modules`); CI runs fresh install and gates merge.

## What's NOT in this PR (deferred)

- **MCP-tool registration unit test.** The local node_modules pollution blocks importing `mcp-tools.ts` at test time. The catalog registration is plain structural code; CI's typecheck + kernel-gate integration tests cover it. The dispatch logic itself is exercised by the server-action test (same `inngest.send` shape).
- **Phase 6** — retention sweep + `PlatformNotification` writes for prolonged failure / stale heartbeat. Follow-up PR.
- **Phase 7 functional verification of the Refresh button** — pending merge of the two sibling fix PRs ([#1217 Inngest env](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1217) is merged; [#1220 heartbeat upsert](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1220) pending). After that the button can be driven end-to-end against `:3001`.

## Composition

- **Builds on [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213)** (Phases 1-4). `lane-projection.ts` and `types.ts` are explicitly not modified.
- **Composes with [#1217](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1217)** (dev-portal Inngest env) and [#1220](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1220) (heartbeat upsert) — both required for end-to-end functional verification through `:3001`.
- **Rebased** onto current `origin/main` after PR #1216 (marketing execution loop) landed touching the same `mcp-tools.ts` and `agent-grants.ts` files. No conflicts; clean three-way merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)