### PR TITLE
fix(self-upgrade): reconcile merge-stamped upgrades

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -3,15 +3,44 @@ import {
   areOptionalStartupTasksEnabled,
   isInngestSelfSyncOnBootEnabled,
   isStartupModelRevalidationEnabled,
+  reconcileSelfUpgradeRunsOnBoot,
   warnIfLegacyHiveTokenEnvSet,
   syncPlatformVersionOnBoot,
 } from "./instrumentation";
 
 const syncPlatformVersionConfigMock = vi.fn();
+const getDeployedShaMock = vi.fn();
+const completeRunMock = vi.fn();
+const failRunMock = vi.fn();
+const selfUpgradeRunFindManyMock = vi.fn();
 
 vi.mock("@/lib/platform/version-config", () => ({
   syncPlatformVersionConfig: (...args: unknown[]) => syncPlatformVersionConfigMock(...args),
 }));
+
+vi.mock("@/lib/self-upgrade/completion", () => ({
+  getDeployedSha: () => getDeployedShaMock(),
+}));
+
+vi.mock("@/lib/self-upgrade/run-store", () => ({
+  completeRun: (...args: unknown[]) => completeRunMock(...args),
+  failRun: (...args: unknown[]) => failRunMock(...args),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    selfUpgradeRun: {
+      findMany: (...args: unknown[]) => selfUpgradeRunFindManyMock(...args),
+    },
+  },
+}));
+
+beforeEach(() => {
+  getDeployedShaMock.mockReset();
+  completeRunMock.mockReset();
+  failRunMock.mockReset();
+  selfUpgradeRunFindManyMock.mockReset();
+});
 
 describe("warnIfLegacyHiveTokenEnvSet", () => {
   let originalEnvToken: string | undefined;
@@ -82,6 +111,53 @@ describe("syncPlatformVersionOnBoot", () => {
     expect(error.mock.calls[0]![0]).toContain("[platform-version]");
     expect(error.mock.calls[0]![0]).toContain("Failed");
     expect(error.mock.calls[0]![1]).toBe(boom);
+  });
+});
+
+describe("reconcileSelfUpgradeRunsOnBoot", () => {
+  it("marks an upstream-mode run succeeded when deployed SHA matches expected deployed merge SHA", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("merge-sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
+      { runId: "SUR-MERGE", deployedSha: "merge-sha", targetSha: "upstream-sha" },
+    ]);
+    completeRunMock.mockResolvedValueOnce({});
+    const log = vi.fn();
+    const error = vi.fn();
+
+    const result = await reconcileSelfUpgradeRunsOnBoot({ log, error });
+
+    expect(result).toEqual({ succeeded: 1, failed: 0 });
+    expect(completeRunMock).toHaveBeenCalledWith("SUR-MERGE");
+    expect(failRunMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to targetSha for legacy/local rows without deployedSha", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("same-sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
+      { runId: "SUR-LOCAL", deployedSha: null, targetSha: "same-sha" },
+    ]);
+    completeRunMock.mockResolvedValueOnce({});
+
+    const result = await reconcileSelfUpgradeRunsOnBoot({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ succeeded: 1, failed: 0 });
+    expect(completeRunMock).toHaveBeenCalledWith("SUR-LOCAL");
+  });
+
+  it("fails an orphaned run with deployed, expected, and target evidence", async () => {
+    getDeployedShaMock.mockResolvedValueOnce("actual-sha");
+    selfUpgradeRunFindManyMock.mockResolvedValueOnce([
+      { runId: "SUR-ORPHAN", deployedSha: "expected-sha", targetSha: "upstream-sha" },
+    ]);
+    failRunMock.mockResolvedValueOnce({});
+
+    const result = await reconcileSelfUpgradeRunsOnBoot({ log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ succeeded: 0, failed: 1 });
+    expect(failRunMock).toHaveBeenCalledWith(
+      "SUR-ORPHAN",
+      expect.stringContaining("deployed=actual-sha expected=expected-sha target=upstream-sha"),
+    );
   });
 });
 

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -80,9 +80,13 @@ export async function syncPlatformVersionOnBoot(
  * container, which kills the orchestrating process mid-swap — so it can never
  * mark its own run succeeded. The NEW portal closes the loop here: any run
  * left "running" is resolved against the SHA we actually came up on. If the
- * deployed SHA matches the run's target, the swap landed → succeeded;
+ * deployed SHA matches the run's expected deployed identity, the swap landed → succeeded;
  * otherwise the run is an orphan → failed (also clears the stuck-"running"
  * state that would otherwise block all future triggers).
+ *
+ * In upstream mode `targetSha` is the upstream lineage marker. The deployed
+ * identity is the install-branch merge commit stored in `deployedSha` when the
+ * run is created; falling back to targetSha preserves local-mode and legacy rows.
  *
  * Single-host assumption: at boot, a "running" run belongs to the swap that
  * just recreated us, not a concurrent replica. Non-fatal.
@@ -99,15 +103,19 @@ export async function reconcileSelfUpgradeRunsOnBoot(
     let succeeded = 0;
     let failed = 0;
     for (const run of running) {
-      const target = run.targetSha ?? null;
-      if (deployedSha && target && target.toLowerCase() === deployedSha.toLowerCase()) {
+      const expectedDeployedSha = run.deployedSha ?? run.targetSha ?? null;
+      if (
+        deployedSha &&
+        expectedDeployedSha &&
+        expectedDeployedSha.toLowerCase() === deployedSha.toLowerCase()
+      ) {
         await completeRun(run.runId);
         succeeded++;
         logger.log(`[self-upgrade-reconcile] ${run.runId} -> succeeded (deployed ${deployedSha})`);
       } else {
         await failRun(
           run.runId,
-          `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} target=${target ?? "unknown"}`,
+          `Reconciled on boot: orchestrator did not complete the swap. deployed=${deployedSha ?? "unknown"} expected=${expectedDeployedSha ?? "unknown"} target=${run.targetSha ?? "unknown"}`,
         );
         failed++;
         logger.log(`[self-upgrade-reconcile] ${run.runId} -> failed (orphaned)`);

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -196,6 +196,10 @@ export async function runSelfUpgrade(
     // targetSha column carries the upstream lineage marker (what the build
     // contains), falling back to the built stamp in local mode.
     toVersion: upstreamSha ?? builtStamp,
+    // deployedSha carries the expected runtime identity the rebuilt image will
+    // report after boot. In upstream mode this is the install-branch merge
+    // commit, not the upstream lineage marker above.
+    expectedDeployedSha: builtStamp,
   });
   await startRun(run.runId);
   await emitUpgradeEvent({ type: "upgrade.started", runId: run.runId });

--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -8,13 +8,32 @@
  * with a real Postgres + Prisma; those are tracked separately under
  * BI-QUIESCE-002 follow-up integration work.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  taskRunFindMany: vi.fn(),
+  buildPhaseRunFindMany: vi.fn(),
+  buildPhaseRunUpdateMany: vi.fn(),
+  toolExecutionFindMany: vi.fn(),
+}));
 
 vi.mock("@dpf/db", () => ({
-  prisma: {},
+  prisma: {
+    taskRun: {
+      findMany: (...args: unknown[]) => prismaMock.taskRunFindMany(...args),
+    },
+    buildPhaseRun: {
+      findMany: (...args: unknown[]) => prismaMock.buildPhaseRunFindMany(...args),
+      updateMany: (...args: unknown[]) => prismaMock.buildPhaseRunUpdateMany(...args),
+    },
+    toolExecution: {
+      findMany: (...args: unknown[]) => prismaMock.toolExecutionFindMany(...args),
+    },
+  },
 }));
 
 import {
+  captureActiveSessionBlockers,
   getQuiescenceConfig,
   invalidateQuiescenceCache,
   isTerminalQuiescenceStatus,
@@ -23,10 +42,19 @@ import {
   pickPrimaryBlocker,
   QuiescingError,
   QUIESCENCE_RUN_STATUSES,
+  reconcileTerminalBuildPhaseRuns,
   TERMINAL_QUIESCENCE_STATUSES,
   type ActiveSessionBlockers,
   type SurfaceBlocker,
 } from "./quiescence";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.taskRunFindMany.mockResolvedValue([]);
+  prismaMock.buildPhaseRunFindMany.mockResolvedValue([]);
+  prismaMock.buildPhaseRunUpdateMany.mockResolvedValue({ count: 0 });
+  prismaMock.toolExecutionFindMany.mockResolvedValue([]);
+});
 
 describe("parseQuiescenceConfig", () => {
   it("returns default config on null", () => {
@@ -137,6 +165,50 @@ describe("phaseBudgetMs", () => {
 
   it("returns 5min default for unknown phase (defensive)", () => {
     expect(phaseBudgetMs("garbage")).toBe(5 * 60 * 1000);
+  });
+});
+
+describe("reconcileTerminalBuildPhaseRuns", () => {
+  it("closes open phase runs whose parent build is terminal or abandoned", async () => {
+    const now = new Date("2026-05-31T19:30:00.000Z");
+    prismaMock.buildPhaseRunUpdateMany.mockResolvedValueOnce({ count: 3 });
+
+    await expect(reconcileTerminalBuildPhaseRuns(now)).resolves.toBe(3);
+
+    expect(prismaMock.buildPhaseRunUpdateMany).toHaveBeenCalledWith({
+      where: {
+        completedAt: null,
+        build: {
+          OR: [
+            { phase: { in: ["complete", "failed", "abandoned"] } },
+            { abandonedAt: { not: null } },
+          ],
+        },
+      },
+      data: { completedAt: now },
+    });
+  });
+});
+
+describe("captureActiveSessionBlockers", () => {
+  it("repairs terminal build phase rows and only queries non-terminal parent builds as blockers", async () => {
+    const now = new Date("2026-05-31T19:30:00.000Z");
+
+    const snapshot = await captureActiveSessionBlockers({ now, thresholdMs: 300_000 });
+
+    expect(snapshot.hardBlockers).toBe(0);
+    expect(prismaMock.buildPhaseRunUpdateMany).toHaveBeenCalledOnce();
+    expect(prismaMock.buildPhaseRunFindMany).toHaveBeenCalledWith({
+      where: {
+        completedAt: null,
+        build: {
+          phase: { notIn: ["complete", "failed", "abandoned"] },
+          abandonedAt: null,
+        },
+      },
+      select: { buildId: true, phase: true, startedAt: true },
+      take: 25,
+    });
   });
 });
 

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -544,6 +544,28 @@ export type BlockerSignal =
 
 const TOOL_EXECUTION_RECENCY_MS = 5 * 60 * 1000;
 const EDGE_AGENT_PREFIX = "edge-node:";
+const TERMINAL_BUILD_PHASES = ["complete", "failed", "abandoned"] as const;
+
+/**
+ * Repair stale phase-run rows from terminal builds before blocker capture.
+ * Abandon/fail paths that predate BI-2CC024DB can leave completedAt null, which
+ * otherwise makes quiescence defer forever on work that is no longer active.
+ */
+export async function reconcileTerminalBuildPhaseRuns(now: Date = new Date()): Promise<number> {
+  const result = await prisma.buildPhaseRun.updateMany({
+    where: {
+      completedAt: null,
+      build: {
+        OR: [
+          { phase: { in: [...TERMINAL_BUILD_PHASES] } },
+          { abandonedAt: { not: null } },
+        ],
+      },
+    },
+    data: { completedAt: now },
+  });
+  return result.count;
+}
 
 /**
  * Capture a snapshot of every surface that has in-flight work right now.
@@ -561,6 +583,8 @@ export async function captureActiveSessionBlockers(opts?: {
   const now = opts?.now ?? new Date();
   const thresholdMs = opts?.thresholdMs ?? TOOL_EXECUTION_RECENCY_MS;
   const surfaces: SurfaceBlocker[] = [];
+
+  await reconcileTerminalBuildPhaseRuns(now);
 
   // A-class: coworker reasoning loops (TaskRun in working/active)
   const activeTaskRuns = await prisma.taskRun.findMany({
@@ -595,7 +619,13 @@ export async function captureActiveSessionBlockers(opts?: {
 
   // A-class: BuildPhaseRun in flight (phase mid-execution)
   const inFlightPhases = await prisma.buildPhaseRun.findMany({
-    where: { completedAt: null },
+    where: {
+      completedAt: null,
+      build: {
+        phase: { notIn: [...TERMINAL_BUILD_PHASES] },
+        abandonedAt: null,
+      },
+    },
     select: { buildId: true, phase: true, startedAt: true },
     take: 25,
   });

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -12,6 +12,7 @@ export async function createRun(params: {
   triggeredBy?: string;
   fromVersion?: string;
   toVersion?: string;
+  expectedDeployedSha?: string;
 }) {
   const runId = `SUR-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
   return prisma.selfUpgradeRun.create({
@@ -21,6 +22,7 @@ export async function createRun(params: {
       trigger: params.triggeredBy ?? "unknown",
       currentSha: params.fromVersion ?? null,
       targetSha: params.toVersion ?? null,
+      deployedSha: params.expectedDeployedSha ?? null,
     },
   });
 }


### PR DESCRIPTION
## Summary
- store the expected deployed image identity on self-upgrade runs so boot reconciliation can distinguish upstream target SHA from install-branch merge SHA
- repair stale open BuildPhaseRun rows whose parent build is already terminal or abandoned before quiescence checks
- add regression coverage for merge-stamped reconciliation and abandoned build phase quiescence

## Backlog
- Closes BI-F6928328
- Closes BI-2CC024DB

## Verification
- `vitest run instrumentation.test.ts lib/self-upgrade/quiescence.test.ts lib/queue/functions/self-upgrade.test.ts --config vitest.config.ts` — 83 passed
- `next typegen && tsc --noEmit` — passed
- `next build` — passed; existing Turbopack Edge/runtime and NFT tracing warnings emitted