### PR TITLE
feat(web): report-kit Chart (recharts) for business-data charting (BI-6A842691)

### DIFF
--- a/apps/web/components/ui/report-kit/Chart.tsx
+++ b/apps/web/components/ui/report-kit/Chart.tsx
@@ -1,0 +1,134 @@
+// apps/web/components/ui/report-kit/Chart.tsx
+//
+// Business-data charting for the reporting palette — a thin, token-themed
+// wrapper over recharts (line / bar / area). Distinct from the Prometheus-bound
+// monitoring SVG charts: this takes arbitrary in-memory data via props.
+//
+// Client component (recharts measures its container). A server page passes
+// already-fetched, serialized data down — same pattern as DataTable.
+
+"use client";
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  BarChart,
+  AreaChart,
+  Line,
+  Bar,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+import {
+  axisTick,
+  gridStroke,
+  resolveSeriesColor,
+  tooltipStyle,
+  type ChartSeries,
+} from "./chartTheme";
+
+export type { ChartSeries } from "./chartTheme";
+
+export interface ChartProps {
+  type: "line" | "bar" | "area";
+  data: Record<string, unknown>[];
+  /** Row key for the X axis. */
+  xKey: string;
+  series: ChartSeries[];
+  height?: number;
+  showGrid?: boolean;
+  showLegend?: boolean;
+  className?: string;
+}
+
+export function Chart({
+  type,
+  data,
+  xKey,
+  series,
+  height = 240,
+  showGrid = true,
+  showLegend = false,
+  className = "",
+}: ChartProps) {
+  const grid = showGrid ? (
+    <CartesianGrid stroke={gridStroke} strokeDasharray="3 3" vertical={false} />
+  ) : null;
+  const axes = (
+    <>
+      <XAxis dataKey={xKey} tick={axisTick} stroke={gridStroke} />
+      <YAxis tick={axisTick} stroke={gridStroke} width={36} />
+    </>
+  );
+  const tooltip = <Tooltip contentStyle={tooltipStyle} />;
+  const legend = showLegend ? <Legend wrapperStyle={{ fontSize: 11 }} /> : null;
+
+  return (
+    <div className={className} style={{ width: "100%", height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        {type === "line" ? (
+          <LineChart data={data}>
+            {grid}
+            {axes}
+            {tooltip}
+            {legend}
+            {series.map((s, i) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.label ?? s.key}
+                stroke={resolveSeriesColor(s, i)}
+                strokeWidth={2}
+                dot={false}
+              />
+            ))}
+          </LineChart>
+        ) : type === "bar" ? (
+          <BarChart data={data}>
+            {grid}
+            {axes}
+            {tooltip}
+            {legend}
+            {series.map((s, i) => (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={s.label ?? s.key}
+                fill={resolveSeriesColor(s, i)}
+                radius={[2, 2, 0, 0]}
+              />
+            ))}
+          </BarChart>
+        ) : (
+          <AreaChart data={data}>
+            {grid}
+            {axes}
+            {tooltip}
+            {legend}
+            {series.map((s, i) => {
+              const color = resolveSeriesColor(s, i);
+              return (
+                <Area
+                  key={s.key}
+                  type="monotone"
+                  dataKey={s.key}
+                  name={s.label ?? s.key}
+                  stroke={color}
+                  fill={color}
+                  fillOpacity={0.15}
+                  strokeWidth={2}
+                />
+              );
+            })}
+          </AreaChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/README.md
+++ b/apps/web/components/ui/report-kit/README.md
@@ -27,12 +27,17 @@ import {
 | `DataTable` | client¹ | tabular lists with sort, paging, empty/loading states |
 | `FilterBar` | client¹ | search + select + pill facets above a table |
 | `ExportButton` / `toCsv` | client | CSV export of rows (papaparse-backed) |
+| `Chart` | client² | business-data line / bar / area charts (recharts) |
 | `statusColors` (`intentStyle`, `resolveIntent`, `STATUS_INTENT`) | ✅ | the one place status→color semantics live |
 
 ¹ `DataTable` / `FilterBar` are `"use client"` (they manage sort/page/onChange
 state). A server page uses them by rendering them inside a small client child —
 the page still fetches data on the server and passes rows down. A pure
 server-rendered (URL-driven) table mode is a documented follow-up.
+
+² `Chart` pulls in **recharts** (client-only, heavy), so it is **not** re-exported
+from the barrel — import it by subpath to keep the barrel and server components
+recharts-free: `import { Chart } from "@/components/ui/report-kit/Chart"`.
 
 ## The intent model (always use tokens, never hex)
 
@@ -157,6 +162,29 @@ CSV export for a list/table, backed by papaparse. `toCsv` is exported and pure
 />
 ```
 
+## Chart
+
+Token-themed line / bar / area charts over **recharts**, for arbitrary in-memory
+business data (distinct from the Prometheus-bound monitoring SVG charts). Client
+component — a server page passes serialized data down (like `DataTable`). Series
+colors resolve from tokens (explicit `color`, an `intent`, or the default ramp).
+
+```tsx
+import { Chart } from "@/components/ui/report-kit/Chart";
+
+<Chart
+  type="area"
+  data={monthly}            // [{ month: "Jan", revenue: 1200, spend: 800 }, …]
+  xKey="month"
+  series={[
+    { key: "revenue", label: "Revenue", intent: "success" },
+    { key: "spend", label: "Spend", intent: "danger" },
+  ]}
+  height={260}
+  showLegend
+/>
+```
+
 ## Conventions
 
 - **No raw hex.** Colors come from `intentStyle` / `--dpf-*` tokens only.
@@ -169,6 +197,6 @@ CSV export for a list/table, backed by papaparse. `toCsv` is exported and pure
 - **Phase 1 (this):** primitives + tests + this doc. Additive only.
 - **Phase 2:** migrate reference surfaces (complaints, finance/payments), grow
   `STATUS_INTENT`, fold `ChangeLaneStatusBadge` onto `StatusBadge`.
-- **Phase 3:** ✅ `StatCard` + `ExportButton` (CSV via papaparse). Remaining:
-  PDF export (`@react-pdf`), business-data charting decision, server-rendered
-  `DataTable` URL mode.
+- **Phase 3:** ✅ `StatCard` + `ExportButton` (CSV via papaparse) + `Chart`
+  (recharts — charting decision resolved). Remaining: PDF export (`@react-pdf`),
+  server-rendered `DataTable` URL mode.

--- a/apps/web/components/ui/report-kit/chartTheme.test.ts
+++ b/apps/web/components/ui/report-kit/chartTheme.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SERIES_PALETTE,
+  resolveSeriesColor,
+  axisTick,
+  gridStroke,
+  tooltipStyle,
+} from "./chartTheme";
+
+describe("chartTheme", () => {
+  it("palette + shared styles are token-backed (no raw hex)", () => {
+    for (const c of DEFAULT_SERIES_PALETTE) expect(c).toMatch(/var\(--dpf-/);
+    expect(axisTick.fill).toMatch(/var\(--dpf-/);
+    expect(gridStroke).toMatch(/var\(--dpf-/);
+    expect(tooltipStyle.background).toMatch(/var\(--dpf-/);
+    expect(JSON.stringify({ DEFAULT_SERIES_PALETTE, axisTick, gridStroke, tooltipStyle }))
+      .not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("resolves an explicit color first", () => {
+    expect(resolveSeriesColor({ key: "a", color: "var(--dpf-success)" }, 3)).toBe(
+      "var(--dpf-success)",
+    );
+  });
+
+  it("resolves an intent to its token color", () => {
+    expect(resolveSeriesColor({ key: "a", intent: "danger" }, 0)).toBe("var(--dpf-error)");
+  });
+
+  it("falls back to the palette by index (wrapping)", () => {
+    expect(resolveSeriesColor({ key: "a" }, 0)).toBe(DEFAULT_SERIES_PALETTE[0]);
+    expect(resolveSeriesColor({ key: "a" }, 1)).toBe(DEFAULT_SERIES_PALETTE[1]);
+    // wraps past the end
+    const n = DEFAULT_SERIES_PALETTE.length;
+    expect(resolveSeriesColor({ key: "a" }, n)).toBe(DEFAULT_SERIES_PALETTE[0]);
+  });
+});

--- a/apps/web/components/ui/report-kit/chartTheme.ts
+++ b/apps/web/components/ui/report-kit/chartTheme.ts
@@ -1,0 +1,50 @@
+// apps/web/components/ui/report-kit/chartTheme.ts
+//
+// Pure theming helpers for the report-kit charts. Kept free of any recharts
+// import so it is safe to unit-test in the node test environment (recharts is
+// browser-oriented and renders via a sized container, not in SSR/node).
+//
+// All colors resolve to --dpf-* design tokens — never raw hex.
+
+import { intentStyle, type Intent } from "./statusColors";
+
+/** Default series color ramp, drawn from the design tokens. */
+export const DEFAULT_SERIES_PALETTE: string[] = [
+  "var(--dpf-accent)",
+  "var(--dpf-info)",
+  "var(--dpf-success)",
+  "var(--dpf-warning)",
+  "var(--dpf-error)",
+];
+
+export interface ChartSeries {
+  /** Key into each data row. */
+  key: string;
+  /** Legend/tooltip label (defaults to `key`). */
+  label?: string;
+  /** Explicit color, or an intent to resolve from tokens; else palette by index. */
+  color?: string;
+  intent?: Intent;
+}
+
+/** Resolve the stroke/fill color for a series at a given index. */
+export function resolveSeriesColor(series: ChartSeries, index: number): string {
+  if (series.color) return series.color;
+  if (series.intent) return intentStyle(series.intent).fg;
+  return DEFAULT_SERIES_PALETTE[index % DEFAULT_SERIES_PALETTE.length];
+}
+
+/** Axis tick styling shared by every chart type. */
+export const axisTick = { fill: "var(--dpf-muted)", fontSize: 11 } as const;
+
+/** Cartesian grid stroke. */
+export const gridStroke = "var(--dpf-border)";
+
+/** Tooltip container styling (token-backed surface). */
+export const tooltipStyle = {
+  background: "var(--dpf-surface-1)",
+  border: "1px solid var(--dpf-border)",
+  borderRadius: 8,
+  fontSize: 12,
+  color: "var(--dpf-text)",
+} as const;

--- a/apps/web/components/ui/report-kit/index.ts
+++ b/apps/web/components/ui/report-kit/index.ts
@@ -43,6 +43,11 @@ export {
   type ExportColumn,
 } from "./ExportButton";
 
+// NOTE: Chart is intentionally NOT re-exported here. It pulls in recharts
+// (client-only, heavy), so it is imported via subpath to keep this barrel
+// — and every server component that uses it — recharts-free:
+//   import { Chart } from "@/components/ui/report-kit/Chart";
+
 export {
   intentStyle,
   resolveIntent,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "read-excel-file": "9.0.10",
+    "recharts": "^3.8.1",
     "sharp": "^0.34.5",
     "undici": "^8.3.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 1.2.1
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+        version: 5.0.14(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
       '@testing-library/react-native':
         specifier: ^13.3.3
@@ -234,7 +234,7 @@ importers:
         version: 0.7.54
       '@xyflow/react':
         specifier: ^12.10.2
-        version: 12.10.2(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 12.10.2(@types/react@19.2.15)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -310,6 +310,9 @@ importers:
       read-excel-file:
         specifier: 9.0.10
         version: 9.0.10
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.6)(react@19.2.6)(redux@5.0.1)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -3442,6 +3445,17 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@ricky0123/vad-web@0.0.30':
     resolution: {integrity: sha512-cJyYrh4YeeUBJcbR9Bic/bFDyB9qBkAepvpuWM3vLxnAi7bC3VHzf51UeNdT+OtY4D7MLAgV8iJMc4z41ZnaWg==}
 
@@ -3554,6 +3568,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@stoplight/http-spec@7.1.0':
     resolution: {integrity: sha512-Z2XqKX2SV8a1rrgSzFqccX2TolfcblT+l4pNvUU+THaLl50tKDoeidwWWZTzYUzqU0+UV97ponvqEbWWN3PaXg==}
@@ -4036,6 +4053,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5204,6 +5224,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -5482,6 +5505,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -6182,6 +6208,9 @@ packages:
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -8176,6 +8205,18 @@ packages:
       '@types/react':
         optional: true
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -8255,9 +8296,25 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
@@ -8304,6 +8361,9 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -8873,6 +8933,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -9187,6 +9250,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-compatible-readable-stream@3.6.1:
     resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
@@ -13032,6 +13098,18 @@ snapshots:
     dependencies:
       react: 19.2.6
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.6
+      react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
+
   '@ricky0123/vad-web@0.0.30':
     dependencies:
       onnxruntime-web: 1.26.0
@@ -13098,6 +13176,8 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@stoplight/http-spec@7.1.0':
     dependencies:
@@ -13723,6 +13803,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/use-sync-external-store@0.0.6': {}
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.35':
@@ -13871,13 +13953,13 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xyflow/react@12.10.2(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@xyflow/react@12.10.2(@types/react@19.2.15)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@xyflow/system': 0.0.76
       classcat: 5.0.5
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      zustand: 4.5.7(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -14917,6 +14999,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
@@ -15148,6 +15232,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -15976,6 +16062,8 @@ snapshots:
   immediate@3.0.6: {}
 
   immer@10.2.0: {}
+
+  immer@11.1.8: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -18489,6 +18577,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      redux: 5.0.1
+
   react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.15)(react@19.2.6):
@@ -18578,10 +18675,36 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  recharts@3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.6)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-is: 19.2.6
+      react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -18643,6 +18766,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  reselect@5.1.1: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -19286,6 +19411,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinycolor2@1.6.0: {}
@@ -19590,6 +19717,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-compatible-readable-stream@3.6.1:
     dependencies:
       inherits: 2.0.4
@@ -19846,18 +19990,18 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@4.5.7(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6):
+  zustand@4.5.7(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6):
     dependencies:
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
-      immer: 10.2.0
+      immer: 11.1.8
       react: 19.2.6
 
-  zustand@5.0.14(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+  zustand@5.0.14(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:
       '@types/react': 19.2.15
-      immer: 10.2.0
+      immer: 11.1.8
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
 


### PR DESCRIPTION
## What

Resolves the **charting decision** (recharts, per design review). Adds token-themed line / bar / area charts for arbitrary in-memory business data — the gap the audit flagged (charts were Prometheus-only).

## Design

- **`chartTheme.ts`** — pure, **recharts-free** theming: token color ramp, per-series color resolution (explicit `color` → `intent` → default ramp), axis/grid/tooltip styles. Node-unit-testable.
- **`Chart.tsx`** — thin client wrapper over recharts (`type: line|bar|area`), `ResponsiveContainer`, series colored from `--dpf-*` tokens. Server pages pass serialized data down (same pattern as `DataTable`).
- **Not re-exported from the barrel.** recharts is heavy + client-only, so `Chart` is imported by subpath (`@/components/ui/report-kit/Chart`) to keep the barrel — and every server component using it — recharts-free.
- **recharts@^3.8.1** added to the `web` workspace (latest, per the dependency-currency principle).

## Verification

- `npx vitest run components/ui/report-kit` → **39 passed** (chartTheme color/resolution covered; no raw hex)
- `tsc --noEmit` clean (recharts 3.x types compile)
- Visual render is verified in the contributor preview (recharts measures its container, so SVG output isn't asserted in the node test env — by design)

Phase 3 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)