### PR TITLE
feat(corpus): research execution-on-approval (BI-8A58C65A slice C)

### DIFF
--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -10,6 +10,7 @@ import { agentTaskDispatch } from "./agent-task-dispatch";
 import { taskrunWatchdog } from "./taskrun-watchdog";
 import { evalBackground, probeBackground } from "./eval-background";
 import { brandExtract } from "./brand-extract";
+import { researchExecute } from "./research-execute";
 import { buildReviewVerification } from "./build-review-verification";
 import { assuranceBomGenerate } from "./assurance-bom";
 import { assuranceScanRun } from "./assurance-scan";
@@ -67,6 +68,7 @@ export const eventFunctions = [
   evalBackground,
   probeBackground,
   brandExtract,
+  researchExecute,
   buildReviewVerification,
   assuranceBomGenerate,
   assuranceScanRun,

--- a/apps/web/lib/queue/functions/research-execute.ts
+++ b/apps/web/lib/queue/functions/research-execute.ts
@@ -1,0 +1,26 @@
+// Inngest job: execute an approved research proposal (BI-8A58C65A slice C).
+// Triggered by `research/execute.run` (enqueued from approveResearch's
+// onApproved seam). Runs the research engine and lands draft corpus material;
+// the pure logic + outcome stamping live in lib/wiki/research-execution.ts.
+
+import { inngest } from "@/lib/queue/inngest-client";
+import {
+  runResearchExecution,
+  type RunResearchExecutionInput,
+} from "@/lib/wiki/research-execution";
+
+export const researchExecute = inngest.createFunction(
+  {
+    id: "research/execute",
+    retries: 1,
+    // One research run per org at a time — keeps web/LLM load + corpus writes serial.
+    concurrency: [{ key: "event.data.organizationId", limit: 1 }],
+    triggers: [{ event: "research/execute.run" }],
+  },
+  async ({ event, step }) => {
+    const result = await step.run("run-research-execution", async () =>
+      runResearchExecution(event.data as unknown as RunResearchExecutionInput),
+    );
+    return { ok: true, ...result };
+  },
+);

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -3,6 +3,14 @@ import { Inngest } from "inngest";
 export const inngest = new Inngest({ id: "dpf-platform" });
 
 // Event payload types for type-safe event sending
+
+/** BI-8A58C65A: execute an approved research proposal (enqueued from the
+ *  approval seam; handled by research-execute.ts). */
+export interface ResearchExecuteRunEvent {
+  name: "research/execute.run";
+  data: { proposalId: string; organizationId: string; topic: string; query: string };
+}
+
 export interface CwqItemCreatedEvent {
   name: "cwq/item.created";
   data: { workItemId: string; sourceType: string; urgency: string };

--- a/apps/web/lib/wiki/research-execution.test.ts
+++ b/apps/web/lib/wiki/research-execution.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  runResearchExecution,
+  type ResearchExecutionDeps,
+} from "./research-execution";
+
+type Row = Record<string, any>;
+function makeDeps(over: Partial<ResearchExecutionDeps> = {}): {
+  deps: ResearchExecutionDeps;
+  updates: Row[];
+} {
+  const updates: Row[] = [];
+  const deps: ResearchExecutionDeps = {
+    db: {
+      researchProposal: {
+        update: vi.fn(async (args: any) => {
+          updates.push(args.data);
+          return args.data;
+        }),
+      },
+    },
+    research: vi.fn(async () => ({
+      text: "Findings: the market is fragmented.\n\n## Sources\n- [a](https://ex.com/a)",
+      sources: [{ title: "a", url: "https://ex.com/a" }],
+      empty: false,
+    })),
+    enrich: vi.fn(async () => ({ committed: [{ pageId: "wp_1", slug: "stances/market" }] })),
+    ...over,
+  };
+  return { deps, updates };
+}
+
+const INPUT = { proposalId: "rp_1", organizationId: "org_1", topic: "competitive-landscape", query: "HVAC competitors" };
+
+describe("runResearchExecution", () => {
+  it("runs research, enriches the corpus, and marks the proposal executed", async () => {
+    const { deps, updates } = makeDeps();
+    const res = await runResearchExecution(INPUT, deps);
+
+    expect(res.status).toBe("executed");
+    expect(res.pagesCommitted).toBe(1);
+
+    // enrich called as research-trust with proposal provenance
+    const enrichArg = (deps.enrich as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(enrichArg).toMatchObject({
+      organizationId: "org_1",
+      trust: "researched",
+      provenance: { sourceType: "research" },
+    });
+    expect(enrichArg.provenance.sourceRef).toMatchObject({ proposalId: "rp_1", topic: "competitive-landscape" });
+
+    // proposal updated to executed with a summary + executedAt
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ status: "executed" });
+    expect(updates[0].executedAt).toBeTruthy();
+    expect(updates[0].resultSummary).toContain("draft");
+  });
+
+  it("marks executed with no corpus write when research finds nothing", async () => {
+    const { deps, updates } = makeDeps({
+      research: vi.fn(async () => ({ text: "", sources: [], empty: true })),
+    });
+    const res = await runResearchExecution(INPUT, deps);
+
+    expect(res.status).toBe("executed");
+    expect(res.pagesCommitted).toBe(0);
+    expect(deps.enrich).not.toHaveBeenCalled();
+    expect(updates[0]).toMatchObject({ status: "executed" });
+    expect(updates[0].resultSummary.toLowerCase()).toContain("no findings");
+  });
+
+  it("marks the proposal failed (fail-open) when research throws", async () => {
+    const { deps, updates } = makeDeps({
+      research: vi.fn(async () => { throw new Error("brave down"); }),
+    });
+    const res = await runResearchExecution(INPUT, deps);
+
+    expect(res.status).toBe("failed");
+    expect(updates[0]).toMatchObject({ status: "failed" });
+    expect(updates[0].resultSummary).toContain("brave down");
+  });
+
+  it("marks the proposal failed when enrichment throws", async () => {
+    const { deps, updates } = makeDeps({
+      enrich: vi.fn(async () => { throw new Error("ollama down"); }),
+    });
+    const res = await runResearchExecution(INPUT, deps);
+
+    expect(res.status).toBe("failed");
+    expect(updates[0]).toMatchObject({ status: "failed" });
+  });
+});

--- a/apps/web/lib/wiki/research-execution.ts
+++ b/apps/web/lib/wiki/research-execution.ts
@@ -1,0 +1,122 @@
+// Research execution-on-approval (BI-8A58C65A, EP-CORPUS-BOOTSTRAP) — slice C.
+//
+// When a ResearchProposal is approved (slice B's onApproved seam), this runs the
+// research engine (slice A) and lands the findings in the org WWWD corpus as a
+// DRAFT (research trust, per BI-1378), then stamps the proposal executed/failed.
+//
+// Designed to run as an Inngest job (research/execute.run) off the approval, so
+// the operator's approve click isn't blocked on web+LLM work. `runResearch
+// Execution` is the pure, testable core; the job wrapper lives in
+// queue/functions/research-execute.ts.
+
+import { prisma } from "@dpf/db";
+import { runMarketResearch } from "./market-research";
+import { enrichOrgCorpus } from "./enrich-org-corpus";
+import { createProductionInference } from "./inference-adapter";
+
+export type RunResearchExecutionInput = {
+  proposalId: string;
+  organizationId: string;
+  topic: string;
+  query: string;
+};
+
+type ResearchOutcome = {
+  text: string;
+  sources: { title: string; url: string }[];
+  empty: boolean;
+};
+
+type EnrichInput = {
+  organizationId: string;
+  text: string;
+  title: string;
+  provenance: { sourceType: "research"; sourceRef: Record<string, unknown> };
+  trust: "researched";
+};
+
+export type ResearchExecutionDeps = {
+  db?: {
+    researchProposal: { update: (args: unknown) => Promise<unknown> };
+  };
+  /** Defaults to runMarketResearch (slice A). */
+  research?: (input: { organizationId: string; query: string }) => Promise<ResearchOutcome>;
+  /** Defaults to enrichOrgCorpus with a production inference adapter. */
+  enrich?: (input: EnrichInput) => Promise<{ committed: Array<{ pageId: string; slug: string }> }>;
+};
+
+export type RunResearchExecutionResult = {
+  status: "executed" | "failed";
+  pagesCommitted: number;
+  summary: string;
+};
+
+export async function runResearchExecution(
+  input: RunResearchExecutionInput,
+  deps: ResearchExecutionDeps = {},
+): Promise<RunResearchExecutionResult> {
+  const db = deps.db ?? (prisma as unknown as NonNullable<ResearchExecutionDeps["db"]>);
+  const research = deps.research ?? ((i) => runMarketResearch(i));
+  const enrich =
+    deps.enrich ??
+    ((i: EnrichInput) =>
+      enrichOrgCorpus({
+        ...i,
+        infer: createProductionInference({ taskType: "market_research" }),
+      }) as Promise<{ committed: Array<{ pageId: string; slug: string }> }>);
+
+  try {
+    const result = await research({ organizationId: input.organizationId, query: input.query });
+
+    if (result.empty) {
+      const summary = "No findings — web search returned nothing to add.";
+      await db.researchProposal.update({
+        where: { proposalId: input.proposalId },
+        data: { status: "executed", executedAt: new Date(), resultSummary: summary },
+      });
+      return { status: "executed", pagesCommitted: 0, summary };
+    }
+
+    const enriched = await enrich({
+      organizationId: input.organizationId,
+      text: result.text,
+      title: `Market research: ${input.topic}`,
+      provenance: {
+        sourceType: "research",
+        sourceRef: {
+          proposalId: input.proposalId,
+          topic: input.topic,
+          urls: result.sources.map((s) => s.url),
+        },
+      },
+      trust: "researched",
+    });
+
+    const pagesCommitted = enriched?.committed?.length ?? 0;
+    const summary = `Added ${pagesCommitted} draft page(s) from ${result.sources.length} source(s) — awaiting review.`;
+    await db.researchProposal.update({
+      where: { proposalId: input.proposalId },
+      data: { status: "executed", executedAt: new Date(), resultSummary: summary },
+    });
+    return { status: "executed", pagesCommitted, summary };
+  } catch (err) {
+    const summary = `Research execution failed: ${err instanceof Error ? err.message : String(err)}`;
+    await db.researchProposal
+      .update({
+        where: { proposalId: input.proposalId },
+        data: { status: "failed", executedAt: new Date(), resultSummary: summary },
+      })
+      .catch(() => undefined);
+    return { status: "failed", pagesCommitted: 0, summary };
+  }
+}
+
+// ─── Enqueue seam (the target of slice B's approveResearch onApproved) ────────
+
+/** Enqueue execution for an approved proposal. Wire this into approveResearch's
+ *  `onApproved` seam at the approval call site (slice E). Fire-and-forget at the
+ *  call site; the Inngest job carries retries. */
+export async function enqueueResearchExecution(proposal: RunResearchExecutionInput): Promise<void> {
+  const { inngest } = await import("@/lib/queue/inngest-client");
+  await inngest.send({ name: "research/execute.run", data: proposal });
+}


### PR DESCRIPTION
Slice C of **BI-8A58C65A** — execution-on-approval (founder open-Q#4: *scheduled → approve → execute → draft*). With slices A (engine) and B (proposal/approval) merged, this runs the research when a proposal is approved and lands the findings as a **draft** for review.

## Changes
- `lib/wiki/research-execution.ts` (+ 4 tests): `runResearchExecution` — `runMarketResearch` → `enrichOrgCorpus(origin="research", trust="researched", sourceRef={proposalId,topic,urls})` → proposal `executed`. Empty research → `executed` with no corpus write. Any failure → proposal `failed` (**fail-open** — never throws out of the job). Plus `enqueueResearchExecution()`, the Inngest send the approval seam (slice E) calls.
- `queue/functions/research-execute.ts`: Inngest job `research/execute.run`, retries + per-org `concurrency=1`, mirroring the brand-extract template; registered in `eventFunctions`.
- `inngest-client.ts`: `ResearchExecuteRunEvent` type.

Per BI-1378, research lands `draft`/`candidate` — nothing auto-publishes.

## Slice status (BI-8A58C65A)
A ✅ engine (#1394) · B ✅ proposal/approval (#1411) · **C ✅ this PR** · D Inngest cron (proposes per-org) · E approval UI (list + approve/decline, wires `onApproved`→`enqueueResearchExecution`).

## Tests
4 unit tests (research→enrich→executed; empty→executed no-write; research-throws→failed; enrich-throws→failed); typecheck clean (pre-commit enforced).

## Note
Built in an **isolated git worktree** to avoid the shared-root-checkout contamination that hit #1411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)