### PR TITLE
refactor(web): migrate finance/payments to report-kit + server-safe FilterBar url-mode (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/finance/payments/PaymentsTable.test.tsx
+++ b/apps/web/app/(shell)/finance/payments/PaymentsTable.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PaymentsTable, type PaymentRow } from "./PaymentsTable";
+
+const ROWS: PaymentRow[] = [
+  {
+    id: "p1",
+    paymentRef: "PMT-001",
+    method: "card",
+    direction: "inbound",
+    invoiceId: "inv1",
+    invoiceRef: "INV-100",
+    dateISO: "2026-03-28T14:30:00.000Z",
+    amount: 1234.5,
+  },
+  {
+    id: "p2",
+    paymentRef: "PMT-002",
+    method: "transfer",
+    direction: "outbound",
+    invoiceId: null,
+    invoiceRef: null,
+    dateISO: "2026-03-27T09:00:00.000Z",
+    amount: 50,
+  },
+];
+
+describe("PaymentsTable (report-kit migration)", () => {
+  const html = renderToStaticMarkup(<PaymentsTable rows={ROWS} currencySymbol="£" />);
+
+  it("renders rows with refs and a linked invoice", () => {
+    expect(html).toContain("PMT-001");
+    expect(html).toContain('href="/finance/invoices/inv1"');
+    expect(html).toContain("INV-100");
+  });
+
+  it("renders direction via token-backed StatusBadge (no raw hex)", () => {
+    // inbound → success, outbound → warning
+    expect(html).toContain('data-intent="success"');
+    expect(html).toContain('data-intent="warning"');
+    expect(html).not.toMatch(/#(4ade80|f97316)/i);
+  });
+
+  it("formats money with the currency symbol", () => {
+    expect(html).toContain("£1,234.50");
+    expect(html).toContain("£50.00");
+  });
+
+  it("renders an em dash when there is no linked invoice", () => {
+    expect(html).toContain("—");
+  });
+});

--- a/apps/web/app/(shell)/finance/payments/PaymentsTable.tsx
+++ b/apps/web/app/(shell)/finance/payments/PaymentsTable.tsx
@@ -1,0 +1,103 @@
+// apps/web/app/(shell)/finance/payments/PaymentsTable.tsx
+//
+// Client wrapper that renders the report-kit DataTable for payments. The page
+// (a Server Component) fetches + serializes rows and passes them here; DataTable
+// needs a client boundary for sort/pagination, and its function-based columns
+// can't cross the server→client boundary, so the columns live here.
+
+"use client";
+
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { DataTable, StatusBadge, type Column } from "@/components/ui/report-kit";
+
+export interface PaymentRow {
+  id: string;
+  paymentRef: string;
+  method: string;
+  direction: string;
+  invoiceId: string | null;
+  invoiceRef: string | null;
+  dateISO: string;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function PaymentsTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: PaymentRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<PaymentRow>[] = [
+    { key: "ref", header: "Ref", cell: (p) => p.paymentRef, mono: true },
+    {
+      key: "method",
+      header: "Method",
+      cell: (p) => <span className="capitalize text-[var(--dpf-muted)]">{p.method}</span>,
+      sortAccessor: (p) => p.method,
+    },
+    {
+      key: "direction",
+      header: "Direction",
+      cell: (p) => (
+        <StatusBadge domain="paymentDirection" status={p.direction} variant="soft" uppercase={false} />
+      ),
+      sortAccessor: (p) => p.direction,
+    },
+    {
+      key: "invoice",
+      header: "Invoice",
+      cell: (p) =>
+        p.invoiceId ? (
+          <Link
+            href={`/finance/invoices/${p.invoiceId}`}
+            className="font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+          >
+            {p.invoiceRef}
+          </Link>
+        ) : (
+          <span className="text-[var(--dpf-muted)]">—</span>
+        ),
+    },
+    {
+      key: "date",
+      header: "Date",
+      cell: (p) => (
+        <span className="text-[var(--dpf-muted)]">
+          <LocalTime value={p.dateISO} mode="date" />
+        </span>
+      ),
+      sortAccessor: (p) => p.dateISO,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (p) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(p.amount)}
+        </span>
+      ),
+      sortAccessor: (p) => p.amount,
+    },
+  ];
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] p-1">
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(p) => p.id}
+        initialSort={{ key: "date", dir: "desc" }}
+        empty="No payments found."
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/payments/page.tsx
+++ b/apps/web/app/(shell)/finance/payments/page.tsx
@@ -3,8 +3,10 @@ import { prisma } from "@dpf/db";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-import { LocalTime } from "@/components/ui/LocalTime";
+import { FilterBar } from "@/components/ui/report-kit";
 import Link from "next/link";
+
+import { PaymentsTable, type PaymentRow } from "./PaymentsTable";
 
 type Props = { searchParams: Promise<{ direction?: string }> };
 
@@ -29,29 +31,20 @@ export default async function PaymentsPage({ searchParams }: Props) {
   ]);
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
-  const formatMoney = (amount: number) =>
-    amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
-
-  const directionBadge = (dir: string) => {
-    if (dir === "inbound") {
-      return (
-        <span
-          className="text-[9px] px-1.5 py-0.5 rounded-full"
-          style={{ color: "#4ade80", backgroundColor: "#4ade8020" }}
-        >
-          inbound
-        </span>
-      );
-    }
-    return (
-      <span
-        className="text-[9px] px-1.5 py-0.5 rounded-full"
-        style={{ color: "#f97316", backgroundColor: "#f9731620" }}
-      >
-        outbound
-      </span>
-    );
-  };
+  // Serialize to plain rows for the client table (no Decimal/Date across the boundary).
+  const rows: PaymentRow[] = payments.map((pmt) => {
+    const linkedInvoice = pmt.allocations[0]?.invoice ?? null;
+    return {
+      id: pmt.id,
+      paymentRef: pmt.paymentRef,
+      method: pmt.method,
+      direction: pmt.direction,
+      invoiceId: linkedInvoice?.id ?? null,
+      invoiceRef: linkedInvoice?.invoiceRef ?? null,
+      dateISO: (pmt.receivedAt ?? pmt.createdAt).toISOString(),
+      amount: Number(pmt.amount),
+    };
+  });
 
   return (
     <div>
@@ -74,115 +67,29 @@ export default async function PaymentsPage({ searchParams }: Props) {
 
       <FinanceTabNav />
 
-      {/* Direction filter pills */}
-      <div className="flex gap-2 mb-6">
-        <Link
-          href="/finance/payments"
-          className={`text-[10px] px-2.5 py-1 rounded-full border transition-colors ${
-            !direction
-              ? "border-[var(--dpf-accent)] text-[var(--dpf-text)] bg-[var(--dpf-accent)]/10"
-              : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-          }`}
-        >
-          All
-        </Link>
-        <Link
-          href="/finance/payments?direction=inbound"
-          className={`text-[10px] px-2.5 py-1 rounded-full border transition-colors ${
-            direction === "inbound"
-              ? "border-[var(--dpf-accent)] text-[var(--dpf-text)] bg-[var(--dpf-accent)]/10"
-              : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-          }`}
-        >
-          Inbound
-        </Link>
-        <Link
-          href="/finance/payments?direction=outbound"
-          className={`text-[10px] px-2.5 py-1 rounded-full border transition-colors ${
-            direction === "outbound"
-              ? "border-[var(--dpf-accent)] text-[var(--dpf-text)] bg-[var(--dpf-accent)]/10"
-              : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-          }`}
-        >
-          Outbound
-        </Link>
+      {/* Direction filter — report-kit FilterBar in url mode (server-rendered) */}
+      <div className="my-6">
+        <FilterBar
+          mode="url"
+          basePath="/finance/payments"
+          value={direction ? { direction: direction.toLowerCase() } : {}}
+          facets={[
+            {
+              kind: "pills",
+              key: "direction",
+              label: "Direction",
+              options: [
+                { value: "inbound", label: "Inbound" },
+                { value: "outbound", label: "Outbound" },
+              ],
+            },
+          ]}
+          resultCount={rows.length}
+        />
       </div>
 
       {/* Payments table */}
-      {payments.length === 0 ? (
-        <p className="text-sm text-[var(--dpf-muted)]">No payments found.</p>
-      ) : (
-        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)]">
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Ref
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Method
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Direction
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Invoice
-                </th>
-                <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Date
-                </th>
-                <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                  Amount
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {payments.map((pmt) => {
-                const linkedInvoice = pmt.allocations[0]?.invoice ?? null;
-                return (
-                  <tr
-                    key={pmt.id}
-                    className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <span className="text-[9px] font-mono text-[var(--dpf-muted)]">
-                        {pmt.paymentRef}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)] capitalize">
-                      {pmt.method}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      {directionBadge(pmt.direction)}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      {linkedInvoice ? (
-                        <Link
-                          href={`/finance/invoices/${linkedInvoice.id}`}
-                          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                        >
-                          {linkedInvoice.invoiceRef}
-                        </Link>
-                      ) : (
-                        <span className="text-[var(--dpf-muted)]">—</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2.5 text-[var(--dpf-muted)]">
-                      <LocalTime
-                        value={pmt.receivedAt ?? pmt.createdAt}
-                        mode="date"
-                      />
-                    </td>
-                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                      {sym}{formatMoney(Number(pmt.amount))}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <PaymentsTable rows={rows} currencySymbol={sym} />
     </div>
   );
 }

--- a/apps/web/components/ui/report-kit/FilterBar.test.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.test.tsx
@@ -54,19 +54,36 @@ describe("FilterBar", () => {
     expect(html).toMatch(/var\(--dpf-accent\)/);
   });
 
-  it("url mode renders pills as links via hrefBuilder", () => {
+  it("url mode renders pills as links built from basePath + value", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar mode="url" facets={FACETS} value={{}} basePath="/finance/payments" />,
+    );
+    expect(html).toContain('href="/finance/payments?direction=in"');
+    expect(html).toContain('href="/finance/payments?direction=out"');
+  });
+
+  it("url mode preserves other facet values in the href and toggles active off", () => {
     const html = renderToStaticMarkup(
       <FilterBar
         mode="url"
         facets={FACETS}
-        value={{}}
-        hrefBuilder={(key, value) =>
-          value ? `?${key}=${value}` : `?${key}=`
-        }
+        value={{ direction: "in", status: "paid" }}
+        basePath="/finance/payments"
       />,
     );
-    expect(html).toContain('href="?direction=in"');
-    expect(html).toContain('href="?direction=out"');
+    // switching direction keeps status=paid
+    expect(html).toContain("direction=out");
+    expect(html).toContain("status=paid");
+    // the active "in" pill links back to a cleared direction (just status)
+    expect(html).toContain('href="/finance/payments?status=paid"');
+  });
+
+  it("url mode renders search/select as GET forms targeting basePath", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar mode="url" facets={FACETS} value={{}} basePath="/finance/payments" />,
+    );
+    expect(html).toContain('action="/finance/payments"');
+    expect(html).toContain('method="get"');
   });
 
   it("singularizes the result count", () => {

--- a/apps/web/components/ui/report-kit/FilterBar.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.tsx
@@ -6,8 +6,14 @@
 //
 // Two modes:
 //   - "client": controlled via `value` + `onChange` (matches complaints today).
-//   - "url":    renders <Link> pills / <select> bound to the given hrefBuilder
-//               (server-friendly, matches finance/compliance today).
+//   - "url":    server-friendly. Pills are <Link>s whose hrefs are built from a
+//               `basePath` + the current `value` (no function prop, so it can be
+//               rendered directly from a Server Component). search/select render
+//               as GET forms that preserve the other facets via hidden inputs.
+//
+// url mode is intentionally function-free: passing a callback from a Server
+// Component to this ("use client") component is not allowed, so the href is
+// derived internally from serializable props.
 
 "use client";
 
@@ -33,25 +39,46 @@ interface CommonProps {
 interface ClientProps extends CommonProps {
   mode?: "client";
   onChange: (next: Record<string, string>) => void;
-  hrefBuilder?: never;
+  basePath?: never;
 }
 
 interface UrlProps extends CommonProps {
   mode: "url";
-  /** Build the href for a facet set to a value (omit value = cleared). */
-  hrefBuilder: (key: string, value: string | null) => string;
+  /** Route the filter links/forms target, e.g. "/finance/payments". */
+  basePath: string;
   onChange?: never;
 }
 
 export type FilterBarProps = ClientProps | UrlProps;
 
-const PILL_BASE =
-  "rounded border px-2 py-0.5 text-[11px] transition-colors";
+const PILL_BASE = "rounded border px-2 py-0.5 text-[11px] transition-colors";
 
 function pillClass(active: boolean): string {
   return active
     ? `${PILL_BASE} border-[var(--dpf-accent)] text-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)]`
     : `${PILL_BASE} border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]`;
+}
+
+/** Merge `key`→`next` into the current filter set and serialize to an href. */
+function buildHref(
+  basePath: string,
+  value: Record<string, string>,
+  key: string,
+  next: string | null,
+): string {
+  const merged: Record<string, string> = { ...value };
+  if (next === null || next === "") delete merged[key];
+  else merged[key] = next;
+  const params = Object.entries(merged).filter(([, v]) => v != null && v !== "");
+  const qs = new URLSearchParams(params).toString();
+  return qs ? `${basePath}?${qs}` : basePath;
+}
+
+/** Hidden inputs carrying every facet value except `exceptKey` (url forms). */
+function hiddenInputs(value: Record<string, string>, exceptKey: string) {
+  return Object.entries(value)
+    .filter(([k, v]) => k !== exceptKey && v)
+    .map(([k, v]) => <input key={k} type="hidden" name={k} value={v} />);
 }
 
 export function FilterBar(props: FilterBarProps) {
@@ -75,6 +102,21 @@ export function FilterBar(props: FilterBarProps) {
         const current = value[facet.key] ?? "";
 
         if (facet.kind === "search") {
+          if (isUrl) {
+            return (
+              <form key={facet.key} action={props.basePath} method="get">
+                {hiddenInputs(value, facet.key)}
+                <input
+                  type="search"
+                  name={facet.key}
+                  aria-label={facet.placeholder ?? "Search"}
+                  placeholder={facet.placeholder ?? "Search…"}
+                  defaultValue={current}
+                  className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+                />
+              </form>
+            );
+          }
           return (
             <input
               key={facet.key}
@@ -82,20 +124,52 @@ export function FilterBar(props: FilterBarProps) {
               aria-label={facet.placeholder ?? "Search"}
               placeholder={facet.placeholder ?? "Search…"}
               defaultValue={current}
-              onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+              onChange={(e) => set(facet.key, e.target.value)}
               className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
             />
           );
         }
 
         if (facet.kind === "select") {
+          if (isUrl) {
+            return (
+              <form
+                key={facet.key}
+                action={props.basePath}
+                method="get"
+                className="flex items-center gap-1 text-[11px]"
+              >
+                {hiddenInputs(value, facet.key)}
+                <span className="text-[var(--dpf-muted)]">{facet.label}</span>
+                <select
+                  name={facet.key}
+                  defaultValue={current}
+                  aria-label={facet.label}
+                  className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+                >
+                  <option value="">All</option>
+                  {facet.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="submit"
+                  className="rounded border border-[var(--dpf-border)] px-2 py-1 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                >
+                  Apply
+                </button>
+              </form>
+            );
+          }
           return (
             <label key={facet.key} className="flex items-center gap-1 text-[11px]">
               <span className="text-[var(--dpf-muted)]">{facet.label}</span>
               <select
                 value={current}
                 aria-label={facet.label}
-                onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+                onChange={(e) => set(facet.key, e.target.value)}
                 className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
               >
                 <option value="">All</option>
@@ -119,7 +193,7 @@ export function FilterBar(props: FilterBarProps) {
                 return (
                   <Link
                     key={opt.value}
-                    href={props.hrefBuilder(facet.key, active ? null : opt.value)}
+                    href={buildHref(props.basePath, value, facet.key, active ? null : opt.value)}
                     className={pillClass(active)}
                   >
                     {opt.label}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -80,6 +80,11 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     resolved: "success",
     closed: "neutral",
   },
+  // Payment direction (was raw hex in finance/payments — now token-backed).
+  paymentDirection: {
+    inbound: "success",
+    outbound: "warning",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",


### PR DESCRIPTION
## What

Second **reference adoption** of `report-kit` (#1305) — this time a **Server Component** — plus a fix to FilterBar that the adoption surfaced.

## Changes

**`finance/payments/page.tsx`** (server)
- raw-hex `directionBadge` (`#4ade80` / `#f97316`) → `StatusBadge` via a new `paymentDirection` registry entry (`inbound→success`, `outbound→warning`)
- hand-rolled `<table>` → `<PaymentsTable>` (client wrapper over `DataTable`)
- bespoke `<Link>` filter pills → `FilterBar` in **url mode**

**`PaymentsTable.tsx`** (new, client)
- Holds the function-based `DataTable` columns. Canonical **server→client table pattern**: the page serializes rows (no Decimal/Date across the boundary) and passes them down.

**FilterBar url-mode hardening** (`FilterBar.tsx`)
- The adoption surfaced a real bug: the old `hrefBuilder` **callback prop can't cross the server→client boundary**, so url mode never actually worked from a Server Component.
- Reworked to be **function-free**: pills are `<Link>`s whose hrefs are built internally from `basePath` + current `value` (preserving other facets, toggling active off); search/select render as GET forms carrying the other facets as hidden inputs. Tests updated.

## Verification

- `npx vitest run components/ui/report-kit` → **25 passed** (incl. 2 new url-mode tests)
- `npx vitest run app/(shell)/finance/payments` → **4 passed** (PaymentsTable smoke: token badges, no hex, money/links)
- `tsc --noEmit` clean; no raw color hex remains in the payments surface

## Notes

- Self-contained against main (the `paymentDirection` entry + url-mode fix ship together).
- Independent of the complaints PR #1308 (that uses FilterBar **client** mode, whose API is unchanged).
- Phase 2 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)