### PR TITLE
feat: teach decision skills to use org WWWD corpus + archetype-intelligent seed (BI-CC64ECE4)

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveBusinessProfile,
+  GENERIC_BUSINESS_PROFILE,
+} from "./archetype-business-context";
+
+describe("resolveBusinessProfile", () => {
+  it("returns the industry profile for a known category", () => {
+    const p = resolveBusinessProfile({ industry: "healthcare-wellness" });
+    expect(p.missionTheme.toLowerCase()).toContain("care");
+    expect(p.whoWeServe.toLowerCase()).toContain("patient");
+    expect(p.howWeDecide.toLowerCase()).toContain("safety");
+  });
+
+  it("falls back to the generic profile for an unknown / missing industry", () => {
+    expect(resolveBusinessProfile({ industry: "made-up" })).toBe(GENERIC_BUSINESS_PROFILE);
+    expect(resolveBusinessProfile({})).toBe(GENERIC_BUSINESS_PROFILE);
+  });
+
+  it("merges a flagship archetype override over its industry profile", () => {
+    const industry = resolveBusinessProfile({ industry: "healthcare-wellness" });
+    const dental = resolveBusinessProfile({
+      archetypeId: "dental-practice",
+      industry: "healthcare-wellness",
+    });
+    // Override specialises missionTheme + businessModel...
+    expect(dental.missionTheme).not.toBe(industry.missionTheme);
+    expect(dental.missionTheme.toLowerCase()).toContain("smile");
+    // ...but inherits the non-overridden fields from the industry profile.
+    expect(dental.whoWeServe).toBe(industry.whoWeServe);
+  });
+
+  it("ignores an unknown archetypeId and uses the industry profile", () => {
+    const p = resolveBusinessProfile({ archetypeId: "no-such-archetype", industry: "retail-goods" });
+    expect(p).toBe(resolveBusinessProfile({ industry: "retail-goods" }));
+  });
+
+  it("varies the profile across distinct industries", () => {
+    const food = resolveBusinessProfile({ industry: "food-hospitality" });
+    const pro = resolveBusinessProfile({ industry: "professional-services" });
+    expect(food.missionTheme).not.toBe(pro.missionTheme);
+    expect(food.howWeDecide).not.toBe(pro.howWeDecide);
+  });
+});

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -1,0 +1,185 @@
+// Archetype-intelligent business context for onboarding.
+//
+// One source of business-model-aware starter doctrine, keyed by archetype
+// category (and, for a few flagship archetypes, the specific slug). It feeds:
+//   - suggestMission()         → the mission starter on the business-context form
+//   - seedOrgWwwdCorpus()      → the org-overlay WWWD wiki page bodies
+//
+// The goal: a fresh install's WWWD corpus reads like it already understands the
+// operator's line of work — appointment-based care reads differently from
+// project-based professional services, which reads differently from
+// transactional retail — so new users feel understood on day one. Everything
+// here is an EDITABLE STARTER; the operator refines it.
+//
+// EXTENDING (the "periodical seed refresh" the founder asked for): as archetypes
+// evolve, (a) add/adjust an INDUSTRY_PROFILES entry for a new category, and/or
+// (b) add an ARCHETYPE_PROFILES override (merged over its industry profile) to
+// deepen a specific business model. Keep entries to broad, true, editable
+// starters — do not encode brittle specifics that read as fabricated.
+
+export type ArchetypeBusinessProfile = {
+  /** Completes the clause "we exist to …". */
+  missionTheme: string;
+  /** One-line characterisation of the revenue / operating model. */
+  businessModel: string;
+  /** Who-we-serve stance body (markdown paragraph). */
+  whoWeServe: string;
+  /** How-we-decide stance body — the trade-offs this business model leans on. */
+  howWeDecide: string;
+};
+
+export const GENERIC_BUSINESS_PROFILE: ArchetypeBusinessProfile = {
+  missionTheme:
+    "deliver real value to the people we serve and build a business we are proud of",
+  businessModel:
+    "We earn trust by doing good work for the people we serve and being worth coming back to.",
+  whoWeServe:
+    "We serve the people and stakeholders our business exists to help — the customers, clients, and community who rely on what we do.",
+  howWeDecide:
+    "We start from our mission and the people we serve, prefer durable quality over shortcuts, stay transparent about trade-offs, and keep humans in final authority over consequential calls.",
+};
+
+// ─── Industry-category profiles (the 9 archetype categories) ─────────────────
+
+const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
+  "healthcare-wellness": {
+    missionTheme:
+      "deliver attentive, high-quality care that improves the health and wellbeing of every patient",
+    businessModel:
+      "Care is delivered through booked appointments and ongoing treatment relationships; reputation and continuity drive repeat visits and referrals.",
+    whoWeServe:
+      "We serve patients and their families who trust us with their health. Many return over time, so each visit is part of a longer relationship, not a one-off transaction.",
+    howWeDecide:
+      "Patient safety and clinical quality come first — always. After that we weigh access, continuity of care, and a calm, respectful experience. We never trade a patient's wellbeing for speed or margin, and we are transparent when something is uncertain.",
+  },
+  "beauty-personal-care": {
+    missionTheme:
+      "help every client look and feel their best through skilled, personal service",
+    businessModel:
+      "Revenue comes from booked appointments and walk-ins; loyalty and word-of-mouth are built one great experience at a time.",
+    whoWeServe:
+      "We serve clients who want to look and feel good and who come back when they trust our hands and enjoy the experience. Regulars are the heart of the business.",
+    howWeDecide:
+      "We decide for the client's confidence and the personal relationship: skilled work, a welcoming chair, honest advice about what will suit them, and a result they are proud to show off. Repeat trust beats a one-time upsell.",
+  },
+  "fitness-recreation": {
+    missionTheme:
+      "help our members move, train, and live healthier, more active lives",
+    businessModel:
+      "A membership / recurring model — long-term member results and retention matter far more than one-off sign-ups.",
+    whoWeServe:
+      "We serve members on a journey — from first-timers to regulars — who want to get stronger, healthier, and more confident. Their progress and sense of belonging keep them with us.",
+    howWeDecide:
+      "We decide for member results and a welcoming, motivating community. We favour what keeps people coming back and progressing over what merely sells a membership, and we keep the space safe, clean, and encouraging.",
+  },
+  "food-hospitality": {
+    missionTheme:
+      "create welcoming experiences and food and hospitality our guests come back for",
+    businessModel:
+      "High-volume service where consistency, speed, and repeat custom drive the business; a great visit earns the next one.",
+    whoWeServe:
+      "We serve guests who choose to spend their time and money with us — locals, regulars, and first-timers we want to turn into regulars. Every guest's experience is the product.",
+    howWeDecide:
+      "We decide for the guest experience and consistency: quality and hospitality every time, cleanliness and safety without compromise, and speed that never costs care. A guest who leaves happy is the whole point.",
+  },
+  "professional-services": {
+    missionTheme:
+      "deliver expert advice and dependable service that helps our clients succeed",
+    businessModel:
+      "Project- and retainer-based expertise; the business runs on trust, reputation, and long-term client relationships.",
+    whoWeServe:
+      "We serve clients who hire us for judgment and results they cannot easily get elsewhere. The relationship is built on trust and tends to compound over years and referrals.",
+    howWeDecide:
+      "We decide for client success and long-term trust over a quick win. We give honest advice even when it is not what the client hoped to hear, protect confidentiality, and stand behind the quality of our work.",
+  },
+  "hoa-property-management": {
+    missionTheme:
+      "care for the properties and communities entrusted to us so owners and residents can thrive",
+    businessModel:
+      "Ongoing stewardship of properties on behalf of owners and residents; responsiveness and fairness sustain the relationship.",
+    whoWeServe:
+      "We serve property owners who trust us with a major asset and the residents who live there. We answer to both, and balancing their interests fairly is the job.",
+    howWeDecide:
+      "We decide to protect the asset, treat residents fairly, and respond quickly when something needs attention. We are transparent about costs and decisions, and we hold the long-term health of the property above any short-term convenience.",
+  },
+  "education-training": {
+    missionTheme:
+      "help our learners grow, in a safe and supportive environment",
+    businessModel:
+      "Enrolment- and term-based; the business is sustained by learner progress and the trust of families and learners.",
+    whoWeServe:
+      "We serve learners and the families who entrust them to us. Their growth, safety, and confidence are why we exist, and their progress is our reputation.",
+    howWeDecide:
+      "We decide for the learner's growth and wellbeing first. Safety and care are non-negotiable; beyond that we favour what genuinely helps people learn over what is merely convenient to deliver.",
+  },
+  "retail-goods": {
+    missionTheme:
+      "offer products our customers love, backed by service they can trust",
+    businessModel:
+      "Transactional sales with repeat custom; product quality, fair value, and service turn a first purchase into a returning customer.",
+    whoWeServe:
+      "We serve customers looking for products they can rely on at a fair price, with help when they need it. Repeat buyers and recommendations are what make the business sustainable.",
+    howWeDecide:
+      "We decide for the customer's trust: products we would recommend to a friend, honest descriptions and fair pricing, and service that makes returns and questions painless. A customer who trusts us comes back.",
+  },
+  "nonprofit-community": {
+    missionTheme:
+      "advance our cause and serve our community with integrity",
+    businessModel:
+      "Mission- and donor-funded; impact for beneficiaries and careful stewardship of every donation sustain the organisation.",
+    whoWeServe:
+      "We serve the people and cause at the heart of our mission, alongside the donors, volunteers, and community who make the work possible. We are accountable to all of them.",
+    howWeDecide:
+      "We decide for mission impact and the people we serve, steward every donation carefully, and stay transparent about where resources go. We hold our purpose above growth for its own sake.",
+  },
+};
+
+// ─── Flagship specific-archetype overrides (merged over the industry profile) ─
+// Add entries here to deepen a particular business model. Partial — only the
+// fields you want to specialise; the rest inherit from the industry profile.
+
+const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
+  "dental-practice": {
+    missionTheme:
+      "keep our patients' smiles healthy with gentle, expert dental care they trust",
+    businessModel:
+      "Recurring check-ups plus planned treatment; long-term patient relationships and gentle, anxiety-aware care drive retention and referrals.",
+  },
+  restaurant: {
+    missionTheme:
+      "serve food and hospitality our guests look forward to coming back for",
+  },
+  "law-firm": {
+    missionTheme:
+      "protect our clients' interests with expert, dependable legal counsel",
+    howWeDecide:
+      "We decide for the client's interests and long-term trust, give candid advice even when unwelcome, protect confidentiality absolutely, and never let a short-term win compromise our professional integrity.",
+  },
+  "fitness-gym": {
+    missionTheme:
+      "help our members get stronger, healthier, and more confident — and keep coming back",
+  },
+  "ecommerce-general": {
+    businessModel:
+      "Online transactional sales with repeat custom; product quality, fast fulfilment, and easy support turn first orders into loyal customers.",
+  },
+  nonprofit: {
+    missionTheme:
+      "advance our cause and serve our community with integrity and impact",
+  },
+};
+
+/**
+ * Resolve the best business profile for an org: a flagship archetype override
+ * (merged over its industry profile) when available, else the industry profile,
+ * else the generic profile. Pure and deterministic.
+ */
+export function resolveBusinessProfile(input: {
+  archetypeId?: string | null;
+  industry?: string | null;
+}): ArchetypeBusinessProfile {
+  const base: ArchetypeBusinessProfile =
+    (input.industry ? INDUSTRY_PROFILES[input.industry] : undefined) ?? GENERIC_BUSINESS_PROFILE;
+  const override = input.archetypeId ? ARCHETYPE_PROFILES[input.archetypeId] : undefined;
+  return override ? { ...base, ...override } : base;
+}

--- a/apps/web/lib/onboarding/mission-suggestion.ts
+++ b/apps/web/lib/onboarding/mission-suggestion.ts
@@ -2,8 +2,15 @@
 // onboarding business-context step. Pure and deterministic — no I/O — so it
 // can be evaluated server-side to pre-fill the form and reused by the WWWD
 // seeding helper. The output is a *starter* the operator is expected to edit.
+//
+// The mission theme comes from the shared archetype-business-context layer so
+// the suggestion and the seeded WWWD corpus speak with one voice.
+
+import { resolveBusinessProfile } from "./archetype-business-context";
 
 export type MissionSuggestionInput = {
+  /** Specific archetype slug (e.g. "dental-practice"); enables a flagship override. */
+  archetypeId?: string | null;
   /** Archetype category (e.g. "healthcare-wellness"); see ARCHETYPE_TO_INDUSTRY. */
   industry?: string | null;
   /** Friendly archetype name (e.g. "Dental Practice"); currently advisory. */
@@ -14,44 +21,19 @@ export type MissionSuggestionInput = {
   orgName?: string | null;
 };
 
-/**
- * Themes keyed by the coarse industry category emitted by ARCHETYPE_TO_INDUSTRY.
- * Each completes the clause "we exist to …". Keep these broad — they are
- * deliberately editable starters, not finished mission statements.
- */
-const INDUSTRY_THEMES: Record<string, string> = {
-  "healthcare-wellness":
-    "deliver attentive, high-quality care that improves the health and wellbeing of the people we serve",
-  "beauty-personal-care":
-    "help every client look and feel their best through skilled, personal service",
-  "fitness-recreation":
-    "help our members move, train, and live healthier, more active lives",
-  "food-hospitality":
-    "create welcoming experiences and memorable food and hospitality for every guest",
-  "professional-services":
-    "deliver expert advice and dependable service that helps our clients succeed",
-  "hoa-property-management":
-    "manage and care for properties so owners and residents can thrive",
-  "retail-ecommerce":
-    "offer products our customers love, backed by service they can trust",
-  "trades-field-service":
-    "provide reliable, high-quality workmanship that keeps our customers' homes and businesses running",
-};
-
-const GENERIC_THEME =
-  "deliver real value to the people we serve and build a business we are proud of";
-
 function cleanName(orgName?: string | null): string | null {
   const trimmed = (orgName ?? "").trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 
 export function suggestMission(input: MissionSuggestionInput): string {
-  const theme =
-    (input.industry && INDUSTRY_THEMES[input.industry]) || GENERIC_THEME;
+  const { missionTheme } = resolveBusinessProfile({
+    archetypeId: input.archetypeId ?? null,
+    industry: input.industry ?? null,
+  });
   const name = cleanName(input.orgName);
   const sentence = name
-    ? `At ${name}, we exist to ${theme}.`
-    : `We exist to ${theme}.`;
+    ? `At ${name}, we exist to ${missionTheme}.`
+    : `We exist to ${missionTheme}.`;
   return sentence.charAt(0).toUpperCase() + sentence.slice(1);
 }

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -26,6 +26,7 @@ import { prisma } from "@dpf/db";
 import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
 import { suggestMission } from "./mission-suggestion";
+import { resolveBusinessProfile } from "./archetype-business-context";
 
 /** Platform fallback our org profile chains to (material.ts:14). */
 export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
@@ -101,21 +102,30 @@ type BusinessContextRow = {
 
 function buildPages(
   bc: BusinessContextRow,
-  archetypeName: string | null,
+  archetypeId: string | null,
   industry: string | null,
   orgName: string | null,
 ): SeedPage[] {
+  const profile = resolveBusinessProfile({ archetypeId, industry: industry ?? bc?.industry ?? null });
+
   const mission =
     (bc?.mission ?? "").trim() ||
     suggestMission({
+      archetypeId,
       industry: industry ?? bc?.industry ?? null,
-      archetypeName,
       description: bc?.description ?? null,
       orgName,
     });
   const who = (bc?.targetMarket ?? "").trim();
   const what = (bc?.description ?? "").trim();
   const orgLabel = (orgName ?? "").trim() || "this organization";
+
+  // Who-we-serve: lead with the captured target market when present, then the
+  // archetype-aware framing so the page reads like it understands the business.
+  const whoLead = who
+    ? `We serve ${who}.`
+    : profile.whoWeServe;
+  const whoAbstract = who ? `We serve ${who}.` : profile.whoWeServe;
 
   const pages: SeedPage[] = [
     {
@@ -143,15 +153,12 @@ function buildPages(
       body: [
         "# Who we serve",
         "",
-        who
-          ? `We serve ${who}.`
-          : `We serve the people and stakeholders ${orgLabel} exists to help.`,
+        whoLead,
         what ? `\nWhat we do: ${what}` : "",
+        `\nHow this business works: ${profile.businessModel}`,
         "\nWhen we decide \"what would we do?\", we weigh the interests of the people we serve first.",
       ].join("\n"),
-      abstract: who
-        ? `We serve ${who}.`
-        : `The stakeholders ${orgLabel} serves.`,
+      abstract: whoAbstract,
     },
     {
       slug: "org-how-we-decide",
@@ -160,11 +167,11 @@ function buildPages(
       body: [
         "# How we decide",
         "",
-        `When ${orgLabel} faces a decision, we start from our mission and the people we serve, prefer durable quality over shortcuts, stay transparent about trade-offs, and keep humans in final authority over consequential calls.`,
+        profile.howWeDecide,
         "",
-        "This is the organization's default stance until more specific guidance is captured.",
+        `This is ${orgLabel}'s starting decision stance, derived from how this kind of business tends to operate. Refine it as the organization's own judgment is captured.`,
       ].join("\n"),
-      abstract: "The organization's default decision stance: mission-first, stakeholder-first, quality over shortcuts, transparent, human-authoritative.",
+      abstract: profile.howWeDecide,
     },
   ];
   return pages;
@@ -186,15 +193,18 @@ export async function seedOrgWwwdCorpus(
       select: { mission: true, description: true, targetMarket: true, industry: true },
     }) as Promise<BusinessContextRow>,
     db.storefrontConfig.findFirst({
-      select: { archetype: { select: { name: true, category: true } } },
-    }) as Promise<{ archetype: { name: string; category: string } | null } | null>,
+      select: { archetypeId: true, archetype: { select: { name: true, category: true } } },
+    }) as Promise<{
+      archetypeId: string | null;
+      archetype: { name: string; category: string } | null;
+    } | null>,
     db.organization.findUnique({
       where: { id: organizationId },
       select: { name: true },
     }) as Promise<{ name: string | null } | null>,
   ]);
 
-  const archetypeName = sf?.archetype?.name ?? null;
+  const archetypeId = sf?.archetypeId ?? null;
   const industry = sf?.archetype?.category ?? bc?.industry ?? null;
   const orgName = org?.name ?? null;
 
@@ -238,7 +248,7 @@ export async function seedOrgWwwdCorpus(
   });
 
   // 3. Org-overlay wiki pages (the working WWWD lever) + materials.
-  const pages = buildPages(bc, archetypeName, industry, orgName);
+  const pages = buildPages(bc, archetypeId, industry, orgName);
   const wikiPageIds: string[] = [];
   let embedded = true;
 

--- a/packages/dpf-skill-pack/skills/dpf-compare-options/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-compare-options/SKILL.md
@@ -30,6 +30,8 @@ Compare 2-4 architecturally distinct options with WWMD after the context has bee
 - The trade-off should be shaped by founder-kernel principles, not by agent preference.
 - The result needs a recommendation and a clear reason for the operator.
 
+> **Platform vs business decisions.** `principle_decide` scores against the **founder kernel** — that's the right lens for *platform/WWMD* options. For a *business/WWWD* option set ("which way should the **organization** go?"), the deciding doctrine is the org's **mission + WWWD corpus**, not the platform kernel: gather it with `dpf-retrieve-decision-context`, weigh the options against the org's own stance first, and only lean on `principle_decide`/kernel reasoning where the org corpus is silent. Don't let platform doctrine override a business call the org has a stated stance on.
+
 ## Enforces
 
 - `kernel/principles/architecture-over-shortcuts`

--- a/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
@@ -33,6 +33,8 @@ enforces:
 When you face an open question with 2+ architecturally-distinct options inside the DPF codebase, **do not pick by gut**. Map each option to the closed `PRINCIPLE_DIMENSIONS` registry, call the `principle_decide` MCP tool, and surface the contribution ledger to the operator. This is "What Would Mark Do" (WWMD) as a tool, not a guess — and it sits in front of `dpf-brainstorming` whenever the brainstorm produces multiple viable options.
 
 > **Surface boundary (WWMD vs WWWD).** This skill is the **platform-development (WWMD)** decision surface — it scores against the founder kernel and is for DPF contributors and Build Studio *platform* work. It is **not** the path for a customer's *business* decision: those route through the Decision Perspective Gate against the organization's **WWWD** profile, which enforces the non-inherit boundary (a customer profile does not inherit platform business judgment as authority). The two surfaces are being consolidated so the Gate is the single governed door (BI-E1FB2307). See AGENTS.md §16 and `docs/user-guide/ai-workforce/decision-perspective.md`.
+>
+> **The org WWWD corpus is now populated at onboarding** (company mission + org-overlay `stance`/`principle` pages, seeded from the chosen archetype — BI-CC64ECE4). So "what would *we* do?" answers from the **organization's own doctrine first**: gather it with `dpf-retrieve-decision-context` (query `wiki_query` for org-overlay `stance`/`heuristic`/`principle` pages + the company mission) and let it govern. Fall back to this kernel/WWMD path **only when the org corpus is silent** on the question — never substitute Mark's platform doctrine for a business call the org has its own stance on.
 
 ## When to use
 

--- a/packages/dpf-skill-pack/skills/dpf-retrieve-decision-context/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-retrieve-decision-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-retrieve-decision-context
-description: "Use in the DPF codebase before a WWMD/kernel decision when the agent needs repo, backlog, spec, evidence, or principle context. Queries DPF MCP and local repo state before options are scored."
+description: "Use before a WWMD/kernel OR a WWWD/business decision when the agent needs context. Queries DPF MCP and local repo state — and, for business decisions, the organization's own mission + WWWD corpus (org-overlay stance/principle pages) — before options are scored."
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: mcp__dpf__wiki_query mcp__dpf__search_specs_and_plans mcp__dpf__list_backlog_items mcp__dpf__list_epics Bash(rg *)
@@ -23,13 +23,14 @@ enforces:
 
 # DPF Retrieve Decision Context
 
-Gather the evidence needed before a WWMD decision. Query current specs, live backlog, and relevant principles before scoring options.
+Gather the evidence needed before a decision. For a **platform/WWMD** decision, query current specs, live backlog, and founder-kernel principles. For a **business/WWWD** decision ("what would *we* do?"), also gather the organization's own context first: its **mission** and its **WWWD corpus** — the org-overlay `stance` / `heuristic` / `principle` pages seeded at onboarding from the company mission + archetype. The org speaks for itself before the platform kernel does.
 
 ## When to use
 
 - A Build Studio, Claude, Codex, or coworker thread has an open architecture or workflow decision.
 - The options mention new tables, tools, skills, epics, agent behavior, routing, or verification policy.
 - The answer depends on live backlog state, current specs, founder-kernel principles, or repo substrate.
+- **A business/WWWD decision** turns on how *this organization* operates — who it serves, what it stands for, how it weighs trade-offs. Its mission + WWWD corpus are the primary evidence; the platform kernel is only the fallback when that corpus is silent.
 
 ## Enforces
 
@@ -39,12 +40,13 @@ Gather the evidence needed before a WWMD decision. Query current specs, live bac
 
 ## Steps
 
-1. Restate the decision question in one sentence.
-2. Query `wiki_query` for directly relevant principles, using `pageKind = "principle"` when available.
-3. Search specs and plans for the domain terms in the question.
-4. Query current epics and backlog items for overlapping work.
-5. Use `rg` for local code, skill, schema, and route substrate before proposing new artifacts.
-6. Return a compact context bundle: relevant principles, existing substrate, live backlog overlap, missing evidence, and any assumptions that remain.
+1. Restate the decision question in one sentence, and classify it: **platform/WWMD** (how the *platform* should be built) or **business/WWWD** (how the *organization* should act).
+2. **For a business/WWWD decision, retrieve the org's own doctrine first.** Query `wiki_query` for the organization's WWWD corpus — `pageKind = "stance"`, then `"heuristic"`, then `"principle"` — phrasing the query around the decision topic. These org-overlay pages (origin `overlay`, seeded at onboarding from the company mission + archetype) are the primary evidence. The company **mission** is already in the coworker's context as Block 0, and also lives as the `org-mission` overlay page. Distinguish `overlay` (this org) from `kernel` (platform) origin in what you return.
+3. For a platform/WWMD decision (or as the fallback when the org corpus is silent), query `wiki_query` for directly relevant founder-kernel principles, using `pageKind = "principle"`.
+4. Search specs and plans for the domain terms in the question.
+5. Query current epics and backlog items for overlapping work.
+6. Use `rg` for local code, skill, schema, and route substrate before proposing new artifacts.
+7. Return a compact context bundle: the org's mission + WWWD stance (for business decisions), relevant kernel principles, existing substrate, live backlog overlap, missing evidence, and any assumptions that remain. Label org-overlay vs kernel sources so the next step knows which doctrine spoke.
 
 ## Guardrails
 


### PR DESCRIPTION
## What & why

Follow-on to [#1360](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1360) (merged), which captures the company mission and seeds a per-org WWWD corpus at onboarding. This makes that corpus **usable by agents** and **richer at seed time**.

Founder ask: *"update the skills used in the AI coworker, and here in Claude / Codex use"* + *"deepen the seed with archetype context — be more intelligent about various business models on startup so new users are comfortable and impressed."*

### 1 — Decision skills now consult the org mission + WWWD corpus

Single-source edits in `packages/dpf-skill-pack` propagate to **all three surfaces** — Claude plugin (`.claude-plugin`), Codex plugin (`.codex-plugin`), and the in-portal **coworker** (seeded via `packages/db/src/seed-skills.ts`). No separate copies; `seed-skills.test` mirror-field parity stays green (body + descriptions only, no tool-grant changes).

- **dpf-retrieve-decision-context** — classify platform/WWMD vs business/WWWD; for WWWD, gather the org's own doctrine first (`wiki_query` org-overlay `stance`/`heuristic`/`principle` + the company mission), labelling overlay vs kernel origin.
- **dpf-decision-via-kernel** — the org WWWD corpus is now populated at onboarding, so "what would *we* do?" answers from org doctrine first and falls back to the kernel/WWMD **only when the org corpus is silent**.
- **dpf-compare-options** — for business/WWWD option sets, weigh against the org mission + WWWD corpus, not the platform kernel.

### 2 — Archetype-intelligent WWWD seed content

- New `apps/web/lib/onboarding/archetype-business-context.ts` — one source of business-model-aware starter doctrine keyed by archetype **category** (all 9), with flagship **specific-archetype overrides** (e.g. dental-practice, restaurant, law-firm) merged over the industry profile. Structured for the periodic seed refresh as archetypes evolve.
- `mission-suggestion.ts` delegates its theme to the shared layer (corrects stale industry keys) so the form suggestion and the seeded corpus speak with one voice.
- `seedOrgWwwdCorpus` resolves by archetype slug + industry and uses the richer who-we-serve / how-we-decide / business-model content. Still idempotent; captured mission/target-market lead when present.

## Tests
`resolveBusinessProfile` (industry resolution, override-merge, generic fallback, variance); existing seed + mission + apply-mission-prompt tests stay green (18 onboarding tests). Typecheck clean; `seed-skills` parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)