### PR TITLE
fix(self-upgrade): manual "Upgrade now" runs immediately; window gates only the scheduled poll

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -77,11 +77,11 @@ describe("SelfUpgradeClient – disabled", () => {
     expect(html).toContain("Disabled");
   });
 
-  it("does not render the Trigger Now button when disabled", () => {
+  it("does not render the Upgrade now button when disabled", () => {
     const html = renderToStaticMarkup(
       <SelfUpgradeClient {...baseStatus} enabled={false} />,
     );
-    expect(html).not.toContain("Trigger Now");
+    expect(html).not.toContain("Upgrade now");
   });
 
   it("shows the disabled notice copy", () => {
@@ -101,9 +101,9 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("stable");
   });
 
-  it("renders the Trigger Now button when enabled", () => {
+  it("renders the Upgrade now button when enabled", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Trigger Now");
+    expect(html).toContain("Upgrade now");
   });
 
   it("shows the deployed and target SHA values", () => {
@@ -236,7 +236,7 @@ describe("SelfUpgradeClient – trigger control", () => {
 
   it("button is not disabled when no run is active", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Trigger Now");
+    expect(html).toContain("Upgrade now");
     expect(html).not.toContain('disabled=""');
   });
 
@@ -251,11 +251,13 @@ describe("SelfUpgradeClient – trigger control", () => {
 // ─── Loading state ────────────────────────────────────────────────────────────
 
 describe("SelfUpgradeClient – loading", () => {
-  it("shows Triggering... text when pending", () => {
+  it("shows Upgrading... text when pending", () => {
     shared.isPending = true;
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Triggering...");
-    expect(html).not.toContain("Trigger Now");
+    expect(html).toContain("Upgrading...");
+    // The idle button label ">Upgrade now<" is replaced while pending (the
+    // aria-label "Upgrade now" stays, so assert on the visible button text).
+    expect(html).not.toContain(">Upgrade now<");
   });
 
   it("button is disabled while pending", () => {

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -135,7 +135,8 @@ export default function SelfUpgradeClient({
                 type="checkbox"
                 checked={override}
                 onChange={(e) => setOverride(e.target.checked)}
-                aria-label="Emergency override: bypass maintenance window"
+                aria-label="Emergency override: bypass the safety drain"
+                title="Bypass the quiescence safety drain. Only for emergencies — it can interrupt in-flight work."
                 className="accent-[var(--dpf-warning)]"
               />
               Emergency override
@@ -145,11 +146,11 @@ export default function SelfUpgradeClient({
               onClick={handleTrigger}
               disabled={isPending || latestRun?.status === "running"}
               aria-busy={isPending}
-              aria-label="Trigger self-upgrade now"
+              aria-label="Upgrade now"
               data-override={override ? "true" : "false"}
               className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
             >
-              {isPending ? "Triggering..." : override ? "Force upgrade now" : "Trigger Now"}
+              {isPending ? "Upgrading..." : override ? "Force upgrade now" : "Upgrade now"}
             </button>
           </div>
         )}

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -478,21 +478,21 @@ describe("triggerSelfUpgrade – dispatch", () => {
 
 // ─── triggerSelfUpgrade – maintenance window gate + emergency override ─────────
 
-describe("triggerSelfUpgrade – window gate", () => {
-  it("returns queued: false / outside-window when not in a maintenance window", async () => {
+describe("triggerSelfUpgrade – manual is not window-gated", () => {
+  it("QUEUES even when the store is open — the operator chose now", async () => {
+    // Manual trigger must run regardless of the (store-closed) window; the window
+    // only governs the unattended scheduled poll. (BI-F0E4272B)
     vi.mocked(isUpgradeWindowOpen).mockReturnValue(false);
 
     const result = await triggerSelfUpgrade();
 
-    expect(result).toEqual(
-      expect.objectContaining({ queued: false, reason: "outside-window" }),
-    );
-    expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
+    expect(result).toEqual({ queued: true });
+    expect(vi.mocked(inngest.send)).toHaveBeenCalled();
+    // It doesn't even consult the window for a manual trigger.
+    expect(vi.mocked(isUpgradeWindowOpen)).not.toHaveBeenCalled();
   });
 
-  it("force=true bypasses the window gate and dispatches with force in the event", async () => {
-    vi.mocked(isUpgradeWindowOpen).mockReturnValue(false);
-
+  it("emergency override dispatches with force (bypasses the quiescence drain)", async () => {
     const result = await triggerSelfUpgrade({ force: true });
 
     expect(result).toEqual({ queued: true });
@@ -503,9 +503,7 @@ describe("triggerSelfUpgrade – window gate", () => {
     );
   });
 
-  it("does not include force in the event for a normal in-window trigger", async () => {
-    vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
-
+  it("does not include force in the event for a normal manual trigger", async () => {
     await triggerSelfUpgrade();
 
     const sent = vi.mocked(inngest.send).mock.calls[0][0] as { data: Record<string, unknown> };

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -660,19 +660,10 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
     if (!config.enabled) {
       return { queued: false, reason: "disabled" } as const;
     }
-    // Honest feedback: a manual trigger while the store is open (outside the
-    // upgrade window) is a no-op (runSelfUpgrade skips before creating a run).
-    // Surface that here instead of optimistically reporting "queued". force =
-    // emergency override that bypasses the window.
-    if (!opts?.force) {
-      const { schedule, timezone } = await resolveOperatingScheduleForSystem();
-      const allowed = isUpgradeWindowOpen({
-        explicitWindows: config.maintenanceWindows,
-        schedule,
-        timeZone: timezone,
-      });
-      if (!allowed) return { queued: false, reason: "outside-window" } as const;
-    }
+    // A manual trigger is NOT window-gated: the operator clicking "Upgrade now"
+    // has chosen this moment. The store-closed window only governs the unattended
+    // scheduled poll (runSelfUpgrade skips the window for non-scheduled runs).
+    // `force` is reserved for bypassing the quiescence drain in an emergency.
   }
 
   const latestRun = await getLatestRun();

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -386,17 +386,26 @@ describe("maintenance window gate + emergency override", () => {
     mocks.completeRun.mockResolvedValue({});
   });
 
-  it("skips with outside-window when not in a window and no force", async () => {
+  it("SCHEDULED run skips with outside-window when the store is open", async () => {
     mocks.isUpgradeWindowOpen.mockReturnValue(false);
-    const result = await runSelfUpgrade({ triggeredBy: "manual:ops" });
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
     expect(result).toMatchObject({ skipped: true, reason: "outside-window" });
     expect(mocks.createRun).not.toHaveBeenCalled();
     expect(mocks.runPromoter).not.toHaveBeenCalled();
   });
 
-  it("force=true bypasses the window gate and runs the promoter", async () => {
+  it("MANUAL run is NOT window-gated — runs even when the store is open", async () => {
     mocks.isUpgradeWindowOpen.mockReturnValue(false);
-    const result = await runSelfUpgrade({ triggeredBy: "manual:ops", force: true });
+    const result = await runSelfUpgrade({ triggeredBy: "manual:ops" }); // scheduled unset
+    expect(result).toMatchObject({ ok: true, status: "succeeded" });
+    expect(mocks.runPromoter).toHaveBeenCalled();
+    // a manual trigger doesn't even consult the window gate
+    expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
+  });
+
+  it("force=true bypasses the window gate on the scheduled path too", async () => {
+    mocks.isUpgradeWindowOpen.mockReturnValue(false);
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true, force: true });
     expect(result).toMatchObject({ ok: true, status: "succeeded" });
     expect(mocks.runPromoter).toHaveBeenCalled();
   });

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -61,13 +61,13 @@ export async function runSelfUpgrade(
   const config = await getSelfUpgradeConfig();
 
   if (!config.enabled && !params.dryRun) return { skipped: true, reason: "disabled" };
-  // The upgrade window is "whenever the storefront is closed", derived from the
-  // operator's operating hours (single source of truth — no separate window to
-  // configure, no "enabled but no window → never runs" dead-end). An explicit
-  // maintenanceWindows config still overrides for bespoke schedules.
-  // force = operator emergency override: bypass the window (and, below, the
-  // quiescence defer). Never set by the scheduled cron.
-  if (!params.dryRun && !params.force) {
+  // The upgrade window ("whenever the storefront is closed", derived from
+  // operating hours) gates ONLY the unattended scheduled poll. A manual operator
+  // trigger means "upgrade now" — the operator has explicitly chosen this moment,
+  // so it is NOT window-gated (it still drains via quiescence below unless force).
+  // An explicit maintenanceWindows config overrides the derived window for the
+  // scheduled path. force never set by the cron.
+  if (params.scheduled && !params.force) {
     const { schedule, timezone } = await resolveOperatingScheduleForSystem();
     const allowed = isUpgradeWindowOpen({
       explicitWindows: config.maintenanceWindows,


### PR DESCRIPTION
## Why
An explicit operator **Trigger Now** click returned `outside-window` unless they *also* ticked **Emergency override** — confusing, because a manual click already means "upgrade now" (**BI-F0E4272B**). The store-closed window exists to gate the **unattended scheduled cron**, not a deliberate operator action.

## Change
- **`runSelfUpgrade`**: the window gate is now **scheduled-only** (`params.scheduled`). Manual runs skip the window entirely (they still drain via quiescence unless `force`).
- **`triggerSelfUpgrade`**: drops the window pre-check — a manual trigger always queues; `enabled` + already-running guards remain.
- **Panel**: primary button is **"Upgrade now"** (it runs). **"Emergency override"** is relabelled to its real meaning — bypass the **quiescence safety drain** (emergency), not the window.

## Verify
- Orchestrator: scheduled-skips-when-open / **manual-runs-when-open** / force-bypasses-scheduled.
- Action: manual **queues even when the store is open** and never consults the window; emergency override still dispatches `force`.
- Panel label assertions updated. Affected suite green; `tsc` + `next build` clean.

Completes the trio of self-upgrade scheduling fixes (with #1280 / #1297). Refs BI-F0E4272B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)