### PR TITLE
docs(self-upgrade): add sandbox recovery rehearsal research

### DIFF
--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -44,6 +44,15 @@ recovery point for completed non-running runs; the action records
 `rollback-failed`. If the portal is unavailable, use the recorded `BackupRun`
 ids to restore through the backup substrate directly.
 
+Research note (2026-06-02): the sandbox server is a recovery rehearsal target,
+not a backup of record. Use it to prove that a recovery point can restore and
+boot before production state is touched. Today only the Postgres trial-restore
+path is shipped end-to-end. The default Build Studio sandbox has isolated
+Postgres, but its base compose configuration still points Neo4j and Qdrant at
+the shared services; full graph/vector rehearsal requires isolated Neo4j and
+Qdrant endpoints first. Never use the dev-against-live-DB compose overlay for
+recovery rehearsal because it can write to live data.
+
 **Key principle:** if you can't find your loss in this table, that means there's no automatic recovery for it. Stop and ask for help BEFORE doing anything destructive — the action you take next may be the difference between a 1-hour and 6-hour recovery.
 
 ---
@@ -172,20 +181,55 @@ not as a fresh install problem.
    and use the recovery-point restore action; it knows the exact
    Postgres/Neo4j/Qdrant backup rows created for the run and records rollback
    evidence on the run.
-3. If the portal is unavailable, use `/admin/backups` after bringing the
+3. If production is impaired but stable enough to wait, prefer a sandbox-assisted
+   rehearsal before touching production: restore the recovery-point members into
+   an isolated nonproduction target, boot the portal against that target, and
+   capture health/smoke evidence on the `SelfUpgradeRun`. Until the full
+   rehearsal tool lands, treat Postgres trial-restore as the only shipped
+   restore proof and mark Neo4j/Qdrant rehearsal `not-run` unless isolated
+   endpoints are provisioned.
+4. If the portal is unavailable, use `/admin/backups` after bringing the
    database services up. Restore the Postgres backup associated with the failed
    upgrade first. Restore Neo4j and Qdrant only when graph/vector data is
    missing or incompatible; both are usually regenerable from Postgres, but
    restoring the matched recovery-point members is faster.
-4. After recovery, capture the failed `SelfUpgradeRun`, `BackupRun`, and
+5. After recovery, capture the failed `SelfUpgradeRun`, `BackupRun`, and
    restore records in the incident notes. Do not delete the failed recovery
    point until the next successful nightly backup and trial restore have passed.
-5. If the incident involved Build Studio or an external worker such as Grok,
+6. If the incident involved Build Studio or an external worker such as Grok,
    preserve the worker worktree before cleanup. Record its branch, dirty state,
    touched paths, and whether it was `compile-ready` or `source-only`. A
    source-only worktree is useful forensic evidence, but its local test/build
    claims are not recovery evidence unless the same gates also ran in canonical
    runtime or the shared local-CI sandbox.
+
+### 3.5b Sandbox-assisted recovery rehearsal
+
+Use this when a restore is high-risk but not yet an emergency volume-loss
+situation. The goal is to turn a restore from an act of faith into evidence:
+the same recovery point that would be applied to production is first applied to
+an isolated target and smoke-tested.
+
+Safe targets:
+
+- `local-integration-ci`, when leased through the nonproduction environment
+  lease system and backed by isolated Postgres, Neo4j, and Qdrant endpoints.
+- A future dedicated `recovery-drill` environment key for longer BC/DR drills.
+- The Build Studio `sandbox` only for source, seed, migration, and Postgres
+  rehearsal until its graph/vector endpoints are isolated.
+
+Unsafe targets:
+
+- `docker-compose.dev-against-live-db.yml`, because it intentionally writes to
+  live databases.
+- Any sandbox whose Neo4j/Qdrant URLs resolve to the production containers.
+- Docker named volumes by themselves. Volumes persist container data, but the
+  durable recovery artifact is the host-retained backup plus restore evidence.
+
+The rehearsal should record lease id, backup run ids, restore log paths,
+health/smoke results, image/source identity, and expiry/cleanup status. If a
+member is skipped because isolation is missing, record `not-run` rather than
+implying that the whole recovery point was proven.
 
 ### 3.6 Lost a Claude Code session transcript (forensic recovery)
 
@@ -260,6 +304,7 @@ Cross-references for engineers reading this:
 | Backups OUTSIDE install root | [`runtime-kernel-commandments.md`](runtime-kernel-commandments.md) + spec `2026-05-17-postgres-daily-backup-design.md` §5.3 | Shipped (BI-8004BCD8) |
 | Runtime gate that blocks destructive commands | [`runtime-kernel-commandments.md`](runtime-kernel-commandments.md) | Shipped (BI-43F95F77) |
 | Nightly trial-restore verification | spec `2026-05-17-postgres-daily-backup-design.md` §4.7 | Shipped (BI-31C9FBDF) |
+| Sandbox-assisted recovery rehearsal | spec `2026-05-23-governed-platform-upgrade-lifecycle-design.md` §5.2.7 | Designed 2026-06-02; Postgres proof pattern shipped, full graph/vector rehearsal pending isolated endpoints |
 | Worktree janitor (lib + tests) | spec `2026-05-16-worktree-hygiene-design.md` | Phase 1 shipped (BI-E5002629); Phase 2-5 pending |
 | Claude Code transcript snapshots | [`session-transcript-recovery.md`](session-transcript-recovery.md) | Shipped (BI-C8655C8C) |
 | Pre-destructive snapshots | [`runtime-kernel-commandments.md`](runtime-kernel-commandments.md) §"Pre-destructive snapshots" | Shipped (BI-611C25F3) |

--- a/docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md
@@ -857,6 +857,61 @@ becomes active: backup time, targets covered, integrity status, and retention
 risk. This makes BC/DR part of the upgrade workflow, not a separate document
 the operator is expected to remember under stress.
 
+#### 5.2.7 Sandbox-assisted recovery rehearsal
+
+Research addendum (2026-06-02): the sandbox should become the place where a
+recovery point is rehearsed before production state is touched. NIST SP 800-34
+frames contingency planning around recovery strategies, alternate processing
+capacity, and testing/training/exercises; the same principle applies here:
+DPF should prove a recovery point on an alternate target, then use that
+evidence to reduce the risk of the production restore.
+
+Current substrate:
+
+| Surface | Current shape | Recovery use | Constraint |
+|---|---|---|---|
+| Build Studio `sandbox` | `sandbox` service on `3035` with isolated `sandbox-postgres` and shared `sandbox_workspace` | Good for source-local development, seed/migration rehearsal, and Postgres restore rehearsal against a non-production DB | Base compose still points `NEO4J_URI` and `QDRANT_INTERNAL_URL` at the shared `neo4j`/`qdrant` services, so it is not yet safe for destructive graph/vector restore drills. |
+| Shared `local-integration-ci` | Lease-governed `local-ci-portal` on `3010`, with configurable Postgres/Neo4j/Qdrant endpoints | Best v1 target for canonical runtime-bound upgrade verification and future full recovery rehearsal | Requires provisioned isolated DB endpoints and a live lease before recording evidence. |
+| `docker-compose.dev-against-live-db.yml` | Opt-in dev portal connected to live databases | Excluded | It can write to live state and must never be used for recovery drills. |
+| Existing Postgres trial restore | `scripts/postgres-trial-restore.sh` restores a dump into a temporary DB and asserts critical row counts | Shipped proof pattern for rehearsal | Postgres-only today; does not prove Neo4j/Qdrant members. |
+
+The v1 recovery rehearsal should be a governed operation, not an operator
+runbook command:
+
+1. Claim `local-integration-ci` with a purpose such as
+   `self-upgrade-recovery-rehearsal`.
+2. Prepare isolated targets: empty Postgres DB, isolated Neo4j container, and
+   isolated Qdrant endpoint. If graph/vector endpoints are not isolated, mark
+   those members `not-run` instead of touching shared services.
+3. Restore the selected recovery point members into those targets:
+   Postgres via `pg_restore`, Neo4j via `neo4j-admin database load` against an
+   offline isolated DBMS, and Qdrant via snapshot recovery against the isolated
+   Qdrant node.
+4. Start the portal against the rehearsal targets and run `/api/health`,
+   migration/schema checks, seed-delta smoke, and a small operator-state smoke
+   set such as users, backlog items, model providers, and Build Studio records.
+5. Persist evidence on the upgrade run, for example
+   `SelfUpgradeRun.completionEvidence.recoveryPointVerification`, including
+   lease id, environment key, member restore outcomes, log paths, smoke
+   results, source/image identity, and expiry time.
+
+Upgrade Center behavior:
+
+- Show recovery-point verification beside the restore button:
+  `verified`, `partially-verified`, `stale`, `not-run`, or `failed`.
+- Block unattended auto-apply for schema-changing upgrades when Postgres
+  verification is stale or failed.
+- Allow an operator-confirmed production restore without full graph/vector
+  rehearsal only when the UI states which members were not rehearsed and why.
+- Never treat sandbox evidence as the durable backup. Backups remain the
+  host-retained `BackupRun` artifacts; the sandbox is the disposable proof
+  target.
+
+Follow-up provision: add a dedicated `recovery-drill` nonproduction environment
+key once the lease substrate supports multiple named runtime purposes. That
+keeps routine Build Studio verification from blocking long restore rehearsals
+and gives BC/DR an explicit capacity lane.
+
 ### 5.3 Operator surface
 
 Extend the existing `/ops/self-upgrade` route into the Upgrade Center. Do not create a parallel `/admin/platform/upgrade` workflow; the current product already routes operational change controls through `/ops`, and the triage docs call out that update banners should link to the real trigger surface. Admin/platform pages may deep-link here.
@@ -1173,6 +1228,11 @@ These do not block spec approval, but should be settled before Phase 2 ships:
 
 - [Semantic Versioning 2.0.0](https://semver.org/)
 - [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- [NIST SP 800-34 Rev. 1, Contingency Planning Guide for Federal Information Systems](https://csrc.nist.gov/pubs/sp/800/34/r1/upd1/final) — recovery strategies, alternate processing, and exercising contingency plans.
+- [PostgreSQL `pg_restore`](https://www.postgresql.org/docs/17/app-pgrestore.html) — custom/archive restore behavior used by Postgres recovery and trial restore.
+- [Docker volumes: back up, restore, or migrate data volumes](https://docs.docker.com/engine/storage/volumes/#back-up-restore-or-migrate-data-volumes) — reminder that volume persistence is not a backup by itself; restore testing needs an explicit target.
+- [Neo4j Operations Manual: restore a database dump](https://neo4j.com/docs/operations-manual/current/backup-restore/restore-dump/) — isolated graph restore rehearsal requirements, including offline load constraints for Community edition.
+- [Qdrant snapshots](https://qdrant.tech/documentation/operations/snapshots/) — full-storage and collection snapshot recovery constraints for the vector member.
 - [Sigstore/cosign signing overview](https://docs.sigstore.dev/cosign/signing/overview/)
 - [GitHub Releases API — latest release](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release)
 - [GitLab release and maintenance policy](https://docs.gitlab.com/policy/maintenance/)


### PR DESCRIPTION
## Summary
- Adds the 2026-06-02 sandbox-assisted recovery rehearsal research addendum to the governed upgrade lifecycle spec.
- Distinguishes the Build Studio sandbox, the shared `local-integration-ci` environment, and the dev-against-live-DB overlay for recovery use.
- Updates the DR runbook with safe/unsafe sandbox rehearsal targets and incident-flow guidance for self-upgrade recovery points.

## Test plan
- [x] `git diff --check`
- [x] Commit pre-commit gitleaks scan passed
- [x] Documentation-only change; app build/tests not rerun

## Notes
- PR #1409 merged while this follow-up was being added, so this is a separate follow-up PR based on fresh `origin/main`.
- The current conclusion is intentionally conservative: use sandbox/local-CI as a rehearsal/evidence target, not as the durable backup, and do not run graph/vector restore drills until Neo4j/Qdrant are isolated from production.

Generated with OpenAI Codex.
