### PR TITLE
feat(onboarding): capture company mission + seed org WWWD corpus (BI-CC64ECE4)

### DIFF
--- a/apps/web/app/(shell)/storefront/settings/business/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/business/page.tsx
@@ -1,11 +1,12 @@
 import { prisma } from "@dpf/db";
 import { BusinessContextForm } from "@/components/admin/BusinessContextForm";
 import { getSetupContext } from "@/lib/actions/setup-progress";
+import { suggestMission } from "@/lib/onboarding/mission-suggestion";
 
 export default async function StorefrontBusinessSettingsPage() {
   const [org, setupContext, storefrontConfig] = await Promise.all([
     prisma.organization.findFirst({
-      select: { id: true, email: true, phone: true },
+      select: { id: true, name: true, email: true, phone: true },
     }),
     getSetupContext(),
     prisma.storefrontConfig.findFirst({
@@ -28,6 +29,7 @@ export default async function StorefrontBusinessSettingsPage() {
 
   const initial = {
     description: businessContext?.description ?? suggestions?.description ?? "",
+    mission: businessContext?.mission ?? "",
     targetMarket: businessContext?.targetMarket ?? "",
     companySize: businessContext?.companySize ?? null,
     geographicScope: businessContext?.geographicScope ?? suggestions?.geographicScope ?? null,
@@ -35,6 +37,13 @@ export default async function StorefrontBusinessSettingsPage() {
     contactEmail: org?.email ?? suggestions?.contactEmail ?? "",
     contactPhone: org?.phone ?? suggestions?.contactPhone ?? "",
   };
+
+  const missionSuggestion = suggestMission({
+    industry: storefrontConfig?.archetype?.category ?? setupContext?.suggestedIndustry ?? null,
+    archetypeName: storefrontConfig?.archetype?.name ?? setupContext?.suggestedArchetypeName ?? null,
+    description: initial.description || null,
+    orgName: org?.name ?? null,
+  });
 
   const autoFilledFields = suggestions
     ? Object.entries(suggestions)
@@ -60,6 +69,7 @@ export default async function StorefrontBusinessSettingsPage() {
         archetypeSummary={archetypeSummary}
         isEdit={!!businessContext}
         autoFilledFields={autoFilledFields}
+        missionSuggestion={missionSuggestion}
       />
     </div>
   );

--- a/apps/web/app/api/business-context/setup/route.ts
+++ b/apps/web/app/api/business-context/setup/route.ts
@@ -10,6 +10,7 @@ export async function POST(req: NextRequest) {
 
   const {
     description,
+    mission,
     targetMarket,
     companySize,
     geographicScope,
@@ -18,6 +19,7 @@ export async function POST(req: NextRequest) {
     contactPhone,
   } = (await req.json()) as {
     description?: string;
+    mission?: string;
     targetMarket?: string;
     companySize?: string;
     geographicScope?: string;
@@ -49,6 +51,7 @@ export async function POST(req: NextRequest) {
     create: {
       organizationId: org.id,
       description: description ?? null,
+      mission: mission ?? null,
       targetMarket: targetMarket ?? null,
       companySize: companySize ?? null,
       geographicScope: geographicScope ?? null,
@@ -57,6 +60,7 @@ export async function POST(req: NextRequest) {
     },
     update: {
       ...(description !== undefined && { description }),
+      ...(mission !== undefined && { mission }),
       ...(targetMarket !== undefined && { targetMarket }),
       ...(companySize !== undefined && { companySize }),
       ...(geographicScope !== undefined && { geographicScope }),

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -25,6 +25,7 @@ const GEOGRAPHIC_SCOPE_OPTIONS = [
 
 type BusinessContextData = {
   description: string;
+  mission: string;
   targetMarket: string;
   companySize: string | null;
   geographicScope: string | null;
@@ -41,6 +42,8 @@ type BusinessContextFormProps = {
   isEdit?: boolean;
   /** Fields that were auto-populated from URL import during setup. */
   autoFilledFields?: string[];
+  /** Archetype-aware starter mission the operator can apply with one click. */
+  missionSuggestion?: string;
 };
 
 function AutoFillHint({ field, editedFields }: { field: string; editedFields: Set<string> }) {
@@ -53,7 +56,7 @@ function AutoFillHint({ field, editedFields }: { field: string; editedFields: Se
   );
 }
 
-export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFilledFields }: BusinessContextFormProps) {
+export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFilledFields, missionSuggestion }: BusinessContextFormProps) {
   const archetypeState = resolveArchetypeSummaryState(archetypeSummary);
   const [data, setData] = useState<BusinessContextData>(initial);
   const [submitting, setSubmitting] = useState(false);
@@ -179,6 +182,41 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             Your AI coworker uses this to understand your business when building features and providing guidance.
           </div>
           {autoFilledFields?.includes("description") && <AutoFillHint field="description" editedFields={editedFields} />}
+        </label>
+
+        {/* Mission */}
+        <label style={labelStyle}>
+          <div style={{ ...fieldLabelStyle, display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 8 }}>
+            <span>Why does your business exist?</span>
+            {missionSuggestion && data.mission.trim() === "" && (
+              <button
+                type="button"
+                onClick={() => update("mission", missionSuggestion)}
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: "var(--dpf-accent)",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                Suggest a starter
+              </button>
+            )}
+          </div>
+          <textarea
+            value={data.mission}
+            onChange={(e) => update("mission", e.target.value)}
+            placeholder={missionSuggestion ?? "Your mission in a sentence — the difference you set out to make"}
+            rows={2}
+            style={{ ...inputStyle, resize: "none" }}
+          />
+          <div style={hintStyle}>
+            Your company mission. Every AI coworker keeps this in mind, and it seeds what your
+            organization &quot;would do&quot; when a decision comes up.
+          </div>
         </label>
 
         {/* Target market */}

--- a/apps/web/lib/actions/prompt-admin.ts
+++ b/apps/web/lib/actions/prompt-admin.ts
@@ -55,6 +55,7 @@ export type PromptTemplateDetail = {
 // ─── Category Labels ────────────────────────────────────────────────────────
 
 const CATEGORY_LABELS: Record<string, string> = {
+  "platform-mission": "Company Mission",
   "platform-identity": "Platform Identity",
   "platform-preamble": "Platform Preamble",
   "route-persona": "Route Personas",
@@ -65,6 +66,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 const CATEGORY_ORDER = [
+  "platform-mission",
   "platform-identity",
   "platform-preamble",
   "route-persona",

--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -2,6 +2,34 @@
 
 import { prisma } from "@dpf/db";
 import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from "./setup-constants";
+import { seedOrgWwwdCorpus } from "@/lib/onboarding/seed-org-wwwd-corpus";
+import { applyMissionPrompt } from "@/lib/onboarding/apply-mission-prompt";
+
+/**
+ * Runs once when initial setup completes: persist the captured mission into
+ * the company-mission prompt (visible to every coworker) and seed the per-org
+ * WWWD corpus. Fail-open and idempotent — onboarding completion must never
+ * block on embedding/seeding errors, and the seed is safe to re-run.
+ */
+async function finalizeSetupCompletion(organizationId: string | null): Promise<void> {
+  try {
+    const orgId =
+      organizationId ??
+      (await prisma.organization.findFirst({ select: { id: true } }))?.id ??
+      null;
+    if (!orgId) return;
+
+    const bc = await prisma.businessContext.findUnique({
+      where: { organizationId: orgId },
+      select: { mission: true },
+    });
+
+    await applyMissionPrompt({ mission: bc?.mission ?? null });
+    await seedOrgWwwdCorpus({ organizationId: orgId });
+  } catch (err) {
+    console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", err);
+  }
+}
 
 const BOOTSTRAP_PLATFORM_ORG = {
   orgId: "ORG-PLATFORM",
@@ -75,7 +103,7 @@ export async function advanceStep(
   const nextIdx = currentIdx + 1;
   const nextStep = nextIdx < SETUP_STEPS.length ? SETUP_STEPS[nextIdx] : null;
 
-  return prisma.platformSetupProgress.update({
+  const updated = await prisma.platformSetupProgress.update({
     where: { id: progressId },
     data: {
       currentStep: nextStep ?? progress.currentStep,
@@ -84,6 +112,9 @@ export async function advanceStep(
       ...(nextStep === null ? { completedAt: new Date() } : {}),
     },
   });
+
+  if (nextStep === null) await finalizeSetupCompletion(progress.organizationId);
+  return updated;
 }
 
 /** Mark current step skipped and advance. */
@@ -105,7 +136,7 @@ export async function skipStep(progressId: string) {
   const nextIdx = currentIdx + 1;
   const nextStep = nextIdx < SETUP_STEPS.length ? SETUP_STEPS[nextIdx] : null;
 
-  return prisma.platformSetupProgress.update({
+  const updated = await prisma.platformSetupProgress.update({
     where: { id: progressId },
     data: {
       currentStep: nextStep ?? progress.currentStep,
@@ -114,6 +145,9 @@ export async function skipStep(progressId: string) {
       ...(nextStep === null ? { completedAt: new Date() } : {}),
     },
   });
+
+  if (nextStep === null) await finalizeSetupCompletion(progress.organizationId);
+  return updated;
 }
 
 /** Record that the COO auto-message trigger has fired for this step.
@@ -145,10 +179,13 @@ export async function pauseSetup(progressId: string) {
 
 /** Mark setup as complete. */
 export async function completeSetup(progressId: string) {
-  return prisma.platformSetupProgress.update({
+  const updated = await prisma.platformSetupProgress.update({
     where: { id: progressId },
     data: { completedAt: new Date() },
+    select: { id: true, organizationId: true, completedAt: true },
   });
+  await finalizeSetupCompletion(updated.organizationId);
+  return updated;
 }
 
 /** Link setup progress to a user after account creation (Step 2). */

--- a/apps/web/lib/onboarding/apply-mission-prompt.test.ts
+++ b/apps/web/lib/onboarding/apply-mission-prompt.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyMissionPrompt,
+  renderMissionPromptContent,
+  MISSION_PROMPT_CATEGORY,
+  MISSION_PROMPT_SLUG,
+  type ApplyMissionPromptClient,
+} from "./apply-mission-prompt";
+
+function makeDb() {
+  const upsert = vi.fn<(args: unknown) => Promise<unknown>>(async () => ({}));
+  const db: ApplyMissionPromptClient = { promptTemplate: { upsert } };
+  return { db, upsert };
+}
+
+describe("renderMissionPromptContent", () => {
+  it("bakes the captured mission into the Block-0 content", () => {
+    const content = renderMissionPromptContent("  Help families breathe easier.  ");
+    expect(content).toContain("Mission: Help families breathe easier.");
+    expect(content).toContain("COMPANY MISSION CONTEXT");
+    expect(content).not.toContain("[Your company mission");
+  });
+});
+
+describe("applyMissionPrompt", () => {
+  it("upserts the global company-mission template with the mission", async () => {
+    const { db, upsert } = makeDb();
+
+    const result = await applyMissionPrompt({
+      mission: "Help families breathe easier.",
+      db,
+      invalidate: false,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const args = upsert.mock.calls[0][0] as any;
+    expect(args.where.category_slug).toEqual({
+      category: MISSION_PROMPT_CATEGORY,
+      slug: MISSION_PROMPT_SLUG,
+    });
+    expect(args.update.content).toContain("Help families breathe easier.");
+    expect(args.update.isOverridden).toBe(true);
+    expect(args.update.updatedBy).toBe("setup");
+    expect(args.create.content).toContain("Help families breathe easier.");
+  });
+
+  it("is a no-op when the mission is blank", async () => {
+    const { db, upsert } = makeDb();
+
+    expect((await applyMissionPrompt({ mission: "", db, invalidate: false })).applied).toBe(false);
+    expect((await applyMissionPrompt({ mission: "   ", db, invalidate: false })).applied).toBe(false);
+    expect((await applyMissionPrompt({ mission: null, db, invalidate: false })).applied).toBe(false);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/onboarding/apply-mission-prompt.ts
+++ b/apps/web/lib/onboarding/apply-mission-prompt.ts
@@ -1,0 +1,90 @@
+// Persist the captured company mission into the global company-mission
+// PromptTemplate (category=platform-mission, slug=company-mission). That row
+// is injected as Block 0 of every coworker prompt (prompt-assembler.ts), so
+// writing it here is what makes the mission visible to every coworker.
+//
+// PromptTemplate is global (no organizationId) — a DPF install is single-org,
+// so the one global row IS the org's mission. Editable post-setup once
+// platform-mission is in the prompt-admin catalog.
+
+import { prisma } from "@dpf/db";
+import { invalidatePromptCache } from "@/lib/tak/prompt-loader";
+
+export const MISSION_PROMPT_CATEGORY = "platform-mission";
+export const MISSION_PROMPT_SLUG = "company-mission";
+
+/** Render the Block-0 mission content with the captured mission baked in. */
+export function renderMissionPromptContent(mission: string): string {
+  return [
+    "COMPANY MISSION CONTEXT",
+    "",
+    "This section defines the overarching mission that governs all work — whether performed by humans or AI coworkers. Every action, recommendation, and decision should align with this mission.",
+    "",
+    `Mission: ${mission.trim()}`,
+    "",
+    "Values:",
+    "- Quality over speed — deliver work that meets professional standards",
+    "- Transparency — surface risks, trade-offs, and limitations honestly",
+    "- Continuous improvement — every task is an opportunity to improve the platform and its processes",
+    "- Human authority — AI coworkers augment human decision-making; humans retain final authority on all consequential decisions",
+    "",
+    "When making recommendations or taking actions, consider whether your work advances this mission. If a request conflicts with the company mission or values, flag the conflict transparently rather than proceeding silently.",
+  ].join("\n");
+}
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type ApplyMissionPromptClient = {
+  promptTemplate: { upsert: (args: unknown) => Promise<unknown> };
+};
+
+export type ApplyMissionPromptInput = {
+  mission: string | null | undefined;
+  /** Defaults to the shared prisma client. */
+  db?: ApplyMissionPromptClient;
+  /** Invalidate the prompt cache after writing. Defaults to true. */
+  invalidate?: boolean;
+};
+
+export type ApplyMissionPromptResult = { applied: boolean };
+
+/**
+ * Upsert the company-mission prompt from the captured mission. No-op when the
+ * mission is blank (we never overwrite the editable default with emptiness).
+ */
+export async function applyMissionPrompt(
+  input: ApplyMissionPromptInput,
+): Promise<ApplyMissionPromptResult> {
+  const mission = (input.mission ?? "").trim();
+  if (mission.length === 0) return { applied: false };
+
+  const db = input.db ?? (prisma as unknown as ApplyMissionPromptClient);
+  const content = renderMissionPromptContent(mission);
+
+  await db.promptTemplate.upsert({
+    where: {
+      category_slug: { category: MISSION_PROMPT_CATEGORY, slug: MISSION_PROMPT_SLUG },
+    },
+    update: {
+      content,
+      isOverridden: true,
+      updatedBy: "setup",
+    },
+    create: {
+      category: MISSION_PROMPT_CATEGORY,
+      slug: MISSION_PROMPT_SLUG,
+      name: "Company Mission",
+      description:
+        "Overarching company mission and values injected into every AI coworker's context",
+      content,
+      contentFormat: "markdown",
+      isOverridden: true,
+      updatedBy: "setup",
+    },
+  });
+
+  if (input.invalidate !== false) {
+    invalidatePromptCache(MISSION_PROMPT_CATEGORY, MISSION_PROMPT_SLUG);
+  }
+
+  return { applied: true };
+}

--- a/apps/web/lib/onboarding/mission-suggestion.test.ts
+++ b/apps/web/lib/onboarding/mission-suggestion.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { suggestMission } from "./mission-suggestion";
+
+describe("suggestMission", () => {
+  it("returns a non-empty single-sentence starter for an empty input", () => {
+    const s = suggestMission({});
+    expect(s.length).toBeGreaterThan(0);
+    expect(s.endsWith(".")).toBe(true);
+    expect(s[0]).toBe(s[0]?.toUpperCase());
+  });
+
+  it("produces an industry-flavoured suggestion for a known category", () => {
+    const health = suggestMission({ industry: "healthcare-wellness" });
+    expect(health.toLowerCase()).toContain("care");
+  });
+
+  it("varies the suggestion across distinct industries", () => {
+    const health = suggestMission({ industry: "healthcare-wellness" });
+    const food = suggestMission({ industry: "food-hospitality" });
+    expect(health).not.toBe(food);
+  });
+
+  it("falls back to the generic suggestion for an unknown industry", () => {
+    expect(suggestMission({ industry: "something-unmapped" })).toBe(suggestMission({}));
+  });
+
+  it("personalises the opening with the org name when provided", () => {
+    const s = suggestMission({ orgName: "Acme Dental", industry: "healthcare-wellness" });
+    expect(s.startsWith("At Acme Dental, ")).toBe(true);
+  });
+
+  it("trims whitespace in the org name and ignores a blank one", () => {
+    expect(suggestMission({ orgName: "   " })).toBe(suggestMission({}));
+    expect(suggestMission({ orgName: "  Acme  ", industry: "x" })).toBe(
+      suggestMission({ orgName: "Acme", industry: "x" }),
+    );
+  });
+});

--- a/apps/web/lib/onboarding/mission-suggestion.ts
+++ b/apps/web/lib/onboarding/mission-suggestion.ts
@@ -1,0 +1,57 @@
+// Archetype/industry-aware company-mission starter, offered during the
+// onboarding business-context step. Pure and deterministic — no I/O — so it
+// can be evaluated server-side to pre-fill the form and reused by the WWWD
+// seeding helper. The output is a *starter* the operator is expected to edit.
+
+export type MissionSuggestionInput = {
+  /** Archetype category (e.g. "healthcare-wellness"); see ARCHETYPE_TO_INDUSTRY. */
+  industry?: string | null;
+  /** Friendly archetype name (e.g. "Dental Practice"); currently advisory. */
+  archetypeName?: string | null;
+  /** Free-text "what does your business do" answer, if already captured. */
+  description?: string | null;
+  /** Organization name, used to personalise the opening. */
+  orgName?: string | null;
+};
+
+/**
+ * Themes keyed by the coarse industry category emitted by ARCHETYPE_TO_INDUSTRY.
+ * Each completes the clause "we exist to …". Keep these broad — they are
+ * deliberately editable starters, not finished mission statements.
+ */
+const INDUSTRY_THEMES: Record<string, string> = {
+  "healthcare-wellness":
+    "deliver attentive, high-quality care that improves the health and wellbeing of the people we serve",
+  "beauty-personal-care":
+    "help every client look and feel their best through skilled, personal service",
+  "fitness-recreation":
+    "help our members move, train, and live healthier, more active lives",
+  "food-hospitality":
+    "create welcoming experiences and memorable food and hospitality for every guest",
+  "professional-services":
+    "deliver expert advice and dependable service that helps our clients succeed",
+  "hoa-property-management":
+    "manage and care for properties so owners and residents can thrive",
+  "retail-ecommerce":
+    "offer products our customers love, backed by service they can trust",
+  "trades-field-service":
+    "provide reliable, high-quality workmanship that keeps our customers' homes and businesses running",
+};
+
+const GENERIC_THEME =
+  "deliver real value to the people we serve and build a business we are proud of";
+
+function cleanName(orgName?: string | null): string | null {
+  const trimmed = (orgName ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function suggestMission(input: MissionSuggestionInput): string {
+  const theme =
+    (input.industry && INDUSTRY_THEMES[input.industry]) || GENERIC_THEME;
+  const name = cleanName(input.orgName);
+  const sentence = name
+    ? `At ${name}, we exist to ${theme}.`
+    : `We exist to ${theme}.`;
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { StoreWikiPageInput } from "@/lib/wiki/embeddings";
+import {
+  seedOrgWwwdCorpus,
+  ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+  type SeedOrgWwwdClient,
+} from "./seed-org-wwwd-corpus";
+
+type EmbedFn = (input: StoreWikiPageInput) => Promise<boolean>;
+
+// ─── In-memory fake of the Prisma surface the seeder touches ────────────────
+// Implements upsert/findFirst/create/update with real keyed semantics so the
+// idempotency assertions are meaningful (re-runs must not duplicate rows).
+
+type Row = Record<string, any>;
+
+function makeFakeDb(opts: {
+  businessContext: Row | null;
+  archetype: { name: string; category: string } | null;
+  orgName: string | null;
+}) {
+  const profiles: Row[] = [];
+  const versions: Row[] = [];
+  const materials: Row[] = [];
+  const wikiPages: Row[] = [];
+  const revisions: Row[] = [];
+
+  let pageSeq = 0;
+
+  function upsertBy(coll: Row[], key: string, value: string, create: Row, update: Row): Row {
+    const found = coll.find((r) => r[key] === value);
+    if (found) {
+      Object.assign(found, update);
+      return found;
+    }
+    const row = { ...create };
+    coll.push(row);
+    return row;
+  }
+
+  const db: SeedOrgWwwdClient = {
+    businessContext: {
+      findUnique: vi.fn(async () => opts.businessContext),
+    },
+    storefrontConfig: {
+      findFirst: vi.fn(async () => (opts.archetype ? { archetype: opts.archetype } : null)),
+    },
+    organization: {
+      findUnique: vi.fn(async () => ({ name: opts.orgName })),
+    },
+    decisionPerspectiveProfile: {
+      upsert: vi.fn(async (args: any) =>
+        upsertBy(profiles, "profileId", args.where.profileId, args.create, args.update),
+      ),
+      update: vi.fn(async (args: any) => {
+        const found = profiles.find((r) => r.profileId === args.where.profileId);
+        if (found) Object.assign(found, args.data);
+        return found;
+      }),
+    },
+    decisionPerspectiveProfileVersion: {
+      upsert: vi.fn(async (args: any) =>
+        upsertBy(versions, "versionId", args.where.versionId, args.create, args.update),
+      ),
+    },
+    perspectiveMaterial: {
+      upsert: vi.fn(async (args: any) =>
+        upsertBy(materials, "materialId", args.where.materialId, args.create, args.update),
+      ),
+    },
+    wikiPage: {
+      findFirst: vi.fn(async (args: any) => {
+        const { organizationId, slug } = args.where;
+        return (
+          wikiPages.find((r) => r.organizationId === organizationId && r.slug === slug) ?? null
+        );
+      }),
+      create: vi.fn(async (args: any) => {
+        const row = { id: `wp_${++pageSeq}`, ...args.data };
+        wikiPages.push(row);
+        return row;
+      }),
+      update: vi.fn(async (args: any) => {
+        const found = wikiPages.find((r) => r.id === args.where.id);
+        if (found) Object.assign(found, args.data);
+        return found;
+      }),
+    },
+    wikiPageRevision: {
+      findFirst: vi.fn(async (args: any) => {
+        const rev = revisions
+          .filter((r) => r.pageId === args.where.pageId)
+          .sort((a, b) => b.version - a.version)[0];
+        return rev ?? null;
+      }),
+      create: vi.fn(async (args: any) => {
+        revisions.push({ ...args.data });
+        return args.data;
+      }),
+    },
+  };
+
+  return { db, profiles, versions, materials, wikiPages, revisions };
+}
+
+const ORG = "org_123";
+
+describe("seedOrgWwwdCorpus", () => {
+  let embed: ReturnType<typeof vi.fn<EmbedFn>>;
+
+  beforeEach(() => {
+    embed = vi.fn<EmbedFn>(async () => true);
+  });
+
+  it("seeds the org profile, v1 version, materials, and published org wiki pages", async () => {
+    const fake = makeFakeDb({
+      businessContext: {
+        mission: "Help local families breathe easier.",
+        description: "We install and service home HVAC systems.",
+        targetMarket: "homeowners in the tri-county area",
+        industry: "trades-field-service",
+      },
+      archetype: { name: "HVAC Contractor", category: "trades-field-service" },
+      orgName: "Dale's Heating & Air",
+    });
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    // Profile container
+    expect(result.profileId).toBe(`org-perspective-${ORG}`);
+    expect(fake.profiles).toHaveLength(1);
+    expect(fake.profiles[0]).toMatchObject({
+      kind: "organization",
+      ownerOrganizationId: ORG,
+      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      currentVersionId: result.versionId,
+    });
+
+    // Version v1
+    expect(fake.versions).toHaveLength(1);
+    expect(fake.versions[0]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
+
+    // Three materials, each linked to a wiki page + the version
+    expect(result.materialCount).toBe(3);
+    expect(fake.materials).toHaveLength(3);
+    for (const m of fake.materials) {
+      expect(m.profileVersionId).toBe(result.versionId);
+      expect(m.domainClass).toBe("plan-readiness");
+      expect(m.reviewStatus).toBe("approved");
+      expect(m.promotionState).toBe("promoted");
+      expect(m.sourceRef.wikiPageId).toBeTruthy();
+    }
+
+    // Three published, org-scoped, non-kernel wiki pages
+    expect(fake.wikiPages).toHaveLength(3);
+    for (const p of fake.wikiPages) {
+      expect(p.status).toBe("published");
+      expect(p.organizationId).toBe(ORG);
+      expect(p.isKernel).toBe(false);
+    }
+    expect(fake.wikiPages.map((p) => p.slug).sort()).toEqual([
+      "org-how-we-decide",
+      "org-mission",
+      "org-who-we-serve",
+    ]);
+
+    // Captured mission lands in the mission page body
+    const mission = fake.wikiPages.find((p) => p.slug === "org-mission");
+    expect(mission).toBeDefined();
+    expect(mission!.body).toContain("Help local families breathe easier.");
+    expect(mission!.pageKind).toBe("principle");
+
+    // Every published page was embedded into Qdrant
+    expect(embed).toHaveBeenCalledTimes(3);
+    expect(result.embedded).toBe(true);
+    expect(result.wikiPageIds).toHaveLength(3);
+  });
+
+  it("is idempotent — re-running produces no duplicate profile/version/material/page rows", async () => {
+    const fake = makeFakeDb({
+      businessContext: {
+        mission: "Help local families breathe easier.",
+        description: "HVAC",
+        targetMarket: "homeowners",
+        industry: "trades-field-service",
+      },
+      archetype: { name: "HVAC Contractor", category: "trades-field-service" },
+      orgName: "Dale's",
+    });
+
+    await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+    await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    expect(fake.profiles).toHaveLength(1);
+    expect(fake.versions).toHaveLength(1);
+    expect(fake.materials).toHaveLength(3);
+    expect(fake.wikiPages).toHaveLength(3);
+    // Body unchanged on the 2nd run → no extra revision, no re-embed
+    expect(fake.revisions).toHaveLength(3);
+    expect(embed).toHaveBeenCalledTimes(3);
+  });
+
+  it("still seeds a non-empty corpus when no mission was captured (archetype fallback)", async () => {
+    const fake = makeFakeDb({
+      businessContext: { mission: null, description: null, targetMarket: null, industry: "healthcare-wellness" },
+      archetype: { name: "Dental Practice", category: "healthcare-wellness" },
+      orgName: "Bright Smiles",
+    });
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    expect(result.materialCount).toBe(3);
+    const mission = fake.wikiPages.find((p) => p.slug === "org-mission");
+    expect(mission).toBeDefined();
+    expect(mission!.body.trim().length).toBeGreaterThan(20);
+    expect(mission!.abstract.toLowerCase()).toContain("care"); // healthcare theme
+  });
+
+  it("reports embedded=false when the embed step fails (fail-open)", async () => {
+    const fake = makeFakeDb({
+      businessContext: { mission: "M", description: null, targetMarket: null, industry: null },
+      archetype: null,
+      orgName: null,
+    });
+    const failing = vi.fn<EmbedFn>(async () => false);
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed: failing });
+
+    expect(result.embedded).toBe(false);
+    // DB rows still created despite embedding failure
+    expect(fake.wikiPages).toHaveLength(3);
+    expect(fake.materials).toHaveLength(3);
+  });
+});

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -1,0 +1,349 @@
+// Onboarding WWWD ("What Would We Do") seeding.
+//
+// Runs once when initial portal setup completes. It turns the captured
+// company mission + the chosen archetype into a real, per-org decision
+// corpus so coworkers stop falling straight back to Mark's platform
+// doctrine when asked "what would we do?".
+//
+// Two substrates are seeded (verified against live code, 2026-05-31):
+//   1. The WORKING WWWD lever — org-overlay WikiPages (organizationId set,
+//      isKernel=false, pageKind stance/principle, status "published"),
+//      embedded into Qdrant via storeWikiPage. agent-coworker.ts retrieves
+//      these by org for WWWD answers (recallWikiContext).
+//   2. The corpus CONTAINER — a per-org DecisionPerspectiveProfile
+//      (kind=organization, ownerOrganizationId, fallback
+//      dpf-organizational-principles) + a v1 version + PerspectiveMaterial
+//      rows linking back to the wiki pages. No decision path consumes the
+//      profile by ownerOrganizationId yet (see BI-230C9EF7); it is seeded
+//      so the corpus exists the moment resolution lands.
+//
+// Idempotent: profile / version / material writes are upserts keyed on
+// stable ids, wiki pages are upserted by (organizationId, slug), and a new
+// revision + re-embed only happen when the page body actually changes.
+// Safe to re-run on re-completion or replay.
+
+import { prisma } from "@dpf/db";
+import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
+import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
+import { suggestMission } from "./mission-suggestion";
+
+/** Platform fallback our org profile chains to (material.ts:14). */
+export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
+const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
+
+const DEFAULT_AUTONOMY_POLICY = {
+  allowRecommendation: true,
+  allowArbitration: false,
+  maxRiskForArbitration: "low",
+  minimumConfidenceForRecommendation: 0.55,
+  minimumConfidenceForArbitration: 0.9,
+};
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type SeedOrgWwwdClient = {
+  businessContext: { findUnique: (args: unknown) => Promise<unknown> };
+  storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
+  organization: { findUnique: (args: unknown) => Promise<unknown> };
+  decisionPerspectiveProfile: {
+    upsert: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  decisionPerspectiveProfileVersion: { upsert: (args: unknown) => Promise<unknown> };
+  perspectiveMaterial: { upsert: (args: unknown) => Promise<unknown> };
+  wikiPage: {
+    findFirst: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  wikiPageRevision: {
+    findFirst: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type SeedOrgWwwdCorpusInput = {
+  organizationId: string;
+  /** Defaults to the shared prisma client. */
+  db?: SeedOrgWwwdClient;
+  /** Qdrant index step; injectable for tests. Defaults to storeWikiPage. */
+  embed?: (input: StoreWikiPageInput) => Promise<boolean>;
+};
+
+export type SeedOrgWwwdCorpusResult = {
+  profileId: string;
+  versionId: string;
+  wikiPageIds: string[];
+  materialCount: number;
+  /** True only if every published page was successfully embedded. */
+  embedded: boolean;
+};
+
+type SeedPage = {
+  slug: string;
+  title: string;
+  pageKind: "principle" | "stance";
+  body: string;
+  abstract: string;
+  /** Set on the mission principle page so it is well-formed. */
+  principle?: {
+    principleTier: "core";
+    principleAppliesTo: string[];
+    principleDirection: string;
+  };
+};
+
+type BusinessContextRow = {
+  mission: string | null;
+  description: string | null;
+  targetMarket: string | null;
+  industry: string | null;
+} | null;
+
+function buildPages(
+  bc: BusinessContextRow,
+  archetypeName: string | null,
+  industry: string | null,
+  orgName: string | null,
+): SeedPage[] {
+  const mission =
+    (bc?.mission ?? "").trim() ||
+    suggestMission({
+      industry: industry ?? bc?.industry ?? null,
+      archetypeName,
+      description: bc?.description ?? null,
+      orgName,
+    });
+  const who = (bc?.targetMarket ?? "").trim();
+  const what = (bc?.description ?? "").trim();
+  const orgLabel = (orgName ?? "").trim() || "this organization";
+
+  const pages: SeedPage[] = [
+    {
+      slug: "org-mission",
+      title: "Our mission",
+      pageKind: "principle",
+      body: [
+        "# Our mission",
+        "",
+        mission,
+        "",
+        "Every action, recommendation, and decision should advance this mission. When a request conflicts with it, surface the conflict rather than proceeding silently.",
+      ].join("\n"),
+      abstract: mission,
+      principle: {
+        principleTier: "core",
+        principleAppliesTo: ["in_platform_coworker", "human"],
+        principleDirection: mission,
+      },
+    },
+    {
+      slug: "org-who-we-serve",
+      title: "Who we serve",
+      pageKind: "stance",
+      body: [
+        "# Who we serve",
+        "",
+        who
+          ? `We serve ${who}.`
+          : `We serve the people and stakeholders ${orgLabel} exists to help.`,
+        what ? `\nWhat we do: ${what}` : "",
+        "\nWhen we decide \"what would we do?\", we weigh the interests of the people we serve first.",
+      ].join("\n"),
+      abstract: who
+        ? `We serve ${who}.`
+        : `The stakeholders ${orgLabel} serves.`,
+    },
+    {
+      slug: "org-how-we-decide",
+      title: "How we decide",
+      pageKind: "stance",
+      body: [
+        "# How we decide",
+        "",
+        `When ${orgLabel} faces a decision, we start from our mission and the people we serve, prefer durable quality over shortcuts, stay transparent about trade-offs, and keep humans in final authority over consequential calls.`,
+        "",
+        "This is the organization's default stance until more specific guidance is captured.",
+      ].join("\n"),
+      abstract: "The organization's default decision stance: mission-first, stakeholder-first, quality over shortcuts, transparent, human-authoritative.",
+    },
+  ];
+  return pages;
+}
+
+export async function seedOrgWwwdCorpus(
+  input: SeedOrgWwwdCorpusInput,
+): Promise<SeedOrgWwwdCorpusResult> {
+  const db = (input.db ?? (prisma as unknown as SeedOrgWwwdClient));
+  const embed = input.embed ?? storeWikiPage;
+  const organizationId = input.organizationId;
+
+  const profileId = `org-perspective-${organizationId}`;
+  const versionId = `${profileId}-v1`;
+
+  const [bc, sf, org] = await Promise.all([
+    db.businessContext.findUnique({
+      where: { organizationId },
+      select: { mission: true, description: true, targetMarket: true, industry: true },
+    }) as Promise<BusinessContextRow>,
+    db.storefrontConfig.findFirst({
+      select: { archetype: { select: { name: true, category: true } } },
+    }) as Promise<{ archetype: { name: string; category: string } | null } | null>,
+    db.organization.findUnique({
+      where: { id: organizationId },
+      select: { name: true },
+    }) as Promise<{ name: string | null } | null>,
+  ]);
+
+  const archetypeName = sf?.archetype?.name ?? null;
+  const industry = sf?.archetype?.category ?? bc?.industry ?? null;
+  const orgName = org?.name ?? null;
+
+  // 1. Profile (container).
+  await db.decisionPerspectiveProfile.upsert({
+    where: { profileId },
+    update: {
+      name: `${orgName ?? "Organization"} perspective`,
+      kind: "organization",
+      scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+      ownerOrganizationId: organizationId,
+      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+    create: {
+      profileId,
+      name: `${orgName ?? "Organization"} perspective`,
+      kind: "organization",
+      scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+      ownerOrganizationId: organizationId,
+      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+  });
+
+  // 2. Version v1.
+  await db.decisionPerspectiveProfileVersion.upsert({
+    where: { versionId },
+    update: { changeSummary: "Organization perspective seeded at onboarding." },
+    create: {
+      versionId,
+      profileId,
+      versionNumber: 1,
+      materialFingerprint: `seed:${profileId}:v1`,
+      changeSummary: "Organization perspective seeded at onboarding.",
+    },
+  });
+
+  // 3. Org-overlay wiki pages (the working WWWD lever) + materials.
+  const pages = buildPages(bc, archetypeName, industry, orgName);
+  const wikiPageIds: string[] = [];
+  let embedded = true;
+
+  for (const page of pages) {
+    const existing = (await db.wikiPage.findFirst({
+      where: { organizationId, slug: page.slug },
+      select: { id: true, body: true },
+    })) as { id: string; body: string } | null;
+
+    const saved = (await upsertWikiPage(db as unknown as Parameters<typeof upsertWikiPage>[0], {
+      organizationId,
+      slug: page.slug,
+      title: page.title,
+      body: page.body,
+      pageKind: page.pageKind,
+      status: "published",
+      isKernel: false,
+      abstract: page.abstract,
+      ...(page.principle
+        ? {
+            principleTier: page.principle.principleTier,
+            principleAppliesTo: page.principle.principleAppliesTo,
+            principleDirection: page.principle.principleDirection,
+          }
+        : {}),
+    })) as { id: string };
+
+    wikiPageIds.push(saved.id);
+
+    // Only append a revision + re-embed when the content actually changed —
+    // keeps re-runs a true no-op on the revision log and the embedding API.
+    const changed = !existing || existing.body !== page.body;
+    if (changed) {
+      await appendRevision(db as unknown as Parameters<typeof appendRevision>[0], {
+        pageId: saved.id,
+        title: page.title,
+        body: page.body,
+        changeKind: "ingest",
+        changeSummary: "onboarding seed",
+      });
+
+      const ok = await embed({
+        pageId: saved.id,
+        slug: page.slug,
+        title: page.title,
+        body: page.body,
+        abstract: page.abstract,
+        pageKind: page.pageKind,
+        status: "published",
+        isKernel: false,
+        kernelVersion: null,
+        organizationId,
+        kernelPageId: null,
+        ...(page.principle
+          ? {
+              principleTier: page.principle.principleTier,
+              principleAppliesTo: page.principle.principleAppliesTo,
+            }
+          : {}),
+      });
+      if (!ok) embedded = false;
+    }
+
+    // Material linking the version to the wiki page.
+    const materialId = `${profileId}:${page.slug}`;
+    await db.perspectiveMaterial.upsert({
+      where: { materialId },
+      update: {
+        profileVersionId: versionId,
+        sourceType: page.pageKind,
+        sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
+        summary: page.abstract,
+        freshness: "current",
+      },
+      create: {
+        materialId,
+        profileId,
+        profileVersionId: versionId,
+        sourceType: page.pageKind,
+        sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
+        scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+        domainClass: PLAN_READINESS_DOMAIN_CLASS,
+        direction: "support",
+        domains: [PLAN_READINESS_DOMAIN_CLASS],
+        freshness: "current",
+        evidenceGrade: "B",
+        confidenceWeight: 0.6,
+        reviewStatus: "approved",
+        promotionState: "promoted",
+        summary: page.abstract,
+      },
+    });
+  }
+
+  // 4. Point the profile at v1.
+  await db.decisionPerspectiveProfile.update({
+    where: { profileId },
+    data: { currentVersionId: versionId },
+  });
+
+  return {
+    profileId,
+    versionId,
+    wikiPageIds,
+    materialCount: pages.length,
+    embedded,
+  };
+}

--- a/packages/db/prisma/migrations/20260531130000_add_mission_to_business_context/migration.sql
+++ b/packages/db/prisma/migrations/20260531130000_add_mission_to_business_context/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BusinessContext" ADD COLUMN "mission" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2782,6 +2782,9 @@ model BusinessContext {
   // What the company does (richer than tagline)
   description      String?
   valueProposition String?
+  // Why the company exists — captured at onboarding (business-context step).
+  // Seeds the company-mission prompt (Block 0) and the org WWWD corpus.
+  mission          String?
 
   // Who they serve
   targetMarket     String?

--- a/prompts/route-persona/onboarding-coo.prompt.md
+++ b/prompts/route-persona/onboarding-coo.prompt.md
@@ -81,7 +81,7 @@ The runtime grants for this agent come from [`apps/web/lib/inference/bootstrap-f
 
 **branding** — Ask if they have a logo file and brand colours ready, or if they want to import from a website URL. Let them know they can skip and come back — branding doesn't block anything.
 
-**business-context** — This is the most important step. Their answers here shape the AI coworkers' vocabulary and understanding across the entire platform. Ask what they do and who their primary customers are — two sentences is enough to start.
+**business-context** — This is the most important step. Their answers here shape the AI coworkers' vocabulary and understanding across the entire platform. Ask what they do and who their primary customers are — two sentences is enough to start. Then ask the mission question explicitly: "In one sentence, why does your business exist — the difference you set out to make?" Their answer becomes the company mission every coworker keeps in mind, and it seeds what the organization "would do" when a decision comes up. If they're unsure, offer the suggested starter on the form as a draft they can edit — capturing something real now beats leaving it blank.
 
 **operating-hours** — Quick step. Ask whether they have fixed hours or whether it varies by service or staff member.
 


### PR DESCRIPTION
## What & why

During initial portal configuration, the platform now **captures the company mission** at the business-context step and, on setup completion, **begins seeding a real per-org WWWD ("What Would We Do") decision corpus**. Today WWWD is a shipped surface with empty content that falls straight back to the platform/WWMD (Mark's) doctrine; this gives a fresh install a real org corpus from day one.

Backlog: **BI-CC64ECE4** (triaged build/large, epic EP-WWMD-MCP).

## Substrate verification (corrected two BI assumptions)

- **`PromptTemplate` is global** (no `organizationId`). A DPF install is single-org, so the captured mission is upserted into the one global `platform-mission/company-mission` row (Block 0 of every coworker prompt).
- **The working WWWD lever is org-overlay WikiPages, not the profile.** `agent-coworker.ts` answers WWWD via `recallWikiContext({ organizationId, preferredPageKinds })`; retrieval needs `status="published"` + a Qdrant embedding + matching org. So seeding published, embedded org WikiPages is what changes behaviour.
- **`ownerOrganizationId` is never read** by any decision path today (`build-studio-gate` always enters at `mark-dpf-platform`). The per-org `DecisionPerspectiveProfile` is therefore seeded as a **corpus container**; selecting it by `ownerOrganizationId` is split to follow-up **BI-230C9EF7**.

## Changes

- **Capture** — `BusinessContext.mission` column (+ migration); mission textarea on `BusinessContextForm` with an archetype-aware starter (`suggestMission`); persisted via `/api/business-context/setup`.
- **Seed on completion** (idempotent, fail-open) — `applyMissionPrompt` upserts the company-mission PromptTemplate from the captured mission; `seedOrgWwwdCorpus` creates a per-org `DecisionPerspectiveProfile` (kind=organization, fallback `dpf-organizational-principles`) + v1 + `PerspectiveMaterial` rows, plus 2–3 published, embedded org-overlay WikiPages (principle/stance). Wired into `advanceStep`/`skipStep`/`completeSetup`.
- **Catalog** — `platform-mission` added to the prompt-admin catalog (editable post-setup).
- **Persona** — `onboarding-coo` now asks the mission question explicitly.

## Tests

`pnpm -F @dpf/web test` (new): `suggestMission`; `seedOrgWwwdCorpus` (correct rows, **idempotency**, archetype-fallback when mission blank, embed fail-open); `applyMissionPrompt` (content + no-op on blank). Typecheck clean; related setup/prompt/business-context tests pass.

## Acceptance

A fresh install completing onboarding ends with a captured mission visible to coworkers (Block 0) **and** a non-empty, embedded org WWWD corpus — so "what would we do?" no longer falls straight back to Mark's platform doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)