### PR TITLE
revert(codeql): undo #1318 — broken local pack-load breaks CodeQL jobs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,9 +15,14 @@ name: "DPF CodeQL Config"
 queries:
   - uses: security-extended
 
-# NOTE: the local data-extension pack is loaded via the init action's
-# `packs:` input in .github/workflows/codeql.yml — NOT here. A relative PATH
-# in this config file's `packs:` list is rejected by the codeql-action
-# ("Invalid CodeQL pack specification: './.github/codeql/dpf-sanitizers'.
-# Ignoring."), which silently disabled every DPF sanitiser. Do not re-add a
-# path-based `packs:` entry here.
+# Load our custom data-extensions model pack so the JS sanitiser
+# declarations apply at scan time.
+#
+# IMPORTANT — path-based packs must be in the flat list form. The
+# per-language map form (`packs: { javascript: [...] }`) is only for
+# *published* registry packs; path entries are silently rejected with
+# "Invalid CodeQL pack specification" and the pack is ignored. The pack
+# itself declares its target language via `extensionTargets:` in
+# `.github/codeql/dpf-sanitizers/qlpack.yml`.
+packs:
+  - ./.github/codeql/dpf-sanitizers

--- a/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
+++ b/.github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml
@@ -52,19 +52,15 @@ extensions:
       # Declared neutral so the alert doesn't recur.
       - ["codebase-tools", "Module", "Member[makeLineMatcher]", "ReturnValue", "manual"]
 
-  # ─── safe-log — js/log-injection sanitiser (barrier) ─────────────────────
-  # sanitizeForLog strips C0 control characters (U+0000..U+001F) and DEL
-  # (U+007F) — including CR + LF — so the returned string cannot forge a log
-  # line. This must be a BARRIER, not a taint-preserving summary: a
-  # `summaryModel` with kind `taint` declares arg→return PROPAGATION (taint
-  # flows through), which never suppresses js/log-injection. `barrierModel`
-  # (CodeQL 2.25.2+; repo runs 2.25.5) declares the return value a sanitised
-  # barrier for the `log-injection` taint kind. Columns: [type, path, kind].
+  # ─── safe-log — js/log-injection sanitiser ───────────────────────────────
   - addsTo:
       pack: codeql/javascript-all
-      extensible: barrierModel
+      extensible: summaryModel
     data:
-      - ["safe-log", "Member[sanitizeForLog].ReturnValue", "log-injection"]
+      # sanitizeForLog strips C0 control characters (U+0000..U+001F) and
+      # DEL (U+007F) — including CR + LF — so the returned string cannot
+      # forge a log line. Breaks taint flow for js/log-injection (CWE-117).
+      - ["safe-log", "Module", "Member[sanitizeForLog]", "Argument[0]", "ReturnValue", "taint", "manual"]
 
   # ─── safe-property — js/remote-property-injection guard ──────────────────
   - addsTo:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,12 +63,6 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
-          # Load the local data-extension pack via the init `packs:` input.
-          # A relative PATH in the config file's `packs:` list is rejected by
-          # the codeql-action ("Invalid CodeQL pack specification … Ignoring",
-          # verified in run 26695341527), so the DPF sanitizers never loaded.
-          # The init `packs:` input does resolve a local path pack.
-          packs: ./.github/codeql/dpf-sanitizers
 
       # continue-on-error keeps this workflow non-blocking until the one-time
       # "Settings → Code security → CodeQL → Advanced" toggle flips. While


### PR DESCRIPTION
## What
Reverts **#1318**, which broke main's CodeQL workflow.

## Why
#1318 loaded the local `dpf-sanitizers` data-extension pack via the codeql-action **init `packs:` input**. The action rejects a relative local path there:
```
##[error]"./.github/codeql/dpf-sanitizers" is not a valid pack
CodeQL job status was configuration error.
```
Result on main (run 26696132850): the **javascript** job config-errors and the **go** job fails — strictly worse than before #1318, when all CodeQL jobs passed (the config-file `packs:` path was silently ignored; pack inert). Reverting restores the known-good, all-green state.

## On the underlying alerts
`js/log-injection` **#255/#256 are false positives** — the code is already sanitized (`sanitizeForLog` strips CR/LF/control, verified at byte level; the real alerts #250/#251 are `fixed`). The right disposition is to **dismiss them as false-positive**. Correctly loading a local CodeQL model pack with the codeql-action needs a verified mechanism (neither the config-file `packs:` list nor the init `packs:` input accepts a relative path) — deferred to a properly-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)