### PR TITLE
fix(codeql): load sanitizer model pack via init + declare safe-log a barrier

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,14 +15,9 @@ name: "DPF CodeQL Config"
 queries:
   - uses: security-extended
 
-# Load our custom data-extensions model pack so the JS sanitiser
-# declarations apply at scan time.
-#
-# IMPORTANT — path-based packs must be in the flat list form. The
-# per-language map form (`packs: { javascript: [...] }`) is only for
-# *published* registry packs; path entries are silently rejected with
-# "Invalid CodeQL pack specification" and the pack is ignored. The pack
-# itself declares its target language via `extensionTargets:` in
-# `.github/codeql/dpf-sanitizers/qlpack.yml`.
-packs:
-  - ./.github/codeql/dpf-sanitizers
+# NOTE: the local data-extension pack is loaded via the init action's
+# `packs:` input in .github/workflows/codeql.yml — NOT here. A relative PATH
+# in this config file's `packs:` list is rejected by the codeql-action
+# ("Invalid CodeQL pack specification: './.github/codeql/dpf-sanitizers'.
+# Ignoring."), which silently disabled every DPF sanitiser. Do not re-add a
+# path-based `packs:` entry here.

--- a/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
+++ b/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
@@ -52,15 +52,19 @@ extensions:
       # Declared neutral so the alert doesn't recur.
       - ["codebase-tools", "Module", "Member[makeLineMatcher]", "ReturnValue", "manual"]
 
-  # ─── safe-log — js/log-injection sanitiser ───────────────────────────────
+  # ─── safe-log — js/log-injection sanitiser (barrier) ─────────────────────
+  # sanitizeForLog strips C0 control characters (U+0000..U+001F) and DEL
+  # (U+007F) — including CR + LF — so the returned string cannot forge a log
+  # line. This must be a BARRIER, not a taint-preserving summary: a
+  # `summaryModel` with kind `taint` declares arg→return PROPAGATION (taint
+  # flows through), which never suppresses js/log-injection. `barrierModel`
+  # (CodeQL 2.25.2+; repo runs 2.25.5) declares the return value a sanitised
+  # barrier for the `log-injection` taint kind. Columns: [type, path, kind].
   - addsTo:
       pack: codeql/javascript-all
-      extensible: summaryModel
+      extensible: barrierModel
     data:
-      # sanitizeForLog strips C0 control characters (U+0000..U+001F) and
-      # DEL (U+007F) — including CR + LF — so the returned string cannot
-      # forge a log line. Breaks taint flow for js/log-injection (CWE-117).
-      - ["safe-log", "Module", "Member[sanitizeForLog]", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["safe-log", "Member[sanitizeForLog].ReturnValue", "log-injection"]
 
   # ─── safe-property — js/remote-property-injection guard ──────────────────
   - addsTo:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,6 +63,12 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
+          # Load the local data-extension pack via the init `packs:` input.
+          # A relative PATH in the config file's `packs:` list is rejected by
+          # the codeql-action ("Invalid CodeQL pack specification … Ignoring",
+          # verified in run 26695341527), so the DPF sanitizers never loaded.
+          # The init `packs:` input does resolve a local path pack.
+          packs: ./.github/codeql/dpf-sanitizers
 
       # continue-on-error keeps this workflow non-blocking until the one-time
       # "Settings → Code security → CodeQL → Advanced" toggle flips. While


### PR DESCRIPTION
## What
Repairs the DPF CodeQL **sanitizer model pack** so it suppresses false-positive `js/log-injection` alerts on the already-runtime-safe `sanitizeForLog` call sites — alerts **#255 / #256**, which re-opened after PR #1290.

The original vulnerability is already fixed (alerts **#250 / #251 closed**). This PR only makes CodeQL *recognize* the sanitizer.

## Two compounding defects (both verified)
**Bug 1 — pack never loaded.** It was passed via the config file's `packs:` list; a relative path there is rejected by the codeql-action — run `26695341527`'s JS job logs `WARNING: Invalid CodeQL pack specification: './.github/codeql/dpf-sanitizers'. Ignoring.` So **all six** sanitizers were dead. Fix: pass via the **init** action's `packs:` input; drop the path entry from `codeql-config.yml`.

**Bug 2 — wrong model form.** `safe-log` used `summaryModel` + kind `taint` = arg→return *propagation*, the opposite of a barrier. Fix: `barrierModel` for kind `log-injection` (CodeQL 2.25.2+; repo runs 2.25.5).

## Not changed
`apps/web/lib/security/safe-log.ts` — its regex is the byte sequence `[\x00-\x1F\x7F]+` (control bytes render blank in editors). Verified by executing the real bytes: `"good\r\nFAKE\tx"` → `"good_FAKE_x"`. PR #1290's runtime fix is sound.

## Verification (this PR's own CodeQL run)
1. `Invalid CodeQL pack specification` warning **gone**.
2. log-injection alert **not** re-raised on the sanitizeForLog sinks.

If the `barrierModel` form needs a tweak, this PR's scan shows it before merge — I'll iterate.

## Follow-up
The other 5 sanitizer rows share Bug 2's shape and should also move to `barrierModel` once this confirms the form — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)