### PR TITLE
fix(self-upgrade): align platform-version test with "Platform build:" label (unblocks CI)

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -454,7 +454,7 @@ describe("SelfUpgradeClient – config summary null SHAs", () => {
 describe("SelfUpgradeClient – platform version", () => {
   it("renders the Platform version label and value", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Platform version");
+    expect(html).toContain("Platform build:");
     expect(html).toContain("1.0.0");
   });
 
@@ -476,7 +476,7 @@ describe("SelfUpgradeClient – platform version", () => {
         }}
       />,
     );
-    expect(html).toContain("Platform version");
+    expect(html).toContain("Platform build:");
     expect(html).toContain("1.0.0");
     expect(html).not.toContain("9f8e7d6");
   });
@@ -485,7 +485,7 @@ describe("SelfUpgradeClient – platform version", () => {
     const html = renderToStaticMarkup(
       <SelfUpgradeClient {...baseStatus} enabled={false} />,
     );
-    expect(html).toContain("Platform version");
+    expect(html).toContain("Platform build:");
     expect(html).toContain("1.0.0");
   });
 });


### PR DESCRIPTION
## Problem
`main` is red: the **Unit Tests** job fails on `SelfUpgradeClient.test.tsx`, which blocks CI on **every** open PR.

## Cause
#1258 (`fix(self-upgrade): derive portal version from real build identity`) renamed the rendered label from **"Platform version"** to **"Platform build:"** in `SelfUpgradeClient.tsx`, but three assertions in `SelfUpgradeClient.test.tsx` still check `toContain("Platform version")`.

## Fix
Update the three stale assertions to the merged label `"Platform build:"`. Test-only change; `SelfUpgradeClient.test.tsx` is now 50/50 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
