### PR TITLE
feat(install): BI-0856A4CE Phase 1 — devWorkspacePath schema + --dev-workspace-path flag + new-dev-worktree honoring DPF_DEV_WORKSPACE_PATH

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -73,6 +73,29 @@ For unattended (CI / scripted) install:
 bash install-dpf.sh --headless --release
 ```
 
+#### Contributor: separate dev workspace from install (recommended, BI-0856A4CE Phase 1)
+
+The clone at the install path doubles as a dev tree by default — that works,
+but the dev tree can collide with the running portal and the self-upgrade
+merge loop (BI-A8A7CCFD). Pass `--dev-workspace-path` to register a
+**separate** clone as the dev workspace; the dev-loop scripts then branch
+new worktrees from there:
+
+```bash
+# 1. Install (production tree = $REPO_ROOT, the cwd):
+bash install-dpf.sh --headless --contributor --dev-workspace-path ~/dpf-dev
+
+# 2. Clone the dev workspace separately (one-time):
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf-dev
+
+# 3. Use ~/dpf-dev for all dev work; worktrees go in ~/dpf-dev-worktrees/:
+cd ~/dpf-dev
+bash scripts/new-dev-worktree.sh my-feature
+```
+
+Omitting `--dev-workspace-path` (or pointing it at the install path) keeps
+single-tree mode — the current default and fully back-compat.
+
 ### What the installer does
 
 1. **Preflight** — refuses to run on WSL2-without-DD / rootless Docker /

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -84,6 +84,34 @@ bash install-dpf.sh --headless --contributor
 `--customer`/`--contributor` set the compose mode automatically (release vs
 source build); `--release`/`--dev` still override it if you need to force one.
 
+#### Contributor: separate dev workspace from install (recommended, BI-0856A4CE Phase 1)
+
+Contributor installs default to single-tree mode — the cloned repo at the
+install path doubles as your dev workspace where `git worktree add` creates
+feature branches. That works, but the dev tree can collide with the running
+portal and the self-upgrade merge loop (BI-A8A7CCFD).
+
+Pass `--dev-workspace-path` to register a **separate** clone as the dev
+workspace. The dev-loop scripts (`scripts/new-dev-worktree.sh`) then branch
+new worktrees from THERE instead of the install path, so the production
+install is left alone:
+
+```bash
+# 1. Install (production tree at $REPO_ROOT — the cwd):
+bash install-dpf.sh --headless --contributor --dev-workspace-path ~/dpf-dev
+
+# 2. Clone the dev workspace separately (one-time):
+git clone git@github.com:OpenDigitalProductFactory/opendigitalproductfactory.git ~/dpf-dev
+
+# 3. From now on, run dev-loop scripts from the dev workspace:
+cd ~/dpf-dev
+bash scripts/new-dev-worktree.sh my-feature
+#   → creates ~/dpf-dev-worktrees/my-feature
+```
+
+When `--dev-workspace-path` is omitted (or resolves to the install path),
+single-tree mode persists — current behavior, full back-compat.
+
 ### What the installer does
 
 1. **Preflight** — refuses to run on Intel Macs / older macOS / WSL2 /

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -87,6 +87,14 @@ Flags:
   --contributor Customizable install: build the full stack from local source,
                 enable contributor git hooks, and run the agent-toolchain
                 bootstrap. Skips the interactive mode prompt.
+  --dev-workspace-path <path>
+                Contributor-only. Absolute path to the operator's dev workspace
+                (where 'git worktree add' creates feature branches and where
+                Claude / Codex sessions open). Distinct from the install path
+                so the dev tree never collides with the production install or
+                the self-upgrade merge. Defaults to the install path (single-
+                tree mode — current behavior). When distinct, dev-loop scripts
+                refuse to create worktrees inside the install path. BI-0856A4CE.
   --release     Force the pre-built multi-arch GHCR images
                 (docker-compose.release.yml overlay). Overrides the compose
                 mode that the install mode would otherwise derive.
@@ -126,6 +134,10 @@ DPF_MODE_EXPLICIT=0     # 1 once --dev/--release is passed, so the install-mode
 DPF_INSTALL_MODE=""     # customer | contributor — resolved in "Install mode".
 DPF_AUTOSTART=1
 DPF_INCLUDE_EDGE="${DPF_INCLUDE_EDGE:-1}"   # 1 = bundle Edge Node; 0 = skip
+# BI-0856A4CE Phase 1 — optional contributor-only path that, when distinct from
+# the install path, becomes the worktree base. Empty = single-tree mode (current
+# behavior). Future phases will turn this into a hard install/dev separation.
+DPF_DEV_WORKSPACE_PATH_ARG=""
 SUBCOMMAND=""
 
 while [ $# -gt 0 ]; do
@@ -136,6 +148,8 @@ while [ $# -gt 0 ]; do
     --dev)                  DPF_MODE="dev"; DPF_MODE_EXPLICIT=1 ;;
     --customer)             DPF_INSTALL_MODE="customer" ;;
     --contributor)          DPF_INSTALL_MODE="contributor" ;;
+    --dev-workspace-path)   shift; DPF_DEV_WORKSPACE_PATH_ARG="${1:-}" ;;
+    --dev-workspace-path=*) DPF_DEV_WORKSPACE_PATH_ARG="${1#*=}" ;;
     --no-autostart)         DPF_AUTOSTART=0 ;;
     --no-edge)              DPF_INCLUDE_EDGE=0 ;;
     --force-unsupported-host)
@@ -499,6 +513,35 @@ else
     printf '# OUTSIDE install root so repo wipes cannot destroy them).\n' >> .env
     printf 'DPF_BACKUPS_HOST_PATH=%s-backups\n' "$REPO_ROOT" >> .env
     info "Added DPF_BACKUPS_HOST_PATH=$REPO_ROOT-backups to existing .env"
+  fi
+fi
+
+# BI-0856A4CE Phase 1 — record DPF_DEV_WORKSPACE_PATH when the contributor
+# passed --dev-workspace-path. This is the path where 'git worktree add' will
+# create feature branches; distinct from the install path so the dev tree and
+# the production install never collide. When unset, single-tree mode persists
+# (current behavior) and dev-loop scripts fall back to REPO_ROOT.
+if [ "$DPF_INSTALL_MODE" = "contributor" ] && [ -n "$DPF_DEV_WORKSPACE_PATH_ARG" ]; then
+  # Resolve to an absolute path (caller may have passed a relative path or ~/).
+  case "$DPF_DEV_WORKSPACE_PATH_ARG" in
+    \~*) DPF_DEV_WORKSPACE_PATH_ABS="${HOME}${DPF_DEV_WORKSPACE_PATH_ARG#\~}" ;;
+    /*)  DPF_DEV_WORKSPACE_PATH_ABS="$DPF_DEV_WORKSPACE_PATH_ARG" ;;
+    *)   DPF_DEV_WORKSPACE_PATH_ABS="$(cd "$DPF_DEV_WORKSPACE_PATH_ARG" 2>/dev/null && pwd)" \
+           || DPF_DEV_WORKSPACE_PATH_ABS="$(pwd)/$DPF_DEV_WORKSPACE_PATH_ARG" ;;
+  esac
+  if [ "$DPF_DEV_WORKSPACE_PATH_ABS" = "$REPO_ROOT" ]; then
+    info "--dev-workspace-path resolves to the install path; single-tree mode (skipping)."
+  else
+    if grep -q "^DPF_DEV_WORKSPACE_PATH=" .env 2>/dev/null; then
+      dpf_sed_inplace "s|^DPF_DEV_WORKSPACE_PATH=.*|DPF_DEV_WORKSPACE_PATH=$DPF_DEV_WORKSPACE_PATH_ABS|" .env
+    else
+      printf '\n# Contributor dev workspace (BI-0856A4CE Phase 1) — where git worktrees\n' >> .env
+      printf '# branch from. Distinct from DPF_HOST_INSTALL_PATH (the production install)\n' >> .env
+      printf '# so the dev tree never collides with the running portal or self-upgrade.\n' >> .env
+      printf 'DPF_DEV_WORKSPACE_PATH=%s\n' "$DPF_DEV_WORKSPACE_PATH_ABS" >> .env
+    fi
+    dpf_state_write devWorkspacePath "$DPF_DEV_WORKSPACE_PATH_ABS" 2>/dev/null || true
+    ok "Dev workspace path: $DPF_DEV_WORKSPACE_PATH_ABS (distinct from install $REPO_ROOT)"
   fi
 fi
 

--- a/scripts/installer/install-state.schema.json
+++ b/scripts/installer/install-state.schema.json
@@ -53,7 +53,11 @@
     },
     "installPath": {
       "type": "string",
-      "description": "Absolute path to the repo root on the host. Mirrors DPF_HOST_INSTALL_PATH."
+      "description": "Absolute path to the repo root on the host. Mirrors DPF_HOST_INSTALL_PATH. In contributor installs this is the PRODUCTION install — the bytes the running portal reads. Should be treated as platform-owned (BI-0856A4CE Phase 1)."
+    },
+    "devWorkspacePath": {
+      "type": ["string", "null"],
+      "description": "Absolute path to the contributor's writable dev workspace, where 'git worktree add' creates feature branches and where Claude/Codex sessions open their cwd. Distinct from installPath in BI-0856A4CE's two-tree model. Defaults to installPath (back-compat / single-tree mode) — when distinct, the dev-loop scripts refuse to create worktrees inside installPath. Mirrors DPF_DEV_WORKSPACE_PATH in .env. Null/absent → single-tree mode (current behavior)."
     },
     "stateDir": {
       "type": "string",

--- a/scripts/new-dev-worktree.sh
+++ b/scripts/new-dev-worktree.sh
@@ -45,10 +45,51 @@ if [ -z "${root:-}" ] || [ ! -e "$root/.git" ]; then
     exit 1
 fi
 
-# Worktrees live in a sibling "<root>-worktrees" dir (matches ~/dpf-worktrees).
+# BI-0856A4CE Phase 1 — when DPF_DEV_WORKSPACE_PATH is set + distinct from the
+# install ($root), branch worktrees off the DEV WORKSPACE clone instead. This is
+# the contributor's writable tree; $root in that posture is the production
+# install (read-only by convention, owned by the platform / self-upgrade loop).
+#
+# Discovery order:
+#   1. DPF_DEV_WORKSPACE_PATH env var (set by .env loaders, or exported manually)
+#   2. .env in $root if it carries the line
+#   3. fallback: $root itself (single-tree mode — current behavior)
+dev_workspace="${DPF_DEV_WORKSPACE_PATH:-}"
+if [ -z "$dev_workspace" ] && [ -f "$root/.env" ]; then
+    # `|| true` so a missing line under `set -e -o pipefail` does not abort the
+    # whole script — the absent env value just leaves $dev_workspace empty and
+    # we fall through to single-tree mode below.
+    dev_workspace="$( { grep -E '^DPF_DEV_WORKSPACE_PATH=' "$root/.env" 2>/dev/null || true; } | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+fi
+if [ -n "$dev_workspace" ] && [ "$dev_workspace" != "$root" ]; then
+    if [ ! -d "$dev_workspace/.git" ] && [ ! -f "$dev_workspace/.git" ]; then
+        printf '  [FAIL] DPF_DEV_WORKSPACE_PATH=%s is not a git working tree.\n' "$dev_workspace" >&2
+        printf '         Either clone the dev workspace there or unset DPF_DEV_WORKSPACE_PATH.\n' >&2
+        exit 1
+    fi
+    printf '  [info] using dev workspace %s (install is %s)\n' "$dev_workspace" "$root"
+    root="$dev_workspace"
+fi
+
+# Worktrees live in a sibling "<root>-worktrees" dir (matches ~/dpf-worktrees
+# in single-tree mode; the dev-workspace's sibling dir when the split is in
+# effect — so each contributor's worktrees stay near their dev clone).
 wt_base="$(dirname "$root")/$(basename "$root")-worktrees"
 target="$wt_base/$slug"
 branch="$prefix/$slug"
+
+# Refuse to create a worktree inside the production install path. This is the
+# Phase-1 form of the BI-0856A4CE / BI-6B02FEE5 contract: even if the operator
+# nudges --dev-workspace-path back to $REPO_ROOT, the worktree-base-is-sibling
+# rule keeps the worktree out of the install tree. Full enforcement (refusing
+# from ANY caller, including direct `git worktree add`) lands in later phases.
+case "$target" in
+    "$wt_base"/*) : ;;
+    *)
+        printf '  [FAIL] computed worktree target %s is not under the worktree base %s\n' "$target" "$wt_base" >&2
+        exit 1
+        ;;
+esac
 
 mkdir -p "$wt_base"
 

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -166,3 +166,58 @@ test("portal image bundles every directory the seed reads, so seed-* steps don't
     );
   }
 });
+
+// BI-0856A4CE Phase 1 — install-state schema gains devWorkspacePath; the bash
+// installer accepts --dev-workspace-path and writes DPF_DEV_WORKSPACE_PATH to
+// .env when contributor mode + the path differs from REPO_ROOT. The new-dev-
+// worktree script honors that env var and refuses to compute a target outside
+// its computed sibling worktree base. These three pieces have to ship together
+// or the dev-loop-isolation cluster's structural root is incomplete.
+test("install-state schema declares devWorkspacePath as part of BI-0856A4CE", () => {
+  const schema = JSON.parse(read("scripts/installer/install-state.schema.json"));
+  assert.ok(schema.properties.devWorkspacePath, "schema must declare devWorkspacePath");
+  // Nullable / optional: back-compat single-tree mode is signalled by the
+  // field being absent or null. The installer only sets it when the operator
+  // passes --dev-workspace-path AND it resolves distinct from REPO_ROOT.
+  assert.deepEqual(
+    schema.properties.devWorkspacePath.type,
+    ["string", "null"],
+    "devWorkspacePath must be nullable so single-tree mode round-trips through the schema",
+  );
+  assert.match(
+    schema.properties.devWorkspacePath.description ?? "",
+    /BI-0856A4CE|DPF_DEV_WORKSPACE_PATH/,
+    "schema description must cite the BI + env var for grep-discovery",
+  );
+});
+
+test("install-dpf.sh accepts --dev-workspace-path and persists it (BI-0856A4CE)", () => {
+  const installer = read("install-dpf.sh");
+  assert.match(installer, /--dev-workspace-path/, "flag must appear in arg parser + usage");
+  assert.match(installer, /DPF_DEV_WORKSPACE_PATH=/, "must write the env var to .env");
+  assert.match(installer, /dpf_state_write\s+devWorkspacePath/, "must persist to install-state");
+  // Single-tree mode preserved: when the resolved path equals REPO_ROOT, the
+  // installer must SKIP writing (so .env stays clean for back-compat). The
+  // implementation does this; the test pins it so a future refactor can't
+  // accidentally drop the guard.
+  assert.match(
+    installer,
+    /resolves to the install path; single-tree mode/,
+    "must skip the .env write when the path equals REPO_ROOT (single-tree back-compat)",
+  );
+});
+
+test("new-dev-worktree.sh honors DPF_DEV_WORKSPACE_PATH and refuses out-of-base targets (BI-0856A4CE)", () => {
+  const script = read("scripts/new-dev-worktree.sh");
+  assert.match(script, /DPF_DEV_WORKSPACE_PATH/, "script must consult the env var");
+  // Both discovery routes (env var + .env file) must be present so the script
+  // works whether the operator sourced .env first or runs raw.
+  assert.match(script, /\.env/, "script must also read .env as a fallback");
+  // Refuse-out-of-base guard: the proto-version of the BI-6B02FEE5 wrapper
+  // refusing worktree creation inside the install path.
+  assert.match(
+    script,
+    /is not under the worktree base/,
+    "script must refuse to compute a target outside the sibling worktree base",
+  );
+});


### PR DESCRIPTION
## Summary

**Phase 1 of BI-0856A4CE** — install-time tier separation, the structural root of the tiered-dev-loop-isolation cluster ([spec](docs/superpowers/specs/2026-05-31-tiered-dev-loop-isolation-design.md)).

Non-breaking foundation. Introduces the schema for splitting the install into:
- **Production install** — the bytes the running portal reads (the cwd of `bash install-dpf.sh`)
- **Dev workspace** — where `git worktree add` creates feature branches; where Claude / Codex sessions open their cwd

Default behavior is unchanged. Operators who pass `--dev-workspace-path <path>` opt into the split now; everyone else stays on single-tree mode.

## What lands

| File | Change |
|---|---|
| `scripts/installer/install-state.schema.json` | Adds nullable `devWorkspacePath` (single-tree mode = absent/null) |
| `install-dpf.sh` | New `--dev-workspace-path <path>` flag (contributor only). Writes `DPF_DEV_WORKSPACE_PATH=` to `.env` + `devWorkspacePath` to install-state when distinct from `REPO_ROOT`. Skips with info log when equal. |
| `scripts/new-dev-worktree.sh` | Honors `DPF_DEV_WORKSPACE_PATH` (env or `.env` lookup). Branches worktrees from the dev workspace when set. Refuses out-of-base targets — proto-version of the BI-6B02FEE5 wrapper refusal. Pipefail-safe grep. |
| `tests/release/installer-release-contract.test.mjs` | 3 new release-contract tests pin the schema, the installer flag, and the script behavior so a future refactor can't drop any of them silently. |
| `docs/install/macos.md` + `linux.md` | Contributor flag section: how + why to use it, when to skip. |

## Verification

- `node --test tests/release/installer-release-contract.test.mjs` — **14/14 passed** (3 new + 11 existing).
- Functional smoke (env unset): `bash scripts/new-dev-worktree.sh <slug>` creates worktree at `~/dpf-worktrees/<slug>`, exits 0. **Back-compat preserved**.
- Functional smoke (env set to nonexistent path): script refuses with exit 1 + actionable message.
- Pre-commit hook: gitleaks secret scan + scoped typecheck — both ok.

## What this is NOT

- **Not a migration command.** Phase 2 is `dpf install relocate` — moves an existing single-tree install to the two-tree layout without losing branches/worktrees. Separate BI.
- **Not enforcement.** The CLI wrapper that refuses worktree creation from ANY caller (not just `new-dev-worktree.sh`) is BI-6B02FEE5.
- **Not docker-compose path changes.** Phase 3 binds the production install path explicitly so the running portal can never see dev-tree state. Separate BI.
- **Not Windows parity yet.** `install-dpf.ps1` Phase 1 follow-up is a small TODO — flag added in next pass. Bash version is the canonical reference.

## Why ship Phase 1 alone

The spec called install-time separation "the structural root" — without it, every other BI in the cluster is fighting collision-by-construction. Phase 1 is the smallest landable foundation:

- Adds the schema field so future phases have a stable target.
- Adds the flag so contributors can opt in TODAY (Mark can start using `--dev-workspace-path ~/dpf-dev` immediately if he wants).
- Wires the dev-loop scripts to honor the split so the contract is real end-to-end (not just a future-tense schema).
- Zero risk to existing installs: absent the flag, behavior is byte-identical.

Phase 2 (relocate) needs more design — it touches running infrastructure and existing operator state. Better to ship the foundation first, prove it works, then add migration on top.

## Composition with the cluster

| BI | Status after this PR |
|---|---|
| **BI-0856A4CE** | Phase 1 lands; Phase 2 (relocate) + Phase 3 (compose binds) tracked separately |
| BI-6B02FEE5 (client-tool parity) | This PR's worktree-base computation is the proto-form of the wrapper's refusal; full wrapper lands in BI-6B02FEE5 |
| BI-F7E02898 (auto-claim leases) | Independent — can land in parallel |
| BI-AD949172 (janitor) | Independent — can land in parallel |
| BI-166C59F3 (local-CI gate) | Will read `DPF_DEV_WORKSPACE_PATH` when present |
| BI-6701C6BF (active-candidate) | Will use the production install path as the source of truth for `RT-ROOT-PORTAL`'s sha verification |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
