### PR TITLE
fix(build-studio): derive fix-build UX verification from fixContext (BI-AC5CFDB0)

### DIFF
--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -78,6 +78,31 @@ export type FeatureBrief = {
   fixContext?: FixContext;
 };
 
+/**
+ * Derive the UX-verification assertion(s) for a fix build from its diagnosis.
+ * A fix's UX check is "the reported defect no longer reproduces on the affected
+ * route" — NOT the feature `acceptanceCriteria` (which on a fix build can be
+ * polluted with fixContext prose, producing nonsense browser-use navigations
+ * like `https://fixContext.reproSteps`). Returns [] when there's nothing
+ * actionable to verify in a browser. (BI-AC5CFDB0)
+ */
+export function deriveFixUxTestCases(fixContext: FixContext | null | undefined): string[] {
+  if (!fixContext) return [];
+  const route = fixContext.routeContext?.trim();
+  const expected = fixContext.expected?.trim();
+  const actual = fixContext.actual?.trim();
+  // Nothing browser-verifiable (e.g. a pure server/tool fix with no route) →
+  // let the caller skip UX rather than invent a navigation target.
+  if (!route && !expected) return [];
+  const where = route ? `Navigate to ${route} and ` : "";
+  const wasClause = actual ? ` (previously: ${actual})` : "";
+  const expectClause = expected ? ` Expected: ${expected}.` : "";
+  return [
+    `${where}verify the previously-reported defect no longer occurs${wasClause}.` +
+      `${expectClause} The page must load without a runtime error overlay or blank-screen crash.`,
+  ];
+}
+
 export type TaxonomyAttributionView = {
   method: "rule" | "heuristic" | "ai_proposed" | "manual" | "invalid_portfolio";
   confidence: number;

--- a/apps/web/lib/explore/fix-flow.test.ts
+++ b/apps/web/lib/explore/fix-flow.test.ts
@@ -3,6 +3,7 @@ import {
   FEATURE_BUILD_KIND_VALUES,
   isFixContextComplete,
   checkPhaseGate,
+  deriveFixUxTestCases,
   type FixContext,
 } from "./feature-build-types";
 import { getBuildPhasePrompt } from "@/lib/integrate/build-agent-prompts";
@@ -134,5 +135,44 @@ describe("getBuildPhasePrompt — fix variants", () => {
   it("terminal phases keep empty-prompt behavior for both kinds", async () => {
     expect(await getBuildPhasePrompt("complete", "fix")).toBe("");
     expect(await getBuildPhasePrompt("failed", "fix")).toBe("");
+  });
+});
+
+describe("deriveFixUxTestCases — fix UX verification source (BI-AC5CFDB0)", () => {
+  it("navigates to the affected route and asserts the defect is gone", () => {
+    const cases = deriveFixUxTestCases({
+      routeContext: "/admin/diagnostics",
+      expected: "the diagnostics table renders",
+      actual: "the page throws a runtime error",
+    });
+    expect(cases).toHaveLength(1);
+    const assertion = cases[0]!;
+    expect(assertion).toContain("Navigate to /admin/diagnostics");
+    expect(assertion).toContain("the diagnostics table renders");
+    expect(assertion).toContain("the page throws a runtime error");
+    // Never emits a fixContext field name as a literal URL — that was the bug
+    // (browser-use tried to visit `https://fixContext.reproSteps`).
+    expect(assertion).not.toContain("fixContext");
+    expect(assertion).not.toContain("https://");
+  });
+
+  it("works from expected-only context with no route", () => {
+    const cases = deriveFixUxTestCases({ expected: "the form submits successfully" });
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).not.toContain("Navigate to");
+    expect(cases[0]).toContain("the form submits successfully");
+  });
+
+  it("returns [] when there's nothing browser-verifiable (caller skips UX)", () => {
+    expect(deriveFixUxTestCases(null)).toEqual([]);
+    expect(deriveFixUxTestCases(undefined)).toEqual([]);
+    // a pure server/tool fix with diagnosis but no route or expected behavior
+    expect(deriveFixUxTestCases({ rootCause: "off-by-one in parser", reproSteps: "call parse('')" })).toEqual([]);
+  });
+
+  it("does not leak the polluted feature acceptanceCriteria shape", () => {
+    // Even with an empty/whitespace route, it must not produce a bare URL nav.
+    const cases = deriveFixUxTestCases({ routeContext: "   ", expected: "ok" });
+    expect(cases[0]).not.toContain("Navigate to    ");
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10448,12 +10448,23 @@ export async function executeTool(
     case "run_ux_test": {
       const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
-      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true, sandboxPort: true, brief: true } });
+      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true, sandboxPort: true, brief: true, kind: true } });
       if (!build?.sandboxPort || !build.sandboxId || !build.brief) return { success: false, error: "Sandbox or brief not ready.", message: "Launch sandbox and save brief first." };
 
-      const brief = build.brief as { acceptanceCriteria?: string[] };
-      const testCases = (params.tests as string[] | undefined) ?? brief.acceptanceCriteria ?? [];
-      if (testCases.length === 0) return { success: false, error: "No test cases.", message: "No acceptance criteria or test cases to run." };
+      const { deriveFixUxTestCases } = await import("@/lib/explore/feature-build-types");
+      const brief = build.brief as {
+        acceptanceCriteria?: string[];
+        fixContext?: import("@/lib/explore/feature-build-types").FixContext;
+      };
+      // Explicit `tests` always win. Otherwise, for a fix build derive the
+      // assertion from the structured fix diagnosis (defect-gone on its route)
+      // rather than the polluted feature acceptanceCriteria. (BI-AC5CFDB0)
+      const testCases =
+        (params.tests as string[] | undefined) ??
+        (build.kind === "fix"
+          ? deriveFixUxTestCases(brief.fixContext)
+          : brief.acceptanceCriteria ?? []);
+      if (testCases.length === 0) return { success: false, error: "No test cases.", message: build.kind === "fix" ? "No fix context (route/expected) or test cases to verify." : "No acceptance criteria or test cases to run." };
 
       try {
         const BROWSER_USE_URL = process.env.BROWSER_USE_URL || "http://browser-use:8500/mcp";

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -35,7 +35,7 @@ export const buildReviewVerification = inngest.createFunction(
       const { prisma } = await import("@dpf/db");
       return prisma.featureBuild.findUnique({
         where: { buildId },
-        select: { sandboxId: true, sandboxPort: true, brief: true, threadId: true },
+        select: { sandboxId: true, sandboxPort: true, brief: true, threadId: true, kind: true },
       });
     });
 
@@ -43,8 +43,20 @@ export const buildReviewVerification = inngest.createFunction(
       return { skipped: true, reason: "sandbox or build missing" };
     }
 
-    const brief = build.brief as { acceptanceCriteria?: string[] } | null;
-    const testCases = brief?.acceptanceCriteria ?? [];
+    const { deriveFixUxTestCases } = await import("@/lib/explore/feature-build-types");
+    const brief = build.brief as {
+      acceptanceCriteria?: string[];
+      fixContext?: import("@/lib/explore/feature-build-types").FixContext;
+    } | null;
+    // For a fix build, `acceptanceCriteria` is often polluted with fixContext
+    // prose (the brief reuses the feature shape), which produced nonsense
+    // browser-use navigations like `https://fixContext.reproSteps`. Derive the
+    // UX assertion from the structured fix diagnosis instead — verify the
+    // reported defect no longer reproduces on its route. (BI-AC5CFDB0)
+    const testCases =
+      build.kind === "fix"
+        ? deriveFixUxTestCases(brief?.fixContext)
+        : brief?.acceptanceCriteria ?? [];
 
     await step.run("start-verification", async () => {
       const { prisma } = await import("@dpf/db");


### PR DESCRIPTION
## What

For `kind === "fix"` Build Studio builds, the review-phase UX verification now derives its browser-use assertion from the structured **fix diagnosis** (`fixContext`) instead of the feature `acceptanceCriteria`.

## Why

A fix build reuses the feature `FeatureBrief` shape, so its `acceptanceCriteria` are typically empty or polluted with `fixContext` prose. The verification path (`build-review-verification` Inngest function and the `run_ux_test` MCP tool) fed those straight to browser-use, which produced nonsense navigations like visiting `https://fixContext.reproSteps` — yielding spurious failures or vacuous skips. This was the open follow-up from the lifecycle dogfood (BI-AC5CFDB0), filed under EP-BUILD-STUDIO.

## How

- **`feature-build-types.ts`** — new `deriveFixUxTestCases(fixContext)` helper. Builds one assertion: *"Navigate to {routeContext} and verify the previously-reported defect no longer occurs (previously: {actual}). Expected: {expected}. The page must load without a runtime error overlay or blank-screen crash."* Returns `[]` when there is nothing browser-verifiable (no route and no expected behavior) so the caller skips UX cleanly.
- **`build-review-verification.ts`** — adds `kind` to the build select; branches `testCases` on `kind === "fix"`.
- **`mcp-tools.ts` (`run_ux_test`)** — same kind-aware derivation; an explicit `tests` param still wins; fix-specific empty-case message.
- **`fix-flow.test.ts`** — 4 new tests: route-nav, expected-only, empty→skip, and a regression asserting the output never contains a `fixContext`-field-as-URL.

Feature builds are byte-for-byte unchanged (the `kind !== "fix"` path still reads `acceptanceCriteria`). Built on top of #1348's `(work-type, work-size)` substrate.

## Verification

- `vitest run lib/explore/fix-flow.test.ts` → 17/17 pass
- `tsc --noEmit` → clean
- `next build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)