### PR TITLE
fix(installer): use POSIX [[:space:]] instead of GNU \s in sed/grep (BSD/macOS portability)

### DIFF
--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -396,7 +396,7 @@ step "Host hardware profile"
 DPF_SELECTED_MODEL=""
 if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec tsx scripts/detect-hardware-host.ts 2>/dev/null)"; then
   export DPF_HOST_PROFILE="$DPF_HOST_PROFILE_JSON"
-  DPF_SELECTED_MODEL="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"selectedModel"\s*:\s*"([^"]+)".*/\1/p')"
+  DPF_SELECTED_MODEL="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"selectedModel"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
   if [ -n "$DPF_SELECTED_MODEL" ]; then
     ok "Hardware profile detected — selected AI model: $DPF_SELECTED_MODEL"
   else

--- a/scripts/installer/lib/docker.sh
+++ b/scripts/installer/lib/docker.sh
@@ -72,7 +72,7 @@ dpf_docker_endpoint() {
   # cloud-deployment spec (Phase 5 docker.ts discovery alignment).
   docker context inspect 2>/dev/null \
     | grep -m1 '"Host"' \
-    | sed -E 's/.*"Host"\s*:\s*"([^"]+)".*/\1/' \
+    | sed -E 's/.*"Host"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
     || echo ""
 }
 

--- a/scripts/installer/lib/state.sh
+++ b/scripts/installer/lib/state.sh
@@ -99,7 +99,7 @@ dpf_state_read() {
     python3 -c "import json,sys; d=json.load(open('$path')); v=d.get('$key',''); print('' if v is None else (v if isinstance(v,str) else json.dumps(v)))"
   else
     # Last-resort scalar grep (string and number top-level fields).
-    grep -E "\"${key}\"\s*:" "$path" | head -1 | sed -E 's/.*:\s*"?([^",}]*)"?.*/\1/'
+    grep -E "\"${key}\"[[:space:]]*:" "$path" | head -1 | sed -E 's/.*:[[:space:]]*"?([^",}]*)"?.*/\1/'
   fi
 }
 


### PR DESCRIPTION
## Problem

`\s` is a GNU sed/grep extension. macOS ships **BSD** sed/grep, which treat `\s` as a literal `s` rather than a whitespace class — so the substitutions silently fail to match and echo the input line back verbatim.

**Reported symptom:** `dpf_docker_endpoint()` in `scripts/installer/lib/docker.sh` piped `docker context inspect` through `sed -E 's/.*"Host"\s*:\s*"([^"]+)".*/\1/'`. On macOS that produced the raw JSON fragment

```
                "Host": "unix:///Users/.../docker.sock",
```

which was then written into `~/.dpf/install-state.json` as `dockerEndpoint` instead of the clean `unix:///.../docker.sock` socket URI.

Verified on macOS 15 (Darwin 25.5.0, BSD sed): the old regex emits the raw line; `[[:space:]]` (POSIX bracket class, works on both BSD and GNU) emits the clean value.

## Audit

Swept the macOS installer surface — `install-dpf.sh`, `scripts/setup.sh`, the lifecycle `dpf-*.sh` scripts, and `scripts/installer/lib/*.sh` — for the same class of GNU-only constructs: `\s \S \w \d`, BRE `\+`/`\?`, bare `sed -i` (BSD needs `sed -i ''`), `grep -P`, `mapfile`/`readarray`, `${var^^}`, and associative arrays.

Found and fixed **two more** `\s` sites beyond the reported one:

- **`install-dpf.sh`** — `selectedModel` extraction from the host hardware profile JSON. Returned empty on macOS, so the installer never printed the "selected AI model" line.
- **`scripts/installer/lib/state.sh`** — the jq/python3-less fallback JSON reader (`grep` + `sed`) used by `dpf_state_read` for top-level scalar keys. The same reader that backs `install-state.json`; on BSD it returned a leading-space-prefixed value (or nothing).

**No other GNU-isms found.** `sed -i` already routes through the portable `dpf_sed_inplace` wrapper in `platform.sh` (which uses BSD `sed -i ''`), and there are no `mapfile`/`${var^^}`/associative-array uses — the bash 3.2 baseline holds.

## Verification

- Empirically reproduced each broken→fixed case on BSD sed/grep (Darwin 25.5.0).
- `shellcheck --shell=bash --severity=error` (the CI installer-surface gate) passes on all three touched files.

One concern per branch — this is the BSD-sed portability class only, separate from the prometheus/macOS monitoring work. References `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` Phase 2, which flagged this class in `setup.sh`; `docker.sh` slipped through because the macos-14 CI runner can't nest-virtualize Docker Desktop and only partially exercises the BSD path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)