### PR TITLE
feat(wiki): enrichOrgCorpus façade + ingestRawSourceFromText entry (BI-7C9D6198)

### DIFF
--- a/apps/web/lib/wiki/enrich-org-corpus.test.ts
+++ b/apps/web/lib/wiki/enrich-org-corpus.test.ts
@@ -1,0 +1,376 @@
+// EP-CORPUS-BOOTSTRAP Phase 1 — tests for enrichOrgCorpus (BI-7C9D6198).
+
+import { describe, it, expect, vi } from "vitest";
+import { enrichOrgCorpus, type EnrichCorpusClient } from "./enrich-org-corpus";
+import type { InferenceCallable } from "./proposal";
+
+// ─── Test doubles ───────────────────────────────────────────────────────────
+
+/** Build a stubbed Prisma-shaped client with vi.fn spies for every method
+ *  enrichOrgCorpus touches. Defaults model the happy path; individual tests
+ *  override `.mockResolvedValueOnce` as needed. */
+function makeDbStub(opts: {
+  /** Pre-existing wiki pages by slug (for findFirst inside commit step). */
+  existingWikiPages?: Array<{ id: string; organizationId: string; slug: string; status: string; pageKind: string; body: string; abstract: string | null }>;
+  /** Org profile presence — null means "not seeded yet". */
+  profile?: { profileId: string; currentVersionId: string | null } | null;
+} = {}) {
+  const existingPages = opts.existingWikiPages ?? [];
+
+  const rawSourceUpsert = vi.fn();
+  const wikiIngestEventCreate = vi.fn();
+
+  const wikiPageFindFirst = vi.fn();
+  const wikiPageFindMany = vi.fn();
+  const wikiPageCreate = vi.fn();
+  const wikiPageUpdate = vi.fn();
+  const wikiPageRevisionCreate = vi.fn();
+  const wikiPageRevisionFindFirst = vi.fn();
+  const wikiPageSourceUpsert = vi.fn();
+  const wikiPageLinkUpsert = vi.fn();
+
+  const profileFindUnique = vi.fn();
+  const materialUpsert = vi.fn();
+
+  // Default behaviors
+
+  // RawSource upsert returns a fresh row each call.
+  let rsCounter = 0;
+  rawSourceUpsert.mockImplementation(async () => {
+    rsCounter++;
+    const now = new Date();
+    return { id: `rs_${rsCounter}`, createdAt: now, updatedAt: now };
+  });
+
+  wikiIngestEventCreate.mockImplementation(async () => ({ id: `evt_${rsCounter}` }));
+
+  // WikiPage stubs — track created pages so findFirst/findMany after the
+  // commit step see them.
+  const createdPages: Array<{
+    id: string; organizationId: string; slug: string; title: string; body: string;
+    abstract: string | null; pageKind: string; status: string; isKernel: boolean;
+  }> = [];
+  for (const p of existingPages) {
+    createdPages.push({
+      ...p,
+      title: p.slug,
+      isKernel: false,
+    });
+  }
+  let pageCounter = 100;
+  wikiPageCreate.mockImplementation(async (args: { data: Record<string, unknown> }) => {
+    pageCounter++;
+    const id = `wp_${pageCounter}`;
+    const row = {
+      id,
+      organizationId: args.data.organizationId as string,
+      slug: args.data.slug as string,
+      title: (args.data.title as string) ?? "",
+      body: (args.data.body as string) ?? "",
+      abstract: (args.data.abstract as string | null) ?? null,
+      pageKind: (args.data.pageKind as string) ?? "summary",
+      status: (args.data.status as string) ?? "draft",
+      isKernel: false,
+    };
+    createdPages.push(row);
+    return row;
+  });
+  wikiPageUpdate.mockImplementation(async (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => {
+    const id = args.where.id as string;
+    const idx = createdPages.findIndex((p) => p.id === id);
+    if (idx === -1) return { id };
+    createdPages[idx] = { ...createdPages[idx], ...(args.data as object) } as typeof createdPages[number];
+    return createdPages[idx];
+  });
+  wikiPageFindFirst.mockImplementation(async (args: { where: Record<string, unknown> }) => {
+    const where = args.where;
+    return createdPages.find(
+      (p) =>
+        (where.organizationId === undefined || p.organizationId === where.organizationId) &&
+        (where.slug === undefined || p.slug === where.slug) &&
+        (where.id === undefined || p.id === where.id),
+    ) ?? null;
+  });
+  wikiPageFindMany.mockImplementation(async (args: { where: Record<string, unknown> }) => {
+    const where = args.where;
+    const slugFilter = (where.slug as { in?: string[] } | string | undefined);
+    return createdPages.filter((p) => {
+      if (where.organizationId !== undefined && p.organizationId !== where.organizationId) return false;
+      if (where.status !== undefined && p.status !== where.status) return false;
+      if (slugFilter && typeof slugFilter === "object" && Array.isArray(slugFilter.in)) {
+        return slugFilter.in.includes(p.slug);
+      }
+      if (typeof slugFilter === "string" && p.slug !== slugFilter) return false;
+      return true;
+    });
+  });
+  wikiPageRevisionCreate.mockImplementation(async () => ({ id: "rev_x" }));
+  wikiPageRevisionFindFirst.mockImplementation(async () => null);
+  wikiPageSourceUpsert.mockImplementation(async () => ({ id: "ps_x" }));
+  wikiPageLinkUpsert.mockImplementation(async () => ({ id: "pl_x" }));
+
+  // Profile stub — by default seeded with v1.
+  const profile = opts.profile === undefined
+    ? { profileId: "default", currentVersionId: "v1" }
+    : opts.profile;
+  profileFindUnique.mockImplementation(async (args: { where: { profileId: string } }) => {
+    if (!profile) return null;
+    return { profileId: args.where.profileId, currentVersionId: profile.currentVersionId };
+  });
+
+  materialUpsert.mockImplementation(async (args: {
+    where: { materialId: string };
+    create: Record<string, unknown>;
+    update: Record<string, unknown>;
+  }) => ({ materialId: args.where.materialId }));
+
+  const db = {
+    rawSource: { upsert: rawSourceUpsert },
+    wikiIngestEvent: { create: wikiIngestEventCreate },
+    wikiPage: {
+      findFirst: wikiPageFindFirst,
+      findMany: wikiPageFindMany,
+      create: wikiPageCreate,
+      update: wikiPageUpdate,
+    },
+    wikiPageRevision: {
+      create: wikiPageRevisionCreate,
+      findFirst: wikiPageRevisionFindFirst,
+    },
+    wikiPageSource: { upsert: wikiPageSourceUpsert },
+    wikiPageLink: { upsert: wikiPageLinkUpsert },
+    decisionPerspectiveProfile: { findUnique: profileFindUnique },
+    perspectiveMaterial: { upsert: materialUpsert },
+  } as unknown as EnrichCorpusClient;
+
+  return {
+    db,
+    spies: {
+      rawSourceUpsert,
+      wikiIngestEventCreate,
+      wikiPageCreate,
+      wikiPageFindMany,
+      profileFindUnique,
+      materialUpsert,
+    },
+    createdPages,
+  };
+}
+
+/** LLM inference stub that returns a deterministic 1-claim proposal targeting
+ *  a fresh stance slug. Tests can override via vi.fn().mockImplementation. */
+function makeProposalInfer(opts: {
+  claimSlug?: string;
+  pageKind?: "stance" | "entity" | "principle";
+  proposeNew?: boolean;
+} = {}): InferenceCallable {
+  const slug = opts.claimSlug ?? "stances/we-default-to-rentals";
+  const kind = opts.pageKind ?? "stance";
+  const proposeNew = opts.proposeNew ?? true;
+
+  return vi.fn(async (req) => {
+    if (req.tier === "utility") {
+      return "Auto-generated abstract for the source.";
+    }
+    if (req.systemPrompt.includes("PASS 2") || req.systemPrompt.includes("CLAIM EXTRACTION")) {
+      return JSON.stringify({
+        claims: [
+          {
+            claim: "We default to rentals over one-time sales.",
+            target_slug: kind === "stance" ? slug : `entities/${slug.split("/")[1]}`,
+            page_kind: kind === "stance" ? "stance" : kind,
+            propose_new: proposeNew,
+            confidence: 0.9,
+            supporting_excerpt: "default to rentals",
+          },
+        ],
+      });
+    }
+    // Pass 3 — return empty stances/heuristics so the test focuses on the
+    // claims/commit path.
+    return JSON.stringify({ stances: [], heuristics: [] });
+  });
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("enrichOrgCorpus (BI-7C9D6198)", () => {
+  it("normalises input → ingest text → propose → commit → upsert PerspectiveMaterial (first-party trust)", async () => {
+    const { db, spies, createdPages } = makeDbStub();
+    const infer = makeProposalInfer({ claimSlug: "entities/rental-business", pageKind: "entity" });
+
+    const result = await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "We default to rentals. We serve seasonal customers.",
+      provenance: { sourceType: "data-entry", sourceRef: { field: "mission" } },
+      trust: "first-party",
+      db,
+      infer,
+    });
+
+    // RawSource upserted with the deterministic sourceKey.
+    expect(spies.rawSourceUpsert).toHaveBeenCalledTimes(1);
+    const rsArg = spies.rawSourceUpsert.mock.calls[0][0] as { where: { sourceKey: string }; create: Record<string, unknown> };
+    expect(rsArg.where.sourceKey).toBe('enrich:org_acme:data-entry:{"field":"mission"}');
+    expect(rsArg.create.organizationId).toBe("org_acme");
+    expect(rsArg.create.locator).toMatchObject({ field: "mission", sourceType: "data-entry" });
+
+    // WikiPage was created (commit step ran).
+    expect(spies.wikiPageCreate).toHaveBeenCalled();
+    const created = createdPages.find((p) => p.slug.startsWith("entities/"));
+    expect(created).toBeDefined();
+
+    // Result surfaces the committed page id + slug.
+    expect(result.committed.length).toBeGreaterThan(0);
+    expect(result.committed[0].slug).toBe("entities/rental-business");
+    expect(result.committed[0].pageId).toBe(created!.id);
+
+    // PerspectiveMaterial upserted with first-party trust shape.
+    expect(spies.materialUpsert).toHaveBeenCalledTimes(1);
+    const matArg = spies.materialUpsert.mock.calls[0][0] as {
+      where: { materialId: string };
+      create: Record<string, unknown>;
+    };
+    expect(matArg.where.materialId).toBe("org-perspective-org_acme:entities/rental-business");
+    expect(matArg.create).toMatchObject({
+      profileId: "org-perspective-org_acme",
+      profileVersionId: "v1",
+      evidenceGrade: "A",
+      reviewStatus: "approved",
+      promotionState: "promoted",
+      direction: "support",
+      freshness: "current",
+    });
+    expect((matArg.create.sourceRef as Record<string, unknown>).enrichment).toMatchObject({
+      sourceType: "data-entry",
+      trust: "first-party",
+    });
+    expect(result.materialIds).toContain("org-perspective-org_acme:entities/rental-business");
+  });
+
+  it("researched trust → PerspectiveMaterial lands as draft/candidate with evidence grade C", async () => {
+    const { db, spies } = makeDbStub();
+    const infer = makeProposalInfer({ claimSlug: "entities/market-segment", pageKind: "entity" });
+
+    await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "AI research finding: market is fragmented across 5 segments.",
+      provenance: { sourceType: "research", sourceRef: { agent: "scout-coworker", urls: ["https://example.org/market"] } },
+      trust: "researched",
+      db,
+      infer,
+    });
+
+    const matArg = spies.materialUpsert.mock.calls[0][0] as { create: Record<string, unknown> };
+    expect(matArg.create).toMatchObject({
+      evidenceGrade: "C",
+      reviewStatus: "draft",
+      promotionState: "candidate",
+    });
+    // confidenceWeight reduced for research-trust material.
+    expect(matArg.create.confidenceWeight).toBeLessThan(0.5);
+  });
+
+  it("derived trust → grade B, approved/promoted (uploaded-doc extraction shape)", async () => {
+    const { db, spies } = makeDbStub();
+    const infer = makeProposalInfer({ claimSlug: "entities/extracted-fact", pageKind: "entity" });
+
+    await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "Extracted from business plan: margin target is 38%.",
+      provenance: { sourceType: "document", sourceRef: { documentId: "doc_42", page: 3 } },
+      trust: "derived",
+      db,
+      infer,
+    });
+
+    const matArg = spies.materialUpsert.mock.calls[0][0] as { create: Record<string, unknown> };
+    expect(matArg.create).toMatchObject({
+      evidenceGrade: "B",
+      reviewStatus: "approved",
+      promotionState: "promoted",
+    });
+  });
+
+  it("idempotent: re-invoking with the same provenance dedups by sourceKey, creates no new pages, leaves state stable", async () => {
+    const { db, spies, createdPages } = makeDbStub();
+    const infer = makeProposalInfer({ claimSlug: "entities/idem-target", pageKind: "entity" });
+
+    const r1 = await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "Idempotent body.",
+      provenance: { sourceType: "data-entry", sourceRef: { field: "mission", version: 1 } },
+      trust: "first-party",
+      db,
+      infer,
+    });
+
+    const pagesAfterFirst = createdPages.length;
+    expect(r1.materialIds.length).toBeGreaterThan(0);
+
+    const r2 = await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "Idempotent body.",
+      provenance: { sourceType: "data-entry", sourceRef: { version: 1, field: "mission" } }, // key order swapped
+      trust: "first-party",
+      db,
+      infer,
+    });
+
+    // Both RawSource upsert calls used the SAME stable sourceKey — key order
+    // in sourceRef must not affect the idempotency key.
+    const k1 = (spies.rawSourceUpsert.mock.calls[0][0] as { where: { sourceKey: string } }).where.sourceKey;
+    const k2 = (spies.rawSourceUpsert.mock.calls[1][0] as { where: { sourceKey: string } }).where.sourceKey;
+    expect(k2).toBe(k1);
+
+    // No NEW WikiPage created on re-invoke for the same slug (the commit step
+    // appended to the existing page; with no body delta, nothing is touched).
+    const sameSlugPages = createdPages.filter((p) => p.slug === "entities/idem-target");
+    expect(sameSlugPages.length).toBe(1);
+    expect(createdPages.length).toBe(pagesAfterFirst);
+
+    // The commit-touched set is empty on the no-op round; materialIds reflects
+    // that honestly (no work to redo). State is stable.
+    expect(r2.committed).toEqual([]);
+    expect(r2.materialIds).toEqual([]);
+  });
+
+  it("missing DecisionPerspectiveProfile → wiki pages still commit, no PerspectiveMaterial rows, warning surfaced", async () => {
+    const { db, spies } = makeDbStub({ profile: null });
+    const infer = makeProposalInfer({ claimSlug: "entities/pre-onboarding", pageKind: "entity" });
+
+    const result = await enrichOrgCorpus({
+      organizationId: "org_no_profile",
+      text: "Captured before onboarding seeded the profile.",
+      provenance: { sourceType: "qa", sourceRef: { question: "Where do you serve?" } },
+      trust: "first-party",
+      db,
+      infer,
+    });
+
+    expect(result.committed.length).toBeGreaterThan(0);  // page committed
+    expect(spies.materialUpsert).not.toHaveBeenCalled(); // no material upsert
+    expect(result.materialIds).toEqual([]);
+    expect(result.warnings.some((w) => w.includes("DecisionPerspectiveProfile"))).toBe(true);
+  });
+
+  it("fail-open embed: storeWikiPage returns false → page still persists, warning recorded", async () => {
+    const { db } = makeDbStub();
+    const infer = makeProposalInfer({ claimSlug: "entities/embed-failed", pageKind: "entity" });
+    const failingEmbed = vi.fn(async () => false);
+
+    const result = await enrichOrgCorpus({
+      organizationId: "org_acme",
+      text: "Body to embed.",
+      provenance: { sourceType: "data-entry", sourceRef: { field: "description" } },
+      trust: "first-party",
+      db,
+      embed: failingEmbed,
+      infer,
+    });
+
+    expect(failingEmbed).toHaveBeenCalled();
+    expect(result.committed.length).toBeGreaterThan(0); // page persisted
+    expect(result.warnings.some((w) => w.includes("embedding"))).toBe(true);
+  });
+});

--- a/apps/web/lib/wiki/enrich-org-corpus.ts
+++ b/apps/web/lib/wiki/enrich-org-corpus.ts
@@ -1,0 +1,517 @@
+// EP-CORPUS-BOOTSTRAP Phase 1: the enrichOrgCorpus façade (BI-7C9D6198).
+// Spec: docs/superpowers/specs/2026-05-31-continuous-corpus-enrichment-design.md
+//
+// One governed contract that every continuous-enrichment SOURCE feeds:
+// data-entry, Q&A, document upload, AI research, integration import,
+// gap-detection. Each source normalises its input to { text, provenance,
+// trust } and calls enrichOrgCorpus(); we own the rest — ingest the raw
+// source, run the LLM proposer, commit the resulting overlay pages, embed
+// them, and link them to the org's DecisionPerspectiveProfile via
+// PerspectiveMaterial rows. Idempotent on re-invoke.
+//
+// Why a façade, not a per-source pipeline: a corpus that grows from many
+// heterogeneous sources at many different times must converge on ONE
+// trust/dedup/provenance contract. The seed step (seed-org-wwwd-corpus.ts,
+// PR #1360) handles the first-time profile + opinionated archetype seed;
+// THIS module handles every enrichment afterwards.
+
+import { prisma } from "@dpf/db";
+import {
+  ingestRawSourceFromText,
+  type IngestRawSourceFromTextInput,
+} from "./ingest";
+import {
+  proposeWikiDiff,
+  type InferenceCallable,
+  type WikiDiffProposal,
+} from "./proposal";
+import { loadExistingSlugSnapshot } from "./schema-context";
+import {
+  commitIngestProposal,
+  type CommitProposalResult,
+} from "./proposal-commit";
+import {
+  storeWikiPage,
+  type StoreWikiPageInput,
+} from "./embeddings";
+
+// ─── Trust → routing rules ──────────────────────────────────────────────────
+// Spec §4 routing rule, made concrete:
+//   first-party (operator typed)         → committed, grade A, approved+promoted
+//   derived    (extracted from upload)   → committed, grade B, approved+promoted
+//   researched (AI found, must be vetted)→ committed at the WikiPage level (so
+//                                          the operator can see the candidate),
+//                                          but the linked PerspectiveMaterial
+//                                          lands in draft+candidate state — it
+//                                          will NOT influence WWWD answers
+//                                          until a human promotes it.
+//
+// Page status itself follows the existing commit-step convention: NEW pages
+// land as status="draft" regardless, NEW APPENDS to existing published pages
+// go straight in. Reviewers publish drafts via the existing review affordance.
+// We layer trust as PerspectiveMaterial state, NOT as a parallel page status.
+
+export type EnrichmentTrust = "first-party" | "derived" | "researched";
+
+type MaterialTrustShape = {
+  evidenceGrade: "A" | "B" | "C";
+  confidenceWeight: number;
+  reviewStatus: "approved" | "draft";
+  promotionState: "promoted" | "candidate";
+};
+
+const TRUST_TO_MATERIAL: Record<EnrichmentTrust, MaterialTrustShape> = {
+  "first-party": {
+    evidenceGrade: "A",
+    confidenceWeight: 0.85,
+    reviewStatus: "approved",
+    promotionState: "promoted",
+  },
+  derived: {
+    evidenceGrade: "B",
+    confidenceWeight: 0.65,
+    reviewStatus: "approved",
+    promotionState: "promoted",
+  },
+  researched: {
+    evidenceGrade: "C",
+    confidenceWeight: 0.4,
+    reviewStatus: "draft",
+    promotionState: "candidate",
+  },
+};
+
+// ─── Provenance input ───────────────────────────────────────────────────────
+
+/** The closed set of corpus-bootstrap source kinds (spec §3, §6). */
+export type EnrichmentSourceType =
+  | "data-entry"
+  | "qa"
+  | "document"
+  | "research"
+  | "integration"
+  | "gap-detection";
+
+/** Each sourceType has an idiomatic sourceRef shape. We capture it as a
+ *  free-form JSON object so the contract stays open as new feeders land. */
+export type EnrichmentProvenance = {
+  sourceType: EnrichmentSourceType;
+  /** Free-form structured pointer — varies by sourceType. Examples:
+   *  - data-entry: { field: "mission" }
+   *  - qa:         { question, askedBy }
+   *  - document:   { documentId, version, page? }
+   *  - research:   { agent, urls, model }
+   *  - integration:{ provider: "quickbooks", recordKind: "vendor", recordId }
+   *  - gap-detection: { topic, originatingQuery } */
+  sourceRef: Record<string, unknown>;
+};
+
+// ─── Input / Result ─────────────────────────────────────────────────────────
+
+export type EnrichOrgCorpusInput = {
+  organizationId: string;
+  /** Normalised content the proposer will read. Plain text or markdown. */
+  text: string;
+  provenance: EnrichmentProvenance;
+  trust: EnrichmentTrust;
+  /** Optional human-readable title for the RawSource row + audit. Derived
+   *  from provenance when omitted. */
+  title?: string;
+  /** Optional one-paragraph abstract. Recommended for `document` and
+   *  `research` sources where the body is long. */
+  abstract?: string | null;
+  /** Stable idempotency key. Derived from (organizationId, sourceType,
+   *  sourceRef) when omitted — sourceRef is JSON-stringified deterministically. */
+  sourceKey?: string;
+  /** Mapped from provenance.sourceType when omitted. */
+  rawSourceType?: import("@dpf/db/wiki-store").RawSourceType;
+  /** Attribution forwarded to the audit row + commit. */
+  agentId?: string | null;
+  userId?: string | null;
+  /** Production wiring: `createProductionInference()`. Tests inject a stub. */
+  infer: InferenceCallable;
+  /** Tests inject a fake DB; production omits and we use the shared prisma. */
+  db?: EnrichCorpusClient;
+  /** Tests inject a fake embed; production omits and we use storeWikiPage. */
+  embed?: (input: StoreWikiPageInput) => Promise<boolean>;
+};
+
+export type EnrichOrgCorpusResult = {
+  rawSourceId: string;
+  /** WikiPages created/updated by this enrichment. */
+  committed: Array<{ pageId: string; slug: string }>;
+  /** PerspectiveMaterial ids upserted by this enrichment. */
+  materialIds: string[];
+  /** Future hook: materials this enrichment supersedes (V1 always empty). */
+  superseded: string[];
+  /** Reviewer-visible signal — claims dropped below the commit threshold,
+   *  pages skipped because the org has no profile yet, etc. */
+  warnings: string[];
+  /** Underlying proposal + commit results, exposed for tests + downstream
+   *  observability without re-running the pipeline. */
+  proposal: WikiDiffProposal;
+  commit: CommitProposalResult;
+};
+
+// ─── Structural DB client (testable; matched by real Prisma) ────────────────
+
+/** Subset of PrismaClient the façade needs. Defined structurally so the
+ *  test suite can pass a fake without importing the real client. */
+export type EnrichCorpusClient = {
+  rawSource: { upsert: (args: unknown) => Promise<unknown> };
+  wikiIngestEvent: { create: (args: unknown) => Promise<unknown> };
+  wikiPage: {
+    findFirst: (args: unknown) => Promise<unknown>;
+    findMany: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  wikiPageRevision: {
+    create: (args: unknown) => Promise<unknown>;
+    findFirst?: (args: unknown) => Promise<unknown>;
+  };
+  wikiPageSource?: {
+    create?: (args: unknown) => Promise<unknown>;
+    findFirst?: (args: unknown) => Promise<unknown>;
+  };
+  rawSourceClient?: unknown;
+  decisionPerspectiveProfile: {
+    findUnique: (args: unknown) => Promise<unknown>;
+  };
+  perspectiveMaterial: {
+    upsert: (args: unknown) => Promise<unknown>;
+  };
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
+
+/** Stable JSON-stringify for sourceRef so the idempotency key is the same
+ *  across re-invocations. Keys are sorted to defeat ordering noise from
+ *  callers (e.g. {a,b} vs {b,a}). */
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableJsonStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+function deriveSourceKey(
+  organizationId: string,
+  provenance: EnrichmentProvenance,
+): string {
+  return `enrich:${organizationId}:${provenance.sourceType}:${stableJsonStringify(provenance.sourceRef)}`;
+}
+
+function deriveTitle(provenance: EnrichmentProvenance, fallback: string): string {
+  const ref = provenance.sourceRef;
+  if (typeof ref.title === "string" && ref.title.trim().length > 0) {
+    return ref.title;
+  }
+  if (typeof ref.field === "string" && ref.field.trim().length > 0) {
+    return `${provenance.sourceType}: ${ref.field}`;
+  }
+  if (typeof ref.documentId === "string") {
+    return `Document ${ref.documentId}`;
+  }
+  if (typeof ref.question === "string" && ref.question.trim().length > 0) {
+    return ref.question.length > 80 ? `${ref.question.slice(0, 77)}...` : ref.question;
+  }
+  if (typeof ref.recordId === "string" && typeof ref.provider === "string") {
+    return `${ref.provider}: ${ref.recordKind ?? "record"} ${ref.recordId}`;
+  }
+  if (typeof ref.topic === "string") {
+    return `Gap: ${ref.topic}`;
+  }
+  return fallback;
+}
+
+/** Provenance.sourceType → RawSource.sourceType mapping. The corpus design
+ *  taxonomy (data-entry/qa/document/research/integration/gap-detection) is
+ *  richer than the RawSource type registry (paper/article/spec/...). We
+ *  collapse the corpus axis onto the storage axis here so existing RawSource
+ *  filtering keeps working without a schema change. */
+function mapProvenanceToRawSourceType(
+  sourceType: EnrichmentSourceType,
+): import("@dpf/db/wiki-store").RawSourceType {
+  switch (sourceType) {
+    case "document":
+      return "doc";
+    case "research":
+      return "article";
+    case "qa":
+    case "data-entry":
+    case "gap-detection":
+      return "doc";
+    case "integration":
+      return "external-url";
+  }
+}
+
+// ─── The façade ─────────────────────────────────────────────────────────────
+
+/**
+ * Enrich a single org's WWWD corpus with one new piece of content from one
+ * source. The pipeline:
+ *
+ *   1. Upsert RawSource (sourceKey-keyed; idempotent) + WikiIngestEvent audit
+ *      via {@link ingestRawSourceFromText} — no filesystem access.
+ *   2. Load the org-scoped existing-slug snapshot so the proposer dedups
+ *      against pages that already exist.
+ *   3. Run the three-pass LLM proposer to extract claims/stances/heuristics.
+ *   4. Commit the proposal: create draft pages, append to existing published
+ *      ones, write WikiPageRevisions, link WikiPageSource citations.
+ *   5. For each touched page: embed it into Qdrant (fail-open) and upsert a
+ *      PerspectiveMaterial row linking the page to the org's
+ *      DecisionPerspectiveProfile current version. Material state reflects
+ *      the trust level (researched → draft/candidate; first-party/derived →
+ *      approved/promoted).
+ *
+ * Idempotency contract:
+ * - Re-invoking with the same (organizationId, sourceType, sourceRef) upserts
+ *   the same RawSource row, finds the same overlay pages, and re-asserts the
+ *   same PerspectiveMaterial rows. New audit/revision rows are written each
+ *   call (audit IS append-only by design); the resulting corpus state is
+ *   stable.
+ *
+ * Profile contract:
+ * - The org's DecisionPerspectiveProfile must already exist (seeded by
+ *   `seedOrgWwwdCorpus` at onboarding completion). If absent, the WikiPages
+ *   still commit (the operator can see the candidate content), but no
+ *   PerspectiveMaterial rows are written and a warning is returned. This
+ *   keeps the contract honest — enrichment never silently overrides the
+ *   "no profile yet" intent — while still letting pre-onboarding flows
+ *   capture content for later promotion.
+ */
+export async function enrichOrgCorpus(
+  input: EnrichOrgCorpusInput,
+): Promise<EnrichOrgCorpusResult> {
+  const db = (input.db ?? (prisma as unknown as EnrichCorpusClient));
+  const embed = input.embed ?? storeWikiPage;
+  const warnings: string[] = [];
+
+  const sourceKey =
+    input.sourceKey ?? deriveSourceKey(input.organizationId, input.provenance);
+  const sourceType =
+    input.rawSourceType ?? mapProvenanceToRawSourceType(input.provenance.sourceType);
+  const title = input.title ?? deriveTitle(input.provenance, sourceKey);
+
+  // 1. Source-layer ingest (no filesystem).
+  const textIngestInput: IngestRawSourceFromTextInput = {
+    sourceKey,
+    sourceType,
+    title,
+    body: input.text,
+    abstract: input.abstract ?? null,
+    locator: { ...input.provenance.sourceRef, sourceType: input.provenance.sourceType },
+    organizationId: input.organizationId,
+    isKernel: false,
+    agentId: input.agentId ?? null,
+    userId: input.userId ?? null,
+  };
+  const source = await ingestRawSourceFromText(
+    db as unknown as Parameters<typeof ingestRawSourceFromText>[0],
+    textIngestInput,
+  );
+
+  // 2. Org-scoped snapshot for the proposer + the commit step.
+  const snapshot = await loadExistingSlugSnapshot(
+    db as unknown as Parameters<typeof loadExistingSlugSnapshot>[0],
+    { organizationId: input.organizationId },
+  );
+
+  // 3. Three-pass LLM extraction.
+  const proposal = await proposeWikiDiff({
+    source: {
+      sourceKey,
+      title,
+      body: input.text,
+      abstract: input.abstract ?? null,
+    },
+    snapshot,
+    infer: input.infer,
+  });
+
+  // 4. Commit overlay pages.
+  const commit = await commitIngestProposal(
+    db as unknown as Parameters<typeof commitIngestProposal>[0],
+    {
+      rawSourceId: source.rawSourceId,
+      sourceKey,
+      proposal,
+      organizationId: input.organizationId,
+      agentId: input.agentId ?? null,
+      userId: input.userId ?? null,
+    },
+  );
+
+  // 5a. Resolve { slug → pageId, body, abstract, pageKind, status } for every
+  //     touched page, in one query, so we can embed + upsert materials below.
+  const touchedSlugs = [
+    ...commit.createdPageSlugs,
+    ...commit.updatedPageSlugs,
+  ];
+  const touchedRows = touchedSlugs.length > 0
+    ? ((await db.wikiPage.findMany({
+        where: { organizationId: input.organizationId, slug: { in: touchedSlugs } },
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          body: true,
+          abstract: true,
+          pageKind: true,
+          status: true,
+        },
+      })) as Array<{
+        id: string;
+        slug: string;
+        title: string;
+        body: string;
+        abstract: string | null;
+        pageKind: string;
+        status: string;
+      }>)
+    : [];
+
+  const committed: EnrichOrgCorpusResult["committed"] = touchedRows.map((r) => ({
+    pageId: r.id,
+    slug: r.slug,
+  }));
+
+  // 5b. Embed each touched page (fail-open: false → embedded=false on result,
+  //     page still exists in Postgres; next embed cycle retries).
+  for (const row of touchedRows) {
+    const ok = await embed({
+      pageId: row.id,
+      slug: row.slug,
+      title: row.title,
+      body: row.body,
+      abstract: row.abstract,
+      pageKind: row.pageKind,
+      status: row.status,
+      isKernel: false,
+      kernelVersion: null,
+      organizationId: input.organizationId,
+      kernelPageId: null,
+    });
+    if (!ok) {
+      warnings.push(`embedding for page ${row.slug} failed (fail-open: page persisted, embed will retry)`);
+    }
+  }
+
+  // 5c. PerspectiveMaterial upserts — link each touched page to the org's
+  //     DecisionPerspectiveProfile. If no profile exists, we DO NOT auto-
+  //     create one (that's seedOrgWwwdCorpus's job). We commit the WikiPages
+  //     anyway so candidate content isn't lost, and warn so the caller can
+  //     trigger seeding.
+  const profileId = `org-perspective-${input.organizationId}`;
+  const profileRow = (await db.decisionPerspectiveProfile.findUnique({
+    where: { profileId },
+    select: { profileId: true, currentVersionId: true },
+  })) as { profileId: string; currentVersionId: string | null } | null;
+
+  const materialIds: string[] = [];
+  if (!profileRow) {
+    warnings.push(
+      `org ${input.organizationId} has no DecisionPerspectiveProfile (${profileId}) — ` +
+        `WikiPages committed but no PerspectiveMaterial rows linked. ` +
+        `Run seedOrgWwwdCorpus to create the profile, then re-enrich (idempotent).`,
+    );
+  } else {
+    const profileVersionId = profileRow.currentVersionId;
+    const trustShape = TRUST_TO_MATERIAL[input.trust];
+
+    for (const row of touchedRows) {
+      const materialId = `${profileId}:${row.slug}`;
+      await db.perspectiveMaterial.upsert({
+        where: { materialId },
+        update: {
+          profileVersionId: profileVersionId,
+          sourceType: row.pageKind,
+          sourceRef: {
+            wikiPageId: row.id,
+            slug: row.slug,
+            organizationId: input.organizationId,
+            enrichment: {
+              sourceType: input.provenance.sourceType,
+              sourceRef: input.provenance.sourceRef,
+              trust: input.trust,
+              rawSourceId: source.rawSourceId,
+            },
+          },
+          summary: row.abstract,
+          freshness: "current",
+          // Re-enrichment of an existing material from a fresher source can
+          // upgrade the trust shape, but we never DOWNGRADE — a previously-
+          // approved material does not get demoted by a later researched feed.
+          ...(trustShape.reviewStatus === "approved"
+            ? {
+                reviewStatus: trustShape.reviewStatus,
+                promotionState: trustShape.promotionState,
+                evidenceGrade: trustShape.evidenceGrade,
+                confidenceWeight: trustShape.confidenceWeight,
+              }
+            : {}),
+        },
+        create: {
+          materialId,
+          profileId,
+          profileVersionId: profileVersionId,
+          sourceType: row.pageKind,
+          sourceRef: {
+            wikiPageId: row.id,
+            slug: row.slug,
+            organizationId: input.organizationId,
+            enrichment: {
+              sourceType: input.provenance.sourceType,
+              sourceRef: input.provenance.sourceRef,
+              trust: input.trust,
+              rawSourceId: source.rawSourceId,
+            },
+          },
+          scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+          domainClass: PLAN_READINESS_DOMAIN_CLASS,
+          direction: "support",
+          domains: [PLAN_READINESS_DOMAIN_CLASS],
+          freshness: "current",
+          evidenceGrade: trustShape.evidenceGrade,
+          confidenceWeight: trustShape.confidenceWeight,
+          reviewStatus: trustShape.reviewStatus,
+          promotionState: trustShape.promotionState,
+          summary: row.abstract,
+        },
+      });
+      materialIds.push(materialId);
+    }
+  }
+
+  // Surface dropped-claim signal so the caller can show the reviewer what
+  // the LLM proposed but didn't make the cut.
+  for (const dropped of commit.skippedLowConfidence) {
+    warnings.push(
+      `claim skipped (confidence below threshold): "${dropped.claim}" → ${dropped.targetSlug}`,
+    );
+  }
+  for (const err of commit.errors) {
+    warnings.push(`commit error: ${err}`);
+  }
+
+  return {
+    rawSourceId: source.rawSourceId,
+    committed,
+    materialIds,
+    superseded: [],
+    warnings,
+    proposal,
+    commit,
+  };
+}

--- a/apps/web/lib/wiki/ingest.test.ts
+++ b/apps/web/lib/wiki/ingest.test.ts
@@ -11,6 +11,7 @@ import {
   deriveSourceKeyFromPath,
   deriveSourceTypeFromPath,
   ingestRawSourceFromFile,
+  ingestRawSourceFromText,
 } from "./ingest";
 
 // ─── Path helpers ───────────────────────────────────────────────────────────
@@ -297,5 +298,154 @@ body`);
 
     expect(result.sourceType).toBe("external-url");
     expect(result.sourceKey).toBe("external-urls/custom");
+  });
+});
+
+// ─── ingestRawSourceFromText (BI-7C9D6198, EP-CORPUS-BOOTSTRAP) ─────────────
+// Sibling entry for sources that did NOT originate as a file on disk:
+// uploaded documents (DocumentBlob → extracted text), AI research output,
+// Q&A answers, integration imports, gap-detection synthesis. No filesystem
+// read, no frontmatter parse, no allow-list gate — caller stamps provenance.
+
+describe("ingestRawSourceFromText", () => {
+  it("forwards normalised payload to upsertRawSource without touching the filesystem", async () => {
+    const { db, upsert, create } = makeIngestMock();
+    upsert.mockResolvedValueOnce({
+      id: "rs_text_1",
+      createdAt: new Date("2026-05-31T15:00:00Z"),
+      updatedAt: new Date("2026-05-31T15:00:00Z"),
+    });
+    create.mockResolvedValueOnce({ id: "evt_text_1" });
+
+    const result = await ingestRawSourceFromText(db, {
+      sourceKey: "enrich:org_acme:document:doc_42",
+      sourceType: "doc",
+      title: "Acme Business Plan",
+      body: "We sell rentals to seasonal customers. Margin is 38%.",
+      abstract: "Rental-business mission, market, and margin.",
+      locator: { kind: "document", documentId: "doc_42", page: 1 },
+      organizationId: "org_acme",
+    });
+
+    expect(result.rawSourceId).toBe("rs_text_1");
+    expect(result.sourceKey).toBe("enrich:org_acme:document:doc_42");
+    expect(result.sourceType).toBe("doc");
+    expect(result.isNew).toBe(true);
+    expect(result.eventId).toBe("evt_text_1");
+
+    const upsertArg = upsert.mock.calls[0][0] as {
+      where: { sourceKey: string };
+      create: Record<string, unknown>;
+    };
+    expect(upsertArg.where).toEqual({ sourceKey: "enrich:org_acme:document:doc_42" });
+    expect(upsertArg.create).toMatchObject({
+      sourceKey: "enrich:org_acme:document:doc_42",
+      sourceType: "doc",
+      title: "Acme Business Plan",
+      abstract: "Rental-business mission, market, and margin.",
+      excerpt: "We sell rentals to seasonal customers. Margin is 38%.",
+      locator: { kind: "document", documentId: "doc_42", page: 1 },
+      organizationId: "org_acme",
+      isKernel: false,
+    });
+
+    const eventArg = create.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(eventArg.data).toMatchObject({
+      sourceId: "rs_text_1",
+      organizationId: "org_acme",
+      touchedPageIds: [],
+    });
+  });
+
+  it("rejects empty title and empty sourceKey before touching the DB", async () => {
+    const { db, upsert, create } = makeIngestMock();
+
+    await expect(
+      ingestRawSourceFromText(db, {
+        sourceKey: "k",
+        sourceType: "doc",
+        title: "   ",
+        body: "body",
+      }),
+    ).rejects.toThrow(/title/);
+
+    await expect(
+      ingestRawSourceFromText(db, {
+        sourceKey: "",
+        sourceType: "doc",
+        title: "Title",
+        body: "body",
+      }),
+    ).rejects.toThrow(/sourceKey/);
+
+    expect(upsert).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("flags isNew=false when the upserted row's createdAt and updatedAt diverge (re-ingest)", async () => {
+    const { db, upsert, create } = makeIngestMock();
+    upsert.mockResolvedValueOnce({
+      id: "rs_text_re",
+      createdAt: new Date("2026-05-30T00:00:00Z"),
+      updatedAt: new Date("2026-05-31T00:00:00Z"),
+    });
+    create.mockResolvedValueOnce({ id: "evt_text_re" });
+
+    const result = await ingestRawSourceFromText(db, {
+      sourceKey: "k_re",
+      sourceType: "doc",
+      title: "Re-ingest",
+      body: "body",
+    });
+    expect(result.isNew).toBe(false);
+  });
+
+  it("stores body in excerpt when non-empty, null when blank", async () => {
+    const { db, upsert, create } = makeIngestMock();
+    upsert.mockResolvedValue({
+      id: "rs_x",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    create.mockResolvedValue({ id: "evt_x" });
+
+    await ingestRawSourceFromText(db, {
+      sourceKey: "k_blank",
+      sourceType: "doc",
+      title: "Blank body",
+      body: "   \n  \n",
+    });
+    const firstUpsert = upsert.mock.calls[0][0] as { create: Record<string, unknown> };
+    expect(firstUpsert.create["excerpt"]).toBeNull();
+  });
+
+  it("forwards agent/user/kernelVersion attribution to the audit row", async () => {
+    const { db, upsert, create } = makeIngestMock();
+    upsert.mockResolvedValueOnce({
+      id: "rs_attr",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    create.mockResolvedValueOnce({ id: "evt_attr" });
+
+    await ingestRawSourceFromText(db, {
+      sourceKey: "k_attr",
+      sourceType: "doc",
+      title: "Attributed",
+      body: "body",
+      organizationId: "org_acme",
+      agentId: "agent_coo",
+      userId: "user_mark",
+      kernelVersion: "0.4.0",
+    });
+
+    const eventArg = create.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(eventArg.data).toMatchObject({
+      sourceId: "rs_attr",
+      organizationId: "org_acme",
+      agentId: "agent_coo",
+      userId: "user_mark",
+      kernelVersion: "0.4.0",
+    });
   });
 });

--- a/apps/web/lib/wiki/ingest.ts
+++ b/apps/web/lib/wiki/ingest.ts
@@ -186,7 +186,79 @@ function parseDate(value: string | undefined): Date | null {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
-// ─── Orchestrator ───────────────────────────────────────────────────────────
+// ─── Shared upsert + audit primitive ───────────────────────────────────────
+
+/**
+ * Normalised payload accepted by both the file-path and text/buffer entry
+ * points. Once a caller has produced sourceKey + sourceType + title + the
+ * mutable RawSource fields, the work is identical: upsert the row and write
+ * the audit event. Factored so the two entry points stay in lockstep.
+ */
+type CommitRawSourcePayload = {
+  sourceKey: string;
+  sourceType: RawSourceType;
+  title: string;
+  authors?: string[];
+  publishedAt?: Date | null;
+  url?: string | null;
+  doi?: string | null;
+  abstract?: string | null;
+  excerpt?: string | null;
+  license?: string | null;
+  locator?: Record<string, unknown> | null;
+  organizationId?: string | null;
+  isKernel?: boolean;
+  agentId?: string | null;
+  userId?: string | null;
+  kernelVersion?: string | null;
+};
+
+async function commitRawSourceAndAudit(
+  db: IngestClient,
+  payload: CommitRawSourcePayload,
+): Promise<IngestRawSourceResult> {
+  const retrievedAt = new Date();
+  const row = (await upsertRawSource(db, {
+    sourceKey: payload.sourceKey,
+    sourceType: payload.sourceType,
+    title: payload.title,
+    authors: payload.authors,
+    publishedAt: payload.publishedAt ?? null,
+    url: payload.url ?? null,
+    doi: payload.doi ?? null,
+    locator: payload.locator ?? null,
+    abstract: payload.abstract ?? null,
+    excerpt: payload.excerpt ?? null,
+    license: payload.license ?? null,
+    retrievedAt,
+    organizationId: payload.organizationId ?? null,
+    isKernel: payload.isKernel ?? false,
+  })) as { id: string; createdAt: Date; updatedAt: Date };
+
+  const isNew =
+    row.createdAt instanceof Date && row.updatedAt instanceof Date
+      ? row.createdAt.getTime() === row.updatedAt.getTime()
+      : false;
+
+  const event = (await recordIngestEvent(db, {
+    sourceId: row.id,
+    organizationId: payload.organizationId ?? null,
+    touchedPageIds: [],
+    agentId: payload.agentId ?? null,
+    userId: payload.userId ?? null,
+    kernelVersion: payload.kernelVersion ?? null,
+  })) as { id: string };
+
+  return {
+    rawSourceId: row.id,
+    sourceKey: payload.sourceKey,
+    sourceType: payload.sourceType,
+    isNew,
+    eventId: event.id,
+  };
+}
+
+// ─── Orchestrator: file-path entry ─────────────────────────────────────────
 
 /**
  * Read a raw-source file from disk, upsert the `RawSource` row, and append
@@ -197,6 +269,10 @@ function parseDate(value: string | undefined): Date | null {
  * touch any wiki page, does not write to Qdrant. The returned event row
  * carries `touchedPageIds: []` until Phase 2.2/2.3 wires the proposal
  * pipeline through.
+ *
+ * Path-injection trust model unchanged (CodeQL #62): MCP-callable entry
+ * points must run `assertAllowedIngestPath()` first; library callers trust
+ * their own input.
  */
 export async function ingestRawSourceFromFile(
   db: IngestClient,
@@ -227,8 +303,7 @@ export async function ingestRawSourceFromFile(
     );
   }
 
-  const retrievedAt = new Date();
-  const row = (await upsertRawSource(db, {
+  return commitRawSourceAndAudit(db, {
     sourceKey,
     sourceType,
     title,
@@ -239,30 +314,91 @@ export async function ingestRawSourceFromFile(
     abstract: frontmatter.abstract ?? null,
     excerpt: body.trim().length > 0 ? body : null,
     license: frontmatter.license ?? null,
-    retrievedAt,
     organizationId: input.organizationId ?? null,
     isKernel: input.isKernel ?? false,
-  })) as { id: string; createdAt: Date; updatedAt: Date };
-
-  const isNew =
-    row.createdAt instanceof Date && row.updatedAt instanceof Date
-      ? row.createdAt.getTime() === row.updatedAt.getTime()
-      : false;
-
-  const event = (await recordIngestEvent(db, {
-    sourceId: row.id,
-    organizationId: input.organizationId ?? null,
-    touchedPageIds: [],
     agentId: input.agentId ?? null,
     userId: input.userId ?? null,
     kernelVersion: input.kernelVersion ?? null,
-  })) as { id: string };
+  });
+}
 
-  return {
-    rawSourceId: row.id,
-    sourceKey,
-    sourceType,
-    isNew,
-    eventId: event.id,
-  };
+// ─── Orchestrator: text/buffer entry ───────────────────────────────────────
+
+/**
+ * Sibling of `ingestRawSourceFromFile` for sources that did NOT originate as
+ * a markdown file under one of the allow-listed roots — e.g. an uploaded
+ * business plan (DocumentBlob → extracted text), an AI research result, a
+ * Q&A answer, a QuickBooks supplier record summary, a coverage-gap synthesis.
+ *
+ * The caller supplies the normalised payload directly: sourceKey, sourceType,
+ * title, body text, and any provenance fields. There is NO filesystem read,
+ * NO frontmatter parsing, NO derivation from a path, and NO allow-list gate —
+ * the trust model lives with the caller, who is responsible for stamping the
+ * provenance object so the audit trail records WHERE this content came from.
+ *
+ * Same idempotency contract as the file-path entry: keyed on `sourceKey @unique`,
+ * re-ingesting the same logical source upserts the row and writes a new audit
+ * event. The path-injection posture of `ingestRawSourceFromFile` is preserved
+ * for that variant; this entry simply does not expose a path to gate.
+ *
+ * BI-7C9D6198 (EP-CORPUS-BOOTSTRAP Phase 1) — the foundational gap fill that
+ * unblocks every continuous-enrichment source per the corpus design.
+ */
+export type IngestRawSourceFromTextInput = {
+  /** Stable, caller-controlled idempotency key (e.g. `enrich:<orgId>:<provider>:<recordId>`). */
+  sourceKey: string;
+  sourceType: RawSourceType;
+  title: string;
+  /** The content body — what the LLM proposer will eventually read. */
+  body: string;
+  abstract?: string | null;
+  authors?: string[];
+  publishedAt?: Date | null;
+  url?: string | null;
+  doi?: string | null;
+  license?: string | null;
+  /** Free-form structured pointer — use it to capture provider/recordId/etc. */
+  locator?: Record<string, unknown> | null;
+  /** Org-scoped ingests pass an organizationId; kernel ingests omit it. */
+  organizationId?: string | null;
+  isKernel?: boolean;
+  agentId?: string | null;
+  userId?: string | null;
+  kernelVersion?: string | null;
+};
+
+export async function ingestRawSourceFromText(
+  db: IngestClient,
+  input: IngestRawSourceFromTextInput,
+): Promise<IngestRawSourceResult> {
+  const title = input.title.trim();
+  if (!title) {
+    throw new Error(
+      `ingestRawSourceFromText: title is required (got empty string).`,
+    );
+  }
+  if (!input.sourceKey.trim()) {
+    throw new Error(
+      `ingestRawSourceFromText: sourceKey is required (got empty string).`,
+    );
+  }
+
+  return commitRawSourceAndAudit(db, {
+    sourceKey: input.sourceKey,
+    sourceType: input.sourceType,
+    title,
+    authors: input.authors,
+    publishedAt: input.publishedAt ?? null,
+    url: input.url ?? null,
+    doi: input.doi ?? null,
+    abstract: input.abstract ?? null,
+    excerpt: input.body.trim().length > 0 ? input.body : null,
+    license: input.license ?? null,
+    locator: input.locator ?? null,
+    organizationId: input.organizationId ?? null,
+    isKernel: input.isKernel ?? false,
+    agentId: input.agentId ?? null,
+    userId: input.userId ?? null,
+    kernelVersion: input.kernelVersion ?? null,
+  });
 }


### PR DESCRIPTION
## Summary

Phase 1 of EP-CORPUS-BOOTSTRAP — the single governed contract every continuous-enrichment source feeds. Spec: [`docs/superpowers/specs/2026-05-31-continuous-corpus-enrichment-design.md`](docs/superpowers/specs/2026-05-31-continuous-corpus-enrichment-design.md).

This is the backbone BI; with it in place, Phase 2–8 source adapters (business-plan upload, market Q&A, AI research, supplier content, QuickBooks import, gap-detection triggers, governance) can each land independently as small feeders that call `enrichOrgCorpus()`.

## What this lands

**`ingestRawSourceFromText(db, {sourceKey, sourceType, title, body, ..., organizationId, locator})`** — sibling of `ingestRawSourceFromFile` for sources without a filesystem path. Reuses `upsertRawSource` + `recordIngestEvent` via a shared `commitRawSourceAndAudit` helper so the file-path and text-path entries stay in lockstep. No allow-list gate (no path to validate); caller stamps provenance.

**`enrichOrgCorpus({organizationId, text, provenance, trust, ...})`** — the façade. Pipeline:
1. Normalise input → `ingestRawSourceFromText` (RawSource + audit, idempotent by sourceKey).
2. `loadExistingSlugSnapshot` org-scoped.
3. `proposeWikiDiff` (3-pass LLM).
4. `commitIngestProposal` → WikiPage + WikiPageRevision + WikiPageSource.
5. `storeWikiPage` embed per touched page (fail-open).
6. Upsert `PerspectiveMaterial` per touched page tying it to the org's `DecisionPerspectiveProfile` current version.

**Trust → routing (spec §4):**
- `first-party` → grade A, approved + promoted
- `derived`    → grade B, approved + promoted
- `researched` → grade C, draft + candidate (must be human-vetted before influencing WWWD answers)

**Idempotency.** `sourceKey` deterministically derived from `(orgId, sourceType, sourceRef)` with stable JSON serialization so key-order can't break dedup. PerspectiveMaterial.materialId = `\${profileId}:\${slug}` matching the seed pattern. Re-invoke is a true no-op when nothing changed.

**Profile contract.** If the org has no `DecisionPerspectiveProfile` (pre-onboarding flow), WikiPages still commit but no PerspectiveMaterial rows are written and a warning is returned. Keeps `seedOrgWwwdCorpus` authoritative for profile creation rather than racing with it.

## Acceptance per BI-7C9D6198

- [x] Unit-tested `enrichOrgCorpus` that lands committed org-overlay material idempotently given (org, source-text, provenance) — 6 tests
- [x] Buffer/text ingest path with tests — 5 new tests
- [x] No regression on the existing file-path ingest — all 14 existing tests still pass; file-path entry now delegates to the shared helper

## Test plan

- [x] `pnpm exec vitest run lib/wiki/enrich-org-corpus.test.ts lib/wiki/ingest.test.ts` — 25 passed
- [x] `pnpm exec vitest run lib/wiki` (no regression) — 337 passed
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm exec next build` — compiles successfully (turbopack warnings unrelated to touched files)
- [x] Pre-commit hook: gitleaks secret scan + scoped typecheck — both ok
- [ ] Post-merge: a feeder BI (e.g. BI-C97C0873 business-plan upload) wires through this façade and the round-trip lands material in the live DB

## Out of scope (separate BIs)

- Phase 2-8 source adapters — each is its own small BI calling `enrichOrgCorpus`
- Auto-creating the DecisionPerspectiveProfile when absent (kept seed-step authoritative on purpose)
- `RawSource.sourceType` extension to cover the corpus-bootstrap taxonomy directly (collapsed to existing types for now)
- Periodic freshness refresh / staleness aging — Phase 3 governance BI

🤖 Generated with [Claude Code](https://claude.com/claude-code)