### PR TITLE
fix: stream full voice responses

### DIFF
--- a/apps/web/app/api/voice/synthesize/stream/route.test.ts
+++ b/apps/web/app/api/voice/synthesize/stream/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(async () => ({ user: { id: "user-1" } })),
+}))
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    voiceProfile: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}))
+
+vi.mock("@/lib/voice-synthesis/adapters/mlx", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/voice-synthesis/adapters/mlx")>()
+  return {
+    ...actual,
+    resolveReferenceHostPath: vi.fn(() => "/host/uploads/voices/profile-1/reference.wav"),
+  }
+})
+
+import { prisma } from "@dpf/db"
+import { DEFAULT_REF_TEXT } from "@/lib/voice-synthesis/adapters/mlx"
+import { POST } from "./route"
+
+const voiceProfile = {
+  provider: "chatterbox",
+  providerVoiceId: "voices/profile-1/reference.wav",
+  status: "ready",
+  language: "en",
+  voiceSettings: {
+    speed: 1.12,
+    exaggeration: 0.5,
+    cfgWeight: 0.3,
+    temperature: 0.8,
+  },
+}
+
+describe("POST /api/voice/synthesize/stream", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.mocked(prisma.voiceProfile.findUnique).mockResolvedValue(voiceProfile as never)
+    vi.mocked(prisma.voiceProfile.findFirst).mockResolvedValue(voiceProfile as never)
+    vi.stubEnv("TTS_PROVIDER", "mlx")
+    global.fetch = vi.fn(async () => new Response(new Uint8Array([0, 0, 0, 0]), {
+      status: 200,
+      headers: { "X-Sentence-Count": "1" },
+    })) as typeof fetch
+  })
+
+  it("defaults the streaming sidecar to the Chatterbox port and includes ref_text", async () => {
+    const req = new Request("http://dpf.local/api/voice/synthesize/stream", {
+      method: "POST",
+      body: JSON.stringify({
+        text: "Hello there.",
+        voiceProfileId: "profile-1",
+      }),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://host.docker.internal:8771/v1/audio/speech/stream",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(String),
+      }),
+    )
+    const body = JSON.parse(vi.mocked(global.fetch).mock.calls[0][1]?.body as string)
+    expect(body).toMatchObject({
+      input: "Hello there.",
+      response_format: "wav",
+      speed: 1.12,
+      ref_audio: "/host/uploads/voices/profile-1/reference.wav",
+      ref_text: DEFAULT_REF_TEXT,
+      exaggeration: 0.5,
+      cfg_weight: 0.3,
+      temperature: 0.8,
+    })
+  })
+})

--- a/apps/web/app/api/voice/synthesize/stream/route.ts
+++ b/apps/web/app/api/voice/synthesize/stream/route.ts
@@ -8,10 +8,8 @@
 
 import { auth } from "@/lib/auth"
 import { prisma } from "@dpf/db"
-import { resolveVoiceStorageRoot } from "@/lib/voice-synthesis/storage-root"
 import { defaultProvider } from "@/lib/voice-synthesis/voice-service"
-import { resolveReferenceHostPath } from "@/lib/voice-synthesis/adapters/mlx"
-import * as path from "node:path"
+import { DEFAULT_REF_TEXT, resolveReferenceHostPath } from "@/lib/voice-synthesis/adapters/mlx"
 
 interface StreamBody {
   text: string
@@ -25,7 +23,7 @@ interface StreamBody {
 }
 
 function getTtsStreamUrl(): string {
-  const base = process.env.DPF_TTS_URL ?? "http://host.docker.internal:8770"
+  const base = process.env.DPF_TTS_URL ?? "http://host.docker.internal:8771"
   return `${base}/v1/audio/speech/stream`
 }
 
@@ -110,6 +108,7 @@ export async function POST(req: Request): Promise<Response> {
     const refPath = resolveReferenceHostPath(voiceProfile.providerVoiceId)
     if (refPath) {
       sidecarBody.ref_audio = refPath
+      sidecarBody.ref_text = DEFAULT_REF_TEXT
       if (settings?.exaggeration !== undefined) sidecarBody.exaggeration = settings.exaggeration
       if (settings?.cfgWeight !== undefined) sidecarBody.cfg_weight = settings.cfgWeight
       sidecarBody.temperature = settings?.temperature ?? 0.6

--- a/apps/web/lib/voice-synthesis/adapters/mlx.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.ts
@@ -44,7 +44,7 @@ function getFallbackVoice(): string {
 // the reference clip at registration, so until it does we send a neutral
 // non-empty placeholder. Cloning still keys off ref_audio; an accurate
 // transcript only improves prosody alignment.
-const DEFAULT_REF_TEXT =
+export const DEFAULT_REF_TEXT =
   "This is a reference recording of my voice for the platform."
 
 export interface MlxSynthesisConfig extends VoiceSynthesisConfig {

--- a/scripts/tts/chatterbox_server.py
+++ b/scripts/tts/chatterbox_server.py
@@ -10,17 +10,17 @@
 #     Time-to-first-audio approx 1-2s regardless of total text length.
 #
 # Spec: docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md
-import io, os, re, shutil, struct, subprocess, tempfile, time, wave
+import io, os, shutil, struct, subprocess, tempfile, time, wave
 from typing import AsyncGenerator
 import numpy as np, torch
 import torchaudio as ta  # noqa: F401
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from chatterbox.tts import ChatterboxTTS
+from chatterbox_text import split_speech_chunks
 
 DEVICE = os.environ.get("DPF_CB_DEVICE") or ("mps" if torch.backends.mps.is_available() else "cpu")
 FFMPEG = shutil.which("ffmpeg") or "/opt/homebrew/bin/ffmpeg"
-MIN_SENTENCE_CHARS = 12
 
 
 def _envf(key, default):
@@ -96,19 +96,6 @@ def _to_wav(wav_tensor, speed):
     return data
 
 
-def _split_sentences(text):
-    raw = re.split(r"(?<=[.!?])\s+", text.strip())
-    merged, carry = [], ""
-    for s in raw:
-        carry = (carry + " " + s).strip() if carry else s
-        if len(carry) >= MIN_SENTENCE_CHARS:
-            merged.append(carry); carry = ""
-    if carry:
-        if merged: merged[-1] = merged[-1] + " " + carry
-        else: merged.append(carry)
-    return merged or [text]
-
-
 def _params(body):
     ex  = _clamp(float(body.get("exaggeration", _envf("DPF_CB_EXAGGERATION", 0.5))), 0.25, 1.0)
     cfg = _clamp(float(body.get("cfg_weight",   _envf("DPF_CB_CFG_WEIGHT",   0.5))), 0.2,  1.0)
@@ -164,7 +151,7 @@ async def speech_stream(req: Request):
     try: decoded_ref, cleanup = _resolve_ref(body)
     except ValueError: return JSONResponse({"error": "invalid reference audio"}, status_code=400)
     ex, cfg, tmp, spd = _params(body)
-    sentences = _split_sentences(text)
+    sentences = split_speech_chunks(text)
     kw_base = _make_kw(decoded_ref, ex, cfg, tmp)
     print(f"[chatterbox/stream] {len(sentences)} sentences ex={ex} cfg={cfg} spd={spd}", flush=True)
 

--- a/scripts/tts/chatterbox_text.py
+++ b/scripts/tts/chatterbox_text.py
@@ -1,0 +1,74 @@
+import re
+
+MIN_SENTENCE_CHARS = 12
+MAX_SENTENCE_CHARS = 220
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+_SOFT_BOUNDARY = re.compile(r"(?<=[,;:])\s+")
+_BULLET_PREFIX = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+")
+
+
+def _split_long_segment(segment):
+    if len(segment) <= MAX_SENTENCE_CHARS:
+        return [segment]
+
+    chunks, carry = [], ""
+    for part in _SOFT_BOUNDARY.split(segment):
+        part = part.strip()
+        if not part:
+            continue
+        candidate = f"{carry} {part}".strip() if carry else part
+        if len(candidate) <= MAX_SENTENCE_CHARS:
+            carry = candidate
+            continue
+        if carry:
+            chunks.append(carry)
+        while len(part) > MAX_SENTENCE_CHARS:
+            split_at = part.rfind(" ", 0, MAX_SENTENCE_CHARS + 1)
+            if split_at < MIN_SENTENCE_CHARS:
+                split_at = MAX_SENTENCE_CHARS
+            chunks.append(part[:split_at].strip())
+            part = part[split_at:].strip()
+        carry = part
+    if carry:
+        chunks.append(carry)
+    return chunks
+
+
+def split_speech_chunks(text):
+    """Split prose, headings, and newline lists into bounded TTS chunks."""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not normalized:
+        return []
+
+    segments = []
+    for line in normalized.split("\n"):
+        line = _BULLET_PREFIX.sub("", line).strip()
+        if not line:
+            continue
+        for part in _SENTENCE_BOUNDARY.split(line):
+            part = part.strip()
+            if part:
+                segments.extend(_split_long_segment(part))
+
+    merged, carry = [], ""
+    for segment in segments:
+        candidate = f"{carry} {segment}".strip() if carry else segment
+        if len(candidate) < MIN_SENTENCE_CHARS:
+            carry = candidate
+            continue
+        if carry and len(candidate) <= MAX_SENTENCE_CHARS:
+            merged.append(candidate)
+        else:
+            if carry:
+                merged.append(carry)
+            merged.append(segment)
+        carry = ""
+
+    if carry:
+        if merged and len(f"{merged[-1]} {carry}") <= MAX_SENTENCE_CHARS:
+            merged[-1] = f"{merged[-1]} {carry}"
+        else:
+            merged.append(carry)
+
+    return merged or [normalized]

--- a/scripts/tts/setup-chatterbox-tts-macos.sh
+++ b/scripts/tts/setup-chatterbox-tts-macos.sh
@@ -36,8 +36,10 @@ CB_HOME="${HOME}/.dpf/chatterbox"
 VENV_DIR="${CB_HOME}/venv"
 LOG_DIR="${CB_HOME}/logs"
 SERVER_DEST="${CB_HOME}/chatterbox_server.py"
+TEXT_DEST="${CB_HOME}/chatterbox_text.py"
 LAUNCH_SCRIPT="${CB_HOME}/run-chatterbox.sh"
 SERVER_SRC="${SCRIPT_DIR}/chatterbox_server.py"
+TEXT_SRC="${SCRIPT_DIR}/chatterbox_text.py"
 PLIST_TMPL="${SCRIPT_DIR}/com.dpf.chatterbox-tts.plist.tmpl"
 PLIST_LABEL="local.dpf-chatterbox-tts"
 PLIST_DEST="${HOME}/Library/LaunchAgents/${PLIST_LABEL}.plist"
@@ -58,6 +60,7 @@ die() { printf '[chatterbox setup] ERROR: %s\n' "$1" >&2; exit 1; }
 [ "$(uname -s)" = "Darwin" ] || die "macOS only (uname=$(uname -s))."
 [ "$(uname -m)" = "arm64" ] || die "Apple Silicon (arm64) only; this host is $(uname -m)."
 [ -f "$SERVER_SRC" ] || die "server source missing: ${SERVER_SRC}"
+[ -f "$TEXT_SRC" ] || die "text helper source missing: ${TEXT_SRC}"
 
 UV="$(command -v uv || true)"
 [ -n "$UV" ] || UV="/opt/homebrew/bin/uv"
@@ -91,6 +94,8 @@ log "deps installed"
 # --- Install server + launch script ------------------------------------------
 cp "$SERVER_SRC" "$SERVER_DEST"
 log "server: ${SERVER_DEST}"
+cp "$TEXT_SRC" "$TEXT_DEST"
+log "text helper: ${TEXT_DEST}"
 
 cat > "$LAUNCH_SCRIPT" <<EOF
 #!/usr/bin/env bash

--- a/scripts/tts/test_chatterbox_text.py
+++ b/scripts/tts/test_chatterbox_text.py
@@ -1,0 +1,65 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from chatterbox_text import MAX_SENTENCE_CHARS, split_speech_chunks
+
+
+SAMPLE = """AI Ops Engineer
+Your 17 AI coworkers cover the full operating backbone of your digital product factory. Here's how they align to your business:
+
+Leadership & Strategy
+
+COO -- runs daily operations, flags risks, coordinates across functions
+HR Director -- manages your workforce (the AI team itself), tracks capability gaps, resolves conflicts
+Finance Controller -- tracks spend, forecasts cash flow, flags budget issues
+Product & Delivery
+
+Software Engineer -- builds features and fixes defects; your primary shipping person
+Scrum Master -- manages your backlog, triage, work queues, and delivery cadence
+Portfolio Analyst -- tracks which digital products are in flight, maps work to strategy
+Data Architect -- designs data schemas and integration architecture
+Infrastructure & Systems
+
+AI Ops Engineer (me) -- keeps your AI workforce healthy and cost-controlled
+System Admin -- manages servers, databases, security, deployments
+Enterprise Architect -- aligns infrastructure to business goals, integrates new systems
+Product Intelligence & Growth
+
+Digital Product Estate Specialist -- catalogs everything you build and own, tracks dependencies and health
+External Catalog Scout -- monitors the external market for components you could reuse (vs. rebuild)
+Documentation Specialist -- writes runbooks, policies, how-to guides
+Compliance Officer -- ensures you meet regulatory obligations
+Customer-Facing
+
+Customer Success Manager -- owns relationships with your small-business clients, collects feedback
+Marketing Strategist -- positions your services, supports sales pipeline
+Storefront Operations Manager -- manages your public-facing presence and inquiries
+My Role I watch whether each coworker has the right AI provider and model to do their job, control costs, and catch when failover chains break.
+
+For a solo founder, this is your extended operating team. What gaps do you see, or where would you like to go deeper?"""
+
+
+class SplitSpeechChunksTest(unittest.TestCase):
+    def test_splits_newline_coworker_list_into_many_bounded_chunks(self):
+        chunks = split_speech_chunks(SAMPLE)
+
+        self.assertGreaterEqual(len(chunks), 20)
+        self.assertTrue(all(len(chunk) <= MAX_SENTENCE_CHARS for chunk in chunks))
+        self.assertTrue(any("COO -- runs daily operations" in chunk for chunk in chunks))
+        self.assertTrue(any("Storefront Operations Manager" in chunk for chunk in chunks))
+        self.assertTrue(chunks[-1].startswith("What gaps do you see"))
+
+    def test_splits_long_punctuationless_line_on_soft_boundaries(self):
+        chunks = split_speech_chunks(
+            "Operations review: " + ", ".join(f"checkpoint {i}" for i in range(40))
+        )
+
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(all(len(chunk) <= MAX_SENTENCE_CHARS for chunk in chunks))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix streaming text-to-voice truncation on long assistant replies by splitting headings, newline lists, and long punctuation-light lines into bounded TTS chunks.
- Align the streaming proxy with the Chatterbox sidecar defaults: port `8771` and non-empty `ref_text` for cloned/reference voices.
- Add regression coverage for the reported long AI coworker list response and the streaming proxy request body.

## Test plan
- [x] `python3 -m unittest scripts/tts/test_chatterbox_text.py` — 2 passing
- [x] `python3 -m py_compile scripts/tts/chatterbox_text.py scripts/tts/chatterbox_server.py scripts/tts/test_chatterbox_text.py`
- [x] `pnpm --filter web exec vitest run app/api/voice/synthesize/stream/route.test.ts components/agent/hooks/useVoiceSynth.test.ts` — 2 files / 4 tests passing
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web build` — completed successfully; existing Turbopack Edge/NFT warnings remain unrelated

## Verification notes
- Rebased on current `origin/main` before opening.
- Overlap sweep: one open PR (`#1396`, install dev workspace), no overlap with TTS streaming.
- The provided sample now splits into 28 bounded chunks, max 143 chars, including the final prompt line.
