### PR TITLE
fix(scripts): redeploy-portal.sh empty-array expansion breaks on macOS bash 3.2

### DIFF
--- a/scripts/redeploy-portal.sh
+++ b/scripts/redeploy-portal.sh
@@ -62,13 +62,18 @@ sha="$(git rev-parse HEAD)"
 export DPF_VERSION="$sha"
 echo "[redeploy-portal] Building portal and portal-init with DPF_VERSION=$sha"
 
-docker compose "${compose_args[@]}" build "${build_flags[@]}" portal portal-init
+# Expand possibly-empty arrays with the bash 3.2-safe idiom: bare
+# "${arr[@]}" on an empty array under `set -u` aborts with "unbound variable"
+# on macOS's stock bash 3.2 (it's tolerated on bash 4.4+). build_flags is empty
+# unless --no-cache/flags are passed, and compose_args is empty when no env
+# file is found, so guard both.
+docker compose ${compose_args[@]+"${compose_args[@]}"} build ${build_flags[@]+"${build_flags[@]}"} portal portal-init
 
 echo "[redeploy-portal] Recreating portal-init and portal from the built images"
-docker compose "${compose_args[@]}" up -d --no-build --force-recreate portal-init portal
+docker compose ${compose_args[@]+"${compose_args[@]}"} up -d --no-build --force-recreate portal-init portal
 
-portal_container="$(docker compose "${compose_args[@]}" ps -a -q portal | head -n 1)"
-portal_init_container="$(docker compose "${compose_args[@]}" ps -a -q portal-init | head -n 1)"
+portal_container="$(docker compose ${compose_args[@]+"${compose_args[@]}"} ps -a -q portal | head -n 1)"
+portal_init_container="$(docker compose ${compose_args[@]+"${compose_args[@]}"} ps -a -q portal-init | head -n 1)"
 
 if [ -z "$portal_container" ] || [ -z "$portal_init_container" ]; then
   echo "[redeploy-portal] Missing portal or portal-init container after recreate." >&2


### PR DESCRIPTION
## Problem

`redeploy-portal.sh` runs under `set -euo pipefail`. Bare `"${build_flags[@]}"` / `"${compose_args[@]}"` on an **empty** array aborts with `unbound variable` on macOS's stock **bash 3.2** (tolerated on the bash 4.4+ used on Linux). `build_flags` is empty unless `--no-cache`/flags are passed; `compose_args` is empty when no env file is found.

On a Mac the build step (line 65) dies immediately:
```
scripts/redeploy-portal.sh: line 65: build_flags[@]: unbound variable
```
…so the local redeploy / clean-bootstrap path is unusable on macOS.

## Fix

Use the bash 3.2-safe guarded expansion `${arr[@]+"${arr[@]}"}` for both arrays at all call sites (build, up, ps).

## Verification

With this change, `redeploy-portal.sh` builds + recreates `portal`/`portal-init` successfully on macOS (Darwin, bash 3.2) and the version-verify step passes — this was used to perform the clean bootstrap deploy that this exact change unblocked.

Same macOS-portability class as the BSD-sed / bash-3.2 installer fixes already tracked under `EP-INSTALL-HARDENING-2026-05-23`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)