### PR TITLE
refactor(web): migrate finance home to report-kit StatCard + DataTable (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/finance/RecentInvoicesTable.test.tsx
+++ b/apps/web/app/(shell)/finance/RecentInvoicesTable.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RecentInvoicesTable, type RecentInvoiceRow } from "./RecentInvoicesTable";
+
+const ROWS: RecentInvoiceRow[] = [
+  { id: "i1", invoiceRef: "INV-001", accountName: "Acme Ltd", status: "overdue", amount: 1200 },
+  { id: "i2", invoiceRef: "INV-002", accountName: "Globex", status: "paid", amount: 50.5 },
+  { id: "i3", invoiceRef: "INV-003", accountName: "Initech", status: "partially_paid", amount: 300 },
+];
+
+describe("RecentInvoicesTable (report-kit migration)", () => {
+  const html = renderToStaticMarkup(<RecentInvoicesTable rows={ROWS} currencySymbol="£" />);
+
+  it("renders invoice rows with drill-down links", () => {
+    expect(html).toContain("INV-001");
+    expect(html).toContain('href="/finance/invoices/i1"');
+    expect(html).toContain("Acme Ltd");
+  });
+
+  it("renders status via the finance registry StatusBadge (no raw hex)", () => {
+    expect(html).toContain('data-intent="danger"'); // overdue
+    expect(html).toContain('data-intent="success"'); // paid
+    expect(html).toContain('data-intent="warning"'); // partially_paid
+    expect(html).toContain("partially paid"); // underscore replaced
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("formats amounts with the currency symbol", () => {
+    expect(html).toContain("£1,200.00");
+    expect(html).toContain("£50.50");
+  });
+});

--- a/apps/web/app/(shell)/finance/RecentInvoicesTable.tsx
+++ b/apps/web/app/(shell)/finance/RecentInvoicesTable.tsx
@@ -1,0 +1,89 @@
+// apps/web/app/(shell)/finance/RecentInvoicesTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for the finance home
+// "Recent Invoices" list. The page (server component) serializes rows and
+// passes them down.
+
+"use client";
+
+import Link from "next/link";
+
+import { DataTable, StatusBadge, type Column } from "@/components/ui/report-kit";
+
+export interface RecentInvoiceRow {
+  id: string;
+  invoiceRef: string;
+  accountName: string;
+  status: string;
+  amount: number;
+}
+
+function formatMoney(amount: number): string {
+  return amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
+}
+
+export function RecentInvoicesTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: RecentInvoiceRow[];
+  currencySymbol: string;
+}) {
+  const columns: Column<RecentInvoiceRow>[] = [
+    {
+      key: "ref",
+      header: "Ref",
+      mono: true,
+      cell: (inv) => (
+        <Link
+          href={`/finance/invoices/${inv.id}`}
+          className="text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+        >
+          {inv.invoiceRef}
+        </Link>
+      ),
+    },
+    {
+      key: "account",
+      header: "Account",
+      cell: (inv) => (
+        <Link href={`/finance/invoices/${inv.id}`} className="text-[var(--dpf-text)] hover:underline">
+          {inv.accountName}
+        </Link>
+      ),
+      sortAccessor: (inv) => inv.accountName,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (inv) => (
+        <StatusBadge
+          domain="finance"
+          status={inv.status}
+          label={inv.status.replace("_", " ")}
+          variant="soft"
+          uppercase={false}
+        />
+      ),
+      sortAccessor: (inv) => inv.status,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      cell: (inv) => (
+        <span className="text-[var(--dpf-text)]">
+          {currencySymbol}
+          {formatMoney(inv.amount)}
+        </span>
+      ),
+      sortAccessor: (inv) => inv.amount,
+    },
+  ];
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] p-1">
+      <DataTable columns={columns} rows={rows} getRowKey={(inv) => inv.id} empty="No invoices yet." />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -8,21 +8,8 @@ import { AccountantWorkLanePanel } from "@/components/finance/AccountantWorkLane
 import { getBookkeeperAccountantWorkLane } from "@/lib/finance/accountant-work-lane";
 import { FinanceSummaryCard } from "@/components/finance/FinanceSummaryCard";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
-
-const STATUS_COLOURS: Record<string, string> = {
-  draft: "var(--dpf-muted)",
-  sent: "var(--dpf-info)",
-  viewed: "var(--dpf-accent)",
-  overdue: "var(--dpf-error)",
-  partially_paid: "var(--dpf-warning)",
-  paid: "var(--dpf-success)",
-  void: "var(--dpf-muted)",
-  written_off: "var(--dpf-muted)",
-};
-
-const POSITIVE_COLOUR = "var(--dpf-success)";
-const ATTENTION_COLOUR = "var(--dpf-error)";
-const MUTED_COLOUR = "var(--dpf-muted)";
+import { StatCard } from "@/components/ui/report-kit";
+import { RecentInvoicesTable, type RecentInvoiceRow } from "./RecentInvoicesTable";
 
 export default async function FinancePage() {
   const now = new Date();
@@ -191,6 +178,14 @@ export default async function FinancePage() {
   const formatMoney = (amount: number) =>
     amount.toLocaleString("en-GB", { minimumFractionDigits: 2 });
 
+  const recentInvoiceRows: RecentInvoiceRow[] = recentInvoices.map((inv) => ({
+    id: inv.id,
+    invoiceRef: inv.invoiceRef,
+    accountName: inv.account.name,
+    status: inv.status,
+    amount: Number(inv.totalAmount),
+  }));
+
   return (
     <div>
       {/* Setup prompt banner */}
@@ -278,196 +273,111 @@ export default async function FinancePage() {
 
       {/* Row 1: Cash Position + 30-day Forecast + Outstanding + Overdue */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
-        {/* Widget 1: Cash Position */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Cash Position
-          </p>
-          {bankAccounts.length === 0 ? (
-            <div>
-              <p className="text-xs text-[var(--dpf-muted)] mb-2">No bank accounts</p>
-              <Link
-                href="/finance/banking"
-                className="text-[10px] text-[var(--dpf-accent)] hover:underline"
-              >
+        {bankAccounts.length === 0 ? (
+          <StatCard
+            label="Cash Position"
+            value="No accounts"
+            intent="neutral"
+            hint={
+              <Link href="/finance/banking" className="text-[var(--dpf-accent)] hover:underline">
                 Add one →
               </Link>
-            </div>
-          ) : (
-            <>
-              <p
-                className="text-2xl font-bold"
-                style={{ color: totalCash >= 0 ? POSITIVE_COLOUR : ATTENTION_COLOUR }}
-              >
-                {sym}{formatMoney(totalCash)}
-              </p>
-              <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-                across {bankAccounts.length} account{bankAccounts.length !== 1 ? "s" : ""}
-              </p>
-            </>
-          )}
-        </div>
-
-        {/* Widget 2: 30-Day Cash Flow Forecast */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            30-Day Forecast
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: forecastBalance >= totalCash ? POSITIVE_COLOUR : ATTENTION_COLOUR }}
-          >
-            {sym}{formatMoney(forecastBalance)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-            +{sym}{formatMoney(inflowsIn30)} in · -{sym}{formatMoney(outflowsIn30)} out
-          </p>
-        </div>
-
-        {/* Widget 3: Outstanding Invoices */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Money Owed To You
-          </p>
-          <p className="text-2xl font-bold text-[var(--dpf-text)]">
-            {sym}{formatMoney(owedAmount)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-            {owedCount} invoice{owedCount !== 1 ? "s" : ""} outstanding
-          </p>
-        </div>
-
-        {/* Widget 4: Overdue */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Overdue
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: overdueCount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
-          >
-            {overdueCount}
-          </p>
-          {overdueCount > 0 && oldestOverdue ? (
-            <p className="text-[10px] text-[var(--dpf-muted)] mt-1 truncate">
-              Oldest:{" "}
-              <span className="text-[var(--dpf-text)]">{oldestOverdue.account.name}</span>
-            </p>
-          ) : (
-            <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-              All up to date
-            </p>
-          )}
-        </div>
+            }
+          />
+        ) : (
+          <StatCard
+            label="Cash Position"
+            value={`${sym}${formatMoney(totalCash)}`}
+            intent={totalCash >= 0 ? "success" : "danger"}
+            hint={`across ${bankAccounts.length} account${bankAccounts.length !== 1 ? "s" : ""}`}
+          />
+        )}
+        <StatCard
+          label="30-Day Forecast"
+          value={`${sym}${formatMoney(forecastBalance)}`}
+          intent={forecastBalance >= totalCash ? "success" : "danger"}
+          hint={`+${sym}${formatMoney(inflowsIn30)} in · -${sym}${formatMoney(outflowsIn30)} out`}
+        />
+        <StatCard
+          label="Money Owed To You"
+          value={`${sym}${formatMoney(owedAmount)}`}
+          hint={`${owedCount} invoice${owedCount !== 1 ? "s" : ""} outstanding`}
+        />
+        <StatCard
+          label="Overdue"
+          value={overdueCount}
+          intent={overdueCount > 0 ? "danger" : "success"}
+          hint={
+            overdueCount > 0 && oldestOverdue ? (
+              <>Oldest: <span className="text-[var(--dpf-text)]">{oldestOverdue.account.name}</span></>
+            ) : (
+              "All up to date"
+            )
+          }
+        />
       </div>
 
       {/* Row 2: Money In + Money You Owe + Active Recurring + Overdue >30 days */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        {/* Money In This Month */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Money In This Month
-          </p>
-          <p className="text-2xl font-bold text-[var(--dpf-text)]">
-            {sym}{formatMoney(paidAmount)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-            {paidCount} invoice{paidCount !== 1 ? "s" : ""} paid
-          </p>
-        </div>
-
-        {/* Money You Owe */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Money You Owe
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: moneyOweAmount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
-          >
-            {sym}{formatMoney(moneyOweAmount)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-            {moneyOweCount} bill{moneyOweCount !== 1 ? "s" : ""} awaiting payment
-          </p>
-        </div>
-
-        {/* Active Recurring */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Active Recurring
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: activeRecurringCount > 0 ? POSITIVE_COLOUR : MUTED_COLOUR }}
-          >
-            {activeRecurringCount}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
+        <StatCard
+          label="Money In This Month"
+          value={`${sym}${formatMoney(paidAmount)}`}
+          hint={`${paidCount} invoice${paidCount !== 1 ? "s" : ""} paid`}
+        />
+        <StatCard
+          label="Money You Owe"
+          value={`${sym}${formatMoney(moneyOweAmount)}`}
+          intent={moneyOweAmount > 0 ? "danger" : "success"}
+          hint={`${moneyOweCount} bill${moneyOweCount !== 1 ? "s" : ""} awaiting payment`}
+        />
+        <StatCard
+          label="Active Recurring"
+          value={activeRecurringCount}
+          intent={activeRecurringCount > 0 ? "success" : "neutral"}
+          hint={
             <Link href="/finance/recurring" className="hover:underline">
               schedule{activeRecurringCount !== 1 ? "s" : ""} running →
             </Link>
-          </p>
-        </div>
-
-        {/* Overdue > 30 days */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Overdue &gt; 30 Days
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: overdueGt30Amount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
-          >
-            {sym}{formatMoney(overdueGt30Amount)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
+          }
+        />
+        <StatCard
+          label="Overdue > 30 Days"
+          value={`${sym}${formatMoney(overdueGt30Amount)}`}
+          intent={overdueGt30Amount > 0 ? "danger" : "success"}
+          hint={
             <Link href="/finance/reports/aged-debtors" className="hover:underline">
               view aged debtors →
             </Link>
-          </p>
-        </div>
+          }
+        />
       </div>
 
       {/* Row 3: People + Asset widgets */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        {/* Pending Expenses */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Pending Expenses
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: pendingExpenseCount > 0 ? "var(--dpf-accent)" : POSITIVE_COLOUR }}
-          >
-            {pendingExpenseCount}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
+        <StatCard
+          label="Pending Expenses"
+          value={pendingExpenseCount}
+          intent={pendingExpenseCount > 0 ? "accent" : "success"}
+          hint={
             <Link href="/finance/expense-claims?status=submitted" className="hover:underline">
               claim{pendingExpenseCount !== 1 ? "s" : ""} awaiting approval →
             </Link>
-          </p>
-        </div>
-
-        {/* Total Asset Value */}
-        <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-2">
-            Total Asset Value
-          </p>
-          <p
-            className="text-2xl font-bold"
-            style={{ color: totalAssetValue > 0 ? POSITIVE_COLOUR : MUTED_COLOUR }}
-          >
-            {sym}{formatMoney(totalAssetValue)}
-          </p>
-          <p className="text-[10px] text-[var(--dpf-muted)] mt-1">
-            {activeAssets.length} asset{activeAssets.length !== 1 ? "s" : ""} across{" "}
-            {assetCategoryCount} categor{assetCategoryCount !== 1 ? "ies" : "y"} ·{" "}
-            <Link href="/finance/assets" className="hover:underline">
-              view register →
-            </Link>
-          </p>
-        </div>
+          }
+        />
+        <StatCard
+          label="Total Asset Value"
+          value={`${sym}${formatMoney(totalAssetValue)}`}
+          intent={totalAssetValue > 0 ? "success" : "neutral"}
+          hint={
+            <>
+              {activeAssets.length} asset{activeAssets.length !== 1 ? "s" : ""} across{" "}
+              {assetCategoryCount} categor{assetCategoryCount !== 1 ? "ies" : "y"} ·{" "}
+              <Link href="/finance/assets" className="hover:underline">
+                view register →
+              </Link>
+            </>
+          }
+        />
       </div>
 
       {/* Navigation links */}
@@ -628,68 +538,7 @@ export default async function FinancePage() {
             No invoices yet. Create your first invoice to get started.
           </p>
         ) : (
-          <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-[var(--dpf-border)]">
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Ref
-                  </th>
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Account
-                  </th>
-                  <th className="text-left text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Status
-                  </th>
-                  <th className="text-right text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] px-4 py-2 font-normal">
-                    Amount
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {recentInvoices.map((inv) => {
-                  const colour = STATUS_COLOURS[inv.status] ?? MUTED_COLOUR;
-                  return (
-                    <tr
-                      key={inv.id}
-                      className="border-b border-[var(--dpf-border)] last:border-0 hover:bg-[var(--dpf-surface-1)] transition-colors"
-                    >
-                      <td className="px-4 py-2.5">
-                        <Link
-                          href={`/finance/invoices/${inv.id}`}
-                          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-                        >
-                          {inv.invoiceRef}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <Link
-                          href={`/finance/invoices/${inv.id}`}
-                          className="text-[var(--dpf-text)] hover:underline"
-                        >
-                          {inv.account.name}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <span
-                          className="text-[9px] px-1.5 py-0.5 rounded-full"
-                          style={{
-                            color: colour,
-                            backgroundColor: `color-mix(in srgb, ${colour} 16%, transparent)`,
-                          }}
-                        >
-                          {inv.status.replace("_", " ")}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">
-                        {sym}{formatMoney(Number(inv.totalAmount))}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          <RecentInvoicesTable rows={recentInvoiceRows} currencySymbol={sym} />
         )}
       </section>
     </div>

--- a/apps/web/components/ui/report-kit/StatCard.tsx
+++ b/apps/web/components/ui/report-kit/StatCard.tsx
@@ -19,7 +19,7 @@ export interface StatDelta {
 export interface StatCardProps {
   label: string;
   value: React.ReactNode;
-  hint?: string;
+  hint?: React.ReactNode;
   /** Colors the left accent border (and is the default delta basis). */
   intent?: Intent;
   delta?: StatDelta;


### PR DESCRIPTION
## What

Converts the finance hub to report-kit (your requested target: 12 KPI cards → StatCard).

- **10 KPI metric cards** (3 grid rows: cash, forecast, receivables, overdue, payables, recurring, expenses, assets…) → **`StatCard`** with intent-mapped accents (e.g. overdue/owed flip to danger when non-zero).
- **Recent Invoices table** → **`DataTable`** wrapper (`RecentInvoicesTable`) with finance-registry **`StatusBadge`**.
- Drops the page-local `STATUS_COLOURS` / `POSITIVE_COLOUR` / `ATTENTION_COLOUR` / `MUTED_COLOUR` constants — colors now flow through the intent model.

**Adoption-driven primitive tweak:** `StatCard.hint` widened `string` → `ReactNode` (non-breaking) so cards can carry link hints ("view aged debtors →", etc.).

Untouched: `FinanceSummaryCard` (the 4 section cards), the nav-link card grid, and the accountant work-lane panel.

## Verification

- `npx vitest run app/(shell)/finance/RecentInvoicesTable components/ui/report-kit/StatCard` → **8 passed**
- `tsc --noEmit` clean; no raw hex, no leftover color-constant refs

Phase 2/3 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)