### PR TITLE
fix(email): stop faking send-success in prod + real expense item count (BI-390C0967, BI-C2E2F8D9)

### DIFF
--- a/apps/web/lib/actions/expenses.test.ts
+++ b/apps/web/lib/actions/expenses.test.ts
@@ -211,6 +211,7 @@ describe("submitExpenseClaim", () => {
       currency: "USD",
       totalAmount: 77.5,
       employee: { id: "emp-001", displayName: "Alice Smith", workEmail: "alice@example.com", userId: "user-001" },
+      _count: { items: 2 },
     });
     mockPrisma.user.findMany.mockResolvedValue([{ id: "mgr-001", email: "mgr@example.com" }]);
     mockPrisma.expenseClaim.update.mockResolvedValue({});

--- a/apps/web/lib/actions/expenses.ts
+++ b/apps/web/lib/actions/expenses.ts
@@ -153,6 +153,7 @@ export async function submitExpenseClaim(id: string): Promise<void> {
     where: { id },
     include: {
       employee: { select: { id: true, displayName: true, workEmail: true, userId: true } },
+      _count: { select: { items: true } },
     },
   });
   if (!claim) throw new Error("Expense claim not found");
@@ -208,7 +209,7 @@ export async function submitExpenseClaim(id: string): Promise<void> {
       title: claim.title,
       totalAmount: Number(claim.totalAmount).toFixed(2),
       currency: claim.currency,
-      itemCount: 0, // items count will be fetched separately if needed
+      itemCount: claim._count.items,
       approveUrl,
     });
     await sendEmail(emailPayload);

--- a/apps/web/lib/shared/email.test.ts
+++ b/apps/web/lib/shared/email.test.ts
@@ -57,4 +57,31 @@ describe("sendEmail", () => {
     delete process.env.SMTP_HOST;
     expect(result.messageId).toBe("test-123");
   });
+
+  it("throws in production when SMTP is unconfigured (no fake success)", async () => {
+    const savedHost = process.env.SMTP_HOST;
+    delete process.env.SMTP_HOST;
+    vi.stubEnv("NODE_ENV", "production");
+
+    await expect(
+      sendEmail({ to: "x@example.com", subject: "S", text: "t", html: "<p>t</p>" }),
+    ).rejects.toThrow(/SMTP is not configured/);
+
+    vi.unstubAllEnvs();
+    if (savedHost === undefined) delete process.env.SMTP_HOST;
+    else process.env.SMTP_HOST = savedHost;
+  });
+
+  it("logs and returns a dev messageId when SMTP is unconfigured outside production", async () => {
+    const savedHost = process.env.SMTP_HOST;
+    delete process.env.SMTP_HOST;
+    vi.stubEnv("NODE_ENV", "test");
+
+    const result = await sendEmail({ to: "x@example.com", subject: "S", text: "t", html: "<p>t</p>" });
+    expect(result.messageId).toMatch(/^dev-/);
+
+    vi.unstubAllEnvs();
+    if (savedHost === undefined) delete process.env.SMTP_HOST;
+    else process.env.SMTP_HOST = savedHost;
+  });
 });

--- a/apps/web/lib/shared/email.ts
+++ b/apps/web/lib/shared/email.ts
@@ -302,9 +302,17 @@ export async function sendEmail(options: EmailOptions): Promise<{ messageId: str
   const pass = process.env.SMTP_PASS;
   const from = process.env.SMTP_FROM || "noreply@example.com";
 
-  // In dev without SMTP config, log to console
+  // Without SMTP config: in production this is a hard failure — returning a
+  // fake success would let callers record an email as "sent" that never went
+  // out (silently dropping invoices, dunning, approvals). Only the dev path
+  // may log-and-continue.
   if (!host) {
-    console.log("[email] No SMTP configured. Would send:", {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "[email] SMTP is not configured (SMTP_HOST unset); refusing to report a fake send in production",
+      );
+    }
+    console.log("[email] No SMTP configured (dev). Would send:", {
       to: options.to,
       subject: options.subject,
       attachments: options.attachments?.map((a) => a.filename),


### PR DESCRIPTION
## What & why

Two communications findings from the Ship Real Functionality audit (epic **EP-SHIP-REAL-AUDIT**):

**BI-390C0967 — `sendEmail` faked delivery success (operator-misleading).** `apps/web/lib/shared/email.ts` returned a fabricated `{ messageId: dev-${Date.now()} }` whenever `SMTP_HOST` was unset, with no production guard. Callers treat the return as success — dunning writes a `DunningLog`, invoices flip to `"sent"`, send routes return `{sent:true}`. A misconfigured **production** install therefore silently drops every invoice/dunning/approval email while recording them as delivered.
- Fix: in `NODE_ENV==='production'`, `sendEmail` now **throws** when SMTP is unconfigured so callers surface a real failure instead of recording a phantom send. The log-and-continue path is dev-only.

**BI-C2E2F8D9 — expense approval email always said "0 items" (fabricated metric).** `expenses.ts` passed `itemCount: 0` with a "fetched separately if needed" comment that never happened.
- Fix: `submitExpenseClaim` now includes `_count: { items: true }` and passes the real `claim._count.items`.

## Verification
- `email.test.ts`: new cases — throws in production when SMTP unconfigured; logs + returns a `dev-` id outside production. `expenses.test.ts`: submit test now carries a real item count.
- 22/22 in the two suites pass; `tsc --noEmit` clean.

## Not in this PR (filed separately under the epic)
- BI-1546B81B — org brand identity in emails (from `noreply@example.com`, subject "your provider", localhost links).
- BI-DDE6FE27 — invoice PDF omits issuer identity (company/VAT/bank/logo).
- BI-9B96BC01 — customer password reset is non-functional (returns success, sends nothing).
These need a shared org-identity resolver / the EP-NOTIFY-001 reset flow and are larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)