### PR TITLE
fix(voice): tag recorded blob with actual container so preview plays …

### DIFF
--- a/apps/web/components/agent/hooks/mime-probe.test.ts
+++ b/apps/web/components/agent/hooks/mime-probe.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   selectSupportedMimeType,
+  resolveRecordingBlobMimeType,
   PREFERRED_MEDIA_RECORDER_MIME_TYPES,
 } from "./mime-probe";
 
@@ -68,5 +69,31 @@ describe("selectSupportedMimeType", () => {
     const recorder = recorderStub(["audio/webm", "audio/webm;codecs=opus"]);
     // The order in the priority list matters more than insertion order in the stub.
     expect(selectSupportedMimeType(recorder)).toBe("audio/webm;codecs=opus");
+  });
+});
+
+describe("resolveRecordingBlobMimeType", () => {
+  it("prefers the recorder's actual mimeType over the requested one", () => {
+    // Safari default path: requested "" sentinel, but the recorder reports mp4.
+    expect(resolveRecordingBlobMimeType("audio/mp4", "")).toBe("audio/mp4");
+  });
+
+  it("never returns an empty string when both inputs are empty (the playback bug)", () => {
+    // The "" sentinel must NOT survive — a Blob tagged type:"" is undecodable.
+    expect(resolveRecordingBlobMimeType("", "")).toBe("audio/webm");
+  });
+
+  it("falls back to the requested type when the recorder reports nothing", () => {
+    expect(resolveRecordingBlobMimeType("", "audio/webm;codecs=opus")).toBe("audio/webm;codecs=opus");
+    expect(resolveRecordingBlobMimeType(undefined, "audio/mp4")).toBe("audio/mp4");
+  });
+
+  it("falls back to audio/webm when neither value is available", () => {
+    expect(resolveRecordingBlobMimeType(null, null)).toBe("audio/webm");
+    expect(resolveRecordingBlobMimeType(undefined, undefined)).toBe("audio/webm");
+  });
+
+  it("treats empty recorder mimeType as absent and uses the requested type", () => {
+    expect(resolveRecordingBlobMimeType("", "audio/mp4")).toBe("audio/mp4");
   });
 });

--- a/apps/web/components/agent/hooks/mime-probe.ts
+++ b/apps/web/components/agent/hooks/mime-probe.ts
@@ -59,3 +59,27 @@ export function selectSupportedMimeType(
   }
   return null;
 }
+
+/**
+ * Resolve the MIME type to tag a recorded Blob with for client-side <audio>
+ * playback.
+ *
+ * `MediaRecorder.mimeType` is authoritative: after construction the UA sets it
+ * to the container it is ACTUALLY producing, even on the browser-default path
+ * (when the recorder was constructed without an explicit type because
+ * selectSupportedMimeType() returned the "" sentinel — e.g. Safari, which
+ * rejects webm/ogg and records mp4/AAC by default). We prefer it over the
+ * requested type so the blob is never mislabelled.
+ *
+ * Empty strings are treated as absent (the `||` chain, NOT `??`): a Blob built
+ * with `type: ""` produces an object URL with no content type, which <audio>
+ * cannot decode — the recording captures fine but playback silently fails.
+ * The final "audio/webm" is a last-resort default for environments that report
+ * neither value.
+ */
+export function resolveRecordingBlobMimeType(
+  recorderMimeType: string | null | undefined,
+  requestedMimeType: string | null | undefined,
+): string {
+  return recorderMimeType || requestedMimeType || "audio/webm";
+}

--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition, useRef, useCallback } from "react"
 import { VoiceConsentForm } from "@/components/admin/VoiceConsentForm"
 import { setVoiceEnabled, resetVoiceProfile } from "@/lib/actions/voice-profile"
-import { selectSupportedMimeType } from "@/components/agent/hooks/mime-probe"
+import { resolveRecordingBlobMimeType, selectSupportedMimeType } from "@/components/agent/hooks/mime-probe"
 import { useVoiceSynth } from "@/components/agent/hooks/useVoiceSynth"
 import { LoaderCircle, Pause, Play, VolumeX } from "lucide-react"
 
@@ -317,7 +317,11 @@ function MicRecorder({ profileId }: { profileId: string }) {
 
       recorder.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data) }
       recorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: mimeType ?? "audio/webm" })
+        // Tag the blob with the container the recorder ACTUALLY produced so the
+        // <audio> preview can decode it (see resolveRecordingBlobMimeType).
+        const blob = new Blob(chunksRef.current, {
+          type: resolveRecordingBlobMimeType(recorder.mimeType, mimeType),
+        })
         const url = URL.createObjectURL(blob)
         setAudioUrl(url)
         setAudioBlob(blob)


### PR DESCRIPTION
…back

The voice-profile mic recorder built its preview Blob with `type: mimeType ?? "audio/webm"`. The `??` does not catch the "" sentinel that selectSupportedMimeType() returns on the browser-default path (e.g. macOS Safari, which rejects webm/ogg and records mp4/AAC), so the Blob was tagged type:"" — an undecodable object URL. Recording succeeded but <audio> playback silently failed.

Tag the Blob from recorder.mimeType (the container the UA actually produced) via a new resolveRecordingBlobMimeType helper, falling back to the requested type then audio/webm. Mirrors the correct fallback already in useVoiceCapture.ts:257.

Adds unit tests covering the empty-sentinel and fallback cases.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
