### PR TITLE
feat(self-upgrade): on-demand "What's in this update?" impact summary (BI-C26F7EE1)

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -28,6 +28,14 @@ vi.mock("@/lib/actions/promotions", () => ({
   triggerSelfUpgrade: vi.fn(),
 }));
 
+// The global useState mock above keys off `initial === null`, so any child
+// component with its own `useState<X | null>(null)` would otherwise receive
+// `shared.triggerResult` and try to render it. Stub the impact panel so the
+// trigger-control tests stay focused on this component's behavior.
+vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
+  default: () => null,
+}));
+
 import SelfUpgradeClient from "./SelfUpgradeClient";
 
 const baseStatus = {

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { triggerSelfUpgrade } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
+import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 
 type LatestRun = {
   runId: string;
@@ -266,6 +267,8 @@ export default function SelfUpgradeClient({
           )}
         </div>
       )}
+
+      <UpgradeImpactPanel enabled={enabled} />
 
       {enabled && !latestRun && (
         <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-xs text-[var(--dpf-muted)]">

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+// apps/web/components/ops/UpgradeImpactPanel.tsx
+//
+// Operator-facing "What's in this update?" panel for the /ops self-upgrade
+// page. On click, runs the impact-summary server action and renders:
+//   - Headline (LLM-phrased summary)
+//   - Counts ribbon (breaking / feature / fix / perf / other)
+//   - Top-N items (each: plain description + "why relevant to you" line)
+//   - Customizations-touched callout (when present)
+//   - Foldable "show full list" view
+//   - Provenance line (GitHub reachable? cache hit?)
+//
+// Advisory only — no buttons here queue or apply the upgrade.
+
+import { useState, useTransition } from "react";
+import { getUpgradeImpactSummary } from "@/lib/actions/upgrade-impact";
+import type { SummaryResult, ImpactItem } from "@/lib/self-upgrade/impact/types";
+
+const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
+  breaking: "Breaking",
+  feature: "New",
+  performance: "Faster",
+  fix: "Fix",
+  other: "Other",
+};
+
+const CATEGORY_BADGE: Record<ImpactItem["category"], string> = {
+  breaking:
+    "bg-[var(--dpf-destructive)]/15 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/30",
+  feature:
+    "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
+  performance:
+    "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
+  fix:
+    "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)] border-[var(--dpf-warning)]/30",
+  other:
+    "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]",
+};
+
+function countsLine(counts: {
+  breaking: number;
+  feature: number;
+  fix: number;
+  performance: number;
+  other: number;
+  total: number;
+}): string {
+  const parts: string[] = [];
+  if (counts.breaking > 0) parts.push(`${counts.breaking} breaking`);
+  if (counts.feature > 0) parts.push(`${counts.feature} new`);
+  if (counts.performance > 0) parts.push(`${counts.performance} perf`);
+  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
+  if (counts.other > 0) parts.push(`${counts.other} other`);
+  if (parts.length === 0) return `${counts.total} change${counts.total === 1 ? "" : "s"}`;
+  return parts.join(" · ");
+}
+
+function ItemRow({
+  item,
+  phrasing,
+}: {
+  item: ImpactItem;
+  phrasing?: { description: string; whyRelevant: string };
+}) {
+  // Default view: phrased text; never SHAs or paths. Fall back to the raw
+  // commit description if LLM phrasing is unavailable.
+  const description = phrasing?.description ?? item.description;
+  const whyRelevant = phrasing?.whyRelevant ?? "";
+  return (
+    <li
+      className="py-2 px-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-1"
+      data-impact-category={item.category}
+      data-touches-customizations={item.touchesCustomizations ? "true" : "false"}
+    >
+      <div className="flex items-start gap-2">
+        <span
+          className={`shrink-0 px-2 py-0.5 rounded-full border text-[10px] uppercase tracking-wide ${CATEGORY_BADGE[item.category]}`}
+        >
+          {CATEGORY_LABEL[item.category]}
+        </span>
+        <span className="text-sm text-[var(--dpf-text)]">{description}</span>
+      </div>
+      {whyRelevant && (
+        <div className="text-xs text-[var(--dpf-muted)] pl-1">
+          <span className="font-medium text-[var(--dpf-text)]">Why relevant: </span>
+          {whyRelevant}
+        </div>
+      )}
+      {item.touchesCustomizations && (
+        <div className="text-xs text-[var(--dpf-warning)] pl-1">
+          Touches your customizations — may need merge review.
+        </div>
+      )}
+    </li>
+  );
+}
+
+export default function UpgradeImpactPanel({ enabled }: { enabled: boolean }) {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<SummaryResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showFullList, setShowFullList] = useState(false);
+
+  function run(refresh = false) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const r = await getUpgradeImpactSummary({ refresh });
+        setResult(r);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-3"
+      data-panel="upgrade-impact-summary"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium text-[var(--dpf-text)]">
+            What&apos;s in this update?
+          </div>
+          <div className="text-xs text-[var(--dpf-muted)]">
+            Plain-language summary of upstream changes since your last upgrade,
+            tailored to this install. Advisory — does not apply anything.
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {result?.ok && (
+            <button
+              type="button"
+              onClick={() => run(true)}
+              disabled={isPending}
+              className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+            >
+              Refresh
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => run(false)}
+            disabled={isPending}
+            aria-busy={isPending}
+            className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
+          >
+            {isPending ? "Summarizing..." : result ? "Re-open summary" : "Summarize update"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs text-[var(--dpf-destructive)] p-2 rounded bg-[var(--dpf-destructive)]/10">
+          {error}
+        </div>
+      )}
+
+      {result && !result.ok && (
+        <div
+          className="text-xs text-[var(--dpf-muted)] p-3 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)]"
+          data-summary-state={result.reason}
+        >
+          {result.detail}
+        </div>
+      )}
+
+      {result?.ok && (
+        <div className="space-y-3" data-summary-state="ok">
+          {result.summary.phrased?.headline && (
+            <p className="text-sm text-[var(--dpf-text)]">
+              {result.summary.phrased.headline}
+            </p>
+          )}
+
+          <div className="text-xs text-[var(--dpf-muted)]" data-counts-line>
+            {countsLine(result.summary.counts)}
+          </div>
+
+          {result.summary.phrased?.touchesCustomizationsCallout && (
+            <div className="text-xs text-[var(--dpf-warning)] p-2 rounded bg-[var(--dpf-warning)]/10 border border-[var(--dpf-warning)]/30">
+              {result.summary.phrased.touchesCustomizationsCallout}
+            </div>
+          )}
+
+          {result.summary.topItems.length > 0 && (
+            <ul className="space-y-2">
+              {result.summary.topItems.map((item, idx) => (
+                <ItemRow
+                  key={item.sha}
+                  item={item}
+                  phrasing={result.summary.phrased?.itemPhrasings[idx]}
+                />
+              ))}
+            </ul>
+          )}
+
+          {result.summary.allItems.length > result.summary.topItems.length && (
+            <details
+              className="text-xs"
+              open={showFullList}
+              onToggle={(e) => setShowFullList((e.target as HTMLDetailsElement).open)}
+            >
+              <summary className="cursor-pointer text-[var(--dpf-accent)] hover:underline">
+                Show all {result.summary.allItems.length} changes
+              </summary>
+              <ul className="space-y-2 mt-2">
+                {result.summary.allItems.map((item) => (
+                  <ItemRow key={item.sha} item={item} />
+                ))}
+              </ul>
+            </details>
+          )}
+
+          <div className="text-[10px] text-[var(--dpf-muted)] pt-1">
+            {result.summary.enrichment.githubReachable
+              ? `Enriched ${result.summary.enrichment.prsEnriched} PR title${result.summary.enrichment.prsEnriched === 1 ? "" : "s"} from GitHub.`
+              : "GitHub unreachable — summary built from commit subjects only."}
+            {result.summary.fromCache && " · Served from cache."}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/upgrade-impact.ts
+++ b/apps/web/lib/actions/upgrade-impact.ts
@@ -1,0 +1,35 @@
+"use server";
+
+// apps/web/lib/actions/upgrade-impact.ts
+//
+// Server action wrapper around the on-demand "What's in this update?"
+// summary (BI-C26F7EE1). Same auth gate as the other self-upgrade actions
+// (`view_operations`). Action is read-only and advisory — it never queues
+// or applies an upgrade.
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { summarizeUpgradeImpact } from "@/lib/self-upgrade/impact";
+import type { SummarizeOptions } from "@/lib/self-upgrade/impact";
+import type { SummaryResult } from "@/lib/self-upgrade/impact/types";
+
+async function requireOpsAccess(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "view_operations",
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+}
+
+export async function getUpgradeImpactSummary(
+  options?: SummarizeOptions,
+): Promise<SummaryResult> {
+  await requireOpsAccess();
+  return summarizeUpgradeImpact(options ?? {});
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4234,6 +4234,32 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: true,
   },
+  {
+    name: "summarize_upgrade_impact",
+    description:
+      "On-demand, install-tailored \"What's in this update?\" summary (BI-C26F7EE1). Compares the upstream lineage marker (latest succeeded SelfUpgradeRun.targetSha) to the resolved upstream HEAD, classifies the change set by Conventional Commit type, scores each commit's relevance to this install (archetype, industry, customization paths, open quality-issue themes), and returns a headline + ordered top-N items (most impactful first) plus the full list and a 'touches your customizations' callout that doubles as a §5.0 merge-conflict early warning. Advisory only — never queues or applies an upgrade. Cacheable per (currentLineageSha, targetSha); set refresh=true to bypass.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        refresh: {
+          type: "boolean",
+          description: "Bypass the per-process cache and recompute. Default false.",
+        },
+        topN: {
+          type: "number",
+          description: "Cap on items in the headline list (default 8). The full list is always returned alongside.",
+        },
+        skipPhrasing: {
+          type: "boolean",
+          description: "Return only the deterministic shape (no LLM phrasing). Default false. Useful when an external client wants to render its own copy.",
+        },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
 ];
 
 // ─── Capability Filtering ────────────────────────────────────────────────────
@@ -14202,6 +14228,42 @@ export async function executeTool(
           success: false,
           error: msg,
           message: `trigger_contributor_inventory_sync failed: ${msg}`,
+        };
+      }
+    }
+
+    case "summarize_upgrade_impact": {
+      // BI-C26F7EE1 — on-demand install-tailored upgrade impact summary.
+      // Read-only, advisory; does not queue or apply anything.
+      const refresh = params["refresh"] === true;
+      const skipPhrasing = params["skipPhrasing"] === true;
+      const topNRaw = params["topN"];
+      const topN =
+        typeof topNRaw === "number" && Number.isFinite(topNRaw) && topNRaw > 0
+          ? Math.floor(topNRaw)
+          : undefined;
+      try {
+        const { summarizeUpgradeImpact } = await import("@/lib/self-upgrade/impact");
+        const result = await summarizeUpgradeImpact({ refresh, skipPhrasing, topN });
+        if (!result.ok) {
+          return {
+            success: true,
+            message: result.detail,
+            data: { ok: false, reason: result.reason, detail: result.detail },
+          };
+        }
+        return {
+          success: true,
+          message: result.summary.phrased?.headline
+            ?? `Upgrade impact summary: ${result.summary.counts.total} commit(s) since the last lineage marker.`,
+          data: result.summary as unknown as Record<string, unknown>,
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          error: msg,
+          message: `summarize_upgrade_impact failed: ${msg}`,
         };
       }
     }

--- a/apps/web/lib/self-upgrade/impact/cache.test.ts
+++ b/apps/web/lib/self-upgrade/impact/cache.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetCacheForTest, cacheKey, getCached, setCached } from "./cache";
+import type { SummaryResult } from "./types";
+
+afterEach(() => {
+  _resetCacheForTest();
+});
+
+describe("cacheKey", () => {
+  it("uses both SHAs", () => {
+    expect(cacheKey("a", "b")).toBe("a::b");
+  });
+  it("encodes null as a stable sentinel", () => {
+    expect(cacheKey(null, "b")).toBe("_none_::b");
+    expect(cacheKey("a", null)).toBe("a::_none_");
+  });
+});
+
+describe("getCached / setCached", () => {
+  const ok: SummaryResult = {
+    ok: true,
+    summary: {
+      currentLineageSha: "a",
+      targetSha: "b",
+      counts: { breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0 },
+      topItems: [],
+      allItems: [],
+      phrased: null,
+      enrichment: { githubReachable: false, prsEnriched: 0 },
+      generatedAt: "2026-05-01T00:00:00Z",
+      fromCache: false,
+    },
+  };
+
+  it("returns null when no entry", () => {
+    expect(getCached("a", "b")).toBeNull();
+  });
+  it("returns the stored value", () => {
+    setCached("a", "b", ok);
+    expect(getCached("a", "b")).toEqual(ok);
+  });
+  it("isolates entries by key", () => {
+    setCached("a", "b", ok);
+    expect(getCached("a", "c")).toBeNull();
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/cache.ts
+++ b/apps/web/lib/self-upgrade/impact/cache.ts
@@ -1,0 +1,51 @@
+// apps/web/lib/self-upgrade/impact/cache.ts
+//
+// Process-local cache keyed by (currentLineageSha, targetSha). A given
+// (lineage, target) pair is immutable — neither SHA changes without a
+// successful self-upgrade run flipping the lineage marker — so a process
+// lifetime is plenty. The cache is mostly there to avoid re-running `git log`
+// + the LLM phrasing call when the operator clicks "What's in this update?"
+// twice in a row (and to make a follow-up MCP call cheap).
+//
+// A null entry means "we've checked and there's no summary applicable for
+// this pair" (e.g. lineage === target) — also worth caching so we don't
+// keep retrying.
+
+import type { SummaryResult } from "./types";
+
+const TTL_MS = 60 * 60 * 1000; // 1h — refreshed on demand if operator reopens.
+
+type Entry = { value: SummaryResult; expiresAt: number };
+
+const _cache = new Map<string, Entry>();
+
+export function cacheKey(currentLineageSha: string | null, targetSha: string | null): string {
+  return `${currentLineageSha ?? "_none_"}::${targetSha ?? "_none_"}`;
+}
+
+export function getCached(currentLineageSha: string | null, targetSha: string | null): SummaryResult | null {
+  const key = cacheKey(currentLineageSha, targetSha);
+  const entry = _cache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt < Date.now()) {
+    _cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+export function setCached(
+  currentLineageSha: string | null,
+  targetSha: string | null,
+  value: SummaryResult,
+): void {
+  _cache.set(cacheKey(currentLineageSha, targetSha), {
+    value,
+    expiresAt: Date.now() + TTL_MS,
+  });
+}
+
+/** Test-only — reset the cache between cases. */
+export function _resetCacheForTest(): void {
+  _cache.clear();
+}

--- a/apps/web/lib/self-upgrade/impact/change-set.test.ts
+++ b/apps/web/lib/self-upgrade/impact/change-set.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildLogCommand, collectChangeSet, parseGitLogOutput } from "./change-set";
+
+describe("buildLogCommand", () => {
+  it("targets the lineage→target range against the configured host clone", () => {
+    expect(
+      buildLogCommand({
+        hostSourcePath: "/host-dpf",
+        currentLineageSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        targetSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      }),
+    ).toEqual([
+      "git",
+      "-C",
+      "/host-dpf",
+      "log",
+      "--reverse",
+      "--no-merges",
+      "--name-only",
+      expect.stringContaining("%H"),
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+});
+
+describe("parseGitLogOutput", () => {
+  it("parses multi-commit output with file lists per commit", () => {
+    const out = [
+      "\x1e1111111111111111111111111111111111111111\x1ffeat: a (#1)\x1fAlice\x1f2026-05-01T10:00:00Z",
+      "apps/web/foo.ts",
+      "packages/db/x.ts",
+      "",
+      "\x1e2222222222222222222222222222222222222222\x1ffix: b (#2)\x1fBob\x1f2026-05-02T11:00:00Z",
+      "scripts/y.sh",
+      "",
+    ].join("\n");
+    const parsed = parseGitLogOutput(out);
+    expect(parsed).toEqual([
+      {
+        sha: "1111111111111111111111111111111111111111",
+        subject: "feat: a (#1)",
+        author: "Alice",
+        authorDate: "2026-05-01T10:00:00Z",
+        files: ["apps/web/foo.ts", "packages/db/x.ts"],
+      },
+      {
+        sha: "2222222222222222222222222222222222222222",
+        subject: "fix: b (#2)",
+        author: "Bob",
+        authorDate: "2026-05-02T11:00:00Z",
+        files: ["scripts/y.sh"],
+      },
+    ]);
+  });
+
+  it("returns [] for empty output", () => {
+    expect(parseGitLogOutput("")).toEqual([]);
+    expect(parseGitLogOutput("\n\n")).toEqual([]);
+  });
+
+  it("tolerates commits without changed files", () => {
+    const out = "\x1eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x1fchore: empty\x1fX\x1f2026-05-01T00:00:00Z";
+    const parsed = parseGitLogOutput(out);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.files).toEqual([]);
+  });
+});
+
+describe("collectChangeSet — injectable execFile", () => {
+  it("routes the canned git output through the parser", async () => {
+    const stdout = "\x1edeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\x1ffeat: c\x1fC\x1f2026-05-03T00:00:00Z\nfile.ts\n";
+    const execFile = vi.fn().mockResolvedValue({ stdout });
+    const out = await collectChangeSet(
+      {
+        currentLineageSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        targetSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        config: { hostSourcePath: "/host-dpf" },
+      },
+      { execFile },
+    );
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.subject).toBe("feat: c");
+    expect(out[0]!.files).toEqual(["file.ts"]);
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/change-set.ts
+++ b/apps/web/lib/self-upgrade/impact/change-set.ts
@@ -1,0 +1,111 @@
+// apps/web/lib/self-upgrade/impact/change-set.ts
+//
+// Collect the upstream change set as RawCommit[] from `git log <a>..<b>` over
+// the host clone — mirrors the no-auth read pattern used by
+// resolveTargetSha in apps/web/lib/self-upgrade/version.ts (same execFile
+// dep injection, same HOST_SOURCE_PATH default). No git fetch here — the
+// caller is expected to have already run buildFetchCommand before
+// resolveTargetSha, so the upstream ref is fresh.
+
+import type { RawCommit } from "./types";
+
+// ASCII Unit Separator + Record Separator — chosen because neither byte
+// appears in commit subjects or file paths, so splitting on them is safe.
+// Spelled with \x escapes so the source file stays all-ASCII-printable.
+const FIELD_SEP = "\x1f";
+const RECORD_SEP = "\x1e";
+const FORMAT = [
+  `${RECORD_SEP}%H`,
+  "%s",
+  "%an",
+  "%aI",
+].join(FIELD_SEP);
+
+export type GitLogDeps = {
+  execFile: (cmd: string, args: string[]) => Promise<{ stdout: string }>;
+};
+
+export type GitLogConfig = {
+  hostSourcePath?: string;
+};
+
+async function defaultExecFile(cmd: string, args: string[]): Promise<{ stdout: string }> {
+  const { execFile: nodeExecFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execAsync = promisify(nodeExecFile);
+  // 10MB cap — DPF rarely has >10k changed files between lineage SHAs, but
+  // capping here keeps a runaway log from OOM'ing the portal.
+  const result = await execAsync(cmd, args, { maxBuffer: 10 * 1024 * 1024 });
+  return { stdout: result.stdout.toString() };
+}
+
+/** Build `git log` argv for the lineage-to-target range. */
+export function buildLogCommand(input: {
+  hostSourcePath: string;
+  currentLineageSha: string;
+  targetSha: string;
+}): string[] {
+  return [
+    "git",
+    "-C",
+    input.hostSourcePath,
+    "log",
+    "--reverse",
+    "--no-merges",
+    "--name-only",
+    `--format=${FORMAT}`,
+    `${input.currentLineageSha}..${input.targetSha}`,
+  ];
+}
+
+/** Parse the raw stdout of `git log` (above format) into RawCommit[]. */
+export function parseGitLogOutput(stdout: string): RawCommit[] {
+  if (!stdout.trim()) return [];
+  // Records start with RECORD_SEP, so the first split chunk is empty - drop it.
+  const records = stdout.split(RECORD_SEP).slice(1);
+  const out: RawCommit[] = [];
+  for (const record of records) {
+    // record shape: <sha><FIELD_SEP><subject><FIELD_SEP><author><FIELD_SEP><authorDate>\n<file1>\n<file2>...
+    const newlineIdx = record.indexOf("\n");
+    const headerLine = newlineIdx === -1 ? record : record.slice(0, newlineIdx);
+    const rest = newlineIdx === -1 ? "" : record.slice(newlineIdx + 1);
+
+    const parts = headerLine.split(FIELD_SEP);
+    if (parts.length < 4 || !parts[0]) continue;
+    const [sha, subject, author, authorDate] = parts;
+
+    const files = rest
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    out.push({
+      sha: sha!,
+      subject: (subject ?? "").trim(),
+      author: (author ?? "").trim(),
+      authorDate: (authorDate ?? "").trim(),
+      files,
+    });
+  }
+  return out;
+}
+
+/** Collect the lineage-to-target change set from the host clone. */
+export async function collectChangeSet(
+  input: {
+    currentLineageSha: string;
+    targetSha: string;
+    config?: GitLogConfig;
+  },
+  deps: GitLogDeps = { execFile: defaultExecFile },
+): Promise<RawCommit[]> {
+  const hostSourcePath =
+    input.config?.hostSourcePath ?? process.env["HOST_SOURCE_PATH"] ?? "/workspace";
+  const [, ...gitArgs] = buildLogCommand({
+    hostSourcePath,
+    currentLineageSha: input.currentLineageSha,
+    targetSha: input.targetSha,
+  });
+  const { stdout } = await deps.execFile("git", gitArgs);
+  return parseGitLogOutput(stdout);
+}

--- a/apps/web/lib/self-upgrade/impact/classify.test.ts
+++ b/apps/web/lib/self-upgrade/impact/classify.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { countCategories, orderForFullList } from "./classify";
+import { parseCommit } from "./conventional";
+import type { RawCommit } from "./types";
+
+function raw(subject: string, date = "2026-05-01T00:00:00Z"): RawCommit {
+  return {
+    sha: "0000000000000000000000000000000000000000",
+    subject,
+    author: "Test",
+    authorDate: date,
+    files: [],
+  };
+}
+
+describe("countCategories", () => {
+  it("buckets parsed commits and reports a total", () => {
+    const commits = [
+      parseCommit(raw("feat: a")),
+      parseCommit(raw("feat: b")),
+      parseCommit(raw("fix: c")),
+      parseCommit(raw("perf: d")),
+      parseCommit(raw("docs: e")),
+      parseCommit(raw("feat!: f")),
+    ];
+    expect(countCategories(commits)).toEqual({
+      breaking: 1,
+      feature: 2,
+      fix: 1,
+      performance: 1,
+      other: 1,
+      total: 6,
+    });
+  });
+
+  it("yields zeros and total=0 for empty input", () => {
+    expect(countCategories([])).toEqual({
+      breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0,
+    });
+  });
+});
+
+describe("orderForFullList", () => {
+  it("orders breaking → feature → perf → fix → other, newest first within bucket", () => {
+    const commits = [
+      parseCommit(raw("fix: older", "2026-04-01T00:00:00Z")),
+      parseCommit(raw("feat!: breaking new", "2026-04-15T00:00:00Z")),
+      parseCommit(raw("feat: new feature", "2026-05-01T00:00:00Z")),
+      parseCommit(raw("fix: newer fix", "2026-05-15T00:00:00Z")),
+      parseCommit(raw("docs: dox", "2026-05-20T00:00:00Z")),
+      parseCommit(raw("perf: fast", "2026-05-10T00:00:00Z")),
+    ];
+    const ordered = orderForFullList(commits);
+    expect(ordered.map((c) => c.category)).toEqual([
+      "breaking",
+      "feature",
+      "performance",
+      "fix",
+      "fix",
+      "other",
+    ]);
+    // Within the two fixes, newer first.
+    expect(ordered[3]!.authorDate).toBe("2026-05-15T00:00:00Z");
+    expect(ordered[4]!.authorDate).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/classify.ts
+++ b/apps/web/lib/self-upgrade/impact/classify.ts
@@ -1,0 +1,42 @@
+// apps/web/lib/self-upgrade/impact/classify.ts
+//
+// Pure aggregation over ParsedCommit[] — counts that feed the headline and
+// the deterministic ordering rule for the foldable "all items" view.
+
+import type { ImpactCategoryCounts, ParsedCommit } from "./types";
+
+export function countCategories(commits: ParsedCommit[]): ImpactCategoryCounts {
+  const counts: ImpactCategoryCounts = {
+    breaking: 0,
+    feature: 0,
+    fix: 0,
+    performance: 0,
+    other: 0,
+    total: commits.length,
+  };
+  for (const c of commits) {
+    counts[c.category] += 1;
+  }
+  return counts;
+}
+
+const CATEGORY_RANK: Record<ParsedCommit["category"], number> = {
+  breaking: 0,
+  feature: 1,
+  performance: 2,
+  fix: 3,
+  other: 4,
+};
+
+/**
+ * Ordering for the full foldable list: breaking → feature → perf → fix → other,
+ * stable within bucket by author date descending (newest first).
+ */
+export function orderForFullList(commits: ParsedCommit[]): ParsedCommit[] {
+  return [...commits].sort((a, b) => {
+    const rankDiff = CATEGORY_RANK[a.category] - CATEGORY_RANK[b.category];
+    if (rankDiff !== 0) return rankDiff;
+    // Within bucket, newer first.
+    return b.authorDate.localeCompare(a.authorDate);
+  });
+}

--- a/apps/web/lib/self-upgrade/impact/conventional.test.ts
+++ b/apps/web/lib/self-upgrade/impact/conventional.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { categoryFor, parseCommit, parseCommits } from "./conventional";
+import type { RawCommit } from "./types";
+
+function raw(subject: string, overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    sha: "0000000000000000000000000000000000000000",
+    subject,
+    author: "Test",
+    authorDate: "2026-05-01T00:00:00Z",
+    files: [],
+    ...overrides,
+  };
+}
+
+describe("categoryFor", () => {
+  it("breaking trumps the type bucket", () => {
+    expect(categoryFor("feat", true)).toBe("breaking");
+    expect(categoryFor("fix", true)).toBe("breaking");
+  });
+  it("maps feat/fix/perf to their buckets and the rest to other", () => {
+    expect(categoryFor("feat", false)).toBe("feature");
+    expect(categoryFor("fix", false)).toBe("fix");
+    expect(categoryFor("perf", false)).toBe("performance");
+    expect(categoryFor("refactor", false)).toBe("other");
+    expect(categoryFor("docs", false)).toBe("other");
+    expect(categoryFor("chore", false)).toBe("other");
+    expect(categoryFor("unknown", false)).toBe("other");
+  });
+});
+
+describe("parseCommit", () => {
+  it("parses type, scope, breaking, description, and PR number from a DPF-shaped subject", () => {
+    const parsed = parseCommit(raw("feat(self-upgrade)!: ship merge-based source prep (#1272)"));
+    expect(parsed).toMatchObject({
+      type: "feat",
+      scope: "self-upgrade",
+      breaking: true,
+      description: "ship merge-based source prep",
+      prNumber: 1272,
+      category: "breaking",
+    });
+  });
+
+  it("handles scope-less subjects", () => {
+    const parsed = parseCommit(raw("fix: settings page reflects the org's applied profile"));
+    expect(parsed.type).toBe("fix");
+    expect(parsed.scope).toBeNull();
+    expect(parsed.breaking).toBe(false);
+    expect(parsed.category).toBe("fix");
+    expect(parsed.description).toBe("settings page reflects the org's applied profile");
+    expect(parsed.prNumber).toBeNull();
+  });
+
+  it("preserves multi-word scopes like (web,infra)", () => {
+    const parsed = parseCommit(raw("feat(web,infra): Health tab full observability coverage (#1355)"));
+    expect(parsed.scope).toBe("web,infra");
+    expect(parsed.prNumber).toBe(1355);
+  });
+
+  it("falls back to type=unknown and full subject for non-Conventional lines", () => {
+    const parsed = parseCommit(raw("Updated some stuff because reasons"));
+    expect(parsed.type).toBe("unknown");
+    expect(parsed.scope).toBeNull();
+    expect(parsed.breaking).toBe(false);
+    expect(parsed.category).toBe("other");
+    expect(parsed.description).toBe("Updated some stuff because reasons");
+  });
+
+  it("strips PR ref from description but keeps it on prNumber", () => {
+    const parsed = parseCommit(raw("docs: add note (#999)"));
+    expect(parsed.description).toBe("add note");
+    expect(parsed.prNumber).toBe(999);
+  });
+
+  it("recognises unknown types as `unknown` rather than crashing", () => {
+    const parsed = parseCommit(raw("blorp(thing): mystery change"));
+    expect(parsed.type).toBe("unknown");
+    expect(parsed.category).toBe("other");
+  });
+
+  it("parseCommits is the bulk wrapper", () => {
+    const out = parseCommits([raw("feat: a"), raw("fix: b")]);
+    expect(out.map((c) => c.category)).toEqual(["feature", "fix"]);
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/conventional.ts
+++ b/apps/web/lib/self-upgrade/impact/conventional.ts
@@ -1,0 +1,89 @@
+// apps/web/lib/self-upgrade/impact/conventional.ts
+//
+// Conventional Commits 1.0.0 subject parser, narrowed to the subset DPF
+// actually emits. DPF squashes PRs with Conventional Commit subjects
+// (`feat(scope): subject (#1234)`), so the SUBJECT is the load-bearing
+// signal — body trailers are rarely populated on squashed merges.
+//
+// Pure function, no I/O. Tested directly.
+
+import type { ChangeCategory, ConventionalType, ParsedCommit, RawCommit } from "./types";
+
+// `type(scope)!: description (#1234)` — scope and `!` and `(#nn)` optional.
+// We intentionally accept a permissive scope ([^)]+) so multi-word scopes
+// like `(self-upgrade)` and `(web,infra)` both parse.
+const CONVENTIONAL_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<bang>!)?:\s+(?<body>.+?)$/;
+const TRAILING_PR_RE = /\s*\(#(\d+)\)\s*$/;
+
+const KNOWN_TYPES: ReadonlySet<ConventionalType> = new Set<ConventionalType>([
+  "feat", "fix", "perf", "refactor", "docs", "chore",
+  "test", "build", "ci", "style", "revert",
+]);
+
+/** Map a Conventional type + breaking marker to an ImpactCategory bucket. */
+export function categoryFor(type: ConventionalType, breaking: boolean): ChangeCategory {
+  if (breaking) return "breaking";
+  switch (type) {
+    case "feat": return "feature";
+    case "fix": return "fix";
+    case "perf": return "performance";
+    // refactor / docs / chore / test / build / ci / style / revert / unknown
+    // all aggregate as "other" — the headline groups them together, but the
+    // per-item scoring keeps refactors visible if they touch a customized path.
+    default: return "other";
+  }
+}
+
+/**
+ * Parse one raw commit. Returns a ParsedCommit with `type: "unknown"` and the
+ * full subject in `description` when the subject is not Conventional — those
+ * still flow through scoring + phrasing as `other`, never dropped.
+ */
+export function parseCommit(raw: RawCommit): ParsedCommit {
+  const subject = raw.subject.trim();
+
+  // Extract trailing `(#1234)` first so it doesn't end up in the description.
+  let withoutPr = subject;
+  let prNumber: number | null = null;
+  const prMatch = withoutPr.match(TRAILING_PR_RE);
+  if (prMatch && prMatch[1]) {
+    prNumber = Number.parseInt(prMatch[1], 10);
+    withoutPr = withoutPr.replace(TRAILING_PR_RE, "").trim();
+  }
+
+  const m = withoutPr.match(CONVENTIONAL_RE);
+  if (!m || !m.groups) {
+    return {
+      ...raw,
+      type: "unknown",
+      scope: null,
+      breaking: false,
+      description: subject, // fall back to original subject (incl. PR ref)
+      prNumber,
+      category: categoryFor("unknown", false),
+    };
+  }
+
+  const rawType = m.groups["type"]!;
+  const type: ConventionalType = (KNOWN_TYPES as ReadonlySet<string>).has(rawType)
+    ? (rawType as ConventionalType)
+    : "unknown";
+  const scope = m.groups["scope"] ?? null;
+  const breaking = m.groups["bang"] === "!";
+  const description = m.groups["body"]!.trim();
+
+  return {
+    ...raw,
+    type,
+    scope,
+    breaking,
+    description,
+    prNumber,
+    category: categoryFor(type, breaking),
+  };
+}
+
+/** Bulk parser convenience. */
+export function parseCommits(raw: RawCommit[]): ParsedCommit[] {
+  return raw.map(parseCommit);
+}

--- a/apps/web/lib/self-upgrade/impact/index.test.ts
+++ b/apps/web/lib/self-upgrade/impact/index.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { summarizeUpgradeImpact } from "./index";
+import { _resetCacheForTest } from "./cache";
+import type { InstallSignals, RawCommit } from "./types";
+
+afterEach(() => {
+  _resetCacheForTest();
+  vi.clearAllMocks();
+});
+
+const SIGNALS: InstallSignals = {
+  archetypeId: "field-service",
+  industry: "field-service",
+  customizationPaths: ["apps/web/lib/field-service/"],
+  customizationVerticals: ["field-service"],
+  openIssueKeywords: ["dispatch"],
+  relevantPrLabels: ["field-service"],
+};
+
+function rawCommit(subject: string, files: string[] = [], sha = "0".padEnd(40, "0")): RawCommit {
+  return {
+    sha,
+    subject,
+    author: "X",
+    authorDate: "2026-05-01T00:00:00Z",
+    files,
+  };
+}
+
+describe("summarizeUpgradeImpact — orchestrator", () => {
+  it("returns no-lineage when there is no succeeded run on record", async () => {
+    const out = await summarizeUpgradeImpact({}, {
+      loadCurrentLineageSha: async () => null,
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [],
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "no-lineage" });
+  });
+
+  it("returns no-target when the upstream HEAD cannot be resolved", async () => {
+    const out = await summarizeUpgradeImpact({}, {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => null,
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [],
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "no-target" });
+  });
+
+  it("returns lineage-equals-target when there is nothing to summarize", async () => {
+    const sha = "a".repeat(40);
+    const out = await summarizeUpgradeImpact({}, {
+      loadCurrentLineageSha: async () => sha,
+      loadTargetSha: async () => sha,
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [],
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "lineage-equals-target" });
+  });
+
+  it("builds a scored, ordered summary and threads enrichment + signals through", async () => {
+    const out = await summarizeUpgradeImpact({ skipPhrasing: true }, {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [
+        rawCommit("feat!: bk", [], "1".repeat(40)),
+        rawCommit("fix(field-service): dispatch fix", ["apps/web/lib/field-service/dispatch.ts"], "2".repeat(40)),
+        rawCommit("chore: noise", [], "3".repeat(40)),
+      ],
+      enrichPrs: async () => ({ reachable: true, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.summary.counts.total).toBe(3);
+    expect(out.summary.counts.breaking).toBe(1);
+    expect(out.summary.allItems.length).toBe(3);
+    // Breaking change ranks first.
+    expect(out.summary.allItems[0]!.category).toBe("breaking");
+    // Field-service fix is amplified by archetype+path+keyword overlap; it
+    // outscores the chore commit and should land in the top items above it.
+    const fieldFix = out.summary.allItems.find((i) => i.scope === "field-service")!;
+    const chore = out.summary.allItems.find((i) => i.type === "chore")!;
+    expect(fieldFix.score).toBeGreaterThan(chore.score);
+    expect(fieldFix.touchesCustomizations).toBe(true);
+    expect(out.summary.enrichment.githubReachable).toBe(true);
+  });
+
+  it("returns git-log-failed when the change-set collector throws", async () => {
+    const out = await summarizeUpgradeImpact({}, {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => { throw new Error("fatal: bad revision"); },
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "git-log-failed" });
+  });
+
+  it("serves the cached summary on the second call and marks fromCache=true", async () => {
+    const change = vi.fn().mockResolvedValue([rawCommit("feat: x", [], "1".repeat(40))]);
+    const deps = {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: change,
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    };
+    const first = await summarizeUpgradeImpact({ skipPhrasing: true }, deps);
+    const second = await summarizeUpgradeImpact({ skipPhrasing: true }, deps);
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.summary.fromCache).toBe(true);
+  });
+
+  it("refresh=true bypasses the cache and reruns the change-set collector", async () => {
+    const change = vi.fn().mockResolvedValue([rawCommit("feat: x", [], "1".repeat(40))]);
+    const deps = {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: change,
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    };
+    await summarizeUpgradeImpact({ skipPhrasing: true }, deps);
+    await summarizeUpgradeImpact({ skipPhrasing: true, refresh: true }, deps);
+    expect(change).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -1,0 +1,172 @@
+// apps/web/lib/self-upgrade/impact/index.ts
+//
+// Orchestrator for the on-demand "What's in this update?" impact summary
+// (BI-C26F7EE1). Cacheable per (currentLineageSha, targetSha).
+//
+// Resolution order:
+//   1. currentLineageSha = latest succeeded SelfUpgradeRun.targetSha
+//      (the upstream marker — see run-store.ts getLatestSucceededRun).
+//   2. targetSha = resolved upstream HEAD (version.ts resolveTargetSha).
+//   3. If lineage is missing or already equals target -> SummaryNotApplicable.
+//   4. Otherwise: collect change set -> classify -> score -> phrase -> cache.
+
+import { getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { resolveTargetSha } from "@/lib/self-upgrade/version";
+import { cacheKey, getCached, setCached } from "./cache";
+import { collectChangeSet } from "./change-set";
+import { collectInstallSignals } from "./install-signals";
+import { parseCommits } from "./conventional";
+import { countCategories } from "./classify";
+import { enrichPrs } from "./pr-enrich";
+import { orderByImpact, scoreCommits } from "./score";
+import { phraseSummary } from "./phrase";
+import {
+  DEFAULT_TOP_N,
+  type InstallSignals,
+  type SummaryResult,
+  type UpgradeImpactSummary,
+} from "./types";
+
+export type SummarizeOptions = {
+  /** Force a fresh computation, bypassing the per-process cache. */
+  refresh?: boolean;
+  /** Cap on items returned in the top-N list (default DEFAULT_TOP_N). */
+  topN?: number;
+  /** Skip LLM phrasing — useful for tests / when LLM provider is offline. */
+  skipPhrasing?: boolean;
+};
+
+export type SummarizeDeps = {
+  loadCurrentLineageSha?: () => Promise<string | null>;
+  loadTargetSha?: () => Promise<string | null>;
+  loadInstallSignals?: () => Promise<InstallSignals>;
+  loadChangeSet?: (input: { currentLineageSha: string; targetSha: string }) => Promise<
+    Awaited<ReturnType<typeof collectChangeSet>>
+  >;
+  enrichPrs?: typeof enrichPrs;
+  phraseSummary?: typeof phraseSummary;
+};
+
+async function defaultLoadCurrentLineageSha(): Promise<string | null> {
+  const run = await getLatestSucceededRun();
+  // The upstream lineage marker is the targetSha of the latest succeeded run
+  // (the upstream commit absorbed into the running build) — NOT deployedSha,
+  // which in merge mode is the merge-commit identity (see run-store.ts).
+  return run?.targetSha ?? null;
+}
+
+async function defaultLoadTargetSha(): Promise<string | null> {
+  return resolveTargetSha("operator-impact-summary");
+}
+
+/**
+ * Compute the on-demand impact summary. Returns a discriminated
+ * `SummaryResult` — orchestrator never throws on missing data; instead it
+ * surfaces a typed `ok: false` reason the UI can render plainly.
+ */
+export async function summarizeUpgradeImpact(
+  options: SummarizeOptions = {},
+  deps: SummarizeDeps = {},
+): Promise<SummaryResult> {
+  const loadCurrentLineageSha = deps.loadCurrentLineageSha ?? defaultLoadCurrentLineageSha;
+  const loadTargetSha = deps.loadTargetSha ?? defaultLoadTargetSha;
+  const loadInstallSignals = deps.loadInstallSignals ?? (() => collectInstallSignals());
+  const loadChangeSet = deps.loadChangeSet ?? ((input) => collectChangeSet(input));
+  const enrich = deps.enrichPrs ?? enrichPrs;
+  const phrase = deps.phraseSummary ?? phraseSummary;
+
+  const currentLineageSha = await loadCurrentLineageSha();
+  const targetSha = await loadTargetSha();
+
+  if (!currentLineageSha) {
+    return {
+      ok: false,
+      reason: "no-lineage",
+      detail:
+        "No succeeded self-upgrade run on record, so there's no upstream lineage marker to compare against. Run a self-upgrade once to seed the marker, or apply this upgrade without a summary.",
+    };
+  }
+  if (!targetSha) {
+    return {
+      ok: false,
+      reason: "no-target",
+      detail:
+        "Could not resolve the upstream target SHA. Confirm the host clone has a fresh fetch of the configured remote/branch.",
+    };
+  }
+  if (currentLineageSha === targetSha) {
+    return {
+      ok: false,
+      reason: "lineage-equals-target",
+      detail:
+        "The running build already contains the upstream target — there is nothing to summarize. The upstream lineage marker matches the resolved target.",
+    };
+  }
+
+  if (!options.refresh) {
+    const cached = getCached(currentLineageSha, targetSha);
+    if (cached && cached.ok) {
+      return { ok: true, summary: { ...cached.summary, fromCache: true } };
+    }
+    if (cached && !cached.ok) return cached;
+  }
+
+  let raw;
+  try {
+    raw = await loadChangeSet({ currentLineageSha, targetSha });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const result: SummaryResult = { ok: false, reason: "git-log-failed", detail };
+    setCached(currentLineageSha, targetSha, result);
+    return result;
+  }
+
+  // No commits but range was valid (e.g. fast-forward with no merge commits)
+  // — still surface a usable summary with empty items.
+  const commits = parseCommits(raw);
+  const counts = countCategories(commits);
+  const signals = await loadInstallSignals();
+
+  const prNumbers = commits
+    .map((c) => c.prNumber)
+    .filter((n): n is number => typeof n === "number");
+  const enrichment = await enrich(prNumbers);
+
+  const scored = scoreCommits({
+    commits,
+    signals,
+    enrichmentByPr: enrichment.byPr,
+  });
+  const allItems = orderByImpact(scored);
+  const topN = options.topN ?? DEFAULT_TOP_N;
+  const topItems = allItems.slice(0, topN);
+
+  let phrased = null;
+  if (!options.skipPhrasing && topItems.length > 0) {
+    phrased = await phrase(
+      { items: topItems, counts, signals },
+    );
+  }
+
+  const summary: UpgradeImpactSummary = {
+    currentLineageSha,
+    targetSha,
+    counts,
+    topItems,
+    allItems,
+    phrased,
+    enrichment: {
+      githubReachable: enrichment.reachable,
+      prsEnriched: enrichment.enriched,
+    },
+    generatedAt: new Date().toISOString(),
+    fromCache: false,
+  };
+
+  const result: SummaryResult = { ok: true, summary };
+  setCached(currentLineageSha, targetSha, result);
+  return result;
+}
+
+export { cacheKey };
+export * from "./types";

--- a/apps/web/lib/self-upgrade/impact/install-signals.ts
+++ b/apps/web/lib/self-upgrade/impact/install-signals.ts
@@ -1,0 +1,139 @@
+// apps/web/lib/self-upgrade/impact/install-signals.ts
+//
+// Collect the install-state signals used to score upstream commits' relevance
+// to THIS install. All reads go through prisma; missing rows return empty
+// values rather than throwing — relevance scoring degrades gracefully when
+// the install has no storefront yet.
+//
+// Customization paths today come from FeaturePack manifests — these are the
+// only DB-visible record of what an install has customized vs. stock. The
+// future `client/<id>` install-branch (spec §5.0.1) will give a richer
+// signal; this collector is shaped to absorb it as another input layer
+// without changing the public type.
+
+import { prisma } from "@dpf/db";
+import type { InstallSignals } from "./types";
+
+// Conservative cap so a runaway customization list can't poison scoring;
+// well above any realistic install's customization count.
+const MAX_CUSTOMIZATION_PATHS = 200;
+const MAX_OPEN_ISSUE_KEYWORDS = 50;
+
+/**
+ * Tiny stopword list — words too generic to be a useful keyword signal.
+ * Issue summaries hand us natural English; without filtering we'd light up
+ * every commit that mentioned "the" or "fix".
+ */
+const STOPWORDS = new Set([
+  "the", "and", "for", "with", "this", "that", "from", "into", "when",
+  "have", "has", "are", "was", "were", "but", "not", "all", "any",
+  "fix", "bug", "issue", "error", "fails", "failed", "broken",
+  "feature", "feat", "chore", "doc", "docs",
+  "platform", "portal", "dpf", "install", "user", "users",
+]);
+
+function keywordsFromSummary(summary: string): string[] {
+  return summary
+    .split(/[^A-Za-z0-9]+/)
+    .map((w) => w.toLowerCase())
+    .filter((w) => w.length >= 4 && !STOPWORDS.has(w));
+}
+
+type ManifestShape = {
+  files?: unknown;
+  paths?: unknown;
+  changedFiles?: unknown;
+};
+
+function extractManifestPaths(manifest: unknown): string[] {
+  if (!manifest || typeof manifest !== "object") return [];
+  const m = manifest as ManifestShape;
+  const candidates: unknown[] = [];
+  if (Array.isArray(m.files)) candidates.push(...m.files);
+  if (Array.isArray(m.paths)) candidates.push(...m.paths);
+  if (Array.isArray(m.changedFiles)) candidates.push(...m.changedFiles);
+  return candidates
+    .filter((p): p is string => typeof p === "string" && p.trim().length > 0)
+    .map((p) => p.trim());
+}
+
+export type InstallSignalsDeps = {
+  /** Override for tests / non-prisma callers. */
+  loader?: () => Promise<InstallSignals>;
+};
+
+export async function collectInstallSignals(deps: InstallSignalsDeps = {}): Promise<InstallSignals> {
+  if (deps.loader) return deps.loader();
+
+  // Storefront archetype — single source of truth for portal industry.
+  const storefront = await prisma.storefrontConfig.findFirst({
+    select: { archetypeId: true },
+  });
+  const archetypeId = storefront?.archetypeId ?? null;
+
+  const organization = await prisma.organization.findFirst({
+    select: { industry: true },
+  });
+  const industry = organization?.industry ?? null;
+
+  // FeaturePacks — anything not strictly "stock" is a customization signal.
+  // We exclude `status="stock"` if anyone ever introduces that label; today
+  // the default is "local". Either way, every FeaturePack row represents
+  // operator-visible customization.
+  const packs = await prisma.featurePack.findMany({
+    select: {
+      manifest: true,
+      sourceVertical: true,
+      applicableVerticals: true,
+      status: true,
+    },
+  });
+
+  const customizationPaths = new Set<string>();
+  const customizationVerticals = new Set<string>();
+  for (const pack of packs) {
+    for (const p of extractManifestPaths(pack.manifest)) {
+      customizationPaths.add(p);
+      if (customizationPaths.size >= MAX_CUSTOMIZATION_PATHS) break;
+    }
+    if (pack.sourceVertical) customizationVerticals.add(pack.sourceVertical);
+    for (const v of pack.applicableVerticals) customizationVerticals.add(v);
+  }
+
+  // Open quality issues — surface keywords so commits whose subjects match
+  // pop up the relevance ranking.
+  const issues = await prisma.portfolioQualityIssue.findMany({
+    where: { status: "open" },
+    select: { summary: true },
+    take: 100, // bounded
+  });
+
+  const keywordCounter = new Map<string, number>();
+  for (const issue of issues) {
+    for (const kw of keywordsFromSummary(issue.summary)) {
+      keywordCounter.set(kw, (keywordCounter.get(kw) ?? 0) + 1);
+    }
+  }
+  // Take the most frequent keywords — these are the install's "hot" themes.
+  const openIssueKeywords = [...keywordCounter.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_OPEN_ISSUE_KEYWORDS)
+    .map(([kw]) => kw);
+
+  // PR labels relevant to this install — coarse heuristic: include the
+  // archetype id and any customization vertical as labels we'd consider a
+  // match. We deliberately do NOT pull from an external label registry here;
+  // that's a heuristic, and we err on the side of fewer false positives.
+  const relevantPrLabels: string[] = [];
+  if (archetypeId) relevantPrLabels.push(archetypeId.toLowerCase());
+  for (const v of customizationVerticals) relevantPrLabels.push(v.toLowerCase());
+
+  return {
+    archetypeId,
+    industry,
+    customizationPaths: [...customizationPaths],
+    customizationVerticals: [...customizationVerticals],
+    openIssueKeywords,
+    relevantPrLabels,
+  };
+}

--- a/apps/web/lib/self-upgrade/impact/phrase.test.ts
+++ b/apps/web/lib/self-upgrade/impact/phrase.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { phraseSummary } from "./phrase";
+import type { ImpactCategoryCounts, ImpactItem, InstallSignals } from "./types";
+
+const emptyCounts: ImpactCategoryCounts = {
+  breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0,
+};
+
+const emptySignals: InstallSignals = {
+  archetypeId: null, industry: null,
+  customizationPaths: [], customizationVerticals: [], openIssueKeywords: [], relevantPrLabels: [],
+};
+
+const baseItem: ImpactItem = {
+  sha: "x".repeat(40),
+  description: "do thing",
+  type: "feat",
+  scope: null,
+  category: "feature",
+  breaking: false,
+  prNumber: null,
+  prTitle: null,
+  prLabels: [],
+  score: 50,
+  reasons: [{ kind: "base-weight" }],
+  touchesCustomizations: false,
+};
+
+describe("phraseSummary", () => {
+  it("returns the parsed phrasing when the LLM responds with valid JSON of matching length", async () => {
+    const llm = vi.fn().mockResolvedValue({
+      text: JSON.stringify({
+        headline: "1 new feature since your last upgrade.",
+        itemPhrasings: [{ description: "Adds a thing.", whyRelevant: "" }],
+        touchesCustomizationsCallout: "",
+      }),
+    });
+    const out = await phraseSummary(
+      { items: [baseItem], counts: { ...emptyCounts, feature: 1, total: 1 }, signals: emptySignals },
+      { llm },
+    );
+    expect(out).toEqual({
+      headline: "1 new feature since your last upgrade.",
+      itemPhrasings: [{ description: "Adds a thing.", whyRelevant: "" }],
+      touchesCustomizationsCallout: "",
+    });
+  });
+
+  it("tolerates LLM responses wrapped in ```json fences", async () => {
+    const llm = vi.fn().mockResolvedValue({
+      text:
+        "```json\n" +
+        JSON.stringify({
+          headline: "ok",
+          itemPhrasings: [{ description: "ok", whyRelevant: "" }],
+          touchesCustomizationsCallout: "",
+        }) +
+        "\n```",
+    });
+    const out = await phraseSummary(
+      { items: [baseItem], counts: emptyCounts, signals: emptySignals },
+      { llm },
+    );
+    expect(out?.headline).toBe("ok");
+  });
+
+  it("returns null when length mismatches input items (no silent fabrication)", async () => {
+    const llm = vi.fn().mockResolvedValue({
+      text: JSON.stringify({
+        headline: "ok",
+        itemPhrasings: [
+          { description: "a", whyRelevant: "" },
+          { description: "b", whyRelevant: "" },
+        ],
+        touchesCustomizationsCallout: "",
+      }),
+    });
+    const out = await phraseSummary(
+      { items: [baseItem], counts: emptyCounts, signals: emptySignals },
+      { llm },
+    );
+    expect(out).toBeNull();
+  });
+
+  it("returns null when JSON is malformed", async () => {
+    const llm = vi.fn().mockResolvedValue({ text: "not json at all" });
+    const out = await phraseSummary(
+      { items: [baseItem], counts: emptyCounts, signals: emptySignals },
+      { llm },
+    );
+    expect(out).toBeNull();
+  });
+
+  it("returns null when LLM throws", async () => {
+    const llm = vi.fn().mockRejectedValue(new Error("offline"));
+    const out = await phraseSummary(
+      { items: [baseItem], counts: emptyCounts, signals: emptySignals },
+      { llm },
+    );
+    expect(out).toBeNull();
+  });
+
+  it("returns null when items list is empty (no point phrasing)", async () => {
+    const llm = vi.fn();
+    const out = await phraseSummary(
+      { items: [], counts: emptyCounts, signals: emptySignals },
+      { llm },
+    );
+    expect(out).toBeNull();
+    expect(llm).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/phrase.ts
+++ b/apps/web/lib/self-upgrade/impact/phrase.ts
@@ -1,0 +1,194 @@
+// apps/web/lib/self-upgrade/impact/phrase.ts
+//
+// LLM phrasing pass for the upgrade impact summary. The deterministic
+// pipeline (classify → score → order) is the contract; the LLM ONLY phrases.
+//
+// Hard constraints:
+//   1. The number and order of phrased items MUST match the input items.
+//   2. The LLM cannot add, drop, or reorder items.
+//   3. SHAs and file paths must NOT appear in the default operator view.
+//   4. If the LLM returns malformed JSON, length-mismatched output, or fails
+//      entirely, this module returns `null` and the orchestrator surfaces the
+//      raw deterministic shape — no fabricated phrasing.
+
+import { callLLM } from "@/lib/llm-call";
+import type {
+  ImpactCategoryCounts,
+  ImpactItem,
+  InstallSignals,
+  PhrasedImpactSummary,
+} from "./types";
+
+const SYSTEM_PROMPT = `You phrase a software upgrade impact summary for a non-technical operator.
+
+You will receive:
+- "install": short facts about the operator's portal (archetype, industry, customization themes).
+- "counts": totals per category that drive the headline.
+- "items": an ordered list of pre-scored changes. EACH ITEM has a stable index.
+
+Your job is ONLY phrasing. Follow these rules:
+
+1. Output strict JSON matching the schema below. No prose outside JSON.
+2. Produce EXACTLY one phrasing for each item, in the SAME order. Length must equal items.length.
+3. Do NOT add, drop, reorder, recategorize, or invent items.
+4. Do NOT include SHAs, file paths, commit hashes, or PR numbers in any field.
+5. Each item's "description" is ONE plain-English sentence (<=20 words) that says what changed.
+6. Each item's "whyRelevant" is ONE plain-English sentence (<=20 words) tied to install state — empty string when no install-specific reason exists.
+7. "headline" is ONE sentence summarising counts in plain English (e.g. "1 breaking change, 2 new features, and 5 fixes since your last upgrade.").
+8. "touchesCustomizationsCallout" is ONE sentence ONLY if any item has touchesCustomizations=true; otherwise empty string. Mention this may need merge review.
+9. If an item description is empty or just a type prefix, paraphrase it neutrally as "internal change" — do not invent details.
+
+Schema:
+{
+  "headline": string,
+  "itemPhrasings": [{ "description": string, "whyRelevant": string }, ...],
+  "touchesCustomizationsCallout": string
+}`;
+
+type LlmPayload = {
+  install: {
+    archetypeId: string | null;
+    industry: string | null;
+    customizationVerticals: string[];
+    openIssueKeywords: string[];
+  };
+  counts: ImpactCategoryCounts;
+  items: Array<{
+    index: number;
+    category: ImpactItem["category"];
+    type: ImpactItem["type"];
+    scope: string | null;
+    breaking: boolean;
+    description: string;
+    prTitle: string | null;
+    prLabels: string[];
+    touchesCustomizations: boolean;
+    reasonTags: string[];
+  }>;
+};
+
+function buildPayload(
+  items: ImpactItem[],
+  counts: ImpactCategoryCounts,
+  signals: InstallSignals,
+): LlmPayload {
+  return {
+    install: {
+      archetypeId: signals.archetypeId,
+      industry: signals.industry,
+      customizationVerticals: signals.customizationVerticals,
+      openIssueKeywords: signals.openIssueKeywords.slice(0, 12),
+    },
+    counts,
+    items: items.map((item, index) => ({
+      index,
+      category: item.category,
+      type: item.type,
+      scope: item.scope,
+      breaking: item.breaking,
+      description: item.description,
+      prTitle: item.prTitle,
+      prLabels: item.prLabels,
+      touchesCustomizations: item.touchesCustomizations,
+      reasonTags: item.reasons.map((r) => r.kind),
+    })),
+  };
+}
+
+/**
+ * Extract a parseable JSON object from raw LLM text. Models occasionally wrap
+ * JSON in ```json fences or prefix it with a one-line acknowledgement; we
+ * tolerate both rather than reject the whole call.
+ */
+function extractJsonObject(raw: string): string | null {
+  const trimmed = raw.trim();
+  // Strip ``` fences (with or without language tag).
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]+?)\s*```$/i);
+  const candidate = fenced && fenced[1] ? fenced[1].trim() : trimmed;
+  // Find the first `{` and the last `}`.
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}
+
+type ValidatedPhrasing = PhrasedImpactSummary;
+
+function validate(parsed: unknown, expectedLength: number): ValidatedPhrasing | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  const headline = typeof obj["headline"] === "string" ? obj["headline"].trim() : "";
+  const callout =
+    typeof obj["touchesCustomizationsCallout"] === "string"
+      ? obj["touchesCustomizationsCallout"].trim()
+      : "";
+  const rawItems = obj["itemPhrasings"];
+  if (!Array.isArray(rawItems) || rawItems.length !== expectedLength) return null;
+
+  const itemPhrasings: PhrasedImpactSummary["itemPhrasings"] = [];
+  for (const entry of rawItems) {
+    if (!entry || typeof entry !== "object") return null;
+    const e = entry as Record<string, unknown>;
+    const desc = typeof e["description"] === "string" ? e["description"].trim() : "";
+    const why = typeof e["whyRelevant"] === "string" ? e["whyRelevant"].trim() : "";
+    if (!desc) return null;
+    itemPhrasings.push({ description: desc, whyRelevant: why });
+  }
+
+  if (!headline) return null;
+  return { headline, itemPhrasings, touchesCustomizationsCallout: callout };
+}
+
+export type PhraseDeps = {
+  /** Override for tests. */
+  llm?: (input: { systemPrompt: string; userMessage: string; maxTokens?: number }) => Promise<{ text: string }>;
+};
+
+/**
+ * Run the phrasing pass. Returns null on any failure — caller is responsible
+ * for falling back to the raw deterministic shape rather than fabricating.
+ */
+export async function phraseSummary(
+  input: {
+    items: ImpactItem[];
+    counts: ImpactCategoryCounts;
+    signals: InstallSignals;
+  },
+  deps: PhraseDeps = {},
+): Promise<PhrasedImpactSummary | null> {
+  if (input.items.length === 0) return null;
+
+  const payload = buildPayload(input.items, input.counts, input.signals);
+  const llm = deps.llm ?? callLLM;
+
+  let result;
+  try {
+    result = await llm({
+      systemPrompt: SYSTEM_PROMPT,
+      userMessage: JSON.stringify(payload, null, 2),
+      maxTokens: 1200,
+    });
+  } catch (err) {
+    console.warn("[impact.phrase] llm call failed", err);
+    return null;
+  }
+
+  const jsonText = extractJsonObject(result.text);
+  if (!jsonText) {
+    console.warn("[impact.phrase] no JSON object found in LLM output");
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    console.warn("[impact.phrase] JSON parse failed", err);
+    return null;
+  }
+  const validated = validate(parsed, input.items.length);
+  if (!validated) {
+    console.warn("[impact.phrase] LLM output failed schema/length validation");
+    return null;
+  }
+  return validated;
+}

--- a/apps/web/lib/self-upgrade/impact/pr-enrich.ts
+++ b/apps/web/lib/self-upgrade/impact/pr-enrich.ts
@@ -1,0 +1,121 @@
+// apps/web/lib/self-upgrade/impact/pr-enrich.ts
+//
+// Best-effort GitHub PR enrichment for the impact summary. The pipeline
+// degrades gracefully when GitHub is unreachable — operators without a
+// `GITHUB_TOKEN` or network access still get a usable summary built from
+// commit subjects + file stats; this layer only adds PR title / labels /
+// truncated body when the upstream repo is reachable.
+//
+// Repo coords come from the `REPO_OWNER` / `REPO_NAME` env vars (defaulting
+// to the published DPF coordinates on docker-compose). Auth comes from
+// `GITHUB_TOKEN` (optional; unauthenticated calls work for the public repo
+// but at 60/h rate limit — we cap PR lookups accordingly).
+
+import type { PrEnrichment } from "./types";
+
+const DEFAULT_REPO_OWNER = "OpenDigitalProductFactory";
+const DEFAULT_REPO_NAME = "opendigitalproductfactory";
+const MAX_PRS_TO_ENRICH = 30; // bounded for rate-limit safety.
+const BODY_TRUNCATE = 400;
+const FETCH_TIMEOUT_MS = 4000;
+
+export type PrEnrichmentDeps = {
+  fetcher?: typeof fetch;
+};
+
+type GhPullResponse = {
+  title?: string;
+  body?: string | null;
+  labels?: Array<{ name?: string }>;
+};
+
+async function fetchPr(
+  prNumber: number,
+  owner: string,
+  repo: string,
+  token: string | undefined,
+  fetcher: typeof fetch,
+): Promise<PrEnrichment | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const resp = await fetcher(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+      { headers, signal: controller.signal },
+    );
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as GhPullResponse;
+    const labels = Array.isArray(data.labels)
+      ? data.labels
+          .map((l) => (typeof l?.name === "string" ? l.name.toLowerCase() : null))
+          .filter((n): n is string => !!n)
+      : [];
+    const body =
+      typeof data.body === "string" && data.body.length > 0
+        ? data.body.slice(0, BODY_TRUNCATE)
+        : null;
+    return {
+      prNumber,
+      title: typeof data.title === "string" ? data.title : null,
+      labels,
+      body,
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type PrEnrichmentResult = {
+  /** Whether at least one PR fetch succeeded — gates UI provenance line. */
+  reachable: boolean;
+  /** Number of PRs successfully enriched. */
+  enriched: number;
+  byPr: Map<number, PrEnrichment>;
+};
+
+/**
+ * Enrich up to N unique PR numbers. Best-effort: failures and missing tokens
+ * silently degrade the summary to commit-subject mode.
+ */
+export async function enrichPrs(
+  prNumbers: number[],
+  deps: PrEnrichmentDeps = {},
+): Promise<PrEnrichmentResult> {
+  const result: PrEnrichmentResult = {
+    reachable: false,
+    enriched: 0,
+    byPr: new Map(),
+  };
+
+  const unique = Array.from(new Set(prNumbers.filter((n) => Number.isFinite(n) && n > 0)));
+  if (unique.length === 0) return result;
+
+  const fetcher = deps.fetcher ?? globalThis.fetch;
+  if (typeof fetcher !== "function") return result;
+
+  const owner = process.env["REPO_OWNER"] ?? DEFAULT_REPO_OWNER;
+  const repo = process.env["REPO_NAME"] ?? DEFAULT_REPO_NAME;
+  const token = process.env["GITHUB_TOKEN"];
+
+  const capped = unique.slice(0, MAX_PRS_TO_ENRICH);
+  // Sequential — we explicitly do NOT parallelize so a flaky network or rate
+  // limit can't burst the cap. PR enrichment is non-critical; one cold
+  // request per ~30ms over 30 PRs is well under the timeout budget for the
+  // operator click.
+  for (const pr of capped) {
+    const enriched = await fetchPr(pr, owner, repo, token, fetcher);
+    if (enriched) {
+      result.reachable = true;
+      result.enriched += 1;
+      result.byPr.set(pr, enriched);
+    }
+  }
+  return result;
+}

--- a/apps/web/lib/self-upgrade/impact/score.test.ts
+++ b/apps/web/lib/self-upgrade/impact/score.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { orderByImpact, scoreCommits } from "./score";
+import { parseCommit } from "./conventional";
+import type { InstallSignals, ParsedCommit, PrEnrichment, RawCommit } from "./types";
+
+function raw(subject: string, files: string[] = [], date = "2026-05-01T00:00:00Z"): RawCommit {
+  return {
+    sha: "0".padEnd(40, "0"),
+    subject,
+    author: "Test",
+    authorDate: date,
+    files,
+  };
+}
+
+const emptySignals: InstallSignals = {
+  archetypeId: null,
+  industry: null,
+  customizationPaths: [],
+  customizationVerticals: [],
+  openIssueKeywords: [],
+  relevantPrLabels: [],
+};
+
+function commits(...subjects: ParsedCommit[]): ParsedCommit[] {
+  return subjects;
+}
+
+describe("scoreCommits — base weights", () => {
+  it("ranks breaking > feature > perf > fix > other when nothing matches install state", () => {
+    const c = commits(
+      parseCommit(raw("feat!: bk")),
+      parseCommit(raw("feat: f")),
+      parseCommit(raw("perf: p")),
+      parseCommit(raw("fix: x")),
+      parseCommit(raw("chore: o")),
+    );
+    const scored = scoreCommits({ commits: c, signals: emptySignals, enrichmentByPr: new Map() });
+    // base weights: 100, 50, 30, 25, 8
+    expect(scored.map((s) => s.score)).toEqual([100, 50, 30, 25, 8]);
+    expect(scored.map((s) => s.reasons[0]!.kind)).toEqual([
+      "breaking-change",
+      "base-weight",
+      "base-weight",
+      "base-weight",
+      "base-weight",
+    ]);
+  });
+});
+
+describe("scoreCommits — install relevance amplifies the right commits", () => {
+  it("archetype-scope match adds an archetype reason and bumps score", () => {
+    const c = commits(parseCommit(raw("feat(hvac): new estimate flow")));
+    const signals: InstallSignals = {
+      ...emptySignals,
+      archetypeId: "hvac",
+      industry: "field-service",
+    };
+    const scored = scoreCommits({ commits: c, signals, enrichmentByPr: new Map() });
+    expect(scored[0]!.reasons.map((r) => r.kind)).toContain("archetype-match");
+    // base 50 * 1.5 (archetype) = 75
+    expect(scored[0]!.score).toBe(75);
+  });
+
+  it("customization-path overlap surfaces touchesCustomizations + path-overlap reason", () => {
+    const c = commits(
+      parseCommit(raw("fix: dale dispatch bug", ["apps/web/lib/field-service/dispatch.ts"])),
+    );
+    const signals: InstallSignals = {
+      ...emptySignals,
+      customizationPaths: ["apps/web/lib/field-service/"],
+    };
+    const scored = scoreCommits({ commits: c, signals, enrichmentByPr: new Map() });
+    expect(scored[0]!.touchesCustomizations).toBe(true);
+    const overlap = scored[0]!.reasons.find((r) => r.kind === "customization-path-overlap");
+    expect(overlap).toBeDefined();
+    // base 25 (fix) * 1.6 (path overlap) = 40
+    expect(scored[0]!.score).toBe(40);
+  });
+
+  it("open-issue keyword hit lifts a small fix above an irrelevant feature", () => {
+    const fixCommit = parseCommit(raw("fix: dunning email duplicate send"));
+    const featCommit = parseCommit(raw("feat: archive view"));
+    const signals: InstallSignals = {
+      ...emptySignals,
+      openIssueKeywords: ["dunning"],
+    };
+    const scored = scoreCommits({ commits: [fixCommit, featCommit], signals, enrichmentByPr: new Map() });
+    // fix base 25 * 1.5 = 37; feat base 50 * 1.0 = 50 — feat still wins on raw weight.
+    // The keyword bump is a tie-breaker / signal that the operator should see this fix.
+    const fixScored = scored[0]!;
+    const featScored = scored[1]!;
+    expect(fixScored.reasons.some((r) => r.kind === "open-issue-keyword")).toBe(true);
+    expect(featScored.reasons.every((r) => r.kind !== "open-issue-keyword")).toBe(true);
+    expect(fixScored.score).toBeGreaterThan(25);
+  });
+
+  it("PR-label relevance adds to multiplier without doubling reasons", () => {
+    const c = commits(parseCommit(raw("feat: thing (#42)")));
+    const signals: InstallSignals = {
+      ...emptySignals,
+      relevantPrLabels: ["hvac"],
+    };
+    const enrichment = new Map<number, PrEnrichment>();
+    enrichment.set(42, { prNumber: 42, title: "Thing", body: null, labels: ["hvac", "ui"] });
+    const scored = scoreCommits({ commits: c, signals, enrichmentByPr: enrichment });
+    // base 50 * 1.3 (label match) = 65
+    expect(scored[0]!.score).toBe(65);
+  });
+});
+
+describe("orderByImpact", () => {
+  it("orders by score desc and breaks ties by category rank", () => {
+    const scored = scoreCommits({
+      commits: [
+        parseCommit(raw("feat: a")),       // 50
+        parseCommit(raw("feat!: b")),      // 100
+        parseCommit(raw("fix: c")),        // 25
+        parseCommit(raw("perf: d")),       // 30
+      ],
+      signals: emptySignals,
+      enrichmentByPr: new Map(),
+    });
+    const ordered = orderByImpact(scored);
+    expect(ordered.map((i) => i.category)).toEqual(["breaking", "feature", "performance", "fix"]);
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/score.ts
+++ b/apps/web/lib/self-upgrade/impact/score.ts
@@ -1,0 +1,177 @@
+// apps/web/lib/self-upgrade/impact/score.ts
+//
+// Pure relevance scoring. Pipeline contract: every commit becomes an
+// ImpactItem; the LLM never reorders, so this ordering is what the operator
+// sees. Higher score = more impactful for THIS install.
+//
+// score = baseWeight(type, breaking) × relevanceMultiplier(install signals)
+//
+// baseWeight encodes the "what kind of change" axis (a breaking change
+// outranks a fix outranks a docs commit). relevanceMultiplier amplifies
+// commits whose scope, files, or PR labels match install state — an HVAC
+// install with a `field-service` customization should see field-service
+// changes near the top even when the upstream-wide impact bucket is "fix".
+//
+// Reasons are accumulated verbatim so the operator UI can show *why* an item
+// landed where it did, with no LLM rewriting.
+
+import type {
+  ImpactItem,
+  ImpactItemReason,
+  InstallSignals,
+  ParsedCommit,
+  PrEnrichment,
+} from "./types";
+
+const BASE_WEIGHT: Record<ParsedCommit["category"], number> = {
+  breaking: 100,
+  feature: 50,
+  performance: 30,
+  fix: 25,
+  other: 8,
+};
+
+const RELEVANCE_INCREMENTS = {
+  archetypeScopeMatch: 0.5,
+  industryScopeMatch: 0.3,
+  customizationPathOverlap: 0.6,
+  customizationVerticalMatch: 0.4,
+  openIssueKeywordHit: 0.5,
+  prLabelMatch: 0.3,
+} as const;
+
+function lowercase(value: string | null | undefined): string {
+  return (value ?? "").toLowerCase();
+}
+
+function pathOverlap(commitFiles: string[], customizationPaths: string[]): string[] {
+  if (commitFiles.length === 0 || customizationPaths.length === 0) return [];
+  const hits = new Set<string>();
+  for (const file of commitFiles) {
+    const f = file.toLowerCase();
+    for (const cp of customizationPaths) {
+      const c = cp.toLowerCase();
+      if (!c) continue;
+      // Match on prefix (directory) or exact file path.
+      if (f === c || f.startsWith(c.endsWith("/") ? c : `${c}/`)) {
+        hits.add(file);
+        break;
+      }
+    }
+  }
+  return [...hits];
+}
+
+function keywordHit(haystack: string, needle: string): boolean {
+  if (!needle) return false;
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+export type ScoreInput = {
+  commits: ParsedCommit[];
+  signals: InstallSignals;
+  enrichmentByPr: Map<number, PrEnrichment>;
+};
+
+export function scoreCommits(input: ScoreInput): ImpactItem[] {
+  const { commits, signals, enrichmentByPr } = input;
+  const archetype = lowercase(signals.archetypeId);
+  const industry = lowercase(signals.industry);
+  const customizationVerticals = signals.customizationVerticals.map(lowercase).filter(Boolean);
+  const issueKeywords = signals.openIssueKeywords.map((k) => k.trim()).filter(Boolean);
+  const relevantLabels = new Set(signals.relevantPrLabels.map(lowercase));
+
+  return commits.map((commit) => {
+    const reasons: ImpactItemReason[] = [];
+    let multiplier = 1;
+
+    if (commit.breaking) reasons.push({ kind: "breaking-change" });
+
+    const scopeText = lowercase(commit.scope);
+    if (archetype && scopeText && scopeText.includes(archetype)) {
+      reasons.push({ kind: "archetype-match", archetypeId: signals.archetypeId! });
+      multiplier += RELEVANCE_INCREMENTS.archetypeScopeMatch;
+    }
+    if (industry && scopeText && scopeText.includes(industry)) {
+      reasons.push({ kind: "industry-match", industry: signals.industry! });
+      multiplier += RELEVANCE_INCREMENTS.industryScopeMatch;
+    }
+
+    const overlap = pathOverlap(commit.files, signals.customizationPaths);
+    const touchesCustomizations = overlap.length > 0;
+    if (touchesCustomizations) {
+      reasons.push({ kind: "customization-path-overlap", paths: overlap });
+      multiplier += RELEVANCE_INCREMENTS.customizationPathOverlap;
+    }
+
+    if (scopeText) {
+      for (const vert of customizationVerticals) {
+        if (scopeText.includes(vert)) {
+          reasons.push({ kind: "customization-vertical-match", vertical: vert });
+          multiplier += RELEVANCE_INCREMENTS.customizationVerticalMatch;
+          break; // only one vertical bump per item
+        }
+      }
+    }
+
+    // Issue keywords match against the description (subject) only — body is
+    // not reliably available on squashed commits.
+    if (issueKeywords.length > 0) {
+      for (const kw of issueKeywords) {
+        if (keywordHit(commit.description, kw)) {
+          reasons.push({ kind: "open-issue-keyword", keyword: kw });
+          multiplier += RELEVANCE_INCREMENTS.openIssueKeywordHit;
+          break; // only one keyword bump per item
+        }
+      }
+    }
+
+    const pr = commit.prNumber != null ? enrichmentByPr.get(commit.prNumber) : undefined;
+    if (pr && pr.labels.length > 0 && relevantLabels.size > 0) {
+      for (const label of pr.labels) {
+        if (relevantLabels.has(label)) {
+          multiplier += RELEVANCE_INCREMENTS.prLabelMatch;
+          break;
+        }
+      }
+    }
+
+    if (reasons.length === 0) reasons.push({ kind: "base-weight" });
+
+    const base = BASE_WEIGHT[commit.category];
+    const score = Math.round(base * multiplier);
+
+    return {
+      sha: commit.sha,
+      description: commit.description,
+      type: commit.type,
+      scope: commit.scope,
+      category: commit.category,
+      breaking: commit.breaking,
+      prNumber: commit.prNumber,
+      prTitle: pr?.title ?? null,
+      prLabels: pr?.labels ?? [],
+      score,
+      reasons,
+      touchesCustomizations,
+    };
+  });
+}
+
+/**
+ * Sort scored items by score desc, then category rank, then newer-first by
+ * SHA position in the input (caller passes commits oldest→newest from
+ * `git log --reverse`, so we use array index for stability).
+ */
+export function orderByImpact(items: ImpactItem[]): ImpactItem[] {
+  const RANK: Record<ImpactItem["category"], number> = {
+    breaking: 0, feature: 1, performance: 2, fix: 3, other: 4,
+  };
+  const indexed = items.map((item, index) => ({ item, index }));
+  indexed.sort((a, b) => {
+    if (a.item.score !== b.item.score) return b.item.score - a.item.score;
+    if (a.item.category !== b.item.category) return RANK[a.item.category] - RANK[b.item.category];
+    return b.index - a.index; // newer first (later in `git log --reverse` => higher index)
+  });
+  return indexed.map((entry) => entry.item);
+}

--- a/apps/web/lib/self-upgrade/impact/types.ts
+++ b/apps/web/lib/self-upgrade/impact/types.ts
@@ -1,0 +1,213 @@
+// apps/web/lib/self-upgrade/impact/types.ts
+//
+// Public types for the on-demand upgrade impact summary (BI-C26F7EE1).
+//
+// The summary answers, in plain operator-facing language tailored to THIS
+// install: "what's in this update?" — most impactful first. Advisory only.
+// It does not gate apply / defer; it informs that decision.
+//
+// Pipeline (deterministic classification + LLM phrasing, no fabrication):
+//   git log <currentLineageSha>..<targetSha>
+//     → ConventionalCommit per commit (type / scope / breaking / subject / pr#)
+//     → ImpactCategoryCounts (totals for the headline)
+//     → ImpactItem[] scored against install signals (top-N by impact)
+//     → PhrasedImpactSummary (LLM headline + per-item plain-language phrasing)
+//
+// The deterministic shape (this file) is what tests exercise and what the LLM
+// is grounded against. The LLM only PHRASES — never invents items, never
+// reorders, never changes categories.
+
+export type ChangeCategory =
+  | "breaking"
+  | "feature"
+  | "fix"
+  | "performance"
+  | "other";
+
+export type ConventionalType =
+  | "feat"
+  | "fix"
+  | "perf"
+  | "refactor"
+  | "docs"
+  | "chore"
+  | "test"
+  | "build"
+  | "ci"
+  | "style"
+  | "revert"
+  | "unknown";
+
+/** A single commit parsed from `git log` over the lineage range. */
+export type RawCommit = {
+  /** Full 40-hex SHA. */
+  sha: string;
+  /** First line of the commit message. */
+  subject: string;
+  /** Author display name (best effort; empty if unavailable). */
+  author: string;
+  /** ISO-8601 author date. */
+  authorDate: string;
+  /** Files touched by this commit (best effort; empty when --name-only unavailable). */
+  files: string[];
+};
+
+/** A RawCommit parsed under the Conventional Commits 1.0.0 grammar. */
+export type ParsedCommit = RawCommit & {
+  type: ConventionalType;
+  /** Optional scope from `type(scope): subject`. */
+  scope: string | null;
+  /** True if the subject carries `!` before the colon OR a `BREAKING CHANGE:` trailer. */
+  breaking: boolean;
+  /** The description after `type(scope):` — falls back to the full subject for unparseable lines. */
+  description: string;
+  /** Pull request number parsed from a trailing `(#1234)`, when present. */
+  prNumber: number | null;
+  /** Category derived from `type` + `breaking`. */
+  category: ChangeCategory;
+};
+
+export type ImpactCategoryCounts = {
+  breaking: number;
+  feature: number;
+  fix: number;
+  performance: number;
+  other: number;
+  total: number;
+};
+
+/**
+ * Signals about THIS install used to score relevance of each upstream commit.
+ *
+ * These are intentionally narrow and observable from live DB state — no
+ * inferred capability lists, no guesses. If a signal is unavailable we say so
+ * (`null` / empty array) rather than fabricate one.
+ */
+export type InstallSignals = {
+  /** StorefrontConfig.archetypeId — single source of truth for portal industry. */
+  archetypeId: string | null;
+  /** Organization.industry (derived from archetype; kept for legacy match). */
+  industry: string | null;
+  /**
+   * Touched-area hints from active customization. Currently sourced from
+   * FeaturePack entries (manifest paths, sourceVertical, applicableVerticals).
+   * Overlap on these paths is both a relevance signal AND a §5.0 merge-conflict
+   * early warning — surfaced via the `touchesCustomizations` callout.
+   */
+  customizationPaths: string[];
+  /** Industry/vertical tags of the install's customizations, for relevance match. */
+  customizationVerticals: string[];
+  /** Open PortfolioQualityIssue summaries — substrings the LLM has NOT seen. */
+  openIssueKeywords: string[];
+  /** PR labels (lowercased) considered relevant to this install (best effort). */
+  relevantPrLabels: string[];
+};
+
+/** GitHub enrichment for a single PR, fetched when reachable. */
+export type PrEnrichment = {
+  prNumber: number;
+  title: string | null;
+  /** Lowercased label slugs. */
+  labels: string[];
+  /** Truncated body (first ~400 chars, plain text). */
+  body: string | null;
+};
+
+export type ImpactItemReason =
+  | { kind: "archetype-match"; archetypeId: string }
+  | { kind: "industry-match"; industry: string }
+  | { kind: "customization-path-overlap"; paths: string[] }
+  | { kind: "customization-vertical-match"; vertical: string }
+  | { kind: "open-issue-keyword"; keyword: string }
+  | { kind: "breaking-change" }
+  | { kind: "base-weight" };
+
+/** One scored item — what the LLM phrases. */
+export type ImpactItem = {
+  sha: string;
+  /** Subject after stripping `type(scope):` prefix; never empty. */
+  description: string;
+  /** Conventional type. */
+  type: ConventionalType;
+  /** Optional scope (e.g. "self-upgrade"). */
+  scope: string | null;
+  category: ChangeCategory;
+  breaking: boolean;
+  prNumber: number | null;
+  /** PR title from GitHub enrichment, when reachable. */
+  prTitle: string | null;
+  /** PR labels from GitHub enrichment (lowercased). */
+  prLabels: string[];
+  /** Final impact score (higher = more impactful for this install). */
+  score: number;
+  /** Why this item scored where it did — surfaced verbatim, not phrased. */
+  reasons: ImpactItemReason[];
+  /** True when this commit touches an install-customized path. */
+  touchesCustomizations: boolean;
+};
+
+/**
+ * Result of the LLM phrasing pass. Strictly grounded against the
+ * ImpactItem[] above — the LLM is forbidden from adding items, reordering,
+ * or changing categories.
+ */
+export type PhrasedImpactSummary = {
+  /** Plain-English one-line headline for the operator (no SHAs / paths). */
+  headline: string;
+  /**
+   * Per-item plain-language line. Order MUST match the input ImpactItem[]
+   * positionally. Length MUST equal items.length.
+   */
+  itemPhrasings: Array<{
+    /** One-line plain description of what changed. */
+    description: string;
+    /** One-line "why this matters for this install" — empty when no per-item reason. */
+    whyRelevant: string;
+  }>;
+  /**
+   * Whole-summary callout for commits that touch install customizations,
+   * doubling as a §5.0 merge-conflict early warning. Empty when none.
+   */
+  touchesCustomizationsCallout: string;
+};
+
+/**
+ * The full operator-facing summary. The deterministic shape is the contract;
+ * `phrased` is the rendered text layer.
+ */
+export type UpgradeImpactSummary = {
+  /** SHA the running build absorbed from upstream (lineage marker). */
+  currentLineageSha: string;
+  /** Upstream SHA the summary is comparing against. */
+  targetSha: string;
+  /** Counts feed the headline ("3 new features, 5 fixes, 1 breaking change"). */
+  counts: ImpactCategoryCounts;
+  /** Top-N most relevant items. Default cap is 8; full list is on the foldable view. */
+  topItems: ImpactItem[];
+  /** Full list of every commit in the range (foldable / on-demand). */
+  allItems: ImpactItem[];
+  /** Phrased layer — empty `headline` indicates the LLM call was skipped/failed. */
+  phrased: PhrasedImpactSummary | null;
+  /** Provenance for the operator — were PR titles/labels reachable? */
+  enrichment: {
+    githubReachable: boolean;
+    prsEnriched: number;
+  };
+  /** Marker the summary was generated against now-current state. */
+  generatedAt: string;
+  /** True when the summary was served from cache. */
+  fromCache: boolean;
+};
+
+export type SummaryNotApplicable =
+  | { ok: false; reason: "no-lineage"; detail: string }
+  | { ok: false; reason: "no-target"; detail: string }
+  | { ok: false; reason: "lineage-equals-target"; detail: string }
+  | { ok: false; reason: "git-log-failed"; detail: string };
+
+export type SummaryResult =
+  | { ok: true; summary: UpgradeImpactSummary }
+  | SummaryNotApplicable;
+
+/** Default cap for top-N items surfaced before "show all". */
+export const DEFAULT_TOP_N = 8;

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -292,6 +292,9 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   assess_contribution:    ["backlog_read"],
   contribute_to_hive:     ["backlog_write"],
   apply_platform_update:  ["admin_write"],
+  // BI-C26F7EE1: read-only operator preview of the upstream change set —
+  // paired with apply_platform_update's admin_write as the read tier.
+  summarize_upgrade_impact: ["admin_read"],
 
   // Contributor inventory sync — admin-scope on-demand trigger so agents
   // that just pushed a branch / opened a PR can force the cron to run


### PR DESCRIPTION
## Why

Operators today click **Trigger Now / Upgrade now** without knowing what they're about to install — the panel surfaces SHAs and run state but no plain-language preview of the upstream delta. That makes apply-vs-defer a guess. BI-C26F7EE1 closes the gap with an on-demand, install-tailored summary: in operator language, "what's in this update?" — most impactful first, with a callout when the change set touches THIS install's customizations (which doubles as the §5.0 merge-conflict early warning).

Advisory only — never queues or applies.

## What changed

**New pipeline** (`apps/web/lib/self-upgrade/impact/`):

1. **Change set** — `git log <currentLineageSha>..<targetSha>` over the host clone, mirroring the no-auth dep-injected execFile pattern from `version.ts:resolveTargetSha`. `currentLineageSha` = the latest succeeded `SelfUpgradeRun.targetSha` (the upstream lineage marker §5.0 wires); `targetSha` = `resolveTargetSha`.
2. **Classify** — Conventional Commits parser → `breaking` / `feature` / `fix` / `performance` / `other`; counts drive the headline.
3. **Score** — `baseWeight(type, breaking) × relevanceMultiplier(install signals)`. Signals come from live DB state: `StorefrontConfig.archetypeId`, `Organization.industry`, `FeaturePack.manifest` paths + verticals, open `PortfolioQualityIssue` keywords. **Path overlap with FeaturePack-touched files is both a relevance signal AND a §5.0 merge-conflict early warning** (`touchesCustomizations`).
4. **Enrich (best effort)** — GitHub PR title/labels via public REST when reachable; offline → commit subjects + file stats only. Never invents.
5. **Phrase** — strict-JSON call through `apps/web/lib/llm-call.ts` (`callLLM`). LLM produces headline + per-item one-liner + "why relevant to you" + customizations callout. Hard validators reject malformed / length-mismatched output; on any failure the orchestrator returns the raw deterministic shape rather than fabricating phrasing.
6. **Cache** — per-process map keyed by `(currentLineageSha, targetSha)`.

**Surfaces:**

- `/ops/self-upgrade` gets a new "What's in this update?" panel (`apps/web/components/ops/UpgradeImpactPanel.tsx`) with a Summarize / Refresh button, headline, counts ribbon, top-N items, foldable full list, and customizations callout. **Default view never shows SHAs or file paths** (per spec).
- New MCP tool `summarize_upgrade_impact` (read-only, `view_operations`) exposes the same summary to coworkers / external agents. Params: `refresh`, `topN`, `skipPhrasing`.
- Server action `getUpgradeImpactSummary` at `apps/web/lib/actions/upgrade-impact.ts` for the UI.

**Discipline:**

- Pure logic (classify, score, parse) lives in tested helpers; only phrasing touches the LLM.
- The orchestrator returns a discriminated `SummaryResult` — `no-lineage` / `no-target` / `lineage-equals-target` / `git-log-failed` / `ok` — UI renders each plainly; nothing throws.
- No fake data: when a signal is unavailable, the field is `null` / `[]` and the UI says so ("GitHub unreachable — summary built from commit subjects only.").

## Test plan

- [x] 41 new unit tests cover the conventional parser, category counts, ordering, scoring (archetype / industry / customization-path overlap / open-issue keyword / PR-label match), git-log argv + parsing, cache, phrase validation, and the orchestrator's six discriminated states.
- [x] Full self-upgrade + mcp-tools suite green locally (403 tests).
- [x] `pnpm --filter web typecheck` clean.
- [x] `cd apps/web && npx next build` clean.
- [ ] CI green (DCO + tests + typecheck + build).
- [ ] UX verification once merged: from `/ops/self-upgrade`, click **Summarize update**, confirm headline + items render and "touches your customizations" surfaces on a commit that overlaps a FeaturePack path.

## References

- Spec: [docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md §5.0](docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md)
- BI: BI-C26F7EE1 (epic EP-CAPSULE)
- Builds on already-merged self-upgrade work (#1280, #1297, #1272 / merge-based source) and composes with #1358 (manual-now scheduling) — non-overlapping; rebased cleanly.