### PR TITLE
fix(self-upgrade): run the promoter as a sibling container, not bash in-portal

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -167,7 +167,9 @@ const ENABLED_CONFIG = {
   checkIntervalHours: 24,
   healthTarget: 100,
   maintenanceWindows: [],
+  hostInstallPath: "/Users/me/dpf",
   hostSourceMountPath: "/host-dpf",
+  promoterImage: "dpf-promoter",
   repositoryRemote: "origin",
   repositoryBranch: "main",
   healthUrl: "http://localhost:3000/api/health",
@@ -202,14 +204,17 @@ describe("success path", () => {
     expect(mocks.resolveTargetSha).toHaveBeenCalledWith("stable", ENABLED_CONFIG);
   });
 
-  it("runs the promoter with configured source, backup, and health paths", async () => {
+  it("runs the promoter with the host install path, backup, image, and health paths", async () => {
     await runSelfUpgrade({ triggeredBy: "ops" });
     expect(mocks.runPromoter).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourcePath: "/host-dpf",
+        // The promoter is launched as a sibling container against the HOST
+        // install path (daemon-resolved), not an in-portal source path.
+        hostInstallPath: "/Users/me/dpf",
         targetSha: "abc1234deadbeef",
         backupPath: "/backups/self-upgrade/SUR-AAAABBBB",
         healthUrl: "http://localhost:3000/api/health",
+        promoterImage: "dpf-promoter",
       }),
     );
   });

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -114,10 +114,20 @@ export async function runSelfUpgrade(
   }
 
   const result = await runPromoter({
-    sourcePath: config.hostSourceMountPath ?? process.env.PROMOTE_SOURCE ?? "",
+    // HOST path of the install tree, bind-mounted into the promoter
+    // container. Daemon-resolved, so it must be a host path (not an
+    // in-portal path). hostSourceMountPath is the in-container mount and
+    // is no longer passed — runPromoter mounts to a fixed /host-source.
+    hostInstallPath:
+      config.hostInstallPath ??
+      process.env.DPF_HOST_INSTALL_PATH ??
+      process.env.PROMOTE_SOURCE ??
+      "",
     targetSha,
     backupPath: process.env.PROMOTE_BACKUP_PATH ?? `/backups/self-upgrade/${run.runId}`,
+    backupHostPath: process.env.DPF_BACKUPS_HOST_PATH ?? undefined,
     healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
+    promoterImage: config.promoterImage,
     dryRun: params.dryRun,
   });
 

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { buildPromoterCommand } from "./promoter";
+
+const BASE = {
+  hostInstallPath: "/Users/me/dpf",
+  targetSha: "abc1234",
+  backupPath: "/backups/self-upgrade/run-1",
+  healthUrl: "http://localhost:3000/api/health",
+};
+
+describe("buildPromoterCommand", () => {
+  it("launches the promoter as a sibling container, not bash in-portal", () => {
+    const { command, args } = buildPromoterCommand(BASE);
+    const joined = args.join(" ");
+
+    // The previous defect spawned bash against an in-portal script. The
+    // promoter must run as a separate docker container instead.
+    expect(command).toBe("docker");
+    expect(args.slice(0, 2)).toEqual(["run", "--rm"]);
+    expect(joined).not.toContain("bash");
+    expect(joined).not.toContain("promote.sh");
+    expect(joined).not.toContain("scripts/");
+  });
+
+  it("mounts the docker socket and the host source tree read-only", () => {
+    const { args } = buildPromoterCommand(BASE);
+    expect(args).toContain("/var/run/docker.sock:/var/run/docker.sock");
+    expect(args).toContain("/Users/me/dpf:/host-source:ro");
+  });
+
+  it("passes the promote contract via env and targets the promoter image", () => {
+    const { args } = buildPromoterCommand(BASE);
+    expect(args).toContain("PROMOTE_SOURCE=/host-source");
+    expect(args).toContain("PROMOTE_TARGET_SHA=abc1234");
+    expect(args).toContain("PROMOTE_BACKUP_PATH=/backups/self-upgrade/run-1");
+    expect(args).toContain("PROMOTE_HEALTH_URL=http://localhost:3000/api/health");
+    // Image is a positional arg followed by the entrypoint flag.
+    expect(args).toContain("dpf-promoter");
+    expect(args).toContain("--self-upgrade");
+    expect(args.indexOf("dpf-promoter")).toBeLessThan(args.indexOf("--self-upgrade"));
+  });
+
+  it("honors a custom promoter image", () => {
+    const { args } = buildPromoterCommand({ ...BASE, promoterImage: "ghcr.io/x/dpf-promoter:v1" });
+    expect(args).toContain("ghcr.io/x/dpf-promoter:v1");
+    expect(args).not.toContain("dpf-promoter");
+  });
+
+  it("appends --dry-run only when requested", () => {
+    expect(buildPromoterCommand(BASE).args).not.toContain("--dry-run");
+    expect(buildPromoterCommand({ ...BASE, dryRun: true }).args).toContain("--dry-run");
+    // --dry-run must come after the image + --self-upgrade entrypoint flag.
+    const dry = buildPromoterCommand({ ...BASE, dryRun: true }).args;
+    expect(dry.indexOf("--self-upgrade")).toBeLessThan(dry.indexOf("--dry-run"));
+  });
+
+  it("mounts the backups volume only when a host path is provided", () => {
+    expect(buildPromoterCommand(BASE).args).not.toContain("/backups");
+    const withBackup = buildPromoterCommand({ ...BASE, backupHostPath: "/Users/me/dpf-backups" });
+    expect(withBackup.args).toContain("/Users/me/dpf-backups:/backups");
+  });
+});

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -1,11 +1,48 @@
 import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+
+/**
+ * The promoter runs as a SIBLING container, never inside the portal.
+ *
+ * scripts/promote.sh rebuilds the portal image and runs
+ * `docker compose up -d --force-recreate`, which recreates the portal
+ * container. If the script ran inside the portal (the previous behavior:
+ * `spawn("bash", "scripts/promote.sh")` against process.cwd()), the
+ * recreate would kill the very process executing it mid-swap — and the
+ * portal image (Alpine) ships neither bash nor the script, so it could
+ * never run there at all.
+ *
+ * Instead we launch the dedicated promoter image (Dockerfile.promoter:
+ * docker-cli + compose + git + promote.sh as ENTRYPOINT) as a separate
+ * container via the docker socket the portal already mounts. The promoter
+ * survives the portal recycle. This mirrors the `promoter` service +
+ * `promoterImage` contract in docker-compose.yml / the self_upgrade config.
+ *
+ * Scope note: this fixes WHERE the promoter runs. The promote.sh apply
+ * logic itself (real image rebuild, layer-aware L1–L4 ordering, rollback,
+ * /sha verify) remains the Phase-5 work of the governed-upgrade-lifecycle
+ * epic (BI-UPGRADE-011/012); see
+ * docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md §5.5/§5.6.
+ */
+
+const DEFAULT_PROMOTER_IMAGE = "dpf-promoter";
+// Where the host source tree is mounted inside the promoter container.
+// Matches the `promoter` service's `:/host-source:ro` mount in
+// docker-compose.yml so promote.sh sees the same path either way.
+const PROMOTER_CONTAINER_SOURCE = "/host-source";
 
 export type PromoterParams = {
-  sourcePath: string;
+  /** HOST path of the install tree; bind-mounted into the promoter. */
+  hostInstallPath: string;
+  /** Git SHA to promote to. */
   targetSha: string;
+  /** In-container path the promoter writes its pre-swap backup to. */
   backupPath: string;
+  /** Health URL the promoter curls after the swap. */
   healthUrl: string;
+  /** Promoter image tag. Defaults to "dpf-promoter". */
+  promoterImage?: string;
+  /** HOST path for the backups volume; mounted to /backups when provided. */
+  backupHostPath?: string;
   dryRun?: boolean;
 };
 
@@ -15,27 +52,68 @@ export type PromoterResult = {
   stderr: string;
 };
 
-export async function runPromoter(params: PromoterParams): Promise<PromoterResult> {
-  const scriptPath = resolve(process.cwd(), "scripts/promote.sh");
-  const args = ["--self-upgrade"];
+/**
+ * Pure builder for the `docker run` invocation that launches the promoter
+ * container. Separated from runPromoter so it can be unit-tested without
+ * spawning a process. Returns the command and argv exactly as spawned.
+ */
+export function buildPromoterCommand(
+  params: PromoterParams,
+): { command: string; args: string[] } {
+  const image =
+    params.promoterImage && params.promoterImage.length > 0
+      ? params.promoterImage
+      : DEFAULT_PROMOTER_IMAGE;
+
+  const args = [
+    "run",
+    "--rm",
+    // Sibling-container control: the promoter drives the daemon to rebuild
+    // and recreate the portal.
+    "-v",
+    "/var/run/docker.sock:/var/run/docker.sock",
+    // Host source tree (read-only): build context + backup source.
+    "-v",
+    `${params.hostInstallPath}:${PROMOTER_CONTAINER_SOURCE}:ro`,
+  ];
+
+  if (params.backupHostPath && params.backupHostPath.length > 0) {
+    args.push("-v", `${params.backupHostPath}:/backups`);
+  }
+
+  args.push(
+    "-e",
+    `PROMOTE_SOURCE=${PROMOTER_CONTAINER_SOURCE}`,
+    "-e",
+    `PROMOTE_TARGET_SHA=${params.targetSha}`,
+    "-e",
+    `PROMOTE_BACKUP_PATH=${params.backupPath}`,
+    "-e",
+    `PROMOTE_HEALTH_URL=${params.healthUrl}`,
+    image,
+    "--self-upgrade",
+  );
+
   if (params.dryRun) args.push("--dry-run");
 
+  return { command: "docker", args };
+}
+
+export async function runPromoter(params: PromoterParams): Promise<PromoterResult> {
+  const { command, args } = buildPromoterCommand(params);
+
   return new Promise((done, reject) => {
-    const child = spawn("bash", [scriptPath, ...args], {
-      env: {
-        ...process.env,
-        PROMOTE_SOURCE: params.sourcePath,
-        PROMOTE_TARGET_SHA: params.targetSha,
-        PROMOTE_BACKUP_PATH: params.backupPath,
-        PROMOTE_HEALTH_URL: params.healthUrl,
-      },
-    });
+    const child = spawn(command, args, { env: { ...process.env } });
 
     let stdout = "";
     let stderr = "";
 
-    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk; });
-    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk; });
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk;
+    });
 
     child.on("close", (code: number | null) => {
       done({ exitCode: code ?? 1, stdout, stderr });


### PR DESCRIPTION
## Problem

Found on the first macOS contributor install while validating `/ops/self-upgrade` (the feature had **0 runs** and even a dry-run errored).

`runPromoter` spawned **`bash scripts/promote.sh`** against `process.cwd()` — i.e. **inside the portal container**. That can't work:
- The portal image (Alpine) ships **no `bash`** and **no `scripts/promote.sh`** (verified in-container).
- `promote.sh` runs `docker compose up -d --force-recreate`, which **recreates the portal container** — killing the very process executing the script mid-swap.

The platform already has a dedicated promoter (`Dockerfile.promoter`: docker-cli + compose + git + `promote.sh` as ENTRYPOINT; the `promoter` compose service; `self_upgrade.promoterImage`), but `runPromoter` bypassed all of it.

## Fix

Launch the promoter **image as a sibling container** via the docker socket the portal already mounts, so it survives the portal recycle:
- New pure `buildPromoterCommand()` builds the `docker run --rm` argv — mounts the docker socket + the **HOST** install path (daemon-resolved) read-only at `/host-source`, passes the `PROMOTE_*` contract via `-e`, optionally mounts the backups volume, targets `promoterImage` (default `dpf-promoter`), appends `--dry-run` when requested.
- `runPromoter` spawns that instead of in-portal bash.
- Caller passes `hostInstallPath` / `promoterImage` / `backupHostPath` from the `self_upgrade` config.

## Scope

This fixes **where** the promoter runs — necessary groundwork. The `promote.sh` apply logic itself (real image rebuild, layer-aware L1–L4 ordering, rollback, `/sha` verify) remains **Phase-5** of the governed-upgrade-lifecycle epic (`BI-UPGRADE-011/012`; `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md` §5.5/§5.6). So this PR alone does not make end-to-end self-upgrade succeed on a dev install.

## Verification

- `promoter.test.ts` — 6/6 pass (pure `buildPromoterCommand` argv: container not bash, socket + source mounts, PROMOTE_* env, image selection, `--dry-run` gating, backups mount).
- `pnpm --filter web typecheck` — clean.
- `self-upgrade.test.ts` assertion updated to the new param shape. (Note: that file currently can't load in an isolated worktree due to a pre-existing `@/lib/tak/agent-event-bus` alias-resolution issue that reproduces on clean `main` — unrelated to this change.)

First real-hardware macOS run finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)