### PR TITLE
feat(db): CoworkerActionEnvelope table + ToolExecution audit columns (BI-D887CD3B)

### DIFF
--- a/packages/db/prisma/migrations/20260531140000_coworker_action_envelope/migration.sql
+++ b/packages/db/prisma/migrations/20260531140000_coworker_action_envelope/migration.sql
@@ -1,0 +1,58 @@
+-- Pseudo-User Contract — Phase 1 substrate (spec §6.4 + §6.5 + §8).
+-- Adds the CoworkerActionEnvelope table for destructive-action proposals
+-- and three nullable columns on ToolExecution for dual-principal audit +
+-- envelope back-reference. Backfill not required: new columns are nullable
+-- and only populated for executions/proposals created after this migration.
+-- BI-D887CD3B / EP-COWORKER-INTERACTIVITY.
+
+-- CreateTable
+CREATE TABLE "CoworkerActionEnvelope" (
+    "id" TEXT NOT NULL,
+    "coworkerAgentId" TEXT NOT NULL,
+    "delegatingUserId" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "chatMessageId" TEXT,
+    "manifestActionId" TEXT NOT NULL,
+    "argsJson" JSONB NOT NULL,
+    "rationale" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'proposed',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "CoworkerActionEnvelope_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CoworkerActionEnvelope_threadId_createdAt_idx" ON "CoworkerActionEnvelope"("threadId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CoworkerActionEnvelope_coworkerAgentId_createdAt_idx" ON "CoworkerActionEnvelope"("coworkerAgentId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CoworkerActionEnvelope_status_idx" ON "CoworkerActionEnvelope"("status");
+
+-- CreateIndex
+CREATE INDEX "CoworkerActionEnvelope_chatMessageId_idx" ON "CoworkerActionEnvelope"("chatMessageId");
+
+-- AlterTable
+ALTER TABLE "ToolExecution" ADD COLUMN "delegatingUserId" TEXT;
+ALTER TABLE "ToolExecution" ADD COLUMN "chatMessageId" TEXT;
+ALTER TABLE "ToolExecution" ADD COLUMN "envelopeId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ToolExecution_envelopeId_idx" ON "ToolExecution"("envelopeId");
+
+-- CreateIndex
+CREATE INDEX "ToolExecution_delegatingUserId_createdAt_idx" ON "ToolExecution"("delegatingUserId", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "CoworkerActionEnvelope" ADD CONSTRAINT "CoworkerActionEnvelope_delegatingUserId_fkey" FOREIGN KEY ("delegatingUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerActionEnvelope" ADD CONSTRAINT "CoworkerActionEnvelope_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "AgentThread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerActionEnvelope" ADD CONSTRAINT "CoworkerActionEnvelope_chatMessageId_fkey" FOREIGN KEY ("chatMessageId") REFERENCES "AgentMessage"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ToolExecution" ADD CONSTRAINT "ToolExecution_envelopeId_fkey" FOREIGN KEY ("envelopeId") REFERENCES "CoworkerActionEnvelope"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3859,6 +3859,16 @@ model ToolExecution {
   receipt                 ToolExecutionReceipt?
   assuranceRun            AssuranceRun?
   documentLifecycleEvents DocumentLifecycleEvent[]
+  // Pseudo-User Contract (spec §6.5 + §8). Dual-principal audit + envelope:
+  // delegatingUserId is the human the coworker acted for (distinct from
+  // userId which is the executing identity); chatMessageId is the
+  // AgentMessage that initiated this execution (null for non-chat runs);
+  // envelopeId points to the CoworkerActionEnvelope that approved a
+  // destructive action (null for non-envelope executions).
+  delegatingUserId        String?
+  chatMessageId           String?
+  envelopeId              String?
+  envelope                CoworkerActionEnvelope?  @relation(fields: [envelopeId], references: [id])
 
   @@index([agentId, createdAt])
   @@index([userId, createdAt])
@@ -3869,6 +3879,37 @@ model ToolExecution {
   @@index([apiTokenId, createdAt(sort: Desc)])
   @@index([taskRunId, createdAt(sort: Desc)])
   @@index([skillId, createdAt(sort: Desc)])
+  @@index([envelopeId])
+  @@index([delegatingUserId, createdAt(sort: Desc)])
+}
+
+// Pseudo-User Contract (spec §6.4 + §8): destructive-action confirmation
+// envelope. A coworker proposes a destructive action via screen_propose_action;
+// the user approves/declines; the underlying tool executes (or not) and the
+// outcome is recorded. Lifecycle: proposed → approved|declined →
+// executed|failed|cancelled (resolved). Coworker identity is captured as
+// coworkerAgentId (Agent.agentId semantic id), matching the existing
+// ToolExecution.agentId convention; Principal convergence is via
+// PrincipalAlias lookup at query time (AGENTS.md §11), not a direct FK.
+model CoworkerActionEnvelope {
+  id               String    @id @default(cuid())
+  coworkerAgentId  String
+  delegatingUserId String
+  threadId         String
+  chatMessageId    String?
+  manifestActionId String
+  argsJson         Json
+  rationale        String
+  status           String    @default("proposed")
+  createdAt        DateTime  @default(now())
+  resolvedAt       DateTime?
+
+  toolExecutions ToolExecution[]
+
+  @@index([threadId, createdAt(sort: Desc)])
+  @@index([coworkerAgentId, createdAt(sort: Desc)])
+  @@index([status])
+  @@index([chatMessageId])
 }
 
 model ToolExecutionReceipt {


### PR DESCRIPTION
## Summary

First Phase 1 substrate BI of `EP-COWORKER-INTERACTIVITY` — the schema migration that lets the [Pseudo-User Contract](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1361) record destructive-action proposals and dual-principal audit attribution. Schema only; runtime state machine + tool family land in follow-on BIs.

## What's in this PR

**New model: `CoworkerActionEnvelope`**

Records a coworker's proposed destructive action (`screen_propose_action`) so the user can approve/deny/modify before the underlying tool runs. Lifecycle: `proposed → approved|declined → executed|failed|cancelled (resolved)`. Keyed by `coworkerAgentId` (the `Agent.agentId` semantic id, e.g. `AGT-BUILD-SE`), `delegatingUserId`, `threadId`, optional `chatMessageId`, plus `manifestActionId`, `argsJson`, `rationale`.

**`ToolExecution` columns added (all nullable):**
- `delegatingUserId` — the human the coworker acted on behalf of (distinct from `userId`, which is the executing identity).
- `chatMessageId` — the `AgentMessage` that initiated this execution. Null for non-chat runs.
- `envelopeId` — back-reference to the approving envelope (Prisma `@relation`). Null for non-envelope executions.

**Indexes:** envelope by `(threadId, createdAt DESC)`, `(coworkerAgentId, createdAt DESC)`, `status`, `chatMessageId`; ToolExecution by `envelopeId` and `(delegatingUserId, createdAt DESC)`.

**Foreign keys:** `delegatingUserId → User (CASCADE)`, `threadId → AgentThread (CASCADE)`, `chatMessageId → AgentMessage (SET NULL)`, `ToolExecution.envelopeId → CoworkerActionEnvelope (SET NULL)`.

## Implementation notes vs spec §8

Two simplifications discovered during implementation, documented in the commit:

1. **Dual-FK collapse.** The chief-architect review proposed `coworker_principal_id` + `coworker_agent_id` as a dual pattern. Implementation found there is no direct `Agent ↔ Principal` FK in the schema — Principal convergence (AGENTS.md §11) is via `PrincipalAlias` lookup at query time. Simplified to single `coworkerAgentId` matching the established `ToolExecution.agentId` convention. Principal id resolution is available to any caller that needs it.

2. **State-machine CHECK deferred.** The spec's `CHECK (status IN (...))` constraint is deferred to `BI-0F9C291C` (envelope flow implementation). The legal-transition table belongs with the runtime state machine, not the migration. Default `'proposed'` keeps the column non-null in the meantime.

## Verification

- ✓ `prisma format` + `prisma validate` clean
- ✓ `prisma generate` — client regenerated (Prisma 7.8.0)
- ✓ `pnpm --filter web typecheck` — clean (no consumer breakage)
- ✓ `pnpm --filter @dpf/db test` — 627/646 passing. The 19 failures are pre-existing DB-connectivity issues in 5 integration test files (`test/agent-thread-cli-session`, `test/adapter-capability-profile`, `test/adapter-run-telemetry`, `test/capability-maturity-schema`, `scripts/seed-integration-coverage`) — none reference the new tables/columns. The canonical local DB is missing baseline `20260531120000_orgsettings_applied_profile_slug` so a local `migrate deploy` would fail mid-chain regardless. CI's fresh-DB run is the authoritative migration gate.

## Linked work

- **Spec PR:** [#1361](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1361) — Pseudo-User Contract design (parallel review)
- **Epic:** `EP-COWORKER-INTERACTIVITY` (priority 2)
- **This BI:** `BI-D887CD3B` (sized small; in-progress)
- **Sibling Phase 1 BIs:** `BI-B2F7ABF5` (grants), `BI-D9487754` (manifest runtime), `BI-DF6079E9` (screen_* tools), `BI-0F9C291C` (envelope flow)

This BI is foundational — all 4 sibling Phase 1 BIs depend on these types existing.

## Test plan

- [ ] CI: typecheck clean
- [ ] CI: production build clean
- [ ] CI: unit tests pass (excluding pre-existing DB-connectivity failures noted above — those should match `main`'s current state)
- [ ] CI: migration applies cleanly against fresh DB
- [ ] CodeQL clean

## Founder attention

Two things worth a quick look:

1. **Dual-FK collapse rationale.** Confirm that single `coworkerAgentId` (not paired with `coworkerPrincipalId`) matches your intent. The spec PR will be updated to reflect this implementation decision once this lands.
2. **State-machine CHECK timing.** The CHECK constraint lives with `BI-0F9C291C` instead of here — confirm you're OK with the column being open at the DB layer until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)