### PR TITLE
feat(web): report-kit — shared reporting/data-display UX primitives (BI-6A842691)

### DIFF
--- a/apps/web/components/ui/report-kit/DataTable.test.tsx
+++ b/apps/web/components/ui/report-kit/DataTable.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  DataTable,
+  pageCount,
+  paginateRows,
+  sortRows,
+  type Column,
+} from "./DataTable";
+
+type Row = { id: string; name: string; amount: number };
+
+const ROWS: Row[] = [
+  { id: "C-3", name: "Charlie", amount: 30 },
+  { id: "C-1", name: "Alice", amount: 10 },
+  { id: "C-2", name: "Bob", amount: 20 },
+];
+
+const COLUMNS: Column<Row>[] = [
+  { key: "id", header: "ID", cell: (r) => r.id, mono: true },
+  { key: "name", header: "Name", cell: (r) => r.name, sortAccessor: (r) => r.name },
+  {
+    key: "amount",
+    header: "Amount",
+    cell: (r) => r.amount,
+    align: "right",
+    sortAccessor: (r) => r.amount,
+  },
+];
+
+describe("DataTable pure helpers", () => {
+  it("sorts numerically ascending and descending", () => {
+    const asc = sortRows(ROWS, (r) => r.amount, "asc").map((r) => r.amount);
+    expect(asc).toEqual([10, 20, 30]);
+    const desc = sortRows(ROWS, (r) => r.amount, "desc").map((r) => r.amount);
+    expect(desc).toEqual([30, 20, 10]);
+  });
+
+  it("sorts strings locale-aware", () => {
+    const names = sortRows(ROWS, (r) => r.name, "asc").map((r) => r.name);
+    expect(names).toEqual(["Alice", "Bob", "Charlie"]);
+  });
+
+  it("is a stable sort on ties", () => {
+    const tied = [
+      { id: "a", name: "x", amount: 1 },
+      { id: "b", name: "x", amount: 1 },
+      { id: "c", name: "x", amount: 1 },
+    ];
+    const out = sortRows(tied, (r) => r.amount, "asc").map((r) => r.id);
+    expect(out).toEqual(["a", "b", "c"]);
+  });
+
+  it("paginates by 0-based page index", () => {
+    expect(paginateRows([1, 2, 3, 4, 5], 0, 2)).toEqual([1, 2]);
+    expect(paginateRows([1, 2, 3, 4, 5], 2, 2)).toEqual([5]);
+  });
+
+  it("computes page count with a floor of 1", () => {
+    expect(pageCount(0, 10)).toBe(1);
+    expect(pageCount(21, 10)).toBe(3);
+  });
+});
+
+describe("DataTable render", () => {
+  it("renders headers and rows", () => {
+    const html = renderToStaticMarkup(
+      <DataTable columns={COLUMNS} rows={ROWS} getRowKey={(r) => r.id} />,
+    );
+    expect(html).toContain("Name");
+    expect(html).toContain("Charlie");
+    expect(html).toContain("font-mono"); // mono ID column
+  });
+
+  it("renders the empty state when there are no rows", () => {
+    const html = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={[]}
+        getRowKey={(r) => r.id}
+        empty="Nothing here"
+      />,
+    );
+    expect(html).toContain("Nothing here");
+  });
+
+  it("renders skeleton rows while loading", () => {
+    const html = renderToStaticMarkup(
+      <DataTable columns={COLUMNS} rows={ROWS} getRowKey={(r) => r.id} loading />,
+    );
+    expect(html).toContain("animate-pulse");
+    expect(html).not.toContain("Charlie");
+  });
+
+  it("wraps cells in a drill-down link when rowHref is provided", () => {
+    const html = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={ROWS}
+        getRowKey={(r) => r.id}
+        rowHref={(r) => `/x/${r.id}`}
+      />,
+    );
+    expect(html).toContain('href="/x/C-1"');
+  });
+});

--- a/apps/web/components/ui/report-kit/DataTable.tsx
+++ b/apps/web/components/ui/report-kit/DataTable.tsx
@@ -1,0 +1,262 @@
+// apps/web/components/ui/report-kit/DataTable.tsx
+//
+// Presentational, typed data table for the reporting palette. Replaces the
+// hand-rolled <table> markup repeated across portal surfaces: consistent
+// header styling, hover rows, right-aligned numerics, monospace ID columns,
+// built-in empty + loading states, optional client-side sort and pagination.
+//
+// Data-source-agnostic: the caller fetches rows (often in a server component)
+// and passes them in. Interactive sort/pagination make this a client
+// component; a server page that wants interactivity wraps it in a thin client
+// child (see README). Server-driven sort/paginate is a documented follow-up.
+
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+
+export type Align = "left" | "right" | "center";
+
+export interface Column<T> {
+  key: string;
+  header: React.ReactNode;
+  cell: (row: T) => React.ReactNode;
+  align?: Align;
+  /** Provide to make this column sortable. */
+  sortAccessor?: (row: T) => string | number;
+  /** Render cell content in a monospace font (ID/reference columns). */
+  mono?: boolean;
+  width?: string;
+}
+
+export interface DataTableProps<T> {
+  columns: Column<T>[];
+  rows: T[];
+  getRowKey: (row: T) => string;
+  /** Whole-row drill-down link. */
+  rowHref?: (row: T) => string;
+  /** Custom empty state (defaults to a muted "No records" row). */
+  empty?: React.ReactNode;
+  loading?: boolean;
+  initialSort?: { key: string; dir: SortDir };
+  /** Enable client-side pagination at this page size. Omit for no paging. */
+  pageSize?: number;
+  dense?: boolean;
+  className?: string;
+}
+
+export type SortDir = "asc" | "desc";
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported so logic is unit-testable without a DOM.
+// ---------------------------------------------------------------------------
+
+/** Stable sort `rows` by `accessor`. Strings compare locale-insensitively. */
+export function sortRows<T>(
+  rows: T[],
+  accessor: (row: T) => string | number,
+  dir: SortDir,
+): T[] {
+  const factor = dir === "asc" ? 1 : -1;
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const av = accessor(a.row);
+      const bv = accessor(b.row);
+      let cmp: number;
+      if (typeof av === "number" && typeof bv === "number") {
+        cmp = av - bv;
+      } else {
+        cmp = String(av).localeCompare(String(bv));
+      }
+      // Stable: fall back to original index on ties.
+      return cmp !== 0 ? cmp * factor : a.index - b.index;
+    })
+    .map((entry) => entry.row);
+}
+
+/** Slice `rows` for a 0-based page index at `pageSize`. */
+export function paginateRows<T>(rows: T[], page: number, pageSize: number): T[] {
+  const start = page * pageSize;
+  return rows.slice(start, start + pageSize);
+}
+
+/** Total number of pages for `total` rows at `pageSize` (min 1). */
+export function pageCount(total: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+// ---------------------------------------------------------------------------
+
+const ALIGN_CLASS: Record<Align, string> = {
+  left: "text-left",
+  right: "text-right",
+  center: "text-center",
+};
+
+export function DataTable<T>({
+  columns,
+  rows,
+  getRowKey,
+  rowHref,
+  empty,
+  loading = false,
+  initialSort,
+  pageSize,
+  dense = false,
+  className = "",
+}: DataTableProps<T>) {
+  const [sort, setSort] = useState<{ key: string; dir: SortDir } | null>(
+    initialSort ?? null,
+  );
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => {
+    if (!sort) return rows;
+    const col = columns.find((c) => c.key === sort.key);
+    if (!col?.sortAccessor) return rows;
+    return sortRows(rows, col.sortAccessor, sort.dir);
+  }, [rows, sort, columns]);
+
+  const total = sorted.length;
+  const pages = pageSize ? pageCount(total, pageSize) : 1;
+  const clampedPage = Math.min(page, pages - 1);
+  const visible = pageSize
+    ? paginateRows(sorted, clampedPage, pageSize)
+    : sorted;
+
+  const cellPad = dense ? "px-2 py-1" : "px-3 py-2";
+
+  function toggleSort(col: Column<T>) {
+    if (!col.sortAccessor) return;
+    setSort((prev) => {
+      if (prev?.key !== col.key) return { key: col.key, dir: "asc" };
+      return { key: col.key, dir: prev.dir === "asc" ? "desc" : "asc" };
+    });
+    setPage(0);
+  }
+
+  return (
+    <div className={className}>
+      <table className="w-full border-collapse text-xs">
+        <thead>
+          <tr className="border-b border-[var(--dpf-border)] text-left">
+            {columns.map((col) => {
+              const sortable = Boolean(col.sortAccessor);
+              const active = sort?.key === col.key;
+              return (
+                <th
+                  key={col.key}
+                  style={col.width ? { width: col.width } : undefined}
+                  className={[
+                    cellPad,
+                    "font-medium uppercase tracking-wide text-[var(--dpf-muted)]",
+                    ALIGN_CLASS[col.align ?? "left"],
+                    sortable ? "cursor-pointer select-none" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  onClick={sortable ? () => toggleSort(col) : undefined}
+                  aria-sort={
+                    active ? (sort?.dir === "asc" ? "ascending" : "descending") : undefined
+                  }
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.header}
+                    {sortable ? (
+                      <span aria-hidden="true" className="text-[8px]">
+                        {active ? (sort?.dir === "asc" ? "▲" : "▼") : "↕"}
+                      </span>
+                    ) : null}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            Array.from({ length: pageSize ?? 3 }).map((_, i) => (
+              <tr key={`skeleton-${i}`} className="border-b border-[var(--dpf-border)]">
+                {columns.map((col) => (
+                  <td key={col.key} className={cellPad}>
+                    <span className="block h-3 w-2/3 animate-pulse rounded bg-[var(--dpf-surface-2)]" />
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : visible.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className={`${cellPad} text-center text-[var(--dpf-muted)]`}
+              >
+                {empty ?? "No records"}
+              </td>
+            </tr>
+          ) : (
+            visible.map((row) => {
+              const href = rowHref?.(row);
+              return (
+                <tr
+                  key={getRowKey(row)}
+                  className="border-b border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)]"
+                >
+                  {columns.map((col) => {
+                    const content = col.cell(row);
+                    return (
+                      <td
+                        key={col.key}
+                        className={[
+                          cellPad,
+                          ALIGN_CLASS[col.align ?? "left"],
+                          col.mono ? "font-mono text-[var(--dpf-text-secondary)]" : "",
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                      >
+                        {href ? (
+                          <Link href={href} className="block">
+                            {content}
+                          </Link>
+                        ) : (
+                          content
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+
+      {pageSize && pages > 1 && !loading ? (
+        <div className="mt-2 flex items-center justify-between text-[10px] text-[var(--dpf-muted)]">
+          <span>
+            {total} record{total === 1 ? "" : "s"} · page {clampedPage + 1} of {pages}
+          </span>
+          <span className="flex gap-1">
+            <button
+              type="button"
+              className="rounded border border-[var(--dpf-border)] px-2 py-0.5 disabled:opacity-40"
+              disabled={clampedPage <= 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              className="rounded border border-[var(--dpf-border)] px-2 py-0.5 disabled:opacity-40"
+              disabled={clampedPage >= pages - 1}
+              onClick={() => setPage((p) => Math.min(pages - 1, p + 1))}
+            >
+              Next
+            </button>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/FilterBar.test.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { FilterBar, type FacetDef } from "./FilterBar";
+
+const FACETS: FacetDef[] = [
+  { kind: "search", key: "q", placeholder: "Search invoices" },
+  {
+    kind: "select",
+    key: "status",
+    label: "Status",
+    options: [
+      { value: "paid", label: "Paid" },
+      { value: "overdue", label: "Overdue" },
+    ],
+  },
+  {
+    kind: "pills",
+    key: "direction",
+    label: "Direction",
+    options: [
+      { value: "in", label: "Inbound" },
+      { value: "out", label: "Outbound" },
+    ],
+  },
+];
+
+describe("FilterBar", () => {
+  it("renders all facet kinds with a result count", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar
+        mode="client"
+        facets={FACETS}
+        value={{ direction: "in" }}
+        onChange={() => {}}
+        resultCount={7}
+      />,
+    );
+    expect(html).toContain("Search invoices");
+    expect(html).toContain("Status");
+    expect(html).toContain("Inbound");
+    expect(html).toContain("7 results");
+  });
+
+  it("marks the active pill via the accent token", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar
+        mode="client"
+        facets={FACETS}
+        value={{ direction: "out" }}
+        onChange={() => {}}
+      />,
+    );
+    expect(html).toMatch(/var\(--dpf-accent\)/);
+  });
+
+  it("url mode renders pills as links via hrefBuilder", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar
+        mode="url"
+        facets={FACETS}
+        value={{}}
+        hrefBuilder={(key, value) =>
+          value ? `?${key}=${value}` : `?${key}=`
+        }
+      />,
+    );
+    expect(html).toContain('href="?direction=in"');
+    expect(html).toContain('href="?direction=out"');
+  });
+
+  it("singularizes the result count", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar
+        mode="client"
+        facets={[]}
+        value={{}}
+        onChange={() => {}}
+        resultCount={1}
+      />,
+    );
+    expect(html).toContain("1 result");
+    expect(html).not.toContain("1 results");
+  });
+});

--- a/apps/web/components/ui/report-kit/FilterBar.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.tsx
@@ -1,0 +1,151 @@
+// apps/web/components/ui/report-kit/FilterBar.tsx
+//
+// Composable filter row for the reporting palette. Unifies the three idioms
+// currently scattered across surfaces (URL link-pills, <select> forms, client
+// useState buttons) behind one facet model.
+//
+// Two modes:
+//   - "client": controlled via `value` + `onChange` (matches complaints today).
+//   - "url":    renders <Link> pills / <select> bound to the given hrefBuilder
+//               (server-friendly, matches finance/compliance today).
+
+"use client";
+
+import Link from "next/link";
+
+export type FacetDef =
+  | { kind: "search"; key: string; placeholder?: string }
+  | { kind: "select"; key: string; label: string; options: FacetOption[] }
+  | { kind: "pills"; key: string; label: string; options: FacetOption[] };
+
+export interface FacetOption {
+  value: string;
+  label: string;
+}
+
+interface CommonProps {
+  facets: FacetDef[];
+  value: Record<string, string>;
+  resultCount?: number;
+  className?: string;
+}
+
+interface ClientProps extends CommonProps {
+  mode?: "client";
+  onChange: (next: Record<string, string>) => void;
+  hrefBuilder?: never;
+}
+
+interface UrlProps extends CommonProps {
+  mode: "url";
+  /** Build the href for a facet set to a value (omit value = cleared). */
+  hrefBuilder: (key: string, value: string | null) => string;
+  onChange?: never;
+}
+
+export type FilterBarProps = ClientProps | UrlProps;
+
+const PILL_BASE =
+  "rounded border px-2 py-0.5 text-[11px] transition-colors";
+
+function pillClass(active: boolean): string {
+  return active
+    ? `${PILL_BASE} border-[var(--dpf-accent)] text-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)]`
+    : `${PILL_BASE} border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]`;
+}
+
+export function FilterBar(props: FilterBarProps) {
+  const { facets, value, resultCount, className = "" } = props;
+  const isUrl = props.mode === "url";
+
+  function set(key: string, next: string) {
+    if (!isUrl) props.onChange({ ...value, [key]: next });
+  }
+
+  return (
+    <div
+      className={[
+        "flex flex-wrap items-center gap-3 text-[var(--dpf-text)]",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {facets.map((facet) => {
+        const current = value[facet.key] ?? "";
+
+        if (facet.kind === "search") {
+          return (
+            <input
+              key={facet.key}
+              type="search"
+              aria-label={facet.placeholder ?? "Search"}
+              placeholder={facet.placeholder ?? "Search…"}
+              defaultValue={current}
+              onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+              className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+            />
+          );
+        }
+
+        if (facet.kind === "select") {
+          return (
+            <label key={facet.key} className="flex items-center gap-1 text-[11px]">
+              <span className="text-[var(--dpf-muted)]">{facet.label}</span>
+              <select
+                value={current}
+                aria-label={facet.label}
+                onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+                className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+              >
+                <option value="">All</option>
+                {facet.options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          );
+        }
+
+        // pills
+        return (
+          <div key={facet.key} className="flex flex-wrap items-center gap-1">
+            <span className="text-[11px] text-[var(--dpf-muted)]">{facet.label}</span>
+            {facet.options.map((opt) => {
+              const active = current === opt.value;
+              if (isUrl) {
+                return (
+                  <Link
+                    key={opt.value}
+                    href={props.hrefBuilder(facet.key, active ? null : opt.value)}
+                    className={pillClass(active)}
+                  >
+                    {opt.label}
+                  </Link>
+                );
+              }
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={pillClass(active)}
+                  onClick={() => set(facet.key, active ? "" : opt.value)}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
+
+      {typeof resultCount === "number" ? (
+        <span className="ml-auto text-[11px] text-[var(--dpf-muted)]">
+          {resultCount} result{resultCount === 1 ? "" : "s"}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/README.md
+++ b/apps/web/components/ui/report-kit/README.md
@@ -1,0 +1,147 @@
+# report-kit — Reporting & Data-Display Palette
+
+Shared, token-backed primitives for building reporting/analytics surfaces in the
+portal. Compose these instead of hand-rolling `<table>` markup, status-color
+maps, or filter rows — and instead of researching component libraries externally.
+
+> Spec: [`docs/specs/reporting-ux-primitives-spec.md`](../../../../../docs/specs/reporting-ux-primitives-spec.md)
+> · Backlog: BI-6A842691 (EP Portal UX hardening)
+>
+> **Not** related to `apps/web/lib/reporting-types.ts` (compliance-posture math).
+
+```ts
+import {
+  StatusBadge,
+  DataTable,
+  FilterBar,
+  resolveIntent,
+} from "@/components/ui/report-kit";
+```
+
+## What's in the palette
+
+| Primitive | Server-usable? | Use it for |
+|---|---|---|
+| `StatusBadge` | ✅ (pure) | status / severity / lifecycle pills |
+| `DataTable` | client¹ | tabular lists with sort, paging, empty/loading states |
+| `FilterBar` | client¹ | search + select + pill facets above a table |
+| `statusColors` (`intentStyle`, `resolveIntent`, `STATUS_INTENT`) | ✅ | the one place status→color semantics live |
+
+¹ `DataTable` / `FilterBar` are `"use client"` (they manage sort/page/onChange
+state). A server page uses them by rendering them inside a small client child —
+the page still fetches data on the server and passes rows down. A pure
+server-rendered (URL-driven) table mode is a documented follow-up.
+
+## The intent model (always use tokens, never hex)
+
+Every color flows through a semantic **intent**, and intent maps to `--dpf-*`
+design tokens:
+
+`success · warning · danger · info · neutral · accent`
+
+A domain status string resolves to an intent via the central registry in
+`statusColors.ts`. Adding a domain/status is a one-line edit there — not a new
+color map in a page.
+
+```tsx
+// explicit intent
+<StatusBadge intent="success" label="Paid" />
+
+// resolve from the registry (domain + status)
+<StatusBadge domain="finance" status="overdue" />        // → danger
+<StatusBadge domain="complaintSeverity" status="critical" variant="soft" />
+```
+
+Variants: `outline` (default) · `soft` · `solid`. Sizes: `sm` (default) · `md`.
+
+## DataTable
+
+Presentational + typed. The caller fetches rows; columns are render functions.
+
+```tsx
+"use client";
+import { DataTable, type Column } from "@/components/ui/report-kit";
+
+const columns: Column<Invoice>[] = [
+  { key: "ref", header: "Invoice", cell: (r) => r.ref, mono: true },
+  { key: "customer", header: "Customer", cell: (r) => r.customer,
+    sortAccessor: (r) => r.customer },
+  { key: "status", header: "Status",
+    cell: (r) => <StatusBadge domain="finance" status={r.status} /> },
+  { key: "amount", header: "Amount", align: "right",
+    cell: (r) => formatMoney(r.amount), sortAccessor: (r) => r.amount },
+];
+
+<DataTable
+  columns={columns}
+  rows={invoices}
+  getRowKey={(r) => r.id}
+  rowHref={(r) => `/finance/invoices/${r.id}`}
+  initialSort={{ key: "amount", dir: "desc" }}
+  pageSize={25}
+  empty="No invoices yet"
+/>;
+```
+
+- Sort: provide `sortAccessor` on a column to make its header clickable.
+- Pagination: pass `pageSize` (omit for none).
+- States: `loading` renders skeleton rows; `empty` renders a centered message.
+- Pure helpers `sortRows` / `paginateRows` / `pageCount` are exported and unit-tested.
+
+### Server page → client table
+
+```tsx
+// page.tsx (server component)
+const rows = await getInvoices();
+return <InvoiceTable rows={rows} />;
+
+// InvoiceTable.tsx ("use client")
+export function InvoiceTable({ rows }: { rows: Invoice[] }) {
+  return <DataTable columns={columns} rows={rows} getRowKey={(r) => r.id} />;
+}
+```
+
+## FilterBar
+
+One facet model, two modes.
+
+```tsx
+// client mode — controlled
+<FilterBar
+  mode="client"
+  facets={[
+    { kind: "search", key: "q", placeholder: "Search…" },
+    { kind: "select", key: "status", label: "Status",
+      options: [{ value: "open", label: "Open" }] },
+    { kind: "pills", key: "direction", label: "Direction",
+      options: [{ value: "in", label: "Inbound" }, { value: "out", label: "Outbound" }] },
+  ]}
+  value={filters}
+  onChange={setFilters}
+  resultCount={rows.length}
+/>
+
+// url mode — links bound to searchParams (server-friendly)
+<FilterBar
+  mode="url"
+  facets={facets}
+  value={{ direction: searchParams.direction ?? "" }}
+  hrefBuilder={(key, value) => buildHref({ ...searchParams, [key]: value ?? undefined })}
+/>
+```
+
+## Conventions
+
+- **No raw hex.** Colors come from `intentStyle` / `--dpf-*` tokens only.
+- **Time:** render timestamps with the shared `LocalTime` component, not `toLocaleString`.
+- **Tests:** Vitest, `node` environment — render components with
+  `renderToStaticMarkup` and unit-test exported pure helpers (no DOM needed).
+
+## Roadmap
+
+- **Phase 1 (this):** primitives + tests + this doc. Additive only.
+- **Phase 2:** migrate reference surfaces (complaints, finance/payments), grow
+  `STATUS_INTENT`, fold `ChangeLaneStatusBadge` onto `StatusBadge`.
+- **Phase 3 (follow-up):** `StatCard`, `ExportButton` (papaparse / `@react-pdf`
+  are already installed), business-data charting decision, server-rendered
+  `DataTable` URL mode.

--- a/apps/web/components/ui/report-kit/StatusBadge.test.tsx
+++ b/apps/web/components/ui/report-kit/StatusBadge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { StatusBadge } from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("renders an explicit intent with its label and data attribute", () => {
+    const html = renderToStaticMarkup(
+      <StatusBadge intent="success" label="Paid" />,
+    );
+    expect(html).toContain('data-intent="success"');
+    expect(html).toContain("Paid");
+  });
+
+  it("resolves domain + status through the registry", () => {
+    const html = renderToStaticMarkup(
+      <StatusBadge domain="finance" status="overdue" />,
+    );
+    expect(html).toContain('data-intent="danger"');
+    // default label falls back to the status value
+    expect(html).toContain("overdue");
+  });
+
+  it("falls back to neutral for an unknown status", () => {
+    const html = renderToStaticMarkup(
+      <StatusBadge domain="finance" status="mystery" />,
+    );
+    expect(html).toContain('data-intent="neutral"');
+  });
+
+  it("applies token-backed colors (never raw hex)", () => {
+    const html = renderToStaticMarkup(
+      <StatusBadge intent="danger" label="Critical" variant="soft" />,
+    );
+    expect(html).toMatch(/var\(--dpf-error\)/);
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("honors uppercase=false", () => {
+    const html = renderToStaticMarkup(
+      <StatusBadge intent="info" label="Sent" uppercase={false} />,
+    );
+    expect(html).not.toContain("uppercase");
+  });
+});

--- a/apps/web/components/ui/report-kit/StatusBadge.tsx
+++ b/apps/web/components/ui/report-kit/StatusBadge.tsx
@@ -1,0 +1,82 @@
+// apps/web/components/ui/report-kit/StatusBadge.tsx
+//
+// Canonical status/severity badge for the reporting palette. Server-usable
+// (no hooks, no "use client"): badges appear inside server-rendered tables and
+// lists across the portal.
+//
+// Color comes from the intent model in ./statusColors — never raw hex.
+
+import type { CSSProperties } from "react";
+
+import { intentStyle, resolveIntent, type Intent } from "./statusColors";
+
+type Variant = "soft" | "outline" | "solid";
+type Size = "sm" | "md";
+
+type IntentProps =
+  | { intent: Intent; domain?: never; status?: never }
+  | { intent?: never; domain: string; status: string };
+
+export type StatusBadgeProps = IntentProps & {
+  /** Visible text. Defaults to the raw `status` (or intent) when omitted. */
+  label?: string;
+  variant?: Variant;
+  size?: Size;
+  uppercase?: boolean;
+  className?: string;
+};
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: "px-2 py-0.5 text-[10px] leading-4",
+  md: "px-2.5 py-1 text-xs leading-5",
+};
+
+function variantStyle(variant: Variant, intent: Intent): CSSProperties {
+  const { fg, border, softBg } = intentStyle(intent);
+  switch (variant) {
+    case "solid":
+      return { backgroundColor: fg, borderColor: fg, color: "var(--dpf-surface-1)" };
+    case "soft":
+      return { backgroundColor: softBg, borderColor: "transparent", color: fg };
+    case "outline":
+    default:
+      return { backgroundColor: "transparent", borderColor: border, color: fg };
+  }
+}
+
+/**
+ * Render a status badge. Supply either an explicit `intent`, or a
+ * `domain` + `status` pair that resolves through the central registry.
+ */
+export function StatusBadge({
+  label,
+  variant = "outline",
+  size = "sm",
+  uppercase = true,
+  className = "",
+  ...rest
+}: StatusBadgeProps) {
+  const intent: Intent =
+    "intent" in rest && rest.intent
+      ? rest.intent
+      : resolveIntent(rest.domain as string, rest.status as string);
+
+  const text = label ?? ("status" in rest ? rest.status : rest.intent) ?? "";
+
+  return (
+    <span
+      data-intent={intent}
+      className={[
+        "inline-flex max-w-full items-center gap-1 rounded border font-medium",
+        uppercase ? "uppercase tracking-wide" : "",
+        SIZE_CLASS[size],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={variantStyle(variant, intent)}
+    >
+      <span className="truncate">{text}</span>
+    </span>
+  );
+}

--- a/apps/web/components/ui/report-kit/index.ts
+++ b/apps/web/components/ui/report-kit/index.ts
@@ -1,0 +1,39 @@
+// apps/web/components/ui/report-kit/index.ts
+//
+// Reporting & data-display palette. Import shared, token-backed primitives:
+//
+//   import { StatusBadge, DataTable, FilterBar } from "@/components/ui/report-kit";
+//
+// See ./README.md for the full palette and usage recipes.
+// Spec: docs/specs/reporting-ux-primitives-spec.md
+
+export {
+  StatusBadge,
+  type StatusBadgeProps,
+} from "./StatusBadge";
+
+export {
+  DataTable,
+  sortRows,
+  paginateRows,
+  pageCount,
+  type Column,
+  type DataTableProps,
+  type Align,
+  type SortDir,
+} from "./DataTable";
+
+export {
+  FilterBar,
+  type FilterBarProps,
+  type FacetDef,
+  type FacetOption,
+} from "./FilterBar";
+
+export {
+  intentStyle,
+  resolveIntent,
+  STATUS_INTENT,
+  type Intent,
+  type IntentStyle,
+} from "./statusColors";

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  intentStyle,
+  resolveIntent,
+  STATUS_INTENT,
+  type Intent,
+} from "./statusColors";
+
+const ALL_INTENTS: Intent[] = [
+  "success",
+  "warning",
+  "danger",
+  "info",
+  "neutral",
+  "accent",
+];
+
+describe("statusColors", () => {
+  it("maps every intent to --dpf-* tokens (no raw hex)", () => {
+    for (const intent of ALL_INTENTS) {
+      const style = intentStyle(intent);
+      expect(style.fg).toMatch(/var\(--dpf-/);
+      expect(style.border).toMatch(/var\(--dpf-/);
+      expect(style.fg).not.toMatch(/#[0-9a-f]{3,6}/i);
+    }
+  });
+
+  it("derives soft backgrounds via color-mix for non-neutral intents", () => {
+    expect(intentStyle("success").softBg).toContain("color-mix");
+    // neutral uses a surface token, not a tint
+    expect(intentStyle("neutral").softBg).toBe("var(--dpf-surface-2)");
+  });
+
+  it("every registered status resolves to a valid intent", () => {
+    for (const [domain, map] of Object.entries(STATUS_INTENT)) {
+      for (const status of Object.keys(map)) {
+        expect(ALL_INTENTS).toContain(resolveIntent(domain, status));
+      }
+    }
+  });
+
+  it("falls back to neutral for unknown domain or status", () => {
+    expect(resolveIntent("nope", "whatever")).toBe("neutral");
+    expect(resolveIntent("finance", "not-a-status")).toBe("neutral");
+  });
+
+  it("maps known finance + complaint statuses to expected intents", () => {
+    expect(resolveIntent("finance", "overdue")).toBe("danger");
+    expect(resolveIntent("finance", "paid")).toBe("success");
+    expect(resolveIntent("complaintSeverity", "critical")).toBe("danger");
+    expect(resolveIntent("complaintStatus", "resolved")).toBe("success");
+  });
+});

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -1,0 +1,99 @@
+// apps/web/components/ui/report-kit/statusColors.ts
+//
+// Central status/severity color semantics for the reporting palette.
+//
+// A domain status string (e.g. "overdue", "critical") maps to a semantic
+// `Intent`, and an Intent maps to DPF design tokens. This is the single place
+// that defines those mappings, so individual surfaces stop re-declaring their
+// own color maps (and stop bypassing tokens with raw hex).
+//
+// NOTE: unrelated to apps/web/lib/reporting-types.ts (compliance-posture math).
+
+export type Intent =
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "neutral"
+  | "accent";
+
+export interface IntentStyle {
+  /** Foreground (text/icon) color — a CSS value, always a --dpf-* token. */
+  fg: string;
+  /** Border color — a CSS value, always a --dpf-* token. */
+  border: string;
+  /** Soft background wash derived from the foreground token via color-mix. */
+  softBg: string;
+}
+
+const INTENT_TOKEN: Record<Intent, { fg: string; border: string }> = {
+  success: { fg: "var(--dpf-success)", border: "var(--dpf-success)" },
+  warning: { fg: "var(--dpf-warning)", border: "var(--dpf-warning)" },
+  danger: { fg: "var(--dpf-error)", border: "var(--dpf-error)" },
+  info: { fg: "var(--dpf-info)", border: "var(--dpf-info)" },
+  accent: { fg: "var(--dpf-accent)", border: "var(--dpf-accent)" },
+  neutral: { fg: "var(--dpf-muted)", border: "var(--dpf-border)" },
+};
+
+/**
+ * Resolve the token-backed style for a semantic intent. Soft backgrounds use
+ * color-mix so we never introduce new tokens for tints.
+ */
+export function intentStyle(intent: Intent): IntentStyle {
+  const token = INTENT_TOKEN[intent];
+  const softBg =
+    intent === "neutral"
+      ? "var(--dpf-surface-2)"
+      : `color-mix(in srgb, ${token.fg} 12%, transparent)`;
+  return { fg: token.fg, border: token.border, softBg };
+}
+
+/**
+ * Per-domain status → intent registry. Adding a new domain (or status) is a
+ * one-line change here rather than a new color map inside a page component.
+ *
+ * Keys are domain namespaces; some domains split severity vs. lifecycle status
+ * (e.g. complaints) so each gets its own namespace.
+ */
+export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
+  // Finance invoice/payment lifecycle (was app/(shell)/finance STATUS_COLOURS).
+  finance: {
+    draft: "neutral",
+    sent: "info",
+    viewed: "accent",
+    overdue: "danger",
+    partially_paid: "warning",
+    paid: "success",
+    void: "neutral",
+    written_off: "neutral",
+  },
+  // Complaints (was raw hex in ComplaintsClient — now token-backed).
+  complaintSeverity: {
+    low: "success",
+    medium: "warning",
+    high: "warning",
+    critical: "danger",
+  },
+  complaintStatus: {
+    open: "info",
+    investigating: "accent",
+    resolved: "success",
+    closed: "neutral",
+  },
+  // Generic severity ramp, reusable by any surface that has none of its own.
+  severity: {
+    info: "info",
+    low: "success",
+    medium: "warning",
+    high: "warning",
+    critical: "danger",
+  },
+};
+
+/**
+ * Resolve a (domain, status) pair to an intent. Unknown domain/status falls
+ * back to "neutral" so a surface never crashes on an unmapped value.
+ */
+export function resolveIntent(domain: string, status: string): Intent {
+  return STATUS_INTENT[domain]?.[status] ?? "neutral";
+}

--- a/docs/specs/reporting-ux-primitives-spec.md
+++ b/docs/specs/reporting-ux-primitives-spec.md
@@ -1,0 +1,274 @@
+# Reporting & Data-Display UX Primitives — Spec
+
+**Status:** Draft (spec-first; implementation staged in phases below)
+**Owner:** Platform / Web UX
+**Date:** 2026-05-30
+**Surface:** `apps/web` (portal)
+**Backlog:** BI-6A842691 · Epic: EP-2b79c5c6 (Portal UX hardening)
+
+---
+
+## 1. Problem
+
+DPF's portal has ~30 reporting/data-display surfaces (finance, compliance, customer/CRM,
+complaints, admin/cockpit, EA, monitoring, platform). They repeat the same visual
+patterns — KPI cards, status/severity badges, filterable tables, drill-down detail —
+but **almost every surface hand-rolls them inline**. Concretely:
+
+- **No shared `StatusBadge`.** Each page re-declares its own status→color map.
+  - `app/(shell)/finance/page.tsx` maps statuses to `var(--dpf-*)` tokens (correct).
+  - `app/(shell)/complaints/ComplaintsClient.tsx` maps to **raw hex** (`#22c55e`,
+    `#ef4444`) — bypasses the design tokens entirely.
+  - `components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx` is a
+    well-built one-off that already encodes the right idea (status → intent → token)
+    but only serves contributor lanes.
+- **No shared `DataTable`.** Every list re-implements `<table>` markup, hover states,
+  empty states, alignment, and monospace ID columns. Sorting/pagination are absent or
+  reinvented.
+- **No shared `FilterBar`.** Three competing idioms coexist: URL link-pills (finance
+  payments), `<form><select>` (compliance controls), and client `useState` buttons
+  (complaints).
+- **Charts are Prometheus-bound.** The `components/monitoring/*` SVG charts
+  (`MetricGauge`, `SparkLine`, `MetricTimeSeries`) are good but query Prometheus; there
+  is no primitive for charting arbitrary business data.
+
+The result: inconsistent color semantics, duplicated maintenance, uneven accessibility,
+and no clear "palette" for prototyping new surfaces — pushing contributors to research
+externally instead of composing what we have.
+
+> **Naming note — avoid confusion.** `apps/web/lib/reporting-types.ts` already exists but
+> is **compliance-posture scoring** (regulatory reporting math: `calculatePostureScore`,
+> submission status flow). It is *unrelated* to UI primitives. This spec deliberately uses
+> the name **`report-kit`** for the new UI layer to avoid collision.
+
+---
+
+## 2. Goals
+
+1. Establish a small, documented **palette of shared reporting primitives** that any
+   surface can compose, so contributors don't research externally.
+2. Unify **status/severity color semantics** behind the existing `--dpf-state-*` /
+   `--dpf-*` tokens — one registry, zero raw hex.
+3. Ship the three highest-leverage shared primitives that everyone currently hand-rolls:
+   **`StatusBadge`**, **`DataTable`**, **`FilterBar`**.
+4. Keep primitives **data-source-agnostic** (presentational), driven by props — distinct
+   from the Prometheus-bound monitoring charts.
+5. Provide a **migration path**: new surfaces adopt immediately; existing surfaces migrate
+   opportunistically without a big-bang refactor.
+
+## 3. Non-Goals
+
+- **Not** introducing a charting library (recharts/tremor/etc.) in this phase. Charting of
+  business data is a follow-up; this phase is tables/badges/filters/cards only.
+- **Not** rewriting the monitoring SVG charts or coupling them to this layer.
+- **Not** migrating all ~30 surfaces in one PR. Phase 1 ships primitives + docs only;
+  reference adoptions are Phase 2.
+- **Not** building server-side pagination/query infra; `DataTable` is presentational and
+  accepts already-fetched rows (client sort/paginate over a page of data).
+
+---
+
+## 4. Design tokens (the anchor)
+
+`app/globals.css` already defines the full token set. Primitives MUST use these and never
+raw hex:
+
+| Group | Tokens |
+|---|---|
+| Surfaces | `--dpf-surface-1/2/3`, `--dpf-bg` |
+| Text | `--dpf-text`, `--dpf-text-secondary`, `--dpf-muted` |
+| Borders | `--dpf-border`, `--dpf-border-strong` |
+| Accent | `--dpf-accent`, `--dpf-accent-soft` |
+| Semantic state | `--dpf-state-success|warning|error|info`, plus `--dpf-success|warning|error|info` |
+| Fonts | `--dpf-font-heading`, `--dpf-font-body` |
+
+### 4.1 Status intent model
+
+The unifying abstraction (already implicit in `ChangeLaneStatusBadge`): a domain status
+string maps to a **semantic intent**, and intent maps to tokens.
+
+```
+Intent = "success" | "warning" | "danger" | "info" | "neutral" | "accent"
+```
+
+| Intent | Foreground token | Border token | Soft bg |
+|---|---|---|---|
+| success | `--dpf-success` | `--dpf-success` | `color-mix` of success @ ~12% |
+| warning | `--dpf-warning` | `--dpf-warning` | warning @ ~12% |
+| danger  | `--dpf-error`   | `--dpf-error`   | error @ ~12% |
+| info    | `--dpf-info`    | `--dpf-info`    | info @ ~12% |
+| accent  | `--dpf-accent`  | `--dpf-accent`  | `--dpf-accent-soft` |
+| neutral | `--dpf-muted`   | `--dpf-border`  | `--dpf-surface-2` |
+
+Soft backgrounds use `color-mix(in srgb, var(--dpf-success) 12%, transparent)` so we don't
+add new tokens.
+
+---
+
+## 5. The palette (catalog: keep / extend / add)
+
+### KEEP (already shared, document as canonical)
+- **KPI/summary:** `components/finance/FinanceSummaryCard.tsx`,
+  `components/platform/PlatformSummaryCard.tsx`, `components/shell/WorkspaceTiles.tsx`
+- **Charts (Prometheus):** `components/monitoring/{MetricStat,MetricGauge,SparkLine,MetricTimeSeries,MetricTable}.tsx`
+- **Graphs:** `components/build/ProcessGraph.tsx`, `components/ea/EaCanvas.tsx` (`@xyflow/react`)
+- **Time/date:** `components/ui/LocalTime.tsx`, `components/ui/DatePicker.tsx`
+- **Drawer/timeline:** `components/build/DetailsDrawer.tsx`, `components/build/UnifiedEvidenceTimeline.tsx`
+- **Existing libs sanctioned:** `@xyflow/react`, `@fullcalendar/*`, `react-day-picker`,
+  `papaparse` (CSV — currently unused), `@react-pdf/renderer` (PDF — finance only)
+
+### ADD (this spec) — new shared layer under `components/ui/report-kit/`
+1. **`statusColors.ts`** — central registry: intent model + helper to resolve a domain
+   status to an intent, with per-domain maps (finance, compliance, complaints, …).
+2. **`StatusBadge.tsx`** — the canonical badge (server-usable, pure).
+3. **`DataTable.tsx`** — presentational, typed, sortable, optional client pagination,
+   built-in empty/loading states.
+4. **`FilterBar.tsx`** — composable filter row (search input + select/pill facets),
+   client + URL modes.
+
+### FOLLOW-UP (not this phase)
+- `StatCard` (generalize `FinanceSummaryCard` cross-domain)
+- Business-data charts (decide recharts vs. extend monitoring SVG)
+- `ExportButton` (wire up the already-present `papaparse` / `@react-pdf/renderer`)
+- Server-rendered (URL-driven) `DataTable` mode
+
+---
+
+## 6. API design
+
+### 6.1 `statusColors.ts`
+
+```ts
+export type Intent = "success" | "warning" | "danger" | "info" | "neutral" | "accent";
+export interface IntentStyle { fg: string; border: string; softBg: string; }
+export function intentStyle(intent: Intent): IntentStyle;
+
+// Per-domain status → intent maps. Adding a domain = one entry here, not in a page.
+export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
+  finance: { draft: "neutral", sent: "info", viewed: "accent", overdue: "danger",
+             partially_paid: "warning", paid: "success", void: "neutral", written_off: "neutral" },
+  complaintSeverity: { low: "success", medium: "warning", high: "warning", critical: "danger" },
+  complaintStatus:   { open: "info", investigating: "accent", resolved: "success", closed: "neutral" },
+};
+export function resolveIntent(domain: string, status: string): Intent; // → "neutral" fallback
+```
+
+### 6.2 `StatusBadge`
+
+```tsx
+interface StatusBadgeProps {
+  label?: string;                          // defaults to status/intent text
+  intent?: Intent;                         // explicit intent…
+  domain?: string; status?: string;        // …or resolve via registry
+  variant?: "soft" | "outline" | "solid";  // default "outline"
+  size?: "sm" | "md";                      // default "sm"
+  uppercase?: boolean;                     // default true
+}
+```
+- Exactly one of `{intent}` or `{domain,status}` (enforced by a union type).
+- Pure, no hooks → usable directly in server components.
+
+### 6.3 `DataTable`
+
+```tsx
+interface Column<T> {
+  key: string; header: ReactNode; cell: (row: T) => ReactNode;
+  align?: "left" | "right" | "center";
+  sortAccessor?: (row: T) => string | number;  // enables sort
+  mono?: boolean; width?: string;
+}
+interface DataTableProps<T> {
+  columns: Column<T>[]; rows: T[]; getRowKey: (row: T) => string;
+  rowHref?: (row: T) => string; empty?: ReactNode; loading?: boolean;
+  initialSort?: { key: string; dir: "asc" | "desc" }; pageSize?: number; dense?: boolean;
+}
+// exported pure helpers: sortRows, paginateRows, pageCount
+```
+- Presentational; caller fetches rows. Client sort/paginate over the provided page.
+- `"use client"`; server pages wrap it in a thin client child.
+
+### 6.4 `FilterBar`
+
+```tsx
+type FacetDef =
+  | { kind: "search"; key: string; placeholder?: string }
+  | { kind: "select"; key: string; label: string; options: { value: string; label: string }[] }
+  | { kind: "pills";  key: string; label: string; options: { value: string; label: string }[] };
+
+interface FilterBarProps {
+  facets: FacetDef[]; value: Record<string, string>; resultCount?: number;
+  mode?: "client" | "url";
+  onChange?: (next: Record<string, string>) => void;          // client mode
+  hrefBuilder?: (key: string, value: string | null) => string; // url mode
+}
+```
+
+---
+
+## 7. File layout
+
+```
+apps/web/components/ui/report-kit/
+  index.ts            # barrel export
+  statusColors.ts     + statusColors.test.ts
+  StatusBadge.tsx     + StatusBadge.test.tsx
+  DataTable.tsx       + DataTable.test.tsx
+  FilterBar.tsx       + FilterBar.test.tsx
+  README.md           # the palette doc + usage recipes
+```
+Import via `@/components/ui/report-kit`.
+
+## 8. Migration / adoption
+
+- **New surfaces:** use `report-kit` from day one.
+- **Existing surfaces (Phase 2):** migrate opportunistically. First two references:
+  1. `app/(shell)/complaints/ComplaintsClient.tsx` — removes raw-hex maps → `StatusBadge` +
+     `DataTable` + `FilterBar` (client mode). Highest value: it currently violates tokens.
+  2. `app/(shell)/finance/payments/page.tsx` — server component, `url`-mode `FilterBar` +
+     `DataTable`. Proves server-side usage.
+- `ChangeLaneStatusBadge` is already conformant; fold onto `StatusBadge` in Phase 2.
+- Each migrated domain adds its status map to `STATUS_INTENT` (one place).
+
+> **Sequencing note.** A separate in-flight working-tree sweep is adopting shared
+> `LocalTime`/input primitives across these same surfaces. Phase 1 is therefore
+> **additive only** (new `report-kit` files, no edits to existing surfaces) to avoid
+> conflicting with that sweep; the reference migrations land in Phase 2 once the sweep
+> has merged.
+
+## 9. Testing
+
+- Unit (Vitest, `node` env — matches repo convention; render via `renderToStaticMarkup`,
+  unit-test exported pure helpers without a DOM):
+  - `statusColors`: every status resolves to a valid intent; unknown → neutral; no hex.
+  - `StatusBadge`: intent vs domain/status paths; token colors; uppercase toggle.
+  - `DataTable`: sort asc/desc + stability, paginate slice, page count, empty/loading,
+    `rowHref` linking.
+  - `FilterBar`: client onChange; url-mode renders links via `hrefBuilder`; result count.
+- Visual: verify on the **Contributor preview (port 3001)** via `dev-portal-start` once a
+  surface is migrated (Phase 2).
+- No raw hex: tests assert primitives emit `var(--dpf-*)` and never `#rrggbb`.
+
+## 10. Rollout phases
+
+| Phase | Deliverable | Gate |
+|---|---|---|
+| **0** | This spec + BI filed | review |
+| **1** | `report-kit` primitives + tests + README (additive only) | unit green + typecheck |
+| **2** | Migrate complaints + finance/payments; grow `STATUS_INTENT`; fold ChangeLaneStatusBadge | preview verified |
+| **3** (follow-up) | `StatCard`, `ExportButton`, server `DataTable` URL mode, charting decision | new spec |
+
+## 11. Open questions
+
+1. `DataTable` client-only now, or stub a `serverSort`/`serverPaginate` seam from the
+   start? (Recommend: client-only now, seam documented.)
+2. Fold `ChangeLaneStatusBadge` onto `StatusBadge` in Phase 2 (recommended) vs leave as-is.
+3. Charting library decision (recharts vs. extend monitoring SVG) — deferred to Phase 3.
+
+---
+
+## 12. Process note
+
+Build Studio is not fully functional (per current platform status), so this work is done
+**directly via a DCO PR** with backlog item **BI-6A842691** filed for the record, rather
+than promoted through the BS pipeline. Work is committed + pushed promptly because the
+shared root checkout is contended by concurrent cleanup processes.


### PR DESCRIPTION
## What

Adds **`report-kit`** — a shared, token-backed palette of reporting/data-display primitives under `apps/web/components/ui/report-kit/` — so portal surfaces stop hand-rolling tables, status-color maps, and filter rows (and stop bypassing design tokens with raw hex).

Investigation found ~30 reporting surfaces repeating the same patterns with **no shared primitives**: every page re-declares its own status→color map (some using raw hex like `#22c55e`, bypassing `--dpf-*` tokens), re-implements `<table>` markup, and uses one of three competing filter idioms.

## Contents (Phase 1 — additive only)

| File | Purpose |
|---|---|
| `statusColors.ts` | Intent model (`success\|warning\|danger\|info\|neutral\|accent`) → `--dpf-*` tokens + central per-domain status→intent registry |
| `StatusBadge.tsx` | Canonical, **server-usable** badge (explicit `intent` OR `domain`+`status`) |
| `DataTable.tsx` | Presentational typed table: client sort, optional pagination, empty/loading states, row drill-down; pure helpers exported |
| `FilterBar.tsx` | search / select / pill facets in `client` + `url` modes |
| `index.ts`, `README.md` | barrel + palette doc with usage recipes |
| `*.test.*` | 23 Vitest unit tests |

Spec: `docs/specs/reporting-ux-primitives-spec.md`

## Why additive only

A separate in-flight working-tree sweep is adopting shared `LocalTime`/input primitives across these same surfaces. Phase 1 touches **only new files** to avoid conflicting with it. The reference-surface migrations (complaints raw-hex removal, finance/payments) are **Phase 2**, landing after that sweep merges.

## Verification

- `npx vitest run components/ui/report-kit` → **23 passed**
- `tsc --noEmit` → clean for report-kit
- No raw hex: tests assert primitives emit `var(--dpf-*)` only

## Notes

- Unrelated to `apps/web/lib/reporting-types.ts` (compliance-posture math) — named `report-kit` to avoid collision.
- Build Studio not fully functional → direct DCO PR, BI-6A842691 filed for the record (Epic EP-2b79c5c6 Portal UX hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)