### PR TITLE
feat(onboarding): capture business documents into the DMS (BI-C97C0873)

### DIFF
--- a/apps/web/app/api/onboarding/business-document/route.ts
+++ b/apps/web/app/api/onboarding/business-document/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { captureBusinessDocument } from "@/lib/onboarding/capture-business-document";
+
+export const runtime = "nodejs";
+
+// Capture a business plan / key document uploaded during onboarding into the
+// Document DMS (org-scoped). Corpus indexing (enrichOrgCorpus) is wired later
+// via the capture lib's `enrich` seam once BI-7C9D6198 lands.
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return NextResponse.json(
+      { error: "Organization not found. Complete account setup first." },
+      { status: 400 },
+    );
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file required" }, { status: 400 });
+  }
+  const titleRaw = formData.get("title");
+  const title = typeof titleRaw === "string" && titleRaw.trim().length > 0 ? titleRaw : null;
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const result = await captureBusinessDocument({
+      organizationId: org.id,
+      fileName: file.name,
+      mimeType: file.type,
+      buffer,
+      title,
+    });
+    return NextResponse.json({ success: true, ...result });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Capture failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -8,6 +8,7 @@ import {
 } from "./business-context-form-state";
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
+import { BusinessDocumentUpload } from "@/components/admin/BusinessDocumentUpload";
 
 const COMPANY_SIZE_OPTIONS = [
   { value: "solo", label: "Solo", description: "Just me" },
@@ -218,6 +219,9 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             organization &quot;would do&quot; when a decision comes up.
           </div>
         </label>
+
+        {/* Business document upload (optional) */}
+        <BusinessDocumentUpload />
 
         {/* Target market */}
         <label style={labelStyle}>

--- a/apps/web/components/admin/BusinessDocumentUpload.tsx
+++ b/apps/web/components/admin/BusinessDocumentUpload.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+// Optional onboarding affordance: upload a business plan / key document. It is
+// stored in the Document DMS and (once the enrichment pipeline lands) indexed
+// into the org WWWD corpus. Independent of the rest of the business-context
+// form — failure here never blocks setup.
+
+type Captured = { title: string; summary: string | null; textLength: number };
+
+export function BusinessDocumentUpload() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [captured, setCaptured] = useState<Captured | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setError(null);
+    setUploading(true);
+    try {
+      const body = new FormData();
+      body.append("file", file);
+      const res = await fetch("/api/onboarding/business-document", { method: "POST", body });
+      const data = (await res.json().catch(() => ({}))) as Partial<Captured> & { error?: string };
+      if (!res.ok) throw new Error(data.error ?? "Upload failed");
+      setCaptured({
+        title: data.title ?? file.name,
+        summary: data.summary ?? null,
+        textLength: data.textLength ?? 0,
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Upload failed");
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  const hintStyle: React.CSSProperties = { fontSize: 11, color: "var(--dpf-muted)", marginTop: 4 };
+
+  return (
+    <div style={{ fontSize: 13 }}>
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        Have a business plan or key document?{" "}
+        <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}>(optional)</span>
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".pdf,.doc,.docx,.txt,.md,.rtf"
+        disabled={uploading}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+        }}
+        style={{ fontSize: 13, color: "var(--dpf-text)" }}
+      />
+      <div style={hintStyle}>
+        We&apos;ll store it and use it to understand your business — it helps seed what your
+        organization &quot;would do&quot; when a decision comes up.
+      </div>
+      {uploading && <p style={{ color: "var(--dpf-muted)", fontSize: 12, margin: "6px 0 0" }}>Uploading…</p>}
+      {error && <p style={{ color: "var(--dpf-error)", fontSize: 12, margin: "6px 0 0" }}>{error}</p>}
+      {captured && (
+        <p style={{ color: "var(--dpf-success)", fontSize: 12, margin: "6px 0 0" }}>
+          Saved “{captured.title}” ({captured.textLength.toLocaleString()} characters captured).
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/onboarding/capture-business-document.test.ts
+++ b/apps/web/lib/onboarding/capture-business-document.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ManagedDocument } from "@/lib/documents/document-store";
+import {
+  captureBusinessDocument,
+  BUSINESS_DOCUMENT_KIND,
+  type CaptureBusinessDocumentDeps,
+  type DocumentEnricher,
+} from "./capture-business-document";
+
+function deps(over: Partial<CaptureBusinessDocumentDeps> = {}): CaptureBusinessDocumentDeps {
+  return {
+    parse: vi.fn(async () => ({
+      type: "document" as const,
+      summary: "3 pages, 1200 characters",
+      fullText: "We are an HVAC company serving the tri-county area. Our mission is...",
+    })),
+    save: vi.fn(async (input) =>
+      ({
+        id: "doc_row_1",
+        documentId: "doc_abc",
+        title: input.title,
+        documentKind: input.documentKind,
+        contentFormat: input.contentFormat,
+        currentState: "draft",
+        accessScope: "organization",
+        sourceKind: "managed",
+      }) as ManagedDocument,
+    ),
+    ...over,
+  };
+}
+
+const ORG = "org_123";
+const buf = Buffer.from("pretend pdf bytes");
+
+describe("captureBusinessDocument", () => {
+  it("parses the file and stores it in the DMS as a plan document", async () => {
+    const d = deps();
+    const res = await captureBusinessDocument(
+      { organizationId: ORG, fileName: "business-plan.pdf", mimeType: "application/pdf", buffer: buf },
+      d,
+    );
+
+    expect(d.parse).toHaveBeenCalledWith(buf, "application/pdf", "business-plan.pdf");
+    expect(d.save).toHaveBeenCalledTimes(1);
+    const saveArg = (d.save as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(saveArg).toMatchObject({
+      organizationId: ORG,
+      documentKind: BUSINESS_DOCUMENT_KIND, // "plan"
+      contentFormat: "application/pdf",
+      sourceKind: "managed",
+    });
+    expect(saveArg.contentText).toContain("HVAC company");
+    expect(saveArg.tags).toContain("onboarding");
+
+    expect(res.documentId).toBe("doc_abc");
+    expect(res.textLength).toBeGreaterThan(0);
+  });
+
+  it("derives a title from the file name when none is given", async () => {
+    const d = deps();
+    await captureBusinessDocument(
+      { organizationId: ORG, fileName: "Q3 Business Plan.pdf", mimeType: "application/pdf", buffer: buf },
+      d,
+    );
+    const saveArg = (d.save as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(saveArg.title).toBe("Q3 Business Plan");
+  });
+
+  it("prefers an explicit title over the file name", async () => {
+    const d = deps();
+    await captureBusinessDocument(
+      { organizationId: ORG, fileName: "plan.pdf", mimeType: "application/pdf", buffer: buf, title: "Our Plan" },
+      d,
+    );
+    expect((d.save as ReturnType<typeof vi.fn>).mock.calls[0][0].title).toBe("Our Plan");
+  });
+
+  it("throws on an unsupported document type (parser returns null)", async () => {
+    const d = deps({ parse: vi.fn(async () => null) });
+    await expect(
+      captureBusinessDocument(
+        { organizationId: ORG, fileName: "logo.png", mimeType: "image/png", buffer: buf },
+        d,
+      ),
+    ).rejects.toThrow(/unsupported/i);
+    expect(d.save).not.toHaveBeenCalled();
+  });
+
+  it("invokes the enrichment seam when provided and text is present", async () => {
+    const enrich = vi.fn<DocumentEnricher>(async () => {});
+    const d = deps({ enrich });
+    const res = await captureBusinessDocument(
+      { organizationId: ORG, fileName: "plan.pdf", mimeType: "application/pdf", buffer: buf },
+      d,
+    );
+    expect(enrich).toHaveBeenCalledTimes(1);
+    expect(enrich.mock.calls[0][0]).toMatchObject({ organizationId: ORG, documentId: "doc_abc" });
+    expect(res.enrichmentQueued).toBe(true);
+  });
+
+  it("stores without enrichment when no seam is wired (pipeline not yet merged)", async () => {
+    const d = deps(); // no enrich
+    const res = await captureBusinessDocument(
+      { organizationId: ORG, fileName: "plan.pdf", mimeType: "application/pdf", buffer: buf },
+      d,
+    );
+    expect(res.enrichmentQueued).toBe(false);
+    expect(d.save).toHaveBeenCalledTimes(1); // doc still captured
+  });
+
+  it("does not enrich when extracted text is empty", async () => {
+    const enrich = vi.fn<DocumentEnricher>(async () => {});
+    const d = deps({
+      parse: vi.fn(async () => ({ type: "document" as const, summary: "0 characters", fullText: "   " })),
+      enrich,
+    });
+    const res = await captureBusinessDocument(
+      { organizationId: ORG, fileName: "empty.pdf", mimeType: "application/pdf", buffer: buf },
+      d,
+    );
+    expect(enrich).not.toHaveBeenCalled();
+    expect(res.enrichmentQueued).toBe(false);
+  });
+});

--- a/apps/web/lib/onboarding/capture-business-document.ts
+++ b/apps/web/lib/onboarding/capture-business-document.ts
@@ -1,0 +1,120 @@
+// Onboarding business-document capture (BI-C97C0873, EP-CORPUS-BOOTSTRAP).
+//
+// Stores a business plan / key document the operator uploads during onboarding
+// in the Document DMS (org-scoped, documentKind="plan"), extracting its text so
+// it can later be indexed into the org WWWD corpus.
+//
+// Indexing into the corpus is the SECOND half of this BI and depends on the
+// enrichment pipeline (BI-7C9D6198, `enrichOrgCorpus`). That call is wired
+// through the optional `enrich` seam below: until the pipeline merges, the
+// route passes no enricher and the document is simply captured in the DMS;
+// once it lands, the route passes an enricher that calls enrichOrgCorpus with
+// origin="document", trust="derived" — which, per the founder's draft-by-default
+// decision, lands the derived material as a draft for review.
+
+import {
+  saveManagedDocument,
+  type SaveManagedDocumentInput,
+  type ManagedDocument,
+} from "@/lib/documents/document-store";
+import {
+  parseFileContent,
+  capParsedContentSize,
+  type ParsedFileContent,
+} from "@/lib/shared/file-parsers";
+
+/** DMS documentKind for an onboarding-captured business document. */
+export const BUSINESS_DOCUMENT_KIND = "plan";
+/** Tags applied so these are findable as onboarding business docs. */
+export const BUSINESS_DOCUMENT_TAGS = ["onboarding", "business-document"];
+
+/** Deferred seam to the enrichment pipeline (BI-7C9D6198). */
+export type DocumentEnricher = (args: {
+  organizationId: string;
+  documentId: string;
+  title: string;
+  text: string;
+}) => Promise<void>;
+
+export type CaptureBusinessDocumentInput = {
+  organizationId: string;
+  fileName: string;
+  mimeType: string;
+  buffer: Buffer;
+  /** Optional human title; falls back to the file name stem. */
+  title?: string | null;
+  actorPrincipalId?: string | null;
+};
+
+/** Injectable dependencies (real defaults; fakes in tests). */
+export type CaptureBusinessDocumentDeps = {
+  parse?: (buffer: Buffer, mimeType: string, fileName: string) => Promise<ParsedFileContent | null>;
+  save?: (input: SaveManagedDocumentInput) => Promise<ManagedDocument>;
+  /** When provided (post BI-7C9D6198), index the captured text into the corpus. */
+  enrich?: DocumentEnricher;
+};
+
+export type CaptureBusinessDocumentResult = {
+  documentId: string;
+  title: string;
+  summary: string | null;
+  textLength: number;
+  /** True when the enrichment seam was invoked (pipeline wired + text present). */
+  enrichmentQueued: boolean;
+};
+
+function deriveTitleFromFileName(fileName: string): string {
+  const base = fileName.replace(/\.[^.]+$/, "").trim();
+  return base.length > 0 ? base : "Business document";
+}
+
+export async function captureBusinessDocument(
+  input: CaptureBusinessDocumentInput,
+  deps: CaptureBusinessDocumentDeps = {},
+): Promise<CaptureBusinessDocumentResult> {
+  const parse = deps.parse ?? parseFileContent;
+  const save = deps.save ?? saveManagedDocument;
+
+  const parsed = await parse(input.buffer, input.mimeType, input.fileName);
+  if (!parsed) {
+    throw new Error(
+      `Unsupported document type: ${input.fileName} (${input.mimeType || "unknown"}). ` +
+        `Upload a PDF, Word doc, or text/markdown file.`,
+    );
+  }
+
+  const capped = capParsedContentSize(parsed);
+  const text = (capped.fullText ?? "").trim();
+  const title = (input.title ?? "").trim() || deriveTitleFromFileName(input.fileName);
+
+  const doc = await save({
+    organizationId: input.organizationId,
+    title,
+    documentKind: BUSINESS_DOCUMENT_KIND,
+    contentFormat: input.mimeType || "application/octet-stream",
+    contentText: text.length > 0 ? text : null,
+    summary: capped.summary ?? null,
+    tags: BUSINESS_DOCUMENT_TAGS,
+    sourceKind: "managed",
+    actorPrincipalId: input.actorPrincipalId ?? null,
+  });
+
+  let enrichmentQueued = false;
+  if (deps.enrich && text.length > 0) {
+    await deps.enrich({
+      organizationId: input.organizationId,
+      documentId: doc.documentId,
+      title,
+      text,
+    });
+    enrichmentQueued = true;
+  }
+
+  return {
+    documentId: doc.documentId,
+    title,
+    summary: capped.summary ?? null,
+    textLength: text.length,
+    enrichmentQueued,
+  };
+}


### PR DESCRIPTION
## What

Stream-1 increment of **EP-CORPUS-BOOTSTRAP**: during onboarding, the operator can upload a **business plan / key document**. It's text-extracted and stored in the **Document DMS** (org-scoped, `documentKind="plan"`).

## Why this is a clean increment
The founder's vision has documents *captured in the DMS* **and** *indexed into the WWWD corpus*. This PR delivers the capture+DMS half — which is independently valuable and **does not depend on** the in-flight enrichment pipeline (BI-7C9D6198). Corpus indexing is wired through an explicit injectable `enrich` seam: until the pipeline merges the route passes no enricher; once it lands, the route passes one that calls `enrichOrgCorpus(origin="document", trust="derived")` → **draft for review** per the founder's draft-by-default decision (#1378).

## Changes
- `lib/onboarding/capture-business-document.ts` (+ 7 tests): parse → DMS store, title derivation, unsupported-type error, deferred enrich seam.
- `app/api/onboarding/business-document/route.ts`: admin multipart POST.
- `BusinessDocumentUpload.tsx`: optional upload affordance in the business-context step (fail-soft — never blocks setup).

## Reuse (substrate-verified)
`saveManagedDocument` (DMS, `lib/documents/document-store.ts`), `parseFileContent`/`capParsedContentSize` (`lib/shared/file-parsers.ts` — pdf-parse/mammoth/text).

## Tests
7 unit tests (parse→store, title derivation, unsupported type, enrich-seam wired/absent, empty-text). `pnpm exec vitest run lib/onboarding/` green (33); typecheck clean.

## Concurrency
No overlap with the BI-7C9D6198 pipeline worktree — touches `lib/onboarding`, a new route, and the form only; not `apps/web/lib/wiki/*`.

## Follow-up
Wire the `enrich` seam to `enrichOrgCorpus` once BI-7C9D6198 merges (one-line route change). UI gets functional verification in the deferred end-to-end pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)