### PR TITLE
refactor(web): migrate compliance detail pages to report-kit — clean set (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/compliance/audits/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/audits/[id]/page.tsx
@@ -2,14 +2,15 @@ import { prisma } from "@dpf/db";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
 
-const FINDING_COLORS: Record<string, string> = {
-  "nonconformity-major": "bg-red-900/30 text-red-400",
-  "nonconformity-minor": "bg-orange-900/30 text-orange-400",
-  observation: "bg-yellow-900/30 text-yellow-400",
-  opportunity: "bg-blue-900/30 text-blue-400",
+const FINDING_INTENT: Record<string, Intent> = {
+  "nonconformity-major": "danger",
+  "nonconformity-minor": "warning",
+  observation: "warning",
+  opportunity: "info",
 };
 
 export default async function AuditDetailPage({ params }: Props) {
@@ -89,12 +90,8 @@ export default async function AuditDetailPage({ params }: Props) {
               <div>
                 <span className="text-sm text-[var(--dpf-text)]">{f.title}</span>
                 <div className="flex gap-2 mt-1">
-                  <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${FINDING_COLORS[f.findingType] ?? "bg-gray-900/30 text-gray-400"}`}>
-                    {f.findingType}
-                  </span>
-                  <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${f.status === "open" ? "bg-yellow-900/30 text-yellow-400" : "bg-green-900/30 text-green-400"}`}>
-                    {f.status}
-                  </span>
+                  <StatusBadge intent={FINDING_INTENT[f.findingType] ?? "neutral"} label={f.findingType} variant="soft" uppercase={false} />
+                  <StatusBadge intent={f.status === "open" ? "warning" : "success"} label={f.status} variant="soft" uppercase={false} />
                   {f.control && <span className="text-[9px] text-[var(--dpf-muted)]">Control: {f.control.title}</span>}
                 </div>
               </div>

--- a/apps/web/app/(shell)/compliance/controls/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/controls/[id]/page.tsx
@@ -5,22 +5,9 @@ import { LinkObligationForm } from "@/components/compliance/LinkObligationForm";
 import { UnlinkControlButton } from "@/components/compliance/UnlinkControlButton";
 import { EditControlForm } from "@/components/compliance/EditControlForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const STATUS_COLORS: Record<string, string> = {
-  implemented: "bg-green-900/30 text-green-400",
-  "in-progress": "bg-yellow-900/30 text-yellow-400",
-  planned: "bg-blue-900/30 text-blue-400",
-  "not-applicable": "bg-gray-900/30 text-gray-400",
-};
-
-const EFFECTIVENESS_COLORS: Record<string, string> = {
-  effective: "bg-green-900/30 text-green-400",
-  "partially-effective": "bg-yellow-900/30 text-yellow-400",
-  ineffective: "bg-red-900/30 text-red-400",
-  "not-assessed": "bg-gray-900/30 text-gray-400",
-};
 
 export default async function ControlDetailPage({ params }: Props) {
   const { id } = await params;
@@ -56,13 +43,9 @@ export default async function ControlDetailPage({ params }: Props) {
         </div>
         <div className="flex gap-2 mt-1">
           <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{control.controlType}</span>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[control.implementationStatus] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {control.implementationStatus}
-          </span>
+          <StatusBadge domain="controlStatus" status={control.implementationStatus} variant="soft" uppercase={false} />
           {control.effectiveness && (
-            <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${EFFECTIVENESS_COLORS[control.effectiveness] ?? "bg-gray-900/30 text-gray-400"}`}>
-              {control.effectiveness}
-            </span>
+            <StatusBadge domain="controlEffectiveness" status={control.effectiveness} variant="soft" uppercase={false} />
           )}
         </div>
       </div>

--- a/apps/web/app/(shell)/compliance/policies/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/policies/[id]/page.tsx
@@ -5,16 +5,9 @@ import { transitionPolicyStatus } from "@/lib/actions/policy";
 import { EditPolicyForm } from "@/components/compliance/EditPolicyForm";
 import { LinkPolicyObligationForm } from "@/components/compliance/LinkPolicyObligationForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const STATUS_COLORS: Record<string, string> = {
-  draft: "bg-gray-900/30 text-gray-400",
-  "in-review": "bg-yellow-900/30 text-yellow-400",
-  approved: "bg-blue-900/30 text-blue-400",
-  published: "bg-green-900/30 text-green-400",
-  retired: "bg-gray-900/30 text-gray-400",
-};
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   "draft":     ["in-review"],
@@ -35,9 +28,9 @@ const TRANSITION_LABELS: Record<string, string> = {
 const TRANSITION_STYLES: Record<string, string> = {
   "in-review": "bg-[var(--dpf-accent)] text-white hover:opacity-90",
   approved: "bg-[var(--dpf-accent)] text-white hover:opacity-90",
-  published: "bg-green-700 text-white hover:bg-green-600",
-  retired: "bg-red-700 text-white hover:bg-red-600",
-  draft: "bg-gray-700 text-gray-200 hover:bg-gray-600",
+  published: "bg-[var(--dpf-success)] text-white hover:opacity-90",
+  retired: "bg-[var(--dpf-error)] text-white hover:opacity-90",
+  draft: "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] hover:opacity-90",
 };
 
 export default async function PolicyDetailPage({ params }: Props) {
@@ -90,9 +83,7 @@ export default async function PolicyDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{policy.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[policy.lifecycleStatus] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {policy.lifecycleStatus}
-          </span>
+          <StatusBadge domain="compliancePolicy" status={policy.lifecycleStatus} variant="soft" uppercase={false} />
           <EditPolicyForm id={policy.id} policy={policy} />
         </div>
         {policy.description && <p className="text-sm text-[var(--dpf-muted)]">{policy.description}</p>}

--- a/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/regulations/[id]/page.tsx
@@ -41,7 +41,7 @@ export default async function RegulationDetailPage({ params }: Props) {
         <p className="text-sm text-[var(--dpf-muted)]">{regulation.name}</p>
         {regulation.sourceUrl && (
           <a href={regulation.sourceUrl} target="_blank" rel="noopener noreferrer"
-            className="text-xs text-blue-400 hover:underline mt-1 inline-block">
+            className="text-xs text-[var(--dpf-info)] hover:underline mt-1 inline-block">
             Source document
           </a>
         )}
@@ -85,7 +85,7 @@ export default async function RegulationDetailPage({ params }: Props) {
               <div key={o.id} className="p-3 rounded-lg border border-[var(--dpf-border)] flex items-start justify-between">
                 <div>
                   <div className="flex items-center gap-2">
-                    <span className={`w-2 h-2 rounded-full ${hasControls ? "bg-green-400" : "bg-red-400"}`} />
+                    <span className="w-2 h-2 rounded-full" style={{ backgroundColor: hasControls ? "var(--dpf-success)" : "var(--dpf-error)" }} />
                     <span className="text-sm text-[var(--dpf-text)]">{o.title}</span>
                   </div>
                   <div className="flex gap-2 mt-1">

--- a/apps/web/app/(shell)/compliance/submissions/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/submissions/[id]/page.tsx
@@ -2,16 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getSubmission, transitionSubmissionStatus } from "@/lib/actions/reporting";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const STATUS_COLORS: Record<string, string> = {
-  draft: "bg-gray-900/30 text-gray-400",
-  pending: "bg-yellow-900/30 text-yellow-400",
-  submitted: "bg-blue-900/30 text-blue-400",
-  acknowledged: "bg-green-900/30 text-green-400",
-  rejected: "bg-red-900/30 text-red-400",
-};
 
 const SUBMISSION_TRANSITIONS: Record<string, string[]> = {
   draft: ["pending"],
@@ -32,9 +25,9 @@ const SUBMISSION_TRANSITION_LABELS: Record<string, string> = {
 const SUBMISSION_TRANSITION_STYLES: Record<string, string> = {
   pending: "bg-[var(--dpf-accent)] text-white hover:opacity-90",
   submitted: "bg-[var(--dpf-accent)] text-white hover:opacity-90",
-  acknowledged: "bg-green-700 text-white hover:bg-green-600",
-  rejected: "bg-red-700 text-white hover:bg-red-600",
-  draft: "bg-gray-700 text-gray-200 hover:bg-gray-600",
+  acknowledged: "bg-[var(--dpf-success)] text-white hover:opacity-90",
+  rejected: "bg-[var(--dpf-error)] text-white hover:opacity-90",
+  draft: "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] hover:opacity-90",
 };
 
 export default async function SubmissionDetailPage({ params }: Props) {
@@ -64,9 +57,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{submission.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[submission.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {submission.status}
-          </span>
+          <StatusBadge domain="complianceSubmission" status={submission.status} variant="soft" uppercase={false} />
         </div>
         <p className="text-sm text-[var(--dpf-muted)]">{submission.recipientBody} · {submission.submissionType}</p>
       </div>
@@ -91,7 +82,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
         {submission.dueDate && (
           <div className="p-3 rounded-lg border border-[var(--dpf-border)]">
             <p className="text-xs text-[var(--dpf-muted)]">Due Date</p>
-            <p className={`text-sm font-semibold ${daysRemaining !== null && daysRemaining < 0 ? "text-red-400" : daysRemaining !== null && daysRemaining < 7 ? "text-yellow-400" : "text-[var(--dpf-text)]"}`}>
+            <p className={`text-sm font-semibold ${daysRemaining !== null && daysRemaining < 0 ? "text-[var(--dpf-error)]" : daysRemaining !== null && daysRemaining < 7 ? "text-[var(--dpf-warning)]" : "text-[var(--dpf-text)]"}`}>
               <LocalTime value={submission.dueDate} utc />
               {daysRemaining !== null && (
                 <span className="text-xs ml-1">({daysRemaining < 0 ? `${Math.abs(daysRemaining)}d overdue` : `${daysRemaining}d remaining`})</span>
@@ -121,7 +112,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
 
       {/* Regulation link */}
       {submission.regulation ? (
-        <p className="text-xs text-blue-400 mb-6">
+        <p className="text-xs text-[var(--dpf-info)] mb-6">
           Regulation:{" "}
           <a href={`/compliance/regulations/${submission.regulation.id}`} className="underline">
             {submission.regulation.name} ({submission.regulation.shortName})
@@ -140,7 +131,7 @@ export default async function SubmissionDetailPage({ params }: Props) {
           {submission.checklist.map((item: { obligationId: string; title: string; hasEvidence: boolean; evidenceCount: number }) => (
             <div key={item.obligationId} className="p-3 rounded-lg border border-[var(--dpf-border)] flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <span className={`w-2 h-2 rounded-full ${item.hasEvidence ? "bg-green-400" : "bg-red-400"}`} />
+                <span className="w-2 h-2 rounded-full" style={{ backgroundColor: item.hasEvidence ? "var(--dpf-success)" : "var(--dpf-error)" }} />
                 <span className="text-sm text-[var(--dpf-text)]">{item.title}</span>
               </div>
               <span className="text-xs text-[var(--dpf-muted)]">{item.evidenceCount} evidence record{item.evidenceCount !== 1 ? "s" : ""}</span>


### PR DESCRIPTION
## What

Migrates 5 compliance **`[id]` detail pages** off raw Tailwind-palette colors onto report-kit `StatusBadge` + `--dpf-*` tokens (reuses the registry domains merged in #1351).

- **controls/[id]**: status + effectiveness badges → `StatusBadge` (controlStatus / controlEffectiveness)
- **audits/[id]**: finding-type + finding-status badges → `StatusBadge` (local intent map for finding types)
- **regulations/[id]**: source link + obligation coverage dot → tokens
- **policies/[id]**: lifecycle badge → `StatusBadge`; status-transition action buttons (green-700/red-700/gray-700) → `--dpf-success/error/surface-2`
- **submissions/[id]**: status badge → `StatusBadge`; transition buttons + due-date + linked-accent + evidence coverage dot → tokens

## Verification

- `tsc --noEmit` clean; zero raw palette colors remain in the 5 pages

Continues BI-6A842691 (follows merged list-page PRs #1351/#1354). Remaining compliance detail pages (actions, evidence, incidents, obligations, risks — heavier patterns) are a follow-up batch. Authored in an isolated worktree per the collision-free workflow (#1359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)