### PR TITLE
feat(coworker): envelope state machine + Prisma actions (BI-0F9C291C part 1)

### DIFF
--- a/apps/web/lib/coworker/envelope-actions.ts
+++ b/apps/web/lib/coworker/envelope-actions.ts
@@ -1,0 +1,213 @@
+// Pseudo-User Contract (spec §6.4) — Prisma-bound envelope actions.
+// Wraps the pure state machine (envelope-state-machine.ts) with the
+// minimum DB I/O needed by the chat handler, the API routes, and the
+// future screen_propose_action / screen_dispatch_action handlers.
+//
+// Each action:
+//   1. Loads the current envelope row by id.
+//   2. Validates the transition via the state machine.
+//   3. Writes the new status (plus side fields — resolvedAt, link to
+//      the resulting ToolExecution row when relevant).
+//   4. Returns a discriminated union so callers can render a clear
+//      success or refusal without exception handling.
+//
+// Tests live in the integration tier (require a DB connection); the
+// pure state-machine layer is covered by unit tests in
+// envelope-state-machine.test.ts.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { prisma } from "@dpf/db";
+
+import {
+  describeTransitionError,
+  isEnvelopeStatus,
+  transitionOnApprove,
+  transitionOnCancel,
+  transitionOnDeny,
+  transitionOnExecutionFailure,
+  transitionOnExecutionSuccess,
+  type EnvelopeStatus,
+} from "./envelope-state-machine";
+
+export interface EnvelopeRow {
+  id: string;
+  coworkerAgentId: string;
+  delegatingUserId: string;
+  threadId: string;
+  chatMessageId: string | null;
+  manifestActionId: string;
+  argsJson: unknown;
+  rationale: string;
+  status: EnvelopeStatus;
+  createdAt: Date;
+  resolvedAt: Date | null;
+}
+
+export type ActionResult<T = EnvelopeRow> =
+  | { ok: true; envelope: T }
+  | { ok: false; reason: string; httpStatus: number };
+
+/** Common load + validate prelude. Returns the row in a known-good shape
+ *  (with `status` typed as EnvelopeStatus) or a structured refusal. */
+async function loadEnvelope(envelopeId: string): Promise<ActionResult<EnvelopeRow>> {
+  const row = await prisma.coworkerActionEnvelope.findUnique({ where: { id: envelopeId } });
+  if (!row) {
+    return { ok: false, reason: `Envelope ${envelopeId} not found.`, httpStatus: 404 };
+  }
+  if (!isEnvelopeStatus(row.status)) {
+    return {
+      ok: false,
+      reason: `Envelope ${envelopeId} has an unrecognised status: ${JSON.stringify(row.status)}.`,
+      httpStatus: 500,
+    };
+  }
+  return { ok: true, envelope: row as EnvelopeRow };
+}
+
+/** Verify the calling user matches the envelope's delegating user. Coworker
+ *  actions only ever resolve on behalf of the user who initiated the
+ *  chat turn that produced the proposal. */
+function assertCallerIsDelegate(envelope: EnvelopeRow, callerUserId: string): ActionResult<EnvelopeRow> {
+  if (envelope.delegatingUserId !== callerUserId) {
+    return {
+      ok: false,
+      reason: `User ${callerUserId} cannot act on envelope ${envelope.id} — delegating user is ${envelope.delegatingUserId}.`,
+      httpStatus: 403,
+    };
+  }
+  return { ok: true, envelope };
+}
+
+// ─── Verbs ───────────────────────────────────────────────────────────────────
+
+/** User-side approve: proposed → approved. The actual underlying-tool
+ *  execution happens in a follow-on call (markExecutedOnSuccess /
+ *  markFailedOnExecutionError); they're split so the approval audit row
+ *  lands before the side effect runs and the side-effect outcome is
+ *  recorded against the same envelope. */
+export async function approveEnvelope(
+  envelopeId: string,
+  callerUserId: string,
+): Promise<ActionResult<EnvelopeRow>> {
+  const load = await loadEnvelope(envelopeId);
+  if (!load.ok) return load;
+  const authz = assertCallerIsDelegate(load.envelope, callerUserId);
+  if (!authz.ok) return authz;
+
+  const transition = transitionOnApprove(load.envelope.status);
+  if (!transition.ok) {
+    return {
+      ok: false,
+      reason: describeTransitionError(transition) ?? "Transition refused.",
+      httpStatus: 409,
+    };
+  }
+
+  const updated = await prisma.coworkerActionEnvelope.update({
+    where: { id: envelopeId },
+    data: { status: "approved" },
+  });
+  return { ok: true, envelope: updated as EnvelopeRow };
+}
+
+/** User-side deny: proposed → declined. Terminal — the envelope cannot
+ *  be reopened. (If the user wants the same action they re-prompt the
+ *  coworker; this is auditable as a fresh envelope.) */
+export async function denyEnvelope(
+  envelopeId: string,
+  callerUserId: string,
+): Promise<ActionResult<EnvelopeRow>> {
+  const load = await loadEnvelope(envelopeId);
+  if (!load.ok) return load;
+  const authz = assertCallerIsDelegate(load.envelope, callerUserId);
+  if (!authz.ok) return authz;
+
+  const transition = transitionOnDeny(load.envelope.status);
+  if (!transition.ok) {
+    return {
+      ok: false,
+      reason: describeTransitionError(transition) ?? "Transition refused.",
+      httpStatus: 409,
+    };
+  }
+
+  const updated = await prisma.coworkerActionEnvelope.update({
+    where: { id: envelopeId },
+    data: { status: "declined", resolvedAt: new Date() },
+  });
+  return { ok: true, envelope: updated as EnvelopeRow };
+}
+
+/** Cancellation: either status (proposed | approved) → cancelled. Used
+ *  by the chat handler when the user navigates away or the turn ends
+ *  with an envelope still in flight. */
+export async function cancelEnvelope(
+  envelopeId: string,
+  callerUserId: string,
+): Promise<ActionResult<EnvelopeRow>> {
+  const load = await loadEnvelope(envelopeId);
+  if (!load.ok) return load;
+  const authz = assertCallerIsDelegate(load.envelope, callerUserId);
+  if (!authz.ok) return authz;
+
+  const transition = transitionOnCancel(load.envelope.status);
+  if (!transition.ok) {
+    return {
+      ok: false,
+      reason: describeTransitionError(transition) ?? "Transition refused.",
+      httpStatus: 409,
+    };
+  }
+
+  const updated = await prisma.coworkerActionEnvelope.update({
+    where: { id: envelopeId },
+    data: { status: "cancelled", resolvedAt: new Date() },
+  });
+  return { ok: true, envelope: updated as EnvelopeRow };
+}
+
+/** Side-effect-side finalisers. Called by the dispatcher after the
+ *  underlying tool runs. The dispatcher itself owns the executeTool
+ *  call; these helpers only record the outcome against the envelope.
+ *  Status flow: approved → executed (on success) or approved → failed
+ *  (on error). Both are terminal. */
+export async function markEnvelopeExecuted(envelopeId: string): Promise<ActionResult<EnvelopeRow>> {
+  const load = await loadEnvelope(envelopeId);
+  if (!load.ok) return load;
+
+  const transition = transitionOnExecutionSuccess(load.envelope.status);
+  if (!transition.ok) {
+    return {
+      ok: false,
+      reason: describeTransitionError(transition) ?? "Transition refused.",
+      httpStatus: 409,
+    };
+  }
+
+  const updated = await prisma.coworkerActionEnvelope.update({
+    where: { id: envelopeId },
+    data: { status: "executed", resolvedAt: new Date() },
+  });
+  return { ok: true, envelope: updated as EnvelopeRow };
+}
+
+export async function markEnvelopeFailed(envelopeId: string): Promise<ActionResult<EnvelopeRow>> {
+  const load = await loadEnvelope(envelopeId);
+  if (!load.ok) return load;
+
+  const transition = transitionOnExecutionFailure(load.envelope.status);
+  if (!transition.ok) {
+    return {
+      ok: false,
+      reason: describeTransitionError(transition) ?? "Transition refused.",
+      httpStatus: 409,
+    };
+  }
+
+  const updated = await prisma.coworkerActionEnvelope.update({
+    where: { id: envelopeId },
+    data: { status: "failed", resolvedAt: new Date() },
+  });
+  return { ok: true, envelope: updated as EnvelopeRow };
+}

--- a/apps/web/lib/coworker/envelope-state-machine.test.ts
+++ b/apps/web/lib/coworker/envelope-state-machine.test.ts
@@ -1,0 +1,240 @@
+// Tests for the envelope state machine (spec §6.4). Pure functions, no
+// DB I/O — every legal and illegal transition is exercised here so the
+// API routes and dispatcher logic can rely on canTransition /
+// checkTransition / the named-transition helpers without re-verifying.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ENVELOPE_STATUSES,
+  TERMINAL_STATUSES,
+  canTransition,
+  checkTransition,
+  describeTransitionError,
+  isEnvelopeStatus,
+  isTerminal,
+  transitionOnApprove,
+  transitionOnCancel,
+  transitionOnDeny,
+  transitionOnExecutionFailure,
+  transitionOnExecutionSuccess,
+  type EnvelopeStatus,
+} from "./envelope-state-machine";
+
+describe("ENVELOPE_STATUSES + TERMINAL_STATUSES", () => {
+  it("exposes the six lifecycle statuses", () => {
+    expect(ENVELOPE_STATUSES).toEqual([
+      "proposed",
+      "approved",
+      "declined",
+      "executed",
+      "failed",
+      "cancelled",
+    ]);
+  });
+
+  it("terminal statuses are exactly the four end-of-life states", () => {
+    expect([...TERMINAL_STATUSES].sort()).toEqual(
+      ["cancelled", "declined", "executed", "failed"].sort(),
+    );
+  });
+});
+
+describe("isEnvelopeStatus", () => {
+  it("accepts every declared status", () => {
+    for (const s of ENVELOPE_STATUSES) expect(isEnvelopeStatus(s)).toBe(true);
+  });
+
+  it("rejects non-statuses (typos, neighbouring strings, non-strings)", () => {
+    expect(isEnvelopeStatus("approve")).toBe(false); // verb, not status
+    expect(isEnvelopeStatus("Approved")).toBe(false); // case-sensitive
+    expect(isEnvelopeStatus("")).toBe(false);
+    expect(isEnvelopeStatus(null)).toBe(false);
+    expect(isEnvelopeStatus(undefined)).toBe(false);
+    expect(isEnvelopeStatus(123)).toBe(false);
+    expect(isEnvelopeStatus({})).toBe(false);
+  });
+});
+
+describe("isTerminal", () => {
+  it("marks declined / executed / failed / cancelled terminal", () => {
+    expect(isTerminal("declined")).toBe(true);
+    expect(isTerminal("executed")).toBe(true);
+    expect(isTerminal("failed")).toBe(true);
+    expect(isTerminal("cancelled")).toBe(true);
+  });
+
+  it("marks proposed / approved non-terminal", () => {
+    expect(isTerminal("proposed")).toBe(false);
+    expect(isTerminal("approved")).toBe(false);
+  });
+});
+
+describe("canTransition — legal transitions", () => {
+  it("proposed → approved | declined | cancelled", () => {
+    expect(canTransition("proposed", "approved")).toBe(true);
+    expect(canTransition("proposed", "declined")).toBe(true);
+    expect(canTransition("proposed", "cancelled")).toBe(true);
+  });
+
+  it("approved → executed | failed | cancelled", () => {
+    expect(canTransition("approved", "executed")).toBe(true);
+    expect(canTransition("approved", "failed")).toBe(true);
+    expect(canTransition("approved", "cancelled")).toBe(true);
+  });
+});
+
+describe("canTransition — illegal transitions", () => {
+  it("proposed cannot skip approval to execution", () => {
+    expect(canTransition("proposed", "executed")).toBe(false);
+    expect(canTransition("proposed", "failed")).toBe(false);
+  });
+
+  it("approved cannot regress to proposed", () => {
+    expect(canTransition("approved", "proposed")).toBe(false);
+  });
+
+  it("declined cannot reopen", () => {
+    expect(canTransition("declined", "approved")).toBe(false);
+    expect(canTransition("declined", "executed")).toBe(false);
+  });
+
+  it("executed / failed / cancelled are dead ends", () => {
+    for (const terminal of TERMINAL_STATUSES) {
+      for (const target of ENVELOPE_STATUSES) {
+        expect(canTransition(terminal, target)).toBe(false);
+      }
+    }
+  });
+
+  it("no transition lands on the same status (no self-loops)", () => {
+    for (const s of ENVELOPE_STATUSES) {
+      expect(canTransition(s, s)).toBe(false);
+    }
+  });
+});
+
+describe("checkTransition — structured results", () => {
+  it("returns ok: true on a legal transition", () => {
+    const r = checkTransition("proposed", "approved");
+    expect(r).toEqual({ ok: true, from: "proposed", to: "approved" });
+  });
+
+  it("returns reason: already_terminal when starting from a terminal status", () => {
+    const r = checkTransition("declined", "approved");
+    expect(r).toEqual({ ok: false, reason: "already_terminal", from: "declined", attemptedTo: "approved" });
+  });
+
+  it("returns reason: illegal_transition when starting from a valid non-terminal status with an unreachable target", () => {
+    const r = checkTransition("proposed", "executed");
+    expect(r).toEqual({ ok: false, reason: "illegal_transition", from: "proposed", attemptedTo: "executed" });
+  });
+
+  it("returns reason: unknown_status when the input is not a valid EnvelopeStatus", () => {
+    const r = checkTransition("not-a-real-status" as EnvelopeStatus, "approved");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unknown_status");
+  });
+});
+
+describe("Named transition helpers", () => {
+  it("transitionOnApprove resolves the proposed → approved transition", () => {
+    expect(transitionOnApprove("proposed")).toEqual({ ok: true, from: "proposed", to: "approved" });
+    expect(transitionOnApprove("approved").ok).toBe(false);
+    expect(transitionOnApprove("declined").ok).toBe(false);
+  });
+
+  it("transitionOnDeny works from proposed only", () => {
+    expect(transitionOnDeny("proposed")).toEqual({ ok: true, from: "proposed", to: "declined" });
+    expect(transitionOnDeny("approved").ok).toBe(false);
+  });
+
+  it("transitionOnCancel works from proposed and approved (not from terminal)", () => {
+    expect(transitionOnCancel("proposed").ok).toBe(true);
+    expect(transitionOnCancel("approved").ok).toBe(true);
+    expect(transitionOnCancel("declined").ok).toBe(false);
+    expect(transitionOnCancel("executed").ok).toBe(false);
+  });
+
+  it("transitionOnExecutionSuccess requires approved (not proposed)", () => {
+    expect(transitionOnExecutionSuccess("approved").ok).toBe(true);
+    expect(transitionOnExecutionSuccess("proposed").ok).toBe(false);
+  });
+
+  it("transitionOnExecutionFailure requires approved (not proposed)", () => {
+    expect(transitionOnExecutionFailure("approved").ok).toBe(true);
+    expect(transitionOnExecutionFailure("proposed").ok).toBe(false);
+  });
+});
+
+describe("describeTransitionError", () => {
+  it("returns null on success", () => {
+    expect(describeTransitionError({ ok: true, from: "proposed", to: "approved" })).toBeNull();
+  });
+
+  it("renders already_terminal with the specific status", () => {
+    const msg = describeTransitionError({
+      ok: false,
+      reason: "already_terminal",
+      from: "declined",
+      attemptedTo: "approved",
+    });
+    expect(msg).toMatch(/terminal/);
+    expect(msg).toMatch(/declined/);
+  });
+
+  it("renders illegal_transition with the legal alternatives listed", () => {
+    const msg = describeTransitionError({
+      ok: false,
+      reason: "illegal_transition",
+      from: "proposed",
+      attemptedTo: "executed",
+    });
+    // Must mention the from-state, the bad target, and the legal targets.
+    expect(msg).toMatch(/proposed/);
+    expect(msg).toMatch(/executed/);
+    expect(msg).toMatch(/approved/);
+  });
+
+  it("renders unknown_status with the bad input quoted", () => {
+    const msg = describeTransitionError({
+      ok: false,
+      reason: "unknown_status",
+      from: "garbage" as EnvelopeStatus,
+      attemptedTo: "approved",
+    });
+    expect(msg).toMatch(/garbage/);
+  });
+});
+
+// Adversarial cross-check: walk the full reachability graph and confirm
+// the table is consistent (every legal transition is bidirectional with
+// checkTransition's positive path; every illegal one fails).
+describe("exhaustive consistency", () => {
+  it("checkTransition agrees with canTransition for every status pair", () => {
+    for (const from of ENVELOPE_STATUSES) {
+      for (const to of ENVELOPE_STATUSES) {
+        const canT = canTransition(from, to);
+        const checkResult = checkTransition(from, to);
+        expect(checkResult.ok).toBe(canT);
+      }
+    }
+  });
+
+  it("every non-terminal status has at least one legal outgoing transition", () => {
+    for (const s of ENVELOPE_STATUSES) {
+      if (isTerminal(s)) continue;
+      const hasOutgoing = ENVELOPE_STATUSES.some((t) => canTransition(s, t));
+      expect(hasOutgoing).toBe(true);
+    }
+  });
+
+  it("every terminal status has zero legal outgoing transitions", () => {
+    for (const s of TERMINAL_STATUSES) {
+      const outgoing = ENVELOPE_STATUSES.filter((t) => canTransition(s, t));
+      expect(outgoing).toEqual([]);
+    }
+  });
+});

--- a/apps/web/lib/coworker/envelope-state-machine.ts
+++ b/apps/web/lib/coworker/envelope-state-machine.ts
@@ -1,0 +1,156 @@
+// Pseudo-User Contract (spec §6.4 + §6.5) — CoworkerActionEnvelope state
+// machine. Pure functions; no DB I/O lives here so the rules are
+// independently testable and reusable from the API routes, the chat
+// handler, and the future screen_propose_action handler refactor.
+//
+// Envelope lifecycle:
+//
+//   proposed ──approve──> approved ──execute──> executed
+//        │                                     ╲
+//        │                                      ╲──fail──> failed
+//        ├──deny──> declined
+//        └──cancel──> cancelled       (e.g. user navigated away, turn ended)
+//
+// The legal-transition table below is the canonical source of truth. The
+// schema (BI-D887CD3B) keeps `status` as a plain TEXT column because the
+// CHECK constraint was deliberately deferred here (commit on BI-D887CD3B);
+// the state machine enforces the same invariant in application code,
+// which is the layer where a useful error message can be produced.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+/** The closed enum of envelope statuses. Matches the schema string column
+ *  and the spec §6.4 lifecycle. */
+export type EnvelopeStatus =
+  | "proposed"
+  | "approved"
+  | "declined"
+  | "executed"
+  | "failed"
+  | "cancelled";
+
+/** All valid statuses, exposed for runtime validation (e.g. when reading a
+ *  row that might predate a future schema migration). */
+export const ENVELOPE_STATUSES: readonly EnvelopeStatus[] = [
+  "proposed",
+  "approved",
+  "declined",
+  "executed",
+  "failed",
+  "cancelled",
+] as const;
+
+/** Terminal statuses — an envelope in one of these never transitions
+ *  again. Used by callers that want to short-circuit (e.g. "this envelope
+ *  is settled, no need to re-render the approval card"). */
+export const TERMINAL_STATUSES: readonly EnvelopeStatus[] = [
+  "declined",
+  "executed",
+  "failed",
+  "cancelled",
+] as const;
+
+/** Legal transitions. The KEY is the current status; the VALUE is the
+ *  set of statuses we can move to. */
+const TRANSITIONS: Readonly<Record<EnvelopeStatus, readonly EnvelopeStatus[]>> = {
+  proposed: ["approved", "declined", "cancelled"],
+  approved: ["executed", "failed", "cancelled"],
+  declined: [],
+  executed: [],
+  failed: [],
+  cancelled: [],
+};
+
+/** True when `to` is reachable from `from` via a single transition. */
+export function canTransition(from: EnvelopeStatus, to: EnvelopeStatus): boolean {
+  return TRANSITIONS[from].includes(to);
+}
+
+/** True when the envelope is in a terminal status. */
+export function isTerminal(status: EnvelopeStatus): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
+
+/** Narrow guard: is the unknown string a valid EnvelopeStatus? Useful
+ *  when reading raw DB rows or untrusted input. */
+export function isEnvelopeStatus(value: unknown): value is EnvelopeStatus {
+  return typeof value === "string" && (ENVELOPE_STATUSES as readonly string[]).includes(value);
+}
+
+// ─── Transition outcomes ─────────────────────────────────────────────────────
+
+/** Discriminated union returned by transition helpers. Lets callers
+ *  distinguish "you can move ahead" from "the state machine refused this
+ *  transition" without exception handling. */
+export type TransitionResult =
+  | { ok: true; from: EnvelopeStatus; to: EnvelopeStatus }
+  | { ok: false; reason: TransitionError; from: EnvelopeStatus; attemptedTo: EnvelopeStatus };
+
+export type TransitionError =
+  | "unknown_status" // input wasn't a valid EnvelopeStatus (corrupt row?)
+  | "already_terminal" // current status is terminal — no further changes allowed
+  | "illegal_transition"; // current status is valid, but `to` isn't reachable from it
+
+/** Validate a proposed transition without applying it. Use this when the
+ *  caller already has the envelope's status in hand (e.g. after a Prisma
+ *  read) and wants a yes/no with a structured error. */
+export function checkTransition(
+  from: EnvelopeStatus,
+  to: EnvelopeStatus,
+): TransitionResult {
+  if (!isEnvelopeStatus(from)) {
+    return { ok: false, reason: "unknown_status", from, attemptedTo: to };
+  }
+  if (!isEnvelopeStatus(to)) {
+    return { ok: false, reason: "unknown_status", from, attemptedTo: to };
+  }
+  if (isTerminal(from)) {
+    return { ok: false, reason: "already_terminal", from, attemptedTo: to };
+  }
+  if (!canTransition(from, to)) {
+    return { ok: false, reason: "illegal_transition", from, attemptedTo: to };
+  }
+  return { ok: true, from, to };
+}
+
+// ─── Named transitions (semantic verbs the API routes use) ──────────────────
+//
+// These are convenience wrappers around checkTransition with the target
+// status hardcoded. They mirror the verbs in the spec §6.4 (approve,
+// deny/decline, cancel) and the verbs the underlying tool execution
+// emits (execute → executed | failed). Pure — they don't write anything.
+
+export function transitionOnApprove(from: EnvelopeStatus): TransitionResult {
+  return checkTransition(from, "approved");
+}
+
+export function transitionOnDeny(from: EnvelopeStatus): TransitionResult {
+  return checkTransition(from, "declined");
+}
+
+export function transitionOnCancel(from: EnvelopeStatus): TransitionResult {
+  return checkTransition(from, "cancelled");
+}
+
+export function transitionOnExecutionSuccess(from: EnvelopeStatus): TransitionResult {
+  return checkTransition(from, "executed");
+}
+
+export function transitionOnExecutionFailure(from: EnvelopeStatus): TransitionResult {
+  return checkTransition(from, "failed");
+}
+
+/** Human-readable description for a transition error. Stable strings so
+ *  test assertions can pin them; the API routes pass these straight back
+ *  in the response body. */
+export function describeTransitionError(result: TransitionResult): string | null {
+  if (result.ok) return null;
+  switch (result.reason) {
+    case "unknown_status":
+      return `Envelope status is not a recognised value (got ${JSON.stringify(result.from)}); cannot transition to ${JSON.stringify(result.attemptedTo)}.`;
+    case "already_terminal":
+      return `Envelope is already in a terminal status (${result.from}); no further transitions are allowed.`;
+    case "illegal_transition":
+      return `Envelope cannot transition from ${result.from} to ${result.attemptedTo}. Legal transitions from ${result.from}: ${TRANSITIONS[result.from].join(", ") || "(none)"}.`;
+  }
+}


### PR DESCRIPTION
## Summary

Fifth Phase 1 substrate BI of `EP-COWORKER-INTERACTIVITY`. Delivers the **state-machine core + DB-bound CRUD actions** for the destructive-action envelope flow (spec §6.4 + §6.5). API routes, React approval card, per-turn N=3 cap, and irreversible typed-phrase hard floor are follow-on chunks within this BI.

## The lifecycle

```
proposed ──approve──> approved ──execute──> executed
     │                                     ╲
     │                                      ╲──fail──> failed
     ├──deny──> declined
     └──cancel──> cancelled
```

| From | Can move to | Terminal? |
|---|---|---|
| `proposed` | `approved`, `declined`, `cancelled` | no |
| `approved` | `executed`, `failed`, `cancelled` | no |
| `declined` | (none) | yes |
| `executed` | (none) | yes |
| `failed` | (none) | yes |
| `cancelled` | (none) | yes |

The split between user-side approve and execution-side finalisers (`markEnvelopeExecuted` / `markEnvelopeFailed`) is deliberate: the approval audit row lands BEFORE the underlying tool side effect runs, and the outcome is recorded against the same envelope. No "approved-but-never-finalised" zombie rows.

## What's in the PR

**`apps/web/lib/coworker/envelope-state-machine.ts`** — pure functions, no I/O:
- `canTransition(from, to)`, `isTerminal`, `isEnvelopeStatus` (narrow type guard for raw DB reads)
- `checkTransition(from, to)` returns a discriminated union with structured reasons (`unknown_status` | `already_terminal` | `illegal_transition`)
- Named verbs: `transitionOnApprove`, `transitionOnDeny`, `transitionOnCancel`, `transitionOnExecutionSuccess`, `transitionOnExecutionFailure`
- `describeTransitionError()` renders a human-readable message that lists legal alternatives

**`apps/web/lib/coworker/envelope-actions.ts`** — Prisma-bound wrappers:
- `approveEnvelope`, `denyEnvelope`, `cancelEnvelope`, `markEnvelopeExecuted`, `markEnvelopeFailed`
- Each loads → validates via state machine → authorises (delegating-user check) → writes status → returns discriminated `ActionResult` with `httpStatus` codes ready for API routes

**`apps/web/lib/coworker/envelope-state-machine.test.ts`** — 29 vitest cases including:
- Every legal + illegal transition
- Type guard against typos, casing, null, non-strings
- Structured error reasons
- An exhaustive consistency check (canTransition agrees with checkTransition for every pair of statuses)

## Verification

- ✓ `pnpm --filter web exec vitest run lib/coworker/envelope-state-machine.test.ts` — **29/29 pass**
- ✓ `pnpm --filter web typecheck` — clean
- ✓ DCO-signed; pre-commit guards all fired clean

## What this PR does NOT do (follow-on chunks of BI-0F9C291C)

- `POST /api/agent/envelope/:envelopeId/approve` route
- `POST /api/agent/envelope/:envelopeId/deny` route
- React approval-card component (inline chat UI)
- Per-turn N=3 destructive auto-approval cap (spec §6.4 safety floor)
- Irreversible typed-phrase hard-floor enforcement
- Refactor `screen_propose_action` handler (PR #1386) to call `approveEnvelope` / `cancelEnvelope` at the right turn points

Each is tight enough to be its own focused PR — the state machine + actions are the substrate they all consume.

## Linked work

- **Epic:** `EP-COWORKER-INTERACTIVITY`
- **This BI:** `BI-0F9C291C` (in-progress — this PR is part 1 of an N-part series)
- **Schema this builds on:** `CoworkerActionEnvelope` table from `BI-D887CD3B` (merged #1366)
- **Cousin in flight:** `BI-DF6079E9` (#1386) — defines `screen_propose_action` / `screen_dispatch_action` tools; their handlers will call into these actions once both PRs merge

## Founder attention

One design choice worth a quick look: **execution finalisers don't take the calling user id.** `markEnvelopeExecuted` / `markEnvelopeFailed` are called by the dispatcher AFTER the underlying tool runs — at that point the "caller" is the platform itself, not the user. The authz check happens at approval time; the dispatcher then runs and writes the outcome. If you'd rather thread an auth context all the way through, that's a small refactor — file a comment and I'll fold it in before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)