### PR TITLE
fix(email): org sender identity + no dead localhost links (BI-1546B81B)

### DIFF
--- a/apps/web/lib/actions/ap.test.ts
+++ b/apps/web/lib/actions/ap.test.ts
@@ -22,6 +22,10 @@ vi.mock("@/lib/email", () => ({
   }),
 }));
 
+vi.mock("@/lib/org-identity", () => ({
+  getOrgIdentity: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@dpf/db", () => ({
   prisma: {
     supplier: { create: vi.fn(), findUnique: vi.fn(), findMany: vi.fn() },

--- a/apps/web/lib/actions/ap.ts
+++ b/apps/web/lib/actions/ap.ts
@@ -6,6 +6,8 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 import { sendEmail, composeApprovalEmail } from "@/lib/email";
+import { getOrgIdentity } from "@/lib/org-identity";
+import { resolveAppBaseUrl } from "@/lib/app-url";
 import type { CreateSupplierInput, CreateBillInput, CreatePOInput, CreatePaymentRunInput } from "@/lib/ap-validation";
 
 // ─── Auth guard ───────────────────────────────────────────────────────────────
@@ -244,8 +246,12 @@ export async function submitBillForApproval(billId: string): Promise<void> {
     },
   });
 
-  // Create a BillApproval record per matching rule
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  // Create a BillApproval record per matching rule. The record (and its
+  // in-portal approval queue) is always created; the email is only sent when a
+  // real base URL is available so we never mail a dead localhost approve link.
+  const issuer = await getOrgIdentity();
+  const fromHeader = issuer?.email ? `${issuer.name} <${issuer.email}>` : undefined;
+  const baseUrl = resolveAppBaseUrl();
 
   for (const rule of rules) {
     const token = nanoid(32);
@@ -258,7 +264,13 @@ export async function submitBillForApproval(billId: string): Promise<void> {
       },
     });
 
-    // Send approval email
+    // Send approval email (only with a usable link)
+    if (!baseUrl) {
+      console.warn(
+        `[ap] No app base URL configured; skipped approval email for bill ${bill.billRef} (approval still queued in-portal)`,
+      );
+      continue;
+    }
     const approveUrl = `${baseUrl}/finance/ap/approvals/${token}`;
     const emailPayload = composeApprovalEmail({
       to: rule.approver.email,
@@ -268,7 +280,7 @@ export async function submitBillForApproval(billId: string): Promise<void> {
       currency: bill.currency,
       approveUrl,
     });
-    await sendEmail(emailPayload);
+    await sendEmail({ ...emailPayload, from: fromHeader });
   }
 
   await prisma.bill.update({

--- a/apps/web/lib/actions/dunning.test.ts
+++ b/apps/web/lib/actions/dunning.test.ts
@@ -31,6 +31,10 @@ vi.mock("@/lib/email", () => ({
   sendEmail: vi.fn().mockResolvedValue({ messageId: "msg-1" }),
 }));
 
+vi.mock("@/lib/org-identity", () => ({
+  getOrgIdentity: vi.fn().mockResolvedValue(null),
+}));
+
 import { prisma } from "@dpf/db";
 import { composeDunningEmail, sendEmail } from "@/lib/email";
 import {

--- a/apps/web/lib/actions/dunning.ts
+++ b/apps/web/lib/actions/dunning.ts
@@ -2,6 +2,8 @@
 
 import { prisma } from "@dpf/db";
 import { composeDunningEmail, sendEmail } from "@/lib/email";
+import { getOrgIdentity } from "@/lib/org-identity";
+import { resolveAppBaseUrl } from "@/lib/app-url";
 
 // ─── Default dunning sequence ─────────────────────────────────────────────────
 
@@ -90,6 +92,11 @@ export async function runDunning(): Promise<{ remindersSent: number }> {
   const sequence = await getDefaultDunningSequence();
   if (!sequence || sequence.steps.length === 0) return { remindersSent: 0 };
 
+  // Resolve sender identity + base URL once for the whole run.
+  const issuer = await getOrgIdentity();
+  const fromHeader = issuer?.email ? `${issuer.name} <${issuer.email}>` : undefined;
+  const baseUrl = resolveAppBaseUrl();
+
   // Find invoices that need dunning (not paid/void/draft)
   const invoices = await prisma.invoice.findMany({
     where: {
@@ -130,9 +137,8 @@ export async function runDunning(): Promise<{ remindersSent: number }> {
 
     // Compose and send reminder email
     if (recipientEmail) {
-      const payUrl = invoice.payToken
-        ? `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/pay/${invoice.payToken}`
-        : undefined;
+      const payUrl =
+        baseUrl && invoice.payToken ? `${baseUrl}/pay/${invoice.payToken}` : undefined;
 
       const emailParams = composeDunningEmail({
         to: recipientEmail,
@@ -145,7 +151,7 @@ export async function runDunning(): Promise<{ remindersSent: number }> {
         payUrl,
       });
 
-      await sendEmail(emailParams);
+      await sendEmail({ ...emailParams, from: fromHeader });
     }
 
     // Log the dunning action

--- a/apps/web/lib/actions/expenses.test.ts
+++ b/apps/web/lib/actions/expenses.test.ts
@@ -22,6 +22,10 @@ vi.mock("@/lib/email", () => ({
   }),
 }));
 
+vi.mock("@/lib/org-identity", () => ({
+  getOrgIdentity: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@dpf/db", () => ({
   prisma: {
     expenseClaim: {

--- a/apps/web/lib/actions/expenses.ts
+++ b/apps/web/lib/actions/expenses.ts
@@ -6,6 +6,8 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 import { sendEmail, composeExpenseApprovalEmail } from "@/lib/email";
+import { getOrgIdentity } from "@/lib/org-identity";
+import { resolveAppBaseUrl } from "@/lib/app-url";
 import type { CreateExpenseClaimInput } from "@/lib/expense-validation";
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
@@ -196,10 +198,14 @@ export async function submitExpenseClaim(id: string): Promise<void> {
     },
   });
 
-  // Send approval email if a manager was found
-  if (managers.length > 0) {
+  // Send approval email if a manager was found and a usable link exists.
+  // The claim is already submitted (and visible in the in-portal queue); we
+  // never mail a dead localhost approve link in production.
+  const baseUrl = resolveAppBaseUrl();
+  if (managers.length > 0 && baseUrl) {
     const manager = managers[0]!;
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const issuer = await getOrgIdentity();
+    const fromHeader = issuer?.email ? `${issuer.name} <${issuer.email}>` : undefined;
     const approveUrl = `${baseUrl}/finance/expenses/approvals/${approvalToken}`;
 
     const emailPayload = composeExpenseApprovalEmail({
@@ -212,7 +218,11 @@ export async function submitExpenseClaim(id: string): Promise<void> {
       itemCount: claim._count.items,
       approveUrl,
     });
-    await sendEmail(emailPayload);
+    await sendEmail({ ...emailPayload, from: fromHeader });
+  } else if (managers.length > 0 && !baseUrl) {
+    console.warn(
+      `[expenses] No app base URL configured; skipped approval email for claim ${claim.claimId} (approval still queued in-portal)`,
+    );
   }
 
   revalidatePath("/finance/expenses");

--- a/apps/web/lib/app-url.test.ts
+++ b/apps/web/lib/app-url.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveAppBaseUrl } from "./app-url";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveAppBaseUrl", () => {
+  it("prefers NEXT_PUBLIC_BASE_URL and strips trailing slashes", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://app.example.com/");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://other.example.com");
+    expect(resolveAppBaseUrl()).toBe("https://app.example.com");
+  });
+
+  it("falls back to NEXT_PUBLIC_APP_URL when base url unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://portal.example.com");
+    expect(resolveAppBaseUrl()).toBe("https://portal.example.com");
+  });
+
+  it("uses localhost outside production when nothing is configured", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(resolveAppBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("returns null in production when nothing is configured (no broken localhost link)", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(resolveAppBaseUrl()).toBeNull();
+  });
+});

--- a/apps/web/lib/app-url.ts
+++ b/apps/web/lib/app-url.ts
@@ -1,0 +1,12 @@
+// Resolve the install's public base URL for links embedded in outbound emails.
+//
+// Prefers explicit configuration (NEXT_PUBLIC_BASE_URL / NEXT_PUBLIC_APP_URL).
+// In non-production it falls back to localhost (correct for local dev). In
+// production with nothing configured it returns null — callers must NOT emit a
+// knowingly-broken "http://localhost:3000" link in a real customer email.
+export function resolveAppBaseUrl(): string | null {
+  const configured = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (configured && configured.trim()) return configured.trim().replace(/\/+$/, "");
+  if (process.env.NODE_ENV !== "production") return "http://localhost:3000";
+  return null;
+}


### PR DESCRIPTION
## What & why

Completes **BI-1546B81B** (epic **EP-SHIP-REAL-AUDIT**) — the remainder after #1344 handled invoice email. Reuses the merged `getOrgIdentity()` resolver across the other outbound senders.

**Sender identity** — dunning, bill-approval, and expense-approval emails now send `From` = org `name <email>` instead of `noreply@example.com`.

**No dead localhost links in prod** — new `resolveAppBaseUrl()` (`lib/app-url.ts`): prefers configured `NEXT_PUBLIC_BASE_URL`/`NEXT_PUBLIC_APP_URL`, falls back to `localhost:3000` **only outside production**, and returns `null` in production when unconfigured. Previously every link used a hardcoded `localhost`/empty fallback that breaks in a real install.
- Dunning: omits the Pay Now link when no base URL (the reminder still sends).
- Bill/expense approval: skip the email with a `console.warn` when no base URL — the approval is still queued in the in-portal queue — rather than mailing an approve/reject link that 404s.

## Verification
- New `app-url.test.ts` (config precedence, trailing-slash strip, dev localhost, prod-null). dunning/ap/expenses tests stub `getOrgIdentity`; all send paths exercised.
- **56/56** across the four suites; `tsc --noEmit` clean.

With this, BI-1546B81B is fully resolved (invoice via #1344 + the rest here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)