### PR TITLE
feat(corpus): draft-by-default routing + wire business-doc → corpus

### DIFF
--- a/apps/web/app/api/onboarding/business-document/route.ts
+++ b/apps/web/app/api/onboarding/business-document/route.ts
@@ -2,12 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { captureBusinessDocument } from "@/lib/onboarding/capture-business-document";
+import { enrichOrgCorpus } from "@/lib/wiki/enrich-org-corpus";
+import { createProductionInference } from "@/lib/wiki/inference-adapter";
 
 export const runtime = "nodejs";
 
 // Capture a business plan / key document uploaded during onboarding into the
-// Document DMS (org-scoped). Corpus indexing (enrichOrgCorpus) is wired later
-// via the capture lib's `enrich` seam once BI-7C9D6198 lands.
+// Document DMS (org-scoped), then index its text into the org WWWD corpus via
+// the enrichment pipeline (BI-7C9D6198). Per the founder's draft-by-default
+// decision (BI-1378), document-derived material (`trust: "derived"`) lands as a
+// draft for review — it never auto-promotes.
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.user || (session.user as { type?: string }).type !== "admin") {
@@ -32,13 +36,34 @@ export async function POST(req: NextRequest) {
 
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
-    const result = await captureBusinessDocument({
-      organizationId: org.id,
-      fileName: file.name,
-      mimeType: file.type,
-      buffer,
-      title,
-    });
+    const result = await captureBusinessDocument(
+      {
+        organizationId: org.id,
+        fileName: file.name,
+        mimeType: file.type,
+        buffer,
+        title,
+      },
+      {
+        // Index the captured document into the org WWWD corpus. Fire-and-forget
+        // so the upload response isn't blocked on multi-pass LLM extraction; the
+        // portal is a long-lived process. BI-741B6329 will move this onto the
+        // durable enrichment queue with retries. Fail-open: the document is
+        // already safely stored in the DMS regardless of enrichment outcome.
+        enrich: async ({ organizationId, documentId, title: docTitle, text }) => {
+          void enrichOrgCorpus({
+            organizationId,
+            text,
+            title: docTitle,
+            provenance: { sourceType: "document", sourceRef: { documentId } },
+            trust: "derived",
+            infer: createProductionInference({ taskType: "wiki_proposal" }),
+          }).catch((e) =>
+            console.warn("[business-document] corpus enrichment failed (fail-open):", e),
+          );
+        },
+      },
+    );
     return NextResponse.json({ success: true, ...result });
   } catch (e) {
     return NextResponse.json(

--- a/apps/web/lib/wiki/enrich-org-corpus.test.ts
+++ b/apps/web/lib/wiki/enrich-org-corpus.test.ts
@@ -236,8 +236,9 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       profileId: "org-perspective-org_acme",
       profileVersionId: "v1",
       evidenceGrade: "A",
-      reviewStatus: "approved",
-      promotionState: "promoted",
+      // Draft by default (BI-1378): even first-party enrichment awaits review.
+      reviewStatus: "draft",
+      promotionState: "candidate",
       direction: "support",
       freshness: "current",
     });
@@ -271,7 +272,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
     expect(matArg.create.confidenceWeight).toBeLessThan(0.5);
   });
 
-  it("derived trust → grade B, approved/promoted (uploaded-doc extraction shape)", async () => {
+  it("derived trust → grade B, draft/candidate (uploaded-doc extraction; draft by default)", async () => {
     const { db, spies } = makeDbStub();
     const infer = makeProposalInfer({ claimSlug: "entities/extracted-fact", pageKind: "entity" });
 
@@ -285,10 +286,12 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
     });
 
     const matArg = spies.materialUpsert.mock.calls[0][0] as { create: Record<string, unknown> };
+    // Per BI-1378: document-derived material lands as a draft for review, not
+    // auto-promoted. The grade still reflects derived-from-first-party-doc trust.
     expect(matArg.create).toMatchObject({
       evidenceGrade: "B",
-      reviewStatus: "approved",
-      promotionState: "promoted",
+      reviewStatus: "draft",
+      promotionState: "candidate",
     });
   });
 

--- a/apps/web/lib/wiki/enrich-org-corpus.ts
+++ b/apps/web/lib/wiki/enrich-org-corpus.ts
@@ -36,20 +36,23 @@ import {
 } from "./embeddings";
 
 // ─── Trust → routing rules ──────────────────────────────────────────────────
-// Spec §4 routing rule, made concrete:
-//   first-party (operator typed)         → committed, grade A, approved+promoted
-//   derived    (extracted from upload)   → committed, grade B, approved+promoted
-//   researched (AI found, must be vetted)→ committed at the WikiPage level (so
-//                                          the operator can see the candidate),
-//                                          but the linked PerspectiveMaterial
-//                                          lands in draft+candidate state — it
-//                                          will NOT influence WWWD answers
-//                                          until a human promotes it.
+// FOUNDER DECISION (2026-05-31, BI-1378 / design §6): DRAFT BY DEFAULT so we can
+// review. EVERY enrichOrgCorpus output lands as draft + candidate — regardless
+// of trust — so a human reviews before it becomes authoritative. The ONLY
+// auto-publish path in the platform is the initial onboarding seed
+// (seed-org-wwwd-corpus.ts), which is a separate bootstrap, not this façade.
 //
-// Page status itself follows the existing commit-step convention: NEW pages
-// land as status="draft" regardless, NEW APPENDS to existing published pages
-// go straight in. Reviewers publish drafts via the existing review affordance.
-// We layer trust as PerspectiveMaterial state, NOT as a parallel page status.
+// Trust no longer changes review/promotion state; it only sets the evidence
+// grade + confidence weight (for later weighting) so the review surface can
+// still distinguish first-party facts from AI-found research:
+//   first-party (operator typed)       → draft, candidate, grade A
+//   derived     (extracted from upload)→ draft, candidate, grade B
+//   researched  (AI found, vetted)     → draft, candidate, grade C
+//
+// Page status follows the existing commit-step convention: NEW pages land as
+// status="draft"; appends to already-published pages go straight in. Reviewers
+// publish drafts via the existing review affordance (list_wiki_overlay_drafts).
+// We layer trust as PerspectiveMaterial grade, NOT as a parallel page status.
 
 export type EnrichmentTrust = "first-party" | "derived" | "researched";
 
@@ -61,17 +64,18 @@ type MaterialTrustShape = {
 };
 
 const TRUST_TO_MATERIAL: Record<EnrichmentTrust, MaterialTrustShape> = {
+  // Draft by default (BI-1378): trust sets grade/weight, NOT review state.
   "first-party": {
     evidenceGrade: "A",
     confidenceWeight: 0.85,
-    reviewStatus: "approved",
-    promotionState: "promoted",
+    reviewStatus: "draft",
+    promotionState: "candidate",
   },
   derived: {
     evidenceGrade: "B",
     confidenceWeight: 0.65,
-    reviewStatus: "approved",
-    promotionState: "promoted",
+    reviewStatus: "draft",
+    promotionState: "candidate",
   },
   researched: {
     evidenceGrade: "C",
@@ -450,13 +454,15 @@ export async function enrichOrgCorpus(
           },
           summary: row.abstract,
           freshness: "current",
-          // Re-enrichment of an existing material from a fresher source can
-          // upgrade the trust shape, but we never DOWNGRADE — a previously-
-          // approved material does not get demoted by a later researched feed.
-          ...(trustShape.reviewStatus === "approved"
+          // Enrichment never sets review/promotion state (draft by default,
+          // BI-1378) — and crucially never DEMOTES: if a human has since
+          // reviewed this material to approved/promoted, re-enrichment must
+          // preserve that. So on update we refresh only content-derived grading
+          // (evidenceGrade/confidenceWeight) and leave reviewStatus/promotionState
+          // untouched. trustShape.reviewStatus is always "draft" now, so this
+          // guard is belt-and-suspenders against a future non-draft trust shape.
+          ...(trustShape.reviewStatus === "draft"
             ? {
-                reviewStatus: trustShape.reviewStatus,
-                promotionState: trustShape.promotionState,
                 evidenceGrade: trustShape.evidenceGrade,
                 confidenceWeight: trustShape.confidenceWeight,
               }


### PR DESCRIPTION
Now that the enrichment pipeline (BI-7C9D6198, #1374) has merged, this does the two things to finish the document → corpus path end-to-end.

## 1. Draft-by-default routing (honors BI-1378 decision)
The merged `TRUST_TO_MATERIAL` table auto-promoted **first-party AND derived** material (`approved`/`promoted`); only `researched` drafted. The founder's decision (#1378, design §6) is **draft by default so we can review**: every `enrichOrgCorpus` output lands `draft` + `candidate`; trust now only sets the evidence grade (A/B/C) + confidence weight. The only auto-publish path remains the initial onboarding seed (a separate bootstrap, not this façade).

The re-enrichment update path now refreshes content grading but **never touches review/promotion state**, so a material a human has reviewed→approved is never demoted by a later feed.

## 2. Wire BI-C97C0873's deferred seam
The onboarding business-document route now indexes captured document text via `enrichOrgCorpus(origin="document", trust="derived")` → **reviewable draft** corpus material. Fire-and-forget (upload isn't blocked on multi-pass LLM extraction) and fail-open (the doc is already in the DMS regardless). BI-741B6329 will move this onto the durable queue with retries.

## Tests
`enrich-org-corpus` trust assertions updated (first-party + derived → draft/candidate); 39 wiki+onboarding tests green; typecheck clean (pre-commit enforced).

## Note
Touches `apps/web/lib/wiki/enrich-org-corpus.ts` (the pipeline file) — its PR #1374 is already merged, so this edits main, not an active worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)