### PR TITLE
feat(coworker): add interaction closeout contract

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -37,6 +37,7 @@ import { assembleSystemPrompt } from "@/lib/prompt-assembler";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import type { PortalContextEnvelope, PortalObjectAnchor } from "@/lib/portal-context";
+import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -1431,9 +1432,22 @@ export async function sendMessage(input: {
       const needsReview = (activeBuild!.taskResults as { tasks?: Array<{ outcome: string; title: string }> })?.tasks
         ?.filter(t => t.outcome !== "DONE") ?? [];
       const reviewItems = needsReview.length > 0
-        ? `\n\n**${needsReview.length} item${needsReview.length > 1 ? "s" : ""} flagged for review:**\n${needsReview.map(t => `- ${t.title}`).join("\n")}\n\nWould you like me to walk through each one, or do you want to check the sandbox preview first?`
-        : "\n\nAll tasks completed cleanly. Would you like me to run a final verification (tests + typecheck), or do you want to check the sandbox preview first?";
-      responseContent = `Build complete — ${storedResults!.completedTasks}/${storedResults!.totalTasks} tasks done.${reviewItems}`;
+        ? `\n\n**${needsReview.length} item${needsReview.length > 1 ? "s" : ""} flagged for review:**\n${needsReview.map(t => `- ${t.title}`).join("\n")}`
+        : "\n\nAll tasks completed cleanly.";
+      const closeout = needsReview.length > 0
+        ? formatCoworkerOperationalCloseout({
+          status: "needs review",
+          evidence: `${storedResults!.completedTasks}/${storedResults!.totalTasks} tasks are complete; ${needsReview.length} item${needsReview.length === 1 ? "" : "s"} are flagged for review.`,
+          nextAction: "review the flagged item output, then run the Build Studio review phase.",
+          owner: "Build Studio review agent",
+        })
+        : formatCoworkerOperationalCloseout({
+          status: "ready for review",
+          evidence: `${storedResults!.completedTasks}/${storedResults!.totalTasks} tasks are complete with no flagged task output.`,
+          nextAction: "run final verification in the Build Studio review phase.",
+          owner: "Build Studio review agent",
+        });
+      responseContent = `Build complete — ${storedResults!.completedTasks}/${storedResults!.totalTasks} tasks done.${reviewItems}\n\n${closeout}`;
       responseProviderId = "orchestrator";
       responseModelId = "multi-specialist";
       // Fall through to message persistence below

--- a/apps/web/lib/integrate/build-agent-prompts.test.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { bumpVersion } from "@/lib/feature-build-types";
 import { getBuildPhasePrompt, getBuildContextSection } from "./build-agent-prompts";
-import { SPECIALIST_TOOLS } from "./specialist-prompts";
+import { buildSpecialistPrompt, SPECIALIST_TOOLS } from "./specialist-prompts";
 import type { FeatureBrief } from "@/lib/feature-build-types";
 
 describe("bumpVersion", () => {
@@ -50,6 +50,8 @@ describe("getBuildPhasePrompt", () => {
       'NEVER ask "want me to proceed?", "should I continue?", "ready to build X?"',
     );
     expect(prompt).toContain("Never reward-hack");
+    expect(prompt).toContain("COWORKER INTERACTION CONTRACT");
+    expect(prompt).toContain("Owner:");
   });
   it("returns review prompt for review phase", async () => {
     const prompt = await getBuildPhasePrompt("review");
@@ -68,6 +70,22 @@ describe("getBuildPhasePrompt", () => {
   it("returns empty string for terminal phases", async () => {
     expect(await getBuildPhasePrompt("complete")).toBe("");
     expect(await getBuildPhasePrompt("failed")).toBe("");
+  });
+});
+
+describe("buildSpecialistPrompt", () => {
+  it("applies the coworker interaction contract to specialist handoffs", async () => {
+    const prompt = await buildSpecialistPrompt({
+      role: "qa-engineer",
+      taskDescription: "Run the scoped verification checks.",
+      buildContext: "Build ID: FB-12345678",
+    });
+
+    expect(prompt).toContain("COWORKER INTERACTION CONTRACT");
+    expect(prompt).toContain("Status:");
+    expect(prompt).toContain("Evidence:");
+    expect(prompt).toContain("Next action:");
+    expect(prompt).toContain("Owner:");
   });
 });
 

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/feature-build-types";
 import { PROJECT_CONTEXT } from "./build-project-context";
 import { loadPrompt } from "@/lib/tak/prompt-loader";
+import { withCoworkerInteractionContract } from "@/lib/tak/coworker-interaction-contract";
 
 // ─── IT4IT Value Stream Mapping ─────────────────────────────────────────────
 // Each build phase maps to an IT4IT value stream stage and responsible agents.
@@ -700,7 +701,7 @@ export async function getBuildPhasePrompt(
   if (!hardcoded) return "";
 
   const slug = variant === "feature" ? phase : `${phase}-${variant}`;
-  return loadPrompt("build-phase", slug, hardcoded);
+  return withCoworkerInteractionContract(await loadPrompt("build-phase", slug, hardcoded));
 }
 
 export type PhaseHandoffSummary = {

--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -206,8 +206,12 @@ describe("orchestrator communication templates", () => {
       ],
     });
     expect(msg).toContain("all 4 tasks done");
-    expect(msg).toContain("Ready for review");
+    expect(msg).toContain("Status: ready for review");
+    expect(msg).toContain("Evidence: 4/4 tasks completed");
+    expect(msg).toContain("Next action: run the review phase");
+    expect(msg).toContain("Owner: Build Studio review agent");
     expect(msg).toContain("Add Complaint model");
+    expect(msg).not.toContain("Ready for review?");
   });
 
   it("formats partial failure message", () => {
@@ -225,7 +229,9 @@ describe("orchestrator communication templates", () => {
     expect(msg).toContain("3 of 4 tasks completed");
     expect(msg).toContain("1 need review");
     expect(msg).toContain("Create API routes");
-    expect(msg).not.toContain("Ready for review");
+    expect(msg).toContain("Status: not ready for review");
+    expect(msg).toContain("Owner: Build Studio build agent");
+    expect(msg).not.toContain("Ready for review?");
   });
 });
 

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -43,6 +43,7 @@ import {
   artifactTypeForPhase,
   type ReviewBranchInput,
 } from "./build-reviewers";
+import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -343,11 +344,26 @@ export function formatBuildCompleteMessage(summary: BuildSummary): string {
 
   // Call to action
   if (hasBlocked || failedTasks > 0) {
-    parts.push("\nSome tasks need attention before proceeding.");
+    parts.push("\n" + formatCoworkerOperationalCloseout({
+      status: "not ready for review",
+      evidence: `${completedTasks}/${totalTasks} tasks completed; ${failedTasks} task${failedTasks === 1 ? "" : "s"} need review or repair.`,
+      nextAction: "resolve the blocked task output, then rerun Build Studio implementation or verification for the affected task.",
+      owner: "Build Studio build agent",
+    }));
   } else if (concerns.length > 0) {
-    parts.push("\nReady for review?");
+    parts.push("\n" + formatCoworkerOperationalCloseout({
+      status: "needs review",
+      evidence: `${completedTasks}/${totalTasks} tasks completed with ${concerns.length} concern${concerns.length === 1 ? "" : "s"} flagged.`,
+      nextAction: "run the review phase so acceptance, UX, and release-readiness evidence are checked.",
+      owner: "Build Studio review agent",
+    }));
   } else {
-    parts.push("\nReady for review?");
+    parts.push("\n" + formatCoworkerOperationalCloseout({
+      status: "ready for review",
+      evidence: `${completedTasks}/${totalTasks} tasks completed with no blocked task output.`,
+      nextAction: "run the review phase so tests, UX verification, and acceptance evidence are recorded.",
+      owner: "Build Studio review agent",
+    }));
   }
 
   return parts.join("\n");
@@ -966,7 +982,12 @@ export async function runBuildOrchestrator(params: {
       message: `Build plan refers to files that no longer exist: ${missingTargets}`,
     });
     return {
-      content: `Build cannot start because the implementation plan targets files that no longer exist in the current repo: ${missingTargets}. Refresh the plan against the current Build Studio file layout, then retry implementation.`,
+      content: formatCoworkerOperationalCloseout({
+        status: "blocked before implementation",
+        evidence: `the implementation plan targets files that no longer exist: ${missingTargets}.`,
+        nextAction: "refresh the plan against the current Build Studio file layout, then retry implementation.",
+        owner: "Build Studio plan agent",
+      }),
       totalTasks: 0,
       completedTasks: 0,
       failedTasks: 0,
@@ -1084,7 +1105,12 @@ export async function runBuildOrchestrator(params: {
           }).catch(() => {});
         }
         return {
-          content: `Build cannot start — the ${label} provider "${providerId}" is not connected.\n\nGo to Admin > AI Workforce > External Services and configure credentials, or switch providers in Build Studio.`,
+          content: formatCoworkerOperationalCloseout({
+            status: "blocked before implementation",
+            evidence: `the ${label} provider "${providerId}" is not connected.`,
+            nextAction: "connect the provider in Admin > AI Workforce > External Services, or switch providers in Build Studio.",
+            owner: "operator/admin",
+          }),
           totalTasks: 0, completedTasks: 0, failedTasks: 0,
           specialistResults: [], totalInputTokens: 0, totalOutputTokens: 0,
         };
@@ -1113,7 +1139,12 @@ export async function runBuildOrchestrator(params: {
         }).catch(() => {});
       }
       return {
-        content: "Build cannot start — could not verify AI provider credentials.\n\nGo to Admin > AI Workforce and ensure at least one code generation provider is connected.",
+        content: formatCoworkerOperationalCloseout({
+          status: "blocked before implementation",
+          evidence: "Build Studio could not verify AI provider credentials.",
+          nextAction: "confirm at least one code generation provider is connected in Admin > AI Workforce, then retry implementation.",
+          owner: "operator/admin",
+        }),
         totalTasks: 0, completedTasks: 0, failedTasks: 0,
         specialistResults: [], totalInputTokens: 0, totalOutputTokens: 0,
       };

--- a/apps/web/lib/integrate/specialist-prompts.ts
+++ b/apps/web/lib/integrate/specialist-prompts.ts
@@ -4,6 +4,7 @@
 
 import type { SpecialistRole } from "./task-dependency-graph";
 import { loadPrompt } from "@/lib/tak/prompt-loader";
+import { withCoworkerInteractionContract } from "@/lib/tak/coworker-interaction-contract";
 
 const SHARED_IDENTITY = `You are a specialist sub-agent in the Digital Product Factory Build Studio.
 You are executing a SINGLE task assigned by the Build Process Orchestrator.
@@ -246,7 +247,7 @@ export async function buildSpecialistPrompt(params: {
   priorResults?: string;
 }): Promise<string> {
   const hardcoded = SPECIALIST_PROMPTS[params.role];
-  const specialistPrompt = await loadPrompt("specialist", params.role, hardcoded);
+  const specialistPrompt = withCoworkerInteractionContract(await loadPrompt("specialist", params.role, hardcoded));
   const parts = [specialistPrompt];
 
   if (params.buildContext) {

--- a/apps/web/lib/tak/agent-routing-server.ts
+++ b/apps/web/lib/tak/agent-routing-server.ts
@@ -11,6 +11,7 @@ import type { AgentInfo, AgentSkill } from "@/lib/agent-coworker-types";
 import { ensureAgentPrincipalIdentity } from "@/lib/identity/principal-linking";
 import { resolveCoworkerIdentity } from "@/lib/coworker-identity";
 import type { UserContext } from "@/lib/permissions";
+import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 
 async function loadPromptBackplane(agentId: string, fallbackPrompt: string): Promise<string> {
   const dbPrompt = await loadPrompt("route-persona", agentId, fallbackPrompt);
@@ -18,7 +19,8 @@ async function loadPromptBackplane(agentId: string, fallbackPrompt: string): Pro
   const dbPreamble = await loadPrompt("platform-preamble", "platform-preamble");
   const dbMission = await loadPrompt("platform-mission", "company-mission");
   const preamble = [dbIdentity, dbMission, dbPreamble].filter(Boolean).join("\n\n");
-  return preamble ? preamble + "\n\n" + dbPrompt : dbPrompt;
+  const prompt = preamble ? preamble + "\n\n" + dbPrompt : dbPrompt;
+  return withCoworkerInteractionContract(prompt);
 }
 
 /**

--- a/apps/web/lib/tak/coworker-interaction-contract.test.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  COWORKER_INTERACTION_CONTRACT_HEADING,
+  formatCoworkerOperationalCloseout,
+  withCoworkerInteractionContract,
+} from "./coworker-interaction-contract";
+
+describe("coworker interaction contract", () => {
+  it("appends the contract to prompts once", () => {
+    const prompt = withCoworkerInteractionContract("Base prompt");
+    const twice = withCoworkerInteractionContract(prompt);
+
+    expect(prompt).toContain("Base prompt");
+    expect(prompt).toContain(COWORKER_INTERACTION_CONTRACT_HEADING);
+    expect(prompt).toContain("Status:");
+    expect(prompt).toContain("Evidence:");
+    expect(prompt).toContain("Next action:");
+    expect(prompt).toContain("Owner:");
+    expect(twice.match(new RegExp(COWORKER_INTERACTION_CONTRACT_HEADING, "g"))).toHaveLength(1);
+  });
+
+  it("formats deterministic closeouts with the required four fields", () => {
+    expect(formatCoworkerOperationalCloseout({
+      status: "ready for PR",
+      evidence: "typecheck and scoped tests passed on branch feat/example",
+      nextAction: "open the governed PR",
+      owner: "agent",
+    })).toBe([
+      "Status: ready for PR",
+      "Evidence: typecheck and scoped tests passed on branch feat/example",
+      "Next action: open the governed PR",
+      "Owner: agent",
+    ].join("\n"));
+  });
+});

--- a/apps/web/lib/tak/coworker-interaction-contract.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.ts
@@ -1,0 +1,37 @@
+export const COWORKER_INTERACTION_CONTRACT_HEADING = "COWORKER INTERACTION CONTRACT";
+
+export const COWORKER_INTERACTION_CONTRACT_PROMPT = `${COWORKER_INTERACTION_CONTRACT_HEADING}
+Every response, status update, phase handoff, final task report, notification, or review request must close with an operational next step. The closeout can be compact, but it must include:
+- Status: one plain state such as done, blocked, still running, needs review, not PR-ready, ready for PR, queued, or failed.
+- Evidence: the specific evidence behind that status, such as tests, build status, runtime observation, task count, build ID, PR link, or blocker. On business-facing surfaces, translate technical evidence into plain language unless Dev mode explicitly asks for exact identifiers.
+- Next action: one concrete action that advances or unblocks the work.
+- Owner: the agent, Build Studio, CI, reviewer, operator/admin, or human decision-maker responsible for that next action.
+
+Do not end with ambiguous handoffs such as "keep working it to ready", "let me know", "we can continue", "should be good", or a bare question like "Ready for review?" unless the same closeout also names the recommended next action and owner. Never ask the human to run terminal commands; if a command or system action is required, name the responsible agent, platform surface, CI job, or operator/admin path.`;
+
+export type CoworkerOperationalCloseout = {
+  status: string;
+  evidence: string;
+  nextAction: string;
+  owner: string;
+};
+
+export function withCoworkerInteractionContract(prompt: string): string {
+  if (prompt.includes(COWORKER_INTERACTION_CONTRACT_HEADING)) {
+    return prompt;
+  }
+
+  const trimmed = prompt.trimEnd();
+  return trimmed
+    ? `${trimmed}\n\n${COWORKER_INTERACTION_CONTRACT_PROMPT}`
+    : COWORKER_INTERACTION_CONTRACT_PROMPT;
+}
+
+export function formatCoworkerOperationalCloseout(closeout: CoworkerOperationalCloseout): string {
+  return [
+    `Status: ${closeout.status}`,
+    `Evidence: ${closeout.evidence}`,
+    `Next action: ${closeout.nextAction}`,
+    `Owner: ${closeout.owner}`,
+  ].join("\n");
+}

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -235,6 +235,17 @@ describe("assembleSystemPrompt", () => {
     expect(prompt).toContain("Do not turn this into a sales pitch");
   });
 
+  it("includes the cross-surface interaction closeout contract", async () => {
+    const prompt = await assembleSystemPrompt(fullInput);
+
+    expect(prompt).toContain("COWORKER INTERACTION CONTRACT");
+    expect(prompt).toContain("Status:");
+    expect(prompt).toContain("Evidence:");
+    expect(prompt).toContain("Next action:");
+    expect(prompt).toContain("Owner:");
+    expect(prompt).toContain("Never ask the human to run terminal commands");
+  });
+
   // ─── EP-WIKI-001 §7: wikiContext injection in Block 5 ─────────────────────
 
   it("omits the wiki block when wikiContext is null or undefined", async () => {

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -8,6 +8,7 @@ import {
   formatQuestionPacketPromptBlock,
   type QuestionPacket,
 } from "./question-packet";
+import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 
 export type PromptInput = {
   hrRole: string;
@@ -175,7 +176,7 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     dynamicBlocks.push(input.attachmentContext);
   }
 
-  return staticBlocks.join("\n\n")
+  return withCoworkerInteractionContract(staticBlocks.join("\n\n")
     + SYSTEM_PROMPT_DYNAMIC_BOUNDARY
-    + dynamicBlocks.join("\n\n");
+    + dynamicBlocks.join("\n\n"));
 }

--- a/prompts/build-phase/build.prompt.md
+++ b/prompts/build-phase/build.prompt.md
@@ -18,11 +18,17 @@ sensitivity: internal
 You are building a feature following the approved implementation plan.
 
 Call start_build FIRST. It verifies the sandbox is running and creates your git branch.
-If start_build returns "not running" — STOP. Do not retry. Tell the user: "The sandbox is not running. Please run: docker compose up -d sandbox"
+If start_build returns "not running":
+  1. Call diagnose_sandbox to classify the sandbox state and read the recommended recovery actions.
+  2. If the state is "stopped", call start_sandbox and retry start_build.
+  3. If the state is "not_found", "detached", or "mixed_compose_project", stop with Status, Evidence, Next action, and Owner. Do not hand Docker commands to the user.
 
 {{include:context/project-context}}
 
 YOU HAVE THESE TOOLS — use the right one for the job:
+- diagnose_sandbox(): Diagnose the active build sandbox and return platform-owned recovery actions. Use when start_build fails.
+- check_sandbox(): Quick running/stopped/not-found check. For anything other than stopped, use diagnose_sandbox.
+- start_sandbox(): Start the sandbox container if it is stopped. Call after diagnose_sandbox confirms "stopped".
 - start_build(): FIRST CALL. Creates the build branch and verifies sandbox is running. Call once.
 - write_sandbox_file(path, content): CREATE a new file with full content. Both parameters required.
 - read_sandbox_file(path, offset?, limit?): READ a file before changing it. ALWAYS read first. Use offset/limit for large files.

--- a/skills/build/check-status.skill.md
+++ b/skills/build/check-status.skill.md
@@ -33,7 +33,7 @@ Do not use this to start or restart sandbox infrastructure; use `manage-sandbox`
 1. Read PAGE DATA for the active build and current phase.
 2. Identify completed work, current phase, visible blockers, and pending verification.
 3. Separate facts from inferences; label missing evidence as missing.
-4. Return a short status with one next action.
+4. Return a short status with one next action and the owner of that action.
 5. If no build is active, say so and offer the smallest valid start path.
 
 ## Output Template
@@ -43,6 +43,7 @@ Do not use this to start or restart sandbox infrastructure; use `manage-sandbox`
 - Blocked by: `<blocker or none visible>`
 - Verification: `<tests/typecheck/build/UX evidence present or missing>`
 - Next action: `<one step>`
+- Owner: `<agent, Build Studio, operator/admin, reviewer, CI, or human decision-maker>`
 
 ## Guidelines
 
@@ -55,4 +56,4 @@ Do not use this to start or restart sandbox infrastructure; use `manage-sandbox`
 
 Input: "Where are we on this build?"
 
-Output: "Current phase: build. Completed: feature brief and plan exist. Blocked by: sandbox not running. Verification: no test output yet. Next action: run `manage-sandbox`, then resume build execution."
+Output: "Current phase: build. Completed: feature brief and plan exist. Blocked by: sandbox not running. Verification: no test output yet. Next action: restore sandbox readiness, then resume build execution. Owner: Build Studio sandbox manager."


### PR DESCRIPTION
## Summary
- Adds a shared Coworker Interaction Contract for AI/coworker prompts requiring Status, Evidence, Next action, and Owner in interaction closeouts.
- Wires the contract into unified coworker prompt assembly, legacy route-persona prompts, Build Studio phase prompts, and specialist prompts.
- Updates deterministic Build Studio completion/preflight/status messages to avoid ambiguous endings and avoid asking humans to run commands.

## Test plan
- [x] `pnpm --filter @dpf/db generate` via Docker image after rebasing on current `origin/main`: Prisma client generated successfully.
- [x] `pnpm --filter web exec vitest run lib/tak/coworker-interaction-contract.test.ts lib/tak/prompt-assembler.test.ts lib/integrate/build-agent-prompts.test.ts lib/integrate/build-orchestrator.test.ts` via Docker image after rebase: 4 files passed, 105 tests passed, 5 todo.
- [x] `pnpm --filter web typecheck` via Docker image after rebase and via pre-commit hook wrapper before rebase: clean.
- [x] `pnpm --filter web build` via Docker image after rebase: production build passed; existing Edge Runtime / NFT tracing warnings remain warnings.
- [x] Staged gitleaks scan: no leaks found.
- [x] UX verification: n/a, shared prompt/status formatter change with no new UI route or component.
- [x] Migration apply: n/a, no schema migration.

## Operator notes
- Branch: `feat/coworker-interaction-contract`
- Commit: `1a5856bc` with DCO sign-off.
- Rebased onto current `origin/main` after `main` advanced by #1403.
- Overlap sweep: open PRs #1404 and #1405 checked; no shared file paths with this branch.
