### PR TITLE
fix(coworker): stop false-positive fabrication guard on advise-mode s…

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -372,6 +372,32 @@ describe("detectFabrication", () => {
       new Set(["run_discovery_triage"]),
     )).toBe(false);
   });
+
+  it("does not flag advise-mode guidance when no authoritative tool is available", () => {
+    // Setup-tour case: the route persona is asked to "guide me through this
+    // step" with only read-only tools (wiki_query, search_knowledge). Its
+    // guidance naturally says "configured"/"set up", but with no action/build
+    // tool to call there is nothing it could have fabricated.
+    expect(detectFabrication(
+      "Once your operating hours are configured, bookings and availability stay aligned.",
+      0,
+      false,
+      [],
+      new Set(),
+      false, // hasAuthoritativeToolAvailable
+    )).toBe(false);
+  });
+
+  it("still flags completion claims when an authoritative tool was available but unused", () => {
+    expect(detectFabrication(
+      "I've configured your operating hours.",
+      0,
+      false,
+      [],
+      new Set(["create_backlog_item"]),
+      true, // hasAuthoritativeToolAvailable
+    )).toBe(true);
+  });
 });
 
 describe("runAgenticLoop", () => {
@@ -1245,7 +1271,17 @@ describe("runAgenticLoop", () => {
 
     mockExecuteTool.mockResolvedValueOnce({ success: true, message: "Found Build Studio workflow files." });
 
-    const result = await runAgenticLoop(baseParams);
+    // A real /build session exposes the authoritative build tools — the
+    // scenario is "the plan wasn't persisted via saveBuildEvidence", so those
+    // tools must be present for the read-only-claim to count as fabrication.
+    const result = await runAgenticLoop({
+      ...baseParams,
+      tools: [
+        ...baseParams.tools,
+        { name: "saveBuildEvidence", description: "Save evidence", inputSchema: {}, requiredCapability: null, executionMode: "immediate" as const, sideEffect: false, buildPhases: ["plan"] as const },
+        { name: "reviewBuildPlan", description: "Review plan", inputSchema: {}, requiredCapability: null, executionMode: "immediate" as const, sideEffect: false, buildPhases: ["plan"] as const },
+      ],
+    });
 
     expect(result.content).not.toContain("Plan ready");
     expect(mockExecuteTool).toHaveBeenCalledTimes(1);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -252,8 +252,22 @@ export function detectFabrication(
   hasProposal: boolean,
   executedToolNames?: string[],
   authoritativeToolNames?: Set<string>,
+  hasAuthoritativeToolAvailable: boolean = true,
 ): boolean {
   if (hasProposal) return false;
+
+  // If the agent has no authoritative (action/build) tool available to call,
+  // a completion-claim or narration in its reply is ordinary conversational
+  // advice — there is no tool-backed work it could have recorded, so there is
+  // nothing to fabricate. This is the normal case for advise-mode coworkers:
+  // e.g. the setup tour, where the route persona is asked to "guide me through
+  // this step" and naturally says things like "once your hours are configured".
+  // Flagging that as fabrication kills a perfectly good reply and replaces it
+  // with the build-oriented failure copy. Note: authoritative ≠ side-effecting
+  // — internal build tools (saveBuildEvidence, reviewBuildPlan, …) are
+  // sideEffect:false yet still authoritative, so the caller computes this flag
+  // against both the side-effecting set and BUILD_TOOL_NAMES.
+  if (!hasAuthoritativeToolAvailable) return false;
 
   // If no tools were called at all, any completion claim is fabrication
   if (executedToolCount === 0) return COMPLETION_CLAIM_PATTERN.test(response);
@@ -1257,12 +1271,16 @@ export async function runAgenticLoop(params: {
         };
       }
 
+      const hasAuthoritativeToolAvailable = tools.some(
+        (tool) => tool.sideEffect || BUILD_TOOL_NAMES.has(tool.name),
+      );
       const looksFabricated = detectFabrication(
         trimmed,
         executedTools.length,
         false,
         executedTools.map((t) => t.name),
         new Set(tools.filter((tool) => tool.sideEffect).map((tool) => tool.name)),
+        hasAuthoritativeToolAvailable,
       );
 
       const isBuildRoute = BUILD_ROUTE_PATTERN.test(routeContext);
@@ -1697,6 +1715,7 @@ export async function runAgenticLoop(params: {
     false,
     executedTools.map((tool) => tool.name),
     new Set(tools.filter((tool) => tool.sideEffect).map((tool) => tool.name)),
+    tools.some((tool) => tool.sideEffect || BUILD_TOOL_NAMES.has(tool.name)),
   );
   const exhaustedMessage = buildMaxIterationsExhaustedMessage({
     downgraded: lastResult?.downgraded ?? false,


### PR DESCRIPTION
…etup tour

During the setup tour the route persona is auto-sent a conversational trigger ("Guide me through this step"). At advise-mode routes like /storefront the coworker has every side-effecting tool stripped, so it can only give guidance. Its advice naturally contains completion-claim words ("configured", "set up"), which tripped detectFabrication() even though no authoritative tool existed to call — replacing a good reply with the build-oriented "open the build details" failure copy.

detectFabrication now takes hasAuthoritativeToolAvailable. When no authoritative tool (side-effecting OR build tool — build tools are intentionally sideEffect:false) is available, a completion claim is ordinary advisory conversation and is not flagged. The guard still fires on /build sessions and act-mode coworkers, which do expose authoritative tools.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
