### PR TITLE
fix(api-client): don't force JSON content-type on FormData uploads (BI-CCBAECBC)

### DIFF
--- a/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
+++ b/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
@@ -743,8 +743,9 @@ if (!(options.body instanceof FormData)) {
 if (token) headers["Authorization"] = `Bearer ${token}`;
 ```
 
-Tracked as a follow-up backlog item; needs unit-test coverage for
-the FormData branch before merge.
+Tracked as **BI-CCBAECBC**. Fixed in `packages/api-client/src/client.ts`
+with vitest coverage (`client.test.ts`) for the FormData branch
+(asserts no JSON content-type is set, bearer token still attached).
 
 ### Identity convergence — links to Enterprise Auth addendum
 

--- a/packages/api-client/src/client.test.ts
+++ b/packages/api-client/src/client.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DpfClient } from "./client";
+
+function makeClient(token: string | null = "tok") {
+  return new DpfClient({
+    baseUrl: "https://api.example.test",
+    getToken: async () => token,
+  });
+}
+
+function mockFetch(status = 200, body: unknown = {}) {
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function headersFrom(fetchMock: ReturnType<typeof vi.fn>): Record<string, string> {
+  return fetchMock.mock.calls[0][1].headers as Record<string, string>;
+}
+
+describe("DpfClient request headers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("sets JSON content-type for non-FormData bodies", async () => {
+    const fetchMock = mockFetch();
+    await makeClient().post("/things", { a: 1 });
+
+    const headers = headersFrom(fetchMock);
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("does NOT set a JSON content-type for FormData uploads", async () => {
+    const fetchMock = mockFetch();
+    const form = new FormData();
+    form.append("file", new Blob(["data"]), "scan.pdf");
+
+    await makeClient().upload("/uploads", form);
+
+    const headers = headersFrom(fetchMock);
+    // The runtime must own Content-Type so it can append the multipart boundary.
+    expect(headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("still attaches the bearer token on FormData uploads", async () => {
+    const fetchMock = mockFetch();
+    await makeClient("abc123").upload("/uploads", new FormData());
+
+    const headers = headersFrom(fetchMock);
+    expect(headers["Authorization"]).toBe("Bearer abc123");
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -7,9 +7,13 @@ export class DpfClient {
   async request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const token = await this.config.getToken();
     const headers: Record<string, string> = {
-      "Content-Type": "application/json",
       ...((options.headers as Record<string, string>) || {}),
     };
+    // FormData bodies must keep the runtime-generated multipart boundary;
+    // forcing application/json here breaks camera/PDF uploads in dynamic forms.
+    if (!(options.body instanceof FormData)) {
+      headers["Content-Type"] = "application/json";
+    }
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
     const response = await fetch(`${this.config.baseUrl}${path}`, {


### PR DESCRIPTION
## Problem

`packages/api-client/src/client.ts` `request()` unconditionally set `headers["Content-Type"] = "application/json"` before spreading caller headers. `upload()` passes `headers: {}` intending to let the runtime set the multipart boundary, but the empty object does not override the JSON default.

Result: every `FormData` upload was sent with `Content-Type: application/json`, so no multipart boundary was emitted and the server could not parse the body — **breaking dynamic-form camera/PDF uploads** (the regulated-industry features the mobile companion app is built for).

## Fix

Only set the JSON content-type when the body is **not** a `FormData` instance:

```ts
const headers: Record<string, string> = {
  ...((options.headers as Record<string, string>) || {}),
};
if (!(options.body instanceof FormData)) {
  headers["Content-Type"] = "application/json";
}
if (token) headers["Authorization"] = `Bearer ${token}`;
```

## Tests

New `packages/api-client/src/client.test.ts` (vitest):
- JSON body still gets `Content-Type: application/json`
- **FormData upload sets no JSON content-type** (runtime owns the boundary)
- Bearer token is still attached on FormData uploads

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```
Package `tsc --noEmit` is clean.

## Tracking

Filed as **BI-CCBAECBC**. Documented in `docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md` (2026-05-09 addendum, "Multipart upload header bug"), updated here to reference the BI and mark it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)