### PR TITLE
fix(self-upgrade): derive portal version from real build identity + stamp images

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -148,6 +148,14 @@ jobs:
           platforms: linux/${{ matrix.platform.arch }}
           provenance: mode=max
           sbom: true
+          # Stamp the published image's source identity (/app/.dpf-image-version)
+          # with the release commit SHA so /ops/self-upgrade can compare a
+          # customer's deployed image to the upgrade target. Without this the
+          # Dockerfile falls back to a content hash that never matches a git SHA,
+          # leaving freshness checks permanently inert on customer installs.
+          # Harmless for images whose Dockerfile ignores DPF_VERSION.
+          build-args: |
+            DPF_VERSION=${{ github.sha }}
           # Push by digest only — the merge job assembles the named
           # tag manifest list. `type=image,name=...,push-by-digest=true`
           # uploads the layers under the digest with no human tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,11 @@ RUN if [ -n "$DPF_VERSION" ]; then \
         | sort -k 2 | sha256sum | cut -d ' ' -f 1 > /app/.dpf-image-version; \
     fi
 
+# Build timestamp (UTC, ISO-8601), surfaced alongside the source identity in
+# /ops/self-upgrade so operators can see when the running image was produced,
+# independent of the static version.json baseline.
+RUN date -u +%Y-%m-%dT%H:%M:%SZ > /app/.dpf-image-built-at
+
 # Promoter build context (autonomous deployment pipeline)
 # These files let the portal build the dpf-promoter image on first use.
 COPY Dockerfile.promoter /promoter/Dockerfile.promoter

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -56,6 +56,7 @@ const baseStatus = {
     publishedAt: "2026-05-24T00:00:00.000Z",
     gitSha: "abc1234",
     imageVersion: null,
+    buildDate: null,
     note: "baseline",
   },
 } as const;

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -35,6 +35,7 @@ type Props = {
     publishedAt: string;
     gitSha: string | null;
     imageVersion?: { raw: string; source: ImageVersionSource } | null;
+    buildDate?: string | null;
     note: string | null;
   };
 };
@@ -155,16 +156,27 @@ export default function SelfUpgradeClient({
         data-platform-version={platformVersion.version}
       >
         <div className="text-xs text-[var(--dpf-muted)]">
-          <span className="font-medium text-[var(--dpf-text)]">Platform version:</span>{" "}
-          <span className="font-mono text-[var(--dpf-text)]">
-            {platformVersion.version}
-          </span>
-          {(platformVersion.gitSha || platformVersion.imageVersion?.raw) && (
-            <span className="ml-2 font-mono text-[var(--dpf-muted)]">
-              ({sourceLabel(platformVersion.imageVersion?.source)}{" "}
-              {shortSha(platformVersion.gitSha ?? platformVersion.imageVersion?.raw ?? null)})
+          <span className="font-medium text-[var(--dpf-text)]">Platform build:</span>{" "}
+          {platformVersion.gitSha || platformVersion.imageVersion?.raw ? (
+            <span className="font-mono text-[var(--dpf-text)]">
+              {shortSha(platformVersion.gitSha ?? platformVersion.imageVersion?.raw ?? null)}
+            </span>
+          ) : (
+            <span className="font-mono text-[var(--dpf-text)]">dev (unbuilt)</span>
+          )}
+          {platformVersion.imageVersion?.source && (
+            <span className="ml-2 text-[var(--dpf-muted)]">
+              ({sourceLabel(platformVersion.imageVersion.source)})
             </span>
           )}
+          {platformVersion.buildDate && (
+            <span className="ml-2 text-[var(--dpf-muted)]">
+              · built {formatDate(platformVersion.buildDate)}
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-[var(--dpf-muted)]">
+          baseline v{platformVersion.version}
         </div>
         {enabled && (
           <>
@@ -192,10 +204,11 @@ export default function SelfUpgradeClient({
             )}
             {!isFresh && targetSha && deployedShaSource === "content-hash" && (
               <div className="text-xs text-[var(--dpf-warning)]">
-                Image built without a git-SHA stamp; cannot compare to remote
-                target. Rebuild with{" "}
-                <span className="font-mono">scripts/build-images.ps1</span> to
-                enable freshness checks.
+                This image wasn&apos;t stamped with a git commit, so it
+                can&apos;t be compared to the upgrade target. Published releases
+                are stamped automatically by CI; for a local build, rebuild with{" "}
+                <span className="font-mono">scripts/build-images.sh</span>{" "}
+                (<span className="font-mono">build-images.ps1</span> on Windows).
               </div>
             )}
             {!isFresh && targetSha && deployedShaSource !== "content-hash" && (

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -608,6 +608,7 @@ export async function getSelfUpgradeStatus() {
       publishedAt: platformVersion.publishedAt.toISOString(),
       gitSha: platformVersion.gitSha,
       imageVersion: platformVersion.imageVersion,
+      buildDate: platformVersion.buildDate,
       note: platformVersion.note,
     },
   };

--- a/apps/web/lib/platform/image-version.ts
+++ b/apps/web/lib/platform/image-version.ts
@@ -35,6 +35,25 @@ export async function readImageVersion(
   }
 }
 
+const IMAGE_BUILT_AT_PATH = "/app/.dpf-image-built-at";
+
+/**
+ * Read the build timestamp baked into the running portal image by the
+ * Dockerfile (see /app/.dpf-image-built-at). ISO-8601 UTC. Returns null when
+ * the marker is absent — non-container environments (next dev, vitest) and
+ * images built before this marker existed.
+ */
+export async function readImageBuiltAt(
+  path: string = IMAGE_BUILT_AT_PATH,
+): Promise<string | null> {
+  try {
+    const raw = (await readFile(path, "utf-8")).trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Classify the version string by shape. A 40-char hex string is treated as a
  * git SHA; a 64-char hex string is treated as a sha256 content hash. Anything

--- a/apps/web/lib/platform/version-config.test.ts
+++ b/apps/web/lib/platform/version-config.test.ts
@@ -11,6 +11,7 @@ describe("syncPlatformVersionConfig", () => {
         publishedAt: new Date("2026-05-24T00:00:00.000Z"),
         gitSha: "abc123",
         imageVersion: { raw: "abc123", source: "git-sha" },
+        buildDate: null,
         note: "baseline",
       }),
       platformConfig: { upsert },

--- a/apps/web/lib/platform/version.test.ts
+++ b/apps/web/lib/platform/version.test.ts
@@ -53,6 +53,7 @@ describe("loadPlatformVersion", () => {
           raw: "b5cdebc05e7fefb39f3d78b42348de1e81c64bae0e2bd57632387aef9c6ab5b2",
           source: "content-hash",
         }),
+      readImageBuiltAt: vi.fn().mockResolvedValue(null),
     }));
     const { loadPlatformVersion } = await import("./version");
     const v = await loadPlatformVersion();

--- a/apps/web/lib/platform/version.ts
+++ b/apps/web/lib/platform/version.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import { readImageVersion, type ImageVersion } from "./image-version";
+import { readImageBuiltAt, readImageVersion, type ImageVersion } from "./image-version";
 
 export type PlatformVersion = {
   version: string;
@@ -21,6 +21,11 @@ export type PlatformVersion = {
    * git SHA is available.
    */
   imageVersion: ImageVersion | null;
+  /**
+   * ISO-8601 UTC timestamp baked into the image at build time
+   * (/app/.dpf-image-built-at). Null in dev/test and pre-marker images.
+   */
+  buildDate: string | null;
   note: string | null;
 };
 
@@ -41,7 +46,10 @@ export async function loadPlatformVersion(): Promise<PlatformVersion> {
       const path = resolveVersionJsonPath();
       const raw = await readFile(path, "utf8");
       const parsed = parseVersionJson(JSON.parse(raw));
-      const image = await readImageVersion();
+      const [image, buildDate] = await Promise.all([
+        readImageVersion(),
+        readImageBuiltAt(),
+      ]);
       const envSha = process.env.DEPLOYED_SHA;
       return {
         version: parsed.version,
@@ -53,6 +61,7 @@ export async function loadPlatformVersion(): Promise<PlatformVersion> {
               ? image.raw
               : null,
         imageVersion: image,
+        buildDate,
         note: parsed.note ?? null,
       };
     })();

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -625,6 +625,18 @@ fi
 #     resolves to (Docker Model Runner on Docker Desktop; Ollama on
 #     Linux native Docker via docker-compose.linux.yml).
 step "Bringing up the platform"
+# Stamp the build with the current commit so /ops/self-upgrade can compare the
+# running image to the upgrade target. Contributor mode builds from local
+# source; without this the Dockerfile falls back to a content hash that can
+# never match a git-SHA target, leaving freshness checks inert. Customer mode
+# pulls CI-stamped images, so we leave DPF_VERSION unset there (the host
+# checkout SHA is unrelated to the pulled image and would mislabel DEPLOYED_SHA).
+if [ "$DPF_INSTALL_MODE" = "contributor" ] && [ -d .git ]; then
+  if DPF_VERSION="$(git rev-parse HEAD 2>/dev/null)" && [ -n "$DPF_VERSION" ]; then
+    export DPF_VERSION
+    ok "Stamping local build with DPF_VERSION=$DPF_VERSION"
+  fi
+fi
 docker compose "${DPF_COMPOSE_FILES[@]}" up -d
 ok "docker compose up returned"
 


### PR DESCRIPTION
## Problem

On a fresh Mac deploy, **/ops/self-upgrade** showed misinformation:

- **"Platform version: 1.0.0"** — a hardcoded value from static `version.json`, decoupled from the actual running build. Every install shows `1.0.0` regardless of what's deployed.
- **"image hash 01016e…"** — a 64-char content hash instead of a git SHA, so the deployed identity can never be compared to the upgrade target (freshness check is permanently inert).
- A warning telling the Mac operator to **"Rebuild with `scripts/build-images.ps1`"** — a Windows-only script, wrong platform and wrong audience (customers pull pre-built images; they don't rebuild).

### Root cause
Images built **without `DPF_VERSION`** fall back to a `sha256` content hash in the Dockerfile. The macOS installer and CI both built/published without setting it, so the deployed identity was never a comparable git SHA.

## Changes

| File | Change |
|---|---|
| `.github/workflows/publish-image.yml` | Stamp published GHCR images with `DPF_VERSION=${{ github.sha }}` → customer installs get a real commit SHA |
| `install-dpf.sh` | Stamp local **contributor** builds from `git rev-parse HEAD` before `compose up` (guarded to contributor mode + a `.git` checkout, so it never mislabels a pulled customer image) |
| `Dockerfile` | Bake `/app/.dpf-image-built-at` build timestamp |
| `lib/platform/{version,image-version}.ts` | Surface `buildDate` via new `readImageBuiltAt()` |
| `components/ops/SelfUpgradeClient.tsx` | Lead with **real build identity** (commit/image-hash + build date); demote `version.json` semver to a small "baseline vX" line; cross-platform warning text |
| `lib/actions/promotions.ts` | Pass `buildDate` to the client |
| tests | Fixtures updated for the new `buildDate` field |

## Scope / not included
Portal **display + image stamping only**. The self-upgrade *promoter* blockers found during the first Mac test are **out of scope** and tracked separately:
- Manual "Trigger Now" no-ops outside the maintenance window (skips before creating a run; UI still says "queued").
- `scripts/promote.sh` curls a `/sha` endpoint that doesn't exist, never checks out the target SHA, and its rebuild is unstamped.

## Test
- `tsc --noEmit` clean for touched areas.
- `vitest`: `version`, `version-config`, `image-version`, `self-upgrade/page`, `promote-script-contract`, `promotions.self-upgrade` — 73 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)