### PR TITLE
fix(backlog): advisory when a build item is flipped to in-progress without a build (BI-59344EA2)

### DIFF
--- a/apps/web/lib/backlog/promote-advisory.test.ts
+++ b/apps/web/lib/backlog/promote-advisory.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPromoteAdvisory } from "./promote-advisory";
+
+describe("buildPromoteAdvisory", () => {
+  it("warns when a build item with no active build is moved to in-progress", () => {
+    const advisory = buildPromoteAdvisory({
+      itemId: "BI-F9E7B780",
+      targetStatus: "in-progress",
+      triageOutcome: "build",
+      hasActiveBuild: false,
+    });
+    expect(advisory).not.toBeNull();
+    expect(advisory).toContain("BI-F9E7B780");
+    expect(advisory).toContain("promote_to_build_studio");
+    expect(advisory).toContain("does NOT create a build");
+    expect(advisory).toContain("requires status=open");
+    expect(advisory!.toLowerCase()).toContain("do not report");
+  });
+
+  it("stays silent when the build item already has an active build", () => {
+    expect(
+      buildPromoteAdvisory({
+        itemId: "BI-1",
+        targetStatus: "in-progress",
+        triageOutcome: "build",
+        hasActiveBuild: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("stays silent for non-build items", () => {
+    for (const outcome of ["runbook", "coworker-task", "defer", null]) {
+      expect(
+        buildPromoteAdvisory({
+          itemId: "BI-2",
+          targetStatus: "in-progress",
+          triageOutcome: outcome,
+          hasActiveBuild: false,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("stays silent for transitions other than in-progress", () => {
+    for (const status of ["open", "done", "deferred", "triaging"]) {
+      expect(
+        buildPromoteAdvisory({
+          itemId: "BI-3",
+          targetStatus: status,
+          triageOutcome: "build",
+          hasActiveBuild: false,
+        }),
+      ).toBeNull();
+    }
+  });
+});

--- a/apps/web/lib/backlog/promote-advisory.ts
+++ b/apps/web/lib/backlog/promote-advisory.ts
@@ -1,0 +1,48 @@
+// Advisory guard for the "status flip mistaken for starting work" failure.
+// BI-59344EA2 (coworker over-claim guard). Relates to EP-COWORKER-RT / EP-BIZ-CAP.
+//
+// A coworker (the COO) was told to "execute" the top recommended backlog item
+// and called update_backlog_item_status(in-progress) on a triageOutcome=build
+// item — then reported it as "added active throughput". But flipping a build
+// item to in-progress does NOT create a FeatureBuild, nothing enters Build
+// Studio, and (worse) it leaves the item ineligible for promote_to_build_studio,
+// which requires status=open. The status change is bookkeeping, not work.
+//
+// This is a non-blocking advisory: the transition still succeeds, but the tool
+// result carries a message the model is expected to surface/act on, so prompt
+// drift can't silently re-introduce the over-claim. It encodes the
+// structural-verification-is-not-functional commandment at the tool boundary.
+
+export type PromoteAdvisoryInput = {
+  itemId: string;
+  /** The status the item is being moved to. */
+  targetStatus: string;
+  /** The item's triage outcome (only "build" items go through Build Studio). */
+  triageOutcome: string | null;
+  /** Whether the item already has an active FeatureBuild linked. */
+  hasActiveBuild: boolean;
+};
+
+/**
+ * Return an advisory string when a triaged build item is being marked
+ * in-progress without an active Build Studio build — i.e. when a status flip
+ * is about to be mistaken for starting the work. Returns null otherwise (the
+ * common case), so callers attach it only when it matters.
+ */
+export function buildPromoteAdvisory(
+  input: PromoteAdvisoryInput,
+): string | null {
+  const movingToInProgress = input.targetStatus === "in-progress";
+  const isBuildItem = input.triageOutcome === "build";
+  if (!movingToInProgress || !isBuildItem || input.hasActiveBuild) {
+    return null;
+  }
+
+  return (
+    `${input.itemId} is a build item (triageOutcome=build) with no active Build Studio build. ` +
+    `Marking it in-progress only changes the status field — it does NOT create a build or start any work, ` +
+    `and it does not engage Build Studio. To actually start a build item, use promote_to_build_studio ` +
+    `(which creates the FeatureBuild and begins Ideate); note that promotion requires status=open, so this ` +
+    `item must be returned to open first. Do NOT report this status change as work started, in progress, or building.`
+  );
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1023,7 +1023,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "update_backlog_item_status",
-    description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table in apps/web/lib/backlog/transitions.ts; same-status calls are no-op successes. Setting status='triaging' on an already-triaged item is the *retriage* path — clears triageOutcome and effortSize so triage_backlog_item can re-decide. Setting status='done' requires a resolution. Writes a status_change activity row and may auto-close the parent epic.",
+    description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table in apps/web/lib/backlog/transitions.ts; same-status calls are no-op successes. Setting status='triaging' on an already-triaged item is the *retriage* path — clears triageOutcome and effortSize so triage_backlog_item can re-decide. Setting status='done' requires a resolution. Writes a status_change activity row and may auto-close the parent epic. NOTE: this only changes the status field — it does NOT start work. For a triageOutcome=build item, starting the work means promote_to_build_studio (creates the FeatureBuild + Build Studio Ideate); flipping such an item to in-progress returns an advisory and does not build anything.",
     inputSchema: {
       type: "object",
       properties: {
@@ -5595,7 +5595,7 @@ export async function executeTool(
       // (Reason is checked against the *current* status below, after the item is loaded.)
       const item = await prisma.backlogItem.findUnique({
         where: { itemId: itemIdRaw },
-        select: { id: true, status: true, epicId: true, triageOutcome: true, effortSize: true },
+        select: { id: true, status: true, epicId: true, triageOutcome: true, effortSize: true, activeBuildId: true },
       });
       if (!item)
         return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
@@ -5680,11 +5680,28 @@ export async function executeTool(
         }
         return next;
       });
+      // Advisory: flipping a build item to in-progress is not the same as
+      // starting the work — surface the promote_to_build_studio path so the
+      // coworker can't report a no-op status change as "throughput".
+      const { buildPromoteAdvisory } = await import("@/lib/backlog/promote-advisory");
+      const promoteAdvisory = buildPromoteAdvisory({
+        itemId: updated.itemId,
+        targetStatus: updated.status,
+        triageOutcome: item.triageOutcome,
+        hasActiveBuild: item.activeBuildId != null,
+      });
       return {
         success: true,
         entityId: updated.itemId,
-        message: `${updated.itemId}: ${item.status} → ${updated.status}`,
-        data: { itemId: updated.itemId, status: updated.status, completedAt: updated.completedAt },
+        message:
+          `${updated.itemId}: ${item.status} → ${updated.status}` +
+          (promoteAdvisory ? ` — ADVISORY: ${promoteAdvisory}` : ""),
+        data: {
+          itemId: updated.itemId,
+          status: updated.status,
+          completedAt: updated.completedAt,
+          ...(promoteAdvisory ? { advisory: promoteAdvisory } : {}),
+        },
       };
     }
 


### PR DESCRIPTION
## What & why

Founder-observed: the COO coworker, told to "execute / go ahead" on the top recommended item, called `update_backlog_item_status(in-progress)` on a `triageOutcome=build` item and reported it as *"added active throughput."* Nothing entered Build Studio.

Verified on **BI-F9E7B780**: `activeBuild: null`, a single `status_change` (open → in-progress) activity row, no FeatureBuild. A status flip on a build item:
- creates **no FeatureBuild** and never engages Build Studio;
- and (because `promote_to_build_studio` requires `status=open`) leaves the item **ineligible** for the correct promotion path.

This was **not** a missing interface — `coo-orchestrator` holds the `build_promote` grant and could have called `promote_to_build_studio` (which creates the FeatureBuild + starts Ideate). There is no UI "Start" button; the model freely chose the wrong tool and over-claimed. It's a structural-vs-functional / "never claim you did something you didn't do" violation.

## Fix (founder decision: tool-layer advisory, non-blocking)

- **New pure helper** [promote-advisory.ts](apps/web/lib/backlog/promote-advisory.ts) — `buildPromoteAdvisory()` returns a message **only** when a `triageOutcome=build` item with no `activeBuild` is moved to `in-progress`; it names `promote_to_build_studio` as the real start path, notes promotion needs `status=open`, and forbids reporting the change as "work started/in progress/building."
- **Wired into** the `update_backlog_item_status` MCP handler ([mcp-tools.ts](apps/web/lib/mcp-tools.ts)) — advisory attached to the success result (`message` + `data.advisory`). The transition still succeeds (non-blocking) — a durable guard so prompt drift can't silently re-introduce the over-claim.
- **Tool description** updated: the status field is not "starting work" for build items.

## Scope notes (per founder)

- BI-F9E7B780 left **as-is** (not reverted/promoted).
- No persona/identity prompt changes and no deflection-loop rework in this pass — the advisory is the chosen durable mechanism.

## Tests

`promote-advisory.test.ts` — 4 cases (fires correctly; silent when a build exists / not a build item / target ≠ in-progress). `tsc` clean on changed files (only pre-existing unrelated `complaints.ts` errors remain).

Backlog: BI-59344EA2 · Observed instance: BI-F9E7B780

🤖 Generated with [Claude Code](https://claude.com/claude-code)