### PR TITLE
feat(installer/macos): add customer vs contributor mode prompt

### DIFF
--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -105,8 +105,14 @@ source build); `--release`/`--dev` still override it if you need to force one.
 6. **Node / pnpm sanity check** — refuses if Node < 20 or pnpm missing.
 7. **Workspace dependencies** — `pnpm install`. In **contributor** mode the
    installer also enables the in-repo `.githooks/` (`git config
-   core.hooksPath .githooks`) and runs the agent-toolchain bootstrap so
-   Claude Code / Codex are wired up. Customer mode skips both.
+   core.hooksPath .githooks`), **auto-installs the GitHub CLI (`gh`)** into
+   `~/.dpf/tools/bin` (no Homebrew/sudo — downloaded from the official
+   release and checksum-verified) and adds it to your `PATH`, then runs the
+   agent-toolchain bootstrap so Claude Code / Codex are wired up. It does
+   **not** sign you in — finish with `gh auth login --git-protocol https
+   --web` (the OAuth flow, which avoids the fine-grained-PAT lifetime limits
+   some orgs enforce) and `gh auth setup-git`. Customer mode skips all of
+   this.
 8. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
    and emits `DPF_HOST_PROFILE` (Apple Silicon reports
    `architecture: "unified"` for memory).

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -60,12 +60,29 @@ cd ~/dpf
 bash install-dpf.sh
 ```
 
-The installer is interactive by default. For an unattended (CI / scripted)
-install:
+The installer is interactive by default and first asks **how you want to use
+DPF**:
+
+- **`[1] Ready to go` (customer)** — runs the pre-built release images. No
+  contributor tooling. This is the default.
+- **`[2] Customizable` (contributor)** — builds the full stack from your local
+  source, enables the in-repo git hooks, and runs the agent-toolchain
+  bootstrap so Claude Code / Codex are wired up.
+
+Your choice is saved to `~/.dpf/install-state.json` (`installMode`) and reused
+on re-runs without re-prompting. To skip the prompt, pass `--customer` or
+`--contributor`. For an unattended (CI / scripted) install:
 
 ```bash
-bash install-dpf.sh --headless --release
+# Customer (release images) is the headless default:
+bash install-dpf.sh --headless
+
+# Or pick explicitly:
+bash install-dpf.sh --headless --contributor
 ```
+
+`--customer`/`--contributor` set the compose mode automatically (release vs
+source build); `--release`/`--dev` still override it if you need to force one.
 
 ### What the installer does
 
@@ -73,25 +90,35 @@ bash install-dpf.sh --headless --release
    rootless Docker / Podman.
 2. **`~/.dpf/install-state.json`** — initializes or migrates the install
    state file (schema-versioned).
-3. **Compose chain** — assembles `docker-compose.yml` +
+3. **Install mode** — prompts for customer vs contributor (or honors
+   `--customer`/`--contributor`), saves it to `install-state.json`, and
+   derives the compose mode (customer → release images; contributor →
+   source build) unless `--release`/`--dev` forces one.
+4. **Compose chain** — assembles `docker-compose.yml` +
    `docker-compose.macos.yml` + `docker-compose.edge.yml` (+
-   `docker-compose.release.yml` if `--release`). The Edge Node
+   `docker-compose.release.yml` in release/customer mode). The Edge Node
    container is bundled by default for single-host installs; pass
    `--no-edge` to skip it.
-4. **Docker Desktop** — installs the `.dmg` if missing
+5. **Docker Desktop** — installs the `.dmg` if missing
    (`hdiutil attach` + `cp -R /Applications`), then starts it and waits
    for the daemon.
-5. **Node / pnpm sanity check** — refuses if Node < 20 or pnpm missing.
-6. **Workspace dependencies** — `pnpm install`.
-7. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
+6. **Node / pnpm sanity check** — refuses if Node < 20 or pnpm missing.
+7. **Workspace dependencies** — `pnpm install`. In **contributor** mode the
+   installer also enables the in-repo `.githooks/` (`git config
+   core.hooksPath .githooks`) and runs the agent-toolchain bootstrap so
+   Claude Code / Codex are wired up. Customer mode skips both.
+8. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
    and emits `DPF_HOST_PROFILE` (Apple Silicon reports
    `architecture: "unified"` for memory).
-8. **`.env` generation** — only on first install; existing `.env` is
+9. **`.env` generation** — only on first install; existing `.env` is
    preserved.
-9. **`docker compose up -d`** on the macOS overlay.
-10. **Health check** — polls `http://localhost:3000/api/health` for up
+10. **Release image availability** (customer mode only) — probes the GHCR
+    portal image and, if it's gated behind early-access auth, points you at
+    `docker login ghcr.io` before bring-up.
+11. **`docker compose up -d`** on the macOS overlay.
+12. **Health check** — polls `http://localhost:3000/api/health` for up
     to 5 minutes (configurable via `DPF_HEALTH_TIMEOUT`).
-11. **Edge Node bootstrap** (unless `--no-edge`) — mints a single-use
+13. **Edge Node bootstrap** (unless `--no-edge`) — mints a single-use
     auto-approve bootstrap token, writes it to `.env` as
     `DPF_BOOTSTRAP_TOKEN`, restarts the `edge-node` container so it
     enrolls. The new EdgeNode lands directly in `trustState=trusted`
@@ -103,9 +130,9 @@ bash install-dpf.sh --headless --release
     native macOS Edge Node binary (T3) — until then, the Edge Node
     here demonstrates the enrollment + heartbeat + submission path
     but not L2 host-network discovery.
-12. **Persist state** — records `lastSuccessfulInstallVersion` and
+14. **Persist state** — records `lastSuccessfulInstallVersion` and
     `lastHealthCheck`.
-13. **LaunchAgent** — installs `~/Library/LaunchAgents/local.dpf-autostart.plist`
+15. **LaunchAgent** — installs `~/Library/LaunchAgents/local.dpf-autostart.plist`
     so the stack auto-starts at login (skip with `--no-autostart`).
 
 Total wall time: ~10 minutes including the AI-model download (varies

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -13,9 +13,17 @@
 #   - --headless flag: non-interactive (default for CI).
 #   - doctor subcommand: emits a diagnostic bundle for support reports.
 #
-# Companion: scripts/setup.sh is the *contributor* bootstrap (clone,
-# install deps, run the dev loop). install-dpf.sh is the *end-user*
-# installer (release images, full stack, autostart).
+# Install modes (parity with install-dpf.ps1 Step 5): the installer prompts
+# for one of two modes, or takes --customer / --contributor:
+#   - customer    "Ready to go"  — pre-built release images, no contributor
+#                                  tooling. The default in headless/CI.
+#   - contributor "Customizable" — full stack built from local source, with
+#                                  contributor git hooks + agent-toolchain
+#                                  bootstrap.
+#
+# Companion: scripts/setup.sh remains the lightweight *contributor dev*
+# bootstrap (dev DB stack + `pnpm dev`), distinct from this installer's
+# from-source containerized contributor mode.
 #
 # Per the deployment doctrine: this implements Contracts 2 (runtime
 # config), 3 (lifecycle), 8 (secrets — via .env generation), and is
@@ -69,12 +77,19 @@ Subcommands:
 Flags:
   --dry-run     Print the planned actions without touching the host.
                 Honors --headless. Useful for CI smoke and pre-flight review.
-  --headless    Non-interactive (no prompts). Defaults are used; required
-                for CI / unattended installs.
-  --release     Use pre-built multi-arch GHCR images
-                (docker-compose.release.yml overlay). Default in Phase 7+.
-  --dev         Build images locally (default for Phase 6 framework slice
-                until release-mode integration lands).
+  --headless    Non-interactive (no prompts). Defaults are used (install
+                mode defaults to "customer"); required for CI / unattended
+                installs.
+  --customer    Ready-to-go install: run the pre-built release images and
+                skip contributor tooling. Skips the interactive mode prompt.
+  --contributor Customizable install: build the full stack from local source,
+                enable contributor git hooks, and run the agent-toolchain
+                bootstrap. Skips the interactive mode prompt.
+  --release     Force the pre-built multi-arch GHCR images
+                (docker-compose.release.yml overlay). Overrides the compose
+                mode that the install mode would otherwise derive.
+  --dev         Force locally-built images. Overrides the derived compose
+                mode (e.g. release images for a customer install).
   --force-unsupported-host
                 Override unsupported-host preflight refusal (advanced).
                 Equivalent to DPF_FORCE_UNSUPPORTED_HOST=1.
@@ -91,11 +106,10 @@ Flags:
                 § Approval policy.
   -h, --help    Show this help.
 
-Status: Phase 6 (framework vertical slice). Full end-user install (Docker
-auto-install, autostart, model pulls) lands in Phase 7. Until then,
-install-dpf.sh validates preflight, persists install-state.json, and
-prints the planned compose chain. Use scripts/setup.sh for contributor
-bootstrap.
+Status: Phase 6+ vertical slice. Full end-user install (Docker
+auto-install, autostart, model pulls) lands incrementally per the roadmap.
+Run with no flags for the interactive customer/contributor mode prompt, or
+pass --customer / --contributor to skip it.
 
 Roadmap: docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
 Doctrine: docs/superpowers/specs/2026-05-09-deployment-contracts.md
@@ -103,7 +117,11 @@ EOF
 }
 
 DPF_DRY_RUN=0
-DPF_MODE="dev"   # dev | release
+DPF_MODE="dev"          # dev | release — compose chain. Derived from the
+                        # install mode below unless set explicitly via a flag.
+DPF_MODE_EXPLICIT=0     # 1 once --dev/--release is passed, so the install-mode
+                        # prompt does not override an explicit compose choice.
+DPF_INSTALL_MODE=""     # customer | contributor — resolved in "Install mode".
 DPF_AUTOSTART=1
 DPF_INCLUDE_EDGE="${DPF_INCLUDE_EDGE:-1}"   # 1 = bundle Edge Node; 0 = skip
 SUBCOMMAND=""
@@ -112,8 +130,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)              DPF_DRY_RUN=1 ;;
     --headless)             DPF_HEADLESS=1; export DPF_HEADLESS ;;
-    --release)              DPF_MODE="release" ;;
-    --dev)                  DPF_MODE="dev" ;;
+    --release)              DPF_MODE="release"; DPF_MODE_EXPLICIT=1 ;;
+    --dev)                  DPF_MODE="dev"; DPF_MODE_EXPLICIT=1 ;;
+    --customer)             DPF_INSTALL_MODE="customer" ;;
+    --contributor)          DPF_INSTALL_MODE="contributor" ;;
     --no-autostart)         DPF_AUTOSTART=0 ;;
     --no-edge)              DPF_INCLUDE_EDGE=0 ;;
     --force-unsupported-host)
@@ -147,7 +167,7 @@ echo "  =================================================================="
 dpf_platform
 dpf_arch
 echo "  Platform: $DPF_PLATFORM ($DPF_ARCH)"
-echo "  Mode: $DPF_MODE$(if [ "$DPF_DRY_RUN" = "1" ]; then echo "  [dry-run]"; fi)"
+if [ "$DPF_DRY_RUN" = "1" ]; then echo "  [dry-run]"; fi
 echo ""
 
 # 1. Preflight: unsupported-host detection + port conflicts.
@@ -190,6 +210,59 @@ case "$rc" in
      dpf_state_migrate ;;
   *) fail "Install state validation failed (see message above)" ;;
 esac
+
+# 2b. Choose install mode (parity with install-dpf.ps1 Step 5). Must run
+#     before the compose chain (Step 3) and the dry-run gate (Step 4) since
+#     it can derive DPF_MODE.
+#       customer    "Ready to go"  → release images, no contributor tooling
+#       contributor "Customizable" → from-source build + git hooks + toolchain
+step "Install mode"
+if [ -z "$DPF_INSTALL_MODE" ]; then
+  # Resume: reuse a previously-selected mode without re-prompting.
+  prior_mode="$(dpf_state_read installMode 2>/dev/null || true)"
+  if [ -n "$prior_mode" ]; then
+    DPF_INSTALL_MODE="$prior_mode"
+    ok "Using previously selected mode: $DPF_INSTALL_MODE"
+  elif [ "${DPF_HEADLESS:-0}" = "1" ] || [ "$DPF_DRY_RUN" = "1" ]; then
+    # Non-interactive (CI / dry-run): default to the end-user install.
+    DPF_INSTALL_MODE="customer"
+    info "Non-interactive run; defaulting to customer mode."
+  else
+    echo ""
+    echo "  How do you want to use Digital Product Factory?"
+    echo ""
+    echo "    [1] Ready to go   - Pre-built: use Build Studio inside the portal to extend the platform."
+    echo "    [2] Customizable  - Full source: Build Studio + your editor work from the same workspace."
+    echo ""
+    printf "  Choose [1/2] (default 1): "
+    read -r mode_choice
+    case "$mode_choice" in
+      2) DPF_INSTALL_MODE="contributor" ;;
+      *) DPF_INSTALL_MODE="customer" ;;
+    esac
+  fi
+fi
+
+case "$DPF_INSTALL_MODE" in
+  customer|contributor) ;;
+  *) fail "Unknown install mode '$DPF_INSTALL_MODE' (expected customer|contributor)." ;;
+esac
+
+# Derive the compose mode unless the operator forced it with --dev/--release.
+if [ "$DPF_MODE_EXPLICIT" = "0" ]; then
+  if [ "$DPF_INSTALL_MODE" = "contributor" ]; then
+    DPF_MODE="dev"      # build the stack from local source
+  else
+    DPF_MODE="release"  # pull pre-built GHCR images
+  fi
+fi
+
+# Persist only on a real run. A --dry-run defaults to customer; persisting it
+# would make a later real run "resume" that default and skip the prompt.
+if [ "$DPF_DRY_RUN" != "1" ]; then
+  dpf_state_write installMode "$DPF_INSTALL_MODE" 2>/dev/null || true
+fi
+ok "Install mode: $DPF_INSTALL_MODE (compose mode: $DPF_MODE)"
 
 # 3. Resolve the compose -f chain (per-platform via compose.sh).
 step "Compose chain"
@@ -261,24 +334,41 @@ step "Workspace dependencies"
 pnpm install
 ok "Dependencies installed"
 
+# Contributor git hooks (contributor mode only). Mirrors scripts/setup.sh:
+# enables the in-repo .githooks/ (Prisma migration guard + secret scan).
+# Idempotent; customer installs skip it (they don't author commits here).
+if [ "$DPF_INSTALL_MODE" = "contributor" ] && [ -d .git ]; then
+  step "Contributor git hooks"
+  if git config core.hooksPath .githooks 2>/dev/null; then
+    ok "Git hooks path set to .githooks"
+  else
+    warn "Could not set core.hooksPath; run 'git config core.hooksPath .githooks' manually."
+  fi
+fi
+
 # Agent toolchain bootstrap (BI-4B17051B Phase 4): converges Claude Code +
 # Codex CLI sessions, seeds kernel memory, persists agentToolchain readiness.
 # The script prints a six-state readiness banner (ready / partial /
 # missing_cli / missing_token / needs_refresh / failed_smoke) with no
 # substrate names or command snippets in operator-visible output.
-step "Agent toolchain bootstrap"
-bootstrap_script="$REPO_ROOT/scripts/dpf-bootstrap-agent-toolchain.sh"
-if [ -f "$bootstrap_script" ]; then
-  bootstrap_args=("$REPO_ROOT")
-  if [ "${DPF_HEADLESS:-0}" = "1" ]; then
-    bootstrap_args=(--headless "${bootstrap_args[@]}")
+# Contributor mode only — customer installs don't need agent CLIs wired up.
+if [ "$DPF_INSTALL_MODE" = "contributor" ]; then
+  step "Agent toolchain bootstrap"
+  bootstrap_script="$REPO_ROOT/scripts/dpf-bootstrap-agent-toolchain.sh"
+  if [ -f "$bootstrap_script" ]; then
+    bootstrap_args=("$REPO_ROOT")
+    if [ "${DPF_HEADLESS:-0}" = "1" ]; then
+      bootstrap_args=(--headless "${bootstrap_args[@]}")
+    fi
+    if [ "${DPF_DRY_RUN:-0}" = "1" ]; then
+      bootstrap_args=(--dry-run "${bootstrap_args[@]}")
+    fi
+    bash "$bootstrap_script" "${bootstrap_args[@]}" || warn "Agent toolchain bootstrap reported an issue (non-fatal)."
+  else
+    warn "scripts/dpf-bootstrap-agent-toolchain.sh not found; skipping agent toolchain convergence."
   fi
-  if [ "${DPF_DRY_RUN:-0}" = "1" ]; then
-    bootstrap_args=(--dry-run "${bootstrap_args[@]}")
-  fi
-  bash "$bootstrap_script" "${bootstrap_args[@]}" || warn "Agent toolchain bootstrap reported an issue (non-fatal)."
 else
-  warn "scripts/dpf-bootstrap-agent-toolchain.sh not found; skipping agent toolchain convergence."
+  info "Skipping agent toolchain bootstrap (customer mode)."
 fi
 
 # 8. Resolve host hardware profile (Phase 5 macOS / Linux detector).
@@ -462,6 +552,23 @@ export PATH="$SAFETY_BIN:$PATH"
 
 ok "Shell guard installed at $SAFETY_BIN"
 info "  Open a new terminal for the PATH change to take effect in other shells."
+
+# 9c. Customer mode pulls pre-built GHCR images (parity with the Windows
+#     consumer path). During early access those images may require a (free)
+#     GitHub login. Probe once and point the operator at `docker login`
+#     rather than letting `compose up` fail with an opaque manifest error.
+#     We never create accounts or store credentials on the operator's behalf.
+if [ "$DPF_INSTALL_MODE" = "customer" ]; then
+  step "Release image availability"
+  if docker pull ghcr.io/opendigitalproductfactory/dpf-portal:latest >/dev/null 2>&1; then
+    ok "Release images reachable"
+  else
+    warn "Could not pull the pre-built platform image."
+    info "  During early access the images need a free GitHub login:"
+    info "    docker login ghcr.io"
+    info "  Then re-run install-dpf.sh. (Contributor mode builds from source instead.)"
+  fi
+fi
 
 # 10. Bring up the platform-aware compose stack. Per the doctrine's
 #     Contract 9: the entrypoint is provider-aware, so model pulls

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -57,6 +57,8 @@ LIB_DIR="$REPO_ROOT/scripts/installer/lib"
 . "$LIB_DIR/docker.sh"
 # shellcheck source=scripts/installer/lib/autostart.sh
 . "$LIB_DIR/autostart.sh"
+# shellcheck source=scripts/installer/lib/github-cli.sh
+. "$LIB_DIR/github-cli.sh"
 
 # Installer version (semver-ish; bump per release).
 DPF_INSTALLER_VERSION="2026.05.11-phase10a"
@@ -343,6 +345,22 @@ if [ "$DPF_INSTALL_MODE" = "contributor" ] && [ -d .git ]; then
     ok "Git hooks path set to .githooks"
   else
     warn "Could not set core.hooksPath; run 'git config core.hooksPath .githooks' manually."
+  fi
+fi
+
+# GitHub CLI (contributor mode only). Auto-installs `gh` without Homebrew/sudo
+# so contributors can push branches and open PRs (and Build Studio's contribution
+# flow works) without the manual "install gh" detour on a fresh machine. Sign-in
+# is left to the operator: `gh auth login` is an interactive browser flow and the
+# OAuth path it uses is exempt from the fine-grained-PAT lifetime limits some orgs
+# enforce. Non-fatal: a failed auto-install just prints the manual fallback.
+if [ "$DPF_INSTALL_MODE" = "contributor" ]; then
+  step "GitHub CLI"
+  dpf_ensure_gh || warn "GitHub CLI auto-install incomplete (non-fatal)."
+  if command -v gh >/dev/null 2>&1 && ! gh auth status >/dev/null 2>&1; then
+    info "Sign in to GitHub to enable pushes and PRs (OAuth — avoids PAT lifetime limits):"
+    info "    gh auth login --git-protocol https --web"
+    info "  Then wire git:  gh auth setup-git"
   fi
 fi
 

--- a/scripts/installer/lib/github-cli.sh
+++ b/scripts/installer/lib/github-cli.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# GitHub CLI (gh) provisioning for the DPF installer.
+# Source this file; do not execute directly.
+#
+# Installs the official `gh` binary into a user-writable directory (no
+# Homebrew, no sudo) when it is missing, and adds that directory to PATH via
+# an idempotent shell-rc marker block. This is the contributor-onboarding
+# slice that removes the manual "install gh" friction on a fresh machine.
+#
+# OAuth sign-in (`gh auth login`) is intentionally NOT performed here — it is
+# an interactive browser flow, and it is the org-policy-friendly path (OAuth
+# tokens are exempt from the fine-grained-PAT lifetime limits some orgs set).
+# The installer points the operator at it; wiring the git credential helper
+# (`gh auth setup-git`) is a follow-up slice.
+#
+# Bash 3.2 baseline (macOS default).
+
+if [ "${DPF_LIB_GITHUB_CLI_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_GITHUB_CLI_LOADED=1
+
+# Pull in platform.sh (dpf_platform / dpf_arch) and logging.sh (ok/info/warn)
+# so the lib is usable standalone (e.g. in unit tests), not only when sourced
+# after them by install-dpf.sh.
+if [ -z "${DPF_LIB_PLATFORM_LOADED:-}" ]; then
+  # shellcheck source=platform.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/platform.sh"
+fi
+if [ -z "${DPF_LIB_LOGGING_LOADED:-}" ]; then
+  # shellcheck source=logging.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/logging.sh"
+fi
+
+# Directory where DPF installs user-local CLIs. Host-level (under ~/.dpf, the
+# install-state home) so it survives a repo re-clone. Override with
+# DPF_TOOLS_DIR for tests.
+dpf_tools_bin() {
+  echo "${DPF_TOOLS_DIR:-$HOME/.dpf/tools}/bin"
+}
+
+# Prepend a directory to PATH via an idempotent marker block in the operator's
+# shell rc files. Mirrors the safety-bin PATH wiring in install-dpf.sh, but
+# also (a) covers ~/.zprofile — the zsh login file that modern macOS uses — and
+# (b) creates ~/.zprofile if NONE of the candidate rc files exist, so a fresh
+# zsh account (no .zshrc/.profile) still gets the PATH change. Without that, the
+# block would land nowhere and the tool would vanish in new terminals.
+# Args: $1 = directory, $2 = marker label (e.g. "dpf-tools-bin")
+dpf_add_dir_to_path() {
+  local dir="$1" label="$2"
+  local begin="# >>> ${label} >>>"
+  local end="# <<< ${label} <<<"
+  local block="${begin}
+export PATH=\"${dir}:\$PATH\"
+${end}"
+  local rc wrote=0
+  for rc in "$HOME/.profile" "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.zprofile"; do
+    [ -e "$rc" ] || continue
+    if grep -q "$begin" "$rc" 2>/dev/null; then
+      wrote=1            # already present — counts as wired
+    else
+      printf '\n%s\n' "$block" >> "$rc"
+      wrote=1
+    fi
+  done
+  # No shell rc existed at all (common on a brand-new zsh account): create the
+  # zsh login file so the PATH change actually persists.
+  if [ "$wrote" = "0" ]; then
+    printf '\n%s\n' "$block" >> "$HOME/.zprofile"
+  fi
+  export PATH="${dir}:$PATH"
+}
+
+# Portable sha256 of a file (macOS shasum / Linux sha256sum). Empty if neither.
+dpf_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    echo ""
+  fi
+}
+
+# Ensure the GitHub CLI (`gh`) is available, installing it without Homebrew or
+# sudo if missing. Honors DPF_DRY_RUN (reports intent, no download).
+# Returns 0 if gh ends up available, non-zero (non-fatal to the caller) if the
+# auto-install could not complete — the caller should treat it as advisory.
+dpf_ensure_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    ok "GitHub CLI present ($(gh --version 2>/dev/null | head -1))"
+    return 0
+  fi
+
+  if [ "${DPF_DRY_RUN:-0}" = "1" ]; then
+    info "DRY-RUN: would download + install the GitHub CLI (gh) into $(dpf_tools_bin)"
+    return 0
+  fi
+
+  dpf_platform
+  dpf_arch
+
+  local gh_os gh_ext
+  case "$DPF_PLATFORM" in
+    darwin) gh_os="macOS"; gh_ext="zip" ;;
+    linux)  gh_os="linux"; gh_ext="tar.gz" ;;
+    *) warn "Unsupported platform '$DPF_PLATFORM' for gh auto-install; install manually from https://cli.github.com"; return 1 ;;
+  esac
+  local gh_arch
+  case "$DPF_ARCH" in
+    arm64) gh_arch="arm64" ;;
+    amd64) gh_arch="amd64" ;;
+    *) warn "Unknown arch '$DPF_ARCH' for gh auto-install; install manually from https://cli.github.com"; return 1 ;;
+  esac
+
+  if ! command -v curl >/dev/null 2>&1; then
+    warn "curl not found; cannot auto-install gh. Install manually from https://cli.github.com"
+    return 1
+  fi
+
+  # Resolve the latest release + matching asset via the GitHub API. jq is a
+  # hard installer dependency (verified in install-dpf.sh preflight).
+  local rel tag ver asset url sums_url
+  rel="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+         https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null)" || rel=""
+  if [ -z "$rel" ]; then
+    warn "Could not reach the GitHub API to resolve the latest gh release; install manually from https://cli.github.com"
+    return 1
+  fi
+  tag="$(printf '%s' "$rel" | jq -r '.tag_name // empty')"
+  ver="${tag#v}"
+  if [ -z "$ver" ]; then
+    warn "Could not parse the latest gh version; install manually from https://cli.github.com"
+    return 1
+  fi
+  asset="gh_${ver}_${gh_os}_${gh_arch}.${gh_ext}"
+  url="$(printf '%s' "$rel" | jq -r --arg a "$asset" '.assets[] | select(.name==$a) | .browser_download_url' | head -1)"
+  if [ -z "$url" ] || [ "$url" = "null" ]; then
+    warn "No gh release asset named '$asset' in $tag; install manually from https://cli.github.com"
+    return 1
+  fi
+  sums_url="$(printf '%s' "$rel" | jq -r '.assets[] | select(.name|endswith("checksums.txt")) | .browser_download_url' | head -1)"
+
+  local tmp; tmp="$(mktemp -d)"
+  info "Downloading GitHub CLI $tag ($asset)..."
+  if ! curl -fsSL "$url" -o "$tmp/$asset"; then
+    warn "gh download failed; install manually from https://cli.github.com"
+    rm -rf "$tmp"; return 1
+  fi
+
+  # Verify against the release checksums when available; refuse on mismatch.
+  if [ -n "$sums_url" ] && [ "$sums_url" != "null" ] && curl -fsSL "$sums_url" -o "$tmp/checksums.txt" 2>/dev/null; then
+    local expected actual
+    expected="$(grep " ${asset}\$" "$tmp/checksums.txt" 2>/dev/null | awk '{print $1}' | head -1)"
+    actual="$(dpf_sha256 "$tmp/$asset")"
+    if [ -n "$expected" ] && [ -n "$actual" ]; then
+      if [ "$expected" != "$actual" ]; then
+        warn "Checksum mismatch for $asset; refusing to install. Get gh from https://cli.github.com"
+        rm -rf "$tmp"; return 1
+      fi
+      ok "Checksum verified for $asset"
+    else
+      warn "Could not compute/locate checksum for $asset; proceeding (binary is smoke-tested below)."
+    fi
+  else
+    warn "Release checksums unavailable; proceeding (binary is smoke-tested below)."
+  fi
+
+  # Extract.
+  local extract_dir="$tmp/extract"
+  mkdir -p "$extract_dir"
+  case "$gh_ext" in
+    zip)
+      if ! unzip -q "$tmp/$asset" -d "$extract_dir" 2>/dev/null; then
+        warn "Could not unzip the gh archive; install manually from https://cli.github.com"
+        rm -rf "$tmp"; return 1
+      fi ;;
+    tar.gz)
+      if ! tar -xzf "$tmp/$asset" -C "$extract_dir" 2>/dev/null; then
+        warn "Could not untar the gh archive; install manually from https://cli.github.com"
+        rm -rf "$tmp"; return 1
+      fi ;;
+  esac
+
+  # Locate the gh binary (archive layout: gh_<ver>_<os>_<arch>/bin/gh).
+  local gh_bin
+  gh_bin="$(find "$extract_dir" -type f -name gh -path '*/bin/gh' 2>/dev/null | head -1)"
+  [ -n "$gh_bin" ] || gh_bin="$(find "$extract_dir" -type f -name gh 2>/dev/null | head -1)"
+  if [ -z "$gh_bin" ]; then
+    warn "Could not find the gh binary in the download; install manually from https://cli.github.com"
+    rm -rf "$tmp"; return 1
+  fi
+
+  local bin_dir; bin_dir="$(dpf_tools_bin)"
+  mkdir -p "$bin_dir"
+  cp "$gh_bin" "$bin_dir/gh"
+  chmod +x "$bin_dir/gh"
+  rm -rf "$tmp"
+
+  dpf_add_dir_to_path "$bin_dir" "dpf-tools-bin"
+
+  if "$bin_dir/gh" --version >/dev/null 2>&1; then
+    ok "GitHub CLI installed: $("$bin_dir/gh" --version 2>/dev/null | head -1)"
+    info "  Installed at $bin_dir/gh — open a new terminal for PATH changes in other shells."
+    return 0
+  fi
+  warn "Installed gh but it failed to run; install manually from https://cli.github.com"
+  return 1
+}

--- a/scripts/installer/lib/state.sh
+++ b/scripts/installer/lib/state.sh
@@ -69,6 +69,7 @@ dpf_state_init() {
   "dockerEndpoint": null,
   "installPath": "${install_path}",
   "stateDir": "${state_dir}",
+  "installMode": null,
   "composeFiles": [],
   "imageTag": null,
   "llmProvider": null,


### PR DESCRIPTION
The macOS/Linux installer never presented the install-mode choice that Windows (install-dpf.ps1 Step 5) does, because the two workflows were split across install-dpf.sh (end-user) and scripts/setup.sh (contributor). First-run users saw no Customer-vs-Contributor selection.

Bring Windows parity into install-dpf.sh:
- New DPF_INSTALL_MODE (customer|contributor), distinct from the dev|release compose flag. Flags: --customer / --contributor; --dev/--release still force the compose mode (DPF_MODE_EXPLICIT guard).
- New "Install mode" step (after Install state, before Compose chain): resumes a saved mode, defaults to customer when headless/dry-run, else prompts a [1] Ready to go / [2] Customizable menu. Derives DPF_MODE (customer→release, contributor→dev) and persists installMode to install-state.json (skipped on --dry-run so it can't poison a later run).
- Contributor-only steps gated on the mode: enable .githooks/ and run the agent-toolchain bootstrap. Customer mode skips both and gets a GHCR release-image availability probe with a docker-login hint.
- state.sh: add installMode to the init doc (no schema bump — dpf_state_write already sets arbitrary keys).
- docs/install/macos.md: document the prompt, flags, and per-mode steps.

Verified: bash -n; dry-run headless (customer→release overlay) and --contributor (dev, no overlay); non-headless dry-run does not block; interactive menu selects contributor, persists installMode, sets git hooks, runs toolchain, assembles the dev chain; re-run resumes the saved mode without re-prompting; schemaVersion stays 1.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
