### PR TITLE
feat(coworker): screen_* view-command tool surface (BI-DF6079E9 part 1)

### DIFF
--- a/apps/web/lib/mcp-tools.screen.test.ts
+++ b/apps/web/lib/mcp-tools.screen.test.ts
@@ -1,0 +1,229 @@
+// Tests for the Pseudo-User Contract screen_* view-command tool family
+// (BI-DF6079E9). Verifies:
+//
+//   1. Each handler returns success: true with the expected event payload
+//      under data.event when called with valid args.
+//   2. Each handler returns success: false with a clear error message when
+//      required args are missing or invalid.
+//   3. Grant resolution: each tool requires the spec'd coworker_screen_*
+//      grant (cross-referenced in agent-grants.test.ts; smoke-checked here).
+//
+// The handlers do not emit SSE events yet — that plumbing is a follow-on
+// (the second half of BI-DF6079E9). Returning the event payload
+// structurally is what makes the surface testable today; the chat handler
+// will pipe data.event into /api/agent/stream when it's wired.
+
+import { describe, expect, it } from "vitest";
+
+import { executeTool } from "./mcp-tools";
+import { isToolAllowedByGrants } from "./tak/agent-grants";
+
+const userId = "user-test";
+
+async function call(tool: string, params: Record<string, unknown> = {}) {
+  return executeTool(tool, params, userId);
+}
+
+describe("screen_describe + screen_get_state — read-only discovery", () => {
+  it("screen_describe returns success and a describe_requested event", async () => {
+    const r = await call("screen_describe");
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toMatchObject({ type: "screen:describe_requested" });
+  });
+
+  it("screen_get_state returns success and a state_requested event", async () => {
+    const r = await call("screen_get_state");
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toMatchObject({ type: "screen:state_requested" });
+  });
+
+  it("both require coworker_screen_read", () => {
+    expect(isToolAllowedByGrants("screen_describe", ["coworker_screen_read"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_get_state", ["coworker_screen_read"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_describe", ["coworker_screen_drive"])).toBe(false);
+    expect(isToolAllowedByGrants("screen_get_state", [])).toBe(false);
+  });
+});
+
+describe("screen_select_entity", () => {
+  it("dispatches with valid args", async () => {
+    const r = await call("screen_select_entity", { selectionId: "build", entityId: "FB-X" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({
+      type: "screen:select_entity",
+      payload: { selectionId: "build", entityId: "FB-X" },
+    });
+  });
+
+  it("rejects empty selectionId", async () => {
+    const r = await call("screen_select_entity", { selectionId: "", entityId: "FB-X" });
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("missing_args");
+  });
+
+  it("rejects empty entityId", async () => {
+    const r = await call("screen_select_entity", { selectionId: "build", entityId: "" });
+    expect(r.success).toBe(false);
+  });
+
+  it("requires coworker_screen_drive", () => {
+    expect(isToolAllowedByGrants("screen_select_entity", ["coworker_screen_drive"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_select_entity", ["coworker_screen_read"])).toBe(false);
+  });
+});
+
+describe("screen_navigate", () => {
+  it("dispatches a bare route", async () => {
+    const r = await call("screen_navigate", { route: "/build" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({ type: "screen:navigate", payload: { route: "/build" } });
+  });
+
+  it("forwards params when provided as a plain object", async () => {
+    const r = await call("screen_navigate", { route: "/build", params: { buildId: "FB-X" } });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({
+      type: "screen:navigate",
+      payload: { route: "/build", params: { buildId: "FB-X" } },
+    });
+  });
+
+  it("ignores non-object params (model artifact)", async () => {
+    const r = await call("screen_navigate", { route: "/x", params: "string-not-object" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({ type: "screen:navigate", payload: { route: "/x" } });
+  });
+
+  it("rejects empty route", async () => {
+    const r = await call("screen_navigate", { route: "" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("screen_open_panel + screen_close_panel", () => {
+  it("open dispatches a screen:open_panel event", async () => {
+    const r = await call("screen_open_panel", { panelId: "design-doc" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({ type: "screen:open_panel", payload: { panelId: "design-doc" } });
+  });
+
+  it("close dispatches a screen:close_panel event", async () => {
+    const r = await call("screen_close_panel", { panelId: "plan" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({ type: "screen:close_panel", payload: { panelId: "plan" } });
+  });
+
+  it("both reject empty panelId", async () => {
+    expect((await call("screen_open_panel", { panelId: "" })).success).toBe(false);
+    expect((await call("screen_close_panel", { panelId: "" })).success).toBe(false);
+  });
+});
+
+describe("screen_focus_field", () => {
+  it("dispatches with valid form + field", async () => {
+    const r = await call("screen_focus_field", { formId: "design-doc-form", fieldId: "title" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({
+      type: "screen:focus_field",
+      payload: { formId: "design-doc-form", fieldId: "title" },
+    });
+  });
+
+  it("rejects when either field is missing", async () => {
+    expect((await call("screen_focus_field", { formId: "x" })).success).toBe(false);
+    expect((await call("screen_focus_field", { fieldId: "y" })).success).toBe(false);
+  });
+});
+
+describe("screen_set_input", () => {
+  it("dispatches a string value", async () => {
+    const r = await call("screen_set_input", { formId: "f", fieldId: "title", value: "Hello" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({
+      type: "screen:set_input",
+      payload: { formId: "f", fieldId: "title", value: "Hello" },
+    });
+  });
+
+  it("dispatches a falsy value (zero, false, empty string) — they are valid inputs", async () => {
+    expect((await call("screen_set_input", { formId: "f", fieldId: "n", value: 0 })).success).toBe(true);
+    expect((await call("screen_set_input", { formId: "f", fieldId: "b", value: false })).success).toBe(true);
+    expect((await call("screen_set_input", { formId: "f", fieldId: "s", value: "" })).success).toBe(true);
+  });
+
+  it("rejects when value is absent (not just falsy)", async () => {
+    const r = await call("screen_set_input", { formId: "f", fieldId: "g" });
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("missing_args");
+  });
+
+  it("requires the dedicated coworker_screen_fill grant — not satisfied by coworker_screen_drive", () => {
+    expect(isToolAllowedByGrants("screen_set_input", ["coworker_screen_fill"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_set_input", ["coworker_screen_drive"])).toBe(false);
+    expect(isToolAllowedByGrants("screen_set_input", ["coworker_screen_read"])).toBe(false);
+  });
+});
+
+describe("screen_scroll_to — read-class per POLA review", () => {
+  it("dispatches with valid anchor", async () => {
+    const r = await call("screen_scroll_to", { anchor: "evidence-panel" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({ type: "screen:scroll_to", payload: { anchor: "evidence-panel" } });
+  });
+
+  it("satisfies coworker_screen_read, not coworker_screen_drive", () => {
+    expect(isToolAllowedByGrants("screen_scroll_to", ["coworker_screen_read"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_scroll_to", ["coworker_screen_drive"])).toBe(false);
+  });
+});
+
+describe("screen_propose_action + screen_dispatch_action — envelope flow stubs", () => {
+  it("propose_action dispatches with valid args + carries the envelope follow-on note", async () => {
+    const r = await call("screen_propose_action", {
+      manifestActionId: "save-design-doc",
+      args: { buildId: "FB-X" },
+      rationale: "User asked to save the design doc.",
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toMatchObject({
+      type: "screen:action_proposed",
+      payload: { manifestActionId: "save-design-doc", rationale: "User asked to save the design doc." },
+    });
+    // Documents that the actual envelope DB write lands in BI-0F9C291C.
+    expect(r.data?.note).toMatch(/BI-0F9C291C/);
+  });
+
+  it("propose_action defaults args to {} when omitted", async () => {
+    const r = await call("screen_propose_action", {
+      manifestActionId: "x",
+      rationale: "y",
+    });
+    expect(r.success).toBe(true);
+    expect((r.data?.event as { payload: { args: unknown } }).payload.args).toEqual({});
+  });
+
+  it("propose_action rejects missing manifestActionId or rationale", async () => {
+    expect((await call("screen_propose_action", { manifestActionId: "", rationale: "x" })).success).toBe(false);
+    expect((await call("screen_propose_action", { manifestActionId: "x", rationale: "" })).success).toBe(false);
+  });
+
+  it("dispatch_action dispatches with valid envelopeId + carries follow-on note", async () => {
+    const r = await call("screen_dispatch_action", { envelopeId: "env-123" });
+    expect(r.success).toBe(true);
+    expect(r.data?.event).toEqual({
+      type: "screen:dispatch_requested",
+      payload: { envelopeId: "env-123" },
+    });
+    expect(r.data?.note).toMatch(/BI-0F9C291C/);
+  });
+
+  it("dispatch_action rejects empty envelopeId", async () => {
+    expect((await call("screen_dispatch_action", { envelopeId: "" })).success).toBe(false);
+  });
+
+  it("both require coworker_screen_drive (the underlying tool's grant is resolved when the envelope is dispatched — BI-0F9C291C)", () => {
+    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_drive"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_dispatch_action", ["coworker_screen_drive"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_read"])).toBe(false);
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4294,6 +4294,200 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
   },
+
+  // ─── Pseudo-User Contract: screen_* view-command tool family (BI-DF6079E9) ──
+  // Spec §6.2. Each tool returns a structured `data.event` payload describing
+  // the requested screen action; the chat SSE stream emits the payload and the
+  // client-side relay (AgentCoworkerPanel.tsx) dispatches it as a window
+  // CustomEvent that the active page handles via its registered ScreenManifest
+  // (BI-D9487754). Per-tool MCP annotations are exact — destructiveHint flags
+  // propose_action and dispatch_action explicitly; the rest are advisory UI
+  // mutations the user can still see and override.
+  //
+  // The SSE emission + window-event relay plumbing lands as the follow-on
+  // half of this BI. For now the handlers return the event payload
+  // structurally so the chat surface is queryable and grant-checked.
+
+  {
+    name: "screen_describe",
+    description:
+      "Pseudo-User Contract (spec §6.1, BI-D9487754/BI-DF6079E9). Return the active ScreenManifest summary for the chat's current routeContext — the list of selections, navigations, panels, forms, and domain actions the coworker may invoke on this page. Read-only. Call once at the start of a turn to discover what's available before dispatching screen_* actions. Returns the manifest's serialisable metadata; live handlers stay on the client.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "screen_get_state",
+    description:
+      "Pseudo-User Contract. Return the current observable state of the active screen — selected entities (by selectionId), focused field id, open panel ids, current scroll anchor, current form values. Read-only. Source of truth is the page; this tool returns the snapshot the chat session plumbed in via screenState. Call screen_describe first for the manifest shape, then screen_get_state for the live values.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  },
+  {
+    name: "screen_select_entity",
+    description:
+      "Pseudo-User Contract. Change the active screen's selection — e.g. switch which FeatureBuild is currently focused in Build Studio. The selectionId must match one declared by the active ScreenManifest; the entityId must come from that selection's listSource. Dispatches via the chat SSE channel; the page applies the change through its registered handler.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        selectionId: { type: "string", description: "Manifest selection id (e.g. \"build\")." },
+        entityId: { type: "string", description: "Id of the entity to select (from the manifest's listSource enumeration)." },
+      },
+      required: ["selectionId", "entityId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_navigate",
+    description:
+      "Pseudo-User Contract. Navigate to another route within the portal — e.g. /build → /storefront. Conditionally destructive: if the current page has unsaved form state the chat handler auto-wraps the call in an envelope (spec §6.4). Cross-coworker-ownership navigations will fire a HITL handoff gate when BI-A32801C5 lands.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        route: { type: "string", description: "Target route path, e.g. \"/build/FB-5E20E793\"." },
+        params: { type: "object", description: "Optional path/query parameters." },
+      },
+      required: ["route"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_open_panel",
+    description:
+      "Pseudo-User Contract. Open a panel registered in the active manifest — drawer, collapsible section, modal. Idempotent: opening an already-open panel is a no-op.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        panelId: { type: "string", description: "Manifest panel id." },
+      },
+      required: ["panelId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_close_panel",
+    description:
+      "Pseudo-User Contract. Close a panel registered in the active manifest. Idempotent.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        panelId: { type: "string", description: "Manifest panel id." },
+      },
+      required: ["panelId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_focus_field",
+    description:
+      "Pseudo-User Contract. Focus a specific form field on the active screen — useful when guiding the user to fix a validation error or fill in a missing value. The field must belong to a form declared in the manifest. Idempotent; cosmetic if the field is already focused.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        formId: { type: "string", description: "Manifest form id." },
+        fieldId: { type: "string", description: "Field id within the form." },
+      },
+      required: ["formId", "fieldId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_set_input",
+    description:
+      "Pseudo-User Contract. Pre-fill a form field on the user's behalf. The user can still review and modify before submit; the visual cue contract (BI-5696B4D7) highlights coworker-set fields with an amber affordance + \"Set by <Coworker>\" tooltip. Not destructive by itself (reversible until submit) — submit is the destructive action and goes through the envelope flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        formId: { type: "string", description: "Manifest form id." },
+        fieldId: { type: "string", description: "Field id within the form." },
+        value: { description: "Value to set. Type depends on the field's declared type." },
+      },
+      required: ["formId", "fieldId", "value"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_scroll_to",
+    description:
+      "Pseudo-User Contract. Scroll the page to a named anchor — useful when surfacing a row, section, or message that's currently off-screen. Read-class side effect (page state, no domain mutation).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        anchor: { type: "string", description: "Anchor id, route fragment, or manifest-declared landmark." },
+      },
+      required: ["anchor"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_propose_action",
+    description:
+      "Pseudo-User Contract (spec §6.4 — destructive-action envelope flow). Propose a domain action that needs explicit user approval before execution. Creates a CoworkerActionEnvelope (BI-D887CD3B schema) in `proposed` status, emits the proposal to the chat UI, and returns the envelope id so the chat handler can correlate the user's approve/deny response. Subject to the per-turn N=3 destructive auto-approval cap (spec §6.4); irreversible actions require an explicit typed-phrase floor and ignore elevation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        manifestActionId: { type: "string", description: "actionId from the active manifest's domainActions list." },
+        args: { type: "object", description: "Arguments to pass to the underlying MCP tool when the envelope is approved." },
+        rationale: { type: "string", description: "One-line plain-English reason shown to the user in the approval card." },
+      },
+      required: ["manifestActionId", "rationale"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false, irreversibleHint: false },
+    screenSurface: "*",
+  },
+  {
+    name: "screen_dispatch_action",
+    description:
+      "Pseudo-User Contract. Execute a previously-proposed envelope by id once it's been approved (spec §6.4). Resolves the underlying tool from the envelope's manifestActionId + the active manifest's domainActions, runs it with the merged args, and records the outcome on the envelope (`executed` | `failed`). Destructive in the same sense as the underlying tool — the destructiveHint reflects the proposal's intent.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        envelopeId: { type: "string", description: "CoworkerActionEnvelope id returned by screen_propose_action." },
+      },
+      required: ["envelopeId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false, irreversibleHint: false },
+    screenSurface: "*",
+  },
 ];
 
 // ─── Capability Filtering ────────────────────────────────────────────────────
@@ -14393,6 +14587,238 @@ export async function executeTool(
           message: `summarize_upgrade_impact failed: ${msg}`,
         };
       }
+    }
+
+    // ─── Pseudo-User Contract: screen_* view-command handlers (BI-DF6079E9) ─
+    // Each handler validates its args and returns a structured event payload
+    // under `data.event`. The chat SSE relay (a follow-on integration —
+    // tracked as the second half of this BI) will plumb the payload through
+    // /api/agent/stream so the client's screen-event listener can dispatch
+    // the corresponding action on the page via its registered manifest. For
+    // now the handler shape is testable and grant-checked; the actual SSE
+    // emission is wired by the chat handler in a focused follow-on PR.
+
+    case "screen_describe": {
+      const routeContext = context?.routeContext;
+      return {
+        success: true,
+        message: routeContext
+          ? `Active screen manifest discovery requested for ${routeContext}.`
+          : "Active screen manifest discovery requested (no routeContext plumbed).",
+        data: {
+          event: {
+            type: "screen:describe_requested",
+            payload: { routeContext: routeContext ?? null },
+          },
+          // The actual manifest summary will be returned by the chat handler
+          // once it plumbs the active manifest into the executeTool context
+          // (tracked in BI-DF6079E9 follow-on). Returning the request shape
+          // here makes the tool callable and grant-checked today.
+          note: "Manifest summary plumbing lands in BI-DF6079E9 follow-on.",
+        },
+      };
+    }
+
+    case "screen_get_state": {
+      return {
+        success: true,
+        message: "Screen state snapshot requested.",
+        data: {
+          event: {
+            type: "screen:state_requested",
+            payload: { routeContext: context?.routeContext ?? null },
+          },
+          note: "Screen state plumbing lands in BI-DF6079E9 follow-on.",
+        },
+      };
+    }
+
+    case "screen_select_entity": {
+      const selectionId = typeof params["selectionId"] === "string" ? params["selectionId"].trim() : "";
+      const entityId = typeof params["entityId"] === "string" ? params["entityId"].trim() : "";
+      if (!selectionId || !entityId) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_select_entity requires non-empty selectionId and entityId.",
+        };
+      }
+      return {
+        success: true,
+        message: `Selection ${selectionId} → ${entityId} dispatched.`,
+        data: {
+          event: {
+            type: "screen:select_entity",
+            payload: { selectionId, entityId },
+          },
+        },
+      };
+    }
+
+    case "screen_navigate": {
+      const route = typeof params["route"] === "string" ? params["route"].trim() : "";
+      if (!route) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_navigate requires a non-empty route.",
+        };
+      }
+      const navParams =
+        params["params"] && typeof params["params"] === "object" && !Array.isArray(params["params"])
+          ? (params["params"] as Record<string, unknown>)
+          : undefined;
+      return {
+        success: true,
+        message: `Navigation to ${route} dispatched.`,
+        data: {
+          event: {
+            type: "screen:navigate",
+            payload: navParams ? { route, params: navParams } : { route },
+          },
+        },
+      };
+    }
+
+    case "screen_open_panel":
+    case "screen_close_panel": {
+      const panelId = typeof params["panelId"] === "string" ? params["panelId"].trim() : "";
+      if (!panelId) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: `${toolName} requires a non-empty panelId.`,
+        };
+      }
+      const opening = toolName === "screen_open_panel";
+      return {
+        success: true,
+        message: `Panel ${panelId} ${opening ? "open" : "close"} dispatched.`,
+        data: {
+          event: {
+            type: opening ? "screen:open_panel" : "screen:close_panel",
+            payload: { panelId },
+          },
+        },
+      };
+    }
+
+    case "screen_focus_field": {
+      const formId = typeof params["formId"] === "string" ? params["formId"].trim() : "";
+      const fieldId = typeof params["fieldId"] === "string" ? params["fieldId"].trim() : "";
+      if (!formId || !fieldId) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_focus_field requires non-empty formId and fieldId.",
+        };
+      }
+      return {
+        success: true,
+        message: `Focus dispatched: ${formId}/${fieldId}.`,
+        data: { event: { type: "screen:focus_field", payload: { formId, fieldId } } },
+      };
+    }
+
+    case "screen_set_input": {
+      const formId = typeof params["formId"] === "string" ? params["formId"].trim() : "";
+      const fieldId = typeof params["fieldId"] === "string" ? params["fieldId"].trim() : "";
+      if (!formId || !fieldId) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_set_input requires non-empty formId and fieldId.",
+        };
+      }
+      if (!("value" in params)) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_set_input requires a value (any type).",
+        };
+      }
+      return {
+        success: true,
+        message: `Field ${formId}/${fieldId} set dispatched (visual cue BI-5696B4D7 will land alongside this in the client).`,
+        data: {
+          event: {
+            type: "screen:set_input",
+            payload: { formId, fieldId, value: params["value"] },
+          },
+        },
+      };
+    }
+
+    case "screen_scroll_to": {
+      const anchor = typeof params["anchor"] === "string" ? params["anchor"].trim() : "";
+      if (!anchor) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_scroll_to requires a non-empty anchor.",
+        };
+      }
+      return {
+        success: true,
+        message: `Scroll to ${anchor} dispatched.`,
+        data: { event: { type: "screen:scroll_to", payload: { anchor } } },
+      };
+    }
+
+    case "screen_propose_action": {
+      const manifestActionId =
+        typeof params["manifestActionId"] === "string" ? params["manifestActionId"].trim() : "";
+      const rationale = typeof params["rationale"] === "string" ? params["rationale"].trim() : "";
+      if (!manifestActionId || !rationale) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_propose_action requires manifestActionId and rationale.",
+        };
+      }
+      const args =
+        params["args"] && typeof params["args"] === "object" && !Array.isArray(params["args"])
+          ? (params["args"] as Record<string, unknown>)
+          : {};
+      // The actual CoworkerActionEnvelope row creation (and per-turn N=3 cap
+      // + irreversible typed-phrase floor) lands in BI-0F9C291C. Until then
+      // the tool returns the structured proposal payload so the agent can
+      // see what would be proposed, and the chat handler can stub-write the
+      // envelope when wiring SSE emission.
+      return {
+        success: true,
+        message: `Proposal '${manifestActionId}' dispatched.`,
+        data: {
+          event: {
+            type: "screen:action_proposed",
+            payload: { manifestActionId, rationale, args },
+          },
+          note: "Envelope creation + per-turn cap enforcement lands in BI-0F9C291C.",
+        },
+      };
+    }
+
+    case "screen_dispatch_action": {
+      const envelopeId =
+        typeof params["envelopeId"] === "string" ? params["envelopeId"].trim() : "";
+      if (!envelopeId) {
+        return {
+          success: false,
+          error: "missing_args",
+          message: "screen_dispatch_action requires an envelopeId.",
+        };
+      }
+      return {
+        success: true,
+        message: `Envelope ${envelopeId} dispatch requested.`,
+        data: {
+          event: {
+            type: "screen:dispatch_requested",
+            payload: { envelopeId },
+          },
+          note: "Envelope execution (read row → run underlying tool → mark executed) lands in BI-0F9C291C.",
+        },
+      };
     }
 
     default: {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -363,6 +363,25 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // HR — query
   query_employees: ["consumer_read", "registry_read"],
+
+  // ─── Pseudo-User Contract: screen_* view-command family (BI-DF6079E9) ─────
+  // Three finer grants (coworker_screen_read / drive / fill) carry the view-
+  // command surface. screen_scroll_to is read-class per the chief-architect
+  // review (PR #1361). screen_dispatch_action gates on coworker_screen_drive
+  // at the entry; the underlying tool resolved from the envelope's
+  // manifestActionId carries its own grant check (BI-0F9C291C will wire
+  // the second-key resolution).
+  screen_describe:         ["coworker_screen_read"],
+  screen_get_state:        ["coworker_screen_read"],
+  screen_scroll_to:        ["coworker_screen_read"],
+  screen_select_entity:    ["coworker_screen_drive"],
+  screen_navigate:         ["coworker_screen_drive"],
+  screen_open_panel:       ["coworker_screen_drive"],
+  screen_close_panel:      ["coworker_screen_drive"],
+  screen_focus_field:      ["coworker_screen_drive"],
+  screen_propose_action:   ["coworker_screen_drive"],
+  screen_dispatch_action:  ["coworker_screen_drive"],
+  screen_set_input:        ["coworker_screen_fill"],
 };
 
 const grantCache = new Map<string, string[]>();

--- a/docs/superpowers/audits/2026-04-27-coworker-tool-grant-audit.json
+++ b/docs/superpowers/audits/2026-04-27-coworker-tool-grant-audit.json
@@ -2,7 +2,7 @@
   "generatedAt": "2026-04-29T05:50:51.037Z",
   "spec": "docs/superpowers/specs/2026-04-27-coworker-tool-grant-spec-design.md",
   "invariantsChecked": 6,
-  "errorCount": 76,
+  "errorCount": 73,
   "warnCount": 0,
   "findings": [
     {
@@ -587,30 +587,6 @@
       "agentId": null,
       "file": "packages/db/data/grant_catalog.json",
       "summary": "Catalog grant 'build_promote' has no honored_by_tools",
-      "detail": "Aspirational grant: declared in registry, present in catalog, but no tool implementation in apps/web/lib/tak/agent-grants.ts checks it. Either implement a tool that requires this grant or remove the grant from the registry and catalog."
-    },
-    {
-      "invariantId": "GRANT-002",
-      "severity": "error",
-      "agentId": null,
-      "file": "packages/db/data/grant_catalog.json",
-      "summary": "Catalog grant 'coworker_screen_drive' has no honored_by_tools",
-      "detail": "Aspirational grant: declared in registry, present in catalog, but no tool implementation in apps/web/lib/tak/agent-grants.ts checks it. Either implement a tool that requires this grant or remove the grant from the registry and catalog."
-    },
-    {
-      "invariantId": "GRANT-002",
-      "severity": "error",
-      "agentId": null,
-      "file": "packages/db/data/grant_catalog.json",
-      "summary": "Catalog grant 'coworker_screen_fill' has no honored_by_tools",
-      "detail": "Aspirational grant: declared in registry, present in catalog, but no tool implementation in apps/web/lib/tak/agent-grants.ts checks it. Either implement a tool that requires this grant or remove the grant from the registry and catalog."
-    },
-    {
-      "invariantId": "GRANT-002",
-      "severity": "error",
-      "agentId": null,
-      "file": "packages/db/data/grant_catalog.json",
-      "summary": "Catalog grant 'coworker_screen_read' has no honored_by_tools",
       "detail": "Aspirational grant: declared in registry, present in catalog, but no tool implementation in apps/web/lib/tak/agent-grants.ts checks it. Either implement a tool that requires this grant or remove the grant from the registry and catalog."
     }
   ]

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -373,26 +373,40 @@
     },
     {
       "key": "coworker_screen_drive",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): drive the screen the user is on — select entities, navigate routes, open/close panels, focus fields, scroll. Read-only for the user (the coworker drives). No tools honored yet; consumers land in BI-DF6079E9 (screen_* view-command tool family).",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): drive the screen the user is on — select entities, navigate routes, open/close panels, focus fields. Read-only for the user (the coworker drives).",
       "category": "platform",
       "sensitivity": "internal",
-      "honored_by_tools": [],
+      "honored_by_tools": [
+        "screen_close_panel",
+        "screen_dispatch_action",
+        "screen_focus_field",
+        "screen_navigate",
+        "screen_open_panel",
+        "screen_propose_action",
+        "screen_select_entity"
+      ],
       "implies": []
     },
     {
       "key": "coworker_screen_fill",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): pre-fill form fields on behalf of the user. Higher tier than coworker_screen_drive — the user can still override before submit, but the coworker is setting input without explicit user keystrokes. Consumers land in BI-DF6079E9 (screen_set_input).",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): pre-fill form fields on behalf of the user. Higher tier than coworker_screen_drive — the user can still override before submit, but the coworker is setting input without explicit user keystrokes.",
       "category": "platform",
       "sensitivity": "internal",
-      "honored_by_tools": [],
+      "honored_by_tools": [
+        "screen_set_input"
+      ],
       "implies": []
     },
     {
       "key": "coworker_screen_read",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): read the current screen's state — selected entities, focused field, open panels, route. Read-only side of the coworker view-command surface. Consumers land in BI-DF6079E9 (screen_describe, screen_get_state).",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): read the current screen's state — selected entities, focused field, open panels, route, scroll anchor. Read-only side of the coworker view-command surface (POLA-aligned per chief-architect review of PR #1361 — screen_scroll_to is read-class).",
       "category": "platform",
       "sensitivity": "internal",
-      "honored_by_tools": [],
+      "honored_by_tools": [
+        "screen_describe",
+        "screen_get_state",
+        "screen_scroll_to"
+      ],
       "implies": []
     },
     {


### PR DESCRIPTION
## Summary

Fourth Phase 1 substrate BI of `EP-COWORKER-INTERACTIVITY`. Delivers the **tool-catalog half** of `BI-DF6079E9`: 11 new MCP tools that form the coworker's screen-driving vocabulary, plus their handlers, grants, catalog entries, and tests. The **SSE event emission + relay-vocabulary migration** lands as a focused follow-on PR (part 2 of this BI).

## What's new

**11 tools added to `PLATFORM_TOOLS`** with MCP annotations, descriptions, schemas, grants, and screenSurface metadata:

| Tool | Grant | Destructive? |
|---|---|---|
| `screen_describe` | `coworker_screen_read` | no |
| `screen_get_state` | `coworker_screen_read` | no |
| `screen_scroll_to` | `coworker_screen_read` | no (POLA-aligned per architect review) |
| `screen_select_entity` | `coworker_screen_drive` | no |
| `screen_navigate` | `coworker_screen_drive` | no (conditionally — handled at envelope layer) |
| `screen_open_panel` | `coworker_screen_drive` | no |
| `screen_close_panel` | `coworker_screen_drive` | no |
| `screen_focus_field` | `coworker_screen_drive` | no |
| `screen_set_input` | `coworker_screen_fill` | no (cue + envelope at submit) |
| `screen_propose_action` | `coworker_screen_drive` | yes |
| `screen_dispatch_action` | `coworker_screen_drive` | yes |

**11 `executeTool` case handlers** — each validates required args and returns a structured `data.event = { type: "screen:*", payload }` result. The SSE plumbing to actually emit that payload is the follow-on.

**Grant catalog updates** — `coworker_screen_read` / `drive` / `fill` move from "aspirational" (empty `honored_by_tools`) to "honored by these tools" with concrete lists.

**Baseline audit cleanup** — 3 resolved `GRANT-002` entries removed.

**28 vitest cases** at `apps/web/lib/mcp-tools.screen.test.ts` covering each handler's happy + error paths, event-payload shapes, and grant resolution.

## What this PR does NOT do (BI-DF6079E9 part 2, follow-on)

- Pipe `data.event` from tool results into `/api/agent/stream` so the client receives it
- Add `screen:*` to `RELAY_TYPES` in `AgentCoworkerPanel.tsx`
- Add the new `coworker-screen-event` window CustomEvent name
- Migrate the 9 existing `build-progress-update` consumer sites
- Plumb `ScreenStateSnapshot` through the chat handler → `executeTool` context (needed for `screen_describe` / `screen_get_state` to return real manifest + state instead of acknowledge events)

These are kept separate because they touch the chat-streaming surface where a wrong move silently breaks Build Studio's existing progress UI. Better as a focused review with the existing relay code on screen.

## Verification

- ✓ `pnpm --filter web exec vitest run lib/mcp-tools.screen.test.ts` — 28/28 pass
- ✓ `pnpm --filter web exec tsx scripts/audit-coworker-tool-grants.ts --baseline …` — `unchanged=73 resolved=0 new=0`
- ✓ `pnpm --filter web typecheck` — clean
- ✓ DCO-signed, pre-commit guards all fired (chmod fix is live in main now)

## Linked work

- **Epic:** `EP-COWORKER-INTERACTIVITY`
- **This BI:** `BI-DF6079E9` — *in-progress*; this PR is part 1, SSE wiring is part 2
- **Substrate this builds on:** `BI-D887CD3B` (schema ✓ merged #1366), `BI-B2F7ABF5` (grants ✓ merged #1372), `BI-D9487754` (manifest types ✓ merged #1381)
- **Downstream:** `BI-0F9C291C` (envelope flow — uses `screen_propose_action` / `screen_dispatch_action`), `BI-6C9CC0EC` (Build Studio manifest — consumes the manifest substrate + these tools)

## Founder attention

Two flags worth a quick look:

1. **`screen_propose_action` doesn't yet write the envelope DB row.** It returns the proposal payload structurally; envelope creation, the N=3 per-turn cap, and the irreversible typed-phrase floor all land in `BI-0F9C291C`. The `data.note` field on the response says so explicitly. Tradeoff: ship a queryable, grant-checked surface now; wire the lifecycle when the envelope-flow BI gets picked up.
2. **`screen_describe` / `screen_get_state` return acknowledge events instead of real data.** Same reason — the chat handler needs to plumb `ScreenStateSnapshot` into the executeTool context first, which is part 2. This BI's surface is queryable today; the read-real-state behaviour is one chat-handler change away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)