### PR TITLE
feat(backlog): unify PIR/BacklogItem surface — add workType + split source (BI-FD37173A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,17 @@ Tool-specific files (`CLAUDE.md`, `.cursor/rules/`, `.clinerules/`, `.github/cop
 
 DB string columns with fixed valid values are canonical enums. Source of truth: `apps/web/lib/backlog.ts` (`EPIC_STATUSES`, union types) and `apps/web/lib/mcp-tools.ts` (`enum:` arrays). Match exactly.
 
-| Model         | Field    | Valid values                                |
-| ------------- | -------- | ------------------------------------------- |
-| `Epic`        | `status` | `open`, `in-progress`, `done`               |
-| `BacklogItem` | `status` | `open`, `in-progress`, `done`, `deferred`   |
-| `BacklogItem` | `type`   | `portfolio`, `product`                      |
+| Model         | Field      | Valid values                                                                |
+| ------------- | ---------- | --------------------------------------------------------------------------- |
+| `Epic`        | `status`   | `open`, `in-progress`, `done`                                               |
+| `BacklogItem` | `status`   | `open`, `in-progress`, `done`, `deferred`                                   |
+| `BacklogItem` | `type`     | `portfolio`, `product`                                                      |
+| `BacklogItem` | `workType` | `bug`, `feature`, `chore`, `doc`, `tool`, `skill`, `refactor`               |
+| `BacklogItem` | `source`   | `user-request`, `automated-detection`                                       |
 
 Hyphens, not underscores. Adding a new value requires updating both `backlog.ts` and the MCP tool definition in the same commit, before any data uses it.
+
+`BacklogItem.workType` is the closed *work-type* axis (the WHAT) and `BacklogItem.source` is the closed *intake-origin* axis (the HOW). Together they replace the legacy mixed-axis `source` enum (which had `feature-gap`, `bug`, `tool-gap`, `skill-gap`, `doc-gap`, `user-request`, `automated-detection` in one list). `FeatureBuild.kind` is derived from `workType` at promote time (`workType==="bug" ? "fix" : "feature"`). Spec: [`docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md`](docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md).
 
 ## 4. Branching, Commits & PRs
 

--- a/apps/web/app/(shell)/admin/issue-reports/page.tsx
+++ b/apps/web/app/(shell)/admin/issue-reports/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { IssueReportPanel } from "@/components/admin/IssueReportPanel";
 import { getIssueReports, getIssueReportStats } from "@/lib/actions/quality";
@@ -13,7 +14,12 @@ export default async function AdminIssueReportsPage() {
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Admin</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          Issue Reports — {data.total} total
+          Runtime evidence feed — {data.total} report{data.total === 1 ? "" : "s"}.
+          Each open report projects to a{" "}
+          <Link href="/ops" className="text-[var(--dpf-accent)] hover:underline">
+            backlog item
+          </Link>
+          {" "}with workType=bug on the next 15-minute triage tick.
         </p>
       </div>
 

--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -77,11 +77,15 @@ export function BacklogItemRow({ item, onEdit, focused = false }: Props) {
         {item.priority ?? "—"}
       </span>
 
+      {/* Work-type badge */}
+      <WorkTypeBadge workType={item.workType} />
+
       {/* Main content */}
       <div className="flex-1 min-w-0">
         <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight truncate">{item.title}</p>
         <p className="text-[10px] text-[var(--dpf-muted)] mt-0.5 truncate">
           {item.taxonomyNode?.nodeId ?? "—"}
+          {item.source ? ` · via ${item.source}` : ""}
           {item.digitalProduct ? ` · ${item.digitalProduct.name}` : ""}
           {item.agentId ? ` · ${AGENT_NAME_MAP[item.agentId] ?? item.agentId}` : ""}
           {item.submittedBy ? ` · by ${item.submittedBy.email}` : ""}
@@ -245,4 +249,31 @@ function statusBadgeClassName(status: string): string {
   };
 
   return classes[status] ?? classes.deferred;
+}
+
+const WORK_TYPE_BADGE_CLASS: Record<string, string> = {
+  bug: "border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 text-[var(--dpf-error)]",
+  feature: "border-[var(--dpf-accent)]/40 bg-[var(--dpf-accent-soft)] text-[var(--dpf-accent)]",
+  chore: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+  doc: "border-[var(--dpf-info)]/40 bg-[var(--dpf-info)]/10 text-[var(--dpf-info)]",
+  tool: "border-[var(--dpf-info)]/40 bg-[var(--dpf-info)]/10 text-[var(--dpf-info)]",
+  skill: "border-[var(--dpf-info)]/40 bg-[var(--dpf-info)]/10 text-[var(--dpf-info)]",
+  refactor: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+};
+
+function WorkTypeBadge({ workType }: { workType: string | null }) {
+  const label = workType ?? "unclassified";
+  const cls =
+    workType && WORK_TYPE_BADGE_CLASS[workType]
+      ? WORK_TYPE_BADGE_CLASS[workType]
+      : "border-dashed border-[var(--dpf-border)] bg-transparent text-[var(--dpf-muted)]";
+  return (
+    <span
+      className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${cls}`}
+      title={workType ? `work type: ${workType}` : "work type not classified — open and reclassify"}
+      aria-label={`work type ${label}`}
+    >
+      {label}
+    </span>
+  );
 }

--- a/apps/web/components/ops/BacklogPanel.tsx
+++ b/apps/web/components/ops/BacklogPanel.tsx
@@ -9,8 +9,10 @@ import { registerActiveFormAssist } from "@/lib/agent-form-assist";
 import { AGENT_NAME_MAP } from "@/lib/agent-routing";
 import {
   validateBacklogInput,
+  BACKLOG_WORK_TYPE_VALUES,
   type BacklogItemInput,
   type BacklogItemWithRelations,
+  type BacklogWorkType,
   type DigitalProductSelect,
   type TaxonomyNodeSelect,
   type EpicForSelect,
@@ -29,7 +31,9 @@ type Props = {
 };
 
 function emptyForm(type: "portfolio" | "product" = "portfolio", epicId?: string): BacklogItemInput {
-  return { title: "", type, status: "open", body: "", ...(epicId ? { epicId } : {}) };
+  // workType defaults to "feature" — the most common case for hand-filed BIs.
+  // The operator can change it via the form select before saving.
+  return { title: "", type, workType: "feature", status: "open", body: "", ...(epicId ? { epicId } : {}) };
 }
 
 export function BacklogPanel({
@@ -49,9 +53,11 @@ export function BacklogPanel({
 
   useEffect(() => {
     if (item) {
+      const itemWorkType = item.workType as BacklogWorkType | null;
       const next: BacklogItemInput = {
         title:  item.title,
         type:   item.type as "product" | "portfolio",
+        workType: itemWorkType ?? "feature",
         status: item.status as BacklogItemInput["status"],
         body:   item.body ?? "",
       };
@@ -176,6 +182,23 @@ export function BacklogPanel({
               ))}
             </div>
           </div>
+
+          {/* Work type */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Work Type *</span>
+            <select
+              value={form.workType}
+              onChange={(e) => set("workType", e.target.value as BacklogWorkType)}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-[var(--dpf-text)] focus:outline-none focus:border-[var(--dpf-accent)]"
+              required
+            >
+              {BACKLOG_WORK_TYPE_VALUES.map((wt) => (
+                <option key={wt} value={wt} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                  {wt}
+                </option>
+              ))}
+            </select>
+          </label>
 
           {/* Status */}
           <label className="flex flex-col gap-1">

--- a/apps/web/components/ops/OpsClient.test.tsx
+++ b/apps/web/components/ops/OpsClient.test.tsx
@@ -48,6 +48,8 @@ function item(overrides: Partial<BacklogItemWithRelations>): BacklogItemWithRela
     title: "Backlog item",
     status: "open",
     type: "product",
+    workType: "feature",
+    source: "user-request",
     body: null,
     priority: 1,
     epicId: "epic-id",

--- a/apps/web/components/ops/backlog-form-assist.test.ts
+++ b/apps/web/components/ops/backlog-form-assist.test.ts
@@ -5,7 +5,7 @@ import { applyBacklogFormAssistUpdates } from "./backlog-form-assist";
 describe("applyBacklogFormAssistUpdates", () => {
   it("applies supported scalar fields", () => {
     const next = applyBacklogFormAssistUpdates(
-      { title: "", type: "portfolio", status: "open", body: "" },
+      { title: "", type: "portfolio", workType: "feature", status: "open", body: "" },
       {
         title: "Investigate provider filtering",
         priority: 2,
@@ -16,6 +16,7 @@ describe("applyBacklogFormAssistUpdates", () => {
     expect(next).toEqual<BacklogItemInput>({
       title: "Investigate provider filtering",
       type: "portfolio",
+      workType: "feature",
       status: "open",
       priority: 2,
       body: "Use local providers for restricted routes.",
@@ -27,6 +28,7 @@ describe("applyBacklogFormAssistUpdates", () => {
       {
         title: "Existing",
         type: "product",
+        workType: "feature",
         status: "open",
         digitalProductId: "prod-1",
       },
@@ -40,6 +42,7 @@ describe("applyBacklogFormAssistUpdates", () => {
     expect(next).toEqual<BacklogItemInput>({
       title: "Existing",
       type: "portfolio",
+      workType: "feature",
       status: "open",
     });
   });

--- a/apps/web/lib/actions/backlog.ts
+++ b/apps/web/lib/actions/backlog.ts
@@ -41,6 +41,9 @@ export async function createBacklogItem(input: BacklogItemInput): Promise<void> 
     itemId:           `BI-${crypto.randomUUID()}`,
     title:            input.title.trim(),
     type:             input.type,
+    workType:         input.workType,
+    // Hand-filed BIs from the ops UI are human requests by definition.
+    source:           input.source ?? "user-request",
     status:           input.status,
     priority:         input.priority ?? null,
     taxonomyNodeId:   input.taxonomyNodeId ?? null,
@@ -64,6 +67,8 @@ export async function updateBacklogItem(id: string, input: BacklogItemInput): Pr
   const updateData = {
     title:            input.title.trim(),
     type:             input.type,
+    workType:         input.workType,
+    ...(input.source !== undefined ? { source: input.source } : {}),
     status:           input.status,
     priority:         input.priority ?? null,
     taxonomyNodeId:   input.taxonomyNodeId ?? null,

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -151,7 +151,7 @@ export async function sendIssueReportToBuildStudioAsFix(
   // cron and this action both embed the public report id in the BI body.
   let itemId: string | null = null;
   const existingItem = await prisma.backlogItem.findFirst({
-    where: { source: "bug", body: { contains: report.reportId } },
+    where: { workType: "bug", body: { contains: report.reportId } },
     orderBy: { createdAt: "desc" },
     select: { itemId: true, status: true, triageOutcome: true, effortSize: true, activeBuild: { select: { buildId: true } } },
   });
@@ -188,7 +188,11 @@ export async function sendIssueReportToBuildStudioAsFix(
         body: bodyParts.join("\n\n"),
         status: "open",
         type: report.digitalProductId ? "product" : "portfolio",
-        source: "bug",
+        // Operator clicked the admin "Send to Build Studio as a fix" action —
+        // that is a human request acting on automated runtime evidence. The
+        // originating PIR is linked via the body + back-link.
+        source: "user-request",
+        workType: "bug",
         triageOutcome: "build",
         effortSize: "small",
         priority: SEVERITY_PRIORITY[report.severity ?? "medium"] ?? 3,

--- a/apps/web/lib/assurance/finding-actions.ts
+++ b/apps/web/lib/assurance/finding-actions.ts
@@ -219,6 +219,8 @@ export async function createBacklogItemFromFinding(
       body,
       status: "triaging",
       source: "automated-detection",
+      // Assurance/supply-chain findings are bug-class remediation work.
+      workType: "bug",
       proposedOutcome: "build",
       effortSize: "medium",
       epicId: epic?.id ?? null,

--- a/apps/web/lib/backlog-enums.test.ts
+++ b/apps/web/lib/backlog-enums.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BACKLOG_TRIAGE_OUTCOMES,
   BACKLOG_SOURCE_VALUES,
+  BACKLOG_WORK_TYPE_VALUES,
   BACKLOG_EFFORT_SIZES,
   BACKLOG_STATUS_VALUES,
   EPIC_STATUSES,
@@ -28,6 +29,32 @@ describe("backlog enum parity between backlog.ts and mcp-tools.ts", () => {
 
   it("source matches on create_backlog_item.source", () => {
     expect(toolInputEnum("create_backlog_item", "source")).toEqual([...BACKLOG_SOURCE_VALUES]);
+  });
+
+  it("workType matches on create_backlog_item.workType", () => {
+    expect(toolInputEnum("create_backlog_item", "workType")).toEqual([...BACKLOG_WORK_TYPE_VALUES]);
+  });
+
+  it("workType matches on update_backlog_item.workType", () => {
+    expect(toolInputEnum("update_backlog_item", "workType")).toEqual([...BACKLOG_WORK_TYPE_VALUES]);
+  });
+
+  it("source matches on update_backlog_item.source", () => {
+    expect(toolInputEnum("update_backlog_item", "source")).toEqual([...BACKLOG_SOURCE_VALUES]);
+  });
+
+  it("workType matches on list_backlog_items.workType filter", () => {
+    expect(toolInputEnum("list_backlog_items", "workType")).toEqual([...BACKLOG_WORK_TYPE_VALUES]);
+  });
+
+  it("source matches on list_backlog_items.source filter", () => {
+    expect(toolInputEnum("list_backlog_items", "source")).toEqual([...BACKLOG_SOURCE_VALUES]);
+  });
+
+  it("create_backlog_item declares workType as required", () => {
+    const tool = PLATFORM_TOOLS.find((t) => t.name === "create_backlog_item");
+    const required = (tool?.inputSchema as { required?: string[] } | undefined)?.required ?? [];
+    expect(required).toContain("workType");
   });
 
   it("effortSize matches on size_backlog_item.size", () => {

--- a/apps/web/lib/explore/backlog-data.ts
+++ b/apps/web/lib/explore/backlog-data.ts
@@ -21,6 +21,8 @@ export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[
       title: true,
       status: true,
       type: true,
+      workType: true,
+      source: true,
       body: true,
       priority: true,
       epicId: true,

--- a/apps/web/lib/explore/backlog.test.ts
+++ b/apps/web/lib/explore/backlog.test.ts
@@ -12,12 +12,12 @@ import {
 
 describe("validateBacklogInput()", () => {
   it("returns null for a valid portfolio-type item", () => {
-    const input: BacklogItemInput = { title: "My item", type: "portfolio", status: "open" };
+    const input: BacklogItemInput = { title: "My item", type: "portfolio", workType: "feature", status: "open" };
     expect(validateBacklogInput(input)).toBeNull();
   });
 
   it("returns an error string for a product-type item missing digitalProductId", () => {
-    const input: BacklogItemInput = { title: "My item", type: "product", status: "open" };
+    const input: BacklogItemInput = { title: "My item", type: "product", workType: "feature", status: "open" };
     expect(validateBacklogInput(input)).toMatch(/digital product/i);
   });
 
@@ -25,6 +25,7 @@ describe("validateBacklogInput()", () => {
     const input: BacklogItemInput = {
       title: "My item",
       type: "product",
+      workType: "feature",
       status: "open",
       digitalProductId: "clxabc123",
     };
@@ -32,7 +33,7 @@ describe("validateBacklogInput()", () => {
   });
 
   it("returns an error for a blank title", () => {
-    const input: BacklogItemInput = { title: "   ", type: "portfolio", status: "open" };
+    const input: BacklogItemInput = { title: "   ", type: "portfolio", workType: "feature", status: "open" };
     expect(validateBacklogInput(input)).toMatch(/title/i);
   });
 });

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -3,7 +3,9 @@
 export type BacklogItemInput = {
   title: string;
   type: "product" | "portfolio";
+  workType: BacklogWorkType;
   status: BacklogStatus;
+  source?: BacklogSource;
   priority?: number;
   body?: string;
   taxonomyNodeId?: string;
@@ -17,6 +19,8 @@ export type BacklogItemWithRelations = {
   title: string;
   status: string;
   type: string;
+  workType: string | null;
+  source: string | null;
   body: string | null;
   priority: number | null;
   epicId: string | null;
@@ -119,16 +123,38 @@ export const BACKLOG_TRIAGE_OUTCOMES = [
 ] as const;
 export type BacklogTriageOutcome = (typeof BACKLOG_TRIAGE_OUTCOMES)[number];
 
+// Pure intake-origin enum. The previous mixed-axis values
+// (feature-gap, bug, tool-gap, skill-gap, doc-gap) moved into
+// BACKLOG_WORK_TYPE_VALUES below; this enum now answers "how did it arrive"
+// not "what kind of work is it".
+//
+// New values are added only when a writer needs them
+// (single-source-of-truth + YAGNI).
 export const BACKLOG_SOURCE_VALUES = [
-  "feature-gap",
-  "bug",
-  "tool-gap",
-  "skill-gap",
-  "doc-gap",
   "user-request",
   "automated-detection",
 ] as const;
 export type BacklogSource = (typeof BACKLOG_SOURCE_VALUES)[number];
+
+// Closed work-type enum (the WHAT). Required on every new BacklogItem.
+// Aligned with the Conventional Commits subset that maps cleanly to today's
+// BI consumers: bug == fix, feature == feat, plus chore | doc | tool | skill |
+// refactor. perf | test | security | ci | style | revert are deferred until a
+// writer needs them.
+//
+// Adding a value requires updating this enum AND the mirror in
+// apps/web/lib/mcp-tools.ts (create_backlog_item, update_backlog_item,
+// list_backlog_items) in the same commit per AGENTS.md §3.
+export const BACKLOG_WORK_TYPE_VALUES = [
+  "bug",
+  "feature",
+  "chore",
+  "doc",
+  "tool",
+  "skill",
+  "refactor",
+] as const;
+export type BacklogWorkType = (typeof BACKLOG_WORK_TYPE_VALUES)[number];
 
 export const BACKLOG_EFFORT_SIZES = ["small", "medium", "large", "xlarge"] as const;
 export type BacklogEffortSize = (typeof BACKLOG_EFFORT_SIZES)[number];

--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -74,25 +74,34 @@ describe("normalizeType / normalizeSize", () => {
   });
 });
 
-describe("deriveBuildProcessType — source-to-kind mapping", () => {
-  it("maps source=bug to fix", () => {
-    expect(deriveBuildProcessType({ source: "bug", body: null })).toBe("fix");
+describe("deriveBuildProcessType — workType-to-kind mapping", () => {
+  it("maps workType=bug to fix", () => {
+    expect(deriveBuildProcessType({ workType: "bug", body: null })).toBe("fix");
   });
 
-  it("maps source=doc-gap to doc", () => {
-    expect(deriveBuildProcessType({ source: "doc-gap", body: null })).toBe("doc");
+  it("maps workType=doc to doc", () => {
+    expect(deriveBuildProcessType({ workType: "doc", body: null })).toBe("doc");
   });
 
-  it("detects chores via a body-line marker (Phase 1 conservative path)", () => {
-    expect(deriveBuildProcessType({ source: "feature-gap", body: "chore: bump react to 18.4" })).toBe("chore");
-    expect(deriveBuildProcessType({ source: null, body: "Chore: rename internal helpers" })).toBe("chore");
-    expect(deriveBuildProcessType({ source: null, body: "Some unrelated body" })).toBe("feature");
+  it("maps workType=chore to chore", () => {
+    expect(deriveBuildProcessType({ workType: "chore", body: null })).toBe("chore");
   });
 
-  it("defaults everything else to feature (back-compat)", () => {
-    expect(deriveBuildProcessType({ source: "feature-gap", body: null })).toBe("feature");
-    expect(deriveBuildProcessType({ source: "user-request", body: null })).toBe("feature");
-    expect(deriveBuildProcessType({ source: null, body: null })).toBe("feature");
+  it("maps the feature-shaped workTypes to feature (feature | tool | skill | refactor)", () => {
+    expect(deriveBuildProcessType({ workType: "feature", body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ workType: "tool", body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ workType: "skill", body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ workType: "refactor", body: null })).toBe("feature");
+  });
+
+  it("legacy unclassified-row fallback: body-line chore marker still detected when workType is NULL", () => {
+    expect(deriveBuildProcessType({ workType: null, body: "chore: bump react to 18.4" })).toBe("chore");
+    expect(deriveBuildProcessType({ workType: null, body: "Chore: rename internal helpers" })).toBe("chore");
+  });
+
+  it("defaults to feature when workType is NULL and no body marker matches (back-compat)", () => {
+    expect(deriveBuildProcessType({ workType: null, body: null })).toBe("feature");
+    expect(deriveBuildProcessType({ workType: null, body: "Some unrelated body" })).toBe("feature");
   });
 });
 

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -390,24 +390,34 @@ export function normalizeSize(
 
 /**
  * Single source of truth for "given this BI, what build-process type does it
- * become?". The fix-flow design landed `bug -> fix`; this extends to docs
- * and (Phase 1 conservatively) chores via a body-line marker. The parallel
- * unified-BI-work-type branch will eventually replace this with a direct
- * read of `BacklogItem.workType`; when it does, this is the one site that
- * changes.
+ * become?". Reads the clean `BacklogItem.workType` closed enum (introduced
+ * in BI-FD37173A / 2026-05-30) and maps it to the build-process type:
+ *   - workType="bug"       -> "fix"   (fix-flow spec, 2026-05-29)
+ *   - workType="doc"       -> "doc"   (#1348 right-sizing)
+ *   - workType="chore"     -> "chore" (#1348 right-sizing)
+ *   - workType in {feature,tool,skill,refactor} -> "feature"
+ *     (all four are feature-shaped builds — design, plan, ship a change;
+ *      a future spec can split them further if a distinct prompt/gate path
+ *      proves useful)
+ *
+ * Legacy fallback: if workType is NULL (rows from the freeform-tail backfill
+ * that pre-date BI-FD37173A and the operator has not yet reclassified), fall
+ * back to the previous body-marker heuristic for chore. Eventually retire
+ * this fallback once Phase 1 makes workType non-null at the DB level.
  *
  * Accepts a structurally-minimal subset of BacklogItem fields so the helper
  * is callable from anywhere (promote, MCP tool wiring, tests) without
  * dragging in the full Prisma row type.
  */
 export function deriveBuildProcessType(
-  bi: Pick<BacklogItemWithRelations, "body"> & { source?: string | null },
+  bi: Pick<BacklogItemWithRelations, "body"> & { workType?: string | null },
 ): BuildProcessType {
-  const source = bi.source ?? null;
-  if (source === "bug") return "fix";
-  if (source === "doc-gap") return "doc";
-  // Phase 1 conservative chore detection: body starts (line-wise) with
-  // "chore:" (case-insensitive). Phase 2 replaces with a BI workType field.
+  const workType = bi.workType ?? null;
+  if (workType === "bug") return "fix";
+  if (workType === "doc") return "doc";
+  if (workType === "chore") return "chore";
+  if (workType) return "feature";
+  // Legacy unclassified-row fallback (deleted in Phase 1).
   if (/^\s*chore\s*:/im.test(bi.body ?? "")) return "chore";
   return "feature";
 }

--- a/apps/web/lib/governed-backlog-tee-up.test.ts
+++ b/apps/web/lib/governed-backlog-tee-up.test.ts
@@ -442,7 +442,7 @@ describe("governed backlog tee-up", () => {
       });
     });
 
-    it("promotes a bug-sourced item as kind=fix, carries fixContext, and back-links the issue report", async () => {
+    it("promotes a bug workType item as kind=fix, carries fixContext, and back-links the issue report", async () => {
       mockPrisma.backlogItem.findUnique.mockResolvedValueOnce({
         id: "bi-cuid-bug",
         itemId: "BI-PIR-abcd1234",
@@ -455,7 +455,11 @@ describe("governed backlog tee-up", () => {
         digitalProductId: null,
         epicId: null,
         taxonomyNodeId: null,
-        source: "bug",
+        // workType drives kind derivation (post 2026-05-30 spec). The legacy
+        // source value is left at the canonicalized origin so any reader of
+        // source sees the intake channel, not the work-type.
+        workType: "bug",
+        source: "automated-detection",
         epic: null,
       });
       mockPrisma.platformIssueReport.findUnique.mockResolvedValueOnce({

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -219,14 +219,20 @@ export async function promoteBacklogItemToBuildDraft(
   const plan = { ...planBase, processSize };
 
   // Work-kind derivation + fix-context carry-through.
-  // deriveBuildProcessType is the single source of truth for source→kind
-  // mapping; today it returns "fix" for bug-sourced BIs, "doc" for doc-gap,
-  // "chore" for body-marked chores, "feature" otherwise. For fixes we pull
-  // the originating PlatformIssueReport (linked from the triage-created BI
-  // body as "Source report: PIR-XXXXX") so the build starts from the real
-  // diagnosis (severity, route, error stack) instead of a blank brief.
-  // reproSteps/rootCause/fixApproach are left for ideate to fill.
-  const kind = deriveBuildProcessType({ source: item.source ?? null, body: item.body });
+  // deriveBuildProcessType is the single source of truth for "given this BI,
+  // what build-process type does it become?" — see build-process-matrix.ts.
+  // After BI-FD37173A (this PR) it reads the clean `BacklogItem.workType`
+  // closed enum: workType="bug" -> "fix", "doc" -> "doc", "chore" -> "chore",
+  // everything else (feature | tool | skill | refactor) -> "feature".
+  // Pre-2026-05-30 BIs whose source was "bug" were backfilled to
+  // workType="bug" in 20260530170000_backlog_item_work_type, so this is
+  // byte-identical for every existing row.
+  //
+  // For fixes we pull the originating PlatformIssueReport (linked from the
+  // triage-created BI body as "Source report: PIR-XXXXX") so the build starts
+  // from the real diagnosis (severity, route, error stack) instead of a blank
+  // brief. reproSteps/rootCause/fixApproach are left for ideate to fill.
+  const kind = deriveBuildProcessType({ workType: item.workType ?? null, body: item.body });
   let fixBrief: Record<string, unknown> | null = null;
   let originatingReportId: string | null = null;
   if (kind === "fix") {

--- a/apps/web/lib/governed-backlog-workflow.ts
+++ b/apps/web/lib/governed-backlog-workflow.ts
@@ -23,6 +23,7 @@ export type StorefrontInquiryBacklogDraft = {
   type: "product";
   status: "triaging";
   source: "user-request";
+  workType: "feature";
   priority: number;
   body: string;
   recommendedTriageOutcome: "build";
@@ -103,6 +104,9 @@ export function createStorefrontInquiryBacklogDraft(
     type: "product",
     status: "triaging",
     source: "user-request",
+    // Storefront inquiries become product feature work — the operator chose
+    // to engage. The eventual build will design + ship a new capability.
+    workType: "feature",
     priority: 2,
     recommendedTriageOutcome: "build",
     signalLabel: "customer-zero",

--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -101,7 +101,7 @@ describe("backlog MCP tool execution", () => {
         title: "WWMD Decision Perspective Kernel",
         description: "Governed autonomy gate for ambiguous decisions.",
         status: "open",
-        source: "feature-gap",
+        source: "user-request",
       },
       "user-1",
       { agentId: "AGT-1" },
@@ -176,7 +176,7 @@ describe("backlog MCP tool execution", () => {
         status: "in-progress",
         priority: 2,
         owner: "owner@dpf.local",
-        source: "tool-gap",
+        source: "automated-detection",
       },
       "user-1",
     );

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10,7 +10,7 @@ import { kernelGateDecisionsTotal } from "@/lib/operate/metrics";
 import * as crypto from "crypto";
 import { lazyFs, lazyFsPromises, lazyPath, lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { mergeHappyPathStateIntoPlan, generateBuildId } from "@/lib/feature-build-types";
-import { BACKLOG_SOURCE_VALUES, BACKLOG_STATUS_VALUES, EPIC_STATUSES } from "@/lib/explore/backlog";
+import { BACKLOG_SOURCE_VALUES, BACKLOG_STATUS_VALUES, BACKLOG_WORK_TYPE_VALUES, EPIC_STATUSES } from "@/lib/explore/backlog";
 import {
   analyzePublicWebsiteBranding,
   fetchPublicWebsiteEvidence,
@@ -406,7 +406,8 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         type: { type: "string", enum: ["portfolio", "product"], description: "Item type" },
         status: { type: "string", enum: ["triaging", "open", "in-progress"], description: "Initial status (defaults to triaging). Non-triaging requires a paired triageOutcome." },
         triageOutcome: { type: "string", enum: ["build", "runbook", "coworker-task", "defer", "duplicate", "discard"], description: "Required when status is not triaging" },
-        source: { type: "string", enum: ["feature-gap", "bug", "tool-gap", "skill-gap", "doc-gap", "user-request", "automated-detection"], description: "What kind of gap or signal produced this item" },
+        workType: { type: "string", enum: [...BACKLOG_WORK_TYPE_VALUES], description: "What kind of work this is (closed enum). bug == defect; feature == new capability; chore | doc | tool | skill | refactor for the corresponding work categories." },
+        source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "Intake origin — how did this item arrive. user-request (a human asked for it) or automated-detection (the platform observed it). Defaults to user-request when omitted." },
         proposedOutcome: { type: "string", enum: ["build", "runbook", "coworker-task", "defer", "duplicate", "discard"], description: "Advisory suggestion for Scrum Master triage (non-binding)" },
         priority: { type: "integer", description: "Optional ranked priority within the open pool (lower = higher priority)." },
         effortSize: { type: "string", enum: ["small", "medium", "large", "xlarge"], description: "Required when triageOutcome=build (skipping triage). Otherwise applied if provided." },
@@ -414,7 +415,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         epicId: { type: "string", description: "Epic ID to link to (optional)" },
         itemId: { type: "string", description: "Optional custom item ID (e.g. BI-PORT-005). Auto-generated if omitted." },
       },
-      required: ["title", "type", "source"],
+      required: ["title", "type", "workType"],
     },
     requiredCapability: "manage_backlog",
     sideEffect: true,
@@ -577,7 +578,8 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         status: { type: "string", enum: [...BACKLOG_STATUS_VALUES], description: "Update status. For triaged items only; use triage_backlog_item to leave triaging." },
         priority: { type: "number", description: "Priority number (lower = higher priority)" },
         body: { type: "string", description: "Updated description" },
-        source: { type: "string", enum: ["feature-gap", "bug", "tool-gap", "skill-gap", "doc-gap", "user-request", "automated-detection"], description: "Reclassify the source signal" },
+        workType: { type: "string", enum: [...BACKLOG_WORK_TYPE_VALUES], description: "Reclassify what kind of work this is (closed enum)." },
+        source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "Reclassify the intake origin." },
         proposedOutcome: { type: "string", enum: ["build", "runbook", "coworker-task", "defer", "duplicate", "discard"], description: "Advisory recommendation; non-binding on triage" },
       },
       required: ["itemId"],
@@ -990,12 +992,14 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "list_backlog_items",
-    description: "List backlog items filtered by status, type, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids.",
+    description: "List backlog items filtered by status, type, workType, source, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids.",
     inputSchema: {
       type: "object",
       properties: {
         status: { type: "string", enum: ["triaging", "open", "in-progress", "done", "deferred"] },
         type: { type: "string", enum: ["portfolio", "product"] },
+        workType: { type: "string", enum: [...BACKLOG_WORK_TYPE_VALUES], description: "Filter by work-type (bug | feature | chore | doc | tool | skill | refactor)." },
+        source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "Filter by intake origin (user-request | automated-detection)." },
         epicId: { type: "string", description: "Semantic epic id (EP-*) to filter to" },
         unclaimed: { type: "boolean", description: "Only items with no user/agent claim" },
         hasActiveBuild: { type: "boolean", description: "Only items currently linked to a Build Studio build" },
@@ -4803,10 +4807,25 @@ export async function executeTool(
         : `BI-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
       const status = typeof params["status"] === "string" ? params["status"] : "triaging";
       const triageOutcome = typeof params["triageOutcome"] === "string" ? params["triageOutcome"] : null;
-      const source = typeof params["source"] === "string" ? params["source"] : null;
+      // workType is required by the tool schema; default to "feature" defensively
+      // so a missing payload field surfaces as a Prisma validation error rather
+      // than a silent insert with workType=NULL.
+      const workType = typeof params["workType"] === "string" ? params["workType"] : null;
+      // source defaults to "user-request" (the MCP tool is human-driven by
+      // contract — agents calling it on behalf of an operator are forwarding a
+      // human request).
+      const source = typeof params["source"] === "string" ? params["source"] : "user-request";
       const proposedOutcome = typeof params["proposedOutcome"] === "string" ? params["proposedOutcome"] : null;
       const effortSize = typeof params["effortSize"] === "string" ? params["effortSize"] : null;
       const priority = typeof params["priority"] === "number" ? params["priority"] : null;
+
+      if (!workType) {
+        return {
+          success: false,
+          error: "workType is required",
+          message: "workType is required (bug | feature | chore | doc | tool | skill | refactor).",
+        };
+      }
 
       // Validate the status / triageOutcome pairing rule from the tool description:
       // "supply status+triageOutcome together only when explicitly skipping triage"
@@ -4858,7 +4877,8 @@ export async function executeTool(
           ...(status === "done" ? { completedAt: new Date() } : {}),
           ...(typeof params["body"] === "string" ? { body: params["body"] } : {}),
           ...(epicCuid ? { epicId: epicCuid } : {}),
-          ...(source ? { source } : {}),
+          workType,
+          source,
           ...(triageOutcome ? { triageOutcome } : {}),
           ...(proposedOutcome ? { proposedOutcome } : {}),
           ...(effortSize ? { effortSize } : {}),
@@ -5284,6 +5304,7 @@ export async function executeTool(
       }
       if (typeof params["priority"] === "number") data["priority"] = params["priority"];
       if (typeof params["body"] === "string") data["body"] = params["body"];
+      if (typeof params["workType"] === "string") data["workType"] = params["workType"];
       if (typeof params["source"] === "string") data["source"] = params["source"];
       if (typeof params["proposedOutcome"] === "string") data["proposedOutcome"] = params["proposedOutcome"];
       await prisma.backlogItem.update({ where: { itemId: String(params["itemId"]) }, data });
@@ -5413,6 +5434,8 @@ export async function executeTool(
       const where: Record<string, unknown> = {};
       if (typeof params["status"] === "string") where["status"] = params["status"];
       if (typeof params["type"] === "string") where["type"] = params["type"];
+      if (typeof params["workType"] === "string") where["workType"] = params["workType"];
+      if (typeof params["source"] === "string") where["source"] = params["source"];
       if (typeof params["epicId"] === "string" && params["epicId"].trim()) {
         const epicRow = await prisma.epic.findFirst({
           where: { OR: [{ epicId: params["epicId"].trim() }, { id: params["epicId"].trim() }] },
@@ -5443,6 +5466,8 @@ export async function executeTool(
           title: true,
           status: true,
           type: true,
+          workType: true,
+          source: true,
           priority: true,
           effortSize: true,
           activeBuildId: true,
@@ -5458,6 +5483,8 @@ export async function executeTool(
         title: i.title,
         status: i.status,
         type: i.type,
+        workType: i.workType,
+        source: i.source,
         priority: i.priority,
         effortSize: i.effortSize,
         triageOutcome: i.triageOutcome,
@@ -5520,6 +5547,8 @@ export async function executeTool(
           title: item.title,
           status: item.status,
           type: item.type,
+          workType: item.workType,
+          source: item.source,
           priority: item.priority,
           effortSize: item.effortSize,
           triageOutcome: item.triageOutcome,

--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -16,11 +16,17 @@ const report = {
 beforeEach(() => _resetCache());
 
 describe("buildIssueBacklogItem", () => {
-  it("creates item with BI-PIR prefix and canonical bug source", () => {
+  it("creates item with BI-PIR prefix, workType=bug, source=automated-detection", () => {
     const item = buildIssueBacklogItem(report, "prod-1", "tax-1");
     expect(item.itemId).toMatch(/^BI-PIR-/);
-    // Canonical source per BACKLOG_SOURCE_VALUES; maps to FeatureBuild.kind="fix".
-    expect(item.source).toBe("bug");
+    // workType is the closed work-type axis; source is intake origin.
+    // PIR rows are runtime evidence captured automatically, so:
+    //   source       = automated-detection
+    //   workType     = bug  (the bug discriminator that
+    //                       governed-backlog-tee-up reads to derive
+    //                       FeatureBuild.kind="fix")
+    expect(item.source).toBe("automated-detection");
+    expect(item.workType).toBe("bug");
     expect(item.type).toBe("product");
     expect(item.priority).toBe(1); // critical → 1
     expect(item.digitalProductId).toBe("prod-1");

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -49,9 +49,11 @@ export function buildIssueBacklogItem(
     status: "open",
     type: digitalProductId ? "product" : "portfolio",
     priority: severityToPriority((report.severity || "medium") as Severity),
-    // Canonical backlog source (BACKLOG_SOURCE_VALUES). Issue-report-originated
-    // items are bugs; "bug" is what maps to FeatureBuild.kind="fix" at promote.
-    source: "bug",
+    // PIR rows are runtime evidence collected by the platform; intake origin is
+    // automated detection. workType is the bug discriminator that
+    // governed-backlog-tee-up reads to derive FeatureBuild.kind="fix".
+    source: "automated-detection",
+    workType: "bug",
     digitalProductId,
     taxonomyNodeId,
   };
@@ -253,7 +255,8 @@ export async function checkForSpike(deps: {
     status: "open",
     type: "product",
     priority: 1,
-    source: "bug",
+    source: "automated-detection",
+    workType: "bug",
     digitalProductId: null,
     taxonomyNodeId: null,
   });

--- a/apps/web/lib/operate/process-observer-hook.ts
+++ b/apps/web/lib/operate/process-observer-hook.ts
@@ -140,8 +140,13 @@ export async function observeConversation(
     { digitalProductId, routeContext },
     {
       getExistingTitles: async () => {
+        // Dedup pool = every bug-class BI filed via automated detection.
+        // The pre-2026-05-30 process-observer drift value
+        // (source='process_observer') backfilled to workType='bug' +
+        // source='automated-detection', so this predicate returns the
+        // same row set without depending on the legacy literal.
         const items = await prisma.backlogItem.findMany({
-          where: { source: "process_observer" },
+          where: { workType: "bug", source: "automated-detection" },
           select: { title: true },
         });
         return items.map((i) => i.title);

--- a/apps/web/lib/operate/process-observer-triage.test.ts
+++ b/apps/web/lib/operate/process-observer-triage.test.ts
@@ -25,9 +25,11 @@ describe("resolveBacklogTarget", () => {
 });
 
 describe("buildBacklogItemData", () => {
-  it("creates item with observer source", () => {
+  it("creates item with workType=bug, source=automated-detection", () => {
     const d = buildBacklogItemData(finding, "t1", "p1");
-    expect(d.source).toBe("process_observer");
+    // Process observer is an automated detector; every finding is bug-class.
+    expect(d.source).toBe("automated-detection");
+    expect(d.workType).toBe("bug");
     expect(d.itemId).toMatch(/^BI-OBS-/);
     expect(d.priority).toBe(2);
   });

--- a/apps/web/lib/operate/process-observer-triage.ts
+++ b/apps/web/lib/operate/process-observer-triage.ts
@@ -19,7 +19,12 @@ export interface BacklogItemData {
   status: string;
   type: string;
   priority: number;
+  // Intake-origin (BACKLOG_SOURCE_VALUES in apps/web/lib/explore/backlog.ts):
+  // "user-request" | "automated-detection".
   source: string;
+  // Work-type (BACKLOG_WORK_TYPE_VALUES in apps/web/lib/explore/backlog.ts):
+  // "bug" | "feature" | "chore" | "doc" | "tool" | "skill" | "refactor".
+  workType: string;
   digitalProductId: string | null;
   taxonomyNodeId: string | null;
 }
@@ -76,7 +81,9 @@ export function buildBacklogItemData(
     status: "open",
     type: digitalProductId ? "product" : "portfolio",
     priority: severityToPriority(finding.severity),
-    source: "process_observer",
+    // Process observer is an automated detector; findings are defect-class.
+    source: "automated-detection",
+    workType: "bug",
     digitalProductId,
     taxonomyNodeId,
   };

--- a/apps/web/lib/queue/functions/issue-report-triage.ts
+++ b/apps/web/lib/queue/functions/issue-report-triage.ts
@@ -57,8 +57,13 @@ export const issueReportTriage = inngest.createFunction(
           }),
 
         getExistingTitles: async () => {
+          // Dedup pool = every bug-class BI regardless of intake origin.
+          // Pre-2026-05-30 BIs carried the legacy mixed source values
+          // (source IN ('bug','process_observer')); the workType backfill
+          // landed them all as workType='bug', so this single predicate
+          // returns the same row set.
           const items = await prisma.backlogItem.findMany({
-            where: { source: { in: ["bug", "process_observer"] } },
+            where: { workType: "bug" },
             select: { title: true },
           });
           return items.map((i) => i.title);
@@ -72,7 +77,7 @@ export const issueReportTriage = inngest.createFunction(
           const existing = await prisma.backlogItem.findFirst({
             where: {
               title: { contains: title, mode: "insensitive" },
-              source: "bug",
+              workType: "bug",
             },
           });
           if (existing) {
@@ -127,7 +132,7 @@ export const issueReportTriage = inngest.createFunction(
 
         getExistingTitles: async () => {
           const items = await prisma.backlogItem.findMany({
-            where: { source: "bug", title: { startsWith: "Issue report spike detected" } },
+            where: { workType: "bug", title: { startsWith: "Issue report spike detected" } },
             select: { title: true },
           });
           return items.map((i) => i.title);

--- a/docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md
+++ b/docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md
@@ -1,0 +1,460 @@
+# Unified Backlog + BacklogItem WorkType Design
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft |
+| Date | 2026-05-30 |
+| Backlog item | To be filed against EP-INTAKE-UNIFY (or current backlog-hygiene epic). Live MCP check on 2026-05-30 (`search_specs_and_plans`, `search_knowledge`) found one adjacent spec — the 2026-05-29 fix-flow design — but **no** indexed spec or backlog item for unifying `PlatformIssueReport` with `BacklogItem` or for a first-class `workType` attribute on `BacklogItem`. |
+| Epic recommendation | Extend the existing backlog-hygiene / governed-intake epic if one is open; create `EP-INTAKE-UNIFY` only if scope grows beyond what is described here. Do **not** file a new epic for the Phase 0 enum-canonicalization slice — it belongs under existing hygiene. |
+| Related substrate | [`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts); [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts); [`apps/web/lib/governed-backlog-tee-up.ts`](../../../apps/web/lib/governed-backlog-tee-up.ts); [`apps/web/lib/quality/platform-issue-reports.ts`](../../../apps/web/lib/quality/platform-issue-reports.ts); [`apps/web/lib/quality/issue-report-status.ts`](../../../apps/web/lib/quality/issue-report-status.ts); [`apps/web/lib/operate/issue-report-triage.ts`](../../../apps/web/lib/operate/issue-report-triage.ts); [`apps/web/lib/queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts); [`apps/web/lib/operate/process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts); [`apps/web/lib/actions/quality.ts`](../../../apps/web/lib/actions/quality.ts); [`apps/web/app/(shell)/admin/issue-reports/page.tsx`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx); [`apps/web/components/admin/IssueReportPanel.tsx`](../../../apps/web/components/admin/IssueReportPanel.tsx); [`apps/web/app/(shell)/ops/page.tsx`](../../../apps/web/app/(shell)/ops/page.tsx); [`apps/web/components/ops/BacklogPanel.tsx`](../../../apps/web/components/ops/BacklogPanel.tsx); [`apps/web/components/ops/BacklogItemRow.tsx`](../../../apps/web/components/ops/BacklogItemRow.tsx); `BacklogItem`; `PlatformIssueReport`; `FeatureBuild` |
+| Related specs | [Fix flow through Build Studio (2026-05-29)](2026-05-29-fix-flow-through-build-studio-design.md); [Capacity-aware feedback escalation (2026-05-24)](2026-05-24-capacity-aware-feedback-escalation-design.md); [Feedback resolution closure (2026-05-26)](2026-05-26-feedback-resolution-closure-design.md); [Quality feedback (2026-03-14)](2026-03-14-quality-feedback-design.md) |
+| Scope | Add a first-class `workType` attribute to `BacklogItem` as a closed enum (`bug | feature | chore | doc | tool | skill | refactor`); split today's overloaded `source` into pure intake-origin values; canonicalize the already-leaking source values (`issue_report`, `process_observer`); backfill `workType` from current `source`; surface `workType` in the `/ops` backlog UI as a badge + filter and in `list_backlog_items` MCP; map `FeatureBuild.kind` from `workType` (cleaner than reading `source`); explicitly demote `PlatformIssueReport` from "parallel issue log" to "runtime evidence sidecar" for `workType=bug` BIs, with the Admin issue-reports page reframed accordingly. Phase 2 (synchronous PIR→BI projection on intake; fold `/admin/issue-reports` into a `workType=bug` filtered backlog view) is named and deferred. |
+| Out of scope | Replacing the 15-minute issue-report triage cron (Phase 2); building a new audit/incident surface on top of `PortfolioQualityIssue`/`EaConformanceIssue`/`TaxIssue` (those remain audit-only domains); a parallel `BacklogItemEvidence` table to absorb PIR's runtime-only columns (Phase 2 decision); per-`workType` SLA/scheduling; auto-closing PIRs on ship (carried over from fix-flow Phase 2); upstream GitHub escalation. |
+
+---
+
+## Architect Verdict
+
+The user's framing is correct and the gap is real. Today `BacklogItem.source` carries two
+independent axes muddled into one column:
+
+- **WORK-TYPE / CATEGORY** of the gap: `bug, feature-gap, tool-gap, skill-gap, doc-gap`
+- **ORIGIN / INTAKE CHANNEL**: `user-request, automated-detection`
+
+Plus two values that already leak through in production without ever being in the canonical
+enum (verified at [`backlog.ts:122-130`](../../../apps/web/lib/explore/backlog.ts)):
+[`queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts)
+queries `source: { in: ["bug", "process_observer"] }`, and the process-observer triage path
+writes `source: "process_observer"`. The issue-report triage path historically wrote
+`source: "issue_report"` (canonicalized to `"bug"` by fix-flow Phase 0, but the same
+underlying defect — the enum doesn't constrain the column). This is exactly the failure mode
+[`strongly-typed-string-enums`](../../founder-kernel/wiki/principles/strongly-typed-string-enums.md)
+and [`schema-honesty-over-aspirational-naming`](../../founder-kernel/wiki/principles/schema-honesty-over-aspirational-naming.md)
+warn against.
+
+Two consequences flow from the muddle:
+
+1. **Operators cannot filter the backlog by what kind of work it is.** `/ops` filters on
+   `status` and `type` (portfolio vs product, the ownership axis), never on `source`. There
+   is no `workType` badge on a row, and `list_backlog_items` MCP has no `source`/`workType`
+   filter. So "show me all open bugs" is not a query the backlog can answer.
+2. **`FeatureBuild.kind` derivation reads the muddled column.** The fix-flow spec mapped
+   `source === "bug" ? "fix" : "feature"` at promote time as a Phase-1 pragmatism, with the
+   explicit assumption that the source enum would not drift further. A clean `workType`
+   gives that mapping a stable, single-axis input.
+
+On `PlatformIssueReport` specifically: it is **not** a parallel backlog and should not be
+treated as one. It is a runtime-evidence record — `errorStack, userAgent, threadId,
+taskRunId, triggerKind, supportSessionId`, etc. — that today is also dressed up as a
+queue (statuses, an Admin queue UI, a 15-minute triage cron). The honest target state is:
+PIR is the diagnostic-evidence sidecar for `workType=bug` BIs; the backlog (the work) lives
+in one place (`BacklogItem`). This spec moves us toward that target without rewriting the
+cron in the same PR.
+
+Five guardrails for the implementation:
+
+1. **`workType` is additive and closed.** New column on `BacklogItem`; closed enum
+   `bug | feature | chore | doc | tool | skill | refactor`; new MCP enum mirrored in
+   `mcp-tools.ts` in the **same commit** per AGENTS.md §3. Required on new items.
+2. **Source becomes pure origin.** Closed enum `user-request | automated-detection`
+   (extensible later — `runtime-error`, `feedback`, `governance-rule`, `manual-triage`,
+   `coworker-detection` are anticipated but only added when something writes them; do not
+   pre-add unused values per [`single-source-of-truth`](../../founder-kernel/wiki/principles/single-source-of-truth.md)
+   and YAGNI). Deterministic backfill from today's `source` values; canonicalize the two
+   leaked values (`issue_report → automated-detection`, `process_observer → automated-detection`)
+   inline in the migration.
+3. **`kind` derivation moves to `workType`.** `governed-backlog-tee-up.ts` reads
+   `item.workType === "bug" ? "fix" : "feature"`. The behavior is byte-identical (every
+   `source="bug"` BI is mapped to `workType="bug"` in the backfill), but the input is now
+   a stable single-axis field. The fix-flow spec's PIR carry-through logic is unchanged.
+4. **PIR is demoted in narrative, not yet in schema.** The Admin issue-reports page header
+   and route description say "runtime evidence feed for `workType=bug` backlog items," not
+   "issue log." A "See backlog item" link is added on each report row when a BI projection
+   exists. The 15-minute cron and the `triaged_local` lifecycle remain unchanged in this
+   PR; their replacement (synchronous projection) is a follow-up BI.
+5. **Back-compat by construction.** `workType` defaults `null` in the schema for the
+   transitional window the migration occupies; the migration's inline backfill populates
+   every existing row before the new readers go live. `source` keeps its current `String?`
+   type; the runtime validators on the new enum are introduced in writers and the MCP tool
+   schema, not the DB column, so a future enum-tightening migration (Phase 2) is safe.
+
+This is the chief-architect lens applied to the user's framing. It composes with — and
+does not contradict — the 2026-05-29 fix-flow spec. The fix-flow spec said "don't add `kind`
+to `BacklogItem` because `source` already distinguishes `bug`." That was correct against the
+muddled `source`; this spec gives `BacklogItem` the clean axis the fix-flow spec assumed.
+
+## 1. Problem
+
+### 1.1 The muddled `source`
+
+Verified from [`apps/web/lib/explore/backlog.ts:122-130`](../../../apps/web/lib/explore/backlog.ts):
+
+```ts
+export const BACKLOG_SOURCE_VALUES = [
+  "feature-gap", "bug", "tool-gap", "skill-gap", "doc-gap",   // ← WORK-TYPE / CATEGORY
+  "user-request", "automated-detection",                       // ← INTAKE ORIGIN
+] as const;
+```
+
+Mixing axes in one closed enum has three concrete consequences:
+
+- **`feature-gap` and `user-request` are not alternatives.** A user-requested feature gap
+  is *both* — the muddled enum forces a writer to pick one and lose the other.
+- **`bug` and `automated-detection` are not alternatives either.** A runtime-detected bug
+  is both. Today the issue-report triage writer commits to `bug` and the automated-detection
+  signal is lost.
+- **Operators can't filter on either axis cleanly.** `list_backlog_items` doesn't expose
+  `source` as a filter; the `/ops` row doesn't render it. Even if it did, filtering by
+  `bug` excludes user-requested bug reports tagged otherwise, and filtering by
+  `automated-detection` mixes bugs with auto-detected non-bug gaps.
+
+### 1.2 Enum drift already in production
+
+[`apps/web/lib/queue/functions/issue-report-triage.ts:61`](../../../apps/web/lib/queue/functions/issue-report-triage.ts)
+queries `where: { source: { in: ["bug", "process_observer"] } }`, but `process_observer`
+is **not** in `BACKLOG_SOURCE_VALUES`. The process-observer triage path
+([`apps/web/lib/operate/process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts))
+writes that value. The DB column is `String?`, so nothing rejects it. The 2026-05-29
+fix-flow spec landed Phase 0 to canonicalize one drift case (`issue_report → bug`); this
+spec must canonicalize the rest before adding readers that depend on the enum being closed.
+
+### 1.3 Two surfaces for one concept
+
+[`/admin/issue-reports`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx) renders
+`PlatformIssueReport` rows with their own status vocabulary, severity badges, and queue
+posture cards ([`apps/web/components/admin/IssueReportPanel.tsx`](../../../apps/web/components/admin/IssueReportPanel.tsx)).
+[`/ops`](../../../apps/web/app/(shell)/ops/page.tsx) renders `BacklogItem` rows with their
+own status vocabulary and (currently no) source/work-type badges. The cron projects open
+PIRs into BIs every 15 minutes, so an operator looking at the two surfaces sees the same
+underlying issue twice — once as a PIR with a stack trace, once as a BI with `source=bug`
+and a back-reference body line `Source report: PIR-XXXXX` parsed by the promote path
+([`governed-backlog-tee-up.ts:230`](../../../apps/web/lib/governed-backlog-tee-up.ts)).
+
+The honest single source of truth is the `BacklogItem`. The `PlatformIssueReport` is the
+runtime-evidence record for the bug-class BI (statuses, severity, stack, route). The
+Admin issue-reports surface should be a view of the evidence, not a parallel queue.
+
+### 1.4 What this spec does *not* try to fix in one PR
+
+- It does **not** rewrite the triage cron to project synchronously. That is a behavioral
+  change to a 15-minute-tick path that other features (capacity-aware feedback,
+  reflection triggers) read; it is staged as Phase 2 with its own BI.
+- It does **not** merge the `/admin/issue-reports` page into `/ops` in this PR. It reframes
+  the page header and adds the "See backlog item" cross-link so the conceptual unification
+  is visible to the operator. The route-level merge is Phase 2.
+- It does **not** retire any PIR columns. They are runtime evidence that BIs do not (and
+  should not) carry. The `BacklogItemEvidence` sidecar question is Phase 2.
+
+## 2. Current Repo Truth
+
+| Area | Verified current behavior | Design implication |
+| ---- | ------------------------- | ------------------ |
+| Source enum | `BACKLOG_SOURCE_VALUES` at [`backlog.ts:122-130`](../../../apps/web/lib/explore/backlog.ts) mixes work-type with origin. Column at [`schema.prisma:963`](../../../packages/db/prisma/schema.prisma) is `String?` with no DB-level constraint. | Add `workType` (closed enum, separate column). Split today's values: category values backfill into `workType`; origin values stay in (or backfill into) a refined `source`. |
+| Drift in writers | `process_observer` written by [`operate/process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts) and queried by [`queue/functions/issue-report-triage.ts:61`](../../../apps/web/lib/queue/functions/issue-report-triage.ts) is **not** in the canonical enum. `issue_report` was canonicalized to `bug` in fix-flow Phase 0 already. | Canonicalize `process_observer` to `automated-detection` in the same migration as the workType backfill (inline SQL per AGENTS.md §2). Update the writer + the query in the same commit. |
+| Workers that write `source` | [`mcp-tools.ts:409`](../../../apps/web/lib/mcp-tools.ts) (`create_backlog_item` enum), [`mcp-tools.ts:577`](../../../apps/web/lib/mcp-tools.ts) (`update_backlog_item` reclassify), [`operate/issue-report-triage.ts:54,256`](../../../apps/web/lib/operate/issue-report-triage.ts) (`source: "bug"`), [`actions/quality.ts:191`](../../../apps/web/lib/actions/quality.ts) (`sendIssueReportToBuildStudioAsFix` writes `source: "bug"`), `operate/process-observer-triage.ts` (`source: "process_observer"`). | Every writer learns to set `workType` alongside `source`. The MCP `create_backlog_item` makes `workType` required (parallel to today's required `source`); `source` becomes optional input that defaults to the writer's intake channel; both enums mirrored in the tool schema. |
+| Workers that read `source` | [`governed-backlog-tee-up.ts:217`](../../../apps/web/lib/governed-backlog-tee-up.ts) (`source === "bug" ? "fix" : "feature"`), [`queue/functions/issue-report-triage.ts:61,130`](../../../apps/web/lib/queue/functions/issue-report-triage.ts) (dedup queries), [`actions/quality.ts:154`](../../../apps/web/lib/actions/quality.ts) (idempotency check). | Move the `kind` derivation to read `workType`; behavior byte-identical because every `source="bug"` BI is mapped to `workType="bug"` in the backfill. Dedup queries stay on `source` (origin) — finding "all bug-class items from the runtime-error origin" is the natural shape. |
+| `BacklogItem.type` | `String` non-null; values `"portfolio" | "product"` ([`backlog.ts:78`](../../../apps/web/lib/explore/backlog.ts) input type, [`mcp-tools.ts:406`](../../../apps/web/lib/mcp-tools.ts) enum). | Distinct axis (organizational ownership), not a work-type. Untouched. |
+| `FeatureBuild.kind` | `String @default("feature")` ([`schema.prisma:4413`](../../../packages/db/prisma/schema.prisma)); enum `FEATURE_BUILD_KIND_VALUES` at [`feature-build-types.ts`](../../../apps/web/lib/explore/feature-build-types.ts). Derived at promote time from `BacklogItem.source`. | Switch the derivation input from `source` to `workType`. No change to `kind` semantics or enum. |
+| PlatformIssueReport | 19 columns of runtime evidence ([`schema.prisma:4284-4319`](../../../packages/db/prisma/schema.prisma)). Single writer `createPlatformIssueReport()` ([`platform-issue-reports.ts:99`](../../../apps/web/lib/quality/platform-issue-reports.ts)). Surfaced at [`/admin/issue-reports`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx) with its own status vocab ([`issue-report-status.ts`](../../../apps/web/lib/quality/issue-report-status.ts)). 15-min triage cron at [`queue/functions/issue-report-triage.ts`](../../../apps/web/lib/queue/functions/issue-report-triage.ts) projects open reports into BIs with `source="bug"`. Manual "Send to Build Studio as a fix" affordance shipped in PR #1285 — [`actions/quality.ts:110-227`](../../../apps/web/lib/actions/quality.ts). | Reframe — not rewrite — the surface in this PR. Page header says "runtime evidence feed for bug-class backlog items"; each row gets a "See backlog item" link when the projected BI is resolvable (by `featureBuildId`/PIR-public-id body match). Cron stays. Status vocab stays. Phase 2 plans the synchronous projection + route merge. |
+| Other "issue-shaped" models | `TaxIssue`, `LicenseReadinessIssue`, `PortfolioQualityIssue`, `EaConformanceIssue`, `DeliberationIssueSet`, `FeedbackNote` are all audit/governance surfaces, not runtime intake. `ImprovementSignal` ([`schema.prisma:4322`](../../../packages/db/prisma/schema.prisma)) feeds the improvement flywheel separately. | Out of scope. None compete with the unified backlog as intake. If any audit surface later wants to file a BI, it goes through `create_backlog_item` like every other writer. |
+| Admin queue posture | [`IssueReportPanel.tsx`](../../../apps/web/components/admin/IssueReportPanel.tsx) shows actionable / process-guard / warmup-noise / triaged / resolved counts derived from PIR status + source classification. | Untouched — these counts are PIR diagnostic posture, not backlog state. The page header text changes (§4.6). |
+| Ops backlog UI | [`BacklogPanel.tsx:78-79`](../../../apps/web/components/ops/BacklogPanel.tsx) filters on `type` and `status` only. [`BacklogItemRow.tsx`](../../../apps/web/components/ops/BacklogItemRow.tsx) renders priority badge, status badge, taxonomy, product, agent, submitter — no source/work-type. | Add `workType` filter + per-row badge. Origin is secondary metadata — exposed as text in the row's metadata line, not a primary filter, because filtering by origin is rarely the operator's question. |
+
+## 3. Research & Benchmarking
+
+How established issue/work trackers and dev-tool product backlogs model the
+work-type-vs-origin axis. Reading the data models, not feature lists.
+
+| System | Model (verified from product docs) | Adopt | Reject |
+| ------ | ---------------------------------- | ----- | ------ |
+| **GitHub Issues — issue types vs issue forms** | Org-level **issue types** (Bug, Feature, Task) are a first-class typed field, separate from labels; **issue forms** capture structured intake fields per type. Sources: [GitHub issue types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization), [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). | First-class typed field for what-kind-of-work; structured intake separate. | Free-form labels for work-type (label proliferation: Bug/Defect/Regression/Hotfix/…). |
+| **Linear — Issue type + Source** | Issue type (Bug/Feature/Improvement) is a closed primitive; [Customer requests](https://linear.app/docs/customer-requests) preserve the source link (customer feedback → linked issues) as a distinct concept. | Two-axis model: type ⊥ source. Source is a *link to the originating signal*, not a value crammed into type. | Encoding source into type ("customer-bug" vs "internal-bug"). |
+| **Jira — issue type schemes + Service Management request types** | Issue types (Bug/Story/Task) drive workflow & field schemes; in [Service Management](https://support.atlassian.com/jira-service-management-cloud/docs/what-are-request-types/), *request types* present a friendly intake face *over* the typed issue. Sources: [Jira issue types](https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-types/). | Typed work-kind drives workflow/prompts (DPF analogue: `workType` drives Build Studio prompt branching via `FeatureBuild.kind`); operator never picks a raw type — the platform derives it. | Exposing scheme/workflow configuration to non-technical operators. |
+| **ServiceNow — incident / problem / change** | Sharp separation: incident records the signal, problem investigates root cause, change implements the remediation; all linked. Source: [ServiceNow problem management](https://www.servicenow.com/docs/r/it-service-management/problem-management/c_ProblemManagementProcess.html). | Conceptual mapping: `PlatformIssueReport` ≈ incident evidence; `BacklogItem` (workType=bug) ≈ problem/work record; `FeatureBuild` (kind=fix) ≈ controlled change. Keep them linked, separate, and queryable. | Three parallel tables for one DPF concept. DPF already has PIR + BI + FeatureBuild; do not add a fourth. |
+| **Sentry — event / issue / resolution** | Runtime events group into issues with stack/context; issues link to resolution activity. Source: [Sentry issue details](https://docs.sentry.dev/product/issues/issue-details/). | PIR rows ≈ events; a `workType=bug` BI ≈ the grouped issue; the FeatureBuild=fix ≈ resolution. Cross-link the BI from the PIR row. | Surfacing raw stacks/PII upstream (governed by existing privacy spec, out of scope here). |
+| **Conventional Commits + Karma-style commit types** | Closed lowercase set `feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert`. Source: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/), [Angular commit conventions](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format). | Names — `bug` (== `fix` shipped), `feature` (== `feat`), `chore`, `doc` (singular for DPF: matches today's `doc-gap`), `refactor`. Aligns DPF backlog vocabulary with the same vocabulary engineers use in commit messages. | The full 11-value set is too many up front. Start with the seven that map to today's BI consumers + the work the user named (Phase 1 = 7 values). `perf`, `test`, `ci`, `style`, `revert` are deferred. |
+
+**Patterns adopted:** first-class closed `workType` enum as a typed field; orthogonal
+intake `source` field as origin-only; lightweight commit-style vocabulary; preserved
+source link (`PlatformIssueReport.featureBuildId` already exists from fix-flow Phase 1).
+
+**Anti-patterns rejected:** work-type as a label; mixing origin into work-type; a
+parallel work-item table; forcing classification onto the operator (the platform derives
+`workType` from the intake path); discriminated-union BIs that fragment readers.
+
+## 4. Design
+
+### 4.1 The `workType` enum
+
+Declared in [`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts),
+the canonical home for `BacklogItem` contracts:
+
+```ts
+export const BACKLOG_WORK_TYPE_VALUES = [
+  "bug",       // a defect — broken behavior in shipped substrate
+  "feature",   // a new user-visible capability
+  "chore",     // operational / housekeeping work (no user-visible behavior change)
+  "doc",       // documentation gap or update
+  "tool",      // tooling/DX gap — missing or broken developer tool
+  "skill",     // coworker/agent capability gap
+  "refactor",  // structural cleanup with no behavior change
+] as const;
+export type BacklogWorkType = (typeof BACKLOG_WORK_TYPE_VALUES)[number];
+```
+
+Single-word lowercase per AGENTS.md §3 (note: `doc` singular, matching today's `doc-gap`
+ergonomics). Mirrored in [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts)
+in the **same commit** for `create_backlog_item`, `update_backlog_item`, and
+`list_backlog_items` (new filter). A vitest parity test asserts the MCP tool definition
+matches the canonical enum (mirror of the AGENTS.md §3 contract for `BACKLOG_STATUS_VALUES`
+already in use).
+
+Adding an eighth value later (e.g. `perf`, `test`, `security`) requires updating the
+canonical enum + every MCP mirror in one commit, before any data uses it.
+
+### 4.2 Refined `source` (origin) enum
+
+Same file, redefined:
+
+```ts
+export const BACKLOG_SOURCE_VALUES = [
+  "user-request",          // operator/employee/customer asked for it
+  "automated-detection",   // platform observation (process observer, runtime error triage, drift detection)
+] as const;
+export type BacklogSource = (typeof BACKLOG_SOURCE_VALUES)[number];
+```
+
+Two values now. The previously-mixed category values (`feature-gap, bug, tool-gap,
+skill-gap, doc-gap`) move into `workType`. Anticipated future origin values
+(`feedback`, `governance-rule`, `coworker-detection`, `external-import`) are *not* added
+until a writer needs them — see [`single-source-of-truth`](../../founder-kernel/wiki/principles/single-source-of-truth.md)
+and the YAGNI guidance in the AGENTS.md First Principles. The leaked value
+`process_observer` collapses into `automated-detection` (the process observer **is** an
+automated detector).
+
+### 4.3 Schema change
+
+Add to `BacklogItem` ([`schema.prisma:950-1000`](../../../packages/db/prisma/schema.prisma)):
+
+```prisma
+workType String?  // BACKLOG_WORK_TYPE_VALUES - see apps/web/lib/explore/backlog.ts
+```
+
+Nullable for the transitional window the migration occupies; the migration's inline
+backfill (§4.4) populates every existing row before any new reader fires. A follow-up
+Phase 2 migration tightens to `String` non-null once the writers are all required to set
+it (this PR makes the MCP tool require it; the DB constraint follows separately to keep
+the migration small).
+
+No new index — `workType` is a low-cardinality enum and existing queries filter primarily
+on `status`/`epicId`. If a `workType + status` composite query becomes hot in Phase 2,
+add the index then.
+
+### 4.4 Migration: `backlog_item_work_type` (with inline backfill)
+
+Single migration. Sections:
+
+```sql
+-- 1. Schema
+ALTER TABLE "BacklogItem" ADD COLUMN "workType" TEXT;
+
+-- 2. Backfill workType from today's overloaded source
+UPDATE "BacklogItem" SET "workType" = 'bug'      WHERE "source" = 'bug';
+UPDATE "BacklogItem" SET "workType" = 'feature'  WHERE "source" = 'feature-gap';
+UPDATE "BacklogItem" SET "workType" = 'tool'     WHERE "source" = 'tool-gap';
+UPDATE "BacklogItem" SET "workType" = 'skill'    WHERE "source" = 'skill-gap';
+UPDATE "BacklogItem" SET "workType" = 'doc'      WHERE "source" = 'doc-gap';
+
+-- 3. Backfill: items whose source was pure origin keep null workType. They land
+--    in a triage queue ("workType unknown") that the ops backlog shows as a
+--    badge so an operator can classify them. New writers must supply workType.
+--    Rows with NULL source also stay NULL — they predate the enum entirely.
+
+-- 4. Canonicalize source drift to the refined origin vocabulary.
+UPDATE "BacklogItem" SET "source" = 'automated-detection'
+  WHERE "source" IN ('feature-gap', 'bug', 'tool-gap', 'skill-gap', 'doc-gap', 'process_observer', 'issue_report');
+--    Rationale: the category-shaped values entered the column via writers in
+--    paths that all qualify as automated-detection or system-triage — runtime
+--    triage, process observer, gap-detection. The classification is now in
+--    workType where it belongs. Hand-filed BIs from a human operator are
+--    already source='user-request'; those rows are untouched.
+```
+
+The migration is reversible by `prisma migrate reset` in development; in production it is
+forward-only (the original `source` text is reconstructible from `workType` for backfilled
+rows). The backfill matrix is recorded in the migration comment for audit.
+
+### 4.5 Writers and MCP
+
+All BI-creating call sites are updated in the same PR to set `workType` explicitly. The
+mapping per writer:
+
+| Writer | New behavior |
+| ------ | ------------ |
+| [`mcp-tools.ts:create_backlog_item`](../../../apps/web/lib/mcp-tools.ts) | `workType` becomes a **required** input field (enum mirror of `BACKLOG_WORK_TYPE_VALUES`); `source` becomes optional with default `user-request` (consistent with the only non-automated writers being humans calling the MCP tool). |
+| [`mcp-tools.ts:update_backlog_item`](../../../apps/web/lib/mcp-tools.ts) | Adds optional `workType` reclassify field; existing `source` field continues to allow reclassify but with the new closed enum. |
+| [`mcp-tools.ts:list_backlog_items`](../../../apps/web/lib/mcp-tools.ts) | Adds optional `workType` filter (single value or array); also adds optional `source` filter for completeness. |
+| [`operate/issue-report-triage.ts:buildIssueBacklogItem`](../../../apps/web/lib/operate/issue-report-triage.ts) | Writes `workType: "bug", source: "automated-detection"`. |
+| [`operate/issue-report-triage.ts:checkForSpike`](../../../apps/web/lib/operate/issue-report-triage.ts) | Same — spike alerts are bug-class auto-detection items. |
+| [`actions/quality.ts:sendIssueReportToBuildStudioAsFix`](../../../apps/web/lib/actions/quality.ts) | Writes `workType: "bug", source: "user-request"` (the operator clicked the action — that is a human request acting on automated evidence; the originating PIR's evidence is already linked via `featureBuildId`). |
+| [`operate/process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts) | Writes `workType: "bug", source: "automated-detection"`. The previous `source: "process_observer"` value is removed; the queue dedup query at [`queue/functions/issue-report-triage.ts:61`](../../../apps/web/lib/queue/functions/issue-report-triage.ts) is updated to read `workType: "bug"` (the correct shape — "have we already filed a bug for this signal?"). |
+
+Server actions and admin UI forms that create BIs pass `workType` through from the
+operator's choice in the form (or a sensible default for the surface — e.g., the
+"submit a bug" action defaults to `bug`).
+
+### 4.6 PIR is demoted in narrative (this PR)
+
+[`/admin/issue-reports`](../../../apps/web/app/(shell)/admin/issue-reports/page.tsx)
+stays where it is. The page header subtitle changes from the current framing to:
+
+> Runtime evidence feed. Each open report projects to a `workType=bug` backlog item on
+> the 15-minute triage tick; see the backlog at `/ops`.
+
+Each report row gains a "See backlog item" affordance when a projection can be resolved.
+Resolution uses the same lookup the promote path already performs: `featureBuildId`
+back-link → originator BI; otherwise PIR-public-id body match against open `workType=bug`
+BIs ([`actions/quality.ts:154`](../../../apps/web/lib/actions/quality.ts) pattern). When
+no projection is resolved, the affordance shows "Awaiting triage cron (next tick at …)"
+with the next scheduled run time read from the queue function's schedule.
+
+The PIR status vocabulary, the triage cron, and the "Send to Build Studio as a fix"
+action all remain. The narrative shift is honest about what PIR is — runtime evidence —
+without rewriting cron behavior in the same PR.
+
+### 4.7 Ops backlog UI
+
+[`BacklogPanel.tsx:78-79`](../../../apps/web/components/ops/BacklogPanel.tsx) gains a
+`workType` filter chip next to the existing `type` and `status` filters. The filter is
+multi-select with the seven enum values.
+
+[`BacklogItemRow.tsx`](../../../apps/web/components/ops/BacklogItemRow.tsx) gains a small
+work-type badge to the left of the title (mirror of the existing priority badge styling),
+using the canonical CSS vars per AGENTS.md §12:
+
+| workType | Badge color (CSS var) | Glyph |
+| -------- | --------------------- | ----- |
+| `bug`      | `--dpf-danger`     | "Bug" |
+| `feature`  | `--dpf-accent`     | "Feature" |
+| `chore`    | `--dpf-muted`      | "Chore" |
+| `doc`      | `--dpf-info`       | "Doc" |
+| `tool`     | `--dpf-info`       | "Tool" |
+| `skill`    | `--dpf-info`       | "Skill" |
+| `refactor` | `--dpf-muted`      | "Refactor" |
+
+The metadata line gains the `source` value as plain text after the existing taxonomy
+node, in the form `via user-request` or `via automated-detection`. Origin is secondary —
+text, not a primary filter — because the operator's question is almost always "what
+work-type is this" not "how did it arrive."
+
+The row keeps existing behavior for "Start in Build Studio" / "Edit" / "Delete" actions.
+
+### 4.8 `FeatureBuild.kind` derivation moves to `workType`
+
+[`governed-backlog-tee-up.ts:217`](../../../apps/web/lib/governed-backlog-tee-up.ts):
+
+```ts
+// Before
+const kind: "feature" | "fix" = item.source === "bug" ? "fix" : "feature";
+
+// After
+const kind: "feature" | "fix" = item.workType === "bug" ? "fix" : "feature";
+```
+
+Byte-identical behavior for every existing path (because every `source="bug"` row is
+backfilled to `workType="bug"`). The input is now a stable single-axis closed enum. The
+PIR carry-through, `fixContext` population, and PIR `featureBuildId` back-link logic in
+the same function are unchanged.
+
+The fix-flow spec's chief-architect verdict ("kind is the discriminator; source is the
+input; map once at promote") still holds, with one refinement: the **input** is now
+`workType`, not `source`. The fix-flow spec wrote "source already distinguishes `bug`" as
+a pragmatism against the muddled enum; with this spec, the input is a clean closed enum
+whose name says what it means.
+
+When workType grows past `bug | feature` (e.g. `chore`, `doc`, `tool`, `skill`,
+`refactor`), the mapping stays binary at promote time: only `workType === "bug"` produces
+`kind="fix"`; everything else produces `kind="feature"`. The `chore | doc | tool | skill |
+refactor` types are still feature-shaped *builds* — they design, plan, and ship a change.
+They differ from defects only in the kind of substrate they add. A future spec can split
+`kind` further if a chore/doc/refactor build needs different prompts; this spec does not
+prejudge that.
+
+### 4.9 Phase 0 (this PR) — single-PR scope summary
+
+1. `BACKLOG_WORK_TYPE_VALUES` enum + `BACKLOG_SOURCE_VALUES` redefinition in
+   [`backlog.ts`](../../../apps/web/lib/explore/backlog.ts).
+2. `workType` column + migration + inline backfill.
+3. MCP tool schema updates in [`mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts) for
+   `create_backlog_item`, `update_backlog_item`, `list_backlog_items` (same commit).
+4. Writers updated: issue-report triage, process-observer triage,
+   `sendIssueReportToBuildStudioAsFix`, every server action that creates BIs.
+5. `governed-backlog-tee-up.ts` reads `workType` for `kind` derivation.
+6. Queue dedup queries updated from `source: { in: ["bug", "process_observer"] }` to
+   `workType: "bug"`.
+7. Ops backlog UI: filter chip + row badge + source-as-text in metadata.
+8. Admin issue-reports page: header reframe + "See backlog item" cross-link.
+9. Vitest: enum/MCP parity test, gate behavior unchanged, intake writers emit correct
+   `(workType, source)` pair, kind derivation byte-identical.
+10. AGENTS.md §3 enum table updated to include `BacklogItem.workType`.
+
+### 4.10 Phase 2 — deferred (filed as follow-up BI)
+
+| Item | Why deferred |
+| ---- | ------------ |
+| Synchronous PIR→BI projection on intake (replace the 15-min cron) | Behavior change to a tick path other features read (capacity-aware feedback, reflection triggers, the Hermes thread-linking). Needs its own design + migration of in-flight queue state. |
+| Tighten `BacklogItem.workType` to `String` non-null | Requires every writer in the tree to have been migrated; cleaner as a second small migration after Phase 0 lands and accrues evidence. |
+| Tighten `BacklogItem.source` to enum-constrained at DB level | Same reasoning. |
+| Fold `/admin/issue-reports` into a `workType=bug` filtered view of `/ops` with a PIR evidence drawer | A real product call (the runtime-evidence posture cards are useful as-is). Decide after operators use the cross-link affordance for a week. |
+| Sidecar `BacklogItemEvidence` model to absorb PIR's runtime-only columns from a unified intake | Only if Phase 2's synchronous projection makes the sidecar pattern cleaner than the existing back-link. |
+| Per-`workType` SLA/scheduling | Out of scope; coupled with capacity-aware feedback. |
+| Auto-close PIR on FeatureBuild ship | Inherited from fix-flow Phase 2. |
+
+## 5. Implementation Phasing
+
+| Phase | Scope | Standalone? |
+| ----- | ----- | ----------- |
+| **0 (this PR)** | Items 1-10 in §4.9. Schema-additive + closed-enum + writers + MCP + UI badge/filter + UX cross-link + tests + build gate. | Yes. Migration is reversible in dev; production is forward-only with full backfill. |
+| **1 (next PR)** | Tighten `workType` to non-null at DB level; tighten `source` to enum-constrained. Two small migrations, no behavior change. | Yes. Depends on Phase 0 having all writers migrated. |
+| **2 (filed as follow-up BI)** | Synchronous PIR→BI projection; UX fold of `/admin/issue-reports` into `/ops` filtered view; possible `BacklogItemEvidence` sidecar; cron retired. | Yes. Larger product call; needs its own design slice. |
+
+## 6. Verification Gates
+
+Phase 0 must meet the AGENTS.md §5 build gate:
+
+| Layer | What to run / show |
+| ----- | ------------------ |
+| Unit tests | `pnpm --filter web exec vitest run` for: enum/MCP parity (`BACKLOG_WORK_TYPE_VALUES` vs `create_backlog_item`/`update_backlog_item`/`list_backlog_items` tool schemas); migration backfill matrix (every legacy `source` value maps to the expected `(workType, source)` pair); `governed-backlog-tee-up.ts` produces byte-identical `kind` for the seven backfill cases; intake writers (`buildIssueBacklogItem`, `checkForSpike`, `sendIssueReportToBuildStudioAsFix`, process-observer triage) emit the right `(workType, source)`; dedup queue query returns the same rows as before for a representative fixture. |
+| Typecheck / build | `pnpm --filter web typecheck`; `cd apps/web && pnpm exec next build` with zero errors (TypeScript errors only surface in `next build`). |
+| Migration | `backlog_item_work_type` applies cleanly via `prisma migrate dev`. Down direction is `prisma migrate reset` in dev; production migration is forward-only. The backfill is asserted by a unit test that loads representative fixtures into a temporary schema. |
+| UX | Against the Docker-served portal: load `/ops`; observe the new work-type badge on every row, the new work-type filter chip, the `via <source>` metadata; load `/admin/issue-reports`; observe the reframed header and the "See backlog item" cross-link on rows where a projection exists. Use the `build-studio-operator` lens for the lifecycle gates. |
+
+This spec's own quality gate (pre-implementation): `dpf-architecture-review` lens applied;
+live MCP duplicate-spec check done (only the 2026-05-29 fix-flow spec hit; reconciled in
+§Architect Verdict); every code reference ground-truthed against the current tree on
+`feat/unify-backlog-worktype` worktree at `~/dpf-worktrees/unify-backlog-worktype`.
+
+## 7. Risks & Open Decisions
+
+| Item | Resolution |
+| ---- | ---------- |
+| Drift in `source` enum (`process_observer`, historical `issue_report`) | Migration backfill canonicalizes to `automated-detection`. Writers updated in the same PR. The DB-level enum tightening is Phase 1, not Phase 0, to keep the migration small. |
+| Back-compat for in-flight builds and queue dedup | The backfill mapping is exhaustive (every legacy `source` value maps to a `(workType, source)` pair). `kind` derivation produces byte-identical output. The dedup query change (`source: { in: ["bug", "process_observer"] }` → `workType: "bug"`) is asserted by a unit test against representative fixtures to confirm row identity. |
+| `workType` proliferation | Closed enum, seven values. New values require AGENTS.md §3 discipline (canonical enum + MCP mirrors in one commit, before any data uses it). Concretely deferred: `perf, test, security, ci, style, revert` (from Conventional Commits) — none has a writer today; adding them when one appears. |
+| Should `chore`/`refactor` produce a different `kind` than `feature`? | Not in this PR. Both are still feature-shaped builds (design, plan, ship a change). A future spec can split `kind` further if a chore/doc/refactor build proves to need a distinct prompt/gate path. |
+| Should `/admin/issue-reports` fold into `/ops` in this PR? | No. The runtime-evidence posture cards are useful as-is. Reframe + cross-link only in this PR; full fold is Phase 2 with operator evidence. |
+| Should we add a `BacklogItem → PlatformIssueReport` FK? | Inherited from fix-flow spec; deferred to Phase 2 unless the PIR-public-id body match proves lossy in real use. |
+| Should `source` keep more values for non-automated origins (e.g. `feedback`, `governance-rule`)? | Add when a writer needs them, per [`single-source-of-truth`](../../founder-kernel/wiki/principles/single-source-of-truth.md). The two values declared now cover every current writer after the migration. |
+| Migration safety on a populated production DB | The backfill is `UPDATE` against a small enum cardinality (the largest legacy bucket is `source='bug'` which is bounded by issue-report triage activity). No table rewrite; no FK changes. Reviewed against the AGENTS.md §11 schema-stewardship checklist. |
+| What about `BacklogItem.type` (portfolio | product) | Untouched. It is a different axis (organizational ownership). The risk of operator confusion between `type` and `workType` is real but small; the row badge for `workType` is visually distinct from the existing `type` distinction (which today shows as the product link in the metadata line). A future cleanup might rename `type → ownership` for clarity; not in scope here. |
+
+## 8. Next Step After Sign-Off
+
+On approval, file the backlog item against the backlog-hygiene epic (or
+`EP-INTAKE-UNIFY` if scope warrants), then implement **Phase 0 directly in this repo**
+— per the standing rule recorded in operator memory (`build-studio-down-route-direct-pr`),
+Build Studio is being stabilized as of 2026-05-29 and direct DCO PR is the current
+ship path — on the `feat/unify-backlog-worktype` topic branch, via a DCO-signed PR off
+`origin/main`, meeting the full build gate. Phase 1 (DB enum tightening) and Phase 2
+(synchronous projection + UX fold) are filed as follow-up BIs and not started until
+Phase 0 has landed and accrued evidence.

--- a/packages/db/prisma/migrations/20260530170000_backlog_item_work_type/migration.sql
+++ b/packages/db/prisma/migrations/20260530170000_backlog_item_work_type/migration.sql
@@ -1,0 +1,63 @@
+-- Add BacklogItem.workType (closed enum, source-of-truth in
+-- apps/web/lib/explore/backlog.ts:BACKLOG_WORK_TYPE_VALUES) and split today's
+-- overloaded BacklogItem.source into pure intake-origin values
+-- (BACKLOG_SOURCE_VALUES = user-request | automated-detection).
+--
+-- Spec: docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md
+-- BI:   BI-FD37173A
+--
+-- Behavior change for downstream readers:
+--   - apps/web/lib/governed-backlog-tee-up.ts now derives FeatureBuild.kind
+--     from workType ("bug" -> "fix", else "feature"). The backfill below
+--     produces byte-identical kind for every existing row because every
+--     legacy source='bug' BI becomes workType='bug'.
+--   - apps/web/lib/queue/functions/issue-report-triage.ts dedup query
+--     changes from source IN ('bug','process_observer') to workType='bug';
+--     same row set because both backfill to workType='bug'.
+
+-- 1. Schema
+ALTER TABLE "BacklogItem" ADD COLUMN "workType" TEXT;
+
+-- 2. Backfill workType from the legacy mixed-axis source values.
+--    The category-shaped legacy values move into workType:
+UPDATE "BacklogItem" SET "workType" = 'bug'      WHERE "source" = 'bug';
+UPDATE "BacklogItem" SET "workType" = 'feature'  WHERE "source" = 'feature-gap';
+UPDATE "BacklogItem" SET "workType" = 'tool'     WHERE "source" = 'tool-gap';
+UPDATE "BacklogItem" SET "workType" = 'skill'    WHERE "source" = 'skill-gap';
+UPDATE "BacklogItem" SET "workType" = 'doc'      WHERE "source" = 'doc-gap';
+
+-- Two in-production drift values that were never in the canonical source
+-- enum. Both are bug-class auto-detection signals.
+UPDATE "BacklogItem" SET "workType" = 'bug'      WHERE "source" = 'process_observer';
+UPDATE "BacklogItem" SET "workType" = 'bug'      WHERE "source" = 'issue_report';
+
+-- Rows whose source is a pure origin value (user-request, automated-detection)
+-- or NULL stay workType=NULL. The ops backlog UI shows an "Unclassified" badge
+-- for these and surfaces them in a triage filter so an operator can classify.
+
+-- 3. Canonicalize source to the refined origin-only enum
+--    (BACKLOG_SOURCE_VALUES = user-request | automated-detection).
+--
+--    The historical column was free-form (no DB constraint), so production
+--    accumulated ~150 distinct values besides the documented enum: the legacy
+--    category values (feature-gap, bug, tool-gap, skill-gap, doc-gap), the
+--    in-production drift values (process_observer, issue_report), and a long
+--    tail of freeform tags (pr-XXX PR numbers, worktree names, phase labels,
+--    hive-scout, spec, …) that were never intended as enum values.
+--
+--    Every row whose source is NOT NULL and NOT already a canonical origin
+--    value is collapsed to 'automated-detection' — the right honest label
+--    for "the system put this in the backlog through some path we no longer
+--    track precisely." Hand-filed BIs from human operators are already
+--    source='user-request' and are untouched. NULL stays NULL.
+--
+--    The work-type classification for the legacy CATEGORY values is captured
+--    in step 2 above (workType). For the freeform tail (pr-XXX, worktree-*,
+--    hive-scout, spec, etc.) workType remains NULL and the UI surfaces an
+--    "unclassified" badge so an operator can reclassify when they next touch
+--    the item. Phase 1 will tighten this column to a DB-level enum once
+--    Phase 0 has accrued evidence.
+UPDATE "BacklogItem"
+SET "source" = 'automated-detection'
+WHERE "source" IS NOT NULL
+  AND "source" NOT IN ('user-request', 'automated-detection');

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -961,6 +961,7 @@ model BacklogItem {
   taxonomyNodeId          String?
   epicId                  String?
   source                  String?
+  workType                String?
   triageOutcome           String?
   effortSize              String?
   proposedOutcome         String?


### PR DESCRIPTION
## Summary

- Adds a first-class `workType` attribute to `BacklogItem` (closed enum: `bug | feature | chore | doc | tool | skill | refactor`) — the WHAT axis.
- Refines `BacklogItem.source` to a pure intake-origin enum (`user-request | automated-detection`) — the HOW axis. Eliminates the mixed-axis muddle and canonicalizes ~150 distinct production drift values (`pr-XXX`, `worktree-*`, `hive-scout`, `spec`, etc.).
- Reframes `PlatformIssueReport` (and `/admin/issue-reports`) from "parallel issue log" to "runtime evidence feed for `workType=bug` backlog items."
- `FeatureBuild.kind` derivation now reads `workType` (clean closed enum) instead of `source`. Byte-identical behavior because every legacy `source='bug'` BI is backfilled to `workType='bug'`.
- Ops backlog row gets a `workType` badge; editor adds a required Work Type select; `list_backlog_items` MCP exposes `workType`/`source` filters; AGENTS.md §3 enum table updated.

**Phase 0** of a three-phase rollout. **Phase 1** (DB-level enum tightening) and **Phase 2** (synchronous PIR→BI projection + UX fold of `/admin/issue-reports` into `/ops` bug-filtered view) are filed as follow-up BIs.

**Spec**: [`docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/feat/unify-backlog-worktype/docs/superpowers/specs/2026-05-30-unified-backlog-worktype-design.md)
**Predecessor spec**: [`2026-05-29-fix-flow-through-build-studio-design.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-29-fix-flow-through-build-studio-design.md) — this PR delivers the clean closed-enum input that spec's `kind` derivation always wanted.
**Backlog item**: BI-FD37173A (linked to EP-BUILD-STUDIO).

Ship direct per the `build-studio-down-route-direct-pr` standing rule (Build Studio is being stabilized as of 2026-05-29; direct DCO PR is the current ship path).

## Test plan

- [x] `pnpm --filter web exec vitest run` for affected files — 83/83 pass across 8 files (enum parity, backfill semantics, kind derivation byte-identity, intake writer outputs)
- [x] `pnpm --filter web typecheck` — clean (TS errors only surface in `next build`)
- [x] `cd apps/web && pnpm exec next build` — exit 0
- [x] `pnpm security:secrets:staged` — no leaks
- [x] Migration applied to live portal DB: 1 ALTER + 6 UPDATE statements with expected counts (96 source=bug→workType=bug, 111 feature-gap→feature, 8 tool-gap→tool, 4 skill-gap→skill, 7 doc-gap→doc, 1 process_observer→bug, 514 freeform-tail source values canonicalized to `automated-detection`)
- [x] Routes compile + auth-redirect cleanly (`/ops` and `/admin/issue-reports` both return 307 to `/login`)
- [ ] Full visual UX verification of the new badge + filter + reframed header — deferred to post-merge against the rebuilt portal image (Build Studio is down; portal-image rebuild + visual sweep is the recommended verification once this merges)
- [ ] Phase 1 follow-up BI to tighten `workType` + `source` to DB-level enum constraints once writers have all migrated and accrued evidence
- [ ] Phase 2 follow-up BI for synchronous PIR→BI projection (replaces 15-min cron) and `/admin/issue-reports` fold into `/ops` filtered view

🤖 Generated with [Claude Code](https://claude.com/claude-code)