### PR TITLE
feat(queue): Phase 6 — retention sweep + PlatformNotification writes for contributor inventory sync

### DIFF
--- a/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
@@ -20,8 +20,15 @@ const mocks = vi.hoisted(() => ({
   syncRunUpdateMany: vi.fn(),
   syncRunCreate: vi.fn(),
   syncRunUpdate: vi.fn(),
+  syncRunFindFirst: vi.fn(),
+  syncRunFindMany: vi.fn(),
+  syncRunDeleteMany: vi.fn(),
   snapshotCreateMany: vi.fn(),
   scheduledJobUpsert: vi.fn(),
+  scheduledJobFindUnique: vi.fn(),
+  notificationFindFirst: vi.fn(),
+  notificationCreate: vi.fn(),
+  notificationUpdateMany: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -30,12 +37,21 @@ vi.mock("@dpf/db", () => ({
       updateMany: mocks.syncRunUpdateMany,
       create: mocks.syncRunCreate,
       update: mocks.syncRunUpdate,
+      findFirst: mocks.syncRunFindFirst,
+      findMany: mocks.syncRunFindMany,
+      deleteMany: mocks.syncRunDeleteMany,
     },
     contributorInventorySnapshot: {
       createMany: mocks.snapshotCreateMany,
     },
     scheduledJob: {
       upsert: mocks.scheduledJobUpsert,
+      findUnique: mocks.scheduledJobFindUnique,
+    },
+    platformNotification: {
+      findFirst: mocks.notificationFindFirst,
+      create: mocks.notificationCreate,
+      updateMany: mocks.notificationUpdateMany,
     },
   },
   // Constants the runner imports from the @dpf/db barrel — the seed module
@@ -87,6 +103,15 @@ beforeEach(() => {
     count: data.length,
   }));
   mocks.scheduledJobUpsert.mockResolvedValue({});
+  // Phase 6 — sane defaults so the heartbeat-only tests don't have to
+  // arrange the retention / notification mocks.
+  mocks.scheduledJobFindUnique.mockResolvedValue({ lastRunAt: null });
+  mocks.syncRunFindFirst.mockResolvedValue(null); // no successful runs yet
+  mocks.syncRunFindMany.mockResolvedValue([]);
+  mocks.syncRunDeleteMany.mockResolvedValue({ count: 0 });
+  mocks.notificationFindFirst.mockResolvedValue(null);
+  mocks.notificationCreate.mockResolvedValue({});
+  mocks.notificationUpdateMany.mockResolvedValue({ count: 0 });
 });
 
 describe("runContributorInventorySync", () => {
@@ -288,5 +313,261 @@ describe("runContributorInventorySync", () => {
       lastError: null,
       nextRunAt: new Date(FIXED_NOW.getTime() + 10 * 60_000),
     });
+  });
+});
+
+// ─── Phase 6 — retention sweep + PlatformNotification writes ────────────────
+
+describe("runContributorInventorySync — Phase 6 retention sweep", () => {
+  it("preserves the latest-successful run per source via syncRunId notIn, regardless of age", async () => {
+    mocks.syncRunFindFirst.mockImplementation(async ({ where }) => {
+      const path = (where.perSourceResult.path as string[])[0];
+      if (path === "git-worktree") return { syncRunId: "civs-wt-keep" };
+      if (path === "git-branch") return { syncRunId: "civs-br-keep" };
+      if (path === "github-pr") return { syncRunId: "civs-gh-keep" };
+      return null;
+    });
+    mocks.syncRunDeleteMany.mockResolvedValue({ count: 5 });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.cleanupDeletedRuns).toBe(5);
+
+    const deleteCall = mocks.syncRunDeleteMany.mock.calls[0]?.[0];
+    expect(deleteCall?.where.startedAt.lt).toEqual(
+      new Date(FIXED_NOW.getTime() - 7 * 24 * 60 * 60 * 1000),
+    );
+    const notIn = deleteCall?.where.syncRunId.notIn as string[];
+    expect(notIn.sort()).toEqual(["civs-br-keep", "civs-gh-keep", "civs-wt-keep"]);
+  });
+
+  it("retention sweep failure is caught and logged; the run still returns ok", async () => {
+    mocks.syncRunFindFirst.mockResolvedValue(null);
+    mocks.syncRunDeleteMany.mockRejectedValue(new Error("connection lost"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.cleanupDeletedRuns).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retention sweep failed"),
+      "connection lost",
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe("runContributorInventorySync — Phase 6 GitHub failure notification", () => {
+  function recentRuns(failures: number, total = 6) {
+    // Returns `total` rows; the first `failures` are failed, the rest succeeded.
+    const rows = [];
+    for (let i = 0; i < total; i++) {
+      rows.push({
+        perSourceResult: {
+          "github-pr": {
+            ok: i >= failures,
+            state: i >= failures ? "ok" : "error",
+          },
+        },
+      });
+    }
+    return rows;
+  }
+
+  it("fires a warning when GitHub failed in all 6 most-recent runs and no notification exists", async () => {
+    mocks.syncRunFindMany.mockResolvedValue(recentRuns(6));
+    mocks.notificationFindFirst.mockResolvedValue(null);
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsCreated).toBeGreaterThanOrEqual(1);
+    expect(mocks.notificationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          severity: "warning",
+          category: "contributor-inventory-github",
+          subjectId: "github-pr-sync",
+          message: expect.stringContaining("Contributor MCP card"),
+        }),
+      }),
+    );
+  });
+
+  it("is idempotent: does not duplicate an existing open warning at the same severity", async () => {
+    mocks.syncRunFindMany.mockResolvedValue(recentRuns(6));
+    mocks.notificationFindFirst.mockResolvedValueOnce({
+      id: "pn-1",
+      severity: "warning",
+    });
+    // Stale-cron notification path still null:
+    mocks.notificationFindFirst.mockResolvedValueOnce(null);
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsCreated).toBe(0);
+    expect(mocks.notificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("resolves the open notification when at least one of the most recent 6 runs succeeded", async () => {
+    mocks.syncRunFindMany.mockResolvedValue(recentRuns(5, 6)); // 5 failed, 1 succeeded
+    mocks.notificationFindFirst.mockResolvedValueOnce({
+      id: "pn-1",
+      severity: "warning",
+    });
+    mocks.notificationFindFirst.mockResolvedValueOnce(null);
+    mocks.notificationUpdateMany.mockResolvedValue({ count: 1 });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsResolved).toBeGreaterThanOrEqual(1);
+    expect(mocks.notificationUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          category: "contributor-inventory-github",
+          resolvedAt: null,
+        }),
+        data: { resolvedAt: FIXED_NOW },
+      }),
+    );
+  });
+
+  it("does NOT fire when GitHub is not-configured (no credential bound) across the recent runs", async () => {
+    mocks.syncRunFindMany.mockResolvedValue(
+      Array.from({ length: 6 }, () => ({
+        perSourceResult: {
+          "github-pr": { ok: false, state: "not-configured" },
+        },
+      })),
+    );
+    mocks.notificationFindFirst.mockResolvedValue(null);
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsCreated).toBe(0);
+    expect(mocks.notificationCreate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when fewer than 6 historical runs exist (cold-start window)", async () => {
+    mocks.syncRunFindMany.mockResolvedValue(
+      Array.from({ length: 3 }, () => ({
+        perSourceResult: { "github-pr": { ok: false } },
+      })),
+    );
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsCreated).toBe(0);
+  });
+});
+
+describe("runContributorInventorySync — Phase 6 stale-cron notification", () => {
+  it("fires a critical notification when the prior lastRunAt is >2h old (resumed-after-gap)", async () => {
+    const priorLastRunAt = new Date(FIXED_NOW.getTime() - 3 * 60 * 60 * 1000); // 3h ago
+    mocks.scheduledJobFindUnique.mockResolvedValue({ lastRunAt: priorLastRunAt });
+    mocks.notificationFindFirst.mockResolvedValue(null);
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsCreated).toBeGreaterThanOrEqual(1);
+    expect(mocks.notificationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          severity: "critical",
+          category: "contributor-inventory-cron",
+          subjectId: "contributor-inventory-sync",
+          message: expect.stringContaining("180-minute gap"),
+        }),
+      }),
+    );
+  });
+
+  it("does NOT fire when prior lastRunAt is within 2h (normal cadence)", async () => {
+    const priorLastRunAt = new Date(FIXED_NOW.getTime() - 15 * 60 * 1000); // 15min ago
+    mocks.scheduledJobFindUnique.mockResolvedValue({ lastRunAt: priorLastRunAt });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(mocks.notificationCreate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          category: "contributor-inventory-cron",
+        }),
+      }),
+    );
+    expect(result.notificationsCreated).toBe(0);
+  });
+
+  it("does NOT fire on a fresh install where lastRunAt is null", async () => {
+    mocks.scheduledJobFindUnique.mockResolvedValue({ lastRunAt: null });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(mocks.notificationCreate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          category: "contributor-inventory-cron",
+        }),
+      }),
+    );
+    expect(result.notificationsCreated).toBe(0);
+  });
+
+  it("resolves an open stale-cron notification once the gap closes (lastRunAt is now recent)", async () => {
+    const priorLastRunAt = new Date(FIXED_NOW.getTime() - 5 * 60 * 1000); // 5min ago — recent
+    mocks.scheduledJobFindUnique.mockResolvedValue({ lastRunAt: priorLastRunAt });
+    // syncRunFindMany returns empty by default — the github branch
+    // short-circuits without calling notificationFindFirst at all, so the
+    // stale-cron branch is the only consumer of the mock.
+    mocks.notificationFindFirst.mockResolvedValue({
+      id: "pn-cron-1",
+      severity: "critical",
+    });
+    mocks.notificationUpdateMany.mockResolvedValue({ count: 1 });
+
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders(),
+    });
+
+    expect(result.notificationsResolved).toBeGreaterThanOrEqual(1);
+    expect(mocks.notificationUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          category: "contributor-inventory-cron",
+          resolvedAt: null,
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -42,6 +42,17 @@ export const CONTRIBUTOR_INVENTORY_SYNC_JOB_ID = CONTRIBUTOR_INVENTORY_JOB_ID;
 const CRON_INTERVAL_MIN = 10;
 const STUCK_THRESHOLD_MS = 2 * CRON_INTERVAL_MIN * 60_000;
 
+// Phase 6 — retention + notifications. Spec §"Cleanup strategy" /
+// §"Operator notifications".
+const RETENTION_WINDOW_DAYS = 7;
+const RETENTION_WINDOW_MS = RETENTION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+const PROLONGED_FAILURE_RUN_COUNT = 6;
+const STALE_CRON_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const NOTIFICATION_GITHUB_CATEGORY = "contributor-inventory-github";
+const NOTIFICATION_CRON_CATEGORY = "contributor-inventory-cron";
+const NOTIFICATION_GITHUB_SUBJECT = "github-pr-sync";
+const NOTIFICATION_CRON_SUBJECT = "contributor-inventory-sync";
+
 export type SyncSourceKey = "git-worktree" | "git-branch" | "github-pr";
 
 export type SyncSourceResult =
@@ -73,6 +84,12 @@ export type RunSyncResult = {
   insertedRows: number;
   reaped?: number;
   durationMs: number;
+  /** Phase 6 — rows deleted by the retention sweep; undefined if cleanup failed or was skipped. */
+  cleanupDeletedRuns?: number;
+  /** Phase 6 — notifications written this run (one new row per category that flipped state). */
+  notificationsCreated?: number;
+  /** Phase 6 — notifications resolved (set resolvedAt) this run. */
+  notificationsResolved?: number;
 };
 
 export type PerSourceSummary = {
@@ -189,6 +206,13 @@ export async function runContributorInventorySync(
           .join("; ") || "all sources failed"
       : null;
   const nextRunAt = new Date(now.getTime() + CRON_INTERVAL_MIN * 60_000);
+  // Capture lastRunAt BEFORE the upsert so the stale-cron check below can
+  // see how long the previous run was ago — useful for "cron resumed after
+  // a gap" notifications.
+  const priorHeartbeat = await prisma.scheduledJob.findUnique({
+    where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
+    select: { lastRunAt: true },
+  });
   await prisma.scheduledJob.upsert({
     where: { jobId: CONTRIBUTOR_INVENTORY_JOB_ID },
     create: {
@@ -208,6 +232,49 @@ export async function runContributorInventorySync(
     },
   });
 
+  // Phase 6 — retention + notifications. Each is wrapped in its own try/catch
+  // so a cleanup or notification failure does not fail the run as a whole.
+  // Spec §"Cleanup strategy" / §"Operator notifications".
+  let cleanupDeletedRuns: number | undefined;
+  let notificationsCreated = 0;
+  let notificationsResolved = 0;
+
+  try {
+    cleanupDeletedRuns = await runRetentionSweep(now);
+  } catch (err) {
+    // Cleanup failure is logged but does not break the cron — the next tick
+    // will retry, and the read path is unaffected by stale rows.
+    console.warn(
+      "[contributor-inventory-sync] retention sweep failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    const githubResult = await syncGithubFailureNotification(now);
+    notificationsCreated += githubResult.created;
+    notificationsResolved += githubResult.resolved;
+  } catch (err) {
+    console.warn(
+      "[contributor-inventory-sync] github notification sync failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    const cronResult = await syncStaleCronNotification(
+      now,
+      priorHeartbeat?.lastRunAt ?? null,
+    );
+    notificationsCreated += cronResult.created;
+    notificationsResolved += cronResult.resolved;
+  } catch (err) {
+    console.warn(
+      "[contributor-inventory-sync] cron heartbeat notification sync failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
   return {
     syncRunId,
     status,
@@ -215,7 +282,217 @@ export async function runContributorInventorySync(
     insertedRows,
     reaped: reapStuckRuns ? reaped : undefined,
     durationMs,
+    cleanupDeletedRuns,
+    notificationsCreated,
+    notificationsResolved,
   };
+}
+
+// ─── Phase 6 helpers: retention + notifications ─────────────────────────────
+
+/**
+ * Retention sweep — delete ContributorInventorySyncRun rows older than the
+ * 7-day window EXCEPT those that are the latest-successful for any of the
+ * three snapshot sources. The schema has ON DELETE CASCADE from
+ * ContributorInventorySnapshot.syncRunId so the snapshot rows go with their
+ * run row atomically.
+ *
+ * The preservation guard defends against the "cron has been broken for
+ * >7 days" failure mode: even an ancient snapshot stays around as long as
+ * it's still the freshest the dashboard has, so the page never goes blank
+ * after a long outage. Spec §"Cleanup strategy".
+ *
+ * Returns the count of run rows actually deleted (cascade-delete on
+ * snapshot rows is implicit).
+ */
+async function runRetentionSweep(now: Date): Promise<number> {
+  const { prisma } = await import("@dpf/db");
+  const cutoff = new Date(now.getTime() - RETENTION_WINDOW_MS);
+
+  // Find the latest-successful syncRunId per source. At most three.
+  const sources: SyncSourceKey[] = ["git-worktree", "git-branch", "github-pr"];
+  const preserveSet = new Set<string>();
+  for (const source of sources) {
+    const row = await prisma.contributorInventorySyncRun.findFirst({
+      where: { perSourceResult: { path: [source, "ok"], equals: true } },
+      orderBy: { startedAt: "desc" },
+      select: { syncRunId: true },
+    });
+    if (row) preserveSet.add(row.syncRunId);
+  }
+
+  const result = await prisma.contributorInventorySyncRun.deleteMany({
+    where: {
+      startedAt: { lt: cutoff },
+      syncRunId: { notIn: Array.from(preserveSet) },
+    },
+  });
+  return result.count;
+}
+
+/**
+ * Prolonged-GitHub-failure notification.
+ *
+ * Looks at the most recent N completed runs. If the GitHub source was NOT
+ * ok in EVERY one of those runs, fire a warning notification (idempotent via
+ * the existing-row check). If GitHub was ok in ANY of those runs, resolve
+ * any open notification.
+ *
+ * The `not-configured` state (no credential bound) does NOT count as a
+ * failure — that's the normal customer-install posture. Spec
+ * §"Operator notifications" point 3.
+ *
+ * Returns the count of notifications created and resolved this run.
+ */
+async function syncGithubFailureNotification(
+  now: Date,
+): Promise<{ created: number; resolved: number }> {
+  const { prisma } = await import("@dpf/db");
+
+  const recentRuns = await prisma.contributorInventorySyncRun.findMany({
+    where: { status: { in: ["completed", "partial"] } },
+    orderBy: { startedAt: "desc" },
+    take: PROLONGED_FAILURE_RUN_COUNT,
+    select: { perSourceResult: true },
+  });
+
+  if (recentRuns.length < PROLONGED_FAILURE_RUN_COUNT) {
+    // Not enough history yet — neither fire nor resolve.
+    return { created: 0, resolved: 0 };
+  }
+
+  const allFailed = recentRuns.every((r) => {
+    const psr = (r.perSourceResult ?? {}) as Record<
+      string,
+      { ok?: boolean; state?: string }
+    >;
+    const gh = psr["github-pr"];
+    // not-configured is NOT a failure — operator hasn't connected GitHub
+    // and we should not nag them about it.
+    if (gh?.state === "not-configured") return false;
+    return gh?.ok === false;
+  });
+
+  if (allFailed) {
+    const existing = await prisma.platformNotification.findFirst({
+      where: {
+        category: NOTIFICATION_GITHUB_CATEGORY,
+        subjectId: NOTIFICATION_GITHUB_SUBJECT,
+        resolvedAt: null,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existing && existing.severity === "warning") {
+      return { created: 0, resolved: 0 }; // idempotent — same tier
+    }
+    if (existing) {
+      await prisma.platformNotification.updateMany({
+        where: {
+          category: NOTIFICATION_GITHUB_CATEGORY,
+          subjectId: NOTIFICATION_GITHUB_SUBJECT,
+          resolvedAt: null,
+        },
+        data: { resolvedAt: now },
+      });
+    }
+    await prisma.platformNotification.create({
+      data: {
+        severity: "warning",
+        category: NOTIFICATION_GITHUB_CATEGORY,
+        subjectId: NOTIFICATION_GITHUB_SUBJECT,
+        message:
+          "GitHub inventory sync has been failing for over an hour. Reconnect on the Contributor MCP card.",
+      },
+    });
+    return { created: 1, resolved: existing ? 1 : 0 };
+  }
+
+  // GitHub succeeded in at least one of the most recent N runs — resolve any
+  // open notification.
+  const resolved = await prisma.platformNotification.updateMany({
+    where: {
+      category: NOTIFICATION_GITHUB_CATEGORY,
+      subjectId: NOTIFICATION_GITHUB_SUBJECT,
+      resolvedAt: null,
+    },
+    data: { resolvedAt: now },
+  });
+  return { created: 0, resolved: resolved.count };
+}
+
+/**
+ * Stale-cron-heartbeat notification.
+ *
+ * If the previous `ScheduledJob.lastRunAt` was more than 2 hours ago, fire a
+ * critical notification — the cron resumed after a gap. If it was recent
+ * (or the heartbeat row didn't exist before this run, meaning we're on a
+ * fresh install), resolve any open notification.
+ *
+ * The check is done against the PRIOR lastRunAt captured before the upsert.
+ * That makes "cron has been silent for hours and just woke up" detectable.
+ *
+ * A truly silent cron (one that's never running) cannot fire its own
+ * notification from inside this runner — that's an external-watcher concern
+ * deliberately scoped out of this slice. Spec §"Operator notifications"
+ * point 2.
+ */
+async function syncStaleCronNotification(
+  now: Date,
+  priorLastRunAt: Date | null,
+): Promise<{ created: number; resolved: number }> {
+  const { prisma } = await import("@dpf/db");
+
+  const gapMs = priorLastRunAt ? now.getTime() - priorLastRunAt.getTime() : 0;
+  const isStale = priorLastRunAt !== null && gapMs > STALE_CRON_THRESHOLD_MS;
+
+  const existing = await prisma.platformNotification.findFirst({
+    where: {
+      category: NOTIFICATION_CRON_CATEGORY,
+      subjectId: NOTIFICATION_CRON_SUBJECT,
+      resolvedAt: null,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (isStale) {
+    if (existing && existing.severity === "critical") {
+      return { created: 0, resolved: 0 }; // idempotent
+    }
+    if (existing) {
+      await prisma.platformNotification.updateMany({
+        where: {
+          category: NOTIFICATION_CRON_CATEGORY,
+          subjectId: NOTIFICATION_CRON_SUBJECT,
+          resolvedAt: null,
+        },
+        data: { resolvedAt: now },
+      });
+    }
+    const gapMinutes = Math.round(gapMs / 60_000);
+    await prisma.platformNotification.create({
+      data: {
+        severity: "critical",
+        category: NOTIFICATION_CRON_CATEGORY,
+        subjectId: NOTIFICATION_CRON_SUBJECT,
+        message: `Contributor inventory cron resumed after a ${gapMinutes}-minute gap. Check Inngest health.`,
+      },
+    });
+    return { created: 1, resolved: existing ? 1 : 0 };
+  }
+
+  // Fresh / no-prior-run / recent — resolve any open notification.
+  if (existing) {
+    await prisma.platformNotification.updateMany({
+      where: {
+        category: NOTIFICATION_CRON_CATEGORY,
+        subjectId: NOTIFICATION_CRON_SUBJECT,
+        resolvedAt: null,
+      },
+      data: { resolvedAt: now },
+    });
+    return { created: 0, resolved: 1 };
+  }
+  return { created: 0, resolved: 0 };
 }
 
 function summarize(res: SyncSourceResult): PerSourceSummary {


### PR DESCRIPTION
## Summary

Implements Phase 6 of [`BI-063BDF1B`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-063BDF1B) (epic `EP-REDUCTION-GEAR-ARCH`) per the spec in [#1210](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1210). Adds three behaviors after the heartbeat upsert, each wrapped in its own try/catch so a single failure doesn't break the run.

Builds on [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213) (Phases 1-4) and [#1220](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1220) (heartbeat upsert).

## What's in this PR

**1. Retention sweep (`runRetentionSweep`)**

Deletes `ContributorInventorySyncRun` rows older than the 7-day window EXCEPT those that are the latest-successful for any of the three snapshot sources. Schema's `ON DELETE CASCADE` from `ContributorInventorySnapshot.syncRunId` handles the row payload atomically.

Defends against the "cron broken >7 days" failure mode: even an ancient snapshot stays around as long as it's still the freshest the dashboard has, so the page never goes blank after a long outage.

**2. Prolonged-GitHub-failure notification (`syncGithubFailureNotification`)**

Looks at the most recent 6 completed runs. If GitHub failed in ALL of them, upserts a `warning` `PlatformNotification` (`category: "contributor-inventory-github"`, `subjectId: "github-pr-sync"`). Idempotent at same severity (no-op), resolves the open notification when GitHub succeeds in any of the 6 recent runs. Skipped when fewer than 6 historical runs exist (cold-start window). **The `not-configured` state (no credential bound) is explicitly NOT a failure** — that's the normal customer-install posture, no nag.

**3. Stale-cron-resumed notification (`syncStaleCronNotification`)**

Captures the prior `ScheduledJob.lastRunAt` BEFORE the heartbeat upsert. If the gap is >2 hours, upserts a `critical` notification (`category: "contributor-inventory-cron"`). Idempotent same-severity, resolves on close. **This is "cron resumed after a gap"** — a truly silent cron cannot fire from inside the runner. External-watcher detection of never-running is deliberately scoped out of this slice.

**Observability:** `RunSyncResult` gains three optional fields — `cleanupDeletedRuns`, `notificationsCreated`, `notificationsResolved`.

## What's NOT in this PR (deferred)

- Phase 7: end-to-end functional verification of these helpers against `:3001` — pending merge of [#1224](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1224) (Phase 5 Refresh button) so the cron can be operator-triggered for tests.
- Phase 8: delete `runners-node.ts` — follow-up PR after one rollback window.
- External-watcher for truly-silent-cron — would need to live in a separate cron (e.g., extend `discovery-poll` or add a small health watcher); out of this scope.

## Verification

- **Vitest (local)**: 11 new runner cases for retention + notifications. Existing 10 heartbeat cases pass unchanged. Full contributor-related suite: **65/65 pass** (6 files).
- **Pre-commit gitleaks**: clean. Pre-commit typecheck skipped locally because dev-portal-start polluted host `node_modules` workspace symlinks during Phase 7 verification (memory `dev_portal_polluted_node_modules`); CI runs fresh install and gates merge.

## Composition

- **Builds on [#1213](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1213) + [#1220](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1220).**
- **Independent of [#1224](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1224)** (Phase 5 Refresh button) — disjoint files (#1224 touches server actions / button / MCP tool; this PR touches the runner only). Both can merge in any order.
- `lane-projection.ts` and `types.ts` continue to be untouched by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)