### PR TITLE
fix(test): catch VoiceSynthesisError atomically to prevent unhandled rejection

### DIFF
--- a/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
@@ -184,8 +184,13 @@ describe("synthesizeWithMlx", () => {
     const fetchMock = stubSequence([{ ok: true, buf: SHORT_AUDIO }]) // always short
     vi.useFakeTimers()
     const p = synthesizeWithMlx("x", baseConfig)
-    await vi.runAllTimersAsync()
-    await expect(p).rejects.toThrow("VoiceSynthesisError [mlx]")
+    // Advance timers and catch the rejection atomically — if we await timers
+    // before attaching the rejection handler, the VoiceSynthesisError escapes
+    // as an unhandled rejection and causes a CI unhandled-error failure.
+    await Promise.all([
+      vi.runAllTimersAsync(),
+      expect(p).rejects.toThrow("VoiceSynthesisError [mlx]"),
+    ])
     vi.useRealTimers()
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })


### PR DESCRIPTION
## Problem
The `gives up after DPF_TTS_MLX_MAX_ATTEMPTS` test in `mlx.test.ts` used fake timers with a pattern that left a brief window where the thrown `VoiceSynthesisError` was an unhandled rejection:

```ts
// BEFORE — rejection escapes between these two lines:
await vi.runAllTimersAsync()         // p settles (rejects) here…
await expect(p).rejects.toThrow(…)  // …but handler isn't attached yet
```

Vitest caught it as an unhandled error and failed CI even though all 8827 tests passed.

## Fix
Wrap both in `Promise.all` so the rejection is caught the instant timers fire:

```ts
await Promise.all([
  vi.runAllTimersAsync(),
  expect(p).rejects.toThrow('VoiceSynthesisError [mlx]'),
])
```

## Verification
13/13 mlx adapter tests pass, no unhandled errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)