### PR TITLE
fix(self-upgrade): lazy-load recovery backup runners

### DIFF
--- a/apps/web/lib/self-upgrade/index.test.ts
+++ b/apps/web/lib/self-upgrade/index.test.ts
@@ -58,4 +58,9 @@ describe("self-upgrade barrel export", () => {
   it("exports notification APIs", () => {
     expect(SelfUpgrade).toHaveProperty("emitUpgradeEvent");
   });
+
+  it("exports recovery-point APIs without eagerly loading backup runners", () => {
+    expect(SelfUpgrade).toHaveProperty("createSelfUpgradeRecoveryPoint");
+    expect(SelfUpgrade).toHaveProperty("summarizeRecoveryPointFailure");
+  });
 });

--- a/apps/web/lib/self-upgrade/recovery-point.ts
+++ b/apps/web/lib/self-upgrade/recovery-point.ts
@@ -1,7 +1,23 @@
-import { runNeo4jBackup } from "@/lib/operate/backups/neo4j-backup-runner";
-import { runPostgresBackup } from "@/lib/operate/backups/postgres-backup-runner";
-import { runQdrantBackup } from "@/lib/operate/backups/qdrant-backup-runner";
 import type { BackupTarget } from "@/lib/operate/backups/types";
+
+const RECOVERY_TRIGGER = "pre-upgrade-recovery" as const;
+
+type BackupRunnerResult = { runId: string; status: "ok" | "failed" };
+type ClusteredBackupRunner = (args: {
+  trigger: typeof RECOVERY_TRIGGER;
+  composeProject?: string;
+  backupsRoot?: string;
+}) => Promise<BackupRunnerResult>;
+type QdrantBackupRunner = (args: {
+  trigger: typeof RECOVERY_TRIGGER;
+  backupsRoot?: string;
+}) => Promise<BackupRunnerResult>;
+
+interface RecoveryPointRunners {
+  postgres: ClusteredBackupRunner;
+  neo4j: ClusteredBackupRunner;
+  qdrant: QdrantBackupRunner;
+}
 
 export type SelfUpgradeRecoveryPointStatus = "ok" | "failed" | "skipped";
 
@@ -27,15 +43,9 @@ interface CreateRecoveryPointArgs {
   dryRun?: boolean;
   composeProject?: string;
   backupsRoot?: string;
-  runners?: {
-    postgres?: typeof runPostgresBackup;
-    neo4j?: typeof runNeo4jBackup;
-    qdrant?: typeof runQdrantBackup;
-  };
+  runners?: Partial<RecoveryPointRunners>;
   now?: () => Date;
 }
-
-const RECOVERY_TRIGGER = "pre-upgrade-recovery" as const;
 
 export async function createSelfUpgradeRecoveryPoint(
   args: CreateRecoveryPointArgs,
@@ -55,11 +65,7 @@ export async function createSelfUpgradeRecoveryPoint(
     };
   }
 
-  const runners = {
-    postgres: args.runners?.postgres ?? runPostgresBackup,
-    neo4j: args.runners?.neo4j ?? runNeo4jBackup,
-    qdrant: args.runners?.qdrant ?? runQdrantBackup,
-  };
+  const runners = await resolveRecoveryPointRunners(args.runners);
 
   const members: SelfUpgradeRecoveryPointMember[] = [];
   members.push(
@@ -99,9 +105,30 @@ export async function createSelfUpgradeRecoveryPoint(
   };
 }
 
+async function resolveRecoveryPointRunners(
+  overrides?: Partial<RecoveryPointRunners>,
+): Promise<RecoveryPointRunners> {
+  const [postgres, neo4j, qdrant] = await Promise.all([
+    overrides?.postgres ??
+      import("@/lib/operate/backups/postgres-backup-runner").then(
+        (module) => module.runPostgresBackup,
+      ),
+    overrides?.neo4j ??
+      import("@/lib/operate/backups/neo4j-backup-runner").then(
+        (module) => module.runNeo4jBackup,
+      ),
+    overrides?.qdrant ??
+      import("@/lib/operate/backups/qdrant-backup-runner").then(
+        (module) => module.runQdrantBackup,
+      ),
+  ]);
+
+  return { postgres, neo4j, qdrant };
+}
+
 async function runMember(
   target: BackupTarget,
-  run: () => Promise<{ runId: string; status: "ok" | "failed" }>,
+  run: () => Promise<BackupRunnerResult>,
 ): Promise<SelfUpgradeRecoveryPointMember> {
   try {
     const result = await run();


### PR DESCRIPTION
## Summary
- Fix the Unit Tests failure from #1403 by keeping the self-upgrade barrel export from eagerly importing physical backup runners.
- Lazy-load Postgres, Neo4j, and Qdrant backup runners only when a real recovery point is created.
- Add a regression assertion that recovery-point APIs are exported from the self-upgrade barrel.

## Test plan
- [x] `docker compose run --rm --no-deps -v /Users/markbodman/dpf-worktrees/worktree-upgrade-safety:/workspace -w /workspace portal sh -lc 'set -eu; export NODE_ENV=development; corepack pnpm install --frozen-lockfile; corepack pnpm --filter web exec vitest run lib/self-upgrade/index.test.ts lib/self-upgrade/recovery-point.test.ts'`
- [x] `docker compose run --rm --no-deps -v /Users/markbodman/dpf-worktrees/worktree-upgrade-safety:/workspace -w /workspace portal sh -lc 'export NODE_ENV=development; corepack pnpm --filter web typecheck'`
- [x] Previous identical working tree verification before the squash-merge follow-up: `corepack pnpm --filter web build` passed with existing Turbopack/Edge warnings.

Generated with Codex.
