### PR TITLE
fix(finance): real org issuer identity on invoice PDF + email (BI-DDE6FE27, BI-1546B81B)

### DIFF
--- a/apps/web/app/api/v1/finance/invoices/[id]/pdf/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/pdf/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { authenticateRequest } from "@/lib/api/auth-middleware";
 import { ApiError, apiError } from "@/lib/api/error";
 import { getInvoice } from "@/lib/actions/finance";
+import { getOrgIdentity } from "@/lib/org-identity";
 import { generateInvoicePdf, getInvoicePdfFilename } from "@/lib/invoice-pdf";
 
 export async function GET(
@@ -16,7 +17,8 @@ export async function GET(
     const invoice = await getInvoice(id);
     if (!invoice) throw apiError("NOT_FOUND", "Invoice not found", 404);
 
-    const pdfBuffer = await generateInvoicePdf(invoice);
+    const issuer = await getOrgIdentity();
+    const pdfBuffer = await generateInvoicePdf({ ...invoice, issuer });
     const filename = getInvoicePdfFilename(invoice.invoiceRef, invoice.account.name);
 
     return new Response(new Uint8Array(pdfBuffer), {

--- a/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
@@ -5,6 +5,7 @@ import { authenticateRequest } from "@/lib/api/auth-middleware";
 import { ApiError, apiError } from "@/lib/api/error";
 import { apiSuccess } from "@/lib/api/response";
 import { getInvoice, sendInvoice } from "@/lib/actions/finance";
+import { getOrgIdentity } from "@/lib/org-identity";
 import { generateInvoicePdf, getInvoicePdfFilename } from "@/lib/invoice-pdf";
 import { sendEmail, composeInvoiceEmail } from "@/lib/email";
 
@@ -28,13 +29,15 @@ export async function POST(
       "http://localhost:3000";
     const payUrl = `${baseUrl}/s/pay/${payToken}`;
 
-    const pdf = await generateInvoicePdf(invoice);
+    const issuer = await getOrgIdentity();
+    const pdf = await generateInvoicePdf({ ...invoice, issuer });
     const filename = getInvoicePdfFilename(invoice.invoiceRef, invoice.account.name);
 
     const email = composeInvoiceEmail({
       to: invoice.contact.email,
       invoiceRef: invoice.invoiceRef,
       accountName: invoice.account.name,
+      orgName: issuer?.name ?? null,
       totalAmount: Number(invoice.totalAmount).toLocaleString("en-GB", {
         minimumFractionDigits: 2,
       }),
@@ -49,6 +52,7 @@ export async function POST(
 
     await sendEmail({
       ...email,
+      from: issuer?.email ? `${issuer.name} <${issuer.email}>` : undefined,
       attachments: [{ filename, content: pdf, contentType: "application/pdf" }],
     });
 

--- a/apps/web/lib/invoice-pdf.test.ts
+++ b/apps/web/lib/invoice-pdf.test.ts
@@ -39,6 +39,22 @@ describe("generateInvoicePdf", () => {
     const header = result.subarray(0, 5).toString("ascii");
     expect(header).toBe("%PDF-");
   });
+
+  it("generates a valid PDF when an issuer (org identity) is supplied", async () => {
+    const withIssuer = {
+      ...mockInvoice,
+      issuer: {
+        name: "Acme Trading Ltd",
+        email: "billing@acme.example",
+        addressLines: ["1 High St", "London", "EC1A 1BB"],
+        vatNumber: "GB123456789",
+        bank: { bankName: "Big Bank", accountName: "Acme Current", accountNumber: "12345678", sortCode: "12-34-56", iban: null },
+      },
+    };
+    const result = await generateInvoicePdf(withIssuer as never);
+    expect(result.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+    expect(result.length).toBeGreaterThan(100);
+  });
 });
 
 describe("getInvoicePdfFilename", () => {

--- a/apps/web/lib/invoice-pdf.tsx
+++ b/apps/web/lib/invoice-pdf.tsx
@@ -1,9 +1,28 @@
 import React from "react";
 import { Document, Page, Text, View, StyleSheet, renderToBuffer } from "@react-pdf/renderer";
 
+export type InvoiceIssuer = {
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  website?: string | null;
+  addressLines?: string[];
+  vatNumber?: string | null;
+  bank?: {
+    bankName?: string | null;
+    accountName?: string | null;
+    accountNumber?: string | null;
+    sortCode?: string | null;
+    iban?: string | null;
+  } | null;
+};
+
 export type InvoiceForPdf = {
   invoiceRef: string;
   type: string;
+  // The issuing business. Optional so callers that have not yet resolved org
+  // identity still render, but the download path supplies it from live DB.
+  issuer?: InvoiceIssuer | null;
   status: string;
   issueDate: Date | string;
   dueDate: Date | string;
@@ -84,6 +103,19 @@ const styles = StyleSheet.create({
   headerMetaValue: {
     minWidth: 80,
     textAlign: "right",
+  },
+  // From (issuer)
+  fromBlock: {
+    marginBottom: 20,
+  },
+  fromName: {
+    fontFamily: "Helvetica-Bold",
+    fontSize: 12,
+    marginBottom: 2,
+  },
+  fromLine: {
+    color: "#444",
+    marginBottom: 1,
   },
   // Bill To
   sectionLabel: {
@@ -215,6 +247,17 @@ function InvoiceDocument({ invoice }: { invoice: InvoiceForPdf }) {
   const taxNum = toNum(invoice.taxAmount);
   const sortedItems = [...invoice.lineItems].sort((a, b) => a.sortOrder - b.sortOrder);
 
+  const bank = invoice.issuer?.bank;
+  const bankLines = bank
+    ? [
+        bank.bankName ? `Bank: ${bank.bankName}` : null,
+        bank.accountName ? `Account name: ${bank.accountName}` : null,
+        bank.accountNumber ? `Account number: ${bank.accountNumber}` : null,
+        bank.sortCode ? `Sort code: ${bank.sortCode}` : null,
+        bank.iban ? `IBAN: ${bank.iban}` : null,
+      ].filter((l): l is string => Boolean(l))
+    : [];
+
   return (
     <Document>
       <Page size="A4" style={styles.page}>
@@ -236,6 +279,23 @@ function InvoiceDocument({ invoice }: { invoice: InvoiceForPdf }) {
             </View>
           </View>
         </View>
+
+        {/* From (issuer identity) */}
+        {invoice.issuer ? (
+          <View style={styles.fromBlock}>
+            <Text style={styles.sectionLabel}>From</Text>
+            <Text style={styles.fromName}>{invoice.issuer.name}</Text>
+            {(invoice.issuer.addressLines ?? []).map((line, i) => (
+              <Text key={i} style={styles.fromLine}>{line}</Text>
+            ))}
+            {invoice.issuer.email ? <Text style={styles.fromLine}>{invoice.issuer.email}</Text> : null}
+            {invoice.issuer.phone ? <Text style={styles.fromLine}>{invoice.issuer.phone}</Text> : null}
+            {invoice.issuer.website ? <Text style={styles.fromLine}>{invoice.issuer.website}</Text> : null}
+            {invoice.issuer.vatNumber ? (
+              <Text style={styles.fromLine}>VAT No: {invoice.issuer.vatNumber}</Text>
+            ) : null}
+          </View>
+        ) : null}
 
         {/* Bill To */}
         <View style={styles.billToBlock}>
@@ -325,13 +385,21 @@ function InvoiceDocument({ invoice }: { invoice: InvoiceForPdf }) {
           </View>
         </View>
 
-        {/* Footer: Payment Terms + Notes */}
-        {(invoice.paymentTerms || invoice.notes) ? (
+        {/* Footer: Payment Terms + Bank Details + Notes */}
+        {(invoice.paymentTerms || invoice.notes || bankLines.length > 0) ? (
           <View style={styles.footer}>
             {invoice.paymentTerms ? (
               <>
                 <Text style={styles.footerLabel}>PAYMENT TERMS</Text>
                 <Text style={styles.footerText}>{invoice.paymentTerms}</Text>
+              </>
+            ) : null}
+            {bankLines.length > 0 ? (
+              <>
+                <Text style={styles.footerLabel}>BANK DETAILS</Text>
+                {bankLines.map((line, i) => (
+                  <Text key={i} style={styles.footerText}>{line}</Text>
+                ))}
               </>
             ) : null}
             {invoice.notes ? (

--- a/apps/web/lib/org-identity.test.ts
+++ b/apps/web/lib/org-identity.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    organization: { findFirst: vi.fn() },
+    bankAccount: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+import { getOrgIdentity } from "./org-identity";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getOrgIdentity", () => {
+  it("returns null when no Organization exists", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue(null);
+    expect(await getOrgIdentity()).toBeNull();
+    expect(mockPrisma.bankAccount.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("maps org fields, prefers legalName, formats address, and resolves VAT + bank", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue({
+      name: "Acme Trading",
+      legalName: "Acme Trading Ltd",
+      email: "hello@acme.example",
+      phone: "+44 20 7946 0000",
+      website: "https://acme.example",
+      address: { line1: "1 High St", city: "London", postalCode: "EC1A 1BB", country: "UK" },
+      logoUrl: "https://acme.example/logo.png",
+      taxProfile: {
+        registrations: [
+          { taxType: "income", registrationNumber: "INC-1", registrationStatus: "active" },
+          { taxType: "VAT", registrationNumber: "GB123456789", registrationStatus: "active" },
+        ],
+      },
+    });
+    mockPrisma.bankAccount.findFirst.mockResolvedValue({
+      name: "Acme Current",
+      bankName: "Big Bank",
+      accountNumber: "12345678",
+      sortCode: "12-34-56",
+      iban: "GB00BIGB12345678",
+    });
+
+    const id = await getOrgIdentity();
+
+    expect(id?.name).toBe("Acme Trading Ltd"); // legalName preferred
+    expect(id?.email).toBe("hello@acme.example");
+    expect(id?.addressLines).toEqual(["1 High St", "London", "EC1A 1BB", "UK"]);
+    expect(id?.vatNumber).toBe("GB123456789"); // VAT registration chosen over income
+    expect(id?.bank).toEqual({
+      bankName: "Big Bank",
+      accountName: "Acme Current",
+      accountNumber: "12345678",
+      sortCode: "12-34-56",
+      iban: "GB00BIGB12345678",
+    });
+  });
+
+  it("falls back to name and leaves fields null when data is absent", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue({
+      name: "Solo Co",
+      legalName: null,
+      email: null,
+      phone: null,
+      website: null,
+      address: null,
+      logoUrl: null,
+      taxProfile: null,
+    });
+    mockPrisma.bankAccount.findFirst.mockResolvedValue(null);
+
+    const id = await getOrgIdentity();
+    expect(id?.name).toBe("Solo Co");
+    expect(id?.vatNumber).toBeNull();
+    expect(id?.bank).toBeNull();
+    expect(id?.addressLines).toEqual([]);
+  });
+
+  it("ignores draft registrations without a number", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue({
+      name: "Co", legalName: null, email: null, phone: null, website: null, address: null, logoUrl: null,
+      taxProfile: { registrations: [{ taxType: "VAT", registrationNumber: null, registrationStatus: "draft" }] },
+    });
+    mockPrisma.bankAccount.findFirst.mockResolvedValue(null);
+    const id = await getOrgIdentity();
+    expect(id?.vatNumber).toBeNull();
+  });
+});

--- a/apps/web/lib/org-identity.ts
+++ b/apps/web/lib/org-identity.ts
@@ -1,0 +1,117 @@
+import { prisma } from "@dpf/db";
+
+// Shared resolver for the install's own business identity — the issuer behind
+// invoices, emails, and other outbound artifacts. Sourced from live DB
+// (Organization + tax registration + bank account), never a hardcoded
+// "Acme"/"your provider"/example.com placeholder.
+
+export type OrgBankDetails = {
+  bankName: string | null;
+  accountName: string | null;
+  accountNumber: string | null;
+  sortCode: string | null;
+  iban: string | null;
+};
+
+export type OrgIdentity = {
+  name: string;
+  email: string | null;
+  phone: string | null;
+  website: string | null;
+  addressLines: string[];
+  logoUrl: string | null;
+  vatNumber: string | null;
+  bank: OrgBankDetails | null;
+};
+
+const ADDRESS_KEYS = [
+  "line1",
+  "line2",
+  "street",
+  "city",
+  "region",
+  "state",
+  "county",
+  "postalCode",
+  "postcode",
+  "zip",
+  "country",
+];
+
+function formatAddress(address: unknown): string[] {
+  if (!address || typeof address !== "object") return [];
+  const a = address as Record<string, unknown>;
+  const lines: string[] = [];
+  const seen = new Set<string>();
+  for (const key of ADDRESS_KEYS) {
+    const v = a[key];
+    if (typeof v === "string") {
+      const t = v.trim();
+      if (t && !seen.has(t)) {
+        seen.add(t);
+        lines.push(t);
+      }
+    }
+  }
+  return lines;
+}
+
+/**
+ * Resolve the install's business identity. Returns null if no Organization
+ * record exists. Callers MUST treat null / missing fields as "unknown" rather
+ * than substituting a placeholder.
+ */
+export async function getOrgIdentity(): Promise<OrgIdentity | null> {
+  const org = await prisma.organization.findFirst({
+    select: {
+      name: true,
+      legalName: true,
+      email: true,
+      phone: true,
+      website: true,
+      address: true,
+      logoUrl: true,
+      taxProfile: {
+        select: {
+          registrations: {
+            select: { taxType: true, registrationNumber: true, registrationStatus: true },
+          },
+        },
+      },
+    },
+  });
+  if (!org) return null;
+
+  const regs = org.taxProfile?.registrations ?? [];
+  const withNumber = regs.filter((r) => r.registrationNumber && r.registrationStatus !== "draft");
+  const vat =
+    withNumber.find((r) => /vat/i.test(r.taxType)) ??
+    withNumber[0] ??
+    regs.find((r) => r.registrationNumber) ??
+    null;
+
+  const bankRow = await prisma.bankAccount.findFirst({
+    where: { status: "active" },
+    orderBy: { name: "asc" },
+    select: { name: true, bankName: true, accountNumber: true, sortCode: true, iban: true },
+  });
+
+  return {
+    name: org.legalName?.trim() || org.name,
+    email: org.email ?? null,
+    phone: org.phone ?? null,
+    website: org.website ?? null,
+    addressLines: formatAddress(org.address),
+    logoUrl: org.logoUrl ?? null,
+    vatNumber: vat?.registrationNumber ?? null,
+    bank: bankRow
+      ? {
+          bankName: bankRow.bankName ?? null,
+          accountName: bankRow.name ?? null,
+          accountNumber: bankRow.accountNumber ?? null,
+          sortCode: bankRow.sortCode ?? null,
+          iban: bankRow.iban ?? null,
+        }
+      : null,
+  };
+}

--- a/apps/web/lib/shared/email.test.ts
+++ b/apps/web/lib/shared/email.test.ts
@@ -27,6 +27,17 @@ describe("composeInvoiceEmail", () => {
     expect(result.to).toBe("jane@acme.com");
   });
 
+  it("names the issuing org in the subject when provided", () => {
+    const result = composeInvoiceEmail({ ...params, orgName: "Acme Trading Ltd" });
+    expect(result.subject).toBe("Invoice INV-2026-0001 from Acme Trading Ltd");
+  });
+
+  it("omits the issuer clause (no 'your provider' placeholder) when org is unknown", () => {
+    const result = composeInvoiceEmail(params);
+    expect(result.subject).toBe("Invoice INV-2026-0001");
+    expect(result.subject).not.toContain("your provider");
+  });
+
   it("includes pay URL in html body", () => {
     const result = composeInvoiceEmail(params);
     expect(result.html).toContain("https://example.com/s/pay/abc123");

--- a/apps/web/lib/shared/email.ts
+++ b/apps/web/lib/shared/email.ts
@@ -5,6 +5,8 @@ type EmailOptions = {
   subject: string;
   text: string;
   html: string;
+  /** Resolved sender ("Name <email>"). Falls back to SMTP_FROM when unset. */
+  from?: string;
   attachments?: Array<{
     filename: string;
     content: Buffer;
@@ -20,12 +22,15 @@ type InvoiceEmailParams = {
   currency: string;
   dueDate: string;
   payUrl: string;
+  /** Issuing business name (from live org identity). Omitted when unknown — we
+   *  never substitute a placeholder like "your provider". */
+  orgName?: string | null;
 };
 
 export function composeInvoiceEmail(params: InvoiceEmailParams) {
-  const { to, invoiceRef, accountName, totalAmount, currency, dueDate, payUrl } = params;
+  const { to, invoiceRef, accountName, totalAmount, currency, dueDate, payUrl, orgName } = params;
 
-  const subject = `Invoice ${invoiceRef} from your provider`;
+  const subject = orgName ? `Invoice ${invoiceRef} from ${orgName}` : `Invoice ${invoiceRef}`;
 
   const text = [
     `Invoice ${invoiceRef}`,
@@ -300,7 +305,7 @@ export async function sendEmail(options: EmailOptions): Promise<{ messageId: str
   const port = parseInt(process.env.SMTP_PORT || "587", 10);
   const user = process.env.SMTP_USER;
   const pass = process.env.SMTP_PASS;
-  const from = process.env.SMTP_FROM || "noreply@example.com";
+  const from = options.from || process.env.SMTP_FROM || "noreply@example.com";
 
   // In dev without SMTP config, log to console
   if (!host) {


### PR DESCRIPTION
## What & why

Ship Real Functionality audit (epic **EP-SHIP-REAL-AUDIT**). Invoices were being issued — as a downloadable PDF and as an email — with **no issuer identity**. This PR adds a shared resolver and wires real org identity into both.

### New: `lib/org-identity.ts` — `getOrgIdentity()`
Resolves the install's business identity from live DB: `Organization` (legal/display name, address, email/phone/website, logo), the VAT/tax `registrationNumber` from `OrganizationTaxProfile → TaxRegistration`, and the active `BankAccount` remittance details. Returns `null` / null fields when absent — callers treat that as **unknown**, never a placeholder.

### BI-DDE6FE27 — invoice PDF issuer (safety)
`invoice-pdf.tsx` previously rendered only the customer "Bill To" + totals: no company name, address, VAT number, or bank details — not a valid commercial/VAT invoice. Now renders a **From** block (name, address, contact, `VAT No:`) and a **BANK DETAILS** footer. Both the PDF download route and the send route load the issuer from `getOrgIdentity()`. (Issuer is optional on `InvoiceForPdf`, so it's backward-compatible.)

### BI-1546B81B — invoice email identity (partial)
- Subject: `Invoice <ref> from <org>` instead of the hardcoded **"your provider"** (and omits the clause entirely when org is unknown — no placeholder).
- `From`: org `name <email>` instead of `noreply@example.com` (threaded via a new optional `EmailOptions.from`).

## Verification
- New `org-identity.test.ts` (field mapping, legalName preference, VAT selection over other registrations, draft-skip, bank mapping, null org). `invoice-pdf.test.ts`: issuer-supplied PDF still renders valid `%PDF-`. `email.test.ts`: org named in subject; no "your provider" when unknown.
- **17/17** across the three suites; `tsc --noEmit` clean.

## Notes
- Touches `lib/shared/email.ts` in different regions than open PR **#1340** (this edits `composeInvoiceEmail` subject + the `from` const + `EmailOptions`; #1340 edits the `sendEmail` SMTP guard). Expected to auto-merge; trivial if not.
- **Remaining for BI-1546B81B (follow-up):** from-address + base-URL identity for the non-invoice senders (dunning/approval) and the `localhost` link fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)