### PR TITLE
feat(self-upgrade): restore recovery points from upgrade center

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -26,6 +26,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/actions/promotions", () => ({
   triggerSelfUpgrade: vi.fn(),
+  rollbackSelfUpgrade: vi.fn(),
 }));
 
 // The global useState mock above keys off `initial === null`, so any child
@@ -65,6 +66,7 @@ function makeRun(status: string, overrides: Record<string, unknown> = {}) {
     deployedSha: "def5678",
     startedAt: new Date("2026-05-20T02:00:00Z"),
     completedAt: new Date("2026-05-20T02:05:00Z"),
+    completionEvidence: null,
     failureLog: null as string | null,
     createdAt: new Date("2026-05-20T02:00:00Z"),
     ...overrides,
@@ -189,6 +191,56 @@ describe("SelfUpgradeClient – succeeded", () => {
     );
     expect(html).toContain("Triggered by:");
     expect(html).toContain("scheduled");
+  });
+
+  it("shows rollback controls when the latest run has a complete recovery point", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded", {
+          completionEvidence: {
+            recoveryPoint: {
+              schemaVersion: 1,
+              status: "ok",
+              trigger: "pre-upgrade-recovery",
+              members: [
+                { target: "postgres", runId: "BR-PG", status: "ok" },
+                { target: "neo4j", runId: "BR-N4J", status: "ok" },
+                { target: "qdrant", runId: "BR-QD", status: "ok" },
+              ],
+            },
+          },
+        })}
+      />,
+    );
+    expect(html).toContain("Recovery point: ok");
+    expect(html).toContain("postgres:BR-PG");
+    expect(html).toContain("Restore recovery point");
+  });
+
+  it("does not show rollback button after recovery point rollback succeeds", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded", {
+          completionEvidence: {
+            recoveryPoint: {
+              schemaVersion: 1,
+              status: "ok",
+              trigger: "pre-upgrade-recovery",
+              members: [
+                { target: "postgres", runId: "BR-PG", status: "ok" },
+                { target: "neo4j", runId: "BR-N4J", status: "ok" },
+                { target: "qdrant", runId: "BR-QD", status: "ok" },
+              ],
+            },
+            rollback: { status: "ok" },
+          },
+        })}
+      />,
+    );
+    expect(html).toContain('data-rollback-status="ok"');
+    expect(html).not.toContain("Restore recovery point");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { triggerSelfUpgrade } from "@/lib/actions/promotions";
+import { rollbackSelfUpgrade, triggerSelfUpgrade } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 
@@ -15,8 +15,15 @@ type LatestRun = {
   deployedSha: string | null;
   startedAt: Date | string | null;
   completedAt: Date | string | null;
+  completionEvidence?: unknown;
   failureLog: string | null;
   createdAt: Date | string;
+};
+
+type RecoveryPointSummary = {
+  status: string;
+  members: Array<{ target: string; runId: string | null; status: string }>;
+  rollbackStatus: string | null;
 };
 
 type ImageVersionSource = "git-sha" | "content-hash" | "unknown";
@@ -72,6 +79,30 @@ function formatDuration(start: Date | string, end: Date | string): string {
   return `${minutes}m ${seconds}s`;
 }
 
+function record(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function recoveryPointSummary(run: LatestRun | null): RecoveryPointSummary | null {
+  const evidence = record(run?.completionEvidence);
+  const point = record(evidence?.recoveryPoint);
+  if (!point || !Array.isArray(point.members)) return null;
+  const rollback = record(evidence?.rollback);
+  return {
+    status: String(point.status ?? "unknown"),
+    members: point.members.map((member) => {
+      const m = record(member);
+      return {
+        target: String(m?.target ?? "unknown"),
+        runId: typeof m?.runId === "string" ? m.runId : null,
+        status: String(m?.status ?? "unknown"),
+      };
+    }),
+    rollbackStatus: typeof rollback?.status === "string" ? rollback.status : null,
+  };
+}
+
 const RUN_STATUS_STYLES: Record<string, string> = {
   running: "bg-[var(--dpf-info)]/20 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
   succeeded: "bg-[var(--dpf-success)]/20 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
@@ -100,8 +131,20 @@ export default function SelfUpgradeClient({
 }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [isRollbackPending, startRollbackTransition] = useTransition();
   const [override, setOverride] = useState(false);
   const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(null);
+  const [rollbackConfirmation, setRollbackConfirmation] = useState("");
+  const [rollbackResult, setRollbackResult] = useState<{
+    status: "idle" | "ok" | "error";
+    message: string;
+  }>({ status: "idle", message: "" });
+  const latestRecoveryPoint = recoveryPointSummary(latestRun);
+  const canRollbackLatest =
+    latestRun &&
+    latestRun.status !== "running" &&
+    latestRecoveryPoint?.status === "ok" &&
+    latestRecoveryPoint.rollbackStatus !== "ok";
 
   function handleTrigger() {
     setTriggerResult(null);
@@ -109,6 +152,25 @@ export default function SelfUpgradeClient({
     startTransition(async () => {
       const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
       setTriggerResult(result);
+      router.refresh();
+    });
+  }
+
+  function handleRollback(runId: string) {
+    setRollbackResult({ status: "idle", message: "" });
+    startRollbackTransition(async () => {
+      const result = await rollbackSelfUpgrade(runId, rollbackConfirmation);
+      if (result.ok) {
+        setRollbackResult({
+          status: "ok",
+          message: "Recovery point restored.",
+        });
+      } else {
+        setRollbackResult({
+          status: "error",
+          message: result.error ?? "Recovery point restore failed.",
+        });
+      }
       router.refresh();
     });
   }
@@ -370,6 +432,65 @@ export default function SelfUpgradeClient({
                 {latestRun.failureLog}
               </div>
             </details>
+          )}
+
+          {latestRecoveryPoint && (
+            <div
+              className="mt-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs"
+              data-recovery-point-status={latestRecoveryPoint.status}
+            >
+              <div className="font-medium text-[var(--dpf-text)]">
+                Recovery point: {latestRecoveryPoint.status}
+              </div>
+              <div className="mt-1 text-[var(--dpf-muted)]">
+                {latestRecoveryPoint.members
+                  .map((member) => `${member.target}:${member.runId ?? "missing"}`)
+                  .join(" · ")}
+              </div>
+              {latestRecoveryPoint.rollbackStatus && (
+                <div
+                  className="mt-1 text-[var(--dpf-muted)]"
+                  data-rollback-status={latestRecoveryPoint.rollbackStatus}
+                >
+                  Rollback: {latestRecoveryPoint.rollbackStatus}
+                </div>
+              )}
+              {canRollbackLatest && (
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <input
+                    type="text"
+                    value={rollbackConfirmation}
+                    onChange={(event) => setRollbackConfirmation(event.target.value)}
+                    aria-label="Rollback confirmation"
+                    placeholder="Type ROLLBACK"
+                    className="w-full sm:w-44 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRollback(latestRun.runId)}
+                    disabled={
+                      isRollbackPending ||
+                      rollbackConfirmation !== "ROLLBACK"
+                    }
+                    aria-busy={isRollbackPending}
+                    className="rounded-md border border-[var(--dpf-destructive)]/40 bg-[var(--dpf-destructive)]/10 px-3 py-1 text-xs font-medium text-[var(--dpf-destructive)] transition-colors hover:bg-[var(--dpf-destructive)]/20 disabled:opacity-50"
+                  >
+                    {isRollbackPending ? "Restoring..." : "Restore recovery point"}
+                  </button>
+                </div>
+              )}
+              {rollbackResult.status !== "idle" && (
+                <div
+                  className={`mt-2 rounded-md border px-2 py-1 ${
+                    rollbackResult.status === "ok"
+                      ? "border-[var(--dpf-success)]/30 bg-[var(--dpf-success)]/10 text-[var(--dpf-success)]"
+                      : "border-[var(--dpf-destructive)]/30 bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)]"
+                  }`}
+                >
+                  {rollbackResult.message}
+                </div>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -71,6 +71,38 @@ vi.mock("@/lib/platform/version", () => ({
   }),
 }));
 
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/self-upgrade/rollback", () => {
+  class SelfUpgradeRollbackError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "SelfUpgradeRollbackError";
+    }
+  }
+  class RestoreIntegrityError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "RestoreIntegrityError";
+    }
+  }
+  class RestoreLockedError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "RestoreLockedError";
+    }
+  }
+  return {
+    SELF_UPGRADE_ROLLBACK_CONFIRMATION_TEXT: "ROLLBACK",
+    SelfUpgradeRollbackError,
+    RestoreIntegrityError,
+    RestoreLockedError,
+    runSelfUpgradeRollback: vi.fn(),
+  };
+});
+
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
@@ -78,7 +110,14 @@ import * as SelfUpgrade from "@/lib/self-upgrade";
 import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
-import { getSelfUpgradeStatus, listSelfUpgradeRuns, triggerSelfUpgrade } from "./promotions";
+import { revalidatePath } from "next/cache";
+import { runSelfUpgradeRollback, SelfUpgradeRollbackError } from "@/lib/self-upgrade/rollback";
+import {
+  getSelfUpgradeStatus,
+  listSelfUpgradeRuns,
+  rollbackSelfUpgrade,
+  triggerSelfUpgrade,
+} from "./promotions";
 
 const mockSession = {
   user: {
@@ -107,6 +146,7 @@ const mockRun = {
   deployedSha: "def5678",
   startedAt: new Date("2026-05-20T02:00:00Z"),
   completedAt: new Date("2026-05-20T02:05:00Z"),
+  completionEvidence: null,
   failureLog: null,
   createdAt: new Date("2026-05-20T02:00:00Z"),
   updatedAt: new Date("2026-05-20T02:05:00Z"),
@@ -327,6 +367,7 @@ const mockRunRow1 = {
   deployedSha: "def5678",
   startedAt: new Date("2026-05-20T02:00:00Z"),
   completedAt: new Date("2026-05-20T02:05:00Z"),
+  completionEvidence: { recoveryPoint: { status: "ok" } },
   failureLog: null,
   createdAt: new Date("2026-05-20T02:00:00Z"),
 };
@@ -340,6 +381,7 @@ const mockRunRow2 = {
   deployedSha: null,
   startedAt: new Date("2026-05-19T02:00:00Z"),
   completedAt: new Date("2026-05-19T02:01:00Z"),
+  completionEvidence: null,
   failureLog: "promoter exited with code 1",
   createdAt: new Date("2026-05-19T02:00:00Z"),
 };
@@ -451,6 +493,7 @@ describe("listSelfUpgradeRuns – DTO shape", () => {
     expect(run.currentSha).toBe(mockRunRow1.currentSha);
     expect(run.targetSha).toBe(mockRunRow1.targetSha);
     expect(run.deployedSha).toBe(mockRunRow1.deployedSha);
+    expect(run.completionEvidence).toEqual(mockRunRow1.completionEvidence);
     expect(run.startedAt).toEqual(mockRunRow1.startedAt);
     expect(run.completedAt).toEqual(mockRunRow1.completedAt);
     expect(run.failureLog).toBeNull();
@@ -475,6 +518,7 @@ describe("listSelfUpgradeRuns – DTO shape", () => {
     expect(select.currentSha).toBe(true);
     expect(select.targetSha).toBe(true);
     expect(select.deployedSha).toBe(true);
+    expect(select.completionEvidence).toBe(true);
     expect(select.startedAt).toBe(true);
     expect(select.completedAt).toBe(true);
     expect(select.failureLog).toBe(true);
@@ -484,6 +528,71 @@ describe("listSelfUpgradeRuns – DTO shape", () => {
     expect(select).not.toHaveProperty("fromVersion");
     expect(select).not.toHaveProperty("toVersion");
     expect(select).not.toHaveProperty("error");
+  });
+});
+
+// ─── rollbackSelfUpgrade ───────────────────────────────────────────────────────
+
+describe("rollbackSelfUpgrade", () => {
+  beforeEach(() => {
+    vi.mocked(runSelfUpgradeRollback).mockResolvedValue({
+      ok: true,
+      status: "ok",
+      runId: "SUR-AAAA0001",
+      restores: [
+        {
+          target: "postgres",
+          sourceBackupRunId: "BR-PG",
+          restoreId: "RR-PG",
+          status: "ok",
+        },
+      ],
+    });
+  });
+
+  it("rejects callers without restore authority", async () => {
+    vi.mocked(can).mockImplementation((_user, capability) => capability === "view_operations");
+
+    const result = await rollbackSelfUpgrade("SUR-AAAA0001", "ROLLBACK");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "You do not have permission to restore upgrade recovery points.",
+    });
+    expect(runSelfUpgradeRollback).not.toHaveBeenCalled();
+  });
+
+  it("requires the exact rollback confirmation text", async () => {
+    const result = await rollbackSelfUpgrade("SUR-AAAA0001", "restore");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Confirmation text must be exactly "ROLLBACK"');
+    expect(runSelfUpgradeRollback).not.toHaveBeenCalled();
+  });
+
+  it("runs the governed rollback and revalidates operations views", async () => {
+    const result = await rollbackSelfUpgrade("SUR-AAAA0001", "ROLLBACK");
+
+    expect(result).toMatchObject({ ok: true, status: "ok" });
+    expect(runSelfUpgradeRollback).toHaveBeenCalledWith({
+      runId: "SUR-AAAA0001",
+      initiatedByUserId: mockSession.user.id,
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/backups");
+  });
+
+  it("returns governed rollback errors as operator-safe messages", async () => {
+    vi.mocked(runSelfUpgradeRollback).mockRejectedValue(
+      new SelfUpgradeRollbackError("Self-upgrade run has no governed recovery point."),
+    );
+
+    const result = await rollbackSelfUpgrade("SUR-AAAA0001", "ROLLBACK");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Self-upgrade run has no governed recovery point.",
+    });
   });
 });
 

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -590,6 +590,7 @@ export type SelfUpgradeRunDto = {
   currentSha: string | null;    // schema: currentSha (was: fromVersion)
   targetSha: string | null;     // schema: targetSha (was: toVersion)
   deployedSha: string | null;   // schema: deployedSha (was: absent — adding for completeness)
+  completionEvidence?: Prisma.JsonValue | null;
   startedAt: Date | null;
   completedAt: Date | null;
   failureLog: string | null;    // schema: failureLog (was: error)
@@ -616,6 +617,7 @@ export async function listSelfUpgradeRuns(opts?: {
       currentSha: true,
       targetSha: true,
       deployedSha: true,
+      completionEvidence: true,
       startedAt: true,
       completedAt: true,
       failureLog: true,
@@ -734,4 +736,76 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
     },
   });
   return { queued: true } as const;
+}
+
+export async function rollbackSelfUpgrade(
+  runId: string,
+  typedConfirmation: string,
+): Promise<{
+  ok: boolean;
+  status?: "ok" | "failed";
+  error?: string;
+  restores?: Array<{
+    target: string;
+    sourceBackupRunId: string;
+    restoreId: string | null;
+    status: "ok" | "failed";
+    error?: string;
+  }>;
+}> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "view_operations",
+    ) ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    return { ok: false, error: "You do not have permission to restore upgrade recovery points." };
+  }
+
+  const {
+    SELF_UPGRADE_ROLLBACK_CONFIRMATION_TEXT,
+    SelfUpgradeRollbackError,
+    RestoreIntegrityError,
+    RestoreLockedError,
+    runSelfUpgradeRollback,
+  } = await import("@/lib/self-upgrade/rollback");
+
+  if (typedConfirmation !== SELF_UPGRADE_ROLLBACK_CONFIRMATION_TEXT) {
+    return {
+      ok: false,
+      error: `Confirmation text must be exactly "${SELF_UPGRADE_ROLLBACK_CONFIRMATION_TEXT}" to proceed.`,
+    };
+  }
+
+  try {
+    const result = await runSelfUpgradeRollback({
+      runId,
+      initiatedByUserId: user.id ?? null,
+    });
+    revalidatePath("/ops/self-upgrade");
+    revalidatePath("/admin/backups");
+    return {
+      ok: result.ok,
+      status: result.status,
+      restores: result.restores,
+      ...(result.error ? { error: result.error } : {}),
+    };
+  } catch (err) {
+    if (
+      err instanceof SelfUpgradeRollbackError ||
+      err instanceof RestoreIntegrityError ||
+      err instanceof RestoreLockedError
+    ) {
+      return { ok: false, error: err.message };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
 }

--- a/apps/web/lib/operate/backups/neo4j-restore-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-restore-runner.ts
@@ -41,11 +41,13 @@ const RUNNER_TIMEOUT_MS = 10 * 60 * 1000;
 export interface Neo4jRestoreArgs {
   sourceBackupRunId: string;
   initiatedByUserId?: string | null;
+  trigger?: string | null;
   backupsRoot?: string;
   scriptPath?: string;
   prismaClient?: PrismaLike;
   now?: () => Date;
   takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+  acquireLock?: boolean;
 }
 
 type PrismaLike = typeof import("@dpf/db").prisma;
@@ -116,7 +118,9 @@ export async function runNeo4jRestore(
   const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
-  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const release = args.acquireLock === false
+    ? () => {}
+    : acquireRestoreLock(args.sourceBackupRunId);
   const startedAt = now();
   restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
 
@@ -187,6 +191,7 @@ export async function runNeo4jRestore(
         startedAt,
         finishedAt,
         status: outcome.ok ? "ok" : "failed",
+        trigger: args.trigger ?? null,
         sourceBackupRunId: source.id,
         preRestoreBackupRunId: safety.runId,
         initiatedByUserId: args.initiatedByUserId ?? null,

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -67,6 +67,8 @@ export interface RestoreArgs {
   sourceBackupRunId: string;
   /** User id who clicked confirm. Stored on BackupRestore for audit. */
   initiatedByUserId?: string | null;
+  /** Restore trigger discriminator written to BackupRestore.trigger. */
+  trigger?: string | null;
   /** Override backups root for tests. */
   backupsRoot?: string;
   /** Override restore script path for tests. */
@@ -80,9 +82,30 @@ export interface RestoreArgs {
    * runPostgresBackup with trigger="pre-restore-safety".
    */
   takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+  /** Internal orchestration hook: caller already holds the shared restore lock. */
+  acquireLock?: boolean;
 }
 
 type PrismaLike = typeof import("@dpf/db").prisma;
+
+type BackupRunSnapshot = {
+  id: string;
+  target: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+  status: string;
+  trigger: string;
+  schedule: string | null;
+  sizeBytes: bigint | number | null;
+  durationMs: number | null;
+  sha256: string | null;
+  pgVersion: string | null;
+  dpfVersion: string | null;
+  storagePath: string;
+  errorMessage: string | null;
+  prunedAt: Date | null;
+  createdAt: Date;
+};
 
 function restoreTraceLog(...parts: unknown[]) {
   // CodeQL js/log-injection: parts may contain user-influenced values.
@@ -197,7 +220,9 @@ export async function runPostgresRestore(
   const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
-  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const release = args.acquireLock === false
+    ? () => {}
+    : acquireRestoreLock(args.sourceBackupRunId);
   const startedAt = now();
   restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
 
@@ -293,41 +318,24 @@ export async function runPostgresRestore(
     const durationMs = finishedAt.getTime() - startedAt.getTime();
 
     // ── 4. Re-insert audit rows AFTER the restore ─────────────────────────
-    // The DB is now in the source-dump state. The safety BackupRun row is
-    // gone; our BackupRestore row was never inserted. Re-insert both so the
-    // operator sees the restore in history and can find the safety dump.
+    // The DB is now in the source-dump state. The source BackupRun row may
+    // have been rewound to its initial "running" state because the backup row
+    // is created before pg_dump and updated to "ok" after pg_dump completes.
+    // The safety BackupRun row is gone; our BackupRestore row was never
+    // inserted. Re-insert/update all three audit facts so the operator sees
+    // the restore in history and can find both source and safety dumps.
     //
-    // We use upsert on BackupRun because the safety dump's id may collide
-    // with whatever the dump contains (extremely unlikely with cuids but
-    // defensive). We use create on BackupRestore because it's fresh.
-    await prisma.backupRun.upsert({
-      where: { id: safetyRowSnapshot.id },
-      update: {}, // if it somehow exists, leave alone
-      create: {
-        id: safetyRowSnapshot.id,
-        target: safetyRowSnapshot.target,
-        startedAt: safetyRowSnapshot.startedAt,
-        finishedAt: safetyRowSnapshot.finishedAt,
-        status: safetyRowSnapshot.status,
-        trigger: safetyRowSnapshot.trigger,
-        schedule: safetyRowSnapshot.schedule,
-        sizeBytes: safetyRowSnapshot.sizeBytes,
-        durationMs: safetyRowSnapshot.durationMs,
-        sha256: safetyRowSnapshot.sha256,
-        pgVersion: safetyRowSnapshot.pgVersion,
-        dpfVersion: safetyRowSnapshot.dpfVersion,
-        storagePath: safetyRowSnapshot.storagePath,
-        errorMessage: safetyRowSnapshot.errorMessage,
-        prunedAt: safetyRowSnapshot.prunedAt,
-        createdAt: safetyRowSnapshot.createdAt,
-      },
-    });
+    // We use upsert on BackupRun because the dump may already contain an older
+    // copy of the row. We use create on BackupRestore because it's fresh.
+    await upsertBackupRunSnapshot(prisma, source);
+    await upsertBackupRunSnapshot(prisma, safetyRowSnapshot);
 
     const created = await prisma.backupRestore.create({
       data: {
         startedAt,
         finishedAt: outcome.ok ? finishedAt : finishedAt,
         status: outcome.ok ? "ok" : "failed",
+        trigger: args.trigger ?? null,
         sourceBackupRunId: source.id,
         preRestoreBackupRunId: safety.runId,
         initiatedByUserId: args.initiatedByUserId ?? null,
@@ -353,6 +361,35 @@ export async function runPostgresRestore(
     release();
     restoreTraceLog("released lock");
   }
+}
+
+async function upsertBackupRunSnapshot(
+  prisma: PrismaLike,
+  row: BackupRunSnapshot | null,
+) {
+  if (!row) return;
+  const data = {
+    target: row.target,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+    status: row.status,
+    trigger: row.trigger,
+    schedule: row.schedule,
+    sizeBytes: row.sizeBytes,
+    durationMs: row.durationMs,
+    sha256: row.sha256,
+    pgVersion: row.pgVersion,
+    dpfVersion: row.dpfVersion,
+    storagePath: row.storagePath,
+    errorMessage: row.errorMessage,
+    prunedAt: row.prunedAt,
+    createdAt: row.createdAt,
+  };
+  await prisma.backupRun.upsert({
+    where: { id: row.id },
+    update: data,
+    create: { id: row.id, ...data },
+  });
 }
 
 // Test-only exports

--- a/apps/web/lib/operate/backups/qdrant-restore-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-restore-runner.ts
@@ -40,11 +40,13 @@ const RUNNER_TIMEOUT_MS = 30 * 60 * 1000;
 export interface QdrantRestoreArgs {
   sourceBackupRunId: string;
   initiatedByUserId?: string | null;
+  trigger?: string | null;
   backupsRoot?: string;
   scriptPath?: string;
   prismaClient?: PrismaLike;
   now?: () => Date;
   takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+  acquireLock?: boolean;
 }
 
 type PrismaLike = typeof import("@dpf/db").prisma;
@@ -114,7 +116,9 @@ export async function runQdrantRestore(
   const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
-  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const release = args.acquireLock === false
+    ? () => {}
+    : acquireRestoreLock(args.sourceBackupRunId);
   const startedAt = now();
   restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
 
@@ -176,6 +180,7 @@ export async function runQdrantRestore(
         startedAt,
         finishedAt,
         status: outcome.ok ? "ok" : "failed",
+        trigger: args.trigger ?? null,
         sourceBackupRunId: source.id,
         preRestoreBackupRunId: safety.runId,
         initiatedByUserId: args.initiatedByUserId ?? null,

--- a/apps/web/lib/self-upgrade/rollback.test.ts
+++ b/apps/web/lib/self-upgrade/rollback.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    selfUpgradeRun: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+    backupRun: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/operate/metrics", () => ({
+  postgresRestoreRunsTotal: { inc: vi.fn() },
+  postgresRestoreDurationSeconds: { observe: vi.fn() },
+}));
+
+import { prisma } from "@dpf/db";
+import { __test__ as restoreLockTest } from "@/lib/operate/backups/postgres-restore-runner";
+import {
+  hasGovernedRecoveryPoint,
+  runSelfUpgradeRollback,
+  SelfUpgradeRollbackError,
+} from "./rollback";
+
+const mockPrisma = prisma as unknown as {
+  selfUpgradeRun: {
+    findUnique: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+  backupRun: {
+    findMany: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+};
+
+const recoveryPoint = {
+  schemaVersion: 1,
+  status: "ok",
+  trigger: "pre-upgrade-recovery",
+  selfUpgradeRunId: "SUR-ROLLBACK",
+  createdAt: "2026-06-01T00:00:00.000Z",
+  members: [
+    { target: "postgres", runId: "BR-PG", status: "ok" },
+    { target: "neo4j", runId: "BR-N4J", status: "ok" },
+    { target: "qdrant", runId: "BR-QD", status: "ok" },
+  ],
+};
+
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "SUR-ROLLBACK",
+    trigger: "manual:user-ops",
+    status: "succeeded",
+    currentSha: "before-sha",
+    targetSha: "after-sha",
+    deployedSha: "after-sha",
+    startedAt: new Date("2026-06-01T00:01:00.000Z"),
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    completionEvidence: { recoveryPoint },
+    failureLog: null,
+    ...overrides,
+  };
+}
+
+function makeBackupRun(id: string, target: string) {
+  return {
+    id,
+    target,
+    startedAt: new Date("2026-06-01T00:00:00.000Z"),
+    finishedAt: new Date("2026-06-01T00:00:10.000Z"),
+    status: "ok",
+    trigger: "pre-upgrade-recovery",
+    schedule: null,
+    sizeBytes: null,
+    durationMs: 10_000,
+    sha256: `sha-${id}`,
+    pgVersion: target === "postgres" ? "16" : null,
+    dpfVersion: "before-sha",
+    storagePath: `${target}/${id}`,
+    errorMessage: null,
+    prunedAt: null,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  };
+}
+
+function mockRecoveryBackupRuns() {
+  mockPrisma.backupRun.findMany.mockResolvedValue([
+    makeBackupRun("BR-PG", "postgres"),
+    makeBackupRun("BR-N4J", "neo4j"),
+    makeBackupRun("BR-QD", "qdrant"),
+  ]);
+}
+
+describe("self-upgrade rollback", () => {
+  beforeEach(() => {
+    restoreLockTest.resetLockForTest();
+    vi.clearAllMocks();
+    mockPrisma.selfUpgradeRun.findUnique.mockResolvedValue(makeRun());
+    mockPrisma.selfUpgradeRun.upsert.mockResolvedValue({});
+    mockPrisma.backupRun.upsert.mockResolvedValue({});
+    mockRecoveryBackupRuns();
+  });
+
+  it("rejects missing self-upgrade runs", async () => {
+    mockPrisma.selfUpgradeRun.findUnique.mockResolvedValue(null);
+
+    await expect(
+      runSelfUpgradeRollback({
+        runId: "SUR-MISSING",
+        prismaClient: mockPrisma as never,
+      }),
+    ).rejects.toThrow(SelfUpgradeRollbackError);
+    expect(mockPrisma.backupRun.findMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects runs without governed recovery-point evidence", async () => {
+    mockPrisma.selfUpgradeRun.findUnique.mockResolvedValue(
+      makeRun({ completionEvidence: {} }),
+    );
+
+    await expect(
+      runSelfUpgradeRollback({
+        runId: "SUR-NO-POINT",
+        prismaClient: mockPrisma as never,
+      }),
+    ).rejects.toThrow(/no governed recovery point/i);
+  });
+
+  it("rejects incomplete recovery points before restoring anything", async () => {
+    mockPrisma.selfUpgradeRun.findUnique.mockResolvedValue(
+      makeRun({
+        completionEvidence: {
+          recoveryPoint: {
+            ...recoveryPoint,
+            members: recoveryPoint.members.filter((member) => member.target !== "qdrant"),
+          },
+        },
+      }),
+    );
+    const postgres = vi.fn();
+
+    await expect(
+      runSelfUpgradeRollback({
+        runId: "SUR-INCOMPLETE",
+        prismaClient: mockPrisma as never,
+        runners: { postgres },
+      }),
+    ).rejects.toThrow(/missing successful backup members: qdrant/i);
+    expect(postgres).not.toHaveBeenCalled();
+  });
+
+  it("restores postgres, neo4j, then qdrant from the recovery point", async () => {
+    const calls: string[] = [];
+    const now = vi
+      .fn()
+      .mockReturnValueOnce(new Date("2026-06-01T00:10:00.000Z"))
+      .mockReturnValueOnce(new Date("2026-06-01T00:15:00.000Z"));
+    const postgres = vi.fn(async (args) => {
+      calls.push("postgres");
+      expect(args).toMatchObject({
+        sourceBackupRunId: "BR-PG",
+        initiatedByUserId: "user-ops",
+        trigger: "self-upgrade-rollback",
+        acquireLock: false,
+      });
+      expect(args.prismaClient).toBe(mockPrisma);
+      return { restoreId: "RR-PG", status: "ok" as const };
+    });
+    const neo4j = vi.fn(async (args) => {
+      calls.push("neo4j");
+      expect(args).toMatchObject({
+        sourceBackupRunId: "BR-N4J",
+        trigger: "self-upgrade-rollback",
+        acquireLock: false,
+      });
+      expect(args.prismaClient).toBe(mockPrisma);
+      return { restoreId: "RR-N4J", status: "ok" as const };
+    });
+    const qdrant = vi.fn(async (args) => {
+      calls.push("qdrant");
+      expect(args).toMatchObject({
+        sourceBackupRunId: "BR-QD",
+        trigger: "self-upgrade-rollback",
+        acquireLock: false,
+      });
+      expect(args.prismaClient).toBe(mockPrisma);
+      return { restoreId: "RR-QD", status: "ok" as const };
+    });
+
+    const result = await runSelfUpgradeRollback({
+      runId: "SUR-ROLLBACK",
+      initiatedByUserId: "user-ops",
+      prismaClient: mockPrisma as never,
+      now,
+      runners: { postgres, neo4j, qdrant },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "ok",
+      runId: "SUR-ROLLBACK",
+      restores: [
+        { target: "postgres", sourceBackupRunId: "BR-PG", restoreId: "RR-PG", status: "ok" },
+        { target: "neo4j", sourceBackupRunId: "BR-N4J", restoreId: "RR-N4J", status: "ok" },
+        { target: "qdrant", sourceBackupRunId: "BR-QD", restoreId: "RR-QD", status: "ok" },
+      ],
+    });
+    expect(calls).toEqual(["postgres", "neo4j", "qdrant"]);
+    expect(mockPrisma.backupRun.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["BR-PG", "BR-N4J", "BR-QD"] } },
+    });
+    expect(mockPrisma.backupRun.upsert).toHaveBeenCalledTimes(3);
+    expect(mockPrisma.backupRun.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: { id: "BR-PG" } }),
+    );
+    expect(mockPrisma.selfUpgradeRun.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { runId: "SUR-ROLLBACK" },
+        update: expect.objectContaining({
+          status: "rolled-back",
+          failureLog: null,
+        }),
+      }),
+    );
+    const upsertCall = mockPrisma.selfUpgradeRun.upsert.mock.calls[0][0];
+    expect(upsertCall.update.completionEvidence.rollback).toMatchObject({
+      schemaVersion: 1,
+      trigger: "self-upgrade-rollback",
+      status: "ok",
+      selfUpgradeRunId: "SUR-ROLLBACK",
+      restoreOrder: ["postgres", "neo4j", "qdrant"],
+    });
+  });
+
+  it("stops after a failed member restore and records rollback-failed evidence", async () => {
+    const postgres = vi.fn().mockResolvedValue({ restoreId: "RR-PG", status: "ok" });
+    const neo4j = vi.fn().mockRejectedValue(new Error("neo4j volume missing"));
+    const qdrant = vi.fn().mockResolvedValue({ restoreId: "RR-QD", status: "ok" });
+
+    const result = await runSelfUpgradeRollback({
+      runId: "SUR-ROLLBACK",
+      prismaClient: mockPrisma as never,
+      runners: { postgres, neo4j, qdrant },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "failed",
+      error: "self-upgrade rollback failed at neo4j: neo4j volume missing",
+    });
+    expect(postgres).toHaveBeenCalledTimes(1);
+    expect(neo4j).toHaveBeenCalledTimes(1);
+    expect(qdrant).not.toHaveBeenCalled();
+    expect(mockPrisma.backupRun.upsert).toHaveBeenCalledTimes(3);
+    expect(mockPrisma.selfUpgradeRun.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          status: "rollback-failed",
+          failureLog: "self-upgrade rollback failed at neo4j: neo4j volume missing",
+        }),
+      }),
+    );
+  });
+
+  it("reports whether completion evidence contains a restorable recovery point", () => {
+    expect(hasGovernedRecoveryPoint({ recoveryPoint })).toBe(true);
+    expect(hasGovernedRecoveryPoint({ recoveryPoint: { ...recoveryPoint, status: "failed" } })).toBe(false);
+    expect(hasGovernedRecoveryPoint({})).toBe(false);
+  });
+});

--- a/apps/web/lib/self-upgrade/rollback.ts
+++ b/apps/web/lib/self-upgrade/rollback.ts
@@ -1,0 +1,429 @@
+import { prisma as defaultPrisma, type Prisma } from "@dpf/db";
+
+import type { BackupTarget } from "@/lib/operate/backups/types";
+import {
+  acquireRestoreLock,
+  RestoreIntegrityError,
+  RestoreLockedError,
+  runPostgresRestore,
+} from "@/lib/operate/backups/postgres-restore-runner";
+import { runNeo4jRestore } from "@/lib/operate/backups/neo4j-restore-runner";
+import { runQdrantRestore } from "@/lib/operate/backups/qdrant-restore-runner";
+
+export const SELF_UPGRADE_ROLLBACK_CONFIRMATION_TEXT = "ROLLBACK";
+const ROLLBACK_TRIGGER = "self-upgrade-rollback";
+const RESTORE_ORDER: BackupTarget[] = ["postgres", "neo4j", "qdrant"];
+
+type PrismaLike = typeof defaultPrisma;
+
+type BackupRunSnapshot = {
+  id: string;
+  target: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+  status: string;
+  trigger: string;
+  schedule: string | null;
+  sizeBytes: bigint | number | null;
+  durationMs: number | null;
+  sha256: string | null;
+  pgVersion: string | null;
+  dpfVersion: string | null;
+  storagePath: string;
+  errorMessage: string | null;
+  prunedAt: Date | null;
+  createdAt: Date;
+};
+
+type RestoreRunnerResult = { restoreId: string; status: "ok" | "failed" };
+type RestoreRunner = (args: {
+  sourceBackupRunId: string;
+  initiatedByUserId?: string | null;
+  trigger?: string | null;
+  prismaClient?: PrismaLike;
+  acquireLock?: boolean;
+}) => Promise<RestoreRunnerResult>;
+
+export interface SelfUpgradeRollbackMemberResult {
+  target: BackupTarget;
+  sourceBackupRunId: string;
+  restoreId: string | null;
+  status: "ok" | "failed";
+  error?: string;
+}
+
+export interface SelfUpgradeRollbackEvidence {
+  schemaVersion: 1;
+  trigger: typeof ROLLBACK_TRIGGER;
+  status: "ok" | "failed";
+  selfUpgradeRunId: string;
+  startedAt: string;
+  completedAt: string;
+  initiatedByUserId: string | null;
+  restoreOrder: BackupTarget[];
+  restores: SelfUpgradeRollbackMemberResult[];
+}
+
+export interface SelfUpgradeRollbackResult {
+  ok: boolean;
+  status: "ok" | "failed";
+  runId: string;
+  restores: SelfUpgradeRollbackMemberResult[];
+  error?: string;
+}
+
+export class SelfUpgradeRollbackError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SelfUpgradeRollbackError";
+  }
+}
+
+interface SelfUpgradeRecoveryPointMemberLike {
+  target: BackupTarget;
+  runId: string | null;
+  status: "ok" | "failed";
+  error?: string;
+}
+
+interface SelfUpgradeRecoveryPointLike {
+  schemaVersion: 1;
+  status: "ok" | "failed" | "skipped";
+  trigger: "pre-upgrade-recovery";
+  selfUpgradeRunId: string;
+  createdAt: string;
+  members: SelfUpgradeRecoveryPointMemberLike[];
+}
+
+interface RollbackArgs {
+  runId: string;
+  initiatedByUserId?: string | null;
+  prismaClient?: PrismaLike;
+  now?: () => Date;
+  runners?: Partial<Record<BackupTarget, RestoreRunner>>;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseRecoveryPoint(value: unknown): SelfUpgradeRecoveryPointLike | null {
+  const evidence = toRecord(value);
+  const point = toRecord(evidence?.recoveryPoint);
+  if (!point) return null;
+  if (point.schemaVersion !== 1) return null;
+  if (point.trigger !== "pre-upgrade-recovery") return null;
+  if (!Array.isArray(point.members)) return null;
+
+  return point as unknown as SelfUpgradeRecoveryPointLike;
+}
+
+function memberMap(point: SelfUpgradeRecoveryPointLike): Record<BackupTarget, string> {
+  if (point.status !== "ok") {
+    throw new SelfUpgradeRollbackError(
+      `Recovery point status is ${point.status}; only complete recovery points can be restored.`,
+    );
+  }
+
+  const byTarget = new Map<BackupTarget, string>();
+  for (const member of point.members) {
+    if (member.status === "ok" && member.runId) {
+      byTarget.set(member.target, member.runId);
+    }
+  }
+
+  const missing = RESTORE_ORDER.filter((target) => !byTarget.has(target));
+  if (missing.length > 0) {
+    throw new SelfUpgradeRollbackError(
+      `Recovery point is missing successful backup members: ${missing.join(", ")}.`,
+    );
+  }
+
+  return {
+    postgres: byTarget.get("postgres")!,
+    neo4j: byTarget.get("neo4j")!,
+    qdrant: byTarget.get("qdrant")!,
+  };
+}
+
+async function resolveRunners(
+  overrides?: Partial<Record<BackupTarget, RestoreRunner>>,
+): Promise<Record<BackupTarget, RestoreRunner>> {
+  return {
+    postgres: overrides?.postgres ?? runPostgresRestore,
+    neo4j: overrides?.neo4j ?? runNeo4jRestore,
+    qdrant: overrides?.qdrant ?? runQdrantRestore,
+  };
+}
+
+function backupRunSnapshotData(row: BackupRunSnapshot) {
+  return {
+    target: row.target,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+    status: row.status,
+    trigger: row.trigger,
+    schedule: row.schedule,
+    sizeBytes: row.sizeBytes,
+    durationMs: row.durationMs,
+    sha256: row.sha256,
+    pgVersion: row.pgVersion,
+    dpfVersion: row.dpfVersion,
+    storagePath: row.storagePath,
+    errorMessage: row.errorMessage,
+    prunedAt: row.prunedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+async function upsertBackupRunSnapshots(
+  prisma: PrismaLike,
+  snapshots: BackupRunSnapshot[],
+) {
+  for (const row of snapshots) {
+    const data = backupRunSnapshotData(row);
+    await prisma.backupRun.upsert({
+      where: { id: row.id },
+      update: data,
+      create: { id: row.id, ...data },
+    });
+  }
+}
+
+function toJson(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+function mergeRollbackEvidence(args: {
+  existingEvidence: unknown;
+  recoveryPoint: SelfUpgradeRecoveryPointLike;
+  rollback: SelfUpgradeRollbackEvidence;
+}): Prisma.InputJsonValue {
+  return toJson({
+    ...(toRecord(args.existingEvidence) ?? {}),
+    recoveryPoint: args.recoveryPoint,
+    rollback: args.rollback,
+  });
+}
+
+function summarizeRestoreFailure(restores: SelfUpgradeRollbackMemberResult[]): string {
+  const failed = restores.find((restore) => restore.status === "failed");
+  if (!failed) return "self-upgrade rollback failed";
+  return `self-upgrade rollback failed at ${failed.target}: ${failed.error ?? failed.restoreId ?? "restore failed"}`;
+}
+
+async function recordRollbackEvidence(args: {
+  prisma: PrismaLike;
+  run: {
+    runId: string;
+    trigger: string;
+    currentSha: string | null;
+    targetSha: string | null;
+    deployedSha: string | null;
+    startedAt: Date | null;
+    createdAt: Date;
+    completionEvidence: unknown;
+    failureLog: string | null;
+  };
+  recoveryPoint: SelfUpgradeRecoveryPointLike;
+  rollback: SelfUpgradeRollbackEvidence;
+}) {
+  const failed = args.rollback.status === "failed";
+  const failureLog = failed
+    ? [
+        args.run.failureLog,
+        summarizeRestoreFailure(args.rollback.restores),
+      ].filter(Boolean).join("\n")
+    : args.run.failureLog;
+
+  await args.prisma.selfUpgradeRun.upsert({
+    where: { runId: args.run.runId },
+    update: {
+      status: failed ? "rollback-failed" : "rolled-back",
+      completedAt: new Date(args.rollback.completedAt),
+      failureLog: failureLog || null,
+      completionEvidence: mergeRollbackEvidence({
+        existingEvidence: args.run.completionEvidence,
+        recoveryPoint: args.recoveryPoint,
+        rollback: args.rollback,
+      }),
+    },
+    create: {
+      runId: args.run.runId,
+      trigger: args.run.trigger,
+      status: failed ? "rollback-failed" : "rolled-back",
+      currentSha: args.run.currentSha,
+      targetSha: args.run.targetSha,
+      deployedSha: args.run.deployedSha,
+      startedAt: args.run.startedAt,
+      completedAt: new Date(args.rollback.completedAt),
+      createdAt: args.run.createdAt,
+      failureLog: failureLog || null,
+      completionEvidence: mergeRollbackEvidence({
+        existingEvidence: args.run.completionEvidence,
+        recoveryPoint: args.recoveryPoint,
+        rollback: args.rollback,
+      }),
+    },
+  });
+}
+
+async function loadRecoverySourceSnapshots(
+  prisma: PrismaLike,
+  memberRunIds: Record<BackupTarget, string>,
+): Promise<BackupRunSnapshot[]> {
+  const ids = RESTORE_ORDER.map((target) => memberRunIds[target]);
+  const rows = await prisma.backupRun.findMany({
+    where: { id: { in: ids } },
+  });
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const missing = ids.filter((id) => !rowsById.has(id));
+  if (missing.length > 0) {
+    throw new SelfUpgradeRollbackError(
+      `Recovery point BackupRun rows are missing: ${missing.join(", ")}.`,
+    );
+  }
+  return ids.map((id) => rowsById.get(id)!);
+}
+
+async function runRestoreMember(args: {
+  target: BackupTarget;
+  sourceBackupRunId: string;
+  runner: RestoreRunner;
+  initiatedByUserId: string | null;
+  prisma: PrismaLike;
+}): Promise<SelfUpgradeRollbackMemberResult> {
+  try {
+    const result = await args.runner({
+      sourceBackupRunId: args.sourceBackupRunId,
+      initiatedByUserId: args.initiatedByUserId,
+      trigger: ROLLBACK_TRIGGER,
+      prismaClient: args.prisma,
+      acquireLock: false,
+    });
+    return {
+      target: args.target,
+      sourceBackupRunId: args.sourceBackupRunId,
+      restoreId: result.restoreId,
+      status: result.status,
+    };
+  } catch (err) {
+    return {
+      target: args.target,
+      sourceBackupRunId: args.sourceBackupRunId,
+      restoreId: null,
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function runSelfUpgradeRollback(
+  args: RollbackArgs,
+): Promise<SelfUpgradeRollbackResult> {
+  const prisma = args.prismaClient ?? defaultPrisma;
+  const now = args.now ?? (() => new Date());
+  const initiatedByUserId = args.initiatedByUserId ?? null;
+  const startedAt = now();
+
+  const run = await prisma.selfUpgradeRun.findUnique({
+    where: { runId: args.runId },
+    select: {
+      runId: true,
+      trigger: true,
+      currentSha: true,
+      targetSha: true,
+      deployedSha: true,
+      startedAt: true,
+      createdAt: true,
+      status: true,
+      completionEvidence: true,
+      failureLog: true,
+    },
+  });
+  if (!run) {
+    throw new SelfUpgradeRollbackError(`SelfUpgradeRun ${args.runId} not found.`);
+  }
+  if (run.status === "running") {
+    throw new SelfUpgradeRollbackError("Cannot rollback while the self-upgrade run is still running.");
+  }
+
+  const recoveryPoint = parseRecoveryPoint(run.completionEvidence);
+  if (!recoveryPoint) {
+    throw new SelfUpgradeRollbackError("Self-upgrade run has no governed recovery point.");
+  }
+  const memberRunIds = memberMap(recoveryPoint);
+  const sourceSnapshots = await loadRecoverySourceSnapshots(prisma, memberRunIds);
+  const runners = await resolveRunners(args.runners);
+
+  const restores: SelfUpgradeRollbackMemberResult[] = [];
+  const release = acquireRestoreLock(`${ROLLBACK_TRIGGER}:${args.runId}`);
+  try {
+    for (const target of RESTORE_ORDER) {
+      const result = await runRestoreMember({
+        target,
+        sourceBackupRunId: memberRunIds[target],
+        runner: runners[target],
+        initiatedByUserId,
+        prisma,
+      });
+      restores.push(result);
+
+      // Postgres restore rewinds the DB to a point before the Neo4j/Qdrant
+      // BackupRun rows existed. Reinsert all source rows before continuing.
+      if (target === "postgres") {
+        await upsertBackupRunSnapshots(prisma, sourceSnapshots);
+      }
+
+      if (result.status === "failed") break;
+    }
+  } finally {
+    release();
+  }
+
+  const status = restores.every((restore) => restore.status === "ok") &&
+    restores.length === RESTORE_ORDER.length
+    ? "ok"
+    : "failed";
+  const completedAt = now();
+  const rollback: SelfUpgradeRollbackEvidence = {
+    schemaVersion: 1,
+    trigger: ROLLBACK_TRIGGER,
+    status,
+    selfUpgradeRunId: args.runId,
+    startedAt: startedAt.toISOString(),
+    completedAt: completedAt.toISOString(),
+    initiatedByUserId,
+    restoreOrder: RESTORE_ORDER,
+    restores,
+  };
+
+  await recordRollbackEvidence({
+    prisma,
+    run,
+    recoveryPoint,
+    rollback,
+  });
+
+  return {
+    ok: status === "ok",
+    status,
+    runId: args.runId,
+    restores,
+    ...(status === "failed" ? { error: summarizeRestoreFailure(restores) } : {}),
+  };
+}
+
+export function hasGovernedRecoveryPoint(completionEvidence: unknown): boolean {
+  const recoveryPoint = parseRecoveryPoint(completionEvidence);
+  if (!recoveryPoint) return false;
+  try {
+    memberMap(recoveryPoint);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export { RestoreIntegrityError, RestoreLockedError };

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -34,11 +34,14 @@ The DR-hardening epic (BIs shipped 2026-05-24) put recovery artifacts in **speci
 | Tool config / installer state | `install-state.json` in install dir | If lost: re-run `install-dpf.{ps1,sh}`; it's idempotent |
 | Failed platform upgrade / bad seed apply / migration damage | Governed upgrade recovery point: linked `BackupRun` rows under `$DPF_BACKUPS_HOST_PATH/{postgres,neo4j,qdrant}/<ts>/` plus previous runtime identity under `$DPF_BACKUPS_HOST_PATH/self-upgrade/<runId>/` | Upgrade Center rollback/restore flow; if unavailable, restore the Postgres member first, then Neo4j/Qdrant as needed |
 
-Implementation note (2026-06-01): self-upgrade runs now record the linked
+Implementation note (2026-06-01): self-upgrade runs record the linked
 Postgres/Neo4j/Qdrant backup members in
 `SelfUpgradeRun.completionEvidence.recoveryPoint` after quiescence drains active
-work and before the swap boundary. The dedicated Upgrade Center rollback action
-is still pending, so if the portal is unavailable, use the recorded `BackupRun`
+work and before the swap boundary. `/ops/self-upgrade` can restore that matched
+recovery point for completed non-running runs; the action records
+`completionEvidence.rollback`, writes `self-upgrade-rollback` into
+`BackupRestore.trigger`, and marks the run `rolled-back` or
+`rollback-failed`. If the portal is unavailable, use the recorded `BackupRun`
 ids to restore through the backup substrate directly.
 
 **Key principle:** if you can't find your loss in this table, that means there's no automatic recovery for it. Stop and ask for help BEFORE doing anything destructive — the action you take next may be the difference between a 1-hour and 6-hour recovery.
@@ -164,9 +167,11 @@ not as a fresh install problem.
 
 1. Do not reinstall and do not reset volumes. The recovery point taken before
    apply is the boundary between recoverable and data-lossy.
-2. In the portal, open `/ops/self-upgrade` and inspect the failed run. If the
-   governed lifecycle is active, use its rollback/restore action; it knows the
-   exact Postgres/Neo4j/Qdrant backup rows created for the run.
+2. In the portal, open `/ops/self-upgrade` and inspect the failed run. When the
+   run has a complete `pre-upgrade-recovery` point, type the confirmation text
+   and use the recovery-point restore action; it knows the exact
+   Postgres/Neo4j/Qdrant backup rows created for the run and records rollback
+   evidence on the run.
 3. If the portal is unavailable, use `/admin/backups` after bringing the
    database services up. Restore the Postgres backup associated with the failed
    upgrade first. Restore Neo4j and Qdrant only when graph/vector data is

--- a/docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md
@@ -215,11 +215,15 @@ Neo4j, and Qdrant under `/backups/<target>/...`, with `BackupRun` rows and
 retention. Restore runners exist for all three targets, and Postgres also has
 trial-restore verification.
 
-Remaining gap: the Upgrade Center still needs a first-class rollback/restore
-action that reads the linked `SelfUpgradeRun.completionEvidence.recoveryPoint`
-and walks the operator through the matched restore members. Until then, this
-slice creates the recovery point and durable evidence; restore orchestration is
-still manual through the backup restore substrate.
+Implementation note (2026-06-02): `/ops/self-upgrade` now exposes a
+first-class recovery-point restore action for completed non-running runs with a
+complete `SelfUpgradeRun.completionEvidence.recoveryPoint`. The action acquires
+the shared restore lock once, restores Postgres, Neo4j, then Qdrant from the
+matched `BackupRun` rows, writes `self-upgrade-rollback` into
+`BackupRestore.trigger` for each member, and records
+`SelfUpgradeRun.completionEvidence.rollback` with per-member restore results.
+The remaining gap is layer-aware automatic rollback; this action is an operator
+confirmed restore from the pre-upgrade data recovery point.
 
 ### 2.8 What can go wrong today
 


### PR DESCRIPTION
## Summary
- Add governed self-upgrade rollback orchestration that restores the recorded pre-upgrade recovery point in Postgres -> Neo4j -> Qdrant order.
- Surface recovery-point restore controls on `/ops/self-upgrade` with typed `ROLLBACK` confirmation and rollback evidence/status display.
- Preserve restore audit rows through Postgres rewinds and document the new DR/upgrade rollback behavior.

## Test plan
- [x] `docker compose run --rm --no-deps -v /Users/markbodman/dpf-worktrees/self-upgrade-rollback:/workspace -w /workspace portal sh -lc 'pnpm install --frozen-lockfile && pnpm --filter web exec vitest run lib/self-upgrade/rollback.test.ts components/ops/SelfUpgradeClient.test.tsx lib/actions/promotions.self-upgrade.test.ts lib/operate/backups/postgres-restore-runner.test.ts && pnpm --filter web typecheck'` — 110 tests passed; typecheck passed.
- [x] `docker compose build portal` — production build passed on the rebased branch. Existing Edge-runtime/NFT trace warnings were emitted but did not fail the build.
- [x] `git diff --check` — passed.
- [x] UX coverage: static-render tests cover the recovery-point controls; the live restore button was not clicked because it performs a destructive data restore.

## Notes
- Overlap sweep before push: `gh pr list --state open --limit 50` returned no open PRs.
- Branch was rebased onto `origin/main` after #1408 landed; no file overlap with #1408's wiki changes.
- This opens as a regular PR, not draft, per the updated Codex/PR handoff expectation.