### PR TITLE
refactor(web): migrate compliance module status badges to report-kit (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/compliance/audits/page.tsx
+++ b/apps/web/app/(shell)/compliance/audits/page.tsx
@@ -3,13 +3,7 @@ import { AUDIT_TYPES, AUDIT_STATUSES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateAuditForm } from "@/components/compliance/CreateAuditForm";
 import { LocalTime } from "@/components/ui/LocalTime";
-
-const STATUS_COLORS: Record<string, string> = {
-  planned: "bg-blue-900/30 text-blue-400",
-  "in-progress": "bg-yellow-900/30 text-yellow-400",
-  completed: "bg-green-900/30 text-green-400",
-  cancelled: "bg-gray-900/30 text-gray-400",
-};
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { searchParams: Promise<{ auditType?: string; status?: string }> };
 
@@ -74,9 +68,7 @@ export default async function AuditsPage({ searchParams }: Props) {
                   <span className="text-sm text-[var(--dpf-text)]">{a.title}</span>
                   <div className="flex gap-2 mt-1">
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{a.auditType}</span>
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[a.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-                      {a.status}
-                    </span>
+                    <StatusBadge domain="complianceAudit" status={a.status} variant="soft" uppercase={false} />
                     {a.overallRating && (
                       <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{a.overallRating}</span>
                     )}

--- a/apps/web/app/(shell)/compliance/incidents/page.tsx
+++ b/apps/web/app/(shell)/compliance/incidents/page.tsx
@@ -3,13 +3,7 @@ import { INCIDENT_SEVERITIES, INCIDENT_STATUSES } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateIncidentForm } from "@/components/compliance/CreateIncidentForm";
 import { LocalTime } from "@/components/ui/LocalTime";
-
-const SEVERITY_COLORS: Record<string, string> = {
-  low: "bg-green-900/30 text-green-400",
-  medium: "bg-yellow-900/30 text-yellow-400",
-  high: "bg-orange-900/30 text-orange-400",
-  critical: "bg-red-900/30 text-red-400",
-};
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { searchParams: Promise<{ severity?: string; status?: string; regulatoryNotifiable?: string }> };
 
@@ -79,28 +73,22 @@ export default async function IncidentsPage({ searchParams }: Props) {
             const isOpen = inc.status === "open" || inc.status === "investigating";
             const isNotifiable = inc.regulatoryNotifiable;
             return (
-              <Link key={inc.id} href={`/compliance/incidents/${inc.id}`} className={`block p-3 rounded-lg border ${isNotifiable && isOpen ? "border-red-500/50" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}>
+              <Link key={inc.id} href={`/compliance/incidents/${inc.id}`} className={`block p-3 rounded-lg border ${isNotifiable && isOpen ? "border-[color-mix(in_srgb,var(--dpf-error)_50%,transparent)]" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}>
                 <div className="flex items-start justify-between">
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-[var(--dpf-text)]">{inc.title}</span>
                       {isNotifiable && (
-                        <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-red-900/30 text-red-400 font-semibold">
-                          NOTIFIABLE
-                        </span>
+                        <StatusBadge intent="danger" label="Notifiable" variant="soft" />
                       )}
                     </div>
                     <div className="flex gap-2 mt-1">
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SEVERITY_COLORS[inc.severity] ?? "bg-gray-900/30 text-gray-400"}`}>
-                        {inc.severity}
-                      </span>
+                      <StatusBadge domain="severity" status={inc.severity} variant="soft" uppercase={false} />
                       {inc.category && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{inc.category}</span>}
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${isOpen ? "bg-yellow-900/30 text-yellow-400" : "bg-green-900/30 text-green-400"}`}>
-                        {inc.status}
-                      </span>
+                      <StatusBadge intent={isOpen ? "warning" : "success"} label={inc.status} variant="soft" uppercase={false} />
                     </div>
                     {isNotifiable && inc.notificationDeadline && isOpen && (
-                      <p className="text-[9px] text-red-400 mt-1">
+                      <p className="text-[9px] text-[var(--dpf-error)] mt-1">
                         Notification deadline: <LocalTime value={inc.notificationDeadline} />
                       </p>
                     )}

--- a/apps/web/app/(shell)/compliance/policies/page.tsx
+++ b/apps/web/app/(shell)/compliance/policies/page.tsx
@@ -1,13 +1,6 @@
 import { prisma } from "@dpf/db";
 import { CreatePolicyForm } from "@/components/compliance/CreatePolicyForm";
-
-const STATUS_COLORS: Record<string, string> = {
-  draft: "bg-gray-900/30 text-gray-400",
-  "in-review": "bg-yellow-900/30 text-yellow-400",
-  approved: "bg-blue-900/30 text-blue-400",
-  published: "bg-green-900/30 text-green-400",
-  retired: "bg-gray-900/30 text-gray-400",
-};
+import { StatusBadge } from "@/components/ui/report-kit";
 
 export default async function PoliciesPage() {
   const policies = await prisma.policy.findMany({
@@ -38,9 +31,7 @@ export default async function PoliciesPage() {
               className="block p-4 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors">
               <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-semibold text-[var(--dpf-text)]">{p.title}</span>
-                <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[p.lifecycleStatus] ?? "bg-gray-900/30 text-gray-400"}`}>
-                  {p.lifecycleStatus}
-                </span>
+                <StatusBadge domain="compliancePolicy" status={p.lifecycleStatus} variant="soft" uppercase={false} />
               </div>
               <div className="flex gap-2 mt-1">
                 <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{p.category}</span>
@@ -52,7 +43,7 @@ export default async function PoliciesPage() {
                 <span>{p._count.acknowledgments} ack{p._count.acknowledgments !== 1 ? "s" : ""}</span>
               </div>
               {p.obligation && (
-                <p className="text-[9px] text-blue-400 mt-1">Linked: {p.obligation.title}</p>
+                <p className="text-[9px] text-[var(--dpf-info)] mt-1">Linked: {p.obligation.title}</p>
               )}
             </a>
           ))}

--- a/apps/web/app/(shell)/compliance/regulations/page.tsx
+++ b/apps/web/app/(shell)/compliance/regulations/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import Link from "next/link";
 import { CreateRegulationForm } from "@/components/compliance/CreateRegulationForm";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { searchParams: Promise<{ type?: string }> };
 
@@ -50,9 +51,7 @@ export default async function RegulationsPage({ searchParams }: Props) {
               <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-semibold text-[var(--dpf-text)]">{r.shortName}</span>
                 <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{r.jurisdiction}</span>
-                <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${r.status === "active" ? "bg-green-900/30 text-green-400" : "bg-red-900/30 text-red-400"}`}>
-                  {r.status}
-                </span>
+                <StatusBadge domain="complianceRegulation" status={r.status} variant="soft" uppercase={false} />
               </div>
               <p className="text-xs text-[var(--dpf-muted)] mb-1">{r.name}</p>
               <p className="text-xs text-[var(--dpf-muted)]">

--- a/apps/web/app/(shell)/compliance/risks/page.tsx
+++ b/apps/web/app/(shell)/compliance/risks/page.tsx
@@ -2,13 +2,7 @@ import { listRiskAssessments } from "@/lib/actions/compliance";
 import { RISK_LEVELS } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateRiskAssessmentForm } from "@/components/compliance/CreateRiskAssessmentForm";
-
-const RISK_COLORS: Record<string, string> = {
-  low: "bg-green-900/30 text-green-400",
-  medium: "bg-yellow-900/30 text-yellow-400",
-  high: "bg-orange-900/30 text-orange-400",
-  critical: "bg-red-900/30 text-red-400",
-};
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { searchParams: Promise<{ inherentRisk?: string; status?: string }> };
 
@@ -70,13 +64,9 @@ export default async function RisksPage({ searchParams }: Props) {
                 <div>
                   <span className="text-sm text-[var(--dpf-text)]">{r.title}</span>
                   <div className="flex gap-2 mt-1">
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${RISK_COLORS[r.inherentRisk] ?? "bg-gray-900/30 text-gray-400"}`}>
-                      Inherent: {r.inherentRisk}
-                    </span>
+                    <StatusBadge domain="severity" status={r.inherentRisk} label={`Inherent: ${r.inherentRisk}`} variant="soft" uppercase={false} />
                     {r.residualRisk && (
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${RISK_COLORS[r.residualRisk] ?? "bg-gray-900/30 text-gray-400"}`}>
-                        Residual: {r.residualRisk}
-                      </span>
+                      <StatusBadge domain="severity" status={r.residualRisk} label={`Residual: ${r.residualRisk}`} variant="soft" uppercase={false} />
                     )}
                     <span className="text-[9px] text-[var(--dpf-muted)]">{r.likelihood} / {r.severity}</span>
                   </div>

--- a/apps/web/app/(shell)/compliance/submissions/page.tsx
+++ b/apps/web/app/(shell)/compliance/submissions/page.tsx
@@ -4,14 +4,7 @@ import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { CreateSubmissionForm } from "@/components/compliance/CreateSubmissionForm";
 import { LocalTime } from "@/components/ui/LocalTime";
-
-const STATUS_COLORS: Record<string, string> = {
-  draft: "bg-gray-900/30 text-gray-400",
-  pending: "bg-yellow-900/30 text-yellow-400",
-  submitted: "bg-blue-900/30 text-blue-400",
-  acknowledged: "bg-green-900/30 text-green-400",
-  rejected: "bg-red-900/30 text-red-400",
-};
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { searchParams: Promise<{ status?: string; submissionType?: string }> };
 
@@ -84,15 +77,13 @@ export default async function SubmissionsPage({ searchParams }: Props) {
                   <div className="flex gap-2 mt-1">
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{s.recipientBody}</span>
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{s.submissionType}</span>
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[s.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-                      {s.status}
-                    </span>
+                    <StatusBadge domain="complianceSubmission" status={s.status} variant="soft" uppercase={false} />
                     {s.regulation && <span className="text-[9px] text-[var(--dpf-muted)]">{s.regulation.shortName}</span>}
                   </div>
                 </div>
                 <div className="text-right text-xs text-[var(--dpf-muted)]">
                   {s.dueDate && (
-                    <p className={daysRemaining !== null && daysRemaining < 0 ? "text-red-400" : daysRemaining !== null && daysRemaining < 7 ? "text-yellow-400" : undefined}>
+                    <p className={daysRemaining !== null && daysRemaining < 0 ? "text-[var(--dpf-error)]" : daysRemaining !== null && daysRemaining < 7 ? "text-[var(--dpf-warning)]" : undefined}>
                       Due: <LocalTime value={s.dueDate} utc />
                       {daysRemaining !== null && (
                         <span className="ml-1">({daysRemaining < 0 ? `${Math.abs(daysRemaining)}d overdue` : `${daysRemaining}d`})</span>

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -99,6 +99,38 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     ineffective: "danger",
     "not-assessed": "neutral",
   },
+  // Compliance module lifecycle statuses (were raw Tailwind palette classes).
+  complianceAudit: {
+    planned: "info",
+    "in-progress": "warning",
+    completed: "success",
+    cancelled: "neutral",
+  },
+  complianceAction: {
+    open: "warning",
+    "in-progress": "warning",
+    completed: "info",
+    verified: "success",
+    "not-applicable": "neutral",
+  },
+  complianceSubmission: {
+    draft: "neutral",
+    pending: "warning",
+    submitted: "info",
+    acknowledged: "success",
+    rejected: "danger",
+  },
+  compliancePolicy: {
+    draft: "neutral",
+    "in-review": "warning",
+    approved: "info",
+    published: "success",
+    retired: "neutral",
+  },
+  complianceRegulation: {
+    active: "success",
+    inactive: "danger",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",


### PR DESCRIPTION
## What

Migrates the **compliance module list surfaces** off raw Tailwind-palette status colors onto report-kit `StatusBadge` + new registry domains. This was the largest remaining cluster of token violations in the portal.

**Surfaces (6):** audits, policies, submissions, regulations, risks, incidents.

- Raw class maps like `bg-green-900/30 text-green-400` / `bg-red-900/30 text-red-400` → `StatusBadge` via new `STATUS_INTENT` domains: `complianceAudit`, `complianceSubmission`, `compliancePolicy`, `complianceRegulation`, `complianceAction` (severity reused for risks/incidents).
- Stray accent colors (`text-blue-400` linked-badge, `text-red-400`/`text-yellow-400` due-date warnings, `border-red-500/50` notifiable card) → `--dpf-*` tokens.

## Verification

- `npx vitest run components/ui/report-kit/statusColors` → **5 passed** (registry test auto-covers every new domain → valid intent)
- `tsc --noEmit` clean
- Zero raw palette colors remain across all 6 pages

## Process note

Done in an **isolated git worktree** — the shared root checkout was being branch-switched / `git reset` by concurrent processes mid-edit (twice destroying uncommitted work). The worktree is the durable fix.

Follow-ups: compliance `[id]` detail pages + actions/gaps/obligations (coverage-dot pattern) still have palette colors — a natural next batch. Phase 2 of `docs/specs/reporting-ux-primitives-spec.md`. BI-6A842691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)