### PR TITLE
fix(complaints): persist complaints to the DB instead of mock state (BI-C10A4648)

### DIFF
--- a/apps/web/app/(shell)/complaints/ComplaintsClient.test.tsx
+++ b/apps/web/app/(shell)/complaints/ComplaintsClient.test.tsx
@@ -1,27 +1,42 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
+// The component imports the "use server" actions module; stub it so the test
+// does not pull server-only deps (prisma, next/cache) into jsdom.
+vi.mock("@/lib/actions/complaints", () => ({
+  createComplaint: vi.fn(),
+}));
+
 import { ComplaintsClient } from "./ComplaintsClient";
+import type { ComplaintView } from "@/lib/actions/complaints";
 
-describe("ComplaintsClient (report-kit migration)", () => {
-  const html = renderToStaticMarkup(<ComplaintsClient />);
+const SAMPLE: ComplaintView[] = [
+  { id: "C-AAAA1111", customerName: "Sarah Chen", description: "Charged twice for order #4521", severity: "high", category: "Billing", status: "investigating", createdAt: "2026-03-28T14:30:00Z" },
+  { id: "C-BBBB2222", customerName: "Lisa Patel", description: "Data export missing February records", severity: "critical", category: "Data", status: "investigating", createdAt: "2026-03-28T11:20:00Z" },
+];
 
-  it("renders the demo rows through DataTable", () => {
+describe("ComplaintsClient", () => {
+  const html = renderToStaticMarkup(<ComplaintsClient initialComplaints={SAMPLE} />);
+
+  it("renders server-provided complaint rows through DataTable", () => {
     expect(html).toContain("Sarah Chen");
     expect(html).toContain("Lisa Patel");
   });
 
   it("renders status/severity via token-backed StatusBadge (no raw hex)", () => {
-    // critical severity → danger intent; investigating status → accent intent
-    expect(html).toContain('data-intent="danger"');
-    expect(html).toContain('data-intent="accent"');
+    expect(html).toContain('data-intent="danger"'); // critical severity
+    expect(html).toContain('data-intent="accent"'); // investigating status
     expect(html).toMatch(/var\(--dpf-/);
-    // the old raw-hex color maps must be gone from the rendered output
     expect(html).not.toMatch(/#(22c55e|ef4444|eab308|f97316|3b82f6|a855f7|6b7280)/i);
   });
 
   it("renders the FilterBar status facet", () => {
     expect(html).toContain("Status");
     expect(html).toContain("Investigating");
+  });
+
+  it("shows the empty-state message when there are no complaints", () => {
+    const emptyHtml = renderToStaticMarkup(<ComplaintsClient initialComplaints={[]} />);
+    expect(emptyHtml).toContain("No complaints");
   });
 });

--- a/apps/web/app/(shell)/complaints/ComplaintsClient.tsx
+++ b/apps/web/app/(shell)/complaints/ComplaintsClient.tsx
@@ -1,9 +1,10 @@
 // apps/web/app/(shell)/complaints/ComplaintsClient.tsx
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
+import { createComplaint, type ComplaintView } from "@/lib/actions/complaints";
 import {
   DataTable,
   FilterBar,
@@ -11,15 +12,7 @@ import {
   type Column,
 } from "@/components/ui/report-kit";
 
-type Complaint = {
-  id: string;
-  customerName: string;
-  description: string;
-  severity: "low" | "medium" | "high" | "critical";
-  category: string;
-  status: "open" | "investigating" | "resolved" | "closed";
-  createdAt: string;
-};
+type Complaint = ComplaintView;
 
 // Severity ordering for the sortable column (low → critical).
 const SEVERITY_RANK: Record<Complaint["severity"], number> = {
@@ -28,14 +21,6 @@ const SEVERITY_RANK: Record<Complaint["severity"], number> = {
   high: 2,
   critical: 3,
 };
-
-const DEMO_COMPLAINTS: Complaint[] = [
-  { id: "C-001", customerName: "Sarah Chen", description: "Payment processing error during checkout — charged twice for order #4521", severity: "high", category: "Billing", status: "investigating", createdAt: "2026-03-28T14:30:00Z" },
-  { id: "C-002", customerName: "Marcus Johnson", description: "Product page shows incorrect pricing for the Enterprise tier", severity: "medium", category: "Product", status: "open", createdAt: "2026-03-29T09:15:00Z" },
-  { id: "C-003", customerName: "Emily Rodriguez", description: "Cannot reset password — reset email never arrives", severity: "high", category: "Account", status: "open", createdAt: "2026-03-29T10:45:00Z" },
-  { id: "C-004", customerName: "David Kim", description: "Dashboard loading time exceeds 30 seconds on mobile", severity: "low", category: "Performance", status: "resolved", createdAt: "2026-03-27T16:00:00Z" },
-  { id: "C-005", customerName: "Lisa Patel", description: "Data export missing records from February", severity: "critical", category: "Data", status: "investigating", createdAt: "2026-03-28T11:20:00Z" },
-];
 
 const CATEGORIES = ["Billing", "Product", "Account", "Performance", "Data", "Other"];
 const SEVERITIES: Complaint["severity"][] = ["low", "medium", "high", "critical"];
@@ -87,12 +72,14 @@ const COLUMNS: Column<Complaint>[] = [
   },
 ];
 
-export function ComplaintsClient() {
-  const [complaints, setComplaints] = useState<Complaint[]>(DEMO_COMPLAINTS);
+export function ComplaintsClient({ initialComplaints }: { initialComplaints: Complaint[] }) {
+  const [complaints, setComplaints] = useState<Complaint[]>(initialComplaints);
   const [showForm, setShowForm] = useState(false);
   // Empty status = "all".
   const [filters, setFilters] = useState<Record<string, string>>({ status: "" });
   const [formData, setFormData] = useState({ customerName: "", description: "", severity: "medium" as Complaint["severity"], category: "Other" });
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   const activeStatus = filters.status ?? "";
   const filtered = activeStatus
@@ -101,15 +88,17 @@ export function ComplaintsClient() {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const newComplaint: Complaint = {
-      id: `C-${String(complaints.length + 1).padStart(3, "0")}`,
-      ...formData,
-      status: "open",
-      createdAt: new Date().toISOString(),
-    };
-    setComplaints([newComplaint, ...complaints]);
-    setFormData({ customerName: "", description: "", severity: "medium", category: "Other" });
-    setShowForm(false);
+    setError(null);
+    startTransition(async () => {
+      const result = await createComplaint(formData);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      setComplaints((prev) => [result.complaint, ...prev]);
+      setFormData({ customerName: "", description: "", severity: "medium", category: "Other" });
+      setShowForm(false);
+    });
   }
 
   return (
@@ -193,12 +182,16 @@ export function ComplaintsClient() {
               style={{ background: "var(--dpf-surface-2)", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)" }}
             />
           </div>
+          {error && (
+            <p className="mb-3 text-sm" style={{ color: "var(--dpf-error)" }}>{error}</p>
+          )}
           <button
             type="submit"
-            className="px-5 py-2 text-sm font-semibold text-white rounded-md transition-opacity hover:opacity-90"
+            disabled={isPending}
+            className="px-5 py-2 text-sm font-semibold text-white rounded-md transition-opacity hover:opacity-90 disabled:opacity-50"
             style={{ background: "var(--dpf-accent)" }}
           >
-            Submit Complaint
+            {isPending ? "Submitting…" : "Submit Complaint"}
           </button>
         </form>
       )}

--- a/apps/web/app/(shell)/complaints/page.tsx
+++ b/apps/web/app/(shell)/complaints/page.tsx
@@ -1,8 +1,11 @@
 // apps/web/app/(shell)/complaints/page.tsx
 // Customer Complaint Tracker — built by AI Coworker (Build Studio FB-BB6567DC)
+import { listComplaints } from "@/lib/actions/complaints";
 import { ComplaintsClient } from "./ComplaintsClient";
 
-export default function ComplaintsPage() {
+export default async function ComplaintsPage() {
+  const complaints = await listComplaints();
+
   return (
     <div>
       <div className="mb-6">
@@ -11,7 +14,7 @@ export default function ComplaintsPage() {
           Track and manage customer complaints from submission to resolution
         </p>
       </div>
-      <ComplaintsClient />
+      <ComplaintsClient initialComplaints={complaints} />
     </div>
   );
 }

--- a/apps/web/lib/actions/complaints.ts
+++ b/apps/web/lib/actions/complaints.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { nanoid } from "nanoid";
+import { revalidatePath } from "next/cache";
+
+export type ComplaintSeverity = "low" | "medium" | "high" | "critical";
+export type ComplaintStatus = "open" | "investigating" | "resolved" | "closed";
+
+export type ComplaintView = {
+  id: string; // human reference, e.g. C-AB12CD34
+  customerName: string;
+  description: string;
+  severity: ComplaintSeverity;
+  category: string;
+  status: ComplaintStatus;
+  createdAt: string; // ISO
+};
+
+const SEVERITIES: ComplaintSeverity[] = ["low", "medium", "high", "critical"];
+const CATEGORIES = ["Billing", "Product", "Account", "Performance", "Data", "Other"];
+
+function toView(row: {
+  reference: string;
+  customerName: string;
+  description: string;
+  severity: string;
+  category: string;
+  status: string;
+  createdAt: Date;
+}): ComplaintView {
+  return {
+    id: row.reference,
+    customerName: row.customerName,
+    description: row.description,
+    severity: (SEVERITIES.includes(row.severity as ComplaintSeverity)
+      ? row.severity
+      : "medium") as ComplaintSeverity,
+    category: row.category,
+    status: (["open", "investigating", "resolved", "closed"].includes(row.status)
+      ? row.status
+      : "open") as ComplaintStatus,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/** Live complaint register, newest first. */
+export async function listComplaints(): Promise<ComplaintView[]> {
+  const rows = await prisma.complaint.findMany({
+    orderBy: { createdAt: "desc" },
+    select: {
+      reference: true,
+      customerName: true,
+      description: true,
+      severity: true,
+      category: true,
+      status: true,
+      createdAt: true,
+    },
+  });
+  return rows.map(toView);
+}
+
+export type CreateComplaintResult =
+  | { success: true; complaint: ComplaintView }
+  | { success: false; error: string };
+
+/** Persist a new complaint and return the stored record. */
+export async function createComplaint(input: {
+  customerName: string;
+  description: string;
+  severity: ComplaintSeverity;
+  category: string;
+}): Promise<CreateComplaintResult> {
+  const customerName = input.customerName?.trim();
+  const description = input.description?.trim();
+
+  if (!customerName) return { success: false, error: "Customer name is required" };
+  if (!description) return { success: false, error: "Description is required" };
+
+  const severity: ComplaintSeverity = SEVERITIES.includes(input.severity)
+    ? input.severity
+    : "medium";
+  const category = CATEGORIES.includes(input.category) ? input.category : "Other";
+
+  const created = await prisma.complaint.create({
+    data: {
+      reference: `C-${nanoid(8).toUpperCase()}`,
+      customerName,
+      description,
+      severity,
+      category,
+      status: "open",
+    },
+    select: {
+      reference: true,
+      customerName: true,
+      description: true,
+      severity: true,
+      category: true,
+      status: true,
+      createdAt: true,
+    },
+  });
+
+  revalidatePath("/complaints");
+  return { success: true, complaint: toView(created) };
+}

--- a/docs/superpowers/plans/2026-05-30-complaints-persistence.md
+++ b/docs/superpowers/plans/2026-05-30-complaints-persistence.md
@@ -1,0 +1,68 @@
+# Complaints Persistence — Implementation Plan (BI-C10A4648)
+
+> Ship Real Functionality audit follow-up. Epic: EP-SHIP-REAL-AUDIT.
+> Status: IMPLEMENTED on branch `fix/complaints-persistence` (this plan documents the approach for review and for the BI record).
+
+## Context
+
+`/complaints` (built by Build Studio FB-BB6567DC) rendered a `DEMO_COMPLAINTS`
+array held in React `useState`, with a "Submit Complaint" button whose handler
+only mutated local state. It was a fictional surface: five fabricated named
+customers (Sarah Chen, …) presented as the live complaint register, and filed
+complaints vanished on refresh. There was no `Complaint` model.
+
+**What already exists (reuse, do not rebuild):**
+- `components/ui/report-kit` — `DataTable`, `FilterBar`, `StatusBadge` with
+  `complaintSeverity` / `complaintStatus` domains already defined in
+  `statusColors.ts`. The presentation is correct; only the data was fake.
+- `lib/actions/*` server-action conventions (`"use server"`, `nanoid` refs,
+  `revalidatePath`).
+- Prisma migration convention: timestamped dir under
+  `packages/db/prisma/migrations/` with a `migration.sql`.
+
+## Concurrency note
+
+The complaints UI was under concurrent work on `feat/report-kit-complaints`
+(BI-6A842691, report-kit migration). This change is based on `origin/main`'s
+current `ComplaintsClient.tsx`. If that branch is still open it must rebase onto
+this; the collision surface is `ComplaintsClient.tsx` only.
+
+## Approach
+
+Backend-first, then a minimal client rewire that preserves the existing
+report-kit presentation.
+
+### Phase 1 — Data model
+- Add `model Complaint` to `packages/db/prisma/schema.prisma`: `id` (cuid),
+  `reference` (unique human ref `C-XXXXXXXX`), `customerName`, `description`,
+  `severity` (default `medium`), `category` (default `Other`), `status`
+  (default `open`), `createdAt`, `updatedAt`; indexes on `status`, `createdAt`.
+- Migration `20260530160000_add_complaint_model/migration.sql` (CREATE TABLE +
+  indexes), matching Prisma's deterministic output. No tenant FK — the surface
+  is a single-install internal register, consistent with `OrgSettings`/finance.
+
+### Phase 2 — Server actions (`lib/actions/complaints.ts`)
+- `listComplaints(): ComplaintView[]` — `prisma.complaint.findMany` newest-first,
+  mapped to the view shape (`reference` → `id`, `createdAt` → ISO).
+- `createComplaint(input)` — trims + validates required fields, whitelists
+  severity/category, inserts with a `nanoid` reference, `revalidatePath`,
+  returns the stored row (`{ success, complaint } | { success: false, error }`).
+
+### Phase 3 — Wire the surface
+- `page.tsx` → async server component: `await listComplaints()` →
+  `<ComplaintsClient initialComplaints={…} />`.
+- `ComplaintsClient.tsx`: drop `DEMO_COMPLAINTS`; type alias to `ComplaintView`;
+  `useState(initialComplaints)`; `handleSubmit` calls `createComplaint` inside
+  `useTransition`, prepends the returned row, surfaces errors and a pending
+  state on the submit button. Empty register shows the existing empty-state.
+
+### Phase 4 — Tests / verification
+- `ComplaintsClient.test.tsx`: pass `initialComplaints` fixtures (mock the
+  `"use server"` module), assert rows render, StatusBadge intents, the filter
+  facet, and the empty-state.
+- `tsc --noEmit` clean (requires `prisma generate` after the schema change).
+
+## Follow-ups (out of scope here)
+- Status transitions (open → investigating → resolved → closed) from the table.
+- Linking complaints to customer accounts / portal support intake.
+- Tenant scoping if/when the install model becomes multi-org.

--- a/packages/db/prisma/migrations/20260530160000_add_complaint_model/migration.sql
+++ b/packages/db/prisma/migrations/20260530160000_add_complaint_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "Complaint" (
+    "id" TEXT NOT NULL,
+    "reference" TEXT NOT NULL,
+    "customerName" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "severity" TEXT NOT NULL DEFAULT 'medium',
+    "category" TEXT NOT NULL DEFAULT 'Other',
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Complaint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Complaint_reference_key" ON "Complaint"("reference");
+
+-- CreateIndex
+CREATE INDEX "Complaint_status_idx" ON "Complaint"("status");
+
+-- CreateIndex
+CREATE INDEX "Complaint_createdAt_idx" ON "Complaint"("createdAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7978,6 +7978,23 @@ model ExchangeRate {
   @@index([baseCurrency, targetCurrency])
 }
 
+// ─── Customer Complaints ───────────────────────────────────────────
+
+model Complaint {
+  id           String   @id @default(cuid())
+  reference    String   @unique
+  customerName String
+  description  String
+  severity     String   @default("medium")
+  category     String   @default("Other")
+  status       String   @default("open")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([status])
+  @@index([createdAt])
+}
+
 model OrgSettings {
   id              String    @id @default(cuid())
   baseCurrency    String    @default("GBP")


### PR DESCRIPTION
## What & why

Closes the last finding of the Ship Real Functionality audit (**BI-C10A4648**, epic **EP-SHIP-REAL-AUDIT**). `/complaints` rendered a `DEMO_COMPLAINTS` array — five fabricated named customers (Sarah Chen, Marcus Johnson, …) — as the live complaint register, and the "Submit Complaint" button only mutated React state, so filed complaints vanished on refresh. There was no `Complaint` model. (Landmine types 4 mock-data + 1 fake IDs + 8/6 dead submit.)

## Change

**Data model** — new `Complaint` model (`packages/db/prisma/schema.prisma`) + migration `20260530160000_add_complaint_model`: `reference` (unique `C-XXXXXXXX`), `customerName`, `description`, `severity`/`category`/`status` (defaulted), `createdAt`/`updatedAt`, indexed on `status` + `createdAt`.

**Server actions** (`lib/actions/complaints.ts`):
- `listComplaints()` — real `prisma.complaint.findMany`, newest first.
- `createComplaint()` — validates, inserts with a `nanoid` reference, `revalidatePath("/complaints")`, returns the stored row.

**Surface** — `page.tsx` is now an async server component that fetches real rows and passes them to `ComplaintsClient`. The client takes `initialComplaints`, and `handleSubmit` calls the real action inside `useTransition` (pending state + error surfacing), prepending the persisted row. The report-kit `DataTable`/`FilterBar`/`StatusBadge` presentation is unchanged.

## Concurrency note
Based on `origin/main`'s current `ComplaintsClient.tsx`. The report-kit migration work (BI-6A842691) touches the same file — if its branch is still open it should rebase onto this; collision surface is `ComplaintsClient.tsx` only.

## Verification
- `ComplaintsClient.test.tsx` rewritten: server-provided rows render, StatusBadge intents, filter facet, and **empty-state** all asserted (mocks the `"use server"` module).
- `tsc --noEmit` clean (after `prisma generate`). The migration is hand-written to Prisma's deterministic output (no DB needed; applied by `migrate deploy`).
- Full web suite green except a pre-existing, unrelated flaky `voice-synthesis/adapters/mlx.test.ts` (passes in isolation; I touch no voice files).

Plan: `docs/superpowers/plans/2026-05-30-complaints-persistence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)