### PR TITLE
spec(workspace): architect-revise archetype-aware workspace spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md
+++ b/docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md
@@ -41,7 +41,7 @@ Backlog routing after review:
 
 | Plan slice | Existing BI to use | Notes |
 | --- | --- | --- |
-| Resolver, contribution, layering audit, setup-activation summary | `BI-1CCC6264` | Extend `apps/web/lib/workspace-home/registry.ts` + `types.ts` (and the proposed `contributions/` boundary from parent §9). Add audit fields (`omittedBlocks`, `explanations`, `sourceLayers`) onto the existing `WorkspaceHomeResolution`. Do NOT introduce a parallel `WorkspaceCompositionResolution`. |
+| Resolver, contribution, layering audit, setup-activation summary | `BI-1CCC6264` | Extend `apps/web/lib/workspace-home/registry.ts` + `types.ts` (and the proposed `contributions/` boundary from parent §9). Add audit fields (`omittedSlots`, `explanations`, `sourceLayers`) onto the existing `WorkspaceHomeResolution`. Do NOT introduce a parallel resolver union. |
 | Compose canonical primitives + per-slot priority/zone metadata | `BI-5B8FE5C1` | BI-5B8FE5C1 is the **typed primitive registry contract** (11 primitive specs, applicability metadata) — not a "block registry". This plan slice contributes new slot bindings + applicability rows where category sweeps reveal gaps. Primitive-key additions (e.g. a potential `kpi-strip`) are filed as parent-spec amendments. |
 | Signal/projection-driven states | `BI-3E8D2CF5` | Reuse `loadWorkspaceHomeSignals(...)` (GearInterface + Calibrator + Governor unified). Forbid direct `prisma.gearInterface` reads from block components. |
 | WWWD/coworker explanations via WikiPages | `EP-CORPUS-BOOTSTRAP` items plus `EP-COWORKER-INTERACTIVITY` PUC items | Consume `recallWikiContext` with `principleRingScope = worker`. The `DecisionPerspectiveProfile` chain remains a forward-looking input — gated on **BI-230C9EF7** (per-org profile resolver). File a narrow BI only if explanation persistence cannot fit existing corpus/coworker work. |
@@ -69,7 +69,7 @@ Files likely to change:
 
 Implementation notes:
 
-- Add `WorkspaceCompositionAudit` and a typed `WorkspaceCompositionResolution = WorkspaceHomeResolution & { audit }` alias. Do NOT introduce a parallel union.
+- Add `WorkspaceCompositionAudit` and a typed `AuditedWorkspaceHomeResolution = WorkspaceHomeResolution & { audit }` alias. Do NOT introduce a parallel union.
 - Preserve existing `WorkspaceHomeContribution` shape. If `WorkspaceHomeSlotSpec` needs `priority`, `zone`, `explanationPolicy`, prefer adding them as optional fields on the parent type (parent-spec amendment) over duplicating the slot shape.
 - Match exact semantic `StorefrontArchetype.archetypeId` slug before category fallback. `StorefrontConfig.archetypeId` is the FK read path, never the match key.
 - Return explainable omitted slots with reasons (`permission-hidden`, `missing-required-source`, `archetype-mismatch`, etc.).
@@ -274,10 +274,11 @@ Files likely to change:
 
 Implementation notes:
 
-- First use an existing preference/config store if one fits.
-- If no existing store fits, file a separate schema-backed BI before adding `WorkspacePreference`.
-- V1 admin overrides: enable optional blocks, reorder within zones, set block thresholds.
-- V1 user preferences: collapse, density, saved filters.
+- No existing general-purpose workspace preference store is approved for V1. `CommunicationChannelBinding.preferences` is channel-specific, and `BuildPhaseHandoff.userPreferences` is build-evidence context, not portal UI state.
+- V1 may ship server-rendered defaults and ephemeral client collapse state only.
+- Durable org/user overrides require a separate substrate sweep and schema-backed BI before adding `WorkspacePreference`.
+- Admin authority uses existing grants: `manage_business_models` for org/archetype composition choices, `manage_platform` for registry/primitive definitions and platform fallback behavior.
+- Coworker recommendations route through `CoworkerActionEnvelope` and then the same admin override command path; until a durable override store exists, they can open setup tasks or explain gaps but cannot persist layout changes.
 
 Tests:
 
@@ -323,7 +324,7 @@ Per DPF rulebook, implementation is not done until:
 
 ## Acceptance Checklist
 
-- [ ] Existing `WorkspaceHomeContribution` + 11-primitive substrate is extended, not duplicated. No new `WorkspaceBlock*` types or parallel `WorkspaceCompositionResolution` introduced.
+- [ ] Existing `WorkspaceHomeContribution` + 11-primitive substrate is extended, not duplicated. No new `WorkspaceBlock*` types or parallel resolver union introduced.
 - [ ] Every contribution satisfies the parent-mandated slot covenant (today/now, exceptions/needs-review, coworker-handoffs).
 - [ ] Composition matches on `StorefrontArchetype.archetypeId` semantic slug; the `StorefrontConfig.archetypeId` FK is never the match key.
 - [ ] Category contributions produce materially different first-screen compositions.

--- a/docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md
+++ b/docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md
@@ -1,0 +1,337 @@
+# Archetype-Aware Workspace Implementation Plan
+
+> This plan implements [Archetype-Aware Workspace Design](../specs/2026-05-31-archetype-aware-workspace-design.md), which itself extends the two anchor specs from 2026-05-24: [Vertical Workspace Home Design](../specs/2026-05-24-vertical-workspace-home-design.md) and [Workspace-home primitive registry](../specs/2026-05-24-workspace-home-primitive-registry-design.md). It composes the canonical `WorkspaceHomeContribution` + 11 `WorkspaceHomePrimitiveKey` substrate and adds layered configuration + audited explanations on top. It does NOT build a parallel "block" registry, a dashboard builder, or a new `WorkspaceBlock*` type family.
+
+## Substrate Alignment (architect-revised 2026-05-31)
+
+Before any slice runs, the implementer reads the anchor specs and grounds work in the existing substrate:
+
+- Resolver / contribution / setup-activation substrate already exists in [apps/web/lib/workspace-home/](../../../apps/web/lib/workspace-home) (`types.ts`, `registry.ts`, `activation-summary.ts`, `platform-loader.ts`).
+- The 11 canonical primitive keys (`decision-queue`, `geo-map`, `capacity-lanes`, `health-board`, `inventory-watch`, `case-board`, `service-period-board`, `communication-exceptions`, `handoff-queue`, `appointment-schedule`, `volunteer-program-board`) are the unit of reuse — not a new "block" enum.
+- WWWD lever today is `recallWikiContext` against org-overlay `WikiPage` rows (`apps/web/lib/actions/agent-coworker.ts`); `DecisionPerspectiveProfile.ownerOrganizationId` is unread and gated on BI-230C9EF7.
+- Signal source is `loadWorkspaceHomeSignals(...)` (BI-3E8D2CF5) unifying GearInterface + Calibrator + Governor; block components MUST NOT read `prisma.gearInterface` directly.
+- Banned-copy lint and ring-scope discipline (BI-4AA1074B) apply.
+- Match key is `StorefrontArchetype.archetypeId` semantic slug — never the FK.
+
+## Goal
+
+Make `/workspace` meaningfully archetype-aware by composing a small, prioritized set of canonical primitive slots from the active `StorefrontConfig -> StorefrontArchetype` (matched on semantic slug), while keeping the platform workspace as the fallback and making missing data actionable. Layer configuration through DPF-seed → category → exact-archetype → org → role → coworker → user, and carry an audit trail for every resolved slot.
+
+## Backlog Positioning
+
+Do not create a new epic. Link or create implementation BIs under existing epics after owner review:
+
+- Primary parent: `EP-REDUCTION-GEAR-ARCH` for workspace-home substrate and MSP/home composition.
+- Related: `EP-CORPUS-BOOTSTRAP` for WWWD/corpus guidance and gap detection.
+- Related: `EP-COWORKER-INTERACTIVITY` for coworker proposals and action envelopes.
+- Related: `EP-TRADES-FIELD-SERVICE` for field-service/HVAC first exact archetype.
+- Related: `EP-AI-OPSMAP` for integration/service-health signal reuse.
+
+Existing overlap to link:
+
+- `BI-FE002675` - MSP workspace-home research/design.
+- `BI-89C19AAF` - Vertical workspace home design.
+- `BI-5B8FE5C1` - Workspace-home primitive registry contract.
+- `BI-1CCC6264` - Workspace-home substrate follow-up from prior vertical home work.
+- `BI-3E8D2CF5` - Vertical workspace home projections from GearInterface, Calibrator, and Governor signals.
+- `BI-CE6AF925` - HVAC dispatcher workspace home implementation.
+- `BI-5656E9C3` - Dale's AC Repair workspace-home research/design.
+
+Backlog routing after review:
+
+| Plan slice | Existing BI to use | Notes |
+| --- | --- | --- |
+| Resolver, contribution, layering audit, setup-activation summary | `BI-1CCC6264` | Extend `apps/web/lib/workspace-home/registry.ts` + `types.ts` (and the proposed `contributions/` boundary from parent §9). Add audit fields (`omittedBlocks`, `explanations`, `sourceLayers`) onto the existing `WorkspaceHomeResolution`. Do NOT introduce a parallel `WorkspaceCompositionResolution`. |
+| Compose canonical primitives + per-slot priority/zone metadata | `BI-5B8FE5C1` | BI-5B8FE5C1 is the **typed primitive registry contract** (11 primitive specs, applicability metadata) — not a "block registry". This plan slice contributes new slot bindings + applicability rows where category sweeps reveal gaps. Primitive-key additions (e.g. a potential `kpi-strip`) are filed as parent-spec amendments. |
+| Signal/projection-driven states | `BI-3E8D2CF5` | Reuse `loadWorkspaceHomeSignals(...)` (GearInterface + Calibrator + Governor unified). Forbid direct `prisma.gearInterface` reads from block components. |
+| WWWD/coworker explanations via WikiPages | `EP-CORPUS-BOOTSTRAP` items plus `EP-COWORKER-INTERACTIVITY` PUC items | Consume `recallWikiContext` with `principleRingScope = worker`. The `DecisionPerspectiveProfile` chain remains a forward-looking input — gated on **BI-230C9EF7** (per-org profile resolver). File a narrow BI only if explanation persistence cannot fit existing corpus/coworker work. |
+| First exact HVAC composition | `BI-CE6AF925` plus completed `BI-5656E9C3` | Research is done; implementation should consume it. Reuse [Dale's AC Repair visual design](../specs/2026-05-24-dales-ac-repair-workspace-home-visual-design.md) + [docs/personas/dale-hvac.md](../../personas/dale-hvac.md). |
+| MSP composition | `BI-FE002675` | Keep MSP-specific research/design in the existing item. |
+
+Do not create duplicate BIs for these slices. A new BI is justified only after a focused substrate sweep proves the gap is not covered by the items above. Concrete candidates the implementer may surface as separate narrow BIs after the sweep: (a) a `kpi-strip` primitive amendment under BI-5B8FE5C1's parent spec, (b) a `WorkspacePreference` schema BI for org/user overrides if no existing store fits.
+
+## Sequenced Slices
+
+### Slice 1 - Extend Resolver With Layering Audit
+
+**Outcome:** the existing `resolveWorkspaceHomeContribution` returns the canonical `WorkspaceHomeResolution` extended with an `audit: WorkspaceCompositionAudit` carrying `sourceLayers`, `omittedSlots`, and per-slot explanations. No new resolution type.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/types.ts` (extend, do not replace existing types)
+- `apps/web/lib/workspace-home/registry.ts`
+- `apps/web/lib/workspace-home/activation-summary.ts`
+- `apps/web/lib/workspace-home/index.ts`
+- `apps/web/app/(shell)/workspace/page.tsx`
+- `apps/web/lib/workspace-home/registry.test.ts`
+- `apps/web/lib/workspace-home/activation-summary.test.ts`
+- `apps/web/app/(shell)/workspace/page.test.tsx`
+
+Implementation notes:
+
+- Add `WorkspaceCompositionAudit` and a typed `WorkspaceCompositionResolution = WorkspaceHomeResolution & { audit }` alias. Do NOT introduce a parallel union.
+- Preserve existing `WorkspaceHomeContribution` shape. If `WorkspaceHomeSlotSpec` needs `priority`, `zone`, `explanationPolicy`, prefer adding them as optional fields on the parent type (parent-spec amendment) over duplicating the slot shape.
+- Match exact semantic `StorefrontArchetype.archetypeId` slug before category fallback. `StorefrontConfig.archetypeId` is the FK read path, never the match key.
+- Return explainable omitted slots with reasons (`permission-hidden`, `missing-required-source`, `archetype-mismatch`, etc.).
+- Keep production registry empty or minimal until Slice 2 wires actual contributions.
+
+Tests:
+
+- Exact slug match beats category fallback.
+- Category fallback applies when exact match is absent.
+- Missing config returns unconfigured/platform fallback.
+- Role/capability hidden slot is omitted with reason recorded in audit.
+- Re-resolution after archetype change returns a new composition (parent §5.4 — no cached resolution).
+- Slot covenant (today/now, exceptions/needs-review, coworker-handoffs) is enforced at registration time and at resolution time.
+
+### Slice 2 - Register Concrete Slot Components Against Canonical Primitives
+
+**Outcome:** V1 component registry binds concrete renderers (`TechnicianLoadSlot`, `CustomerUpdatesSlot`, …) to the 11 canonical primitive keys. Contributions compose by `(primitiveKey, componentKey, dataRef, vocabulary)`. No new "block" enum.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/types.ts` (extend `WorkspaceHomePrimitiveKey` only if a parent-spec amendment lands)
+- `apps/web/lib/workspace-home/registry.ts`
+- `apps/web/lib/workspace-home/primitives/registry.ts` (new — per parent §9; implements primitive-registry-spec §5 typed contract)
+- `apps/web/lib/workspace-home/primitives/data-loaders.ts` (new — `WorkspaceHomeCanonicalLoaderId` enum)
+- `apps/web/lib/workspace-home/primitives/signals.ts` (new — `WorkspaceHomeSignalKindId` enum)
+- `apps/web/lib/workspace-home/primitives/lint/banned-copy.ts` (new — per primitive-registry spec §7)
+- `apps/web/components/workspace-home/slots/*` (concrete renderers)
+- `apps/web/components/ui/report-kit/statusColors.ts` if new status mappings are needed
+- Tests under `apps/web/lib/workspace-home/**.test.ts`
+
+Conceptual block ↔ canonical primitive mapping (per design spec §"Workspace Block ↔ Primitive Mapping"):
+
+| Conceptual block | Canonical primitive |
+| --- | --- |
+| `work-queue`, `next-best-actions`, `open-decisions` | `decision-queue` |
+| `schedule` | `appointment-schedule` |
+| `coworker-briefing` | `handoff-queue` (covenant slot) |
+| `communication-exceptions` | `communication-exceptions` |
+| `inventory-supplier-risk` | `inventory-watch` |
+| `integration-health`, `service-health` | `health-board` |
+| `customer-activity` | `case-board` or `decision-queue` |
+| `revenue-snapshot`, `kpi-strip` | parent-spec amendment proposal (file as separate BI before adding) |
+| `wwwd-guidance` | signal overlay on top of any primitive (not its own primitive) |
+| `setup-gaps` | the missing-data state of each primitive |
+
+Implementation notes:
+
+- Each slot binds: primitive key, concrete component key (from typed `WorkspaceHomeComponentRegistry`), `dataRef`, vocabulary tokens, priority, mobileCollapse — exactly the parent-spec `WorkspaceHomeSlotSpec` shape.
+- New optional slot fields (`zone`, `explanationPolicy`) ride on `WorkspaceHomeSlotSpec` as a parent-spec amendment, not in a parallel type.
+- Data display components compose report-kit.
+- Banned-copy lint runs at build time over resolved copy values.
+- Do not add a Prisma table in this slice.
+
+Tests:
+
+- Registry rejects unknown primitive/component key (fail-closed per parent §5.5).
+- Every registered slot has an empty/loading/stale/misconfigured state per primitive contract.
+- Slot covenant enforced at contribution registration.
+- Required covenant slots cannot be disabled by org/user preference.
+- Status rendering uses report-kit intents.
+- Banned-copy lint passes on every slot's rendered output.
+
+### Slice 3 - Archetype Category Contributions
+
+**Outcome:** common archetype categories ship as code-owned `WorkspaceHomeContribution` manifests with materially different first-screen slot priorities.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/contributions/registry.ts` (new — per parent §9)
+- `apps/web/lib/workspace-home/contributions/trades-maintenance.ts` (new)
+- `apps/web/lib/workspace-home/contributions/msp.ts` (new)
+- `apps/web/lib/workspace-home/contributions/retail-goods.ts` (new)
+- `apps/web/lib/workspace-home/contributions/restaurant-hospitality.ts` (new)
+- `apps/web/lib/workspace-home/contributions/professional-services.ts` (new)
+- `apps/web/lib/workspace-home/contributions/software-platform.ts` (new)
+- `apps/web/lib/onboarding/archetype-business-context.ts`
+- `apps/web/components/storefront-admin/ArchetypeActivationSummary.tsx`
+- `apps/web/components/storefront-admin/SetupWizard.tsx`
+- Related tests
+
+Category contributions:
+
+- Trades / field service
+- MSP / IT services
+- Retail / ecommerce
+- Hospitality / restaurant
+- Professional services
+- SaaS / software operator
+
+Implementation notes:
+
+- Contributions bind canonical primitive keys to slot positions, zones, and priorities. Composition is by primitive (not by inventing new primitives).
+- Setup activation summaries enumerate the resolved primitive widgets and required canonical data per the parent primitive-registry spec §8 aggregation.
+- Load `StorefrontArchetype` through the `StorefrontConfig.archetypeId` FK; match contributions on `StorefrontArchetype.archetypeId` semantic slug.
+
+Tests:
+
+- Each contribution satisfies the slot covenant (today/now, exceptions/needs-review, coworker-handoffs).
+- Each contribution has critical-strip / next-best-action equivalent coverage.
+- Setup activation summary reflects exact / category / no-home outcomes.
+
+### Slice 4 - Missing-Data and Degraded States
+
+**Outcome:** configured businesses see useful prompts rather than blank slots — driven by each primitive's declared empty/loading/stale/misconfigured contract.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/signals/load-workspace-home-signals.ts` (new — per parent §5.7 and §9; unifies GearInterface raw stream + Calibrator + Governor)
+- `apps/web/lib/workspace-home/signals/translate-gear-signal.ts` (new — per parent §9)
+- `apps/web/components/workspace-home/SetupGapTile.tsx` (new)
+- `apps/web/components/workspace-home/WorkspaceSlotFrame.tsx` (new)
+- Existing slot components from Slice 2
+- Tests for state helpers
+
+Implementation notes:
+
+- Reuse the primitive-level states (`empty`, `loading`, `stale`, `misconfigured`) declared in the primitive-registry spec §5. The four conceptual missing-data modes (`positive-empty`, `setup-action`, `degraded`, `hide`) map to those states per the primitive's `dataContract.rendersWhenEmpty` flag and the contribution's `missingDataBehavior`.
+- Admin users see setup CTAs; non-admin workers see concise "not configured yet" copy.
+- Source freshness and connector state route through `loadWorkspaceHomeSignals` (BI-3E8D2CF5). Slots MUST NOT call `prisma.gearInterface` or `getSlipByReason` directly.
+
+Tests:
+
+- Missing required source produces a setup-action state.
+- Optional empty source hides or shows positive-empty per the slot's primitive contract.
+- Stale data marks slot degraded but still renders available facts.
+- Non-admin users do not see admin-only setup actions.
+
+### Slice 5 - WWWD and Coworker Explanations (via `recallWikiContext`)
+
+**Outcome:** slots can explain why they are present and what missing context should be captured, citing org-overlay `WikiPage` rows retrieved by `recallWikiContext` with `principleRingScope = worker`.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/explanations.ts` (new — read-only wrapper around `recallWikiContext`)
+- `apps/web/lib/actions/agent-coworker.ts` for route context only if needed
+- `apps/web/components/workspace-home/slots/CoworkerBriefingSlot.tsx` (new — bound to `handoff-queue` primitive, covenant slot)
+- Tests under `apps/web/lib/workspace-home/explanations.test.ts`
+
+Implementation notes:
+
+- Start read-only. Canonical lever today: `recallWikiContext({ organizationId, preferredPageKinds: ["stance","heuristic","principle","decision"] })` against `WikiPage` rows with `status="published"` + Qdrant embedding (`apps/web/lib/wiki/embeddings.ts`).
+- `DecisionPerspectiveProfile` / `PerspectiveMaterial` / `DecisionInteraction` are **forward-looking** — gated on BI-230C9EF7 landing a per-org profile resolver. Until then, do not assume `resolveProfileMaterial` is wired per-org.
+- Ring-scope discipline: all recall/decide calls from workspace slots scope by `principleRingScope = worker` (BI-4AA1074B).
+- A coworker recommendation is **proposed**, not applied. Persist proposals through `CoworkerActionEnvelope`; mutate only on user acknowledgement (PAR — Propose → Acknowledge → Reassign).
+- If `recallWikiContext` returns no published WikiPages for the archetype's expected stance keys, surface a setup/corpus gap rather than render a fake answer. Once the perspective chain is wired, a `defer` outcome also routes to gap creation.
+
+Tests:
+
+- Explanation output cites `WikiPage` id(s) returned by `recallWikiContext` when present.
+- Missing WWWD material returns a gap explanation, not silent omission.
+- Recall calls assert `principleRingScope = worker`.
+- Coworker recommendations do not mutate layout without `CoworkerActionEnvelope` acknowledgement.
+- Recommendation confidence and status are serializable.
+
+### Slice 6 - First Exact Archetype Composition
+
+**Outcome:** one archetype demonstrates the layered model end to end against canonical primitives.
+
+Recommended first exact archetype:
+
+- **HVAC / field service** (preferred) — paired with `EP-TRADES-FIELD-SERVICE`, `BI-CE6AF925`, persona [docs/personas/dale-hvac.md](../../personas/dale-hvac.md), and visual design [Dale's AC Repair workspace-home](../specs/2026-05-24-dales-ac-repair-workspace-home-visual-design.md).
+- MSP if paired with `BI-FE002675` and customer-estate/service-health data.
+
+Files likely to change:
+
+- `apps/web/lib/workspace-home/contributions/trades-maintenance.ts` (add `hvac-contractor` exact match)
+- `apps/web/lib/workspace-home/signals/load-workspace-home-signals.ts`
+- `apps/web/components/workspace-home/slots/*` (concrete renderers for primitive bindings)
+- Domain loaders for the chosen archetype, reusing existing records
+- Tests for exact archetype composition
+
+HVAC first-slice slot composition (mapping conceptual block → canonical primitive):
+
+- **Critical strip:** `decision-queue` (next-best-actions binding) + `communication-exceptions`.
+- **Primary:** `appointment-schedule` (schedule), `decision-queue` (work-queue binding), `inventory-watch` (parts/truck stock), `handoff-queue` (coworker briefing — covenant slot).
+- **Secondary:** `case-board` (customer activity), setup-gap state aggregation.
+
+MSP first-slice slot composition:
+
+- **Critical strip:** `health-board` (service-health binding) + `decision-queue` (open-decisions binding).
+- **Primary:** `health-board` (integration-health binding), `decision-queue` (work-queue), `handoff-queue`, `case-board` (customer activity).
+- **Secondary:** setup-gap state aggregation.
+
+Tests:
+
+- Exact archetype resolves to exact contribution; category fallback never wins when an exact match exists.
+- Slots render from available canonical data or the primitive's empty/setup/degraded state.
+- No slot uses hardcoded colors.
+- Banned-copy lint passes on every rendered slot.
+- Snapshot/render tests cover desktop and mobile ordering where practical.
+
+### Slice 7 - Bounded Overrides and Preferences
+
+**Outcome:** admins and users can tune the Workspace without page-builder scope.
+
+Files likely to change:
+
+- Existing preference/config store if available, or new plan/spec before adding schema.
+- `apps/web/lib/workspace-home/preferences.ts` (new)
+- `apps/web/components/workspace-home/WorkspaceCustomizePanel.tsx` (new, only if approved)
+- Tests for preference application
+
+Implementation notes:
+
+- First use an existing preference/config store if one fits.
+- If no existing store fits, file a separate schema-backed BI before adding `WorkspacePreference`.
+- V1 admin overrides: enable optional blocks, reorder within zones, set block thresholds.
+- V1 user preferences: collapse, density, saved filters.
+
+Tests:
+
+- Preferences cannot remove required blocks.
+- Preferences cannot reveal permission-hidden blocks.
+- User preference is lower priority than org override and role projection.
+
+## UX Verification Path
+
+Run against the production-path **Live portal** at the install URL from `.env` (`AUTH_URL` / `APP_URL`, normally `http://localhost:3000`) — not a stale dev server, not `127.0.0.1`, not the LAN IP (per `project_portal_address` and the parent spec §10).
+
+Verify on the Live portal (desktop AND mobile viewports):
+
+- `/login` as `admin@dpf.local` using `ADMIN_PASSWORD` from repo-root `.env`.
+- `/workspace` with no archetype/configured fallback: setup notice + platform fallback render.
+- `/storefront/setup`: archetype choices show workspace activation summary (resolved primitive widgets + required canonical data).
+- Configure/select the first tested archetype.
+- `/workspace`: archetype-specific slot order renders with the slot covenant present (today/now, exceptions, coworker-handoffs).
+- Admin user sees setup prompts; non-admin worker does not see admin-only setup actions.
+- Missing integration/data produces the primitive's declared empty/setup/degraded state.
+- Coworker briefing explains at least one slot or gap with a cited `WikiPage` reference (or honest "no WWWD material yet" gap state).
+- Mobile viewport preserves priority order and avoids overlapping text.
+
+Submit a structured dynamic-analysis report (per `feedback_dynamic_analysis_is_evidence` and parent §10): **drove X → observed Y → signed off Z**. Screenshots are evidence, not the report.
+
+## Build Gate Requirements
+
+Per DPF rulebook, implementation is not done until:
+
+- Unit tests for affected files pass with `pnpm --filter web exec vitest run <affected tests>`.
+- Typecheck passes with `pnpm --filter web typecheck`.
+- Production build passes with `cd apps/web && pnpm exec next build` or the repository-standard build command for the current branch.
+- UX verification path above is exercised against the Live portal.
+- If any migration is added later, it applies cleanly through Prisma and includes inline backfill SQL when moving data.
+
+## Non-Goals for V1
+
+- No general drag-and-drop dashboard builder.
+- No custom user-authored React/HTML blocks.
+- No hidden AI-generated layout mutations.
+- No new dashboard/widget Prisma table unless a later plan proves the existing stores cannot carry bounded preferences.
+- No replacement of the existing platform workspace fallback.
+
+## Acceptance Checklist
+
+- [ ] Existing `WorkspaceHomeContribution` + 11-primitive substrate is extended, not duplicated. No new `WorkspaceBlock*` types or parallel `WorkspaceCompositionResolution` introduced.
+- [ ] Every contribution satisfies the parent-mandated slot covenant (today/now, exceptions/needs-review, coworker-handoffs).
+- [ ] Composition matches on `StorefrontArchetype.archetypeId` semantic slug; the `StorefrontConfig.archetypeId` FK is never the match key.
+- [ ] Category contributions produce materially different first-screen compositions.
+- [ ] At least one exact archetype composition works end to end on the Live portal, with the parent's structured dynamic-analysis report shape.
+- [ ] Setup activation summaries name resolved primitive widgets and required canonical data per primitive-registry spec §8.
+- [ ] WWWD/coworker explanations cite `WikiPage` ids via `recallWikiContext` with `principleRingScope = worker`. Profile-chain consumption is deferred until BI-230C9EF7 lands.
+- [ ] Signals route through `loadWorkspaceHomeSignals(...)` (BI-3E8D2CF5). No direct `prisma.gearInterface` or `getSlipByReason` reads from slot components.
+- [ ] Coworker recommendations require `CoworkerActionEnvelope` acknowledgement (PAR) before changing configuration.
+- [ ] All data-display UI uses report-kit and DPF tokens.
+- [ ] Banned-copy lint passes on every rendered slot fixture (parent primitive-registry spec §7 token list).
+- [ ] Unit/type/build/UX gates are recorded before handoff. Build = `pnpm --filter web typecheck` + `cd apps/web && pnpm exec next build`; UX = Live portal verification with desktop AND mobile viewport sign-off.

--- a/docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md
+++ b/docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md
@@ -25,7 +25,7 @@
 4. **Projection service is the canonical signal source.** Block "why-this-matters" and confidence overlays flow through `loadWorkspaceHomeSignals(...)` from `apps/web/lib/workspace-home/signals/` (BI-3E8D2CF5), which unifies GearInterface raw stream + Calibrator + Governor outputs. Block components MUST NOT call `prisma.gearInterface` or `getSlipByReason` directly. (Parent §5.7.)
 5. **Ring-scope discipline (BI-4AA1074B).** Any wiki recall/decide MCP call from a workspace block scopes by `principleRingScope = worker`. Platform-engineering principles must not surface into the in-trench surface.
 6. **Banned-copy lint applies.** Worker-facing strings from any configured slot pass the parent's banned-copy token list (`gear`, `ring`, `torque`, `slip`, `wear`, `triple`, `shaft`, `calibration`, `contribution model`, `cockpit`, `reduction-gear`, `GearInterface`, architecture-loop language). Every new component ships at least one fixture exercising rendered slot output against the lint. (Parent primitive-registry spec §7.)
-7. **Resolver type reused.** The resolver returns the canonical `WorkspaceHomeResolution` (or a typed extension carrying `omittedBlocks` / `explanations` / `sourceLayers` audit fields), not a new `WorkspaceCompositionResolution` parallel type.
+7. **Resolver type reused.** The resolver returns the canonical `WorkspaceHomeResolution` (or a typed extension carrying `omittedSlots` / `explanations` / `sourceLayers` audit fields), not a new parallel resolution type.
 8. **Archetype identity match-key clarified.** Composition matches on `StorefrontArchetype.archetypeId` *semantic slug* only. `StorefrontConfig.archetypeId` is the FK used to load the row; it is never the match key. (Parent §5.3; gated on BI-44C34478 normalization.)
 9. **Plan file boundary aligns to parent.** The implementation plan's "Files likely to change" lists are updated to land under `apps/web/lib/workspace-home/{contributions,primitives,signals}/` per parent §9, not a new `blocks.ts` / `block-resolution.ts` boundary.
 
@@ -177,7 +177,7 @@ Secondary blocks follow in dense sections. Reporting-heavy blocks use report-kit
 
 ## Configuration Layering Model
 
-Workspace resolution should produce an audited `WorkspaceCompositionResolution` at render time.
+Workspace resolution should produce an audited extension of the canonical `WorkspaceHomeResolution` at render time. The extension carries source-layer and explanation metadata; it does not replace the resolver type from the anchor spec.
 
 ```ts
 type WorkspaceConfigurationLayer =
@@ -189,29 +189,28 @@ type WorkspaceConfigurationLayer =
   | "coworker-recommendation"
   | "user-preference";
 
-type WorkspaceCompositionResolution = {
-  organizationId: string;
-  archetypeSlug: string | null;
-  category: string | null;
-  roleKey: string;
-  blocks: WorkspaceBlockInstance[];
-  omittedBlocks: WorkspaceOmittedBlock[];
-  explanations: WorkspaceBlockExplanation[];
+type WorkspaceCompositionAudit = {
   sourceLayers: WorkspaceConfigurationLayer[];
+  omittedSlots: WorkspaceOmittedSlot[];
+  explanations: WorkspaceSlotExplanation[];
+};
+
+type AuditedWorkspaceHomeResolution = WorkspaceHomeResolution & {
+  audit: WorkspaceCompositionAudit;
 };
 ```
 
 Layer order:
 
-1. **DPF seed:** baseline block registry and universal block constraints.
+1. **DPF seed:** baseline primitive registry and universal slot constraints.
 2. **Archetype category:** default composition for broad category, such as field service, retail, hospitality, professional services, SaaS, MSP.
 3. **Exact archetype:** semantic slug-specific overrides, such as `hvac-contractor`.
-4. **Organization override:** bounded admin choices: enable/disable optional blocks, reorder within allowed zones, choose saved filters, set target thresholds.
-5. **Role projection:** hide or down-rank blocks/actions the user cannot use.
+4. **Organization override:** bounded admin choices: enable/disable optional slots, reorder within allowed zones, choose saved filters, set target thresholds.
+5. **Role projection:** hide or down-rank slots/actions the user cannot use.
 6. **Coworker recommendation:** pending proposed change, not automatic mutation.
 7. **User preference:** collapse/expand, density, saved filters, default time window.
 
-Conflict rule: a lower layer cannot re-enable a block/action forbidden by a higher governed layer or by permissions. The UI must be able to show "hidden because role lacks X" or "recommended because WWWD material Y says Z."
+Conflict rule: a lower layer cannot re-enable a slot/action forbidden by a higher governed layer or by permissions. The UI must be able to show "hidden because role lacks X" or "recommended because WWWD material Y says Z."
 
 ## Workspace Block ↔ Primitive Mapping
 
@@ -236,16 +235,16 @@ If a future archetype proves an operating model the existing 11 primitives genui
 
 ### Audit fields layered onto the resolver
 
-The Configuration Layering Model (above) produces an audited resolution. To preserve the canonical resolver shape, the audit fields ride on `WorkspaceHomeResolution` (or a thin typed extension) rather than introducing a parallel `WorkspaceCompositionResolution`:
+The Configuration Layering Model (above) produces an audited resolution. To preserve the canonical resolver shape, the audit fields ride on `WorkspaceHomeResolution` (or a thin typed extension) rather than introducing a parallel resolver union:
 
 ```ts
 type WorkspaceCompositionAudit = {
   sourceLayers: WorkspaceConfigurationLayer[];   // which layers contributed to the resolved composition
-  omittedBlocks: WorkspaceOmittedBlock[];        // slot definitions that were dropped, with reason
-  explanations: WorkspaceBlockExplanation[];     // per-slot "why this is here" with cited WikiPage / signal refs
+  omittedSlots: WorkspaceOmittedSlot[];          // slot definitions that were dropped, with reason
+  explanations: WorkspaceSlotExplanation[];      // per-slot "why this is here" with cited WikiPage / signal refs
 };
 
-type WorkspaceCompositionResolution = WorkspaceHomeResolution & { audit: WorkspaceCompositionAudit };
+type AuditedWorkspaceHomeResolution = WorkspaceHomeResolution & { audit: WorkspaceCompositionAudit };
 ```
 
 Implementation MAY put the audit on the existing resolution union; implementation MUST NOT replace `WorkspaceHomeResolution` with a parallel type. Slot priority / zone / explanation-policy fields are either added as optional members of `WorkspaceHomeSlotSpec` (preferred, parent-spec amendment) or ride on the audit (acceptable fallback). The implementation BI picks one after sweeping current `WorkspaceHomeSlotSpec` consumers.
@@ -427,13 +426,18 @@ Do not add a generic `Dashboard`, `Widget`, or `PageBuilder` table for V1.
 | Archetype mismatch via FK vs semantic slug | Match contribution manifests on `StorefrontArchetype.archetypeId` semantic slug only. |
 | Page becomes card-heavy and slow | Limit primary blocks, prioritize queues/actions, lazy-load secondary charts. |
 
-## Open Questions
+## Resolved Review Questions
 
-1. Which existing preference/config store should carry org/user workspace overrides, or is a small `WorkspacePreference` table justified after V1?
-2. Should accepted coworker layout recommendations be persisted as org overrides immediately, or as reviewed recommendations applied at render time?
-3. What is the first exact archetype after MSP and HVAC: retail, restaurant/hospitality, professional-services, or SaaS operator?
-4. Which role/capability grants should own workspace configuration separate from storefront setup?
-5. How much of the existing `PlatformWorkspaceHome` should remain visible to admins when an archetype workspace is active?
+1. **Preference persistence.** No existing general-purpose org/user workspace preference store was found in schema. `CommunicationChannelBinding.preferences` is channel-specific, and `BuildPhaseHandoff.userPreferences` is build-evidence context, not portal UI preference storage. V1 therefore implements no durable user reordering beyond server-rendered defaults. If Slice 7 needs persistence, file a narrow `WorkspacePreference` schema BI after another substrate sweep.
+2. **Accepted coworker recommendations.** Accepted recommendations do not mutate layout directly. They resolve through PAR (`CoworkerActionEnvelope`) into the same admin/org override command path a human would use. Until a durable override store exists, coworker recommendations can open setup tasks or explain gaps, but they cannot create persistent layout changes.
+3. **Next exact archetype after HVAC and MSP.** Retail/ecommerce is the next proving archetype because it stress-tests revenue snapshot, inventory/supplier risk, customer activity, and the likely `kpi-strip` primitive amendment. It should route through existing `BI-3F3B535D` / `BI-E0D7B790` work rather than a new BI.
+4. **Configuration authority.** V1 uses existing grants: `manage_business_models` owns org/archetype workspace composition choices; `manage_platform` owns registry/primitive definitions and platform fallback behavior; `view_storefront` remains read/setup visibility only. A new `manage_workspace_home` grant is deferred until implementation proves the existing split is too coarse.
+5. **Platform fallback visibility.** When an archetype workspace is active, `PlatformWorkspaceHome` is not blended into the worker home. Authorized operators with `view_platform` or `manage_platform` get an explicit operator switch or link to the platform fallback. Ordinary workers stay in the archetype workspace.
+
+## Remaining Open Questions
+
+1. Should `WorkspaceHomeSlotSpec` grow optional fields (`explanationPolicy`, `recommendationsConsumed`, `zone`) or should all audit metadata ride on `AuditedWorkspaceHomeResolution`? This is deliberately left to `BI-1CCC6264` after a local consumer sweep.
+2. Is `kpi-strip` a justified primitive-registry amendment, or can retail/SaaS express header metrics with existing primitives plus report-kit `StatCard` composition? Decide in `BI-5B8FE5C1` / retail implementation evidence.
 
 ## Acceptance Criteria
 

--- a/docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md
+++ b/docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md
@@ -1,0 +1,450 @@
+# Archetype-Aware Workspace Design
+
+| Field | Value |
+| --- | --- |
+| Status | Draft — architect-revised 2026-05-31 (alignment corrections folded; awaiting founder review) |
+| Date | 2026-05-31 |
+| Author | Codex; architect revisions by Enterprise Architect persona (Mark Bodman session) |
+| Scope | Internal `/workspace` composition, archetype-aware operational blocks, WWWD/coworker guidance |
+| Anchor specs | [Vertical Workspace Home Design](2026-05-24-vertical-workspace-home-design.md) (canonical contribution/resolver/projection contract), [Workspace-home primitive registry](2026-05-24-workspace-home-primitive-registry-design.md) (canonical 11-primitive typed registry) |
+| Extends | The two anchor specs. This spec adds the *configuration layering* model (DPF-seed → category → exact → org → role → coworker → user) and audited explanation/recommendation contract on top of the existing contribution + primitive substrate. It does NOT introduce a new "block" registry. |
+| Related epics | EP-CORPUS-BOOTSTRAP, EP-COWORKER-INTERACTIVITY, EP-REDUCTION-GEAR-ARCH, EP-TRADES-FIELD-SERVICE, EP-AI-OPSMAP |
+| Related backlog | BI-1CCC6264, BI-5B8FE5C1, BI-3E8D2CF5, BI-CE6AF925, BI-FE002675, BI-89C19AAF, BI-5656E9C3, BI-34936764, BI-8A58C65A, BI-846C297F |
+| Related personas | [Dale (HVAC)](../../personas/dale-hvac.md), [Linda (clinic)](../../personas/linda-clinic.md), [Marisol (retail)](../../personas/marisol-retail.md) |
+| Related docs | [Customer Surface Archetype Activation](2026-05-22-customer-surface-archetype-activation-design.md), [Continuous Corpus Enrichment](2026-05-31-continuous-corpus-enrichment-design.md), [Decision Perspective & Persona Voice](../../user-guide/ai-workforce/decision-perspective.md), [Dale's AC Repair workspace-home visual design](2026-05-24-dales-ac-repair-workspace-home-visual-design.md) |
+
+## Architect Verdict (2026-05-31)
+
+**Verdict:** the configuration-layering model and the audited recommendation/explanation contract are keepable and a useful extension of the existing substrate. The original v1 draft, however, invented a parallel `WorkspaceBlock*` registry and cited the wrong WWWD substrate; both are corrected in this revision. After folding, this spec is positioned as the **layering + audit extension** on top of the canonical contribution + primitive substrate, not a replacement of it.
+
+**Required corrections folded into this revision:**
+
+1. **No second substrate.** The 14 proposed "block kinds" are reframed as *configured slot instances* (`WorkspaceHomeSlotSpec`) of the canonical 11 `WorkspaceHomePrimitiveKey` primitives defined in the parent specs. The mapping is made explicit in §"Workspace Block ↔ Primitive Mapping". No new `WorkspaceBlock*` types or `blocks.ts` module are introduced. (`single-source-of-truth`, `verify-substrate-before-proposing-new`, `architecture-over-shortcuts`.)
+2. **WWWD lever is org WikiPages.** The canonical workspace explanation path is `recallWikiContext({ organizationId, preferredPageKinds: ["stance","heuristic","principle","decision"] })` (`apps/web/lib/actions/agent-coworker.ts`), grounded in published+embedded `WikiPage` rows seeded by `apps/web/lib/onboarding/seed-org-wwwd-corpus.ts`. The `DecisionPerspectiveProfile` / `PerspectiveMaterial` chain is **not yet wired** — `DecisionPerspectiveProfile.ownerOrganizationId` is unread and `resolveProfileMaterial` always enters at `mark-dpf-platform`. The profile chain becomes a workspace input only after BI-230C9EF7 lands a per-org profile resolver. (Schema-grounded; see [[wwwd-corpus-lever-is-org-wikipages]] context memory.)
+3. **Slot covenant remains mandatory.** Every contribution still carries the parent-mandated `today-now`, `exceptions-needs-review`, and `coworker-handoffs` baseline slots. The new zone vocabulary (`critical-strip` / `primary` / `secondary` / `briefing` / `setup`) is presentation *above* the covenant, not a replacement. (Parent spec §5.5 slot covenant.)
+4. **Projection service is the canonical signal source.** Block "why-this-matters" and confidence overlays flow through `loadWorkspaceHomeSignals(...)` from `apps/web/lib/workspace-home/signals/` (BI-3E8D2CF5), which unifies GearInterface raw stream + Calibrator + Governor outputs. Block components MUST NOT call `prisma.gearInterface` or `getSlipByReason` directly. (Parent §5.7.)
+5. **Ring-scope discipline (BI-4AA1074B).** Any wiki recall/decide MCP call from a workspace block scopes by `principleRingScope = worker`. Platform-engineering principles must not surface into the in-trench surface.
+6. **Banned-copy lint applies.** Worker-facing strings from any configured slot pass the parent's banned-copy token list (`gear`, `ring`, `torque`, `slip`, `wear`, `triple`, `shaft`, `calibration`, `contribution model`, `cockpit`, `reduction-gear`, `GearInterface`, architecture-loop language). Every new component ships at least one fixture exercising rendered slot output against the lint. (Parent primitive-registry spec §7.)
+7. **Resolver type reused.** The resolver returns the canonical `WorkspaceHomeResolution` (or a typed extension carrying `omittedBlocks` / `explanations` / `sourceLayers` audit fields), not a new `WorkspaceCompositionResolution` parallel type.
+8. **Archetype identity match-key clarified.** Composition matches on `StorefrontArchetype.archetypeId` *semantic slug* only. `StorefrontConfig.archetypeId` is the FK used to load the row; it is never the match key. (Parent §5.3; gated on BI-44C34478 normalization.)
+9. **Plan file boundary aligns to parent.** The implementation plan's "Files likely to change" lists are updated to land under `apps/web/lib/workspace-home/{contributions,primitives,signals}/` per parent §9, not a new `blocks.ts` / `block-resolution.ts` boundary.
+
+**Not folded in (deferred to implementation BI):**
+- Whether `WorkspaceHomeSlotSpec` should grow new optional fields (`explanationPolicy`, `recommendationsConsumed`, `zone`) or whether the audit fields ride on the resolver result only. Implementer to pick after grepping current `WorkspaceHomeSlotSpec` consumers — both options preserve the no-second-substrate constraint.
+
+## Problem Statement
+
+The current Workspace route is useful as a platform operator home, but it is still too generic for the businesses DPF is meant to run. A field-service dispatcher, retail owner, restaurant manager, professional-services partner, SaaS founder, and MSP operator should not all land on the same command-center composition. They need the same governed platform underneath, but different first-screen concerns: schedule risk, customer updates, inventory, open decisions, revenue movement, supplier exposure, service health, setup gaps, and coworker handoffs.
+
+The Workspace must become an archetype-aware operational screen. It should bring each business archetype's daily concerns forward without becoming a per-customer drag-and-drop page builder. The design should use typed, testable composition: DPF seeds a canonical archetype layout, org owners can make bounded overrides, coworkers can recommend changes with explanation and audit, and end users can save low-risk preferences.
+
+## Current Substrate Inventory
+
+### Existing route and composition
+
+- `apps/web/app/(shell)/workspace/page.tsx` authenticates, loads `loadPlatformWorkspaceHomeData`, resolves a workspace-home contribution, renders an unconfigured notice when needed, and falls back to `PlatformWorkspaceHome`.
+- `apps/web/components/workspace-home/PlatformWorkspaceHome.tsx` renders the existing platform home: command center, attention strip, permission-derived tile sections, calendar, and activity feed.
+- `apps/web/lib/workspace-home/platform-loader.ts` centralizes current platform-home data loading and already includes `StorefrontConfig -> StorefrontArchetype` data.
+- `apps/web/lib/workspace-home/registry.ts` defines a first workspace-home contribution registry and exact/category matching against the active storefront archetype.
+- `apps/web/lib/workspace-home/types.ts` defines `WorkspaceHomeContribution`, baseline slots, component descriptors, setup activation metadata, and the `WorkspaceHomeResolution` union.
+- `apps/web/lib/workspace-home/activation-summary.ts` is exposed through setup to show which workspace-home primitives activate for an archetype.
+
+### Existing archetype and business-context substrate
+
+- `StorefrontConfig.archetypeId` is the canonical installed archetype source, linked to `StorefrontArchetype.id`.
+- `StorefrontArchetype.archetypeId` is the semantic archetype slug and must be the matching key for workspace contributions.
+- `StorefrontArchetype` already carries `category`, `activationProfile`, `customVocabulary`, `itemTemplates`, `sectionTemplates`, `formSchema`, and `marketingSkillRules`.
+- `BusinessContext.industry` and `BusinessContext.archetypeId` are derived/deprecated context fields, not the workspace resolver source.
+- `Organization` is the canonical identity model for name, slug, contact, address, logo, and design tokens.
+
+### Existing WWWD/corpus substrate
+
+**Canonical WWWD lever as of 2026-05-31: org-overlay `WikiPage` rows, retrieved by `recallWikiContext`.** The workspace explanation/guidance path is `apps/web/lib/actions/agent-coworker.ts → recallWikiContext({ organizationId, preferredPageKinds: ["stance","heuristic","principle","decision"] })`, which calls `searchWikiPages` / `apps/web/lib/wiki/embeddings.ts`. Retrieval requires `status="published"` + a Qdrant embedding (written by `storeWikiPage`, fail-open if Ollama is down) + matching `organizationId`. The seed path is `apps/web/lib/onboarding/seed-org-wwwd-corpus.ts`.
+
+`DecisionPerspectiveProfile` / `DecisionPerspectiveProfileVersion` / `PerspectiveMaterial` / `DecisionInteraction` and the continuous-corpus chain (`RawSource`, `WikiPage`, `WikiPageRevision`, `WikiPageSource`, `WikiIngestEvent`) exist in schema, **but `DecisionPerspectiveProfile.ownerOrganizationId` is never read by any decision path today**. `resolveProfileMaterial` always enters at `mark-dpf-platform`; no caller selects a per-org profile. The profile chain becomes a Workspace input only after **BI-230C9EF7** lands a per-org profile resolution entry-point. Until then, the Workspace MUST consume WWWD through `recallWikiContext` and treat profile-chain references as forward-looking.
+
+The Decision Perspective Gate already returns governed outcomes (`recommend`, `arbitrate`, `escalate`, `defer`) with confidence and cited material. Once BI-230C9EF7 lands, Workspace composition may show "why this block matters" and "what context is missing" by calling that surface. Until then, "why this block matters" cites the `WikiPage`(s) recall returned, plus, where applicable, the `loadWorkspaceHomeSignals` source (§"Existing UI/reporting substrate").
+
+**Ring-scope discipline (BI-4AA1074B).** Any wiki recall/decide call from a workspace block scopes by `principleRingScope = worker`. Platform-engineering principles must not surface into the in-trench surface; the Cockpit owns broader ring scopes.
+
+### Existing coworker/action substrate
+
+- `Agent`, `SkillDefinition`, `SkillAssignment`, and coworker route context already define who can advise or act.
+- `CoworkerActionEnvelope` captures proposed destructive or side-effecting coworker actions before user approval.
+- `ToolExecution` and receipts capture tool calls, route context, delegated user identity, and action envelope linkage.
+- `EP-COWORKER-INTERACTIVITY` and the Pseudo-User Contract work provide the intended path for coworker-driven screen actions.
+
+### Existing UI/reporting substrate
+
+- Reporting and data-display UX should use `apps/web/components/ui/report-kit/`: `StatusBadge`, `StatCard`, `DataTable`, `FilterBar`, `ExportButton`, `Chart`, and the `statusColors` intent registry.
+- Workspace-home code already has a primitive registry concept. This spec should extend that substrate rather than inventing an unrelated "dashboard widget" system.
+- Theme-aware styling is mandatory: block renderers must use `var(--dpf-*)` tokens and report-kit status intent helpers. No raw hex or local status color maps.
+
+### Live backlog and overlap verification
+
+MCP/backlog sweep on 2026-05-31 found no need for a new epic. Relevant existing work:
+
+- `EP-CORPUS-BOOTSTRAP`: onboarding-seeded, continuously enriched org WWWD corpus.
+- `EP-COWORKER-INTERACTIVITY`: coworker drives the screen with symmetric authority and audit.
+- `EP-REDUCTION-GEAR-ARCH`: contains vertical workspace-home substrate and MSP workspace-home follow-up work.
+- `EP-TRADES-FIELD-SERVICE`: field-service archetype, dispatcher coworker, notification skills, and lifecycle work.
+- `EP-AI-OPSMAP`: operations map and functional-failure routing.
+- `BI-1CCC6264`: workspace-home contribution registry, resolver, and platform fallback implementation.
+- `BI-5B8FE5C1`: vertical workspace primitive library.
+- `BI-3E8D2CF5`: translated workspace-home projections from GearInterface, Calibrator, and Governor signals.
+- `BI-CE6AF925`: HVAC dispatcher workspace home implementation.
+- `BI-FE002675`: direct overlap for MSP workspace-home research/design.
+- `BI-5656E9C3`: Dale's AC Repair workspace-home research/design, already completed.
+
+Open PR sweep found one open PR on this branch (`#1380`, onboarding document upload to DMS), not a competing Workspace design PR.
+
+Follow-up sweep after review confirmed the cross-cutting implementation work should be routed through those existing BIs rather than filed as new backlog items. The only new work that should be filed later is a narrow gap proven not to fit the existing BI bodies, such as a missing persistence store for bounded workspace preferences.
+
+## Research & Benchmarking
+
+### Open-source and source-available systems
+
+| System | Configuration model | Pattern to adopt | Pattern to reject |
+| --- | --- | --- | --- |
+| [ERPNext/Frappe Workspaces](https://docs.frappe.io/erpnext/workspace) | Workspaces represent modules, combine dashboard, shortcuts, masters, reports, and optional user-specific customization. | Module/work-domain homes made from typed sections are a proven model. DPF should expose a stable home for the work domain, not one giant dashboard. | User-specific arbitrary workspace documents as the primary DPF model. DPF needs seedable, archetype-owned defaults and governed overrides. |
+| [Apache Superset dashboards](https://superset.apache.org/user-docs/using-superset/creating-your-first-dashboard/) | Charts are stored with query/type/options; dashboard access can use dataset permissions or dashboard-level roles. | Separate data contract, visual block definition, and access model. Published vs draft dashboard state is useful precedent for override review. | Free-form analytical dashboards as the day-one workspace. Superset optimizes exploration, while DPF's Workspace optimizes daily operation and action. |
+| [Grafana folders and permissions](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/folder-access-control/) | Folders organize dashboards and cascade permissions across contained resources. | Configuration and visibility must inherit from a higher container while keeping effective permissions explainable. | Folder-style dashboard sprawl. DPF blocks should be few, governed, and archetype-relevant. |
+
+### Commercial products
+
+| Product | Configuration model | Pattern to adopt | Pattern to reject |
+| --- | --- | --- | --- |
+| [Microsoft Dynamics 365 Finance & Operations workspaces](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/user-interface/page-navigation) | Workspaces are activity-oriented pages tied to targeted user questions and frequent tasks; access depends on roles. | Workspace purpose should be "answer the targeted user's most pressing activity questions and initiate frequent tasks." This is the strongest benchmark for DPF. | Generic dashboard-as-landing-page when the user really needs an activity board. |
+| [Shopify Analytics overview](https://help.shopify.com/en/manual/reports-and-analytics/shopify-reports/overview-dashboard) | Customizable metric cards can be added, removed, rearranged, sectioned, resized; insights and targets are surfaced. | Bounded card customization, labeled sections, and system-generated insights are useful for owner/admin reporting blocks. | Letting metric-card rearrangement become the whole Workspace model; operations queues and decisions must outrank vanity metrics. |
+| [HubSpot record cards](https://knowledge.hubspot.com/object-settings/create-cards-on-records?product=crm) | Cards display data/actions in fixed regions of record views; customization requires admin permissions. | Region-specific cards with permissions are a good model for bounded owner/admin overrides. | Object-record page customization as the default mental model. Workspace blocks should be operating concerns, not schema-object decoration. |
+| [Salesforce Dynamic Forms / visibility rules](https://help.salesforce.com/s/articleView?id=sf.lightning_page_components_visibility.htm&language=en_US&type=5) | Page fields/sections can show/hide based on record data, user details, permission, or device, with documented caveats. | Conditional visibility is useful only when explainable and testable. DPF should record why a block is present or absent. | Complex hidden layout rules that make required or important content disappear without an audit trail. |
+
+### Adopted Patterns
+
+- Activity-oriented workspaces beat generic dashboards.
+- Layered configuration is viable when each layer has clear authority.
+- Blocks need typed data contracts and fixed renderers, not arbitrary HTML or script.
+- Role/access constraints must be part of the configuration model, not an afterthought.
+- User customization should be bounded to ordering, collapse, and saved filters until the system proves a need for deeper overrides.
+- AI insights are valuable when they cite source material, explain why, and produce auditable recommendations.
+
+### Rejected Patterns
+
+- Drag-and-drop dashboard builder as V1.
+- Per-customer React component injection.
+- Hidden AI layout generation that silently changes the workspace.
+- Local per-page status colors and one-off table/card implementations.
+- Forcing every archetype into KPI-first analytics.
+- Treating `BusinessContext.industry` as equivalent to active archetype.
+
+### DPF-Specific Gaps
+
+- The current registry names primitive/component concepts, but it does not yet express the full layered configuration model: seed default, org override, role projection, coworker recommendation, user preference.
+- Existing first-screen Workspace still renders the platform home even when a vertical contribution could be resolved.
+- WWWD guidance can inform recommendations, but there is no block-level explanation/audit model yet.
+- Coworker handoffs exist as a concept, but Workspace blocks do not yet consume `CoworkerActionEnvelope` and `ToolExecution` as a first-class operational queue.
+- Setup activation summaries exist, but missing-data behavior needs to be user-facing: setup prompt, empty positive state, degraded block, or hidden block.
+
+## Design Principles
+
+1. **Archetype first, role second.** The active archetype determines the operating model; role determines which blocks/actions within that model are visible or actionable.
+2. **Configuration is layered, not bespoke.** DPF seeds the default; org admins make bounded overrides; coworkers recommend with citations; users save personal display preferences.
+3. **Blocks are operational units.** A block answers a daily question, supports a workflow, and has a data contract.
+4. **WWWD explains and prioritizes, it does not secretly lay out the page.** Layout changes from WWWD/coworkers are recommendations with rationale and audit.
+5. **Data gaps are first-class.** Missing integrations, empty canonical records, and unseeded capabilities render setup/action prompts instead of blank charts.
+6. **No second substrate.** Extend workspace-home registry, report-kit, decision perspective, ToolExecution, and corpus primitives before adding schema.
+7. **Dense and repeatable.** The screen is for people who use it every day. It should be compact, scannable, and action-oriented.
+8. **Theme-aware and report-kit composed.** Any KPI, status, table, filter, CSV export, or chart uses the shared palette.
+
+## Proposed Information Architecture
+
+The Workspace route remains `/workspace`, but the page should resolve into one of three modes:
+
+| Mode | When | First-screen behavior |
+| --- | --- | --- |
+| `archetype-workspace` | Active `StorefrontConfig.archetype` matches exact/category workspace contribution | Render archetype-specific block composition and active coworker briefing. |
+| `configured-fallback` | Archetype exists but no contribution matches | Render platform home with a compact setup notice and "workspace home not configured for this archetype" telemetry. |
+| `unconfigured` | No storefront/archetype setup | Render setup notice and platform home fallback. |
+
+The first viewport should have:
+
+1. **Operating header:** business-native title, current day/window, primary action.
+2. **Critical strip:** exceptions and next-best actions, not marketing copy.
+3. **Primary block row:** 2-4 high-priority blocks for the archetype.
+4. **Coworker briefing rail/dock:** current handoffs, explanation, missing-context prompts.
+
+Secondary blocks follow in dense sections. Reporting-heavy blocks use report-kit, but the page should not become KPI-card wallpaper.
+
+## Configuration Layering Model
+
+Workspace resolution should produce an audited `WorkspaceCompositionResolution` at render time.
+
+```ts
+type WorkspaceConfigurationLayer =
+  | "dpf-seed"
+  | "archetype-category"
+  | "exact-archetype"
+  | "organization-override"
+  | "role-projection"
+  | "coworker-recommendation"
+  | "user-preference";
+
+type WorkspaceCompositionResolution = {
+  organizationId: string;
+  archetypeSlug: string | null;
+  category: string | null;
+  roleKey: string;
+  blocks: WorkspaceBlockInstance[];
+  omittedBlocks: WorkspaceOmittedBlock[];
+  explanations: WorkspaceBlockExplanation[];
+  sourceLayers: WorkspaceConfigurationLayer[];
+};
+```
+
+Layer order:
+
+1. **DPF seed:** baseline block registry and universal block constraints.
+2. **Archetype category:** default composition for broad category, such as field service, retail, hospitality, professional services, SaaS, MSP.
+3. **Exact archetype:** semantic slug-specific overrides, such as `hvac-contractor`.
+4. **Organization override:** bounded admin choices: enable/disable optional blocks, reorder within allowed zones, choose saved filters, set target thresholds.
+5. **Role projection:** hide or down-rank blocks/actions the user cannot use.
+6. **Coworker recommendation:** pending proposed change, not automatic mutation.
+7. **User preference:** collapse/expand, density, saved filters, default time window.
+
+Conflict rule: a lower layer cannot re-enable a block/action forbidden by a higher governed layer or by permissions. The UI must be able to show "hidden because role lacks X" or "recommended because WWWD material Y says Z."
+
+## Workspace Block ↔ Primitive Mapping
+
+**No new registry.** This spec's "blocks" are *configured slot instances* of the canonical primitives defined in the parent [primitive-registry spec](2026-05-24-workspace-home-primitive-registry-design.md) and bound through `WorkspaceHomeSlotSpec` (parent vertical-workspace-home spec §5.5). A configured slot is `{ slotId, primitive, component, title, tone, dataRef, priority, mobileCollapse }` — the layering model below adds presentation metadata around the existing shape, it does not replace it.
+
+The 14 conceptual "blocks" enumerated in earlier drafts collapse onto the 11 canonical primitives as follows. New work composes by selecting a primitive, binding a `dataRef`, and (optionally) attaching the new audit fields below — it does NOT introduce new primitive keys without amending the parent spec.
+
+| Conceptual block | Canonical primitive | Notes |
+| --- | --- | --- |
+| `work-queue`, `next-best-actions`, `open-decisions` | `decision-queue` | Three flavours of "what needs human sequencing" — distinguished by `dataRef` loader (e.g. `work-queue-by-role`, `priority-tasks`, governor `require-hitl`), not by a new primitive. |
+| `schedule` | `appointment-schedule` | Time-slotted view. Capacity view of the same dataset uses `capacity-lanes`; period view uses `service-period-board`. |
+| `coworker-briefing` | `handoff-queue` | Bound to the mandatory `coworker-handoffs` baseline slot — PAR acknowledge/reassign capabilities, 30s staleness. Briefing prose is the slot's vocabulary, not a separate primitive. |
+| `communication-exceptions` | `communication-exceptions` | 1-to-1. |
+| `inventory-supplier-risk` | `inventory-watch` | Supplier exposure is `inventory-watch` with a supplier-aware loader binding. |
+| `integration-health`, `service-health` | `health-board` | Source freshness, MSP/SaaS estate, and connector status are all `health-board` flavours, distinguished by loader (`managed-estate-health` vs `service-uptime` vs connector inventory). |
+| `customer-activity` | `case-board` (longer-running) or `decision-queue` (short-lived activity) | Pick by operating model — open `case-board` for relationship/case streams, `decision-queue` for daily activity needing action. |
+| `revenue-snapshot`, `kpi-strip` | `kpi-strip` (parent-spec extension request) | The parent's 11 primitives do NOT include a generic header-strip KPI primitive. If the implementer concludes one is genuinely warranted (likely yes for retail/SaaS), the addition is filed as a parent-spec amendment, not as a new substrate in this spec. Open in §"Open Questions". |
+| `wwwd-guidance` | Not a primitive — a *signal overlay* on top of any block | WWWD guidance is rendered by attaching `recallWikiContext` citations to a block's explanation, not as its own primitive. |
+| `setup-gaps` | Not a primitive — the `missing-data behavior` of every primitive | Per the parent primitive-registry spec §8: setup-gap is the slot's empty/setup state aggregated by the setup-activation summary, not a separate slot. |
+
+If a future archetype proves an operating model the existing 11 primitives genuinely cannot express (the parent spec's bar is "different sort, density, and action semantics"), the path is a primitive-registry-spec amendment + parent-spec table edit, then a new `WorkspaceHomePrimitiveKey` value — NOT a new "block" layer.
+
+### Audit fields layered onto the resolver
+
+The Configuration Layering Model (above) produces an audited resolution. To preserve the canonical resolver shape, the audit fields ride on `WorkspaceHomeResolution` (or a thin typed extension) rather than introducing a parallel `WorkspaceCompositionResolution`:
+
+```ts
+type WorkspaceCompositionAudit = {
+  sourceLayers: WorkspaceConfigurationLayer[];   // which layers contributed to the resolved composition
+  omittedBlocks: WorkspaceOmittedBlock[];        // slot definitions that were dropped, with reason
+  explanations: WorkspaceBlockExplanation[];     // per-slot "why this is here" with cited WikiPage / signal refs
+};
+
+type WorkspaceCompositionResolution = WorkspaceHomeResolution & { audit: WorkspaceCompositionAudit };
+```
+
+Implementation MAY put the audit on the existing resolution union; implementation MUST NOT replace `WorkspaceHomeResolution` with a parallel type. Slot priority / zone / explanation-policy fields are either added as optional members of `WorkspaceHomeSlotSpec` (preferred, parent-spec amendment) or ride on the audit (acceptable fallback). The implementation BI picks one after sweeping current `WorkspaceHomeSlotSpec` consumers.
+
+## Archetype-to-Block Mapping Strategy
+
+Archetype mapping is expressed as code-owned contribution manifests — exactly the existing `WorkspaceHomeContribution` shape from parent §5.5 — using semantic archetype slugs and category fallbacks. **Composition matches on `StorefrontArchetype.archetypeId` semantic slug only; the `StorefrontConfig.archetypeId` FK is the read path, never the match key** (parent §5.3, gated on BI-44C34478 normalization). Each contribution still satisfies the mandatory slot covenant (today/now, exceptions/needs-review, coworker-handoffs).
+
+```ts
+type ArchetypeWorkspaceProfile = {
+  archetypeIds: string[];
+  categories: string[];
+  primaryOperatingQuestion: string;
+  defaultZones: {
+    criticalStrip: string[];
+    primary: string[];
+    secondary: string[];
+    briefing: string[];
+  };
+  requiredCanonicalData: string[];
+  optionalCanonicalData: string[];
+};
+```
+
+Recommended category defaults:
+
+| Category | Front-and-center blocks | Secondary blocks |
+| --- | --- | --- |
+| Trades / field service | `schedule`, `work-queue`, `communication-exceptions`, `inventory-supplier-risk`, `coworker-briefing` | `revenue-snapshot`, `customer-activity`, `setup-gaps` |
+| MSP / IT services | `service-health`, `open-decisions`, `work-queue`, `integration-health`, `coworker-briefing` | `customer-activity`, `revenue-snapshot`, `setup-gaps` |
+| Retail / ecommerce | `revenue-snapshot`, `inventory-supplier-risk`, `customer-activity`, `next-best-actions` | `integration-health`, `setup-gaps`, `coworker-briefing` |
+| Hospitality / restaurant | `schedule`, `inventory-supplier-risk`, `communication-exceptions`, `next-best-actions` | `revenue-snapshot`, `setup-gaps`, `coworker-briefing` |
+| Professional services | `work-queue`, `open-decisions`, `schedule`, `revenue-snapshot` | `customer-activity`, `wwwd-guidance`, `setup-gaps` |
+| SaaS / software operator | `service-health`, `open-decisions`, `integration-health`, `customer-activity` | `revenue-snapshot`, `coworker-briefing`, `setup-gaps` |
+
+Exact archetypes may reorder or specialize labels, but they should not invent one-off primitives without first extending the shared registry.
+
+## WWWD and Coworker Integration Model
+
+WWWD participates in three explicit ways. **Today (2026-05-31) all three flow through `recallWikiContext` against org-overlay `WikiPage` rows; the `DecisionPerspectiveProfile` chain is a forward-looking input that activates only after BI-230C9EF7 lands a per-org profile resolver.**
+
+1. **Block explanation:** show why a block is present, based on the active archetype, org corpus material, and DPF seed. The explanation cites the `WikiPage`(s) `recallWikiContext` returned and (where applicable) the `loadWorkspaceHomeSignals` source. Example: "This is high priority because your operating stance — [stance: same-day response for emergency calls](wiki-page-ref) — emphasizes immediate dispatch."
+2. **Recommendation ranking:** next-best actions can include a rationale and confidence drawn from `recallWikiContext` results, especially when trade-offs exist. Once BI-230C9EF7 lands, `DecisionPerspective` outcomes (`recommend` / `arbitrate` / `escalate` / `defer`) become an additional input.
+3. **Gap detection:** if a block lacks required data, or `recallWikiContext` returns no published WikiPages for the archetype's expected stance keys, create or link an enrichment/setup gap instead of silently hiding the block. Once the perspective chain is wired, a `defer` outcome also routes to gap creation.
+
+**Ring scope.** All wiki recall calls from workspace blocks scope by `principleRingScope = worker` (BI-4AA1074B). Block-rendered principles must filter the same way — platform-engineering principles must not surface into the in-trench workspace.
+
+Coworkers participate through:
+
+- Static assigned coworker briefings where an archetype has known helper roles, such as dispatcher, bookkeeper, inventory assistant, customer-success coworker.
+- Dynamic recommendations that produce `CoworkerActionEnvelope` proposals for layout changes or operational actions.
+- "Ask why this matters" explanations that cite block data, corpus material, and decision interactions.
+- Gap detection when archetype-critical blocks have missing canonical data, stale integrations, or low-confidence guidance.
+
+Coworker recommendations are not automatic layout mutations in V1. They render as explainable proposals:
+
+```ts
+type WorkspaceRecommendation = {
+  id: string;
+  kind: "pin-block" | "unpin-block" | "change-threshold" | "setup-source" | "open-decision";
+  rationale: string;
+  citedMaterialIds: string[];
+  citedToolExecutionIds: string[];
+  confidence: "low" | "medium" | "high";
+  status: "proposed" | "accepted" | "dismissed" | "expired";
+};
+```
+
+## Configurability Rules
+
+### Configurable by DPF seed/archetype definition
+
+- Which block kinds are available for an archetype/category.
+- Required baseline blocks for that archetype.
+- Default priority zones and density.
+- Vocabulary tokens and empty-state copy keys.
+- Required canonical data and default missing-data behavior.
+- Which coworker roles are suggested for briefings.
+
+### Configurable by org owner/admin
+
+- Enable/disable optional blocks.
+- Reorder blocks within allowed zones.
+- Choose saved filters, target thresholds, and "business hours" windows.
+- Accept or dismiss coworker layout/setup recommendations.
+- Configure integrations that power blocks.
+
+### Configurable by coworker recommendation
+
+- Proposed priority changes based on recent signals.
+- Proposed setup tasks or corpus enrichment prompts.
+- Suggested block additions when an archetype-critical concern lacks visibility.
+- Suggested threshold changes with cited evidence.
+
+### Configurable by end user
+
+- Collapse/expand secondary blocks.
+- Saved filters and date windows.
+- Personal ordering within a zone when it does not hide required blocks.
+- Notification preferences for block alerts.
+
+### Not configurable in V1
+
+- Removing the critical strip or all baseline blocks.
+- Re-enabling blocks/actions hidden by role/capability.
+- Adding arbitrary custom React/HTML blocks.
+- Changing the active archetype outside the canonical storefront/business setup flow.
+- Bypassing WWWD review/audit for recommendations.
+- Local color/status maps or non-report-kit data-display components.
+
+## Degraded and Missing-Data Behavior
+
+Each block must choose one of four missing-data modes:
+
+| Mode | Use when | Worker output |
+| --- | --- | --- |
+| `positive-empty` | Empty is a good state, such as no failed updates | Compact "nothing needs attention" state. |
+| `setup-action` | The data source is required for the archetype | Clear setup prompt for admins; worker-safe explanation for non-admins. |
+| `degraded` | Partial data exists but is incomplete/stale | Render available facts and mark what is missing. |
+| `hide` | Optional block has no meaningful data | Omit and record explainable omission for admins. |
+
+Integrations and corpus gaps should fail open: the page still renders, but the relevant block shows stale/missing state. Failures must be observable in `ToolExecution`/integration status and in setup gaps where appropriate.
+
+## Data Model Impact
+
+Preferred V1 data model impact: none.
+
+Use code-owned registries plus existing tables:
+
+- `StorefrontConfig` and `StorefrontArchetype` for active archetype resolution. Match key is `StorefrontArchetype.archetypeId` semantic slug; `StorefrontConfig.archetypeId` is the FK read path.
+- `Organization` and `BusinessContext` for identity/context display only.
+- **WWWD/corpus today (canonical):** `WikiPage`, `WikiPageRevision`, `WikiPageSource`, `RawSource`, `WikiIngestEvent` — retrieved via `recallWikiContext`/`searchWikiPages` (`apps/web/lib/wiki/embeddings.ts`).
+- **WWWD/corpus forward-looking (gated on BI-230C9EF7):** `DecisionPerspectiveProfile`, `DecisionPerspectiveProfileVersion`, `PerspectiveMaterial`, `DecisionInteraction` — workspace must not assume these are wired until the per-org profile resolver lands.
+- **Signal source (canonical):** `loadWorkspaceHomeSignals(...)` (BI-3E8D2CF5) — unifies GearInterface raw stream + Calibrator + Governor outputs behind one translated `WorkspaceHomeSignal` type. Block components MUST NOT call `prisma.gearInterface` or `getSlipByReason` directly.
+- `Agent`, `AgentThread`, `AgentMessage`, `ToolExecution`, and `CoworkerActionEnvelope` for coworker participation and action audit.
+- Existing domain records for block data.
+
+Potential later addition, only after V1 proves the need:
+
+- `WorkspacePreference` for org/user-level saved overrides if existing preference/config stores cannot carry it. File as a separate schema BI.
+- Parent primitive-registry amendment to add a `kpi-strip` primitive key if retail/SaaS implementation proves the existing 11 cannot express it.
+
+Do not add a generic `Dashboard`, `Widget`, or `PageBuilder` table for V1.
+
+## UI/UX Behavior
+
+- The first screen is the operational workspace, not a hero or marketing page.
+- Blocks render in stable zones with predictable density. Large charts belong below the primary operating row unless the archetype's daily job truly depends on the chart.
+- Critical strip items are terse and actionable.
+- Coworker briefing is a dock/rail or compact section, not a chat transcript takeover.
+- Every block has ready, empty, missing-source, stale, loading, and permission-hidden states — per the canonical primitive's state contract in the parent registry spec §6.
+- Reporting/data blocks use report-kit primitives.
+- Status badges use `StatusBadge` and `statusColors`, never local color maps.
+- Tables use `DataTable`; filters use `FilterBar`; exports use `ExportButton`; charts use `Chart` by subpath when needed.
+- `<option>` elements and custom controls must use DPF tokens.
+- Mobile order follows block priority: critical strip, current/next work, handoffs, then secondary metrics.
+- **Banned-copy lint applies** (parent primitive-registry spec §7). Worker-facing strings — titles, labels, action labels, empty-state copy, tooltips — must pass the lint over the token list (`gear`, `ring`, `torque`, `slip`, `wear`, `triple`, `shaft`, `calibration`, `contribution model`, `cockpit`, `reduction-gear`, `GearInterface`, architecture-loop language). Every new component ships at least one fixture exercising rendered slot output against the lint.
+- **Times use shared `LocalTime`** (viewer browser TZ), never raw UTC in worker-facing copy.
+
+## Permission and Configuration Rules
+
+- Workspace route remains authenticated.
+- Block visibility is resolved from organization archetype, role/capability, and block definition.
+- Actions inside blocks require the same platform permissions/tool grants as their destination flows.
+- Admin-only setup and configuration affordances must not render for ordinary workers.
+- Coworker layout recommendations must be proposed through auditable action/recommendation records, not silent mutations.
+- If a user lacks permission for a required block, the resolution records `permission-hidden` and, where appropriate, shows an admin-facing configuration warning elsewhere.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Duplicate substrate with prior vertical workspace-home work | Extend `apps/web/lib/workspace-home` and existing specs; do not create a parallel dashboard registry. |
+| Dashboard builder sprawl | V1 allows bounded seed/admin/user layers only; no arbitrary custom components. |
+| Hidden AI layout decisions | Coworker/WWWD changes are recommendations with citations, confidence, and audit. |
+| Blank widgets when data is missing | Every block declares missing-data behavior and setup prompts. |
+| Role leakage | Block resolution includes capability checks and explainable omissions. |
+| Hardcoded colors/status maps | Use report-kit and token-backed styling only. |
+| Archetype mismatch via FK vs semantic slug | Match contribution manifests on `StorefrontArchetype.archetypeId` semantic slug only. |
+| Page becomes card-heavy and slow | Limit primary blocks, prioritize queues/actions, lazy-load secondary charts. |
+
+## Open Questions
+
+1. Which existing preference/config store should carry org/user workspace overrides, or is a small `WorkspacePreference` table justified after V1?
+2. Should accepted coworker layout recommendations be persisted as org overrides immediately, or as reviewed recommendations applied at render time?
+3. What is the first exact archetype after MSP and HVAC: retail, restaurant/hospitality, professional-services, or SaaS operator?
+4. Which role/capability grants should own workspace configuration separate from storefront setup?
+5. How much of the existing `PlatformWorkspaceHome` should remain visible to admins when an archetype workspace is active?
+
+## Acceptance Criteria
+
+- `/workspace` resolves the active archetype from `StorefrontConfig -> StorefrontArchetype`, matching on `StorefrontArchetype.archetypeId` semantic slug, then `category`.
+- V1 reuses the existing `WorkspaceHomeContribution` + `WorkspaceHomePrimitiveSpec` substrate. No new `WorkspaceBlock*` registry, no new dashboard/page-builder substrate, no new `Dashboard`/`Widget` tables.
+- Every contribution satisfies the parent-mandated slot covenant (today/now, exceptions/needs-review, coworker-handoffs).
+- At least one exact/category archetype composition renders a prioritized slot set with critical strip, primary slots, coworker-handoffs briefing, and setup-gap surfacing.
+- Missing data renders the primitive's declared empty/setup-action/degraded state per the canonical contract.
+- WWWD/coworker explanations cite `WikiPage` ids retrieved by `recallWikiContext` (ring-scope `worker`) and, where applicable, `WorkspaceHomeSignal.source` from `loadWorkspaceHomeSignals`. Once BI-230C9EF7 lands, profile-chain outcomes are an additional input.
+- Admin/org/user configurability is bounded by the layer model. Coworker recommendations are proposed via `CoworkerActionEnvelope` and never mutate layout without acknowledgement (PAR).
+- All reporting/data-display UI uses report-kit primitives and DPF tokens. Banned-copy lint passes.
+- Unit tests cover resolver layering, slot covenant enforcement, missing-data states, ring-scope filtering on wiki recall, banned-copy assertion, and role/capability filtering.
+- UX verification exercises `/workspace` for configured and unconfigured archetype states on the Live portal at `http://localhost:3000/workspace`, desktop AND mobile viewports, with the structured dynamic-analysis report shape (drove X → observed Y → signed off Z).
+- Production build passes before implementation work is considered complete.


### PR DESCRIPTION
## Summary

- Architect-revised the archetype-aware Workspace spec so it extends the canonical 2026-05-24 vertical-workspace-home + primitive-registry substrate rather than introducing a parallel `WorkspaceBlock*` registry.
- Corrected the WWWD substrate reference: `recallWikiContext` against org-overlay `WikiPage` rows is canonical today; the `DecisionPerspectiveProfile` chain is forward-looking, gated on BI-230C9EF7.
- Reoriented the implementation plan around existing BIs: BI-1CCC6264, BI-5B8FE5C1, BI-3E8D2CF5, BI-CE6AF925, BI-FE002675, and related corpus/coworker work.
- Resolved review questions: no durable preference store in V1, coworker recommendations flow through PAR, retail/ecommerce is the next proving archetype after HVAC/MSP, and V1 authority uses `manage_business_models` + `manage_platform`.

## Architect verdict

Folded the alignment corrections into the spec's Architect Verdict section:

1. No second substrate; conceptual blocks are configured `WorkspaceHomeSlotSpec` instances of canonical primitives.
2. WWWD lever clarified; `recallWikiContext` is canonical until BI-230C9EF7 lands.
3. Slot covenant remains mandatory; zones are presentation above the covenant.
4. Signal source is `loadWorkspaceHomeSignals` (BI-3E8D2CF5); no direct diagnostic substrate reads from slot components.
5. Ring-scope discipline: wiki recall scopes by `principleRingScope = worker`.
6. Banned-copy lint applies per parent primitive-registry spec.
7. Resolver returns canonical `WorkspaceHomeResolution` plus an audit rider, not a parallel resolver union.
8. Composition matches on `StorefrontArchetype.archetypeId` semantic slug; FK is never the match key.
9. Plan file boundary aligns to parent `contributions/`, `primitives/`, and `signals/` directories.

## Backlog routing

No duplicate BIs were filed. The plan routes implementation to existing backlog items and names narrow future-BI conditions only where substrate evidence is still needed, such as a possible `WorkspacePreference` schema BI or `kpi-strip` primitive amendment.

## Test plan

- [x] `git diff --check` for the two touched docs.
- [x] DCO trailers present on both branch commits.
- [x] Local pre-commit gitleaks scan passed for the new commit.
- [ ] CI checks pass on PR.
- [ ] Reviewer confirms the spec/plan do not introduce `WorkspaceBlock*` types, a parallel resolver union, or dashboard/page-builder substrate.

Refs: BI-1CCC6264, BI-5B8FE5C1, BI-3E8D2CF5, BI-CE6AF925, BI-FE002675, BI-230C9EF7, BI-4AA1074B, BI-44C34478.