### PR TITLE
feat(decision): resolve + name governing profile in principle_decide (C2a, BI-E1FB2307)

### DIFF
--- a/apps/web/lib/decision/caller-context.test.ts
+++ b/apps/web/lib/decision/caller-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveDecisionCallerContext,
+  WWMD_PLATFORM_PROFILE_ID,
+  WWWD_ORGANIZATION_PROFILE_ID,
+} from "./caller-context";
+
+/** Minimal PrincipalAlias-findFirst mock. `rows` maps aliasType -> aliasValue -> principalId. */
+function mockDb(rows: Record<string, Record<string, string>>) {
+  return {
+    principalAlias: {
+      findFirst: vi.fn(async ({ where }: { where: { aliasType: string; aliasValue: string } }) => {
+        const principalId = rows[where.aliasType]?.[where.aliasValue];
+        return principalId ? { principal: { principalId } } : null;
+      }),
+    },
+  } as unknown as Parameters<typeof resolveDecisionCallerContext>[1];
+}
+
+describe("resolveDecisionCallerContext (BI-E1FB2307)", () => {
+  it("routes an in-portal coworker to the organization (WWWD) profile", async () => {
+    const ctx = await resolveDecisionCallerContext(
+      { callingPopulation: "in_platform_coworker", agentId: "build-specialist" },
+      mockDb({ agent: { "build-specialist": "PRIN-AGENT-1" } }),
+    );
+    expect(ctx.governingProfileId).toBe(WWWD_ORGANIZATION_PROFILE_ID);
+    expect(ctx.governingProfileKind).toBe("organization");
+    expect(ctx.principalId).toBe("PRIN-AGENT-1");
+    expect(ctx.resolvedVia).toBe("calling-population");
+  });
+
+  it("routes an external coding agent to the platform (WWMD) profile", async () => {
+    const ctx = await resolveDecisionCallerContext(
+      { callingPopulation: "external_coding_agent", userId: "user-42" },
+      mockDb({ user: { "user-42": "PRIN-USER-42" } }),
+    );
+    expect(ctx.governingProfileId).toBe(WWMD_PLATFORM_PROFILE_ID);
+    expect(ctx.governingProfileKind).toBe("platform");
+    expect(ctx.principalId).toBe("PRIN-USER-42");
+  });
+
+  it("routes a human to the platform (WWMD) profile", async () => {
+    const ctx = await resolveDecisionCallerContext(
+      { callingPopulation: "human", userId: "user-7" },
+      mockDb({ user: { "user-7": "PRIN-7" } }),
+    );
+    expect(ctx.governingProfileKind).toBe("platform");
+    expect(ctx.governingProfileId).toBe(WWMD_PLATFORM_PROFILE_ID);
+  });
+
+  it("prefers the agent alias, then falls back to the user alias", async () => {
+    const ctx = await resolveDecisionCallerContext(
+      { callingPopulation: "in_platform_coworker", agentId: "ghost", userId: "user-9" },
+      mockDb({ user: { "user-9": "PRIN-9" } }), // no agent alias for "ghost"
+    );
+    expect(ctx.principalId).toBe("PRIN-9");
+  });
+
+  it("returns a null principal when nothing resolves but still picks a profile", async () => {
+    const ctx = await resolveDecisionCallerContext(
+      { callingPopulation: "in_platform_coworker", agentId: "unknown" },
+      mockDb({}),
+    );
+    expect(ctx.principalId).toBeNull();
+    expect(ctx.governingProfileKind).toBe("organization");
+  });
+});

--- a/apps/web/lib/decision/caller-context.ts
+++ b/apps/web/lib/decision/caller-context.ts
@@ -1,0 +1,74 @@
+// Decision caller-context resolution (decision-surface consolidation, BI-E1FB2307).
+//
+// Maps a decision caller to (a) its Principal (for attribution/ledger) and
+// (b) the governing decision-perspective profile, enforcing the WWMD-vs-WWWD
+// boundary (AGENTS.md §16): an in-portal coworker's *business* decision is
+// governed by the organization's WWWD profile; platform-development work
+// (external coding agents, humans contributing to the platform) is governed by
+// the founder/platform WWMD profile.
+//
+// Resolution here is callingPopulation-based BY DESIGN. Richer
+// ownerPrincipalId/defaultResolver/fallback-chain selection and true
+// multi-tenant org scoping (no caller->org link exists today) are tracked by
+// BI-E1FB2307 (Gate routing) and BI-EF3F4A2D (multi-tenant identity).
+
+import {
+  resolvePrincipalIdForUser,
+  resolvePrincipalIdForAgent,
+} from "@/lib/identity/principal-linking";
+
+export type DecisionCallingPopulation =
+  | "in_platform_coworker"
+  | "external_coding_agent"
+  | "human";
+
+export type GoverningProfileKind = "platform" | "organization";
+
+/** WWMD — founder / platform-development profile (`kind: "platform"`). */
+export const WWMD_PLATFORM_PROFILE_ID = "mark-dpf-platform";
+/** WWWD — customer / organization business-operating-principles profile (`kind: "organization"`). */
+export const WWWD_ORGANIZATION_PROFILE_ID = "dpf-organizational-principles";
+
+export type DecisionCallerContext = {
+  /** Principal behind the caller, when resolvable (for the decision ledger). */
+  principalId: string | null;
+  /** The decision-perspective profile that governs this caller's decisions. */
+  governingProfileId: string;
+  governingProfileKind: GoverningProfileKind;
+  callingPopulation: DecisionCallingPopulation;
+  /** How the profile was chosen — for the response + audit trail. */
+  resolvedVia: "calling-population";
+};
+
+type PrincipalResolverDb = Parameters<typeof resolvePrincipalIdForUser>[1];
+
+export async function resolveDecisionCallerContext(
+  input: {
+    callingPopulation: DecisionCallingPopulation;
+    userId?: string | null;
+    agentId?: string | null;
+  },
+  db?: PrincipalResolverDb,
+): Promise<DecisionCallerContext> {
+  // Attribute to a principal where possible: prefer the agent alias for
+  // in-portal coworkers, fall back to the user alias.
+  let principalId: string | null = null;
+  if (input.agentId) {
+    principalId = await resolvePrincipalIdForAgent(input.agentId, db);
+  }
+  if (!principalId && input.userId) {
+    principalId = await resolvePrincipalIdForUser(input.userId, db);
+  }
+
+  const isBusiness = input.callingPopulation === "in_platform_coworker";
+
+  return {
+    principalId,
+    governingProfileId: isBusiness
+      ? WWWD_ORGANIZATION_PROFILE_ID
+      : WWMD_PLATFORM_PROFILE_ID,
+    governingProfileKind: isBusiness ? "organization" : "platform",
+    callingPopulation: input.callingPopulation,
+    resolvedVia: "calling-population",
+  };
+}

--- a/apps/web/lib/identity/principal-linking.ts
+++ b/apps/web/lib/identity/principal-linking.ts
@@ -405,3 +405,31 @@ export async function resolvePrincipalIdForUser(
 
   return alias?.principal?.principalId ?? null;
 }
+
+/**
+ * Resolve the Principal id behind an agent (coworker) id, via the
+ * `aliasType: "agent"` PrincipalAlias (principal-convergence, AGENTS.md §11).
+ * Sibling of resolvePrincipalIdForUser; used by decision caller-context
+ * resolution so a coworker decision can be attributed to its principal.
+ */
+export async function resolvePrincipalIdForAgent(
+  agentId: string,
+  db: PrincipalDb = prisma,
+): Promise<string | null> {
+  const alias = await db.principalAlias.findFirst({
+    where: {
+      aliasType: "agent",
+      aliasValue: agentId,
+      issuer: INTERNAL_ISSUER,
+    },
+    include: {
+      principal: {
+        select: {
+          principalId: true,
+        },
+      },
+    },
+  });
+
+  return alias?.principal?.principalId ?? null;
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -11996,8 +11996,22 @@ export async function executeTool(
         semanticFallbackWarnRatio: semanticWarnRatio,
       });
 
+      // BI-E1FB2307: resolve which decision-perspective profile governs this
+      // caller (WWMD platform vs WWWD organization) and name it in the response
+      // so agents/operators know which kernel weighed in. Additive — does not
+      // change scoring yet; Gate-routed scoring + boundary enforcement is the
+      // follow-on (C2b). callingPopulation was validated above.
+      const { resolveDecisionCallerContext } = await import(
+        "@/lib/decision/caller-context"
+      );
+      const governingProfile = await resolveDecisionCallerContext({
+        callingPopulation:
+          callingPopulation as "in_platform_coworker" | "external_coding_agent" | "human",
+        agentId: context?.agentId ?? null,
+      });
+
       const summary = result.recommendation
-        ? `Recommends ${result.recommendation.optionId} (confidence: ${result.recommendation.confidence}, composite ${result.recommendation.composite.toFixed(3)})`
+        ? `Recommends ${result.recommendation.optionId} (confidence: ${result.recommendation.confidence}, composite ${result.recommendation.composite.toFixed(3)}; governing profile: ${governingProfile.governingProfileKind})`
         : "No applicable principles to evaluate.";
 
       return {
@@ -12009,6 +12023,11 @@ export async function executeTool(
           flags: result.flags,
           reasoning: result.reasoning,
           appliedPrincipleCount: cappedPrinciples.length,
+          governingProfile: {
+            profileId: governingProfile.governingProfileId,
+            kind: governingProfile.governingProfileKind,
+            resolvedVia: governingProfile.resolvedVia,
+          },
         },
       };
     }


### PR DESCRIPTION
First **behavioral** slice of the decision-surface consolidation (BI-E1FB2307, plan PR #1304). Stacks on C1 (PR #1307, the pure engine).

Resolves **which decision-perspective profile governs** a caller and names it in the `principle_decide` response — so coworkers/agents and operators can see which kernel weighed in, the visible step toward the WWMD-vs-WWWD boundary.

- **New `lib/decision/caller-context.ts`** — `resolveDecisionCallerContext` maps `callingPopulation` → governing profile (`in_platform_coworker` → **WWWD** organization; `external_coding_agent`/`human` → **WWMD** platform) and attributes the caller to a `Principal` (agent alias preferred, user alias fallback). Enforces the AGENTS.md §16 boundary.
- **identity:** `resolvePrincipalIdForAgent` (sibling of `resolvePrincipalIdForUser`).
- **`principle_decide` handler:** resolves caller context, adds `data.governingProfile { profileId, kind, resolvedVia }`, names the profile in the summary.

**Scope honesty:** additive — does **not** change scoring yet (still org-overlay + kernel via the existing path); the Gate option-vector evaluator + boundary-enforced retrieval is the follow-on **C2b**. Resolution is `callingPopulation`-based by design; richer `ownerPrincipalId`/`defaultResolver`/fallback resolution and multi-tenant org scoping are tracked by BI-E1FB2307 / BI-EF3F4A2D.

**Verification:** `caller-context` tests **5/5**; no type errors on touched files (`tsc` filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)