### PR TITLE
feat(web): localize portal timestamps + live-formatting phone/email inputs

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 // apps/web/app/(auth)/login/page.tsx
+import { EmailInput } from "@/components/ui/EmailInput";
 import { signIn } from "@/lib/auth";
 import { AuthError } from "next-auth";
 import { redirect } from "next/navigation";
@@ -45,10 +46,9 @@ export default async function LoginPage({ searchParams }: Props) {
             <label className="block text-sm text-[var(--dpf-muted)] mb-1" htmlFor="email">
               Email
             </label>
-            <input
+            <EmailInput
               id="email"
               name="email"
-              type="email"
               required
               className="w-full px-3 py-2 rounded-lg bg-[var(--dpf-bg)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm focus:outline-none focus:border-[var(--dpf-accent)]"
             />

--- a/apps/web/app/(customer-auth)/customer-login/login-form.tsx
+++ b/apps/web/app/(customer-auth)/customer-login/login-form.tsx
@@ -5,6 +5,7 @@ import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { SocialButtons, SocialDivider } from "@/components/social-buttons";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export function CustomerLoginForm({ socialEnabled }: { socialEnabled: boolean }) {
   const router = useRouter();
@@ -64,10 +65,9 @@ export function CustomerLoginForm({ socialEnabled }: { socialEnabled: boolean })
         <form onSubmit={handleSubmit}>
           <div style={{ marginBottom: 16 }}>
             <label style={{ display: "block", color: "var(--dpf-muted)", fontSize: 12, marginBottom: 4 }}>Email</label>
-            <input
-              type="email"
+            <EmailInput
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onValueChange={(v) => setEmail(v)}
               required
               autoFocus
               style={{

--- a/apps/web/app/(customer-auth)/customer-signup/signup-form.tsx
+++ b/apps/web/app/(customer-auth)/customer-signup/signup-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { customerSignup } from "@/lib/actions/customer-auth";
 import { SocialButtons, SocialDivider } from "@/components/social-buttons";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export function CustomerSignupForm({ socialEnabled }: { socialEnabled: boolean }) {
   const router = useRouter();
@@ -88,10 +89,9 @@ export function CustomerSignupForm({ socialEnabled }: { socialEnabled: boolean }
 
           <div style={{ marginBottom: 16 }}>
             <label style={{ display: "block", color: "var(--dpf-muted)", fontSize: 12, marginBottom: 4 }}>Email</label>
-            <input
-              type="email"
+            <EmailInput
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onValueChange={(v) => setEmail(v)}
               required
               placeholder="you@company.com"
               style={{

--- a/apps/web/app/(portal)/portal/account/page.tsx
+++ b/apps/web/app/(portal)/portal/account/page.tsx
@@ -2,6 +2,7 @@
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function AccountPage() {
   const session = await auth();
@@ -53,7 +54,7 @@ export default async function AccountPage() {
             <div>
               <span style={{ fontSize: 13, color: "var(--dpf-text)" }}>{c.email}</span>
               <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 8 }}>
-                since {new Date(c.createdAt).toLocaleDateString()}
+                since <LocalTime value={c.createdAt} mode="date" />
               </span>
             </div>
             <span style={{

--- a/apps/web/app/(setup)/setup/AccountBootstrapForm.tsx
+++ b/apps/web/app/(setup)/setup/AccountBootstrapForm.tsx
@@ -1,3 +1,4 @@
+import { EmailInput } from "@/components/ui/EmailInput";
 import { bootstrapFirstRunOwner } from "@/lib/actions/first-run-account-bootstrap";
 import { AccountBootstrapSubmitButton } from "./AccountBootstrapSubmitButton";
 
@@ -52,10 +53,9 @@ export function AccountBootstrapForm({ setupId }: Props) {
             <label className="block text-sm font-medium text-[var(--dpf-text)] mb-1" htmlFor="first-run-owner-email">
               Your Email
             </label>
-            <input
+            <EmailInput
               id="first-run-owner-email"
               name="email"
-              type="email"
               autoComplete="email"
               required
               className="w-full rounded-lg"

--- a/apps/web/app/(shell)/admin/cockpit/page.tsx
+++ b/apps/web/app/(shell)/admin/cockpit/page.tsx
@@ -37,6 +37,7 @@ import {
   resolveCockpitRowLabels,
 } from "@/lib/cockpit/install-terminology";
 import { GraduationVetoButton } from "@/components/cockpit/GraduationVetoButton";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 // All four ring interfaces. Phase 0 only emits at 1→2; the others render as
 // "no data" lanes so the operator sees the gear train honestly, not hidden.
@@ -392,7 +393,7 @@ export default async function CockpitPage({
               );
               return (
                 <li key={g.id} className="flex items-center gap-2 flex-wrap">
-                  <span className="text-[var(--dpf-muted)]">{g.recordedAt.toISOString()}</span>
+                  <LocalTime value={g.recordedAt} className="text-[var(--dpf-muted)]" />
                   <span className="font-semibold">{labels.capabilityLabel}</span>
                   <span className="text-[var(--dpf-muted)]">for</span>
                   <span>{labels.agentLabel}</span>
@@ -476,7 +477,7 @@ export default async function CockpitPage({
                   return (
                     <tr key={row.id} className="border-t" style={{ borderColor: "var(--dpf-border)" }}>
                       <td className="py-1.5 pr-3 text-[var(--dpf-muted)] whitespace-nowrap">
-                        {row.recordedAt.toISOString().slice(11, 19)}
+                        <LocalTime value={row.recordedAt} mode="time" />
                       </td>
                       <td className="px-3 py-1.5 truncate" title={labels.interfaceLabel}>
                         {labels.interfaceLabel}

--- a/apps/web/app/(shell)/admin/page.tsx
+++ b/apps/web/app/(shell)/admin/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { AdminUserAccessPanel } from "@/components/admin/AdminUserAccessPanel";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function AdminPage() {
   const [users, roles] = await Promise.all([
@@ -70,7 +71,7 @@ export default async function AdminPage() {
                   </span>
                 </div>
               </div>
-              <p className="text-[9px] text-[var(--dpf-muted)]">Joined {new Date(u.createdAt).toLocaleDateString()}</p>
+              <p className="text-[9px] text-[var(--dpf-muted)]">Joined <LocalTime value={u.createdAt} mode="date" /></p>
               {u.groups.length === 0 ? (
                 <p className="text-[9px] text-[var(--dpf-muted)] mt-2">No roles assigned</p>
               ) : (

--- a/apps/web/app/(shell)/complaints/ComplaintsClient.tsx
+++ b/apps/web/app/(shell)/complaints/ComplaintsClient.tsx
@@ -3,6 +3,8 @@
 
 import { useState } from "react";
 
+import { LocalTime } from "@/components/ui/LocalTime";
+
 type Complaint = {
   id: string;
   customerName: string;
@@ -185,7 +187,7 @@ export function ComplaintsClient() {
                     {c.status}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-xs" style={{ color: "var(--dpf-muted)" }}>{new Date(c.createdAt).toLocaleDateString()}</td>
+                <td className="px-4 py-3 text-xs" style={{ color: "var(--dpf-muted)" }}><LocalTime value={c.createdAt} mode="date" /></td>
               </tr>
             ))}
             {filtered.length === 0 && (

--- a/apps/web/app/(shell)/compliance/actions/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/actions/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getCorrectiveAction } from "@/lib/actions/compliance";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { EditCorrectiveActionForm } from "@/components/compliance/EditCorrectiveActionForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -60,13 +61,13 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
         {action.dueDate && (
           <div className={`p-3 rounded-lg border ${isOverdue ? "border-red-500/50" : "border-[var(--dpf-border)]"}`}>
             <p className="text-xs text-[var(--dpf-muted)]">Due Date</p>
-            <p className={`text-sm font-semibold ${isOverdue ? "text-red-400" : "text-[var(--dpf-text)]"}`}>{new Date(action.dueDate).toLocaleDateString()}</p>
+            <LocalTime value={action.dueDate} utc className={`text-sm font-semibold ${isOverdue ? "text-red-400" : "text-[var(--dpf-text)]"}`} />
           </div>
         )}
         {action.completedAt && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Completed At</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(action.completedAt).toLocaleDateString()}</p>
+            <LocalTime value={action.completedAt} mode="date" className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         {action.owner && (
@@ -99,7 +100,7 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
             {action.verificationDate && (
               <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
                 <p className="text-xs text-[var(--dpf-muted)]">Verification Date</p>
-                <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(action.verificationDate).toLocaleDateString()}</p>
+                <LocalTime value={action.verificationDate} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
               </div>
             )}
             {action.verifiedBy && (

--- a/apps/web/app/(shell)/compliance/actions/page.tsx
+++ b/apps/web/app/(shell)/compliance/actions/page.tsx
@@ -2,6 +2,7 @@ import { listCorrectiveActions } from "@/lib/actions/compliance";
 import { CORRECTIVE_ACTION_STATUSES, CORRECTIVE_ACTION_SOURCE_TYPES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateCorrectiveActionForm } from "@/components/compliance/CreateCorrectiveActionForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { searchParams: Promise<{ status?: string; sourceType?: string; overdue?: string }> };
 
@@ -94,7 +95,7 @@ export default async function ActionsPage({ searchParams }: Props) {
                     </div>
                   </div>
                   <div className="text-right text-xs text-[var(--dpf-muted)]">
-                    {a.dueDate && <p className={isOverdue ? "text-red-400" : ""}>Due: {new Date(a.dueDate).toLocaleDateString()}</p>}
+                    {a.dueDate && <p className={isOverdue ? "text-red-400" : ""}>Due: <LocalTime value={a.dueDate} utc /></p>}
                     {a.owner && <p>{a.owner.displayName}</p>}
                   </div>
                 </div>

--- a/apps/web/app/(shell)/compliance/audits/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/audits/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -50,13 +51,13 @@ export default async function AuditDetailPage({ params }: Props) {
         {audit.scheduledAt && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Scheduled</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(audit.scheduledAt).toLocaleDateString()}</p>
+            <LocalTime value={audit.scheduledAt} mode="date" className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         {audit.conductedAt && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Conducted</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(audit.conductedAt).toLocaleDateString()}</p>
+            <LocalTime value={audit.conductedAt} mode="date" className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -98,7 +99,7 @@ export default async function AuditDetailPage({ params }: Props) {
                 </div>
               </div>
               <div className="text-right text-xs text-[var(--dpf-muted)]">
-                {f.dueDate && <p>Due: {new Date(f.dueDate).toLocaleDateString()}</p>}
+                {f.dueDate && <p>Due: <LocalTime value={f.dueDate} utc /></p>}
                 <p>{f._count.correctiveActions} action{f._count.correctiveActions !== 1 ? "s" : ""}</p>
               </div>
             </div>

--- a/apps/web/app/(shell)/compliance/audits/page.tsx
+++ b/apps/web/app/(shell)/compliance/audits/page.tsx
@@ -2,6 +2,7 @@ import { listAudits } from "@/lib/actions/compliance";
 import { AUDIT_TYPES, AUDIT_STATUSES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateAuditForm } from "@/components/compliance/CreateAuditForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLORS: Record<string, string> = {
   planned: "bg-blue-900/30 text-blue-400",
@@ -82,7 +83,7 @@ export default async function AuditsPage({ searchParams }: Props) {
                   </div>
                 </div>
                 <div className="text-right text-xs text-[var(--dpf-muted)]">
-                  {a.scheduledAt && <p>Scheduled: {new Date(a.scheduledAt).toLocaleDateString()}</p>}
+                  {a.scheduledAt && <p>Scheduled: <LocalTime value={a.scheduledAt} mode="date" /></p>}
                   <p>{a._count.findings} finding{a._count.findings !== 1 ? "s" : ""}</p>
                   {a.auditor && <p>{a.auditor.displayName}</p>}
                 </div>

--- a/apps/web/app/(shell)/compliance/controls/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/controls/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { LinkObligationForm } from "@/components/compliance/LinkObligationForm";
 import { UnlinkControlButton } from "@/components/compliance/UnlinkControlButton";
 import { EditControlForm } from "@/components/compliance/EditControlForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -96,7 +97,7 @@ export default async function ControlDetailPage({ params }: Props) {
         {control.nextReviewDate && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Next Review</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(control.nextReviewDate).toLocaleDateString()}</p>
+            <LocalTime value={control.nextReviewDate} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
       </div>
@@ -152,7 +153,7 @@ export default async function ControlDetailPage({ params }: Props) {
                   <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{ev.evidenceType}</span>
                 </div>
               </div>
-              <span className="text-xs text-[var(--dpf-muted)]">{new Date(ev.collectedAt).toLocaleDateString()}</span>
+              <LocalTime value={ev.collectedAt} mode="date" className="text-xs text-[var(--dpf-muted)]" />
             </div>
           ))}
         </div>

--- a/apps/web/app/(shell)/compliance/evidence/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/evidence/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { getEvidence } from "@/lib/actions/compliance";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -63,7 +64,7 @@ export default async function EvidenceDetailPage({ params }: Props) {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Collected At</p>
-          <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(evidence.collectedAt).toLocaleString()}</p>
+          <LocalTime value={evidence.collectedAt} className="text-sm font-semibold text-[var(--dpf-text)]" />
         </div>
         {evidence.collectedBy && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -80,7 +81,7 @@ export default async function EvidenceDetailPage({ params }: Props) {
         {evidence.retentionUntil && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Retain Until</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(evidence.retentionUntil).toLocaleDateString()}</p>
+            <LocalTime value={evidence.retentionUntil} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
       </div>

--- a/apps/web/app/(shell)/compliance/evidence/page.tsx
+++ b/apps/web/app/(shell)/compliance/evidence/page.tsx
@@ -3,6 +3,7 @@ import { EVIDENCE_TYPES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CreateEvidenceForm } from "@/components/compliance/CreateEvidenceForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { searchParams: Promise<{ evidenceType?: string; status?: string }> };
 
@@ -75,7 +76,7 @@ export default async function EvidencePage({ searchParams }: Props) {
                   </div>
                 </div>
                 <div className="text-right text-xs text-[var(--dpf-muted)]">
-                  <p>{new Date(e.collectedAt).toLocaleDateString()}</p>
+                  <LocalTime value={e.collectedAt} mode="date" />
                   {e.collectedBy && <p>{e.collectedBy.displayName}</p>}
                 </div>
               </div>

--- a/apps/web/app/(shell)/compliance/incidents/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/incidents/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getIncident } from "@/lib/actions/compliance";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { EditIncidentForm } from "@/components/compliance/EditIncidentForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -70,12 +71,12 @@ export default async function IncidentDetailPage({ params }: Props) {
           </div>
           {incident.notificationDeadline && (
             <p className={`text-xs ${deadlinePassed && !incident.notifiedAt ? "text-red-400" : "text-amber-400"}`}>
-              Notification deadline: {new Date(incident.notificationDeadline).toLocaleString()}
+              Notification deadline: <LocalTime value={incident.notificationDeadline} />
               {deadlinePassed && !incident.notifiedAt && " — OVERDUE"}
             </p>
           )}
           {incident.notifiedAt && (
-            <p className="text-xs text-green-400">Notified at: {new Date(incident.notifiedAt).toLocaleString()}</p>
+            <p className="text-xs text-green-400">Notified at: <LocalTime value={incident.notifiedAt} /></p>
           )}
         </div>
       )}
@@ -84,12 +85,12 @@ export default async function IncidentDetailPage({ params }: Props) {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Occurred At</p>
-          <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(incident.occurredAt).toLocaleString()}</p>
+          <LocalTime value={incident.occurredAt} className="text-sm font-semibold text-[var(--dpf-text)]" />
         </div>
         {incident.detectedAt && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Detected At</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(incident.detectedAt).toLocaleString()}</p>
+            <LocalTime value={incident.detectedAt} className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         {incident.category && (
@@ -171,7 +172,7 @@ export default async function IncidentDetailPage({ params }: Props) {
                   </div>
                   {a.dueDate && (
                     <span className={`text-xs ${isOverdue ? "text-red-400" : "text-[var(--dpf-muted)]"}`}>
-                      Due: {new Date(a.dueDate).toLocaleDateString()}
+                      Due: <LocalTime value={a.dueDate} utc />
                     </span>
                   )}
                 </div>

--- a/apps/web/app/(shell)/compliance/incidents/page.tsx
+++ b/apps/web/app/(shell)/compliance/incidents/page.tsx
@@ -2,6 +2,7 @@ import { listIncidents } from "@/lib/actions/compliance";
 import { INCIDENT_SEVERITIES, INCIDENT_STATUSES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateIncidentForm } from "@/components/compliance/CreateIncidentForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const SEVERITY_COLORS: Record<string, string> = {
   low: "bg-green-900/30 text-green-400",
@@ -100,12 +101,12 @@ export default async function IncidentsPage({ searchParams }: Props) {
                     </div>
                     {isNotifiable && inc.notificationDeadline && isOpen && (
                       <p className="text-[9px] text-red-400 mt-1">
-                        Notification deadline: {new Date(inc.notificationDeadline).toLocaleString()}
+                        Notification deadline: <LocalTime value={inc.notificationDeadline} />
                       </p>
                     )}
                   </div>
                   <div className="text-right text-xs text-[var(--dpf-muted)]">
-                    <p>{new Date(inc.occurredAt).toLocaleDateString()}</p>
+                    <LocalTime value={inc.occurredAt} mode="date" />
                     <p>{inc._count.correctiveActions} action{inc._count.correctiveActions !== 1 ? "s" : ""}</p>
                     {inc.reportedBy && <p>{inc.reportedBy.displayName}</p>}
                   </div>

--- a/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { LinkControlForm } from "@/components/compliance/LinkControlForm";
 import { UnlinkControlButton } from "@/components/compliance/UnlinkControlButton";
 import { EditObligationForm } from "@/components/compliance/EditObligationForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -90,7 +91,7 @@ export default async function ObligationDetailPage({ params }: Props) {
         {obligation.reviewDate && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Review Date</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(obligation.reviewDate).toLocaleDateString()}</p>
+            <LocalTime value={obligation.reviewDate} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -185,8 +186,8 @@ export default async function ObligationDetailPage({ params }: Props) {
                 </div>
               </div>
               <div className="text-right text-xs text-[var(--dpf-muted)]">
-                <p>{new Date(e.collectedAt).toLocaleDateString()}</p>
-                {e.retentionUntil && <p>Retain until: {new Date(e.retentionUntil).toLocaleDateString()}</p>}
+                <LocalTime value={e.collectedAt} mode="date" />
+                {e.retentionUntil && <p>Retain until: <LocalTime value={e.retentionUntil} utc /></p>}
               </div>
             </div>
           ))}

--- a/apps/web/app/(shell)/compliance/page.tsx
+++ b/apps/web/app/(shell)/compliance/page.tsx
@@ -2,6 +2,7 @@
 import { prisma } from "@dpf/db";
 import { RegulatoryAlerts } from "@/components/compliance/RegulatoryAlerts";
 import { ScanStatus } from "@/components/compliance/ScanStatus";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function CompliancePage() {
   const [
@@ -94,7 +95,7 @@ export default async function CompliancePage() {
               {upcomingDeadlines.map((e) => (
                 <li key={e.id} className="text-sm text-[var(--dpf-text)] flex justify-between">
                   <span>{e.title}</span>
-                  <span className="text-[var(--dpf-muted)]">{new Date(e.startAt).toLocaleDateString()}</span>
+                  <LocalTime value={e.startAt} mode="date" className="text-[var(--dpf-muted)]" />
                 </li>
               ))}
             </ul>
@@ -110,7 +111,7 @@ export default async function CompliancePage() {
               {recentActivity.map((log) => (
                 <li key={log.id} className="text-sm text-[var(--dpf-muted)]">
                   <span className="text-[var(--dpf-text)]">{log.performedBy?.displayName ?? log.agentId ?? "System"}</span>{" "}
-                  {log.action} {log.entityType} — {new Date(log.performedAt).toLocaleString()}
+                  {log.action} {log.entityType} — <LocalTime value={log.performedAt} />
                 </li>
               ))}
             </ul>

--- a/apps/web/app/(shell)/compliance/policies/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/policies/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { transitionPolicyStatus } from "@/lib/actions/policy";
 import { EditPolicyForm } from "@/components/compliance/EditPolicyForm";
 import { LinkPolicyObligationForm } from "@/components/compliance/LinkPolicyObligationForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -216,7 +217,7 @@ export default async function PolicyDetailPage({ params }: Props) {
           {policy.acknowledgments.map((a) => (
             <div key={a.id} className="flex justify-between text-sm">
               <span className="text-[var(--dpf-text)]">{a.employeeProfile.displayName}</span>
-              <span className="text-[var(--dpf-muted)]">v{a.policyVersion} — {new Date(a.acknowledgedAt).toLocaleDateString()}</span>
+              <span className="text-[var(--dpf-muted)]">v{a.policyVersion} — <LocalTime value={a.acknowledgedAt} mode="date" /></span>
             </div>
           ))}
         </div>

--- a/apps/web/app/(shell)/compliance/posture/page.tsx
+++ b/apps/web/app/(shell)/compliance/posture/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/compliance/posture/page.tsx
 import { getCompliancePosture, getPostureTrend, takeComplianceSnapshot } from "@/lib/actions/reporting";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function PosturePage() {
   const [posture, trend] = await Promise.all([
@@ -85,7 +86,7 @@ export default async function PosturePage() {
               <tbody>
                 {trend.map((s) => (
                   <tr key={s.snapshotId} className="border-b border-[var(--dpf-border)]">
-                    <td className="py-2 pr-4 text-[var(--dpf-text)]">{new Date(s.takenAt).toLocaleDateString()}</td>
+                    <td className="py-2 pr-4 text-[var(--dpf-text)]"><LocalTime value={s.takenAt} mode="date" /></td>
                     <td className="py-2 pr-4">
                       <span className={`font-semibold ${s.overallScore >= 80 ? "text-green-400" : s.overallScore >= 60 ? "text-yellow-400" : "text-red-400"}`}>
                         {s.overallScore}

--- a/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CreateObligationForm } from "@/components/compliance/CreateObligationForm";
 import { EditRegulationForm } from "@/components/compliance/EditRegulationForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -62,7 +63,7 @@ export default async function RegulationDetailPage({ params }: Props) {
         {regulation.effectiveDate && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Effective Date</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(regulation.effectiveDate).toLocaleDateString()}</p>
+            <LocalTime value={regulation.effectiveDate} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
       </div>

--- a/apps/web/app/(shell)/compliance/risks/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/risks/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { LinkRiskControlForm } from "@/components/compliance/LinkRiskControlForm";
 import { UnlinkRiskControlButton } from "@/components/compliance/UnlinkRiskControlButton";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -93,12 +94,12 @@ export default async function RiskDetailPage({ params }: Props) {
         )}
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Assessed At</p>
-          <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(risk.assessedAt).toLocaleDateString()}</p>
+          <LocalTime value={risk.assessedAt} mode="date" className="text-sm font-semibold text-[var(--dpf-text)]" />
         </div>
         {risk.nextReviewDate && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Next Review</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(risk.nextReviewDate).toLocaleDateString()}</p>
+            <LocalTime value={risk.nextReviewDate} utc className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -190,7 +191,7 @@ export default async function RiskDetailPage({ params }: Props) {
                       </span>
                     </div>
                   </div>
-                  <span className="text-xs text-[var(--dpf-muted)]">{new Date(inc.occurredAt).toLocaleDateString()}</span>
+                  <LocalTime value={inc.occurredAt} mode="date" className="text-xs text-[var(--dpf-muted)]" />
                 </div>
               </Link>
             );

--- a/apps/web/app/(shell)/compliance/submissions/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/submissions/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getSubmission, transitionSubmissionStatus } from "@/lib/actions/reporting";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -91,7 +92,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Due Date</p>
             <p className={`text-sm font-semibold ${daysRemaining !== null && daysRemaining < 0 ? "text-red-400" : daysRemaining !== null && daysRemaining < 7 ? "text-yellow-400" : "text-[var(--dpf-text)]"}`}>
-              {new Date(submission.dueDate).toLocaleDateString()}
+              <LocalTime value={submission.dueDate} utc />
               {daysRemaining !== null && (
                 <span className="text-xs ml-1">({daysRemaining < 0 ? `${Math.abs(daysRemaining)}d overdue` : `${daysRemaining}d remaining`})</span>
               )}
@@ -101,7 +102,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
         {submission.submittedAt && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Submitted</p>
-            <p className="text-sm font-semibold text-[var(--dpf-text)]">{new Date(submission.submittedAt).toLocaleDateString()}</p>
+            <LocalTime value={submission.submittedAt} mode="date" className="text-sm font-semibold text-[var(--dpf-text)]" />
           </div>
         )}
         {submission.confirmationRef && (

--- a/apps/web/app/(shell)/compliance/submissions/page.tsx
+++ b/apps/web/app/(shell)/compliance/submissions/page.tsx
@@ -3,6 +3,7 @@ import { SUBMISSION_STATUSES, SUBMISSION_TYPES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CreateSubmissionForm } from "@/components/compliance/CreateSubmissionForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLORS: Record<string, string> = {
   draft: "bg-gray-900/30 text-gray-400",
@@ -92,13 +93,13 @@ export default async function SubmissionsPage({ searchParams }: Props) {
                 <div className="text-right text-xs text-[var(--dpf-muted)]">
                   {s.dueDate && (
                     <p className={daysRemaining !== null && daysRemaining < 0 ? "text-red-400" : daysRemaining !== null && daysRemaining < 7 ? "text-yellow-400" : undefined}>
-                      Due: {new Date(s.dueDate).toLocaleDateString()}
+                      Due: <LocalTime value={s.dueDate} utc />
                       {daysRemaining !== null && (
                         <span className="ml-1">({daysRemaining < 0 ? `${Math.abs(daysRemaining)}d overdue` : `${daysRemaining}d`})</span>
                       )}
                     </p>
                   )}
-                  {s.submittedAt && <p>Submitted: {new Date(s.submittedAt).toLocaleDateString()}</p>}
+                  {s.submittedAt && <p>Submitted: <LocalTime value={s.submittedAt} mode="date" /></p>}
                   {s.confirmationRef && <p>Ref: {s.confirmationRef}</p>}
                   {s.submittedBy && <p>{s.submittedBy.displayName}</p>}
                 </div>

--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
 import { getAccountStatusMeta } from "@/lib/crm/presentation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const ACTIVITY_ICONS: Record<string, string> = {
   note: "📝",
@@ -276,7 +277,7 @@ export default async function AccountDetailPage({
                       </p>
                     )}
                     <div className="flex gap-2 mt-1 text-[9px] text-[var(--dpf-muted)]">
-                      <span>{new Date(act.createdAt).toLocaleString()}</span>
+                      <LocalTime value={act.createdAt} />
                       {act.createdBy && <span>by {act.createdBy.email}</span>}
                       {act.opportunity && (
                         <Link

--- a/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/engagements/page.tsx
@@ -6,6 +6,7 @@ import { createEngagementFromSignalForm } from "@/lib/actions/crm";
 import { getAcquisitionSignalWorkspace } from "@/lib/crm/acquisition-signal-data";
 import { formatAcquisitionSourceLabel } from "@/lib/crm/acquisition-signals";
 import { getEngagementStatusMeta } from "@/lib/crm/presentation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 async function routeSignalToEngagement(formData: FormData) {
   "use server";
@@ -100,9 +101,11 @@ export default async function EngagementsPage() {
                   </p>
                 ) : null}
               </div>
-              <p className="text-[9px] text-[var(--dpf-muted)] shrink-0">
-                {new Date(e.createdAt).toLocaleDateString()}
-              </p>
+              <LocalTime
+                value={e.createdAt}
+                mode="date"
+                className="text-[9px] text-[var(--dpf-muted)] shrink-0"
+              />
             </div>
           );
         })}

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx
@@ -7,6 +7,7 @@ import { PipelineStageInspector } from "@/components/customer/PipelineStageInspe
 import { updateOpportunityStageFromForm } from "@/lib/actions/crm";
 import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
 import { getOpportunityStageMeta, getQuoteStatusMeta } from "@/lib/crm/presentation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const ACTIVITY_ICONS: Record<string, string> = {
   note: "📝", call: "📞", email: "📧", meeting: "📅", task: "☑️",
@@ -104,9 +105,11 @@ export default async function OpportunityDetailPage({
         {opportunity.expectedClose && (
           <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)]">
             <p className="text-[10px] text-[var(--dpf-muted)]">Expected Close</p>
-            <p className="text-sm text-[var(--dpf-text)]">
-              {new Date(opportunity.expectedClose).toLocaleDateString()}
-            </p>
+            <LocalTime
+              value={opportunity.expectedClose}
+              utc
+              className="text-sm text-[var(--dpf-text)]"
+            />
           </div>
         )}
         {opportunity.assignedTo && (
@@ -138,7 +141,7 @@ export default async function OpportunityDetailPage({
                       <p className="text-[10px] text-[var(--dpf-muted)] mt-0.5 line-clamp-2">{act.body}</p>
                     )}
                     <div className="flex gap-2 mt-1 text-[9px] text-[var(--dpf-muted)]">
-                      <span>{new Date(act.createdAt).toLocaleString()}</span>
+                      <LocalTime value={act.createdAt} />
                       {act.createdBy && <span>by {act.createdBy.email}</span>}
                     </div>
                   </div>

--- a/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { CRM_TONE_CLASSES, getQuoteStatusMeta } from "@/lib/crm/presentation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function QuotesPage() {
   const quotes = await prisma.quote.findMany({
@@ -63,7 +64,7 @@ export default async function QuotesPage() {
                     {q.currency} {Number(q.totalAmount).toLocaleString()}
                   </p>
                   <p className="text-[9px] text-[var(--dpf-muted)]">
-                    Valid until {new Date(q.validUntil).toLocaleDateString()}
+                    Valid until <LocalTime value={q.validUntil} utc />
                   </p>
                 </div>
               </div>

--- a/apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { CRM_TONE_CLASSES, getSalesOrderStatusMeta } from "@/lib/crm/presentation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function SalesOrdersPage() {
   const orders = await prisma.salesOrder.findMany({
@@ -53,9 +54,11 @@ export default async function SalesOrdersPage() {
                 <p className="text-sm font-mono font-semibold text-[var(--dpf-text)]">
                   {o.currency} {Number(o.totalAmount).toLocaleString()}
                 </p>
-                <p className="text-[9px] text-[var(--dpf-muted)]">
-                  {new Date(o.createdAt).toLocaleDateString()}
-                </p>
+                <LocalTime
+                  value={o.createdAt}
+                  mode="date"
+                  className="text-[9px] text-[var(--dpf-muted)]"
+                />
               </div>
             </div>
           );

--- a/apps/web/app/(shell)/ea/views/page.tsx
+++ b/apps/web/app/(shell)/ea/views/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { EaTabNav } from "@/components/ea/EaTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const LAYOUT_LABELS: Record<string, string> = {
   graph:    "Graph",
@@ -62,7 +63,7 @@ export default async function EaViewsPage() {
                 <div className="flex items-center gap-3 text-[10px] text-[var(--dpf-muted)]">
                   <span>{SCOPE_LABELS[v.scopeType] ?? v.scopeType}{v.scopeRef ? ` · ${v.scopeRef}` : ""}</span>
                   <span>{v._count.viewElements} element{v._count.viewElements !== 1 ? "s" : ""}</span>
-                  <span>{new Date(v.createdAt).toLocaleDateString()}</span>
+                  <LocalTime value={v.createdAt} mode="date" />
                 </div>
               </div>
             </Link>

--- a/apps/web/app/(shell)/finance/assets/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/assets/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { AssetDisposalForm } from "@/components/finance/AssetDisposalForm";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const CATEGORY_COLOURS: Record<string, string> = {
   equipment: "#38bdf8",
@@ -117,7 +118,7 @@ export default async function AssetDetailPage({ params }: Props) {
         <div className="p-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
           <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-1">Purchase Date</p>
           <p className="text-sm text-[var(--dpf-text)]">
-            {new Date(asset.purchaseDate).toLocaleDateString("en-GB")}
+            <LocalTime value={asset.purchaseDate} utc />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">

--- a/apps/web/app/(shell)/finance/banking/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/banking/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getBankAccount, getReconciliationSummary } from "@/lib/actions/banking"
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const MATCH_STATUS_COLOURS: Record<string, string> = {
   unmatched: "#fbbf24",
@@ -97,9 +98,11 @@ export default async function BankAccountDetailPage({ params }: Props) {
           },
           {
             label: "Last Reconciled",
-            value: account.lastReconciledAt
-              ? new Date(account.lastReconciledAt).toLocaleDateString("en-GB")
-              : "Never",
+            value: account.lastReconciledAt ? (
+              <LocalTime value={account.lastReconciledAt} mode="date" />
+            ) : (
+              "Never"
+            ),
           },
           {
             label: "Bank Rules",
@@ -202,7 +205,7 @@ export default async function BankAccountDetailPage({ params }: Props) {
                       className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
                     >
                       <td className="px-4 py-2.5 text-[var(--dpf-muted)] whitespace-nowrap">
-                        {new Date(tx.transactionDate).toLocaleDateString("en-GB")}
+                        <LocalTime value={tx.transactionDate} utc />
                       </td>
                       <td className="px-4 py-2.5 text-[var(--dpf-text)] max-w-[200px] truncate">
                         {tx.description}

--- a/apps/web/app/(shell)/finance/banking/page.tsx
+++ b/apps/web/app/(shell)/finance/banking/page.tsx
@@ -3,6 +3,7 @@ import { listBankAccounts } from "@/lib/actions/banking";
 import Link from "next/link";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function BankingPage() {
   const accounts = await listBankAccounts();
@@ -124,9 +125,14 @@ export default async function BankingPage() {
                     </span>
                   </div>
                   <p className="text-[9px] text-[var(--dpf-muted)]">
-                    {account.lastReconciledAt
-                      ? `Reconciled ${new Date(account.lastReconciledAt).toLocaleDateString("en-GB")}`
-                      : "Never reconciled"}
+                    {account.lastReconciledAt ? (
+                      <>
+                        Reconciled{" "}
+                        <LocalTime value={account.lastReconciledAt} mode="date" />
+                      </>
+                    ) : (
+                      "Never reconciled"
+                    )}
                   </p>
                 </div>
               </Link>

--- a/apps/web/app/(shell)/finance/bills/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { SubmitBillButton } from "@/components/finance/SubmitBillButton";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -70,8 +71,8 @@ export default async function BillDetailPage({ params }: Props) {
       {/* Metadata row */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {[
-          { label: "Issue Date", value: new Date(bill.issueDate).toLocaleDateString("en-GB") },
-          { label: "Due Date", value: new Date(bill.dueDate).toLocaleDateString("en-GB") },
+          { label: "Issue Date", value: <LocalTime value={bill.issueDate} utc /> },
+          { label: "Due Date", value: <LocalTime value={bill.dueDate} utc /> },
           { label: "Currency", value: bill.currency },
           { label: "Invoice Ref", value: bill.invoiceRef ?? "—" },
         ].map(({ label, value }) => (
@@ -175,7 +176,7 @@ export default async function BillDetailPage({ params }: Props) {
                     </span>
                     {approval.respondedAt && (
                       <p className="text-[9px] text-[var(--dpf-muted)]">
-                        {new Date(approval.respondedAt).toLocaleDateString("en-GB")}
+                        <LocalTime value={approval.respondedAt} mode="date" />
                       </p>
                     )}
                   </div>

--- a/apps/web/app/(shell)/finance/bills/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/page.tsx
@@ -4,6 +4,7 @@ import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -148,7 +149,7 @@ export default async function BillsPage({ searchParams }: Props) {
                       </span>
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {new Date(bill.dueDate).toLocaleDateString("en-GB")}
+                      <LocalTime value={bill.dueDate} utc />
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(bill.totalAmount)}

--- a/apps/web/app/(shell)/finance/expense-claims/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/expense-claims/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ExpenseClaimActions } from "@/components/finance/ExpenseClaimActions";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -86,9 +87,11 @@ export default async function ExpenseClaimDetailPage({ params }: Props) {
         {[
           {
             label: "Submitted",
-            value: claim.submittedAt
-              ? new Date(claim.submittedAt).toLocaleDateString("en-GB")
-              : "—",
+            value: claim.submittedAt ? (
+              <LocalTime value={claim.submittedAt} mode="date" />
+            ) : (
+              "—"
+            ),
           },
           {
             label: "Approved By",
@@ -96,9 +99,11 @@ export default async function ExpenseClaimDetailPage({ params }: Props) {
           },
           {
             label: "Approved Date",
-            value: claim.approvedAt
-              ? new Date(claim.approvedAt).toLocaleDateString("en-GB")
-              : "—",
+            value: claim.approvedAt ? (
+              <LocalTime value={claim.approvedAt} mode="date" />
+            ) : (
+              "—"
+            ),
           },
           {
             label: "Total Amount",
@@ -152,7 +157,7 @@ export default async function ExpenseClaimDetailPage({ params }: Props) {
                     className="border-b border-[var(--dpf-border)] last:border-0"
                   >
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {new Date(item.date).toLocaleDateString("en-GB")}
+                      <LocalTime value={item.date} utc />
                     </td>
                     <td className="px-4 py-2.5">
                       <span

--- a/apps/web/app/(shell)/finance/expense-claims/page.tsx
+++ b/apps/web/app/(shell)/finance/expense-claims/page.tsx
@@ -5,6 +5,7 @@ import { listExpenseClaims } from "@/lib/actions/expenses";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 const STATUS_COLOURS: Record<string, string> = {
@@ -180,9 +181,11 @@ export default async function ExpenseClaimsPage({ searchParams }: Props) {
                       </span>
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {claim.submittedAt
-                        ? new Date(claim.submittedAt).toLocaleDateString("en-GB")
-                        : "—"}
+                      {claim.submittedAt ? (
+                        <LocalTime value={claim.submittedAt} mode="date" />
+                      ) : (
+                        "—"
+                      )}
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(claim.totalAmount)}

--- a/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { InvoiceSendButton } from "@/components/finance/InvoiceSendButton";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -116,13 +117,13 @@ export default async function InvoiceDetailPage({ params }: Props) {
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Issue Date</p>
           <p className="text-sm font-semibold text-[var(--dpf-text)]">
-            {new Date(invoice.issueDate).toLocaleDateString("en-GB")}
+            <LocalTime value={invoice.issueDate} utc />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Due Date</p>
           <p className="text-sm font-semibold text-[var(--dpf-text)]">
-            {new Date(invoice.dueDate).toLocaleDateString("en-GB")}
+            <LocalTime value={invoice.dueDate} utc />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -267,11 +268,11 @@ export default async function InvoiceDetailPage({ params }: Props) {
                       {alloc.payment.method}
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {alloc.payment.receivedAt
-                        ? new Date(alloc.payment.receivedAt).toLocaleDateString(
-                            "en-GB"
-                          )
-                        : "—"}
+                      {alloc.payment.receivedAt ? (
+                        <LocalTime value={alloc.payment.receivedAt} mode="date" />
+                      ) : (
+                        "—"
+                      )}
                     </td>
                     <td className="px-4 py-2.5 text-right font-semibold text-[#4ade80]">
                       {sym}{formatMoney(Number(alloc.amount))}

--- a/apps/web/app/(shell)/finance/invoices/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/page.tsx
@@ -4,6 +4,7 @@ import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -182,7 +183,7 @@ export default async function InvoicesPage({ searchParams }: Props) {
                       </span>
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {new Date(inv.dueDate).toLocaleDateString("en-GB")}
+                      <LocalTime value={inv.dueDate} utc />
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(Number(inv.totalAmount))}

--- a/apps/web/app/(shell)/finance/my-expenses/page.tsx
+++ b/apps/web/app/(shell)/finance/my-expenses/page.tsx
@@ -5,6 +5,7 @@ import { listExpenseClaims } from "@/lib/actions/expenses";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 const STATUS_COLOURS: Record<string, string> = {
@@ -111,9 +112,11 @@ export default async function MyExpensesPage() {
                       </span>
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {claim.submittedAt
-                        ? new Date(claim.submittedAt).toLocaleDateString("en-GB")
-                        : "—"}
+                      {claim.submittedAt ? (
+                        <LocalTime value={claim.submittedAt} mode="date" />
+                      ) : (
+                        "—"
+                      )}
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(claim.totalAmount)}

--- a/apps/web/app/(shell)/finance/payment-runs/page.tsx
+++ b/apps/web/app/(shell)/finance/payment-runs/page.tsx
@@ -2,6 +2,7 @@
 import { listPaymentRuns, listBills } from "@/lib/actions/ap";
 import { PaymentRunBuilder } from "@/components/finance/PaymentRunBuilder";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 export default async function PaymentRunsPage() {
@@ -94,7 +95,7 @@ export default async function PaymentRunsPage() {
                         </span>
                       </td>
                       <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                        {run.receivedAt ? new Date(run.receivedAt).toLocaleDateString("en-GB") : "—"}
+                        <LocalTime value={run.receivedAt} mode="date" />
                       </td>
                       <td className="px-4 py-2.5">
                         <span

--- a/apps/web/app/(shell)/finance/payments/page.tsx
+++ b/apps/web/app/(shell)/finance/payments/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@dpf/db";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 type Props = { searchParams: Promise<{ direction?: string }> };
@@ -167,9 +168,10 @@ export default async function PaymentsPage({ searchParams }: Props) {
                       )}
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {pmt.receivedAt
-                        ? new Date(pmt.receivedAt).toLocaleDateString("en-GB")
-                        : new Date(pmt.createdAt).toLocaleDateString("en-GB")}
+                      <LocalTime
+                        value={pmt.receivedAt ?? pmt.createdAt}
+                        mode="date"
+                      />
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(Number(pmt.amount))}

--- a/apps/web/app/(shell)/finance/purchase-orders/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/purchase-orders/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { POActionButtons } from "@/components/finance/POActionButtons";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -75,14 +76,12 @@ export default async function PODetailPage({ params }: Props) {
           { label: "Currency", value: po.currency },
           {
             label: "Delivery Date",
-            value: po.deliveryDate
-              ? new Date(po.deliveryDate).toLocaleDateString("en-GB")
-              : "—",
+            value: <LocalTime value={po.deliveryDate} utc />,
           },
           { label: "Terms", value: po.terms ?? "—" },
           {
             label: "Created",
-            value: new Date(po.createdAt).toLocaleDateString("en-GB"),
+            value: <LocalTime value={po.createdAt} mode="date" />,
           },
         ].map(({ label, value }) => (
           <div

--- a/apps/web/app/(shell)/finance/purchase-orders/page.tsx
+++ b/apps/web/app/(shell)/finance/purchase-orders/page.tsx
@@ -3,6 +3,7 @@ import { listPurchaseOrders } from "@/lib/actions/ap";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 const STATUS_COLOURS: Record<string, string> = {
@@ -147,9 +148,7 @@ export default async function PurchaseOrdersPage({ searchParams }: Props) {
                       </span>
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {po.deliveryDate
-                        ? new Date(po.deliveryDate).toLocaleDateString("en-GB")
-                        : "—"}
+                      <LocalTime value={po.deliveryDate} utc />
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                       {sym}{formatMoney(po.totalAmount)}

--- a/apps/web/app/(shell)/finance/recurring/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/recurring/[id]/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/(shell)/finance/recurring/[id]/page.tsx
 import { getRecurringSchedule } from "@/lib/actions/recurring";
 import { ScheduleStatusButtons } from "@/components/finance/ScheduleStatusButtons";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -105,21 +106,19 @@ export default async function RecurringDetailPage({ params }: Props) {
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Start Date</p>
           <p className="text-sm font-semibold text-[var(--dpf-text)]">
-            {new Date(schedule.startDate).toLocaleDateString("en-GB")}
+            <LocalTime value={schedule.startDate} utc />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">End Date</p>
           <p className="text-sm font-semibold text-[var(--dpf-text)]">
-            {schedule.endDate
-              ? new Date(schedule.endDate).toLocaleDateString("en-GB")
-              : "Ongoing"}
+            <LocalTime value={schedule.endDate} utc fallback="Ongoing" />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
           <p className="text-xs text-[var(--dpf-muted)]">Next Invoice</p>
           <p className="text-sm font-semibold text-[var(--dpf-text)]">
-            {new Date(schedule.nextInvoiceDate).toLocaleDateString("en-GB")}
+            <LocalTime value={schedule.nextInvoiceDate} utc />
           </p>
         </div>
         <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
@@ -242,10 +241,10 @@ export default async function RecurringDetailPage({ params }: Props) {
                         </Link>
                       </td>
                       <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                        {new Date(inv.issueDate).toLocaleDateString("en-GB")}
+                        <LocalTime value={inv.issueDate} utc />
                       </td>
                       <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                        {new Date(inv.dueDate).toLocaleDateString("en-GB")}
+                        <LocalTime value={inv.dueDate} utc />
                       </td>
                       <td className="px-4 py-2.5">
                         <span

--- a/apps/web/app/(shell)/finance/recurring/page.tsx
+++ b/apps/web/app/(shell)/finance/recurring/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/(shell)/finance/recurring/page.tsx
 import { listRecurringSchedules } from "@/lib/actions/recurring";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 const SCHEDULE_STATUS_COLOURS: Record<string, string> = {
@@ -162,9 +163,7 @@ export default async function RecurringPage({ searchParams }: Props) {
                       {sched.currency} {formatMoney(Number(sched.amount))}
                     </td>
                     <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      {new Date(sched.nextInvoiceDate).toLocaleDateString(
-                        "en-GB",
-                      )}
+                      <LocalTime value={sched.nextInvoiceDate} utc />
                     </td>
                     <td className="px-4 py-2.5">
                       <span

--- a/apps/web/app/(shell)/finance/reports/cash-flow/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/cash-flow/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/finance/reports/cash-flow/page.tsx
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { getCashFlowReport } from "@/lib/actions/reports";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
@@ -102,8 +103,8 @@ export default async function CashFlowPage({
           </span>
         </p>
         <p className="text-xs text-[var(--dpf-muted)] mt-1">
-          {startDate.toLocaleDateString("en-GB")} –{" "}
-          {endDate.toLocaleDateString("en-GB")}
+          <LocalTime value={startDate} utc /> –{" "}
+          <LocalTime value={endDate} utc />
         </p>
       </div>
 

--- a/apps/web/app/(shell)/finance/reports/outstanding/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/outstanding/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/finance/reports/outstanding/page.tsx
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { getOutstandingInvoicesReport } from "@/lib/actions/reports";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
@@ -111,7 +112,7 @@ export default async function OutstandingInvoicesPage() {
                       {formatMoney(inv.amountDue)}
                     </td>
                     <td className="px-4 py-2.5 text-right text-[var(--dpf-muted)]">
-                      {new Date(inv.dueDate).toLocaleDateString("en-GB")}
+                      <LocalTime value={inv.dueDate} utc />
                     </td>
                     <td
                       className="px-4 py-2.5 text-right font-semibold"

--- a/apps/web/app/(shell)/finance/reports/profit-loss/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/profit-loss/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/finance/reports/profit-loss/page.tsx
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { getProfitAndLoss } from "@/lib/actions/reports";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
@@ -101,8 +102,8 @@ export default async function ProfitAndLossPage({
           {profitLabel}
         </p>
         <p className="text-xs text-[var(--dpf-muted)] mt-1">
-          {startDate.toLocaleDateString("en-GB")} –{" "}
-          {endDate.toLocaleDateString("en-GB")}
+          <LocalTime value={startDate} utc /> –{" "}
+          <LocalTime value={endDate} utc />
         </p>
       </div>
 

--- a/apps/web/app/(shell)/finance/reports/vat-summary/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/vat-summary/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/finance/reports/vat-summary/page.tsx
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { getVatSummary } from "@/lib/actions/reports";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
@@ -104,8 +105,8 @@ export default async function VatSummaryPage({
           {summaryText}
         </p>
         <p className="text-xs text-[var(--dpf-muted)] mt-1">
-          {startDate.toLocaleDateString("en-GB")} –{" "}
-          {endDate.toLocaleDateString("en-GB")}
+          <LocalTime value={startDate} utc /> –{" "}
+          <LocalTime value={endDate} utc />
         </p>
       </div>
 

--- a/apps/web/app/(shell)/finance/settings/currency/page.tsx
+++ b/apps/web/app/(shell)/finance/settings/currency/page.tsx
@@ -2,6 +2,7 @@
 import { getOrgSettings } from "@/lib/actions/currency";
 import { prisma } from "@dpf/db";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 import { BaseCurrencySelector } from "@/components/finance/BaseCurrencySelector";
 import { FetchRatesButton } from "@/components/finance/FetchRatesButton";
@@ -138,7 +139,7 @@ export default async function CurrencySettingsPage() {
                     {Number(rate.rate).toFixed(4)}
                   </td>
                   <td className="py-2.5 text-right text-[var(--dpf-muted)]">
-                    {new Date(rate.fetchedAt).toLocaleDateString("en-GB")}
+                    <LocalTime value={rate.fetchedAt} mode="date" />
                   </td>
                 </tr>
               ))}

--- a/apps/web/app/(shell)/finance/suppliers/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/suppliers/[id]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getAiSupplierFinanceDetail } from "@/lib/finance/ai-provider-finance";
 import { AiSupplierFinancePanel } from "@/components/finance/AiSupplierFinancePanel";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const BILL_STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -153,9 +154,7 @@ export default async function SupplierDetailPage({ params }: Props) {
                         </span>
                       </td>
                       <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                        {bill.dueDate
-                          ? new Date(bill.dueDate).toLocaleDateString("en-GB")
-                          : "—"}
+                        <LocalTime value={bill.dueDate} utc />
                       </td>
                       <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
                         {sym}{formatMoney(bill.totalAmount)}

--- a/apps/web/app/(shell)/knowledge/[articleId]/page.tsx
+++ b/apps/web/app/(shell)/knowledge/[articleId]/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { KnowledgeCategoryBadge } from "@/components/knowledge/KnowledgeCategoryBadge";
 import { StalenessIndicator } from "@/components/knowledge/StalenessIndicator";
 import { KnowledgeArticleActions } from "@/components/knowledge/KnowledgeArticleActions";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   params: Promise<{ articleId: string }>;
@@ -86,9 +87,9 @@ export default async function KnowledgeArticleDetailPage({ params }: Props) {
           <h1 className="text-lg font-semibold text-[var(--dpf-text)]">{article.title}</h1>
           <div className="flex items-center gap-3 mt-1 text-[10px] text-[var(--dpf-muted)]">
             <span>By {authorName}</span>
-            <span>Updated {article.updatedAt.toLocaleDateString()}</span>
+            <span>Updated <LocalTime value={article.updatedAt} mode="date" /></span>
             {article.lastReviewedAt && (
-              <span>Reviewed {article.lastReviewedAt.toLocaleDateString()}</span>
+              <span>Reviewed <LocalTime value={article.lastReviewedAt} mode="date" /></span>
             )}
           </div>
         </div>
@@ -163,7 +164,7 @@ export default async function KnowledgeArticleDetailPage({ params }: Props) {
                 <span className="font-medium text-[var(--dpf-text)]">v{rev.version}</span>
                 <span>{rev.changeSummary ?? "No summary"}</span>
                 <span className="ml-auto">{rev.createdBy?.email?.split("@")[0] ?? "system"}</span>
-                <span>{rev.createdAt.toLocaleDateString()}</span>
+                <LocalTime value={rev.createdAt} mode="date" />
               </div>
             ))}
           </div>

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -18,6 +18,8 @@ import { SetupOverlay } from "@/components/setup/SetupOverlay";
 import { getShellNavSections } from "@/lib/permissions";
 import { AppRail } from "@/components/shell/AppRail";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
+import { resolveHomePhoneCountry } from "@/lib/phone-country.server";
+import { PhoneCountryProvider } from "@/components/ui/PhoneCountryContext";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   // First-run check — redirect to setup if no org exists.
@@ -37,23 +39,25 @@ export default async function ShellLayout({ children }: { children: React.ReactN
 
   const user = session.user;
 
-  const [latestDiscoveryRun, activeBranding, organization, useUnifiedCoworker] = await Promise.all([
-    prisma.discoveryRun.findFirst({
-      orderBy: { startedAt: "desc" },
-      select: { id: true },
-    }),
-    prisma.brandingConfig.findUnique({
-      where: { scope: "organization" },
-      select: {
-        logoUrlLight: true,
-        tokens: true,
-      },
-    }),
-    prisma.organization.findFirst({
-      select: { name: true, logoUrl: true },
-    }),
-    isUnifiedCoworkerEnabled(),
-  ]);
+  const [latestDiscoveryRun, activeBranding, organization, useUnifiedCoworker, phoneCountry] =
+    await Promise.all([
+      prisma.discoveryRun.findFirst({
+        orderBy: { startedAt: "desc" },
+        select: { id: true },
+      }),
+      prisma.brandingConfig.findUnique({
+        where: { scope: "organization" },
+        select: {
+          logoUrlLight: true,
+          tokens: true,
+        },
+      }),
+      prisma.organization.findFirst({
+        select: { name: true, logoUrl: true },
+      }),
+      isUnifiedCoworkerEnabled(),
+      resolveHomePhoneCountry(),
+    ]);
 
   if (!latestDiscoveryRun) {
     await executeBootstrapDiscovery(prisma as never, {
@@ -126,7 +130,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       });
 
   return (
-    <>
+    <PhoneCountryProvider country={phoneCountry}>
       {brandingCss && <style dangerouslySetInnerHTML={{ __html: brandingCss }} />}
       <div className="min-h-screen flex flex-col bg-[var(--dpf-bg)]">
         {activeSetup && (
@@ -200,6 +204,6 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         <QueueFlusher />
         <ModelWarmup />
       </div>
-    </>
+    </PhoneCountryProvider>
   );
 }

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -7,6 +7,7 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { getAgentGaidMap } from "@/lib/identity/principal-linking";
 import { AgentModelRoutingCard } from "@/components/platform/AgentModelRoutingCard";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const TIER_LABELS: Record<number, string> = {
   1: "Orchestrator",
@@ -280,7 +281,7 @@ export default async function AgentDetailPage({
                       {p.evaluationCount > 0 ? `${((p.successCount / p.evaluationCount) * 100).toFixed(0)}%` : "n/a"}
                     </td>
                     <td style={tdStyle}>{p.profileConfidence}</td>
-                    <td style={tdStyle}>{p.lastEvaluatedAt ? new Date(p.lastEvaluatedAt).toLocaleDateString() : "never"}</td>
+                    <td style={tdStyle}>{p.lastEvaluatedAt ? <LocalTime value={p.lastEvaluatedAt} mode="date" /> : "never"}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -15,6 +15,7 @@ import { getAllCliPoolStatuses } from "@/lib/routing/cli-pool-status";
 import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
 import { getRecentBudgetEvents, countRecentRejections } from "@/lib/inference/budget-events-data";
 import { AgentBudgetEventsPanel } from "@/components/platform/AgentBudgetEventsPanel";
+import { LocalTime } from "@/components/ui/LocalTime";
 import Link from "next/link";
 
 
@@ -68,7 +69,7 @@ export default async function ProvidersPage() {
         <h1 style={{ fontSize: 18, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>Providers &amp; Routing</h1>
         <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 2 }}>
           {aiProviders.length} provider{aiProviders.length !== 1 ? "s" : ""} registered
-          {lastSync ? ` · last synced ${new Date(lastSync).toLocaleDateString()}` : ""}
+          {lastSync ? <> · last synced <LocalTime value={lastSync} mode="date" /></> : ""}
         </p>
       </div>
 

--- a/apps/web/app/(shell)/platform/tools/catalog/sync/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/catalog/sync/page.tsx
@@ -4,6 +4,7 @@
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { McpSyncButton } from "@/components/platform/McpSyncButton";
 import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
 import { getScheduledJobs } from "@/lib/ai-provider-data";
@@ -50,7 +51,7 @@ export default async function IntegrationsSyncPage() {
           <div className="border rounded-lg p-4 space-y-1 text-sm">
             <p>
               Last sync:{" "}
-              <strong>{new Date(lastSync.startedAt).toLocaleString()}</strong> —{" "}
+              <strong><LocalTime value={lastSync.startedAt} /></strong> —{" "}
               <span
                 className={
                   lastSync.status === "success"
@@ -109,7 +110,7 @@ export default async function IntegrationsSyncPage() {
           <tbody>
             {recentSyncs.map((s) => (
               <tr key={s.id} className="border-t">
-                <td className="p-2">{new Date(s.startedAt).toLocaleDateString()}</td>
+                <td className="p-2"><LocalTime value={s.startedAt} mode="date" /></td>
                 <td className="p-2">{s.triggeredBy}</td>
                 <td className="p-2">{s.totalFetched ?? "—"}</td>
                 <td className="p-2">{s.totalNew ?? "—"}</td>

--- a/apps/web/app/(shell)/platform/tools/integrations/communications/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/communications/page.tsx
@@ -1,5 +1,6 @@
 import { Bell, Building2, MessagesSquare } from "lucide-react";
 import { listCommunicationChannelBindings } from "@/lib/communications/channel-binding-store";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { SpeechToTextCard } from "@/components/admin/SpeechToTextCard";
 
 const groups = [
@@ -163,7 +164,7 @@ export default async function CommunicationsPage() {
                     {binding.allowedUrgencies.join(", ")}
                   </span>
                   <span className="text-xs text-[var(--dpf-muted)]">
-                    {binding.lastTestedAt ? `Tested ${formatBindingDate(binding.lastTestedAt)}` : "Not tested"}
+                    {binding.lastTestedAt ? <>Tested <LocalTime value={binding.lastTestedAt} mode="date" /></> : "Not tested"}
                   </span>
                   {binding.lastError && (
                     <span className="basis-full text-xs text-[var(--dpf-muted)] lg:text-right">
@@ -187,12 +188,4 @@ function BindingMetric({ label, value }: { label: string; value: string }) {
       <dd className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">{value}</dd>
     </div>
   );
-}
-
-function formatBindingDate(value: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(value));
 }

--- a/apps/web/app/(shell)/platform/tools/integrations/facebook-lead-ads/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/facebook-lead-ads/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -168,7 +169,7 @@ function FacebookLeadAdsPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -261,19 +262,6 @@ function hasContent(content: React.ReactNode): boolean {
   return Boolean(content);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 function formatLeadSecondary(lead: {
   formId: string | null;

--- a/apps/web/app/(shell)/platform/tools/integrations/facebook-pages/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/facebook-pages/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -168,7 +169,7 @@ function FacebookPagesPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -267,16 +268,3 @@ function formatMetric(value: number | null): string | null {
   return new Intl.NumberFormat().format(value);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/integrations/google-business-profile/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/google-business-profile/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -178,7 +179,7 @@ function GoogleBusinessProfilePreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -452,16 +453,3 @@ function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/integrations/google-marketing-intelligence/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/google-marketing-intelligence/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -174,7 +175,7 @@ function GoogleMarketingPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -243,19 +244,6 @@ function PreviewListCard({
   );
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 function formatRowMetrics(row: {
   clicks?: number;

--- a/apps/web/app/(shell)/platform/tools/integrations/hubspot/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/hubspot/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -174,7 +175,7 @@ function HubSpotPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -278,19 +279,6 @@ function formatContactName(contact: {
   return full || (contact.properties?.email ?? undefined);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 function formatNumber(value: unknown): string | null {
   if (typeof value !== "number" || Number.isNaN(value)) return null;

--- a/apps/web/app/(shell)/platform/tools/integrations/instagram-business/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/instagram-business/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -170,7 +171,7 @@ function InstagramBusinessPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -268,16 +269,3 @@ function formatMetric(value: number | null): string | null {
   return new Intl.NumberFormat().format(value);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/integrations/mailchimp/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/mailchimp/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -176,7 +177,7 @@ function MailchimpPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -274,16 +275,3 @@ function hasRenderableChildren(value: React.ReactNode): boolean {
   return Boolean(value);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/integrations/microsoft365-communications/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/microsoft365-communications/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -182,7 +183,7 @@ function Microsoft365CommunicationsPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 

--- a/apps/web/app/(shell)/platform/tools/integrations/stripe/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/stripe/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -145,7 +146,7 @@ function StripePreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -241,16 +242,3 @@ function formatCurrencyLike(amount: unknown, currency: unknown): string | null {
   }).format(amount / 100);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { decryptJson } from "@/lib/govern/credential-crypto";
@@ -173,7 +174,7 @@ function WhatsAppBusinessPreviewSection({
           </p>
         </div>
         <p className="text-xs text-[var(--dpf-muted)]">
-          Loaded {formatDateTime(previewData.loadedAt)}
+          Loaded <LocalTime value={previewData.loadedAt} options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }} />
         </p>
       </div>
 
@@ -303,16 +304,3 @@ function hasContent(content: React.ReactNode): boolean {
   return Boolean(content);
 }
 
-function formatDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}

--- a/apps/web/app/(shell)/platform/tools/services/[serverId]/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/services/[serverId]/page.tsx
@@ -5,6 +5,7 @@ import { getMcpServerDetail, deactivateMcpServer } from "@/lib/actions/mcp-servi
 import { HealthCheckButton } from "@/components/platform/HealthCheckButton";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const HEALTH_LABELS: Record<string, { text: string; className: string }> = {
   healthy: { text: "Healthy", className: "text-green-600" },
@@ -52,7 +53,7 @@ export default async function ToolsServiceDetailPage({
         <div className="border rounded-lg p-4 space-y-2 text-sm">
           <p>Status: <span className={`font-medium ${health.className}`}>{health.text}</span></p>
           {server.lastHealthCheck && (
-            <p>Last checked: {new Date(server.lastHealthCheck).toLocaleString()}</p>
+            <p>Last checked: <LocalTime value={server.lastHealthCheck} /></p>
           )}
           {server.lastHealthError && (
             <p className="text-destructive text-xs">{server.lastHealthError}</p>
@@ -105,11 +106,11 @@ export default async function ToolsServiceDetailPage({
         <h2 className="text-lg font-semibold">Metadata</h2>
         <div className="border rounded-lg p-4 text-sm space-y-1">
           {server.activatedBy && <p>Activated by: {server.activatedBy}</p>}
-          {server.activatedAt && <p>Activated: {new Date(server.activatedAt).toLocaleString()}</p>}
+          {server.activatedAt && <p>Activated: <LocalTime value={server.activatedAt} /></p>}
           {server.integration && (
             <p>Catalog entry: <Link href="/platform/tools/catalog" className="text-primary hover:underline">{server.integration.name}</Link></p>
           )}
-          {server.deactivatedAt && <p className="text-destructive">Deactivated: {new Date(server.deactivatedAt).toLocaleString()}</p>}
+          {server.deactivatedAt && <p className="text-destructive">Deactivated: <LocalTime value={server.deactivatedAt} /></p>}
         </div>
       </section>
 

--- a/apps/web/app/(shell)/portfolio/product/[id]/changes/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/changes/page.tsx
@@ -5,6 +5,7 @@
 import { prisma } from "@dpf/db";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -86,9 +87,11 @@ export default async function ProductChangesPage({ params }: Props) {
                 <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">
                   {b.phase}
                 </span>
-                <span className="text-[10px] text-[var(--dpf-muted)]">
-                  {b.createdAt.toLocaleDateString()}
-                </span>
+                <LocalTime
+                  value={b.createdAt}
+                  mode="date"
+                  className="text-[10px] text-[var(--dpf-muted)]"
+                />
               </div>
             ))}
           </div>
@@ -122,9 +125,11 @@ export default async function ProductChangesPage({ params }: Props) {
                   <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">
                     {c.itemType}
                   </span>
-                  <span className="text-[10px] text-[var(--dpf-muted)]">
-                    {c.createdAt.toLocaleDateString()}
-                  </span>
+                  <LocalTime
+                    value={c.createdAt}
+                    mode="date"
+                    className="text-[10px] text-[var(--dpf-muted)]"
+                  />
                 </div>
               );
             })}

--- a/apps/web/app/(shell)/portfolio/product/[id]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/page.tsx
@@ -4,6 +4,7 @@
 
 import { prisma } from "@dpf/db";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -102,11 +103,11 @@ export default async function ProductOverviewPage({ params }: Props) {
           </div>
           <div>
             <dt className="text-[var(--dpf-muted)]">Created</dt>
-            <dd className="text-[var(--dpf-text)] mt-0.5">{product.createdAt.toLocaleDateString()}</dd>
+            <dd className="text-[var(--dpf-text)] mt-0.5"><LocalTime value={product.createdAt} mode="date" /></dd>
           </div>
           <div>
             <dt className="text-[var(--dpf-muted)]">Last Updated</dt>
-            <dd className="text-[var(--dpf-text)] mt-0.5">{product.updatedAt.toLocaleDateString()}</dd>
+            <dd className="text-[var(--dpf-text)] mt-0.5"><LocalTime value={product.updatedAt} mode="date" /></dd>
           </div>
         </dl>
       </div>

--- a/apps/web/app/(shell)/portfolio/product/[id]/versions/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/versions/page.tsx
@@ -4,6 +4,7 @@
 
 import { prisma } from "@dpf/db";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -63,7 +64,7 @@ export default async function ProductVersionsPage({ params }: Props) {
               )}
               <div className="flex gap-3 text-[10px] text-[var(--dpf-muted)]">
                 <span className="font-mono">{v.gitTag}</span>
-                <span>Shipped {v.shippedAt.toLocaleDateString()}</span>
+                <span>Shipped <LocalTime value={v.shippedAt} mode="date" /></span>
                 {v.changeCount > 0 && <span>{v.changeCount} changes</span>}
                 <span>by {v.shippedBy}</span>
               </div>

--- a/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
+++ b/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
@@ -5,6 +5,7 @@ import { Archive, ArchiveRestore, ArrowLeft, CheckCircle2, FileText } from "luci
 import { auth } from "@/lib/auth";
 import { listManagedDocumentReferences, loadManagedDocument } from "@/lib/documents/document-store";
 import { changeDocumentStateAction } from "../actions";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   params: Promise<{ documentId: string }>;
@@ -56,7 +57,7 @@ export default async function DocumentDetailPage({ params }: Props) {
           </div>
           <h1 className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{document.title}</h1>
           <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
-            Updated {document.updatedAt.toLocaleString()} by {document.createdByName ?? document.ownerName ?? "unknown principal"}.
+            Updated <LocalTime value={document.updatedAt} /> by {document.createdByName ?? document.ownerName ?? "unknown principal"}.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -118,7 +119,7 @@ export default async function DocumentDetailPage({ params }: Props) {
                 <div key={version.id} className="border-l-2 border-[var(--dpf-border)] pl-3 text-sm">
                   <p className="font-medium text-[var(--dpf-text)]">v{version.version}</p>
                   <p className="text-xs text-[var(--dpf-muted)]">{version.summary ?? "No summary"}</p>
-                  <p className="text-[11px] text-[var(--dpf-muted)]">{version.createdAt.toLocaleString()}</p>
+                  <LocalTime value={version.createdAt} className="text-[11px] text-[var(--dpf-muted)]" />
                 </div>
               ))}
             </div>
@@ -137,7 +138,7 @@ export default async function DocumentDetailPage({ params }: Props) {
                     </p>
                     <p className="text-xs text-[var(--dpf-muted)]">{event.reason ?? "No reason recorded"}</p>
                     <p className="text-[11px] text-[var(--dpf-muted)]">
-                      {event.createdAt.toLocaleString()} {event.actorName ? `by ${event.actorName}` : ""}
+                      <LocalTime value={event.createdAt} /> {event.actorName ? `by ${event.actorName}` : ""}
                     </p>
                   </div>
                 ))

--- a/apps/web/app/(shell)/workspace/documents/page.tsx
+++ b/apps/web/app/(shell)/workspace/documents/page.tsx
@@ -4,6 +4,7 @@ import { Archive, FileText, Search } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { searchManagedDocuments } from "@/lib/documents/document-store";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = {
   searchParams: Promise<{
@@ -184,7 +185,9 @@ export default async function DocumentsPage({ searchParams }: Props) {
                       ))}
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-right text-xs text-[var(--dpf-muted)]">{doc.updatedAt.toLocaleDateString()}</td>
+                  <td className="px-4 py-3 text-right text-xs text-[var(--dpf-muted)]">
+                    <LocalTime value={doc.updatedAt} mode="date" />
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/app/(shell)/workspace/my-queue/page.tsx
+++ b/apps/web/app/(shell)/workspace/my-queue/page.tsx
@@ -2,6 +2,7 @@
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 const URGENCY_ORDER: Record<string, number> = {
   emergency: 0,
@@ -83,7 +84,7 @@ export default async function MyQueuePage() {
                 <p className="text-sm text-[var(--dpf-text-secondary)] mt-0.5 line-clamp-2">{item.description}</p>
                 {item.dueAt && (
                   <p className="text-xs text-[var(--dpf-muted)] mt-1">
-                    Due: {new Date(item.dueAt).toLocaleDateString()}
+                    Due: <LocalTime value={item.dueAt} mode="date" />
                   </p>
                 )}
               </div>

--- a/apps/web/app/(storefront)/s/approve/[token]/page.tsx
+++ b/apps/web/app/(storefront)/s/approve/[token]/page.tsx
@@ -4,6 +4,7 @@
 
 import { getBillByApprovalToken } from "@/lib/actions/ap";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { ApprovalForm } from "./ApprovalForm";
 
 type Props = { params: Promise<{ token: string }> };
@@ -111,11 +112,11 @@ export default async function ApproveBillPage({ params }: Props) {
             >
               <span style={{ fontSize: 14, color: "var(--dpf-muted)" }}>Due Date</span>
               <span style={{ fontSize: 14, color: "var(--dpf-text)" }}>
-                {new Date(bill.dueDate).toLocaleDateString("en-GB", {
-                  day: "numeric",
-                  month: "long",
-                  year: "numeric",
-                })}
+                <LocalTime
+                  value={bill.dueDate}
+                  utc
+                  options={{ day: "numeric", month: "long", year: "numeric" }}
+                />
               </span>
             </div>
             <div

--- a/apps/web/app/(storefront)/s/expense-approve/[token]/page.tsx
+++ b/apps/web/app/(storefront)/s/expense-approve/[token]/page.tsx
@@ -4,6 +4,7 @@
 
 import { getExpenseClaimByApprovalToken } from "@/lib/actions/expenses";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { ExpenseApprovalForm } from "./ExpenseApprovalForm";
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -157,7 +158,7 @@ export default async function ExpenseApprovePage({ params }: Props) {
               {claim.items.map((item, i) => (
                 <tr key={i} style={{ borderBottom: "1px solid #f3f4f6" }}>
                   <td style={{ padding: "10px 0", fontSize: 14, color: "#6b7280" }}>
-                    {new Date(item.date).toLocaleDateString("en-GB")}
+                    <LocalTime value={item.date} utc />
                   </td>
                   <td style={{ padding: "10px 0", fontSize: 14, color: "#374151" }}>
                     {CATEGORY_LABELS[item.category] ?? item.category}

--- a/apps/web/app/(storefront)/s/pay/[token]/page.tsx
+++ b/apps/web/app/(storefront)/s/pay/[token]/page.tsx
@@ -3,6 +3,7 @@
 
 import { getInvoiceByPayToken, markInvoiceViewed } from "@/lib/actions/finance";
 import { notFound } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { params: Promise<{ token: string }> };
 
@@ -100,11 +101,11 @@ export default async function PayPage({ params }: Props) {
                 </p>
                 <p style={{ margin: "8px 0 0", color: "var(--dpf-muted)", fontSize: 13 }}>
                   Due{" "}
-                  {new Date(invoice.dueDate).toLocaleDateString("en-GB", {
-                    day: "numeric",
-                    month: "long",
-                    year: "numeric",
-                  })}
+                  <LocalTime
+                    value={invoice.dueDate}
+                    utc
+                    options={{ day: "numeric", month: "long", year: "numeric" }}
+                  />
                 </p>
               </>
             )}

--- a/apps/web/components/admin/AdminUserAccessPanel.tsx
+++ b/apps/web/components/admin/AdminUserAccessPanel.tsx
@@ -8,6 +8,7 @@ import {
   type PasswordResetIssueResult,
   type UserActionResult,
 } from "@/lib/actions/users";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 type RoleOption = {
   roleId: string;
@@ -88,10 +89,9 @@ export function AdminUserAccessPanel({ roles, users }: Props) {
           <h4 className="text-xs font-semibold text-[var(--dpf-text)] uppercase tracking-wider">Create user</h4>
           <label className="block">
             <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Email</span>
-            <input
+            <EmailInput
               value={createEmail}
-              onChange={(e) => setCreateEmail(e.target.value)}
-              type="email"
+              onValueChange={(v) => setCreateEmail(v)}
               className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
               placeholder="person@company.com"
             />

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -6,6 +6,8 @@ import {
   resolveArchetypeSummaryState,
   type ArchetypeSummary,
 } from "./business-context-form-state";
+import { EmailInput } from "@/components/ui/EmailInput";
+import { PhoneInput } from "@/components/ui/PhoneInput";
 
 const COMPANY_SIZE_OPTIONS = [
   { value: "solo", label: "Solo", description: "Just me" },
@@ -253,10 +255,9 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
           <label style={labelStyle}>
             <div style={fieldLabelStyle}>Contact email</div>
-            <input
-              type="email"
+            <EmailInput
               value={data.contactEmail}
-              onChange={(e) => update("contactEmail", e.target.value)}
+              onValueChange={(v) => update("contactEmail", v)}
               placeholder="info@example.com"
               style={inputStyle}
             />
@@ -264,11 +265,10 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           </label>
           <label style={labelStyle}>
             <div style={fieldLabelStyle}>Contact phone</div>
-            <input
-              type="tel"
+            <PhoneInput
               value={data.contactPhone}
-              onChange={(e) => update("contactPhone", e.target.value)}
-              placeholder="+1 555 000 0000"
+              onValueChange={(v) => update("contactPhone", v)}
+              placeholder="(415) 555-1234"
               style={inputStyle}
             />
             {autoFilledFields?.includes("contactPhone") && <AutoFillHint field="contactPhone" editedFields={editedFields} />}

--- a/apps/web/components/admin/VoiceConsentForm.tsx
+++ b/apps/web/components/admin/VoiceConsentForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react"
 import { createVoiceConsentRecord } from "@/lib/actions/voice-consent"
+import { EmailInput } from "@/components/ui/EmailInput"
 
 interface Props {
   profileId: string
@@ -99,11 +100,10 @@ export function VoiceConsentForm({ profileId, capturedByPrincipalId, onSuccess }
         <label className="block text-sm font-medium text-gray-700" htmlFor="subjectEmail">
           Subject Email (optional)
         </label>
-        <input
+        <EmailInput
           id="subjectEmail"
-          type="email"
           value={subjectEmail}
-          onChange={(e) => setSubjectEmail(e.target.value)}
+          onValueChange={(v) => setSubjectEmail(v)}
           className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
       </div>

--- a/apps/web/components/auth/ForgotPasswordForm.tsx
+++ b/apps/web/components/auth/ForgotPasswordForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 
 import { requestPasswordReset } from "@/lib/actions/users";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export function ForgotPasswordForm() {
   const [email, setEmail] = useState("");
@@ -23,11 +24,10 @@ export function ForgotPasswordForm() {
       </p>
       <label className="block">
         <span className="block text-sm text-[var(--dpf-muted)] mb-1">Email</span>
-        <input
+        <EmailInput
           value={email}
-          onChange={(event) => setEmail(event.target.value)}
+          onValueChange={(v) => setEmail(v)}
           name="email"
-          type="email"
           required
           className="w-full px-3 py-2 rounded-lg bg-[var(--dpf-bg)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm focus:outline-none focus:border-[var(--dpf-accent)]"
         />

--- a/apps/web/components/build/ReviewPanel.tsx
+++ b/apps/web/components/build/ReviewPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { formatText } from "@/lib/actions/local-format";
 import { DeliberationSummaryCard } from "@/components/deliberation/DeliberationSummaryCard";
 import type {
@@ -551,7 +552,7 @@ function VerificationSection({ verification }: { verification: NormalizedVerific
         )}
         {verification.observedAt && (
           <div className="text-[10px] text-[var(--dpf-muted)]">
-            Run at: {new Date(verification.observedAt).toLocaleString()}
+            Run at: <LocalTime value={verification.observedAt} />
           </div>
         )}
       </div>

--- a/apps/web/components/employee/EmployeeFormPanel.tsx
+++ b/apps/web/components/employee/EmployeeFormPanel.tsx
@@ -12,6 +12,8 @@ import type { WorkforceStatus, EmployeeProfileRecord } from "@/lib/workforce-typ
 import type { AddressWithHierarchy } from "@/lib/address-types";
 import AddressSection from "@/components/employee/AddressSection";
 import { DatePicker } from "@/components/ui/DatePicker";
+import { EmailInput } from "@/components/ui/EmailInput";
+import { PhoneInput } from "@/components/ui/PhoneInput";
 
 const HIRE_STATUSES: WorkforceStatus[] = ["offer", "onboarding", "active"];
 
@@ -227,20 +229,18 @@ export function EmployeeFormPanel({
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <label className="flex flex-col gap-1">
                 <span className={labelClasses}>Work Email</span>
-                <input
-                  type="email"
+                <EmailInput
                   value={form.workEmail ?? ""}
-                  onChange={(e) => setField("workEmail", e.target.value)}
+                  onValueChange={(v) => setField("workEmail", v)}
                   className={inputClasses}
                   placeholder="jane@company.com"
                 />
               </label>
               <label className="flex flex-col gap-1">
                 <span className={labelClasses}>Personal Email</span>
-                <input
-                  type="email"
+                <EmailInput
                   value={form.personalEmail ?? ""}
-                  onChange={(e) => setField("personalEmail", e.target.value)}
+                  onValueChange={(v) => setField("personalEmail", v)}
                   className={inputClasses}
                   placeholder="jane@personal.com"
                 />
@@ -251,32 +251,29 @@ export function EmployeeFormPanel({
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <label className="flex flex-col gap-1">
                 <span className={labelClasses}>Work Phone</span>
-                <input
-                  type="tel"
+                <PhoneInput
                   value={form.phoneWork ?? ""}
-                  onChange={(e) => setField("phoneWork", e.target.value)}
+                  onValueChange={(v) => setField("phoneWork", v)}
                   className={inputClasses}
-                  placeholder="+14155551234"
+                  placeholder="(415) 555-1234"
                 />
               </label>
               <label className="flex flex-col gap-1">
                 <span className={labelClasses}>Mobile Phone</span>
-                <input
-                  type="tel"
+                <PhoneInput
                   value={form.phoneMobile ?? ""}
-                  onChange={(e) => setField("phoneMobile", e.target.value)}
+                  onValueChange={(v) => setField("phoneMobile", v)}
                   className={inputClasses}
-                  placeholder="+14155551234"
+                  placeholder="(415) 555-1234"
                 />
               </label>
               <label className="flex flex-col gap-1">
                 <span className={labelClasses}>Emergency Phone</span>
-                <input
-                  type="tel"
+                <PhoneInput
                   value={form.phoneEmergency ?? ""}
-                  onChange={(e) => setField("phoneEmergency", e.target.value)}
+                  onValueChange={(v) => setField("phoneEmergency", v)}
                   className={inputClasses}
-                  placeholder="+14155551234"
+                  placeholder="(415) 555-1234"
                 />
               </label>
             </div>

--- a/apps/web/components/employee/EmployeeProfilePanel.tsx
+++ b/apps/web/components/employee/EmployeeProfilePanel.tsx
@@ -1,3 +1,4 @@
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { EmployeeProfileRecord } from "@/lib/workforce-types";
 import type { AddressWithHierarchy } from "@/lib/address-types";
 
@@ -5,15 +6,6 @@ type Props = {
   employee: EmployeeProfileRecord | null;
   addresses?: AddressWithHierarchy[];
 };
-
-function formatDate(value: Date | null): string {
-  if (!value) return "Not set";
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(value);
-}
 
 function formatAddress(a: AddressWithHierarchy["address"]): string {
   const parts = [a.addressLine1];
@@ -78,15 +70,21 @@ export function EmployeeProfilePanel({ employee, addresses = [] }: Props) {
               </div>
               <div>
                 <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Start date</dt>
-                <dd className="text-[var(--dpf-text)]">{formatDate(employee.startDate)}</dd>
+                <dd className="text-[var(--dpf-text)]">
+                  <LocalTime value={employee.startDate} utc fallback="Not set" />
+                </dd>
               </div>
               <div>
                 <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Confirmation date</dt>
-                <dd className="text-[var(--dpf-text)]">{formatDate(employee.confirmationDate)}</dd>
+                <dd className="text-[var(--dpf-text)]">
+                  <LocalTime value={employee.confirmationDate} utc fallback="Not set" />
+                </dd>
               </div>
               <div>
                 <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">End date</dt>
-                <dd className="text-[var(--dpf-text)]">{formatDate(employee.endDate)}</dd>
+                <dd className="text-[var(--dpf-text)]">
+                  <LocalTime value={employee.endDate} utc fallback="Not set" />
+                </dd>
               </div>
             </dl>
           </div>

--- a/apps/web/components/employee/EmployeeReachabilityPanel.tsx
+++ b/apps/web/components/employee/EmployeeReachabilityPanel.tsx
@@ -1,5 +1,7 @@
 import { CheckCircle2, Clock3, PauseCircle, XCircle } from "lucide-react";
 
+import { LocalTime } from "@/components/ui/LocalTime";
+
 export type ReachabilityBinding = {
   channel: string;
   label: string;
@@ -14,16 +16,6 @@ const statusIcons = {
   failed: XCircle,
   disabled: PauseCircle,
 } satisfies Record<ReachabilityBinding["status"], typeof CheckCircle2>;
-
-function formatLastTested(value: string | null): string {
-  if (!value) return "Not tested";
-
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(new Date(value));
-}
 
 export function EmployeeReachabilityPanel({
   bindings,
@@ -67,7 +59,7 @@ export function EmployeeReachabilityPanel({
                     </span>
                   </div>
                   <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                    Last tested {formatLastTested(binding.lastTestedAt)}
+                    Last tested <LocalTime value={binding.lastTestedAt} mode="date" fallback="Not tested" />
                   </p>
                 </div>
 

--- a/apps/web/components/employee/LifecycleEventPanel.tsx
+++ b/apps/web/components/employee/LifecycleEventPanel.tsx
@@ -1,3 +1,5 @@
+import { LocalTime } from "@/components/ui/LocalTime";
+
 type LifecycleEvent = {
   id: string;
   eventId: string;
@@ -10,14 +12,6 @@ type LifecycleEvent = {
 type Props = {
   events: LifecycleEvent[];
 };
-
-function formatDate(value: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(value);
-}
 
 export function LifecycleEventPanel({ events }: Props) {
   return (
@@ -43,7 +37,11 @@ export function LifecycleEventPanel({ events }: Props) {
                   <p className="text-xs font-semibold text-[var(--dpf-text)]">{event.eventType}</p>
                   <p className="text-[10px] font-mono text-[var(--dpf-muted)]">{event.eventId}</p>
                 </div>
-                <p className="text-[10px] text-[var(--dpf-muted)]">{formatDate(event.effectiveAt)}</p>
+                <LocalTime
+                  value={event.effectiveAt}
+                  utc
+                  className="text-[10px] text-[var(--dpf-muted)]"
+                />
               </div>
               {event.reason && <p className="mt-2 text-xs text-[var(--dpf-muted)]">{event.reason}</p>}
             </article>

--- a/apps/web/components/finance/AiProviderFinancePanel.tsx
+++ b/apps/web/components/finance/AiProviderFinancePanel.tsx
@@ -1,3 +1,4 @@
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { getAiProviderFinanceDetail } from "@/lib/finance/ai-provider-finance";
 
 type ProviderFinanceDetail = Awaited<ReturnType<typeof getAiProviderFinanceDetail>>;
@@ -66,7 +67,7 @@ export function AiProviderFinancePanel({ detail }: { detail: ProviderFinanceDeta
           <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Latest utilization</p>
           <p className="mt-1 text-sm text-[var(--dpf-text)]">
             {latestSnapshot.utilizationPct?.toFixed(1) ?? "0.0"}% utilized on{" "}
-            {new Date(latestSnapshot.snapshotDate).toLocaleDateString("en-US")}
+            <LocalTime value={latestSnapshot.snapshotDate} utc />
           </p>
         </div>
       )}

--- a/apps/web/components/finance/CreateSupplierForm.tsx
+++ b/apps/web/components/finance/CreateSupplierForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createSupplier } from "@/lib/actions/ap";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 const inputClasses =
   "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none placeholder:text-[var(--dpf-muted)] w-full";
@@ -80,10 +81,9 @@ export function CreateSupplierForm() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div>
           <label className={labelClasses}>Email</label>
-          <input
-            type="email"
+          <EmailInput
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onValueChange={(v) => setEmail(v)}
             placeholder="accounts@supplier.com"
             className={inputClasses}
           />

--- a/apps/web/components/integrations/IntegrationReadinessPanel.tsx
+++ b/apps/web/components/integrations/IntegrationReadinessPanel.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+import { LocalTime } from "@/components/ui/LocalTime";
 import type {
   IntegrationReadinessDescriptor,
   IntegrationReadinessState,
@@ -40,7 +42,16 @@ export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPa
       <dl className="mt-4 grid gap-3 text-sm md:grid-cols-3">
         <ContextItem label="Company" value={descriptor.entityContext.companyName} />
         <ContextItem label="Realm" value={descriptor.entityContext.realmId} />
-        <ContextItem label="Last verified" value={formatDateTime(descriptor.health.lastSuccessfulProbeAt)} />
+        <ContextItem
+          label="Last verified"
+          value={
+            <LocalTime
+              value={descriptor.health.lastSuccessfulProbeAt}
+              options={{ year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }}
+              fallback="Not available"
+            />
+          }
+        />
       </dl>
 
       {descriptor.health.lastProbeErrorCategory && (
@@ -201,11 +212,12 @@ function ImportStagingPosture({ descriptor }: { descriptor: IntegrationImportSta
   );
 }
 
-function ContextItem({ label, value }: { label: string; value: string | null | undefined }) {
+function ContextItem({ label, value }: { label: string; value: ReactNode }) {
+  const display = value == null || value === "" ? "Not available" : value;
   return (
     <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
       <dt className="text-xs uppercase text-[var(--dpf-muted)]">{label}</dt>
-      <dd className="mt-1 font-medium text-[var(--dpf-text)]">{value || "Not available"}</dd>
+      <dd className="mt-1 font-medium text-[var(--dpf-text)]">{display}</dd>
     </div>
   );
 }
@@ -271,22 +283,4 @@ function formatMode(mode: string): string {
     .split("-")
     .map((word) => word.slice(0, 1).toUpperCase() + word.slice(1))
     .join(" ");
-}
-
-function formatDateTime(iso: string | null | undefined): string | null {
-  if (!iso) {
-    return null;
-  }
-
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
 }

--- a/apps/web/components/integrations/Microsoft365CommunicationsConnectPanel.tsx
+++ b/apps/web/components/integrations/Microsoft365CommunicationsConnectPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export interface Microsoft365CommunicationsConnectionState {
   status: "unconfigured" | "connected" | "error";
@@ -147,10 +148,9 @@ export function Microsoft365CommunicationsConnectPanel({
           label="Mailbox user principal name"
           hint="The mailbox UPN DPF should use for read-first inbox and calendar preview."
         >
-          <input
-            type="email"
+          <EmailInput
             value={mailboxUserPrincipalName}
-            onChange={(event) => setMailboxUserPrincipalName(event.target.value)}
+            onValueChange={(v) => setMailboxUserPrincipalName(v)}
             required
             autoComplete="off"
             className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-sm text-[var(--dpf-text)]"

--- a/apps/web/components/knowledge/KnowledgeArticleCard.tsx
+++ b/apps/web/components/knowledge/KnowledgeArticleCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { KnowledgeCategoryBadge } from "./KnowledgeCategoryBadge";
 import { StalenessIndicator } from "./StalenessIndicator";
 
@@ -53,7 +54,7 @@ export function KnowledgeArticleCard({ article }: { article: KnowledgeArticleSum
       <div className="flex items-center gap-3 text-[10px] text-[var(--dpf-muted)] mt-auto pt-1">
         <span>{article.articleId}</span>
         <span>{authorName}</span>
-        <span className="ml-auto">{article.updatedAt.toLocaleDateString()}</span>
+        <LocalTime value={article.updatedAt} mode="date" className="ml-auto" />
       </div>
     </Link>
   );

--- a/apps/web/components/ops/BacklogPanel.tsx
+++ b/apps/web/components/ops/BacklogPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { createBacklogItem, updateBacklogItem } from "@/lib/actions/backlog";
 import { registerActiveFormAssist } from "@/lib/agent-form-assist";
 import { AGENT_NAME_MAP } from "@/lib/agent-routing";
@@ -273,12 +274,12 @@ export function BacklogPanel({
         {item && (
           <div className="px-5 py-3 border-t border-[var(--dpf-border)] space-y-1">
             <p className="text-[10px] text-[var(--dpf-muted)]">
-              Created: {new Date(item.createdAt).toLocaleString()}
+              Created: <LocalTime value={item.createdAt} />
               {item.submittedBy ? ` by ${item.submittedBy.email}` : ""}
               {item.agentId ? ` (${AGENT_NAME_MAP[item.agentId] ?? item.agentId})` : ""}
             </p>
             <p className="text-[10px] text-[var(--dpf-muted)]">
-              Completed: {item.completedAt ? new Date(item.completedAt).toLocaleString() : "—"}
+              Completed: <LocalTime value={item.completedAt} />
             </p>
           </div>
         )}

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { deleteEpic } from "@/lib/actions/backlog";
 import {
   type EpicWithRelations,
@@ -97,10 +98,10 @@ export function EpicCard({ epic, sort, hideDoneItems, onEdit, onItemEdit, focuse
           {epic.title}
           <span className="ml-1.5 text-[9px] text-[var(--dpf-muted)] tabular-nums">({totalCount})</span>
           <span className="ml-2 text-[9px] text-[var(--dpf-muted)]">
-            {new Date(epic.createdAt).toLocaleDateString()}
+            <LocalTime value={epic.createdAt} mode="date" />
             {epic.agentId ? ` · ${AGENT_NAME_MAP[epic.agentId] ?? epic.agentId}` : ""}
             {epic.submittedBy ? ` · ${epic.submittedBy.email}` : ""}
-            {epic.completedAt ? ` · done ${new Date(epic.completedAt).toLocaleDateString()}` : ""}
+            {epic.completedAt ? <> · done <LocalTime value={epic.completedAt} mode="date" /></> : ""}
           </span>
         </p>
 

--- a/apps/web/components/ops/EpicPanel.tsx
+++ b/apps/web/components/ops/EpicPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { createEpic, updateEpic, type EpicOverlap } from "@/lib/actions/backlog";
 import {
   validateEpicInput,
@@ -207,12 +208,12 @@ export function EpicPanel({ isOpen, onClose, epic, portfolios }: Props) {
         {epic && (
           <div className="px-5 py-3 border-t border-[var(--dpf-border)] space-y-1">
             <p className="text-[10px] text-[var(--dpf-muted)]">
-              Created: {new Date(epic.createdAt).toLocaleString()}
+              Created: <LocalTime value={epic.createdAt} />
               {epic.submittedBy ? ` by ${epic.submittedBy.email}` : ""}
               {epic.agentId ? ` (${AGENT_NAME_MAP[epic.agentId] ?? epic.agentId})` : ""}
             </p>
             <p className="text-[10px] text-[var(--dpf-muted)]">
-              Completed: {epic.completedAt ? new Date(epic.completedAt).toLocaleString() : "—"}
+              Completed: <LocalTime value={epic.completedAt} />
             </p>
           </div>
         )}

--- a/apps/web/components/ops/GitPromotionCandidatesPanel.tsx
+++ b/apps/web/components/ops/GitPromotionCandidatesPanel.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, CheckCircle2, Clock3, GitBranch, LoaderCircle, PackageCheck } from "lucide-react";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export type GitPromotionCandidateRow = {
   id: string;
@@ -166,7 +167,7 @@ export function GitPromotionCandidatesPanel({
                     </div>
                   </div>
                   <div className="space-y-2 text-right text-xs text-[var(--dpf-muted)]">
-                    <div>{new Date(candidate.createdAt).toLocaleString()}</div>
+                    <div><LocalTime value={candidate.createdAt} /></div>
                     {candidate.sandboxId && <div className="mt-1 font-mono">{candidate.sandboxId}</div>}
                     {candidate.promotionReview ? (
                       <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-left">

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { triggerSelfUpgrade } from "@/lib/actions/promotions";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type LatestRun = {
   runId: string;
@@ -67,10 +68,6 @@ function formatDuration(start: Date | string, end: Date | string): string {
   if (minutes === 0) return `${seconds}s`;
   if (seconds === 0) return `${minutes}m`;
   return `${minutes}m ${seconds}s`;
-}
-
-function formatDate(d: Date | string): string {
-  return new Date(d).toISOString().slice(0, 16).replace("T", " ") + " UTC";
 }
 
 const RUN_STATUS_STYLES: Record<string, string> = {
@@ -190,7 +187,7 @@ export default function SelfUpgradeClient({
           )}
           {platformVersion.buildDate && (
             <span className="ml-2 text-[var(--dpf-muted)]">
-              · built {formatDate(platformVersion.buildDate)}
+              · built <LocalTime value={platformVersion.buildDate} />
             </span>
           )}
         </div>
@@ -255,7 +252,7 @@ export default function SelfUpgradeClient({
           ) : nextWindowStart ? (
             <span className="text-[var(--dpf-muted)]">
               Next maintenance window:{" "}
-              <span className="font-mono">{formatDate(nextWindowStart)}</span> —
+              <LocalTime className="font-mono" value={nextWindowStart} /> —
               upgrades are evaluated hourly.
             </span>
           ) : (
@@ -307,7 +304,7 @@ export default function SelfUpgradeClient({
           {latestRun.startedAt && (
             <div className="text-xs text-[var(--dpf-muted)]">
               Started:{" "}
-              <span className="font-mono">{formatDate(latestRun.startedAt)}</span>
+              <LocalTime className="font-mono" value={latestRun.startedAt} />
               {latestRun.completedAt && (
                 <> · {formatDuration(latestRun.startedAt, latestRun.completedAt)}</>
               )}

--- a/apps/web/components/ops/SelfUpgradePanel.tsx
+++ b/apps/web/components/ops/SelfUpgradePanel.tsx
@@ -1,12 +1,9 @@
 import type { SelfUpgradeDashboard } from "@/lib/actions/self-upgrade";
 import { requestPortalSelfUpgradeAction } from "@/lib/actions/self-upgrade";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 function shortSha(value: string | null): string {
   return value ? value.slice(0, 12) : "unknown";
-}
-
-function formatDate(value: string | null): string {
-  return value ? new Date(value).toLocaleString() : "not recorded";
 }
 
 function statusLabel(value: string): string {
@@ -102,8 +99,14 @@ export function SelfUpgradePanel({ dashboard }: { dashboard: SelfUpgradeDashboar
                     )}
                   </div>
                   <div className="text-xs text-[var(--dpf-muted)] md:text-right">
-                    <div>started {formatDate(run.startedAt)}</div>
-                    <div>updated {formatDate(run.updatedAt)}</div>
+                    <div>
+                      started{" "}
+                      <LocalTime value={run.startedAt} fallback="not recorded" />
+                    </div>
+                    <div>
+                      updated{" "}
+                      <LocalTime value={run.updatedAt} fallback="not recorded" />
+                    </div>
                   </div>
                 </div>
               </article>

--- a/apps/web/components/platform/CliPoolStatusPanel.tsx
+++ b/apps/web/components/platform/CliPoolStatusPanel.tsx
@@ -4,6 +4,7 @@
 // Shows a banner only when at least one pool is exhausted; hidden when all
 // pools are healthy. No persistent exhaustion rows means no banner.
 
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { CliPoolState } from "@/lib/routing/cli-pool-status";
 
 interface Props {
@@ -97,7 +98,7 @@ export function CliPoolStatusPanel({ statuses }: Props) {
               </span>
             ) : (
               <span style={{ color: "var(--dpf-muted)" }}>
-                Previously limited {new Date(s.rateLimitedAt).toLocaleTimeString()} · pool recovered
+                Previously limited <LocalTime value={s.rateLimitedAt} mode="time" /> · pool recovered
               </span>
             )}
 

--- a/apps/web/components/platform/McpServiceRow.tsx
+++ b/apps/web/components/platform/McpServiceRow.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { McpServerGridRow } from "@/lib/ai-provider-types";
 
 const HEALTH_COLORS: Record<string, string> = {
@@ -137,13 +138,19 @@ export function McpServiceRow({ server }: { server: McpServerGridRow }) {
             <DetailItem label="Transport" value={server.transport ?? "—"} />
             <DetailItem
               label="Last Health Check"
-              value={server.lastHealthCheck ? new Date(server.lastHealthCheck).toLocaleString() : "Never"}
+              node={
+                server.lastHealthCheck ? (
+                  <LocalTime value={server.lastHealthCheck} />
+                ) : (
+                  "Never"
+                )
+              }
             />
             <DetailItem label="Tool Namespace" value={`${server.serverId}__*`} mono />
             {server.activatedAt && (
               <DetailItem
                 label="Activated"
-                value={new Date(server.activatedAt).toLocaleDateString()}
+                node={<LocalTime value={server.activatedAt} mode="date" />}
               />
             )}
           </div>
@@ -193,7 +200,17 @@ export function McpServiceRow({ server }: { server: McpServerGridRow }) {
   );
 }
 
-function DetailItem({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+function DetailItem({
+  label,
+  value,
+  node,
+  mono,
+}: {
+  label: string;
+  value?: string;
+  node?: React.ReactNode;
+  mono?: boolean;
+}) {
   return (
     <div>
       <div style={{ color: "var(--dpf-muted)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 2 }}>
@@ -210,7 +227,7 @@ function DetailItem({ label, value, mono }: { label: string; value: string; mono
         }}
         title={value}
       >
-        {value}
+        {node ?? value}
       </div>
     </div>
   );

--- a/apps/web/components/platform/ServiceCard.tsx
+++ b/apps/web/components/platform/ServiceCard.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { LocalTime } from "@/components/ui/LocalTime";
+
 type McpServerSummary = {
   id: string;
   serverId: string;
@@ -61,7 +63,7 @@ export function ServiceCard({ server }: { server: McpServerSummary }) {
       <div className="flex items-center justify-between mt-auto pt-1 text-xs text-muted-foreground">
         <span>{server._count.tools} tool{server._count.tools !== 1 ? "s" : ""}</span>
         {server.lastHealthCheck && (
-          <span>Checked {new Date(server.lastHealthCheck).toLocaleDateString()}</span>
+          <span>Checked <LocalTime value={server.lastHealthCheck} mode="date" /></span>
         )}
       </div>
     </Link>

--- a/apps/web/components/platform/SkillEvidencePanel.tsx
+++ b/apps/web/components/platform/SkillEvidencePanel.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 
+import { LocalTime } from "@/components/ui/LocalTime";
 import type {
   SkillEvidenceRefs,
   SkillEvidenceResult,
@@ -92,7 +93,11 @@ function EvidenceRow({ item }: { item: SkillEvidenceResult }) {
         <span style={badgeStyle}>{kindLabels[item.kind]}</span>
         <span style={labelStyle}>{item.label}</span>
         <time dateTime={item.createdAt} style={timeStyle}>
-          {formatDate(item.createdAt)}
+          <LocalTime
+            value={item.createdAt}
+            options={{ dateStyle: "medium", timeStyle: "short" }}
+            withZone={false}
+          />
         </time>
       </div>
       <p style={summaryStyle}>{item.summary}</p>
@@ -107,12 +112,6 @@ function EvidenceRow({ item }: { item: SkillEvidenceResult }) {
       )}
     </article>
   );
-}
-
-function formatDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
 }
 
 const rootStyle: CSSProperties = {

--- a/apps/web/components/platform/SkillsObservatoryPanel.tsx
+++ b/apps/web/components/platform/SkillsObservatoryPanel.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState } from "react";
+import { LocalTime } from "@/components/ui/LocalTime";
 import type {
   SkillEntry,
   FinishingPassEntry,
@@ -149,9 +150,11 @@ export function SkillsObservatoryPanel({
                         {fp.passType}
                       </span>
                     )}
-                    <span className="text-[10px] text-[var(--dpf-muted)] ml-auto shrink-0">
-                      {new Date(fp.createdAt).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
-                    </span>
+                    <LocalTime
+                      value={fp.createdAt}
+                      options={{ month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }}
+                      className="text-[10px] text-[var(--dpf-muted)] ml-auto shrink-0"
+                    />
                   </div>
                   <p className="text-xs text-[var(--dpf-text-secondary)] mt-0.5 leading-relaxed">{fp.summary}</p>
                   <span className="text-[10px] text-[var(--dpf-muted)]">Build: {fp.buildId}</span>
@@ -188,9 +191,11 @@ export function SkillsObservatoryPanel({
                 {ex.durationMs !== null && (
                   <span className="text-[10px] text-[var(--dpf-muted)]">{ex.durationMs}ms</span>
                 )}
-                <span className="text-[10px] text-[var(--dpf-muted)] shrink-0">
-                  {new Date(ex.createdAt).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
-                </span>
+                <LocalTime
+                  value={ex.createdAt}
+                  options={{ month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }}
+                  className="text-[10px] text-[var(--dpf-muted)] shrink-0"
+                />
               </div>
             ))
           )}

--- a/apps/web/components/platform/identity/FederationAuthorityCard.tsx
+++ b/apps/web/components/platform/identity/FederationAuthorityCard.tsx
@@ -1,3 +1,5 @@
+import { LocalTime } from "@/components/ui/LocalTime";
+
 type FederationAuthorityCardProps = {
   title: string;
   badge: string;
@@ -66,7 +68,7 @@ export function FederationAuthorityCard({
 
       {lastTestedAt ? (
         <p className="mt-4 text-xs text-[var(--dpf-muted)]">
-          Last validated {formatDateTime(lastTestedAt)}.
+          Last validated <LocalTime value={lastTestedAt} />.
         </p>
       ) : null}
       {lastErrorMsg ? (
@@ -83,18 +85,4 @@ export function FederationAuthorityCard({
       </a>
     </article>
   );
-}
-
-function formatDateTime(value: string) {
-  try {
-    return new Date(value).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return value;
-  }
 }

--- a/apps/web/components/portfolio/DigitalProductDetail.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.tsx
@@ -11,6 +11,7 @@
 
 import type { ReactElement } from "react";
 import type { DigitalProductView } from "@/lib/portfolio/digital-product-view-model";
+import { LocalTime } from "@/components/ui/LocalTime";
 import { FreshnessBadge } from "./FreshnessBadge";
 
 type Props = { vm: DigitalProductView };
@@ -164,7 +165,7 @@ function LinkedEntitiesSection({ vm }: { vm: DigitalProductView }): ReactElement
                     : entity.attributionConfidence.toFixed(2)}
                 </td>
                 <td className="py-2 pr-3 text-[var(--dpf-muted)] text-xs">
-                  {entity.lastSeenAt.toISOString().slice(0, 10)}
+                  <LocalTime value={entity.lastSeenAt} mode="date" />
                 </td>
               </tr>
             ))}

--- a/apps/web/components/product/ProductSupplyChainPanel.tsx
+++ b/apps/web/components/product/ProductSupplyChainPanel.tsx
@@ -7,15 +7,10 @@ import type {
 } from "@/lib/assurance/bom-read";
 import type { ActiveAssuranceFindingRow } from "@/lib/assurance/finding-read";
 import { AssuranceFindingsList } from "@/components/build/AssuranceFindingsList";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 export type ProductSupplyChainComponent = ProductSupplyChainComponentRow;
 export type ProductSupplyChainLatestBom = NonNullable<ProductSupplyChainBomRows["latestBom"]>;
-
-function formatGeneratedAt(value: Date | string): string {
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "unknown";
-  return date.toLocaleString();
-}
 
 function shortDigest(value: string): string {
   return value.length > 16 ? value.slice(0, 16) : value;
@@ -92,7 +87,7 @@ export function ProductSupplyChainPanel({
               icon={<PackageCheck className="h-4 w-4" aria-hidden="true" />}
               label="Components"
               value={packageCountLabel}
-              detail={`Generated ${formatGeneratedAt(latestBom.generatedAt)}`}
+              detail={<>Generated <LocalTime value={latestBom.generatedAt} /></>}
             />
             <Metric
               icon={<BrainCircuit className="h-4 w-4" aria-hidden="true" />}
@@ -176,7 +171,7 @@ function Metric({
   icon: ReactNode;
   label: string;
   value: string;
-  detail: string;
+  detail: ReactNode;
 }) {
   return (
     <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
@@ -185,7 +180,7 @@ function Metric({
         {label}
       </div>
       <p className="mt-2 text-base font-semibold text-[var(--dpf-text)]">{value}</p>
-      <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]" title={detail}>{detail}</p>
+      <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]" title={typeof detail === "string" ? detail : undefined}>{detail}</p>
     </div>
   );
 }

--- a/apps/web/components/storefront-admin/BrandPreview.tsx
+++ b/apps/web/components/storefront-admin/BrandPreview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { BrandDesignSystem } from "@/lib/brand/types";
 
 type Props = {
@@ -13,20 +14,6 @@ type Props = {
 const SCALE_KEYS: Array<keyof BrandDesignSystem["typography"]["scale"]> = [
   "xs", "sm", "base", "lg", "xl", "2xl", "3xl", "4xl",
 ];
-
-const EXTRACTED_AT_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  year: "numeric",
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-  timeZone: "UTC",
-  timeZoneName: "short",
-});
-
-function formatExtractedAt(value: string) {
-  return EXTRACTED_AT_FORMATTER.format(new Date(value));
-}
 
 function ConfidenceBadge({ value }: { value: number }) {
   const pct = Math.round(value * 100);
@@ -91,7 +78,7 @@ export function BrandPreview({ system, onApply, applying = false, applyError = n
           <ConfidenceBadge value={confidence} />
         </div>
         <p style={{ fontSize: 12, color: "var(--dpf-muted)", margin: "4px 0 0 0" }}>
-          Extracted {formatExtractedAt(system.extractedAt)} from {system.sources.length}{" "}
+          Extracted <LocalTime value={system.extractedAt} /> from {system.sources.length}{" "}
           source{system.sources.length === 1 ? "" : "s"}.
         </p>
         {system.gaps.length > 0 && (
@@ -222,7 +209,7 @@ export function BrandPreview({ system, onApply, applying = false, applyError = n
           )}
           {!applyError && appliedAt && (
             <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
-              Applied {appliedAt.toLocaleTimeString()}
+              Applied <LocalTime value={appliedAt} mode="time" />
             </span>
           )}
         </div>

--- a/apps/web/components/storefront-admin/TeamManager.tsx
+++ b/apps/web/components/storefront-admin/TeamManager.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useState } from "react";
 import { ScheduleEditor } from "./ScheduleEditor";
+import { EmailInput } from "@/components/ui/EmailInput";
+import { PhoneInput } from "@/components/ui/PhoneInput";
 
 type AvailabilityRow = {
   id: string;
@@ -217,18 +219,16 @@ export function TeamManager({
               onChange={(e) => setNewName(e.target.value)}
               style={{ padding: "8px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13, width: "100%", boxSizing: "border-box" }}
             />
-            <input
+            <EmailInput
               placeholder="Email"
-              type="email"
               value={newEmail}
-              onChange={(e) => setNewEmail(e.target.value)}
+              onValueChange={setNewEmail}
               style={{ padding: "8px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13, width: "100%", boxSizing: "border-box" }}
             />
-            <input
+            <PhoneInput
               placeholder="Phone"
-              type="tel"
               value={newPhone}
-              onChange={(e) => setNewPhone(e.target.value)}
+              onValueChange={setNewPhone}
               style={{ padding: "8px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13, width: "100%", boxSizing: "border-box" }}
             />
             {addError && <div style={{ fontSize: 12, color: "var(--dpf-error, #ef4444)" }}>{addError}</div>}
@@ -281,18 +281,16 @@ export function TeamManager({
                         onChange={(e) => patchEdit(p.id, { name: e.target.value })}
                         style={{ flex: 1, minWidth: 140, padding: "6px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13 }}
                       />
-                      <input
+                      <EmailInput
                         placeholder="Email"
-                        type="email"
                         value={edit.email}
-                        onChange={(e) => patchEdit(p.id, { email: e.target.value })}
+                        onValueChange={(v) => patchEdit(p.id, { email: v })}
                         style={{ flex: 1, minWidth: 140, padding: "6px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13 }}
                       />
-                      <input
+                      <PhoneInput
                         placeholder="Phone"
-                        type="tel"
                         value={edit.phone}
-                        onChange={(e) => patchEdit(p.id, { phone: e.target.value })}
+                        onValueChange={(v) => patchEdit(p.id, { phone: v })}
                         style={{ flex: 1, minWidth: 120, padding: "6px 10px", border: "1px solid var(--dpf-border)", borderRadius: 5, background: "var(--dpf-surface-2)", color: "inherit", fontSize: 13 }}
                       />
                     </div>

--- a/apps/web/components/storefront/SignInForm.tsx
+++ b/apps/web/components/storefront/SignInForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export function SignInForm({ orgSlug }: { orgSlug?: string }) {
   const router = useRouter();
@@ -30,10 +31,9 @@ export function SignInForm({ orgSlug }: { orgSlug?: string }) {
         {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <label style={{ fontSize: 13, fontWeight: 500 }}>Email address</label>
-          <input
-            type="email"
+          <EmailInput
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onValueChange={(v) => setEmail(v)}
             required
             style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
           />

--- a/apps/web/components/storefront/SignUpForm.tsx
+++ b/apps/web/components/storefront/SignUpForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
+import { EmailInput } from "@/components/ui/EmailInput";
 
 export function SignUpForm({
   orgSlug,
@@ -69,10 +70,9 @@ export function SignUpForm({
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <label style={{ fontSize: 13, fontWeight: 500 }}>Email address</label>
-        <input
-          type="email"
+        <EmailInput
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onValueChange={(v) => setEmail(v)}
           required
           style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
         />

--- a/apps/web/components/storefront/SlotBookingFlow.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { submitBooking } from "@/lib/storefront-actions";
+import { EmailInput } from "@/components/ui/EmailInput";
+import { PhoneInput } from "@/components/ui/PhoneInput";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -776,12 +778,12 @@ function FormStep({
 
         <div style={fieldStyle}>
           <label style={labelStyle}>Email address *</label>
-          <input type="email" name="email" required style={inputStyle} autoComplete="email" />
+          <EmailInput name="email" required style={inputStyle} />
         </div>
 
         <div style={fieldStyle}>
           <label style={labelStyle}>Phone (optional)</label>
-          <input type="tel" name="phone" style={inputStyle} autoComplete="tel" />
+          <PhoneInput name="phone" style={inputStyle} />
         </div>
 
         <div style={fieldStyle}>

--- a/apps/web/components/ui/EmailInput.tsx
+++ b/apps/web/components/ui/EmailInput.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { forwardRef, useCallback } from "react";
+import type { ChangeEvent, FocusEvent, InputHTMLAttributes } from "react";
+
+import { isValidEmail, normalizeEmail } from "@/lib/email-format";
+
+type Props = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "type" | "value" | "onChange"
+> & {
+  /** Provide for a controlled field. Omit (use `defaultValue`/`name`) for an uncontrolled one. */
+  value?: string;
+  /** Receives every keystroke (and the normalized value on blur) for controlled use. */
+  onValueChange?: (value: string) => void;
+  /** Trim + lowercase on blur. Default true. */
+  normalizeOnBlur?: boolean;
+  /** Fired on blur with whether the (normalized) value is valid or empty. */
+  onValidityChange?: (valid: boolean) => void;
+};
+
+/**
+ * A drop-in `<input type="email">` that normalizes the address (trim +
+ * lowercase) when the field loses focus — the least-surprising moment, so it
+ * never fights the user mid-keystroke — and reports validity. Live typing is
+ * untouched; storage gets a clean, canonical value.
+ *
+ * Works controlled (`value` + `onValueChange`) or uncontrolled (`defaultValue`/
+ * `name`, e.g. FormData forms) — in the uncontrolled case the normalized value
+ * is written back to the field so the submitted value is clean.
+ */
+export const EmailInput = forwardRef<HTMLInputElement, Props>(function EmailInput(
+  {
+    value,
+    onValueChange,
+    normalizeOnBlur = true,
+    onValidityChange,
+    onBlur,
+    inputMode,
+    autoComplete,
+    ...rest
+  },
+  ref,
+) {
+  const controlled = value !== undefined;
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onValueChange?.(e.target.value);
+    },
+    [onValueChange],
+  );
+
+  const handleBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      const next = normalizeOnBlur ? normalizeEmail(raw) : raw;
+      if (next !== raw) {
+        if (controlled) onValueChange?.(next);
+        else e.currentTarget.value = next;
+      }
+      if (!controlled) onValueChange?.(next);
+      onValidityChange?.(next === "" || isValidEmail(next));
+      onBlur?.(e);
+    },
+    [controlled, normalizeOnBlur, onValueChange, onValidityChange, onBlur],
+  );
+
+  return (
+    <input
+      ref={ref}
+      type="email"
+      inputMode={inputMode ?? "email"}
+      autoComplete={autoComplete ?? "email"}
+      {...(controlled ? { value } : {})}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      {...rest}
+    />
+  );
+});
+
+export default EmailInput;

--- a/apps/web/components/ui/LocalTime.tsx
+++ b/apps/web/components/ui/LocalTime.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { formatInstant, type DateTimeMode } from "@/lib/datetime";
+
+type Props = {
+  /** A UTC instant: ISO string, epoch ms, or Date. */
+  value: string | number | Date | null | undefined;
+  mode?: DateTimeMode;
+  /** Override the preset format options entirely. */
+  options?: Intl.DateTimeFormatOptions;
+  /** Append the timezone abbreviation. Defaults on for datetime/time. */
+  withZone?: boolean;
+  /**
+   * Pin to UTC and skip localization. Use for pure *calendar dates* (invoice
+   * dates, accounting periods) stored as midnight-UTC, where shifting into the
+   * viewer's timezone would move the displayed day off-by-one. Implies a
+   * date-only render with no zone label.
+   */
+  utc?: boolean;
+  className?: string;
+  /** Rendered when `value` is null/empty. */
+  fallback?: string;
+};
+
+/**
+ * Renders a UTC instant in the *viewer's* local timezone.
+ *
+ * Server components render in the container's timezone (UTC), so a timestamp
+ * formatted on the server is stuck at UTC for every viewer. This client
+ * component fixes that: it first renders a deterministic UTC string (matching
+ * the server markup, so hydration never mismatches) and then, on mount,
+ * re-formats in the browser's timezone with a zone label. The brief UTC→local
+ * swap happens before paint in practice and keeps a useful `title` tooltip with
+ * the UTC value until localized.
+ */
+export function LocalTime({
+  value,
+  mode = "datetime",
+  options,
+  withZone,
+  utc = false,
+  className,
+  fallback = "—",
+}: Props) {
+  const hasValue = value != null && value !== "";
+  const effectiveMode = utc ? "date" : mode;
+  const effectiveWithZone = utc ? false : withZone;
+
+  // Initial state is UTC so SSR and the first client paint agree.
+  const [text, setText] = useState(() =>
+    hasValue
+      ? formatInstant(value as string | number | Date, {
+          mode: effectiveMode,
+          options,
+          withZone: effectiveWithZone,
+          timeZone: "UTC",
+        })
+      : "",
+  );
+  const [localized, setLocalized] = useState(false);
+
+  // Reformat in the viewer's timezone after mount (skipped for pinned UTC dates).
+  const optionsKey = options ? JSON.stringify(options) : "";
+  useEffect(() => {
+    if (!hasValue || utc) return;
+    setText(
+      formatInstant(value as string | number | Date, {
+        mode: effectiveMode,
+        options,
+        withZone: effectiveWithZone,
+      }),
+    );
+    setLocalized(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, effectiveMode, optionsKey, effectiveWithZone, hasValue, utc]);
+
+  if (!hasValue) return <span className={className}>{fallback}</span>;
+
+  const title =
+    localized || utc
+      ? undefined
+      : `${formatInstant(value as string | number | Date, {
+          mode: effectiveMode,
+          options,
+          withZone: effectiveWithZone,
+          timeZone: "UTC",
+        })} (UTC)`;
+
+  return (
+    <span className={className} title={title} suppressHydrationWarning>
+      {text}
+    </span>
+  );
+}
+
+export default LocalTime;

--- a/apps/web/components/ui/PhoneCountryContext.tsx
+++ b/apps/web/components/ui/PhoneCountryContext.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+import { DEFAULT_PHONE_COUNTRY, type CountryCode } from "@/lib/phone";
+
+const PhoneCountryContext = createContext<CountryCode>(DEFAULT_PHONE_COUNTRY);
+
+/**
+ * Provides the install's home country to descendant {@link PhoneInput}s so they
+ * format national numbers correctly without each form passing `country`. The
+ * value is resolved server-side (see `lib/phone-country.server.ts`) and handed
+ * down here. An explicit `country` prop on a PhoneInput still wins.
+ */
+export function PhoneCountryProvider({
+  country,
+  children,
+}: {
+  country: CountryCode;
+  children: ReactNode;
+}) {
+  return (
+    <PhoneCountryContext.Provider value={country}>
+      {children}
+    </PhoneCountryContext.Provider>
+  );
+}
+
+/** The ambient phone country (defaults to {@link DEFAULT_PHONE_COUNTRY} with no provider). */
+export function usePhoneCountry(): CountryCode {
+  return useContext(PhoneCountryContext);
+}

--- a/apps/web/components/ui/PhoneInput.tsx
+++ b/apps/web/components/ui/PhoneInput.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { forwardRef, useCallback } from "react";
+import type { ChangeEvent, InputHTMLAttributes } from "react";
+
+import {
+  formatPhoneAsYouType,
+  isValidPhone,
+  toE164,
+  type CountryCode,
+} from "@/lib/phone";
+import { usePhoneCountry } from "@/components/ui/PhoneCountryContext";
+
+export type PhoneChangeInfo = {
+  /** The formatted value shown in the field. */
+  value: string;
+  /** E.164 normalization ("+14155551234") when the number is valid, else null. */
+  e164: string | null;
+  /** Whether the value is a complete, valid number for `country`. */
+  isValid: boolean;
+  country: CountryCode;
+};
+
+type Props = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "type" | "value" | "onChange"
+> & {
+  /** Provide for a controlled field. Omit (use `defaultValue`/`name`) for an uncontrolled one. */
+  value?: string;
+  /** Receives the value formatted as-you-type. Store this. */
+  onValueChange?: (value: string) => void;
+  /**
+   * Country to format national numbers for. Defaults to the install's home
+   * country from {@link PhoneCountryProvider} (falling back to
+   * {@link DEFAULT_PHONE_COUNTRY} when no provider is present).
+   */
+  country?: CountryCode;
+  /** Optional richer callback with E.164 + validity, fired alongside onValueChange. */
+  onPhoneChange?: (info: PhoneChangeInfo) => void;
+};
+
+/**
+ * A drop-in `<input type="tel">` that formats the number live as the user
+ * types (e.g. "4155551234" -> "(415) 555-1234"), country-aware via
+ * libphonenumber-js. Reformats from scratch on every keystroke, so end-of-field
+ * editing/backspace behaves naturally. Pass `country` (the install's / record's
+ * ISO-2 code) when known for correct national formatting.
+ *
+ * Works controlled (`value` + `onValueChange`) or uncontrolled (`defaultValue`/
+ * `name`, e.g. FormData forms) — in the uncontrolled case the formatted value is
+ * written back to the field so the submitted value is formatted too.
+ */
+export const PhoneInput = forwardRef<HTMLInputElement, Props>(function PhoneInput(
+  {
+    value,
+    onValueChange,
+    country,
+    onPhoneChange,
+    inputMode,
+    autoComplete,
+    ...rest
+  },
+  ref,
+) {
+  const contextCountry = usePhoneCountry();
+  const resolvedCountry = country ?? contextCountry;
+  const controlled = value !== undefined;
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const formatted = formatPhoneAsYouType(e.target.value, resolvedCountry);
+      if (controlled) {
+        onValueChange?.(formatted);
+      } else {
+        e.currentTarget.value = formatted;
+        onValueChange?.(formatted);
+      }
+      onPhoneChange?.({
+        value: formatted,
+        e164: toE164(formatted, resolvedCountry),
+        isValid: isValidPhone(formatted, resolvedCountry),
+        country: resolvedCountry,
+      });
+    },
+    [controlled, resolvedCountry, onValueChange, onPhoneChange],
+  );
+
+  return (
+    <input
+      ref={ref}
+      type="tel"
+      inputMode={inputMode ?? "tel"}
+      autoComplete={autoComplete ?? "tel"}
+      {...(controlled ? { value } : {})}
+      onChange={handleChange}
+      {...rest}
+    />
+  );
+});
+
+export default PhoneInput;

--- a/apps/web/components/wiki/LintFindingCard.tsx
+++ b/apps/web/components/wiki/LintFindingCard.tsx
@@ -4,6 +4,8 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
+import { LocalTime } from "@/components/ui/LocalTime";
+
 // ─── Public types ───────────────────────────────────────────────────────────
 
 export type LintFindingRow = {
@@ -105,9 +107,11 @@ export function LintFindingCard({ finding }: Props): ReactNode {
             overlay · {finding.organizationId}
           </span>
         )}
-        <span className="ml-auto text-[10px] text-[var(--dpf-muted)]">
-          {finding.createdAt.toISOString().slice(0, 10)}
-        </span>
+        <LocalTime
+          value={finding.createdAt}
+          mode="date"
+          className="ml-auto text-[10px] text-[var(--dpf-muted)]"
+        />
       </header>
 
       <div className="mt-1 text-sm text-[var(--dpf-text)]">

--- a/apps/web/components/wiki/WikiPageViewer.tsx
+++ b/apps/web/components/wiki/WikiPageViewer.tsx
@@ -11,6 +11,8 @@ import {
   isPrincipleTier,
 } from "@dpf/db/wiki-taxonomy";
 
+import { LocalTime } from "@/components/ui/LocalTime";
+
 import { WikiBodyRenderer } from "./WikiBodyRenderer";
 import { WikiPageKindBadge } from "./WikiPageKindBadge";
 import { WikiSourceCitations, type WikiSourceCitation } from "./WikiSourceCitations";
@@ -234,9 +236,9 @@ export function WikiPageViewer({ page }: Props): ReactNode {
 
       <footer className="mt-6 text-xs text-[var(--dpf-muted)]">
         {page.lastReviewedAt && (
-          <span>Last reviewed {page.lastReviewedAt.toISOString().slice(0, 10)} · </span>
+          <span>Last reviewed <LocalTime value={page.lastReviewedAt} mode="date" /> · </span>
         )}
-        Updated {page.updatedAt.toISOString().slice(0, 10)}
+        Updated <LocalTime value={page.updatedAt} mode="date" />
       </footer>
     </article>
   );

--- a/apps/web/lib/datetime.ts
+++ b/apps/web/lib/datetime.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared date/time formatting for the portal UI.
+ *
+ * Portal timestamps are stored and transported as UTC instants (ISO strings or
+ * `Date`s). They MUST be displayed in the viewer's local timezone — never UTC —
+ * because portal operators are rarely on UTC and a bare UTC time is useless to
+ * them. See {@link ./../components/ui/LocalTime} for the SSR-safe component that
+ * renders these; server components cannot know the viewer's timezone, so any
+ * user-visible timestamp rendered on the server has to go through `LocalTime`.
+ */
+
+export type DateTimeMode = "datetime" | "date" | "time";
+
+const PRESETS: Record<DateTimeMode, Intl.DateTimeFormatOptions> = {
+  datetime: {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  },
+  date: { year: "numeric", month: "short", day: "numeric" },
+  time: { hour: "numeric", minute: "2-digit" },
+};
+
+export type FormatInstantOptions = {
+  mode?: DateTimeMode;
+  /** Override the preset format options entirely. */
+  options?: Intl.DateTimeFormatOptions;
+  /**
+   * Force a specific IANA timezone. Defaults to the runtime's zone (the
+   * viewer's browser on the client). Pass "UTC" for a deterministic render.
+   */
+  timeZone?: string;
+  /**
+   * Append the timezone abbreviation (e.g. "CDT") so a local time is never
+   * ambiguous. Defaults to true for datetime/time, false for date-only.
+   */
+  withZone?: boolean;
+};
+
+/**
+ * Format a UTC instant for display. With no `timeZone` it uses the runtime's
+ * timezone — the viewer's browser when called on the client.
+ */
+export function formatInstant(
+  value: string | number | Date,
+  opts: FormatInstantOptions = {},
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const mode = opts.mode ?? "datetime";
+  const base = opts.options ?? PRESETS[mode];
+  const withZone = opts.withZone ?? mode !== "date";
+
+  const formatOptions: Intl.DateTimeFormatOptions = { ...base };
+  if (opts.timeZone) formatOptions.timeZone = opts.timeZone;
+  if (withZone && formatOptions.timeZoneName === undefined) {
+    formatOptions.timeZoneName = "short";
+  }
+
+  return new Intl.DateTimeFormat(undefined, formatOptions).format(date);
+}

--- a/apps/web/lib/email-format.test.ts
+++ b/apps/web/lib/email-format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidEmail, normalizeEmail } from "./email-format";
+
+describe("normalizeEmail", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeEmail("  Jane.Doe@Company.COM  ")).toBe("jane.doe@company.com");
+  });
+
+  it("leaves an already-normalized address unchanged", () => {
+    expect(normalizeEmail("a@b.com")).toBe("a@b.com");
+  });
+});
+
+describe("isValidEmail", () => {
+  it.each([
+    "jane@company.com",
+    "a.b-c+tag@sub.example.co.uk",
+  ])("accepts %s", (value) => {
+    expect(isValidEmail(value)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "no-at-sign",
+    "missing@domain",
+    "spaces in@email.com",
+    "two@@at.com",
+  ])("rejects %s", (value) => {
+    expect(isValidEmail(value)).toBe(false);
+  });
+
+  it("rejects addresses longer than 320 chars", () => {
+    const long = `${"a".repeat(320)}@b.com`;
+    expect(isValidEmail(long)).toBe(false);
+  });
+});

--- a/apps/web/lib/email-format.ts
+++ b/apps/web/lib/email-format.ts
@@ -1,0 +1,24 @@
+/**
+ * Client-safe email normalization/validation for the portal UI.
+ *
+ * Pairs with {@link ./../components/ui/EmailInput}, which normalizes on blur.
+ * Kept dependency-free and deliberately permissive — it mirrors HTML5 + Zod's
+ * `.email()` intent (one "@", a dotted domain) without trying to fully model
+ * RFC 5322. Server-side schemas (`@dpf/validators`) remain the authority for
+ * rejection. NOTE: this is distinct from `lib/email.ts`, which is the
+ * server-only (nodemailer) email *sender* and must not be imported by clients.
+ */
+
+// One local part, one "@", a dotted domain. Matches Zod/HTML5 practical intent.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Trim surrounding whitespace and lowercase. Safe to call on any input. */
+export function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/** True when `value` looks like a valid email (after trimming). */
+export function isValidEmail(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 320 && EMAIL_RE.test(trimmed);
+}

--- a/apps/web/lib/phone-country.server.ts
+++ b/apps/web/lib/phone-country.server.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+
+import { coercePhoneCountry, DEFAULT_PHONE_COUNTRY, type CountryCode } from "./phone";
+
+/**
+ * Resolve the install's home country for phone formatting.
+ *
+ * Source of truth is the organization's tax profile `homeCountryCode` (set
+ * during tax setup), falling back to the licensing profile, then to
+ * {@link DEFAULT_PHONE_COUNTRY}. Single-tenant: there is one organization.
+ * Surfaced to the UI via {@link ../components/ui/PhoneCountryContext} so
+ * `PhoneInput` defaults to it without per-form plumbing.
+ */
+export async function resolveHomePhoneCountry(): Promise<CountryCode> {
+  try {
+    const [tax, license] = await Promise.all([
+      prisma.organizationTaxProfile.findFirst({
+        select: { homeCountryCode: true },
+      }),
+      prisma.organizationLicenseProfile.findFirst({
+        select: { homeCountryCode: true },
+      }),
+    ]);
+    return (
+      coercePhoneCountry(tax?.homeCountryCode) ??
+      coercePhoneCountry(license?.homeCountryCode) ??
+      DEFAULT_PHONE_COUNTRY
+    );
+  } catch {
+    return DEFAULT_PHONE_COUNTRY;
+  }
+}

--- a/apps/web/lib/phone.test.ts
+++ b/apps/web/lib/phone.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coercePhoneCountry,
+  formatPhoneAsYouType,
+  formatPhoneDisplay,
+  isValidPhone,
+  toE164,
+} from "./phone";
+
+describe("formatPhoneAsYouType", () => {
+  it("formats a US number progressively", () => {
+    expect(formatPhoneAsYouType("415", "US")).toBe("(415)");
+    expect(formatPhoneAsYouType("4155551234", "US")).toBe("(415) 555-1234");
+  });
+
+  it("honors a leading + as international regardless of country", () => {
+    expect(formatPhoneAsYouType("+442079460000", "US")).toBe("+44 20 7946 0000");
+  });
+
+  it("formats a GB national number when country is GB", () => {
+    expect(formatPhoneAsYouType("02079460000", "GB")).toBe("020 7946 0000");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatPhoneAsYouType("", "US")).toBe("");
+  });
+});
+
+describe("toE164", () => {
+  it("normalizes a formatted US number to E.164", () => {
+    expect(toE164("(415) 555-1234", "US")).toBe("+14155551234");
+  });
+
+  it("returns null for incomplete numbers", () => {
+    expect(toE164("415", "US")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(toE164("", "US")).toBeNull();
+  });
+});
+
+describe("isValidPhone", () => {
+  it("accepts a complete US number", () => {
+    expect(isValidPhone("(415) 555-1234", "US")).toBe(true);
+  });
+
+  it("rejects an incomplete number", () => {
+    expect(isValidPhone("415", "US")).toBe(false);
+  });
+
+  it("rejects empty input", () => {
+    expect(isValidPhone("", "US")).toBe(false);
+  });
+});
+
+describe("coercePhoneCountry", () => {
+  it("accepts and upper-cases a supported ISO-2 code", () => {
+    expect(coercePhoneCountry("gb")).toBe("GB");
+    expect(coercePhoneCountry(" us ")).toBe("US");
+  });
+
+  it("returns null for unset or unrecognized values", () => {
+    expect(coercePhoneCountry(null)).toBeNull();
+    expect(coercePhoneCountry(undefined)).toBeNull();
+    expect(coercePhoneCountry("")).toBeNull();
+    expect(coercePhoneCountry("ZZ")).toBeNull();
+    expect(coercePhoneCountry("United States")).toBeNull();
+  });
+});
+
+describe("formatPhoneDisplay", () => {
+  it("formats a stored E.164 number for display", () => {
+    expect(formatPhoneDisplay("+14155551234", "US")).toBe("(415) 555-1234");
+  });
+
+  it("returns input unchanged when unparseable", () => {
+    expect(formatPhoneDisplay("not a phone", "US")).toBe("not a phone");
+  });
+
+  it("returns empty string for null/empty", () => {
+    expect(formatPhoneDisplay(null, "US")).toBe("");
+    expect(formatPhoneDisplay("", "US")).toBe("");
+  });
+});

--- a/apps/web/lib/phone.ts
+++ b/apps/web/lib/phone.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared phone-number formatting/validation for the portal UI.
+ *
+ * Backed by libphonenumber-js. Inputs are formatted *as the user types*
+ * (see {@link ./../components/ui/PhoneInput}) and can be normalized to E.164
+ * for storage/matching. Formatting is country-aware; callers should pass the
+ * install's / record's country when known, otherwise {@link DEFAULT_PHONE_COUNTRY}
+ * is used.
+ */
+import {
+  AsYouType,
+  parsePhoneNumberFromString,
+  isValidPhoneNumber,
+  isSupportedCountry,
+  type CountryCode,
+} from "libphonenumber-js";
+
+export type { CountryCode };
+
+/** Fallback country when a form has no country context. */
+export const DEFAULT_PHONE_COUNTRY: CountryCode = "US";
+
+/**
+ * Coerce a stored country string (e.g. an install's `homeCountryCode`) to a
+ * libphonenumber-supported ISO-2 `CountryCode`, or null if unset/unrecognized.
+ * Pure — safe to import from client or server.
+ */
+export function coercePhoneCountry(
+  value: string | null | undefined,
+): CountryCode | null {
+  if (!value) return null;
+  const upper = value.trim().toUpperCase();
+  return isSupportedCountry(upper) ? (upper as CountryCode) : null;
+}
+
+/**
+ * Format partial input progressively (e.g. "4155551" -> "(415) 555-1"). A
+ * leading "+" is honored for international numbers regardless of `country`.
+ */
+export function formatPhoneAsYouType(
+  input: string,
+  country: CountryCode = DEFAULT_PHONE_COUNTRY,
+): string {
+  if (!input) return "";
+  return new AsYouType(country).input(input);
+}
+
+/** Normalize to E.164 ("+14155551234") if the value is a valid number, else null. */
+export function toE164(
+  value: string,
+  country: CountryCode = DEFAULT_PHONE_COUNTRY,
+): string | null {
+  if (!value?.trim()) return null;
+  try {
+    const parsed = parsePhoneNumberFromString(value, country);
+    return parsed?.isValid() ? parsed.number : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when `value` is a complete, valid phone number for `country`. */
+export function isValidPhone(
+  value: string,
+  country: CountryCode = DEFAULT_PHONE_COUNTRY,
+): boolean {
+  if (!value?.trim()) return false;
+  try {
+    return isValidPhoneNumber(value, country);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Format a stored number for display (national format for in-country numbers,
+ * international when a country code is present). Returns the input unchanged if
+ * it cannot be parsed, so it is safe on legacy/free-form data.
+ */
+export function formatPhoneDisplay(
+  value: string | null | undefined,
+  country: CountryCode = DEFAULT_PHONE_COUNTRY,
+): string {
+  if (!value?.trim()) return "";
+  try {
+    const parsed = parsePhoneNumberFromString(value, country);
+    if (!parsed) return value;
+    return parsed.country ? parsed.formatNational() : parsed.formatInternational();
+  } catch {
+    return value;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "gray-matter": "^4.0.3",
     "inngest": "^4.5.0",
     "jose": "^6.2.3",
+    "libphonenumber-js": "^1.13.4",
     "lucide-react": "^1.17.0",
     "mammoth": "^1.12.0",
     "nanoid": "^5.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      libphonenumber-js:
+        specifier: ^1.13.4
+        version: 1.13.4
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.6)
@@ -6827,6 +6830,9 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  libphonenumber-js@1.13.4:
+    resolution: {integrity: sha512-/lhWr7vq8foWN9Apksnd9v8/cfwzW6g6qKOCo25XBGkNaVCHucXO57hLy4CWHGvytvLz6Nt3J5Gs8p3jlCGFXA==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -17118,6 +17124,8 @@ snapshots:
   layout-base@2.0.1: {}
 
   leven@3.1.0: {}
+
+  libphonenumber-js@1.13.4: {}
 
   lie@3.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Two cohesive, independent commits that make operator-facing portal data display and entry correct, via shared `components/ui` primitives:

1. **Local timezone for all portal timestamps** — server components were formatting dates on the container's UTC clock, so non-UTC operators saw unusable UTC times. New SSR-safe `LocalTime` component (`lib/datetime.ts` + `components/ui/LocalTime.tsx`) renders a UTC instant in the viewer's browser timezone with a zone label (paints a deterministic UTC string first to avoid hydration mismatch, then localizes on mount). Adopted across ~98 server-rendered surfaces (self-upgrade, compliance, finance, platform, CRM, workspace, portfolio, wiki, admin, storefront). Pure calendar/business dates use a UTC pin to avoid off-by-one day shifts.

2. **Live-formatting phone & email input primitives** — phone/email fields were raw `<input>`s with no formatting/normalization. New `PhoneInput` (libphonenumber-js `AsYouType`, country-aware) and `EmailInput` (trim + lowercase + validity on blur), both supporting controlled and uncontrolled (FormData) usage. Adopted at all 7 phone and ~19 email entry sites. Phone default country resolves from `OrganizationTaxProfile.homeCountryCode` (server-only resolver) via `PhoneCountryProvider` in the shell layout (→ license profile → US); explicit `country` prop still wins. Adds `libphonenumber-js`.

The two commits are cleanly separable if a reviewer prefers two PRs.

## Test plan
- [x] vitest: full suite green on the combined branch (8690 passing); new helpers `lib/phone.test.ts` + `lib/email-format.test.ts` (26) pass on this branch's `origin/main` base
- [x] typecheck: clean on this branch (pure `origin/main` base, Prisma client generated)
- [x] next build: validated by CI on push
- [ ] UX verification: not yet driven against a running portal — recommend a visual pass on a couple of surfaces (self-upgrade timestamps; an employee/team phone field) before merge

## Notes
- Branch is based on `origin/main` (isolated worktree), excluding unrelated local install-branch divergence.
- Overlap sweep: only open PR is #1290 (log-injection sanitize) — no overlap with this UI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)