### PR TITLE
feat(mcp): list_all_capability_needs governance-scope tool (BI-F9E7B780)

### DIFF
--- a/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
+++ b/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
@@ -37,12 +37,45 @@ vi.mock("@/lib/coworker-self-assessment/assessment-service", () => ({
   }),
 }));
 
+vi.mock("@/lib/coworker-self-assessment/review-service", () => ({
+  getCoworkerCapabilityNeedReview: vi.fn().mockResolvedValue({
+    summary: {
+      total: 2,
+      byStatus: { submitted: 2 },
+      bySeverity: { high: 1, medium: 1 },
+      byKind: { tool: 1, skill: 1 },
+    },
+    filterOptions: {
+      statuses: ["submitted", "triaged"],
+      severities: ["high", "medium"],
+      kinds: ["tool", "skill"],
+    },
+    needs: [
+      {
+        needId: "CWN-000001",
+        agentId: "AGT-WS-MARKETING",
+        status: "submitted",
+        kind: "tool",
+        severity: "high",
+      },
+      {
+        needId: "CWN-000002",
+        agentId: "AGT-WS-FINANCE",
+        status: "submitted",
+        kind: "skill",
+        severity: "medium",
+      },
+    ],
+  }),
+}));
+
 import { getToolMarketplaceReadiness } from "@/lib/actions/tool-marketplace-readiness";
 import {
   listCoworkerCapabilityNeeds,
   submitCoworkerSelfAssessment,
 } from "@/lib/coworker-self-assessment/assessment-service";
-import { executeTool, getAvailableTools } from "./mcp-tools";
+import { getCoworkerCapabilityNeedReview } from "@/lib/coworker-self-assessment/review-service";
+import { executeTool, getAvailableTools, PLATFORM_TOOLS } from "./mcp-tools";
 
 describe("coworker self-assessment tools", () => {
   const platformUser = {
@@ -299,5 +332,114 @@ describe("coworker self-assessment tools", () => {
     expect(result.data).toEqual({
       needs: [{ needId: "CWN-000001", status: "submitted", kind: "tool" }],
     });
+  });
+});
+
+describe("list_all_capability_needs (BI-F9E7B780)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is registered in PLATFORM_TOOLS with read-only governance shape", () => {
+    const tool = PLATFORM_TOOLS.find(
+      (t) => t.name === "list_all_capability_needs",
+    );
+    expect(tool).toBeDefined();
+    expect(tool?.requiredCapability).toBe("view_platform");
+    expect(tool?.sideEffect).toBe(false);
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+    expect(tool?.inputSchema.properties?.agentId).toBeDefined();
+    expect(tool?.inputSchema.required ?? []).toEqual([]);
+  });
+
+  it("returns the all-coworker rollup with no filters (no agentId scoping)", async () => {
+    const result = await executeTool(
+      "list_all_capability_needs",
+      {},
+      "user-1",
+    );
+
+    expect(getCoworkerCapabilityNeedReview).toHaveBeenCalledWith({
+      agentId: undefined,
+      status: undefined,
+      kind: undefined,
+      severity: undefined,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.summary).toEqual({
+      total: 2,
+      byStatus: { submitted: 2 },
+      bySeverity: { high: 1, medium: 1 },
+      byKind: { tool: 1, skill: 1 },
+    });
+    expect(result.data?.needs).toHaveLength(2);
+    expect(result.message).toContain("2 capability needs across all coworkers");
+  });
+
+  it("passes filters through to the review-service helper", async () => {
+    await executeTool(
+      "list_all_capability_needs",
+      {
+        agentId: "AGT-WS-FINANCE",
+        status: "submitted",
+        kind: "skill",
+        severity: "medium",
+      },
+      "user-1",
+    );
+
+    expect(getCoworkerCapabilityNeedReview).toHaveBeenCalledWith({
+      agentId: "AGT-WS-FINANCE",
+      status: "submitted",
+      kind: "skill",
+      severity: "medium",
+    });
+  });
+
+  it("drops unknown enum values silently (mirrors list_my_capability_needs)", async () => {
+    await executeTool(
+      "list_all_capability_needs",
+      {
+        status: "not-a-real-status",
+        kind: "garbage",
+        severity: "extremely-spicy",
+      },
+      "user-1",
+    );
+
+    expect(getCoworkerCapabilityNeedReview).toHaveBeenCalledWith({
+      agentId: undefined,
+      status: undefined,
+      kind: undefined,
+      severity: undefined,
+    });
+  });
+
+  it("uses the singular 'need' wording when total is 1", async () => {
+    vi.mocked(getCoworkerCapabilityNeedReview).mockResolvedValueOnce({
+      summary: { total: 1, byStatus: {}, bySeverity: {}, byKind: {} },
+      filterOptions: { statuses: [], severities: [], kinds: [] },
+      needs: [],
+    });
+
+    const result = await executeTool(
+      "list_all_capability_needs",
+      {},
+      "user-1",
+    );
+
+    expect(result.message).toContain("1 capability need across");
+    expect(result.message).not.toContain("needs across");
+  });
+
+  it("does NOT require a coworker context (the all-coworker variant is governance-scoped, not agent-scoped)", async () => {
+    // Note: no agentId in context — should not call requireCurrentCoworker.
+    const result = await executeTool(
+      "list_all_capability_needs",
+      {},
+      "user-1",
+      undefined,
+    );
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
+++ b/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
@@ -38,16 +38,20 @@ vi.mock("@/lib/coworker-self-assessment/assessment-service", () => ({
 }));
 
 vi.mock("@/lib/coworker-self-assessment/review-service", () => ({
+  // Severities mirror the canonical COWORKER_CAPABILITY_NEED_SEVERITIES enum
+  // ("blocker" | "important" | "minor") from
+  // apps/web/lib/coworker-self-assessment/types.ts — anything else would be
+  // filtered out by the validator in mcp-tools.ts.
   getCoworkerCapabilityNeedReview: vi.fn().mockResolvedValue({
     summary: {
       total: 2,
       byStatus: { submitted: 2 },
-      bySeverity: { high: 1, medium: 1 },
+      bySeverity: { blocker: 1, important: 1 },
       byKind: { tool: 1, skill: 1 },
     },
     filterOptions: {
-      statuses: ["submitted", "triaged"],
-      severities: ["high", "medium"],
+      statuses: ["submitted", "reviewing"],
+      severities: ["blocker", "important", "minor"],
       kinds: ["tool", "skill"],
     },
     needs: [
@@ -56,14 +60,14 @@ vi.mock("@/lib/coworker-self-assessment/review-service", () => ({
         agentId: "AGT-WS-MARKETING",
         status: "submitted",
         kind: "tool",
-        severity: "high",
+        severity: "blocker",
       },
       {
         needId: "CWN-000002",
         agentId: "AGT-WS-FINANCE",
         status: "submitted",
         kind: "skill",
-        severity: "medium",
+        severity: "important",
       },
     ],
   }),
@@ -348,8 +352,15 @@ describe("list_all_capability_needs (BI-F9E7B780)", () => {
     expect(tool?.requiredCapability).toBe("view_platform");
     expect(tool?.sideEffect).toBe(false);
     expect(tool?.annotations?.readOnlyHint).toBe(true);
-    expect(tool?.inputSchema.properties?.agentId).toBeDefined();
-    expect(tool?.inputSchema.required ?? []).toEqual([]);
+    // ToolDefinition.inputSchema is typed as Record<string, unknown>, so the
+    // nested `properties` and `required` keys need a narrow cast before
+    // indexing. We treat the shape locally as a minimal JSON-Schema-ish
+    // object — same approach the runtime code takes elsewhere.
+    const schema = tool?.inputSchema as
+      | { properties?: Record<string, unknown>; required?: string[] }
+      | undefined;
+    expect(schema?.properties?.agentId).toBeDefined();
+    expect(schema?.required ?? []).toEqual([]);
   });
 
   it("returns the all-coworker rollup with no filters (no agentId scoping)", async () => {
@@ -383,7 +394,7 @@ describe("list_all_capability_needs (BI-F9E7B780)", () => {
         agentId: "AGT-WS-FINANCE",
         status: "submitted",
         kind: "skill",
-        severity: "medium",
+        severity: "important",
       },
       "user-1",
     );
@@ -392,7 +403,7 @@ describe("list_all_capability_needs (BI-F9E7B780)", () => {
       agentId: "AGT-WS-FINANCE",
       status: "submitted",
       kind: "skill",
-      severity: "medium",
+      severity: "important",
     });
   });
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -3633,6 +3633,35 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    // BI-F9E7B780: governance-surface rollup. Same shape as
+    // list_my_capability_needs but UN-scoped from the calling agent —
+    // returns all coworker needs across all agents, plus filter-options
+    // and counts-by-status/severity/kind summaries that the existing
+    // /platform/ai/capability-needs admin page already renders. Lets
+    // taxonomy audits query governed capability evidence without direct
+    // SQL fallback.
+    name: "list_all_capability_needs",
+    description:
+      "List capability needs submitted by ALL coworkers (not scoped to the calling agent), optionally filtered by agentId, status, kind, or severity. Returns the rich review shape used by the /platform/ai/capability-needs admin page: summary counts by status/severity/kind, filter-option enums, and the full need list. Read-only governance surface for taxonomy audits.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: { type: "string", description: "Optional — filter to one coworker's needs. Omit to return all." },
+        status: { type: "string", enum: [...COWORKER_CAPABILITY_NEED_STATUSES] },
+        kind: { type: "string", enum: [...COWORKER_CAPABILITY_NEED_KINDS] },
+        severity: { type: "string", enum: [...COWORKER_CAPABILITY_NEED_SEVERITIES] },
+      },
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    buildPhases: ["ideate", "plan", "build", "review", "ship"],
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+  },
+  {
     name: "prefill_onboarding_wizard",
     description: "Pre-fill the regulation onboarding wizard with AI-drafted data. Stores a draft and returns the wizard URL for human review.",
     inputSchema: {
@@ -12402,6 +12431,54 @@ export async function executeTool(
         success: true,
         message: `Found ${needs.length} capability need${needs.length === 1 ? "" : "s"}.`,
         data: { needs },
+      };
+    }
+
+    case "list_all_capability_needs": {
+      // BI-F9E7B780 — governance-surface rollup, not scoped to the calling
+      // coworker. Reuses the same review-service helper that powers the
+      // /platform/ai/capability-needs admin page so the MCP surface and the
+      // operator UI agree on shape (summary counts, filter-option enums,
+      // full need list).
+      const { getCoworkerCapabilityNeedReview } = await import(
+        "@/lib/coworker-self-assessment/review-service"
+      );
+      const agentId = typeof params["agentId"] === "string" && params["agentId"].length > 0
+        ? params["agentId"]
+        : undefined;
+      const status = COWORKER_CAPABILITY_NEED_STATUSES.includes(
+        params["status"] as CoworkerCapabilityNeedStatus,
+      )
+        ? (params["status"] as CoworkerCapabilityNeedStatus)
+        : undefined;
+      const kind = COWORKER_CAPABILITY_NEED_KINDS.includes(
+        params["kind"] as CoworkerCapabilityNeedKind,
+      )
+        ? (params["kind"] as CoworkerCapabilityNeedKind)
+        : undefined;
+      const severity = COWORKER_CAPABILITY_NEED_SEVERITIES.includes(
+        params["severity"] as CoworkerCapabilityNeedSeverity,
+      )
+        ? (params["severity"] as CoworkerCapabilityNeedSeverity)
+        : undefined;
+
+      const review = await getCoworkerCapabilityNeedReview({
+        agentId,
+        status,
+        kind,
+        severity,
+      });
+
+      return {
+        success: true,
+        message: `Found ${review.summary.total} capability need${
+          review.summary.total === 1 ? "" : "s"
+        } across all coworkers.`,
+        data: {
+          summary: review.summary,
+          filterOptions: review.filterOptions,
+          needs: review.needs,
+        },
       };
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -90,6 +90,11 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   assess_my_capabilities: ["registry_read"],
   submit_coworker_capability_need: ["registry_read"],
   list_my_capability_needs: ["registry_read"],
+  // BI-F9E7B780: governance-surface variant — same grant tier (registry_read)
+  // because both surfaces are read-only over the same CoworkerCapabilityNeed
+  // model; the scope difference is "your needs" vs "everyone's needs", not
+  // a privilege difference.
+  list_all_capability_needs: ["registry_read"],
   search_knowledge: ["registry_read"],
   search_knowledge_base: ["registry_read"],
   create_knowledge_article: ["registry_write"],


### PR DESCRIPTION
## Summary

Adds a read-only MCP tool that returns coworker capability needs **across all coworkers**, not scoped to the calling agent's token context like the existing `list_my_capability_needs`. Lets taxonomy audits query governed capability evidence without direct SQL fallback.

Closes [`BI-F9E7B780`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-F9E7B780) (epic `EP-BIZ-CAP`).

## What's new

- **`PLATFORM_TOOLS` entry** `list_all_capability_needs` — optional `agentId` / `status` / `kind` / `severity` filters (nothing required). `requiredCapability: view_platform`, `readOnlyHint: true`.
- **`executeTool` case** calls the existing `getCoworkerCapabilityNeedReview(filters)` helper that already powers the `/platform/ai/capability-needs` admin page. Same rich shape (summary counts, filter-option enums, full need list) so the MCP and UI surfaces agree.
- **`TOOL_TO_GRANTS` entry** `["registry_read"]` — same tier as `list_my_capability_needs`. The scope difference is "your needs" vs "everyone's needs", not a privilege difference.

## What's NOT in this PR (deliberate)

- **No new admin page.** `/platform/ai/capability-needs` already exists with the full review shape.
- **No new Prisma model.** `CoworkerCapabilityNeed` is in place and the filter columns (`agentId`, `status`, `kind`, `severity`, `linkedBacklogItemId`) are indexed.
- **No new service helper.** `getCoworkerCapabilityNeedReview` is reused verbatim; the MCP case is a thin wrapper.

## Substrate verified before implementation

| Surface | File:line |
|---|---|
| Prisma model | `packages/db/prisma/schema.prisma:2059-2087` |
| Existing list tool def | `apps/web/lib/mcp-tools.ts:3615-3633` |
| Existing list execute case | `apps/web/lib/mcp-tools.ts:12417-12434` |
| Review-service helper | `apps/web/lib/coworker-self-assessment/review-service.ts:250-271` |
| Admin page consumer | `apps/web/app/(shell)/platform/ai/capability-needs/page.tsx` |
| Grant pattern | `apps/web/lib/tak/agent-grants.ts:88-92` |

## Verification

- **Vitest (mirrors the established pattern)**: 6 new cases in `mcp-tools-coworker-self-assessment.test.ts` — catalog registration shape, all-coworker happy path with summary, filter pass-through, unknown-enum drop semantics, singular/plural message wording, no-coworker-context allowance. The pre-existing `list_my_capability_needs` case stays unchanged.
- **Pre-commit gitleaks**: clean.
- **Local typecheck**: skipped because dev-portal-start polluted host `node_modules` workspace symlinks during the prior session's Phase 7 verification (memory `dev_portal_polluted_node_modules`). CI runs a fresh `pnpm install` and gates merge.

## Note on the BI closure path

While picking the next BI for this session, I found that **three** of the top five `get_next_recommended_work` candidates had merged PRs whose bodies said "Closes BI-X" but the BI status had never been transitioned to `done`. I cleaned those up before starting (`BI-9A7DA4AC`, `BI-E1CFC8FB`, `BI-9A86E2A7` → `done` with resolutions citing the merged PR). To avoid the same drift on this BI, I'll transition `BI-F9E7B780` to `done` via `mcp__dpf__update_backlog_item_status` after this PR merges — not relying on the body-label parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)