### PR TITLE
fix(voice): add 4s retry delay so portal outlasts sidecar restart window

### DIFF
--- a/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
@@ -153,8 +153,12 @@ describe("synthesizeWithMlx", () => {
       { ok: true, buf: new ArrayBuffer(0) },
       { ok: true, buf: VALID_AUDIO },
     ])
-
-    const result = await synthesizeWithMlx("Proceed.", baseConfig)
+    // Run synthesis + advance fake timers for the retry delays concurrently.
+    vi.useFakeTimers()
+    const p = synthesizeWithMlx("Proceed.", baseConfig)
+    await vi.runAllTimersAsync()
+    const result = await p
+    vi.useRealTimers()
     expect(result.audioBuffer.byteLength).toBe(VALID_AUDIO.byteLength)
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
@@ -165,8 +169,11 @@ describe("synthesizeWithMlx", () => {
       { ok: false, status: 500 },
       { ok: true, buf: VALID_AUDIO },
     ])
-
-    const result = await synthesizeWithMlx("Proceed.", baseConfig)
+    vi.useFakeTimers()
+    const p = synthesizeWithMlx("Proceed.", baseConfig)
+    await vi.runAllTimersAsync()
+    const result = await p
+    vi.useRealTimers()
     expect(result.provider).toBe("mlx")
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
@@ -175,8 +182,11 @@ describe("synthesizeWithMlx", () => {
     process.env.DPF_TTS_REFERENCE_HOST_ROOT = "/host/voice-storage"
     process.env.DPF_TTS_MLX_MAX_ATTEMPTS = "3"
     const fetchMock = stubSequence([{ ok: true, buf: SHORT_AUDIO }]) // always short
-
-    await expect(synthesizeWithMlx("x", baseConfig)).rejects.toThrow("VoiceSynthesisError [mlx]")
+    vi.useFakeTimers()
+    const p = synthesizeWithMlx("x", baseConfig)
+    await vi.runAllTimersAsync()
+    await expect(p).rejects.toThrow("VoiceSynthesisError [mlx]")
+    vi.useRealTimers()
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 

--- a/apps/web/lib/voice-synthesis/adapters/mlx.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.ts
@@ -117,9 +117,16 @@ export async function synthesizeWithMlx(
   }
 
   const maxAttempts = getMaxAttempts()
+  // Delay between retries so the loop outlasts a sidecar restart window.
+  // The Chatterbox host sidecar takes ~6-12s to reload after a Jetsam kill;
+  // 4s between each of 4 attempts covers 16s — enough to survive one restart.
+  const RETRY_DELAY_MS = 4_000
   let lastErr: VoiceSynthesisError | null = null
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (attempt > 1) {
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
+    }
     let audioBuffer: ArrayBuffer
     try {
       const res = await fetch(`${baseUrl}/v1/audio/speech`, {
@@ -130,11 +137,11 @@ export async function synthesizeWithMlx(
       if (!res.ok) {
         const detail = await res.text().catch(() => "unknown")
         lastErr = new VoiceSynthesisError(detail, "mlx", res.status)
-        continue // transient server error (CSM IndexError etc.) — retry
+        continue // transient server error — retry after delay
       }
       audioBuffer = await res.arrayBuffer()
     } catch (err) {
-      // Network/abort — retry rather than fail the whole synthesis.
+      // Network/abort (e.g. sidecar mid-restart) — wait then retry.
       lastErr = new VoiceSynthesisError(String(err), "mlx")
       continue
     }

--- a/scripts/tts/chatterbox_server.py
+++ b/scripts/tts/chatterbox_server.py
@@ -34,7 +34,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 from chatterbox.tts import ChatterboxTTS
 
-DEVICE = "mps" if torch.backends.mps.is_available() else "cpu"
+DEVICE = os.environ.get("DPF_CB_DEVICE") or ("mps" if torch.backends.mps.is_available() else "cpu")
 # Resolve ffmpeg from PATH (launchd prepends Homebrew via the launch script);
 # fall back to the common Homebrew location.
 FFMPEG = shutil.which("ffmpeg") or "/opt/homebrew/bin/ffmpeg"


### PR DESCRIPTION
## Problem
When the Chatterbox host sidecar is Jetsam-killed on macOS (memory pressure), it takes ~6-12s to reload. The mlx adapter's retry loop was firing all 4 attempts in <1s (no delay between retries), giving up before the sidecar came back → `fetch failed` → speaker disabled.

## Fix
Add a 4s delay before each retry (attempt 2+):
- 4 retries × 4s spacing = 16s total window — enough to outlast one sidecar restart
- Tests updated to use `vi.useFakeTimers()` so they run in milliseconds

## Result
- If Jetsam kills the MPS sidecar mid-use, the portal waits it out and succeeds on retry (~7s synthesis)
- Without Jetsam kills (normal case), first attempt succeeds with no added delay
- Pairs with #1322 which re-enables MPS for 7s synthesis speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
