### PR TITLE
fix(build-studio): iteration tracking on reviewDesignDoc to break silent oscillation deadlock (BI-CE49D82E)

### DIFF
--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -435,6 +435,7 @@ import {
   normalizeHappyPathState,
   isHappyPathIntakeReady,
   describePlanReviewFailure,
+  describeDesignReviewFailure,
 } from "./feature-build-types";
 import type { FixContext, ReviewResult } from "./feature-build-types";
 
@@ -462,15 +463,15 @@ export function checkRequirement(req: GateRequirement, evidence: GateEvidence): 
       return { allowed: true };
     }
     case "designReview-passed": {
-      const review = evidence.designReview as { decision?: string } | undefined;
+      const review = evidence.designReview as ReviewResult | undefined;
       if (!review) return { allowed: false, reason: "Design review is required before planning." };
-      if (review.decision === "fail") {
+      if ((review as { decision?: string }).decision === "fail") {
         const isFix = evidence.kind === "fix";
         return {
           allowed: false,
           reason: isFix
             ? "Fix review failed. Revise the diagnosis and re-run the review before advancing."
-            : "Design review failed. Revise the design document and re-run reviewDesignDoc before advancing.",
+            : describeDesignReviewFailure(review),
         };
       }
       return { allowed: true };

--- a/apps/web/lib/explore/feature-build-types.test.ts
+++ b/apps/web/lib/explore/feature-build-types.test.ts
@@ -13,6 +13,7 @@ import {
   computeReviewDelta,
   isOscillating,
   describePlanReviewFailure,
+  describeDesignReviewFailure,
 } from "./feature-build-types";
 import type { ReviewResult } from "./feature-build-types";
 
@@ -513,6 +514,74 @@ describe("describePlanReviewFailure (BI-4396EFEC)", () => {
       iteration: {
         round: 2,
         prior: { issueCount: 21, addressed: 10, persisted: 11, newlySurfaced: 0 },
+        oscillating: false,
+      },
+    }));
+    expect(reason).not.toContain("splitting this feature");
+  });
+});
+
+describe("describeDesignReviewFailure (BI-CE49D82E)", () => {
+  // Mirror of describePlanReviewFailure for the design path. Same convergence
+  // / oscillation language so the operator sees consistent trajectory framing
+  // across both phase gates. Live repro that drove this fix: FB-5E20E793
+  // (Voice Slice 1.6) sat silent for 17h after design review failed twice on
+  // the same "missing accessibility" complaint — without iteration metadata
+  // the gate reason looked identical across rounds, hiding the deadlock.
+  function review(overrides: Partial<ReviewResult> = {}): ReviewResult {
+    return {
+      decision: "fail",
+      issues: [{ severity: "critical", description: "x" }],
+      summary: "fail",
+      ...overrides,
+    };
+  }
+
+  it("returns base reason when no iteration metadata is attached", () => {
+    const reason = describeDesignReviewFailure(review());
+    expect(reason).toContain("Design review failed");
+    expect(reason).toContain("re-run reviewDesignDoc");
+    expect(reason).not.toContain("Round");
+  });
+
+  it("includes round label when iteration is present but no prior delta", () => {
+    const reason = describeDesignReviewFailure(review({ iteration: { round: 1 } }));
+    expect(reason).toContain("(Round 1)");
+    expect(reason).not.toContain("addressed");
+  });
+
+  it("includes addressed/persist/new breakdown when prior delta exists", () => {
+    const reason = describeDesignReviewFailure(review({
+      iteration: {
+        round: 2,
+        prior: { issueCount: 5, addressed: 3, persisted: 2, newlySurfaced: 1 },
+      },
+    }));
+    expect(reason).toContain("Round 2");
+    expect(reason).toContain("3 addressed");
+    expect(reason).toContain("2 persist");
+    expect(reason).toContain("1 new");
+  });
+
+  it("recommends scope-splitting when oscillating flag is set", () => {
+    const reason = describeDesignReviewFailure(review({
+      iteration: {
+        round: 3,
+        prior: { issueCount: 5, addressed: 2, persisted: 3, newlySurfaced: 4 },
+        oscillating: true,
+      },
+    }));
+    // The Voice Slice 1.6 deadlock would have surfaced here: operator sees
+    // "this won't converge — split it" in plain English at the gate.
+    expect(reason).toContain("not decreasing across rounds");
+    expect(reason).toContain("splitting this feature into smaller scopes");
+  });
+
+  it("omits the scope-split recommendation when not oscillating", () => {
+    const reason = describeDesignReviewFailure(review({
+      iteration: {
+        round: 2,
+        prior: { issueCount: 5, addressed: 4, persisted: 1, newlySurfaced: 0 },
         oscillating: false,
       },
     }));

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -631,6 +631,26 @@ export function describePlanReviewFailure(planReview: ReviewResult): string {
   return `${base} (${round}: ${trajectory})${oscillation}`;
 }
 
+/** Build the operator-facing reason string for a failed designReview, including
+ *  iteration trajectory when present. Mirror of describePlanReviewFailure for
+ *  the design path (BI-CE49D82E). Same convergence/oscillation language so the
+ *  operator's mental model is consistent across phase gates. */
+export function describeDesignReviewFailure(designReview: ReviewResult): string {
+  const base = "Design review failed. Revise the design document and re-run reviewDesignDoc before advancing.";
+  const iter = designReview.iteration;
+  if (!iter) return base;
+  const round = `Round ${iter.round}`;
+  if (!iter.prior) {
+    return `${base} (${round})`;
+  }
+  const trajectory =
+    `${iter.prior.addressed} addressed, ${iter.prior.persisted} persist, ${iter.prior.newlySurfaced} new`;
+  const oscillation = iter.oscillating
+    ? " — issue count is not decreasing across rounds. Consider splitting this feature into smaller scopes before continuing to iterate."
+    : "";
+  return `${base} (${round}: ${trajectory})${oscillation}`;
+}
+
 // ─── Phase Transitions ──────────────────────────────────────────────────────
 
 const ALLOWED_TRANSITIONS: Record<BuildPhase, BuildPhase[]> = {

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -30,6 +30,61 @@ describe("buildDesignReviewPrompt", () => {
     expect(prompt).toContain("Filter hides done items");
     expect(prompt).toContain("JSON FORMAT");
   });
+
+  // BI-CE49D82E — Delta-aware design review prompt, mirror of the plan path
+  // added in BI-4396EFEC (D38). Live repro that drove this fix: FB-5E20E793
+  // (Voice Slice 1.6) looped on the same "missing accessibility section"
+  // complaint round after round because the reviewer re-evaluated from
+  // scratch each call. Injecting the prior issues breaks the loop.
+  describe("delta-aware prior context (BI-CE49D82E)", () => {
+    const minimalDoc = {
+      problemStatement: "Users need filtering",
+      existingCodeAudit: "No existing filter",
+      reusePlan: "Reuse OpsClient pattern",
+      proposedApproach: "Add checkbox filter",
+      acceptanceCriteria: ["Filter hides done items"],
+    };
+
+    it("omits prior-context block on round 1 (no prior issues)", () => {
+      const prompt = buildDesignReviewPrompt(minimalDoc, "");
+      expect(prompt).not.toContain("PRIOR REVIEW CONTEXT");
+      expect(prompt).not.toContain("Delta-aware review protocol");
+    });
+
+    it("omits prior-context block when prior arg is null", () => {
+      const prompt = buildDesignReviewPrompt(minimalDoc, "", null);
+      expect(prompt).not.toContain("PRIOR REVIEW CONTEXT");
+    });
+
+    it("omits prior-context block when prior issues array is empty", () => {
+      const prompt = buildDesignReviewPrompt(minimalDoc, "", { round: 1, issues: [] });
+      expect(prompt).not.toContain("PRIOR REVIEW CONTEXT");
+    });
+
+    it("includes prior issues verbatim on round 2+ so the reviewer can judge resolution", () => {
+      const prompt = buildDesignReviewPrompt(minimalDoc, "", {
+        round: 1,
+        issues: [
+          { severity: "critical", description: "Missing explicit Accessibility section" },
+          { severity: "important", description: "No alternatives considered" },
+        ],
+      });
+      expect(prompt).toContain("PRIOR REVIEW CONTEXT (this is review round 2)");
+      expect(prompt).toContain("Missing explicit Accessibility section");
+      expect(prompt).toContain("No alternatives considered");
+      expect(prompt).toContain("[critical]");
+      expect(prompt).toContain("[important]");
+    });
+
+    it("instructs the reviewer to honor addressed issues and avoid re-litigation", () => {
+      const prompt = buildDesignReviewPrompt(minimalDoc, "", {
+        round: 2,
+        issues: [{ severity: "critical", description: "Some prior issue" }],
+      });
+      expect(prompt).toContain("Delta-aware review protocol");
+      expect(prompt).toContain("convergence, not re-litigation");
+    });
+  });
 });
 
 describe("buildPlanReviewPrompt", () => {

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -23,12 +23,25 @@ import type {
 
 // ─── Prompt Templates ────────────────────────────────────────────────────────
 
-export function buildDesignReviewPrompt(doc: BuildDesignDoc, projectContext: string): string {
+export function buildDesignReviewPrompt(
+  doc: BuildDesignDoc,
+  projectContext: string,
+  prior?: ReviewPriorContext | null,
+): string {
   // Detect whether this feature has a UI component. Backend-only features
   // (cron jobs, API routes, data models) shouldn't be flagged for accessibility.
   const approachLower = (doc.proposedApproach ?? "").toLowerCase();
   const hasUI = /\bui\b|page\.tsx|component|dashboard|panel|form|modal|button|card|tab/i.test(approachLower)
     || /\b(shell)\b.*page/i.test(approachLower);
+
+  // BI-CE49D82E — Delta-aware design review prompt, mirror of the plan path
+  // added in BI-4396EFEC (D38). Live repro: FB-5E20E793 (Voice Slice 1.6)
+  // looped on the same "missing accessibility section" complaint round after
+  // round because the reviewer re-evaluated from scratch each call. With the
+  // prior issues injected, round 2+ judges resolution instead of re-litigating.
+  const priorSection = prior && prior.issues.length > 0
+    ? `\n\nPRIOR REVIEW CONTEXT (this is review round ${prior.round + 1}):\nThe immediately-prior review of this design surfaced these ${prior.issues.length} issues:\n${prior.issues.map((i, idx) => `  ${idx + 1}. [${i.severity}] ${i.description}`).join("\n")}\n\nDelta-aware review protocol:\n- For each prior issue, judge whether the new design addresses it. If yes, do NOT re-surface it.\n- If a prior issue is still present, re-surface it but reuse the SAME description so the operator sees persistence.\n- Only add NEW issues that this revision genuinely introduces or that the prior round missed.\n- Goal: convergence, not re-litigation. Avoid trading one set of issues for another.\n`
+    : "";
 
   return `You are reviewing a design document for a platform feature.
 
@@ -43,7 +56,7 @@ ${doc.reusabilityAnalysis ? `Reusability Analysis: Scope=${doc.reusabilityAnalys
 ${(doc as { accessibility?: string }).accessibility ? `Accessibility: ${(doc as { accessibility?: string }).accessibility}` : ""}
 
 PROJECT CONTEXT:
-${projectContext}
+${projectContext}${priorSection}
 
 REVIEW CHECKLIST — evaluate EVERY item before responding:
 1. Is the problem statement clear and specific?
@@ -70,18 +83,19 @@ RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
 }`;
 }
 
-/** Optional prior-round context passed to plan review on iterations 2+.
- *  Lets the reviewer judge which prior issues the new plan addresses, so
+/** Optional prior-round context passed to design / plan review on iterations 2+.
+ *  Lets the reviewer judge which prior issues the new artifact addresses, so
  *  the operator sees converging trajectory instead of issue-set churn.
- *  BI-4396EFEC (D38). */
-export type PlanReviewPriorContext = {
+ *  BI-4396EFEC (D38) introduced this for plan review; BI-CE49D82E generalized
+ *  the type so design review uses the same shape. */
+export type ReviewPriorContext = {
   round: number;
   issues: ReadonlyArray<{ severity: string; description: string }>;
 };
 
 export function buildPlanReviewPrompt(
   plan: BuildPlanDoc,
-  prior?: PlanReviewPriorContext | null,
+  prior?: ReviewPriorContext | null,
 ): string {
   const tasks = Array.isArray(plan?.tasks) ? plan.tasks : [];
   const files = Array.isArray(plan?.fileStructure) ? plan.fileStructure : [];

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7397,7 +7397,12 @@ export async function executeTool(
       // fix-flow gate picks the (fix, small | medium | large | xlarge) cell
       // rather than always falling back to (fix, medium). plan is also
       // needed below for the standard feature path's intake fallback.
-      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true, kind: true, brief: true, plan: true } });
+      // BI-CE49D82E — also select prior designReview so we can pass its issues
+      // to the reviewer prompt for delta-awareness and surface the iteration
+      // trajectory in the operator-facing gate reason (mirror of BI-4396EFEC
+      // for the plan path). Live repro: FB-5E20E793 oscillated on the same
+      // "missing accessibility" complaint round after round.
+      const build = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designDoc: true, designReview: true, kind: true, brief: true, plan: true } });
 
       // Fix flow: a fix build has no feature design doc — it carries a structured
       // diagnosis (fixContext) on its brief. Review the diagnosis for completeness
@@ -7448,7 +7453,26 @@ export async function executeTool(
       if (!build?.designDoc) return { success: false, error: "No design document saved yet.", message: "Save designDoc first." };
       const { buildDesignReviewPrompt, buildArchitectureReviewPrompt, architectureAdvisoryFromReview, parseReviewResponse, mergeReviews } = await import("@/lib/build-reviewers");
       const designDocTyped = build.designDoc as Parameters<typeof buildDesignReviewPrompt>[0];
-      const prompt = buildDesignReviewPrompt(designDocTyped, "");
+      // BI-CE49D82E — Compute the iteration context up front so we can
+      // (a) feed prior issues into the reviewer prompt and (b) populate
+      // ReviewResult.iteration on the output. Round is 1-based: first
+      // review = 1, every subsequent reviewDesignDoc call increments.
+      const priorDesignReview = (build.designReview ?? null) as
+        | { issues?: Array<{ severity?: string; description?: string }>; iteration?: { round?: number } }
+        | null;
+      const priorRound = priorDesignReview?.iteration?.round ?? 0;
+      const priorIssues = Array.isArray(priorDesignReview?.issues)
+        ? priorDesignReview!.issues!
+            .filter((i): i is { severity: string; description: string } =>
+              typeof i?.severity === "string" && typeof i?.description === "string",
+            )
+            .map((i) => ({ severity: i.severity, description: i.description }))
+        : [];
+      const currentRound = priorRound + 1;
+      const priorContext = priorIssues.length > 0
+        ? { round: priorRound, issues: priorIssues }
+        : null;
+      const prompt = buildDesignReviewPrompt(designDocTyped, "", priorContext);
       const archPrompt = buildArchitectureReviewPrompt({ kind: "design", doc: designDocTyped }, "");
       const { routeAndCall } = await import("@/lib/routed-inference");
       const messages = [{ role: "user" as const, content: prompt }];
@@ -7482,7 +7506,26 @@ export async function executeTool(
         issues: [{ severity: "critical" as const, description: "Both review agents failed to respond" }],
         summary: "Review could not be completed — retry.",
       };
-      const review = architectureAdvisory ? { ...reviewBase, architectureAdvisory } : reviewBase;
+      // BI-CE49D82E — Compute the iteration delta against the prior round and
+      // attach to the ReviewResult. computeReviewDelta + isOscillating live in
+      // feature-build-types so they're independently unit-testable and shared
+      // with the plan path.
+      const { computeReviewDelta, isOscillating } = await import("@/lib/feature-build-types");
+      const reviewWithIteration = (() => {
+        if (priorIssues.length === 0) {
+          return { ...reviewBase, iteration: { round: currentRound } };
+        }
+        const delta = computeReviewDelta(priorIssues, reviewBase.issues);
+        return {
+          ...reviewBase,
+          iteration: {
+            round: currentRound,
+            prior: delta,
+            oscillating: isOscillating(delta, reviewBase.issues.length),
+          },
+        };
+      })();
+      const review = architectureAdvisory ? { ...reviewWithIteration, architectureAdvisory } : reviewWithIteration;
       const archAdvisoryNote = architectureAdvisory && architectureAdvisory.issues.length > 0
         ? ` Architecture review (advisory): ${architectureAdvisory.summary} Fold actionable items into the design before building — they do not block this gate.`
         : "";
@@ -7541,9 +7584,18 @@ export async function executeTool(
         const issueList = criticalIssues.length > 0
           ? criticalIssues.map((i: { description: string }) => i.description).join("; ")
           : review.summary;
+        // BI-CE49D82E — Include the iteration trajectory in the agent-facing
+        // message so the implementer model sees when its revisions are trading
+        // one set of issues for another instead of converging. The oscillating
+        // signal recommends a scope split rather than another iteration —
+        // matching the plan path established by BI-4396EFEC (D38).
+        const iter = review.iteration;
+        const trajectoryNote = iter?.prior
+          ? ` (Round ${iter.round}: ${iter.prior.addressed} addressed, ${iter.prior.persisted} persist, ${iter.prior.newlySurfaced} new${iter.oscillating ? " — issues are not net-decreasing across rounds; consider proposing a scope split rather than another revision." : ""}.)`
+          : "";
         return {
           success: true,
-          message: `Design review FAILED. Blocking issues: ${issueList}. Revise the design document to address these issues, then call saveBuildEvidence with field "designDoc" and re-run reviewDesignDoc.${archAdvisoryNote}`,
+          message: `Design review FAILED. Blocking issues: ${issueList}. Revise the design document to address these issues, then call saveBuildEvidence with field "designDoc" and re-run reviewDesignDoc.${trajectoryNote}${archAdvisoryNote}`,
           data: { review, blocked: true, action: "revise_and_resubmit" },
         };
       }


### PR DESCRIPTION
## Summary

Mirrors BI-4396EFEC (D38)'s plan-path iteration tracking onto the design path. `reviewDesignDoc` now loads the prior `designReview`, computes round + delta (`addressed` / `persisted` / `newlySurfaced`) + `oscillating` flag, passes prior issues into the reviewer prompt for delta-awareness, and surfaces the trajectory in both the agent-facing fail message and the operator-facing phase-gate reason.

## Why

Live repro: **FB-5E20E793** (Voice Slice 1.6, BI-70DD03D8) sat silent for **17 hours** after `reviewDesignDoc` failed twice on the same "missing Accessibility section" complaint. Activity timeline:

- 20:14:34 `ideate_dispatch` finishes → `saveBuildEvidence(designDoc)`
- 20:15:06 `reviewDesignDoc` FAIL ("missing accessibility + alternatives")
- 20:15:25 `saveBuildEvidence(designDoc)` (refinement)
- 20:16:00 `reviewDesignDoc` FAIL again — *same* "missing accessibility" complaint
- ...17h of silence

Without iteration metadata, the reviewer re-evaluated from scratch each call, the agent kept producing near-identical refinements, and the agentic-loop sticky-veto silently deadlocked. The original BI-A672E4C0 framing ("Approve Start never dispatches Ideate") was correct for the May-24 repros (FB-291BC06C / FB-486B7710) but doesn't match the current install — dispatch fires fine now. This BI is the actually-current symptom.

## What changed

- `apps/web/lib/integrate/build-reviewers.ts` — generalize `PlanReviewPriorContext` → `ReviewPriorContext`; extend `buildDesignReviewPrompt(doc, projectContext, prior?)` with the same `PRIOR REVIEW CONTEXT` block the plan path uses.
- `apps/web/lib/mcp-tools.ts` `reviewDesignDoc` case — also `select: { designReview: true }`, compute `priorRound`/`priorIssues`/`priorContext`/`currentRound`, pass into prompt, attach `iteration` (with `delta` + `oscillating`) to the persisted review, include trajectory note in the fail message.
- `apps/web/lib/explore/feature-build-types.ts` — export `describeDesignReviewFailure(designReview)` mirroring `describePlanReviewFailure`.
- `apps/web/lib/explore/build-process-matrix.ts` `designReview-passed` case — use `describeDesignReviewFailure` so the operator-facing gate reason shows trajectory + scope-split recommendation when oscillating.
- Unit tests added for both new branches (mirror of D38 tests).

`computeReviewDelta`, `isOscillating`, and the `ReviewResult.iteration` type are reused as-is — no schema change, no new helpers, no migration.

## Functional verification

1. Built dev-portal off this branch on :3001 against the live DB.
2. Triggered `reviewDesignDoc` against the stuck FB-5E20E793 via MCP.
3. Observed:
   - Agent-facing message ends with `(Round 1: 3 addressed, 0 persist, 4 new — issues are not net-decreasing across rounds; consider proposing a scope split rather than another revision.)`
   - Persisted `designReview.iteration = { round: 1, prior: { addressed: 3, persisted: 0, newlySurfaced: 4, issueCount: 3 }, oscillating: true }`
   - Fresh `reviewDesignDoc` activity row in the build's BuildActivity log

The deadlock signal is now visible at the gate; the build's silent state is broken.

## Test plan

- [x] `pnpm exec vitest run lib/explore/feature-build-types.test.ts lib/integrate/build-reviewers.test.ts` — 102 passed (5 new tests cover the design-side prior-context branch + `describeDesignReviewFailure`)
- [x] `pnpm exec vitest run lib/explore lib/integrate lib/build` — 1255 passed
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm exec next build` — compiles successfully (turbopack warnings unrelated to touched files)
- [x] Functional: dev-portal at :3001 against live DB, real `reviewDesignDoc` call surfaces the new trajectory + oscillating flag in DB + response message
- [ ] After merge: live portal rebuild will pick this up automatically; the next `reviewDesignDoc` call on any build with a prior failed review will start populating `iteration` and the gate reason will show trajectory

## Out of scope (separate BIs)

- Auto-cap design-review attempts at N (no precedent; D38 didn't cap plan review either)
- UI affordance to "advance past failing review" or "restart ideate from scratch"
- Resolve the agentic-loop `saveBuildEvidence` sticky-veto deadlock (`agentic-loop.ts:690-760`)
- Close BI-A672E4C0 as resolved (dispatch path no longer reproduces on this install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)