### PR TITLE
feat(onboarding): archetype-aware supplier & supply-chain seeded stance (BI-846C297F)

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -42,4 +42,77 @@ describe("resolveBusinessProfile", () => {
     expect(food.missionTheme).not.toBe(pro.missionTheme);
     expect(food.howWeDecide).not.toBe(pro.howWeDecide);
   });
+
+  // ─── supplyChain (archetype-aware supplier / supply-chain stance) ──────────
+
+  describe("supplyChain", () => {
+    const INDUSTRIES = [
+      "healthcare-wellness",
+      "beauty-personal-care",
+      "fitness-recreation",
+      "food-hospitality",
+      "professional-services",
+      "hoa-property-management",
+      "education-training",
+      "retail-goods",
+      "nonprofit-community",
+    ];
+
+    it("populates a non-empty supplyChain on every industry profile", () => {
+      for (const industry of INDUSTRIES) {
+        const p = resolveBusinessProfile({ industry });
+        expect(typeof p.supplyChain).toBe("string");
+        expect(p.supplyChain.trim().length).toBeGreaterThan(20);
+      }
+    });
+
+    it("populates a brief generic supplyChain on the fallback profile", () => {
+      expect(typeof GENERIC_BUSINESS_PROFILE.supplyChain).toBe("string");
+      expect(GENERIC_BUSINESS_PROFILE.supplyChain.trim().length).toBeGreaterThan(20);
+    });
+
+    it("reflects the characteristic posture for representative industries", () => {
+      // Food-hospitality leans on perishables; professional-services explicitly
+      // does not lean on a heavy physical supply chain. These are starter
+      // statements, but they have to read like they understand the business.
+      const food = resolveBusinessProfile({ industry: "food-hospitality" }).supplyChain.toLowerCase();
+      expect(food).toMatch(/perish|cold[- ]chain|local/);
+
+      const pro = resolveBusinessProfile({ industry: "professional-services" }).supplyChain.toLowerCase();
+      expect(pro).toMatch(/light|minimal|software|subscriptions/);
+
+      const retail = resolveBusinessProfile({ industry: "retail-goods" }).supplyChain.toLowerCase();
+      expect(retail).toMatch(/wholesal|inventory|stock/);
+    });
+
+    it("varies supplyChain across distinct industries", () => {
+      const food = resolveBusinessProfile({ industry: "food-hospitality" }).supplyChain;
+      const pro = resolveBusinessProfile({ industry: "professional-services" }).supplyChain;
+      const retail = resolveBusinessProfile({ industry: "retail-goods" }).supplyChain;
+      expect(new Set([food, pro, retail]).size).toBe(3);
+    });
+
+    it("merges a flagship archetype override over the industry supplyChain", () => {
+      const restaurant = resolveBusinessProfile({
+        archetypeId: "restaurant",
+        industry: "food-hospitality",
+      });
+      const industry = resolveBusinessProfile({ industry: "food-hospitality" });
+      // Override specialises the supply-chain text (restaurants — daily perishables)
+      // beyond the industry baseline; both still read like food-hospitality.
+      expect(restaurant.supplyChain).not.toBe(industry.supplyChain);
+      expect(restaurant.supplyChain.toLowerCase()).toMatch(/perish|ingredient|cold[- ]chain|food safety/);
+    });
+
+    it("inherits the industry supplyChain when an override doesn't specialise it", () => {
+      // dental-practice overrides missionTheme/businessModel but not supplyChain,
+      // so it should inherit healthcare-wellness's supply-chain posture verbatim.
+      const dental = resolveBusinessProfile({
+        archetypeId: "dental-practice",
+        industry: "healthcare-wellness",
+      });
+      const industry = resolveBusinessProfile({ industry: "healthcare-wellness" });
+      expect(dental.supplyChain).toBe(industry.supplyChain);
+    });
+  });
 });

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -26,6 +26,12 @@ export type ArchetypeBusinessProfile = {
   whoWeServe: string;
   /** How-we-decide stance body — the trade-offs this business model leans on. */
   howWeDecide: string;
+  /**
+   * Supplier / supply-chain stance — the typical procurement and vendor
+   * posture this kind of business runs on (1–3 sentences). Editable starter,
+   * never fabricated specifics.
+   */
+  supplyChain: string;
 };
 
 export const GENERIC_BUSINESS_PROFILE: ArchetypeBusinessProfile = {
@@ -37,6 +43,8 @@ export const GENERIC_BUSINESS_PROFILE: ArchetypeBusinessProfile = {
     "We serve the people and stakeholders our business exists to help — the customers, clients, and community who rely on what we do.",
   howWeDecide:
     "We start from our mission and the people we serve, prefer durable quality over shortcuts, stay transparent about trade-offs, and keep humans in final authority over consequential calls.",
+  supplyChain:
+    "We rely on a small set of dependable suppliers and service vendors for what the business needs to operate. Refine this as the real purchasing pattern emerges.",
 };
 
 // ─── Industry-category profiles (the 9 archetype categories) ─────────────────
@@ -51,6 +59,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve patients and their families who trust us with their health. Many return over time, so each visit is part of a longer relationship, not a one-off transaction.",
     howWeDecide:
       "Patient safety and clinical quality come first — always. After that we weigh access, continuity of care, and a calm, respectful experience. We never trade a patient's wellbeing for speed or margin, and we are transparent when something is uncertain.",
+    supplyChain:
+      "We rely on medical and clinical supply distributors for consumables, PPE, and pharmaceuticals — much of it on a recurring schedule. Continuity matters: a stock-out can delay patient care, so we keep working relationships with both primary and backup suppliers.",
   },
   "beauty-personal-care": {
     missionTheme:
@@ -61,6 +71,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve clients who want to look and feel good and who come back when they trust our hands and enjoy the experience. Regulars are the heart of the business.",
     howWeDecide:
       "We decide for the client's confidence and the personal relationship: skilled work, a welcoming chair, honest advice about what will suit them, and a result they are proud to show off. Repeat trust beats a one-time upsell.",
+    supplyChain:
+      "Our supply chain centres on professional product distributors plus a curated set of retail brands we resell. Inventory turns matter alongside trust — clients notice when a favourite product is missing, and back-bar consumables drive a real share of unit cost.",
   },
   "fitness-recreation": {
     missionTheme:
@@ -71,6 +83,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve members on a journey — from first-timers to regulars — who want to get stronger, healthier, and more confident. Their progress and sense of belonging keep them with us.",
     howWeDecide:
       "We decide for member results and a welcoming, motivating community. We favour what keeps people coming back and progressing over what merely sells a membership, and we keep the space safe, clean, and encouraging.",
+    supplyChain:
+      "Most of what we buy is durable: equipment, weights, and machines from specialised suppliers, plus regular consumables for cleaning, maintenance, and member amenities. Service relationships matter as much as initial purchase price — equipment downtime is a member-experience issue.",
   },
   "food-hospitality": {
     missionTheme:
@@ -81,6 +95,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve guests who choose to spend their time and money with us — locals, regulars, and first-timers we want to turn into regulars. Every guest's experience is the product.",
     howWeDecide:
       "We decide for the guest experience and consistency: quality and hospitality every time, cleanliness and safety without compromise, and speed that never costs care. A guest who leaves happy is the whole point.",
+    supplyChain:
+      "Perishable goods sit at the centre of our supply chain. We balance local producers (freshness, story) with broadline distributors (consistency, breadth), receive frequently, and treat the cold chain, food safety, and waste discipline as core operations — not back-of-house concerns.",
   },
   "professional-services": {
     missionTheme:
@@ -91,6 +107,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve clients who hire us for judgment and results they cannot easily get elsewhere. The relationship is built on trust and tends to compound over years and referrals.",
     howWeDecide:
       "We decide for client success and long-term trust over a quick win. We give honest advice even when it is not what the client hoped to hear, protect confidentiality, and stand behind the quality of our work.",
+    supplyChain:
+      "Our physical supply chain is intentionally light — most of what we consume is software, research databases, and professional subscriptions. The discipline is in vendor selection and renewal review: a stale tool can cost more than its licence.",
   },
   "hoa-property-management": {
     missionTheme:
@@ -101,6 +119,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve property owners who trust us with a major asset and the residents who live there. We answer to both, and balancing their interests fairly is the job.",
     howWeDecide:
       "We decide to protect the asset, treat residents fairly, and respond quickly when something needs attention. We are transparent about costs and decisions, and we hold the long-term health of the property above any short-term convenience.",
+    supplyChain:
+      "Our 'supply chain' is mostly trusted contractors and service vendors — landscaping, plumbing, electrical, pool service — plus consumables for common areas. We keep a vetted bench so urgent jobs do not become emergency markups.",
   },
   "education-training": {
     missionTheme:
@@ -111,6 +131,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve learners and the families who entrust them to us. Their growth, safety, and confidence are why we exist, and their progress is our reputation.",
     howWeDecide:
       "We decide for the learner's growth and wellbeing first. Safety and care are non-negotiable; beyond that we favour what genuinely helps people learn over what is merely convenient to deliver.",
+    supplyChain:
+      "We provision curriculum materials, classroom consumables, and educational technology — much of it on an annual or term-based cycle tied to the academic calendar. Lead times for textbooks and licensed materials need planning, not last-minute scrambles.",
   },
   "retail-goods": {
     missionTheme:
@@ -121,6 +143,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve customers looking for products they can rely on at a fair price, with help when they need it. Repeat buyers and recommendations are what make the business sustainable.",
     howWeDecide:
       "We decide for the customer's trust: products we would recommend to a friend, honest descriptions and fair pricing, and service that makes returns and questions painless. A customer who trusts us comes back.",
+    supplyChain:
+      "We carry inventory bought from wholesalers, brand distributors, or direct from makers. The rhythm is reorder, receive, sell — managed against shelf space, cash tied up in stock, and how fast items turn. Stock-outs lose sales; over-buying ties up cash.",
   },
   "nonprofit-community": {
     missionTheme:
@@ -131,6 +155,8 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
       "We serve the people and cause at the heart of our mission, alongside the donors, volunteers, and community who make the work possible. We are accountable to all of them.",
     howWeDecide:
       "We decide for mission impact and the people we serve, steward every donation carefully, and stay transparent about where resources go. We hold our purpose above growth for its own sake.",
+    supplyChain:
+      "Our supply chain blends purchased program supplies, in-kind donations from supporters, and contributions from partner organisations. Stewardship matters — we choose suppliers and partners who match our mission and respect that donors' trust comes attached.",
   },
 };
 
@@ -148,6 +174,8 @@ const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
   restaurant: {
     missionTheme:
       "serve food and hospitality our guests look forward to coming back for",
+    supplyChain:
+      "Perishable ingredients drive the rhythm — we receive most days, balance local producers with broadline distributors, and treat cold-chain integrity, food safety, and waste discipline as everyday operations, not back-of-house concerns.",
   },
   "law-firm": {
     missionTheme:
@@ -162,6 +190,8 @@ const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
   "ecommerce-general": {
     businessModel:
       "Online transactional sales with repeat custom; product quality, fast fulfilment, and easy support turn first orders into loyal customers.",
+    supplyChain:
+      "Inventory comes from wholesalers, brand suppliers, or via dropship; some SKUs we hold, some ship direct. We manage against turn rate, lead times, and fulfilment-partner reliability — what is on the website needs to be in stock or shippable, not aspirational.",
   },
   nonprofit: {
     missionTheme:

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -141,9 +141,9 @@ describe("seedOrgWwwdCorpus", () => {
     expect(fake.versions).toHaveLength(1);
     expect(fake.versions[0]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
 
-    // Three materials, each linked to a wiki page + the version
-    expect(result.materialCount).toBe(3);
-    expect(fake.materials).toHaveLength(3);
+    // Four materials, each linked to a wiki page + the version
+    expect(result.materialCount).toBe(4);
+    expect(fake.materials).toHaveLength(4);
     for (const m of fake.materials) {
       expect(m.profileVersionId).toBe(result.versionId);
       expect(m.domainClass).toBe("plan-readiness");
@@ -152,8 +152,8 @@ describe("seedOrgWwwdCorpus", () => {
       expect(m.sourceRef.wikiPageId).toBeTruthy();
     }
 
-    // Three published, org-scoped, non-kernel wiki pages
-    expect(fake.wikiPages).toHaveLength(3);
+    // Four published, org-scoped, non-kernel wiki pages
+    expect(fake.wikiPages).toHaveLength(4);
     for (const p of fake.wikiPages) {
       expect(p.status).toBe("published");
       expect(p.organizationId).toBe(ORG);
@@ -162,6 +162,7 @@ describe("seedOrgWwwdCorpus", () => {
     expect(fake.wikiPages.map((p) => p.slug).sort()).toEqual([
       "org-how-we-decide",
       "org-mission",
+      "org-supply-chain",
       "org-who-we-serve",
     ]);
 
@@ -172,9 +173,9 @@ describe("seedOrgWwwdCorpus", () => {
     expect(mission!.pageKind).toBe("principle");
 
     // Every published page was embedded into Qdrant
-    expect(embed).toHaveBeenCalledTimes(3);
+    expect(embed).toHaveBeenCalledTimes(4);
     expect(result.embedded).toBe(true);
-    expect(result.wikiPageIds).toHaveLength(3);
+    expect(result.wikiPageIds).toHaveLength(4);
   });
 
   it("is idempotent — re-running produces no duplicate profile/version/material/page rows", async () => {
@@ -194,11 +195,11 @@ describe("seedOrgWwwdCorpus", () => {
 
     expect(fake.profiles).toHaveLength(1);
     expect(fake.versions).toHaveLength(1);
-    expect(fake.materials).toHaveLength(3);
-    expect(fake.wikiPages).toHaveLength(3);
+    expect(fake.materials).toHaveLength(4);
+    expect(fake.wikiPages).toHaveLength(4);
     // Body unchanged on the 2nd run → no extra revision, no re-embed
-    expect(fake.revisions).toHaveLength(3);
-    expect(embed).toHaveBeenCalledTimes(3);
+    expect(fake.revisions).toHaveLength(4);
+    expect(embed).toHaveBeenCalledTimes(4);
   });
 
   it("still seeds a non-empty corpus when no mission was captured (archetype fallback)", async () => {
@@ -210,7 +211,7 @@ describe("seedOrgWwwdCorpus", () => {
 
     const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
 
-    expect(result.materialCount).toBe(3);
+    expect(result.materialCount).toBe(4);
     const mission = fake.wikiPages.find((p) => p.slug === "org-mission");
     expect(mission).toBeDefined();
     expect(mission!.body.trim().length).toBeGreaterThan(20);
@@ -229,7 +230,64 @@ describe("seedOrgWwwdCorpus", () => {
 
     expect(result.embedded).toBe(false);
     // DB rows still created despite embedding failure
-    expect(fake.wikiPages).toHaveLength(3);
-    expect(fake.materials).toHaveLength(3);
+    expect(fake.wikiPages).toHaveLength(4);
+    expect(fake.materials).toHaveLength(4);
+  });
+
+  it("seeds an archetype-aware org-supply-chain stance page + material", async () => {
+    // Food-hospitality industry → its profile.supplyChain should drive the
+    // page body (perishables / cold-chain / local-supplier posture).
+    const fake = makeFakeDb({
+      businessContext: {
+        mission: "Feed our neighbourhood food worth coming back for.",
+        description: "We run a small neighbourhood restaurant.",
+        targetMarket: "locals and regulars",
+        industry: "food-hospitality",
+      },
+      archetype: { name: "Restaurant", category: "food-hospitality" },
+      orgName: "Corner Kitchen",
+    });
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    const page = fake.wikiPages.find((p) => p.slug === "org-supply-chain");
+    expect(page).toBeDefined();
+    expect(page!.pageKind).toBe("stance");
+    expect(page!.status).toBe("published");
+    expect(page!.organizationId).toBe(ORG);
+    expect(page!.isKernel).toBe(false);
+    // Page body reflects food-hospitality's characteristic supply posture.
+    expect(page!.body.toLowerCase()).toMatch(/perish|cold[- ]chain|local/);
+    expect(page!.abstract.trim().length).toBeGreaterThan(20);
+
+    // Material follows the same linkage pattern as the other seeded materials.
+    const material = fake.materials.find((m) => m.materialId === `${result.profileId}:org-supply-chain`);
+    expect(material).toBeDefined();
+    expect(material!.sourceType).toBe("stance");
+    expect(material!.domainClass).toBe("plan-readiness");
+    expect(material!.direction).toBe("support");
+    expect(material!.evidenceGrade).toBe("B");
+    expect(material!.reviewStatus).toBe("approved");
+    expect(material!.promotionState).toBe("promoted");
+    expect(material!.sourceRef.wikiPageId).toBe(page!.id);
+    expect(material!.sourceRef.slug).toBe("org-supply-chain");
+    expect(material!.sourceRef.organizationId).toBe(ORG);
+  });
+
+  it("falls back to a brief generic supply-chain stance when the industry is unknown", async () => {
+    const fake = makeFakeDb({
+      businessContext: { mission: "M", description: null, targetMarket: null, industry: null },
+      archetype: null,
+      orgName: null,
+    });
+
+    await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    const page = fake.wikiPages.find((p) => p.slug === "org-supply-chain");
+    expect(page).toBeDefined();
+    expect(page!.body.trim().length).toBeGreaterThan(20);
+    expect(page!.pageKind).toBe("stance");
+    // Generic body is intentionally short / honest — no fabricated specifics.
+    expect(page!.body.toLowerCase()).not.toMatch(/perish|cold[- ]chain|dropship/);
   });
 });

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -173,6 +173,19 @@ function buildPages(
       ].join("\n"),
       abstract: profile.howWeDecide,
     },
+    {
+      slug: "org-supply-chain",
+      title: "How we work with suppliers",
+      pageKind: "stance",
+      body: [
+        "# How we work with suppliers",
+        "",
+        profile.supplyChain,
+        "",
+        `This is ${orgLabel}'s starting supplier and supply-chain stance, derived from how this kind of business typically runs. Refine it as actual suppliers, vendors, and purchasing rhythms are captured.`,
+      ].join("\n"),
+      abstract: profile.supplyChain,
+    },
   ];
   return pages;
 }


### PR DESCRIPTION
## Summary
- Extends the onboarding WWWD seed (PR #1369) so a fresh install's corpus understands the typical **supplier and supply-chain shape** of the chosen archetype — an editable starter, not fabricated specifics.
- `ArchetypeBusinessProfile` gains a `supplyChain` field, populated for all 9 industry profiles + the flagship overrides where it adds real specificity (`restaurant`: daily perishables / cold chain; `ecommerce-general`: dropship + fulfilment). `GENERIC_BUSINESS_PROFILE` keeps a deliberately brief, honest fallback.
- `seedOrgWwwdCorpus.buildPages()` emits a 4th org-overlay WikiPage `org-supply-chain` (pageKind `stance`, status `published`), wired through the same `PerspectiveMaterial` linkage as the existing seeded pages (`${profileId}:org-supply-chain`, sourceType `stance`, domainClass `plan-readiness`, grade `B`, approved/promoted). Re-runs remain a true no-op on revisions and embeds.

## Why
[BI-846C297F](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-846C297F) — part of [EP-CORPUS-BOOTSTRAP](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=EP-CORPUS-BOOTSTRAP). Today the seeded corpus is silent on supply chain even for archetypes where it's a defining concern (food-hospitality: perishables; retail: inventory; trades: parts distributors). Coworkers then fall back to platform doctrine when asked supply-chain questions; this gives the org a first-class, archetype-shaped starting stance the operator can refine.

## Composition
Composes with — does **not** depend on — the BI-7C9D6198 continuous corpus enrichment pipeline (parallel session; touches `apps/web/lib/wiki/*` + a new enrichment façade, not the files in this PR). File ownership was negotiated up front; no overlap.

## What changed
- [archetype-business-context.ts](apps/web/lib/onboarding/archetype-business-context.ts) — `supplyChain: string` field on `ArchetypeBusinessProfile`; populated on `GENERIC_BUSINESS_PROFILE`, every entry of `INDUSTRY_PROFILES`, and on the `restaurant` + `ecommerce-general` overrides (others inherit, by design).
- [seed-org-wwwd-corpus.ts](apps/web/lib/onboarding/seed-org-wwwd-corpus.ts) — `buildPages()` adds the 4th page `org-supply-chain` (title "How we work with suppliers"), with body derived from `profile.supplyChain` and the same upsert / revision / embed / material pipeline as the existing pages.
- Tests on both sides extended (see Test plan).

## Test plan
- [x] `cd apps/web && pnpm exec vitest run lib/onboarding/` — 4 files / 26 tests green (11 new / updated assertions).
- [x] `cd apps/web && pnpm exec tsc --noEmit` — clean.
- [x] Pre-commit gitleaks + scoped typecheck — clean.
- [x] Idempotency assertion: second `seedOrgWwwdCorpus(...)` invocation produces no duplicate profile / version / material / page rows, no extra revisions, no extra embed calls.
- [x] New seed-test assertions: `org-supply-chain` page is `pageKind: "stance"`, `status: "published"`, org-scoped, `isKernel: false`; its material is `sourceType: "stance"`, `domainClass: "plan-readiness"`, `direction: "support"`, `evidenceGrade: "B"`, `reviewStatus: "approved"`, `promotionState: "promoted"`, and its `sourceRef` links back to the page.
- [x] Generic-fallback path (industry unknown) still seeds the page with the brief generic body — no fabricated specifics ("perish", "cold-chain", "dropship" all absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)