### PR TITLE
fix(db): reconcile FeatureBuild.originatingBacklogItemId FK back to BacklogItem(id)

### DIFF
--- a/packages/db/prisma/migrations/20260530020000_fix_featurebuild_originating_fk_drift/migration.sql
+++ b/packages/db/prisma/migrations/20260530020000_fix_featurebuild_originating_fk_drift/migration.sql
@@ -1,0 +1,24 @@
+-- Corrective (drift-repair) migration.
+--
+-- schema.prisma and the original 20260424173000_backlog_governed_delivery
+-- migration both define FeatureBuild.originatingBacklogItemId as a FK to
+-- BacklogItem("id") (the cuid). On at least one install the LIVE constraint
+-- had drifted to reference BacklogItem("itemId") (the semantic BI-* id) and
+-- was marked NOT VALID — so promote_to_build_studio failed with
+--   "Foreign key constraint violated: FeatureBuild_originatingBacklogItemId_fkey"
+-- because the promote path writes the BacklogItem cuid (item.id) into
+-- originatingBacklogItemId (see apps/web/lib/governed-backlog-tee-up.ts and
+-- apps/web/lib/integrate/ideate-on-approval.ts, which both treat it as a
+-- BacklogItem.id). Every Build Studio promotion was blocked as a result.
+--
+-- This reconciles the live constraint back to the committed definition. It is
+-- idempotent (DROP IF EXISTS) and safe to apply where the FK is already
+-- correct. FeatureBuild has no rows with originatingBacklogItemId set on the
+-- affected install, so the re-validated ADD cannot fail on existing data.
+--
+-- The broader drift (all BacklogItem FKs recreated NOT VALID, and
+-- BusinessCapabilityTraceLink.backlogItemId also drifted to itemId) is tracked
+-- separately for investigation + data cleanup before its FK can be corrected.
+
+ALTER TABLE "FeatureBuild" DROP CONSTRAINT IF EXISTS "FeatureBuild_originatingBacklogItemId_fkey";
+ALTER TABLE "FeatureBuild" ADD CONSTRAINT "FeatureBuild_originatingBacklogItemId_fkey" FOREIGN KEY ("originatingBacklogItemId") REFERENCES "BacklogItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## Problem

`promote_to_build_studio` fails on a real install with **`Foreign key constraint violated: FeatureBuild_originatingBacklogItemId_fkey`**, blocking **every** Build Studio promotion (and thus any backlog→build cycle).

## Root cause — live FK drift

- `schema.prisma:4473` (`relation("BacklogItemOriginator", references:[id])`) and the original `20260424173000_backlog_governed_delivery` migration both define the FK as `REFERENCES BacklogItem("id")` (the cuid).
- The promote path writes the BacklogItem **cuid** (`item.id`) into `originatingBacklogItemId` (`governed-backlog-tee-up.ts`; `ideate-on-approval.ts` reads it back via `where: { id }`).
- But the **live** constraint had drifted to `REFERENCES BacklogItem("itemId")` (the semantic `BI-*`) and was marked `NOT VALID`. A cuid never matches an `itemId` → FK violation on insert.

(Part of a broader drift on this install: all `BacklogItem` FKs were recreated `NOT VALID`, and `BusinessCapabilityTraceLink.backlogItemId` also drifted to `itemId` — tracked separately; it needs data cleanup before its FK can be corrected, so it's intentionally **not** in this migration to avoid a failing deploy.)

## Fix

A corrective drift-repair migration that drops and re-adds the FK referencing `BacklogItem("id")`, matching the committed schema. Idempotent (`DROP ... IF EXISTS`) and safe to apply where the FK is already correct. `FeatureBuild` has no rows with `originatingBacklogItemId` set on the affected install, so the re-validated `ADD` cannot fail on existing data.

## Deploy / verify

Applies via `prisma migrate deploy` on portal-init (i.e. on the next self-upgrade). After deploy: `promote_to_build_studio` succeeds; `pg_get_constraintdef` shows the FK referencing `BacklogItem(id)`.

Found while dogfooding the Build Studio backlog→promote→build cycle on macOS. The raw DDL repair was deliberately routed through PR→git→self-upgrade rather than a direct prod DB write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)