### PR TITLE
fix(build-studio): coworker tools target the page's build, not 'most recent'

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4540,6 +4540,28 @@ export async function executeTool(
   // Strip empty optional object params that models send as schema artifacts
   const params = sanitizeToolParams(toolName, rawParams);
 
+  // ─── Build-context hint (BI-2DAB02B4 / BI-F4A30FCB) ────────────────────────
+  // When the coworker is messaging from a specific build, that build is plumbed
+  // here as context.featureBuildId (a cuid). Resolve it to the FB- buildId and
+  // set params.buildId so phase-scoped tools (update_feature_brief,
+  // reviewDesignDoc, saveBuildEvidence, …) target THAT build via
+  // extractBuildIdHint — instead of resolveActiveBuildId silently falling back
+  // to the user's most-recently-updated non-terminal build, which
+  // cross-contaminates when several builds are active (the wrong-build-context
+  // bug). Only fills when the caller didn't pass an explicit buildId, and is
+  // inert for non-build tools (they never read params.buildId).
+  if (context?.featureBuildId && typeof params["buildId"] !== "string") {
+    try {
+      const ctxBuild = await prisma.featureBuild.findUnique({
+        where: { id: context.featureBuildId },
+        select: { buildId: true },
+      });
+      if (ctxBuild?.buildId) params["buildId"] = ctxBuild.buildId;
+    } catch {
+      // Non-fatal — fall back to the existing hint / active-build resolution.
+    }
+  }
+
   // ─── Runtime kernel-commandment gate (BI-43F95F77) ─────────────────────────
   // Consult the gate BEFORE the switch. If a tier-1 commandment matches this
   // tool name in the active session class, refuse (autonomous) or surface a


### PR DESCRIPTION
## Why

Found by driving a fix build (`FB-892ECD67`) through the Build Studio lifecycle in the UI: the coworker's `update_feature_brief`/`reviewDesignDoc` calls silently operated on a **different** build (`FB-5E20E793`, a stale feature build), so the build I was on never advanced and looped in ideate.

**Root cause:** every phase-scoped tool resolves its build via `resolveActiveBuildId(userId, extractBuildIdHint(params))`, which only reads `params.buildId` (the LLM never sets it) and otherwise falls back to the user's **most-recently-updated non-terminal build**. The page's build is already plumbed to the tool layer as `context.featureBuildId` (BI-F4A30FCB), but no handler consumed it.

## Fix

One central injection in `executeTool`: resolve `context.featureBuildId` (a cuid) → its `FB-` `buildId` and set `params.buildId` when the caller didn't pass one. Every existing `extractBuildIdHint(params)` call then targets the build the operator is actually looking at. Inert for non-build tools (they never read `params.buildId`) and for explicit `buildId` args. Addresses the wrong-build-context bug (**BI-2DAB02B4**).

Verified: typecheck + `next build` clean. Functional proof to follow by re-driving FB-892ECD67 after deploy.

Generated with Claude Code
