### PR TITLE
fix(ci): run all workspace test suites, not just web/db/mobile (BI-335D7B54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:prod-runtime": "docker compose up -d portal",
     "dev:sandbox": "docker compose up -d sandbox",
     "build": "pnpm --filter web build",
-    "test": "pnpm --filter web test && pnpm --filter @dpf/db test && pnpm --filter mobile test",
+    "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",
     "test:e2e:demo": "playwright test -c playwright-demo.config.ts",
     "typecheck": "pnpm --filter web typecheck && pnpm --filter @dpf/db typecheck && pnpm --filter @dpf/types typecheck && pnpm --filter @dpf/validators typecheck && pnpm --filter @dpf/api-client typecheck && pnpm --filter mobile typecheck",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

CI's Unit Tests job ran `pnpm test`, which only invoked **3 of 12** workspace test suites:

```
"test": "pnpm --filter web test && pnpm --filter @dpf/db test && pnpm --filter mobile test"
```

Six packages had vitest suites that **ran nowhere** — coverage was false-green:

| Package | Tests |
| --- | --- |
| `@dpf/api-client` | 3 (no `test` script existed) |
| `@dpf/validators` | 4 (no `test` script existed) |
| `@dpf/storefront-templates` | 24 |
| `@dpf/integration-shared` | 6 |
| `@dpf/bootstrap` | 101 |
| `@dpf/finance-templates` | 10 |

## Fix

- Add `"test": "vitest run"` to `packages/api-client` and `packages/validators`.
- Replace the hand-listed root `test` with `pnpm -r --if-present --workspace-concurrency=1 --no-bail test`, so:
  - Every workspace exposing a `test` script runs automatically. A future package can't slip through this gap again.
  - `--workspace-concurrency=1` preserves prior serial behavior (no DB pool contention with `@dpf/db`, readable failure output).
  - `--no-bail` makes every suite's pass/fail visible in the log even if an upstream suite fails. Without it, topo order masks `@dpf/api-client`, which runs after `web` — and `web` is currently red on main (pre-existing).

## Test plan

Local CI simulation (`DATABASE_URL` set, migrations applied, then `pnpm test`):
- [x] All nine newly-wired suites green: api-client (3), validators (4), storefront-templates (24), integration-shared (6), bootstrap (101), finance-templates (10), dpf-adp-mcp (31 passed + 11 HARNESS_E2E-guarded skipped), dpf-edge-node (202), dpf-integration-test-harness (25).
- [x] `@dpf/db` green via the same wiring (646 tests) — CI's existing "Apply migrations" step still runs before `pnpm test`, ordering preserved.
- [x] `apps/mobile` (jest) still picks up via `--if-present`.
- [x] CI's `Run unit tests` step (`.github/workflows/ci.yml:148`) is unchanged — local `pnpm test` == CI `pnpm test`.

## Pre-existing main breakage (NOT introduced here)

The `apps/web` vitest suite is red on main (~20 failures across `lib/actions/promotions.self-upgrade.test.ts`, `lib/tak/prompt-assembler.test.ts`, `lib/integrate/build-agent-prompts.test.ts`, plus several `components/build/*.tsx` timeouts). These were red **before** this change and remain red after — this PR neither introduces nor fixes them. With `--no-bail`, every other suite's outcome is still visible in the CI log so this PR's wiring can be verified independent of the web breakage.

Reference: BI-335D7B54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)