### PR TITLE
fix(bootstrap): re-mint under-provisioned MCP tokens (missing registry_read)

### DIFF
--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/mcp-readiness-probe.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/mcp-readiness-probe.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import {
   planMcpReadinessProbe,
   interpretMcpReadinessResponse,
+  interpretScopeCoverageProbe,
+  SCOPE_COVERAGE_PROBE,
 } from "../mcp-readiness-probe";
 
 const FIXTURES = join(__dirname, "fixtures");
@@ -77,5 +79,56 @@ describe("interpretMcpReadinessResponse", () => {
     const body = { structuredContent: { error: "insufficient_token_scope", requiredScope: "write" } };
     const result = interpretMcpReadinessResponse(403, body, OBSERVED);
     expect(result).toEqual({ ok: false, reason: "scope_insufficient", httpStatus: 403 });
+  });
+});
+
+describe("interpretScopeCoverageProbe (BI-A3DE9A31)", () => {
+  const scopeFailureBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Token lacks the required scope for ${SCOPE_COVERAGE_PROBE.tool}. Required: one of ${SCOPE_COVERAGE_PROBE.requiredScope}; token has: backlog_read, backlog_write.`,
+        },
+      ],
+    },
+  };
+  const successBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      isError: false,
+      content: [{ type: "text", text: JSON.stringify({ success: true, data: { coworker: "x" } }) }],
+    },
+  };
+
+  it("flags an under-provisioned token (explicit registry_read scope failure)", () => {
+    expect(interpretScopeCoverageProbe(200, scopeFailureBody)).toEqual({
+      sufficient: false,
+      missingScope: "registry_read",
+    });
+  });
+
+  it("treats a successful registry-gated call as sufficient", () => {
+    expect(interpretScopeCoverageProbe(200, successBody)).toEqual({ sufficient: true });
+  });
+
+  it("returns null (never re-mint) when the endpoint is unreachable", () => {
+    expect(interpretScopeCoverageProbe(0, null)).toEqual({ sufficient: null, reason: "unreachable" });
+    expect(interpretScopeCoverageProbe(503, null)).toEqual({ sufficient: null, reason: "unreachable" });
+  });
+
+  it("returns null (inconclusive) for a non-scope error — does not assume under-provisioned", () => {
+    const otherError = {
+      result: { isError: true, content: [{ type: "text", text: "Coworker profile not found." }] },
+    };
+    expect(interpretScopeCoverageProbe(200, otherError)).toEqual({ sufficient: null, reason: "inconclusive" });
+  });
+
+  it("returns null for an unrecognized body shape", () => {
+    expect(interpretScopeCoverageProbe(200, {})).toEqual({ sufficient: null, reason: "inconclusive" });
   });
 });

--- a/packages/dpf-bootstrap/src/agent-toolchain/mcp-readiness-probe.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/mcp-readiness-probe.ts
@@ -73,6 +73,89 @@ export function interpretMcpReadinessResponse(
   return { ok: false, reason: "unexpected_shape", httpStatus };
 }
 
+/**
+ * Scope-coverage reconciliation (BI-A3DE9A31).
+ *
+ * Tokens minted before the `write -> development` template fix carry a narrow
+ * legacy scope set MISSING `registry_read` (and the other development reads),
+ * so registry-gated tools like `principle_decide` (WWMD) refuse. The bootstrap
+ * must treat "token present" as distinct from "token sufficient": probe a
+ * registry_read-gated, read-only, no-arg tool and re-mint when it reports a
+ * scope failure.
+ *
+ * This is the SSOT for the probe tool name + the failure markers; the shell
+ * adapters (dpf-bootstrap-agent-toolchain.{sh,ps1}) mirror the marker strings.
+ */
+export const SCOPE_COVERAGE_PROBE = {
+  /** Read-only, no-arg, registry_read-gated tool — the cheapest scope probe. */
+  tool: "get_my_coworker_profile",
+  /** The dev-template scope a legacy "write" token is missing. */
+  requiredScope: "registry_read",
+  /** Substring the DPF MCP emits when a token lacks a required scope. */
+  scopeFailureMarker: "lacks the required scope",
+} as const;
+
+export type ScopeCoverageResult =
+  | { sufficient: true }
+  | { sufficient: false; missingScope: string }
+  | { sufficient: null; reason: "unreachable" | "inconclusive" };
+
+/**
+ * Interpret the `tools/call` response for {@link SCOPE_COVERAGE_PROBE.tool}.
+ *
+ * The DPF MCP returns a scope failure as HTTP 200 with `result.isError === true`
+ * and a content text like "Token lacks the required scope for X. Required: one
+ * of registry_read; …" — NOT as 401/403. So this keys on the tool-call result.
+ *
+ * - `sufficient: true`  — the call succeeded; the token carries the gated scope.
+ * - `sufficient: false` — explicit scope failure naming `requiredScope`.
+ * - `sufficient: null`  — unreachable / ambiguous. **Callers MUST NOT re-mint**
+ *   on null; only an unambiguous `false` justifies replacing a present token.
+ */
+export function interpretScopeCoverageProbe(
+  httpStatus: number,
+  body: unknown,
+  requiredScope: string = SCOPE_COVERAGE_PROBE.requiredScope,
+): ScopeCoverageResult {
+  if (httpStatus === 0 || httpStatus >= 500) {
+    return { sufficient: null, reason: "unreachable" };
+  }
+  if (httpStatus !== 200) {
+    return { sufficient: null, reason: "inconclusive" };
+  }
+  const result = extractToolCallResult(body);
+  if (!result) return { sufficient: null, reason: "inconclusive" };
+
+  if (result.isError && typeof result.text === "string") {
+    const t = result.text;
+    if (t.includes(SCOPE_COVERAGE_PROBE.scopeFailureMarker) && t.includes(requiredScope)) {
+      return { sufficient: false, missingScope: requiredScope };
+    }
+    // An error for some other reason — don't assume under-provisioned.
+    return { sufficient: null, reason: "inconclusive" };
+  }
+
+  // 200 + a non-error tool result => the registry_read-gated call ran.
+  if (result.isError === false || result.isError === undefined) {
+    return { sufficient: true };
+  }
+  return { sufficient: null, reason: "inconclusive" };
+}
+
+function extractToolCallResult(
+  body: unknown,
+): { isError?: boolean; text?: string } | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  const result = b.result as
+    | { isError?: boolean; content?: Array<{ text?: unknown }> }
+    | undefined;
+  if (!result || typeof result !== "object") return null;
+  const first = Array.isArray(result.content) ? result.content[0] : undefined;
+  const text = first && typeof first.text === "string" ? first.text : undefined;
+  return { isError: result.isError, text };
+}
+
 function looksLikeInsufficientScope(body: unknown): boolean {
   if (!body || typeof body !== "object") return false;
   const b = body as Record<string, unknown>;

--- a/scripts/dpf-bootstrap-agent-toolchain.ps1
+++ b/scripts/dpf-bootstrap-agent-toolchain.ps1
@@ -94,6 +94,28 @@ function Resolve-PortalContainer {
     return "dpf-portal-1"
 }
 
+# Reconcile an under-provisioned token (BI-A3DE9A31). "token present" !=
+# "token sufficient": a token minted before the write->development-template fix
+# lacks `registry_read`, so registry-gated tools (principle_decide / WWMD)
+# refuse. Probe a registry_read-gated, read-only, no-arg tool; on an
+# unambiguous scope failure naming registry_read, force a re-mint by clearing
+# $HasToken. Fail safe: leave the token untouched on unreachable/ambiguous
+# responses. Markers mirror interpretScopeCoverageProbe in @dpf/bootstrap (SSOT).
+if ($HasToken -and $AutoMint -and -not $DryRun.IsPresent) {
+    try {
+        $body = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_my_coworker_profile","arguments":{}}}'
+        $headers = @{ "Authorization" = "Bearer $($env:DPF_MCP_BEARER_TOKEN)"; "Accept" = "application/json, text/event-stream" }
+        $resp = Invoke-WebRequest -Uri $McpEndpoint -Method Post -ContentType "application/json" -Headers $headers -Body $body -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        $probe = $resp.Content
+        if ($probe -match 'lacks the required scope' -and $probe -match 'registry_read') {
+            Write-Warn2 "Present MCP token is under-provisioned (missing registry_read); re-minting with the full development template."
+            $HasToken = $false
+        }
+    } catch {
+        # Unreachable / ambiguous — fail safe, leave the present token untouched.
+    }
+}
+
 if (-not $HasToken -and $AutoMint) {
     if ($DryRun.IsPresent) {
         Write-Info "DRY-RUN: would mint a '$MintScope'-scoped MCP token (in portal container) and persist it (User env)."

--- a/scripts/dpf-bootstrap-agent-toolchain.sh
+++ b/scripts/dpf-bootstrap-agent-toolchain.sh
@@ -240,6 +240,31 @@ resolve_portal_container() {
   printf 'dpf-portal-1\n'
 }
 
+# --- Reconcile an under-provisioned token (BI-A3DE9A31) ----------------------
+#
+# "token present" != "token sufficient". A token minted before the
+# write->development-template fix carries a narrow legacy scope set MISSING
+# `registry_read`, so registry-gated tools (e.g. principle_decide / WWMD)
+# refuse. Probe a registry_read-gated, read-only, no-arg tool; on an
+# UNAMBIGUOUS scope failure naming registry_read, force a re-mint by clearing
+# HAS_TOKEN so the mint+persist block below issues a full development token.
+# Fail safe: leave the token untouched on unreachable/ambiguous responses.
+# Markers mirror interpretScopeCoverageProbe in @dpf/bootstrap (SSOT).
+if [ "$HAS_TOKEN" -eq 1 ] && [ "$AUTO_MINT" -eq 1 ] && [ "$DRY_RUN" -eq 0 ] \
+   && command -v curl >/dev/null 2>&1; then
+  _scope_probe="$(curl -s --max-time 5 -X POST "$MCP_ENDPOINT" \
+    -H "Authorization: Bearer ${DPF_MCP_BEARER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    --data '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_my_coworker_profile","arguments":{}}}' \
+    2>/dev/null)"
+  if printf '%s' "$_scope_probe" | grep -q 'lacks the required scope' \
+     && printf '%s' "$_scope_probe" | grep -q 'registry_read'; then
+    warn "Present MCP token is under-provisioned (missing registry_read); re-minting with the full development template."
+    HAS_TOKEN=0
+  fi
+fi
+
 if [ "$HAS_TOKEN" -eq 0 ] && [ "$AUTO_MINT" -eq 1 ]; then
   if [ "$DRY_RUN" -eq 1 ]; then
     info "DRY-RUN: would mint a '$MINT_SCOPE'-scoped MCP token (in portal container) and persist it (POSIX)."


### PR DESCRIPTION
## Problem (BI-A3DE9A31)
The agent-toolchain bootstrap treats **"token present" as "token sufficient."** A token minted before the `write → development`-template fix carries a narrow legacy scope set **missing `registry_read`** (+ the other development reads). Registry-gated tools like `principle_decide` (WWMD) then refuse — and because the bootstrap auto-mints only when `HAS_TOKEN == 0`, a present-but-under-provisioned token never heals. Hit live on this macOS install: every kernel decision had to fall back to a local reproduction because live WWMD was scope-blocked.

The mint mapping itself is already fixed (`issue-mcp-token.ts` resolves `write → development`); this PR fixes the **reconciliation gap**.

## Change
- **`mcp-readiness-probe.ts`** — add `interpretScopeCoverageProbe` + `SCOPE_COVERAGE_PROBE` as the testable SSOT. The DPF MCP returns scope failures as **HTTP 200 + `result.isError` + "lacks the required scope" text** (not 401/403), so the interpreter keys on the tool-call result. Returns `sufficient: null` on unreachable/ambiguous responses — **callers must never re-mint on null** (fail safe).
- **`dpf-bootstrap-agent-toolchain.{sh,ps1}`** — when a token is present, probe a `registry_read`-gated, read-only, no-arg tool (`get_my_coworker_profile`); on an *unambiguous* scope failure naming `registry_read`, clear `HAS_TOKEN` so the existing mint+persist path issues a full development token (and the later `claude mcp add --scope local` rebinds the `~/.claude.json` override). Untouched on unreachable/ambiguous.
- **Tests** — 5 new interpreter cases (failure / success / unreachable / non-scope-error / unknown-shape). Markers mirror `apps/web/app/api/mcp/v1/route.ts:388` (the scope-failure message SSOT).

## Verification
- `@dpf/bootstrap` probe tests **15/15** (10 existing + 5 new).
- `bash -n` clean on the `.sh`. (`pwsh` unavailable on the dev machine; `.ps1` mirrors the verified `.sh` logic.)
- Detection validated live: the probe call returns the scope-failure markers for an under-provisioned token and a normal profile for a sufficient one; failure-text format confirmed against `route.ts:388`.

## Notes
- No overlap with open PR #1295 (`sync-mcp-worktrees.sh`) — different files.
- This machine was already manually healed (re-minted + re-persisted to all four sinks); this PR makes the heal automatic for other pre-fix installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)