### PR TITLE
fix(marketing): wire linkedin-personal-social into count + coverage tests (post-#1231)

### DIFF
--- a/apps/web/lib/actions/connection-catalog.test.ts
+++ b/apps/web/lib/actions/connection-catalog.test.ts
@@ -74,8 +74,8 @@ describe("getConnectionCatalog", () => {
   it("aggregates MCP, native, and built-in entries into separate sections", async () => {
     const result = await getConnectionCatalog({ query: "" });
 
-    expect(result.totalCount).toBe(12);
-    expect(result.counts).toEqual({ mcp: 1, native: 10, builtIn: 1 });
+    expect(result.totalCount).toBe(13);
+    expect(result.counts).toEqual({ mcp: 1, native: 11, builtIn: 1 });
     expect(result.sections.map((section) => section.title)).toEqual([
       "MCP Catalog",
       "Native Integrations",

--- a/apps/web/lib/actions/tool-marketplace-readiness.test.ts
+++ b/apps/web/lib/actions/tool-marketplace-readiness.test.ts
@@ -119,10 +119,10 @@ describe("getToolMarketplaceReadiness", () => {
     const result = await getToolMarketplaceReadiness({ agentId: "coo" });
 
     expect(result.summary).toMatchObject({
-      total: 15,
+      total: 16,
       ready: 3,
       available: 1,
-      needsSetup: 8,
+      needsSetup: 9,
       needsGrant: 3,
       blocked: 0,
     });

--- a/apps/web/lib/tools/integration-coverage-matrix.ts
+++ b/apps/web/lib/tools/integration-coverage-matrix.ts
@@ -340,6 +340,28 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     notes: "Campaign context needs consent and customer-record boundaries before write-back.",
   },
   {
+    id: "linkedin-personal-social",
+    productName: "LinkedIn (personal publishing)",
+    provider: "LinkedIn",
+    kind: "native",
+    nativeIntegrationId: "linkedin-personal-social",
+    category: "Social Publishing",
+    employeeRoles: ["marketer", "owner_operator"],
+    taxonomyNodeIds: [
+      "for_employees/sales_and_marketing/marketing_and_advertising",
+    ],
+    dpfSurfaces: ["/customer/marketing", "/platform/tools/integrations/linkedin-personal-social"],
+    coworkerIds: ["marketing-specialist"],
+    posture: "integration-led",
+    maturity: "write-back",
+    csdmDomain: "application-service",
+    it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
+    nextBacklogItemId: "BI-FBC9BA03",
+    replacementCriteria:
+      "Conduit-only personal publishing; operator brings their own LinkedIn developer app and credentials.",
+    notes: "Phase 2 of the marketing execution loop. Scope w_member_social only; no company-page write, no ads.",
+  },
+  {
     id: "xero-accounting-benchmark",
     productName: "Xero",
     provider: "Xero",


### PR DESCRIPTION
## Summary

PR #1231 (Phase 2 marketing execution loop) added the \`linkedin-personal-social\` native integration descriptor but the snapshot test fixes didn't land in the same commit window before auto-merge — main is currently red on three unit tests that hardcode the native-integration count or iterate every \`NATIVE_INTEGRATIONS\` entry.

- \`connection-catalog.test.ts\`: totalCount 12 → 13, native 10 → 11.
- \`tool-marketplace-readiness.test.ts\`: total 15 → 16, needsSetup 8 → 9 (new entry is unconfigured + marketing_write grant required which the test fixture's coo agent lacks; same bucket).
- \`integration-coverage-matrix.ts\`: new coverage row for \`linkedin-personal-social\` pointing at /customer/marketing + Phase 2 BI, posture integration-led, maturity write-back, csdmDomain application-service.

## Test plan

- [x] 48/48 affected tests passing locally
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)