### PR TITLE
feat(coworker): screen_propose_action writes CoworkerActionEnvelope rows (BI-0F9C291C part 3)

### DIFF
--- a/apps/web/lib/mcp-tools.screen.test.ts
+++ b/apps/web/lib/mcp-tools.screen.test.ts
@@ -1,28 +1,53 @@
 // Tests for the Pseudo-User Contract screen_* view-command tool family
-// (BI-DF6079E9). Verifies:
+// (BI-DF6079E9 + BI-0F9C291C envelope writes). Verifies:
 //
 //   1. Each handler returns success: true with the expected event payload
 //      under data.event when called with valid args.
 //   2. Each handler returns success: false with a clear error message when
-//      required args are missing or invalid.
+//      required args or required context are missing.
 //   3. Grant resolution: each tool requires the spec'd coworker_screen_*
 //      grant (cross-referenced in agent-grants.test.ts; smoke-checked here).
+//   4. screen_propose_action writes a CoworkerActionEnvelope row at
+//      proposal time (the BI-0F9C291C part 3 wiring) and surfaces the
+//      generated envelopeId in the event payload.
 //
 // The handlers do not emit SSE events yet — that plumbing is a follow-on
 // (the second half of BI-DF6079E9). Returning the event payload
 // structurally is what makes the surface testable today; the chat handler
 // will pipe data.event into /api/agent/stream when it's wired.
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const envelopeCreateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    coworkerActionEnvelope: {
+      create: (...args: unknown[]) => envelopeCreateMock(...args),
+    },
+    // featureBuild.findUnique is touched by executeTool's build-context
+    // hint when context.featureBuildId is set; tests in this file never
+    // pass featureBuildId, so this stub is just defensive belt-and-braces.
+    featureBuild: { findUnique: async () => null },
+  },
+}));
 
 import { executeTool } from "./mcp-tools";
 import { isToolAllowedByGrants } from "./tak/agent-grants";
 
 const userId = "user-test";
 
-async function call(tool: string, params: Record<string, unknown> = {}) {
-  return executeTool(tool, params, userId);
+async function call(
+  tool: string,
+  params: Record<string, unknown> = {},
+  context?: { agentId?: string; threadId?: string; routeContext?: string; featureBuildId?: string },
+) {
+  return executeTool(tool, params, userId, context);
 }
+
+beforeEach(() => {
+  envelopeCreateMock.mockReset();
+});
 
 describe("screen_describe + screen_get_state — read-only discovery", () => {
   it("screen_describe returns success and a describe_requested event", async () => {
@@ -177,37 +202,109 @@ describe("screen_scroll_to — read-class per POLA review", () => {
   });
 });
 
-describe("screen_propose_action + screen_dispatch_action — envelope flow stubs", () => {
-  it("propose_action dispatches with valid args + carries the envelope follow-on note", async () => {
-    const r = await call("screen_propose_action", {
-      manifestActionId: "save-design-doc",
-      args: { buildId: "FB-X" },
-      rationale: "User asked to save the design doc.",
-    });
+describe("screen_propose_action — writes a CoworkerActionEnvelope row (BI-0F9C291C part 3)", () => {
+  const goodCtx = { agentId: "AGT-BUILD-SE", threadId: "thread-1" };
+
+  it("writes an envelope row and surfaces the generated envelopeId in the event payload", async () => {
+    envelopeCreateMock.mockResolvedValue({ id: "env-abc" });
+
+    const r = await call(
+      "screen_propose_action",
+      {
+        manifestActionId: "save-design-doc",
+        args: { buildId: "FB-X" },
+        rationale: "User asked to save the design doc.",
+      },
+      goodCtx,
+    );
+
     expect(r.success).toBe(true);
-    expect(r.data?.event).toMatchObject({
+    expect(r.entityId).toBe("env-abc");
+    expect(envelopeCreateMock).toHaveBeenCalledTimes(1);
+    expect(envelopeCreateMock).toHaveBeenCalledWith({
+      data: {
+        coworkerAgentId: "AGT-BUILD-SE",
+        delegatingUserId: userId,
+        threadId: "thread-1",
+        manifestActionId: "save-design-doc",
+        argsJson: { buildId: "FB-X" },
+        rationale: "User asked to save the design doc.",
+      },
+    });
+    expect(r.data?.event).toEqual({
       type: "screen:action_proposed",
-      payload: { manifestActionId: "save-design-doc", rationale: "User asked to save the design doc." },
+      payload: {
+        envelopeId: "env-abc",
+        manifestActionId: "save-design-doc",
+        rationale: "User asked to save the design doc.",
+        args: { buildId: "FB-X" },
+        coworkerAgentId: "AGT-BUILD-SE",
+        delegatingUserId: userId,
+      },
     });
-    // Documents that the actual envelope DB write lands in BI-0F9C291C.
-    expect(r.data?.note).toMatch(/BI-0F9C291C/);
   });
 
-  it("propose_action defaults args to {} when omitted", async () => {
-    const r = await call("screen_propose_action", {
-      manifestActionId: "x",
-      rationale: "y",
-    });
+  it("defaults args to {} when omitted (still writes the row)", async () => {
+    envelopeCreateMock.mockResolvedValue({ id: "env-def" });
+    const r = await call(
+      "screen_propose_action",
+      { manifestActionId: "x", rationale: "y" },
+      goodCtx,
+    );
     expect(r.success).toBe(true);
-    expect((r.data?.event as { payload: { args: unknown } }).payload.args).toEqual({});
+    expect((envelopeCreateMock.mock.calls[0]?.[0] as { data: { argsJson: unknown } }).data.argsJson).toEqual({});
   });
 
-  it("propose_action rejects missing manifestActionId or rationale", async () => {
-    expect((await call("screen_propose_action", { manifestActionId: "", rationale: "x" })).success).toBe(false);
-    expect((await call("screen_propose_action", { manifestActionId: "x", rationale: "" })).success).toBe(false);
+  it("rejects missing manifestActionId or rationale BEFORE touching the DB", async () => {
+    expect((await call("screen_propose_action", { manifestActionId: "", rationale: "x" }, goodCtx)).success).toBe(false);
+    expect((await call("screen_propose_action", { manifestActionId: "x", rationale: "" }, goodCtx)).success).toBe(false);
+    expect(envelopeCreateMock).not.toHaveBeenCalled();
   });
 
-  it("dispatch_action dispatches with valid envelopeId + carries follow-on note", async () => {
+  it("rejects when agentId is missing from execution context", async () => {
+    const r = await call(
+      "screen_propose_action",
+      { manifestActionId: "x", rationale: "y" },
+      { threadId: "thread-1" }, // no agentId
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("missing_context");
+    expect(r.message).toMatch(/agentId/);
+    expect(envelopeCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when threadId is missing from execution context", async () => {
+    const r = await call(
+      "screen_propose_action",
+      { manifestActionId: "x", rationale: "y" },
+      { agentId: "AGT-X" }, // no threadId
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("missing_context");
+    expect(r.message).toMatch(/threadId/);
+    expect(envelopeCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns envelope_create_failed when the DB write throws", async () => {
+    envelopeCreateMock.mockRejectedValue(new Error("connection refused"));
+    const r = await call(
+      "screen_propose_action",
+      { manifestActionId: "x", rationale: "y" },
+      goodCtx,
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("envelope_create_failed");
+    expect(r.message).toMatch(/connection refused/);
+  });
+
+  it("requires coworker_screen_drive", () => {
+    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_drive"])).toBe(true);
+    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_read"])).toBe(false);
+  });
+});
+
+describe("screen_dispatch_action — still a stub (BI-0F9C291C follow-on)", () => {
+  it("dispatches with valid envelopeId and carries the follow-on note", async () => {
     const r = await call("screen_dispatch_action", { envelopeId: "env-123" });
     expect(r.success).toBe(true);
     expect(r.data?.event).toEqual({
@@ -217,13 +314,12 @@ describe("screen_propose_action + screen_dispatch_action — envelope flow stubs
     expect(r.data?.note).toMatch(/BI-0F9C291C/);
   });
 
-  it("dispatch_action rejects empty envelopeId", async () => {
+  it("rejects empty envelopeId", async () => {
     expect((await call("screen_dispatch_action", { envelopeId: "" })).success).toBe(false);
   });
 
-  it("both require coworker_screen_drive (the underlying tool's grant is resolved when the envelope is dispatched — BI-0F9C291C)", () => {
-    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_drive"])).toBe(true);
+  it("requires coworker_screen_drive", () => {
     expect(isToolAllowedByGrants("screen_dispatch_action", ["coworker_screen_drive"])).toBe(true);
-    expect(isToolAllowedByGrants("screen_propose_action", ["coworker_screen_read"])).toBe(false);
+    expect(isToolAllowedByGrants("screen_dispatch_action", ["coworker_screen_read"])).toBe(false);
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -14780,20 +14780,72 @@ export async function executeTool(
         params["args"] && typeof params["args"] === "object" && !Array.isArray(params["args"])
           ? (params["args"] as Record<string, unknown>)
           : {};
-      // The actual CoworkerActionEnvelope row creation (and per-turn N=3 cap
-      // + irreversible typed-phrase floor) lands in BI-0F9C291C. Until then
-      // the tool returns the structured proposal payload so the agent can
-      // see what would be proposed, and the chat handler can stub-write the
-      // envelope when wiring SSE emission.
+      // BI-0F9C291C wiring (part 3): write a CoworkerActionEnvelope row at
+      // proposal time. Status defaults to "proposed" via the schema;
+      // approveEnvelope / denyEnvelope from envelope-actions.ts drive the
+      // row toward terminal. coworkerAgentId + threadId are NOT NULL on
+      // the schema and come from the chat handler's execution context.
+      // chatMessageId stays null until BI-DF6079E9 part 2 plumbs the
+      // proposing AgentMessage id through. Per-turn N=3 destructive cap
+      // and irreversible typed-phrase hard floor remain follow-on chunks.
+      const coworkerAgentId = context?.agentId;
+      if (!coworkerAgentId) {
+        return {
+          success: false,
+          error: "missing_context",
+          message:
+            "screen_propose_action requires the executing coworker's agentId in execution context. Invoke via the chat handler, not directly.",
+        };
+      }
+      const threadId = context?.threadId;
+      if (!threadId) {
+        return {
+          success: false,
+          error: "missing_context",
+          message: "screen_propose_action requires threadId in execution context.",
+        };
+      }
+
+      let envelope;
+      try {
+        envelope = await prisma.coworkerActionEnvelope.create({
+          data: {
+            coworkerAgentId,
+            delegatingUserId: userId,
+            threadId,
+            // chatMessageId left null until BI-DF6079E9 part 2 plumbs
+            // the proposing AgentMessage id through the chat handler.
+            manifestActionId,
+            argsJson: args as import("@dpf/db").Prisma.InputJsonValue,
+            rationale,
+            // status defaults to "proposed" via schema.prisma column default.
+          },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          error: "envelope_create_failed",
+          message: `Failed to create envelope: ${msg}`,
+        };
+      }
+
       return {
         success: true,
-        message: `Proposal '${manifestActionId}' dispatched.`,
+        entityId: envelope.id,
+        message: `Proposal '${manifestActionId}' recorded as envelope ${envelope.id} (proposed).`,
         data: {
           event: {
             type: "screen:action_proposed",
-            payload: { manifestActionId, rationale, args },
+            payload: {
+              envelopeId: envelope.id,
+              manifestActionId,
+              rationale,
+              args,
+              coworkerAgentId,
+              delegatingUserId: userId,
+            },
           },
-          note: "Envelope creation + per-turn cap enforcement lands in BI-0F9C291C.",
         },
       };
     }


### PR DESCRIPTION
## Summary

The `screen_propose_action` handler now actually creates an envelope row at proposal time instead of returning a stub. Real `envelopeId` flows through the event payload so the chat handler can correlate the user's approve/deny response.

End-to-end the propose flow is now:

```
coworker calls screen_propose_action(manifestActionId, args, rationale)
   ↓
handler writes CoworkerActionEnvelope row (status="proposed")
   ↓
event { type: "screen:action_proposed", payload: { envelopeId, ... } }
   ↓
(SSE relay → chat UI card — BI-DF6079E9 part 2)
   ↓
user clicks Approve / Deny
   ↓
POST /api/agent/envelope/:envelopeId/{approve,deny}  (#1392)
   ↓
envelope flips to approved / declined
```

What's missing for full end-to-end: the SSE relay (BI-DF6079E9 part 2), the React card (BI-0F9C291C follow-on), and the underlying-tool dispatch in `screen_dispatch_action` (BI-0F9C291C follow-on). Each is small.

## What's in the PR

**`apps/web/lib/mcp-tools.ts` — handler refactor:**
- Calls `prisma.coworkerActionEnvelope.create` with the spec'd field mapping:
  - `coworkerAgentId` ← `context.agentId` (required — NOT NULL)
  - `delegatingUserId` ← `userId`
  - `threadId` ← `context.threadId` (required — NOT NULL)
  - `chatMessageId` ← `null` (BI-DF6079E9 part 2 will plumb the proposing AgentMessage id)
  - `manifestActionId`, `argsJson`, `rationale` ← params
  - `status` ← defaults to `"proposed"` via schema
- Returns `success: true` with `entityId=envelope.id`; event payload includes `envelopeId`, `coworkerAgentId`, `delegatingUserId` so downstream consumers don't need a re-read.
- Context validation BEFORE the DB write — missing `agentId` or `threadId` returns `missing_context` with a message pointing the caller at the chat handler.
- Try/catch around the create — DB failures surface as `envelope_create_failed`.
- Uses the existing `as import("@dpf/db").Prisma.InputJsonValue` cast pattern other handlers in this file already use for Json columns.

**`apps/web/lib/mcp-tools.screen.test.ts`:**
- Prisma mocked via `vi.hoisted` + `vi.mock` (scoped to this file; other screen-tool tests don't touch the DB).
- Test helper now threads an optional execution context through.
- 7 new `screen_propose_action` cases: envelope created with correct args, args defaults to `{}`, both arg validations reject BEFORE the DB write, missing `agentId` rejected, missing `threadId` rejected, DB error mapped to `envelope_create_failed`, grant resolution.

## Verification

- ✓ `pnpm --filter web exec vitest run lib/mcp-tools.screen.test.ts` — **32/32 pass**
- ✓ `pnpm --filter web typecheck` — clean
- ✓ DCO-signed; pre-commit guards (including the typecheck guard) all fired clean

## Still to come within BI-0F9C291C

- `screen_dispatch_action`: read envelope → dispatch underlying tool → call `markEnvelopeExecuted` / `markEnvelopeFailed`
- React approval-card component (inline chat UI)
- Per-turn N=3 destructive auto-approval cap
- Irreversible typed-phrase hard floor

## Linked work

- **Epic:** `EP-COWORKER-INTERACTIVITY`
- **This BI:** `BI-0F9C291C` (in-progress — this is part 3)
- **Builds on (all merged):** [#1366](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1366) schema, [#1386](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1386) screen_* tools, [#1390](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1390) state machine + actions
- **Cousin in flight:** [#1392](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1392) approve/deny routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)