### PR TITLE
fix(self-upgrade): pass install env to promoter

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -271,6 +271,9 @@ export async function runSelfUpgrade(
       targetSha: builtStamp,
       backupPath: process.env.PROMOTE_BACKUP_PATH ?? `/backups/self-upgrade/${run.runId}`,
       backupHostPath: process.env.DPF_BACKUPS_HOST_PATH ?? undefined,
+      composeEnvFileHostPath: hostInstallPathResolved
+        ? `${hostInstallPathResolved.replace(/\/$/, "")}/.env`
+        : undefined,
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
       promoterImage: config.promoterImage,
       dryRun: params.dryRun,

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -45,7 +45,7 @@ function makeFakeBin(root: string): string {
   // `docker compose exec`) returns a single stable hash so built==running.
   writeFileSync(
     join(bin, "docker"),
-    '#!/bin/sh\ncase "$*" in\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+    '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
   );
   // For any URL ending in /sha, report the stamped DPF_VERSION (inherited from
   // the script's exported env) — modelling a correctly-stamped portal. Other
@@ -64,6 +64,8 @@ function runPromote(opts: {
   backup: string;
   targetSha: string;
   fakeBin: string;
+  composeEnvFile?: string;
+  dockerLog?: string;
 }): { status: number | null; stdout: string; stderr: string } {
   const r = spawnSync("bash", [SCRIPT, "--self-upgrade"], {
     encoding: "utf8",
@@ -77,6 +79,8 @@ function runPromote(opts: {
       PROMOTE_BACKUP_PATH: opts.backup,
       PROMOTE_HEALTH_URL: "http://127.0.0.1:9/api/health",
       PROMOTE_COMPOSE_PROJECT: "dpf-functest",
+      ...(opts.composeEnvFile ? { PROMOTE_COMPOSE_ENV_FILE: opts.composeEnvFile } : {}),
+      ...(opts.dockerLog ? { DOCKER_LOG: opts.dockerLog } : {}),
     },
   });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
@@ -129,6 +133,26 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       // It still stamps the TRUTH (HEAD), and flags the drift.
       expect(r.stdout).toContain(`step=done target=${head}`);
       expect(r.stderr).toContain("warning: build source identity");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes the canonical install env file to docker compose when configured", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    try {
+      const envFile = join(root, "install.env");
+      const dockerLog = join(root, "docker.log");
+      writeFileSync(envFile, "AUTH_SECRET=test-secret\n");
+
+      const r = runPromote({ source, backup, targetSha: head, fakeBin, composeEnvFile: envFile, dockerLog });
+
+      expect(r.status).toBe(0);
+      const log = readFileSync(dockerLog, "utf8");
+      expect(log).toContain(`compose --env-file ${envFile} --project-directory ${source}`);
+      expect(log).toContain("build portal");
+      expect(log).toContain("up -d --no-deps --force-recreate portal");
+      expect(log).toContain("exec -T portal cat /app/.dpf-source-content-hash");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -63,4 +63,16 @@ describe("buildPromoterCommand", () => {
     const withBackup = buildPromoterCommand({ ...BASE, backupHostPath: "/Users/me/dpf-backups" });
     expect(withBackup.args).toContain("/Users/me/dpf-backups:/backups");
   });
+
+  it("mounts the install env file for compose interpolation when provided", () => {
+    const { args } = buildPromoterCommand({
+      ...BASE,
+      hostInstallPath: "/Users/me/dpf/.upgrade-workspace",
+      composeEnvFileHostPath: "/Users/me/dpf/.env",
+    });
+
+    expect(args).toContain("/Users/me/dpf/.upgrade-workspace:/host-source:ro");
+    expect(args).toContain("/Users/me/dpf/.env:/install-env/.env:ro");
+    expect(args).toContain("PROMOTE_COMPOSE_ENV_FILE=/install-env/.env");
+  });
 });

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -29,6 +29,7 @@ const DEFAULT_PROMOTER_IMAGE = "dpf-promoter";
 // Matches the `promoter` service's `:/host-source:ro` mount in
 // docker-compose.yml so promote.sh sees the same path either way.
 const PROMOTER_CONTAINER_SOURCE = "/host-source";
+const PROMOTER_COMPOSE_ENV_FILE = "/install-env/.env";
 
 export type PromoterParams = {
   /** HOST path of the install tree; bind-mounted into the promoter. */
@@ -43,6 +44,8 @@ export type PromoterParams = {
   promoterImage?: string;
   /** HOST path for the backups volume; mounted to /backups when provided. */
   backupHostPath?: string;
+  /** HOST path to the canonical install .env; mounted read-only for compose interpolation. */
+  composeEnvFileHostPath?: string;
   dryRun?: boolean;
 };
 
@@ -93,6 +96,10 @@ export function buildPromoterCommand(
     args.push("-v", `${params.backupHostPath}:/backups`);
   }
 
+  if (params.composeEnvFileHostPath && params.composeEnvFileHostPath.length > 0) {
+    args.push("-v", `${params.composeEnvFileHostPath}:${PROMOTER_COMPOSE_ENV_FILE}:ro`);
+  }
+
   args.push(
     "-e",
     `PROMOTE_SOURCE=${PROMOTER_CONTAINER_SOURCE}`,
@@ -102,6 +109,13 @@ export function buildPromoterCommand(
     `PROMOTE_BACKUP_PATH=${params.backupPath}`,
     "-e",
     `PROMOTE_HEALTH_URL=${healthUrl}`,
+  );
+
+  if (params.composeEnvFileHostPath && params.composeEnvFileHostPath.length > 0) {
+    args.push("-e", `PROMOTE_COMPOSE_ENV_FILE=${PROMOTER_COMPOSE_ENV_FILE}`);
+  }
+
+  args.push(
     image,
     "--self-upgrade",
   );

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -46,6 +46,14 @@ _f_args=()
 for _f in "${_compose_files[@]}"; do
   _f_args+=(-f "$PROMOTE_SOURCE/$_f")
 done
+_env_args=()
+if [[ -n "${PROMOTE_COMPOSE_ENV_FILE:-}" ]]; then
+  [[ -f "$PROMOTE_COMPOSE_ENV_FILE" ]] || {
+    printf 'error: PROMOTE_COMPOSE_ENV_FILE is not readable\n' >&2
+    exit 1
+  }
+  _env_args+=(--env-file "$PROMOTE_COMPOSE_ENV_FILE")
+fi
 
 # Emit a tagged step line; always prints in both dry-run and real modes.
 # Only the step name and target SHA are printed — never source/backup/health
@@ -116,7 +124,7 @@ if [[ $_dry_run -eq 0 ]]; then
       "$_built_sha" "$PROMOTE_TARGET_SHA" >&2
   fi
   export DPF_VERSION="$_built_sha"
-  docker compose --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
     "${_f_args[@]}" build portal
   # Capture the source content hash baked into the FRESHLY BUILT image. It is
   # computed from the actual bundled source bytes (Dockerfile) independent of
@@ -137,7 +145,7 @@ fi
 # SHA of the code it is running at /api/health/sha.
 emit_step docker-up
 if [[ $_dry_run -eq 0 ]]; then
-  docker compose --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
     "${_f_args[@]}" up -d --no-deps --force-recreate portal
 fi  # DPF_PLATFORM_VERSION stays exported from above so any rebuild keeps the stamp
 
@@ -187,7 +195,7 @@ fi
 # is capable of failing.
 emit_step content-verify
 if [[ $_dry_run -eq 0 ]]; then
-  _running_hash=$(docker compose --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+  _running_hash=$(docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
     "${_f_args[@]}" exec -T portal cat /app/.dpf-source-content-hash 2>/dev/null | tr -d '[:space:]' || true)
   [[ -n "$_running_hash" && "$_running_hash" == "$_built_hash" ]] || {
     printf 'error: running content hash %s does not match freshly built %s — recreate did not deploy the new image\n' \


### PR DESCRIPTION
## Summary
- mount the canonical install .env into the sibling promoter container when launching self-upgrade
- have scripts/promote.sh pass that file to every docker compose invocation with --env-file while keeping the isolated source workspace as the build context
- add contract and functional coverage for the env-file path

## Why
A live self-upgrade from b0674fd7 to #1398 failed before build/swap because .upgrade-workspace intentionally has source only and no .env, so Docker Compose could not interpolate AUTH_SECRET.

## Verification
- vitest run lib/self-upgrade/promoter.test.ts lib/self-upgrade/promote-script-functional.test.ts lib/queue/functions/self-upgrade.test.ts --config vitest.config.ts — 55 passed
- next typegen && tsc --noEmit — passed
- runtime verification in progress against canonical portal