### PR TITLE
fix(test): unblock main — add nextUpgradeWindowOpen to self-upgrade window mock (BI-5D20D979)

### DIFF
--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/self-upgrade", () => ({
 vi.mock("@/lib/self-upgrade/window", () => ({
   isStoreOpen: vi.fn().mockReturnValue(false),
   isUpgradeWindowOpen: vi.fn().mockReturnValue(true),
+  nextUpgradeWindowOpen: vi.fn().mockReturnValue(null),
 }));
 
 vi.mock("@/lib/operating-hours-read", () => ({


### PR DESCRIPTION
## What & why

**main's Unit Tests check is currently red.** PR #1320 (activity timestamps + next-window time on `/ops/self-upgrade`) added a `nextUpgradeWindowOpen()` call in `getSelfUpgradeStatus` (`apps/web/lib/actions/promotions.ts:627`) and a new export from `@/lib/self-upgrade/window`, but did not update the `vi.mock("@/lib/self-upgrade/window")` in `promotions.self-upgrade.test.ts`. The mock omitted the new export, so the call threw `No "nextUpgradeWindowOpen" export is defined on the mock` and **5 tests failed**.

This also blocks unrelated PRs whose Unit Tests inherit the main breakage (e.g. #1325, #1330 from the Ship Real Functionality audit).

## Fix

One line: add `nextUpgradeWindowOpen: vi.fn().mockReturnValue(null)` to the window mock.

## Verification
- `promotions.self-upgrade.test.ts`: **34/34 pass** (was 5 failing).

Found during the Ship Real Functionality audit follow-up. BI-5D20D979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)