### PR TITLE
fix(identity): expand grant implications in AIDoc tool surface

### DIFF
--- a/apps/web/lib/identity/aidoc-resolver.ts
+++ b/apps/web/lib/identity/aidoc-resolver.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@dpf/db";
 
-import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import { expandGrants, getToolGrantMapping } from "@/lib/tak/agent-grants";
 import { computeMetadataHash } from "@/lib/routing/metadata-hash";
 
 import {
@@ -90,7 +90,13 @@ function parseIssuerFromGaid(gaid: string): string {
 }
 
 function deriveToolSurface(grantKeys: string[]): string[] {
-  const grantSet = new Set(grantKeys);
+  // Expand the held grants through GRANT_IMPLICATIONS before matching, so the
+  // projected tool surface reflects the same effective permissions as the
+  // authoritative check (isToolAllowedByGrants). Without this, every tool that
+  // was refactored to require a finer implied grant (e.g. record_execution_evidence
+  // on `build_evidence`, satisfied via backlog_write → build_evidence) would be
+  // silently dropped from the AIDoc. BI-B2F7ABF5.
+  const grantSet = new Set(expandGrants(grantKeys));
   const toolMap = getToolGrantMapping();
 
   return Object.entries(toolMap)


### PR DESCRIPTION
## Problem

`aidoc-resolver.test.ts` fails on `origin/main` (also CI run 26719044255):

> `resolveInternalAIDoc > "projects a private AIDoc…"` — `tool_surface` arrayContaining failed, missing `record_execution_evidence`.

## Evidence-before-diagnosis

Diffed the resolver's actual output (69 tools) against the test's expected array. Of the four expected entries, three (`create_backlog_item`, `update_backlog_item_status`, `launch_sandbox`) were present — the vitest diff merely misaligned them by sort order. The **single genuinely missing** tool was `record_execution_evidence`.

Root cause:
- `record_execution_evidence` requires the `build_evidence` grant (`agent-grants.ts:75`).
- The test agent holds `backlog_write`, which **implies** `build_evidence` via `GRANT_IMPLICATIONS` (`agent-grants.ts:27`).
- The authoritative check `isToolAllowedByGrants` expands grants before matching, but `deriveToolSurface` in the resolver matched against **raw** grant keys — so it silently dropped every tool refactored onto a finer implied grant (`record_execution_evidence`, `save_build_notes`, `propose_build_decomposition`, …).

This is a resolver bug, not a legitimate tool rename/removal — so the fix is on the resolver side, not the test.

## Fix

Apply `expandGrants()` in `deriveToolSurface` so the projected AIDoc `tool_surface` reflects the same effective permissions as the runtime grant check. The `operating_profile_fingerprint` is unaffected — it hashes raw, sorted grant keys, not the derived tool surface.

## Verification

```
cd apps/web && pnpm exec vitest run lib/identity/aidoc-resolver.test.ts
# Test Files 1 passed (1) — Tests 3 passed (3)
```

Scoped strictly to this test/resolver; unrelated to EP-CORPUS-BOOTSTRAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)