### PR TITLE
fix(coworker): infra failover must not surface fabrication copy (BI-EFFF19B4)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -54,13 +54,15 @@ function mockResult(overrides: {
   providerId?: string;
   modelId?: string;
   toolsStripped?: boolean;
+  downgraded?: boolean;
+  downgradeMessage?: string | null;
 }) {
   return {
     content: overrides.content,
     providerId: overrides.providerId ?? "anthropic-sub",
     modelId: overrides.modelId ?? "claude-haiku-4-5-20251001",
-    downgraded: false,
-    downgradeMessage: null,
+    downgraded: overrides.downgraded ?? false,
+    downgradeMessage: overrides.downgradeMessage ?? null,
     toolsStripped: overrides.toolsStripped ?? false,
     inputTokens: overrides.inputTokens ?? 100,
     outputTokens: overrides.outputTokens ?? 50,
@@ -1454,6 +1456,96 @@ describe("runAgenticLoop", () => {
     const thirdCallMessages = mockRoute.mock.calls[2]?.[0] ?? [];
     const lastUserMessage = [...thirdCallMessages].reverse().find((m: any) => m.role === "user");
     expect(lastUserMessage?.content).toContain("Do not pause after a failed read");
+  });
+
+  // ─── Infra-aware fabrication guard (routing-resilience Slice D) ───────────
+  // An infrastructure failover (preferred provider failed, a backup answered)
+  // must NOT be reported to the user as model fabrication ("the underlying work
+  // wasn't recorded"). This is the 2026-06-02 incident. detectFabrication stays
+  // strict for healthy-provider false claims.
+  // Tools that make a completion-claim "fabrication" (need an authoritative,
+  // side-effecting tool available, else the claim is ordinary advice).
+  const authoritativeTools = {
+    tools: [
+      { name: "update_estate_posture", description: "Update estate posture", inputSchema: {}, requiredCapability: null, executionMode: "immediate" as const, sideEffect: true },
+    ],
+    toolsForProvider: [
+      { type: "function", function: { name: "update_estate_posture", description: "Update estate posture", parameters: {} } },
+    ],
+  };
+
+  it("keeps the backup's answer on a downgraded conversational turn (does NOT show fabrication copy)", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    // Single downgraded response that trips the completion-claim guard.
+    mockRoute.mockResolvedValueOnce(mockResult({
+      content: "I've completed the analysis and configured the estate posture summary for you.",
+      downgraded: true,
+      downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
+    }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/platform/estate", // NOT a /build route
+      ...authoritativeTools,
+    });
+
+    // The real answer is preserved; the build-recording failure copy is gone.
+    expect(result.content).toContain("completed the analysis");
+    expect(result.content.toLowerCase()).not.toContain("wasn't recorded");
+    expect(result.content.toLowerCase()).not.toContain("was not recorded");
+    expect(result.downgraded).toBe(true);
+  });
+
+  it("uses honest infra copy (not fabrication copy) for a downgraded build-route claim", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    // Two fabricated build claims → retry exhausted → final emission.
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Built and deployed the feature — implementation completed.",
+        downgraded: true,
+        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Built and deployed the feature — implementation completed.",
+        downgraded: true,
+        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
+      }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/build",
+      ...authoritativeTools,
+    });
+
+    // Honest infrastructure attribution, NOT "the underlying work wasn't recorded".
+    expect(result.content.toLowerCase()).not.toContain("wasn't recorded");
+    expect(result.content.toLowerCase()).toMatch(/unavailable|backup/);
+    // Must not leak internals (IDENTITY_BLOCK rule #5).
+    expect(result.content).not.toContain("update_estate_posture");
+  });
+
+  it("STILL fires the fabrication guard on a healthy (non-downgraded) false claim", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    // Healthy provider, repeated fabricated claim → fabrication copy must win.
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Built and deployed the feature — implementation completed.",
+        downgraded: false,
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Built and deployed the feature — implementation completed.",
+        downgraded: false,
+      }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/build",
+      ...authoritativeTools,
+    });
+
+    // The original guard is unchanged for healthy providers.
+    expect(result.content).not.toContain("deployed the feature");
+    expect(result.content.toLowerCase()).toContain("wasn't recorded");
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -336,6 +336,26 @@ function buildFabricationFailureMessage(params: {
   );
 }
 
+/**
+ * Honest, infrastructure-aware copy for when a completion-claim trips the
+ * fabrication guard ON A DOWNGRADED TURN — i.e. the preferred AI provider
+ * failed and a backup produced the answer. The fabrication signal here is most
+ * likely an artifact of the failover (a weaker backup model), NOT the model
+ * faking work, so we must NOT show the build-recording failure copy ("the
+ * underlying work wasn't recorded") — that misreports an infrastructure failure
+ * as model misbehavior. This is the exact 2026-06-02 incident. Respects
+ * IDENTITY_BLOCK rule #5 — no provider/model/tool internals exposed.
+ * See spec docs/specs/routing-resilience-and-failure-observability-spec.md §4.5.
+ */
+function buildDowngradedFabricationMessage(): string {
+  return (
+    "My usual AI provider was unavailable, so I worked through a backup that "
+    + "couldn't fully complete this — nothing was left half-saved on your side. "
+    + "Please try again (the primary connection may have recovered), or break "
+    + "the request into a smaller step."
+  );
+}
+
 function buildLocalToolCallFailureMessage(_result: RoutedInferenceResult): string {
   // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose
   // infrastructure names ("Docker Model Runner"), model IDs, or routing
@@ -1388,6 +1408,31 @@ export async function runAgenticLoop(params: {
       }
 
       if (looksFabricated) {
+        // Routing-resilience Slice D: an infrastructure failover (the preferred
+        // provider failed and a backup answered) is NOT model fabrication. On a
+        // downgraded conversational turn the fabrication signal is a false
+        // positive caused by the failover — keep the backup's answer rather than
+        // replacing it with the build-recording failure copy. This is the exact
+        // 2026-06-02 incident (a good estate answer hidden behind "the
+        // underlying work wasn't recorded"). detectFabrication stays pure; the
+        // infra context (downgraded, build-route) is applied only here.
+        if (result.downgraded && !isBuildRoute) {
+          console.warn(
+            "[agentic-loop] fabrication signal on a downgraded conversational turn — keeping the backup answer (infra failover, not fabrication).",
+          );
+          return {
+            content: trimmed,
+            providerId: result.providerId,
+            modelId: result.modelId,
+            downgraded: result.downgraded,
+            downgradeMessage: result.downgradeMessage,
+            totalInputTokens,
+            totalOutputTokens,
+            executedTools,
+            proposal: null,
+          };
+        }
+
         if (!fabricationRetried) {
           fabricationRetried = true;
           console.warn(
@@ -1409,11 +1454,16 @@ export async function runAgenticLoop(params: {
         }
 
         return {
-          content: buildFabricationFailureMessage({
-            response: trimmed,
-            tools,
-            executedTools,
-          }),
+          // Downgraded build-route claim: the completion claim is load-bearing
+          // ("I shipped it"), so we don't keep it — but we still attribute the
+          // failure to infrastructure, not to the model fabricating work.
+          content: result.downgraded
+            ? buildDowngradedFabricationMessage()
+            : buildFabricationFailureMessage({
+                response: trimmed,
+                tools,
+                executedTools,
+              }),
           providerId: result.providerId,
           modelId: result.modelId,
           downgraded: result.downgraded,
@@ -1762,19 +1812,28 @@ export async function runAgenticLoop(params: {
     new Set(tools.filter((tool) => tool.sideEffect).map((tool) => tool.name)),
     tools.some((tool) => tool.sideEffect || BUILD_TOOL_NAMES.has(tool.name)),
   );
+  const downgraded = lastResult?.downgraded ?? false;
   const exhaustedMessage = buildMaxIterationsExhaustedMessage({
-    downgraded: lastResult?.downgraded ?? false,
+    downgraded,
     executedTools,
   });
   return {
+    // Routing-resilience Slice D: a raw tool-use loop is a genuine model
+    // hallucination and still gets the loop message. But a fabrication signal on
+    // a DOWNGRADED turn yields to the downgrade-aware exhausted message (honest
+    // infra copy) instead of the "underlying work wasn't recorded" build copy —
+    // the exhaustion was driven by the backup provider, not by the model faking
+    // work. Fabrication copy is reserved for healthy-provider false claims.
     content: fallbackIsRawToolUse
       ? buildRuntimeLimitToolLoopMessage(executedTools)
       : fallbackIsFabricated
-      ? buildFabricationFailureMessage({
-          response: fallbackContent,
-          tools,
-          executedTools,
-        })
+      ? (downgraded
+          ? exhaustedMessage
+          : buildFabricationFailureMessage({
+              response: fallbackContent,
+              tools,
+              executedTools,
+            }))
       : (lastResult?.content?.trim() ? lastResult.content : exhaustedMessage),
     providerId: lastResult?.providerId ?? "unknown",
     modelId: lastResult?.modelId ?? "unknown",


### PR DESCRIPTION
## What

**Slice D** of the [routing-resilience spec](docs/specs/routing-resilience-and-failure-observability-spec.md) (§4.5). Fixes the *second* half of the 2026-06-02 incident: a good coworker answer was hidden behind **"I couldn't complete that — the underlying work wasn't recorded."**

That copy is the fabrication guard's substitute message — but the real cause was an **infrastructure failover** (codex failed → a backup provider answered), not the model faking work. `detectFabrication()` can't distinguish a genuine false "I shipped it" from a fallback model's plausible answer, so any completion-claim-without-a-tool on a downgraded turn was mislabeled as fabrication.

## Fix

Applied at the **call sites** so `detectFabrication()` stays pure (spec requirement 3):

- **Main loop:** on a downgraded turn, a **conversational** answer is *kept* (the fabrication signal is a failover artifact — this is the estate-specialist case you saw); a downgraded **build-route** claim gets honest infra copy (`buildDowngradedFabricationMessage()`) instead of the build-recording failure copy.
- **Max-iterations path:** a fabrication signal on a downgraded turn yields to the downgrade-aware `buildMaxIterationsExhaustedMessage()`; a raw tool-use loop (genuine hallucination) still gets the loop message.
- **Healthy providers unchanged** — the guard stays strict for real false claims.

User-facing copy exposes no provider/model/tool internals (IDENTITY_BLOCK rule #5).

## Tests (`78 passing`, `tsc` clean)

- downgraded conversational answer → **kept**, no "wasn't recorded"
- downgraded build claim → honest infra copy, no "wasn't recorded", no tool-name leak
- healthy false claim → fabrication copy **still fires** (regression guard)

## Scope

Independent of Slice A (PR #1424) — branched off `origin/main`, own PR. Touches only `agentic-loop.ts` + its test. Together, A + D turn the incident's *slow + wrong* turn into *fast failover + honest copy* (or the real answer).

Refs: **BI-EFFF19B4** · EP-ROUTING-11 · spec PR #1421

🤖 Generated with [Claude Code](https://claude.com/claude-code)