### PR TITLE
feat: add BI-166C59F3 local-CI pregate

### DIFF
--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+if [ "${DPF_SKIP_PREPUSH_GATE:-}" = "1" ]; then
+  echo "[pre-push-gate] DPF_SKIP_PREPUSH_GATE=1 - skipping local-CI gate check."
+  exit 0
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+sha="$(git rev-parse HEAD)"
+state_file="$(git rev-parse --git-path dpf-local-ci-gate.json)"
+
+if [ ! -f "$state_file" ]; then
+  echo "[pre-push-gate] No local-CI gate record exists for this worktree."
+  echo "[pre-push-gate] Run: scripts/gate-worktree.sh"
+  exit 1
+fi
+
+node -e '
+const fs = require("node:fs");
+const [file, branch, sha] = process.argv.slice(1);
+const state = JSON.parse(fs.readFileSync(file, "utf8"));
+if (state.branch !== branch || state.sha !== sha || state.gatePassed !== true) {
+  console.error("[pre-push-gate] Latest local-CI gate does not pass for this HEAD.");
+  console.error(`[pre-push-gate] expected ${branch}@${sha}`);
+  console.error(`[pre-push-gate] found ${state.branch || "(none)"}@${state.sha || "(none)"} gatePassed=${state.gatePassed}`);
+  process.exit(1);
+}
+' "$state_file" "$branch" "$sha"
+
+echo "[pre-push-gate] local-CI gate passed for $branch@$sha"

--- a/docker-compose.local-ci.yml
+++ b/docker-compose.local-ci.yml
@@ -1,0 +1,45 @@
+name: ${COMPOSE_PROJECT_NAME:-dpf-local-ci}
+
+services:
+  local-ci-portal:
+    build:
+      context: .
+      target: runner
+      args:
+        DPF_VERSION: ${DPF_VERSION:-}
+        DPF_PLATFORM_VERSION: ${DPF_PLATFORM_VERSION:-}
+    restart: unless-stopped
+    profiles: ["local-ci"]
+    ports:
+      - "3010:3000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - dpf-local-ci-source-code:/workspace
+    environment:
+      DATABASE_URL: ${LOCAL_CI_DATABASE_URL:-postgresql://dpf:dpf_dev@host.docker.internal:5433/dpf}
+      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET must be set - run scripts/setup.ps1 or scripts/setup.sh first}
+      AUTH_TRUST_HOST: "true"
+      PUBLIC_URL: ${LOCAL_CI_PUBLIC_URL:-http://localhost:3010}
+      CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:?CREDENTIAL_ENCRYPTION_KEY must be set - run scripts/setup.ps1 or scripts/setup.sh first}
+      NEO4J_URI: ${LOCAL_CI_NEO4J_URI:-bolt://host.docker.internal:7688}
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-dpf_dev_password}
+      QDRANT_INTERNAL_URL: ${LOCAL_CI_QDRANT_INTERNAL_URL:-http://host.docker.internal:6334}
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://model-runner.docker.internal/v1}
+      OLLAMA_INTERNAL_URL: ${OLLAMA_INTERNAL_URL:-http://host.docker.internal:11434}
+      DPF_ENVIRONMENT: local-ci
+      INSTANCE_TYPE: dev
+      PROJECT_ROOT: /workspace
+      APP_URL: http://localhost:3010
+      MCP_INSECURE_INTERNAL_HOSTS: ${MCP_INSECURE_INTERNAL_HOSTS:-portal,host.docker.internal,sandbox,local-ci-portal}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+volumes:
+  dpf-local-ci-source-code:

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -49,6 +49,35 @@ pnpm --filter mobile test
 pnpm test
 ```
 
+## Pre-PR gate (local-CI sandbox)
+
+BI-166C59F3 Phase 1 adds the shared local-CI convergence sandbox workflow.
+The sandbox runtime is declared in `docker-compose.local-ci.yml` behind the
+`local-ci` profile, uses `COMPOSE_PROJECT_NAME=dpf-local-ci`, serves the portal
+on `http://localhost:3010`, and connects to the existing dev data services on
+host ports `5433`, `6334`, and `7475`/`7688`.
+
+From a worktree, the opt-in gate is:
+
+```bash
+pnpm run pregate
+```
+
+The script pushes the current branch, claims a `local-integration-ci` lease,
+waits if the sandbox is already leased, runs the Phase 1 sandbox checkout/build
+stub (`gate passed`), records a local-integration evidence record with the lease
+id and `gatePassed`, releases the lease, and writes the latest passing HEAD to
+Git-local state. Phase 2 replaces the stub with the canonical build and runtime
+verification commands.
+
+The opt-in pre-push hook is `.githooks/pre-push-gate`. It refuses a push when
+the latest local-CI gate record is missing, belongs to another branch/SHA, or
+has `gatePassed=false`. Emergency bypass:
+
+```bash
+DPF_SKIP_PREPUSH_GATE=1 git push
+```
+
 The `apps/web` suite alone runs in roughly 2–4 minutes on a modern laptop;
 the full root `pnpm test` adds another 1–2 minutes for `@dpf/db` and the
 mobile jest suite.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "contributor:preview": "docker compose --profile dev up -d dev-portal",
     "dev:prod-runtime": "docker compose up -d portal",
     "dev:sandbox": "docker compose up -d sandbox",
+    "pregate": "sh scripts/gate-worktree.sh",
     "build": "pnpm --filter web build",
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",

--- a/scripts/gate-worktree.sh
+++ b/scripts/gate-worktree.sh
@@ -1,0 +1,254 @@
+#!/bin/sh
+set -eu
+
+MCP_URL="${DPF_MCP_URL:-http://127.0.0.1:3000/api/mcp/v1}"
+REMOTE="origin"
+BRANCH=""
+SHA=""
+WORKTREE_PATH=""
+OWNER_PROVIDER="${DPF_GATE_OWNER_PROVIDER:-codex}"
+OWNER_SESSION_ID="${DPF_GATE_OWNER_SESSION_ID:-}"
+LEASE_WAIT_SECONDS="${DPF_GATE_LEASE_WAIT_SECONDS:-300}"
+POLL_SECONDS="${DPF_GATE_POLL_SECONDS:-10}"
+EXPIRES_MINUTES="${DPF_GATE_EXPIRES_MINUTES:-60}"
+PUSH_BRANCH=1
+DRY_RUN=0
+URL="${DPF_LOCAL_CI_URL:-http://localhost:3010}"
+PORTS="3010"
+GIT_BIN="${DPF_GATE_GIT_BIN:-git}"
+CURL_BIN="${DPF_GATE_CURL_BIN:-curl}"
+STATE_FILE=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gate-worktree.sh [options]
+
+Options:
+  --branch NAME              Branch to gate (default: current branch)
+  --sha SHA                  Commit SHA to gate (default: HEAD)
+  --worktree PATH            Worktree path (default: git rev-parse --show-toplevel)
+  --remote NAME              Remote to push before claiming the lease (default: origin)
+  --owner-provider NAME      build-studio|claude|codex|coworker (default: codex)
+  --owner-session-id ID      External session id (default: gate-<pid>)
+  --mcp-url URL              MCP endpoint (default: DPF_MCP_URL or local portal)
+  --lease-wait-seconds N     Max time to wait when the lease is busy (default: 300)
+  --poll-seconds N           Busy-lease poll interval (default: 10)
+  --expires-minutes N        Lease expiry window (default: 60)
+  --no-push                  Do not push before claiming the lease
+  --dry-run                  Print planned actions; skip git push and MCP calls
+  --help                     Show this help
+EOF
+}
+
+die() {
+  printf '%s\n' "gate-worktree: $*" >&2
+  exit 1
+}
+
+json_escape() {
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1] ?? ""))' "$1"
+}
+
+json_array_numbers() {
+  node -e 'const xs=(process.argv[1]||"").split(",").filter(Boolean).map(Number); process.stdout.write(JSON.stringify(xs));' "$1"
+}
+
+mcp_call() {
+  tool_name="$1"
+  arguments_json="$2"
+  request_json="$(node -e '
+const name = process.argv[1];
+const args = JSON.parse(process.argv[2]);
+process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:1,method:"tools/call",params:{name,arguments:args}}));
+' "$tool_name" "$arguments_json")"
+  "$CURL_BIN" -sS -X POST "$MCP_URL" \
+    -H "Authorization: Bearer ${DPF_MCP_BEARER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "$request_json"
+}
+
+extract_tool_result() {
+  node -e '
+const fs = require("node:fs");
+const raw = fs.readFileSync(0, "utf8");
+const payload = JSON.parse(raw);
+const content = payload.result && Array.isArray(payload.result.content) ? payload.result.content : [];
+const text = content.find((entry) => entry && entry.type === "text" && typeof entry.text === "string");
+const parsed = text ? JSON.parse(text.text) : (payload.result && payload.result.structuredContent) || payload.result || payload;
+process.stdout.write(JSON.stringify(parsed));
+'
+}
+
+field() {
+  node -e '
+const fs = require("node:fs");
+const raw = fs.readFileSync(0, "utf8");
+const obj = JSON.parse(raw);
+const path = process.argv[1].split(".");
+let value = obj;
+for (const part of path) value = value == null ? undefined : value[part];
+if (value !== undefined && value !== null) process.stdout.write(String(value));
+' "$1"
+}
+
+write_state() {
+  gate_passed="$1"
+  lease_id="$2"
+  evidence_id="$3"
+  status="$4"
+  mkdir -p "$(dirname "$STATE_FILE")"
+  node -e '
+const fs = require("node:fs");
+const out = process.argv[1];
+const payload = {
+  branch: process.argv[2],
+  sha: process.argv[3],
+  gatePassed: process.argv[4] === "true",
+  leaseId: process.argv[5],
+  evidenceRecordId: process.argv[6],
+  status: process.argv[7],
+  recordedAt: new Date().toISOString()
+};
+fs.writeFileSync(out, JSON.stringify(payload, null, 2) + "\n");
+' "$STATE_FILE" "$BRANCH" "$SHA" "$gate_passed" "$lease_id" "$evidence_id" "$status"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --branch) BRANCH="${2:-}"; shift 2 ;;
+    --sha) SHA="${2:-}"; shift 2 ;;
+    --worktree) WORKTREE_PATH="${2:-}"; shift 2 ;;
+    --remote) REMOTE="${2:-}"; shift 2 ;;
+    --owner-provider) OWNER_PROVIDER="${2:-}"; shift 2 ;;
+    --owner-session-id) OWNER_SESSION_ID="${2:-}"; shift 2 ;;
+    --mcp-url) MCP_URL="${2:-}"; shift 2 ;;
+    --lease-wait-seconds) LEASE_WAIT_SECONDS="${2:-}"; shift 2 ;;
+    --poll-seconds) POLL_SECONDS="${2:-}"; shift 2 ;;
+    --expires-minutes) EXPIRES_MINUTES="${2:-}"; shift 2 ;;
+    --no-push) PUSH_BRANCH=0; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$BRANCH" ] || BRANCH="$("$GIT_BIN" rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" != "HEAD" ] || die "cannot gate detached HEAD"
+[ -n "$SHA" ] || SHA="$("$GIT_BIN" rev-parse HEAD)"
+[ -n "$WORKTREE_PATH" ] || WORKTREE_PATH="$("$GIT_BIN" rev-parse --show-toplevel)"
+[ -n "$OWNER_SESSION_ID" ] || OWNER_SESSION_ID="gate-$$"
+STATE_FILE="$("$GIT_BIN" rev-parse --git-path dpf-local-ci-gate.json)"
+
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'gate-worktree dry-run\n'
+  printf 'branch=%s\nsha=%s\nworktree=%s\nremote=%s\nmcpUrl=%s\n' "$BRANCH" "$SHA" "$WORKTREE_PATH" "$REMOTE" "$MCP_URL"
+  printf 'would call claim_nonprod_environment_lease and record_local_integration_result\n'
+  exit 0
+fi
+
+[ -n "${DPF_MCP_BEARER_TOKEN:-}" ] || die "DPF_MCP_BEARER_TOKEN is required to claim the local-CI lease"
+
+if [ "$PUSH_BRANCH" = "1" ]; then
+  "$GIT_BIN" push "$REMOTE" "$BRANCH"
+fi
+
+expires_at="$(node -e 'process.stdout.write(new Date(Date.now() + Number(process.argv[1]) * 60000).toISOString())' "$EXPIRES_MINUTES")"
+deadline="$(node -e 'process.stdout.write(String(Date.now() + Number(process.argv[1]) * 1000))' "$LEASE_WAIT_SECONDS")"
+lease_id=""
+
+while :; do
+  claim_args="$(node -e '
+const args = {
+  environmentKey: "local-integration-ci",
+  ownerProvider: process.argv[1],
+  ownerSessionId: process.argv[2],
+  purpose: `Pre-PR local-CI gate for ${process.argv[3]} @ ${process.argv[4]}`,
+  url: process.argv[5],
+  ports: JSON.parse(process.argv[6]),
+  expiresAt: process.argv[7],
+  worktreePath: process.argv[8],
+  branchName: process.argv[3],
+  cleanupCommand: "docker compose -f docker-compose.local-ci.yml --profile local-ci down"
+};
+process.stdout.write(JSON.stringify(args));
+' "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$BRANCH" "$SHA" "$URL" "$(json_array_numbers "$PORTS")" "$expires_at" "$WORKTREE_PATH")"
+  claim_response="$(mcp_call claim_nonprod_environment_lease "$claim_args" | extract_tool_result)"
+  claim_success="$(printf '%s' "$claim_response" | field success)"
+  claim_error="$(printf '%s' "$claim_response" | field error)"
+  if [ "$claim_success" = "true" ]; then
+    lease_id="$(printf '%s' "$claim_response" | field entityId)"
+    [ -n "$lease_id" ] || lease_id="$(printf '%s' "$claim_response" | field data.lease.leaseId)"
+    break
+  fi
+  if [ "$claim_error" = "lease_conflict" ]; then
+    now_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+    [ "$now_ms" -lt "$deadline" ] || die "local-CI sandbox lease is busy; timed out waiting"
+    printf '%s\n' "local-CI sandbox busy; queued behind active lease. Retrying in ${POLL_SECONDS}s..."
+    sleep "$POLL_SECONDS"
+  else
+    die "failed to claim local-CI lease: $claim_response"
+  fi
+done
+
+gate_passed=false
+evidence_id=""
+status="failed"
+
+set +e
+printf '%s\n' "local-CI sandbox lease claimed: $lease_id"
+printf '%s\n' "sandbox checkout/build stub: gate passed"
+stub_status=0
+set -e
+
+if [ "$stub_status" -eq 0 ]; then
+  gate_passed=true
+  status="passed"
+fi
+
+evidence_args="$(node -e '
+const status = process.argv[1];
+const gatePassed = process.argv[2] === "true";
+const evidence = {
+  bi: "BI-166C59F3",
+  phase: 1,
+  leaseId: process.argv[3],
+  branch: process.argv[4],
+  sha: process.argv[5],
+  gatePassed,
+  commands: ["sandbox checkout/build stub"],
+  output: "gate passed",
+  url: process.argv[6]
+};
+process.stdout.write(JSON.stringify({
+  provider: process.argv[7],
+  externalSessionId: process.argv[8],
+  routeContext: "/build",
+  candidateBranch: process.argv[4],
+  mode: "single-branch",
+  status,
+  summary: gatePassed ? "Phase 1 local-CI lease gate passed." : "Phase 1 local-CI lease gate failed.",
+  evidence
+}));
+' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$OWNER_PROVIDER" "$OWNER_SESSION_ID")"
+evidence_response="$(mcp_call record_local_integration_result "$evidence_args" | extract_tool_result)"
+evidence_success="$(printf '%s' "$evidence_response" | field success)"
+if [ "$evidence_success" = "true" ]; then
+  evidence_id="$(printf '%s' "$evidence_response" | field entityId)"
+else
+  write_state false "$lease_id" "" "failed"
+  mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" >/dev/null || true
+  die "failed to record local integration evidence: $evidence_response"
+fi
+
+release_response="$(mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" | extract_tool_result)"
+release_success="$(printf '%s' "$release_response" | field success)"
+[ "$release_success" = "true" ] || die "failed to release local-CI lease: $release_response"
+
+write_state "$gate_passed" "$lease_id" "$evidence_id" "$status"
+
+if [ "$gate_passed" = "true" ]; then
+  printf '%s\n' "gate passed"
+  exit 0
+fi
+
+die "gate failed"

--- a/tests/release/local-ci-gate-contract.test.mjs
+++ b/tests/release/local-ci-gate-contract.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const repoRoot = new URL("../..", import.meta.url);
+const script = new URL("../../scripts/gate-worktree.sh", import.meta.url);
+
+function runGate(args, options = {}) {
+  return spawnSync("sh", [script.pathname, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: options.env ? { ...options.env } : process.env,
+  });
+}
+
+test("gate-worktree.sh parses explicit flags in dry-run mode", () => {
+  const result = runGate([
+    "--dry-run",
+    "--branch",
+    "feat/local-ci-sandbox",
+    "--sha",
+    "abc123",
+    "--worktree",
+    "/tmp/dpf-worktree",
+    "--remote",
+    "coordination",
+    "--mcp-url",
+    "http://127.0.0.1:3000/api/mcp/v1",
+    "--no-push",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /branch=feat\/local-ci-sandbox/);
+  assert.match(result.stdout, /sha=abc123/);
+  assert.match(result.stdout, /worktree=\/tmp\/dpf-worktree/);
+  assert.match(result.stdout, /remote=coordination/);
+});
+
+test("gate-worktree.sh exits non-zero when DPF_MCP_BEARER_TOKEN is missing", () => {
+  const env = { ...process.env };
+  delete env.DPF_MCP_BEARER_TOKEN;
+  const result = runGate([
+    "--branch",
+    "feat/local-ci-sandbox",
+    "--sha",
+    "abc123",
+    "--worktree",
+    "/tmp/dpf-worktree",
+    "--no-push",
+  ], { env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /DPF_MCP_BEARER_TOKEN is required/);
+});
+
+test("gate-worktree.sh calls claim_nonprod_environment_lease before recording evidence", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-local-ci-gate-"));
+  const callsFile = join(temp, "calls.ndjson");
+  const gitStub = join(temp, "git");
+  const curlStub = join(temp, "curl");
+
+  writeFileSync(gitStub, `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
+  echo "${temp}/gate.json"
+  exit 0
+fi
+if [ "$1" = "push" ]; then
+  exit 0
+fi
+echo "unexpected git call: $*" >&2
+exit 1
+`);
+  writeFileSync(curlStub, `#!/bin/sh
+data=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data) data="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\\n' "$data" >> "${callsFile}"
+tool="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8")); console.log(p.params.name)' <<EOF
+$data
+EOF
+)"
+case "$tool" in
+  claim_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  record_local_integration_result)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"EXT-TEST\\"}"}]}}'
+    ;;
+  release_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  *)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":false,\\"error\\":\\"unexpected_tool\\"}"}]}}'
+    ;;
+esac
+`);
+  chmodSync(gitStub, 0o755);
+  chmodSync(curlStub, 0o755);
+
+  const result = runGate([
+    "--branch",
+    "feat/local-ci-sandbox",
+    "--sha",
+    "abc123",
+    "--worktree",
+    temp,
+  ], {
+    env: {
+      ...process.env,
+      DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+      DPF_GATE_GIT_BIN: gitStub,
+      DPF_GATE_CURL_BIN: curlStub,
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const calls = readFileSync(callsFile, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line).params.name);
+  assert.deepEqual(calls, [
+    "claim_nonprod_environment_lease",
+    "record_local_integration_result",
+    "release_nonprod_environment_lease",
+  ]);
+});


### PR DESCRIPTION
## Summary
- Implements BI-166C59F3 Phase 1: profile-only `docker-compose.local-ci.yml` for the shared local-CI sandbox at `:3010` backed by existing dev services.
- Adds `scripts/gate-worktree.sh` plus `pnpm run pregate` to push, claim `local-integration-ci`, queue on conflict, run the Phase 1 gate stub, record local-integration evidence, and release.
- Adds opt-in `.githooks/pre-push-gate`, release-contract tests, and docs for the Phase 1 workflow.

## Test plan
- [x] `PATH="/Users/markbodman/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm exec vitest run scripts/lib/local-integration-ci.test.mjs`
- [x] `node --test tests/release/local-ci-gate-contract.test.mjs`
- [x] `PATH="/Users/markbodman/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm typecheck`
- [x] `PATH="/Users/markbodman/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm security:secrets:staged`
- [x] `AUTH_SECRET=test-secret CREDENTIAL_ENCRYPTION_KEY=test-key docker compose -f docker-compose.local-ci.yml --profile local-ci config --quiet`
- [x] `scripts/gate-worktree.sh --owner-session-id codex-local-ci-sandbox-<timestamp>`: claimed/released lease `NPEL-8F8D747117`, recorded evidence `cmpuc8yr6000801o7v5qwnhgv`, wrote `gatePassed=true` for HEAD `19dc7ec4e536bd8a946875c1eaa2443d358327f8`.
- [x] `.githooks/pre-push-gate`: accepted the gated HEAD.

## Notes
- Phase 1 intentionally leaves the sandbox checkout/build step as the requested `gate passed` stub. Phase 2 should replace that stub with the canonical sandbox checkout, build, UX, MCP, and migration smoke steps.
- Overlap sweep before PR: `gh pr list --state open --limit 50` returned no open PRs.

Linked backlog item: BI-166C59F3.
