### PR TITLE
feat(corpus): WWWD coverage-gap detection → draft open-question (BI-741B6329)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -44,6 +44,7 @@ import {
 } from "@/lib/skills/runtime";
 import { recordSkillUsageEvents } from "@/lib/skills/usage-events";
 import { recallWikiContext } from "@/lib/wiki/recall";
+import { recordCoverageGap } from "@/lib/wiki/coverage-gap";
 import {
   classifyPerspective,
   extractPageTopic,
@@ -764,9 +765,22 @@ export async function sendMessage(input: {
         ? PERSPECTIVE_PAGE_KINDS[perspective.perspective]
         : undefined,
     });
+    // BI-741B6329: capture the WWWD coverage gap BEFORE the hint is folded into
+    // wikiContext below (which makes it non-null). Empty recall on a WWWD query
+    // means the org has no recorded stance on this topic yet.
+    const wwwdRecallEmpty = perspective.perspective === "wwwd" && !wikiContext;
     if (perspective.perspective) {
       const hint = buildPerspectiveHint(perspective.perspective, pageTopic);
       wikiContext = wikiContext ? `${hint}\n\n${wikiContext}` : hint;
+    }
+    // Continuous enrichment (EP-CORPUS-BOOTSTRAP): record the unanswered WWWD
+    // question as a deduplicated draft "open question" so the gap surfaces for
+    // review/enrichment. Fire-and-forget + fail-open — never block or break the
+    // response path. (Autonomous research to fill it is gated on open-Q#4.)
+    if (wwwdRecallEmpty && wikiOrg?.id) {
+      void recordCoverageGap({ organizationId: wikiOrg.id, query: input.content }).catch(
+        (e) => console.warn("[coverage-gap] record failed (fail-open):", e),
+      );
     }
 
     // Governed Hermes learning Slice 1: eligible skills go into the prompt

--- a/apps/web/lib/wiki/coverage-gap.test.ts
+++ b/apps/web/lib/wiki/coverage-gap.test.ts
@@ -15,6 +15,12 @@ describe("normalizeGapTopic", () => {
   it("caps length", () => {
     expect(normalizeGapTopic("x".repeat(500)).length).toBeLessThanOrEqual(160);
   });
+  it("handles long whitespace/punctuation runs correctly (ReDoS-safe linear trim)", () => {
+    // Pathological input the old anchored /[?!.\s]+$/ backtracked on; the
+    // char-walk trim is linear. Correctness here + CodeQL re-scan confirm the fix.
+    const input = `${"\t".repeat(5000)}what would we do${" ".repeat(5000)}???`;
+    expect(normalizeGapTopic(input)).toBe("what would we do");
+  });
 });
 
 describe("gapFingerprint", () => {

--- a/apps/web/lib/wiki/coverage-gap.test.ts
+++ b/apps/web/lib/wiki/coverage-gap.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  normalizeGapTopic,
+  gapFingerprint,
+  gapPageSlug,
+  recordCoverageGap,
+  type RecordCoverageGapClient,
+} from "./coverage-gap";
+
+describe("normalizeGapTopic", () => {
+  it("lowercases, collapses whitespace, and strips trailing punctuation", () => {
+    expect(normalizeGapTopic("  What  would   WE do?? ")).toBe("what would we do");
+  });
+  it("caps length", () => {
+    expect(normalizeGapTopic("x".repeat(500)).length).toBeLessThanOrEqual(160);
+  });
+});
+
+describe("gapFingerprint", () => {
+  it("is deterministic and org-scoped", () => {
+    const a = gapFingerprint("org_1", "what would we do?");
+    expect(a).toBe(gapFingerprint("org_1", "What would we do"));
+    expect(a).not.toBe(gapFingerprint("org_2", "what would we do?"));
+  });
+});
+
+type Row = Record<string, any>;
+function makeFakeDb() {
+  const pages: Row[] = [];
+  const revisions: Row[] = [];
+  let seq = 0;
+  const db = {
+    wikiPage: {
+      findFirst: vi.fn(async (args: any) =>
+        pages.find((p) => p.organizationId === args.where.organizationId && p.slug === args.where.slug) ?? null,
+      ),
+      create: vi.fn(async (args: any) => {
+        const row = { id: `wp_${++seq}`, ...args.data };
+        pages.push(row);
+        return row;
+      }),
+      update: vi.fn(async (args: any) => {
+        const p = pages.find((r) => r.id === args.where.id);
+        if (p) Object.assign(p, args.data);
+        return p;
+      }),
+    },
+    wikiPageRevision: {
+      findFirst: vi.fn(async () => null),
+      create: vi.fn(async (args: any) => {
+        revisions.push({ ...args.data });
+        return args.data;
+      }),
+    },
+  } as unknown as RecordCoverageGapClient;
+  return { db, pages, revisions };
+}
+
+const ORG = "org_1";
+
+describe("recordCoverageGap", () => {
+  it("records an unanswered WWWD question as a draft, org-scoped stance page", async () => {
+    const fake = makeFakeDb();
+    const res = await recordCoverageGap({ organizationId: ORG, query: "What would we do about weekend pricing?" }, { db: fake.db });
+
+    expect(res.recorded).toBe(true);
+    expect(res.isNew).toBe(true);
+    expect(res.slug.startsWith("open-question-")).toBe(true);
+    expect(fake.pages).toHaveLength(1);
+    expect(fake.pages[0]).toMatchObject({
+      organizationId: ORG,
+      status: "draft",
+      pageKind: "stance",
+      isKernel: false,
+    });
+    expect(fake.pages[0].body).toContain("weekend pricing");
+    expect(fake.revisions).toHaveLength(1);
+  });
+
+  it("is idempotent — the same question coalesces to one draft (dedup by fingerprint slug)", async () => {
+    const fake = makeFakeDb();
+    await recordCoverageGap({ organizationId: ORG, query: "What would we do about refunds?" }, { db: fake.db });
+    const second = await recordCoverageGap({ organizationId: ORG, query: "what would we do about REFUNDS??" }, { db: fake.db });
+
+    expect(second.isNew).toBe(false);
+    expect(fake.pages).toHaveLength(1); // no duplicate
+    expect(fake.revisions).toHaveLength(1); // no extra revision on re-detection
+  });
+
+  it("is a no-op for a blank query", async () => {
+    const fake = makeFakeDb();
+    const res = await recordCoverageGap({ organizationId: ORG, query: "   " }, { db: fake.db });
+    expect(res.recorded).toBe(false);
+    expect(fake.pages).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/wiki/coverage-gap.ts
+++ b/apps/web/lib/wiki/coverage-gap.ts
@@ -19,15 +19,24 @@ import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 
 const MAX_TOPIC_LEN = 160;
 
+/** Trailing characters stripped from a normalised topic (punctuation + space). */
+const TRAILING_TRIM_CHARS = "?!. ";
+
 /** Normalise a query into a stable topic key: lowercase, collapse whitespace,
- *  strip trailing punctuation, cap length. */
+ *  strip trailing punctuation, cap length.
+ *
+ *  Note: the trailing strip is a char-walk loop, NOT an anchored regex like
+ *  `/[?!.\s]+$/`. That pattern is a polynomial-ReDoS vector on user-controlled
+ *  input (CodeQL js/polynomial-redos) — it backtracks badly on long runs of
+ *  whitespace. After `\s+ → " "` collapse there is at most one trailing space
+ *  anyway, so a linear walk is both safe and sufficient. */
 export function normalizeGapTopic(query: string): string {
-  return query
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .replace(/[?!.\s]+$/g, "")
-    .slice(0, MAX_TOPIC_LEN);
+  const collapsed = query.trim().toLowerCase().replace(/\s+/g, " ");
+  let end = collapsed.length;
+  while (end > 0 && TRAILING_TRIM_CHARS.includes(collapsed.charAt(end - 1))) {
+    end--;
+  }
+  return collapsed.slice(0, end).slice(0, MAX_TOPIC_LEN);
 }
 
 /** Deterministic, org-scoped fingerprint of a gap topic (16 hex chars). */

--- a/apps/web/lib/wiki/coverage-gap.ts
+++ b/apps/web/lib/wiki/coverage-gap.ts
@@ -1,0 +1,121 @@
+// Coverage-gap detection (BI-741B6329, EP-CORPUS-BOOTSTRAP).
+//
+// When a "what would WE do?" (WWWD) query finds no org coverage, the corpus is
+// telling us what it's MISSING. We capture that as a deduplicated draft
+// "open question" page so the gap surfaces for review/enrichment — turning
+// everyday usage into a backlog of corpus growth. Per design §6, a gap records
+// a DRAFT PROMPT first; material only follows once a human answers it or
+// research fills it (autonomous research is gated on open-Q#4 and intentionally
+// NOT wired here).
+//
+// V1 is a fast, fail-open DB upsert called fire-and-forget from the coworker
+// recall path. Dedup/coalesce is by a deterministic org-scoped fingerprint slug
+// (open-Q#3): the same topic upserts the same page rather than piling up. A
+// later slice (queue + threshold tuning) can move this onto the durable queue.
+
+import { createHash } from "node:crypto";
+import { prisma } from "@dpf/db";
+import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
+
+const MAX_TOPIC_LEN = 160;
+
+/** Normalise a query into a stable topic key: lowercase, collapse whitespace,
+ *  strip trailing punctuation, cap length. */
+export function normalizeGapTopic(query: string): string {
+  return query
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[?!.\s]+$/g, "")
+    .slice(0, MAX_TOPIC_LEN);
+}
+
+/** Deterministic, org-scoped fingerprint of a gap topic (16 hex chars). */
+export function gapFingerprint(organizationId: string, topic: string): string {
+  return createHash("sha256")
+    .update(`${organizationId}:${normalizeGapTopic(topic)}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function gapPageSlug(fingerprint: string): string {
+  return `open-question-${fingerprint}`;
+}
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type RecordCoverageGapClient = {
+  wikiPage: {
+    findFirst: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  wikiPageRevision: {
+    findFirst: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type RecordCoverageGapInput = {
+  organizationId: string;
+  /** The original WWWD question the coworker couldn't answer from org content. */
+  query: string;
+};
+
+export type RecordCoverageGapResult = {
+  recorded: boolean;
+  slug: string;
+  /** True when this detection created the draft (vs coalescing into an existing one). */
+  isNew: boolean;
+};
+
+export async function recordCoverageGap(
+  input: RecordCoverageGapInput,
+  deps: { db?: RecordCoverageGapClient } = {},
+): Promise<RecordCoverageGapResult> {
+  const topic = normalizeGapTopic(input.query);
+  if (topic.length === 0) return { recorded: false, slug: "", isNew: false };
+
+  const db = deps.db ?? (prisma as unknown as RecordCoverageGapClient);
+  const slug = gapPageSlug(gapFingerprint(input.organizationId, topic));
+
+  const existing = (await db.wikiPage.findFirst({
+    where: { organizationId: input.organizationId, slug },
+    select: { id: true },
+  })) as { id: string } | null;
+
+  const question = input.query.trim();
+  const title = `Open question: ${question.slice(0, 120)}`;
+  const body = [
+    `# ${title}`,
+    "",
+    `A coworker was asked a "what would we do?" question on this topic, but the organization has no recorded WWWD stance yet:`,
+    "",
+    `> ${question}`,
+    "",
+    `Answer this — edit and publish this page — and it becomes part of your organization's "what would we do" corpus.`,
+  ].join("\n");
+
+  const saved = (await upsertWikiPage(db as unknown as Parameters<typeof upsertWikiPage>[0], {
+    organizationId: input.organizationId,
+    slug,
+    title,
+    body,
+    pageKind: "stance",
+    status: "draft", // never retrieved for WWWD answers until a human publishes it
+    isKernel: false,
+    abstract: `Unanswered WWWD question: ${topic}`,
+  })) as { id: string };
+
+  // Only append a revision the first time — re-detection coalesces silently.
+  if (!existing) {
+    await appendRevision(db as unknown as Parameters<typeof appendRevision>[0], {
+      pageId: saved.id,
+      title,
+      body,
+      changeKind: "ingest",
+      changeSummary: "coverage-gap detected",
+    });
+  }
+
+  return { recorded: true, slug, isNew: !existing };
+}


### PR DESCRIPTION
**EP-CORPUS-BOOTSTRAP continuous-enrichment spine.** When a "what would WE do?" (WWWD) query finds no org coverage, the corpus is telling us what it's missing. We capture that as a deduplicated draft **"open question"** so the gap surfaces for review/enrichment — turning everyday usage into corpus growth (the founder's "keep building the corpus when context is needed").

## Changes
- `lib/wiki/coverage-gap.ts` (+ 6 tests): `normalizeGapTopic`, org-scoped `gapFingerprint`, `recordCoverageGap`. Dedup/coalesce by deterministic fingerprint slug (**open-Q#3 default**) — same topic upserts one draft, never piles up. Per design §6 a gap records a **draft prompt first** (`status="draft"`, so it's never retrieved for WWWD answers until a human publishes it).
- `agent-coworker.ts`: **one** fire-and-forget, fail-open hook on the WWWD recall path — never blocks or breaks the response. Captures emptiness before the perspective hint folds into `wikiContext`.

## Deliberately deferred
- **Autonomous research** to *fill* the gap is gated on **open-Q#4** — not wired here.
- **Queue + threshold tuning**: V1 is a fast inline DB upsert (no LLM, no new schema); a later slice moves enrichment triggers onto the durable queue.
- **False-positive note:** `recallWikiContext` returns null on both "empty" and "service degraded" (Ollama down). Dedup-by-slug bounds the blast (one draft per topic) and it's a review-only draft, so harm is low; threshold tuning is future.

## Tests
6 new unit tests (normalize, fingerprint determinism, draft-page creation, idempotency/coalesce, blank no-op); 39 wiki+onboarding tests green; typecheck clean (pre-commit enforced).

## Concurrency note
Extracted cleanly onto its own branch off origin/main (the shared root checkout had been switched to another branch); contains only the 3 coverage-gap files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)