### PR TITLE
feat(wiki): collapse long wiki sections

### DIFF
--- a/apps/web/components/wiki/WikiBodyRenderer.test.ts
+++ b/apps/web/components/wiki/WikiBodyRenderer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { splitWikilinks } from "./WikiBodyRenderer";
+import { renderToStaticMarkup } from "react-dom/server";
+import { splitMarkdownSections, splitWikilinks, WikiBodyRenderer } from "./WikiBodyRenderer";
 
 describe("splitWikilinks", () => {
   it("returns the whole string when no wikilinks are present", () => {
@@ -47,5 +48,35 @@ describe("splitWikilinks", () => {
 
   it("returns an empty array for an empty string", () => {
     expect(splitWikilinks("")).toEqual([]);
+  });
+});
+
+describe("splitMarkdownSections", () => {
+  it("keeps introduction markdown visible before collapsible h2 sections", () => {
+    expect(splitMarkdownSections("Intro copy\n\n## Rule\nBody\n\n## Why\nMore")).toEqual([
+      { kind: "intro", markdown: "Intro copy" },
+      { kind: "section", heading: "Rule", markdown: "Body" },
+      { kind: "section", heading: "Why", markdown: "More" },
+    ]);
+  });
+
+  it("does not split headings inside fenced code blocks", () => {
+    expect(
+      splitMarkdownSections("## Rule\n\n```md\n## Not a section\n```\n\nBody"),
+    ).toEqual([
+      { kind: "section", heading: "Rule", markdown: "```md\n## Not a section\n```\n\nBody" },
+    ]);
+  });
+
+  it("renders h2 sections as native disclosure controls", () => {
+    const html = renderToStaticMarkup(
+      WikiBodyRenderer({ body: "## Rule\nBody\n\n## Why\nMore" }),
+    );
+
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    expect(html).toContain("Rule");
+    expect(html).toContain("Why");
+    expect(html).toContain("Body");
   });
 });

--- a/apps/web/components/wiki/WikiBodyRenderer.tsx
+++ b/apps/web/components/wiki/WikiBodyRenderer.tsx
@@ -8,6 +8,7 @@
 
 import ReactMarkdown from "react-markdown";
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 
 // ─── Wikilink tokenization ──────────────────────────────────────────────────
@@ -65,6 +66,83 @@ function renderWikilinkSpans(text: string): ReactNode[] {
 
 type C = { children?: ReactNode };
 type AnchorC = C & { href?: string };
+type MarkdownSection =
+  | { kind: "intro"; markdown: string }
+  | { kind: "section"; heading: string; markdown: string };
+
+function parseCollapsibleHeading(line: string): string | null {
+  const match = line.match(/^\s{0,3}##\s+(.+?)\s*$/);
+  if (!match) return null;
+  return match[1].replace(/\s+#+$/, "").trim() || null;
+}
+
+function trimMarkdownLines(lines: string[]): string {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start].trim() === "") start += 1;
+  while (end > start && lines[end - 1].trim() === "") end -= 1;
+  return lines.slice(start, end).join("\n");
+}
+
+function fenceMarker(line: string): "`" | "~" | null {
+  const match = line.match(/^\s*(```+|~~~+)/);
+  if (!match) return null;
+  return match[1][0] as "`" | "~";
+}
+
+export function splitMarkdownSections(body: string): MarkdownSection[] {
+  const sections: MarkdownSection[] = [];
+  const introLines: string[] = [];
+  let currentSection: { heading: string; lines: string[] } | null = null;
+  let activeFence: "`" | "~" | null = null;
+
+  function flushIntro() {
+    const markdown = trimMarkdownLines(introLines);
+    if (markdown) sections.push({ kind: "intro", markdown });
+    introLines.length = 0;
+  }
+
+  function flushSection() {
+    if (!currentSection) return;
+    sections.push({
+      kind: "section",
+      heading: currentSection.heading,
+      markdown: trimMarkdownLines(currentSection.lines),
+    });
+    currentSection = null;
+  }
+
+  for (const line of body.split(/\r?\n/)) {
+    const heading = activeFence ? null : parseCollapsibleHeading(line);
+    if (heading) {
+      if (currentSection) {
+        flushSection();
+      } else {
+        flushIntro();
+      }
+      currentSection = { heading, lines: [] };
+      continue;
+    }
+
+    if (currentSection) {
+      currentSection.lines.push(line);
+    } else {
+      introLines.push(line);
+    }
+
+    const marker = fenceMarker(line);
+    if (!marker) continue;
+    if (!activeFence) {
+      activeFence = marker;
+    } else if (activeFence === marker) {
+      activeFence = null;
+    }
+  }
+
+  flushSection();
+  flushIntro();
+  return sections;
+}
 
 const components = {
   h1: ({ children }: C) => (
@@ -137,5 +215,44 @@ function transformChildren(children: ReactNode): ReactNode {
 type WikiBodyRendererProps = { body: string };
 
 export function WikiBodyRenderer({ body }: WikiBodyRendererProps): ReactNode {
-  return <ReactMarkdown components={components}>{body}</ReactMarkdown>;
+  const sections = splitMarkdownSections(body);
+  const hasCollapsibleSections = sections.some((section) => section.kind === "section");
+
+  if (!hasCollapsibleSections) {
+    return <ReactMarkdown components={components}>{body}</ReactMarkdown>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {sections.map((section, index) => {
+        if (section.kind === "intro") {
+          return (
+            <div key={`intro-${index}`}>
+              <ReactMarkdown components={components}>{section.markdown}</ReactMarkdown>
+            </div>
+          );
+        }
+
+        return (
+          <details
+            key={`${section.heading}-${index}`}
+            className="group rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+          >
+            <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-3 py-2 text-left text-sm font-semibold text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 [&::-webkit-details-marker]:hidden">
+              <ChevronRight
+                aria-hidden="true"
+                className="h-3.5 w-3.5 shrink-0 text-[var(--dpf-muted)] transition-transform group-open:rotate-90"
+              />
+              <span className="min-w-0">{section.heading}</span>
+            </summary>
+            {section.markdown && (
+              <div className="border-t border-[var(--dpf-border)] px-3 pb-1 pt-3">
+                <ReactMarkdown components={components}>{section.markdown}</ReactMarkdown>
+              </div>
+            )}
+          </details>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/web/components/wiki/WikiPageList.test.ts
+++ b/apps/web/components/wiki/WikiPageList.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
 import {
   groupPrinciplesByConsumerArchetype,
   groupPrinciplesByTier,
+  WikiPageList,
   type WikiPageListItem,
 } from "./WikiPageList";
 
@@ -160,5 +162,31 @@ describe("groupPrinciplesByConsumerArchetype", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("WikiPageList", () => {
+  it("renders top-level kind groups as native disclosure sections", () => {
+    const html = renderToStaticMarkup(
+      WikiPageList({
+        pages: [
+          makeItem("principle-a", "core", "universal"),
+          {
+            id: "entity-a",
+            slug: "entities/entity-a",
+            title: "Entity A",
+            pageKind: "entity",
+            status: "published",
+            isKernel: true,
+            abstract: null,
+          },
+        ],
+      }),
+    );
+
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    expect(html).toContain("Principles");
+    expect(html).toContain("Entities");
   });
 });

--- a/apps/web/components/wiki/WikiPageList.tsx
+++ b/apps/web/components/wiki/WikiPageList.tsx
@@ -4,6 +4,7 @@
 // Server component. Pages are passed in already filtered + sorted.
 
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 
 import {
@@ -357,28 +358,43 @@ export function WikiPageList({ pages }: Props): ReactNode {
     <div className="space-y-6">
       {orderedKinds.map((kind) => {
         const items = byKind.get(kind) ?? [];
+        const label = KIND_GROUP_LABEL[kind] ?? kind;
         if (kind === "principle") {
           const consumerGroups = groupPrinciplesByConsumerArchetype(items);
           return (
-            <section key={kind}>
-              <h2 className="text-xs uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
-                {KIND_GROUP_LABEL[kind] ?? kind} · {items.length}
-              </h2>
-              <div className="space-y-5">
+            <details
+              key={kind}
+              className="group rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+            >
+              <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 [&::-webkit-details-marker]:hidden">
+                <ChevronRight
+                  aria-hidden="true"
+                  className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90"
+                />
+                <span className="min-w-0">{label} · {items.length}</span>
+              </summary>
+              <div className="space-y-5 border-t border-[var(--dpf-border)] p-3">
                 {renderPrincipleConsumerGroups(consumerGroups)}
               </div>
-            </section>
+            </details>
           );
         }
         return (
-          <section key={kind}>
-            <h2 className="text-xs uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
-              {KIND_GROUP_LABEL[kind] ?? kind} · {items.length}
-            </h2>
-            <ul className="divide-y divide-[var(--dpf-border)] border border-[var(--dpf-border)] rounded">
+          <details
+            key={kind}
+            className="group rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+          >
+            <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 [&::-webkit-details-marker]:hidden">
+              <ChevronRight
+                aria-hidden="true"
+                className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90"
+              />
+              <span className="min-w-0">{label} · {items.length}</span>
+            </summary>
+            <ul className="divide-y divide-[var(--dpf-border)] border-t border-[var(--dpf-border)]">
               {items.map(renderItemRow)}
             </ul>
-          </section>
+          </details>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- Make wiki detail-page `##` body sections collapsible with native disclosure controls.
- Make top-level wiki browse groups collapsible so the index is scannable.
- Preserve Markdown/wikilink rendering and avoid splitting headings inside fenced code blocks.

## Test plan
- [x] `pnpm --filter web exec vitest run components/wiki/WikiBodyRenderer.test.ts components/wiki/WikiPageList.test.ts --config vitest.config.ts` — 19 passed.
- [x] `pnpm --filter web typecheck` — passed.
- [x] `pnpm --filter web build` — passed. Build emitted existing Turbopack Edge-runtime/tracing warnings, but completed successfully.
- [x] UX verification against branch preview on leased `active-candidate` port 3001: `/wiki` groups are collapsed initially and expand; `/wiki/principles/architecture-over-shortcuts` body sections are collapsed initially, `Rule` expands while `Why` remains collapsed.

## Notes
- Work was performed directly in this Codex worktree while Build Studio is not fully reliable.
- Branch is based on `origin/main`; overlap sweep found no open PRs.

Generated with Codex.
