### PR TITLE
feat(skills): DPF-native equivalents for composed superpowers skills

### DIFF
--- a/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
@@ -302,9 +302,11 @@ The first three phases are the minimum viable contract for Windows contributors 
 
 ## Acceptance Criteria
 
+> **Addendum (2026-05-30):** the `superpowers:*` requirement in criteria 1-2 is **superseded**. The composed capabilities are now DPF-native skills in `packages/dpf-skill-pack` (`dpf-brainstorming`, `dpf-systematic-debugging`, `dpf-finishing-a-development-branch`), so the pack no longer depends on upstream `obra/superpowers`. Read "lists `dpf-platform:*` skills and `superpowers:*` skills" as "lists `dpf-platform:*` skills (which now include the DPF-native capability equivalents)". Upstream superpowers is an optional convenience, not a readiness requirement. See [2026-05-30-dpf-native-skill-equivalents-design.md](2026-05-30-dpf-native-skill-equivalents-design.md).
+
 A fresh Windows, macOS, or Linux install of DPF, on a machine where the contributor has just installed Claude Code (or Codex CLI) for the first time and never edited any config file, must produce:
 
-1. A Claude Code session opened from the repo root that lists `dpf-platform:*` skills and `superpowers:*` skills in its available-skills list and that responds to the destructive-action smoke prompt by naming `destructive-actions-require-explicit-go`.
+1. A Claude Code session opened from the repo root that lists `dpf-platform:*` skills (including the DPF-native capability equivalents per the 2026-05-30 addendum above) in its available-skills list and that responds to the destructive-action smoke prompt by naming `destructive-actions-require-explicit-go`.
 2. A Codex CLI session that lists the same set and refuses the same prompt.
 3. `mcp__dpf__*` tools available without re-issuance, and a non-mutating `tools/list` probe recorded in `agentToolchain`.
 4. Re-running the installer is a no-op on a clean install (zero file writes, exit 0) and is reconciling on a drifted install (writes only the deltas, preserves user comments / edits).

--- a/docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md
+++ b/docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md
@@ -1,0 +1,201 @@
+---
+title: DPF-native skill equivalents — own the composed capabilities, retire the dangling superpowers dependency
+status: draft-for-operator-review
+author: Claude (Opus 4.8)
+reviewers:
+  - Mark (operator review pending)
+date: 2026-05-30
+backlog:
+  - "TBD — file after operator review; live MCP check on 2026-05-30 confirmed overlap with BI-98683E68 / BI-90793048, so this should be a scope-revision child or follow-up under EP-REDUCTION-GEAR-ARCH rather than a new epic"
+epics:
+  - EP-REDUCTION-GEAR-ARCH
+related:
+  - packages/dpf-skill-pack/README.md
+  - packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
+  - packages/dpf-skill-pack/skills/dpf-evidence-before-diagnosis/SKILL.md
+  - packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
+  - packages/db/src/seed-skills.ts
+  - packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
+  - packages/dpf-bootstrap/src/agent-toolchain/install-state.ts
+  - scripts/dpf-bootstrap-agent-toolchain.sh
+  - .claude-plugin/marketplace.json
+  - .agents/plugins/marketplace.json
+  - docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
+  - docs/superpowers/drafts/2026-05-24-dpf-skill-pack-formalization-bi-bundle.md
+  - docs/superpowers/audits/2026-05-24-superpowers-snapshot-drift.md
+related_backlog:
+  - "BI-98683E68 (in-progress — auto-install dpf-platform pack; assumes upstream superpowers stays alongside; this spec revises that assumption)"
+  - "BI-90793048 (triaging/captured — parent DPF skill pack formalization bundle)"
+  - "BI-446E169C (in-progress pending operator sign-off — retired the manual superpowers snapshot in commit efd0924a)"
+prs: []
+---
+
+# DPF-native skill equivalents
+
+## Execution note (operator decision, 2026-05-30)
+
+**This work is done directly in this repo, not promoted to Build Studio.** Build Studio is currently non-functional (self-upgrade quiescence deadlock fixed today in `bcaa30a8`, but the broader BS pipeline is not yet exercised on this host). The standing "Build Studio for ALL development" rule (`dpf-promote-to-build-studio`) is therefore **suspended for this BI** by explicit operator authorization. Claude authors the skills directly; the normal BS Ideate→Build→Verify gates are replaced by operator review of this spec plus the acceptance evidence below.
+
+## Purpose
+
+Make the DPF skill pack **self-sufficient**: the procedural capabilities its skills compose with must come from DPF's own kernel-governed source, not from an upstream collection that can drift, be retired, or simply be absent. Today three DPF skills declare hard `composesFrom` dependencies on upstream `obra/superpowers` skills that are present on **none** of the three surfaces, so those compositions dangle. This spec authors DPF-native equivalents so every `composesFrom` resolves from one source on every surface, and demotes the upstream collection to an optional convenience.
+
+## Architecture review delta (folded in 2026-05-30)
+
+This revision incorporates an advisory `dpf-architecture-review` pass. The important fixes:
+
+1. **Live backlog state corrected.** `BI-98683E68`, `BI-90793048`, and `BI-446E169C` were checked through the live MCP backlog tools on 2026-05-30. `BI-446E169C` has retirement evidence but is still `in-progress` pending sign-off; this spec must not describe it as done.
+2. **Installed-cache verification added.** The repo source can contain a skill that the contributor client's installed plugin cache does not yet expose. The current host already shows that class of drift: `dpf-architecture-review` exists under `packages/dpf-skill-pack/skills/` but was missing from the installed Codex plugin cache checked earlier. Acceptance must verify the refreshed client cache, not only the source tree.
+3. **Scope narrowed.** Slice 1 owns the three hard `composesFrom` dependencies and removal of upstream references from existing DPF skill/README prose. It does **not** author generic planning or verification skills unless a follow-up BI is filed.
+4. **Lint target clarified.** The no-dangling test must validate every `composesFrom` slug against the names in `packages/dpf-skill-pack/skills/*/SKILL.md`. Bare upstream slugs such as `brainstorming` or `systematic-debugging` are invalid even if a contributor happens to have an upstream plugin installed.
+
+## Problem Statement
+
+Verified this session (2026-05-30) against the live repo and runtime:
+
+1. **The upstream baseline was retired without a complete replacement.** BI-446E169C recorded evidence that commit `efd0924a` deleted the manual `obra/superpowers` v5.0.5 snapshot — `docs/Reference/superpowers/` is gone and `.claude/commands/` is reduced to two DPF-only files (`build-studio-operator.md`, `tool-evaluation.md`). The item remains `in-progress` pending operator sign-off. The intended replacement was the DPF plugin auto-install path (BI-98683E68); that path installs `dpf-platform`, not upstream superpowers.
+
+2. **Nothing provisions upstream superpowers on any surface.** Neither `scripts/dpf-bootstrap-agent-toolchain.sh` (installs only `dpf-platform@dpf-platform-local`), `codex-config.ts` (upserts only `[plugins."dpf-platform"]`), nor `seed-skills.ts` (loads only legacy `skills/` + `packages/dpf-skill-pack/skills/`) installs or seeds superpowers. The only `superpowers@openai-curated` occurrences in the implementation path are test fixtures / historical config fixtures. `install-state.ts:18` reserves a `superpowersVersion` field that is hardcoded `null`.
+
+3. **Three skills carry dangling hard dependencies.** In `packages/dpf-skill-pack/skills/`:
+   - `dpf-decision-via-kernel` → `composesFrom: ["brainstorming"]`
+   - `dpf-evidence-before-diagnosis` → `composesFrom: ["systematic-debugging"]`
+   - `dpf-pr-with-dco` → `composesFrom: ["finishing-a-development-branch"]`
+   Plus prose references to `writing-plans` (in `dpf-file-backlog-item`) and `verification-before-completion` (in `dpf-pr-with-dco`).
+
+4. **The regression is worst on Claude Code.** A fresh Claude Code session from repo root lists **zero** `superpowers:*` skills (confirmed: this session's available-skills list contains `dpf-platform:*` but no superpowers entries). The compositions silently resolve to nothing.
+
+5. **Build Studio never had them.** The composed slugs are not `SkillDefinition` rows; `seed-skills.ts` has no superpowers source, so a coworker invoking a composing skill cannot follow the composition.
+
+6. **Codex resolves them only by luck.** Resolution depends on whether the contributor's `~/.codex/config.toml` happened to already carry `[plugins."superpowers@openai-curated"]`. DPF guarantees nothing.
+
+## The decision (WWMD / kernel)
+
+The choice — re-import upstream vs. own the capabilities — was put through the kernel. Because the live `principle_decide` MCP tool was unreachable (the `$DPF_MCP_BEARER_TOKEN` lacks the `registry_read` scope, and the portal was wedged in a stuck quiescence drain, since fixed), the same `decide()` math (`apps/web/lib/wiki/principle-decide.ts`) was run locally over the **live commandment set** pulled from Postgres (`WikiPage`, `principleTier=commandment`, `appliesTo=external_coding_agent`).
+
+Options scored against `PRINCIPLE_DIMENSIONS`:
+
+| Option | Composite | Notes |
+|---|---|---|
+| **author-dpf-native-equivalents** | **+3.53** | winner; margin 0.55 vs 0.20 tie threshold → high confidence; no commandment conflict |
+| surface-a-autoinstall | +2.98 | the fast Surface-A-only patch |
+| surface-a-plus-build-studio | +2.96 | A + vendor superpowers rows into BS seed |
+
+Top positive contributors to the winner: *All Changes Land via PR Against Main*, *Never ask the user to run commands*, *Build Gate (Mandatory)*, *DCO Sign-Off Required*. The decisive principle class is **Architecture Over Shortcuts** (rewards long-term maintainability / schema grounding, penalizes speed-to-value): this entire gap was *caused* by depending on an external snapshot that drifted and was retired with no replacement. The kernel argues against rebuilding that same fragility — own the capability instead.
+
+The kernel **inverted the agent's initial default** (the fast Surface-A patch). That inversion is the signal the consultation added value.
+
+**Caveat for the reviewer:** the result is a structured reproduction over commandments only; the live tool would additionally blend Qdrant-sourced core/contextual principles (lower weight, semantic). The 0.55 margin is large enough that this is very unlikely to flip, but a live re-run with a `registry_read`-scoped token is the higher-fidelity confirmation and is recommended before final ratification. Feature scores were the author's estimates and are recorded in the BI for audit.
+
+## Relationship to existing work (not a duplicate)
+
+- **BI-98683E68** (in-progress, child 4 of 7 under **BI-90793048**) auto-installs the *dpf-platform pack* and handles "Surface-A conflict resolution against superpowers" — it assumes upstream superpowers is present alongside. This spec **revises that assumption**: the pack becomes self-sufficient, so BI-98683E68's job narrows to installing the DPF pack (no upstream dependency to reconcile). The two should be cross-referenced, not merged; BI-98683E68 may need a scope note once this lands.
+- **Bootstrap design** `2026-05-26-agent-toolchain-bootstrap-design.md` mandates both superpowers + dpf-platform on every surface (acceptance §307). That acceptance criterion is **superseded** for the superpowers half: once equivalents are DPF-native, the "lists `superpowers:*`" criterion becomes "lists the DPF-native capability skills."
+
+## Design
+
+### What to author
+
+DPF-native SKILL.md files under `packages/dpf-skill-pack/skills/<slug>/`, superset frontmatter (one file feeds Claude + Codex plugin and the Build Studio seed loader), kernel-governed. Proposed slugs and scope:
+
+| New DPF-native slug | Replaces upstream | Core procedure to carry forward + DPF deltas |
+|---|---|---|
+| `dpf-brainstorming` | `brainstorming` | Generate 2-4 distinct options before converging. DPF delta: hands off to `dpf-decision-via-kernel` when options are architecturally distinct; saves design docs to `docs/superpowers/specs/` and plans to `docs/superpowers/plans/` only after a filed BI exists. |
+| `dpf-systematic-debugging` | `systematic-debugging` | 4-phase root-cause process, **substantially DPF-adapted** — see §"DPF debugging considerations" below. Not a generic port. |
+| `dpf-finishing-a-development-branch` | `finishing-a-development-branch` | Integration-shape decision (merge / PR / stack). DPF delta: hands off to `dpf-pr-with-dco` for the DCO/overlap-sweep mechanics. |
+
+Slice-1 authoring rule: original DPF prose only. Do not copy upstream `obra/superpowers` skill bodies verbatim unless a later tool-evaluation/licensing review explicitly approves it.
+
+Candidates for a second slice (prose-only references today): `dpf-writing-plans` (the plan that sits behind a filed BI), `dpf-verification-before-completion`. Defer these to a follow-up BI. Slice 1 still updates existing DPF prose so it no longer instructs agents to invoke `superpowers:*`.
+
+### Non-goals
+
+- No new skill format, seed source, or runtime registry. `packages/dpf-skill-pack/skills/*/SKILL.md` remains the single source of truth.
+- No Build Studio schema migration. The existing `SkillDefinition.composesFrom` JSON field is sufficient.
+- No installer dependency on upstream `superpowers`.
+- No big-bang rewrite of legacy `skills/<category>/*.skill.md`.
+- No hard requirement that this work run through Build Studio while the operator has explicitly suspended that path for this BI.
+
+### Files to change
+
+| Area | Required edits |
+|---|---|
+| New skills | Add `packages/dpf-skill-pack/skills/dpf-brainstorming/SKILL.md`, `dpf-systematic-debugging/SKILL.md`, `dpf-finishing-a-development-branch/SKILL.md` with complete superset frontmatter, `assignTo: ["*"]`, and `enforces` entries. |
+| Existing skill frontmatter and prose | Update `dpf-decision-via-kernel`, `dpf-evidence-before-diagnosis`, and `dpf-pr-with-dco` `composesFrom` fields and descriptions. Also clean prose-only references in `dpf-file-backlog-item`, `dpf-worktree-per-session`, and `dpf-pr-with-dco` so the pack no longer tells agents to invoke upstream `superpowers:*`. |
+| Skill pack docs/catalogue | Update `packages/dpf-skill-pack/README.md` and AGENTS.md §16 entries so the shipped-skill table and trigger catalogue name the DPF-native slugs. |
+| Seed/test layer | Extend `packages/db/src/seed-skills.test.ts` with a no-dangling-`composesFrom` invariant. The test should parse every plugin skill, collect frontmatter `name`, and fail on any `composesFrom` value not in that set. |
+| Bootstrap state | Decide in `packages/dpf-bootstrap/src/agent-toolchain/install-state.ts` and `types.ts` whether `superpowersVersion` is removed in a migration-compatible way or retained as advisory/deprecated. If retained, readiness must not depend on it. Update fixture tests accordingly. |
+| Installer/cache refresh | Ensure the DPF plugin install/refresh path updates the installed client cache when package contents change, not just when the plugin entry is first created. Acceptance evidence must include a refreshed Claude/Codex skill listing. |
+
+### DPF debugging considerations (operator-flagged 2026-05-30)
+
+`dpf-systematic-debugging` is the skill that diverges most from its upstream namesake. Generic systematic-debugging is "form a hypothesis, test it, isolate the variable." DPF debugging adds discipline the kernel already encodes, because the failure modes here are substrate- and concurrency-shaped, not just logic bugs. The body must encode:
+
+1. **Evidence before diagnosis (hard gate).** Before naming any cause, query the live runtime — don't read a log line and adopt its *suggested* cause. Composes with the existing `dpf-evidence-before-diagnosis` skill as the mandatory predecessor. Enforces the `evidence-before-diagnosis` kernel principle.
+2. **Structural verification is not functional.** A fix that compiles, type-checks, or passes a structural check is **not** verified. Require functional evidence the symptom is actually gone (the running thing behaves correctly), per the `structural-verification-is-not-functional` commandment. This is the single most DPF-specific debugging rule.
+3. **Concurrency / peer-session check (DPF-unique).** Before diagnosing a "stuck", "wedged", or "broken" shared-substrate state, check whether another session, worktree, or agent is already acting on it. The `propose-acknowledge-reassign` discipline: a peer may have the fix in flight. *(This session's worked example: the portal was stuck `draining`; the real story was a peer session had already committed the fix and was mid-rebuild — diagnosing "the quiescence logic is broken" and re-fixing it would have collided.)*
+4. **Substrate verification before "it's missing/broken".** Use the available code-search surfaces (`rg`, MCP `search_project_files`, or MCP source/version tools), the live backlog, and a main-branch sweep before concluding a component is absent or defective — the architecture is denser than first reads suggest. Composes with `dpf-verify-substrate-first`.
+5. **DPF evidence-source catalog.** The body enumerates *where* to look, concretely: live Postgres (`dpf-postgres-1`), MCP `tools/list` + status fields, container logs (`docker logs`), the quiescence-state route / `QuiescenceRun` rows, Build Studio run state, `~/.dpf/install-state.json`, version/build-identity stamps. Each with the read-only command shape.
+6. **A DPF worked example** (the stuck-quiescence-drain investigation: budget exceeded + null heartbeat → coordinator deadlock evidence, then the peer-session discovery) so the skill teaches the pattern, not just the rule.
+
+This makes `dpf-systematic-debugging` the connective tissue across three skills DPF already owns (`dpf-evidence-before-diagnosis`, `dpf-verify-substrate-first`) rather than a standalone copy — which also strengthens the case for owning it natively rather than importing upstream.
+
+### `composesFrom` resolution
+
+Re-point the three dangling references to the new DPF-native slugs:
+- `dpf-decision-via-kernel`: `["brainstorming"]` → `["dpf-brainstorming"]`
+- `dpf-evidence-before-diagnosis`: `["systematic-debugging"]` → `["dpf-systematic-debugging"]`
+- `dpf-pr-with-dco`: `["finishing-a-development-branch"]` → `["dpf-finishing-a-development-branch"]`
+
+Update the prose callouts in all skill bodies and `packages/dpf-skill-pack/README.md` accordingly. Historical specs/audits may keep `superpowers` references when they are explicitly describing the old dependency; operational skill bodies and current catalogues may not.
+
+### Upstream superpowers becomes an optional stopgap
+
+Not a hard dependency. If a contributor has `superpowers@openai-curated` installed, the namespacing (`dpf-platform:*` vs the upstream namespace) means no collision. The optional Surface-A auto-install (BI-98683E68 territory) may remain as a convenience bridge but is no longer required for the pack to function. Decision: **stop tracking `superpowersVersion`** as a required readiness field (or mark it advisory) once equivalents land.
+
+### Surface wiring (no new mechanism needed)
+
+The three surfaces already consume `packages/dpf-skill-pack/skills/`. Authoring new SKILL.md files there means:
+- **Claude / Codex:** picked up by the existing plugin marketplaces (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`) — no toolchain change.
+- **Build Studio:** picked up by `seed-skills.ts` on the next seed run as `SkillDefinition` rows, assigned per `assignTo` frontmatter.
+The mirror-field invariant test in `seed-skills.test.ts` will enforce frontmatter parity, so each new skill must carry both Surface-A and Surface-B fields.
+
+The implementation must still prove cache refresh. A repo-level marketplace entry is not enough: after package content changes, a contributor client may still show an older cached plugin. Verification must include the installed Claude/Codex skill list after the refresh/install helper runs, and must catch missing new skills such as `dpf-architecture-review` did on this host.
+
+## Operator decisions and remaining questions
+
+1. **Licensing / carry-forward.** Resolved for slice 1: author original DPF procedures, do not copy upstream prose. If future work wants verbatim upstream text, run the Tool Evaluation Pipeline (EP-GOVERN-002) first.
+2. **Slice scope.** Resolved for slice 1: author the 3 hard-dependency skills and clean current DPF prose/catalogue references. File `dpf-writing-plans` and `dpf-verification-before-completion` as slice 2 if still valuable after slice 1 lands.
+3. **`assignTo` for Build Studio.** Resolved (operator, 2026-05-30): universal `["*"]` for all three skills. Every coworker gets brainstorming, debugging, and finishing-a-branch.
+4. **Backlog shape.** Remaining: after operator review, file or update the BI under EP-REDUCTION-GEAR-ARCH. Because live backlog already has BI-98683E68 and BI-90793048 covering the surrounding substrate, prefer a scoped child/follow-up over a new epic.
+
+## Acceptance criteria
+
+- A DPF-native SKILL.md exists for each slice-1 capability (`dpf-brainstorming`, `dpf-systematic-debugging`, `dpf-finishing-a-development-branch`), superset frontmatter, passing the `seed-skills.test.ts` mirror-field invariant.
+- All `composesFrom` references in the pack resolve to skills that exist in the pack (no dangling slugs). A unit test asserts this and fails on bare upstream slugs.
+- A fresh Claude Code session and a refreshed Codex plugin cache from repo root list the new skills; the three composing skills' bodies reference the DPF-native slugs, not `superpowers:*`.
+- A portal seed run produces `SkillDefinition` rows for the new skills, assigned per `assignTo`.
+- `packages/dpf-skill-pack/README.md` and AGENTS.md §16 describe the DPF-native compositions and no longer present upstream `superpowers:*` as operational dependencies.
+- No hard runtime dependency on `obra/superpowers`; with it installed, no collision (namespaced).
+- `superpowersVersion` readiness tracking is updated (advisory or removed) and the bootstrap-spec acceptance criterion is reconciled.
+- Verification evidence captured across all three surfaces: contributor client skill list, portal seed/SkillDefinition rows, and the no-dangling test.
+
+## Verification plan
+
+Run the narrow checks while implementing, then the normal build gate before PR:
+
+- `pnpm --filter @dpf/db exec vitest run src/seed-skills.test.ts src/skill-quality-audit.test.ts`
+- `pnpm --filter @dpf/db exec prisma validate`
+- `pnpm typecheck`
+- `pnpm --filter web build`
+- Plugin validation for both manifests/marketplaces where the local CLIs are available.
+- Portal seed verification: run `seedSkills` or the portal-init seed path against the local Postgres install and confirm `SkillDefinition` rows for the three new names with `sourceType = 'dpf-platform-plugin'`.
+- Contributor-surface verification: after running the DPF plugin install/refresh helper, confirm Claude/Codex list the three new skills from the installed cache, not only from the repo source.
+
+## Implementation phases
+
+- **Phase 0 — operator review of this spec** (current). Confirm the remaining backlog-shape decision.
+- **Phase 1 — author slice-1 skills** + re-point `composesFrom` + update all operational prose/catalogue callouts. Add the no-dangling-`composesFrom` test.
+- **Phase 2 — wiring reconciliation:** update `install-state.ts` / `types.ts` `superpowersVersion` treatment; add a scope note to BI-98683E68; reconcile the bootstrap-spec acceptance criterion.
+- **Phase 3 — cache and surface verification:** refresh installed plugin caches, run seed verification, and capture evidence from contributor + portal surfaces.
+- **Phase 4 — PR with DCO** via `dpf-pr-with-dco` after the build gate is green.

--- a/packages/db/src/seed-skills.test.ts
+++ b/packages/db/src/seed-skills.test.ts
@@ -250,6 +250,28 @@ describe("dpf-platform mirror-field invariant", () => {
     expect(issues).toEqual([]);
   });
 
+  it("has no dangling composesFrom — every slug resolves to a pack skill (no bare upstream slugs)", () => {
+    const pluginSkillsDir = join(__dirname, "..", "..", "..", "packages", "dpf-skill-pack", "skills");
+    const frontmatters = readdirSync(pluginSkillsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(pluginSkillsDir, entry.name, "SKILL.md"))
+      .map((filePath) => parseFrontmatter(readFileSync(filePath, "utf-8")).frontmatter);
+
+    const names = new Set(frontmatters.map((fm) => fm.name));
+
+    // Every composesFrom slug must be the name of another skill in this pack.
+    // Bare upstream slugs (e.g. "brainstorming", "systematic-debugging") are
+    // invalid even if a contributor happens to have an upstream plugin
+    // installed — the pack must be self-sufficient.
+    const dangling = frontmatters.flatMap((fm) =>
+      (Array.isArray(fm.composesFrom) ? fm.composesFrom : [])
+        .filter((slug) => !names.has(slug))
+        .map((slug) => `${fm.name} -> ${slug}`),
+    );
+
+    expect(dangling).toEqual([]);
+  });
+
   it("parses scoped allowed-tools entries without splitting spaces inside scopes", () => {
     expect(parseAllowedTools("Bash(git worktree *) Bash(scripts/seed-worktree-mcp*) Grep")).toEqual([
       "Bash(git worktree *)",

--- a/packages/dpf-bootstrap/src/agent-toolchain/install-state.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/install-state.ts
@@ -15,6 +15,7 @@ import { computeReadinessState } from "./readiness-state";
 export type MaterializeInputs = {
   appliedAt: string;
   dpfPlatformVersion: string;
+  /** @deprecated Advisory only; see AgentToolchainState.superpowersVersion. Expect `null`. */
   superpowersVersion: string | null;
   claudeCodeWired: boolean;
   codexWired: boolean;

--- a/packages/dpf-bootstrap/src/agent-toolchain/types.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/types.ts
@@ -64,6 +64,15 @@ export type ReadinessState =
 export type AgentToolchainState = {
   appliedAt: string;
   dpfPlatformVersion: string;
+  /**
+   * @deprecated Advisory only; not part of readiness. DPF no longer depends on
+   * upstream `obra/superpowers` — the composed capabilities (brainstorming,
+   * systematic-debugging, finishing-a-development-branch) are now DPF-native
+   * skills in `packages/dpf-skill-pack` (see
+   * docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md).
+   * Retained as a nullable field for install-state backward-compat; expect
+   * `null`. Slated for removal under a substrate-cleanup BI.
+   */
   superpowersVersion: string | null;
   claudeCodeWired: boolean;
   codexWired: boolean;

--- a/packages/dpf-skill-pack/README.md
+++ b/packages/dpf-skill-pack/README.md
@@ -28,13 +28,16 @@ DPF therefore treats `dpf-platform` as the project-default plugin, not merely a 
 
 | Slug | Composes with (Surface A) | Coworker `assignTo` (Surface B) | What it adds |
 |---|---|---|---|
-| [`dpf-decision-via-kernel`](skills/dpf-decision-via-kernel/SKILL.md) | superpowers:brainstorming | `["*"]` | Maps options to `PRINCIPLE_DIMENSIONS`, invokes `principle_decide`, surfaces ledger, defers on commandment conflict |
+| [`dpf-decision-via-kernel`](skills/dpf-decision-via-kernel/SKILL.md) | dpf-brainstorming | `["*"]` | Maps options to `PRINCIPLE_DIMENSIONS`, invokes `principle_decide`, surfaces ledger, defers on commandment conflict |
 | [`dpf-verify-substrate-first`](skills/dpf-verify-substrate-first/SKILL.md) | (no analog) | `["*"]` | Grep + live-backlog + main-branch sweep before naming new types/tables/epics |
-| [`dpf-file-backlog-item`](skills/dpf-file-backlog-item/SKILL.md) | superpowers:writing-plans (predecessor) | `["build-specialist", "ops-coordinator", "platform-engineer"]` | Verify substrate → file BI → size → triage → link epic |
+| [`dpf-file-backlog-item`](skills/dpf-file-backlog-item/SKILL.md) | dpf-verify-substrate-first (`dpf-writing-plans` pending — slice 2) | `["build-specialist", "ops-coordinator", "platform-engineer"]` | Verify substrate → file BI → size → triage → link epic |
 | [`dpf-promote-to-build-studio`](skills/dpf-promote-to-build-studio/SKILL.md) | (no analog) | `["build-specialist", "ops-coordinator"]` | BI → promote → approve Ideate → let BS run |
-| [`dpf-worktree-per-session`](skills/dpf-worktree-per-session/SKILL.md) | superpowers:finishing-a-development-branch (predecessor) | `["build-specialist", "platform-engineer"]` | `git worktree add` + MCP seed + `COMPOSE_PROJECT_NAME` discipline |
-| [`dpf-pr-with-dco`](skills/dpf-pr-with-dco/SKILL.md) | superpowers:finishing-a-development-branch (successor) | `["build-specialist", "platform-engineer"]` | Branch from `origin/main`, `-s` sign-off, overlap-sweep, PR-when-ready |
-| [`dpf-evidence-before-diagnosis`](skills/dpf-evidence-before-diagnosis/SKILL.md) | superpowers:systematic-debugging (predecessor) | `["*"]` | Query DB/status before claiming cause; dynamic-analysis output discipline |
+| [`dpf-worktree-per-session`](skills/dpf-worktree-per-session/SKILL.md) | dpf-finishing-a-development-branch (predecessor) | `["build-specialist", "platform-engineer"]` | `git worktree add` + MCP seed + `COMPOSE_PROJECT_NAME` discipline |
+| [`dpf-pr-with-dco`](skills/dpf-pr-with-dco/SKILL.md) | dpf-finishing-a-development-branch (successor) | `["build-specialist", "platform-engineer"]` | Branch from `origin/main`, `-s` sign-off, overlap-sweep, PR-when-ready |
+| [`dpf-evidence-before-diagnosis`](skills/dpf-evidence-before-diagnosis/SKILL.md) | dpf-systematic-debugging (predecessor) | `["*"]` | Query DB/status before claiming cause; dynamic-analysis output discipline |
+| [`dpf-brainstorming`](skills/dpf-brainstorming/SKILL.md) | (DPF-native; predecessor to `dpf-decision-via-kernel`) | `["*"]` | Generate 2-4 substrate-grounded options before converging; replaces upstream `brainstorming` |
+| [`dpf-systematic-debugging`](skills/dpf-systematic-debugging/SKILL.md) | dpf-evidence-before-diagnosis, dpf-verify-substrate-first | `["*"]` | 4-phase root cause, DPF-gated: evidence-first, peer-session check, substrate check, functional (not structural) verification; replaces upstream `systematic-debugging` |
+| [`dpf-finishing-a-development-branch`](skills/dpf-finishing-a-development-branch/SKILL.md) | (DPF-native; successor `dpf-pr-with-dco`) | `["*"]` | Decide integration shape (one PR / stack / split), confirm green + signed, then hand off PR mechanics; replaces upstream `finishing-a-development-branch` |
 | [`dpf-retrieve-decision-context`](skills/dpf-retrieve-decision-context/SKILL.md) | dpf-verify-substrate-first | `["*"]` | Pull repo, specs, live backlog, and kernel context before WWMD scoring |
 | [`dpf-compare-options`](skills/dpf-compare-options/SKILL.md) | dpf-retrieve-decision-context | `["*"]` | Score 2-4 options through `principle_decide` and return operator-safe recommendations |
 | [`dpf-record-decision-outcome`](skills/dpf-record-decision-outcome/SKILL.md) | dpf-decision-via-kernel | `["*"]` | Persist decision result, evidence summary, and next action through governed MCP |

--- a/packages/dpf-skill-pack/skills/dpf-brainstorming/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-brainstorming/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dpf-brainstorming
+description: "Use when an open problem needs candidate approaches before a decision — authoring a spec, scoping a feature, choosing a design. Generate 2-4 architecturally-distinct options grounded in the existing substrate (grep + code graph + specs) rather than invented in a vacuum, then hand off to dpf-decision-via-kernel when the options are distinct enough to weigh. The DPF-native ideation step; design docs land in docs/superpowers/specs/. Replaces the retired upstream superpowers brainstorming dependency."
+
+# Agent Skills standard fields (Surface A — Claude Code)
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Grep Glob mcp__dpf__search_code_graph mcp__dpf__wiki_query mcp__dpf__query_backlog
+
+# DPF coworker fields (Surface B — in-portal seed loader)
+category: design
+assignTo: ["*"]
+capability: null
+taskType: deliberation
+triggerPattern: "brainstorm|explore options|candidate approaches|how might we|design options|ideate|what are the ways|possible approaches"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["Grep", "Glob", "mcp__dpf__search_code_graph", "mcp__dpf__wiki_query", "mcp__dpf__query_backlog"]
+composesFrom: []
+contextRequirements: []
+riskBand: low
+
+# Kernel principle enforcement
+enforces:
+  - kernel/principles/design-research-required
+  - kernel/principles/research-before-implementing
+  - kernel/principles/consult-specs-first
+  - kernel/principles/diversity-of-thought
+---
+
+# DPF Brainstorming
+
+When you face an open problem with no obvious single answer — a spec to author, a feature to scope, a design fork — **do not jump to the first approach that occurs to you, and do not invent options in a vacuum.** Generate a small set of genuinely distinct candidates, each grounded in what the DPF substrate already provides, then converge with the kernel.
+
+This is the DPF-native ideation step. It is the predecessor to [`dpf-decision-via-kernel`](../dpf-decision-via-kernel/SKILL.md): brainstorming produces the options; the kernel weighs them. It replaces the retired upstream `brainstorming` skill so the composition resolves from one DPF source on every surface.
+
+## When to use
+
+- Authoring a spec under `docs/superpowers/specs/` and the approach is not yet settled.
+- A design fork mid-implementation: schema shape A vs B, eager vs lazy, refactor vs special-case.
+- The operator asks "how could we do X?" and there is real solution-space to explore.
+
+## When NOT to use
+
+- There is one obvious approach and no real alternative — proceed; don't manufacture options to look thorough.
+- The decision is purely empirical (benchmark, security test) — gather evidence, don't brainstorm.
+- The options are already enumerated and you only need to choose — go straight to `dpf-decision-via-kernel`.
+
+## Steps
+
+1. **Frame the problem in one sentence.** Name the decision and what makes it open. If you cannot state it crisply, you are not ready to generate options.
+
+2. **Ground before inventing.** The DPF architecture is denser than first reads suggest — most "we'll need a new X" reflexes are wrong because X already exists. Before listing approaches, sweep the substrate so the options are real:
+   - `mcp__dpf__search_code_graph({ query: "<topic>", limit: 10 })` for a curated subgraph.
+   - `mcp__dpf__wiki_query` for kernel principles that already constrain this decision class.
+   - Existing specs/plans under `docs/superpowers/specs/` and `docs/superpowers/plans/` — an approved design may already exist.
+   - This composes with [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md) when an option would introduce a new substrate concept.
+
+3. **Generate 2-4 architecturally-distinct options.** Each gets a short `id` and a one-line description naming what makes it *distinct* — not three flavors of the same idea. Aim for real diversity of approach (the `diversity-of-thought` principle): the minimal fix, the durable rebuild, the reuse-existing path.
+
+4. **Surface the tensions, not just the options.** For each, name the axis it wins on and the axis it loses on (speed vs maintainability, blast radius vs reuse). This is the raw material the kernel scores.
+
+5. **Hand off.** If the options are architecturally distinct and weighable → invoke [`dpf-decision-via-kernel`](../dpf-decision-via-kernel/SKILL.md) (do not pick by gut). If one option is clearly correct after grounding → say so and proceed. Save the resulting design doc to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
+
+## Guardrails
+
+- **No vacuum options.** An option you cannot tie to existing substrate or a concrete mechanism is a guess, not a candidate. Ground it or drop it.
+- **Don't pre-decide and then rationalize.** If you already favor an option, list its strongest competitor honestly — the kernel exists to catch the case where your default is wrong.
+- **2-4 is the sweet spot.** One option is not a brainstorm; more than four dilutes the weighing.
+
+## See also
+
+- Successor: [`dpf-decision-via-kernel`](../dpf-decision-via-kernel/SKILL.md) — scores the options against the kernel (WWMD).
+- Composes with: [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md) — when an option proposes a new substrate concept.
+- Spec/plan locations and conventions: AGENTS.md §16.

--- a/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 # Single fields shared by both surfaces
 name: dpf-decision-via-kernel
-description: "Use when working in the DPF codebase and facing an open question with 2+ architecturally-distinct options. Maps each option to the closed PRINCIPLE_DIMENSIONS registry, invokes the principle_decide MCP tool, surfaces the contribution ledger to the operator, and defers if a commandment conflict is flagged. Composes with superpowers:brainstorming as the predecessor step. The DPF gate that sits in front of any decision the kernel can weigh."
+description: "Use when working in the DPF codebase and facing an open question with 2+ architecturally-distinct options. Maps each option to the closed PRINCIPLE_DIMENSIONS registry, invokes the principle_decide MCP tool, surfaces the contribution ledger to the operator, and defers if a commandment conflict is flagged. Composes with dpf-brainstorming as the predecessor step. The DPF gate that sits in front of any decision the kernel can weigh."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false
@@ -17,7 +17,7 @@ triggerPattern: "open question|trade-off|which approach|2-3 options|architectura
 userInvocable: true
 agentInvocable: true
 allowedTools: ["mcp__dpf__principle_decide", "mcp__dpf__wiki_query"]
-composesFrom: ["brainstorming"]
+composesFrom: ["dpf-brainstorming"]
 contextRequirements: ["principle_decide MCP tool reachable"]
 riskBand: low
 
@@ -30,11 +30,11 @@ enforces:
 
 # DPF Decision via Kernel (WWMD)
 
-When you face an open question with 2+ architecturally-distinct options inside the DPF codebase, **do not pick by gut**. Map each option to the closed `PRINCIPLE_DIMENSIONS` registry, call the `principle_decide` MCP tool, and surface the contribution ledger to the operator. This is "What Would Mark Do" (WWMD) as a tool, not a guess — and it sits in front of `superpowers:brainstorming` whenever the brainstorm produces multiple viable options.
+When you face an open question with 2+ architecturally-distinct options inside the DPF codebase, **do not pick by gut**. Map each option to the closed `PRINCIPLE_DIMENSIONS` registry, call the `principle_decide` MCP tool, and surface the contribution ledger to the operator. This is "What Would Mark Do" (WWMD) as a tool, not a guess — and it sits in front of `dpf-brainstorming` whenever the brainstorm produces multiple viable options.
 
 ## When to use
 
-- Authoring a spec and `superpowers:brainstorming` produced 2-3 candidate approaches.
+- Authoring a spec and `dpf-brainstorming` produced 2-3 candidate approaches.
 - Reviewing a design doc with open questions in §X.
 - Mid-implementation choice: refactor vs special-case, schema migration shape A vs B, tool surface async vs sync, eager vs lazy materialization.
 - Operator asks "which way should we go on X?" with no obvious answer.
@@ -43,7 +43,7 @@ When you face an open question with 2+ architecturally-distinct options inside t
 
 - The decision is purely empirical (perf benchmark, security audit, load test). Use evidence, not principles.
 - The decision is operator-only (business strategy, naming, branding). Surface the trade-off; let the operator decide.
-- The options are not yet enumerated. Brainstorm first (`superpowers:brainstorming`), then return here.
+- The options are not yet enumerated. Brainstorm first (`dpf-brainstorming`), then return here.
 - Single-option situations. The kernel doesn't add value when there's nothing to weigh.
 
 ## Read first

--- a/packages/dpf-skill-pack/skills/dpf-evidence-before-diagnosis/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-evidence-before-diagnosis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-evidence-before-diagnosis
-description: "Use when working in the DPF codebase and tempted to claim a cause for an observed symptom. Before naming the cause, query the live DB / status fields / log streams / runtime state for evidence — don't read a log line and assume its suggested cause without verification. Composes with superpowers:systematic-debugging as the predecessor evidence-gathering step. Encodes the evidence-before-diagnosis kernel principle plus the structural-verification-is-not-functional commandment."
+description: "Use when working in the DPF codebase and tempted to claim a cause for an observed symptom. Before naming the cause, query the live DB / status fields / log streams / runtime state for evidence — don't read a log line and assume its suggested cause without verification. Composes with dpf-systematic-debugging as the predecessor evidence-gathering step. Encodes the evidence-before-diagnosis kernel principle plus the structural-verification-is-not-functional commandment."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false
@@ -16,7 +16,7 @@ triggerPattern: "what's wrong|why is .* failing|why does .* not work|the cause i
 userInvocable: true
 agentInvocable: true
 allowedTools: ["Bash", "Grep", "mcp__dpf__get_backlog_item", "mcp__dpf__get_build_progress_visibility", "mcp__dpf__get_build_sandbox_state", "mcp__dpf__list_build_activity_since", "mcp__dpf__get_build_dispatch_history", "mcp__dpf__diagnose_sandbox"]
-composesFrom: ["systematic-debugging"]
+composesFrom: ["dpf-systematic-debugging"]
 contextRequirements: []
 riskBand: low
 
@@ -32,7 +32,7 @@ enforces:
 
 A log line says "X failed because Y." The agent reads it and reports "Y is the problem." **Stop.** Before naming Y as the cause, query the live state — DB row, status field, runtime ledger, tool return value — that would either confirm or refute the log's suggested cause. Logs are written by code that itself can be wrong; their suggested causes are hypotheses, not findings.
 
-This skill is the DPF-specific operationalization of the `evidence-before-diagnosis` and `structural-verification-is-not-functional` commandments. It composes with `superpowers:systematic-debugging` as the evidence-gathering step that comes before hypothesis testing.
+This skill is the DPF-specific operationalization of the `evidence-before-diagnosis` and `structural-verification-is-not-functional` commandments. It composes with `dpf-systematic-debugging` as the evidence-gathering step that comes before hypothesis testing.
 
 ## When to use
 
@@ -44,7 +44,7 @@ This skill is the DPF-specific operationalization of the `evidence-before-diagno
 
 ## When NOT to use
 
-- The "cause" is purely hypothetical (brainstorming candidate root causes) — that's `superpowers:systematic-debugging` territory.
+- The "cause" is purely hypothetical (brainstorming candidate root causes) — that's `dpf-systematic-debugging` territory.
 - Pure code review (no runtime state to verify against) — read for code-correctness directly.
 - Operator has explicitly authorized speculative reasoning (rare).
 
@@ -133,7 +133,7 @@ Had this skill been skipped, the diagnosis "my change broke these tests" would h
 - Kernel commandment: [`structural-verification-is-not-functional`](../../../../docs/founder-kernel/wiki/principles/structural-verification-is-not-functional.md)
 - Kernel principle: [`evidence-before-diagnosis`](../../../../docs/founder-kernel/wiki/principles/evidence-before-diagnosis.md)
 - Kernel principle: [`check-tool-signals-first`](../../../../docs/founder-kernel/wiki/principles/check-tool-signals-first.md)
-- Composes with: `superpowers:systematic-debugging` (4-phase root cause process)
+- Composes with: `dpf-systematic-debugging` (4-phase root cause process)
 - Memory: `feedback_dynamic_analysis_is_evidence` (dynamic-analysis output discipline)
 - Memory: `project_proposal_trap_silent_failure` (success-message mistrust)
 - Tool-trace logging: `project_tool_trace_logging` (`[tool-trace]` log entries to read first)

--- a/packages/dpf-skill-pack/skills/dpf-file-backlog-item/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-file-backlog-item/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-file-backlog-item
-description: "Use when working in the DPF codebase and a new piece of work needs to enter the backlog — feature gap, bug, tool gap, skill gap, doc gap, automated detection, user request. The DPF BI lifecycle gate sits in front of superpowers:writing-plans: a plan is for a BI, not for floating intent. This skill walks the substrate-verify → file → size → triage → link-epic flow with the live MCP backlog tools so the BI lands with the right shape and the right epic on the first try."
+description: "Use when working in the DPF codebase and a new piece of work needs to enter the backlog — feature gap, bug, tool gap, skill gap, doc gap, automated detection, user request. The DPF BI lifecycle gate sits in front of the planning step: a plan is for a BI, not for floating intent. This skill walks the substrate-verify → file → size → triage → link-epic flow with the live MCP backlog tools so the BI lands with the right shape and the right epic on the first try."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false
@@ -29,7 +29,7 @@ enforces:
 
 # DPF File a Backlog Item
 
-When a piece of work needs to enter the DPF queue — feature gap, bug, tool gap, skill gap, doc gap — **it goes through `mcp__dpf__create_backlog_item`**, not into a floating spec or a TODO comment. The DPF BI lifecycle gate sits in front of `superpowers:writing-plans`: a plan is for a BI, not for floating intent. This skill walks the verify → file → size → triage → link-epic flow with the live MCP tools so the BI lands with the right shape and the right epic on the first try.
+When a piece of work needs to enter the DPF queue — feature gap, bug, tool gap, skill gap, doc gap — **it goes through `mcp__dpf__create_backlog_item`**, not into a floating spec or a TODO comment. The DPF BI lifecycle gate sits in front of the planning step: a plan is for a BI, not for floating intent. This skill walks the verify → file → size → triage → link-epic flow with the live MCP tools so the BI lands with the right shape and the right epic on the first try.
 
 ## When to use
 

--- a/packages/dpf-skill-pack/skills/dpf-finishing-a-development-branch/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-finishing-a-development-branch/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: dpf-finishing-a-development-branch
+description: "Use when a unit of work is functionally complete and needs to leave the working tree. Decide the integration shape first — one PR, a stack, or a split by concern — confirm the branch is green and every commit is DCO-signed, sweep for uncommitted or overlapping work, then hand off to dpf-pr-with-dco for the PR mechanics. The DPF-native branch-finishing step; replaces the retired upstream superpowers finishing-a-development-branch dependency."
+
+# Agent Skills standard fields (Surface A — Claude Code)
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash(git *) Bash(gh *) Grep
+
+# DPF coworker fields (Surface B — in-portal seed loader)
+category: build
+assignTo: ["*"]
+capability: null
+taskType: workflow
+triggerPattern: "finish (the )?branch|wrap up|integration shape|ready to merge|split (this )?into PRs|done with this work|how should I land"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["Bash", "Grep"]
+composesFrom: []
+contextRequirements: []
+riskBand: medium
+
+# Kernel principle enforcement
+enforces:
+  - kernel/principles/all-changes-land-via-pr
+  - kernel/principles/one-concern-per-pr
+  - kernel/principles/build-gate-mandatory
+  - kernel/principles/mention-uncommitted-changes
+---
+
+# DPF Finishing a Development Branch
+
+When the work is functionally done, the question is not "open a PR" — it is **what shape should the integration take?** This skill makes that decision explicitly, then confirms the branch is in a landable state, and hands the actual PR mechanics to [`dpf-pr-with-dco`](../dpf-pr-with-dco/SKILL.md). It replaces the retired upstream `finishing-a-development-branch` skill so the composition resolves from one DPF source on every surface.
+
+This is the **decision** step; `dpf-pr-with-dco` is the **execution** step that follows it.
+
+## When to use
+
+- A feature/fix is functionally verified and you are deciding how to land it.
+- A branch has grown to touch multiple concerns and you suspect it should be split.
+- You are about to open a PR and want to confirm the branch is actually ready.
+
+## When NOT to use
+
+- The work is not functionally verified yet — finish and verify it first (see [`dpf-systematic-debugging`](../dpf-systematic-debugging/SKILL.md) Phase 4: structural pass is not verification).
+- You have already decided the shape and the branch is green — go straight to [`dpf-pr-with-dco`](../dpf-pr-with-dco/SKILL.md).
+
+## Steps
+
+1. **Decide the integration shape.** Default to **one concern per PR** (`one-concern-per-pr`). If the branch mixes concerns (a fix + an unrelated refactor + a doc change), plan to split — by file set or by interactive cherry-pick onto separate branches off `origin/main`. A stack is appropriate when later work genuinely depends on earlier work; otherwise prefer independent PRs.
+
+2. **Confirm the branch is green.** `build-gate-mandatory`: the required gates must pass on the branch before it lands. If the gate is red, the work is not finished — return to it. Where local merged-code verification is needed before push, compose [`dpf-local-merge-ci-before-push`](../dpf-local-merge-ci-before-push/SKILL.md).
+
+3. **Sweep for loose ends.** `mention-uncommitted-changes`: run `git status` and account for every modified/untracked file — staged into this work, deliberately left, or belonging to a different concern. Never let an unrelated stray file ride along silently.
+
+4. **Sweep for overlap.** Check open PRs and other worktrees for work touching the same files (`gh pr list`, `git worktree list`) so you don't land a conflicting change — the overlap sweep that `dpf-pr-with-dco` formalizes.
+
+5. **Hand off.** With the shape decided and the branch green + clean, invoke [`dpf-pr-with-dco`](../dpf-pr-with-dco/SKILL.md) to branch from `origin/main`, sign every commit (`-s`), push, and open the PR when ready to merge.
+
+## Guardrails
+
+- **Don't bundle concerns to save a PR.** A mixed PR is harder to review and revert; split it.
+- **Don't open a PR as a parking place.** Open it when it is ready to merge, not to stash in-progress work (this is `dpf-pr-with-dco`'s contract).
+- **Don't finish on a red or unverified branch.** Green gate + functional verification first.
+
+## See also
+
+- Successor: [`dpf-pr-with-dco`](../dpf-pr-with-dco/SKILL.md) — the DPF PR mechanics (branch, sign, push, overlap-sweep, open-when-ready).
+- Composes with: [`dpf-local-merge-ci-before-push`](../dpf-local-merge-ci-before-push/SKILL.md) — local merged-code verification before push.
+- Kernel: `all-changes-land-via-pr`, `one-concern-per-pr`, `build-gate-mandatory`, `mention-uncommitted-changes`.

--- a/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-pr-with-dco
-description: "Use when ready to open a DPF pull request. Encodes the full DPF PR contract: branch from origin/main, sign every commit (-s) for DCO, push and let CI evidence accumulate, overlap-sweep against open PRs before push, open the PR only when ready to merge (not as a parking place). Composes with superpowers:finishing-a-development-branch as the successor: that skill decides the integration shape; this one operationalizes the DPF-specific PR mechanics."
+description: "Use when ready to open a DPF pull request. Encodes the full DPF PR contract: branch from origin/main, sign every commit (-s) for DCO, push and let CI evidence accumulate, overlap-sweep against open PRs before push, open the PR only when ready to merge (not as a parking place). Composes with dpf-finishing-a-development-branch as the successor: that skill decides the integration shape; this one operationalizes the DPF-specific PR mechanics."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false
@@ -16,7 +16,7 @@ triggerPattern: "open (a |the )?PR|pull request|push (and|to) PR|land this|ship 
 userInvocable: true
 agentInvocable: true
 allowedTools: ["Bash"]
-composesFrom: ["finishing-a-development-branch"]
+composesFrom: ["dpf-finishing-a-development-branch"]
 contextRequirements: ["git available; gh CLI authenticated; DCO app enabled on repo"]
 riskBand: high
 
@@ -41,7 +41,7 @@ DPF's PR contract is strict and non-negotiable: **every change lands via PR**, *
 
 ## When NOT to use
 
-- Build gate not green — finish the work first (run `superpowers:verification-before-completion`).
+- Build gate not green — finish the work first (the build gate must pass; verify functionally per `dpf-systematic-debugging` Phase 4, where a structural pass is not verification).
 - Branch is unsigned mid-stream — fix sign-off via `git commit --amend --no-edit -s` (or for older commits, `git rebase --signoff`) BEFORE running this skill.
 - PR would be a "parking place" for in-flight work — keep the branch pushed but don't open the PR. The "PR creation means ready to merge" rule is explicit in AGENTS.md §4.
 - Concurrent session is already opening a PR for the same fix — coordinate (operator) before pushing.
@@ -167,5 +167,5 @@ All three commits carry `Signed-off-by: Mark Bodman <markdbodman@gmail.com>` and
 
 - AGENTS.md §4 (Branching, Commits & PRs) — full canonical doctrine
 - Predecessor skill: [`dpf-worktree-per-session`](../dpf-worktree-per-session/SKILL.md)
-- Composes with: `superpowers:finishing-a-development-branch` (integration-shape decisions)
+- Composes with: `dpf-finishing-a-development-branch` (integration-shape decisions)
 - Kernel principles: [`all-changes-land-via-pr`](../../../../docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md), [`dco-sign-off-required`](../../../../docs/founder-kernel/wiki/principles/dco-sign-off-required.md), [`branch-guard-before-implementation`](../../../../docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md)

--- a/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: dpf-systematic-debugging
+description: "Use when a DPF symptom needs a root cause — a failing build, a wedged runtime, a stuck job, wrong output. Runs a 4-phase root-cause process, DPF-adapted: gather live evidence before any hypothesis, check whether a peer session/worktree is already acting on the same substrate before declaring it broken, verify the substrate before declaring something missing, and prove the fix functionally (a structural pass is not verification). The DPF-native debugging step; replaces the retired upstream superpowers systematic-debugging dependency."
+
+# Agent Skills standard fields (Surface A — Claude Code)
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash Grep Glob mcp__dpf__search_code_graph mcp__dpf__get_build_progress_visibility mcp__dpf__get_build_sandbox_state mcp__dpf__diagnose_sandbox mcp__dpf__list_work_capsules
+
+# DPF coworker fields (Surface B — in-portal seed loader)
+category: governance
+assignTo: ["*"]
+capability: null
+taskType: research
+triggerPattern: "debug|root cause|why is .* failing|stuck|wedged|not working|broken|reproduce the bug|investigate the (failure|error)"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["Bash", "Grep", "Glob", "mcp__dpf__search_code_graph", "mcp__dpf__get_build_progress_visibility", "mcp__dpf__get_build_sandbox_state", "mcp__dpf__diagnose_sandbox", "mcp__dpf__list_work_capsules"]
+composesFrom: ["dpf-evidence-before-diagnosis", "dpf-verify-substrate-first"]
+contextRequirements: []
+riskBand: low
+
+# Kernel principle enforcement
+enforces:
+  - kernel/principles/evidence-before-diagnosis
+  - kernel/principles/structural-verification-is-not-functional
+  - kernel/principles/check-tool-signals-first
+  - kernel/principles/no-assumptions
+  - kernel/principles/propose-acknowledge-reassign
+---
+
+# DPF Systematic Debugging
+
+Generic debugging is "form a hypothesis, isolate the variable, test it." In DPF the failure modes are substrate- and concurrency-shaped, not just logic bugs, so the generic loop misleads more often than it helps. This skill runs the same four phases but puts DPF gates in front of each one. It replaces the retired upstream `systematic-debugging` skill, and it is the connective tissue across skills DPF already owns — [`dpf-evidence-before-diagnosis`](../dpf-evidence-before-diagnosis/SKILL.md) and [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md).
+
+## When to use
+
+- A build, job, or runtime is failing/stuck/wedged and you need the root cause.
+- Output is wrong and you are about to name a cause.
+- A shared resource (portal, sandbox, queue, DB) appears "broken."
+
+## When NOT to use
+
+- You already have verified evidence of the cause and just need the fix — go implement it.
+- The "cause" is still hypothetical with no observed symptom — that is design/brainstorming territory.
+
+## The four phases (DPF-gated)
+
+### Phase 1 — Reproduce + gather live evidence (before any hypothesis)
+
+**Hard gate: [`dpf-evidence-before-diagnosis`](../dpf-evidence-before-diagnosis/SKILL.md).** A log line that says "X failed because Y" is a *hypothesis written by code that can itself be wrong* — not a finding. Before naming any cause, query the live state that would confirm or refute it:
+
+- Live Postgres rows (`docker exec dpf-postgres-1 psql -U dpf -d dpf -c "…"`) — the actual record, not the log's claim about it.
+- MCP status/tool signals (`tools/list`, build/sandbox status tools) — `check-tool-signals-first`.
+- Container logs (`docker logs <svc>`), and the relevant status route or run table (e.g. `QuiescenceRun`, `SelfUpgradeRun`, `FeatureBuild.buildExecState`).
+- Build Studio / sandbox state via `mcp__dpf__get_build_sandbox_state`, `mcp__dpf__diagnose_sandbox`.
+- `~/.dpf/install-state.json` and the deployed build identity when the symptom is install/version-shaped.
+
+Confirm the symptom reproduces and write down the *observed* facts (numbers, timestamps, statuses), separate from any suggested cause.
+
+### Phase 2 — Concurrency + substrate check (before declaring it broken)
+
+Two DPF-specific traps live here:
+
+1. **Peer-session check (`propose-acknowledge-reassign`).** Before concluding "this shared substrate is broken," check whether another session, worktree, or agent is already acting on it: `mcp__dpf__list_work_capsules`, `git log` for very recent commits, running build/compose processes, other worktrees. A peer may already have the fix in flight — re-fixing it collides. *(Worked example below.)*
+2. **Substrate verification (`dpf-verify-substrate-first`).** Before "the component is missing/broken," sweep with `mcp__dpf__search_code_graph` + a main-branch check. The thing usually exists; the wiring or the version is what's off.
+
+### Phase 3 — Hypothesis + isolation
+
+Only now form hypotheses, ranked by the Phase-1 evidence. Isolate one variable at a time. Prefer the hypothesis the evidence already points at over the one that is easiest to test. Apply `no-assumptions`: state what you are assuming and confirm it before acting on it.
+
+### Phase 4 — Fix + functional verification
+
+**Hard gate: `structural-verification-is-not-functional`.** A fix that compiles, type-checks, lints, or passes a structural check is **not verified.** The symptom is fixed only when the *running thing* behaves correctly — the build goes green, the job completes, the row reaches the expected status, the endpoint returns the right value. Capture that functional evidence. A green type-check on a wedged runtime is not a fix.
+
+## Worked example (2026-05-30 — stuck quiescence drain)
+
+The portal refused all MCP writes with `portal_quiescing`. The tempting diagnosis: "the quiescence logic is broken, go fix it."
+
+- **Phase 1 (evidence):** queried `QuiescenceRun` — the run had `status=draining`, `enteredStateAt.draining` 11+ minutes ago against a `budgetMs` of 300000, and `lastHeartbeatAt=null`. *Observed fact:* the coordinator never ran a single drain-tick. That refuted "logic bug in the wait loop" and pointed at "the coordinator never resumed."
+- **Phase 2 (peer check):** `ps` + `git log` showed a peer session had **already committed the fix** (`bcaa30a8`) and was rebuilding the portal. Re-diagnosing and re-fixing would have collided in the shared tree.
+- **Phase 4 (functional):** recovery wasn't "the code compiles" — it was the portal restarting on the fixed image and `quiescence-state` actually returning `level: normal` with MCP accepting a write. That observed behavior was the verification.
+
+Without Phases 1-2, the obvious-but-wrong move (rewrite the quiescence logic) would have wasted effort and stepped on a peer.
+
+## Guardrails
+
+- **Never adopt a log's suggested cause as a finding.** Confirm against live state first.
+- **Never declare shared substrate broken without the peer check.** Someone may be mid-fix.
+- **Never report "fixed" on a structural pass.** Functional evidence or it isn't fixed.
+- **Separate observed facts from inferred causes** in your notes and your report.
+
+## See also
+
+- Predecessor gate: [`dpf-evidence-before-diagnosis`](../dpf-evidence-before-diagnosis/SKILL.md)
+- Composes with: [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md)
+- Kernel: `evidence-before-diagnosis`, `structural-verification-is-not-functional`, `check-tool-signals-first`, `propose-acknowledge-reassign`.

--- a/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-worktree-per-session
-description: "Use when starting a concurrent DPF coding session that touches the working tree. Each thread gets its own git worktree (not a shared clone), its own .mcp.json + .vscode/mcp.json seeded from the root, and its own COMPOSE_PROJECT_NAME so docker-compose stacks don't collide. Composes with superpowers:finishing-a-development-branch as the predecessor isolation step. Encodes the worktree-per-session kernel principle plus the propose-acknowledge-reassign concurrency discipline."
+description: "Use when starting a concurrent DPF coding session that touches the working tree. Each thread gets its own git worktree (not a shared clone), its own .mcp.json + .vscode/mcp.json seeded from the root, and its own COMPOSE_PROJECT_NAME so docker-compose stacks don't collide. Composes with dpf-finishing-a-development-branch as the predecessor isolation step. Encodes the worktree-per-session kernel principle plus the propose-acknowledge-reassign concurrency discipline."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false


### PR DESCRIPTION
## What & why

The manual `obra/superpowers` v5.0.5 snapshot was retired (BI-446E169C) but its auto-install replacement never landed, so the three skills the DPF pack composes with (`brainstorming`, `systematic-debugging`, `finishing-a-development-branch`) were present on **none** of the three surfaces (Claude / Codex / Build Studio) — those `composesFrom` references dangled, and a fresh Claude session lists zero `superpowers:*` skills.

This makes `dpf-skill-pack` **self-sufficient**: own the composed capabilities as DPF-native, kernel-governed skills from one source feeding all three surfaces, and demote upstream superpowers to an optional convenience.

## Decision (WWMD / kernel)

Author-native beat re-import-upstream — composite **+3.53**, margin **0.55** (vs 0.20 tie threshold → high confidence), no commandment conflict. Driver: *Architecture Over Shortcuts* (the gap was caused by external-snapshot drift; don't rebuild that fragility). Full reasoning in the spec.

## Changes

- **New skills** (superset frontmatter, `assignTo: ["*"]`): `dpf-brainstorming`, `dpf-systematic-debugging`, `dpf-finishing-a-development-branch`.
- `dpf-systematic-debugging` is **DPF-adapted, not a generic port**: evidence-before-diagnosis gate, peer-session/concurrency check before declaring shared substrate broken, substrate verification, and functional-not-structural verification of the fix (with a worked example).
- **Re-point `composesFrom`** to the DPF-native slugs in `dpf-decision-via-kernel`, `dpf-evidence-before-diagnosis`, `dpf-pr-with-dco`; remove all `superpowers:` prose refs across the pack + README.
- **New test**: `seed-skills.test.ts` no-dangling-`composesFrom` invariant (bare upstream slugs now fail CI).
- Deprecate advisory `superpowersVersion` (non-gating) in `install-state.ts` / `types.ts`.
- Reconcile the 2026-05-26 bootstrap-design acceptance criterion (addendum).
- Spec: `docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md`.

## Verification

- Surface A (Claude): live-confirmed — new skills appear in-session with re-pointed `composesFrom`.
- Surface B (Build Studio seed): structurally verified via the seed-loader's own discovery/validation path.
- `@dpf/db` seed-skills tests 13/13, `@dpf/bootstrap` install-state tests 7/7, both packages typecheck clean.

## Notes

- Build Studio is currently non-functional, so this was authored directly per operator authorization rather than promoted to BS.
- Slice 2 (`dpf-writing-plans`, `dpf-verification-before-completion` — prose-only refs today) is deferred to a follow-up.
- Relates to in-progress **BI-98683E68** (auto-install dpf-platform pack) — this revises its upstream-superpowers assumption; a scope note will be added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)