### PR TITLE
refactor(web): adopt report-kit DataTable for the cockpit transmissions log (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.test.tsx
+++ b/apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CockpitEventsTable, type CockpitEventRow } from "./CockpitEventsTable";
+
+const ROWS: CockpitEventRow[] = [
+  {
+    id: "ev-1",
+    recordedAtISO: "2026-03-28T14:30:00.000Z",
+    interfaceLabel: "Ring 1 → 2",
+    capabilityLabel: "Plan refinement",
+    capabilityName: "plan.refine",
+    sourceLabel: "Build Studio phase",
+    shaftSourceId: "fb-123",
+    actorLabel: "Coworker A",
+    actorId: "agent-a",
+    torqueTechnical: 0.95,
+    outcomeLabel: "engaged",
+    slipDetected: false,
+    graderType: "rubric",
+  },
+  {
+    id: "ev-2",
+    recordedAtISO: "2026-03-28T14:00:00.000Z",
+    interfaceLabel: "Ring 1 → 2",
+    capabilityLabel: "Code gen",
+    capabilityName: "code.gen",
+    sourceLabel: "Build Studio phase",
+    shaftSourceId: "fb-124",
+    actorLabel: "Coworker B",
+    actorId: "agent-b",
+    torqueTechnical: 0.3,
+    outcomeLabel: "slipped",
+    slipDetected: true,
+    graderType: "rubric",
+  },
+];
+
+describe("CockpitEventsTable (report-kit migration)", () => {
+  const html = renderToStaticMarkup(<CockpitEventsTable rows={ROWS} />);
+
+  it("renders the pre-resolved terminology labels", () => {
+    expect(html).toContain("Plan refinement");
+    expect(html).toContain("Coworker B");
+    expect(html).toContain("unknown source route: fb-123");
+  });
+
+  it("colors torque via the token-backed torqueColor (no raw hex)", () => {
+    expect(html).toContain("var(--dpf-success)"); // 0.95
+    expect(html).toContain("var(--dpf-error)"); // 0.3
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("flags slipped outcomes with the error token", () => {
+    expect(html).toContain("slipped");
+  });
+});

--- a/apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.tsx
+++ b/apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.tsx
@@ -1,0 +1,119 @@
+// apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.tsx
+//
+// Client wrapper rendering the report-kit DataTable for the cockpit "Recent
+// transmissions" evidence log — the one cockpit panel that benefits from sort
+// (by torque / time) + pagination. The page (server component) pre-resolves the
+// install-terminology labels and serializes flat rows; the bespoke gear
+// diagnostic panels above remain hand-built per the cockpit spec (§5.4).
+
+"use client";
+
+import { DataTable, type Column } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { formatTorque, torqueColor } from "@/lib/cockpit/cockpit-formatting";
+
+export interface CockpitEventRow {
+  id: string;
+  recordedAtISO: string;
+  interfaceLabel: string;
+  capabilityLabel: string;
+  capabilityName: string;
+  sourceLabel: string;
+  shaftSourceId: string;
+  actorLabel: string;
+  actorId: string;
+  torqueTechnical: number;
+  outcomeLabel: string;
+  slipDetected: boolean;
+  graderType: string;
+}
+
+const COLUMNS: Column<CockpitEventRow>[] = [
+  {
+    key: "when",
+    header: "When",
+    width: "72px",
+    cell: (r) => (
+      <span className="text-[var(--dpf-muted)] whitespace-nowrap">
+        <LocalTime value={r.recordedAtISO} mode="time" />
+      </span>
+    ),
+    sortAccessor: (r) => r.recordedAtISO,
+  },
+  {
+    key: "ring",
+    header: "Ring",
+    width: "210px",
+    cell: (r) => <span className="block truncate" title={r.interfaceLabel}>{r.interfaceLabel}</span>,
+  },
+  {
+    key: "capability",
+    header: "Capability",
+    width: "230px",
+    cell: (r) => <span className="block truncate" title={r.capabilityName}>{r.capabilityLabel}</span>,
+    sortAccessor: (r) => r.capabilityLabel,
+  },
+  {
+    key: "source",
+    header: "Source",
+    width: "220px",
+    cell: (r) => (
+      <div className="text-[var(--dpf-muted)]" title={r.shaftSourceId}>
+        <div className="truncate">{r.sourceLabel}</div>
+        <div className="text-[10px] truncate">unknown source route: {r.shaftSourceId}</div>
+      </div>
+    ),
+  },
+  {
+    key: "actor",
+    header: "Actor",
+    width: "150px",
+    cell: (r) => <span className="block truncate" title={r.actorId}>{r.actorLabel}</span>,
+  },
+  {
+    key: "torque",
+    header: "Torque",
+    width: "82px",
+    align: "right",
+    cell: (r) => (
+      <span className="font-semibold" style={{ color: torqueColor(r.torqueTechnical) }}>
+        {formatTorque(r.torqueTechnical)}
+      </span>
+    ),
+    sortAccessor: (r) => r.torqueTechnical,
+  },
+  {
+    key: "outcome",
+    header: "Outcome",
+    width: "130px",
+    cell: (r) =>
+      r.slipDetected ? (
+        <span style={{ color: "var(--dpf-error)" }}>{r.outcomeLabel}</span>
+      ) : (
+        <span>{r.outcomeLabel}</span>
+      ),
+  },
+  {
+    key: "grader",
+    header: "Grader",
+    width: "90px",
+    cell: (r) => <span className="text-[var(--dpf-muted)]">{r.graderType}</span>,
+  },
+];
+
+export function CockpitEventsTable({ rows }: { rows: CockpitEventRow[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <DataTable
+        className="min-w-[1120px]"
+        columns={COLUMNS}
+        rows={rows}
+        getRowKey={(r) => r.id}
+        initialSort={{ key: "when", dir: "desc" }}
+        pageSize={25}
+        dense
+        empty="No GearInterface records in the window."
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/admin/cockpit/page.tsx
+++ b/apps/web/app/(shell)/admin/cockpit/page.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/lib/cockpit/install-terminology";
 import { GraduationVetoButton } from "@/components/cockpit/GraduationVetoButton";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { CockpitEventsTable, type CockpitEventRow } from "./CockpitEventsTable";
 
 // All four ring interfaces. Phase 0 only emits at 1→2; the others render as
 // "no data" lanes so the operator sees the gear train honestly, not hidden.
@@ -92,6 +93,42 @@ export default async function CockpitPage({
   const activeInterfaceLabel = activeRing
     ? getCockpitInterfaceLabel(activeRing.innerRing, activeRing.outerRing, terminology)
     : null;
+
+  // Pre-resolve install-terminology labels server-side into flat, serializable
+  // rows for the client DataTable (the recent-transmissions log).
+  const eventRows: CockpitEventRow[] = recentRows.map((row) => {
+    const labels = resolveCockpitRowLabels(
+      {
+        innerRing: row.innerRing,
+        outerRing: row.outerRing,
+        transmissionDirection: row.transmissionDirection,
+        agentIdForTriple: row.actorId,
+        actorId: row.actorId,
+        capabilityName: row.capabilityName,
+        archetypeContext: row.archetypeContext,
+        shaftSourceType: row.shaftSourceType,
+        outcomeType: row.outcomeType,
+        slipDetected: row.slipDetected,
+        slipReason: row.slipReason,
+      },
+      terminology,
+    );
+    return {
+      id: row.id,
+      recordedAtISO: new Date(row.recordedAt).toISOString(),
+      interfaceLabel: labels.interfaceLabel,
+      capabilityLabel: labels.capabilityLabel,
+      capabilityName: row.capabilityName,
+      sourceLabel: labels.sourceLabel,
+      shaftSourceId: row.shaftSourceId,
+      actorLabel: labels.actorLabel,
+      actorId: row.actorId,
+      torqueTechnical: row.torqueTechnical,
+      outcomeLabel: labels.outcomeLabel,
+      slipDetected: row.slipDetected,
+      graderType: row.graderType,
+    };
+  });
 
   return (
     <div className="p-6 space-y-6">
@@ -442,73 +479,7 @@ export default async function CockpitPage({
               : "No GearInterface records in the window. Trigger a Build Studio phase completion to produce the first Ring 1→2 emit, or expand the window."}
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-[1120px] w-full table-fixed text-xs">
-              <thead className="text-[var(--dpf-muted)] text-left">
-                <tr>
-                  <th className="w-[72px] pb-1 pr-3 font-medium">When</th>
-                  <th className="w-[210px] px-3 pb-1 font-medium">Ring</th>
-                  <th className="w-[230px] px-3 pb-1 font-medium">Capability</th>
-                  <th className="w-[220px] px-3 pb-1 font-medium">Source</th>
-                  <th className="w-[150px] px-3 pb-1 font-medium">Actor</th>
-                  <th className="w-[82px] px-3 pb-1 text-right font-medium">Torque</th>
-                  <th className="w-[130px] px-3 pb-1 font-medium">Outcome</th>
-                  <th className="w-[90px] pl-3 pb-1 font-medium">Grader</th>
-                </tr>
-              </thead>
-              <tbody className="text-[var(--dpf-text)]">
-                {recentRows.map((row) => {
-                  const labels = resolveCockpitRowLabels(
-                    {
-                      innerRing: row.innerRing,
-                      outerRing: row.outerRing,
-                      transmissionDirection: row.transmissionDirection,
-                      agentIdForTriple: row.actorId,
-                      actorId: row.actorId,
-                      capabilityName: row.capabilityName,
-                      archetypeContext: row.archetypeContext,
-                      shaftSourceType: row.shaftSourceType,
-                      outcomeType: row.outcomeType,
-                      slipDetected: row.slipDetected,
-                      slipReason: row.slipReason,
-                    },
-                    terminology,
-                  );
-                  return (
-                    <tr key={row.id} className="border-t" style={{ borderColor: "var(--dpf-border)" }}>
-                      <td className="py-1.5 pr-3 text-[var(--dpf-muted)] whitespace-nowrap">
-                        <LocalTime value={row.recordedAt} mode="time" />
-                      </td>
-                      <td className="px-3 py-1.5 truncate" title={labels.interfaceLabel}>
-                        {labels.interfaceLabel}
-                      </td>
-                      <td className="px-3 py-1.5 truncate" title={row.capabilityName}>
-                        {labels.capabilityLabel}
-                      </td>
-                      <td className="px-3 py-1.5 text-[var(--dpf-muted)]" title={row.shaftSourceId}>
-                        <div className="truncate">{labels.sourceLabel}</div>
-                        <div className="text-[10px] truncate">unknown source route: {row.shaftSourceId}</div>
-                      </td>
-                      <td className="px-3 py-1.5 truncate" title={row.actorId}>
-                        {labels.actorLabel}
-                      </td>
-                      <td className="px-3 py-1.5 text-right font-semibold" style={{ color: torqueColor(row.torqueTechnical) }}>
-                        {formatTorque(row.torqueTechnical)}
-                      </td>
-                      <td className="px-3 py-1.5">
-                        {row.slipDetected ? (
-                          <span style={{ color: "var(--dpf-error)" }}>{labels.outcomeLabel}</span>
-                        ) : (
-                          labels.outcomeLabel
-                        )}
-                      </td>
-                      <td className="py-1.5 pl-3 text-[var(--dpf-muted)]">{row.graderType}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          <CockpitEventsTable rows={eventRows} />
         )}
       </section>
 


### PR DESCRIPTION
## What

A **scoped, judgment-based** adoption of report-kit on admin/cockpit.

After reading the full surface: admin/cockpit is a **deliberately spec-designed dense ops surface** (reduction-gear cockpit §5.4 — "DPF tokens only, no nested cards, every number clickable") with **no token violations**. Forcing the generic palette onto its bespoke gear-diagnostic panels would *degrade* a purpose-built surface, so the **ring interfaces, slip-by-reason, triple-wear, and graduations panels are intentionally left as-is.**

The one panel with genuine palette value is the **50-row "Recent transmissions" evidence log** → migrated to **`DataTable`**, which adds:
- **sort by torque** (surface worst performers) and by time
- **pagination** (25/page)

Preserved exactly: `torqueColor` + slip-detected outcome coloring (via cell render fns), the multi-line source cell, and the page's filter-aware honest empty states. Install-terminology labels are **pre-resolved server-side** into flat serializable rows (`CockpitEventsTable` client wrapper), since they depend on a server-fetched terminology object.

## Verification

- `npx vitest run app/(shell)/admin/cockpit` → **3 passed** (labels, token torque colors / no hex, slip flagging)
- `tsc --noEmit` clean

## Note for reviewers

This PR is intentionally **partial** — it documents (in the wrapper header + commit) why the gear panels remain bespoke. That's the honest call: adopt the palette where it adds value, respect a spec-designed surface where it doesn't.

Phase 2 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691 (Epic EP-2b79c5c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)