### PR TITLE
feat(build-studio): route reported issues into a fix-kind build

### DIFF
--- a/apps/web/app/api/agent/build/advance-phase/route.ts
+++ b/apps/web/app/api/agent/build/advance-phase/route.ts
@@ -48,6 +48,8 @@ export async function POST(request: NextRequest): Promise<Response> {
       buildId: true,
       title: true,
       phase: true,
+      kind: true,
+      brief: true,
       originatingBacklogItemId: true,
       draftApprovedAt: true,
       designDoc: true,
@@ -99,7 +101,10 @@ export async function POST(request: NextRequest): Promise<Response> {
     );
   }
 
+  const advanceBrief = build.brief as { fixContext?: import("@/lib/feature-build-types").FixContext } | null;
   const gate = checkPhaseGate(currentPhase, targetPhase, {
+    kind: build.kind,
+    fixContext: advanceBrief?.fixContext,
     designDoc: build.designDoc,
     designReview: build.designReview,
     happyPathState: normalizeHappyPathState((build.plan as Record<string, unknown> | null)?.happyPathState ?? null),

--- a/apps/web/components/admin/IssueReportPanel.tsx
+++ b/apps/web/components/admin/IssueReportPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
-import { Archive, Bot, CheckCircle2, Filter, ShieldAlert } from "lucide-react";
-import { updateIssueReportStatus } from "@/lib/actions/quality";
+import { useRouter } from "next/navigation";
+import { Archive, Bot, CheckCircle2, Filter, ShieldAlert, Wrench } from "lucide-react";
+import { updateIssueReportStatus, sendIssueReportToBuildStudioAsFix } from "@/lib/actions/quality";
 import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "@/lib/quality/issue-report-status";
 import {
   classifyIssueReport,
@@ -58,7 +59,9 @@ export function IssueReportPanel({
   const [items, setItems] = useState(initialItems);
   const [expandedId, setExpandedId] = useState<string | null>(items[0]?.id ?? null);
   const [activeFilter, setActiveFilter] = useState<QueueFilter>("needs_action");
+  const [sendError, setSendError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const router = useRouter();
 
   const classifiedItems = useMemo(
     () =>
@@ -83,6 +86,24 @@ export function IssueReportPanel({
       setItems((prev) =>
         prev.map((report) => (report.reportId === reportId ? { ...report, status: newStatus } : report)),
       );
+    });
+  }
+
+  function handleSendToFix(reportId: string) {
+    startTransition(async () => {
+      const result = await sendIssueReportToBuildStudioAsFix(reportId);
+      if (result.status === "blocked") {
+        setSendError(`${reportId}: ${result.error}`);
+        return;
+      }
+      setSendError(null);
+      // The report is now triaged_local; reflect it locally before navigating.
+      setItems((prev) =>
+        prev.map((report) =>
+          report.reportId === reportId ? { ...report, status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL } : report,
+        ),
+      );
+      router.push(result.href);
     });
   }
 
@@ -205,10 +226,16 @@ export function IssueReportPanel({
                 onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
                 onAskAdmin={() => handleAskAdmin(item)}
                 onStatusChange={handleStatusChange}
+                onSendToFix={handleSendToFix}
                 isPending={isPending}
               />
             ))}
           </div>
+        )}
+        {sendError && (
+          <p className="border-t border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-error)]">
+            Could not send to Build Studio — {sendError}
+          </p>
         )}
       </section>
     </div>
@@ -221,6 +248,7 @@ function IssueReportRow({
   onToggle,
   onAskAdmin,
   onStatusChange,
+  onSendToFix,
   isPending,
 }: {
   report: ReportRow;
@@ -228,6 +256,7 @@ function IssueReportRow({
   onToggle: () => void;
   onAskAdmin: () => void;
   onStatusChange: (reportId: string, status: IssueReportStatus) => void;
+  onSendToFix: (reportId: string) => void;
   isPending: boolean;
 }) {
   const classification = classifyIssueReport(report);
@@ -275,6 +304,18 @@ function IssueReportRow({
             >
               <Archive className="h-3.5 w-3.5" aria-hidden="true" />
               Suppress
+            </button>
+          )}
+          {status.isActive && classification.category !== "warmup_noise" && (
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() => onSendToFix(report.reportId)}
+              title="Create a bug backlog item and start a fix-kind Build Studio build from this report"
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+            >
+              <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
+              Send to Build Studio as a fix
             </button>
           )}
           {status.isActive && (

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -163,6 +163,8 @@ function getPhaseGateReason(
   targetPhase: BuildPhase,
 ): string | null {
   const gate = checkPhaseGate(build.phase, targetPhase, {
+    kind: build.kind ?? "feature",
+    fixContext: build.brief?.fixContext,
     designDoc: build.designDoc,
     designReview: build.designReview,
     happyPathState: normalizeHappyPathState(build.happyPathState),

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -353,6 +353,7 @@ export async function advanceBuildPhase(
       buildId: true,
       title: true,
       phase: true,
+      kind: true,
       createdById: true,
       originatingBacklogItemId: true,
       draftApprovedAt: true,
@@ -415,8 +416,10 @@ export async function advanceBuildPhase(
     }
   }
 
-  const brief = build.brief as { acceptanceCriteria?: string[] } | null;
+  const brief = build.brief as { acceptanceCriteria?: string[]; fixContext?: import("@/lib/feature-build-types").FixContext } | null;
   const gate = checkPhaseGate(currentPhase, targetPhase, {
+    kind: build.kind,
+    fixContext: brief?.fixContext,
     designDoc: build.designDoc,
     designReview: build.designReview,
     happyPathState: normalizeHappyPathState((build.plan as Record<string, unknown> | null)?.happyPathState ?? null),

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -1,8 +1,12 @@
 "use server";
 
+import * as crypto from "crypto";
 import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import { startBacklogBuild } from "@/lib/actions/backlog-build";
 import {
   ISSUE_REPORT_STATUS,
   type IssueReportStatus,
@@ -84,6 +88,138 @@ export async function updateIssueReportStatus(
   return prisma.platformIssueReport.update({
     where: { reportId },
     data: { status },
+  });
+}
+
+// ─── Send to Build Studio as a fix ────────────────────────────────────────────
+// Manual intake affordance: turn an issue report into a fix-kind Build Studio
+// build. Idempotent — repeated clicks never create duplicate backlog/build rows.
+//   1. If the report is already linked to a build, return that build.
+//   2. Else reuse an open bug backlog item already filed for this report.
+//   3. Else create a source=bug, triageOutcome=build item seeded from the report.
+//   4. Promote via startBacklogBuild() — the promote path derives kind="fix",
+//      carries fixContext from the report, and back-links the report.
+//   5. Transition the report to triaged_local.
+
+const SEVERITY_PRIORITY: Record<string, number> = { critical: 1, high: 2, medium: 3, low: 4 };
+
+export type SendIssueToFixResult =
+  | { status: "created" | "existing"; buildId: string; href: string }
+  | { status: "blocked"; error: string };
+
+export async function sendIssueReportToBuildStudioAsFix(
+  reportId: string,
+): Promise<SendIssueToFixResult> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")
+  ) {
+    return { status: "blocked", error: "Unauthorized" };
+  }
+
+  const report = await prisma.platformIssueReport.findUnique({
+    where: { reportId },
+    select: {
+      id: true,
+      reportId: true,
+      title: true,
+      description: true,
+      severity: true,
+      routeContext: true,
+      digitalProductId: true,
+      featureBuildId: true,
+    },
+  });
+  if (!report) {
+    return { status: "blocked", error: `Issue report ${reportId} was not found.` };
+  }
+
+  // (1) Already linked to a build — return it (idempotent).
+  if (report.featureBuildId) {
+    const existingBuild = await prisma.featureBuild.findUnique({
+      where: { id: report.featureBuildId },
+      select: { buildId: true },
+    });
+    if (existingBuild) {
+      return { status: "existing", buildId: existingBuild.buildId, href: `/build?buildId=${encodeURIComponent(existingBuild.buildId)}` };
+    }
+  }
+
+  // (2) Reuse an open bug backlog item already filed for this report. The triage
+  // cron and this action both embed the public report id in the BI body.
+  let itemId: string | null = null;
+  const existingItem = await prisma.backlogItem.findFirst({
+    where: { source: "bug", body: { contains: report.reportId } },
+    orderBy: { createdAt: "desc" },
+    select: { itemId: true, status: true, triageOutcome: true, effortSize: true, activeBuild: { select: { buildId: true } } },
+  });
+  if (existingItem?.activeBuild?.buildId) {
+    await markReportTriaged(report.id, existingItem.activeBuild.buildId);
+    return { status: "existing", buildId: existingItem.activeBuild.buildId, href: `/build?buildId=${encodeURIComponent(existingItem.activeBuild.buildId)}` };
+  }
+  if (existingItem) {
+    // Ensure it is promotion-eligible (open + build + sized), then reuse it.
+    await prisma.backlogItem.update({
+      where: { itemId: existingItem.itemId },
+      data: {
+        status: "open",
+        triageOutcome: "build",
+        ...(existingItem.effortSize ? {} : { effortSize: "small" }),
+      },
+    });
+    itemId = existingItem.itemId;
+  }
+
+  // (3) Otherwise create a fresh bug backlog item seeded from the report. The
+  // body embeds the public report id so the promote path can resolve fixContext.
+  if (!itemId) {
+    const newItemId = `BI-PIR-${crypto.randomUUID().slice(0, 8)}`;
+    const bodyParts = [
+      report.description,
+      report.routeContext ? `Route: ${report.routeContext}` : null,
+      `Source report: ${report.reportId}`,
+    ].filter(Boolean);
+    await prisma.backlogItem.create({
+      data: {
+        itemId: newItemId,
+        title: report.title,
+        body: bodyParts.join("\n\n"),
+        status: "open",
+        type: report.digitalProductId ? "product" : "portfolio",
+        source: "bug",
+        triageOutcome: "build",
+        effortSize: "small",
+        priority: SEVERITY_PRIORITY[report.severity ?? "medium"] ?? 3,
+        digitalProductId: report.digitalProductId ?? null,
+      },
+    });
+    itemId = newItemId;
+  }
+
+  // (4) Promote — derives kind="fix", carries fixContext, back-links the report.
+  const promote = await startBacklogBuild(itemId);
+  if (promote.status === "blocked") {
+    return { status: "blocked", error: promote.error };
+  }
+
+  // (5) Transition the report and ensure the back-link (promote sets it when the
+  // body parse resolves the report; set it here defensively for the reuse path).
+  await markReportTriaged(report.id, promote.buildId);
+  revalidatePath("/admin/issue-reports");
+
+  return { status: promote.status, buildId: promote.buildId, href: promote.href };
+}
+
+async function markReportTriaged(reportRowId: string, buildId: string): Promise<void> {
+  const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { id: true } });
+  await prisma.platformIssueReport.update({
+    where: { id: reportRowId },
+    data: {
+      status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL,
+      ...(build ? { featureBuildId: build.id } : {}),
+    },
   });
 }
 

--- a/apps/web/lib/explore/feature-build-data.ts
+++ b/apps/web/lib/explore/feature-build-data.ts
@@ -364,6 +364,7 @@ export async function getFeatureBuildForContext(
       buildId: true,
       title: true,
       phase: true,
+      kind: true,
       brief: true,
       designDoc: true,
       designReview: true,
@@ -589,6 +590,7 @@ export async function getFeatureBuildForContext(
   return {
     buildId: r.buildId,
     phase: r.phase as BuildPhase,
+    kind: r.kind as import("@/lib/feature-build-types").FeatureBuildKind,
     title: r.title,
     brief: r.brief as FeatureBrief | null,
     designDoc: r.designDoc as BuildDesignDoc | null,

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -16,6 +16,37 @@ import type { DecisionInteractionGateView } from "@/lib/decision-perspective/typ
 export const UX_VERIFICATION_STATUSES = ["running", "complete", "failed", "skipped"] as const;
 export type UxVerificationStatus = typeof UX_VERIFICATION_STATUSES[number];
 
+/**
+ * Canonical values for FeatureBuild.kind — the work-kind discriminator that
+ * lets the Build Studio pipeline run a build as a new-capability *feature* or a
+ * targeted defect *fix*. `feature-build-types.ts` is the canonical home (kind is
+ * a FeatureBuild concern; BacklogItem.source stays owned by backlog.ts). The DB
+ * column is plain TEXT defaulting to "feature"; this array is the authority for
+ * valid values. Adding a value requires updating any MCP tool mirror in the same
+ * commit, before any data uses it.
+ */
+export const FEATURE_BUILD_KIND_VALUES = ["feature", "fix"] as const;
+export type FeatureBuildKind = typeof FEATURE_BUILD_KIND_VALUES[number];
+
+/**
+ * Structured defect context for a `kind: "fix"` build. Carried additively on
+ * `FeatureBrief` (not a discriminated union) so every structural reader of the
+ * brief keeps compiling. Populated at promote time from the originating
+ * `PlatformIssueReport`; `rootCause`/`fixApproach` are filled during ideate.
+ */
+export type FixContext = {
+  severity?: string;
+  originatingIssueReportId?: string;
+  originatingIssueReportPublicId?: string;
+  routeContext?: string;
+  errorStackExcerpt?: string;
+  reproSteps?: string;
+  expected?: string;
+  actual?: string;
+  rootCause?: string;
+  fixApproach?: string;
+};
+
 export type FeatureBrief = {
   title: string;
   description: string;
@@ -24,6 +55,8 @@ export type FeatureBrief = {
   inputs: string[];
   dataNeeds: string;
   acceptanceCriteria: string[];
+  /** Present iff the owning build's kind === "fix". */
+  fixContext?: FixContext;
 };
 
 export type TaxonomyAttributionView = {
@@ -368,6 +401,9 @@ export type FeatureBuildRow = {
   buildId: string;
   title: string;
   description: string | null;
+  // Optional for back-compat: rows loaded from selects that predate the kind
+  // column read as undefined and are treated as "feature".
+  kind?: FeatureBuildKind | null;
   portfolioId: string | null;
   parentEpicId?: string | null;
   originatingBacklogItemId: string | null;
@@ -706,6 +742,16 @@ function missingHappyPathAnchors(state: HappyPathState): string[] {
   return missing;
 }
 
+/**
+ * A fix build's diagnosis is "complete enough" to plan against when it has
+ * reproduction steps, a root cause, and a fix approach. This is the fix-flow
+ * analogue of requiring a design document before planning a feature.
+ */
+export function isFixContextComplete(fc: FixContext | null | undefined): boolean {
+  if (!fc) return false;
+  return Boolean(fc.reproSteps?.trim() && fc.rootCause?.trim() && fc.fixApproach?.trim());
+}
+
 export function checkPhaseGate(
   from: BuildPhase,
   to: BuildPhase,
@@ -714,7 +760,23 @@ export function checkPhaseGate(
   if (to === "failed") return { allowed: true };
   if (from === "review" && to === "build") return { allowed: true };
 
+  // Work-kind discriminator. Threaded through `evidence.kind` so existing call
+  // sites that omit it default to feature behavior (byte-identical).
+  const isFix = evidence.kind === "fix";
+
   if (from === "ideate" && to === "plan") {
+    if (isFix) {
+      // Fix flow: a complete diagnosis substitutes for the feature design doc;
+      // taxonomy/epic placement is optional (a defect is not a portfolio feature).
+      if (!isFixContextComplete(evidence.fixContext as FixContext | undefined)) {
+        return { allowed: false, reason: "A complete fix diagnosis (reproduction steps, root cause, and fix approach) is required before planning." };
+      }
+      const fixReview = evidence.designReview as { decision?: string } | undefined;
+      if (fixReview?.decision === "fail") {
+        return { allowed: false, reason: "Fix review failed. Revise the diagnosis and re-run the review before advancing." };
+      }
+      return { allowed: true };
+    }
     if (!evidence.designDoc) return { allowed: false, reason: "A design document is required before planning." };
     if (!evidence.designReview) return { allowed: false, reason: "Design review is required before planning." };
     // Review must pass — a failed review blocks advancement until revision + re-review
@@ -742,10 +804,14 @@ export function checkPhaseGate(
       // count is the "consider splitting scope" signal.
       return { allowed: false, reason: describePlanReviewFailure(planReview) };
     }
-    const happyPathState = normalizeHappyPathState(evidence.happyPathState);
-    if (!isHappyPathIntakeReady(happyPathState)) {
-      const missing = missingHappyPathAnchors(happyPathState).join(", ");
-      return { allowed: false, reason: `Intake is incomplete. Link taxonomy, backlog item, epic, and a constrained goal before building. Missing: ${missing}.` };
+    // Feature builds must anchor in the portfolio (taxonomy + epic) before
+    // building. Fix builds are exempt — a defect is not a portfolio feature.
+    if (!isFix) {
+      const happyPathState = normalizeHappyPathState(evidence.happyPathState);
+      if (!isHappyPathIntakeReady(happyPathState)) {
+        const missing = missingHappyPathAnchors(happyPathState).join(", ");
+        return { allowed: false, reason: `Intake is incomplete. Link taxonomy, backlog item, epic, and a constrained goal before building. Missing: ${missing}.` };
+      }
     }
     return { allowed: true };
   }
@@ -760,7 +826,11 @@ export function checkPhaseGate(
   }
 
   if (from === "review" && to === "ship") {
-    if (!evidence.designDoc) return { allowed: false, reason: "Design document is missing." };
+    if (isFix) {
+      if (!evidence.fixContext) return { allowed: false, reason: "Fix diagnosis is missing." };
+    } else {
+      if (!evidence.designDoc) return { allowed: false, reason: "Design document is missing." };
+    }
     if (!evidence.buildPlan) return { allowed: false, reason: "Implementation plan is missing." };
     if (!evidence.verificationOut) return { allowed: false, reason: "Verification output is missing." };
     if (!evidence.acceptanceMet) return { allowed: false, reason: "Acceptance criteria not evaluated." };

--- a/apps/web/lib/explore/fix-flow.test.ts
+++ b/apps/web/lib/explore/fix-flow.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEATURE_BUILD_KIND_VALUES,
+  isFixContextComplete,
+  checkPhaseGate,
+  type FixContext,
+} from "./feature-build-types";
+import { getBuildPhasePrompt } from "@/lib/integrate/build-agent-prompts";
+
+// The fix flow is the kind="fix" branch of the Build Studio pipeline. These
+// tests pin the behavior the spec requires: a complete diagnosis substitutes
+// for the feature design doc, taxonomy/epic anchors are not required for fixes,
+// and the fix-phase prompts are distinct from the feature prompts while
+// terminal phases keep their empty-prompt behavior.
+
+const completeFix: FixContext = {
+  reproSteps: "Submit the form on /portal/contact",
+  expected: "Form submits and shows a success toast",
+  actual: "500 error",
+  rootCause: "Null deref in submitContact when phone is empty",
+  fixApproach: "Guard the optional phone field before formatting",
+};
+
+describe("FEATURE_BUILD_KIND_VALUES", () => {
+  it("is a closed two-value enum", () => {
+    expect(FEATURE_BUILD_KIND_VALUES).toEqual(["feature", "fix"]);
+  });
+});
+
+describe("isFixContextComplete", () => {
+  it("requires repro, root cause, and fix approach", () => {
+    expect(isFixContextComplete(completeFix)).toBe(true);
+    expect(isFixContextComplete(null)).toBe(false);
+    expect(isFixContextComplete(undefined)).toBe(false);
+    expect(isFixContextComplete({ ...completeFix, rootCause: "" })).toBe(false);
+    expect(isFixContextComplete({ reproSteps: "x" })).toBe(false);
+  });
+});
+
+describe("checkPhaseGate — fix flow", () => {
+  it("ideate→plan advances on a complete fixContext (no design doc, no taxonomy/epic)", () => {
+    const result = checkPhaseGate("ideate", "plan", { kind: "fix", fixContext: completeFix });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("ideate→plan blocks when the fix diagnosis is incomplete", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      kind: "fix",
+      fixContext: { ...completeFix, fixApproach: "" },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/diagnosis/i);
+  });
+
+  it("ideate→plan blocks a fix when an explicit review failed", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      kind: "fix",
+      fixContext: completeFix,
+      designReview: { decision: "fail" },
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("feature ideate→plan still requires a design doc (no regression)", () => {
+    expect(checkPhaseGate("ideate", "plan", { kind: "feature" }).allowed).toBe(false);
+    // Absent kind defaults to feature behavior.
+    expect(checkPhaseGate("ideate", "plan", {}).allowed).toBe(false);
+  });
+
+  it("plan→build does not require taxonomy/epic anchors for a fix", () => {
+    const result = checkPhaseGate("plan", "build", {
+      kind: "fix",
+      buildPlan: { fileStructure: [], tasks: [] },
+      planReview: { decision: "pass" },
+      // intentionally no happyPathState anchors
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("review→ship accepts fixContext in place of a design doc for a fix", () => {
+    const result = checkPhaseGate("review", "ship", {
+      kind: "fix",
+      fixContext: completeFix,
+      buildPlan: { fileStructure: [], tasks: [] },
+      verificationOut: { typecheckPassed: true },
+      acceptanceMet: "verified",
+      uxVerificationStatus: "skipped",
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("review→ship still blocks a feature with no design doc", () => {
+    const result = checkPhaseGate("review", "ship", {
+      kind: "feature",
+      buildPlan: { fileStructure: [], tasks: [] },
+      verificationOut: { typecheckPassed: true },
+      acceptanceMet: "verified",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/design document/i);
+  });
+});
+
+describe("getBuildPhasePrompt — fix variants", () => {
+  it("returns a distinct, non-empty fix prompt for ideate/plan/review", async () => {
+    for (const phase of ["ideate", "plan", "review"] as const) {
+      const fix = await getBuildPhasePrompt(phase, "fix");
+      const feature = await getBuildPhasePrompt(phase, "feature");
+      expect(fix.length).toBeGreaterThan(0);
+      expect(fix).not.toBe(feature);
+    }
+  });
+
+  it("ideate-fix prompt frames the work as a defect, not a feature", async () => {
+    const fix = await getBuildPhasePrompt("ideate", "fix");
+    expect(fix.toLowerCase()).toContain("defect");
+    expect(fix.toLowerCase()).not.toContain("design a new feature");
+  });
+
+  it("build phase falls through to the shared prompt for a fix", async () => {
+    const fix = await getBuildPhasePrompt("build", "fix");
+    const feature = await getBuildPhasePrompt("build", "feature");
+    expect(fix).toBe(feature);
+    expect(fix.length).toBeGreaterThan(0);
+  });
+
+  it("terminal phases keep empty-prompt behavior for both kinds", async () => {
+    expect(await getBuildPhasePrompt("complete", "fix")).toBe("");
+    expect(await getBuildPhasePrompt("failed", "fix")).toBe("");
+  });
+});

--- a/apps/web/lib/governed-backlog-tee-up.test.ts
+++ b/apps/web/lib/governed-backlog-tee-up.test.ts
@@ -29,6 +29,11 @@ const mockPrisma = {
   workCapsuleActivity: {
     create: vi.fn(),
   },
+  platformIssueReport: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+  },
   $transaction: vi.fn(),
 };
 
@@ -53,6 +58,9 @@ describe("governed backlog tee-up", () => {
     });
     mockPrisma.workCapsuleActivity.create.mockResolvedValue({});
     mockPrisma.featureBuild.update.mockResolvedValue({});
+    mockPrisma.platformIssueReport.findUnique.mockResolvedValue(null);
+    mockPrisma.platformIssueReport.findFirst.mockResolvedValue(null);
+    mockPrisma.platformIssueReport.updateMany.mockResolvedValue({ count: 0 });
 
     mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
       return callback(mockPrisma);
@@ -431,6 +439,62 @@ describe("governed backlog tee-up", () => {
         taxonomyNodeId: "taxonomy-cuid-ops",
         constrainedGoal: "Add taxonomy filter to operations map",
         failureReason: null,
+      });
+    });
+
+    it("promotes a bug-sourced item as kind=fix, carries fixContext, and back-links the issue report", async () => {
+      mockPrisma.backlogItem.findUnique.mockResolvedValueOnce({
+        id: "bi-cuid-bug",
+        itemId: "BI-PIR-abcd1234",
+        title: "Contact form 500s on submit",
+        body: "Server error on submit\n\nRoute: /portal/contact\n\nSource report: PIR-ABCDE",
+        status: "open",
+        triageOutcome: "build",
+        effortSize: "small",
+        activeBuildId: null,
+        digitalProductId: null,
+        epicId: null,
+        taxonomyNodeId: null,
+        source: "bug",
+        epic: null,
+      });
+      mockPrisma.platformIssueReport.findUnique.mockResolvedValueOnce({
+        id: "pir-row-1",
+        reportId: "PIR-ABCDE",
+        severity: "high",
+        routeContext: "/portal/contact",
+        errorStack: "TypeError: cannot read 'format' of undefined\n  at submitContact",
+        description: "500 error when submitting the contact form",
+      });
+      mockPrisma.epic.create.mockResolvedValueOnce({ id: "epic-cuid-fix", epicId: "EP-BUILD-FIX001" });
+      mockPrisma.featureBuild.create.mockResolvedValueOnce({ id: "build-row-fix", buildId: "FB-FIX00001" });
+
+      const { promoteBacklogItemToBuildDraft } = await import("./governed-backlog-tee-up");
+      const result = await promoteBacklogItemToBuildDraft({
+        tx: mockPrisma,
+        itemId: "BI-PIR-abcd1234",
+        userId: "user-1",
+        governedBacklogEnabled: true,
+      });
+
+      expect(result.kind).toBe("success");
+
+      const createData = mockPrisma.featureBuild.create.mock.calls[0]![0].data;
+      expect(createData.kind).toBe("fix");
+      expect(createData.brief.fixContext).toEqual(
+        expect.objectContaining({
+          severity: "high",
+          originatingIssueReportId: "pir-row-1",
+          originatingIssueReportPublicId: "PIR-ABCDE",
+          routeContext: "/portal/contact",
+        }),
+      );
+      expect(createData.brief.fixContext.errorStackExcerpt).toContain("TypeError");
+
+      // Back-link written in-transaction, guarded on featureBuildId: null.
+      expect(mockPrisma.platformIssueReport.updateMany).toHaveBeenCalledWith({
+        where: { id: "pir-row-1", featureBuildId: null },
+        data: { featureBuildId: "build-row-fix" },
       });
     });
 

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -58,6 +58,11 @@ type GovernedBacklogTeeUpTx = {
   workCapsuleActivity: {
     create(args: any): Promise<any>;
   };
+  platformIssueReport: {
+    findUnique(args: any): Promise<any>;
+    findFirst(args: any): Promise<any>;
+    updateMany(args: any): Promise<any>;
+  };
 };
 
 type GovernedBacklogTeeUpPrisma = GovernedBacklogTeeUpTx & {
@@ -203,11 +208,64 @@ export async function promoteBacklogItemToBuildDraft(
     },
   });
 
+  // Work-kind derivation + fix-context carry-through.
+  // A bug-sourced backlog item becomes a "fix" build; everything else stays a
+  // "feature". For fixes, pull the originating PlatformIssueReport (linked from
+  // the triage-created BI body as "Source report: PIR-XXXXX") so the build
+  // starts from the real diagnosis (severity, route, error stack) instead of a
+  // blank brief. reproSteps/rootCause/fixApproach are left for ideate to fill.
+  const kind: "feature" | "fix" = item.source === "bug" ? "fix" : "feature";
+  let fixBrief: Record<string, unknown> | null = null;
+  let originatingReportId: string | null = null;
+  if (kind === "fix") {
+    let report: {
+      id: string;
+      reportId: string;
+      severity: string | null;
+      routeContext: string | null;
+      errorStack: string | null;
+      description: string | null;
+    } | null = null;
+    try {
+      const publicIdMatch = (item.body ?? "").match(/PIR-[A-Z0-9]+/);
+      if (publicIdMatch) {
+        report = await tx.platformIssueReport.findUnique({
+          where: { reportId: publicIdMatch[0] },
+          select: { id: true, reportId: true, severity: true, routeContext: true, errorStack: true, description: true },
+        });
+      }
+    } catch {
+      // Non-fatal — proceed with a body-only fix context.
+    }
+    originatingReportId = report?.id ?? null;
+    const fixContext: Record<string, unknown> = {
+      ...(report?.severity ? { severity: report.severity } : {}),
+      ...(report?.id ? { originatingIssueReportId: report.id } : {}),
+      ...(report?.reportId ? { originatingIssueReportPublicId: report.reportId } : {}),
+      ...(report?.routeContext ? { routeContext: report.routeContext } : {}),
+      ...(report?.errorStack ? { errorStackExcerpt: report.errorStack.slice(0, 2000) } : {}),
+      // Seed "actual" from the report/BI body; ideate refines repro/expected/root cause/fix approach.
+      ...((report?.description ?? item.body) ? { actual: (report?.description ?? item.body).slice(0, 2000) } : {}),
+    };
+    fixBrief = {
+      title: item.title,
+      description: item.body ?? item.title,
+      portfolioContext: "",
+      targetRoles: [],
+      inputs: [],
+      dataNeeds: "",
+      acceptanceCriteria: [],
+      fixContext,
+    };
+  }
+
   const created = await tx.featureBuild.create({
     data: {
       buildId: generateBuildId(),
       title: item.title,
+      kind,
       ...(item.body ? { description: item.body } : {}),
+      ...(fixBrief ? { brief: fixBrief } : {}),
       createdById: userId,
       digitalProductId: item.digitalProductId ?? null,
       originatingBacklogItemId: item.id,
@@ -215,6 +273,20 @@ export async function promoteBacklogItemToBuildDraft(
       plan,
     },
   });
+
+  // Back-link the originating issue report to this build, in-transaction so a
+  // rollback cannot orphan the link. updateMany avoids a throw if the report
+  // was already linked/removed.
+  if (originatingReportId) {
+    try {
+      await tx.platformIssueReport.updateMany({
+        where: { id: originatingReportId, featureBuildId: null },
+        data: { featureBuildId: created.id },
+      });
+    } catch {
+      // Non-fatal — the build is the source of truth; the link is a convenience.
+    }
+  }
 
   await tx.backlogItem.update({
     where: { itemId },

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -4,6 +4,7 @@ import type {
   BuildPhase,
   BuildPlanDoc,
   FeatureBrief,
+  FeatureBuildKind,
   ReviewResult,
   UxVerificationStatus,
   VerificationOutput,
@@ -494,7 +495,82 @@ GUARDRAILS:
 If Dev mode is enabled, show the registration details, diff summary, deployment window info, assessment criteria scores, and IT4IT stage references.`,
 };
 
-export async function getBuildPhasePrompt(phase: BuildPhase): Promise<string> {
+// ─── Fix-flow phase prompts ──────────────────────────────────────────────────
+// Used when FeatureBuild.kind === "fix". Only the phases that are still
+// feature-shaped are overridden (ideate/plan/review). The `build` phase reuses
+// the feature prompt (it already documents a "WORKFLOW FOR BUG FIXES AND
+// MODIFICATIONS" path), and `ship` is identical for both kinds.
+const PHASE_PROMPTS_FIX: Record<string, string> = {
+  ideate: `You are diagnosing a reported defect. This is a FIX, not a new feature — do not design new capability.
+
+${PROJECT_CONTEXT}
+
+You are given a fix diagnosis (the "Fix Diagnosis" block in the Build Studio Context) carrying the originating issue report: severity, route, an error-stack excerpt, and reproduction notes.
+
+YOUR JOB — produce a complete diagnosis, then advance:
+  1. REPRODUCE: confirm the failing behavior from the report (route + steps). State the expected vs actual behavior plainly.
+  2. ROOT CAUSE: trace the defect to its source. Name the file/function and the specific cause — not a symptom.
+  3. SCOPE THE SMALLEST CORRECT FIX: the narrowest change that fixes the root cause without redesigning surrounding code. Prefer modifying existing files over adding new capability. Do NOT generalize, parameterize, or expand scope.
+
+Do NOT ask reusability/taxonomy/portfolio questions — a defect is not a portfolio feature.
+
+WHEN THE DIAGNOSIS IS COMPLETE: call update_feature_brief to persist fixContext with reproSteps, expected, actual, rootCause, and fixApproach all filled. Then call reviewDesignDoc — it reviews the diagnosis (not a design doc) and advances to plan when reproSteps + rootCause + fixApproach are all present.
+
+Keep responses short. The defect + reproduction IS the spec — you do not need a full design document.`,
+
+  plan: `You are planning a targeted defect fix. The diagnosis (fixContext) is approved.
+
+${PROJECT_CONTEXT}
+
+DO THIS NOW — in order. Use the approved fixContext (rootCause, fixApproach); do NOT re-research scope.
+
+STEP 1 — SAVE THE PLAN: call saveBuildEvidence with field "buildPlan" containing EXACTLY:
+  {
+    "fileStructure": [
+      { "path": "apps/web/lib/...", "action": "modify", "purpose": "Fix <root cause> at <function>" },
+      ...every file the fix touches — fixes almost always "modify", rarely "create"
+    ],
+    "tasks": [
+      { "title": "Fix <root cause>", "testFirst": "add a regression test that fails on the current bug", "implement": "Edit <full monorepo path> — apply the smallest change that addresses the root cause", "verify": "run the regression test + NODE_ENV=production pnpm --filter web build" },
+      ...keep tasks minimal — a fix is targeted, not a feature build
+    ]
+  }
+  Same format rules as feature plans: top-level "fileStructure" and "tasks" arrays, full monorepo-relative paths.
+  A FIX MUST INCLUDE A REGRESSION TEST: a test that fails against the current (buggy) behavior and passes after the fix. Make it an explicit task.
+
+STEP 2: call reviewBuildPlan. If it fails, revise and re-review.
+STEP 3: one sentence — "Fix plan ready — [N] tasks. Building now." — then call save_phase_handoff.
+
+RULES: do not ask questions; do not expand scope beyond the diagnosed root cause; maximum 1 sentence per response.`,
+
+  review: `You are verifying a defect fix. Acceptance for a fix is "the reported behavior is gone," not "a new capability works."
+
+${PROJECT_CONTEXT}
+
+VERIFY, IN ORDER:
+  1. The originally reported defect NO LONGER REPRODUCES — exercise the exact route/steps from the fix diagnosis.
+  2. A REGRESSION TEST was added that fails against the old behavior and passes now.
+  3. No collateral regressions — run the affected tests and the production build (NODE_ENV=production pnpm --filter web build).
+
+Record acceptance against the diagnosis: each fixContext expected/actual pair should now hold the expected behavior. Then advance toward ship.
+
+Keep responses short. Do not request new-feature acceptance criteria — the success criterion is the absence of the reported defect.`,
+};
+
+export async function getBuildPhasePrompt(
+  phase: BuildPhase,
+  kind: FeatureBuildKind = "feature",
+): Promise<string> {
+  if (kind === "fix") {
+    const fixHardcoded = PHASE_PROMPTS_FIX[phase];
+    if (fixHardcoded) {
+      // DB-overridable via Admin > Prompts under the "<phase>-fix" slug; falls
+      // back to the hardcoded fix prompt (never empty) for active phases.
+      return loadPrompt("build-phase", `${phase}-fix`, fixHardcoded);
+    }
+    // Phases without a fix variant (build/ship/terminal) fall through to the
+    // feature prompt, preserving terminal-phase empty-prompt behavior below.
+  }
   const hardcoded = PHASE_PROMPTS[phase] ?? "";
   if (!hardcoded) return "";
   return loadPrompt("build-phase", phase, hardcoded);
@@ -513,6 +589,8 @@ export type PhaseHandoffSummary = {
 export type BuildContext = {
   buildId: string;
   phase: BuildPhase;
+  /** Work kind. Absent/null is treated as "feature". */
+  kind?: FeatureBuildKind | null;
   title: string;
   brief: FeatureBrief | null;
   designDoc?: BuildDesignDoc | null;
@@ -652,6 +730,23 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
     if (Array.isArray(ctx.brief.acceptanceCriteria) && ctx.brief.acceptanceCriteria.length > 0) {
       lines.push(`  Acceptance criteria: ${ctx.brief.acceptanceCriteria.join("; ")}`);
     }
+
+    // Fix flow: surface the structured defect diagnosis so the coworker starts
+    // from the reproduction + root cause rather than a blank brief.
+    const fc = ctx.brief.fixContext;
+    if (fc) {
+      lines.push("");
+      lines.push("Fix Diagnosis (this is a FIX, not a new feature):");
+      if (fc.severity) lines.push(`  Severity: ${fc.severity}`);
+      if (fc.originatingIssueReportPublicId) lines.push(`  Issue report: ${fc.originatingIssueReportPublicId}`);
+      if (fc.routeContext) lines.push(`  Route: ${fc.routeContext}`);
+      if (fc.reproSteps) lines.push(`  Reproduction: ${fc.reproSteps}`);
+      if (fc.expected) lines.push(`  Expected: ${fc.expected}`);
+      if (fc.actual) lines.push(`  Actual: ${fc.actual}`);
+      if (fc.rootCause) lines.push(`  Root cause: ${fc.rootCause}`);
+      if (fc.fixApproach) lines.push(`  Fix approach: ${fc.fixApproach}`);
+      if (fc.errorStackExcerpt) lines.push(`  Error stack (excerpt):\n${fc.errorStackExcerpt.slice(0, 1500)}`);
+    }
   }
 
   if (ctx.designDoc) {
@@ -746,7 +841,7 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
   }
 
   lines.push("");
-  lines.push(await getBuildPhasePrompt(ctx.phase));
+  lines.push(await getBuildPhasePrompt(ctx.phase, ctx.kind ?? "feature"));
 
   // Contribution mode awareness for all phases — agent should know this for design decisions
   if (ctx.contributionMode) {

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -369,6 +369,7 @@ async function stepGenerateCode(
   const buildContext = await getBuildContextSection({
     buildId,
     phase: "build",
+    kind: build.kind as import("@/lib/feature-build-types").FeatureBuildKind,
     title: brief?.title ?? "Feature",
     brief,
     portfolioId: build.portfolioId,

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6789,7 +6789,7 @@ export async function executeTool(
       if (!buildId) return { success: false, error: "No active build", message: "No active build found" };
       const latestBuild = await prisma.featureBuild.findUnique({
         where: { buildId },
-        select: { buildId: true, phase: true, threadId: true, designDoc: true, designReview: true, buildPlan: true, planReview: true, verificationOut: true, acceptanceMet: true, uxTestResults: true, uxVerificationStatus: true, brief: true, plan: true },
+        select: { buildId: true, phase: true, kind: true, threadId: true, designDoc: true, designReview: true, buildPlan: true, planReview: true, verificationOut: true, acceptanceMet: true, uxTestResults: true, uxVerificationStatus: true, brief: true, plan: true },
       });
       if (!latestBuild) return { success: false, error: "No active build", message: "No active build found" };
 
@@ -6859,11 +6859,13 @@ export async function executeTool(
         if (canTransitionPhase(latestBuild.phase as import("@/lib/feature-build-types").BuildPhase, toPhase as import("@/lib/feature-build-types").BuildPhase)) {
           const plan = (latestBuild.plan as Record<string, unknown> | null) ?? {};
           const happyPathState = normalizeHappyPathState(plan.happyPathState);
-          const handoffBrief = latestBuild.brief as { acceptanceCriteria?: string[] } | null;
+          const handoffBrief = latestBuild.brief as { acceptanceCriteria?: string[]; fixContext?: import("@/lib/feature-build-types").FixContext } | null;
           const gate = checkPhaseGate(
             latestBuild.phase as import("@/lib/feature-build-types").BuildPhase,
             toPhase as import("@/lib/feature-build-types").BuildPhase,
             {
+              kind: latestBuild.kind,
+              fixContext: handoffBrief?.fixContext,
               designDoc: latestBuild.designDoc, designReview: latestBuild.designReview,
               buildPlan: latestBuild.buildPlan, planReview: latestBuild.planReview,
               verificationOut: latestBuild.verificationOut, acceptanceMet: latestBuild.acceptanceMet,
@@ -7264,7 +7266,53 @@ export async function executeTool(
       const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
       let phaseGateBlocker: string | null = null;
-      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true } });
+      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true, kind: true, brief: true } });
+
+      // Fix flow: a fix build has no feature design doc — it carries a structured
+      // diagnosis (fixContext) on its brief. Review the diagnosis for completeness
+      // and advance ideate → plan, instead of running the feature design reviewers.
+      if (build?.kind === "fix") {
+        const { isFixContextComplete, checkPhaseGate } = await import("@/lib/feature-build-types");
+        const fixBrief = (build.brief ?? null) as import("@/lib/feature-build-types").FeatureBrief | null;
+        const fc = fixBrief?.fixContext;
+        const complete = isFixContextComplete(fc);
+        const review = complete
+          ? { decision: "pass" as const, issues: [] as Array<{ severity: string; description: string }>, summary: "Fix diagnosis is complete: reproduction, root cause, and fix approach are all present." }
+          : { decision: "fail" as const, issues: [{ severity: "critical", description: "Fix diagnosis is incomplete. Reproduction steps, root cause, and fix approach are all required — use update_feature_brief to fill fixContext." }], summary: "Incomplete fix diagnosis." };
+        await prisma.featureBuild.update({ where: { buildId }, data: { designReview: review as unknown as import("@dpf/db").Prisma.InputJsonValue } });
+        const { agentEventBus } = await import("@/lib/agent-event-bus");
+        if (context?.threadId) agentEventBus.emit(context.threadId, { type: "evidence:update", buildId, field: "designReview" });
+        logBuildActivity(buildId, "reviewDesignDoc", `Fix review: ${review.decision}. ${review.summary}`);
+        if (review.decision === "fail") {
+          return { success: true, message: `Fix review FAILED. ${review.issues[0]?.description ?? review.summary}`, data: { review, blocked: true, action: "revise_and_resubmit" } };
+        }
+        let fixPhaseGateBlocker: string | null = null;
+        try {
+          const gate = checkPhaseGate("ideate", "plan", { kind: "fix", fixContext: fc, designReview: review });
+          if (gate.allowed) {
+            const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
+            void completeBuildPhaseRun(buildId, "ideate");
+            void startBuildPhaseRun(buildId, "plan");
+            if (context?.threadId) {
+              const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+              void persistPhaseHandoffSummary(context.threadId, "ideate");
+            }
+            await prisma.featureBuild.update({ where: { buildId }, data: { phase: "plan" } });
+            if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "plan" });
+            logBuildActivity(buildId, "phase:advance", "Phase advanced: ideate → plan (fix)");
+          } else {
+            logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "unknown");
+            fixPhaseGateBlocker = gate.reason ?? null;
+          }
+        } catch (err) {
+          console.error("[reviewDesignDoc:fix] auto-advance failed:", err);
+        }
+        const fixMsg = fixPhaseGateBlocker
+          ? `Fix review: ${review.decision}. ${review.summary}\n\nPhase did NOT advance to plan. Reason: ${fixPhaseGateBlocker}`
+          : `Fix review: ${review.decision}. ${review.summary} Phase advanced to plan.`;
+        return { success: true, message: fixMsg, data: { review, phaseGateBlocker: fixPhaseGateBlocker } };
+      }
+
       if (!build?.designDoc) return { success: false, error: "No design document saved yet.", message: "Save designDoc first." };
       const { buildDesignReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews } = await import("@/lib/build-reviewers");
       const designDocTyped = build.designDoc as Parameters<typeof buildDesignReviewPrompt>[0];
@@ -7801,6 +7849,7 @@ export async function executeTool(
             id: true,
             buildId: true,
             title: true,
+            kind: true,
             parentEpicId: true,
             dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
           },
@@ -7809,6 +7858,7 @@ export async function executeTool(
           const plan = (updatedBuild.plan as Record<string, unknown> | null) ?? {};
           const happyPathState = normalizeHappyPathState(plan.happyPathState);
           const gate = checkPhaseGate("plan", "build", {
+            kind: updatedBuild.kind,
             buildPlan: updatedBuild.buildPlan,
             planReview: updatedBuild.planReview,
             happyPathState,

--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -16,10 +16,11 @@ const report = {
 beforeEach(() => _resetCache());
 
 describe("buildIssueBacklogItem", () => {
-  it("creates item with BI-PIR prefix and issue_report source", () => {
+  it("creates item with BI-PIR prefix and canonical bug source", () => {
     const item = buildIssueBacklogItem(report, "prod-1", "tax-1");
     expect(item.itemId).toMatch(/^BI-PIR-/);
-    expect(item.source).toBe("issue_report");
+    // Canonical source per BACKLOG_SOURCE_VALUES; maps to FeatureBuild.kind="fix".
+    expect(item.source).toBe("bug");
     expect(item.type).toBe("product");
     expect(item.priority).toBe(1); // critical → 1
     expect(item.digitalProductId).toBe("prod-1");

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -49,7 +49,9 @@ export function buildIssueBacklogItem(
     status: "open",
     type: digitalProductId ? "product" : "portfolio",
     priority: severityToPriority((report.severity || "medium") as Severity),
-    source: "issue_report",
+    // Canonical backlog source (BACKLOG_SOURCE_VALUES). Issue-report-originated
+    // items are bugs; "bug" is what maps to FeatureBuild.kind="fix" at promote.
+    source: "bug",
     digitalProductId,
     taxonomyNodeId,
   };
@@ -251,7 +253,7 @@ export async function checkForSpike(deps: {
     status: "open",
     type: "product",
     priority: 1,
-    source: "issue_report",
+    source: "bug",
     digitalProductId: null,
     taxonomyNodeId: null,
   });

--- a/apps/web/lib/queue/functions/issue-report-triage.ts
+++ b/apps/web/lib/queue/functions/issue-report-triage.ts
@@ -58,7 +58,7 @@ export const issueReportTriage = inngest.createFunction(
 
         getExistingTitles: async () => {
           const items = await prisma.backlogItem.findMany({
-            where: { source: { in: ["issue_report", "process_observer"] } },
+            where: { source: { in: ["bug", "process_observer"] } },
             select: { title: true },
           });
           return items.map((i) => i.title);
@@ -72,7 +72,7 @@ export const issueReportTriage = inngest.createFunction(
           const existing = await prisma.backlogItem.findFirst({
             where: {
               title: { contains: title, mode: "insensitive" },
-              source: "issue_report",
+              source: "bug",
             },
           });
           if (existing) {
@@ -127,7 +127,7 @@ export const issueReportTriage = inngest.createFunction(
 
         getExistingTitles: async () => {
           const items = await prisma.backlogItem.findMany({
-            where: { source: "issue_report", title: { startsWith: "Issue report spike detected" } },
+            where: { source: "bug", title: { startsWith: "Issue report spike detected" } },
             select: { title: true },
           });
           return items.map((i) => i.title);

--- a/docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md
+++ b/docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md
@@ -1,0 +1,329 @@
+# Fix Flow Through Build Studio Design
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft — chief-architect review applied |
+| Date | 2026-05-29 |
+| Backlog item | To be filed on approval. Live MCP check on 2026-05-29 (`search_specs_and_plans`, `search_knowledge`) found no exact indexed spec or backlog item for an issue→Build-Studio fix flow or a Build-Studio work kind before drafting. |
+| Epic recommendation | Extend the Build Studio lifecycle epic if one is open; create `EP-FIX-FLOW-BUILD-STUDIO` only if the scope grows beyond the work-kind discriminator and intake carry-through described here. Do not file a new epic for the Phase-0 enum-canonicalization slice — it belongs under existing backlog hygiene. |
+| Related substrate | [`apps/web/lib/explore/feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts); [`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts); [`apps/web/lib/integrate/build-agent-prompts.ts`](../../../apps/web/lib/integrate/build-agent-prompts.ts); [`apps/web/lib/integrate/specialist-prompts.ts`](../../../apps/web/lib/integrate/specialist-prompts.ts); [`apps/web/lib/governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts); [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts); [`apps/web/lib/quality/platform-issue-reports.ts`](../../../apps/web/lib/quality/platform-issue-reports.ts); [`apps/web/lib/operate/issue-report-triage.ts`](../../../apps/web/lib/operate/issue-report-triage.ts); [`apps/web/lib/queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts); [`apps/web/app/(shell)/admin/issue-reports/page.tsx`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx); `FeatureBuild`; `BacklogItem`; `PlatformIssueReport` |
+| Related specs | [Capacity-aware feedback escalation (2026-05-24)](2026-05-24-capacity-aware-feedback-escalation-design.md); [Feedback resolution closure contract (2026-05-26)](2026-05-26-feedback-resolution-closure-design.md); [Pseudonymous identity and backlog issue bridge (2026-04-18)](2026-04-18-pseudonymous-identity-and-backlog-issue-bridge-design.md); [Quality feedback (2026-03-14)](2026-03-14-quality-feedback-design.md) |
+| Scope | A first-class **work kind** (`feature` \| `fix`) carried from intake into `FeatureBuild`, the intake carry-through that preserves a reported issue's diagnostic context, the prompt/gate branching that runs a fix as a targeted defect repair rather than a new-capability design, and a manual "Send to Build Studio as a fix" intake affordance on the Admin issue-reports page. |
+| Out of scope | Replacing the issue-report triage cron or the capacity-aware feedback router; building the full capacity-aware `local_build` decision logic (this spec supplies the Build Studio *destination* that path will target); upstream GitHub escalation; auto-closing `PlatformIssueReport`s on ship (named as Phase 2); a parallel bug-tracker abstraction; per-severity SLA/scheduling. |
+
+---
+
+## Architect Verdict
+
+The product instinct is correct and overdue: Build Studio is DPF's build substrate, but today
+it can only **add capability**. A non-technical operator who reports "the submit button 500s"
+has no governed path to a fix — only to a feature-shaped build that fights its own prompts.
+
+The good news from the code is that the **plumbing already exists end to end** and the gap is
+narrow and semantic, not structural:
+
+1. The "issue log" (`PlatformIssueReport`) already captures severity, error stack, route, and
+   trigger kind, and a cron already turns open reports into `BacklogItem`s.
+2. `promote_to_build_studio` already turns a `triageOutcome=build` backlog item into a
+   `FeatureBuild`.
+3. The `build`-phase prompt already contains a "WORKFLOW FOR BUG FIXES AND MODIFICATIONS"
+   section ([`build-agent-prompts.ts:263`](../../../apps/web/lib/integrate/build-agent-prompts.ts)).
+
+So this design does **not** introduce a parallel pipeline. It introduces one discriminator —
+`kind` — and branches the three phases that are still feature-only (ideate, plan, review),
+preserves the issue's context across the promote boundary, and adds the manual intake button.
+
+Four guardrails the implementation must honor:
+
+1. **Additive, not a new type.** `FeatureBrief` is consumed structurally across the orchestrator,
+   gates, panels, and the `update_feature_brief` tool. A discriminated `FeatureBrief | FixBrief`
+   union would force `kind`-narrowing at every read site and break existing casts. Carry fix
+   context as an **optional `fixContext` field** on the one canonical brief.
+2. **`kind` is the discriminator, `source` is the input.** `BacklogItem.source` already
+   distinguishes `bug`. Map `source → kind` once, at promote time. Do not add `kind` to
+   `BacklogItem`.
+3. **Back-compat by construction.** `kind` defaults to `feature` in the schema and in every new
+   parameter; existing in-flight and historical builds are byte-identical.
+4. **Fix the latent enum drift first.** The issue-report triage writers use
+   `source:"issue_report"`, which is not in the canonical source enum. Canonicalize to `bug`
+   (Phase 0) before the mapping, or issue-sourced builds will not classify as fixes.
+
+This is advisory architecture review folded into the design. It sharpens the plan; it does not
+gate the build.
+
+## 1. Problem
+
+Build Studio's pipeline is feature-shaped at every layer:
+
+- **Ideate prompt** opens *"You are helping a user design a new feature."*
+  ([`build-agent-prompts.ts:105`](../../../apps/web/lib/integrate/build-agent-prompts.ts)).
+- **Brief / design-doc types** (`FeatureBrief`, `BuildDesignDoc`, `ReusabilityAnalysis` in
+  [`feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts)) center on new
+  capability: `inputs`, `dataNeeds`, `reusePlan`, scope of generalization. None of these describe
+  a defect.
+- **The `ideate→plan` gate** (`checkPhaseGate`, [`feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts) ~709-806)
+  requires a design doc + design review + taxonomy placement + epic. A one-line regression fix
+  does not belong in the feature taxonomy and is not an epic.
+- **Promotion drops the diagnosis.** [`governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts)
+  copies only `title` and `body` into the new `FeatureBuild`. Severity, error stack, route, repro
+  steps, and the originating `PlatformIssueReport` link are all lost.
+
+Meanwhile the operator-facing intake is already there. The "issue log" the operator uses is the
+`PlatformIssueReport` table (manual reports via the `report_quality_issue` MCP tool / Feedback
+button, plus auto-captured runtime errors from the crash boundary), surfaced at
+[`/admin/issue-reports`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx). A 15-minute
+cron ([`queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts))
+converts open reports into `BacklogItem`s.
+
+The result: an operator can *report* an issue, and the system can *file* it as backlog, but there
+is no governed path that turns it into a **fix** without shoehorning it through the new-feature
+playbook — and even then the build runs blind to the diagnostic context that made the report
+actionable.
+
+### 1.1 Relationship to the capacity-aware feedback spec
+
+The [capacity-aware feedback escalation design](2026-05-24-capacity-aware-feedback-escalation-design.md)
+defines `assessFeedbackRouting()`, whose `expectedClosurePath` includes a **`local_build`** value
+— routing an issue into Build Studio for a local fix. That spec explicitly **defers** designing
+the Build Studio side of `local_build` (Build Studio integration is out of scope there). **This
+spec supplies that missing destination:** the work-kind discriminator and fix intake that the
+`local_build` path will target. The two are complementary — capacity-aware feedback decides
+*whether* an issue should become a local build; this spec defines *what happens* when it does.
+
+## 2. Current Repo Truth
+
+| Area | Verified current behavior | Design implication |
+| ---- | ------------------------- | ------------------ |
+| Work kind | `FeatureBuild` has no `kind`/`intent` field ([`schema.prisma`](../../../packages/db/prisma/schema.prisma)). Everything is implicitly a feature. | Add `kind String @default("feature")`. The default makes the change invisible to existing builds. |
+| Backlog source | `BACKLOG_SOURCE_VALUES` = `feature-gap, bug, tool-gap, skill-gap, doc-gap, user-request, automated-detection` ([`backlog.ts:122`](../../../apps/web/lib/explore/backlog.ts)). `BacklogItem.source` is `String?` ([`schema.prisma:963`](../../../packages/db/prisma/schema.prisma)). | `bug` already exists. Map `source → kind` at promote time; do not add a parallel field. |
+| Triage source drift | [`operate/issue-report-triage.ts:52,254`](../../../apps/web/lib/operate/issue-report-triage.ts) writes `source:"issue_report"`. [`queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts) also writes and queries `source:"issue_report"`. The value is **not** a member of `BACKLOG_SOURCE_VALUES`. | Latent enum drift that reaches the DB and queue dedupe logic. Canonicalize writers and queries to `bug` with a backfill (Phase 0). |
+| Brief consumption | `FeatureBrief` is read structurally (`getBuildContextSection`, `build-pipeline.ts` `as FeatureBrief` cast, `validateFeatureBrief`, brief panels, `update_feature_brief`). | Additive optional `fixContext` field; no union, no cast breakage, no brief migration (`brief` is `Json?`). |
+| Promotion carry-through | [`governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts) `create` block copies only `title`, `description`(=body), `digitalProductId`, `originatingBacklogItemId`. | Add `kind` derivation + `fixContext` population + existing `PlatformIssueReport.featureBuildId` back-link, all inside the existing `prisma.$transaction`. |
+| Phase prompt selector | `getBuildPhasePrompt(phase)` → `loadPrompt("build-phase", phase, hardcoded)` ([`build-agent-prompts.ts:497`](../../../apps/web/lib/integrate/build-agent-prompts.ts)); DB-overridable via Admin > Prompts. Terminal phases currently return `""`. | Thread `kind`; select `<phase>-fix` slug for fixes; guard active-phase fallback so a missing override never yields the empty string while terminal phases keep today's empty prompt. |
+| Build prompt | Already has "WORKFLOW FOR BUG FIXES AND MODIFICATIONS TO EXISTING FILES" ([`build-agent-prompts.ts:263`](../../../apps/web/lib/integrate/build-agent-prompts.ts)) alongside the new-features workflow. | The `build` phase needs **no** Phase-1 prompt change; only ideate/plan/review branch. |
+| Gate | `checkPhaseGate` `ideate→plan` requires `designDoc`, `designReview`, `taxonomyNodeId`, `backlogItemId`, `epicId`, `constrainedGoal`. The `reviewDesignDoc` MCP path ([`mcp-tools.ts` ~7263-7611](../../../apps/web/lib/mcp-tools.ts)) requires `designDoc` and calls the gate. | Branch both on `kind`: for `fix`, a populated `fixContext` substitutes for `designDoc`; taxonomy/epic optional. |
+| Issue log lifecycle | `PlatformIssueReport` statuses in [`issue-report-status.ts`](../../../apps/web/lib/quality/issue-report-status.ts), including `triaged_local`; canonical writer `createPlatformIssueReport()`; admin UI has status/suppress/triaged actions only — no "send to build" affordance. `PlatformIssueReport.featureBuildId` field **already exists**. | The back-link field and status vocabulary exist; add the manual "Send to Build Studio as a fix" action, make it idempotent, populate the link at promote, and transition the report to `triaged_local`. |
+
+## 3. Research & Benchmarking
+
+How established trackers model the feature-vs-fix distinction and intake. The point is the data
+model and routing semantics, not feature lists.
+
+| System | Model (verified from product docs) | Adopt | Reject |
+| ------ | ---------------------------------- | ----- | ------ |
+| **GitHub Issue Types / Issue Forms** | Org-level **issue types** (Bug, Feature, Task) are a first-class field on the issue, distinct from labels; issue forms collect structured fields (repro, expected/actual) per type. Sources: [GitHub issue types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization), [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). | A small **closed** kind enum as a first-class field (not a label) is the right primitive; structured fix fields (repro/expected/actual) mirror issue forms. | Do not model kind as a free-text label or let it proliferate (Bug/Defect/Regression/Hotfix…). Two values now: `feature`, `fix`. |
+| **Jira issue-type schemes + Service Management request types** | Issue types (Bug/Story/Task) drive workflow and field configuration; Service Desk *request types* present a friendly intake face over those issue types so reporters never pick a raw type. Sources: [Jira issue types](https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-types/), [JSM request types](https://support.atlassian.com/jira-service-management-cloud/docs/what-are-request-types/). | Kind drives different prompts/gates (the DPF analogue of type-driven workflow); the operator never picks "kind" — the platform derives it from `source`. | Do not expose kind selection or workflow config to the non-technical operator. |
+| **Linear Bug vs Feature + Customer Requests** | Bug vs Feature is a lightweight attribute; customer requests link source feedback to the issue while preserving the source link. Source: [Linear customer requests](https://linear.app/docs/customer-requests). | Preserve the **source link** from the issue report to the build (`PlatformIssueReport.featureBuildId` back-link) so closure can be projected later. | Do not require heavyweight classification before work can start. |
+| **ServiceNow incident / problem / change** | Sharp separation: incident restores service, problem management investigates root cause, and change implements controlled remediation with linkage. Source: [ServiceNow problem management process](https://www.servicenow.com/docs/r/it-service-management/problem-management/c_ProblemManagementProcess.html). | The conceptual split maps cleanly: `PlatformIssueReport` approximates incident evidence, the fix `FeatureBuild` approximates the controlled change, and `fixContext.rootCause` captures the lightweight problem analysis. | Do not adopt three separate DPF tables; DPF already has report + build. Capture root cause as a field, not a new entity. |
+| **Sentry issue → fix linkage** | Runtime events group into issues with stack/context and links to resolution activity. Source: [Sentry issue details](https://docs.sentry.dev/product/issues/issue-details/). | Carry stack/severity/route from `PlatformIssueReport` into the build's `fixContext` so the fixer starts with the diagnosis, not a blank brief. | Do not ship raw stacks/PII upstream; that is governed by the existing privacy spec, out of scope here. |
+
+**Patterns adopted:** first-class closed kind enum; platform-derived (not operator-chosen) classification; structured fix fields mirroring issue forms; preserved source link for later closure projection. **Anti-patterns rejected:** kind-as-label proliferation; a parallel bug-tracker table; forcing classification/workflow choices onto the operator; a discriminated-union brief that fragments every reader.
+
+## 4. Design
+
+### 4.1 Work kind enum
+
+Declare in [`apps/web/lib/explore/feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts),
+the canonical home for `FeatureBuild` contracts:
+
+```ts
+export const FEATURE_BUILD_KIND_VALUES = ["feature", "fix"] as const;
+export type FeatureBuildKind = (typeof FEATURE_BUILD_KIND_VALUES)[number];
+```
+
+Single hyphen-free words per AGENTS.md §3. `BacklogItem.source` remains owned by
+[`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts); `FeatureBuild.kind`
+is owned by `feature-build-types.ts`. Mirror or import the enum in relevant `FeatureBuild`-facing
+MCP tool definitions in [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts) only
+where a tool accepts or returns `kind`, and add a parity test if the tool schema mirrors the list.
+Adding a third value later (e.g. `chore`) requires updating the canonical enum and any mirror in
+one commit, before any data uses it.
+
+### 4.2 Schema
+
+Add to `FeatureBuild` ([`schema.prisma:4404`](../../../packages/db/prisma/schema.prisma)):
+
+```prisma
+kind String @default("feature")  // feature | fix - see FEATURE_BUILD_KIND_VALUES
+```
+
+Migration `feature_build_kind`. The default backfills all existing rows to `feature`; no manual
+backfill needed. `kind` is **not** added to `BacklogItem` — `source` is the input, `kind` is the
+derived discriminator on the build.
+
+### 4.3 Fix context on the brief (additive)
+
+Extend `FeatureBrief` in [`feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts):
+
+```ts
+type FixContext = {
+  reproSteps?: string;
+  expected?: string;
+  actual?: string;
+  rootCause?: string;
+  fixApproach?: string;
+  severity?: "critical" | "high" | "medium" | "low";
+  originatingIssueReportId?: string;
+  originatingIssueReportPublicId?: string;
+  routeContext?: string;
+  errorStackExcerpt?: string;
+};
+
+type FeatureBrief = {
+  // ...existing fields unchanged...
+  fixContext?: FixContext;  // present iff the build's kind === "fix"
+};
+```
+
+Optional, so every existing reader (`getBuildContextSection`, the `as FeatureBrief` cast in
+`build-pipeline.ts`, `validateFeatureBrief`, `FeatureBriefPanel`, `update_feature_brief`) compiles
+and behaves unchanged. `brief` is a `Json?` column, so no migration for this. `getBuildContextSection`
+gains a small block that renders `fixContext` when present.
+
+The fields are optional because promotion can seed only observed report facts (`severity`,
+`routeContext`, stack excerpt, and public/internal report ids). The fix gate, not the type, is
+responsible for requiring reproduction evidence, root cause, and fix approach before a fix build
+advances from ideate to plan.
+
+### 4.4 Intake carry-through (promote)
+
+In [`governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts), inside the
+existing `prisma.$transaction`:
+
+1. **Derive `kind`:** `item.source === "bug" ? "fix" : "feature"` — set on the new `FeatureBuild`.
+2. **Resolve source report when available.**
+   - Manual admin action: pass the concrete `PlatformIssueReport.id` into the promotion helper; no
+     body parsing is needed.
+   - Cron-created BI path: parse only the stable `Source report: <reportId>` line produced by the
+     triage writer as a Phase-1 compatibility bridge. If parsing fails or the report is missing,
+     still create the fix build and write a `BuildActivity` note that no source report was linked.
+3. **Populate `fixContext`** when `kind === "fix"`: seed `severity`, route, stack excerpt, and
+   report identifiers from the originating `PlatformIssueReport` when known, leaving
+   `rootCause`/`fixApproach` for the ideate phase to fill. When there is no linked report (a
+   manually-filed `source=bug` BI), seed `fixContext` from the BI `body`. Write it into the
+   build's `brief`.
+4. **Back-link:** set the existing `PlatformIssueReport.featureBuildId = <new FeatureBuild.id>`
+   for the originating report. This write lives **inside the same transaction** so a rollback
+   cannot orphan the link.
+
+Do not add a direct `BacklogItem -> PlatformIssueReport` relation in Phase 1. Revisit it in Phase
+2 only if the cron-created BI compatibility bridge proves lossy in real use.
+
+### 4.5 Prompt branching
+
+`getBuildPhasePrompt(phase)` → `getBuildPhasePrompt(phase, kind)`
+([`build-agent-prompts.ts:497`](../../../apps/web/lib/integrate/build-agent-prompts.ts)). For
+`kind === "fix"`, select the `<phase>-fix` `loadPrompt` slug (still DB-overridable via Admin >
+Prompts) with a hardcoded fix-prompt fallback for active phases. Preserve today's terminal-phase
+behavior: `complete` and `failed` still return the empty string.
+
+Phase-1 fix prompts (hardcoded defaults, three phases only):
+
+- **ideate-fix** — *"You are diagnosing a reported defect."* Reproduce the issue, identify the
+  root cause, scope the **smallest correct fix**. No reusability/generalization questions, no
+  taxonomy interrogation. Fill `fixContext.rootCause` and `fixContext.fixApproach`.
+- **plan-fix** — Plan the **targeted change plus a regression test** that fails before and passes
+  after. Prefer modifying existing files over adding new capability.
+- **review-fix** — Verify the defect **no longer reproduces** and that a regression test was added.
+  Acceptance is "the reported behavior is gone," not "a new capability works."
+
+The `build` phase reuses the existing "WORKFLOW FOR BUG FIXES AND MODIFICATIONS" section
+([`build-agent-prompts.ts:263`](../../../apps/web/lib/integrate/build-agent-prompts.ts)) and is
+unchanged in Phase 1.
+
+### 4.6 Gate relaxation
+
+`checkPhaseGate` ([`feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts)
+~709-806) is threaded `kind`. For the `ideate→plan` transition when `kind === "fix"`:
+
+- a populated `fixContext` (reproduction evidence or explicit repro steps + root cause + fix
+  approach) **substitutes for** the feature `designDoc` requirement;
+- a review result in the existing `ReviewResult` shape confirms the fix diagnosis/approach;
+- `taxonomyNodeId` and `epicId` are **optional**.
+
+The `reviewDesignDoc` MCP auto-advance path ([`mcp-tools.ts` ~7263-7611](../../../apps/web/lib/mcp-tools.ts)),
+which today requires `designDoc` and then calls the gate, branches on `kind` to review and require
+a complete `fixContext` instead. `BuildContext` and the context loader
+([`feature-build-data.ts`](../../../apps/web/lib/explore/feature-build-data.ts) select,
+[`build-pipeline.ts`](../../../apps/web/lib/integrate/build-pipeline.ts)) thread `kind` so prompts
+and gate see it. The coworker-chat path flows through `getFeatureBuildForContext`, so it inherits
+`kind` once `BuildContext` carries it — no separate edit.
+
+### 4.7 Manual intake affordance
+
+Add a **"Send to Build Studio as a fix"** action to the Admin issue-reports UI
+([`app/(shell)/admin/issue-reports/page.tsx`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx),
+[`components/admin/IssueReportPanel.tsx`](../../../apps/web/components/admin/IssueReportPanel.tsx))
+backed by a server action in
+[`lib/actions/quality.ts`](../../../apps/web/lib/actions/quality.ts). The action:
+
+1. if `PlatformIssueReport.featureBuildId` is already populated, links to that build instead of
+   creating another;
+2. reuses an existing open bug `BacklogItem` for the report when one can be resolved;
+3. otherwise creates a `BacklogItem` with `source="bug"`, `triageOutcome="build"`, an `effortSize`
+   (default `small`, operator-adjustable), seeded from the report's title/description/severity;
+4. promotes it via the existing promote path, which derives `kind="fix"` and carries `fixContext`
+   + the back-link per §4.4;
+5. transitions the report to the existing `triaged_local` status.
+
+This is the explicit manual "I reported an issue → fix it" path. The 15-minute triage cron remains
+the automatic path; both converge on the same `source=bug → kind=fix` promotion, so behavior is
+consistent regardless of entry point.
+
+### 4.8 Phase 0 — canonicalize the source enum
+
+Before any `source → kind` mapping, fix the drift: issue-report triage code writes and queries
+`source:"issue_report"`, absent from `BACKLOG_SOURCE_VALUES`. Change both
+[`operate/issue-report-triage.ts`](../../../apps/web/lib/operate/issue-report-triage.ts) and
+[`queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts)
+to use the canonical `"bug"`, with an inline backfill in the migration:
+
+```sql
+UPDATE "BacklogItem" SET source = 'bug' WHERE source = 'issue_report';
+```
+
+`bug` is already canonical and semantically correct, so this both removes the drift and makes every
+issue-sourced backlog item eligible to classify as a fix. This slice is standalone and can land
+ahead of the rest.
+
+## 5. Implementation Phasing
+
+| Phase | Scope | Standalone? |
+| ----- | ----- | ----------- |
+| **0** | Canonicalize `issue_report → bug` in both issue-report triage writers/queries + backfill SQL. | Yes — small, no dependency on the rest. |
+| **1** | `FEATURE_BUILD_KIND_VALUES` enum (+ any MCP mirror); `FeatureBuild.kind` column/migration; additive `fixContext` on `FeatureBrief`; promote `source→kind` mapping + `fixContext` population + PIR back-link (in-tx); ideate/plan/review fix prompts + selector threading; gate + `reviewDesignDoc` fix branch; `BuildContext`/loader/pipeline threading; minimal UI (kind badge + `fixContext` render, degrading when absent); Admin "Send to Build Studio as a fix" action with idempotency. | Delivers the full end-to-end fix path. |
+| **2** (deferred) | First-class PIR↔build round-trip + auto-resolve the `PlatformIssueReport` on ship; fix-aware **specialist** prompts ([`specialist-prompts.ts`](../../../apps/web/lib/integrate/specialist-prompts.ts)) + a regression-test-required review gate; wire the capacity-aware spec's `local_build` decision to this destination; an `update_fix_brief` MCP tool; optional `BacklogItem → PlatformIssueReport` FK if body-parsing `fixContext` proves lossy. | Hardening + integration. |
+
+## 6. Verification Gates
+
+Implementation (Phase 0 + 1) must meet the AGENTS.md §5 build gate:
+
+| Layer | What to run / show |
+| ----- | ------------------ |
+| Unit tests | `pnpm --filter web exec vitest run` for: gate fix-path (fix advances on `fixContext`, feature still requires `designDoc`); promote mapping (`source=bug → kind=fix`, `fixContext` populated, PIR `featureBuildId` set); both triage paths emit/query `source=bug`; prompt selector returns a non-empty fix prompt for each branched active phase and preserves empty prompts for terminal phases; admin action is idempotent when `featureBuildId` already exists. |
+| Typecheck / build | `pnpm --filter web typecheck`; `cd apps/web && pnpm exec next build` with zero errors (TS errors only surface in `next build`). |
+| Migration | `feature_build_kind` (+ Phase-0 backfill) applies cleanly via `prisma migrate dev`. |
+| UX | Against the Docker-served portal: file a `runtime_error` (or manual issue) → Admin issue-reports → "Send to Build Studio as a fix" → confirm the build opens in the **fix-branched** ideate phase, `fixContext` is visible, and the kind badge shows `fix`. Use the `build-studio-operator` lens for the lifecycle gates. |
+
+This spec's own quality gate (pre-implementation): `dpf-architecture-review` lens applied; live
+MCP duplicate-spec check done (empty); every code reference ground-truthed against the current tree.
+
+## 7. Risks & Open Decisions
+
+| Item | Resolution |
+| ---- | ---------- |
+| Back-compat for in-flight feature builds | `@default("feature")` + every new `kind` parameter defaults to `feature` ⇒ existing behavior byte-identical. Low risk. |
+| `issue_report` vs `bug` drift | Phase 0 must land first, or issue-sourced builds never classify as fixes. |
+| Concurrency / orphaned link | The `PlatformIssueReport.featureBuildId` write must be inside the promote `prisma.$transaction`. |
+| Empty-prompt regression | Guard the `<phase>-fix` slug for active phases: a missing DB override falls back to the hardcoded fix prompt. Terminal phases continue to return the empty string. |
+| Brief shape | **Decision:** additive optional `fixContext`, not a discriminated union — preserves all structural readers. Revisit a `BacklogItem→PlatformIssueReport` FK only if body-parsing `fixContext` proves lossy (Phase 2). |
+| Kind proliferation | **Decision:** closed enum, two values (`feature`, `fix`) now. New values require the §3 enum-update discipline in the canonical enum and any MCP mirror. |
+| Effort sizing for fixes | Manual affordance defaults `effortSize="small"`, operator-adjustable. The promote eligibility check (`effortSize != null`) is satisfied without forcing the operator to size a defect blind. |
+
+## 8. Next Step After Sign-Off
+
+On approval, file the backlog item(s), then implement **Phase 0 + Phase 1 directly in this repo**
+— the "Build Studio for ALL development" rule is intentionally overridden here because Build Studio
+is not yet fully working — on a topic branch, via a DCO-signed PR, meeting the full build gate.
+Phase 2 is filed as follow-up backlog and not started until Phase 1 has landed and accrued
+evidence.

--- a/packages/db/prisma/migrations/20260530000000_backfill_issue_report_source_to_bug/migration.sql
+++ b/packages/db/prisma/migrations/20260530000000_backfill_issue_report_source_to_bug/migration.sql
@@ -1,0 +1,7 @@
+-- Canonicalize legacy issue-report backlog source to the canonical "bug" value.
+-- The issue-report triage writers (apps/web/lib/operate/issue-report-triage.ts
+-- and apps/web/lib/queue/functions/issue-report-triage.ts) historically wrote
+-- source='issue_report', which is NOT a member of BACKLOG_SOURCE_VALUES
+-- (apps/web/lib/explore/backlog.ts). "bug" is the canonical value and is what
+-- maps to FeatureBuild.kind='fix' at promote time. Data-only migration.
+UPDATE "BacklogItem" SET "source" = 'bug' WHERE "source" = 'issue_report';

--- a/packages/db/prisma/migrations/20260530000100_feature_build_kind/migration.sql
+++ b/packages/db/prisma/migrations/20260530000100_feature_build_kind/migration.sql
@@ -1,0 +1,5 @@
+-- Work-kind discriminator for Build Studio builds (FEATURE_BUILD_KIND_VALUES in
+-- apps/web/lib/explore/feature-build-types.ts): "feature" | "fix".
+-- Default "feature" backfills every existing and in-flight build, so behavior
+-- is byte-identical until a bug-sourced backlog item is promoted as a fix.
+ALTER TABLE "FeatureBuild" ADD COLUMN "kind" TEXT NOT NULL DEFAULT 'feature';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4406,6 +4406,11 @@ model FeatureBuild {
   buildId                  String                   @unique
   title                    String
   description              String?
+  // Work kind discriminator (FEATURE_BUILD_KIND_VALUES in
+  // apps/web/lib/explore/feature-build-types.ts): "feature" | "fix".
+  // Default "feature" backfills all existing/in-flight builds with no behavior
+  // change. Derived from BacklogItem.source ("bug" -> "fix") at promote time.
+  kind                     String                   @default("feature")
   portfolioId              String?
   originatingBacklogItemId String?
   brief                    Json?


### PR DESCRIPTION
## What & why

Build Studio could only build **features**. A reported defect had no governed path to a fix — the pipeline's prompts, gate, and brief are all new-capability-shaped, and promotion dropped the issue's diagnostic context. This adds a first-class **work kind** (`feature | fix`) that carries from intake into the pipeline so a reported issue runs as a targeted fix.

Implements `docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md` (included). Fills the `local_build` path the 2026-05-24 capacity-aware-feedback spec deferred.

## Phases

**Phase 0 — fix(backlog):** canonicalize the issue-report triage source `issue_report` → `bug` (never in `BACKLOG_SOURCE_VALUES`) in both triage writers + dedupe queries, with an inline backfill migration.

**Phase 1 — feat(build-studio):**
- `FEATURE_BUILD_KIND_VALUES` enum + `FeatureBuild.kind` column (`@default("feature")`, back-compat by construction) + migration.
- Additive `FixContext` on `FeatureBrief` (not a discriminated union, so every structural brief reader is untouched).
- Promote carry-through: `source="bug"` → `kind="fix"`, `fixContext` seeded from the originating `PlatformIssueReport`, report back-linked in-transaction.
- Fix-flow ideate/plan/review prompts (build reuses the existing bug-fix workflow); selector branches by kind, active-phase fallback, terminal phases keep empty prompts.
- `checkPhaseGate` branches for fixes (complete `fixContext` substitutes for the design doc; taxonomy/epic optional); `kind` threaded through every production gate call site; `reviewDesignDoc` reviews the diagnosis for fixes.
- Admin "Send to Build Studio as a fix" action (idempotent) + button.

## Build gate

- Unit tests: new fix-flow gate/prompt matrix + promote source->kind+fixContext+back-link; affected suites green (1000+ tests).
- next build: exit 0.
- Migrations: full set + both new migrations apply cleanly to a fresh DB; kind lands as text NOT NULL DEFAULT 'feature'.
- Live UX exercise of the admin button against a portal built from this branch is still pending.

Generated with Claude Code
