### PR TITLE
refactor(web): migrate compliance/posture to report-kit (StatCard + Chart + DataTable) (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/compliance/posture/PostureTrendTable.test.tsx
+++ b/apps/web/app/(shell)/compliance/posture/PostureTrendTable.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PostureTrendTable, type PostureSnapshotRow } from "./PostureTrendTable";
+import { scoreIntent } from "./posture-score";
+
+const ROWS: PostureSnapshotRow[] = [
+  {
+    snapshotId: "snap-1",
+    takenAtISO: "2026-03-28T14:30:00.000Z",
+    overallScore: 92,
+    coveredObligations: 18,
+    totalObligations: 20,
+    implementedControls: 9,
+    totalControls: 10,
+    openIncidents: 0,
+    overdueActions: 1,
+    triggeredBy: "manual",
+  },
+  {
+    snapshotId: "snap-2",
+    takenAtISO: "2026-02-28T14:30:00.000Z",
+    overallScore: 55,
+    coveredObligations: 8,
+    totalObligations: 20,
+    implementedControls: 4,
+    totalControls: 10,
+    openIncidents: 3,
+    overdueActions: 5,
+    triggeredBy: "scheduled",
+  },
+];
+
+describe("posture scoreIntent", () => {
+  it("maps score bands to intents", () => {
+    expect(scoreIntent(92)).toBe("success");
+    expect(scoreIntent(65)).toBe("warning");
+    expect(scoreIntent(40)).toBe("danger");
+  });
+});
+
+describe("PostureTrendTable (report-kit migration)", () => {
+  const html = renderToStaticMarkup(<PostureTrendTable rows={ROWS} />);
+
+  it("renders snapshot rows", () => {
+    expect(html).toContain("manual");
+    expect(html).toContain("scheduled");
+    expect(html).toContain("18/20");
+  });
+
+  it("colors the score via token-backed StatusBadge (no raw hex)", () => {
+    expect(html).toContain('data-intent="success"'); // 92
+    expect(html).toContain('data-intent="danger"'); // 55
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+    expect(html).not.toMatch(/(text|bg)-(green|yellow|red)-[0-9]/);
+  });
+});

--- a/apps/web/app/(shell)/compliance/posture/PostureTrendTable.tsx
+++ b/apps/web/app/(shell)/compliance/posture/PostureTrendTable.tsx
@@ -1,0 +1,96 @@
+// apps/web/app/(shell)/compliance/posture/PostureTrendTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for compliance snapshot
+// history. The page (server component) fetches + serializes rows and passes
+// them here (DataTable needs a client boundary; its columns are functions).
+
+"use client";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { DataTable, StatusBadge, type Column } from "@/components/ui/report-kit";
+
+import { scoreIntent } from "./posture-score";
+
+export interface PostureSnapshotRow {
+  snapshotId: string;
+  takenAtISO: string;
+  overallScore: number;
+  coveredObligations: number;
+  totalObligations: number;
+  implementedControls: number;
+  totalControls: number;
+  openIncidents: number;
+  overdueActions: number;
+  triggeredBy: string;
+}
+
+const COLUMNS: Column<PostureSnapshotRow>[] = [
+  {
+    key: "date",
+    header: "Date",
+    cell: (s) => (
+      <span className="text-[var(--dpf-text)]">
+        <LocalTime value={s.takenAtISO} mode="date" />
+      </span>
+    ),
+    sortAccessor: (s) => s.takenAtISO,
+  },
+  {
+    key: "score",
+    header: "Score",
+    cell: (s) => (
+      <StatusBadge intent={scoreIntent(s.overallScore)} label={String(s.overallScore)} variant="soft" />
+    ),
+    sortAccessor: (s) => s.overallScore,
+  },
+  {
+    key: "obligations",
+    header: "Obligations",
+    cell: (s) => (
+      <span className="text-[var(--dpf-muted)]">
+        {s.coveredObligations}/{s.totalObligations}
+      </span>
+    ),
+  },
+  {
+    key: "controls",
+    header: "Controls",
+    cell: (s) => (
+      <span className="text-[var(--dpf-muted)]">
+        {s.implementedControls}/{s.totalControls}
+      </span>
+    ),
+  },
+  {
+    key: "incidents",
+    header: "Incidents",
+    align: "right",
+    cell: (s) => <span className="text-[var(--dpf-muted)]">{s.openIncidents}</span>,
+    sortAccessor: (s) => s.openIncidents,
+  },
+  {
+    key: "overdue",
+    header: "Overdue",
+    align: "right",
+    cell: (s) => <span className="text-[var(--dpf-muted)]">{s.overdueActions}</span>,
+    sortAccessor: (s) => s.overdueActions,
+  },
+  {
+    key: "trigger",
+    header: "Trigger",
+    cell: (s) => <span className="text-[var(--dpf-muted)]">{s.triggeredBy}</span>,
+  },
+];
+
+export function PostureTrendTable({ rows }: { rows: PostureSnapshotRow[] }) {
+  return (
+    <DataTable
+      columns={COLUMNS}
+      rows={rows}
+      getRowKey={(s) => s.snapshotId}
+      initialSort={{ key: "date", dir: "desc" }}
+      pageSize={12}
+      empty="No snapshots yet."
+    />
+  );
+}

--- a/apps/web/app/(shell)/compliance/posture/page.tsx
+++ b/apps/web/app/(shell)/compliance/posture/page.tsx
@@ -1,6 +1,9 @@
 // apps/web/app/(shell)/compliance/posture/page.tsx
 import { getCompliancePosture, getPostureTrend, takeComplianceSnapshot } from "@/lib/actions/reporting";
-import { LocalTime } from "@/components/ui/LocalTime";
+import { StatCard, StatusBadge, intentStyle } from "@/components/ui/report-kit";
+import { Chart } from "@/components/ui/report-kit/Chart";
+import { PostureTrendTable, type PostureSnapshotRow } from "./PostureTrendTable";
+import { scoreIntent } from "./posture-score";
 
 export default async function PosturePage() {
   const [posture, trend] = await Promise.all([
@@ -8,7 +11,29 @@ export default async function PosturePage() {
     getPostureTrend(12),
   ]);
 
-  const scoreColor = posture.overallScore >= 80 ? "#4ade80" : posture.overallScore >= 60 ? "#fbbf24" : "#ef4444";
+  const obligationPct = posture.totalObligations > 0
+    ? Math.round((posture.coveredObligations / posture.totalObligations) * 100)
+    : 100;
+  const controlPct = posture.totalControls > 0
+    ? Math.round((posture.implementedControls / posture.totalControls) * 100)
+    : 100;
+
+  // Serialize snapshots for the client table + chart (chronological for the trend line).
+  const rows: PostureSnapshotRow[] = trend.map((s) => ({
+    snapshotId: s.snapshotId,
+    takenAtISO: new Date(s.takenAt).toISOString(),
+    overallScore: s.overallScore,
+    coveredObligations: s.coveredObligations,
+    totalObligations: s.totalObligations,
+    implementedControls: s.implementedControls,
+    totalControls: s.totalControls,
+    openIncidents: s.openIncidents,
+    overdueActions: s.overdueActions,
+    triggeredBy: s.triggeredBy,
+  }));
+  const chartData = [...rows]
+    .sort((a, b) => a.takenAtISO.localeCompare(b.takenAtISO))
+    .map((s) => ({ date: s.takenAtISO.slice(0, 10), score: s.overallScore }));
 
   return (
     <div>
@@ -25,17 +50,27 @@ export default async function PosturePage() {
         </form>
       </div>
 
-      {/* Overall Score */}
+      {/* Overall Score + key metrics */}
       <div className="flex items-center gap-6 mb-8">
         <div className="text-center">
-          <p className="text-5xl font-bold" style={{ color: scoreColor }}>{posture.overallScore}</p>
+          <p className="text-5xl font-bold" style={{ color: intentStyle(scoreIntent(posture.overallScore)).fg }}>
+            {posture.overallScore}
+          </p>
           <p className="text-xs text-[var(--dpf-muted)] mt-1">Overall Score</p>
         </div>
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 flex-1">
-          <MetricCard label="Obligation Coverage" value={`${posture.totalObligations > 0 ? Math.round((posture.coveredObligations / posture.totalObligations) * 100) : 100}%`} sub={`${posture.coveredObligations}/${posture.totalObligations}`} />
-          <MetricCard label="Control Implementation" value={`${posture.totalControls > 0 ? Math.round((posture.implementedControls / posture.totalControls) * 100) : 100}%`} sub={`${posture.implementedControls}/${posture.totalControls}`} />
-          <MetricCard label="Open Incidents" value={posture.openIncidents} sub={posture.openIncidents === 0 ? "Clear" : "Active"} />
-          <MetricCard label="Overdue Actions" value={posture.overdueActions} sub={posture.overdueActions === 0 ? "On track" : "Needs attention"} />
+          <StatCard label="Obligation Coverage" value={`${obligationPct}%`}
+            hint={`${posture.coveredObligations}/${posture.totalObligations}`}
+            intent={scoreIntent(obligationPct)} />
+          <StatCard label="Control Implementation" value={`${controlPct}%`}
+            hint={`${posture.implementedControls}/${posture.totalControls}`}
+            intent={scoreIntent(controlPct)} />
+          <StatCard label="Open Incidents" value={posture.openIncidents}
+            hint={posture.openIncidents === 0 ? "Clear" : "Active"}
+            intent={posture.openIncidents === 0 ? "success" : "danger"} />
+          <StatCard label="Overdue Actions" value={posture.overdueActions}
+            hint={posture.overdueActions === 0 ? "On track" : "Needs attention"}
+            intent={posture.overdueActions === 0 ? "success" : "warning"} />
         </div>
       </div>
 
@@ -50,11 +85,11 @@ export default async function PosturePage() {
               <div key={r.id} className="p-3 rounded-lg border border-[var(--dpf-border)] flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-[var(--dpf-text)]">{r.shortName}</span>
-                  <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{r.jurisdiction}</span>
+                  <StatusBadge intent="neutral" label={r.jurisdiction} variant="soft" uppercase={false} />
                 </div>
                 <div className="flex items-center gap-4 text-xs text-[var(--dpf-muted)]">
                   <span>{r.coveredObligations}/{r.totalObligations} covered</span>
-                  <span className={`font-semibold ${r.obligationCoverage >= 80 ? "text-green-400" : r.obligationCoverage >= 50 ? "text-yellow-400" : "text-red-400"}`}>
+                  <span className="font-semibold" style={{ color: intentStyle(scoreIntent(r.obligationCoverage)).fg }}>
                     {r.obligationCoverage}%
                   </span>
                 </div>
@@ -70,50 +105,22 @@ export default async function PosturePage() {
         {trend.length === 0 ? (
           <p className="text-sm text-[var(--dpf-muted)]">No snapshots yet. Take a snapshot to start tracking trends.</p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="text-left text-[var(--dpf-muted)] border-b border-[var(--dpf-border)]">
-                  <th className="py-2 pr-4">Date</th>
-                  <th className="py-2 pr-4">Score</th>
-                  <th className="py-2 pr-4">Obligations</th>
-                  <th className="py-2 pr-4">Controls</th>
-                  <th className="py-2 pr-4">Incidents</th>
-                  <th className="py-2 pr-4">Overdue</th>
-                  <th className="py-2">Trigger</th>
-                </tr>
-              </thead>
-              <tbody>
-                {trend.map((s) => (
-                  <tr key={s.snapshotId} className="border-b border-[var(--dpf-border)]">
-                    <td className="py-2 pr-4 text-[var(--dpf-text)]"><LocalTime value={s.takenAt} mode="date" /></td>
-                    <td className="py-2 pr-4">
-                      <span className={`font-semibold ${s.overallScore >= 80 ? "text-green-400" : s.overallScore >= 60 ? "text-yellow-400" : "text-red-400"}`}>
-                        {s.overallScore}
-                      </span>
-                    </td>
-                    <td className="py-2 pr-4 text-[var(--dpf-muted)]">{s.coveredObligations}/{s.totalObligations}</td>
-                    <td className="py-2 pr-4 text-[var(--dpf-muted)]">{s.implementedControls}/{s.totalControls}</td>
-                    <td className="py-2 pr-4 text-[var(--dpf-muted)]">{s.openIncidents}</td>
-                    <td className="py-2 pr-4 text-[var(--dpf-muted)]">{s.overdueActions}</td>
-                    <td className="py-2 text-[var(--dpf-muted)]">{s.triggeredBy}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-4">
+            {chartData.length > 1 && (
+              <div className="rounded-lg border border-[var(--dpf-border)] p-3">
+                <Chart
+                  type="area"
+                  data={chartData}
+                  xKey="date"
+                  series={[{ key: "score", label: "Overall Score", intent: "accent" }]}
+                  height={220}
+                />
+              </div>
+            )}
+            <PostureTrendTable rows={rows} />
           </div>
         )}
       </section>
-    </div>
-  );
-}
-
-function MetricCard({ label, value, sub }: { label: string; value: number | string; sub: string }) {
-  return (
-    <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
-      <p className="text-xs text-[var(--dpf-muted)]">{label}</p>
-      <p className="text-lg font-bold text-[var(--dpf-text)]">{value}</p>
-      <p className="text-[9px] text-[var(--dpf-muted)]">{sub}</p>
     </div>
   );
 }

--- a/apps/web/app/(shell)/compliance/posture/posture-score.ts
+++ b/apps/web/app/(shell)/compliance/posture/posture-score.ts
@@ -1,0 +1,13 @@
+// apps/web/app/(shell)/compliance/posture/posture-score.ts
+//
+// Shared (non-client) score→intent mapping so both the server page and the
+// client trend table use the same thresholds. Type-only import from the
+// report-kit barrel (erased at compile — no client boundary pulled in).
+
+import type { Intent } from "@/components/ui/report-kit";
+
+export function scoreIntent(score: number): Intent {
+  if (score >= 80) return "success";
+  if (score >= 60) return "warning";
+  return "danger";
+}


### PR DESCRIPTION
## What

Showcase migration — the first surface to exercise **StatCard + Chart + DataTable** together. compliance/posture was a heavy token offender (raw hex score colors *and* raw Tailwind-palette classes).

## Before → after

| Before | After |
|---|---|
| Score hex `#4ade80`/`#fbbf24`/`#ef4444` + `text-green-400`/`text-yellow-400`/`text-red-400` | intent colors via `intentStyle` + a shared `scoreIntent` (≥80 success, ≥60 warning, else danger) |
| local `MetricCard` ×4 | `StatCard` ×4 (intent-aware: incidents/overdue flip color when non-zero) |
| hand-rolled historical **trend table** | **`Chart`** (area, score over time) + `DataTable` detail (`PostureTrendTable`, score as `StatusBadge`) |

`scoreIntent` lives in a **non-client util** (`posture-score.ts`) so the server page and the client table share thresholds without crossing the RSC boundary (importing a function from a `"use client"` module into a server component would turn it into an unusable client reference).

## Verification

- `npx vitest run app/(shell)/compliance/posture` → **3 passed** (table render + score-intent bands; asserts no raw hex / no Tailwind palette colors)
- `tsc --noEmit` clean
- First real consumer of `Chart` (#1333, merged) and `StatCard` (#1324, merged)

Phase 2/3 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)