### PR TITLE
docs: reconcile mobile companion spec metadata and inline inconsistencies

### DIFF
--- a/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
+++ b/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
@@ -1,8 +1,17 @@
 # Mobile Companion App — iOS & Android
 
 **Date:** 2026-03-19
-**Status:** Draft
-**Depends on:** REST API layer (Epic 1, built as prerequisite)
+**Last updated:** 2026-05-09 (see addendum)
+**Status:** Active design — core spec stable; parts superseded by the 2026-05-09 deployment-doctrine addendum (auth model, deployment knobs)
+**Depends on:**
+- REST API layer (Epic 1, built as prerequisite)
+- Deployment doctrine — `docs/superpowers/specs/2026-05-09-deployment-contracts.md` (Contract 10: client packaging targets)
+- Enterprise Auth — `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md` (dual auth mode)
+- Edge Node — `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md` (`MobileDevice` vs `EdgeNode` separation)
+
+> **Reading order:** the core spec below reflects the original v1 design. The addendum at the
+> end (2026-05-09 deployment-doctrine alignment) refines and in places **supersedes** it. Where
+> they conflict, the addendum wins. Superseded passages are flagged inline.
 
 ---
 
@@ -32,7 +41,7 @@ The app also includes a dynamic content rendering engine that displays custom fo
 - Apple Watch / Wear OS companion
 - White-labeling / per-customer app store listings
 - Real-time collaboration / presence indicators
-- SSO/SAML authentication (future enhancement)
+- ~~SSO/SAML authentication (future enhancement)~~ — **superseded** by the 2026-05-09 addendum: dual auth mode (`local-password` | `identity-edge-oidc-pkce`) is an architecture commitment, not deferred work. The app router and token store must accommodate OIDC PKCE from day one.
 
 ## Technology Stack
 
@@ -213,11 +222,11 @@ HTTP status codes: 400 (validation), 401 (unauthenticated), 403 (insufficient ca
 
 **Mobile user types:** v1 supports workforce/admin users only (those with `PlatformRole` assignments). `CustomerContact` users cannot authenticate via mobile in v1 — this is a future enhancement. The login endpoint validates that the authenticated user has at least one `UserGroup` entry.
 
-- All endpoints enforce the same capability gates as existing server actions
+**Capability enforcement:** All `/api/v1/*` endpoints enforce the same capability gates as the existing server actions; authentication establishes identity, but per-action authorization is unchanged from the web path.
 
 ### New Database Models Required
 
-**Notification** (for push notification feed):
+**Notification + PushDeviceRegistration** (push notification feed and token delivery):
 ```prisma
 model Notification {
   id          String    @id @default(cuid())


### PR DESCRIPTION
## What

Editorial-only pass on `docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md`. No design decisions changed — fixes inconsistencies that accumulated as the 2026-05-09 deployment-doctrine addendum was layered onto the original v1 spec.

## Changes

- **Header metadata** — `Status: Draft` → `Active design` (the doc has a dated addendum and five cross-spec dependencies); added `Last updated`; expanded `Depends on` from just "Epic 1" to the four real cross-spec dependencies (deployment-contracts, enterprise-auth, edge-node), all verified to exist; added a reading-order note pointing at the superseding addendum.
- **Non-Goals** — struck the "SSO/SAML is a future enhancement" line and cross-linked the 2026-05-09 addendum, which made dual auth mode (`local-password` | `identity-edge-oidc-pkce`) an architecture commitment. Previously this line contradicted both the addendum and the Assumptions section.
- **Auth section** — promoted an orphaned `- All endpoints enforce the same capability gates…` bullet into a proper **Capability enforcement** note.
- **DB models** — relabeled the `**Notification**` code block, which actually defines *both* `Notification` and `PushDeviceRegistration`.

## Notes

- This started as a larger review against a working-tree copy that also contained an **MDM-Aligned Endpoint Governance addendum**. That content was never committed to any branch (uncommitted WIP that a concurrent session lost in the shared root worktree), so this PR includes only the subset that applies to the committed `main` version. If/when the MDM addendum lands, the relocation + `PushDeviceRegistration`↔`MobileDevice` reconciliation should follow up.
- A separate, still-live **multipart upload Content-Type bug** in `packages/api-client/src/client.ts` (described in the spec's 2026-05-09 addendum) was flagged for its own fix; it is out of scope for this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)