### PR TITLE
feat(onboarding): capture market & scope context → WWWD corpus (BI-34936764)

### DIFF
--- a/apps/web/app/api/onboarding/market-context/route.ts
+++ b/apps/web/app/api/onboarding/market-context/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import {
+  captureMarketContext,
+  type MarketContextAnswers,
+} from "@/lib/onboarding/capture-market-context";
+import { enrichOrgCorpus } from "@/lib/wiki/enrich-org-corpus";
+import { createProductionInference } from "@/lib/wiki/inference-adapter";
+
+export const runtime = "nodejs";
+
+// Capture market/scope context (competitive landscape, market size, etc.) and
+// index it into the org WWWD corpus as first-party narrative. Per BI-1378 it
+// lands as a draft for review.
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return NextResponse.json(
+      { error: "Organization not found. Complete account setup first." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await req.json().catch(() => ({}))) as {
+    competitiveLandscape?: string;
+    marketSize?: string;
+    differentiators?: string;
+    positioning?: string;
+  };
+  const answers: MarketContextAnswers = {
+    competitiveLandscape: body.competitiveLandscape ?? null,
+    marketSize: body.marketSize ?? null,
+    differentiators: body.differentiators ?? null,
+    positioning: body.positioning ?? null,
+  };
+
+  const result = await captureMarketContext(
+    { organizationId: org.id, answers },
+    {
+      // Fire-and-forget + fail-open, mirroring the business-document route.
+      // BI-741B6329 will move enrichment onto the durable queue.
+      enrich: async ({ organizationId, text, title }) => {
+        void enrichOrgCorpus({
+          organizationId,
+          text,
+          title,
+          provenance: { sourceType: "data-entry", sourceRef: { field: "market-context" } },
+          trust: "first-party",
+          infer: createProductionInference({ taskType: "wiki_proposal" }),
+        }).catch((e) =>
+          console.warn("[market-context] corpus enrichment failed (fail-open):", e),
+        );
+      },
+    },
+  );
+
+  return NextResponse.json({ success: true, ...result });
+}

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -9,6 +9,7 @@ import {
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
 import { BusinessDocumentUpload } from "@/components/admin/BusinessDocumentUpload";
+import { MarketContextFields } from "@/components/admin/MarketContextFields";
 
 const COMPANY_SIZE_OPTIONS = [
   { value: "solo", label: "Solo", description: "Just me" },
@@ -237,6 +238,9 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             Your stakeholders — the people who interact with your business. These aren't always "customers."
           </div>
         </label>
+
+        {/* Market & competitive context (optional) */}
+        <MarketContextFields />
 
         {/* Company size */}
         <div style={labelStyle}>

--- a/apps/web/components/admin/MarketContextFields.tsx
+++ b/apps/web/components/admin/MarketContextFields.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+
+// Optional onboarding capture: market & competitive context. Saved as
+// first-party narrative into the org WWWD corpus (draft for review). Independent
+// of the rest of the business-context form — failure here never blocks setup.
+
+type Fields = {
+  competitiveLandscape: string;
+  marketSize: string;
+  differentiators: string;
+  positioning: string;
+};
+
+const FIELDS: { key: keyof Fields; label: string; placeholder: string }[] = [
+  { key: "competitiveLandscape", label: "Competitive landscape", placeholder: "Who do you compete with, and how is the field shaped?" },
+  { key: "marketSize", label: "Market size", placeholder: "How big is your market / who could you reach? (a rough sense is fine)" },
+  { key: "differentiators", label: "What sets you apart", placeholder: "Why do customers choose you over the alternatives?" },
+  { key: "positioning", label: "Positioning", placeholder: "Where do you play — premium, value, niche, broad?" },
+];
+
+const EMPTY: Fields = { competitiveLandscape: "", marketSize: "", differentiators: "", positioning: "" };
+
+export function MarketContextFields() {
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<Fields>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasContent = Object.values(data).some((v) => v.trim().length > 0);
+
+  async function handleSave() {
+    setError(null);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/onboarding/market-context", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Save failed");
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "8px 12px",
+    borderRadius: 6,
+    border: "1px solid var(--dpf-border)",
+    fontSize: 14,
+    color: "var(--dpf-text)",
+    background: "var(--dpf-surface-1)",
+    boxSizing: "border-box",
+    resize: "none",
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: "var(--dpf-accent)",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 0,
+          textAlign: "left",
+        }}
+      >
+        + Add market &amp; competitive context{" "}
+        <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}>(optional)</span>
+      </button>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, fontSize: 13 }}>
+      <div style={{ fontWeight: 600 }}>
+        Market &amp; competitive context{" "}
+        <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}>(optional)</span>
+      </div>
+      {FIELDS.map((f) => (
+        <label key={f.key} style={{ fontSize: 13 }}>
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>{f.label}</div>
+          <textarea
+            value={data[f.key]}
+            onChange={(e) => {
+              setData((prev) => ({ ...prev, [f.key]: e.target.value }));
+              setSaved(false);
+            }}
+            placeholder={f.placeholder}
+            rows={2}
+            style={inputStyle}
+          />
+        </label>
+      ))}
+      <div style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+        We add this to your organization&apos;s knowledge as a draft for you to review — it
+        sharpens what your AI coworkers know about your market.
+      </div>
+      {error && <p style={{ color: "var(--dpf-error)", fontSize: 12, margin: 0 }}>{error}</p>}
+      {saved && <p style={{ color: "var(--dpf-success)", fontSize: 12, margin: 0 }}>Saved for review.</p>}
+      <div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !hasContent}
+          style={{
+            padding: "6px 16px",
+            borderRadius: 6,
+            border: "none",
+            background: "var(--dpf-accent)",
+            color: "#fff",
+            cursor: saving || !hasContent ? "not-allowed" : "pointer",
+            fontSize: 13,
+            fontWeight: 600,
+            opacity: saving || !hasContent ? 0.6 : 1,
+          }}
+        >
+          {saving ? "Saving…" : "Save market context"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/onboarding/capture-market-context.test.ts
+++ b/apps/web/lib/onboarding/capture-market-context.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  captureMarketContext,
+  buildMarketNarrative,
+  type MarketContextEnricher,
+} from "./capture-market-context";
+
+const ORG = "org_123";
+
+describe("buildMarketNarrative", () => {
+  it("includes a labelled section for each non-empty answer", () => {
+    const { text, sections } = buildMarketNarrative({
+      competitiveLandscape: "Two national chains plus local independents.",
+      marketSize: "~12k homeowners in the tri-county area.",
+      differentiators: "Same-day service and transparent pricing.",
+      positioning: "Premium-but-fair local specialist.",
+    });
+    expect(sections).toEqual([
+      "Competitive landscape",
+      "Market size",
+      "What sets us apart",
+      "Positioning",
+    ]);
+    expect(text).toContain("Two national chains");
+    expect(text).toContain("tri-county");
+  });
+
+  it("omits blank answers and returns empty sections when nothing is provided", () => {
+    expect(buildMarketNarrative({}).sections).toEqual([]);
+    expect(buildMarketNarrative({ competitiveLandscape: "   " }).sections).toEqual([]);
+  });
+});
+
+describe("captureMarketContext", () => {
+  it("composes a narrative and invokes the enrichment seam (first-party)", async () => {
+    const enrich = vi.fn<MarketContextEnricher>(async () => {});
+    const res = await captureMarketContext(
+      { organizationId: ORG, answers: { competitiveLandscape: "Local independents.", marketSize: "12k homes." } },
+      { enrich },
+    );
+
+    expect(res.captured).toBe(true);
+    expect(res.enrichmentQueued).toBe(true);
+    expect(res.sections).toContain("Competitive landscape");
+    expect(enrich).toHaveBeenCalledTimes(1);
+    const arg = enrich.mock.calls[0][0];
+    expect(arg.organizationId).toBe(ORG);
+    expect(arg.text).toContain("Local independents.");
+    expect(arg.title.length).toBeGreaterThan(0);
+  });
+
+  it("is a no-op when no answers are provided", async () => {
+    const enrich = vi.fn<MarketContextEnricher>(async () => {});
+    const res = await captureMarketContext({ organizationId: ORG, answers: {} }, { enrich });
+    expect(res.captured).toBe(false);
+    expect(res.enrichmentQueued).toBe(false);
+    expect(enrich).not.toHaveBeenCalled();
+  });
+
+  it("captures without enriching when no seam is wired", async () => {
+    const res = await captureMarketContext(
+      { organizationId: ORG, answers: { marketSize: "12k homes." } },
+      {},
+    );
+    expect(res.captured).toBe(true);
+    expect(res.enrichmentQueued).toBe(false);
+  });
+});

--- a/apps/web/lib/onboarding/capture-market-context.ts
+++ b/apps/web/lib/onboarding/capture-market-context.ts
@@ -1,0 +1,91 @@
+// Onboarding market & scope capture (BI-34936764, EP-CORPUS-BOOTSTRAP).
+//
+// Captures the operator's market/scope context — competitive landscape, market
+// size / TAM, differentiators, positioning — and feeds it into the org WWWD
+// corpus as first-party material. Per design open-Q#6 this is NARRATIVE-first:
+// the answers become an org-overlay stance page (the corpus is the natural home
+// for this kind of judgment), with no new structured BusinessContext columns.
+//
+// Indexing goes through the enrichment pipeline via the injectable `enrich`
+// seam (the route wires it to enrichOrgCorpus(origin="data-entry",
+// trust="first-party")). Per the founder's draft-by-default decision (BI-1378),
+// first-party enrichment still lands as a draft for review.
+
+export type MarketContextAnswers = {
+  /** Who we compete with and how the field is shaped. */
+  competitiveLandscape?: string | null;
+  /** Total addressable market / market sizing notes. */
+  marketSize?: string | null;
+  /** What sets us apart. */
+  differentiators?: string | null;
+  /** Where we play / target-segment posture. */
+  positioning?: string | null;
+};
+
+/** Seam to the enrichment pipeline (wired by the route to enrichOrgCorpus). */
+export type MarketContextEnricher = (args: {
+  organizationId: string;
+  text: string;
+  title: string;
+}) => Promise<void>;
+
+export type CaptureMarketContextInput = {
+  organizationId: string;
+  answers: MarketContextAnswers;
+};
+
+export type CaptureMarketContextDeps = {
+  enrich?: MarketContextEnricher;
+};
+
+export type CaptureMarketContextResult = {
+  /** True when at least one answer had content. */
+  captured: boolean;
+  /** Section labels included in the narrative (for UI confirmation). */
+  sections: string[];
+  /** True when the enrichment seam was invoked. */
+  enrichmentQueued: boolean;
+};
+
+export const MARKET_CONTEXT_TITLE = "Market and competitive context";
+
+const FIELDS: Array<{ key: keyof MarketContextAnswers; label: string }> = [
+  { key: "competitiveLandscape", label: "Competitive landscape" },
+  { key: "marketSize", label: "Market size" },
+  { key: "differentiators", label: "What sets us apart" },
+  { key: "positioning", label: "Positioning" },
+];
+
+export function buildMarketNarrative(answers: MarketContextAnswers): {
+  text: string;
+  sections: string[];
+} {
+  const sections: string[] = [];
+  const blocks: string[] = [];
+  for (const { key, label } of FIELDS) {
+    const value = (answers[key] ?? "").trim();
+    if (value.length === 0) continue;
+    sections.push(label);
+    blocks.push(`## ${label}\n\n${value}`);
+  }
+  const text = blocks.length > 0 ? `# ${MARKET_CONTEXT_TITLE}\n\n${blocks.join("\n\n")}` : "";
+  return { text, sections };
+}
+
+export async function captureMarketContext(
+  input: CaptureMarketContextInput,
+  deps: CaptureMarketContextDeps = {},
+): Promise<CaptureMarketContextResult> {
+  const { text, sections } = buildMarketNarrative(input.answers);
+  if (text.length === 0) {
+    return { captured: false, sections: [], enrichmentQueued: false };
+  }
+
+  let enrichmentQueued = false;
+  if (deps.enrich) {
+    await deps.enrich({ organizationId: input.organizationId, text, title: MARKET_CONTEXT_TITLE });
+    enrichmentQueued = true;
+  }
+
+  return { captured: true, sections, enrichmentQueued };
+}


### PR DESCRIPTION
**EP-CORPUS-BOOTSTRAP stream 2.** During the business-context step the operator can optionally add market/scope context — competitive landscape, market size/TAM, differentiators, positioning.

Per design open-Q#6, **narrative-first** (no new `BusinessContext` columns): the answers compose a narrative and feed the live enrichment pipeline as **first-party** material, landing as a **draft for review** (BI-1378).

## Changes
- `lib/onboarding/capture-market-context.ts` (+ 5 tests): `buildMarketNarrative` (labelled sections, omits blanks) + `captureMarketContext` (no-op when empty; injectable `enrich` seam — same pattern as the doc-capture lib).
- `app/api/onboarding/market-context/route.ts`: admin JSON POST → `enrichOrgCorpus(origin="data-entry", trust="first-party")`, fire-and-forget + fail-open.
- `MarketContextFields.tsx`: optional collapsible section in the business-context step.

## Tests
5 new unit tests; 38 onboarding tests green; typecheck clean (pre-commit enforced).

## Notes
- Independent slice — no overlap with other in-flight worktrees.
- Draft-by-default behavior depends on PR #1382 (the policy fix) landing; this PR only *calls* `enrichOrgCorpus` and doesn't touch its policy.
- Conversational Q&A capture (onboarding-coo asking these in chat) is a follow-up within this BI; this delivers the form-driven path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)