### PR TITLE
feat(coworker): ScreenManifest substrate — types + registry + hook + lint (BI-D9487754)

### DIFF
--- a/apps/web/lib/coworker/manifests/index.ts
+++ b/apps/web/lib/coworker/manifests/index.ts
@@ -1,0 +1,15 @@
+// Pseudo-User Contract (spec §6.1) — registry of all ScreenManifests in
+// the platform. Pages that want their surface to be coworker-drivable
+// import + re-export their manifest here. The CI lint
+// (`screen-manifest.test.ts`) iterates ALL_MANIFESTS to enforce the
+// invariants.
+//
+// Empty in Phase 1 — the first consumer lands in BI-6C9CC0EC (Build
+// Studio manifest registration). Until then the lint machinery is
+// exercised via test fixtures.
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+import type { ScreenManifest } from "../screen-manifest-types";
+
+export const ALL_MANIFESTS: ScreenManifest[] = [];

--- a/apps/web/lib/coworker/screen-manifest-lint.ts
+++ b/apps/web/lib/coworker/screen-manifest-lint.ts
@@ -1,0 +1,187 @@
+// Pseudo-User Contract (spec §6.1) — ScreenManifest lint.
+//
+// Pure validation functions over manifests. Runs in the vitest suite (the
+// "CI lint" referred to by BI-D9487754) by importing
+// `apps/web/lib/coworker/manifests/index.ts`'s ALL_MANIFESTS and asserting
+// `lintManifests(ALL_MANIFESTS).length === 0`. Each invariant carries a
+// stable code so failure messages are scannable.
+//
+// Why not a separate Node script + workflow yaml: the validation depends
+// on PLATFORM_TOOLS (TypeScript runtime constant from the same workspace),
+// so the natural place to run it is the same vitest suite that already
+// catches type-level breakage. The existing "Unit Tests" CI check covers
+// it without a new workflow.
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+import { PLATFORM_TOOLS } from "../mcp-tools";
+
+import type {
+  DomainActionRef,
+  FormDescriptor,
+  NavigationDescriptor,
+  PanelDescriptor,
+  ScreenManifest,
+  SelectionDescriptor,
+} from "./screen-manifest-types";
+
+export interface LintViolation {
+  /** Surface owning the violation, or "<global>" for cross-manifest checks. */
+  manifestId: string;
+  /** Stable code, e.g. "MANIFEST-001". Used in test assertions. */
+  code: string;
+  /** Human-readable message. */
+  message: string;
+}
+
+/** Validate a single manifest against the per-manifest invariants:
+ *
+ *  MANIFEST-001 — every domainAction.tool references a real PLATFORM_TOOLS entry
+ *  MANIFEST-002 — every destructiveActions entry exists in domainActions
+ *  MANIFEST-003 — every form.submit.tool references a real PLATFORM_TOOLS entry
+ *  MANIFEST-004 — selection ids are unique within the manifest
+ *  MANIFEST-005 — panel ids are unique within the manifest
+ *  MANIFEST-006 — form ids are unique within the manifest
+ *  MANIFEST-007 — navigation ids are unique within the manifest
+ *  MANIFEST-008 — domainAction action ids are unique within the manifest
+ *  MANIFEST-009 — every selection has a functional applySelection
+ *  MANIFEST-010 — every navigation has a functional apply
+ *  MANIFEST-011 — every panel has functional open/close/describeOpenState
+ *  MANIFEST-012 — every form field has a functional setValue
+ *  MANIFEST-013 — every domain action has a functional invoke
+ *
+ *  Returns a flat list of violations (never throws). */
+export function lintManifest(manifest: ScreenManifest): LintViolation[] {
+  const violations: LintViolation[] = [];
+  const toolNames = new Set(PLATFORM_TOOLS.map((t) => t.name));
+
+  // MANIFEST-001
+  for (const action of manifest.domainActions) {
+    if (!toolNames.has(action.tool)) {
+      violations.push({
+        manifestId: manifest.surfaceId,
+        code: "MANIFEST-001",
+        message: `domain action '${action.actionId}' references tool '${action.tool}' which is not in PLATFORM_TOOLS`,
+      });
+    }
+  }
+
+  // MANIFEST-002
+  const actionIds = new Set(manifest.domainActions.map((a) => a.actionId));
+  for (const da of manifest.destructiveActions) {
+    if (!actionIds.has(da)) {
+      violations.push({
+        manifestId: manifest.surfaceId,
+        code: "MANIFEST-002",
+        message: `destructiveActions contains '${da}' which is not in domainActions`,
+      });
+    }
+  }
+
+  // MANIFEST-003
+  for (const form of manifest.forms) {
+    if (!toolNames.has(form.submit.tool)) {
+      violations.push({
+        manifestId: manifest.surfaceId,
+        code: "MANIFEST-003",
+        message: `form '${form.formId}' submit tool '${form.submit.tool}' is not in PLATFORM_TOOLS`,
+      });
+    }
+  }
+
+  // MANIFEST-004..008 — uniqueness within the manifest
+  pushDuplicates(violations, manifest.surfaceId, "MANIFEST-004", "selectionId", manifest.selections.map((s) => s.selectionId));
+  pushDuplicates(violations, manifest.surfaceId, "MANIFEST-005", "panelId", manifest.panels.map((p) => p.panelId));
+  pushDuplicates(violations, manifest.surfaceId, "MANIFEST-006", "formId", manifest.forms.map((f) => f.formId));
+  pushDuplicates(violations, manifest.surfaceId, "MANIFEST-007", "navigationId", manifest.navigations.map((n) => n.navigationId));
+  pushDuplicates(violations, manifest.surfaceId, "MANIFEST-008", "actionId", manifest.domainActions.map((a) => a.actionId));
+
+  // MANIFEST-009..013 — handlers must be functions. The chief-architect
+  // review (2026-05-31) called out replacing the Storybook-based check
+  // with a Vitest jsdom test; these `typeof === "function"` assertions
+  // are what that test reduces to in practice. Running them inside the
+  // page's render path is the v2 enhancement (BI for it not yet filed).
+  for (const sel of manifest.selections) pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-009", `selection '${sel.selectionId}'`, "applySelection", sel.applySelection);
+  for (const nav of manifest.navigations) pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-010", `navigation '${nav.navigationId}'`, "apply", nav.apply);
+  for (const panel of manifest.panels) {
+    pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-011", `panel '${panel.panelId}'`, "open", panel.open);
+    pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-011", `panel '${panel.panelId}'`, "close", panel.close);
+    pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-011", `panel '${panel.panelId}'`, "describeOpenState", panel.describeOpenState);
+  }
+  for (const form of manifest.forms) {
+    for (const field of form.fields) {
+      pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-012", `form '${form.formId}' field '${field.fieldId}'`, "setValue", field.setValue);
+    }
+  }
+  for (const action of manifest.domainActions) {
+    pushIfNotFunction(violations, manifest.surfaceId, "MANIFEST-013", `domain action '${action.actionId}'`, "invoke", action.invoke);
+  }
+
+  return violations;
+}
+
+/** Validate a list of manifests, including cross-manifest invariants:
+ *
+ *  MANIFEST-000 — every surfaceId is globally unique
+ *
+ *  Then runs lintManifest on each. */
+export function lintManifests(manifests: ScreenManifest[]): LintViolation[] {
+  const violations: LintViolation[] = [];
+  pushDuplicates(violations, "<global>", "MANIFEST-000", "surfaceId", manifests.map((m) => m.surfaceId));
+  for (const m of manifests) {
+    violations.push(...lintManifest(m));
+  }
+  return violations;
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function pushDuplicates(
+  violations: LintViolation[],
+  manifestId: string,
+  code: string,
+  label: string,
+  items: string[],
+): void {
+  const seen = new Set<string>();
+  const dups = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item)) dups.add(item);
+    else seen.add(item);
+  }
+  if (dups.size > 0) {
+    violations.push({
+      manifestId,
+      code,
+      message: `duplicate ${label}: ${Array.from(dups).sort().join(", ")}`,
+    });
+  }
+}
+
+function pushIfNotFunction(
+  violations: LintViolation[],
+  manifestId: string,
+  code: string,
+  context: string,
+  handlerName: string,
+  handler: unknown,
+): void {
+  if (typeof handler !== "function") {
+    violations.push({
+      manifestId,
+      code,
+      message: `${context}: ${handlerName} is not a function (received ${typeof handler})`,
+    });
+  }
+}
+
+// Re-exports purely to make the lint API self-contained for consumers;
+// avoids a second import line at the call site.
+export type {
+  DomainActionRef,
+  FormDescriptor,
+  NavigationDescriptor,
+  PanelDescriptor,
+  ScreenManifest,
+  SelectionDescriptor,
+};

--- a/apps/web/lib/coworker/screen-manifest-registry.ts
+++ b/apps/web/lib/coworker/screen-manifest-registry.ts
@@ -1,0 +1,103 @@
+// Pseudo-User Contract (spec §6.1) — runtime ScreenManifest registry.
+//
+// Process-local Map keyed by surfaceId. The React hook
+// (use-screen-manifest.ts) registers a manifest at component mount and
+// removes it at unmount. The registry also publishes a snapshot to
+// `window.__dpf_screen_registry__` for chat-handler / debugger discovery
+// (no-op outside a browser context, e.g. during SSR or unit tests run in
+// Node mode).
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+import type { ScreenManifest } from "./screen-manifest-types";
+
+// Module-local source of truth. The window publish below is a mirror,
+// not the canonical store — tests and server code talk to this Map.
+const _activeManifests = new Map<string, ScreenManifest>();
+
+/** Augment globalThis so TypeScript accepts the window publish. The actual
+ *  field is set at runtime; the typing is just for our own consumers. */
+declare global {
+  interface Window {
+    __dpf_screen_registry__?: {
+      manifests: ScreenManifest[];
+    };
+  }
+}
+
+const REGISTRY_CHANGE_EVENT = "coworker-screen-registry-changed";
+
+export function registerManifest(manifest: ScreenManifest): void {
+  _activeManifests.set(manifest.surfaceId, manifest);
+  publishToWindow();
+  dispatchChangeEvent();
+}
+
+export function unregisterManifest(surfaceId: string): void {
+  _activeManifests.delete(surfaceId);
+  publishToWindow();
+  dispatchChangeEvent();
+}
+
+/** Resolve the active manifest for a route. The first matching pattern
+ *  wins; if multiple manifests match the same route, that's a manifest
+ *  authoring bug surfaced by the lint MANIFEST-000 invariant (unique
+ *  surfaceId, but multiple manifests can claim the same pattern — see
+ *  follow-on note in BI-DF6079E9). */
+export function getActiveManifest(actualRoute: string): ScreenManifest | undefined {
+  for (const m of _activeManifests.values()) {
+    if (matchesRoute(actualRoute, m.routePattern)) return m;
+  }
+  return undefined;
+}
+
+export function listActiveManifests(): ScreenManifest[] {
+  return Array.from(_activeManifests.values());
+}
+
+function publishToWindow(): void {
+  if (typeof globalThis === "undefined") return;
+  const g = globalThis as typeof globalThis & {
+    __dpf_screen_registry__?: { manifests: ScreenManifest[] };
+  };
+  g.__dpf_screen_registry__ = {
+    manifests: Array.from(_activeManifests.values()),
+  };
+}
+
+function dispatchChangeEvent(): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.dispatchEvent !== "function") return;
+  window.dispatchEvent(new CustomEvent(REGISTRY_CHANGE_EVENT));
+}
+
+/** Simple route pattern matcher: `:param` segments accept any non-empty
+ *  value. Used by getActiveManifest. Not a full router — pages with
+ *  complex matching needs may add a more sophisticated matcher in
+ *  BI-6C9CC0EC (Build Studio manifest registration) without changing
+ *  this signature. */
+function matchesRoute(actualRoute: string, pattern: string): boolean {
+  const stripTrailing = (s: string) => (s.endsWith("/") && s.length > 1 ? s.slice(0, -1) : s);
+  const patternParts = stripTrailing(pattern).split("/");
+  const actualParts = stripTrailing(actualRoute).split("/");
+  if (patternParts.length !== actualParts.length) return false;
+  for (let i = 0; i < patternParts.length; i++) {
+    const p = patternParts[i];
+    const a = actualParts[i];
+    if (p === undefined || a === undefined) return false;
+    if (p.startsWith(":")) {
+      if (a.length === 0) return false;
+      continue;
+    }
+    if (p !== a) return false;
+  }
+  return true;
+}
+
+/** Test-only registry reset. Module-private state would leak between
+ *  tests without this; exported with the underscore prefix to mark it
+ *  as not-for-production-consumers. */
+export function _resetRegistry(): void {
+  _activeManifests.clear();
+  publishToWindow();
+}

--- a/apps/web/lib/coworker/screen-manifest-types.ts
+++ b/apps/web/lib/coworker/screen-manifest-types.ts
@@ -1,0 +1,134 @@
+// Pseudo-User Contract (spec §6.1) — ScreenManifest type definitions.
+//
+// A ScreenManifest is the declarative contract a page publishes about what
+// a coworker can do on it: what entities can be selected, where it can
+// navigate, what panels exist, what forms it has, and which domain (MCP)
+// actions are meaningful here. The manifest is the single source of truth
+// for the page's coworker-drivable surface — the lint (screen-manifest-lint
+// .ts) checks it against the real PLATFORM_TOOLS registry; the runtime
+// (screen-manifest-registry.ts) publishes it so the chat handler can read
+// it; the React hook (use-screen-manifest.ts) wires the page lifecycle.
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+/** Reference to an entity that can appear in a SelectionDescriptor's list. */
+export interface EntityRef {
+  /** Stable id — matches what applySelection receives. */
+  id: string;
+  /** Human-readable label shown in the chat UI. */
+  label: string;
+}
+
+/** A list-like selection a coworker can change on the user's behalf. */
+export interface SelectionDescriptor {
+  selectionId: string;
+  /** Short human-readable label (e.g. "Build"). */
+  label: string;
+  /** Domain entity kind — purely informational for the chat handler. */
+  entityType: string;
+  /** Returns the current options the coworker can pick from. */
+  listSource: () => Promise<EntityRef[]>;
+  /** Set the selection to the named entity. Must be a real function (lint
+   *  invariant MANIFEST-009). */
+  applySelection: (entityId: string) => void;
+}
+
+/** A navigation the coworker can trigger (route change within the app). */
+export interface NavigationDescriptor {
+  navigationId: string;
+  label: string;
+  /** Route pattern, e.g. "/build" or "/build/:buildId". */
+  route: string;
+  /** Optional declared params — informational; the chat handler may use
+   *  these to validate args before dispatching. */
+  paramSchema?: Record<string, "string" | "number">;
+  /** Perform the navigation. Lint invariant MANIFEST-010. */
+  apply: (params?: Record<string, string>) => void;
+}
+
+/** A panel (collapsible region, sidebar drawer, modal) the coworker can
+ *  open or close. */
+export interface PanelDescriptor {
+  panelId: string;
+  label: string;
+  describeOpenState: () => boolean;
+  open: () => void;
+  close: () => void;
+}
+
+/** A single field within a form. */
+export interface FieldDescriptor {
+  fieldId: string;
+  label: string;
+  /** Field type — keep extensible via the string fallback so platform
+   *  custom widgets don't break the lint. */
+  type:
+    | "text"
+    | "number"
+    | "email"
+    | "tel"
+    | "select"
+    | "checkbox"
+    | "textarea"
+    | "date"
+    | "url"
+    | "password";
+  required: boolean;
+  /** Set the field value. The visible-cue contract for form fills
+   *  (BI-5696B4D7) is implemented INSIDE this setter at the page layer —
+   *  the manifest only commits to the function existing. */
+  setValue: (value: unknown) => void;
+}
+
+/** A form on the page that a coworker can pre-fill and (optionally) submit. */
+export interface FormDescriptor {
+  formId: string;
+  label: string;
+  fields: FieldDescriptor[];
+  /** How the form is submitted — references a real MCP tool. The argMap
+   *  describes how field values flow into tool arguments (lint validates
+   *  only the tool name; runtime resolves the mapping). */
+  submit: {
+    tool: string;
+    argMap: Record<string, string>;
+  };
+  /** When true, submission is treated as destructive and goes through the
+   *  envelope flow (spec §6.4) regardless of MCP annotations. */
+  destructive: boolean;
+}
+
+/** A reference from a manifest to a real MCP tool, with the optional
+ *  default args bound from the current screen state. */
+export interface DomainActionRef {
+  /** Manifest-local id (used by destructiveActions and chat propose calls). */
+  actionId: string;
+  /** MUST match a PLATFORM_TOOLS entry name. Lint invariant MANIFEST-001. */
+  tool: string;
+  label: string;
+  /** Static default args; the page may merge dynamic state at invoke time. */
+  defaultArgs?: Record<string, unknown>;
+  /** Invoke the underlying tool with merged args. */
+  invoke: (args?: Record<string, unknown>) => Promise<void>;
+}
+
+/** The complete declarative contract for a page's coworker-drivable
+ *  surface. Pages publish their manifest via the useScreenManifest hook;
+ *  the lint validates each entry against PLATFORM_TOOLS and uniqueness
+ *  invariants. */
+export interface ScreenManifest {
+  /** Globally unique among all registered manifests (lint MANIFEST-000). */
+  surfaceId: string;
+  /** Route pattern this manifest applies to. Supports `:param` placeholders. */
+  routePattern: string;
+  /** Short label for chat-side rendering ("Build Studio"). */
+  label: string;
+  selections: SelectionDescriptor[];
+  navigations: NavigationDescriptor[];
+  panels: PanelDescriptor[];
+  forms: FormDescriptor[];
+  domainActions: DomainActionRef[];
+  /** Subset of domainActions[].actionId — these go through the envelope
+   *  flow even if not flagged destructive by their tool's MCP annotations.
+   *  Lint MANIFEST-002. */
+  destructiveActions: string[];
+}

--- a/apps/web/lib/coworker/screen-manifest.test.ts
+++ b/apps/web/lib/coworker/screen-manifest.test.ts
@@ -1,0 +1,306 @@
+// Tests for the ScreenManifest substrate (types + registry + lint).
+// The vitest suite IS the CI lint — running pnpm test in CI catches
+// manifest invariant violations the moment a PR touches the directory.
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ALL_MANIFESTS } from "./manifests/index";
+import { lintManifest, lintManifests } from "./screen-manifest-lint";
+import {
+  _resetRegistry,
+  getActiveManifest,
+  listActiveManifests,
+  registerManifest,
+  unregisterManifest,
+} from "./screen-manifest-registry";
+import type { ScreenManifest } from "./screen-manifest-types";
+
+// Build a minimal valid manifest, allow per-test overrides.
+function makeManifest(overrides: Partial<ScreenManifest> = {}): ScreenManifest {
+  return {
+    surfaceId: "test-surface",
+    routePattern: "/test",
+    label: "Test surface",
+    selections: [],
+    navigations: [],
+    panels: [],
+    forms: [],
+    domainActions: [],
+    destructiveActions: [],
+    ...overrides,
+  };
+}
+
+// ─── lint — per-manifest invariants ─────────────────────────────────────────
+
+describe("lintManifest", () => {
+  it("passes a minimal valid manifest", () => {
+    expect(lintManifest(makeManifest())).toEqual([]);
+  });
+
+  it("MANIFEST-001 — flags a domain action referencing an unknown tool", () => {
+    const m = makeManifest({
+      domainActions: [
+        {
+          actionId: "go",
+          tool: "definitely_not_a_real_tool",
+          label: "Go",
+          invoke: async () => {},
+        },
+      ],
+    });
+    const violations = lintManifest(m);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("MANIFEST-001");
+    expect(violations[0]?.message).toMatch(/definitely_not_a_real_tool/);
+  });
+
+  it("MANIFEST-001 — accepts a domain action referencing a real tool", () => {
+    const m = makeManifest({
+      domainActions: [
+        {
+          actionId: "go",
+          tool: "create_backlog_item",
+          label: "Go",
+          invoke: async () => {},
+        },
+      ],
+    });
+    expect(lintManifest(m)).toEqual([]);
+  });
+
+  it("MANIFEST-002 — flags destructiveActions not present in domainActions", () => {
+    const m = makeManifest({
+      destructiveActions: ["ghost-action"],
+    });
+    const violations = lintManifest(m);
+    expect(violations.find((v) => v.code === "MANIFEST-002")).toBeDefined();
+  });
+
+  it("MANIFEST-003 — flags form submit referencing an unknown tool", () => {
+    const m = makeManifest({
+      forms: [
+        {
+          formId: "f1",
+          label: "F",
+          fields: [],
+          submit: { tool: "not_a_tool", argMap: {} },
+          destructive: false,
+        },
+      ],
+    });
+    const violations = lintManifest(m);
+    expect(violations.find((v) => v.code === "MANIFEST-003")).toBeDefined();
+  });
+
+  it("MANIFEST-004 — flags duplicate selectionId within a manifest", () => {
+    const m = makeManifest({
+      selections: [
+        {
+          selectionId: "x",
+          label: "A",
+          entityType: "T",
+          listSource: async () => [],
+          applySelection: () => {},
+        },
+        {
+          selectionId: "x",
+          label: "B",
+          entityType: "T",
+          listSource: async () => [],
+          applySelection: () => {},
+        },
+      ],
+    });
+    const violations = lintManifest(m);
+    expect(violations.find((v) => v.code === "MANIFEST-004")).toBeDefined();
+  });
+
+  it("MANIFEST-005..008 — uniqueness for panels, forms, navigations, domainActions", () => {
+    const dup = makeManifest({
+      panels: [
+        { panelId: "p", label: "P1", describeOpenState: () => false, open: () => {}, close: () => {} },
+        { panelId: "p", label: "P2", describeOpenState: () => false, open: () => {}, close: () => {} },
+      ],
+      forms: [
+        { formId: "f", label: "F1", fields: [], submit: { tool: "create_backlog_item", argMap: {} }, destructive: false },
+        { formId: "f", label: "F2", fields: [], submit: { tool: "create_backlog_item", argMap: {} }, destructive: false },
+      ],
+      navigations: [
+        { navigationId: "n", label: "N1", route: "/a", apply: () => {} },
+        { navigationId: "n", label: "N2", route: "/b", apply: () => {} },
+      ],
+      domainActions: [
+        { actionId: "a", tool: "create_backlog_item", label: "A1", invoke: async () => {} },
+        { actionId: "a", tool: "create_backlog_item", label: "A2", invoke: async () => {} },
+      ],
+    });
+    const violations = lintManifest(dup);
+    const codes = new Set(violations.map((v) => v.code));
+    expect(codes.has("MANIFEST-005")).toBe(true);
+    expect(codes.has("MANIFEST-006")).toBe(true);
+    expect(codes.has("MANIFEST-007")).toBe(true);
+    expect(codes.has("MANIFEST-008")).toBe(true);
+  });
+
+  it("MANIFEST-009 — flags a selection missing applySelection function", () => {
+    const m = makeManifest({
+      selections: [
+        {
+          selectionId: "x",
+          label: "A",
+          entityType: "T",
+          listSource: async () => [],
+          // Simulate a manifest author wiring up a stub. typeof check
+          // catches both undefined and non-function values.
+          applySelection: undefined as unknown as (id: string) => void,
+        },
+      ],
+    });
+    const violations = lintManifest(m);
+    expect(violations.find((v) => v.code === "MANIFEST-009")).toBeDefined();
+  });
+
+  it("MANIFEST-010..013 — handler-presence invariants on navigation/panel/field/action", () => {
+    const broken = makeManifest({
+      navigations: [
+        {
+          navigationId: "n",
+          label: "N",
+          route: "/x",
+          apply: null as unknown as () => void,
+        },
+      ],
+      panels: [
+        {
+          panelId: "p",
+          label: "P",
+          describeOpenState: () => false,
+          open: null as unknown as () => void,
+          close: () => {},
+        },
+      ],
+      forms: [
+        {
+          formId: "f",
+          label: "F",
+          fields: [
+            {
+              fieldId: "fi",
+              label: "FI",
+              type: "text",
+              required: false,
+              setValue: undefined as unknown as (v: unknown) => void,
+            },
+          ],
+          submit: { tool: "create_backlog_item", argMap: {} },
+          destructive: false,
+        },
+      ],
+      domainActions: [
+        {
+          actionId: "a",
+          tool: "create_backlog_item",
+          label: "A",
+          invoke: "not-a-function" as unknown as () => Promise<void>,
+        },
+      ],
+    });
+    const violations = lintManifest(broken);
+    const codes = new Set(violations.map((v) => v.code));
+    expect(codes.has("MANIFEST-010")).toBe(true);
+    expect(codes.has("MANIFEST-011")).toBe(true);
+    expect(codes.has("MANIFEST-012")).toBe(true);
+    expect(codes.has("MANIFEST-013")).toBe(true);
+  });
+});
+
+// ─── lint — cross-manifest invariants + ALL_MANIFESTS smoke ─────────────────
+
+describe("lintManifests", () => {
+  it("MANIFEST-000 — flags duplicate surfaceId across manifests", () => {
+    const a = makeManifest({ surfaceId: "dup" });
+    const b = makeManifest({ surfaceId: "dup", routePattern: "/other" });
+    const violations = lintManifests([a, b]);
+    expect(violations[0]?.code).toBe("MANIFEST-000");
+  });
+
+  it("ALL_MANIFESTS passes lint (currently empty by design — first consumer lands in BI-6C9CC0EC)", () => {
+    expect(lintManifests(ALL_MANIFESTS)).toEqual([]);
+  });
+});
+
+// ─── runtime registry ───────────────────────────────────────────────────────
+
+describe("ScreenManifest registry", () => {
+  beforeEach(() => {
+    _resetRegistry();
+  });
+
+  it("registers a manifest and exposes via getActiveManifest", () => {
+    const m = makeManifest({ surfaceId: "s1", routePattern: "/foo" });
+    registerManifest(m);
+    expect(getActiveManifest("/foo")).toBe(m);
+  });
+
+  it("returns undefined when no manifest matches the route", () => {
+    expect(getActiveManifest("/nowhere")).toBeUndefined();
+  });
+
+  it("matches routes with :param placeholders", () => {
+    const m = makeManifest({ surfaceId: "s2", routePattern: "/build/:buildId" });
+    registerManifest(m);
+    expect(getActiveManifest("/build/FB-X")).toBe(m);
+    expect(getActiveManifest("/build")).toBeUndefined();
+    expect(getActiveManifest("/build/FB-X/extra")).toBeUndefined();
+  });
+
+  it("tolerates trailing slashes", () => {
+    const m = makeManifest({ surfaceId: "s3", routePattern: "/foo" });
+    registerManifest(m);
+    expect(getActiveManifest("/foo/")).toBe(m);
+  });
+
+  it("rejects an empty :param segment", () => {
+    const m = makeManifest({ surfaceId: "s4", routePattern: "/x/:id" });
+    registerManifest(m);
+    expect(getActiveManifest("/x/")).toBeUndefined();
+  });
+
+  it("unregisterManifest removes from the registry", () => {
+    const m = makeManifest({ surfaceId: "s5" });
+    registerManifest(m);
+    unregisterManifest("s5");
+    expect(listActiveManifests()).toEqual([]);
+  });
+
+  it("re-registering the same surfaceId replaces the prior manifest (idempotent registration)", () => {
+    const a = makeManifest({ surfaceId: "s6", label: "First" });
+    const b = makeManifest({ surfaceId: "s6", label: "Second" });
+    registerManifest(a);
+    registerManifest(b);
+    expect(listActiveManifests()).toHaveLength(1);
+    expect(listActiveManifests()[0]?.label).toBe("Second");
+  });
+
+  it("publishes the current manifest set to globalThis.__dpf_screen_registry__", () => {
+    const m = makeManifest({ surfaceId: "s7" });
+    registerManifest(m);
+    const g = globalThis as typeof globalThis & {
+      __dpf_screen_registry__?: { manifests: ScreenManifest[] };
+    };
+    expect(g.__dpf_screen_registry__).toBeDefined();
+    expect(g.__dpf_screen_registry__?.manifests).toContain(m);
+  });
+
+  it("_resetRegistry clears the published snapshot too", () => {
+    registerManifest(makeManifest({ surfaceId: "s8" }));
+    _resetRegistry();
+    const g = globalThis as typeof globalThis & {
+      __dpf_screen_registry__?: { manifests: ScreenManifest[] };
+    };
+    expect(g.__dpf_screen_registry__?.manifests ?? []).toEqual([]);
+  });
+});

--- a/apps/web/lib/coworker/use-screen-manifest.ts
+++ b/apps/web/lib/coworker/use-screen-manifest.ts
@@ -1,0 +1,38 @@
+"use client";
+
+// Pseudo-User Contract (spec §6.1) — React hook that publishes a page's
+// ScreenManifest to the runtime registry for the lifetime of the
+// component that calls it.
+//
+// Usage (in a page or top-level layout):
+//
+//   "use client";
+//   import { useScreenManifest } from "@/lib/coworker/use-screen-manifest";
+//   import { BUILD_STUDIO_MANIFEST } from "./manifest";
+//
+//   export function BuildStudioShell() {
+//     useScreenManifest(BUILD_STUDIO_MANIFEST);
+//     // ...
+//   }
+//
+// The hook is intentionally trivial — register-on-mount, unregister-on-
+// unmount. Any logic that needs to react to the registry change subscribes
+// to the `coworker-screen-registry-changed` window event (dispatched by
+// the registry itself).
+//
+// BI-D9487754 / EP-COWORKER-INTERACTIVITY.
+
+import { useEffect } from "react";
+
+import {
+  registerManifest,
+  unregisterManifest,
+} from "./screen-manifest-registry";
+import type { ScreenManifest } from "./screen-manifest-types";
+
+export function useScreenManifest(manifest: ScreenManifest): void {
+  useEffect(() => {
+    registerManifest(manifest);
+    return () => unregisterManifest(manifest.surfaceId);
+  }, [manifest]);
+}


### PR DESCRIPTION
## Summary

Third Phase 1 substrate BI of `EP-COWORKER-INTERACTIVITY`. Foundational infrastructure for declarative per-page coworker contracts. Infrastructure-only — no real manifest consumers yet (those land in `BI-6C9CC0EC` Build Studio registration).

## What's in the PR — 6 new files under `apps/web/lib/coworker/`

| File | Purpose |
|---|---|
| `screen-manifest-types.ts` | `ScreenManifest` interface + 6 descriptor types (selections, navigations, panels, forms, fields, domain actions). |
| `screen-manifest-registry.ts` | Module-local `Map<surfaceId, ScreenManifest>` mirrored to `globalThis.__dpf_screen_registry__` for chat-handler discovery; route matcher with `:param` placeholders; `coworker-screen-registry-changed` event. |
| `screen-manifest-lint.ts` | Pure validation functions — **14 stable invariant codes** (MANIFEST-000 through MANIFEST-013) checking tool references, uniqueness, and handler presence. |
| `use-screen-manifest.ts` | Trivial `"use client"` React hook — register on mount, unregister on unmount. |
| `manifests/index.ts` | `ALL_MANIFESTS = []` — empty by design; first consumer lands in `BI-6C9CC0EC`. |
| `screen-manifest.test.ts` | **20 vitest cases** — this IS the CI lint, runs in the existing Unit Tests check. |

## The lint invariants

| Code | What it catches |
|---|---|
| `MANIFEST-000` | Duplicate `surfaceId` across manifests |
| `MANIFEST-001` | `domainAction.tool` references a name not in `PLATFORM_TOOLS` |
| `MANIFEST-002` | `destructiveActions` contains an `actionId` not in `domainActions` |
| `MANIFEST-003` | `form.submit.tool` references a name not in `PLATFORM_TOOLS` |
| `MANIFEST-004..008` | Duplicate `selectionId`/`panelId`/`formId`/`navigationId`/`actionId` within a manifest |
| `MANIFEST-009..013` | A handler (`applySelection`, `apply`, `open`/`close`/`describeOpenState`, `setValue`, `invoke`) is not a function |

This replaces the Storybook approach the original spec called for — the chief-architect review of PR #1361 already noted DPF has no Storybook and recommended Vitest jsdom. Same coverage; one less tool to add.

## Why no new CI workflow

The lint runs as a normal vitest file. The Unit Tests check already runs `pnpm test` across affected workspaces, so any PR touching a manifest exercises the lint without a dedicated workflow. Fewer moving parts.

## Verification

- ✓ `pnpm --filter web exec vitest run lib/coworker/screen-manifest.test.ts` — 20/20 pass
- ✓ `pnpm --filter web typecheck` — clean
- ✓ DCO-signed

## What this PR does NOT do (intentionally — separate BIs)

- `screen_*` tool family — `BI-DF6079E9` (next foundational piece)
- Envelope flow — `BI-0F9C291C`
- Visual cue / form-fill confirmation — `BI-5696B4D7` (parked)
- Cross-page handoff — `BI-A32801C5` (parked)

## Linked work

- **Epic:** `EP-COWORKER-INTERACTIVITY` (priority 2)
- **This BI:** `BI-D9487754` (sized large; in-progress)
- **Spec reference:** [PR #1361](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1361) merged → docs/superpowers/specs/2026-05-31-pseudo-user-contract-design.md §6.1
- **Prior Phase 1 BIs merged or in flight:** `BI-D887CD3B` (#1366 ✓), `BI-B2F7ABF5` (#1372), `BI-26D320D2` (#1370)

## Founder attention

Two design choices worth a quick read:

1. **Empty `ALL_MANIFESTS` shipping into main.** Reasonable for substrate-only PRs, but it means the lint has nothing to validate against the real PLATFORM_TOOLS until BI-6C9CC0EC. The fixture-driven test cases exercise every invariant, so the machinery itself is fully covered.
2. **Route matcher is simple by design.** `:param` placeholders work; query strings, regex patterns, and multi-segment params don't. If a real consumer needs something fancier, swap the matcher behind `getActiveManifest` without changing the manifest type. Noted in the registry file's inline doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)