### PR TITLE
fix(voice): CSM sampler params + bounded retry loop (recovers orphaned #1276 work)

### DIFF
--- a/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
@@ -14,7 +14,12 @@ const ENV_KEYS = [
   "DPF_TTS_MLX_MODEL",
   "DPF_TTS_MLX_VOICE",
   "DPF_TTS_REFERENCE_HOST_ROOT",
+  "DPF_TTS_MLX_MAX_ATTEMPTS",
 ] as const
+
+// A "valid" clip must clear the adapter's MIN_VALID_AUDIO_BYTES (16 KB) gate.
+const VALID_AUDIO = new ArrayBuffer(40 * 1024)
+const SHORT_AUDIO = new ArrayBuffer(4 * 1024) // simulates CSM empty/truncated run
 
 describe("synthesizeWithMlx", () => {
   let saved: Record<string, string | undefined>
@@ -32,20 +37,38 @@ describe("synthesizeWithMlx", () => {
     }
   })
 
-  function stubFetch(impl: { ok: boolean; status?: number }) {
+  // Resolves every call to the same valid response.
+  function stubOk(buf: ArrayBuffer = VALID_AUDIO) {
     const fetchMock = vi.fn().mockResolvedValue({
-      ok: impl.ok,
-      status: impl.status ?? 200,
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
-      text: () => Promise.resolve("err"),
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(buf),
+      text: () => Promise.resolve(""),
     })
     vi.stubGlobal("fetch", fetchMock)
     return fetchMock
   }
 
-  it("clones from the host reference path when DPF_TTS_REFERENCE_HOST_ROOT is set", async () => {
+  // Returns a sequence of responses (objects), one per call.
+  function stubSequence(responses: Array<{ ok: boolean; status?: number; buf?: ArrayBuffer }>) {
+    let i = 0
+    const fetchMock = vi.fn().mockImplementation(() => {
+      const r = responses[Math.min(i, responses.length - 1)]
+      i++
+      return Promise.resolve({
+        ok: r.ok,
+        status: r.status ?? (r.ok ? 200 : 500),
+        arrayBuffer: () => Promise.resolve(r.buf ?? VALID_AUDIO),
+        text: () => Promise.resolve("err"),
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    return fetchMock
+  }
+
+  it("clones from the host reference path + sends sampler params", async () => {
     process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
-    const fetchMock = stubFetch({ ok: true })
+    const fetchMock = stubOk()
 
     await synthesizeWithMlx("Proceed to build.", { ...baseConfig, referenceText: "sample transcript" })
 
@@ -57,24 +80,25 @@ describe("synthesizeWithMlx", () => {
     expect(body.response_format).toBe("wav")
     expect(body.ref_audio).toBe("/host/voice-storage/voices/mark-dpf-platform/reference.wav")
     expect(body.ref_text).toBe("sample transcript")
+    expect(body.temperature).toBe(0.6)
+    expect(body.top_k).toBe(50)
     expect(body.voice).toBeUndefined()
   })
 
   it("sends a non-empty default ref_text when no transcript is provided (CSM requires it)", async () => {
     process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
-    const fetchMock = stubFetch({ ok: true })
+    const fetchMock = stubOk()
 
     await synthesizeWithMlx("hi", baseConfig)
 
     const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
     expect(body.ref_audio).toBe("/host/voice-storage/voices/mark-dpf-platform/reference.wav")
-    // CSM (sesame) crashes on empty ref_text; the adapter must supply a default.
     expect(typeof body.ref_text).toBe("string")
     expect((body.ref_text as string).length).toBeGreaterThan(0)
   })
 
   it("falls back to a named voice (no cloning) when the host root is unset", async () => {
-    const fetchMock = stubFetch({ ok: true })
+    const fetchMock = stubOk()
 
     await synthesizeWithMlx("hi", baseConfig)
 
@@ -87,7 +111,7 @@ describe("synthesizeWithMlx", () => {
     process.env.DPF_TTS_URL = "http://127.0.0.1:9000"
     process.env.DPF_TTS_MLX_MODEL = "mlx-community/Kokoro-82M-bf16"
     process.env.DPF_TTS_MLX_VOICE = "bf_emma"
-    const fetchMock = stubFetch({ ok: true })
+    const fetchMock = stubOk()
 
     await synthesizeWithMlx("hi", baseConfig)
 
@@ -98,22 +122,54 @@ describe("synthesizeWithMlx", () => {
     expect(body.voice).toBe("bf_emma")
   })
 
-  it("returns audioBuffer + provider mlx on success", async () => {
-    const fakeAudio = new ArrayBuffer(16)
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true, arrayBuffer: () => Promise.resolve(fakeAudio) }),
-    )
-
+  it("returns audioBuffer + provider mlx on a valid first response", async () => {
+    stubOk(VALID_AUDIO)
     const result = await synthesizeWithMlx("Hello.", baseConfig)
-    expect(result.audioBuffer).toBe(fakeAudio)
+    expect(result.audioBuffer).toBe(VALID_AUDIO)
     expect(result.provider).toBe("mlx")
     expect(result.ttsCostUnits).toBe("Hello.".length)
   })
 
-  it("throws VoiceSynthesisError on non-2xx", async () => {
-    stubFetch({ ok: false, status: 503 })
+  it("RETRIES on empty/truncated cloning output and returns the first valid clip", async () => {
+    process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
+    // Two CSM duds, then a good clip — the documented stochastic failure mode.
+    const fetchMock = stubSequence([
+      { ok: true, buf: SHORT_AUDIO },
+      { ok: true, buf: new ArrayBuffer(0) },
+      { ok: true, buf: VALID_AUDIO },
+    ])
+
+    const result = await synthesizeWithMlx("Proceed.", baseConfig)
+    expect(result.audioBuffer.byteLength).toBe(VALID_AUDIO.byteLength)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("RETRIES on a transient 5xx (CSM IndexError) then succeeds", async () => {
+    process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
+    const fetchMock = stubSequence([
+      { ok: false, status: 500 },
+      { ok: true, buf: VALID_AUDIO },
+    ])
+
+    const result = await synthesizeWithMlx("Proceed.", baseConfig)
+    expect(result.provider).toBe("mlx")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("gives up after DPF_TTS_MLX_MAX_ATTEMPTS and throws", async () => {
+    process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
+    process.env.DPF_TTS_MLX_MAX_ATTEMPTS = "3"
+    const fetchMock = stubSequence([{ ok: true, buf: SHORT_AUDIO }]) // always short
+
     await expect(synthesizeWithMlx("x", baseConfig)).rejects.toThrow("VoiceSynthesisError [mlx]")
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("does NOT retry a short named-voice (non-cloning) clip — it's deterministic", async () => {
+    // No host root → named-voice path; a short clip there won't improve on retry.
+    const fetchMock = stubSequence([{ ok: true, buf: SHORT_AUDIO }])
+    await expect(synthesizeWithMlx("x", baseConfig)).rejects.toThrow("VoiceSynthesisError [mlx]")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/web/lib/voice-synthesis/adapters/mlx.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.ts
@@ -69,6 +69,18 @@ export function resolveReferenceHostPath(providerVoiceId: string | undefined | n
   return path.join(root, providerVoiceId)
 }
 
+// CSM generation is stochastic: identical requests intermittently return empty
+// or truncated audio (measured ~50% failure). The model's own docs say to
+// "rerun generation" and tune the sampler. So we (a) set conservative sampler
+// params and (b) retry until the output passes a validity check. A 24 kHz mono
+// 16-bit WAV is ~48 KB/sec; real 1-2 sentence clips are >100 KB, while the
+// failure mode is 0–~8 KB (empty / sub-0.2s). 16 KB (~0.33s) is a safe floor.
+const MIN_VALID_AUDIO_BYTES = 16 * 1024
+function getMaxAttempts(): number {
+  const n = Number(process.env.DPF_TTS_MLX_MAX_ATTEMPTS)
+  return Number.isFinite(n) && n >= 1 ? Math.min(n, 8) : 4
+}
+
 export async function synthesizeWithMlx(
   text: string,
   config: MlxSynthesisConfig,
@@ -88,22 +100,52 @@ export async function synthesizeWithMlx(
     // ref_text must be non-empty or CSM throws (see DEFAULT_REF_TEXT).
     body.ref_audio = refPath
     body.ref_text = config.referenceText?.trim() || DEFAULT_REF_TEXT
+    // Conservative sampler — lower temperature curbs the degenerate runs that
+    // produce empty/truncated output; CSM ignores these fields harmlessly when
+    // not applicable, and other models accept the same OpenAI-style keys.
+    body.temperature = 0.6
+    body.top_k = 50
   } else {
     // No host-visible reference → fixed named voice (non-cloning fallback).
     body.voice = getFallbackVoice()
   }
 
-  const res = await fetch(`${baseUrl}/v1/audio/speech`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
+  const maxAttempts = getMaxAttempts()
+  let lastErr: VoiceSynthesisError | null = null
 
-  if (!res.ok) {
-    const detail = await res.text().catch(() => "unknown")
-    throw new VoiceSynthesisError(detail, "mlx", res.status)
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let audioBuffer: ArrayBuffer
+    try {
+      const res = await fetch(`${baseUrl}/v1/audio/speech`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "unknown")
+        lastErr = new VoiceSynthesisError(detail, "mlx", res.status)
+        continue // transient server error (CSM IndexError etc.) — retry
+      }
+      audioBuffer = await res.arrayBuffer()
+    } catch (err) {
+      // Network/abort — retry rather than fail the whole synthesis.
+      lastErr = new VoiceSynthesisError(String(err), "mlx")
+      continue
+    }
+
+    // Validity gate: reject empty/truncated output and regenerate.
+    if (audioBuffer.byteLength >= MIN_VALID_AUDIO_BYTES) {
+      return { audioBuffer, provider: "mlx", ttsCostUnits: text.length }
+    }
+    lastErr = new VoiceSynthesisError(
+      `Output too short (${audioBuffer.byteLength} bytes) on attempt ${attempt}/${maxAttempts}`,
+      "mlx",
+      502,
+    )
+    // Non-cloning (named-voice) output is deterministic; if a short clip comes
+    // back there, retrying won't help — surface it instead of looping.
+    if (!refPath) break
   }
 
-  const audioBuffer = await res.arrayBuffer()
-  return { audioBuffer, provider: "mlx", ttsCostUnits: text.length }
+  throw lastErr ?? new VoiceSynthesisError("Synthesis failed", "mlx", 502)
 }


### PR DESCRIPTION
Re-lands the retry-with-validation loop that was orphaned when #1276 auto-merged its ref_text-only version before the amend pushed. CSM is stochastic (~50% empty/truncated); this adds sampler params + reject-and-regenerate (<16KB, up to 4 attempts) + transient-5xx retry. Measured: raw ~50%/call to 10/10 with retry (~1.5 attempts avg, ~1s success path). 12 adapter tests pass; typecheck clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)