### PR TITLE
feat(corpus): research approval UI (BI-8A58C65A slice E — final)

### DIFF
--- a/apps/web/app/(shell)/admin/research/page.tsx
+++ b/apps/web/app/(shell)/admin/research/page.tsx
@@ -1,0 +1,20 @@
+import { listPendingResearchProposalsAction } from "@/lib/actions/research-proposals";
+import { ResearchProposalsPanel } from "@/components/admin/ResearchProposalsPanel";
+
+// Admin surface for scheduled AI research proposals (BI-8A58C65A slice E).
+export default async function ResearchProposalsPage() {
+  const pending = await listPendingResearchProposalsAction();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold text-[var(--dpf-text)]">Research proposals</h2>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Scheduled AI research about your market. Approve a proposal to run it — results land as a
+          draft in your organization&apos;s knowledge for review.
+        </p>
+      </div>
+      <ResearchProposalsPanel initial={pending} />
+    </div>
+  );
+}

--- a/apps/web/components/admin/ResearchProposalsPanel.tsx
+++ b/apps/web/components/admin/ResearchProposalsPanel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  approveResearchProposalAction,
+  declineResearchProposalAction,
+} from "@/lib/actions/research-proposals";
+
+type Proposal = {
+  proposalId: string;
+  topic: string;
+  query: string;
+  proposedBy: string;
+  proposedAt: string | Date;
+};
+
+// Approval UI for scheduled AI research (BI-8A58C65A slice E). Lists pending
+// proposals; Approve enqueues a real research run (results land as a draft for
+// review); Decline drops it. Approval is the human gate before any web/LLM work.
+export function ResearchProposalsPanel({ initial }: { initial: Proposal[] }) {
+  const [proposals, setProposals] = useState<Proposal[]>(initial);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function act(proposalId: string, action: "approve" | "decline") {
+    setError(null);
+    startTransition(async () => {
+      const res =
+        action === "approve"
+          ? await approveResearchProposalAction(proposalId)
+          : await declineResearchProposalAction(proposalId);
+      if (res.ok) {
+        setProposals((prev) => prev.filter((p) => p.proposalId !== proposalId));
+      } else {
+        setError(res.error ?? "Action failed");
+      }
+    });
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <p style={{ fontSize: 13, color: "var(--dpf-muted)" }}>
+        No research proposals awaiting approval. The weekly scan will propose new ones.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 640 }}>
+      {error && <p style={{ color: "var(--dpf-error)", fontSize: 13, margin: 0 }}>{error}</p>}
+      {proposals.map((p) => (
+        <div
+          key={p.proposalId}
+          style={{
+            border: "1px solid var(--dpf-border)",
+            borderRadius: 8,
+            padding: "12px 14px",
+            background: "var(--dpf-surface-1)",
+          }}
+        >
+          <div style={{ fontSize: 11, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: 0.5 }}>
+            {p.topic} · proposed by {p.proposedBy}
+          </div>
+          <div style={{ fontSize: 14, color: "var(--dpf-text)", margin: "4px 0 10px" }}>{p.query}</div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              type="button"
+              onClick={() => act(p.proposalId, "approve")}
+              disabled={pending}
+              style={{
+                padding: "6px 14px",
+                borderRadius: 6,
+                border: "none",
+                background: "var(--dpf-accent)",
+                color: "#fff",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: pending ? "wait" : "pointer",
+              }}
+            >
+              Approve &amp; research
+            </button>
+            <button
+              type="button"
+              onClick={() => act(p.proposalId, "decline")}
+              disabled={pending}
+              style={{
+                padding: "6px 14px",
+                borderRadius: 6,
+                border: "1px solid var(--dpf-border)",
+                background: "transparent",
+                color: "var(--dpf-text)",
+                fontSize: 13,
+                cursor: pending ? "wait" : "pointer",
+              }}
+            >
+              Decline
+            </button>
+          </div>
+        </div>
+      ))}
+      <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: 0 }}>
+        Approved research runs in the background and lands as a <strong>draft</strong> in your
+        organization&apos;s knowledge for you to review before it becomes authoritative.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/research-proposals.ts
+++ b/apps/web/lib/actions/research-proposals.ts
@@ -1,0 +1,53 @@
+"use server";
+
+// Approval-UI server actions for scheduled research proposals (BI-8A58C65A
+// slice E). Approving a proposal wires the onApproved seam to
+// enqueueResearchExecution (slice C) — so approval is the single gate between
+// a scheduled proposal and a real (web+LLM) research run that lands a draft.
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import {
+  approveResearch,
+  declineResearch,
+  listPendingResearchProposals,
+  type PendingResearchProposal,
+} from "@/lib/wiki/research-proposal";
+import { enqueueResearchExecution } from "@/lib/wiki/research-execution";
+
+async function currentOrgId(): Promise<string | null> {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  return org?.id ?? null;
+}
+
+export async function listPendingResearchProposalsAction(): Promise<PendingResearchProposal[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+  const orgId = await currentOrgId();
+  if (!orgId) return [];
+  return listPendingResearchProposals(orgId);
+}
+
+export async function approveResearchProposalAction(
+  proposalId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) return { ok: false, error: "Not authenticated" };
+
+  const res = await approveResearch(
+    { proposalId, decidedByUserId: session.user.id },
+    // The gate: on approval, enqueue the actual research execution (slice C).
+    { onApproved: (p) => enqueueResearchExecution(p) },
+  );
+  return res.approved ? { ok: true } : { ok: false, error: "Proposal is no longer pending." };
+}
+
+export async function declineResearchProposalAction(
+  proposalId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) return { ok: false, error: "Not authenticated" };
+
+  const res = await declineResearch({ proposalId, decidedByUserId: session.user.id });
+  return res.declined ? { ok: true } : { ok: false, error: "Proposal is no longer pending." };
+}

--- a/apps/web/lib/wiki/research-proposal-list.test.ts
+++ b/apps/web/lib/wiki/research-proposal-list.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  listPendingResearchProposals,
+  type ResearchProposalClient,
+} from "./research-proposal";
+
+describe("listPendingResearchProposals", () => {
+  it("returns the org's pending proposals, newest first", async () => {
+    const findMany = vi.fn(async (_args: unknown) => [
+      { proposalId: "rp_2", topic: "market-size", query: "q2", proposedBy: "schedule", proposedAt: new Date() },
+      { proposalId: "rp_1", topic: "competitive-landscape", query: "q1", proposedBy: "gap-detection", proposedAt: new Date() },
+    ]);
+    const db = { researchProposal: { findMany } } as unknown as ResearchProposalClient;
+
+    const res = await listPendingResearchProposals("org_1", { db });
+
+    expect(res).toHaveLength(2);
+    expect(res[0].proposalId).toBe("rp_2");
+    // queries the right org + pending, ordered desc
+    const arg = findMany.mock.calls[0][0] as any;
+    expect(arg.where).toMatchObject({ organizationId: "org_1", status: "pending" });
+    expect(arg.orderBy).toMatchObject({ proposedAt: "desc" });
+  });
+});

--- a/apps/web/lib/wiki/research-proposal.ts
+++ b/apps/web/lib/wiki/research-proposal.ts
@@ -36,6 +36,7 @@ export type OnApproved = (proposal: ApprovedProposal) => Promise<void>;
 export type ResearchProposalClient = {
   researchProposal: {
     findFirst: (args: unknown) => Promise<unknown>;
+    findMany: (args: unknown) => Promise<unknown>;
     create: (args: unknown) => Promise<unknown>;
     update: (args: unknown) => Promise<unknown>;
   };
@@ -141,4 +142,27 @@ export async function declineResearch(
     data: { status: "declined", decidedByUserId: input.decidedByUserId ?? null, decidedAt: new Date() },
   });
   return { declined: true };
+}
+
+// ─── List (approval UI) ──────────────────────────────────────────────────────
+
+export type PendingResearchProposal = {
+  proposalId: string;
+  topic: string;
+  query: string;
+  proposedBy: string;
+  proposedAt: Date;
+};
+
+/** Pending proposals for an org, newest first — feeds the approval UI. */
+export async function listPendingResearchProposals(
+  organizationId: string,
+  deps: { db?: ResearchProposalClient } = {},
+): Promise<PendingResearchProposal[]> {
+  const client = db(deps);
+  return (await client.researchProposal.findMany({
+    where: { organizationId, status: "pending" },
+    orderBy: { proposedAt: "desc" },
+    select: { proposalId: true, topic: true, query: true, proposedBy: true, proposedAt: true },
+  })) as PendingResearchProposal[];
 }


### PR DESCRIPTION
**Final slice of BI-8A58C65A.** The human approval gate in the *scheduled → approve → execute → draft* model (founder open-Q#4). The operator sees pending research proposals and approves/declines; **approval is the single gate** between a scheduled proposal and a real web+LLM research run.

## Changes
- `lib/wiki/research-proposal.ts`: `listPendingResearchProposals` (+ `findMany` on the structural client) + a list test.
- `lib/actions/research-proposals.ts`: list/approve/decline server actions. **`approveResearchProposalAction` wires `approveResearch.onApproved` → `enqueueResearchExecution` (slice C)** — the cross-slice integration that makes approval trigger execution.
- `components/admin/ResearchProposalsPanel.tsx` + `app/(shell)/admin/research/page.tsx`: minimal admin surface (Approve & research / Decline; optimistic removal).

## BI-8A58C65A is now end-to-end
weekly cron proposes (**D** #1418) → operator approves here (**E**) → execution runs research (**C** #1416) via the engine (**A** #1394) → `enrichOrgCorpus` lands a **draft** (BI-1378) for review. Proposal lifecycle/dedup from **B** (#1411).

## Tests
8 unit tests across the proposal lib (incl. the list helper); typecheck clean. Built in the isolated worktree.

## Still pending (noted, not in this PR)
**Functional verification** in a running portal (deferred earlier) — the unit layer is green but the end-to-end path hasn't been walked live. Nav-mounting of `/admin/research` can also follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)