### PR TITLE
fix(monitoring/macos): stop false ContainerDown CRITICAL from windows…

### DIFF
--- a/apps/web/components/monitoring/prometheus-config.test.ts
+++ b/apps/web/components/monitoring/prometheus-config.test.ts
@@ -25,6 +25,29 @@ describe("Prometheus substrate configs", () => {
     expect(config).toContain('targets: ["node-exporter:9100"]');
   });
 
+  it("keeps the Windows-only windows-host job out of the macOS scrape config", () => {
+    const config = readPrometheusConfig("prometheus.macos.yml");
+
+    // windows_exporter is a native Windows service with no macOS equivalent;
+    // scraping it would always fail and fire a false ContainerDown CRITICAL.
+    expect(config).not.toContain('job_name: "windows-host"');
+    // Linux-only exporters cannot run on macOS either.
+    expect(config).not.toContain('targets: ["cadvisor:8080"]');
+    expect(config).not.toContain('targets: ["node-exporter:9100"]');
+    // Cross-platform jobs must still be scraped.
+    expect(config).toContain('job_name: "portal"');
+    expect(config).toContain('job_name: "postgres"');
+    expect(config).toContain('job_name: "prometheus"');
+  });
+
+  it("mounts the macOS scrape config on the macOS overlay", () => {
+    const config = readRepoFile("docker-compose.macos.yml");
+
+    expect(config).toContain(
+      "./monitoring/prometheus/prometheus.macos.yml:/etc/prometheus/prometheus.yml:ro",
+    );
+  });
+
   it("does not page optional Linux exporter jobs through the default ContainerDown rule", () => {
     const config = readPrometheusConfig("alerts.yml");
 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -24,6 +24,14 @@
 #     Docker Desktop's own observability or external tooling per the
 #     Deployment Support Matrix.
 #
+#   - Prometheus mounts monitoring/prometheus/prometheus.macos.yml here
+#     instead of the base prometheus.yml. The base config carries the
+#     Windows-only `windows-host` job (windows_exporter on
+#     host.docker.internal:9182), which can never come up on macOS and
+#     would fire a false ContainerDown CRITICAL in Platform Health. The
+#     macOS config drops that job, mirroring how docker-compose.linux.yml
+#     mounts prometheus.linux.yml for its substrate.
+#
 #   - host.docker.internal is provided automatically by Docker Desktop;
 #     the extra_hosts entries in the base docker-compose.yml are
 #     harmless but redundant on this substrate.
@@ -34,6 +42,14 @@
 # Desktop's defaults align with the platform's needs.
 
 services:
+  prometheus:
+    # Mount the macOS scrape config (no windows-host / no Linux exporters)
+    # in place of the base prometheus.yml. See the header note above.
+    volumes:
+      - ./monitoring/prometheus/prometheus.macos.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+
   portal:
     environment:
       # Re-stating the Docker Desktop default for clarity. The base

--- a/monitoring/prometheus/prometheus.macos.yml
+++ b/monitoring/prometheus/prometheus.macos.yml
@@ -1,0 +1,63 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - "alerts.yml"
+
+scrape_configs:
+  # ─── Infrastructure ──────────────────────────────────────────
+  # macOS substrate (Apple Silicon, Docker Desktop). No host telemetry
+  # exporter is scraped here:
+  #   - cadvisor / node-exporter need /proc, /sys, /var/lib/docker, and
+  #     rootfs bind mounts that do not work on macOS, so docker-compose.macos.yml
+  #     leaves them behind the linux-monitoring profile (they never start).
+  #   - windows_exporter (`windows-host`) is a native Windows service and has
+  #     no macOS equivalent, so scraping host.docker.internal:9182 would always
+  #     fail and fire a false ContainerDown CRITICAL.
+  # Host metrics on macOS rely on Docker Desktop's own observability per the
+  # Deployment Support Matrix. docker-compose.macos.yml mounts this file.
+
+  # ─── Databases ───────────────────────────────────────────────
+  - job_name: "postgres"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  # Neo4j Community Edition does not expose Prometheus metrics.
+  # Neo4j Enterprise users: uncomment and add NEO4J_server_metrics_prometheus_enabled
+  # to the neo4j service environment in docker-compose.yml.
+  # - job_name: "neo4j"
+  #   scrape_interval: 30s
+  #   static_configs:
+  #     - targets: ["neo4j:2004"]
+  #   metrics_path: /metrics
+
+  - job_name: "qdrant"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["qdrant:6333"]
+    metrics_path: /metrics
+
+  # ─── Application ────────────────────────────────────────────
+  - job_name: "portal"
+    static_configs:
+      - targets: ["portal:3000"]
+    metrics_path: /api/metrics
+
+  - job_name: "sandbox"
+    static_configs:
+      - targets:
+          - "sandbox:3000"
+    metrics_path: /api/metrics
+
+  # ─── AI Inference ───────────────────────────────────────────
+  # Docker Model Runner does not expose a Prometheus `/metrics` endpoint
+  # (all paths 404). Inference health is tracked via the portal's
+  # `dpf_ai_inference_duration_seconds_*` application metrics instead.
+  # If/when Model Runner ships a metrics endpoint, re-add the scrape here.
+
+  # ─── Self-monitoring ────────────────────────────────────────
+  - job_name: "prometheus"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
…-host

The base prometheus.yml carries a Windows-only `windows-host` scrape job (windows_exporter on host.docker.internal:9182) that can never come up on macOS, firing a false ContainerDown CRITICAL in Platform Health. Add a macOS scrape config that drops windows-host and the Linux-only exporters (cadvisor/node-exporter), and mount it from docker-compose.macos.yml, mirroring how the Linux overlay mounts prometheus.linux.yml.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
