### PR TITLE
feat(build-studio): right-size lifecycle by (work-type, work-size)

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -417,12 +417,20 @@ export async function advanceBuildPhase(
   }
 
   const brief = build.brief as { acceptanceCriteria?: string[]; fixContext?: import("@/lib/feature-build-types").FixContext } | null;
+  // Right-sizing matrix: read processSize from plan.processSize (written at
+  // promote time) and pass it to checkPhaseGate so the policy lookup picks
+  // the matching LifecyclePolicy. Default "medium" preserves the byte-
+  // identical default cell. See
+  // docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md.
+  const buildPlanState = (build.plan as Record<string, unknown> | null) ?? null;
+  const processSize = (buildPlanState?.["processSize"] as string | undefined) ?? "medium";
   const gate = checkPhaseGate(currentPhase, targetPhase, {
     kind: build.kind,
+    processSize,
     fixContext: brief?.fixContext,
     designDoc: build.designDoc,
     designReview: build.designReview,
-    happyPathState: normalizeHappyPathState((build.plan as Record<string, unknown> | null)?.happyPathState ?? null),
+    happyPathState: normalizeHappyPathState(buildPlanState?.happyPathState ?? null),
     buildPlan: build.buildPlan,
     planReview: build.planReview,
     taskResults: build.taskResults,

--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILD_PROCESS_TYPE_VALUES,
+  BUILD_PROCESS_SIZES,
+  deriveBuildProcessSize,
+  deriveBuildProcessType,
+  describePolicy,
+  getProcessPolicy,
+  normalizeSize,
+  normalizeType,
+  type BuildProcessSize,
+  type BuildProcessType,
+} from "./build-process-matrix";
+import { checkPhaseGate, normalizeHappyPathState, type FixContext } from "./feature-build-types";
+
+// The right-sizing matrix maps (type, size) -> a LifecyclePolicy. These tests
+// pin three contracts the spec calls out:
+//   1. The default cell (feature, medium) is byte-identical to today's
+//      checkPhaseGate behavior.
+//   2. Small fixes / chores / docs get *less* ceremony, not different
+//      ceremony, than the default cell.
+//   3. derive* functions are the single read site for the parallel unified-BI
+//      work-type branch; today they read source/effortSize fields.
+
+const readyHappyPath = normalizeHappyPathState({
+  intake: {
+    status: "ready",
+    taxonomyNodeId: "tax-1",
+    backlogItemId: "BI-1",
+    epicId: "EP-1",
+    constrainedGoal: "Ship a thing",
+  },
+});
+
+const completeFixContext: FixContext = {
+  reproSteps: "Submit /contact",
+  expected: "Success toast",
+  actual: "500 error",
+  rootCause: "Null deref",
+  fixApproach: "Guard the optional field",
+};
+
+describe("BUILD_PROCESS_TYPE_VALUES", () => {
+  it("is a closed enum of four canonical work types", () => {
+    expect(BUILD_PROCESS_TYPE_VALUES).toEqual(["feature", "fix", "chore", "doc"]);
+  });
+});
+
+describe("BUILD_PROCESS_SIZES", () => {
+  it("mirrors the BacklogItem effortSize ordinal", () => {
+    expect(BUILD_PROCESS_SIZES).toEqual(["small", "medium", "large", "xlarge"]);
+  });
+});
+
+describe("normalizeType / normalizeSize", () => {
+  it("normalizes absent/unknown type to feature", () => {
+    expect(normalizeType(null)).toBe("feature");
+    expect(normalizeType(undefined)).toBe("feature");
+    expect(normalizeType("")).toBe("feature");
+    expect(normalizeType("gibberish")).toBe("feature");
+    expect(normalizeType("feature")).toBe("feature");
+    expect(normalizeType("fix")).toBe("fix");
+    expect(normalizeType("chore")).toBe("chore");
+    expect(normalizeType("doc")).toBe("doc");
+  });
+
+  it("normalizes absent/unknown size to medium", () => {
+    expect(normalizeSize(null)).toBe("medium");
+    expect(normalizeSize(undefined)).toBe("medium");
+    expect(normalizeSize("")).toBe("medium");
+    expect(normalizeSize("xxl")).toBe("medium");
+    expect(normalizeSize("small")).toBe("small");
+    expect(normalizeSize("xlarge")).toBe("xlarge");
+  });
+});
+
+describe("deriveBuildProcessType — source-to-kind mapping", () => {
+  it("maps source=bug to fix", () => {
+    expect(deriveBuildProcessType({ source: "bug", body: null })).toBe("fix");
+  });
+
+  it("maps source=doc-gap to doc", () => {
+    expect(deriveBuildProcessType({ source: "doc-gap", body: null })).toBe("doc");
+  });
+
+  it("detects chores via a body-line marker (Phase 1 conservative path)", () => {
+    expect(deriveBuildProcessType({ source: "feature-gap", body: "chore: bump react to 18.4" })).toBe("chore");
+    expect(deriveBuildProcessType({ source: null, body: "Chore: rename internal helpers" })).toBe("chore");
+    expect(deriveBuildProcessType({ source: null, body: "Some unrelated body" })).toBe("feature");
+  });
+
+  it("defaults everything else to feature (back-compat)", () => {
+    expect(deriveBuildProcessType({ source: "feature-gap", body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ source: "user-request", body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ source: null, body: null })).toBe("feature");
+  });
+});
+
+describe("deriveBuildProcessSize", () => {
+  it("reads effortSize verbatim when known", () => {
+    expect(deriveBuildProcessSize({ effortSize: "small" })).toBe("small");
+    expect(deriveBuildProcessSize({ effortSize: "xlarge" })).toBe("xlarge");
+  });
+
+  it("defaults to medium for null / unknown", () => {
+    expect(deriveBuildProcessSize({ effortSize: null })).toBe("medium");
+    expect(deriveBuildProcessSize({ effortSize: "huge" })).toBe("medium");
+  });
+});
+
+describe("getProcessPolicy — matrix coverage", () => {
+  it("returns a policy for every (type, size) combination", () => {
+    for (const type of BUILD_PROCESS_TYPE_VALUES) {
+      for (const size of BUILD_PROCESS_SIZES) {
+        const policy = getProcessPolicy(type, size);
+        expect(policy.label).toBeTruthy();
+        expect(policy.phases.length).toBeGreaterThan(0);
+        expect(policy.promptVariant).toBeTruthy();
+      }
+    }
+  });
+
+  it("default (feature, medium) is the byte-identical baseline cell", () => {
+    const policy = getProcessPolicy("feature", "medium");
+    expect(policy.phases).toEqual(["ideate", "plan", "build", "review", "ship"]);
+    expect(policy.promptVariant).toBe("feature");
+    expect(policy.reviewIntensity).toBe("standard");
+    // ideate->plan requires designDoc + designReview + intake
+    expect(policy.gates["ideate->plan"]).toEqual([
+      "designDoc-present",
+      "designReview-passed",
+      "happyPathIntake-ready",
+    ]);
+  });
+
+  it("fix-small merges ideate+plan ceremony (no portfolio intake)", () => {
+    const policy = getProcessPolicy("fix", "small");
+    // ideate->plan only needs fixContext + non-failed review
+    expect(policy.gates["ideate->plan"]).toEqual([
+      "fixContext-complete",
+      "designReview-not-failed-if-present",
+    ]);
+    // plan->build does not require planReview (merged)
+    expect(policy.gates["plan->build"]).toEqual(["buildPlan-present"]);
+    // review->ship skips acceptance evaluation for small fixes
+    expect(policy.gates["review->ship"]?.includes("acceptance-evaluated")).toBe(false);
+  });
+
+  it("chore-small drops ideate entirely and skips review-phase acceptance ceremony", () => {
+    const policy = getProcessPolicy("chore", "small");
+    expect(policy.phases).not.toContain("ideate");
+    expect(policy.phases).not.toContain("review");
+    expect(policy.promptVariant).toBe("chore");
+    expect(policy.gates["ideate->plan"]).toEqual([]);
+    expect(policy.gates["review->ship"]?.includes("acceptance-evaluated")).toBe(false);
+  });
+
+  it("doc-small drops ideate and runs plan->build->ship without acceptance/UX", () => {
+    const policy = getProcessPolicy("doc", "small");
+    expect(policy.phases).not.toContain("ideate");
+    expect(policy.promptVariant).toBe("doc");
+    expect(policy.gates["review->ship"]?.includes("acceptance-evaluated")).toBe(false);
+  });
+
+  it("xlarge routes everything to the decomposition gate", () => {
+    for (const type of BUILD_PROCESS_TYPE_VALUES) {
+      const policy = getProcessPolicy(type, "xlarge");
+      // The xlarge cell is feature-shaped (full lifecycle) and demands the
+      // same evidence as a thorough feature — the operator-facing label and
+      // the design-time decomposition gate carry the "decompose first" intent.
+      expect(policy.phases).toContain("ideate");
+      expect(policy.phases).toContain("plan");
+    }
+  });
+});
+
+describe("checkPhaseGate via the matrix — back-compat invariant", () => {
+  // These cases mirror feature-build-types.test.ts cases line-for-line. The
+  // contract: with kind/processSize absent or set to feature/medium, the
+  // matrix-driven gate returns the same decisions as the pre-matrix gate.
+
+  it("blocks ideate->plan without designDoc (default cell)", () => {
+    const result = checkPhaseGate("ideate", "plan", {});
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("design document");
+  });
+
+  it("blocks ideate->plan when design review failed (default cell)", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      designDoc: { problemStatement: "x" },
+      designReview: { decision: "fail" },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Design review failed");
+  });
+
+  it("allows ideate->plan with all default-cell evidence present", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      designDoc: { problemStatement: "x" },
+      designReview: { decision: "pass" },
+      happyPathState: readyHappyPath,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks build->review when typecheck fails (default cell)", () => {
+    const result = checkPhaseGate("build", "review", {
+      verificationOut: { testsPassed: 0, testsFailed: 0, typecheckPassed: false, fullOutput: "", timestamp: "" },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Typecheck");
+  });
+
+  it("allows any phase to failed (no gate)", () => {
+    expect(checkPhaseGate("build", "failed", {}).allowed).toBe(true);
+  });
+
+  it("allows review->build backward transition (no gate)", () => {
+    expect(checkPhaseGate("review", "build", {}).allowed).toBe(true);
+  });
+});
+
+describe("checkPhaseGate via the matrix — right-sizing deltas", () => {
+  it("fix-small ideate->plan allows on fixContext alone (no design doc, no intake)", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      kind: "fix",
+      processSize: "small",
+      fixContext: completeFixContext,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("fix-medium ideate->plan still allows on fixContext (designReview optional)", () => {
+    const result = checkPhaseGate("ideate", "plan", {
+      kind: "fix",
+      processSize: "medium",
+      fixContext: completeFixContext,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("chore-small plan->build allows on buildPlan alone (no planReview required)", () => {
+    const result = checkPhaseGate("plan", "build", {
+      kind: "chore",
+      processSize: "small",
+      buildPlan: { fileStructure: [], tasks: [] },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("doc-small plan->build allows on buildPlan alone", () => {
+    const result = checkPhaseGate("plan", "build", {
+      kind: "doc",
+      processSize: "small",
+      buildPlan: { fileStructure: [], tasks: [] },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("chore-small review->ship does not require acceptance evaluation", () => {
+    const result = checkPhaseGate("review", "ship", {
+      kind: "chore",
+      processSize: "small",
+      buildPlan: { fileStructure: [], tasks: [] },
+      // intentionally no acceptanceMet / acceptanceCriteria
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("fix-small review->ship does not require acceptance evaluation", () => {
+    const result = checkPhaseGate("review", "ship", {
+      kind: "fix",
+      processSize: "small",
+      fixContext: completeFixContext,
+      buildPlan: { fileStructure: [], tasks: [] },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("feature-medium review->ship still requires acceptanceMet (no regression)", () => {
+    const result = checkPhaseGate("review", "ship", {
+      kind: "feature",
+      processSize: "medium",
+      designDoc: { problemStatement: "x" },
+      buildPlan: { fileStructure: [], tasks: [] },
+      verificationOut: { testsPassed: 0, testsFailed: 0, typecheckPassed: true, fullOutput: "", timestamp: "" },
+      // intentionally no acceptanceMet
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Acceptance criteria");
+  });
+
+  it("chore-small build->review still requires typecheck (defense in depth)", () => {
+    const result = checkPhaseGate("build", "review", {
+      kind: "chore",
+      processSize: "small",
+      verificationOut: { testsPassed: 0, testsFailed: 0, typecheckPassed: false, fullOutput: "", timestamp: "" },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Typecheck");
+  });
+});
+
+describe("describePolicy", () => {
+  it("renders a human-readable summary of the default cell", () => {
+    const summary = describePolicy("feature", "medium");
+    expect(summary).toContain("Feature · standard");
+    expect(summary).toContain("standard review");
+    expect(summary).toContain("ideate");
+  });
+
+  it("renders a human-readable summary of fix-small (merged ceremony)", () => {
+    const summary = describePolicy("fix", "small");
+    expect(summary).toContain("Fix · merged");
+    expect(summary).toContain("minimal review");
+  });
+
+  it("renders a human-readable summary of chore-small (no ideate, no review in phases)", () => {
+    const summary = describePolicy("chore", "small");
+    expect(summary).toContain("Chore · minimal");
+    // "ideate" / "review" must not appear in the phases list. The
+    // reviewIntensity label still includes the literal word "review"
+    // (as in "minimal review"), so we assert against the phases portion.
+    const phasesPortion = summary.split("phases:")[1] ?? "";
+    expect(phasesPortion).not.toContain("ideate");
+    expect(phasesPortion).not.toContain("review");
+  });
+});
+
+// Static type checks — these don't run at runtime but force compilation
+// errors if BuildProcessType / BuildProcessSize drift.
+const _typeCheck = (): BuildProcessType => "feature";
+const _sizeCheck = (): BuildProcessSize => "medium";
+void _typeCheck;
+void _sizeCheck;

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -1,0 +1,623 @@
+// apps/web/lib/explore/build-process-matrix.ts
+//
+// Right-sizing matrix for Build Studio. Maps (work-type, work-size) -> a
+// LifecyclePolicy that tells the prompt selector + phase gate how much
+// ceremony a given build deserves.
+//
+// Spec: docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+// Seed: docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md
+// Composes with: docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+//
+// Design contract:
+//   - The default cell (feature, medium) is byte-identical to today's behavior.
+//   - The phase graph (PHASE_ORDER, ALLOWED_TRANSITIONS) is global and unchanged.
+//     "Skipping" a phase means its outbound gate auto-passes; the agent can
+//     advance immediately. The matrix never invents new phases.
+//   - Unknown / absent type falls back to "feature"; unknown / absent size
+//     falls back to "medium". Existing in-flight builds keep working.
+
+import type { BacklogItemWithRelations } from "./backlog";
+import { BACKLOG_EFFORT_SIZES } from "./backlog";
+import type { BuildPhase, FeatureBuildKind } from "./feature-build-types";
+import {
+  FEATURE_BUILD_KIND_VALUES,
+} from "./feature-build-types";
+
+// ─── Enums ──────────────────────────────────────────────────────────────────
+
+/**
+ * Closed work-type enum that drives the lifecycle policy. Extends
+ * FEATURE_BUILD_KIND_VALUES (which is now an alias for back-compat).
+ *
+ * Adding a value requires:
+ *   1. Adding it here.
+ *   2. Wiring at least one cell per size in DEFAULT_LIFECYCLE_MATRIX (§4.3).
+ *   3. Adding the matching prompt variant fallbacks in build-agent-prompts.ts
+ *      (or deliberately falling through to "feature").
+ *   4. Updating any MCP tool schema that mirrors the enum, in the same commit,
+ *      before any DB row writes the new value.
+ */
+export const BUILD_PROCESS_TYPE_VALUES = ["feature", "fix", "chore", "doc"] as const;
+export type BuildProcessType = (typeof BUILD_PROCESS_TYPE_VALUES)[number];
+
+/** Mirrors BACKLOG_EFFORT_SIZES so the build inherits the BI's sizing without
+ *  re-classification. The matrix may apply the same policy to multiple sizes;
+ *  that's an internal LifecyclePolicy table detail, not a separate enum. */
+export const BUILD_PROCESS_SIZES = BACKLOG_EFFORT_SIZES;
+export type BuildProcessSize = (typeof BUILD_PROCESS_SIZES)[number];
+
+// Sanity check (compile-time only): BUILD_PROCESS_TYPE_VALUES is a superset
+// of the legacy FEATURE_BUILD_KIND_VALUES enum. Encoded as a function
+// signature so the cyclic import (feature-build-types <-> matrix) doesn't
+// try to read FEATURE_BUILD_KIND_VALUES at module-load time.
+type _SupersetCheck = FEATURE_BUILD_KIND_VALUES_ELEMENT_TYPE extends BuildProcessType ? true : never;
+type FEATURE_BUILD_KIND_VALUES_ELEMENT_TYPE = (typeof FEATURE_BUILD_KIND_VALUES)[number];
+const _supersetCheck: _SupersetCheck = true;
+void _supersetCheck;
+
+// ─── Gate requirements ──────────────────────────────────────────────────────
+
+/**
+ * Closed enum of named gate checks. checkPhaseGate composes a policy's
+ * required list per transition; checkRequirement is a pure switch that
+ * inspects the evidence record and returns {allowed, reason?}.
+ *
+ * Each requirement maps 1:1 to a branch in today's checkPhaseGate, so the
+ * default (feature, medium) policy reconstitutes the existing gate exactly.
+ */
+export const GATE_REQUIREMENTS = [
+  "designDoc-present",
+  "designReview-passed",
+  // Looser variant used by the fix flow: never required to be present,
+  // but if it is present and explicitly failed, block. This preserves
+  // the fix-flow behavior from the 2026-05-29 fix-flow design where the
+  // diagnosis itself is the spec and reviewDesignDoc's review is a
+  // synthetic completeness signal — its absence (e.g. a manually-promoted
+  // fix that bypassed reviewDesignDoc) must not deadlock the gate.
+  "designReview-not-failed-if-present",
+  "fixContext-complete",
+  "buildPlan-present",
+  "planReview-passed",
+  "verification-typecheck-passed",
+  "acceptance-evaluated",
+  "acceptance-all-met-if-array",
+  "uxVerification-not-blocking",
+  "happyPathIntake-ready",
+] as const;
+export type GateRequirement = (typeof GATE_REQUIREMENTS)[number];
+
+// ─── Lifecycle policy ───────────────────────────────────────────────────────
+
+export type BuildTransition =
+  | "ideate->plan"
+  | "plan->build"
+  | "build->review"
+  | "review->ship";
+
+export type ReviewIntensity = "minimal" | "standard" | "thorough";
+
+export type LifecyclePolicy = {
+  /** Visible phases in operator UI + agent dispatch. Always a contiguous
+   *  prefix of VISIBLE_PHASES — the phase graph itself is unchanged.
+   *  Phases not in this list have auto-pass gates and an empty prompt
+   *  (i.e. effectively skipped). */
+  phases: BuildPhase[];
+  /** Prompt slug suffix. getBuildPhasePrompt selects <phase>-<variant>
+   *  (or just <phase> for "feature") and falls back to the hardcoded
+   *  prompt for that variant; missing variants fall through to feature. */
+  promptVariant: BuildProcessType;
+  /** Advisory hint for deliberation pattern selection (review/debate).
+   *  Phase 1 does not act on this; recorded for the operator-facing
+   *  header chip and for Phase 2 deliberation tuning. */
+  reviewIntensity: ReviewIntensity;
+  /** What each transition requires. A missing transition key means
+   *  "no requirements" (auto-pass). Transitions for phases outside
+   *  `phases` are still allowed by the phase graph; the policy
+   *  auto-passes them. */
+  gates: Partial<Record<BuildTransition, ReadonlyArray<GateRequirement>>>;
+  /** Operator-facing label for the policy. Pure presentation. */
+  label: string;
+};
+
+// ─── Default cell — byte-identical to today ─────────────────────────────────
+//
+// This is the contract test: the default policy composes the exact same
+// requirements today's checkPhaseGate enforces for a (feature, medium) build.
+// Every other cell in the matrix is a DELTA against this baseline.
+
+const FEATURE_FULL_GATES: LifecyclePolicy["gates"] = {
+  "ideate->plan": [
+    "designDoc-present",
+    "designReview-passed",
+    "happyPathIntake-ready",
+  ],
+  "plan->build": [
+    "buildPlan-present",
+    "planReview-passed",
+    "happyPathIntake-ready",
+  ],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": [
+    "designDoc-present",
+    "buildPlan-present",
+    "acceptance-evaluated",
+    "acceptance-all-met-if-array",
+    "uxVerification-not-blocking",
+  ],
+};
+
+const FIX_FULL_GATES: LifecyclePolicy["gates"] = {
+  // Fix flow: a complete diagnosis substitutes for the feature design doc.
+  // The designReview gate uses the *looser* "not-failed-if-present"
+  // requirement because reviewDesignDoc on a fix synthesizes a pass/fail
+  // from isFixContextComplete; the review may be absent for manually-
+  // promoted fixes and that path must not deadlock.
+  "ideate->plan": ["fixContext-complete", "designReview-not-failed-if-present"],
+  "plan->build": ["buildPlan-present", "planReview-passed"],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": [
+    "fixContext-complete",
+    "buildPlan-present",
+    "acceptance-evaluated",
+    "acceptance-all-met-if-array",
+    "uxVerification-not-blocking",
+  ],
+};
+
+// Fix-small: merge ideate+plan. No portfolio intake. UX still defended-in-depth
+// at ship-time (the check no-ops when there are no acceptance criteria).
+const FIX_SMALL_GATES: LifecyclePolicy["gates"] = {
+  "ideate->plan": ["fixContext-complete", "designReview-not-failed-if-present"],
+  "plan->build": ["buildPlan-present"],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": [
+    "fixContext-complete",
+    "buildPlan-present",
+    "uxVerification-not-blocking",
+  ],
+};
+
+// Chore: intent-driven, no ideate ceremony. Plan + verify is the whole story.
+const CHORE_SMALL_GATES: LifecyclePolicy["gates"] = {
+  "ideate->plan": [],
+  "plan->build": ["buildPlan-present"],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": ["buildPlan-present", "uxVerification-not-blocking"],
+};
+
+const CHORE_STANDARD_GATES: LifecyclePolicy["gates"] = {
+  "ideate->plan": [],
+  "plan->build": ["buildPlan-present", "planReview-passed"],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": [
+    "buildPlan-present",
+    "acceptance-evaluated",
+    "acceptance-all-met-if-array",
+    "uxVerification-not-blocking",
+  ],
+};
+
+// Doc: content edit, no sandbox boot in spirit. The verification-typecheck
+// gate still applies (typechecking embedded code samples in docs is cheap
+// and catches stale references), but acceptance/UX requirements are dropped.
+const DOC_GATES: LifecyclePolicy["gates"] = {
+  "ideate->plan": [],
+  "plan->build": ["buildPlan-present"],
+  "build->review": ["verification-typecheck-passed"],
+  "review->ship": ["buildPlan-present", "uxVerification-not-blocking"],
+};
+
+// xlarge: route to decomposition. Block the most expensive transition until
+// the operator either decomposes or overrides; the existing decomposition
+// gate (size-design-doc) layers on top.
+const DECOMPOSE_REQUIRED_GATES: LifecyclePolicy["gates"] = {
+  // Same as the standard feature gate, with one extra requirement that the
+  // sizeDesignDoc decision is not "decompose-required" without an override.
+  // Phase 1 keeps this aligned with the existing path; the design-time
+  // decomposition gate already enforces the same thing via reviewDesignDoc.
+  ...FEATURE_FULL_GATES,
+};
+
+// ─── The matrix ─────────────────────────────────────────────────────────────
+
+const PHASES_FULL: BuildPhase[] = ["ideate", "plan", "build", "review", "ship"];
+const PHASES_NO_IDEATE: BuildPhase[] = ["plan", "build", "review", "ship"];
+const PHASES_NO_IDEATE_NO_REVIEW: BuildPhase[] = ["plan", "build", "ship"];
+
+/**
+ * Default (feature, medium) — the baseline. Every other cell is a delta
+ * against this. Changing this cell is a behavior change for the dominant
+ * code path; do not edit without an explicit cross-pipeline review.
+ */
+const POLICY_FEATURE_STANDARD: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "feature",
+  reviewIntensity: "standard",
+  gates: FEATURE_FULL_GATES,
+  label: "Feature · standard",
+};
+
+const POLICY_FEATURE_THOROUGH: LifecyclePolicy = {
+  ...POLICY_FEATURE_STANDARD,
+  reviewIntensity: "thorough",
+  label: "Feature · thorough",
+};
+
+const POLICY_FEATURE_DECOMPOSE: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "feature",
+  reviewIntensity: "thorough",
+  gates: DECOMPOSE_REQUIRED_GATES,
+  label: "Feature · decompose first",
+};
+
+const POLICY_FIX_STANDARD: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "fix",
+  reviewIntensity: "standard",
+  gates: FIX_FULL_GATES,
+  label: "Fix · standard",
+};
+
+const POLICY_FIX_SMALL: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "fix",
+  reviewIntensity: "minimal",
+  gates: FIX_SMALL_GATES,
+  label: "Fix · merged",
+};
+
+const POLICY_FIX_THOROUGH: LifecyclePolicy = {
+  ...POLICY_FIX_STANDARD,
+  reviewIntensity: "thorough",
+  label: "Fix · thorough",
+};
+
+const POLICY_CHORE_SMALL: LifecyclePolicy = {
+  phases: PHASES_NO_IDEATE_NO_REVIEW,
+  promptVariant: "chore",
+  reviewIntensity: "minimal",
+  gates: CHORE_SMALL_GATES,
+  label: "Chore · minimal",
+};
+
+const POLICY_CHORE_STANDARD: LifecyclePolicy = {
+  phases: PHASES_NO_IDEATE,
+  promptVariant: "chore",
+  reviewIntensity: "minimal",
+  gates: CHORE_STANDARD_GATES,
+  label: "Chore · standard",
+};
+
+const POLICY_CHORE_THOROUGH: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "chore",
+  reviewIntensity: "standard",
+  gates: FEATURE_FULL_GATES, // large chores are usually refactors; promote to standard review
+  label: "Chore · refactor",
+};
+
+const POLICY_DOC: LifecyclePolicy = {
+  phases: PHASES_NO_IDEATE,
+  promptVariant: "doc",
+  reviewIntensity: "minimal",
+  gates: DOC_GATES,
+  label: "Doc · minimal",
+};
+
+const POLICY_DOC_STANDARD: LifecyclePolicy = {
+  ...POLICY_DOC,
+  reviewIntensity: "standard",
+  label: "Doc · standard",
+};
+
+const POLICY_DECOMPOSE_REQUIRED: LifecyclePolicy = {
+  phases: PHASES_FULL,
+  promptVariant: "feature",
+  reviewIntensity: "thorough",
+  gates: DECOMPOSE_REQUIRED_GATES,
+  label: "Decompose first",
+};
+
+/**
+ * The matrix. Two-dim lookup keyed by [type][size]. getProcessPolicy
+ * resolves and clones the cell; callers must not mutate the returned
+ * policy.
+ */
+const DEFAULT_LIFECYCLE_MATRIX: Readonly<
+  Record<BuildProcessType, Readonly<Record<BuildProcessSize, LifecyclePolicy>>>
+> = {
+  feature: {
+    small: POLICY_FEATURE_STANDARD,
+    medium: POLICY_FEATURE_STANDARD,
+    large: POLICY_FEATURE_THOROUGH,
+    xlarge: POLICY_FEATURE_DECOMPOSE,
+  },
+  fix: {
+    small: POLICY_FIX_SMALL,
+    medium: POLICY_FIX_STANDARD,
+    large: POLICY_FIX_THOROUGH,
+    xlarge: POLICY_DECOMPOSE_REQUIRED,
+  },
+  chore: {
+    small: POLICY_CHORE_SMALL,
+    medium: POLICY_CHORE_STANDARD,
+    large: POLICY_CHORE_THOROUGH,
+    xlarge: POLICY_DECOMPOSE_REQUIRED,
+  },
+  doc: {
+    small: POLICY_DOC,
+    medium: POLICY_DOC,
+    large: POLICY_DOC_STANDARD,
+    xlarge: POLICY_DECOMPOSE_REQUIRED,
+  },
+};
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the lifecycle policy for a build. Unknown / absent type defaults
+ * to "feature"; unknown / absent size defaults to "medium". This is the
+ * back-compat contract — pre-existing call sites that pass nothing get the
+ * exact same policy as before.
+ */
+export function getProcessPolicy(
+  type: BuildProcessType | FeatureBuildKind | string | null | undefined,
+  size: BuildProcessSize | string | null | undefined,
+): LifecyclePolicy {
+  const t = normalizeType(type);
+  const s = normalizeSize(size);
+  return DEFAULT_LIFECYCLE_MATRIX[t][s];
+}
+
+export function normalizeType(
+  type: string | null | undefined,
+): BuildProcessType {
+  if (!type) return "feature";
+  return (BUILD_PROCESS_TYPE_VALUES as readonly string[]).includes(type)
+    ? (type as BuildProcessType)
+    : "feature";
+}
+
+export function normalizeSize(
+  size: string | null | undefined,
+): BuildProcessSize {
+  if (!size) return "medium";
+  return (BUILD_PROCESS_SIZES as readonly string[]).includes(size)
+    ? (size as BuildProcessSize)
+    : "medium";
+}
+
+/**
+ * Single source of truth for "given this BI, what build-process type does it
+ * become?". The fix-flow design landed `bug -> fix`; this extends to docs
+ * and (Phase 1 conservatively) chores via a body-line marker. The parallel
+ * unified-BI-work-type branch will eventually replace this with a direct
+ * read of `BacklogItem.workType`; when it does, this is the one site that
+ * changes.
+ *
+ * Accepts a structurally-minimal subset of BacklogItem fields so the helper
+ * is callable from anywhere (promote, MCP tool wiring, tests) without
+ * dragging in the full Prisma row type.
+ */
+export function deriveBuildProcessType(
+  bi: Pick<BacklogItemWithRelations, "body"> & { source?: string | null },
+): BuildProcessType {
+  const source = bi.source ?? null;
+  if (source === "bug") return "fix";
+  if (source === "doc-gap") return "doc";
+  // Phase 1 conservative chore detection: body starts (line-wise) with
+  // "chore:" (case-insensitive). Phase 2 replaces with a BI workType field.
+  if (/^\s*chore\s*:/im.test(bi.body ?? "")) return "chore";
+  return "feature";
+}
+
+export function deriveBuildProcessSize(
+  bi: { effortSize?: string | null },
+): BuildProcessSize {
+  return normalizeSize(bi.effortSize ?? null);
+}
+
+// ─── Requirement check primitive ────────────────────────────────────────────
+
+import {
+  isFixContextComplete,
+  normalizeHappyPathState,
+  isHappyPathIntakeReady,
+  describePlanReviewFailure,
+} from "./feature-build-types";
+import type { FixContext, ReviewResult } from "./feature-build-types";
+
+type GateEvidence = Record<string, unknown>;
+
+export type RequirementResult = { allowed: true } | { allowed: false; reason: string };
+
+function missingHappyPathAnchorsFromState(state: ReturnType<typeof normalizeHappyPathState>): string[] {
+  const missing: string[] = [];
+  if (!state.intake.taxonomyNodeId) missing.push("taxonomy");
+  if (!state.intake.backlogItemId) missing.push("backlog item");
+  if (!state.intake.epicId) missing.push("epic");
+  if (!state.intake.constrainedGoal) missing.push("constrained goal");
+  return missing;
+}
+
+/**
+ * Pure check for one named requirement. The wiring matches today's
+ * checkPhaseGate body line-for-line so the default policy preserves behavior.
+ */
+export function checkRequirement(req: GateRequirement, evidence: GateEvidence): RequirementResult {
+  switch (req) {
+    case "designDoc-present": {
+      if (!evidence.designDoc) return { allowed: false, reason: "A design document is required before planning." };
+      return { allowed: true };
+    }
+    case "designReview-passed": {
+      const review = evidence.designReview as { decision?: string } | undefined;
+      if (!review) return { allowed: false, reason: "Design review is required before planning." };
+      if (review.decision === "fail") {
+        const isFix = evidence.kind === "fix";
+        return {
+          allowed: false,
+          reason: isFix
+            ? "Fix review failed. Revise the diagnosis and re-run the review before advancing."
+            : "Design review failed. Revise the design document and re-run reviewDesignDoc before advancing.",
+        };
+      }
+      return { allowed: true };
+    }
+    case "designReview-not-failed-if-present": {
+      // Looser variant for the fix flow: absent = allowed.
+      const review = evidence.designReview as { decision?: string } | undefined;
+      if (review?.decision === "fail") {
+        return {
+          allowed: false,
+          reason: "Fix review failed. Revise the diagnosis and re-run the review before advancing.",
+        };
+      }
+      return { allowed: true };
+    }
+    case "fixContext-complete": {
+      if (!isFixContextComplete(evidence.fixContext as FixContext | undefined)) {
+        return {
+          allowed: false,
+          reason: "A complete fix diagnosis (reproduction steps, root cause, and fix approach) is required before planning.",
+        };
+      }
+      return { allowed: true };
+    }
+    case "buildPlan-present": {
+      if (!evidence.buildPlan) return { allowed: false, reason: "An implementation plan is required before building." };
+      return { allowed: true };
+    }
+    case "planReview-passed": {
+      const planReview = evidence.planReview as ReviewResult | undefined;
+      if (!planReview) return { allowed: false, reason: "Plan review is required before building." };
+      if ((planReview as { decision?: string }).decision === "fail") {
+        return { allowed: false, reason: describePlanReviewFailure(planReview) };
+      }
+      return { allowed: true };
+    }
+    case "verification-typecheck-passed": {
+      const verification = evidence.verificationOut as { testsFailed?: number; typecheckPassed?: boolean } | null | undefined;
+      if (!verification) return { allowed: false, reason: "A verification run (tests + typecheck) is required before review." };
+      if (!verification.typecheckPassed) return { allowed: false, reason: "Typecheck must pass before review." };
+      return { allowed: true };
+    }
+    case "acceptance-evaluated": {
+      if (!evidence.acceptanceMet) return { allowed: false, reason: "Acceptance criteria not evaluated." };
+      return { allowed: true };
+    }
+    case "acceptance-all-met-if-array": {
+      if (Array.isArray(evidence.acceptanceMet)) {
+        const criteria = evidence.acceptanceMet as Array<{ met?: boolean }>;
+        if (criteria.some((c) => !c.met)) return { allowed: false, reason: "Not all acceptance criteria are met." };
+      }
+      return { allowed: true };
+    }
+    case "uxVerification-not-blocking": {
+      const status = evidence.uxVerificationStatus as
+        | "running" | "complete" | "failed" | "skipped" | null | undefined;
+      const hasAcceptance = Array.isArray(evidence.acceptanceCriteria)
+        && (evidence.acceptanceCriteria as unknown[]).length > 0;
+      if (status === "running") {
+        return { allowed: false, reason: "UX verification is still running. Retry in a moment." };
+      }
+      if ((status === null || status === undefined) && hasAcceptance) {
+        return { allowed: false, reason: "UX verification has not run yet." };
+      }
+      if (evidence.uxTestResults) {
+        const uxResults = evidence.uxTestResults as Array<{ passed?: boolean; step?: string }>;
+        const failed = uxResults.filter((s) => !s.passed);
+        if (failed.length > 0) {
+          const stepNames = failed.map((s) => s.step).filter(Boolean).slice(0, 3).join("; ");
+          return {
+            allowed: false,
+            reason: `UX verification failed: ${stepNames || `${failed.length} step(s)`}. Fix issues before shipping.`,
+          };
+        }
+      }
+      return { allowed: true };
+    }
+    case "happyPathIntake-ready": {
+      const state = normalizeHappyPathState(evidence.happyPathState);
+      if (!isHappyPathIntakeReady(state)) {
+        const missing = missingHappyPathAnchorsFromState(state).join(", ");
+        // The exact phrasing varies between ideate->plan and plan->build in
+        // today's code; the caller supplies the verb via evidence.intakeVerb
+        // ("planning" | "building"), defaulting to "planning" to match the
+        // ideate->plan use site that was the original home of this check.
+        const verb = (evidence.intakeVerb as string | undefined) ?? "planning";
+        return {
+          allowed: false,
+          reason: `Intake is incomplete. Link taxonomy, backlog item, epic, and a constrained goal before ${verb}. Missing: ${missing}.`,
+        };
+      }
+      return { allowed: true };
+    }
+  }
+}
+
+// ─── Header-chip presentation helper (consumed by UI in Phase 2) ────────────
+
+export function describePolicy(type: BuildProcessType, size: BuildProcessSize): string {
+  const policy = getProcessPolicy(type, size);
+  return `${policy.label} · ${policy.reviewIntensity} review · phases: ${policy.phases.join(" → ")}`;
+}
+
+// ─── checkPhaseGate — policy-driven gate ────────────────────────────────────
+//
+// Lives here (not in feature-build-types.ts) so the matrix module owns the
+// gate logic + policy table together. feature-build-types.ts re-exports
+// `checkPhaseGate` so existing import sites keep working unchanged.
+
+import type { PhaseGateResult } from "./feature-build-types";
+
+/**
+ * Phase gate — generalized to a policy lookup over the right-sizing matrix.
+ *
+ * The transition graph (ALLOWED_TRANSITIONS) is unchanged. What varies per
+ * build is *which* evidence requirements gate each transition. A small fix,
+ * a chore, and a doc-gap each pull a different `LifecyclePolicy` from
+ * getProcessPolicy(kind, processSize) and only the requirements that policy
+ * lists for the current transition are enforced.
+ *
+ * Back-compat invariant: when `evidence.kind` is absent (or "feature") and
+ * `evidence.processSize` is absent (or "medium"), the resolved policy is
+ * the default feature-standard cell — byte-identical to the pre-matrix
+ * behavior. The fix-flow design's binary kind switch is preserved as the
+ * (fix, medium) cell.
+ *
+ * Threaded inputs:
+ *   evidence.kind        — BuildProcessType (default "feature")
+ *   evidence.processSize — BuildProcessSize (default "medium")
+ *   evidence.intakeVerb  — "planning" | "building" (for the
+ *                          happyPathIntake-ready reason string only)
+ *   (everything else)    — same as before
+ */
+export function checkPhaseGate(
+  from: BuildPhase,
+  to: BuildPhase,
+  evidence: Record<string, unknown>,
+): PhaseGateResult {
+  if (to === "failed") return { allowed: true };
+  if (from === "review" && to === "build") return { allowed: true };
+
+  const policy = getProcessPolicy(
+    evidence.kind as string | undefined,
+    evidence.processSize as string | undefined,
+  );
+  const transition = `${from}->${to}` as BuildTransition;
+  const required = policy.gates[transition] ?? [];
+
+  // The happyPathIntake-ready check has two callers (ideate->plan and
+  // plan->build) with different reason verbs. Surface the verb through
+  // evidence so the matrix's requirement enum stays compact.
+  const verb = transition === "plan->build" ? "building" : "planning";
+  const evidenceWithVerb = { ...evidence, intakeVerb: evidence.intakeVerb ?? verb };
+
+  for (const req of required) {
+    const result = checkRequirement(req, evidenceWithVerb);
+    if (!result.allowed) return result;
+  }
+  return { allowed: true };
+}

--- a/apps/web/lib/explore/feature-build-data.ts
+++ b/apps/web/lib/explore/feature-build-data.ts
@@ -587,10 +587,18 @@ export async function getFeatureBuildForContext(
     }
   }
 
+  // Right-sizing matrix: read the build's processSize from plan.processSize
+  // (written at promote time by governed-backlog-tee-up). Default "medium"
+  // preserves today's policy cell for builds promoted before this field
+  // existed. See docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+  const planObj = (r.plan as Record<string, unknown> | null) ?? null;
+  const processSize = (planObj?.["processSize"] as string | undefined) ?? "medium";
+
   return {
     buildId: r.buildId,
     phase: r.phase as BuildPhase,
     kind: r.kind as import("@/lib/feature-build-types").FeatureBuildKind,
+    size: processSize as import("@/lib/feature-build-types").BuildProcessSize,
     title: r.title,
     brief: r.brief as FeatureBrief | null,
     designDoc: r.designDoc as BuildDesignDoc | null,

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -18,15 +18,34 @@ export type UxVerificationStatus = typeof UX_VERIFICATION_STATUSES[number];
 
 /**
  * Canonical values for FeatureBuild.kind — the work-kind discriminator that
- * lets the Build Studio pipeline run a build as a new-capability *feature* or a
- * targeted defect *fix*. `feature-build-types.ts` is the canonical home (kind is
- * a FeatureBuild concern; BacklogItem.source stays owned by backlog.ts). The DB
- * column is plain TEXT defaulting to "feature"; this array is the authority for
- * valid values. Adding a value requires updating any MCP tool mirror in the same
- * commit, before any data uses it.
+ * lets the Build Studio pipeline run a build as a new-capability *feature*,
+ * a targeted defect *fix*, an intent-driven *chore*, or a *doc* gap.
+ * `feature-build-types.ts` is the canonical home (kind is a FeatureBuild
+ * concern; BacklogItem.source stays owned by backlog.ts).
+ *
+ * The DB column is plain TEXT defaulting to "feature"; this array is the
+ * authority for valid values. Adding a value requires:
+ *   1. Adding it here.
+ *   2. Wiring at least one cell per size in DEFAULT_LIFECYCLE_MATRIX (see
+ *      build-process-matrix.ts §4.3) and any matching prompt variant in
+ *      build-agent-prompts.ts (or deliberately falling through to "feature").
+ *   3. Updating any MCP tool schema that mirrors the enum, in the same commit,
+ *      before any DB row writes the new value.
+ *
+ * Right-sizing matrix: docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
  */
-export const FEATURE_BUILD_KIND_VALUES = ["feature", "fix"] as const;
+export const FEATURE_BUILD_KIND_VALUES = ["feature", "fix", "chore", "doc"] as const;
 export type FeatureBuildKind = typeof FEATURE_BUILD_KIND_VALUES[number];
+
+/**
+ * Process sizes that drive the right-sizing matrix. Mirrors
+ * BACKLOG_EFFORT_SIZES; re-exported here so build-side consumers
+ * (build-agent-prompts, build-pipeline) can import everything they need
+ * from one canonical types module. Single source of truth still lives
+ * in backlog.ts (BACKLOG_EFFORT_SIZES); build-process-matrix.ts re-uses
+ * that array under a build-flavored alias.
+ */
+export type BuildProcessSize = "small" | "medium" | "large" | "xlarge";
 
 /**
  * Structured defect context for a `kind: "fix"` build. Carried additively on
@@ -733,14 +752,9 @@ export function mergeHappyPathStateIntoPlan(
   };
 }
 
-function missingHappyPathAnchors(state: HappyPathState): string[] {
-  const missing: string[] = [];
-  if (!state.intake.taxonomyNodeId) missing.push("taxonomy");
-  if (!state.intake.backlogItemId) missing.push("backlog item");
-  if (!state.intake.epicId) missing.push("epic");
-  if (!state.intake.constrainedGoal) missing.push("constrained goal");
-  return missing;
-}
+// missingHappyPathAnchors moved to build-process-matrix.ts where the
+// happyPathIntake-ready requirement is implemented. The matrix is the only
+// caller now that checkPhaseGate delegates to it.
 
 /**
  * A fix build's diagnosis is "complete enough" to plan against when it has
@@ -752,128 +766,20 @@ export function isFixContextComplete(fc: FixContext | null | undefined): boolean
   return Boolean(fc.reproSteps?.trim() && fc.rootCause?.trim() && fc.fixApproach?.trim());
 }
 
-export function checkPhaseGate(
-  from: BuildPhase,
-  to: BuildPhase,
-  evidence: Record<string, unknown>,
-): PhaseGateResult {
-  if (to === "failed") return { allowed: true };
-  if (from === "review" && to === "build") return { allowed: true };
-
-  // Work-kind discriminator. Threaded through `evidence.kind` so existing call
-  // sites that omit it default to feature behavior (byte-identical).
-  const isFix = evidence.kind === "fix";
-
-  if (from === "ideate" && to === "plan") {
-    if (isFix) {
-      // Fix flow: a complete diagnosis substitutes for the feature design doc;
-      // taxonomy/epic placement is optional (a defect is not a portfolio feature).
-      if (!isFixContextComplete(evidence.fixContext as FixContext | undefined)) {
-        return { allowed: false, reason: "A complete fix diagnosis (reproduction steps, root cause, and fix approach) is required before planning." };
-      }
-      const fixReview = evidence.designReview as { decision?: string } | undefined;
-      if (fixReview?.decision === "fail") {
-        return { allowed: false, reason: "Fix review failed. Revise the diagnosis and re-run the review before advancing." };
-      }
-      return { allowed: true };
-    }
-    if (!evidence.designDoc) return { allowed: false, reason: "A design document is required before planning." };
-    if (!evidence.designReview) return { allowed: false, reason: "Design review is required before planning." };
-    // Review must pass — a failed review blocks advancement until revision + re-review
-    const designReview = evidence.designReview as { decision?: string };
-    if (designReview.decision === "fail") {
-      return { allowed: false, reason: "Design review failed. Revise the design document and re-run reviewDesignDoc before advancing." };
-    }
-    const happyPathState = normalizeHappyPathState(evidence.happyPathState);
-    if (!isHappyPathIntakeReady(happyPathState)) {
-      const missing = missingHappyPathAnchors(happyPathState).join(", ");
-      return { allowed: false, reason: `Intake is incomplete. Link taxonomy, backlog item, epic, and a constrained goal before planning. Missing: ${missing}.` };
-    }
-    return { allowed: true };
-  }
-
-  if (from === "plan" && to === "build") {
-    if (!evidence.buildPlan) return { allowed: false, reason: "An implementation plan is required before building." };
-    if (!evidence.planReview) return { allowed: false, reason: "Plan review is required before building." };
-    // Review must pass — a failed review blocks advancement until revision + re-review
-    const planReview = evidence.planReview as ReviewResult & { decision?: string };
-    if (planReview.decision === "fail") {
-      // BI-4396EFEC (D38): when iteration metadata is present, surface the
-      // trajectory in the operator-facing reason so a stuck Plan loop is
-      // visible without reading DB tables. Three rounds with the same issue
-      // count is the "consider splitting scope" signal.
-      return { allowed: false, reason: describePlanReviewFailure(planReview) };
-    }
-    // Feature builds must anchor in the portfolio (taxonomy + epic) before
-    // building. Fix builds are exempt — a defect is not a portfolio feature.
-    if (!isFix) {
-      const happyPathState = normalizeHappyPathState(evidence.happyPathState);
-      if (!isHappyPathIntakeReady(happyPathState)) {
-        const missing = missingHappyPathAnchors(happyPathState).join(", ");
-        return { allowed: false, reason: `Intake is incomplete. Link taxonomy, backlog item, epic, and a constrained goal before building. Missing: ${missing}.` };
-      }
-    }
-    return { allowed: true };
-  }
-
-  if (from === "build" && to === "review") {
-    const verification = evidence.verificationOut as { testsFailed?: number; typecheckPassed?: boolean } | null;
-    if (!verification) return { allowed: false, reason: "A verification run (tests + typecheck) is required before review." };
-    if (!verification.typecheckPassed) return { allowed: false, reason: "Typecheck must pass before review." };
-    // Unit test failures are informational — the sandbox runs the full platform test
-    // suite, so pre-existing failures in unrelated modules must not block feature builds.
-    return { allowed: true };
-  }
-
-  if (from === "review" && to === "ship") {
-    if (isFix) {
-      if (!evidence.fixContext) return { allowed: false, reason: "Fix diagnosis is missing." };
-    } else {
-      if (!evidence.designDoc) return { allowed: false, reason: "Design document is missing." };
-    }
-    if (!evidence.buildPlan) return { allowed: false, reason: "Implementation plan is missing." };
-    if (!evidence.verificationOut) return { allowed: false, reason: "Verification output is missing." };
-    if (!evidence.acceptanceMet) return { allowed: false, reason: "Acceptance criteria not evaluated." };
-    // The AI may save acceptanceMet as a string description or an array of {criterion, met, evidence}.
-    // Both indicate the AI evaluated criteria. Only block if it's a proper array with unmet items.
-    if (Array.isArray(evidence.acceptanceMet)) {
-      const criteria = evidence.acceptanceMet as Array<{ met?: boolean }>;
-      if (criteria.some((c) => !c.met)) return { allowed: false, reason: "Not all acceptance criteria are met." };
-    }
-    // UX verification gate — three signals in combination:
-    //   status "running"             -> in-flight, block until it settles
-    //   status null + acceptance > 0 -> never ran, block (something's wrong)
-    //   status "skipped"             -> zero acceptance criteria, allow
-    //   status "failed"              -> blocked (unless override)
-    //   failed steps in uxTestResults -> blocked (defense in depth even if
-    //                                    the column got out of sync)
-    const status = evidence.uxVerificationStatus as
-      | "running" | "complete" | "failed" | "skipped" | null | undefined;
-    const hasAcceptance = Array.isArray(evidence.acceptanceCriteria)
-      && (evidence.acceptanceCriteria as unknown[]).length > 0;
-
-    if (status === "running") {
-      return { allowed: false, reason: "UX verification is still running. Retry in a moment." };
-    }
-    if ((status === null || status === undefined) && hasAcceptance) {
-      return { allowed: false, reason: "UX verification has not run yet." };
-    }
-    if (evidence.uxTestResults) {
-      const uxResults = evidence.uxTestResults as Array<{ passed?: boolean; step?: string }>;
-      const failed = uxResults.filter((s) => !s.passed);
-      if (failed.length > 0) {
-        const stepNames = failed.map((s) => s.step).filter(Boolean).slice(0, 3).join("; ");
-        return {
-          allowed: false,
-          reason: `UX verification failed: ${stepNames || `${failed.length} step(s)`}. Fix issues before shipping.`,
-        };
-      }
-    }
-    return { allowed: true };
-  }
-
-  return { allowed: true };
-}
+/**
+ * Phase gate — re-exported from build-process-matrix.ts.
+ *
+ * The implementation moved to build-process-matrix.ts so the right-sizing
+ * matrix module owns the gate logic and the LifecyclePolicy table together.
+ * This re-export preserves every existing import site that reaches
+ * checkPhaseGate via @/lib/feature-build-types.
+ *
+ * Back-compat invariant: when `evidence.kind` is absent (or "feature") and
+ * `evidence.processSize` is absent (or "medium"), the resolved policy is
+ * the default feature-standard cell — byte-identical to the pre-matrix
+ * behavior. See docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md.
+ */
+export { checkPhaseGate } from "./build-process-matrix";
 
 // ─── Validation ──────────────────────────────────────────────────────────────
 

--- a/apps/web/lib/explore/fix-flow.test.ts
+++ b/apps/web/lib/explore/fix-flow.test.ts
@@ -22,8 +22,15 @@ const completeFix: FixContext = {
 };
 
 describe("FEATURE_BUILD_KIND_VALUES", () => {
-  it("is a closed two-value enum", () => {
-    expect(FEATURE_BUILD_KIND_VALUES).toEqual(["feature", "fix"]);
+  it("is a closed enum that still contains feature and fix (extended for right-sizing)", () => {
+    // The 2026-05-30 right-sizing matrix extends this enum with `chore` and
+    // `doc`. The closed-enum guarantee is preserved — adding values still
+    // requires updating mcp-tools.ts mirrors and the matrix at the same time.
+    expect(FEATURE_BUILD_KIND_VALUES).toContain("feature");
+    expect(FEATURE_BUILD_KIND_VALUES).toContain("fix");
+    expect(FEATURE_BUILD_KIND_VALUES).toContain("chore");
+    expect(FEATURE_BUILD_KIND_VALUES).toContain("doc");
+    expect(FEATURE_BUILD_KIND_VALUES).toHaveLength(4);
   });
 });
 

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -1,6 +1,10 @@
 import * as crypto from "crypto";
 import { generateBuildId, mergeHappyPathStateIntoPlan } from "@/lib/feature-build-types";
 import {
+  deriveBuildProcessType,
+  deriveBuildProcessSize,
+} from "@/lib/explore/build-process-matrix";
+import {
   attachBuildStudioWorkCapsule,
   type BuildStudioCapsuleDb,
 } from "@/lib/work-capsules/build-studio-attachment";
@@ -193,7 +197,12 @@ export async function promoteBacklogItemToBuildDraft(
   }
 
   const constrainedGoal = item.title.trim().slice(0, 280);
-  const plan = mergeHappyPathStateIntoPlan(null, {
+  // Right-sizing matrix: persist the BI's effortSize onto the build's plan
+  // so the prompt selector + phase gate can pick the matching lifecycle
+  // policy. Default "medium" preserves today's behavior for BIs without an
+  // explicit effortSize. See build-process-matrix.ts.
+  const processSize = deriveBuildProcessSize({ effortSize: item.effortSize ?? null });
+  const planBase = mergeHappyPathStateIntoPlan(null, {
     intake: {
       status: "ready",
       backlogItemId: item.itemId,
@@ -207,14 +216,17 @@ export async function promoteBacklogItemToBuildDraft(
       constrainedGoal,
     },
   });
+  const plan = { ...planBase, processSize };
 
   // Work-kind derivation + fix-context carry-through.
-  // A bug-sourced backlog item becomes a "fix" build; everything else stays a
-  // "feature". For fixes, pull the originating PlatformIssueReport (linked from
-  // the triage-created BI body as "Source report: PIR-XXXXX") so the build
-  // starts from the real diagnosis (severity, route, error stack) instead of a
-  // blank brief. reproSteps/rootCause/fixApproach are left for ideate to fill.
-  const kind: "feature" | "fix" = item.source === "bug" ? "fix" : "feature";
+  // deriveBuildProcessType is the single source of truth for source→kind
+  // mapping; today it returns "fix" for bug-sourced BIs, "doc" for doc-gap,
+  // "chore" for body-marked chores, "feature" otherwise. For fixes we pull
+  // the originating PlatformIssueReport (linked from the triage-created BI
+  // body as "Source report: PIR-XXXXX") so the build starts from the real
+  // diagnosis (severity, route, error stack) instead of a blank brief.
+  // reproSteps/rootCause/fixApproach are left for ideate to fill.
+  const kind = deriveBuildProcessType({ source: item.source ?? null, body: item.body });
   let fixBrief: Record<string, unknown> | null = null;
   let originatingReportId: string | null = null;
   if (kind === "fix") {

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -495,11 +495,16 @@ GUARDRAILS:
 If Dev mode is enabled, show the registration details, diff summary, deployment window info, assessment criteria scores, and IT4IT stage references.`,
 };
 
-// ─── Fix-flow phase prompts ──────────────────────────────────────────────────
-// Used when FeatureBuild.kind === "fix". Only the phases that are still
-// feature-shaped are overridden (ideate/plan/review). The `build` phase reuses
-// the feature prompt (it already documents a "WORKFLOW FOR BUG FIXES AND
-// MODIFICATIONS" path), and `ship` is identical for both kinds.
+// ─── Per-variant phase prompts ──────────────────────────────────────────────
+//
+// Right-sizing matrix:
+// docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+//
+// Each LifecyclePolicy.promptVariant ∈ {feature, fix, chore, doc} maps to a
+// hardcoded prompt set below. Missing variant cells fall through to the
+// feature prompt for that phase, which preserves the original "fix flow
+// reuses the feature build prompt" behavior.
+
 const PHASE_PROMPTS_FIX: Record<string, string> = {
   ideate: `You are diagnosing a reported defect. This is a FIX, not a new feature — do not design new capability.
 
@@ -557,23 +562,145 @@ Record acceptance against the diagnosis: each fixContext expected/actual pair sh
 Keep responses short. Do not request new-feature acceptance criteria — the success criterion is the absence of the reported defect.`,
 };
 
+// Chore prompts — intent-driven cleanup / refactor. No design research,
+// no portfolio anchoring, no acceptance ceremony. Plan + verify is the work.
+const PHASE_PROMPTS_CHORE: Record<string, string> = {
+  ideate: `This build is a CHORE. There is no feature to design — advance to plan immediately.
+
+${PROJECT_CONTEXT}
+
+CHORES are intent-driven cleanups (refactors, dep bumps, internal moves, log noise reductions). The BI body IS the spec. You do NOT need a design document, taxonomy placement, or portfolio anchor.
+
+Read the BI title + body once. If the intent is already clear, call save_phase_handoff with a one-line summary and move on. If the intent is ambiguous, ask ONE clarifying question (e.g. "is this purely internal or is there any user-visible side?"). Do not generate a design doc.`,
+
+  plan: `You are planning a chore (refactor, cleanup, dep bump, internal move). The BI body is the spec.
+
+${PROJECT_CONTEXT}
+
+STEP 1 — SAVE THE PLAN via saveBuildEvidence field "buildPlan":
+  {
+    "fileStructure": [
+      { "path": "apps/web/...", "action": "modify", "purpose": "<what the cleanup changes here>" }
+    ],
+    "tasks": [
+      { "title": "<smallest unit of cleanup>", "testFirst": "<assertion that the cleanup preserves existing behavior — usually a typecheck or the relevant vitest>", "implement": "<full-path edit>", "verify": "pnpm --filter web typecheck" }
+    ]
+  }
+  Top-level "fileStructure" and "tasks" arrays. Full monorepo-relative paths.
+  A CHORE MUST PRESERVE BEHAVIOR. If your plan changes behavior, this is not a chore — escalate by updating the BI source/kind.
+
+STEP 2: call reviewBuildPlan. Minimal review is fine — chores don't need design deliberation, just a sanity check that the plan preserves behavior and isn't accidentally feature-shaped.
+
+STEP 3: one sentence — "Chore plan ready — [N] tasks. Building now." — then save_phase_handoff.
+
+RULES: no design questions; no scope expansion; max 1 sentence per response.`,
+
+  review: `You are verifying a chore. Acceptance for a chore is "behavior is unchanged and the cleanup intent is achieved".
+
+${PROJECT_CONTEXT}
+
+VERIFY, IN ORDER:
+  1. Typecheck passes (pnpm --filter web typecheck).
+  2. Relevant tests still pass.
+  3. The cleanup intent from the BI is visible in the diff (e.g. the deprecated import is gone, the dep is bumped, the dead code is deleted).
+
+Do NOT generate acceptance-criteria evaluation entries — chores don't have user-visible acceptance criteria. Save a one-line acceptance note covering the three checks above and advance to ship.
+
+Keep responses short.`,
+};
+
+// Doc prompts — content edits. No sandbox boot in spirit; the verification
+// still typechecks anything that imports embedded code samples, but UX
+// verification and acceptance-criteria evaluation are skipped.
+const PHASE_PROMPTS_DOC: Record<string, string> = {
+  ideate: `This build is a DOC gap. There is no feature to design — advance to plan immediately.
+
+${PROJECT_CONTEXT}
+
+A doc-gap fix is a content edit. The BI body identifies what needs to be added/corrected. You do NOT need a design document, portfolio anchor, or sandbox session.
+
+If the BI body names the target file(s), advance to plan with a one-line summary. If it does not, ask ONE clarifying question about which doc surface to edit.`,
+
+  plan: `You are planning a doc-gap fix. The BI body identifies the target.
+
+${PROJECT_CONTEXT}
+
+STEP 1 — SAVE THE PLAN via saveBuildEvidence field "buildPlan":
+  {
+    "fileStructure": [
+      { "path": "docs/...", "action": "create" | "modify", "purpose": "<what the doc edit covers>" }
+    ],
+    "tasks": [
+      { "title": "<doc edit unit>", "testFirst": "<link check / typecheck for embedded code / wiki-lint>", "implement": "<full-path edit>", "verify": "wiki_lint or pnpm --filter web typecheck if code samples are embedded" }
+    ]
+  }
+  Top-level "fileStructure" and "tasks" arrays. Full monorepo-relative paths.
+
+STEP 2: call reviewBuildPlan. Minimal review.
+
+STEP 3: one sentence — "Doc plan ready — [N] edits. Writing now." — then save_phase_handoff.
+
+RULES: no design questions; no scope expansion; max 1 sentence per response.`,
+
+  review: `You are verifying a doc-gap fix. Acceptance is "the doc reads correctly and any embedded code/links resolve".
+
+${PROJECT_CONTEXT}
+
+VERIFY, IN ORDER:
+  1. Any embedded code samples typecheck (or are explicitly marked non-runnable).
+  2. Links resolve (wiki_lint or equivalent).
+  3. The gap the BI identified is closed by the edit.
+
+Do NOT generate acceptance-criteria evaluation entries beyond the three checks above. Advance to ship.
+
+Keep responses short.`,
+};
+
+const PHASE_PROMPTS_BY_VARIANT: Record<string, Record<string, string>> = {
+  feature: PHASE_PROMPTS,
+  fix: PHASE_PROMPTS_FIX,
+  chore: PHASE_PROMPTS_CHORE,
+  doc: PHASE_PROMPTS_DOC,
+};
+
+/**
+ * Resolve the phase prompt for a build. Generalizes the previous
+ * (phase, kind) selector to consult the right-sizing matrix:
+ *
+ *   1. getProcessPolicy(kind, size) yields a LifecyclePolicy.
+ *   2. If `phase` is not in policy.phases, the prompt is empty
+ *      (the phase is effectively skipped — its gate auto-passes).
+ *   3. Otherwise, pick the variant's hardcoded prompt; if none exists for
+ *      this (variant, phase), fall through to the feature prompt for that
+ *      phase. This preserves the original "fix reuses feature build prompt"
+ *      behavior and gives chore/doc graceful fallbacks while the variant
+ *      prompts mature.
+ *   4. Load the DB override at slug "<phase>-<variant>" (or just "<phase>"
+ *      for feature), with the hardcoded prompt as fallback.
+ *
+ * Back-compat: getBuildPhasePrompt(phase) with no kind/size returns the
+ * exact same string as before for every (phase, "feature") pair.
+ */
 export async function getBuildPhasePrompt(
   phase: BuildPhase,
   kind: FeatureBuildKind = "feature",
+  size: import("@/lib/feature-build-types").BuildProcessSize = "medium",
 ): Promise<string> {
-  if (kind === "fix") {
-    const fixHardcoded = PHASE_PROMPTS_FIX[phase];
-    if (fixHardcoded) {
-      // DB-overridable via Admin > Prompts under the "<phase>-fix" slug; falls
-      // back to the hardcoded fix prompt (never empty) for active phases.
-      return loadPrompt("build-phase", `${phase}-fix`, fixHardcoded);
-    }
-    // Phases without a fix variant (build/ship/terminal) fall through to the
-    // feature prompt, preserving terminal-phase empty-prompt behavior below.
-  }
-  const hardcoded = PHASE_PROMPTS[phase] ?? "";
+  const { getProcessPolicy, normalizeType, normalizeSize } = await import("@/lib/explore/build-process-matrix");
+  const policy = getProcessPolicy(normalizeType(kind), normalizeSize(size));
+
+  // Phase not in this policy's visible set → empty prompt (skip). Terminal
+  // phases ("complete", "failed") were always empty; this keeps them so for
+  // every variant.
+  if (!policy.phases.includes(phase)) return "";
+
+  const variant = policy.promptVariant;
+  const variantPrompts = PHASE_PROMPTS_BY_VARIANT[variant] ?? PHASE_PROMPTS;
+  const hardcoded = variantPrompts[phase] ?? PHASE_PROMPTS[phase] ?? "";
   if (!hardcoded) return "";
-  return loadPrompt("build-phase", phase, hardcoded);
+
+  const slug = variant === "feature" ? phase : `${phase}-${variant}`;
+  return loadPrompt("build-phase", slug, hardcoded);
 }
 
 export type PhaseHandoffSummary = {
@@ -591,6 +718,11 @@ export type BuildContext = {
   phase: BuildPhase;
   /** Work kind. Absent/null is treated as "feature". */
   kind?: FeatureBuildKind | null;
+  /** Right-sizing process size, drawn from the originating BI's effortSize
+   *  and persisted at promote time in plan.processSize. Absent/null is
+   *  treated as "medium" — the default policy cell, byte-identical to
+   *  pre-matrix behavior. */
+  size?: import("@/lib/feature-build-types").BuildProcessSize | null;
   title: string;
   brief: FeatureBrief | null;
   designDoc?: BuildDesignDoc | null;
@@ -841,7 +973,7 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
   }
 
   lines.push("");
-  lines.push(await getBuildPhasePrompt(ctx.phase, ctx.kind ?? "feature"));
+  lines.push(await getBuildPhasePrompt(ctx.phase, ctx.kind ?? "feature", ctx.size ?? "medium"));
 
   // Contribution mode awareness for all phases — agent should know this for design decisions
   if (ctx.contributionMode) {

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -365,11 +365,18 @@ async function stepGenerateCode(
     }
   } catch { /* non-fatal */ }
 
+  // Right-sizing matrix: read processSize from plan.processSize (written
+  // at promote time) so the build phase prompt reflects the BI's declared
+  // effortSize. Default "medium" preserves today's behavior for builds
+  // promoted before plan.processSize existed.
+  const processSize = (plan["processSize"] as string | undefined) ?? "medium";
+
   // Build the system prompt with build context (same as the coworker uses)
   const buildContext = await getBuildContextSection({
     buildId,
     phase: "build",
     kind: build.kind as import("@/lib/feature-build-types").FeatureBuildKind,
+    size: processSize as import("@/lib/feature-build-types").BuildProcessSize,
     title: brief?.title ?? "Feature",
     brief,
     portfolioId: build.portfolioId,

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6937,6 +6937,8 @@ export async function executeTool(
             toPhase as import("@/lib/feature-build-types").BuildPhase,
             {
               kind: latestBuild.kind,
+              // Right-sizing matrix: persisted on plan.processSize at promote time.
+              processSize: (plan.processSize as string | undefined) ?? "medium",
               fixContext: handoffBrief?.fixContext,
               designDoc: latestBuild.designDoc, designReview: latestBuild.designReview,
               buildPlan: latestBuild.buildPlan, planReview: latestBuild.planReview,
@@ -7338,7 +7340,11 @@ export async function executeTool(
       const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
       let phaseGateBlocker: string | null = null;
-      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true, kind: true, brief: true } });
+      // Right-sizing matrix: also select plan (carries processSize) so the
+      // fix-flow gate picks the (fix, small | medium | large | xlarge) cell
+      // rather than always falling back to (fix, medium). plan is also
+      // needed below for the standard feature path's intake fallback.
+      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true, kind: true, brief: true, plan: true } });
 
       // Fix flow: a fix build has no feature design doc — it carries a structured
       // diagnosis (fixContext) on its brief. Review the diagnosis for completeness
@@ -7346,6 +7352,7 @@ export async function executeTool(
       if (build?.kind === "fix") {
         const { isFixContextComplete, checkPhaseGate } = await import("@/lib/feature-build-types");
         const fixBrief = (build.brief ?? null) as import("@/lib/feature-build-types").FeatureBrief | null;
+        const fixProcessSize = ((build.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium";
         const fc = fixBrief?.fixContext;
         const complete = isFixContextComplete(fc);
         const review = complete
@@ -7360,7 +7367,7 @@ export async function executeTool(
         }
         let fixPhaseGateBlocker: string | null = null;
         try {
-          const gate = checkPhaseGate("ideate", "plan", { kind: "fix", fixContext: fc, designReview: review });
+          const gate = checkPhaseGate("ideate", "plan", { kind: "fix", processSize: fixProcessSize, fixContext: fc, designReview: review });
           if (gate.allowed) {
             const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
             void completeBuildPhaseRun(buildId, "ideate");
@@ -7513,6 +7520,10 @@ export async function executeTool(
           where: { buildId },
           select: {
             phase: true,
+            // Right-sizing matrix: kind drives policy selection in
+            // checkPhaseGate; pre-existing rows default to "feature" via
+            // the schema default, so this is back-compat-safe.
+            kind: true,
             originatingBacklogItemId: true,
             draftApprovedAt: true,
             designDoc: true,
@@ -7690,6 +7701,8 @@ export async function executeTool(
           }
 
           const gate = checkPhaseGate("ideate", "plan", {
+            kind: updatedBuild.kind,
+            processSize: ((updatedBuild.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium",
             designDoc: updatedBuild.designDoc,
             designReview: updatedBuild.designReview,
             happyPathState,
@@ -7931,6 +7944,8 @@ export async function executeTool(
           const happyPathState = normalizeHappyPathState(plan.happyPathState);
           const gate = checkPhaseGate("plan", "build", {
             kind: updatedBuild.kind,
+            // Right-sizing matrix: persisted on plan.processSize at promote time.
+            processSize: (plan.processSize as string | undefined) ?? "medium",
             buildPlan: updatedBuild.buildPlan,
             planReview: updatedBuild.planReview,
             happyPathState,

--- a/docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+++ b/docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
@@ -1,0 +1,371 @@
+---
+title: Build Studio Right-Sizing — Lifecycle as a Function of (Work Type, Size)
+authoredAt: 2026-05-30
+authoredBy: claude
+status: draft
+specKind: design
+relatedSpecs:
+  - docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md
+  - docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md
+  - docs/superpowers/specs/2026-04-16-build-studio-process-improvements.md
+  - docs/superpowers/specs/2026-03-26-build-studio-it4it-value-stream-alignment-design.md
+relatedPrinciples:
+  - docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+  - docs/founder-kernel/wiki/principles/single-source-of-truth.md
+  - docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
+  - docs/founder-kernel/wiki/principles/strongly-typed-string-enums.md
+externalReferences:
+  - https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization
+  - https://support.atlassian.com/jira-cloud-administration/docs/configure-a-workflow-scheme/
+  - https://linear.app/docs/cycles
+  - https://docs.scrumalliance.org/Scrum-Foundations/Scrum-Guide.html
+  - https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/agile-process
+---
+
+# Build Studio Right-Sizing — Lifecycle as a Function of (Work Type, Size)
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft |
+| Date | 2026-05-30 |
+| Backlog item | To file on approval (`feat-gap`, build, effortSize=medium). |
+| Epic recommendation | Extend the open Build Studio lifecycle epic. Do not file a new epic — this is a generalization of an existing pipeline branch, not a new substrate. |
+| Related substrate | [`apps/web/lib/explore/feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts); [`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts); [`apps/web/lib/integrate/build-agent-prompts.ts`](../../../apps/web/lib/integrate/build-agent-prompts.ts); [`apps/web/lib/build/size-design-doc.ts`](../../../apps/web/lib/build/size-design-doc.ts); [`apps/web/lib/governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts); [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts); [`apps/web/lib/actions/build.ts`](../../../apps/web/lib/actions/build.ts) |
+| Scope | A data-driven **process matrix** that maps `(work-type, work-size) → lifecycle policy` (visible phases, required gate evidence, prompt variant, review intensity). Generalizes today's binary `kind ∈ {feature, fix}` branching in `getBuildPhasePrompt` and `checkPhaseGate` so a one-line bug fix is not driven by the same playbook as a large new feature, a chore is lighter than either, and a doc-gap is lighter still. Sources the type and size from the originating `BacklogItem`. |
+| Out of scope | Adding `tool` / `skill` process kinds (separate governance pipelines — EP-GOVERN-002 tool evaluation, skill authoring); replacing the design-time decomposition gate (this spec composes with it, does not supersede it); changing the IT4IT value-stream alignment (stage mapping is per-phase, unchanged); operator-facing UI for picking type/size (derived from BI, not chosen). |
+
+---
+
+## 1. Problem
+
+Build Studio's lifecycle is **one playbook** that runs on every build. The fix-flow design ([2026-05-29](2026-05-29-fix-flow-through-build-studio-design.md)) carved out a `fix` branch, but the split is binary: every non-fix runs the full feature playbook regardless of how small the work is, and every fix runs the full fix playbook regardless of how large. The system has no notion that "a one-line copy change" and "a 3-week new capability" deserve different ceremony.
+
+Today's pipeline applies the same:
+- Ideate phase prompt (substantial — ~80 lines, expects design research + clarification questions).
+- Design-doc-required `ideate→plan` gate (or its fix-flow analogue requiring a complete `fixContext`).
+- Plan phase with `reviewBuildPlan` deliberation.
+- Build phase with full sandbox cycle.
+- Review phase with acceptance evaluation + UX verification.
+- Ship phase with deployment window + contribution assessment.
+
+This is correct for a medium/large feature. It is **disproportionate** for:
+
+- A **small fix** — a one-line copy correction with a regression test does not need a "design document" (even framed as fix diagnosis), three deliberation rounds, or a UX verification dance.
+- A **chore** — a refactor with zero behavior change does not need design research, a portfolio anchor, or an acceptance-criteria evaluation.
+- A **doc-gap** — a typo or missing README section does not need a sandbox, a build agent, or UX verification.
+- A **large feature** — already gets the existing design-time decomposition gate ([2026-05-24](2026-05-24-build-studio-design-time-decomposition-design.md)), but its "is this too big to plan as one build?" check fires *after* a full ideate cycle. A size-aware lifecycle could pre-trigger decomposition for `xlarge` work.
+
+The cost is real:
+- LLM tokens burnt on irrelevant ceremony (Responsible Capacity Utilization — kernel principle).
+- Operator friction (the fix-flow dogfood session showed the binary split works, but small chores still feel heavy).
+- Pipeline mis-signal — when every build passes through every gate, gate failures stop conveying useful information.
+
+The infrastructure for size-awareness **already exists**:
+- `BacklogItem.effortSize ∈ {small, medium, large, xlarge}` ([`backlog.ts:133`](../../../apps/web/lib/explore/backlog.ts)).
+- `sizeDesignDoc()` ([`size-design-doc.ts`](../../../apps/web/lib/build/size-design-doc.ts)) — deterministic post-design recheck producing a `decompose-recommended | decompose-required` decision.
+- `FeatureBuild.kind ∈ {feature, fix}` ([`feature-build-types.ts:28`](../../../apps/web/lib/explore/feature-build-types.ts)).
+- The `getBuildPhasePrompt(phase, kind)` + `checkPhaseGate(..., {kind, ...})` selector pattern ([`build-agent-prompts.ts:560`](../../../apps/web/lib/integrate/build-agent-prompts.ts); [`feature-build-types.ts:755`](../../../apps/web/lib/explore/feature-build-types.ts)).
+
+What is missing is the *function* that maps `(type, size) → lifecycle policy` and the data threading so prompts and gates consult it.
+
+### 1.1 Relationship to adjacent specs
+
+- **Fix-flow design** ([2026-05-29](2026-05-29-fix-flow-through-build-studio-design.md)) — landed the `kind` discriminator and the feature/fix branching this spec generalizes. The seed of the matrix.
+- **Design-time decomposition** ([2026-05-24](2026-05-24-build-studio-design-time-decomposition-design.md)) — `sizeDesignDoc()` already exists for post-ideate size escalation. This spec adds *pre-ideate* size routing (from `BacklogItem.effortSize`) and composes with the post-design re-check.
+- **Process improvements** ([2026-04-16](2026-04-16-build-studio-process-improvements.md)) — flagged "No right-sizing of interaction" as Problem 3 but proposed only a complexity-assessment step. This spec is the structural answer: the lifecycle itself adapts, not just one mid-pipeline step.
+- **Parallel "unified BI work-type attribute" work** (`feat/unify-backlog-worktype` — branch reserved, no commits). When that lands and rationalizes `BacklogItem.source`/`type`/`workType` (today: `source ∈ {feature-gap, bug, tool-gap, skill-gap, doc-gap, user-request, automated-detection}` plus `type ∈ {portfolio, product}`), this spec's `deriveBuildProcessType(bi)` becomes a one-line read from the unified attribute. The matrix shape is unchanged.
+
+## 2. Current Repo Truth
+
+| Area | Verified current behavior | Design implication |
+| ---- | ------------------------- | ------------------ |
+| Work-kind discriminator | `FEATURE_BUILD_KIND_VALUES = ["feature", "fix"]` ([`feature-build-types.ts:28`](../../../apps/web/lib/explore/feature-build-types.ts)). `FeatureBuild.kind String @default("feature")` ([`schema.prisma:4413`](../../../packages/db/prisma/schema.prisma)). | Extend the closed enum with `chore` and `doc`. No migration — the column is plain TEXT, default still `"feature"`. |
+| Backlog source | `BACKLOG_SOURCE_VALUES = ["feature-gap","bug","tool-gap","skill-gap","doc-gap","user-request","automated-detection"]` ([`backlog.ts:122`](../../../apps/web/lib/explore/backlog.ts)). | Map `source → kind` at promote: today `bug → fix`; extend to `doc-gap → doc`. `chore` has no source today — accept it as an explicit BI field (Phase 2) or via a body keyword (Phase 1, conservative). Other sources default to `feature`. |
+| Effort size | `BACKLOG_EFFORT_SIZES = ["small","medium","large","xlarge"]` ([`backlog.ts:133`](../../../apps/web/lib/explore/backlog.ts)). `BacklogItem.effortSize String?` ([`schema.prisma:965`](../../../packages/db/prisma/schema.prisma)). The eligibility gate excludes `xlarge` ([`governed-backlog-tee-up.ts:8`](../../../apps/web/lib/governed-backlog-tee-up.ts)). | Promote already reads `effortSize`. Carry it into `FeatureBuild.plan.processSize` (no migration). Default to `medium` when null. `xlarge` is intentionally not eligible for direct build promotion today — the matrix preserves that, then routes it to the existing design-time decomposition path. |
+| Prompt selector | `getBuildPhasePrompt(phase, kind = "feature") → loadPrompt("build-phase", phase or phase-fix, hardcoded)` ([`build-agent-prompts.ts:560-577`](../../../apps/web/lib/integrate/build-agent-prompts.ts)). DB-overridable via `PromptTemplate` (category `build-phase`, slug per variant). | Extend the selector to consult a `LifecyclePolicy` derived from `(kind, size)`. The slug becomes `<phase>` for feature/standard, `<phase>-fix` for fix, `<phase>-chore` for chore, `<phase>-doc` for doc; size feeds *intensity* hints in the prompt body but does not split into yet more slugs (combinatorial explosion is worse than parameterization). |
+| Gate | `checkPhaseGate(from, to, evidence)` ([`feature-build-types.ts:755`](../../../apps/web/lib/explore/feature-build-types.ts)) branches on `evidence.kind === "fix"` for the `ideate→plan` and `review→ship` transitions. Other transitions are kind-blind. | Replace the binary `isFix` switch with a *policy lookup*: `policy = getProcessPolicy(kind, size)`. Each transition consults `policy.gates[transition]` for the required evidence. The default policy is byte-identical to today's `feature/medium` flow. |
+| Promote | `governed-backlog-tee-up.ts:217` derives `kind = item.source === "bug" ? "fix" : "feature"` and writes it to `FeatureBuild.kind`. `item.effortSize` is the eligibility filter; it is **not** carried onto the build today. | Generalize the kind derivation to `deriveBuildProcessType(item)` and additionally write `plan.processSize = item.effortSize ?? "medium"`. Both writes inside the existing `prisma.$transaction`. |
+| Build context | `BuildContext.kind` is threaded through `getBuildContextSection` ([`build-agent-prompts.ts:691,844`](../../../apps/web/lib/integrate/build-agent-prompts.ts)); `BuildContext` has no `size` field. | Add `BuildContext.size?: BuildProcessSize` and read it from `build.plan.processSize` at all call sites. |
+| Post-design size re-check | `sizeDesignDoc()` ([`size-design-doc.ts`](../../../apps/web/lib/build/size-design-doc.ts)) returns `decompose-recommended | decompose-required` from a deterministic count over the approved `BuildDesignDoc`. Already runs at `reviewDesignDoc` time. | Compose with `processSize`: if BI said `large` and the design re-check says `decompose-required`, the operator-facing reason should explain both signals. If BI said `small` and the design re-check tries to escalate, that is a useful divergence signal — record it; do not silently override. |
+
+## 3. Research & Benchmarking
+
+How established systems vary process by work type and work size. The pattern matters; vendor specifics are illustrative.
+
+| System | Model (verified from product docs) | Adopt | Reject |
+| ------ | ---------------------------------- | ----- | ------ |
+| **GitHub Issue Types + Workflow Forms** | Org-level issue **types** (Bug, Feature, Task) are a first-class field; per-type issue **forms** collect structured fields and per-type **action workflows** can run different automations. Sources: [GitHub issue types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization). | Type drives different forms / automation; the closed type enum is small. | Do not let type proliferate into Bug/Defect/Regression/Hotfix/etc. — keep four values now. |
+| **Jira Workflow Schemes** | Different issue **types** can be bound to different **workflows** (with different transitions, fields, validators, conditions, post-functions); workflow schemes are administered per project and not chosen per ticket. Sources: [Jira workflow schemes](https://support.atlassian.com/jira-cloud-administration/docs/configure-a-workflow-scheme/). | Drive **per-type pipelines** in the same Build Studio engine, configured (not coded) per type. The "workflow scheme" idea maps cleanly to a `LifecyclePolicy` table. | Do not expose policy configuration to the non-technical operator; derive it from BI fields. Do not let policy diverge per *project*, only per `(type, size)`. |
+| **Linear Cycles + Estimates** | Issues carry an **estimate** (small/medium/large or numeric), and cycles right-size the work-in-progress; "small" tasks can ship without a design pass, larger tasks get more review. Sources: [Linear cycles](https://linear.app/docs/cycles). | Treat size as a first-class lifecycle driver, not a tag — match Linear's idea that estimate informs how much ceremony is appropriate. | Do not require numeric estimates; the existing `small | medium | large | xlarge` ordinal is enough and matches what BIs already carry. |
+| **Scrum / "Definition of Done" per type** | Scrum guides (and most agile playbooks) define DoD per work type — a spike has a different DoD than a story, which has a different DoD than a bug. The DoD is the *gate*, not a label. Sources: [Scrum Guide](https://docs.scrumalliance.org/Scrum-Foundations/Scrum-Guide.html). | Gate evidence per `(type, size)` — the matrix is essentially "Definition of Done per work cell". | Do not write 24 prose definitions; encode the gate requirements as a closed `GateRequirement` enum the matrix can compose. |
+| **Azure DevOps / Microsoft Agile Process** | Different work item types (User Story, Bug, Task, Epic) have different state machines and different mandatory fields, all derived from the chosen Process template. Sources: [Azure DevOps Agile process](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/agile-process). | A small closed set of process templates + a "process scheme" per type is industry-standard; nothing exotic here. | Do not export an editable XML process template to operators (Azure's complexity tax). Keep the matrix as TypeScript data the platform owns. |
+| **GitHub Actions reusable workflows** | A single workflow definition is parameterized and called with inputs; routing is configuration, not code duplication. Sources: [Reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). | Implement the matrix as **one** orchestration engine consuming a parameterized policy, not N forked pipelines. The fix-flow split already showed branches sprawl quickly. | Do not fork the orchestrator per type. |
+
+**Patterns adopted:**
+- Closed work-type enum, platform-derived from BI (not operator-chosen).
+- Size as an ordinal first-class lifecycle driver, not a tag.
+- "Definition of Done per type" expressed as a closed `GateRequirement` enum that the matrix composes.
+- One orchestration engine, parameterized by a `LifecyclePolicy`, configured per `(type, size)`.
+
+**Anti-patterns rejected:**
+- Free-text type/size with operator-facing config.
+- Per-type pipeline forks ("we'll just copy the feature path and prune it").
+- Combinatorial prompt-slug explosion (`<phase>-<type>-<size>` is 4×5×4 = 80 slugs; use 4 slugs and parameterize by size in the body).
+- Coupling the matrix to project / portfolio (universal across DPF).
+
+**Gaps the design fills:**
+- DPF has no per-type *workflow schemes* — the fix-flow PR added the second; this spec turns the binary branch into a closed matrix that other types plug into without orchestrator forks.
+- DPF has size data on BIs but does not propagate it into the build's prompts/gates. This spec closes that loop.
+
+## 4. Design
+
+### 4.1 Process type and size enums
+
+In [`apps/web/lib/explore/feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts):
+
+```ts
+// Extends FEATURE_BUILD_KIND_VALUES. Each value names a process flavor that
+// the matrix knows how to drive. Adding a value requires updating the matrix
+// (§4.3) and any MCP mirror in the same commit, before any data uses it.
+export const BUILD_PROCESS_TYPE_VALUES = ["feature", "fix", "chore", "doc"] as const;
+export type BuildProcessType = (typeof BUILD_PROCESS_TYPE_VALUES)[number];
+
+// Mirrors BACKLOG_EFFORT_SIZES so the build inherits the BI's sizing
+// without re-classification. The matrix may collapse adjacent sizes
+// (e.g. small+medium share a policy) — that's an internal detail of the
+// LifecyclePolicy table, not a separate enum.
+export const BUILD_PROCESS_SIZES = ["small", "medium", "large", "xlarge"] as const;
+export type BuildProcessSize = (typeof BUILD_PROCESS_SIZES)[number];
+```
+
+`FEATURE_BUILD_KIND_VALUES` becomes an **alias** of the first slice of `BUILD_PROCESS_TYPE_VALUES` for back-compat:
+
+```ts
+// Retained for back-compat; new code should import BUILD_PROCESS_TYPE_VALUES.
+// Kept as an alias rather than removed so existing imports (mcp-tools.ts,
+// schema-mirror tests) keep compiling without a wide rename pass.
+export const FEATURE_BUILD_KIND_VALUES = BUILD_PROCESS_TYPE_VALUES;
+export type FeatureBuildKind = BuildProcessType;
+```
+
+`FeatureBuild.kind`'s DB column already stores a TEXT; no migration. Existing rows are `"feature"`. New `chore`/`doc` values are valid the moment the enum extension lands.
+
+### 4.2 Gate requirement primitive
+
+Replace the inline branchy gate logic with a closed `GateRequirement` enum the policy composes:
+
+```ts
+export const GATE_REQUIREMENTS = [
+  // Evidence shapes
+  "designDoc-present",
+  "designReview-passed",
+  "fixContext-complete",
+  "buildPlan-present",
+  "planReview-passed",
+  "verification-typecheck-passed",
+  "acceptance-all-met",
+  "uxVerification-passed-or-skipped",
+  // Intake/portfolio anchors
+  "happyPathIntake-ready",
+  "happyPathIntake-ready-or-skipped",
+] as const;
+export type GateRequirement = (typeof GATE_REQUIREMENTS)[number];
+```
+
+`checkPhaseGate` (§4.4) walks the policy's required list for the transition and short-circuits at the first miss. Each requirement is implemented by a pure function over the existing `evidence` shape — no new evidence types. **Today's branchy gate is the union of these requirements composed correctly; no behavior change for the default policy.**
+
+### 4.3 The matrix — `LifecyclePolicy` per `(type, size)`
+
+```ts
+export type BuildTransition =
+  | "ideate->plan"
+  | "plan->build"
+  | "build->review"
+  | "review->ship";
+
+export type LifecyclePolicy = {
+  /** Visible phases in operator UI + agent dispatch. Always a contiguous
+   *  prefix-of-the-canonical-order (you cannot have "build" without "plan")
+   *  but trailing phases can be skipped via merge (chore-small merges
+   *  "ideate" into "plan"). */
+  phases: BuildPhase[];
+  /** Prompt slug suffix. Selected by getBuildPhasePrompt; if a custom slug
+   *  isn't present in DB / hardcoded, the loader falls back to the next
+   *  generalization (e.g. chore -> feature). */
+  promptVariant: "feature" | "fix" | "chore" | "doc";
+  /** Suggested intensity for review deliberation (review/debate
+   *  pattern selection). Read by the deliberation framework; advisory. */
+  reviewIntensity: "minimal" | "standard" | "thorough";
+  /** What each transition requires. Missing transitions are allowed by
+   *  default (transitions outside the policy's phase set never fire). */
+  gates: Partial<Record<BuildTransition, ReadonlyArray<GateRequirement>>>;
+};
+```
+
+The **default matrix** (Phase 1 implementation):
+
+| type \ size | small | medium | large | xlarge |
+| ----------- | ----- | ------ | ----- | ------ |
+| **feature** | full lifecycle, *standard* review, all gates (today's behavior). Promote eligibility unchanged. | full lifecycle, *standard* review, all gates. **Default policy** — byte-identical to today. | full lifecycle, *thorough* review, all gates + design-time-decomposition warning surfaced. | full lifecycle, *thorough* review, **promote-eligible only after decomposition** — preserves today's `governed-backlog-tee-up.ts:8` exclusion of `xlarge` from auto-tee-up; design-time decomposition (`sizeDesignDoc`) is the explicit gate. |
+| **fix**     | merged ideate+plan, regression-test gate, no portfolio intake, no UX verification (smoke check only — "the defect no longer reproduces"). | full fix lifecycle (today's fix flow). | full fix lifecycle + decomposition warning if `sizeDesignDoc` trips. | route to decomposition: large fixes are almost always misclassified large features. Operator confirmation required to proceed monolithically. |
+| **chore**   | plan→build→ship, no ideate, no design doc, no UX verification, no acceptance evaluation. *Minimal* review (typecheck + tests only). | plan→build→review→ship, design doc replaced by a one-line "what + why", *minimal* review. | full lifecycle, *standard* review (chores at this size usually hide a refactor that needs design). | route to decomposition. |
+| **doc**     | author→review→ship (single Plan+Build merged phase that edits content files; no sandbox boot, no UX verification). *Minimal* review (link check + typecheck of any embedded code). | author→review→ship, *minimal* review. | author→review→ship, *standard* review (large docs cross-reference platform contracts). | route to decomposition. |
+
+**Why these cells.** The choices encode a small set of principles, not 16 independent decisions:
+
+1. **Default cell is unchanged.** `(feature, medium)` is the existing path, byte-identical. No risk of regression for the dominant case.
+2. **Small fixes merge ideate into plan.** The fix-flow dogfood session showed that a one-line fix's "diagnosis" and "plan" are the same act. The matrix encodes that.
+3. **Chores skip ideate.** A chore is *intent-driven*, not problem-driven — there is nothing to ideate. The plan + verification is the whole story.
+4. **Docs don't need a sandbox.** A doc-gap fix is a content edit; sandbox + UX verification are pure overhead.
+5. **xlarge always routes to decomposition.** Today's `governed-backlog-tee-up.ts` already excludes `xlarge` from promote eligibility. The matrix surfaces the *why* — it's not a special case, it's the matrix's xlarge column policy.
+6. **`sizeDesignDoc` composes, not duplicates.** The post-ideate re-check still runs and can escalate any cell to "decompose-recommended/required" if the design grew beyond its BI size. The pre-promote BI size is the *intent*; the design-time re-check is the *truth*.
+
+### 4.4 Selector + gate generalization
+
+```ts
+// apps/web/lib/explore/build-process-matrix.ts (NEW)
+
+export function getProcessPolicy(
+  type: BuildProcessType,
+  size: BuildProcessSize,
+): LifecyclePolicy { /* table lookup */ }
+
+// Derivation from BI. Single source of truth so the parallel
+// "unified BI work-type attribute" work changes one function, not 12 sites.
+export function deriveBuildProcessType(bi: { source: string | null; body?: string | null }): BuildProcessType {
+  if (bi.source === "bug") return "fix";
+  if (bi.source === "doc-gap") return "doc";
+  // Phase 1 conservative: detect "chore" via a body-line marker that
+  // BI-filing skills can write (see §4.7). Phase 2 promotes this to a
+  // dedicated BacklogItem.workType field via the parallel unify work.
+  if (/^chore:/im.test(bi.body ?? "")) return "chore";
+  return "feature";
+}
+
+export function deriveBuildProcessSize(bi: { effortSize: string | null }): BuildProcessSize {
+  const s = bi.effortSize as BuildProcessSize | null;
+  return s && (BUILD_PROCESS_SIZES as readonly string[]).includes(s) ? s : "medium";
+}
+```
+
+`getBuildPhasePrompt` generalizes:
+
+```ts
+export async function getBuildPhasePrompt(
+  phase: BuildPhase,
+  type: BuildProcessType = "feature",
+  size: BuildProcessSize = "medium",
+): Promise<string> {
+  const policy = getProcessPolicy(type, size);
+  // Try DB override at <phase>-<variant>, then <phase>-<variant> hardcoded,
+  // then fall back to <phase> hardcoded (feature). Preserves terminal-phase
+  // empty-prompt behavior (return "" for phases outside policy.phases).
+  if (!policy.phases.includes(phase)) return "";
+  const variant = policy.promptVariant;
+  const slug = variant === "feature" ? phase : `${phase}-${variant}`;
+  const fallback = PHASE_PROMPTS_BY_VARIANT[variant]?.[phase] ?? PHASE_PROMPTS[phase] ?? "";
+  return loadPrompt("build-phase", slug, fallback);
+}
+```
+
+`checkPhaseGate` generalizes:
+
+```ts
+export function checkPhaseGate(
+  from: BuildPhase,
+  to: BuildPhase,
+  evidence: Record<string, unknown>,
+): PhaseGateResult {
+  // Failed transitions and review->build cycles bypass policy.
+  if (to === "failed") return { allowed: true };
+  if (from === "review" && to === "build") return { allowed: true };
+
+  const type = (evidence.kind as BuildProcessType | undefined) ?? "feature";
+  const size = (evidence.processSize as BuildProcessSize | undefined) ?? "medium";
+  const policy = getProcessPolicy(type, size);
+
+  const transition = `${from}->${to}` as BuildTransition;
+  const required = policy.gates[transition] ?? [];
+
+  for (const req of required) {
+    const result = checkRequirement(req, evidence);
+    if (!result.allowed) return result;
+  }
+  return { allowed: true };
+}
+```
+
+`checkRequirement` is a pure function that for each `GateRequirement` returns `{allowed, reason?}`. The implementation is a direct translation of today's gate body — each branch becomes a named requirement function. **No behavior change for the default `(feature, medium)` policy.**
+
+### 4.5 Promote — write type + size onto the build
+
+In [`governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts), inside the existing `prisma.$transaction`:
+
+1. Replace `const kind = item.source === "bug" ? "fix" : "feature"` with `const kind = deriveBuildProcessType(item)`.
+2. Compute `const processSize = deriveBuildProcessSize(item)`.
+3. Pass `processSize` into `mergeHappyPathStateIntoPlan` so `plan.processSize = processSize`.
+4. Continue writing `kind` to `FeatureBuild.kind` (unchanged column).
+
+Eligibility (`isEligibleCandidate`) keeps excluding `xlarge`. The matrix's xlarge cells are reached when an operator manually promotes (admin override) or when post-ideate decomposition produces children that are themselves not `xlarge`.
+
+### 4.6 Threading `processSize` through `BuildContext`
+
+`BuildContext` gains `size?: BuildProcessSize`. The single line in `getBuildContextSection` becomes:
+
+```ts
+lines.push(await getBuildPhasePrompt(ctx.phase, ctx.kind ?? "feature", ctx.size ?? "medium"));
+```
+
+`build-pipeline.ts` and `actions/agent-coworker.ts` each read `processSize` from `build.plan.processSize` (with `"medium"` default) and pass it through. `actions/build.ts` `checkPhaseGate` call adds `processSize` to the evidence record.
+
+### 4.7 Filing chores — Phase 1 conservative path
+
+Until the parallel "unified BI work-type" work lands and gives chores a first-class source value, `deriveBuildProcessType` recognizes a `^chore:` line in the BI body. The `dpf-file-backlog-item` skill is updated to emit that marker when the operator says the BI is a chore. This is conservative — it does not pollute the source enum, it does not require a migration, and it converts cleanly to a real `BacklogItem.workType="chore"` read in Phase 2.
+
+### 4.8 Surfacing the policy to the operator
+
+A small "Process: feature · medium · standard review" chip on the Build Studio header (read-only, derived) so the operator can see *which* lifecycle is running. Click expands to the policy detail (phases, gates, prompt variant). No write affordance — the policy is derived.
+
+### 4.9 What is unchanged
+
+- `PHASE_ORDER`, `PHASE_LABELS`, `PHASE_COLOURS`, `VISIBLE_PHASES`, `canTransitionPhase` — phase identity is global; the matrix selects a *subset* of phases per policy, it does not invent new ones.
+- IT4IT mapping (`BUILD_PHASE_IT4IT`) — still keyed on phase, unchanged.
+- `sizeDesignDoc()` — still runs at design-review time and can escalate the decision regardless of BI-declared size.
+- The deliberation framework — `reviewIntensity` is advisory; the framework's existing pattern selection stays in charge.
+
+## 5. Implementation Phasing
+
+| Phase | Scope | Standalone? |
+| ----- | ----- | ----------- |
+| **1** (this spec, this PR) | `BUILD_PROCESS_TYPE_VALUES` + `BUILD_PROCESS_SIZES` enums; `getProcessPolicy(type, size)` matrix; `GateRequirement` enum + `checkRequirement` decomposition; generalized `getBuildPhasePrompt(phase, type, size)`; generalized `checkPhaseGate`; promote writes `plan.processSize` + uses `deriveBuildProcessType`; minimal chore + doc prompt variants (one paragraph each, can land thin); BuildContext threading; tests across the matrix; **default `(feature, medium)` cell byte-identical to today**. | Yes. Closes the basic right-sizing loop end-to-end. |
+| **2** (deferred) | `tool` and `skill` process types (separate governance pipelines — out of scope of this spec); `BacklogItem.workType` first-class column when the unify branch lands → drop the `^chore:` body sniff; `FeatureBuild.processSize` first-class column (migration) — Phase 1 carries it in `plan.processSize`; richer chore + doc prompt content (Phase 1 is intentionally thin); operator header chip with policy detail. | Hardening + extensibility. |
+| **3** (deferred) | Per-archetype matrix overrides (a vertical can tune `reviewIntensity` for its own work). Composes with the existing reduction-gear architecture. | Polishing. |
+
+## 6. Verification Gates
+
+Implementation (Phase 1) must meet the AGENTS.md §5 build gate:
+
+| Layer | What to run / show |
+| ----- | ------------------ |
+| Unit tests | `pnpm --filter web exec vitest run` covering: `getProcessPolicy(type, size)` returns the expected `LifecyclePolicy` for every cell; `deriveBuildProcessType` + `deriveBuildProcessSize` derivation for representative BIs; **`(feature, medium)` policy yields the exact same gate decisions as today's `checkPhaseGate` over a battery of fixtures** (back-compat invariant); `chore-small` skips ideate; `doc-small` skips the sandbox-required transitions; `fix-small` merges ideate+plan; `xlarge` cells return a gate-blocked result pointing at decomposition; prompt selector returns a non-empty string for each `(type, phase)` in the policy's `phases` set, and an empty string for terminal phases. |
+| Typecheck / build | `pnpm --filter web typecheck`; `cd apps/web && pnpm exec next build` with zero errors. |
+| Migration | None required for Phase 1 (TEXT column already accepts new enum values; size lives in `plan` JSON). |
+| UX | Against the Docker-served portal: promote a `bug`+`small` BI → confirm the build opens in the merged-fix-small lifecycle (no portfolio anchor demand at ideate, regression-test required at ship). Then promote a `feature-gap`+`medium` BI → confirm the build runs the existing feature path with no visible change. Use the `build-studio-operator` skill for the lifecycle gates. |
+
+This spec's own quality gate (pre-implementation): `dpf-architecture-review` lens applied; live MCP duplicate-spec check done (`feat/unify-backlog-worktype` empty; fix-flow design landed; design-time decomposition landed; process improvements spec from 2026-04-16 names but does not solve right-sizing); every code reference ground-truthed against the current tree.
+
+## 7. Risks & Open Decisions
+
+| Item | Resolution |
+| ---- | ---------- |
+| Back-compat for in-flight builds | `processSize` defaults to `"medium"`; `kind` defaults to `"feature"`; the `(feature, medium)` policy is byte-identical to today. Existing builds read as today's behavior with zero migration. **Low risk.** |
+| Slug explosion in `PromptTemplate` | Slugs grow from `{phase, phase-fix}` to `{phase, phase-fix, phase-chore, phase-doc}` — 5 phases × 4 variants = 20 slugs max. Bounded. The size dimension parameterizes the prompt body via a hint block, not via new slugs. |
+| `deriveBuildProcessType` body-sniff for chore | Phase 1 conservative: a `^chore:` line marker. Brittle but isolated to one function. Phase 2 replaces with `BacklogItem.workType`. |
+| Coexistence with the parallel unify branch | `deriveBuildProcessType(bi)` is the single read site. When unify lands, that function changes one line. No call-site churn elsewhere. |
+| Operator-perceived behavior change | Most operators will not notice — the default policy is unchanged. New cells only fire when a BI is explicitly a bug + small, a chore, or a doc-gap. The operator header chip (Phase 2) makes the active policy visible when curiosity arises. |
+| Size from BI vs from re-check | The pre-promote BI size is the *intent*. `sizeDesignDoc()` is the *post-design truth* and can escalate, never silently. When they disagree, the disagreement itself is operator-visible (the existing `sizeAssessment` panel already shows trips). |
+| Gate decomposition risk | The `GateRequirement` enum must encode *every* check today's `checkPhaseGate` performs, including the UX-status branches. A test fixture that asserts byte-identical gate decisions over a representative battery is the primary defense. |
+
+## 8. Next Step After Sign-Off
+
+On approval, file the implementation BI, then implement **Phase 1 directly in this repo** — the "Build Studio for ALL development" rule is intentionally overridden here because Build Studio is currently not running end-to-end (per the session memory record from 2026-05-29) — on a topic branch off `origin/main`, via a DCO-signed PR, meeting the full §5 build gate. Phase 2 and Phase 3 are filed as follow-up backlog and not started until Phase 1 has landed and accrued evidence.


### PR DESCRIPTION
## Summary
- Generalize Build Studio's binary `feature`/`fix` branching into a data-driven **right-sizing matrix**: `getProcessPolicy(type, size)` returns a `LifecyclePolicy` (visible phases, gate requirements, prompt variant, review intensity), and `checkPhaseGate` + `getBuildPhasePrompt` consult it. A one-line bug fix no longer carries the same ceremony as a large new feature; a chore is lighter still; a doc-gap drops the sandbox-required gates entirely.
- Extends `FEATURE_BUILD_KIND_VALUES` with `chore` and `doc` (TEXT column — no migration), threads `processSize` (mirror of `BACKLOG_EFFORT_SIZES`) through `BuildContext` / `build-pipeline` / `reviewDesignDoc` / `actions/build` / `mcp-tools` gate call sites, and writes `plan.processSize` at promote time so the build sees its lifecycle policy on its first read.
- **Back-compat invariant**: when `kind` is absent (or `"feature"`) and `processSize` is absent (or `"medium"`), the policy is the default `feature/standard` cell — byte-identical to today's gate over a battery of fixtures covered by both the pre-existing `feature-build-types` tests and the new back-compat suite in `build-process-matrix.test.ts`.

Spec: [docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/feat/build-studio-right-sizing/docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md).
Seed: [2026-05-29 fix-flow](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md) (binary kind discriminator — this PR generalizes it).
Composes with: [2026-05-24 design-time decomposition](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md) (post-design `sizeDesignDoc` re-check still runs and can escalate any cell).

## Matrix at a glance (Phase 1 — `feature`, `fix`, `chore`, `doc`)

| type \\ size | small | medium | large | xlarge |
| --- | --- | --- | --- | --- |
| **feature** | full lifecycle, standard review | **default cell** — byte-identical to today | full lifecycle, thorough review | thorough + decomposition first |
| **fix** | ideate+plan merged, no portfolio intake, regression test required, no UX | today's fix flow | + thorough review | decompose first (large fix usually = misclassified large feature) |
| **chore** | plan→build→ship, minimal review, no ideate, no acceptance | plan→build→review→ship, minimal review | full lifecycle, standard review | decompose first |
| **doc** | plan→build→ship, content edit, no sandbox/UX | same | + standard review | decompose first |

## Test plan
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web exec vitest run lib/explore lib/integrate lib/actions/build lib/governed-backlog-tee-up` — 942 passed, 5 todo, **0 failed** (includes the existing fix-flow + checkPhaseGate suites, plus 33 new matrix tests)
- [x] `NODE_ENV=production pnpm exec next build` — compiled successfully
- [ ] UX verification against a portal install: promote a `bug`+`small` BI → confirm the build opens in the merged fix-small lifecycle (no portfolio anchor demand at ideate); promote a `feature-gap`+`medium` BI → confirm no visible change versus today.

## Out of scope (filed as Phase 2)
- `tool` and `skill` process types (separate governance pipelines — EP-GOVERN-002 tool evaluation, skill authoring).
- First-class `BacklogItem.workType` column (lands with the parallel `feat/unify-backlog-worktype` branch; `deriveBuildProcessType` is the single read site that needs to change when it does).
- First-class `FeatureBuild.processSize` column with migration (today carried in `plan.processSize`).
- Operator-facing header chip surfacing the active policy.

## Why direct PR (not Build Studio)
Build Studio's build phase is not running end-to-end right now (per [build-studio-down-route-direct-pr](#) session note from 2026-05-29) and this PR changes the very lifecycle Build Studio drives, so dogfooding it on itself would be circular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)