### PR TITLE
fix(self-upgrade): keep impact summary available during drain

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -50,6 +50,7 @@ const baseStatus = {
   windowSource: "operating-hours" as const,
   storeOpen: false,
   nextWindowStart: null,
+  nextScheduledCheckAt: null,
   deployedSha: null,
   deployedShaSource: "unknown" as const,
   targetSha: null,

--- a/apps/web/app/api/ops/self-upgrade/impact-summary/route.test.ts
+++ b/apps/web/app/api/ops/self-upgrade/impact-summary/route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { summarizeUpgradeImpact } from "@/lib/self-upgrade/impact";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/permissions", () => ({ can: vi.fn() }));
+vi.mock("@/lib/self-upgrade/impact", () => ({ summarizeUpgradeImpact: vi.fn() }));
+
+const mockAuth = vi.mocked(auth);
+const mockCan = vi.mocked(can);
+const mockSummarizeUpgradeImpact = vi.mocked(summarizeUpgradeImpact);
+const setAuthSession = (session: unknown) => {
+  mockAuth.mockResolvedValue(session as never);
+};
+
+describe("GET /api/ops/self-upgrade/impact-summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuthSession({
+      user: {
+        id: "user-1",
+        platformRole: "HR-500",
+        isSuperuser: false,
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+    mockCan.mockReturnValue(true);
+    mockSummarizeUpgradeImpact.mockResolvedValue({
+      ok: false,
+      reason: "no-target",
+      detail: "No upstream update target is currently known.",
+    });
+  });
+
+  it("requires an authenticated operator", async () => {
+    setAuthSession(null);
+
+    const res = await GET(new Request("https://dpf.local/api/ops/self-upgrade/impact-summary"));
+
+    expect(res.status).toBe(401);
+    expect(mockSummarizeUpgradeImpact).not.toHaveBeenCalled();
+  });
+
+  it("requires view_operations access", async () => {
+    mockCan.mockReturnValue(false);
+
+    const res = await GET(new Request("https://dpf.local/api/ops/self-upgrade/impact-summary"));
+
+    expect(res.status).toBe(403);
+    expect(mockSummarizeUpgradeImpact).not.toHaveBeenCalled();
+  });
+
+  it("returns the read-only summary with no-store caching", async () => {
+    const res = await GET(new Request("https://dpf.local/api/ops/self-upgrade/impact-summary"));
+
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      reason: "no-target",
+      detail: "No upstream update target is currently known.",
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(mockSummarizeUpgradeImpact).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("passes refresh=true through to the summarizer", async () => {
+    const res = await GET(
+      new Request("https://dpf.local/api/ops/self-upgrade/impact-summary?refresh=true"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSummarizeUpgradeImpact).toHaveBeenCalledWith({ refresh: true });
+  });
+});

--- a/apps/web/app/api/ops/self-upgrade/impact-summary/route.ts
+++ b/apps/web/app/api/ops/self-upgrade/impact-summary/route.ts
@@ -1,0 +1,40 @@
+// GET /api/ops/self-upgrade/impact-summary
+//
+// Read-only endpoint for the operator-facing "What's in this update?" panel.
+// This intentionally uses GET instead of a Server Action so the advisory
+// summary stays available while the quiescence proxy refuses mutation POSTs.
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { summarizeUpgradeImpact } from "@/lib/self-upgrade/impact";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request): Promise<Response> {
+  const session = await auth();
+  const user = session?.user;
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "view_operations",
+    )
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const refresh = url.searchParams.get("refresh") === "true";
+  const result = await summarizeUpgradeImpact({ refresh });
+
+  return NextResponse.json(result, {
+    headers: {
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });
+}

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -42,6 +42,7 @@ const baseStatus = {
   enabled: true,
   channel: "stable",
   inMaintenanceWindow: false,
+  nextScheduledCheckAt: "2026-05-24T18:00:00.000Z",
   deployedSha: "abc1234",
   targetSha: "def5678",
   isFresh: false,
@@ -139,6 +140,8 @@ describe("SelfUpgradeClient – enabled", () => {
       <SelfUpgradeClient {...baseStatus} inMaintenanceWindow={true} />,
     );
     expect(html).toContain("maintenance window");
+    expect(html).toContain("next scheduled check");
+    expect(html).toContain("May 24, 2026");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -27,6 +27,7 @@ type Props = {
   inMaintenanceWindow: boolean;
   windowConfigured?: boolean;
   nextWindowStart?: string | null;
+  nextScheduledCheckAt?: string | null;
   deployedSha: string | null;
   deployedShaSource?: ImageVersionSource;
   targetSha: string | null;
@@ -87,6 +88,7 @@ export default function SelfUpgradeClient({
   inMaintenanceWindow,
   windowConfigured,
   nextWindowStart,
+  nextScheduledCheckAt,
   deployedSha,
   deployedShaSource,
   targetSha,
@@ -165,7 +167,18 @@ export default function SelfUpgradeClient({
 
       {enabled && inMaintenanceWindow && (
         <div className="p-3 rounded-lg bg-[var(--dpf-success)]/10 border border-[var(--dpf-success)]/30 text-sm text-[var(--dpf-text)]">
-          Currently in maintenance window — upgrades are scheduled.
+          Currently in maintenance window — next scheduled check: {" "}
+          {nextScheduledCheckAt ? (
+            <>
+              <LocalTime className="font-mono" value={nextScheduledCheckAt} />
+              <span>. If an update is still available, it can start then.</span>
+            </>
+          ) : (
+            <>
+              <span className="font-mono">pending scheduler tick</span>
+              <span>. If an update is still available, it can start then.</span>
+            </>
+          )}
         </div>
       )}
 
@@ -252,13 +265,31 @@ export default function SelfUpgradeClient({
             </span>
           ) : inMaintenanceWindow ? (
             <span className="text-[var(--dpf-success)]">
-              In maintenance window now — upgrades are evaluated hourly.
+              In maintenance window now — next scheduled check: {" "}
+              {nextScheduledCheckAt ? (
+                <>
+                  <LocalTime className="font-mono" value={nextScheduledCheckAt} />
+                  <span>.</span>
+                </>
+              ) : (
+                <>
+                  <span className="font-mono">pending scheduler tick</span>
+                  <span>.</span>
+                </>
+              )}
             </span>
           ) : nextWindowStart ? (
             <span className="text-[var(--dpf-muted)]">
               Next maintenance window:{" "}
               <LocalTime className="font-mono" value={nextWindowStart} /> —
-              upgrades are evaluated hourly.
+              {nextScheduledCheckAt ? (
+                <>
+                  {" "}next scheduled check: {" "}
+                  <LocalTime className="font-mono" value={nextScheduledCheckAt} />.
+                </>
+              ) : (
+                " upgrades are evaluated hourly."
+              )}
             </span>
           ) : (
             <span className="text-[var(--dpf-muted)]">

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -14,7 +14,6 @@
 // Advisory only — no buttons here queue or apply the upgrade.
 
 import { useState, useTransition } from "react";
-import { getUpgradeImpactSummary } from "@/lib/actions/upgrade-impact";
 import type { SummaryResult, ImpactItem } from "@/lib/self-upgrade/impact/types";
 
 const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
@@ -96,6 +95,42 @@ function ItemRow({
   );
 }
 
+function isSummaryResult(value: unknown): value is SummaryResult {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { ok?: unknown };
+  return candidate.ok === true || candidate.ok === false;
+}
+
+async function fetchUpgradeImpactSummary(refresh: boolean): Promise<SummaryResult> {
+  const params = new URLSearchParams();
+  if (refresh) params.set("refresh", "true");
+  const query = params.toString();
+
+  const res = await fetch(
+    `/api/ops/self-upgrade/impact-summary${query ? `?${query}` : ""}`,
+    {
+      method: "GET",
+      cache: "no-store",
+    },
+  );
+
+  const body: unknown = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `Summary request failed with HTTP ${res.status}`;
+    throw new Error(message);
+  }
+
+  if (!isSummaryResult(body)) {
+    throw new Error("Unexpected summary response from the server.");
+  }
+
+  return body;
+}
+
 export default function UpgradeImpactPanel({ enabled }: { enabled: boolean }) {
   const [isPending, startTransition] = useTransition();
   const [result, setResult] = useState<SummaryResult | null>(null);
@@ -106,7 +141,7 @@ export default function UpgradeImpactPanel({ enabled }: { enabled: boolean }) {
     setError(null);
     startTransition(async () => {
       try {
-        const r = await getUpgradeImpactSummary({ refresh });
+        const r = await fetchUpgradeImpactSummary(refresh);
         setResult(r);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({
   auth: vi.fn(),
@@ -49,6 +49,10 @@ vi.mock("@/lib/operating-hours-read", () => ({
   resolveOperatingScheduleForSystem: vi.fn().mockResolvedValue({ schedule: {}, timezone: "UTC" }),
 }));
 
+vi.mock("@/lib/self-upgrade/last-check", () => ({
+  getLastCheckedAt: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/lib/queue/inngest-client", () => ({
   inngest: {
     send: vi.fn().mockResolvedValue(undefined),
@@ -71,7 +75,8 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import * as SelfUpgrade from "@/lib/self-upgrade";
-import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
 import { getSelfUpgradeStatus, listSelfUpgradeRuns, triggerSelfUpgrade } from "./promotions";
 
@@ -113,9 +118,15 @@ beforeEach(() => {
   vi.mocked(can).mockReturnValue(true);
   vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
   vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
+  vi.mocked(getLastCheckedAt).mockResolvedValue(null);
+  vi.mocked(nextUpgradeWindowOpen).mockReturnValue(null);
   // Default: treat triggers as in-window so dispatch tests exercise the happy
   // path. Tests that care about the window gate override this explicitly.
   vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // ─── Permission Guard ─────────────────────────────────────────────────────────
@@ -175,6 +186,59 @@ describe("getSelfUpgradeStatus", () => {
     expect(result.platformVersion.publishedAt).toBe("2026-05-24T00:00:00.000Z");
     expect(result.platformVersion.gitSha).toBe("abc1234");
     expect(result.platformVersion.note).toBe("baseline");
+    expect(result.nextScheduledCheckAt).toBeTruthy();
+  });
+
+  it("reports when the next scheduled check can run inside the current window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-24T17:21:00.000Z"));
+    vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
+    vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
+    vi.mocked(getLastCheckedAt).mockResolvedValue(new Date("2026-05-23T16:00:00.000Z"));
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(false);
+    vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.nextScheduledCheckAt).toBe("2026-05-24T18:00:00.000Z");
+    vi.useRealTimers();
+  });
+
+  it("delays the scheduled check until the configured interval has elapsed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-24T17:21:00.000Z"));
+    vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
+    vi.mocked(isUpgradeWindowOpen).mockReturnValue(true);
+    vi.mocked(getLastCheckedAt).mockResolvedValue(new Date("2026-05-24T10:30:00.000Z"));
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(false);
+    vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.nextScheduledCheckAt).toBe("2026-05-25T11:00:00.000Z");
+    vi.useRealTimers();
+  });
+
+  it("reports the first hourly tick after the next maintenance window opens", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-24T16:10:00.000Z"));
+    vi.mocked(SelfUpgrade.getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
+    vi.mocked(isUpgradeWindowOpen).mockReturnValue(false);
+    vi.mocked(nextUpgradeWindowOpen).mockReturnValue(new Date("2026-05-24T17:30:00.000Z"));
+    vi.mocked(SelfUpgrade.getDeployedSha).mockResolvedValue("abc1234");
+    vi.mocked(SelfUpgrade.resolveTargetSha).mockResolvedValue("def5678");
+    vi.mocked(SelfUpgrade.isShaFresh).mockReturnValue(false);
+    vi.mocked(SelfUpgrade.getLatestRun).mockResolvedValue(null);
+
+    const result = await getSelfUpgradeStatus();
+
+    expect(result.nextWindowStart).toBe("2026-05-24T17:30:00.000Z");
+    expect(result.nextScheduledCheckAt).toBe("2026-05-24T18:00:00.000Z");
+    vi.useRealTimers();
   });
 
   it("returns isFresh=true when deployed sha matches target", async () => {

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -21,9 +21,52 @@ import {
   nextUpgradeWindowOpen,
 } from "@/lib/self-upgrade/window";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
+import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { loadPlatformVersion } from "@/lib/platform/version";
 import { inngest } from "@/lib/queue/inngest-client";
 import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function nextHourlyCronAtOrAfter(base: Date, now: Date): Date {
+  let candidate = new Date(base);
+  candidate.setUTCMinutes(0, 0, 0);
+  if (candidate.getTime() < base.getTime()) {
+    candidate = new Date(candidate.getTime() + HOUR_MS);
+  }
+  if (candidate.getTime() <= now.getTime()) {
+    candidate = new Date(candidate.getTime() + HOUR_MS);
+  }
+  return candidate;
+}
+
+function computeNextScheduledUpgradeCheckAt(args: {
+  enabled: boolean;
+  inMaintenanceWindow: boolean;
+  nextWindowStart: Date | null;
+  lastCheckedAt: Date | null;
+  checkIntervalHours: number;
+  now: Date;
+}): Date | null {
+  if (!args.enabled) return null;
+
+  const intervalEligibleAt =
+    args.lastCheckedAt && args.checkIntervalHours > 0
+      ? new Date(args.lastCheckedAt.getTime() + args.checkIntervalHours * HOUR_MS)
+      : args.now;
+
+  if (!args.inMaintenanceWindow && !args.nextWindowStart) return null;
+
+  const base = new Date(
+    Math.max(
+      args.now.getTime(),
+      intervalEligibleAt.getTime(),
+      args.inMaintenanceWindow ? args.now.getTime() : args.nextWindowStart?.getTime() ?? 0,
+    ),
+  );
+
+  return nextHourlyCronAtOrAfter(base, args.now);
+}
 
 async function requireOpsAccess(): Promise<string> {
   const session = await auth();
@@ -589,11 +632,12 @@ export async function listSelfUpgradeRuns(opts?: {
 export async function getSelfUpgradeStatus() {
   await requireOpsAccess();
 
-  const [config, latestRun, platformVersion, deployedSha] = await Promise.all([
+  const [config, latestRun, platformVersion, deployedSha, lastCheckedAt] = await Promise.all([
     getSelfUpgradeConfig(),
     getLatestRun(),
     loadPlatformVersion(),
     getDeployedSha(),
+    getLastCheckedAt(),
   ]);
 
   // Upgrade timing follows the storefront's open/closed state (single source of
@@ -625,6 +669,15 @@ export async function getSelfUpgradeStatus() {
     : inMaintenanceWindow
       ? null
       : nextUpgradeWindowOpen(schedule, now, timezone)?.toISOString() ?? null;
+  const nextWindowStartDate = nextWindowStart ? new Date(nextWindowStart) : null;
+  const nextScheduledCheckAt = computeNextScheduledUpgradeCheckAt({
+    enabled: config.enabled,
+    inMaintenanceWindow,
+    nextWindowStart: nextWindowStartDate,
+    lastCheckedAt,
+    checkIntervalHours: config.checkIntervalHours,
+    now,
+  });
   const targetSha = await resolveTargetSha(config.channel, config);
   const isFresh = targetSha ? isShaFresh(deployedSha, targetSha) : false;
 
@@ -636,6 +689,7 @@ export async function getSelfUpgradeStatus() {
     windowSource,
     storeOpen,
     nextWindowStart,
+    nextScheduledCheckAt: nextScheduledCheckAt?.toISOString() ?? null,
     deployedSha,
     deployedShaSource: platformVersion.imageVersion?.source ?? "unknown",
     targetSha,


### PR DESCRIPTION
## Summary
- Move the self-upgrade impact summary from a client-invoked Server Action POST to a read-only GET endpoint.
- Keep the existing view_operations permission gate and no-store response semantics.
- Update the panel to validate the JSON summary response before rendering it.

## Test plan
- [x] pnpm --filter web exec vitest run app/api/ops/self-upgrade/impact-summary/route.test.ts lib/proxy/quiescence-gate.test.ts
- [x] pnpm --filter web typecheck
- [x] pnpm --filter web build
- [x] UX/evidence: reproduced from current screen state; root cause is quiescence blocking advisory Server Action POSTs while allowing GET reads. Build output confirms /api/ops/self-upgrade/impact-summary is present.

## Notes
- Overlap sweep: open PR #1401 is local-CI pregate work; no overlap with this self-upgrade summary fix.
- Build completed with existing Turbopack Edge-runtime/NFT warnings around unrelated self-upgrade/discovery imports.