### PR TITLE
fix(self-upgrade): refuse fast on uncommitted working tree in prep

### DIFF
--- a/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
@@ -162,6 +162,33 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     expect(existsSync(join(install, "upstream.txt"))).toBe(true);
   });
 
+  it("refuses up front on an uncommitted working tree (does not switch branch or merge)", async () => {
+    const { upstream, install, root } = makeWorld();
+    cleanup.push(root);
+    commit(upstream, "upstream.txt", "x\n", "feat: x");
+
+    // Uncommitted local change in the install clone — the real-world case
+    // (e.g. WIP edits). The merge would otherwise abort with "local changes
+    // would be overwritten" and surface as an empty, misleading merge-conflict.
+    const startBranch = git(install, "rev-parse", "--abbrev-ref", "HEAD").trim();
+    writeFileSync(join(install, "base.txt"), "uncommitted edit\n");
+
+    const r = await prepareUpgradeSource(
+      { sourceMode: "upstream", hostSourcePath: install, remote: "origin", branch: "main", installBranch: "dpf/install" },
+      defaultGitRunner,
+    );
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("dirty-tree");
+    expect(r.message).toContain("base.txt");
+    expect(r.message).toContain("uncommitted");
+    // The clone is untouched: still on the original branch, never switched to
+    // the install branch, no merge in progress.
+    expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe(startBranch);
+    expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
+  });
+
   it("local mode stamps the working tree HEAD, with -dirty when uncommitted", async () => {
     const { install, root } = makeWorld();
     cleanup.push(root);

--- a/apps/web/lib/self-upgrade/prepare-source.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.test.ts
@@ -109,6 +109,18 @@ describe("prepareUpgradeSource — upstream mode", () => {
     expect(git.calls.some((c) => c.join(" ").includes("merge --abort"))).toBe(true);
   });
 
+  it("refuses on an uncommitted working tree before fetching or checking out", async () => {
+    const git = fakeGit([
+      ["status --porcelain", ok(" M apps/web/x.ts\n?? apps/web/y.ts\n")],
+    ]);
+    const r = await prepareUpgradeSource(baseUpstream, git);
+    expect(r).toMatchObject({ ok: false, reason: "dirty-tree" });
+    if (r.ok || r.reason !== "dirty-tree") return;
+    expect(r.message).toContain("apps/web/x.ts");
+    // Fails fast: no fetch, checkout, or merge against a dirty tree.
+    expect(git.calls.some((c) => c.includes("fetch") || c.includes("checkout") || c.includes("merge"))).toBe(false);
+  });
+
   it("returns no-target when the upstream ref cannot be resolved", async () => {
     const git = fakeGit([
       ["fetch origin main", ok()],

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -60,12 +60,28 @@ export type PrepareSourceResult =
     }
   | {
       ok: false;
-      reason: "no-target" | "prep-error";
+      reason: "no-target" | "prep-error" | "dirty-tree";
       message: string;
     };
 
 function trim(s: string): string {
   return s.trim();
+}
+
+/**
+ * Repo-relative paths of TRACKED modifications (staged or unstaged) from
+ * `git status --porcelain`, or [] when none. Untracked entries ("??") are
+ * excluded: they don't block a merge the way modified tracked files do, and
+ * counting them would trip on benign artifacts. Note: do NOT trim the whole
+ * porcelain blob first — that would strip the leading status space of the first
+ * line and corrupt the `slice(3)` path extraction.
+ */
+function dirtyFiles(porcelain: string): string[] {
+  return porcelain
+    .split("\n")
+    .filter((l) => l.trim().length > 0 && !l.startsWith("??"))
+    .map((l) => l.slice(3).trim()) // strip the 2-char status + 1 space prefix
+    .filter(Boolean);
 }
 
 async function readHeadStamp(run: GitRunner, hostSourcePath: string): Promise<string> {
@@ -95,6 +111,26 @@ export async function prepareUpgradeSource(
 
   // ── upstream ──────────────────────────────────────────────────────────────
   try {
+    // Refuse FAST on an uncommitted working tree. The merge below would abort
+    // with "local changes would be overwritten" — git reports that as exit 1
+    // with NO conflict markers, so the generic merge path would surface an
+    // empty, misleading "merge-conflict". This design preserves *committed*
+    // local delta (on the install branch); uncommitted changes are unmergeable
+    // and must be committed to the install branch or stashed first. Detecting
+    // them up front (before any checkout) keeps the clone untouched and gives
+    // the operator an actionable message.
+    const preDirty = await run(buildDirtyCheckCommand(hostSourcePath).slice(1));
+    const pending = dirtyFiles(preDirty.stdout);
+    if (pending.length > 0) {
+      const sample = pending.slice(0, 5).join(", ");
+      const more = pending.length > 5 ? `, +${pending.length - 5} more` : "";
+      return {
+        ok: false,
+        reason: "dirty-tree",
+        message: `the install clone has ${pending.length} uncommitted change(s) (${sample}${more}); commit them to ${installBranch} or stash before upgrading`,
+      };
+    }
+
     const fetch = await run(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
     if (fetch.code !== 0) {
       return { ok: false, reason: "prep-error", message: `fetch failed: ${trim(fetch.stderr) || fetch.code}` };


### PR DESCRIPTION
## Why

Follow-up from testing self-upgrade on macOS. After the git-lfs prep fix (#1293), a forced run advanced past the `dpf/install` checkout and failed at **merge** with an empty, misleading `merge-conflict` (0 files). Root cause: the install clone had uncommitted working-tree changes, so `git merge` aborts with *"local changes would be overwritten by merge"* — git reports that as exit 1 with **no conflict markers**, which the generic merge path surfaces as a content conflict it isn't.

## Fix

`prepareUpgradeSource` now runs a dirty-tree precheck **before** fetch/checkout: if tracked modifications exist, it returns `reason: "dirty-tree"` with an actionable message ("commit them to the install branch or stash") and leaves the clone untouched (no branch switch, no merge). Untracked files are excluded — they don't block a merge the same way. The design still preserves *committed* local delta via the install-branch merge; this only rejects *uncommitted* changes, clearly.

Adds unit + integration coverage (incl. asserting the clone is left on its original branch with no merge in progress).

Generated with Claude Code
