### PR TITLE
fix(db): reconcile NOT VALID BacklogItem FK drift — null orphaned accountable refs + enforce

### DIFF
--- a/packages/db/prisma/migrations/20260530030000_reconcile_backlog_fk_drift/migration.sql
+++ b/packages/db/prisma/migrations/20260530030000_reconcile_backlog_fk_drift/migration.sql
@@ -1,0 +1,41 @@
+-- Data-reconciliation migration for the systemic NOT VALID FK drift on
+-- BacklogItem-related foreign keys (BI-0B91EF1C, BI-4B5EE23E).
+--
+-- Background: on at least one install every BacklogItem FK was left NOT VALID
+-- (the committed migrations create them validated), which let dangling
+-- references accumulate. Most visibly, 502 BacklogItem rows carried an
+-- accountableEmployeeId pointing at an EmployeeProfile row that does not exist
+-- on the install — so promote_to_build_studio's backlogItem.update() tripped
+-- BacklogItem_accountableEmployeeId_fkey and blocked ALL Build Studio
+-- promotion. This migration cleans the orphans and flips the constraints back
+-- to enforced so the integrity gap can't recur.
+--
+-- Safety: orphan counts were measured before authoring — only
+-- accountableEmployeeId had orphans (502); all other referencing data is clean
+-- and BusinessCapabilityTraceLink is empty. Each step is therefore guaranteed
+-- to apply. VALIDATE CONSTRAINT on an already-valid constraint is a no-op, so
+-- this is safe/idempotent on installs that never drifted.
+
+-- 1) Null orphaned accountable-employee anchors (referenced EmployeeProfile
+--    rows that don't exist here). accountableEmployeeId is nullable and the FK
+--    is ON DELETE SET NULL, so NULL is a valid resting state; promotion
+--    reassigns a real owner.
+UPDATE "BacklogItem" b
+SET "accountableEmployeeId" = NULL
+WHERE "accountableEmployeeId" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "EmployeeProfile" e WHERE e.id = b."accountableEmployeeId");
+
+-- 2) Correct the BusinessCapabilityTraceLink column drift: the live constraint
+--    referenced BacklogItem("itemId"); schema.prisma:5615 says BacklogItem("id").
+--    Table is empty on the affected install, so the re-add is safe + validated.
+ALTER TABLE "BusinessCapabilityTraceLink" DROP CONSTRAINT IF EXISTS "BusinessCapabilityTraceLink_backlogItemId_fkey";
+ALTER TABLE "BusinessCapabilityTraceLink" ADD CONSTRAINT "BusinessCapabilityTraceLink_backlogItemId_fkey"
+  FOREIGN KEY ("backlogItemId") REFERENCES "BacklogItem"("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- 3) Enforce the previously-NOT-VALID FKs (referencing data is now clean).
+--    Each already references the correct column; VALIDATE flips it to enforced.
+ALTER TABLE "BacklogItem" VALIDATE CONSTRAINT "BacklogItem_accountableEmployeeId_fkey";
+ALTER TABLE "BacklogItem" VALIDATE CONSTRAINT "BacklogItem_duplicateOfId_fkey";
+ALTER TABLE "Epic" VALIDATE CONSTRAINT "Epic_originatingBacklogItemId_fkey";
+ALTER TABLE "BacklogItemActivity" VALIDATE CONSTRAINT "BacklogItemActivity_backlogItemId_fkey";
+ALTER TABLE "CoworkerCapabilityNeed" VALIDATE CONSTRAINT "CoworkerCapabilityNeed_linkedBacklogItemId_fkey";


### PR DESCRIPTION
## Problem

Systemic FK drift on the install left **every `BacklogItem` foreign key `NOT VALID`** (the committed migrations create them validated), which let dangling references accumulate. The damaging one: **502 `BacklogItem` rows carry an `accountableEmployeeId` pointing at an `EmployeeProfile` that doesn't exist** here — so `promote_to_build_studio`'s `backlogItem.update()` tripped `BacklogItem_accountableEmployeeId_fkey` and **blocked all Build Studio promotion** (BI-4B5EE23E). The promote path never writes `accountableEmployeeId` itself, so nulling the orphaned legacy values is enough to unblock it.

## Fix (chosen approach: data reconciliation)

1. **Null orphaned `BacklogItem.accountableEmployeeId`** (502 rows). Column is nullable and the FK is `ON DELETE SET NULL`, so `NULL` is a valid resting state; promotion reassigns a real owner.
2. **Correct `BusinessCapabilityTraceLink.backlogItemId` column drift** (live referenced `itemId`; `schema.prisma:5615` says `id`). Table is empty → safe re-add, validated.
3. **`VALIDATE` the previously-`NOT VALID` `BacklogItem` FKs** (`accountableEmployeeId`, `duplicateOfId`, `Epic.originatingBacklogItemId`, `BacklogItemActivity`, `CoworkerCapabilityNeed`) so referential integrity is **actually enforced** going forward and this drift can't silently recur.

## Safety / deploy

Orphan counts were measured before authoring — **only `accountableEmployeeId` had orphans (502, nulled in step 1)**; all other referencing data is clean and `BusinessCapabilityTraceLink` is empty, so every step is guaranteed to apply. `VALIDATE` on an already-valid constraint is a no-op, so this is **safe/idempotent** on installs that never drifted. Applies via `prisma migrate deploy` on the next self-upgrade.

Addresses **BI-4B5EE23E** and the `BacklogItem` scope of **BI-0B91EF1C**. `FeatureBuild`'s FK was corrected in #1284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)