### PR TITLE
fix(self-upgrade): show real image identity instead of "Deployed: unknown"

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -47,6 +47,7 @@ const baseStatus = {
   channel: "stable",
   inMaintenanceWindow: false,
   deployedSha: null,
+  deployedShaSource: "unknown" as const,
   targetSha: null,
   isFresh: false,
   latestRun: null,
@@ -54,6 +55,7 @@ const baseStatus = {
     version: "1.0.0",
     publishedAt: "2026-05-24T00:00:00.000Z",
     gitSha: "abc1234",
+    imageVersion: null,
     note: "baseline",
   },
 } as const;

--- a/apps/web/app/api/internal/quiescence-state/route.ts
+++ b/apps/web/app/api/internal/quiescence-state/route.ts
@@ -30,7 +30,7 @@ export const dynamic = "force-dynamic";
 export async function GET() {
   try {
     const config = await getQuiescenceConfig();
-    const sha = getDeployedSha();
+    const sha = await getDeployedSha();
     return NextResponse.json(
       {
         level: config.level,

--- a/apps/web/app/api/platform/version/route.test.ts
+++ b/apps/web/app/api/platform/version/route.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/platform/version", () => ({
     version: "1.0.0",
     publishedAt: new Date("2026-05-24T00:00:00.000Z"),
     gitSha: "abc123",
+    imageVersion: { raw: "abc123", source: "git-sha" as const },
     note: "baseline",
   }),
 }));
@@ -12,7 +13,7 @@ vi.mock("@/lib/platform/version", () => ({
 import { GET } from "./route";
 
 describe("GET /api/platform/version", () => {
-  it("returns version, publishedAt, gitSha, and note as JSON", async () => {
+  it("returns version, publishedAt, gitSha, imageVersion, and note as JSON", async () => {
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -20,6 +21,7 @@ describe("GET /api/platform/version", () => {
       version: "1.0.0",
       publishedAt: "2026-05-24T00:00:00.000Z",
       gitSha: "abc123",
+      imageVersion: { raw: "abc123", source: "git-sha" },
       note: "baseline",
     });
   });

--- a/apps/web/app/api/platform/version/route.ts
+++ b/apps/web/app/api/platform/version/route.ts
@@ -15,6 +15,7 @@ export async function GET() {
       version: v.version,
       publishedAt: v.publishedAt.toISOString(),
       gitSha: v.gitSha,
+      imageVersion: v.imageVersion,
       note: v.note,
     },
     { headers: { "cache-control": "no-store" } },

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -17,11 +17,14 @@ type LatestRun = {
   createdAt: Date | string;
 };
 
+type ImageVersionSource = "git-sha" | "content-hash" | "unknown";
+
 type Props = {
   enabled: boolean;
   channel: string;
   inMaintenanceWindow: boolean;
   deployedSha: string | null;
+  deployedShaSource?: ImageVersionSource;
   targetSha: string | null;
   isFresh: boolean;
   latestRun: LatestRun | null;
@@ -31,9 +34,26 @@ type Props = {
     version: string;
     publishedAt: string;
     gitSha: string | null;
+    imageVersion?: { raw: string; source: ImageVersionSource } | null;
     note: string | null;
   };
 };
+
+function shortSha(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.length > 12 ? `${value.slice(0, 12)}…` : value;
+}
+
+function sourceLabel(source: ImageVersionSource | undefined): string {
+  switch (source) {
+    case "git-sha":
+      return "commit";
+    case "content-hash":
+      return "image hash";
+    default:
+      return "image";
+  }
+}
 
 function formatDuration(start: Date | string, end: Date | string): string {
   const ms = new Date(end).getTime() - new Date(start).getTime();
@@ -65,6 +85,7 @@ export default function SelfUpgradeClient({
   channel,
   inMaintenanceWindow,
   deployedSha,
+  deployedShaSource,
   targetSha,
   isFresh,
   latestRun,
@@ -138,9 +159,10 @@ export default function SelfUpgradeClient({
           <span className="font-mono text-[var(--dpf-text)]">
             {platformVersion.version}
           </span>
-          {platformVersion.gitSha && (
+          {(platformVersion.gitSha || platformVersion.imageVersion?.raw) && (
             <span className="ml-2 font-mono text-[var(--dpf-muted)]">
-              ({platformVersion.gitSha.slice(0, 7)})
+              ({sourceLabel(platformVersion.imageVersion?.source)}{" "}
+              {shortSha(platformVersion.gitSha ?? platformVersion.imageVersion?.raw ?? null)})
             </span>
           )}
         </div>
@@ -148,7 +170,18 @@ export default function SelfUpgradeClient({
           <>
             <div className="text-xs text-[var(--dpf-muted)]">
               <span className="font-medium text-[var(--dpf-text)]">Deployed:</span>{" "}
-              <span className="font-mono">{deployedSha ?? "unknown"}</span>
+              {deployedSha ? (
+                <>
+                  <span className="font-mono">{deployedSha}</span>
+                  {deployedShaSource && deployedShaSource !== "unknown" && (
+                    <span className="ml-2 text-[var(--dpf-muted)]">
+                      ({sourceLabel(deployedShaSource)})
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span className="font-mono">unknown</span>
+              )}
             </div>
             <div className="text-xs text-[var(--dpf-muted)]">
               <span className="font-medium text-[var(--dpf-text)]">Target:</span>{" "}
@@ -157,7 +190,15 @@ export default function SelfUpgradeClient({
             {isFresh && (
               <div className="text-xs text-[var(--dpf-success)]">Up to date</div>
             )}
-            {!isFresh && targetSha && (
+            {!isFresh && targetSha && deployedShaSource === "content-hash" && (
+              <div className="text-xs text-[var(--dpf-warning)]">
+                Image built without a git-SHA stamp; cannot compare to remote
+                target. Rebuild with{" "}
+                <span className="font-mono">scripts/build-images.ps1</span> to
+                enable freshness checks.
+              </div>
+            )}
+            {!isFresh && targetSha && deployedShaSource !== "content-hash" && (
               <div className="text-xs text-[var(--dpf-warning)]">Update available</div>
             )}
           </>

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -51,6 +51,7 @@ vi.mock("@/lib/platform/version", () => ({
     version: "1.0.0",
     publishedAt: new Date("2026-05-24T00:00:00.000Z"),
     gitSha: "abc1234",
+    imageVersion: { raw: "abc1234", source: "git-sha" as const },
     note: "baseline",
   }),
 }));
@@ -118,7 +119,7 @@ describe("getSelfUpgradeStatus – access control", () => {
   it("checks view_operations permission with user role", async () => {
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue(null);
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(false);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
@@ -141,7 +142,7 @@ describe("getSelfUpgradeStatus", () => {
   it("returns config fields, window status, sha info, and latest run", async () => {
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(true);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue("abc1234");
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("abc1234");
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue("def5678");
     vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(false);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(mockRun as never);
@@ -164,7 +165,7 @@ describe("getSelfUpgradeStatus", () => {
   it("returns isFresh=true when deployed sha matches target", async () => {
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue("def5678");
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("def5678");
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue("def5678");
     vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(true);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
@@ -178,7 +179,7 @@ describe("getSelfUpgradeStatus", () => {
   it("returns isFresh=false and skips isShaFresh when targetSha is null", async () => {
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue("abc1234");
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("abc1234");
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
 
@@ -193,7 +194,7 @@ describe("getSelfUpgradeStatus", () => {
     const disabledConfig = { ...mockConfig, enabled: false };
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(disabledConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue(null);
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
 
@@ -209,7 +210,7 @@ describe("getSelfUpgradeStatus", () => {
     };
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(windowConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue(null);
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
 
@@ -222,7 +223,7 @@ describe("getSelfUpgradeStatus", () => {
     const betaConfig = { ...mockConfig, channel: "beta" };
     vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(betaConfig as never);
     vi.mocked(SelfUpgrade.isInMaintenanceWindow).mockReturnValue(false);
-    vi.mocked(SelfUpgrade.getDeployedSha).mockReturnValue(null);
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue(null);
     vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
 

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -583,14 +583,14 @@ export async function listSelfUpgradeRuns(opts?: {
 export async function getSelfUpgradeStatus() {
   await requireOpsAccess();
 
-  const [config, latestRun, platformVersion] = await Promise.all([
+  const [config, latestRun, platformVersion, deployedSha] = await Promise.all([
     getSelfUpgradeConfig(),
     getLatestRun(),
     loadPlatformVersion(),
+    getDeployedSha(),
   ]);
 
   const inMaintenanceWindow = isInMaintenanceWindow(config);
-  const deployedSha = getDeployedSha();
   const targetSha = await resolveTargetSha(config.channel, config);
   const isFresh = targetSha ? isShaFresh(deployedSha, targetSha) : false;
 
@@ -599,6 +599,7 @@ export async function getSelfUpgradeStatus() {
     channel: config.channel,
     inMaintenanceWindow,
     deployedSha,
+    deployedShaSource: platformVersion.imageVersion?.source ?? "unknown",
     targetSha,
     isFresh,
     latestRun,
@@ -606,6 +607,7 @@ export async function getSelfUpgradeStatus() {
       version: platformVersion.version,
       publishedAt: platformVersion.publishedAt.toISOString(),
       gitSha: platformVersion.gitSha,
+      imageVersion: platformVersion.imageVersion,
       note: platformVersion.note,
     },
   };

--- a/apps/web/lib/platform/version-config.test.ts
+++ b/apps/web/lib/platform/version-config.test.ts
@@ -10,6 +10,7 @@ describe("syncPlatformVersionConfig", () => {
         version: "1.0.0",
         publishedAt: new Date("2026-05-24T00:00:00.000Z"),
         gitSha: "abc123",
+        imageVersion: { raw: "abc123", source: "git-sha" },
         note: "baseline",
       }),
       platformConfig: { upsert },

--- a/apps/web/lib/platform/version.test.ts
+++ b/apps/web/lib/platform/version.test.ts
@@ -37,11 +37,32 @@ describe("loadPlatformVersion", () => {
     expect(v.gitSha).toBe("abc1234567890abcdef1234567890abcdef12345");
   });
 
-  it("returns null gitSha when DEPLOYED_SHA is unset", async () => {
+  it("returns null gitSha when DEPLOYED_SHA is unset and image-version is absent", async () => {
     vi.stubEnv("DEPLOYED_SHA", "");
     const { loadPlatformVersion } = await import("./version");
     const v = await loadPlatformVersion();
     expect(v.gitSha).toBeNull();
+  });
+
+  it("exposes imageVersion when /app/.dpf-image-version is readable", async () => {
+    vi.stubEnv("DEPLOYED_SHA", "");
+    vi.doMock("./image-version", () => ({
+      readImageVersion: vi
+        .fn()
+        .mockResolvedValue({
+          raw: "b5cdebc05e7fefb39f3d78b42348de1e81c64bae0e2bd57632387aef9c6ab5b2",
+          source: "content-hash",
+        }),
+    }));
+    const { loadPlatformVersion } = await import("./version");
+    const v = await loadPlatformVersion();
+    expect(v.imageVersion).toEqual({
+      raw: "b5cdebc05e7fefb39f3d78b42348de1e81c64bae0e2bd57632387aef9c6ab5b2",
+      source: "content-hash",
+    });
+    // gitSha stays null because content-hash images aren't comparable.
+    expect(v.gitSha).toBeNull();
+    vi.doUnmock("./image-version");
   });
 
   it("throws a useful error for invalid semver", async () => {

--- a/apps/web/lib/platform/version.ts
+++ b/apps/web/lib/platform/version.ts
@@ -2,12 +2,25 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import { readImageVersion } from "./image-version";
+import { readImageVersion, type ImageVersion } from "./image-version";
 
 export type PlatformVersion = {
   version: string;
   publishedAt: Date;
+  /**
+   * Comparable git SHA for the running image — preferred for freshness
+   * comparison and `compare_versions` lookups. Null when the image was built
+   * without a git-SHA build arg (image-version is a content hash) and no
+   * deploy pipeline set DEPLOYED_SHA.
+   */
   gitSha: string | null;
+  /**
+   * Always populated when the running portal was built from a Dockerfile —
+   * the literal contents of /app/.dpf-image-version plus a classification.
+   * Use this for display when you want to show *some* identity even when no
+   * git SHA is available.
+   */
+  imageVersion: ImageVersion | null;
   note: string | null;
 };
 
@@ -39,6 +52,7 @@ export async function loadPlatformVersion(): Promise<PlatformVersion> {
             : image?.source === "git-sha"
               ? image.raw
               : null,
+        imageVersion: image,
         note: parsed.note ?? null,
       };
     })();

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -179,7 +179,7 @@ describe("success path", () => {
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
     mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
-    mocks.getDeployedSha.mockReturnValue("oldsha1");
+    mocks.getDeployedSha.mockResolvedValue("oldsha1");
     mocks.isShaFresh.mockReturnValue(false);
     setupQuiescenceReady();
     mocks.getLatestRun.mockResolvedValue(null);
@@ -296,7 +296,7 @@ describe("failure path", () => {
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
     mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
-    mocks.getDeployedSha.mockReturnValue("oldsha1");
+    mocks.getDeployedSha.mockResolvedValue("oldsha1");
     mocks.isShaFresh.mockReturnValue(false);
     setupQuiescenceReady();
     mocks.getLatestRun.mockResolvedValue(null);
@@ -366,7 +366,7 @@ describe("quiescence-defer path (BI-QUIESCE-010)", () => {
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
     mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
-    mocks.getDeployedSha.mockReturnValue("oldsha1");
+    mocks.getDeployedSha.mockResolvedValue("oldsha1");
     mocks.isShaFresh.mockReturnValue(false);
     mocks.getLatestRun.mockResolvedValue(null);
     mocks.createRun.mockResolvedValue({ runId: "SUR-DEFER" });

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -48,7 +48,7 @@ export async function runSelfUpgrade(
   const targetSha = await resolveTargetSha(config.channel, config);
   if (!targetSha) return { skipped: true, reason: "no-target" };
 
-  const deployedSha = getDeployedSha();
+  const deployedSha = await getDeployedSha();
   if (isShaFresh(deployedSha, targetSha)) return { skipped: true, reason: "up-to-date" };
 
   const latestRun = await getLatestRun();

--- a/apps/web/lib/self-upgrade/completion.test.ts
+++ b/apps/web/lib/self-upgrade/completion.test.ts
@@ -10,8 +10,13 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
+vi.mock("@/lib/platform/image-version", () => ({
+  readImageVersion: vi.fn(),
+}));
+
 import { prisma } from "@dpf/db";
 import { execFileSync } from "node:child_process";
+import { readImageVersion } from "@/lib/platform/image-version";
 import { getDeployedSha, shaContains, getBuildMergeSha, isFeatureBuildDeployed } from "./completion";
 
 function mockBuild(gitCommitHash: string | null): void {
@@ -25,18 +30,49 @@ function mockBuild(gitCommitHash: string | null): void {
 beforeEach(() => {
   vi.resetAllMocks();
   delete process.env.DEPLOYED_SHA;
+  vi.mocked(readImageVersion).mockResolvedValue(null);
 });
 
 // ─── getDeployedSha ──────────────────────────────────────────────────────────
 
 describe("getDeployedSha", () => {
-  it("returns null when DEPLOYED_SHA is not set", () => {
-    expect(getDeployedSha()).toBeNull();
+  it("returns null when DEPLOYED_SHA env var and image-version file are absent", async () => {
+    vi.mocked(readImageVersion).mockResolvedValue(null);
+    expect(await getDeployedSha()).toBeNull();
   });
 
-  it("returns the DEPLOYED_SHA env var value", () => {
+  it("returns the DEPLOYED_SHA env var value when set", async () => {
     process.env.DEPLOYED_SHA = "abc123def456";
-    expect(getDeployedSha()).toBe("abc123def456");
+    expect(await getDeployedSha()).toBe("abc123def456");
+  });
+
+  it("falls back to /app/.dpf-image-version (git-sha source) when env var is unset", async () => {
+    vi.mocked(readImageVersion).mockResolvedValue({
+      raw: "abcdef0123456789abcdef0123456789abcdef01",
+      source: "git-sha",
+    });
+    expect(await getDeployedSha()).toBe(
+      "abcdef0123456789abcdef0123456789abcdef01",
+    );
+  });
+
+  it("falls back to /app/.dpf-image-version (content-hash source) when env var is unset", async () => {
+    vi.mocked(readImageVersion).mockResolvedValue({
+      raw: "b5cdebc05e7fefb39f3d78b42348de1e81c64bae0e2bd57632387aef9c6ab5b2",
+      source: "content-hash",
+    });
+    expect(await getDeployedSha()).toBe(
+      "b5cdebc05e7fefb39f3d78b42348de1e81c64bae0e2bd57632387aef9c6ab5b2",
+    );
+  });
+
+  it("prefers DEPLOYED_SHA env var over image-version file", async () => {
+    process.env.DEPLOYED_SHA = "env-sha-wins";
+    vi.mocked(readImageVersion).mockResolvedValue({
+      raw: "image-sha-loses",
+      source: "git-sha",
+    });
+    expect(await getDeployedSha()).toBe("env-sha-wins");
   });
 });
 
@@ -103,7 +139,8 @@ describe("getBuildMergeSha", () => {
 // ─── isFeatureBuildDeployed ──────────────────────────────────────────────────
 
 describe("isFeatureBuildDeployed", () => {
-  it("returns false when DEPLOYED_SHA is not set", async () => {
+  it("returns false when neither DEPLOYED_SHA env nor image-version is set", async () => {
+    vi.mocked(readImageVersion).mockResolvedValue(null);
     mockBuild("abc123def456");
     expect(await isFeatureBuildDeployed("FB-TEST-001")).toBe(false);
   });

--- a/apps/web/lib/self-upgrade/completion.ts
+++ b/apps/web/lib/self-upgrade/completion.ts
@@ -1,12 +1,28 @@
 import { execFileSync } from "node:child_process";
 import { prisma } from "@dpf/db";
+import { readImageVersion } from "@/lib/platform/image-version";
 
 /**
- * SHA of the currently-running application image.
- * Populated by the deploy pipeline via environment variable.
+ * Identity of the currently-running application image.
+ *
+ * Resolution order:
+ *   1. DEPLOYED_SHA env var — set by the deploy pipeline when it has
+ *      authoritative information (the SHA it just promoted).
+ *   2. /app/.dpf-image-version — baked into the image at build time. Contains
+ *      either a 40-char git SHA (when DPF_VERSION was passed as a build arg,
+ *      e.g. via scripts/build-images.{ps1,sh}) or a 64-char content hash of
+ *      the bundled source as a fallback. Either way, the image has *some*
+ *      identity — returning that is strictly better than "unknown" for the
+ *      operator-facing self-upgrade panel.
+ *
+ * Returns null only when neither source is available (e.g. local `next dev`
+ * outside a built image).
  */
-export function getDeployedSha(): string | null {
-  return process.env.DEPLOYED_SHA ?? null;
+export async function getDeployedSha(): Promise<string | null> {
+  const envSha = process.env.DEPLOYED_SHA;
+  if (envSha && envSha.length > 0) return envSha;
+  const image = await readImageVersion();
+  return image?.raw ?? null;
 }
 
 /**
@@ -58,7 +74,7 @@ export async function getBuildMergeSha(buildId: string): Promise<string | null> 
  * ProductVersion yet.
  */
 export async function isFeatureBuildDeployed(buildId: string): Promise<boolean> {
-  const deployedSha = getDeployedSha();
+  const deployedSha = await getDeployedSha();
   if (!deployedSha) return false;
   const mergeSha = await getBuildMergeSha(buildId);
   if (!mergeSha) return false;

--- a/apps/web/lib/self-upgrade/version.test.ts
+++ b/apps/web/lib/self-upgrade/version.test.ts
@@ -4,6 +4,7 @@ import {
   buildRemoteHeadCommand,
   compareUpgradeVersions,
   getUpgradeVersionState,
+  isShaFresh,
   resolveTargetSha,
 } from "./version";
 
@@ -55,6 +56,39 @@ describe("getUpgradeVersionState", () => {
 
     expect(state.upToDate).toBe(false);
     expect(state.targetSha).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  });
+});
+
+describe("isShaFresh", () => {
+  const SHA_A = "a285216a779f794faa6bdaca95d1d60239bbc264";
+  const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  it("returns true when both sides are the same 40-char git SHA", () => {
+    expect(isShaFresh(SHA_A, SHA_A)).toBe(true);
+  });
+
+  it("returns true with case-insensitive comparison", () => {
+    expect(isShaFresh(SHA_A.toUpperCase(), SHA_A)).toBe(true);
+  });
+
+  it("returns false for two different git SHAs", () => {
+    expect(isShaFresh(SHA_A, SHA_B)).toBe(false);
+  });
+
+  it("returns false when deployedSha is null", () => {
+    expect(isShaFresh(null, SHA_A)).toBe(false);
+  });
+
+  it("returns false when deployedSha is a 64-char content hash even if prefix matches", () => {
+    // A 64-char content hash that happens to start with the same chars as a
+    // 40-char git SHA should NOT be reported as fresh — the previous prefix-
+    // based implementation would have incorrectly returned true here.
+    const contentHash = SHA_A + "0".repeat(24);
+    expect(isShaFresh(contentHash, SHA_A)).toBe(false);
+  });
+
+  it("returns false when target is not a git SHA", () => {
+    expect(isShaFresh(SHA_A, "not-a-sha")).toBe(false);
   });
 });
 

--- a/apps/web/lib/self-upgrade/version.ts
+++ b/apps/web/lib/self-upgrade/version.ts
@@ -138,6 +138,11 @@ export async function resolveTargetSha(
 
 export function isShaFresh(deployedSha: string | null, targetSha: string): boolean {
   if (!deployedSha) return false;
-  const minLen = Math.min(deployedSha.length, targetSha.length);
-  return deployedSha.slice(0, minLen) === targetSha.slice(0, minLen);
+  // Both sides must be git-SHA-shaped (40 hex chars) before declaring fresh.
+  // A 64-char content-hash image identity is not comparable to a git SHA;
+  // returning false here preserves the spec invariant that "isFresh => the
+  // running runtime is at the target commit" rather than a coincidental
+  // hex-prefix collision.
+  if (!isGitSha(deployedSha) || !isGitSha(targetSha)) return false;
+  return deployedSha.toLowerCase() === targetSha.toLowerCase();
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,12 @@ services:
       # docker-compose.linux.yml overlay instead (to http://ollama:11434).
       OLLAMA_INTERNAL_URL: ${OLLAMA_INTERNAL_URL:-http://host.docker.internal:11434}
       DEPLOYED_VERSION: ${DEPLOYED_VERSION:-}
+      # Git SHA of the running image — set by the deploy pipeline (or
+      # scripts/build-images.{ps1,sh}) to give /ops/self-upgrade a comparable
+      # identity. When unset, the portal falls back to /app/.dpf-image-version
+      # (baked at build time). See spec §4.1 of
+      # docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md.
+      DEPLOYED_SHA: ${DEPLOYED_SHA:-${DPF_VERSION:-}}
       DPF_ENVIRONMENT: production
       DPF_HOST_INSTALL_PATH: ${DPF_HOST_INSTALL_PATH:-}
       # Forwarded so scripts/backup-neo4j.sh + scripts/restore-neo4j.sh can


### PR DESCRIPTION
## Summary

- `/ops/self-upgrade` was reporting `Deployed: unknown` even though every built portal image has an identity baked into `/app/.dpf-image-version` (40-char git SHA when `DPF_VERSION` build-arg is set, 64-char content hash as fallback). The code only read `process.env.DEPLOYED_SHA` — which `docker-compose.yml` never passed through — and ignored the file.
- `getDeployedSha()` now falls back to `readImageVersion()` so the operator always sees the running image's identity. `PlatformVersion` gains `imageVersion: { raw, source }` so the UI can label it ("commit abc1234" vs "image hash abc1234") and, when the image is a content-hash build, point the operator at `scripts/build-images.ps1` to enable freshness checks instead of just saying "Update available".
- `isShaFresh` now requires both sides to be 40-char git SHAs before declaring fresh (prevents a coincidental content-hash/git-SHA prefix collision).
- `docker-compose.yml` portal env now passes `DEPLOYED_SHA: ${DEPLOYED_SHA:-${DPF_VERSION:-}}` so the deploy pipeline (or the `build-images` wrapper) flows the SHA into the runtime.

Refs: `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md` §4.1.

## Test plan

- [x] `pnpm vitest run` on the affected suites — 108 self-upgrade/version/platform tests pass (`completion.test.ts`, `version.test.ts`, `platform/version.test.ts`, `route.test.ts`, `promotions.self-upgrade.test.ts`, `self-upgrade.test.ts`).
- [x] `pnpm test` on the full `apps/web` suite — 1032 files pass, 8512 tests pass / 32 skipped / 18 todo.
- [x] `pnpm typecheck` clean.
- [ ] Operator-verified: rebuild + restart the portal locally (`scripts/build-images.ps1` then `docker compose -p dpf up -d portal portal-init`) and confirm the page now shows the running image's identity (a git SHA when stamped) and "Up to date" when it matches `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)