### PR TITLE
fix(storefront): wire Purchase CTA to a real order flow (BI-E050E346)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { getPublicStorefront, getPublicItem } from "@/lib/storefront-data";
+import { OrderForm } from "@/components/storefront/OrderForm";
+
+export default async function OrderItemPage({
+  params,
+}: {
+  params: Promise<{ slug: string; itemId: string }>;
+}) {
+  const { slug, itemId } = await params;
+  const [storefront, item] = await Promise.all([
+    getPublicStorefront(slug),
+    getPublicItem(slug, itemId),
+  ]);
+
+  // A purchasable item must exist and carry a real price. Without a price there
+  // is nothing to charge, so we 404 rather than render a checkout for £0.
+  if (!storefront || !item || item.priceAmount === null) notFound();
+
+  return (
+    <div style={{ paddingTop: 40, maxWidth: 520 }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Order: {item.name}</h1>
+      {item.description && (
+        <p style={{ color: "var(--dpf-muted)", marginBottom: 24, fontSize: 14 }}>{item.description}</p>
+      )}
+      <OrderForm
+        orgSlug={slug}
+        itemId={item.itemId}
+        itemName={item.name}
+        unitPrice={Number(item.priceAmount)}
+        currency={item.priceCurrency}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/storefront/CtaButton.test.tsx
+++ b/apps/web/components/storefront/CtaButton.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import { CtaButton } from "./CtaButton";
+
+function hrefFor(ctaType: string) {
+  const html = renderToStaticMarkup(
+    <CtaButton ctaType={ctaType} ctaLabel={null} orgSlug="acme" itemId="item-1" />,
+  );
+  return html.match(/href="([^"]+)"/)?.[1] ?? null;
+}
+
+describe("CtaButton routing", () => {
+  it("points the purchase CTA at the real order route, not a dead /cart link", () => {
+    expect(hrefFor("purchase")).toBe("/s/acme/order/item-1");
+  });
+
+  it("keeps the other CTAs on their existing routes", () => {
+    expect(hrefFor("booking")).toBe("/s/acme/book/item-1");
+    expect(hrefFor("donation")).toBe("/s/acme/donate");
+    expect(hrefFor("inquiry")).toBe("/s/acme/inquire/item-1");
+  });
+});

--- a/apps/web/components/storefront/CtaButton.tsx
+++ b/apps/web/components/storefront/CtaButton.tsx
@@ -22,7 +22,7 @@ export function CtaButton({
 
   const href =
     ctaType === "booking" ? `/s/${orgSlug}/book/${itemId}`
-    : ctaType === "purchase" ? `/s/${orgSlug}/cart?add=${itemId}`
+    : ctaType === "purchase" ? `/s/${orgSlug}/order/${itemId}`
     : ctaType === "donation" ? `/s/${orgSlug}/donate`
     : `/s/${orgSlug}/inquire/${itemId}`;
 

--- a/apps/web/components/storefront/OrderForm.tsx
+++ b/apps/web/components/storefront/OrderForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { submitOrder } from "@/lib/storefront-actions";
+
+function formatMoney(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(amount);
+  } catch {
+    return `${currency} ${amount.toFixed(2)}`;
+  }
+}
+
+export function OrderForm({
+  orgSlug,
+  itemId,
+  itemName,
+  unitPrice,
+  currency,
+}: {
+  orgSlug: string;
+  itemId: string;
+  itemName: string;
+  unitPrice: number;
+  currency: string;
+}) {
+  const router = useRouter();
+  const [qty, setQty] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const total = unitPrice * qty;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const fd = new FormData(e.currentTarget);
+    const email = (fd.get("email") as string)?.trim();
+    const quantity = Math.max(1, Number(fd.get("quantity")) || 1);
+
+    // totalAmount is recomputed and price-validated server-side in submitOrder;
+    // we send the line for completeness only.
+    const result = await submitOrder(orgSlug, {
+      customerEmail: email,
+      items: [{ itemId, name: itemName, qty: quantity, unitPrice }],
+      totalAmount: unitPrice * quantity,
+      currency,
+    });
+
+    if (!result.success) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+
+    router.push(`/s/${orgSlug}/checkout?ref=${result.ref}&type=order`);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}>
+      {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>Email address *</label>
+        <input
+          type="email"
+          name="email"
+          required
+          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
+        />
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>Quantity *</label>
+        <input
+          type="number"
+          name="quantity"
+          min={1}
+          step={1}
+          value={qty}
+          onChange={(e) => setQty(Math.max(1, Number(e.target.value) || 1))}
+          required
+          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14, maxWidth: 120 }}
+        />
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 14, color: "var(--dpf-text)", borderTop: "1px solid var(--dpf-border)", paddingTop: 12 }}>
+        <span style={{ color: "var(--dpf-muted)" }}>
+          {formatMoney(unitPrice, currency)} × {qty}
+        </span>
+        <strong>{formatMoney(total, currency)}</strong>
+      </div>
+
+      <button
+        type="submit"
+        disabled={loading}
+        style={{
+          padding: "10px 20px",
+          background: "var(--dpf-accent, #4f46e5)",
+          color: "#fff",
+          border: "none",
+          borderRadius: 6,
+          fontSize: 14,
+          fontWeight: 600,
+          cursor: loading ? "not-allowed" : "pointer",
+        }}
+      >
+        {loading ? "Placing order…" : `Place order — ${formatMoney(total, currency)}`}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## What & why

Closes **BI-E050E346** (epic **EP-SHIP-REAL-AUDIT**). The public storefront "Purchase" CTA linked to `/s/{slug}/cart?add={itemId}` — a route that **does not exist anywhere** under `app/(storefront)/`, so every published buy button 404'd. This was the dead-control (type 8) finding from the Ship Real Functionality audit.

## Fix — reuse existing substrate, no new payment logic

The order *server action* and *confirmation page* already existed; only the entry form was missing:
- **`submitOrder()`** (`lib/release/storefront-actions.ts`) — already validates every line price against the DB, recomputes the total server-side, creates a `StorefrontOrder`, and auto-generates an invoice.
- **`/s/{slug}/checkout?ref=&type=order`** — already the order confirmation page.

This PR adds the missing middle, mirroring the booking/inquiry/donation flows:
- **`/s/{slug}/order/{itemId}`** page — loads the real item, 404s if it has no configured price (no £0 checkout).
- **`OrderForm`** client component — email + quantity, calls `submitOrder`, redirects to the existing confirmation.
- **`CtaButton`** — purchase CTA now points at `/order/{itemId}` instead of the dead `/cart`.

## Verification
- New `CtaButton.test.tsx`: purchase → `/s/{slug}/order/{itemId}`; other CTAs unchanged.
- Storefront suite green (13 tests across `storefront-actions`, `storefront-data`, `CtaButton`); `tsc --noEmit` clean. Full suite runs in CI.

Note: consistent with the documented "until Stripe" posture, the order is recorded and invoiced but not card-charged — the `/pay/{token}` page already handles that honestly with a labeled "Pay Now (Coming Soon)" control. This PR removes the 404 dead-end; online card capture remains the separate Stripe follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)