### PR TITLE
fix(build-studio): guard undefined path in normalizeRelativePath (BI-PIR-de54cc63)

### DIFF
--- a/apps/web/lib/consume/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/consume/__snapshots__/index.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`consume barrel export > exports all public symbols 1`] = `
 [
   "buildOnboardingPrompt",
+  "countStaleEntitiesSince",
   "getChecklists",
   "getDiscoveryTriageDecisionHistory",
   "getInventoryEntitiesForPage",

--- a/apps/web/lib/integrate/build-plan-paths.test.ts
+++ b/apps/web/lib/integrate/build-plan-paths.test.ts
@@ -76,4 +76,19 @@ describe("normalizeBuildPlanPaths", () => {
       "apps/web/components/build-studio/MissingPanel.tsx",
     ]);
   });
+
+  it("does not throw when a fileStructure entry has an undefined path (BI-PIR-de54cc63)", () => {
+    const plan = makePlan({
+      // path intentionally absent — LLM-authored plans / JSONB round-trips can
+      // omit it. Previously crashed normalizeRelativePath with .trim() of undefined.
+      fileStructure: [
+        { action: "create", purpose: "new file" } as BuildPlanDoc["fileStructure"][number],
+      ],
+      tasks: [],
+    });
+
+    expect(() => normalizeBuildPlanPaths(plan, { exists: () => false })).not.toThrow();
+    const normalized = normalizeBuildPlanPaths(plan, { exists: () => false });
+    expect(normalized.plan.fileStructure[0]?.path).toBe("");
+  });
 });

--- a/apps/web/lib/integrate/build-plan-paths.ts
+++ b/apps/web/lib/integrate/build-plan-paths.ts
@@ -28,6 +28,11 @@ const LEGACY_BUILD_STUDIO_TEXT_ALIASES: Array<{ from: RegExp; to: string }> = [
 ];
 
 function normalizeRelativePath(relativePath: string): string {
+  // Guard: buildPlan entries (LLM-authored, JSONB round-tripped) can arrive with
+  // an undefined / non-string path. Calling .trim() on that crashed
+  // saveBuildEvidence's buildPlan normalization with "Cannot read properties of
+  // undefined (reading 'trim')", stranding builds in plan phase (BI-PIR-de54cc63).
+  if (typeof relativePath !== "string") return "";
   return relativePath.trim().replace(/\\/g, "/").replace(/^\.\//, "");
 }
 


### PR DESCRIPTION
Closes the bug selected by the full-lifecycle dogfood: `saveBuildEvidence`'s buildPlan normalization called `normalizeRelativePath(entry.path)` → `relativePath.trim()` with no guard, so a `fileStructure`/`task` entry with an undefined path crashed with *"Cannot read properties of undefined (reading 'trim')"*, stranding builds in plan phase.

**Fix:** `normalizeRelativePath` returns `""` for non-string input before `.trim()`. Adds a regression test (`normalizeBuildPlanPaths` handles an undefined-path entry without throwing).

Verified: vitest (3/3), typecheck, `next build` all clean.

Shipped via direct PR because the Build Studio coworker could not drive the build (code-gen) phase autonomously during the dogfood — see the separately-filed coworker findings.

Generated with Claude Code
