### PR TITLE
refactor(web): fold ChangeLaneStatusBadge onto report-kit StatusBadge (BI-6A842691)

### DIFF
--- a/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.test.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ChangeLaneStatusBadge } from "./ChangeLaneStatusBadge";
+import { CONTRIBUTOR_LANE_STATUSES } from "@/lib/contributor-change-lanes/types";
+
+describe("ChangeLaneStatusBadge (report-kit wrapper)", () => {
+  it("renders every lane status with a resolved intent and its label", () => {
+    for (const status of CONTRIBUTOR_LANE_STATUSES) {
+      const html = renderToStaticMarkup(<ChangeLaneStatusBadge status={status} />);
+      expect(html).toMatch(/data-intent="(success|warning|danger|info|neutral|accent)"/);
+      expect(html).toContain(status);
+      // token-backed, never raw hex
+      expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+    }
+  });
+
+  it("maps key statuses to the expected intents", () => {
+    expect(renderToStaticMarkup(<ChangeLaneStatusBadge status="blocked" />)).toContain('data-intent="danger"');
+    expect(renderToStaticMarkup(<ChangeLaneStatusBadge status="ready-for-review" />)).toContain('data-intent="success"');
+    expect(renderToStaticMarkup(<ChangeLaneStatusBadge status="running" />)).toContain('data-intent="accent"');
+    expect(renderToStaticMarkup(<ChangeLaneStatusBadge status="available" />)).toContain('data-intent="neutral"');
+  });
+});

--- a/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx
@@ -1,24 +1,21 @@
 import type { ContributorLaneStatus } from "@/lib/contributor-change-lanes/types";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 
-const STATUS_COLOR_CLASSES: Record<ContributorLaneStatus, string> = {
-  blocked: "border-[var(--dpf-error)] text-[var(--dpf-error)]",
-  starting: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
-  verifying: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
-  running: "border-[var(--dpf-accent)] text-[var(--dpf-accent)]",
-  "ready-for-review": "border-[var(--dpf-success)] text-[var(--dpf-success)]",
-  claimed: "border-[var(--dpf-muted)] text-[var(--dpf-text)]",
-  available: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
-  released: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
-  stale: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
+// Contributor-lane status → semantic intent. Kept local (rather than in the
+// shared STATUS_INTENT registry) because lane status is niche to this surface;
+// the shared StatusBadge still owns all rendering + token color.
+const LANE_INTENT: Record<ContributorLaneStatus, Intent> = {
+  blocked: "danger",
+  starting: "warning",
+  verifying: "warning",
+  running: "accent",
+  "ready-for-review": "success",
+  claimed: "neutral",
+  available: "neutral",
+  released: "neutral",
+  stale: "warning",
 };
 
 export function ChangeLaneStatusBadge({ status }: { status: ContributorLaneStatus }) {
-  const classes = STATUS_COLOR_CLASSES[status];
-  return (
-    <span
-      className={`inline-flex items-center rounded border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${classes}`}
-    >
-      {status}
-    </span>
-  );
+  return <StatusBadge intent={LANE_INTENT[status]} label={status} variant="outline" />;
 }


### PR DESCRIPTION
## What

Folds the contributor-lane status badge onto the shared `StatusBadge` (#1305). Replaces the bespoke `STATUS_COLOR_CLASSES` map + hand-written `<span>` with a thin wrapper.

```tsx
const LANE_INTENT: Record<ContributorLaneStatus, Intent> = {
  blocked: "danger", running: "accent", "ready-for-review": "success",
  starting: "warning", verifying: "warning", stale: "warning",
  available: "neutral", claimed: "neutral", released: "neutral",
};
export function ChangeLaneStatusBadge({ status }) {
  return <StatusBadge intent={LANE_INTENT[status]} label={status} variant="outline" />;
}
```

- The local lane-status→intent map stays local (lane status is niche to this surface); `StatusBadge` owns all rendering + token color.
- `ChangeLaneTable` is untouched — same `{ status }` signature.
- Kept independent of the registry so it doesn't collide with the finance PR (#1313) that edits `statusColors.ts`.

## Verification

- `npx vitest run …/ChangeLaneStatusBadge` → **2 passed** (new test: every `CONTRIBUTOR_LANE_STATUS` resolves to a valid intent, no raw hex)
- `tsc --noEmit` clean

Phase 2 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)