### PR TITLE
fix(voice): short naturally-paced reference recipe (reverses #1283 drawl regression)

### DIFF
--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -244,7 +244,7 @@ function VoiceSampleCapture({ profileId }: { profileId: string }) {
   return (
     <div className="rounded-md border border-border p-4 space-y-4">
       <p className="text-sm text-muted-foreground">
-        Provide 15–30 seconds of clean, single-speaker speech in a quiet room. Your voice is cloned immediately — no training wait.
+        Provide about 6–12 seconds of clean, single-speaker speech in a quiet room, spoken at your natural conversational pace. Your voice is cloned immediately — no training wait.
       </p>
 
       {/* Mode toggle */}
@@ -414,17 +414,14 @@ function MicRecorder({ profileId }: { profileId: string }) {
             <button onClick={() => setShowScript(false)} className="text-xs text-muted-foreground hover:text-foreground">dismiss</button>
           </div>
           <p className="text-sm text-muted-foreground italic leading-relaxed">
-            "My name is [your name], and I consent to this voice profile being
-            used for AI-narrated decision feedback through the platform. I'm
-            reading this short passage at a natural, steady pace so the system can
-            learn how my voice really sounds. The quick brown fox jumps over the
-            lazy dog, while bright autumn leaves drift quietly past the open
-            window. I'm happy to help the team make clearer, faster decisions."
+            "My name is [your name], and I consent to this voice being used for
+            AI-narrated decision feedback. I'm speaking at my normal pace so the
+            system learns how I really sound."
           </p>
           <p className="text-xs text-muted-foreground">
-            Read it all the way through ({MIN_RECORDING_SECONDS}–{RECOMMENDED_MAX_SECONDS}s).
-            A quiet room, a steady pace, and your normal speaking voice give the
-            best clone.
+            Read it once at a natural, conversational pace (~{MIN_RECORDING_SECONDS}–{RECOMMENDED_MAX_SECONDS}s).
+            Keep it short — a quiet room and your everyday speaking voice give the
+            best clone. A long or slowly-read clip makes the cloned voice drawl.
           </p>
         </div>
       )}


### PR DESCRIPTION
## What
Corrects the voice **recording recipe** to favor a **short, naturally-paced** reference clip — reversing PR #1283, which (well-intentioned) pushed users toward long clips (min 15s, "keep going to ~30s") that clone **poorly**.

## Evidence (measured on M5 Max, 2026-05-30)
Same voice, same model (CSM via mlx-audio):
- **35s** slowly-read reference → **7.5s** for a 13-word sentence (~0.58s/word, drawled).
- **~8–10s** reference → natural pacing (~0.3s/word).

A long, slowly-read reference makes the clone copy the slow cadence. The cloning sweet spot is a short (~6–12s), conversational clip. This applies to **both** local cloning models measured (CSM and Chatterbox-native).

## Changes (`VoiceProfileSetup`)
- `MIN_RECORDING_SECONDS` 15→6, `RECOMMENDED_MAX_SECONDS` 30→12 (auto-updates the stop-gate + nudge).
- Shorter suggested script (~10s natural read, **consent retained**); guidance now stresses *short + natural pace* and warns long/slow clips drawl; upload hint → 6–12s.
- Retains #1283's capture improvements (echoCancellation / noiseSuppression / AGC / mono / 48kHz).

## Verification
Typecheck clean; recorder tests pass. Not yet ear-validated end-to-end (requires a human listen + fresh recording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
