### PR TITLE
chore(dev): collision-free worktree workflow — new-dev-worktree.sh + doc

### DIFF
--- a/docs/dev/collision-free-dev-workflow.md
+++ b/docs/dev/collision-free-dev-workflow.md
@@ -1,0 +1,73 @@
+# Collision-Free Dev Workflow
+
+**The one rule:** never do active feature/fix/doc work in the root clone (`~/dpf`).
+Work in a per-session git **worktree**, and **commit + push frequently**.
+
+This is the operational companion to the principles
+[`keep-root-clone-as-merge-worktree`](../founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md)
+and [`worktree-per-session`](../founder-kernel/wiki/principles/worktree-per-session.md),
+and the [`dpf-worktree-per-session`](../../packages/dpf-skill-pack/skills/dpf-worktree-per-session)
+skill — made into a single command.
+
+## Why the root clone eats your work
+
+The root clone at the canonical path (`~/dpf`) is **shared mutable state**. Two
+independent actors rewrite its working tree and HEAD without coordinating with
+your editor:
+
+1. **The self-upgrade loop.** `apps/web/lib/self-upgrade/prepare-source.ts` builds
+   each upgrade by running, on the root clone:
+   `git fetch` → `git checkout dpf/install` → `git merge --no-ff <upstream>`.
+   It *defers* when the root has **tracked** uncommitted changes (good), but it
+   still moves the branch under you, and it deliberately **ignores untracked
+   files** — so brand-new files (a new component, a new spec) are not protected.
+2. **Other concurrent agent sessions.** Each one may `git checkout <its-branch>`
+   and `git reset` the root to do its own work. Observed in the reflog as
+   `checkout: moving from <branchA> to <branchB>` followed by `reset: moving to HEAD`.
+
+Either one will roll back or discard work that lives only in the root's working
+tree. A **linked worktree has its own working tree and HEAD**, so neither actor
+touches it. That is the whole fix.
+
+## The workflow
+
+```sh
+# 1. Start an isolated session (off the freshest origin/main, MCP seeded):
+./scripts/new-dev-worktree.sh <slug> [branch-prefix]      # default prefix: feat
+#   e.g. ./scripts/new-dev-worktree.sh invoice-pdf-export fix
+
+# 2. Move into it and work there — never in the root:
+cd ~/dpf-worktrees/<slug>
+
+# 3. Commit + push after every logical step (nothing should live only in a
+#    working tree):
+git add -A && git commit -s -m "…" && git push -u origin <prefix>/<slug>
+
+# 4. Open the PR from the worktree, let CI run, merge.
+
+# 5. Clean up when merged:
+git -C ~/dpf worktree remove ~/dpf-worktrees/<slug>
+```
+
+`new-dev-worktree.sh` resolves the **true** root clone (via `git worktree list`)
+even when invoked from inside another worktree, bases the new branch on
+`origin/main`, places it at `~/dpf-worktrees/<slug>`, and runs
+`seed-worktree-mcp.sh` so the `dpf` MCP connector and an isolated compose stack
+work immediately.
+
+## Rules of thumb
+
+- **Root clone = merges/releases/inspection only.** Treat it as read-only. Return
+  to it for `git pull` on main and to verify canonical state — not to edit.
+- **Commit + push fast.** The durability boundary is the remote, not your disk.
+  If a worktree is ever removed, a pushed branch loses nothing.
+- **One worktree per concurrent task.** Don't reuse one worktree for two
+  unrelated branches.
+- **Recovery, if you ever edited the root and it got reset:** check
+  `git stash list` (a cleanup may have stashed `-u`) and `git reflog` before
+  assuming the work is gone — but the real fix is to not work there.
+
+## What this is NOT
+
+It does not change the self-upgrade. The self-upgrade is *correct* to own the
+root — that is its job. This workflow keeps **your** work out of its way.

--- a/scripts/new-dev-worktree.sh
+++ b/scripts/new-dev-worktree.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — collision-free dev worktree starter (POSIX shell)
+#
+# Creates an ISOLATED git worktree off origin/main and seeds its MCP config, so
+# feature/fix/doc work never happens in the shared root clone.
+#
+# WHY THIS EXISTS
+#   The root clone (~/dpf) is NOT a safe place to do active work. It is owned by:
+#     1. the self-upgrade loop — prepare-source.ts does `git checkout dpf/install`
+#        + `git merge` on the root to build each upgrade (it defers on *tracked*
+#        uncommitted changes, but the root still moves branches under you); and
+#     2. other concurrent agent sessions, which `git checkout <their-branch>` and
+#        `git reset` the root.
+#   Either will roll back / discard work that lives in the root. A linked worktree
+#   has its own working tree + HEAD, so neither touches it. This is the
+#   "keep-root-clone-as-merge-worktree" + "worktree-per-session" principles, made
+#   into one command.
+#
+# USAGE
+#   ./scripts/new-dev-worktree.sh <slug> [branch-prefix]
+#       <slug>          short kebab name, e.g. report-kit-charts
+#       [branch-prefix] branch namespace, default "feat" → feat/<slug>
+#
+# EXAMPLE
+#   ./scripts/new-dev-worktree.sh invoice-pdf-export fix
+#   # → ~/dpf-worktrees/invoice-pdf-export on branch fix/invoice-pdf-export
+
+set -euo pipefail
+
+slug="${1:-}"
+prefix="${2:-feat}"
+
+if [ -z "$slug" ]; then
+    printf 'usage: %s <slug> [branch-prefix]\n' "$0" >&2
+    exit 1
+fi
+
+# Resolve the TRUE root clone (the main worktree), regardless of whether this
+# script is invoked from the root or from an existing linked worktree. The first
+# `worktree` entry in porcelain output is always the main worktree.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+root="$(git -C "$script_dir" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+if [ -z "${root:-}" ] || [ ! -e "$root/.git" ]; then
+    printf '  [FAIL] could not resolve the root clone from %s\n' "$script_dir" >&2
+    exit 1
+fi
+
+# Worktrees live in a sibling "<root>-worktrees" dir (matches ~/dpf-worktrees).
+wt_base="$(dirname "$root")/$(basename "$root")-worktrees"
+target="$wt_base/$slug"
+branch="$prefix/$slug"
+
+mkdir -p "$wt_base"
+
+# Always base new work on the freshest pushed main.
+git -C "$root" fetch origin --quiet
+
+if [ -d "$target" ]; then
+    printf '  [skip] worktree already exists: %s\n' "$target"
+else
+    # Reuse the branch if it already exists (e.g. resuming); otherwise create it
+    # off origin/main. -b fails on an existing branch, so branch on existence.
+    if git -C "$root" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+        git -C "$root" worktree add "$target" "$branch"
+    else
+        git -C "$root" worktree add "$target" -b "$branch" origin/main
+    fi
+fi
+
+# Seed MCP config (.mcp.json / .vscode + worktree-scoped COMPOSE_PROJECT_NAME) so
+# the dpf connector and isolated compose stack work in the new worktree.
+if [ -x "$root/scripts/seed-worktree-mcp.sh" ]; then
+    "$root/scripts/seed-worktree-mcp.sh" "$target" || \
+        printf '  [warn] MCP seed skipped (root .mcp.json not present yet)\n' >&2
+fi
+
+cat <<EOF
+
+  ✓ Collision-free worktree ready
+    path:   $target
+    branch: $branch  (off origin/main)
+
+  Next:
+    cd "$target"
+
+  Discipline (the root clone $root is reset by the self-upgrade loop and other
+  sessions — uncommitted work there is lost):
+    • do ALL edits in the worktree, never in the root
+    • commit + push FREQUENTLY (after every logical step), so nothing lives only
+      in a working tree
+    • open the PR from the worktree
+
+  When the PR is merged:
+    git -C "$root" worktree remove "$target"
+EOF


### PR DESCRIPTION
## Problem

The root clone (`~/dpf`) is **shared mutable state**. Two independent actors rewrite its working tree + HEAD without coordinating with your editor, discarding in-progress work that lives there:

1. **The self-upgrade loop** — `apps/web/lib/self-upgrade/prepare-source.ts` builds each upgrade by running `git checkout dpf/install` + `git merge --no-ff` on the root. It defers on *tracked* uncommitted changes, but deliberately ignores **untracked** files and still moves the branch under you.
2. **Other concurrent agent sessions** — each `git checkout <its-branch>` + `git reset` the root (observed in the reflog as `checkout … → reset: moving to HEAD`).

This was hit **twice this session** — uncommitted edits silently rolled back mid-task.

## Fix — make the isolated-worktree path frictionless

The discipline already exists (principles `keep-root-clone-as-merge-worktree` + `worktree-per-session`, the `dpf-worktree-per-session` skill, `seed-worktree-mcp.sh`, the janitor). What was missing is a **one-command entry point** so sessions stop defaulting to the contended root.

- **`scripts/new-dev-worktree.sh <slug> [prefix]`** — resolves the **true** root clone (via `git worktree list`, so it works even when invoked from inside another worktree — a bug I caught and fixed in testing), creates `~/dpf-worktrees/<slug>` off `origin/main`, seeds MCP config, and prints the `cd` path + commit-push discipline + cleanup command. Idempotent; reuses an existing branch on resume.
- **`docs/dev/collision-free-dev-workflow.md`** — the why (evidence from `prepare-source.ts`), the how, and the rules; cross-links the existing principles + skill.

Composes existing substrate rather than duplicating it. **Does not change the self-upgrade** — the self-upgrade is correct to own the root; this keeps *your* work out of its way.

## Verification

- Functionally tested: ran the script from a linked worktree → created `~/dpf-worktrees/<slug>` on the right branch off `origin/main`, verified via `git worktree list`, removed cleanly. Caught + fixed the root-resolution bug (was nesting under the invoking worktree).
- `new-dev-worktree.sh` committed with mode 100755.

This whole PR was authored in an isolated worktree, dogfooding the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)