### PR TITLE
feat(self-upgrade): wire merge-based source prep into the orchestrator + prove it

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSelfUpgradeConfig: vi.fn(),
   isInMaintenanceWindow: vi.fn(),
-  resolveTargetSha: vi.fn(),
-  isShaFresh: vi.fn(),
+  defaultGitRunner: vi.fn(),
+  prepareUpgradeSource: vi.fn(),
   getDeployedSha: vi.fn(),
   isFeatureBuildDeployed: vi.fn(),
   createRun: vi.fn(),
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   completeRun: vi.fn(),
   failRun: vi.fn(),
   getLatestRun: vi.fn(),
+  getLatestSucceededRun: vi.fn(),
   runPromoter: vi.fn(),
   emitUpgradeEvent: vi.fn(),
   // BI-QUIESCE-010 — caller API consumed by runSelfUpgrade.
@@ -26,9 +27,29 @@ vi.mock("@/lib/self-upgrade/config", () => ({
   isInMaintenanceWindow: mocks.isInMaintenanceWindow,
 }));
 
+// Real (pure) argv builders so the orchestrator constructs proper git commands;
+// the mocked defaultGitRunner branches on them.
 vi.mock("@/lib/self-upgrade/version", () => ({
-  resolveTargetSha: mocks.resolveTargetSha,
-  isShaFresh: mocks.isShaFresh,
+  buildFetchCommand: (i: { hostSourcePath: string; remote: string; branch: string }) => [
+    "git",
+    "-C",
+    i.hostSourcePath,
+    "fetch",
+    i.remote,
+    i.branch,
+  ],
+  buildRemoteHeadCommand: (i: { hostSourcePath: string; remote: string; branch: string }) => [
+    "git",
+    "-C",
+    i.hostSourcePath,
+    "rev-parse",
+    `${i.remote}/${i.branch}`,
+  ],
+}));
+
+vi.mock("@/lib/self-upgrade/prepare-source", () => ({
+  prepareUpgradeSource: mocks.prepareUpgradeSource,
+  defaultGitRunner: mocks.defaultGitRunner,
 }));
 
 vi.mock("@/lib/self-upgrade/completion", () => ({
@@ -42,6 +63,7 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   completeRun: mocks.completeRun,
   failRun: mocks.failRun,
   getLatestRun: mocks.getLatestRun,
+  getLatestSucceededRun: mocks.getLatestSucceededRun,
 }));
 
 vi.mock("@/lib/self-upgrade/promoter", () => ({
@@ -97,6 +119,26 @@ function setupQuiescenceReady(quiescenceRunId = "QR-2026-05-24-test1234"): void 
   mocks.signalSwapStarting.mockResolvedValue(undefined);
   mocks.signalSwapComplete.mockResolvedValue(undefined);
   mocks.failQuiescenceSwap.mockResolvedValue(undefined);
+}
+
+/**
+ * Set up the source-prep happy path: upstream resolves to `stamp` via the
+ * mocked git runner (rev-parse), no prior succeeded run (lineage gate open),
+ * and prepareUpgradeSource returns a clean merge with `stamp` as the identity.
+ */
+function setupSourceReady(stamp = "abc1234deadbeef"): void {
+  mocks.defaultGitRunner.mockImplementation(async (args: string[]) =>
+    args.includes("rev-parse")
+      ? { stdout: `${stamp}\n`, stderr: "", code: 0 }
+      : { stdout: "", stderr: "", code: 0 },
+  );
+  mocks.getLatestSucceededRun.mockResolvedValue(null);
+  mocks.prepareUpgradeSource.mockResolvedValue({
+    ok: true,
+    mode: "upstream",
+    stamp,
+    upstreamSha: stamp,
+  });
 }
 
 describe("cron metadata", () => {
@@ -173,6 +215,8 @@ const ENABLED_CONFIG = {
   repositoryRemote: "origin",
   repositoryBranch: "main",
   healthUrl: "http://localhost:3000/api/health",
+  sourceMode: "upstream" as const,
+  installBranch: "dpf/install",
 };
 
 describe("success path", () => {
@@ -180,9 +224,8 @@ describe("success path", () => {
     vi.clearAllMocks();
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
-    mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
-    mocks.isShaFresh.mockReturnValue(false);
+    setupSourceReady();
     setupQuiescenceReady();
     mocks.getLatestRun.mockResolvedValue(null);
     mocks.createRun.mockResolvedValue({ runId: "SUR-AAAABBBB" });
@@ -199,9 +242,25 @@ describe("success path", () => {
     expect(mocks.completeRun).toHaveBeenCalledWith("SUR-AAAABBBB");
   });
 
-  it("resolves the target SHA using the configured source checkout", async () => {
+  it("prepares the upgrade source with the configured mode/remote/branch/install branch", async () => {
     await runSelfUpgrade({ triggeredBy: "ops" });
-    expect(mocks.resolveTargetSha).toHaveBeenCalledWith("stable", ENABLED_CONFIG);
+    expect(mocks.prepareUpgradeSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceMode: "upstream",
+        remote: "origin",
+        branch: "main",
+        installBranch: "dpf/install",
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("skips with up-to-date when the running build already contains the upstream SHA", async () => {
+    mocks.getLatestSucceededRun.mockResolvedValue({ targetSha: "abc1234deadbeef" });
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled" });
+    expect(result).toMatchObject({ skipped: true, reason: "up-to-date" });
+    expect(mocks.prepareUpgradeSource).not.toHaveBeenCalled();
+    expect(mocks.runPromoter).not.toHaveBeenCalled();
   });
 
   it("runs the promoter with the host install path, backup, image, and health paths", async () => {
@@ -299,9 +358,8 @@ describe("maintenance window gate + emergency override", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
-    mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
-    mocks.isShaFresh.mockReturnValue(false);
+    setupSourceReady();
     setupQuiescenceReady();
     mocks.getLatestRun.mockResolvedValue(null);
     mocks.createRun.mockResolvedValue({ runId: "SUR-FORCE001" });
@@ -332,9 +390,8 @@ describe("failure path", () => {
     vi.clearAllMocks();
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
-    mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
-    mocks.isShaFresh.mockReturnValue(false);
+    setupSourceReady();
     setupQuiescenceReady();
     mocks.getLatestRun.mockResolvedValue(null);
     mocks.createRun.mockResolvedValue({ runId: "SUR-FAILTEST" });
@@ -397,14 +454,53 @@ describe("failure path", () => {
   });
 });
 
+describe("merge-conflict defer (source prep, §5.0)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
+    mocks.isInMaintenanceWindow.mockReturnValue(true);
+    mocks.getDeployedSha.mockResolvedValue("oldsha1");
+    setupSourceReady();
+    mocks.getLatestRun.mockResolvedValue(null);
+    mocks.createRun.mockResolvedValue({ runId: "SUR-CONFLICT" });
+    mocks.failRun.mockResolvedValue({});
+    mocks.emitUpgradeEvent.mockResolvedValue(undefined);
+  });
+
+  it("defers without draining or promoting when the upstream merge conflicts", async () => {
+    mocks.prepareUpgradeSource.mockResolvedValue({
+      ok: false,
+      reason: "merge-conflict",
+      conflictFiles: ["apps/web/a.ts", "apps/web/b.ts"],
+      upstreamSha: "abc1234deadbeef",
+      message: "upstream merge conflicts in 2 file(s)",
+    });
+
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "deferred-conflict",
+      reason: "merge-conflict",
+      conflictFiles: ["apps/web/a.ts", "apps/web/b.ts"],
+    });
+    // The running build is untouched: no drain, no swap.
+    expect(mocks.startQuiescence).not.toHaveBeenCalled();
+    expect(mocks.runPromoter).not.toHaveBeenCalled();
+    expect(mocks.failRun).toHaveBeenCalledWith(
+      "SUR-CONFLICT",
+      "merge-conflict: apps/web/a.ts, apps/web/b.ts",
+    );
+  });
+});
+
 describe("quiescence-defer path (BI-QUIESCE-010)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isInMaintenanceWindow.mockReturnValue(true);
-    mocks.resolveTargetSha.mockResolvedValue("abc1234deadbeef");
     mocks.getDeployedSha.mockResolvedValue("oldsha1");
-    mocks.isShaFresh.mockReturnValue(false);
+    setupSourceReady();
     mocks.getLatestRun.mockResolvedValue(null);
     mocks.createRun.mockResolvedValue({ runId: "SUR-DEFER" });
     mocks.startRun.mockResolvedValue({});

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -1,9 +1,17 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { getSelfUpgradeConfig, isInMaintenanceWindow } from "@/lib/self-upgrade/config";
-import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
+import { buildFetchCommand, buildRemoteHeadCommand } from "@/lib/self-upgrade/version";
+import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepare-source";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
-import { createRun, startRun, completeRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
+import {
+  createRun,
+  startRun,
+  completeRun,
+  failRun,
+  getLatestRun,
+  getLatestSucceededRun,
+} from "@/lib/self-upgrade/run-store";
 import { runPromoter } from "@/lib/self-upgrade/promoter";
 import { emitUpgradeEvent } from "@/lib/self-upgrade/notifications";
 import {
@@ -50,21 +58,91 @@ export async function runSelfUpgrade(
     return { skipped: true, reason: "outside-window" };
   }
 
-  const targetSha = await resolveTargetSha(config.channel, config);
-  if (!targetSha) return { skipped: true, reason: "no-target" };
+  const gitRun = defaultGitRunner;
+  const hostSourcePath =
+    config.hostSourceMountPath ??
+    process.env.DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT ??
+    process.env.HOST_SOURCE_PATH ??
+    "/host-dpf";
+  const remote = config.repositoryRemote ?? process.env.REPO_REMOTE ?? "origin";
+  const branch = config.repositoryBranch ?? process.env.REPO_BRANCH ?? "main";
 
-  const deployedSha = await getDeployedSha();
-  if (isShaFresh(deployedSha, targetSha)) return { skipped: true, reason: "up-to-date" };
+  // ── Detection: resolve the upstream target and apply the lineage gate ──────
+  // In upstream mode we fetch first (fresh ref) and skip when the running build
+  // already contains this upstream SHA. The running deployedSha is the merge
+  // identity, NOT the upstream SHA it absorbed, so freshness is gated on the
+  // latest succeeded run's targetSha (the upstream lineage marker), per §5.0.
+  let upstreamSha: string | null = null;
+  if (config.sourceMode === "upstream") {
+    await gitRun(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
+    const head = await gitRun(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
+    upstreamSha = head.code === 0 ? head.stdout.trim() : null;
+    if (!upstreamSha) return { skipped: true, reason: "no-target" };
+
+    const lastOk = await getLatestSucceededRun();
+    if (!params.dryRun && !params.force && lastOk?.targetSha === upstreamSha) {
+      return { skipped: true, reason: "up-to-date", upstreamSha };
+    }
+  }
 
   const latestRun = await getLatestRun();
   if (latestRun?.status === "running") {
     return { skipped: true, reason: "active-run", runId: latestRun.runId };
   }
 
+  const deployedSha = await getDeployedSha();
+
+  // ── Source preparation: merge upstream into the durable install branch
+  // (upstream) or stamp the working tree (local). The honest stamp returned
+  // here is the identity the promoter must build and verify. dryRun must not
+  // mutate the host clone, so the merge is skipped and a placeholder stamp used.
+  let builtStamp: string;
+  if (params.dryRun) {
+    builtStamp = upstreamSha ?? deployedSha ?? "dry-run";
+  } else {
+    const prep = await prepareUpgradeSource(
+      {
+        sourceMode: config.sourceMode,
+        hostSourcePath,
+        remote,
+        branch,
+        installBranch: config.installBranch,
+      },
+      gitRun,
+    );
+    if (!prep.ok) {
+      // Conflict / no-target / prep-error: record for audit, do NOT drain or
+      // swap. A merge conflict defers (operator resolves in the Upgrade Center);
+      // the current build keeps running.
+      const failedRun = await createRun({
+        triggeredBy: params.triggeredBy,
+        fromVersion: deployedSha ?? undefined,
+        toVersion: upstreamSha ?? undefined,
+      });
+      const reason =
+        prep.reason === "merge-conflict"
+          ? `merge-conflict: ${prep.conflictFiles.join(", ")}`
+          : `${prep.reason}: ${prep.message}`;
+      await failRun(failedRun.runId, reason);
+      await emitUpgradeEvent({ type: "upgrade.failed", runId: failedRun.runId });
+      return {
+        ok: false,
+        status: prep.reason === "merge-conflict" ? "deferred-conflict" : "failed",
+        runId: failedRun.runId,
+        reason: prep.reason,
+        conflictFiles: prep.reason === "merge-conflict" ? prep.conflictFiles : undefined,
+      };
+    }
+    builtStamp = prep.stamp;
+    upstreamSha = prep.upstreamSha ?? upstreamSha;
+  }
+
   const run = await createRun({
     triggeredBy: params.triggeredBy,
     fromVersion: deployedSha ?? undefined,
-    toVersion: targetSha,
+    // targetSha column carries the upstream lineage marker (what the build
+    // contains), falling back to the built stamp in local mode.
+    toVersion: upstreamSha ?? builtStamp,
   });
   await startRun(run.runId);
   await emitUpgradeEvent({ type: "upgrade.started", runId: run.runId });
@@ -130,7 +208,10 @@ export async function runSelfUpgrade(
         process.env.DPF_HOST_INSTALL_PATH ??
         process.env.PROMOTE_SOURCE ??
         "",
-      targetSha,
+      // The honest built identity from source prep (merge-commit SHA in upstream
+      // mode, HEAD/-dirty in local mode). promote.sh re-derives this from the
+      // tree's HEAD and cross-checks against it.
+      targetSha: builtStamp,
       backupPath: process.env.PROMOTE_BACKUP_PATH ?? `/backups/self-upgrade/${run.runId}`,
       backupHostPath: process.env.DPF_BACKUPS_HOST_PATH ?? undefined,
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",

--- a/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { prepareUpgradeSource, defaultGitRunner } from "./prepare-source";
+
+// Functional proof: exercise the REAL git runner against REAL repos. No mocks.
+// This is the evidence that the merge actually preserves local commits and that
+// a conflict is aborted to a clean tree rather than left mid-merge.
+
+const GIT_AVAILABLE = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+  }).toString();
+}
+
+function commit(cwd: string, file: string, content: string, msg: string): void {
+  writeFileSync(join(cwd, file), content);
+  git(cwd, "add", "-A");
+  git(cwd, "-c", "commit.gpgsign=false", "commit", "-m", msg);
+}
+
+/** upstream repo (on main) + an install clone with a dpf/install branch. */
+function makeWorld(): { upstream: string; install: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "dpf-upg-"));
+  const upstream = join(root, "upstream");
+  const install = join(root, "install");
+  execFileSync("git", ["init", "-b", "main", upstream]);
+  // seed gpgsign off for the upstream too
+  git(upstream, "config", "commit.gpgsign", "false");
+  commit(upstream, "base.txt", "v1\n", "base");
+  execFileSync("git", ["clone", "-q", upstream, install]);
+  git(install, "config", "user.email", "t@t");
+  git(install, "config", "user.name", "t");
+  git(install, "config", "commit.gpgsign", "false");
+  return { upstream, install, root };
+}
+
+describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
+  const cleanup: string[] = [];
+  beforeAll(() => {
+    return () => cleanup.forEach((d) => rmSync(d, { recursive: true, force: true }));
+  });
+
+  it("merges upstream into the install branch, PRESERVING local commits", async () => {
+    const { upstream, install, root } = makeWorld();
+    cleanup.push(root);
+
+    // Local customization on the durable install branch (never pushed upstream).
+    git(install, "checkout", "-b", "dpf/install");
+    commit(install, "local.txt", "my private feature\n", "local: feature");
+    const localCommit = git(install, "rev-parse", "HEAD").trim();
+
+    // Upstream advances with a new feature on a disjoint file.
+    commit(upstream, "upstream.txt", "new upstream feature\n", "feat: upstream thing");
+    const upstreamCommit = git(upstream, "rev-parse", "HEAD").trim();
+
+    const r = await prepareUpgradeSource(
+      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const head = git(install, "rev-parse", "HEAD").trim();
+    // Stamp is the real merge-commit identity.
+    expect(r.stamp).toBe(head);
+    expect(r.upstreamSha).toBe(upstreamCommit);
+    // It is a real merge commit (two parents): one is the local commit, the
+    // other carries the upstream change.
+    const parents = git(install, "rev-list", "--parents", "-n", "1", "HEAD").trim().split(/\s+/).slice(1);
+    expect(parents).toContain(localCommit);
+    expect(parents).toContain(upstreamCommit);
+    // BOTH the local customization AND the upstream feature are present — the
+    // whole point: stay current without losing local work.
+    expect(existsSync(join(install, "local.txt"))).toBe(true);
+    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
+    // We are on the install branch, clean.
+    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
+    expect(git(install, "status", "--porcelain").trim()).toBe("");
+  });
+
+  it("creates the install branch from HEAD on first run when it is absent", async () => {
+    const { upstream, install, root } = makeWorld();
+    cleanup.push(root);
+    commit(upstream, "upstream.txt", "x\n", "feat: x");
+
+    const r = await prepareUpgradeSource(
+      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+
+    expect(r.ok).toBe(true);
+    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
+    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
+  });
+
+  it("ABORTS to a clean tree on a real conflict and reports the file", async () => {
+    const { upstream, install, root } = makeWorld();
+    cleanup.push(root);
+
+    // Local and upstream both edit the same file → genuine merge conflict.
+    git(install, "checkout", "-b", "dpf/install");
+    commit(install, "base.txt", "local edit\n", "local: edit base");
+    const beforeHead = git(install, "rev-parse", "HEAD").trim();
+    commit(upstream, "base.txt", "upstream edit\n", "fix: edit base");
+
+    const r = await prepareUpgradeSource(
+      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("merge-conflict");
+    if (r.reason !== "merge-conflict") return;
+    expect(r.conflictFiles).toContain("base.txt");
+    // Critically: the clone is NOT left mid-merge — it was aborted clean.
+    expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
+    expect(git(install, "status", "--porcelain").trim()).toBe("");
+    expect(git(install, "rev-parse", "HEAD").trim()).toBe(beforeHead);
+  });
+
+  it("local mode stamps the working tree HEAD, with -dirty when uncommitted", async () => {
+    const { install, root } = makeWorld();
+    cleanup.push(root);
+
+    const clean = await prepareUpgradeSource(
+      { sourceMode: "local", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+    expect(clean.ok).toBe(true);
+    if (clean.ok) expect(clean.stamp).toBe(git(install, "rev-parse", "HEAD").trim());
+
+    writeFileSync(join(install, "base.txt"), "uncommitted change\n");
+    const dirty = await prepareUpgradeSource(
+      { sourceMode: "local", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+    expect(dirty.ok).toBe(true);
+    if (dirty.ok) expect(dirty.stamp.endsWith("-dirty")).toBe(true);
+  });
+});

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// High-fidelity functional proof of scripts/promote.sh: run the REAL script
+// through all six steps against a REAL git repo, faking only the external
+// boundaries — `docker` (the image build is orthogonal to the stamp logic) and
+// `curl` (the portal's /api/health/sha). The fake portal "reports" whatever
+// DPF_VERSION the build stamped, by echoing $DPF_VERSION — which is exactly how
+// the real round-trip works (DPF_VERSION build-arg → /app/.dpf-image-version →
+// /api/health/sha). So a passing sha-verify here means the same thing it means
+// in production: the running runtime reports the SHA of the code that was built.
+
+const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
+const BASH_OK = spawnSync("bash", ["--version"], { encoding: "utf8" }).status === 0;
+const GIT_OK = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+
+function gitInit(dir: string): string {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+  execFileSync("git", ["init", "-b", "main", dir], { env });
+  writeFileSync(join(dir, "Dockerfile"), "FROM scratch\n");
+  writeFileSync(join(dir, "docker-compose.yml"), "services: {}\n");
+  writeFileSync(join(dir, "docker-compose.macos.yml"), "services: {}\n");
+  execFileSync("git", ["-C", dir, "add", "-A"], { env });
+  execFileSync("git", ["-C", dir, "-c", "commit.gpgsign=false", "commit", "-m", "seed"], { env });
+  return execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], { env }).toString().trim();
+}
+
+/** Fake `docker` and `curl` on PATH. */
+function makeFakeBin(root: string): string {
+  const bin = join(root, "bin");
+  execFileSync("mkdir", ["-p", bin]);
+  // docker: `build`/`up` are no-ops; any `cat /app/.dpf-source-content-hash`
+  // (the content-verify guard — step 3 `docker run` and step 7
+  // `docker compose exec`) returns a single stable hash so built==running.
+  writeFileSync(
+    join(bin, "docker"),
+    '#!/bin/sh\ncase "$*" in\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+  );
+  // For any URL ending in /sha, report the stamped DPF_VERSION (inherited from
+  // the script's exported env) — modelling a correctly-stamped portal. Other
+  // health probes just succeed.
+  writeFileSync(
+    join(bin, "curl"),
+    '#!/bin/sh\nfor a in "$@"; do url="$a"; done\ncase "$url" in\n  */sha) printf "%s" "$DPF_VERSION" ;;\n  *) printf "ok" ;;\nesac\nexit 0\n',
+  );
+  chmodSync(join(bin, "docker"), 0o755);
+  chmodSync(join(bin, "curl"), 0o755);
+  return bin;
+}
+
+function runPromote(opts: {
+  source: string;
+  backup: string;
+  targetSha: string;
+  fakeBin: string;
+}): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync("bash", [SCRIPT, "--self-upgrade"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${opts.fakeBin}:${process.env.PATH}`,
+      PROMOTE_SOURCE: opts.source,
+      PROMOTE_TARGET_SHA: opts.targetSha,
+      // Backup path is OUTSIDE the source tree (as in production: /backups/...),
+      // so it never dirties the build source.
+      PROMOTE_BACKUP_PATH: opts.backup,
+      PROMOTE_HEALTH_URL: "http://127.0.0.1:9/api/health",
+      PROMOTE_COMPOSE_PROJECT: "dpf-functest",
+    },
+  });
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+/** Scratch root with a clean git source dir (src/) + isolated bin/ and backup/. */
+function makeScratch(): { root: string; source: string; backup: string; fakeBin: string; head: string } {
+  const root = mkdtempSync(join(tmpdir(), "dpf-promote-"));
+  const source = join(root, "src");
+  execFileSync("mkdir", ["-p", source]);
+  const head = gitInit(source);
+  const fakeBin = makeFakeBin(root);
+  return { root, source, backup: join(root, "backup"), fakeBin, head };
+}
+
+describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run", () => {
+  it("stamps the source HEAD and sha-verify passes against a correctly-stamped portal", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    try {
+      // Orchestrator passes the prepared stamp as the expected identity; it
+      // equals HEAD here, so no warning and a clean verify.
+      const r = runPromote({ source, backup, targetSha: head, fakeBin });
+      expect(r.status).toBe(0);
+      // sha-verify completed against the SHA actually built (HEAD).
+      expect(r.stdout).toContain(`step=done target=${head}`);
+      expect(r.stderr).not.toContain("warning: build source identity");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("derives a -dirty stamp when the build source has uncommitted changes", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    try {
+      writeFileSync(join(source, "Dockerfile"), "FROM scratch\n# changed\n"); // dirty a tracked file
+      const r = runPromote({ source, backup, targetSha: `${head}-dirty`, fakeBin });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain(`step=done target=${head}-dirty`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns (does not silently mislabel) when the tree identity differs from the expected stamp", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    try {
+      // Orchestrator expected a different SHA than what's on disk → drift.
+      const r = runPromote({ source, backup, targetSha: "0000000000000000000000000000000000000000", fakeBin });
+      expect(r.status).toBe(0);
+      // It still stamps the TRUTH (HEAD), and flags the drift.
+      expect(r.stdout).toContain(`step=done target=${head}`);
+      expect(r.stderr).toContain("warning: build source identity");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -70,6 +70,20 @@ export async function getLatestRun() {
   });
 }
 
+/**
+ * The most-recent successfully-completed run. Its `targetSha` is the upstream
+ * lineage marker the running build contains — the basis for the §5.0 freshness
+ * gate (don't re-merge an upstream we already carry). Distinct from the running
+ * `deployedSha`, which in merge mode is the merge-commit identity, not the
+ * upstream SHA it absorbed.
+ */
+export async function getLatestSucceededRun() {
+  return prisma.selfUpgradeRun.findFirst({
+    where: { status: "succeeded" },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
 export async function getRun(runId: string) {
   return prisma.selfUpgradeRun.findUnique({ where: { runId } });
 }


### PR DESCRIPTION
## What & why

PR #1272 landed the merge-source substrate (`config` sourceMode/installBranch, `version` helpers, `prepare-source.ts`, `promote.sh` honest stamp) but left `prepare-source` **unwired** — `self-upgrade.ts` still calls `resolveTargetSha`, so `prepareUpgradeSource` is **dead code on main**: never invoked, never run against real git or Docker. This wires it in and proves it.

## Changes (net-new only — no duplication of #1272/#1274)

- **`self-upgrade.ts`** — fetch+resolve upstream → **lineage gate** (skip when the latest succeeded run's `targetSha` already equals upstream HEAD, so a merge build doesn't re-trigger forever) → `prepareUpgradeSource` (merge into the install branch) → promoter with the honest built stamp. Merge conflict ⇒ `deferred-conflict` (recorded, **no drain, no swap**, current build keeps running). `targetSha` column carries the upstream lineage marker; `deployedSha` is the built identity. **No migration** (reuses existing columns).
- **`run-store.ts`** — `getLatestSucceededRun` (the lineage-marker source).
- **`self-upgrade.test.ts`** — rewired to the source-prep path + merge-conflict + up-to-date-lineage cases.
- **`prepare-source.integration.test.ts`** — **real-git** proof: merge preserves local commits while absorbing upstream (2-parent merge commit, stamp == HEAD), install branch created on first run, real conflict aborts to a clean tree.
- **`promote-script-functional.test.ts`** — runs the **real `scripts/promote.sh`** through all steps (incl. the #1274 content-verify guard) against a real git repo, proving the honest HEAD/-dirty stamp and a passing sha-verify.

## Verification

- `vitest` self-upgrade + orchestrator: **204 passing** (against main's `prepare-source`/`promote.sh`).
- `next build`: **exit 0**. `tsc --noEmit`: clean. No migration.
- Real-Docker capstone (separately): `promote.sh` built an image, recreated a container, and `/api/health/sha` reported the **merge-commit SHA** exactly.

Builds on #1272 (substrate) and #1274 (content-verify). Refs the governed-upgrade-lifecycle spec §5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)