### PR TITLE
feat(corpus): market-research producer engine (BI-8A58C65A slice A)

### DIFF
--- a/apps/web/lib/wiki/market-research.test.ts
+++ b/apps/web/lib/wiki/market-research.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  runMarketResearch,
+  buildResearchPrompt,
+  type MarketResearchDeps,
+} from "./market-research";
+import type { NormalizedSearchResult } from "@/lib/public-web-tools";
+
+const RESULTS: NormalizedSearchResult[] = [
+  { title: "HVAC market trends 2026", url: "https://ex.com/a", snippet: "Residential HVAC demand is up 6%." },
+  { title: "Local HVAC competitors", url: "https://ex.com/b", snippet: "Three national chains plus independents." },
+];
+
+function deps(over: Partial<MarketResearchDeps> = {}): MarketResearchDeps {
+  return {
+    search: vi.fn(async () => RESULTS),
+    infer: vi.fn(async () => "Residential demand is rising and the field is split between chains and independents."),
+    ...over,
+  };
+}
+
+describe("buildResearchPrompt", () => {
+  it("includes the query, the snippets, and an anti-fabrication instruction", () => {
+    const { systemPrompt, userPrompt } = buildResearchPrompt("HVAC competitive landscape", RESULTS);
+    expect(systemPrompt.toLowerCase()).toMatch(/do not (fabricate|invent)|only.*provided/);
+    expect(userPrompt).toContain("HVAC competitive landscape");
+    expect(userPrompt).toContain("Residential HVAC demand is up 6%.");
+    expect(userPrompt).toContain("https://ex.com/a");
+  });
+});
+
+describe("runMarketResearch", () => {
+  it("synthesises cited prose from web results", async () => {
+    const d = deps();
+    const res = await runMarketResearch({ organizationId: "org_1", query: "HVAC competitive landscape" }, d);
+
+    expect(res.empty).toBe(false);
+    expect(res.text).toContain("Residential demand is rising");
+    // Sources section cites the backing URLs for provenance.
+    expect(res.text).toContain("## Sources");
+    expect(res.text).toContain("https://ex.com/a");
+    expect(res.sources).toHaveLength(2);
+    expect(res.sources[0]).toMatchObject({ url: "https://ex.com/a" });
+  });
+
+  it("returns empty (and skips inference) when search yields nothing", async () => {
+    const infer = vi.fn(async () => "should not be called");
+    const res = await runMarketResearch(
+      { organizationId: "org_1", query: "x" },
+      { search: vi.fn(async () => []), infer },
+    );
+    expect(res.empty).toBe(true);
+    expect(res.sources).toHaveLength(0);
+    expect(infer).not.toHaveBeenCalled();
+  });
+
+  it("is fail-open when search throws", async () => {
+    const res = await runMarketResearch(
+      { organizationId: "org_1", query: "x" },
+      { search: vi.fn(async () => { throw new Error("brave down"); }), infer: vi.fn(async () => "x") },
+    );
+    expect(res.empty).toBe(true);
+  });
+
+  it("treats blank synthesis as empty (no fabricated findings)", async () => {
+    const res = await runMarketResearch(
+      { organizationId: "org_1", query: "x" },
+      { search: vi.fn(async () => RESULTS), infer: vi.fn(async () => "   ") },
+    );
+    expect(res.empty).toBe(true);
+  });
+
+  it("caps the number of sources", async () => {
+    const many: NormalizedSearchResult[] = Array.from({ length: 20 }, (_, i) => ({
+      title: `r${i}`, url: `https://ex.com/${i}`, snippet: `s${i}`,
+    }));
+    const res = await runMarketResearch(
+      { organizationId: "org_1", query: "x", maxSources: 3 },
+      { search: vi.fn(async () => many), infer: vi.fn(async () => "synthesis") },
+    );
+    expect(res.sources).toHaveLength(3);
+  });
+});

--- a/apps/web/lib/wiki/market-research.ts
+++ b/apps/web/lib/wiki/market-research.ts
@@ -1,0 +1,102 @@
+// Market-research producer (BI-8A58C65A, EP-CORPUS-BOOTSTRAP) — slice A.
+//
+// Composes a web search (`searchPublicWeb`, Brave) with an LLM synthesis pass
+// into cited prose findings the corpus enrichment pipeline can ingest as
+// `origin="research"`, `trust="researched"` (→ draft for review, per BI-1378).
+//
+// This is the reusable ENGINE. The scheduled + approval-gated orchestration
+// (founder decision on open-Q#4) wires it: a periodic cadence proposes a run,
+// a human approves, and only then does execution call runMarketResearch() →
+// enrichOrgCorpus(). Nothing here fires on its own.
+//
+// Guardrail: synthesis is grounded ONLY in the retrieved snippets and must not
+// fabricate figures — research is low-trust (grade C) and always lands as a
+// reviewable draft.
+
+import { searchPublicWeb, type NormalizedSearchResult } from "@/lib/public-web-tools";
+import { createProductionInference } from "@/lib/wiki/inference-adapter";
+import type { InferenceCallable } from "@/lib/wiki/proposal";
+
+const DEFAULT_MAX_SOURCES = 6;
+const MAX_SNIPPET_CHARS = 400;
+
+export type MarketResearchInput = {
+  organizationId: string;
+  /** What to research, e.g. "competitive landscape for an HVAC contractor in Austin TX". */
+  query: string;
+  /** Cap on web sources fed to synthesis. Default 6. */
+  maxSources?: number;
+};
+
+export type ResearchSource = { title: string; url: string };
+
+export type MarketResearchResult = {
+  /** Synthesised markdown findings + a Sources section. Ready for enrichOrgCorpus. */
+  text: string;
+  /** Cited sources backing the findings. */
+  sources: ResearchSource[];
+  /** True when there was nothing to ingest (no sources, or blank synthesis). */
+  empty: boolean;
+};
+
+export type MarketResearchDeps = {
+  /** Web search; defaults to Brave-backed searchPublicWeb. Injectable for tests. */
+  search?: (query: string) => Promise<NormalizedSearchResult[]>;
+  /** LLM synthesis; defaults to the production inference adapter. Injectable for tests. */
+  infer?: InferenceCallable;
+};
+
+export function buildResearchPrompt(
+  query: string,
+  results: NormalizedSearchResult[],
+): { systemPrompt: string; userPrompt: string } {
+  const systemPrompt = [
+    "You are a market-research analyst producing a concise briefing for a business's own knowledge base.",
+    "Synthesise findings ONLY from the provided search results. Do NOT invent or fabricate facts, figures, market sizes, or competitor names that are not supported by the snippets.",
+    "When the evidence is thin or uncertain, say so plainly rather than guessing.",
+    "Write 2-5 short markdown paragraphs (or bullets) of grounded findings. Do not add a sources list — that is appended separately.",
+  ].join(" ");
+
+  const sourceBlock = results
+    .map((r, i) => `[${i + 1}] ${r.title}\n${r.url}\n${r.snippet.slice(0, MAX_SNIPPET_CHARS)}`)
+    .join("\n\n");
+
+  const userPrompt = [
+    `Research topic: ${query}`,
+    "",
+    "Search results to synthesise (cite nothing beyond these):",
+    "",
+    sourceBlock,
+  ].join("\n");
+
+  return { systemPrompt, userPrompt };
+}
+
+export async function runMarketResearch(
+  input: MarketResearchInput,
+  deps: MarketResearchDeps = {},
+): Promise<MarketResearchResult> {
+  const search = deps.search ?? searchPublicWeb;
+  const infer = deps.infer ?? createProductionInference({ taskType: "market_research" });
+  const maxSources = input.maxSources ?? DEFAULT_MAX_SOURCES;
+
+  // Fail-open: a search outage must not throw into the caller (scheduled job).
+  const found = await search(input.query).catch(() => [] as NormalizedSearchResult[]);
+  const results = found.slice(0, maxSources);
+  if (results.length === 0) {
+    return { text: "", sources: [], empty: true };
+  }
+
+  const { systemPrompt, userPrompt } = buildResearchPrompt(input.query, results);
+  const prose = (await infer({ tier: "reasoning", systemPrompt, userPrompt }).catch(() => "")).trim();
+
+  const sources: ResearchSource[] = results.map((r) => ({ title: r.title, url: r.url }));
+  if (prose.length === 0) {
+    // No grounded synthesis → nothing to ingest. Never fabricate to fill the gap.
+    return { text: "", sources, empty: true };
+  }
+
+  const sourcesSection = sources.map((s) => `- [${s.title}](${s.url})`).join("\n");
+  const text = `${prose}\n\n## Sources\n${sourcesSection}`;
+  return { text, sources, empty: false };
+}


### PR DESCRIPTION
First slice of **BI-8A58C65A** (AI market research → WWWD corpus), per your open-Q#4 decision: **scheduled + approval-gated + draft**. This PR is the reusable **research engine**; the schedule/proposal/approval/execution orchestration are the follow-on slices.

## What
`runMarketResearch({ organizationId, query })` composes `searchPublicWeb` (Brave) with an LLM synthesis pass into **cited prose findings** ready for `enrichOrgCorpus(origin="research", trust="researched")` → lands as a **draft for review** (BI-1378).

## Guardrails (matter for low-trust research)
- Synthesis is grounded **only** in retrieved snippets with a hard **anti-fabrication** instruction (no invented market sizes / competitors).
- Blank or absent synthesis → `empty: true` (never fabricates to fill the gap).
- **Fail-open** on search outage; source list capped + cited in a `## Sources` section for provenance.
- Injectable `search` + `infer` → fully unit-tested without network/LLM.

## Decomposition (this BI is multi-part; substrate-verified)
- **A — research producer** ← this PR
- B — scheduled proposal + human approval (reuse `WorkItem`/`ScheduledJob`)
- C — execution on approval → producer → `enrichOrgCorpus` (brand-extract Inngest template)
- D — Inngest cron proposing per-org
- E — approval UI

Nothing fires autonomously: the engine runs only when an approved run executes.

## Tests
6 unit tests (cited synthesis, empty-on-no-results, fail-open, blank→empty, source cap, prompt contents); typecheck clean (pre-commit enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)