### PR TITLE
refactor(web): migrate compliance/controls to report-kit + single-form FilterBar url-mode (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/compliance/controls/page.tsx
+++ b/apps/web/app/(shell)/compliance/controls/page.tsx
@@ -1,13 +1,7 @@
 import { listControls } from "@/lib/actions/compliance";
 import { CreateControlForm } from "@/components/compliance/CreateControlForm";
+import { FilterBar, StatusBadge } from "@/components/ui/report-kit";
 import Link from "next/link";
-
-const STATUS_COLORS: Record<string, string> = {
-  implemented: "bg-green-900/30 text-green-400",
-  "in-progress": "bg-yellow-900/30 text-yellow-400",
-  planned: "bg-blue-900/30 text-blue-400",
-  "not-applicable": "bg-gray-900/30 text-gray-400",
-};
 
 type Props = { searchParams: Promise<{ controlType?: string; implementationStatus?: string; effectiveness?: string }> };
 
@@ -30,46 +24,61 @@ export default async function ControlsPage({ searchParams }: Props) {
         <CreateControlForm />
       </div>
 
-      {/* Filter bar */}
-      <form className="flex flex-wrap gap-3 mb-6">
-        <select name="controlType" defaultValue={sp.controlType ?? ""}
-          className="text-xs px-2 py-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] focus:outline-none focus:border-[var(--dpf-accent)]">
-          <option value="">All types</option>
-          <option value="preventive">Preventive</option>
-          <option value="detective">Detective</option>
-          <option value="corrective">Corrective</option>
-        </select>
-
-        <select name="implementationStatus" defaultValue={sp.implementationStatus ?? ""}
-          className="text-xs px-2 py-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] focus:outline-none focus:border-[var(--dpf-accent)]">
-          <option value="">All statuses</option>
-          <option value="planned">Planned</option>
-          <option value="in-progress">In Progress</option>
-          <option value="implemented">Implemented</option>
-          <option value="not-applicable">Not Applicable</option>
-        </select>
-
-        <select name="effectiveness" defaultValue={sp.effectiveness ?? ""}
-          className="text-xs px-2 py-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] focus:outline-none focus:border-[var(--dpf-accent)]">
-          <option value="">All effectiveness</option>
-          <option value="effective">Effective</option>
-          <option value="partially-effective">Partially Effective</option>
-          <option value="ineffective">Ineffective</option>
-          <option value="not-assessed">Not Assessed</option>
-        </select>
-
-        <button type="submit"
-          className="text-xs px-3 py-1.5 rounded-md bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity">
-          Filter
-        </button>
-
+      {/* Filter bar — report-kit FilterBar in url mode (server-rendered) */}
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <FilterBar
+          mode="url"
+          basePath="/compliance/controls"
+          value={{
+            ...(sp.controlType ? { controlType: sp.controlType } : {}),
+            ...(sp.implementationStatus ? { implementationStatus: sp.implementationStatus } : {}),
+            ...(sp.effectiveness ? { effectiveness: sp.effectiveness } : {}),
+          }}
+          facets={[
+            {
+              kind: "select",
+              key: "controlType",
+              label: "Type",
+              options: [
+                { value: "preventive", label: "Preventive" },
+                { value: "detective", label: "Detective" },
+                { value: "corrective", label: "Corrective" },
+              ],
+            },
+            {
+              kind: "select",
+              key: "implementationStatus",
+              label: "Status",
+              options: [
+                { value: "planned", label: "Planned" },
+                { value: "in-progress", label: "In Progress" },
+                { value: "implemented", label: "Implemented" },
+                { value: "not-applicable", label: "Not Applicable" },
+              ],
+            },
+            {
+              kind: "select",
+              key: "effectiveness",
+              label: "Effectiveness",
+              options: [
+                { value: "effective", label: "Effective" },
+                { value: "partially-effective", label: "Partially Effective" },
+                { value: "ineffective", label: "Ineffective" },
+                { value: "not-assessed", label: "Not Assessed" },
+              ],
+            },
+          ]}
+          resultCount={controls.length}
+        />
         {Object.keys(filters).length > 0 && (
-          <Link href="/compliance/controls"
-            className="text-xs px-3 py-1.5 rounded-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors">
+          <Link
+            href="/compliance/controls"
+            className="text-xs px-3 py-1.5 rounded-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+          >
             Clear
           </Link>
         )}
-      </form>
+      </div>
 
       {controls.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No controls match the current filters.</p>
@@ -81,13 +90,21 @@ export default async function ControlsPage({ searchParams }: Props) {
               <div className="flex items-start justify-between">
                 <div>
                   <span className="text-sm text-[var(--dpf-text)]">{c.title}</span>
-                  <div className="flex gap-2 mt-1">
-                    <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{c.controlType}</span>
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[c.implementationStatus] ?? "bg-gray-900/30 text-gray-400"}`}>
-                      {c.implementationStatus}
-                    </span>
+                  <div className="flex flex-wrap gap-2 mt-1.5">
+                    <StatusBadge intent="neutral" label={c.controlType} variant="soft" uppercase={false} />
+                    <StatusBadge
+                      domain="controlStatus"
+                      status={c.implementationStatus}
+                      variant="soft"
+                      uppercase={false}
+                    />
                     {c.effectiveness && (
-                      <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{c.effectiveness}</span>
+                      <StatusBadge
+                        domain="controlEffectiveness"
+                        status={c.effectiveness}
+                        variant="soft"
+                        uppercase={false}
+                      />
                     )}
                   </div>
                 </div>

--- a/apps/web/components/ui/report-kit/FilterBar.test.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.test.tsx
@@ -86,6 +86,33 @@ describe("FilterBar", () => {
     expect(html).toContain('method="get"');
   });
 
+  it("url mode groups multiple select/search facets under a single Apply form", () => {
+    const multiSelect: FacetDef[] = [
+      { kind: "select", key: "type", label: "Type", options: [{ value: "a", label: "A" }] },
+      { kind: "select", key: "status", label: "Status", options: [{ value: "x", label: "X" }] },
+      { kind: "select", key: "eff", label: "Eff", options: [{ value: "ok", label: "OK" }] },
+    ];
+    const html = renderToStaticMarkup(
+      <FilterBar mode="url" facets={multiSelect} value={{}} basePath="/compliance/controls" />,
+    );
+    // exactly one form and one Apply button for all three selects
+    expect(html.match(/<form/g)).toHaveLength(1);
+    expect(html.match(/Apply/g)).toHaveLength(1);
+  });
+
+  it("url mode preserves pill selections as hidden inputs in the field form", () => {
+    const html = renderToStaticMarkup(
+      <FilterBar
+        mode="url"
+        facets={FACETS}
+        value={{ direction: "in" }}
+        basePath="/finance/payments"
+      />,
+    );
+    expect(html).toContain('type="hidden"');
+    expect(html).toContain('name="direction"');
+  });
+
   it("singularizes the result count", () => {
     const html = renderToStaticMarkup(
       <FilterBar

--- a/apps/web/components/ui/report-kit/FilterBar.tsx
+++ b/apps/web/components/ui/report-kit/FilterBar.tsx
@@ -8,11 +8,12 @@
 //   - "client": controlled via `value` + `onChange` (matches complaints today).
 //   - "url":    server-friendly. Pills are <Link>s whose hrefs are built from a
 //               `basePath` + the current `value` (no function prop, so it can be
-//               rendered directly from a Server Component). search/select render
-//               as GET forms that preserve the other facets via hidden inputs.
+//               rendered directly from a Server Component). search/select facets
+//               share ONE GET <form> with a single Apply button; pill values are
+//               mirrored as hidden inputs so submitting preserves them.
 //
 // url mode is intentionally function-free: passing a callback from a Server
-// Component to this ("use client") component is not allowed, so the href is
+// Component to this ("use client") component is not allowed, so hrefs/forms are
 // derived internally from serializable props.
 
 "use client";
@@ -74,19 +75,100 @@ function buildHref(
   return qs ? `${basePath}?${qs}` : basePath;
 }
 
-/** Hidden inputs carrying every facet value except `exceptKey` (url forms). */
-function hiddenInputs(value: Record<string, string>, exceptKey: string) {
-  return Object.entries(value)
-    .filter(([k, v]) => k !== exceptKey && v)
-    .map(([k, v]) => <input key={k} type="hidden" name={k} value={v} />);
+function pillGroup(
+  facet: Extract<FacetDef, { kind: "pills" }>,
+  value: Record<string, string>,
+  isUrl: boolean,
+  basePath: string,
+  set: (key: string, next: string) => void,
+) {
+  const current = value[facet.key] ?? "";
+  return (
+    <div key={facet.key} className="flex flex-wrap items-center gap-1">
+      <span className="text-[11px] text-[var(--dpf-muted)]">{facet.label}</span>
+      {facet.options.map((opt) => {
+        const active = current === opt.value;
+        if (isUrl) {
+          return (
+            <Link
+              key={opt.value}
+              href={buildHref(basePath, value, facet.key, active ? null : opt.value)}
+              className={pillClass(active)}
+            >
+              {opt.label}
+            </Link>
+          );
+        }
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            className={pillClass(active)}
+            onClick={() => set(facet.key, active ? "" : opt.value)}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 export function FilterBar(props: FilterBarProps) {
   const { facets, value, resultCount, className = "" } = props;
   const isUrl = props.mode === "url";
+  const basePath = isUrl ? props.basePath : "";
 
   function set(key: string, next: string) {
     if (!isUrl) props.onChange({ ...value, [key]: next });
+  }
+
+  const pillFacets = facets.filter((f) => f.kind === "pills") as Extract<
+    FacetDef,
+    { kind: "pills" }
+  >[];
+  const formFacets = facets.filter((f) => f.kind !== "pills");
+
+  function renderFieldFacet(facet: FacetDef) {
+    const current = value[facet.key] ?? "";
+    if (facet.kind === "search") {
+      return (
+        <input
+          key={facet.key}
+          type="search"
+          name={isUrl ? facet.key : undefined}
+          aria-label={facet.placeholder ?? "Search"}
+          placeholder={facet.placeholder ?? "Search…"}
+          defaultValue={isUrl ? current : undefined}
+          value={isUrl ? undefined : current}
+          onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+        />
+      );
+    }
+    if (facet.kind === "select") {
+      return (
+        <label key={facet.key} className="flex items-center gap-1 text-[11px]">
+          <span className="text-[var(--dpf-muted)]">{facet.label}</span>
+          <select
+            name={isUrl ? facet.key : undefined}
+            aria-label={facet.label}
+            defaultValue={isUrl ? current : undefined}
+            value={isUrl ? undefined : current}
+            onChange={isUrl ? undefined : (e) => set(facet.key, e.target.value)}
+            className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
+          >
+            <option value="">All</option>
+            {facet.options.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    }
+    return null;
   }
 
   return (
@@ -98,122 +180,29 @@ export function FilterBar(props: FilterBarProps) {
         .filter(Boolean)
         .join(" ")}
     >
-      {facets.map((facet) => {
-        const current = value[facet.key] ?? "";
+      {pillFacets.map((facet) => pillGroup(facet, value, isUrl, basePath, set))}
 
-        if (facet.kind === "search") {
-          if (isUrl) {
-            return (
-              <form key={facet.key} action={props.basePath} method="get">
-                {hiddenInputs(value, facet.key)}
-                <input
-                  type="search"
-                  name={facet.key}
-                  aria-label={facet.placeholder ?? "Search"}
-                  placeholder={facet.placeholder ?? "Search…"}
-                  defaultValue={current}
-                  className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
-                />
-              </form>
-            );
-          }
-          return (
-            <input
-              key={facet.key}
-              type="search"
-              aria-label={facet.placeholder ?? "Search"}
-              placeholder={facet.placeholder ?? "Search…"}
-              defaultValue={current}
-              onChange={(e) => set(facet.key, e.target.value)}
-              className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
-            />
-          );
-        }
-
-        if (facet.kind === "select") {
-          if (isUrl) {
-            return (
-              <form
-                key={facet.key}
-                action={props.basePath}
-                method="get"
-                className="flex items-center gap-1 text-[11px]"
-              >
-                {hiddenInputs(value, facet.key)}
-                <span className="text-[var(--dpf-muted)]">{facet.label}</span>
-                <select
-                  name={facet.key}
-                  defaultValue={current}
-                  aria-label={facet.label}
-                  className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
-                >
-                  <option value="">All</option>
-                  {facet.options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="submit"
-                  className="rounded border border-[var(--dpf-border)] px-2 py-1 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-                >
-                  Apply
-                </button>
-              </form>
-            );
-          }
-          return (
-            <label key={facet.key} className="flex items-center gap-1 text-[11px]">
-              <span className="text-[var(--dpf-muted)]">{facet.label}</span>
-              <select
-                value={current}
-                aria-label={facet.label}
-                onChange={(e) => set(facet.key, e.target.value)}
-                className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs"
-              >
-                <option value="">All</option>
-                {facet.options.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          );
-        }
-
-        // pills
-        return (
-          <div key={facet.key} className="flex flex-wrap items-center gap-1">
-            <span className="text-[11px] text-[var(--dpf-muted)]">{facet.label}</span>
-            {facet.options.map((opt) => {
-              const active = current === opt.value;
-              if (isUrl) {
-                return (
-                  <Link
-                    key={opt.value}
-                    href={buildHref(props.basePath, value, facet.key, active ? null : opt.value)}
-                    className={pillClass(active)}
-                  >
-                    {opt.label}
-                  </Link>
-                );
-              }
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  className={pillClass(active)}
-                  onClick={() => set(facet.key, active ? "" : opt.value)}
-                >
-                  {opt.label}
-                </button>
-              );
-            })}
-          </div>
-        );
-      })}
+      {formFacets.length > 0 ? (
+        isUrl ? (
+          <form action={basePath} method="get" className="flex flex-wrap items-center gap-3">
+            {/* preserve pill selections across a select/search submit */}
+            {pillFacets
+              .filter((f) => value[f.key])
+              .map((f) => (
+                <input key={f.key} type="hidden" name={f.key} value={value[f.key]} />
+              ))}
+            {formFacets.map(renderFieldFacet)}
+            <button
+              type="submit"
+              className="rounded border border-[var(--dpf-border)] px-2.5 py-1 text-[11px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              Apply
+            </button>
+          </form>
+        ) : (
+          formFacets.map(renderFieldFacet)
+        )
+      ) : null}
 
       {typeof resultCount === "number" ? (
         <span className="ml-auto text-[11px] text-[var(--dpf-muted)]">

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -85,6 +85,20 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     inbound: "success",
     outbound: "warning",
   },
+  // Compliance control implementation status (was raw Tailwind palette classes).
+  controlStatus: {
+    planned: "info",
+    "in-progress": "warning",
+    implemented: "success",
+    "not-applicable": "neutral",
+  },
+  // Compliance control effectiveness.
+  controlEffectiveness: {
+    effective: "success",
+    "partially-effective": "warning",
+    ineffective: "danger",
+    "not-assessed": "neutral",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",


### PR DESCRIPTION
## What

Third surface adoption (server component), now rebased clean onto main (the finance url-mode FilterBar from #1313 has merged).

## Changes (4 files)

- **`compliance/controls/page.tsx`**: raw **Tailwind-palette** badge classes (`bg-green-900/30 text-green-400`, `bg-yellow-900/30`, …) → `StatusBadge` via new `controlStatus` + `controlEffectiveness` registry entries; bespoke `<form><select>` filter → `FilterBar` url mode.
- **FilterBar url-mode refinement** (surfaced by this 3-select surface): search+select facets now share **one GET form with a single Apply button** (was one form per facet → multiple Apply buttons); pill selections mirror as hidden inputs so a select submit preserves them. Pills stay standalone links. Pills-only surfaces (finance/payments) unchanged.

## Verification

- `npx vitest run components/ui/report-kit` → **37 passed** (FilterBar now 8 tests: single-Apply grouping + hidden-pill preservation)
- `tsc --noEmit` clean; no raw Tailwind palette colors remain in the controls page

Phase 2 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)