### PR TITLE
refactor(web): migrate remaining compliance detail pages to report-kit (BI-6A842691)

### DIFF
--- a/apps/web/app/(shell)/compliance/actions/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/actions/[id]/page.tsx
@@ -3,16 +3,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { EditCorrectiveActionForm } from "@/components/compliance/EditCorrectiveActionForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const STATUS_COLORS: Record<string, string> = {
-  open: "bg-yellow-900/30 text-yellow-400",
-  "in-progress": "bg-blue-900/30 text-blue-400",
-  completed: "bg-blue-900/30 text-blue-400",
-  verified: "bg-green-900/30 text-green-400",
-  closed: "bg-gray-900/30 text-gray-400",
-};
 
 export default async function CorrectiveActionDetailPage({ params }: Props) {
   const { id } = await params;
@@ -39,11 +32,9 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{action.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[action.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {action.status}
-          </span>
+          <StatusBadge domain="complianceAction" status={action.status} variant="soft" uppercase={false} />
           {isOverdue && (
-            <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-red-900/30 text-red-400 font-semibold">OVERDUE</span>
+            <StatusBadge intent="danger" label="Overdue" variant="soft" />
           )}
           <EditCorrectiveActionForm id={action.id} action={action} />
         </div>
@@ -59,9 +50,9 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
           <p className="text-sm font-semibold text-[var(--dpf-text)]">{action.sourceType}</p>
         </div>
         {action.dueDate && (
-          <div className={`p-3 rounded-lg border ${isOverdue ? "border-red-500/50" : "border-[var(--dpf-border)]"}`}>
+          <div className={`p-3 rounded-lg border ${isOverdue ? "border-[color-mix(in_srgb,var(--dpf-error)_50%,transparent)]" : "border-[var(--dpf-border)]"}`}>
             <p className="text-xs text-[var(--dpf-muted)]">Due Date</p>
-            <LocalTime value={action.dueDate} utc className={`text-sm font-semibold ${isOverdue ? "text-red-400" : "text-[var(--dpf-text)]"}`} />
+            <LocalTime value={action.dueDate} utc className={`text-sm font-semibold ${isOverdue ? "text-[var(--dpf-error)]" : "text-[var(--dpf-text)]"}`} />
           </div>
         )}
         {action.completedAt && (
@@ -123,7 +114,7 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
           >
             <span className="text-sm font-semibold text-[var(--dpf-text)]">{action.incident.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{action.incident.incidentId}</span>
-            <span className="text-xs text-blue-400">View</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
           </Link>
         </div>
       )}
@@ -138,7 +129,7 @@ export default async function CorrectiveActionDetailPage({ params }: Props) {
           >
             <span className="text-sm font-semibold text-[var(--dpf-text)]">{action.auditFinding.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{action.auditFinding.findingId}</span>
-            <span className="text-xs text-blue-400">View</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
           </Link>
         </div>
       )}

--- a/apps/web/app/(shell)/compliance/evidence/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/evidence/[id]/page.tsx
@@ -2,13 +2,14 @@ import { getEvidence } from "@/lib/actions/compliance";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
 
-const STATUS_COLORS: Record<string, string> = {
-  active: "bg-green-900/30 text-green-400",
-  superseded: "bg-yellow-900/30 text-yellow-400",
-  archived: "bg-gray-900/30 text-gray-400",
+const EVIDENCE_INTENT: Record<string, Intent> = {
+  active: "success",
+  superseded: "warning",
+  archived: "neutral",
 };
 
 export default async function EvidenceDetailPage({ params }: Props) {
@@ -36,9 +37,7 @@ export default async function EvidenceDetailPage({ params }: Props) {
           <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">
             {evidence.evidenceType}
           </span>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[evidence.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {evidence.status}
-          </span>
+          <StatusBadge intent={EVIDENCE_INTENT[evidence.status] ?? "neutral"} label={evidence.status} variant="soft" uppercase={false} />
         </div>
         {evidence.description && (
           <p className="text-sm text-[var(--dpf-muted)]">{evidence.description}</p>
@@ -47,15 +46,15 @@ export default async function EvidenceDetailPage({ params }: Props) {
 
       {/* Superseded banner */}
       {evidence.status === "superseded" && evidence.supersededBy && (
-        <div className="mb-6 p-3 rounded-lg border border-yellow-500/50 bg-yellow-900/10">
-          <p className="text-xs text-yellow-400 mb-1">This evidence has been superseded.</p>
+        <div className="mb-6 p-3 rounded-lg border border-[color-mix(in_srgb,var(--dpf-warning)_50%,transparent)] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,transparent)]">
+          <p className="text-xs text-[var(--dpf-warning)] mb-1">This evidence has been superseded.</p>
           <Link
             href={`/compliance/evidence/${evidence.supersededBy.id}`}
-            className="inline-flex items-center gap-2 text-sm text-[var(--dpf-text)] hover:text-blue-400 transition-colors"
+            className="inline-flex items-center gap-2 text-sm text-[var(--dpf-text)] hover:text-[var(--dpf-info)] transition-colors"
           >
             <span>{evidence.supersededBy.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{evidence.supersededBy.evidenceId}</span>
-            <span className="text-xs text-blue-400">View replacement</span>
+            <span className="text-xs text-[var(--dpf-info)]">View replacement</span>
           </Link>
         </div>
       )}
@@ -96,7 +95,7 @@ export default async function EvidenceDetailPage({ params }: Props) {
           >
             <span className="text-sm font-semibold text-[var(--dpf-text)]">{evidence.obligation.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{evidence.obligation.obligationId}</span>
-            <span className="text-xs text-blue-400">View</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
           </Link>
         </div>
       )}
@@ -111,7 +110,7 @@ export default async function EvidenceDetailPage({ params }: Props) {
           >
             <span className="text-sm font-semibold text-[var(--dpf-text)]">{evidence.control.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{evidence.control.controlId}</span>
-            <span className="text-xs text-blue-400">View</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
           </Link>
         </div>
       )}

--- a/apps/web/app/(shell)/compliance/incidents/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/incidents/[id]/page.tsx
@@ -3,21 +3,15 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { EditIncidentForm } from "@/components/compliance/EditIncidentForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
 
-const SEVERITY_COLORS: Record<string, string> = {
-  low: "bg-green-900/30 text-green-400",
-  medium: "bg-yellow-900/30 text-yellow-400",
-  high: "bg-orange-900/30 text-orange-400",
-  critical: "bg-red-900/30 text-red-400",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  open: "bg-yellow-900/30 text-yellow-400",
-  investigating: "bg-orange-900/30 text-orange-400",
-  resolved: "bg-green-900/30 text-green-400",
-  closed: "bg-gray-900/30 text-gray-400",
+const INCIDENT_STATUS_INTENT: Record<string, Intent> = {
+  open: "warning",
+  investigating: "warning",
+  resolved: "success",
+  closed: "neutral",
 };
 
 export default async function IncidentDetailPage({ params }: Props) {
@@ -45,12 +39,8 @@ export default async function IncidentDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{incident.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SEVERITY_COLORS[incident.severity] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {incident.severity}
-          </span>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${STATUS_COLORS[incident.status] ?? "bg-gray-900/30 text-gray-400"}`}>
-            {incident.status}
-          </span>
+          <StatusBadge domain="severity" status={incident.severity} variant="soft" uppercase={false} />
+          <StatusBadge intent={INCIDENT_STATUS_INTENT[incident.status] ?? "neutral"} label={incident.status} variant="soft" uppercase={false} />
           <EditIncidentForm id={incident.id} incident={incident} />
         </div>
         {incident.description && (
@@ -60,23 +50,21 @@ export default async function IncidentDetailPage({ params }: Props) {
 
       {/* Regulatory notification banner */}
       {incident.regulatoryNotifiable && (
-        <div className={`mb-6 p-3 rounded-lg border ${deadlinePassed && !incident.notifiedAt ? "border-red-500/50 bg-red-900/10" : "border-amber-500/50 bg-amber-900/10"}`}>
+        <div className={`mb-6 p-3 rounded-lg border ${deadlinePassed && !incident.notifiedAt ? "border-[color-mix(in_srgb,var(--dpf-error)_50%,transparent)] bg-[color-mix(in_srgb,var(--dpf-error)_10%,transparent)]" : "border-[color-mix(in_srgb,var(--dpf-warning)_50%,transparent)] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,transparent)]"}`}>
           <div className="flex items-center gap-2 mb-1">
-            <span className={`text-[9px] px-1.5 py-0.5 rounded-full font-semibold ${deadlinePassed && !incident.notifiedAt ? "bg-red-900/30 text-red-400" : "bg-amber-900/30 text-amber-400"}`}>
-              REGULATORY NOTIFIABLE
-            </span>
+            <StatusBadge intent={deadlinePassed && !incident.notifiedAt ? "danger" : "warning"} label="Regulatory notifiable" variant="soft" />
             {incident.notifiedAt && (
-              <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-green-900/30 text-green-400">NOTIFIED</span>
+              <StatusBadge intent="success" label="Notified" variant="soft" />
             )}
           </div>
           {incident.notificationDeadline && (
-            <p className={`text-xs ${deadlinePassed && !incident.notifiedAt ? "text-red-400" : "text-amber-400"}`}>
+            <p className={`text-xs ${deadlinePassed && !incident.notifiedAt ? "text-[var(--dpf-error)]" : "text-[var(--dpf-warning)]"}`}>
               Notification deadline: <LocalTime value={incident.notificationDeadline} />
               {deadlinePassed && !incident.notifiedAt && " — OVERDUE"}
             </p>
           )}
           {incident.notifiedAt && (
-            <p className="text-xs text-green-400">Notified at: <LocalTime value={incident.notifiedAt} /></p>
+            <p className="text-xs text-[var(--dpf-success)]">Notified at: <LocalTime value={incident.notifiedAt} /></p>
           )}
         </div>
       )}
@@ -129,7 +117,7 @@ export default async function IncidentDetailPage({ params }: Props) {
           >
             <span className="text-sm font-semibold text-[var(--dpf-text)]">{incident.riskAssessment.title}</span>
             <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{incident.riskAssessment.assessmentId}</span>
-            <span className="text-xs text-blue-400">View</span>
+            <span className="text-xs text-[var(--dpf-info)]">View</span>
           </Link>
         </div>
       )}
@@ -148,30 +136,23 @@ export default async function IncidentDetailPage({ params }: Props) {
               <Link
                 key={a.id}
                 href={`/compliance/actions/${a.id}`}
-                className={`block p-3 rounded-lg border ${isOverdue ? "border-red-500/50" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}
+                className={`block p-3 rounded-lg border ${isOverdue ? "border-[color-mix(in_srgb,var(--dpf-error)_50%,transparent)]" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}
               >
                 <div className="flex items-start justify-between">
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-[var(--dpf-text)]">{a.title}</span>
                       {isOverdue && (
-                        <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-red-900/30 text-red-400 font-semibold">OVERDUE</span>
+                        <StatusBadge intent="danger" label="Overdue" variant="soft" />
                       )}
                     </div>
                     <div className="flex gap-2 mt-1">
                       <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{a.sourceType}</span>
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${
-                        a.status === "verified" ? "bg-green-900/30 text-green-400" :
-                        a.status === "completed" ? "bg-blue-900/30 text-blue-400" :
-                        a.status === "open" ? "bg-yellow-900/30 text-yellow-400" :
-                        "bg-gray-900/30 text-gray-400"
-                      }`}>
-                        {a.status}
-                      </span>
+                      <StatusBadge domain="complianceAction" status={a.status} variant="soft" uppercase={false} />
                     </div>
                   </div>
                   {a.dueDate && (
-                    <span className={`text-xs ${isOverdue ? "text-red-400" : "text-[var(--dpf-muted)]"}`}>
+                    <span className={`text-xs ${isOverdue ? "text-[var(--dpf-error)]" : "text-[var(--dpf-muted)]"}`}>
                       Due: <LocalTime value={a.dueDate} utc />
                     </span>
                   )}

--- a/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/[id]/page.tsx
@@ -5,15 +5,9 @@ import { LinkControlForm } from "@/components/compliance/LinkControlForm";
 import { UnlinkControlButton } from "@/components/compliance/UnlinkControlButton";
 import { EditObligationForm } from "@/components/compliance/EditObligationForm";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const IMPL_COLORS: Record<string, string> = {
-  implemented: "bg-green-900/30 text-green-400",
-  "in-progress": "bg-yellow-900/30 text-yellow-400",
-  planned: "bg-blue-900/30 text-blue-400",
-  "not-applicable": "bg-gray-900/30 text-gray-400",
-};
 
 export default async function ObligationDetailPage({ params }: Props) {
   const { id } = await params;
@@ -46,9 +40,7 @@ export default async function ObligationDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{obligation.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${obligation.status === "active" ? "bg-green-900/30 text-green-400" : "bg-red-900/30 text-red-400"}`}>
-            {obligation.status}
-          </span>
+          <StatusBadge intent={obligation.status === "active" ? "success" : "danger"} label={obligation.status} variant="soft" uppercase={false} />
           <EditObligationForm id={obligation.id} obligation={obligation} />
         </div>
         {obligation.description && (
@@ -121,7 +113,7 @@ export default async function ObligationDetailPage({ params }: Props) {
         >
           <span className="text-sm font-semibold text-[var(--dpf-text)]">{obligation.regulation.shortName}</span>
           <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{obligation.regulation.jurisdiction}</span>
-          <span className="text-xs text-blue-400">View</span>
+          <span className="text-xs text-[var(--dpf-info)]">View</span>
         </Link>
       </div>
 
@@ -151,9 +143,7 @@ export default async function ObligationDetailPage({ params }: Props) {
                 </Link>
                 <div className="flex gap-2 mt-1">
                   <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{link.control.controlType}</span>
-                  <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${IMPL_COLORS[link.control.implementationStatus] ?? "bg-gray-900/30 text-gray-400"}`}>
-                    {link.control.implementationStatus}
-                  </span>
+                  <StatusBadge domain="controlStatus" status={link.control.implementationStatus} variant="soft" uppercase={false} />
                   {link.control.effectiveness && (
                     <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">{link.control.effectiveness}</span>
                   )}

--- a/apps/web/app/(shell)/compliance/risks/[id]/page.tsx
+++ b/apps/web/app/(shell)/compliance/risks/[id]/page.tsx
@@ -4,22 +4,9 @@ import { notFound } from "next/navigation";
 import { LinkRiskControlForm } from "@/components/compliance/LinkRiskControlForm";
 import { UnlinkRiskControlButton } from "@/components/compliance/UnlinkRiskControlButton";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type Props = { params: Promise<{ id: string }> };
-
-const RISK_COLORS: Record<string, string> = {
-  low: "bg-green-900/30 text-green-400",
-  medium: "bg-yellow-900/30 text-yellow-400",
-  high: "bg-orange-900/30 text-orange-400",
-  critical: "bg-red-900/30 text-red-400",
-};
-
-const SEVERITY_COLORS: Record<string, string> = {
-  low: "bg-green-900/30 text-green-400",
-  medium: "bg-yellow-900/30 text-yellow-400",
-  high: "bg-orange-900/30 text-orange-400",
-  critical: "bg-red-900/30 text-red-400",
-};
 
 export default async function RiskDetailPage({ params }: Props) {
   const { id } = await params;
@@ -52,25 +39,15 @@ export default async function RiskDetailPage({ params }: Props) {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-1">
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{risk.title}</h1>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${risk.status === "active" ? "bg-green-900/30 text-green-400" : "bg-gray-900/30 text-gray-400"}`}>
-            {risk.status}
-          </span>
+          <StatusBadge intent={risk.status === "active" ? "success" : "neutral"} label={risk.status} variant="soft" uppercase={false} />
         </div>
         <div className="flex gap-2 mt-1">
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${RISK_COLORS[risk.inherentRisk] ?? "bg-gray-900/30 text-gray-400"}`}>
-            Inherent: {risk.inherentRisk}
-          </span>
+          <StatusBadge domain="severity" status={risk.inherentRisk} label={`Inherent: ${risk.inherentRisk}`} variant="soft" uppercase={false} />
           {risk.residualRisk && (
-            <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${RISK_COLORS[risk.residualRisk] ?? "bg-gray-900/30 text-gray-400"}`}>
-              Residual: {risk.residualRisk}
-            </span>
+            <StatusBadge domain="severity" status={risk.residualRisk} label={`Residual: ${risk.residualRisk}`} variant="soft" uppercase={false} />
           )}
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${RISK_COLORS[risk.likelihood] ?? "bg-gray-900/30 text-gray-400"}`}>
-            Likelihood: {risk.likelihood}
-          </span>
-          <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SEVERITY_COLORS[risk.severity] ?? "bg-gray-900/30 text-gray-400"}`}>
-            Severity: {risk.severity}
-          </span>
+          <StatusBadge domain="severity" status={risk.likelihood} label={`Likelihood: ${risk.likelihood}`} variant="soft" uppercase={false} />
+          <StatusBadge domain="severity" status={risk.severity} label={`Severity: ${risk.severity}`} variant="soft" uppercase={false} />
         </div>
       </div>
 
@@ -172,23 +149,19 @@ export default async function RiskDetailPage({ params }: Props) {
               <Link
                 key={inc.id}
                 href={`/compliance/incidents/${inc.id}`}
-                className={`block p-3 rounded-lg border ${inc.regulatoryNotifiable && isOpen ? "border-red-500/50" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}
+                className={`block p-3 rounded-lg border ${inc.regulatoryNotifiable && isOpen ? "border-[color-mix(in_srgb,var(--dpf-error)_50%,transparent)]" : "border-[var(--dpf-border)]"} hover:border-[var(--dpf-accent)] transition-colors`}
               >
                 <div className="flex items-start justify-between">
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-[var(--dpf-text)]">{inc.title}</span>
                       {inc.regulatoryNotifiable && (
-                        <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-red-900/30 text-red-400 font-semibold">NOTIFIABLE</span>
+                        <StatusBadge intent="danger" label="Notifiable" variant="soft" />
                       )}
                     </div>
                     <div className="flex gap-2 mt-1">
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SEVERITY_COLORS[inc.severity] ?? "bg-gray-900/30 text-gray-400"}`}>
-                        {inc.severity}
-                      </span>
-                      <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${isOpen ? "bg-yellow-900/30 text-yellow-400" : "bg-green-900/30 text-green-400"}`}>
-                        {inc.status}
-                      </span>
+                      <StatusBadge domain="severity" status={inc.severity} variant="soft" uppercase={false} />
+                      <StatusBadge intent={isOpen ? "warning" : "success"} label={inc.status} variant="soft" uppercase={false} />
                     </div>
                   </div>
                   <LocalTime value={inc.occurredAt} mode="date" className="text-xs text-[var(--dpf-muted)]" />


### PR DESCRIPTION
## What

Completes the compliance module token cleanup — the 5 heavier **`[id]` detail pages** (follows #1362 which did the clean 5).

- **obligations/[id]**: status + linked-control badges → `StatusBadge`; View accent → token
- **evidence/[id]**: status badge (local intent map) + superseded banner + View accents → tokens
- **actions/[id]**: status + OVERDUE badges → `StatusBadge` (complianceAction); overdue border/due-date/View → tokens
- **risks/[id]**: inherent/residual/likelihood/severity + status badges → `StatusBadge` (severity domain); nested incident list (notifiable/severity/status) migrated
- **incidents/[id]**: severity + status badges → `StatusBadge`; regulatory-notification banner (red/amber → error/warning via color-mix), NOTIFIED/OVERDUE badges, nested corrective-action list → tokens

## Verification

- `tsc --noEmit` clean; **zero** raw Tailwind-palette colors remain across all 10 compliance detail pages (this PR + #1362)

With #1351/#1354 (list pages) + #1362 + this, the **entire compliance module is token-clean**. BI-6A842691. Authored in an isolated worktree per the collision-free workflow (#1359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)