### PR TITLE
feat(web): activity timestamps + next-window time on /ops/self-upgrade

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -368,6 +368,29 @@ describe("SelfUpgradeClient – run history", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
     expect(html).not.toContain("Run History");
   });
+
+  it("renders a When column header for the timestamps", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        history={[makeRun("succeeded")]}
+        historyNextCursor={null}
+      />,
+    );
+    expect(html).toContain("When");
+  });
+
+  it("renders each run's duration in the history table", () => {
+    // baseStatus.latestRun is null, so the only 5m span comes from history.
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        history={[makeRun("succeeded")]}
+        historyNextCursor={null}
+      />,
+    );
+    expect(html).toContain("5m");
+  });
 });
 
 // ─── Latest run – timestamps ──────────────────────────────────────────────────
@@ -396,6 +419,34 @@ describe("SelfUpgradeClient – latest run timestamps", () => {
       />,
     );
     expect(html).not.toContain("5m");
+  });
+
+  it("shows a Completed label when a succeeded run has completedAt", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("succeeded")} />,
+    );
+    expect(html).toContain("Completed:");
+  });
+
+  it("labels the end timestamp as Failed for a failed run", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("failed", { failureLog: "boom" })}
+      />,
+    );
+    expect(html).toContain("Failed:");
+  });
+
+  it("falls back to a Created label when the run never started", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("skipped", { startedAt: null, completedAt: null })}
+      />,
+    );
+    expect(html).toContain("Created:");
+    expect(html).not.toContain("Started:");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -304,13 +304,25 @@ export default function SelfUpgradeClient({
             </div>
           )}
 
-          {latestRun.startedAt && (
+          {latestRun.startedAt ? (
             <div className="text-xs text-[var(--dpf-muted)]">
               Started:{" "}
               <LocalTime className="font-mono" value={latestRun.startedAt} />
               {latestRun.completedAt && (
                 <> · {formatDuration(latestRun.startedAt, latestRun.completedAt)}</>
               )}
+            </div>
+          ) : (
+            <div className="text-xs text-[var(--dpf-muted)]">
+              Created:{" "}
+              <LocalTime className="font-mono" value={latestRun.createdAt} />
+            </div>
+          )}
+
+          {latestRun.completedAt && (
+            <div className="text-xs text-[var(--dpf-muted)]">
+              {latestRun.status === "failed" ? "Failed" : "Completed"}:{" "}
+              <LocalTime className="font-mono" value={latestRun.completedAt} />
             </div>
           )}
 
@@ -333,11 +345,19 @@ export default function SelfUpgradeClient({
             <span className="text-xs font-medium text-[var(--dpf-text)]">Run History</span>
           </div>
           <table className="w-full text-xs">
+            <thead>
+              <tr className="text-[var(--dpf-muted)] text-left">
+                <th className="px-3 py-1.5 font-medium">Status</th>
+                <th className="px-3 py-1.5 font-medium">Run</th>
+                <th className="px-3 py-1.5 font-medium">Change</th>
+                <th className="px-3 py-1.5 font-medium text-right">When</th>
+              </tr>
+            </thead>
             <tbody>
               {history.map((run) => (
                 <tr
                   key={run.runId}
-                  className="border-b border-[var(--dpf-border)] last:border-0"
+                  className="border-t border-[var(--dpf-border)]"
                   data-run-id={run.runId}
                 >
                   <td className="px-3 py-2 w-24 shrink-0">
@@ -358,6 +378,14 @@ export default function SelfUpgradeClient({
                         <span className="font-mono">{run.targetSha}</span>
                       </>
                     ) : null}
+                  </td>
+                  <td className="px-3 py-2 text-right text-[var(--dpf-muted)] whitespace-nowrap align-top">
+                    <LocalTime value={run.startedAt ?? run.createdAt} />
+                    {run.startedAt && run.completedAt && (
+                      <span className="ml-1 opacity-70">
+                        · {formatDuration(run.startedAt, run.completedAt)}
+                      </span>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -15,7 +15,11 @@ import {
   getDeployedSha,
   getLatestRun,
 } from "@/lib/self-upgrade";
-import { isStoreOpen, isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import {
+  isStoreOpen,
+  isUpgradeWindowOpen,
+  nextUpgradeWindowOpen,
+} from "@/lib/self-upgrade/window";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { loadPlatformVersion } from "@/lib/platform/version";
 import { inngest } from "@/lib/queue/inngest-client";
@@ -610,9 +614,17 @@ export async function getSelfUpgradeStatus() {
   const windowSource: "explicit" | "operating-hours" = hasExplicitWindows
     ? "explicit"
     : "operating-hours";
+  // Next time the upgrade window opens, so the panel can show WHEN scheduled
+  // upgrades will next be eligible. Explicit windows use their configured start;
+  // the operating-hours model derives it from the next store-close transition
+  // (null only while already in-window or for a 24/7 store, where the panel
+  // already explains the state).
+  const now = new Date();
   const nextWindowStart = hasExplicitWindows
-    ? nextMaintenanceWindowStart(config)?.toISOString() ?? null
-    : null;
+    ? nextMaintenanceWindowStart(config, now)?.toISOString() ?? null
+    : inMaintenanceWindow
+      ? null
+      : nextUpgradeWindowOpen(schedule, now, timezone)?.toISOString() ?? null;
   const targetSha = await resolveTargetSha(config.channel, config);
   const isFresh = targetSha ? isShaFresh(deployedSha, targetSha) : false;
 

--- a/apps/web/lib/self-upgrade/window.test.ts
+++ b/apps/web/lib/self-upgrade/window.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isStoreOpen, isUpgradeWindowOpen, zonedDayAndTime } from "./window";
+import {
+  isStoreOpen,
+  isUpgradeWindowOpen,
+  nextUpgradeWindowOpen,
+  zonedDayAndTime,
+} from "./window";
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
 
 // 9–5 weekdays, closed weekends (the GENERIC_DEFAULTS shape / the user's "until 5PM").
@@ -67,5 +72,40 @@ describe("isUpgradeWindowOpen", () => {
   });
   it("no schedule and no windows → allowed (never silently block forever)", () => {
     expect(isUpgradeWindowOpen({ now: MON_1200_UTC })).toBe(true);
+  });
+});
+
+describe("nextUpgradeWindowOpen", () => {
+  it("returns the next store-close when the store is open now", () => {
+    // Monday noon, open until 17:00 UTC → window opens at 17:00 the same day.
+    const next = nextUpgradeWindowOpen(NINE_TO_FIVE, MON_1200_UTC, "UTC");
+    expect(next?.toISOString()).toBe("2026-05-25T17:00:00.000Z");
+  });
+
+  it("returns `now` when the store is already closed (window open)", () => {
+    // Monday 23:00 → store closed → upgrade window is open right now.
+    const next = nextUpgradeWindowOpen(NINE_TO_FIVE, MON_2300_UTC, "UTC");
+    expect(next).toBe(MON_2300_UTC);
+  });
+
+  it("respects the store timezone when projecting the next close", () => {
+    // 15:00 UTC is 11:00 in New York (EDT) — within 09:00–17:00 local, so the
+    // store is open and the next close is 17:00 local = 21:00 UTC.
+    const monday1500Utc = new Date("2026-05-25T15:00:00Z");
+    const next = nextUpgradeWindowOpen(NINE_TO_FIVE, monday1500Utc, "America/New_York");
+    expect(next?.toISOString()).toBe("2026-05-25T21:00:00.000Z");
+  });
+
+  it("returns null for a 24/7 store that never closes within the horizon", () => {
+    const allDay: WeeklySchedule = {
+      monday: { enabled: true, open: "00:00", close: "24:00" },
+      tuesday: { enabled: true, open: "00:00", close: "24:00" },
+      wednesday: { enabled: true, open: "00:00", close: "24:00" },
+      thursday: { enabled: true, open: "00:00", close: "24:00" },
+      friday: { enabled: true, open: "00:00", close: "24:00" },
+      saturday: { enabled: true, open: "00:00", close: "24:00" },
+      sunday: { enabled: true, open: "00:00", close: "24:00" },
+    };
+    expect(nextUpgradeWindowOpen(allDay, MON_1200_UTC, "UTC")).toBeNull();
   });
 });

--- a/apps/web/lib/self-upgrade/window.ts
+++ b/apps/web/lib/self-upgrade/window.ts
@@ -103,3 +103,33 @@ export function isUpgradeWindowOpen(args: {
   }
   return true;
 }
+
+const SCAN_STEP_MS = 60_000; // 1-minute resolution — close times are HH:mm aligned
+const SCAN_HORIZON_MS = 8 * 24 * 60 * 60 * 1000; // 8 days covers any weekly schedule
+
+/**
+ * The next instant the operating-hours upgrade window OPENS — i.e. the next time
+ * the store is closed. Returns `now` when the store is already closed (the
+ * window is open right now). Returns null when the store never closes within an
+ * 8-day horizon (e.g. 24/7 hours), meaning there is no scheduled window to show.
+ *
+ * Minute-resolution forward scan that reuses isStoreOpen so all timezone and
+ * overnight-span handling stays in one place. Pure + deterministic (inject
+ * `now`) to match the rest of this module and stay cron-safe.
+ */
+export function nextUpgradeWindowOpen(
+  schedule: WeeklySchedule,
+  now: Date,
+  timeZone?: string,
+): Date | null {
+  if (!isStoreOpen(schedule, now, timeZone)) return now;
+  // Align to the next whole minute so the boundary lands on the schedule's
+  // close time (e.g. 17:00) rather than an arbitrary second within it.
+  const start = Math.ceil(now.getTime() / SCAN_STEP_MS) * SCAN_STEP_MS;
+  const limit = now.getTime() + SCAN_HORIZON_MS;
+  for (let t = start; t <= limit; t += SCAN_STEP_MS) {
+    const probe = new Date(t);
+    if (!isStoreOpen(schedule, probe, timeZone)) return probe;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- **Run History**: adds a *When* column with the localized start time and duration (e.g. `· 4m 34s`) for every row; falls back to `createdAt` for runs that never reached `startedAt`
- **Latest Run**: separate *Started* / *Completed* (or *Failed*) timestamp rows, with *Created* fallback for runs that never started
- **Schedule / next window**: the panel already rendered the next explicit maintenance-window start; now also computes it for the default operating-hours model via a new `nextUpgradeWindowOpen` pure helper in `window.ts` — so the "next upgrade window" time appears regardless of whether the operator configured explicit windows or just relies on store hours

## Test plan

- [x] `vitest run lib/self-upgrade/window.test.ts components/ops/SelfUpgradeClient.test.tsx app/(shell)/ops/self-upgrade/page.test.tsx`: 76 passing (4 new `nextUpgradeWindowOpen` cases + 4 new component timestamp cases)
- [x] typecheck: clean on changed files; 2 pre-existing errors in unrelated files (`voice-profile.ts`, `build-pipeline.ts`) untouched
- [x] next build: n/a (UI change only, no new routes)
- [x] UX verification: drove the change against dev-portal at `:3001` — Run History *When* column visible with localized timestamps and durations on all rows; Latest Run shows *Created* / *Failed* labels with correct times; schedule section reflects current in-window state correctly

Overlap sweep: no open PRs or recent main commits touching this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)