### PR TITLE
fix(self-upgrade): run prep git ops with repo hooks disabled (Mac git-lfs blocker)

### DIFF
--- a/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
@@ -136,6 +136,32 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     expect(git(install, "rev-parse", "HEAD").trim()).toBe(beforeHead);
   });
 
+  it("survives a hard-failing post-checkout hook (e.g. Git LFS hook with no git-lfs binary)", async () => {
+    const { upstream, install, root } = makeWorld();
+    cleanup.push(root);
+    commit(upstream, "upstream.txt", "x\n", "feat: x");
+
+    // Reproduce the Mac/container blocker: the clone has a post-checkout hook
+    // that exits non-zero (the git-lfs hook does exactly this when git-lfs is
+    // absent). Without hook-bypassing, `git checkout` returns non-zero and prep
+    // would abort with prep-error even though the checkout itself succeeds.
+    const hooksDir = join(install, ".dpf-hooks");
+    execFileSync("mkdir", ["-p", hooksDir]);
+    const hook = join(hooksDir, "post-checkout");
+    writeFileSync(hook, "#!/bin/sh\necho 'git-lfs not found' >&2\nexit 2\n");
+    execFileSync("chmod", ["+x", hook]);
+    git(install, "config", "core.hooksPath", hooksDir);
+
+    const r = await prepareUpgradeSource(
+      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+
+    expect(r.ok).toBe(true);
+    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
+    expect(existsSync(join(install, "upstream.txt"))).toBe(true);
+  });
+
   it("local mode stamps the working tree HEAD, with -dirty when uncommitted", async () => {
     const { install, root } = makeWorld();
     cleanup.push(root);

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -155,8 +155,20 @@ function errMsg(err: unknown): string {
  */
 export async function defaultGitRunner(args: string[]): Promise<GitResult> {
   const { execFile } = await import("node:child_process");
+  // Run prep's internal git ops with repo hooks DISABLED. The host clone ships a
+  // Git LFS post-checkout/post-merge hook (the repo uses filter=lfs), but the
+  // portal container has no git-lfs binary — so the hook exits non-zero and makes
+  // an otherwise-successful `git checkout`/`merge` look like it failed, aborting
+  // the whole upgrade at prep. Prep is mechanical (move branches, merge for a
+  // build) and never needs LFS smudging, so force core.hooksPath empty and skip
+  // LFS smudge. `-c` is a git GLOBAL option and must precede the subcommand —
+  // prepend it ahead of the caller's args (which start with "-C <path> <cmd>").
+  const safeArgs = ["-c", "core.hooksPath=/dev/null", ...args];
   return new Promise<GitResult>((resolve) => {
-    execFile("git", args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+    execFile("git", safeArgs, {
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" },
+    }, (err, stdout, stderr) => {
       const out = stdout?.toString() ?? "";
       const errOut = stderr?.toString() ?? "";
       if (err) {


### PR DESCRIPTION
## Why

Driving a real self-upgrade on macOS (`/ops/self-upgrade` → Force upgrade) failed immediately at prep:

```
prep-error: checkout dpf/install failed: Switched to a new branch 'dpf/install'
... This repository is configured for Git LFS but 'git-lfs' was not found on your path.
```

**Root cause:** `prepareUpgradeSource()` runs `git checkout`/`merge` **inside the portal container** against the `/host-dpf` mount. The repo uses `filter=lfs` with a `.githooks/post-checkout` Git LFS hook, but the **portal container has no `git-lfs` binary** — so the hook exits non-zero, making an otherwise-successful `git checkout dpf/install` return non-zero. The prep correctly keys on exit code and aborts with `prep-error`, even though the branch switch itself succeeded.

## Fix

`defaultGitRunner` now runs every prep git op with `-c core.hooksPath=/dev/null` and `GIT_LFS_SKIP_SMUDGE=1`. Prep is mechanical (move branches, merge for a build) and never needs LFS smudging, so disabling hooks is safe and environment-independent — no `git-lfs` required in the container. Adds an integration test that reproduces a hard-failing `post-checkout` hook and asserts prep still succeeds.

The prep logic is otherwise unchanged (still keys on exit codes, still preserves local delta via the `dpf/install` merge).

Generated with Claude Code
