### PR TITLE
fix(tts): wire Chatterbox sidecar into Mac installer + fix default URL + deprecate CSM script

### DIFF
--- a/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.test.ts
@@ -88,7 +88,7 @@ describe("synthesizeWithMlx", () => {
     await synthesizeWithMlx("Proceed to build.", { ...baseConfig, referenceText: "sample transcript" })
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe("http://host.docker.internal:8770/v1/audio/speech")
+    expect(url).toBe("http://host.docker.internal:8771/v1/audio/speech")
     const body = JSON.parse(options.body as string)
     expect(body.model).toBe("mlx-community/csm-1b")
     expect(body.input).toBe("Proceed to build.")

--- a/apps/web/lib/voice-synthesis/adapters/mlx.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.ts
@@ -1,24 +1,22 @@
-// MLX TTS adapter — native-host Apple Silicon voice synthesis via mlx-audio.
+// MLX TTS adapter — host-native voice synthesis for Apple Silicon.
 //
-// Talks to an mlx-audio OpenAI-compatible server (POST /v1/audio/speech). On
-// macOS that server runs on the HOST, not in a container: Docker Desktop on
-// macOS has no Metal GPU passthrough, so cloning-grade neural TTS must run
-// host-native and is reached from the portal container via host.docker.internal.
-// This mirrors how DPF already runs local LLMs (Docker Model Runner).
+// On macOS, Docker Desktop has no Metal GPU passthrough, so cloning-grade TTS
+// must run as a native host process. This adapter talks to a host-native sidecar
+// (Chatterbox on :8771 by default, provisioned by setup-chatterbox-tts-macos.sh)
+// via host.docker.internal — the same pattern DPF uses for Docker Model Runner.
 //
-// Unlike the chatterbox adapter, mlx-audio has NO multipart upload endpoint —
-// it clones from a reference audio FILE PATH (ref_audio) that the server reads
-// off disk. We therefore pass the host-visible path of the stored reference
-// clip, computed from DPF_TTS_REFERENCE_HOST_ROOT + providerVoiceId. When that
-// root is not configured (so the host cannot see the clip), we fall back to a
-// fixed named voice (non-cloning) rather than failing.
+// The "mlx" name is historical; the adapter is provider-agnostic: it POSTs to
+// whichever OpenAI-compatible /v1/audio/speech server DPF_TTS_URL points at.
+// The current recommended Mac sidecar is Chatterbox (MIT, ~7s/utterance via MPS,
+// zero-shot cloning). CSM/mlx-audio is available as a fallback.
 //
 // Env:
-//   DPF_TTS_URL                  default http://host.docker.internal:8770
-//   DPF_TTS_MLX_MODEL            default mlx-community/csm-1b (cloning model)
-//   DPF_TTS_MLX_VOICE            default af_heart (fallback named voice)
-//   DPF_TTS_REFERENCE_HOST_ROOT  host path where the voice storage root is
-//                                visible to the mlx-audio process (enables cloning)
+//   DPF_TTS_URL                  sidecar URL — default http://host.docker.internal:8771
+//                                (Chatterbox). Change to :8770 for CSM/mlx-audio.
+//   DPF_TTS_MLX_MODEL            only used by CSM/mlx-audio path (ignored by Chatterbox)
+//   DPF_TTS_MLX_VOICE            fallback named voice when no reference clip is set
+//   DPF_TTS_REFERENCE_HOST_ROOT  host path of the voice storage root so the
+//                                sidecar can read reference clips off disk
 //
 // Spec: docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md
 
@@ -27,7 +25,9 @@ import type { VoiceSynthesisConfig } from "../types"
 import { VoiceSynthesisError, type RawSynthesisResult } from "./cartesia"
 
 function getTtsUrl(): string {
-  return process.env.DPF_TTS_URL ?? "http://host.docker.internal:8770"
+  // Default to Chatterbox on :8771 (provisioned by setup-chatterbox-tts-macos.sh).
+  // Use :8770 for the legacy CSM/mlx-audio sidecar (setup-mlx-tts-macos.sh).
+  return process.env.DPF_TTS_URL ?? "http://host.docker.internal:8771"
 }
 
 function getModel(): string {

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -59,6 +59,17 @@ services:
       # value to scope the override to non-macOS deployments.
       LLM_BASE_URL: ${LLM_BASE_URL:-http://model-runner.docker.internal/v1}
 
+      # Voice / TTS — Apple Silicon path.
+      # The native-host Chatterbox sidecar (provisioned by
+      # scripts/tts/setup-chatterbox-tts-macos.sh) listens on :8771.
+      # Docker Desktop has no Metal GPU passthrough so TTS must run
+      # host-native; the portal reaches it via host.docker.internal.
+      # Run the setup script once to provision the sidecar; it is
+      # idempotent and safe to re-run after updates.
+      TTS_PROVIDER: ${TTS_PROVIDER:-mlx}
+      DPF_TTS_URL: ${DPF_TTS_URL:-http://host.docker.internal:8771}
+      DPF_TTS_REFERENCE_HOST_ROOT: ${DPF_TTS_REFERENCE_HOST_ROOT:-}
+
   browser-use:
     environment:
       LLM_BASE_URL: ${LLM_BASE_URL:-http://model-runner.docker.internal/v1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,12 +188,12 @@ services:
       # Override: TTS_PROVIDER=cartesia or TTS_PROVIDER=fish-audio to use a managed API.
       TTS_PROVIDER: ${TTS_PROVIDER:-chatterbox}
       DPF_TTS_URL: ${DPF_TTS_URL:-http://dpf-tts:8000}
-      # Apple Silicon / non-NVIDIA hosts: set TTS_PROVIDER=mlx and DPF_TTS_URL=
-      # http://host.docker.internal:8770, then provision the native-host sidecar
-      # with scripts/tts/setup-mlx-tts-macos.sh. Docker on macOS has no Metal GPU
-      # passthrough, so cloning TTS runs host-native. DPF_TTS_REFERENCE_HOST_ROOT
-      # is the HOST path of the voice storage dir (the host side of
-      # UPLOAD_STORAGE_PATH) so the sidecar can read reference clips off disk.
+      # Apple Silicon / non-NVIDIA hosts: set TTS_PROVIDER=mlx and run
+      # scripts/tts/setup-chatterbox-tts-macos.sh (idempotent) which provisions
+      # the native-host Chatterbox sidecar and prints the .env values. Docker on
+      # macOS has no Metal GPU passthrough, so cloning TTS runs host-native.
+      # DPF_TTS_URL defaults to http://host.docker.internal:8771 (Chatterbox).
+      # DPF_TTS_REFERENCE_HOST_ROOT is the HOST path of the voice storage dir.
       # Spec: docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md
       DPF_TTS_REFERENCE_HOST_ROOT: ${DPF_TTS_REFERENCE_HOST_ROOT:-}
       DPF_TTS_MLX_MODEL: ${DPF_TTS_MLX_MODEL:-}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -226,6 +226,31 @@ if [ "${DPF_SKIP_EDGE_BOOTSTRAP:-0}" != "1" ]; then
   fi
 fi
 
+# ── Voice / TTS sidecar (Apple Silicon only) ─────────────────────────────────
+# Provisions the native-host Chatterbox TTS sidecar so voice cloning works
+# on macOS without a GPU. Idempotent — safe to re-run. Linux/Windows installs
+# use the dpf-tts Docker container instead; skip this step there.
+
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  step "Provisioning Chatterbox TTS sidecar (Apple Silicon)"
+  if bash scripts/tts/setup-chatterbox-tts-macos.sh \
+       --data-root "$(pwd)/data/uploads" 2>/dev/null; then
+    # The script prints the .env values it needs; wire them in if not set.
+    if ! grep -qE "^TTS_PROVIDER=" .env 2>/dev/null; then
+      printf '\n# Voice / TTS (Apple Silicon — written by setup.sh)\n' >> .env
+      printf 'TTS_PROVIDER=mlx\n' >> .env
+      printf 'DPF_TTS_URL=http://host.docker.internal:8771\n' >> .env
+      printf 'DPF_TTS_REFERENCE_HOST_ROOT=%s/data/uploads\n' "$(pwd)" >> .env
+    fi
+    ok "Chatterbox TTS sidecar provisioned (port 8771)"
+  else
+    warn "TTS sidecar setup failed. Voice cloning will not work until you run:"
+    warn "  bash scripts/tts/setup-chatterbox-tts-macos.sh"
+  fi
+else
+  ok "TTS sidecar (skipped — Linux/Windows uses the dpf-tts Docker container)"
+fi
+
 # ── Agent rulebook conformance ───────────────────────────────────────────────
 # Per AGENTS.md: every install must ship the canonical AGENTS.md plus pointer
 # files for each supported AI tool. Fail the install if any are missing or

--- a/scripts/tts/setup-mlx-tts-macos.sh
+++ b/scripts/tts/setup-mlx-tts-macos.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# DEPRECATED — CSM/mlx-audio sidecar (legacy fallback).
+#
+# This script provisions mlx-audio serving CSM-1b. It works but produces
+# lower-quality cloned speech than Chatterbox and is no longer the recommended
+# engine for Apple Silicon.
+#
+# Use setup-chatterbox-tts-macos.sh instead (Chatterbox, MIT, ~7s/utterance,
+# Windows-quality voice cloning). This script is retained only for users who
+# need the faster-but-lower-quality CSM path or want to A/B test.
+#
 # Provision the native-host MLX TTS sidecar for DPF on Apple Silicon.
 #
 # Docker Desktop on macOS has no Metal GPU passthrough, so cloning-grade neural


### PR DESCRIPTION
## What
Three cleanup and hardening changes following the Apple Silicon voice implementation — the sidecar is now wired into the standard installer so a fresh Mac install gets voice cloning automatically.

## Changes

### 1. Adapter default URL: `:8770` → `:8771`
`mlx.ts` hardcoded `http://host.docker.internal:8770` (CSM/mlx-audio). The recommended Mac sidecar is now Chatterbox on `:8771`. Fresh installs without a custom `.env` now point at the right engine. Comments updated from "mlx-audio" to "Chatterbox/mlx sidecar". Test updated.

### 2. `docker-compose.macos.yml` — TTS defaults for Mac
Added `TTS_PROVIDER=mlx` and `DPF_TTS_URL=http://host.docker.internal:8771` to the portal service env in the Mac overlay. Any `docker compose -f ... -f docker-compose.macos.yml up` now automatically uses Chatterbox without manual `.env` edits.

### 3. `docker-compose.yml` comment update
Updated the Apple Silicon guidance comment to reference `setup-chatterbox-tts-macos.sh` (not the deprecated `setup-mlx-tts-macos.sh`).

### 4. `setup-mlx-tts-macos.sh` — marked DEPRECATED
CSM/mlx-audio is retained as a fallback but Chatterbox is the recommended engine. Header comment updated.

### 5. `setup.sh` — TTS provisioning step (Apple Silicon only)
After the compose stack is running, calls `setup-chatterbox-tts-macos.sh` and writes the resulting `.env` values automatically. Skipped on Linux/Windows (those use the `dpf-tts` Docker container). Idempotent — safe to re-run.

## Result
A fresh macOS/Apple Silicon install now provisions voice cloning end-to-end without any manual steps. Windows/Linux installs are unchanged.

## Verification
- bash syntax: `setup.sh`, `setup-mlx-tts-macos.sh`, `setup-chatterbox-tts-macos.sh` all clean
- typecheck: clean
- 13/13 adapter tests pass (URL updated to match new default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
