### PR TITLE
feat(corpus): scheduled research proposals (BI-8A58C65A slice D)

### DIFF
--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -11,6 +11,7 @@ import { taskrunWatchdog } from "./taskrun-watchdog";
 import { evalBackground, probeBackground } from "./eval-background";
 import { brandExtract } from "./brand-extract";
 import { researchExecute } from "./research-execute";
+import { researchScheduleScan } from "./research-schedule";
 import { buildReviewVerification } from "./build-review-verification";
 import { assuranceBomGenerate } from "./assurance-bom";
 import { assuranceScanRun } from "./assurance-scan";
@@ -55,6 +56,7 @@ export const scheduledFunctions = [
   wikiLint,
   skillMetricsAggregator,
   skillCurator,
+  researchScheduleScan,
   allBackupsDailyScheduled,
   postgresDailyBackupScheduled,
   selfUpgradeScheduled,

--- a/apps/web/lib/queue/functions/research-schedule.ts
+++ b/apps/web/lib/queue/functions/research-schedule.ts
@@ -1,0 +1,19 @@
+// Inngest cron: scheduled research proposals (BI-8A58C65A slice D).
+// Weekly, proposes the standard research topics per org (slice D logic in
+// lib/wiki/research-schedule.ts). Proposals await human approval (slice B);
+// nothing executes here. Cadence is a conservative weekly default — tune the
+// cron below.
+
+import { cron } from "inngest";
+import { inngest } from "@/lib/queue/inngest-client";
+import { proposeScheduledResearch } from "@/lib/wiki/research-schedule";
+
+export const researchScheduleScan = inngest.createFunction(
+  { id: "research/schedule-scan", retries: 1, triggers: [cron("0 9 * * 1")] }, // Mon 09:00
+  async ({ step }) => {
+    const result = await step.run("propose-scheduled-research", async () =>
+      proposeScheduledResearch(),
+    );
+    return { ok: true, ...result };
+  },
+);

--- a/apps/web/lib/wiki/research-schedule.test.ts
+++ b/apps/web/lib/wiki/research-schedule.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  proposeScheduledResearch,
+  STANDARD_RESEARCH_TOPICS,
+  type ProposeScheduledResearchDeps,
+} from "./research-schedule";
+
+type Row = Record<string, any>;
+function makeDeps(orgs: Row[], over: Partial<ProposeScheduledResearchDeps> = {}): {
+  deps: ProposeScheduledResearchDeps;
+  proposeCalls: Row[];
+} {
+  const proposeCalls: Row[] = [];
+  const deps: ProposeScheduledResearchDeps = {
+    db: {
+      businessContext: { findMany: vi.fn(async () => orgs) },
+    },
+    propose: vi.fn(async (input: any) => {
+      proposeCalls.push(input);
+      // First time created, dedup thereafter (per org+topic)
+      const prior = proposeCalls.filter(
+        (c) => c.organizationId === input.organizationId && c.topic === input.topic,
+      ).length;
+      return { proposalId: `rp_${proposeCalls.length}`, created: prior === 1 };
+    }),
+    ...over,
+  };
+  return { deps, proposeCalls };
+}
+
+describe("proposeScheduledResearch", () => {
+  it("proposes every standard topic for each org with a business context", async () => {
+    const { deps, proposeCalls } = makeDeps([
+      { organizationId: "org_1", industry: "healthcare-wellness", description: "dental" },
+      { organizationId: "org_2", industry: null, description: "We sell coffee." },
+    ]);
+
+    const res = await proposeScheduledResearch(deps);
+
+    // 2 orgs × N topics
+    expect(proposeCalls).toHaveLength(2 * STANDARD_RESEARCH_TOPICS.length);
+    expect(res.orgs).toBe(2);
+    expect(res.proposed).toBe(2 * STANDARD_RESEARCH_TOPICS.length);
+    expect(res.deduped).toBe(0);
+
+    // proposedBy = schedule; query mentions the org context
+    expect(proposeCalls[0]).toMatchObject({ organizationId: "org_1", proposedBy: "schedule" });
+    expect(proposeCalls[0].query.toLowerCase()).toContain("healthcare-wellness");
+    // org_2 has no industry → falls back to description
+    const org2 = proposeCalls.find((c) => c.organizationId === "org_2");
+    expect(org2).toBeDefined();
+    expect(org2!.query).toContain("We sell coffee.");
+  });
+
+  it("counts dedups when proposeResearch coalesces to an existing pending proposal", async () => {
+    const { deps } = makeDeps([{ organizationId: "org_1", industry: "retail-goods", description: null }], {
+      // Always reports "already pending" → deduped
+      propose: vi.fn(async () => ({ proposalId: "rp_x", created: false })),
+    });
+    const res = await proposeScheduledResearch(deps);
+    expect(res.proposed).toBe(0);
+    expect(res.deduped).toBe(STANDARD_RESEARCH_TOPICS.length);
+  });
+
+  it("proposes nothing when no org has a business context", async () => {
+    const { deps, proposeCalls } = makeDeps([]);
+    const res = await proposeScheduledResearch(deps);
+    expect(res.orgs).toBe(0);
+    expect(proposeCalls).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/wiki/research-schedule.ts
+++ b/apps/web/lib/wiki/research-schedule.ts
@@ -1,0 +1,92 @@
+// Scheduled research proposals (BI-8A58C65A, EP-CORPUS-BOOTSTRAP) — slice D.
+//
+// The founder's open-Q#4 model: research is SCHEDULED. On a cadence, propose a
+// research run per org (which then awaits human approval — slice B — before any
+// execution — slice C). Proposals are harmless: they only request approval, so
+// a conservative weekly default is safe. proposeResearch dedups by (org, topic)
+// so a recurring scan never piles up duplicate approvals.
+//
+// Defaults (easily tuned): WEEKLY cadence (cron in research-schedule.ts), two
+// standard topics, only for orgs that have completed enough onboarding to have
+// a business context (a mission). Cost is gated downstream by the approval +
+// execution slices — scheduling itself is free.
+
+import { prisma } from "@dpf/db";
+import { proposeResearch, type ProposeResearchInput } from "./research-proposal";
+
+/** Standard recurring research topics. Each builds a query from the org's
+ *  business context. Keep this list short and high-signal. */
+export const STANDARD_RESEARCH_TOPICS: Array<{
+  topic: string;
+  buildQuery: (context: string) => string;
+}> = [
+  {
+    topic: "competitive-landscape",
+    buildQuery: (ctx) =>
+      `Competitive landscape for ${ctx}: who are the main competitors and how is the market positioned?`,
+  },
+  {
+    topic: "market-size",
+    buildQuery: (ctx) => `Market size and total addressable market for ${ctx}.`,
+  },
+];
+
+type BusinessContextRow = {
+  organizationId: string;
+  industry: string | null;
+  description: string | null;
+};
+
+export type ProposeScheduledResearchDeps = {
+  db?: {
+    businessContext: { findMany: (args: unknown) => Promise<unknown> };
+  };
+  /** Defaults to proposeResearch (slice B). */
+  propose?: (input: ProposeResearchInput) => Promise<{ proposalId: string; created: boolean }>;
+};
+
+export type ProposeScheduledResearchResult = {
+  orgs: number;
+  /** Newly-created pending proposals. */
+  proposed: number;
+  /** Coalesced into an already-pending proposal (no duplicate). */
+  deduped: number;
+};
+
+function contextLabel(o: BusinessContextRow): string {
+  return (o.industry ?? "").trim() || (o.description ?? "").trim() || "this business";
+}
+
+/** Propose the standard research topics for every org that has a business
+ *  context. Idempotent across runs via proposeResearch's (org, topic) dedup. */
+export async function proposeScheduledResearch(
+  deps: ProposeScheduledResearchDeps = {},
+): Promise<ProposeScheduledResearchResult> {
+  const db = deps.db ?? prisma;
+  const propose = deps.propose ?? ((input: ProposeResearchInput) => proposeResearch(input));
+
+  // Only orgs that have completed enough onboarding to have a mission — avoids
+  // proposing research for the bootstrap/empty org.
+  const orgs = (await db.businessContext.findMany({
+    where: { mission: { not: null } },
+    select: { organizationId: true, industry: true, description: true },
+  })) as BusinessContextRow[];
+
+  let proposed = 0;
+  let deduped = 0;
+  for (const org of orgs) {
+    const ctx = contextLabel(org);
+    for (const t of STANDARD_RESEARCH_TOPICS) {
+      const r = await propose({
+        organizationId: org.organizationId,
+        topic: t.topic,
+        query: t.buildQuery(ctx),
+        proposedBy: "schedule",
+      });
+      if (r.created) proposed++;
+      else deduped++;
+    }
+  }
+
+  return { orgs: orgs.length, proposed, deduped };
+}


### PR DESCRIPTION
Slice D of **BI-8A58C65A** — the **schedule** in the *scheduled → approve → execute → draft* model (founder open-Q#4). A weekly Inngest cron *proposes* the standard research topics per org; proposals await human approval (slice B) and only then execute (slice C). The cadence itself is free and safe.

## Changes
- `lib/wiki/research-schedule.ts` (+ 3 tests): `proposeScheduledResearch` iterates orgs that have a business context (a mission — skips the bootstrap/empty org), and for each `STANDARD_RESEARCH_TOPIC` (`competitive-landscape`, `market-size`) calls `proposeResearch` with a context-built query. **Idempotent across runs** via proposeResearch's `(org, topic)` dedup.
- `queue/functions/research-schedule.ts`: Inngest cron (Mon 09:00, tunable), registered in `scheduledFunctions`.

Defaults — **weekly / two topics / business-orgs only** — are easily-tuned consts (per your go-ahead).

## Slice status (BI-8A58C65A)
A ✅ engine (#1394) · B ✅ proposal/approval (#1411) · C ✅ execution (#1416) · **D ✅ this PR** · **E** approval UI (the last slice).

## Tests
3 unit tests (proposes per topic per business-org with context-built query; dedup counting; empty when no business orgs); typecheck clean. Built in the isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)