### PR TITLE
fix(security): sanitize user-influenced values in agent log lines

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -24,6 +24,7 @@ import {
 // mcp-tools is imported dynamically at call sites to avoid NFT whole-project tracing;
 // type-only imports are erased at build time and safe.
 import type { ToolDefinition } from "@/lib/mcp-tools";
+import { sanitizeForLog } from "@/lib/security/safe-log";
 import { getActionsForRoute } from "@/lib/agent-action-registry";
 import { getBuildContextSection } from "@/lib/build-agent-prompts";
 import { getFeatureBuildForContext } from "@/lib/feature-build-data";
@@ -1035,13 +1036,14 @@ export async function sendMessage(input: {
   // Log tools available so we can diagnose why a model claims it can't see a
   // tool that should be in scope. Logged for every coworker call, not just
   // build-phase ones — chat coworkers on /workspace etc. were silent before.
-  // CodeQL js/log-injection: input.routeContext + agent.agentId + tool
-  // names are user-influenced. JSON.stringify on each interpolation.
-  console.log(
+  // CodeQL js/log-injection: input.routeContext + agent.agentId + tool names
+  // are user-influenced. Compose the line, then route it through the registered
+  // sanitizeForLog sanitizer so embedded control chars can't forge log entries.
+  const toolsLogLine =
     `[tools] route=${JSON.stringify(input.routeContext)} agent=${JSON.stringify(agent.agentId)} ` +
     `${activeBuildPhase ? `buildPhase=${JSON.stringify(activeBuildPhase)} ` : ""}` +
-    `count=${availableTools.length} tools=[${availableTools.map(t => JSON.stringify(t.name)).join(", ")}]`,
-  );
+    `count=${availableTools.length} tools=[${availableTools.map(t => JSON.stringify(t.name)).join(", ")}]`;
+  console.log(sanitizeForLog(toolsLogLine));
   if (activeBuildPhase) {
 
     // Inject PhaseHandoff context — structured summary from the previous phase

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -6,6 +6,7 @@ import { routeAndCall, type RoutedInferenceResult } from "@/lib/routed-inference
 import { detectRepeatedToolCall, recordRepeatedToolIssue } from "@/lib/tak/runtime-issues";
 import { PLATFORM_TOOLS, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
+import { sanitizeForLog } from "@/lib/security/safe-log";
 import type { ChatMessage } from "@/lib/ai-inference";
 import { prisma } from "@dpf/db";
 import { agentEventBus } from "./agent-event-bus";
@@ -1519,7 +1520,14 @@ export async function runAgenticLoop(params: {
         const nudgeContent = mentionedTool
           ? `Stop narrating — call ${mentionedTool} now. Do not respond with text.`
           : `You have tools available — call one directly instead of describing what you want to do. Available: ${toolListStr}. Call the most relevant one now.`;
-        console.log(`[agentic-loop] nudging (tools used=${executedTools.length}, short response, mentioned=${mentionedTool ?? "none"})`);
+        // Tool names are user-influenced; route through the registered
+        // sanitizeForLog sanitizer (strips control chars) so a CR/LF can't
+        // forge a log entry, and use %s substitution (CodeQL js/log-injection).
+        console.log(
+          "[agentic-loop] nudging (tools used=%d, short response, mentioned=%s)",
+          executedTools.length,
+          sanitizeForLog(mentionedTool ?? "none"),
+        );
         messages = [
           ...messages,
           ...(trimmed.length > 0


### PR DESCRIPTION
## What

Fixes the two open `js/log-injection` (CWE-117) code-scanning alerts:

- [agentic-loop.ts:1522](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security/code-scanning/251) — tool name (`mentionedTool`) logged unsanitized in the nudge line.
- [agent-coworker.ts:1041](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security/code-scanning/250) — `routeContext` + `agentId` + tool names logged in the `[tools]` line.

## How

Both sinks now route their user-influenced values through the repo's CodeQL-registered `sanitizeForLog` sanitizer (`apps/web/lib/security/safe-log.ts`, registered in `.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml`), which strips C0 control characters and DEL so a CR/LF can't forge a downstream log entry. The agentic-loop sink additionally uses `%s` positional substitution per the helper's documented guidance.

An inline `.replace(/[\r\n]/g, ...)` would be functionally safe but CodeQL would not recognize it, so the alerts would not clear — hence the registered helper.

## Verification

- `tsc --noEmit` passes.
- CodeQL alerts close automatically on the next scan after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)