### PR TITLE
fix(installer): populate install-state fields the macOS path left blank

### DIFF
--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -292,6 +292,8 @@ dpf_docker_ensure_installed; rc=$?
 case "$rc" in
   0) ok "Docker present and reachable"
      dpf_state_write dockerEndpoint "$(dpf_docker_endpoint)" 2>/dev/null || true
+     dpf_state_write dockerContext "$(dpf_docker_context)" 2>/dev/null || true
+     dpf_state_write_json composeFiles "$(dpf_compose_files_json)" 2>/dev/null || true
      dpf_preflight_docker_memory ;;
   75) # Docker was just installed; operator must log out / newgrp
       echo ""
@@ -499,6 +501,25 @@ else
     info "Added DPF_BACKUPS_HOST_PATH=$REPO_ROOT-backups to existing .env"
   fi
 fi
+
+# Record the resolved LLM provider and image tag from the generated .env
+# into install-state.json so lifecycle scripts read them from one place
+# instead of re-parsing .env. An empty DPF_LLM_PROVIDER means "use the
+# platform default" (model-runner on macOS, ollama on Linux) per the
+# deployment LLM-provider contract.
+_dpf_env_value() { grep -E "^$1=" .env 2>/dev/null | head -1 | cut -d= -f2-; }
+DPF_RESOLVED_LLM_PROVIDER="$(_dpf_env_value DPF_LLM_PROVIDER)"
+if [ -z "$DPF_RESOLVED_LLM_PROVIDER" ]; then
+  case "$DPF_PLATFORM" in
+    darwin) DPF_RESOLVED_LLM_PROVIDER="model-runner" ;;
+    linux)  DPF_RESOLVED_LLM_PROVIDER="ollama" ;;
+  esac
+fi
+[ -n "$DPF_RESOLVED_LLM_PROVIDER" ] && \
+  dpf_state_write llmProvider "$DPF_RESOLVED_LLM_PROVIDER" 2>/dev/null || true
+DPF_RESOLVED_IMAGE_TAG="$(_dpf_env_value DPF_IMAGE_TAG)"
+[ -n "$DPF_RESOLVED_IMAGE_TAG" ] && \
+  dpf_state_write imageTag "$DPF_RESOLVED_IMAGE_TAG" 2>/dev/null || true
 
 # Ensure the backups host directory exists. Docker refuses to start the
 # service if a bind-mount source is missing, and the source now lives

--- a/scripts/installer/lib/autostart.sh
+++ b/scripts/installer/lib/autostart.sh
@@ -108,7 +108,7 @@ _dpf_autostart_install_darwin() {
     launchctl load -w "$plist_path" 2>/dev/null || warn "  launchctl load also failed; check $plist_path manually"
   fi
 
-  dpf_state_write autostart "{\"enabled\":true,\"kind\":\"launchagent\"}" 2>/dev/null || true
+  dpf_state_write_json autostart "{\"enabled\":true,\"kind\":\"launchagent\"}" 2>/dev/null || true
 }
 
 # Install the systemd user unit (Linux) and enable it.
@@ -124,7 +124,7 @@ _dpf_autostart_install_linux() {
 
   if ! command -v systemctl >/dev/null 2>&1; then
     warn "systemctl not found; skipping autostart unit install."
-    dpf_state_write autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
+    dpf_state_write_json autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
     return 0
   fi
 
@@ -148,7 +148,7 @@ _dpf_autostart_install_linux() {
     info "  Verify with: systemctl --user status $DPF_AUTOSTART_SYSTEMD_UNIT"
   fi
 
-  dpf_state_write autostart "{\"enabled\":true,\"kind\":\"systemd-user\"}" 2>/dev/null || true
+  dpf_state_write_json autostart "{\"enabled\":true,\"kind\":\"systemd-user\"}" 2>/dev/null || true
 }
 
 # Public entry point. Installs autostart for the current platform.
@@ -169,7 +169,7 @@ dpf_autostart_install() {
     linux)   _dpf_autostart_install_linux  "$install_path" "$compose_chain" "$template_dir" ;;
     *)
       warn "Autostart not implemented for platform: $DPF_PLATFORM"
-      dpf_state_write autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
+      dpf_state_write_json autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
       return 1
       ;;
   esac
@@ -196,5 +196,5 @@ dpf_autostart_uninstall() {
       ok "systemd user unit removed"
       ;;
   esac
-  dpf_state_write autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
+  dpf_state_write_json autostart "{\"enabled\":false,\"kind\":\"none\"}" 2>/dev/null || true
 }

--- a/scripts/installer/lib/compose.sh
+++ b/scripts/installer/lib/compose.sh
@@ -115,3 +115,21 @@ dpf_compose_chain() {
   dpf_compose_files "$@"
   printf '%s ' "${DPF_COMPOSE_FILES[@]}" | sed 's/ $//'
 }
+
+# Emit the assembled compose chain as a JSON array of filenames (the
+# `-f` flag tokens stripped), e.g. ["docker-compose.yml",
+# "docker-compose.macos.yml"]. Operates on the already-assembled
+# DPF_COMPOSE_FILES so it reflects whatever mode/platform/edge options
+# the prior dpf_compose_files call resolved. Recorded in
+# install-state.json's composeFiles. Compose filenames are repo-literal
+# (no quotes/backslashes), so manual JSON assembly is safe and keeps
+# this dependency-free on hosts without jq.
+dpf_compose_files_json() {
+  local json="[" first=1 tok
+  for tok in "${DPF_COMPOSE_FILES[@]}"; do
+    [ "$tok" = "-f" ] && continue
+    if [ "$first" = "1" ]; then first=0; else json="$json,"; fi
+    json="$json\"$tok\""
+  done
+  printf '%s]' "$json"
+}

--- a/scripts/installer/lib/docker.sh
+++ b/scripts/installer/lib/docker.sh
@@ -76,6 +76,17 @@ dpf_docker_endpoint() {
     || echo ""
 }
 
+# Resolve the name of the active Docker context (e.g. "desktop-linux"
+# on macOS Docker Desktop, "default" on native Linux Docker Engine).
+# Returns empty string if docker is unavailable. Recorded in
+# install-state.json so lifecycle scripts don't re-detect the context.
+dpf_docker_context() {
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+  docker context show 2>/dev/null || echo ""
+}
+
 # Apple Silicon Docker Desktop .dmg download URL. Hardcoded to the
 # canonical Docker Desktop endpoint; can be overridden via env var
 # for mirror / corporate-proxy setups.

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -36,3 +36,30 @@ test("CI doctor bundle uploads include the hidden .dpf directory", () => {
     assert.match(workflow, /include-hidden-files:\s+true/);
   }
 });
+
+test("autostart persists install-state.autostart as a JSON object, not a quoted string", () => {
+  const autostart = read("scripts/installer/lib/autostart.sh");
+
+  // dpf_state_write quotes its value, so writing the autostart object
+  // through it yields autostart="{...}" (a string). All five sites must
+  // use the object-aware dpf_state_write_json so the field stays an object.
+  assert.doesNotMatch(autostart, /dpf_state_write\s+autostart\s/);
+  assert.match(autostart, /dpf_state_write_json\s+autostart\s+"\{\\"enabled\\":true,\\"kind\\":\\"launchagent\\"\}"/);
+  assert.match(autostart, /dpf_state_write_json\s+autostart\s+"\{\\"enabled\\":true,\\"kind\\":\\"systemd-user\\"\}"/);
+});
+
+test("installer populates the previously-null install-state fields", () => {
+  const installer = read("install-dpf.sh");
+
+  // These were left at their init defaults (null / []) on macOS because
+  // the install flow never wrote them. Each must now be persisted.
+  assert.match(installer, /dpf_state_write\s+dockerContext\s+"\$\(dpf_docker_context\)"/);
+  assert.match(installer, /dpf_state_write_json\s+composeFiles\s+"\$\(dpf_compose_files_json\)"/);
+  assert.match(installer, /dpf_state_write\s+llmProvider\s+"\$DPF_RESOLVED_LLM_PROVIDER"/);
+  assert.match(installer, /dpf_state_write\s+imageTag\s+"\$DPF_RESOLVED_IMAGE_TAG"/);
+});
+
+test("install-state helper functions backing the new fields are defined", () => {
+  assert.match(read("scripts/installer/lib/docker.sh"), /dpf_docker_context\(\)\s*\{/);
+  assert.match(read("scripts/installer/lib/compose.sh"), /dpf_compose_files_json\(\)\s*\{/);
+});


### PR DESCRIPTION
## Problem

On a fresh **macOS** install, `~/.dpf/install-state.json` came out malformed — observed on the first real Apple Silicon run:

```json
"dockerContext": null,
"composeFiles": [],
"llmProvider": null,
"imageTag": null,
"autostart": "{\"enabled\":true,\"kind\":\"launchagent\"}"   // a STRING, not an object
```

Lifecycle scripts (`dpf-start`/`dpf-stop`/`dpf-reinstall`) read these fields and got degraded or wrong data.

## Causes & fixes

| Field | Cause | Fix |
|---|---|---|
| `autostart` | All 5 sites wrote the object through `dpf_state_write`, which **quotes** its value → stored as a string. | Switch to the object-aware `dpf_state_write_json` helper. |
| `dockerContext` | Never written; no resolver existed. | New `dpf_docker_context()` (`docker context show`); persisted next to `dockerEndpoint`. |
| `composeFiles` | Never written. | New `dpf_compose_files_json()` emits the assembled chain as a JSON array of filenames (`-f` tokens stripped); persisted after resolution. |
| `llmProvider` / `imageTag` | Never written. | Read from generated `.env` after env-gen; empty `DPF_LLM_PROVIDER` falls back to the platform default (model-runner on macOS, ollama on Linux) per the LLM-provider contract. |

## Verification

- **Functional, on Apple Silicon**: sourced the installer modules, simulated the install-flow writes against a temp state file, and asserted the resulting JSON types/values — `autostart` is an object, `composeFiles` a filename array, `dockerContext` = `desktop-linux`, `dockerEndpoint` a clean `unix://` URI, `llmProvider`/`imageTag` populated.
- **Contract tests**: 3 new static guards in `tests/release/installer-release-contract.test.mjs` (6/6 pass) lock the `dpf_state_write_json` usage, the new write sites, and the helper definitions.
- All additions are bash 3.2-safe.

The related `dockerEndpoint` `\s`→`[[:space:]]` BSD-sed fix landed separately on `main`.

First real-hardware macOS run; see `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)