### PR TITLE
feat(coworker): envelope approve + deny API routes (BI-0F9C291C part 2)

### DIFF
--- a/apps/web/app/api/agent/envelope/[envelopeId]/approve/route.test.ts
+++ b/apps/web/app/api/agent/envelope/[envelopeId]/approve/route.test.ts
@@ -1,0 +1,117 @@
+// Tests for POST /api/agent/envelope/:envelopeId/approve. Mock the auth
+// session and envelope-actions; verify the route's contract: auth gate,
+// param extraction, error → http-status mapping, success body.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const approveEnvelopeMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: () => authMock(),
+}));
+
+vi.mock("@/lib/coworker/envelope-actions", () => ({
+  approveEnvelope: (...args: unknown[]) => approveEnvelopeMock(...args),
+}));
+
+beforeEach(() => {
+  authMock.mockReset();
+  approveEnvelopeMock.mockReset();
+});
+
+function makeContext(envelopeId: string) {
+  return { params: Promise.resolve({ envelopeId }) };
+}
+
+function makeRequest() {
+  return new Request("http://localhost:3000/api/agent/envelope/env-1/approve", {
+    method: "POST",
+  });
+}
+
+describe("POST /api/agent/envelope/:envelopeId/approve", () => {
+  it("returns 401 when there is no session", async () => {
+    authMock.mockResolvedValue(null);
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(approveEnvelopeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the session has no user.id", async () => {
+    authMock.mockResolvedValue({ user: { email: "x@y" } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when envelopeId is empty", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext(""));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "envelopeId required" });
+    expect(approveEnvelopeMock).not.toHaveBeenCalled();
+  });
+
+  it("calls approveEnvelope with the authenticated user id and returns the envelope on success", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const envelope = { id: "env-1", status: "approved", coworkerAgentId: "AGT-X" };
+    approveEnvelopeMock.mockResolvedValue({ ok: true, envelope });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+
+    expect(approveEnvelopeMock).toHaveBeenCalledWith("env-1", "u1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, envelope });
+  });
+
+  it("maps a state-machine refusal to the action's httpStatus + reason", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    approveEnvelopeMock.mockResolvedValue({
+      ok: false,
+      reason: "Envelope is already in a terminal status (declined); no further transitions are allowed.",
+      httpStatus: 409,
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/terminal/);
+  });
+
+  it("maps not-found from the action layer to 404", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    approveEnvelopeMock.mockResolvedValue({
+      ok: false,
+      reason: "Envelope env-X not found.",
+      httpStatus: 404,
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-X"));
+    expect(res.status).toBe(404);
+  });
+
+  it("maps a delegating-user mismatch to 403", async () => {
+    authMock.mockResolvedValue({ user: { id: "u-attacker" } });
+    approveEnvelopeMock.mockResolvedValue({
+      ok: false,
+      reason: "User u-attacker cannot act on envelope env-1 — delegating user is u-owner.",
+      httpStatus: 403,
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/cannot act/);
+  });
+});

--- a/apps/web/app/api/agent/envelope/[envelopeId]/approve/route.ts
+++ b/apps/web/app/api/agent/envelope/[envelopeId]/approve/route.ts
@@ -1,0 +1,49 @@
+// Pseudo-User Contract (spec §6.4) — user-side envelope approval route.
+//
+// POST /api/agent/envelope/:envelopeId/approve
+//
+// Records the user's consent for a coworker-proposed destructive action.
+// Validates auth, calls approveEnvelope (which enforces the delegating-user
+// check and the state-machine invariants from BI-0F9C291C part 1), and
+// returns the updated envelope row.
+//
+// Status flips from `proposed` to `approved`. The actual underlying-tool
+// execution happens AFTER approval — kicked off either by the chat
+// handler when it sees the envelope flip, or by the agent calling
+// screen_dispatch_action (which lives in PR #1386 and will be refactored
+// to call markEnvelopeExecuted / markEnvelopeFailed via envelope-actions
+// once the chat handler integration lands in BI-DF6079E9 part 2). The
+// approval audit row is committed BEFORE that side effect — see the
+// design rationale on envelope-actions.ts.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { approveEnvelope } from "@/lib/coworker/envelope-actions";
+
+type RouteContext = {
+  params: Promise<{ envelopeId: string }>;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function POST(_request: Request, context: RouteContext): Promise<Response> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { envelopeId } = await context.params;
+  if (!envelopeId || typeof envelopeId !== "string") {
+    return NextResponse.json({ error: "envelopeId required" }, { status: 400 });
+  }
+
+  const result = await approveEnvelope(envelopeId, session.user.id);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: result.httpStatus });
+  }
+
+  return NextResponse.json({ ok: true, envelope: result.envelope });
+}

--- a/apps/web/app/api/agent/envelope/[envelopeId]/deny/route.test.ts
+++ b/apps/web/app/api/agent/envelope/[envelopeId]/deny/route.test.ts
@@ -1,0 +1,93 @@
+// Tests for POST /api/agent/envelope/:envelopeId/deny. Mirrors the
+// approve route's contract — auth gate, param extraction, action
+// dispatch, error → http-status mapping. The interesting branches that
+// don't apply to approve (e.g. deny is terminal whereas approve isn't)
+// are covered at the state-machine layer in envelope-state-machine.test.ts.
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const denyEnvelopeMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: () => authMock(),
+}));
+
+vi.mock("@/lib/coworker/envelope-actions", () => ({
+  denyEnvelope: (...args: unknown[]) => denyEnvelopeMock(...args),
+}));
+
+beforeEach(() => {
+  authMock.mockReset();
+  denyEnvelopeMock.mockReset();
+});
+
+function makeContext(envelopeId: string) {
+  return { params: Promise.resolve({ envelopeId }) };
+}
+
+function makeRequest() {
+  return new Request("http://localhost:3000/api/agent/envelope/env-1/deny", {
+    method: "POST",
+  });
+}
+
+describe("POST /api/agent/envelope/:envelopeId/deny", () => {
+  it("returns 401 with no session", async () => {
+    authMock.mockResolvedValue(null);
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(401);
+    expect(denyEnvelopeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with empty envelopeId", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext(""));
+    expect(res.status).toBe(400);
+  });
+
+  it("dispatches denyEnvelope with the authenticated user id on success", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const envelope = { id: "env-1", status: "declined", resolvedAt: new Date() };
+    denyEnvelopeMock.mockResolvedValue({ ok: true, envelope });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+
+    expect(denyEnvelopeMock).toHaveBeenCalledWith("env-1", "u1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.envelope.status).toBe("declined");
+  });
+
+  it("maps a state-machine refusal (e.g. already-terminal envelope) to 409", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    denyEnvelopeMock.mockResolvedValue({
+      ok: false,
+      reason: "Envelope is already in a terminal status (executed); no further transitions are allowed.",
+      httpStatus: 409,
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(409);
+  });
+
+  it("maps a delegating-user mismatch to 403", async () => {
+    authMock.mockResolvedValue({ user: { id: "u-attacker" } });
+    denyEnvelopeMock.mockResolvedValue({
+      ok: false,
+      reason: "User u-attacker cannot act on envelope env-1 — delegating user is u-owner.",
+      httpStatus: 403,
+    });
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(), makeContext("env-1"));
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/app/api/agent/envelope/[envelopeId]/deny/route.ts
+++ b/apps/web/app/api/agent/envelope/[envelopeId]/deny/route.ts
@@ -1,0 +1,40 @@
+// Pseudo-User Contract (spec §6.4) — user-side envelope denial route.
+//
+// POST /api/agent/envelope/:envelopeId/deny
+//
+// Records the user's refusal of a coworker-proposed destructive action.
+// Terminal — the envelope cannot be reopened; if the user wants the
+// same action they re-prompt the coworker and a fresh envelope is
+// created (auditable as a separate proposal).
+//
+// BI-0F9C291C / EP-COWORKER-INTERACTIVITY.
+
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { denyEnvelope } from "@/lib/coworker/envelope-actions";
+
+type RouteContext = {
+  params: Promise<{ envelopeId: string }>;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function POST(_request: Request, context: RouteContext): Promise<Response> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { envelopeId } = await context.params;
+  if (!envelopeId || typeof envelopeId !== "string") {
+    return NextResponse.json({ error: "envelopeId required" }, { status: 400 });
+  }
+
+  const result = await denyEnvelope(envelopeId, session.user.id);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: result.httpStatus });
+  }
+
+  return NextResponse.json({ ok: true, envelope: result.envelope });
+}


### PR DESCRIPTION
## Summary

User-side HTTP endpoints that record consent for a coworker-proposed destructive action. Thin status-code mappers over the state machine + actions merged in [#1390](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1390).

```
POST /api/agent/envelope/:envelopeId/approve   →  proposed → approved
POST /api/agent/envelope/:envelopeId/deny      →  proposed → declined (terminal)
```

## Why split approve from execute

The approve route ONLY flips the status. The actual underlying-tool execution happens AFTER, kicked off either by the chat handler when it sees the flip or by the agent calling `screen_dispatch_action` (in [#1386](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1386)). The approval audit row is committed BEFORE the side effect runs — no "approved but never finalised" zombie rows. Design rationale lives in `envelope-actions.ts`.

## What's in the PR

- **`approve/route.ts`** — POST handler. Auth gate via `@/lib/auth` (matches cancel/send pattern). Next.js 16 dynamic-segment via `RouteContext { params: Promise<...> }`. Calls `approveEnvelope`; maps the structured `ActionResult` to the right HTTP status.
- **`deny/route.ts`** — POST handler, same shape. Calls `denyEnvelope`.
- **`approve/route.test.ts`** — 7 cases: auth gate, param validation, happy path, state-machine refusal → 409, not-found → 404, delegating-user mismatch → 403.
- **`deny/route.test.ts`** — 5 cases mirroring the same contract.

## Status code map

| Condition | HTTP |
|---|---|
| Happy path | 200 |
| No session / no `user.id` | 401 |
| Empty `envelopeId` | 400 |
| Caller is not the delegating user | 403 |
| Envelope not found | 404 |
| State machine refuses transition (already terminal / illegal) | 409 |
| Unrecognised stored status (corrupt row) | 500 |

The state machine + actions layer is the source of truth for the `httpStatus` field — the route just forwards it.

## Verification

- ✓ `pnpm --filter web exec vitest run app/api/agent/envelope` — **12/12 pass**
- ✓ `pnpm --filter web typecheck` — clean
- ✓ DCO-signed; pre-commit guards all fired clean

## Still to come within BI-0F9C291C

- React approval-card component (the inline chat UI that calls these routes)
- Per-turn N=3 destructive auto-approval cap (spec §6.4 safety floor)
- Irreversible typed-phrase hard-floor enforcement
- Refactor `screen_propose_action` (now in main from #1386) to actually write envelope rows via the actions layer

Each is tight enough to be its own focused PR.

## Linked work

- **Epic:** `EP-COWORKER-INTERACTIVITY`
- **This BI:** `BI-0F9C291C` (in-progress — this is part 2)
- **Substrate this builds on:** state machine + Prisma actions from [#1390](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1390) (✓ merged), envelope schema from [#1366](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1366) (✓ merged)
- **Cousin in flight:** `BI-DF6079E9` part 2 (SSE chat handler wiring) — when it lands, the chat panel can render approve/deny buttons that POST to these routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)