### PR TITLE
fix(estate): stop promoting infrastructure into the product portfolio + reconcile

### DIFF
--- a/packages/db/src/discovery-promotion-policy.test.ts
+++ b/packages/db/src/discovery-promotion-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   LEGACY_PROMOTABLE_TYPES,
   looksLikeRuntimeArtifact,
+  isNonProductEntityType,
   resolvePromotionDecision,
 } from "./discovery-promotion-policy";
 
@@ -51,13 +52,13 @@ describe("resolvePromotionDecision", () => {
     expect(resolvePromotionDecision(baseEntity, taxonomyNode, null).reason).toBe("no_portfolio_root");
   });
 
-  it("emits classifyAs from policy when provided", () => {
-    const node = { ...taxonomyNode, governance: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" } } };
-    // Use an entityType the legacy list would reject, then prove the
-    // policy override wins. Also pass a non-runtime name so the new
-    // name-gate doesn't fire first.
-    const e = { ...baseEntity, entityType: "network_client", name: "Custom Service Endpoint" };
-    expect(resolvePromotionDecision(e, node, portfolio).classifyAs).toBe("infrastructure_endpoint");
+  it("emits classifyAs from policy when provided (on a product-shaped entity)", () => {
+    const node = { ...taxonomyNode, governance: { promotion: { mode: "auto", classifyAs: "managed_service" } } };
+    // A product-shaped type with a non-runtime name promotes, and classifyAs
+    // flows through. (Infra types are blocked by the structural gate even with
+    // an auto policy — see the structural-type-gate describe block below.)
+    const e = { ...baseEntity, entityType: "service", name: "Custom Managed Service" };
+    expect(resolvePromotionDecision(e, node, portfolio).classifyAs).toBe("managed_service");
   });
 
   describe("name-shape gate (BI-79307D22)", () => {
@@ -99,6 +100,61 @@ describe("resolvePromotionDecision", () => {
       expect(decision.decision).toBe("promote");
     });
   });
+
+  describe("structural entityType gate (estate-accuracy)", () => {
+    const autoNode = { ...taxonomyNode, governance: { promotion: { mode: "auto" } } };
+
+    it("rejects a 'host' even when its taxonomy node auto-promotes", () => {
+      // The exact live leak: "foundational/compute/servers" is mode:auto and a
+      // host name like "LAN Host 172.18.0.1" slips past the name-gate.
+      const decision = resolvePromotionDecision(
+        { ...baseEntity, entityType: "host", name: "LAN Host 172.18.0.1" },
+        autoNode,
+        portfolio,
+      );
+      expect(decision.decision).toBe("skip");
+      expect(decision.reason).toBe("type_not_promotable");
+      expect(decision.evidence.source).toBe("structural-type-gate");
+    });
+
+    it("rejects a 'network_interface' even with classifyAs:infrastructure_endpoint", () => {
+      const node = {
+        ...taxonomyNode,
+        governance: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" } },
+      };
+      const decision = resolvePromotionDecision(
+        { ...baseEntity, entityType: "network_interface", name: "eth0 (172.18.0.11)" },
+        node,
+        portfolio,
+      );
+      expect(decision.decision).toBe("skip");
+      expect(decision.reason).toBe("type_not_promotable");
+    });
+
+    it.each(["host", "docker_host", "container", "network_interface", "subnet", "gateway", "switch", "access_point", "router", "network_client"])(
+      "hard-blocks infra type %s regardless of auto policy",
+      (entityType) => {
+        const decision = resolvePromotionDecision(
+          { ...baseEntity, entityType, name: "Some Infra Thing" },
+          autoNode,
+          portfolio,
+        );
+        expect(decision.decision).toBe("skip");
+        expect(decision.evidence.source).toBe("structural-type-gate");
+      },
+    );
+
+    it("still promotes product-shaped types (database, service, application) under auto policy", () => {
+      for (const entityType of ["database", "service", "application", "monitoring_service"]) {
+        const decision = resolvePromotionDecision(
+          { ...baseEntity, entityType, name: "Real Product" },
+          autoNode,
+          portfolio,
+        );
+        expect(decision.decision).toBe("promote");
+      }
+    });
+  });
 });
 
 describe("looksLikeRuntimeArtifact", () => {
@@ -115,6 +171,31 @@ describe("looksLikeRuntimeArtifact", () => {
     ["Real Product Name", false],
   ])("classifies %s as runtime=%s", (name, expected) => {
     expect(looksLikeRuntimeArtifact(name)).toBe(expected);
+  });
+});
+
+describe("isNonProductEntityType", () => {
+  it.each([
+    ["host", true],
+    ["docker_host", true],
+    ["container", true],
+    ["network_interface", true],
+    ["subnet", true],
+    ["gateway", true],
+    ["switch", true],
+    ["access_point", true],
+    ["router", true],
+    ["network_client", true],
+    ["HOST", true], // case-insensitive
+    [" host ", true], // trims
+    ["database", false],
+    ["service", false],
+    ["application", false],
+    ["monitoring_service", false],
+    ["runtime", false],
+    ["ai_service", false],
+  ])("classifies %s as non-product=%s", (entityType, expected) => {
+    expect(isNonProductEntityType(entityType)).toBe(expected);
   });
 });
 

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -49,6 +49,42 @@ export function looksLikeRuntimeArtifact(name: string): boolean {
   return NON_PRODUCT_NAME_PATTERNS.some((pattern) => pattern.test(name));
 }
 
+// Entity types that are infrastructure / transport / runtime instances —
+// never products in their own right, regardless of taxonomy promotion policy.
+// A host or network interface is something products RUN ON, not a product;
+// it belongs as an InventoryEntity attributed to a product (e.g. the
+// "dpf-postgres-1 container" inventory row attributed to the "postgres"
+// product), not as a standalone DigitalProduct.
+//
+// This is a STRUCTURAL gate, like the name-gate: it wins over a taxonomy
+// node's governance.promotion.mode = "auto". Without it, an auto-promotion
+// policy on a node such as "foundational/compute/servers" or
+// "foundational/network_management/network_connectivity" promotes every
+// discovered container IP / NIC / subnet into the product portfolio.
+// (Observed live: 38 host/network_interface/subnet/gateway rows bypassed the
+// name-gate — names like "LAN Host 172.18.0.1" / "eth0 (172.18.0.11)" don't
+// match the runtime-artifact patterns — and were auto-promoted, burying the
+// 3 real products. classifyAs:"infrastructure_endpoint" did NOT save them
+// from polluting the portfolio.)
+export const NON_PRODUCT_ENTITY_TYPES: ReadonlySet<string> = new Set([
+  "host",
+  "docker_host",
+  "container",
+  "network_interface",
+  "subnet",
+  "gateway",
+  "switch",
+  "access_point",
+  "router",
+  "vlan",
+  "wlan",
+  "network_client",
+]);
+
+export function isNonProductEntityType(entityType: string): boolean {
+  return NON_PRODUCT_ENTITY_TYPES.has(entityType.trim().toLowerCase());
+}
+
 export const AUTO_PROMOTE_THRESHOLD = 0.9;
 
 export type PromotionSkipReason =
@@ -162,6 +198,24 @@ export function resolvePromotionDecision(
       evidence: {
         source: "name-gate",
         name: entity.name,
+      },
+    };
+  }
+
+  // Gate 5 (structural, estate-accuracy): infrastructure / transport /
+  // runtime-instance entity types are never products, regardless of taxonomy
+  // governance.promotion. Runs BEFORE the auto-policy lookup so an "auto" node
+  // (e.g. foundational/compute/servers) cannot promote a host / NIC / subnet
+  // into the portfolio. Same precedence rationale as the name-gate: structural
+  // shape wins over taxonomy placement, because the alternative is letting an
+  // over-broad taxonomy policy write bad product rows.
+  if (isNonProductEntityType(entity.entityType)) {
+    return {
+      decision: "skip",
+      reason: "type_not_promotable",
+      evidence: {
+        source: "structural-type-gate",
+        entityType: entity.entityType,
       },
     };
   }

--- a/packages/db/src/discovery-promotion.test.ts
+++ b/packages/db/src/discovery-promotion.test.ts
@@ -157,9 +157,13 @@ describe("promoteInventoryEntities", () => {
     expect(upsertArgs.create.issueType).toBe("type_not_promotable");
   });
 
-  it("promotes network_client with governance.promotion + writes classifyAs into observationConfig", async () => {
-    // Name avoids the BI-79307D22 runtime-artifact gate (no trailing
-    // -N, no dpf- prefix, no IP, no "(WAN)").
+  it("skips an infra entityType (network_client) even with auto governance.promotion + classifyAs", async () => {
+    // Estate-accuracy structural-type-gate: a network_client is infrastructure,
+    // never a product — even when its taxonomy node
+    // ("foundational/network_management/network_connectivity") is mode:auto with
+    // classifyAs:"infrastructure_endpoint" and the name clears the runtime-
+    // artifact name-gate. This is the live leak that promoted "Access Point" /
+    // "eth0 (172.18.0.11)" rows into the product portfolio.
     mockPrisma.inventoryEntity.findMany.mockResolvedValue([{
       id: "ent_nc2",
       entityKey: "network_client:2",
@@ -177,15 +181,14 @@ describe("promoteInventoryEntities", () => {
       governance: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" } },
     });
     mockPrisma.portfolio.findUnique.mockResolvedValue({ id: "port_1" });
-    mockPrisma.digitalProduct.upsert.mockResolvedValue({ id: "dp_ap", productId: "infra-ap-1" });
-    mockPrisma.inventoryEntity.update.mockResolvedValue({});
 
     const result = await promoteInventoryEntities(mockPrisma as never);
 
-    expect(result.promoted).toBe(1);
-    const upsertArgs = mockPrisma.digitalProduct.upsert.mock.calls[0][0];
-    expect(upsertArgs.create.observationConfig).toEqual({ classifyAs: "infrastructure_endpoint" });
-    expect(upsertArgs.update.observationConfig).toEqual({ classifyAs: "infrastructure_endpoint" });
+    expect(result.promoted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockPrisma.digitalProduct.upsert).not.toHaveBeenCalled();
+    const issueArgs = mockPrisma.portfolioQualityIssue.upsert.mock.calls[0][0];
+    expect(issueArgs.create.issueType).toBe("type_not_promotable");
   });
 
   it("skips low-confidence entity with low_confidence_promotion + writes quality issue", async () => {

--- a/packages/db/src/discovery-reconcile.test.ts
+++ b/packages/db/src/discovery-reconcile.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isInfrastructureProduct,
+  reconcilePromotedProducts,
+} from "./discovery-reconcile";
+
+describe("isInfrastructureProduct", () => {
+  it("is true when every linked entity is an infra type", () => {
+    expect(isInfrastructureProduct(["host"])).toBe(true);
+    expect(isInfrastructureProduct(["network_interface", "subnet"])).toBe(true);
+    expect(isInfrastructureProduct(["gateway", "host", "docker_host"])).toBe(true);
+  });
+
+  it("is false when any linked entity is product-shaped", () => {
+    expect(isInfrastructureProduct(["host", "database"])).toBe(false);
+    expect(isInfrastructureProduct(["service"])).toBe(false);
+    expect(isInfrastructureProduct(["application"])).toBe(false);
+  });
+
+  it("is false when there are no linked entities (seed/registered product)", () => {
+    expect(isInfrastructureProduct([])).toBe(false);
+  });
+});
+
+function makeDb(products: Array<{
+  id: string;
+  productId: string;
+  name: string;
+  inventoryEntities: Array<{ id: string; entityType: string }>;
+}>) {
+  return {
+    digitalProduct: {
+      findMany: vi.fn().mockResolvedValue(products),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    inventoryEntity: {
+      updateMany: vi
+        .fn()
+        .mockImplementation(({ where }: { where: { digitalProductId: string } }) => {
+          const p = products.find((x) => x.id === where.digitalProductId);
+          return Promise.resolve({ count: p ? p.inventoryEntities.length : 0 });
+        }),
+    },
+  };
+}
+
+describe("reconcilePromotedProducts", () => {
+  it("demotes infra products, detaches their inventory, and keeps real products", async () => {
+    const db = makeDb([
+      { id: "p_host", productId: "host-lan-host-172-18-0-1", name: "LAN Host 172.18.0.1", inventoryEntities: [{ id: "e1", entityType: "host" }] },
+      { id: "p_nic", productId: "infra-eth0-172-18-0-11", name: "eth0 (172.18.0.11)", inventoryEntities: [{ id: "e2", entityType: "network_interface" }] },
+      { id: "p_db", productId: "infra-postgres-core", name: "PostgreSQL Database", inventoryEntities: [{ id: "e3", entityType: "database" }] },
+    ]);
+
+    const summary = await reconcilePromotedProducts(db as never);
+
+    expect(summary.demoted).toBe(2);
+    expect(summary.detachedEntities).toBe(2);
+    expect(summary.kept).toBe(1);
+    expect(summary.errors).toBe(0);
+
+    // The two infra products were deleted; the database product was not.
+    expect(db.digitalProduct.delete).toHaveBeenCalledTimes(2);
+    const deletedIds = db.digitalProduct.delete.mock.calls.map(
+      (c) => (c[0] as { where: { id: string } }).where.id,
+    );
+    expect(deletedIds).toContain("p_host");
+    expect(deletedIds).toContain("p_nic");
+    expect(deletedIds).not.toContain("p_db");
+
+    // Inventory was detached before delete (preserved as infra inventory).
+    expect(db.inventoryEntity.updateMany).toHaveBeenCalledWith({
+      where: { digitalProductId: "p_host" },
+      data: { digitalProductId: null },
+    });
+  });
+
+  it("is idempotent — a clean estate demotes nothing", async () => {
+    const db = makeDb([
+      { id: "p_db", productId: "infra-postgres-core", name: "PostgreSQL Database", inventoryEntities: [{ id: "e3", entityType: "database" }] },
+    ]);
+    const summary = await reconcilePromotedProducts(db as never);
+    expect(summary.demoted).toBe(0);
+    expect(summary.kept).toBe(1);
+    expect(db.digitalProduct.delete).not.toHaveBeenCalled();
+  });
+
+  it("counts a failed demotion as an error without throwing", async () => {
+    const db = makeDb([
+      { id: "p_host", productId: "host-x", name: "LAN Host", inventoryEntities: [{ id: "e1", entityType: "host" }] },
+    ]);
+    db.digitalProduct.delete.mockRejectedValueOnce(new Error("FK constraint"));
+
+    const summary = await reconcilePromotedProducts(db as never);
+    expect(summary.errors).toBe(1);
+    expect(summary.demoted).toBe(0);
+  });
+});

--- a/packages/db/src/discovery-reconcile.ts
+++ b/packages/db/src/discovery-reconcile.ts
@@ -1,0 +1,117 @@
+// discovery-reconcile.ts
+// Reconciles ALREADY-promoted DigitalProducts against the current promotion
+// policy and demotes the ones that should never have been products.
+//
+// Why this exists: before the structural entityType gate
+// (discovery-promotion-policy.ts), an auto-promotion taxonomy node (e.g.
+// "foundational/compute/servers", "foundational/network_management/
+// network_connectivity") promoted every discovered host / NIC / subnet /
+// gateway into the product portfolio. The gate stops NEW pollution; this
+// routine cleans the EXISTING rows so the portfolio reflects the real estate.
+//
+// Demotion is idempotent and conservative: a product is demoted ONLY when it
+// has at least one linked InventoryEntity AND every linked entity is a
+// non-product (infrastructure / transport / runtime-instance) type. The
+// entities themselves are preserved — they are real discovered infrastructure;
+// they simply stop being mislabeled as products (their digitalProductId is
+// nulled, so they remain attributed to their taxonomy node as inventory).
+
+import { isNonProductEntityType } from "./discovery-promotion-policy";
+
+export type ReconcileSummary = {
+  /** DigitalProducts removed because they were infrastructure, not products. */
+  demoted: number;
+  /** InventoryEntity rows detached (digitalProductId nulled) and kept as inventory. */
+  detachedEntities: number;
+  /** Products inspected but left in place (genuinely product-shaped). */
+  kept: number;
+  /** Demotions that failed (e.g. blocking FK) — left in place, logged. */
+  errors: number;
+};
+
+type ReconcileDb = {
+  digitalProduct: {
+    findMany(args: {
+      where: Record<string, unknown>;
+      select: Record<string, unknown>;
+    }): Promise<Array<{
+      id: string;
+      productId: string;
+      name: string;
+      inventoryEntities: Array<{ id: string; entityType: string }>;
+    }>>;
+    delete(args: { where: { id: string } }): Promise<unknown>;
+  };
+  inventoryEntity: {
+    updateMany(args: {
+      where: { digitalProductId: string };
+      data: { digitalProductId: null };
+    }): Promise<{ count: number }>;
+  };
+};
+
+/**
+ * Decide whether a product is infrastructure that was wrongly promoted.
+ * Pure — exported for unit testing.
+ */
+export function isInfrastructureProduct(
+  linkedEntityTypes: readonly string[],
+): boolean {
+  return (
+    linkedEntityTypes.length > 0 &&
+    linkedEntityTypes.every((t) => isNonProductEntityType(t))
+  );
+}
+
+export async function reconcilePromotedProducts(
+  db: ReconcileDb,
+): Promise<ReconcileSummary> {
+  const summary: ReconcileSummary = {
+    demoted: 0,
+    detachedEntities: 0,
+    kept: 0,
+    errors: 0,
+  };
+
+  // Only products that carry discovered inventory can be discovery-promoted
+  // infrastructure. Seed/registered products with no linked entities are
+  // never touched.
+  const products = await db.digitalProduct.findMany({
+    where: { inventoryEntities: { some: {} } },
+    select: {
+      id: true,
+      productId: true,
+      name: true,
+      inventoryEntities: { select: { id: true, entityType: true } },
+    },
+  });
+
+  for (const product of products) {
+    const types = product.inventoryEntities.map((e) => e.entityType);
+    if (!isInfrastructureProduct(types)) {
+      summary.kept++;
+      continue;
+    }
+
+    try {
+      const detached = await db.inventoryEntity.updateMany({
+        where: { digitalProductId: product.id },
+        data: { digitalProductId: null },
+      });
+      summary.detachedEntities += detached.count;
+      await db.digitalProduct.delete({ where: { id: product.id } });
+      summary.demoted++;
+      console.log(
+        `[discovery-reconcile] Demoted infrastructure product ${product.productId} (${product.name}); kept ${detached.count} inventory rows`,
+      );
+    } catch (err) {
+      summary.errors++;
+      console.error(
+        `[discovery-reconcile] Failed to demote ${product.productId}:`,
+        err,
+      );
+    }
+  }
+
+  return summary;
+}

--- a/packages/db/src/discovery-runner.ts
+++ b/packages/db/src/discovery-runner.ts
@@ -11,6 +11,7 @@ import {
 } from "./discovery-normalize";
 import { persistBootstrapDiscoveryRun } from "./discovery-sync";
 import { promoteInventoryEntities } from "./discovery-promotion";
+import { reconcilePromotedProducts } from "./discovery-reconcile";
 import {
   inferCrossCollectorRelationships,
   inferProductDependencies,
@@ -129,6 +130,21 @@ export async function executeBootstrapDiscovery(
     }
   } catch (err) {
     console.error("[discovery] Promotion pass failed (non-fatal):", err);
+  }
+
+  // Reconcile: demote any previously-promoted infrastructure (host / NIC /
+  // subnet / gateway) that the structural type-gate now rejects, so the
+  // portfolio self-heals from earlier over-promotion instead of accumulating
+  // network noise. Idempotent and conservative (entityType-based).
+  try {
+    const reconcileSummary = await reconcilePromotedProducts(db as never);
+    if (reconcileSummary.demoted > 0) {
+      console.log(
+        `[discovery] Reconciled portfolio: demoted ${reconcileSummary.demoted} infrastructure products, kept ${reconcileSummary.detachedEntities} inventory rows`,
+      );
+    }
+  } catch (err) {
+    console.error("[discovery] Reconcile pass failed (non-fatal):", err);
   }
 
   // Pass 2 & 3: Product-to-infrastructure relationship inference

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -205,6 +205,15 @@ export {
   type PromotionSummary,
 } from "./discovery-promotion";
 export {
+  reconcilePromotedProducts,
+  isInfrastructureProduct,
+  type ReconcileSummary,
+} from "./discovery-reconcile";
+export {
+  isNonProductEntityType,
+  NON_PRODUCT_ENTITY_TYPES,
+} from "./discovery-promotion-policy";
+export {
   TRIAGE_ACTOR_TYPES,
   TRIAGE_OUTCOMES,
   TRIAGE_QUALITY_ISSUE_TYPES,


### PR DESCRIPTION
## What

The Digital Product Estate was polluted: **51 of 54 `DigitalProduct` rows were network-discovery noise.** The bootstrap sweep crawled the platform's *own* Docker network (`172.18.0.0/16`) and promoted every container IP, NIC, subnet, and gateway into the product portfolio as `production/active` — burying the 3 real products. "Products and Services Sold" had 1 product; "Foundational" had 53 mostly-junk rows.

## Root cause

A taxonomy node with `governance.promotion.mode = "auto"` (e.g. `foundational/compute/servers`, `.../network_connectivity`) **bypassed the entityType allowlist** — the type check only ran in the legacy fallback, not when an auto policy was present. The name-gate (BI-79307D22) missed these because names like `"LAN Host 172.18.0.1"` / `"eth0 (172.18.0.11)"` don't match the runtime-artifact patterns. `classifyAs: "infrastructure_endpoint"` then wrote them straight into the portfolio.

## Fix

- **`discovery-promotion-policy.ts`** — a **structural entityType gate** that runs *before* the auto-policy lookup. Infrastructure / transport / runtime-instance types (`host`, `container`, `network_interface`, `subnet`, `gateway`, `switch`, `access_point`, `docker_host`, `router`, …) are never products, regardless of taxonomy governance. Same precedence rationale as the name-gate.
- **`discovery-reconcile.ts`** — `reconcilePromotedProducts()` demotes already-promoted infrastructure. Idempotent and conservative (a product is demoted only when **every** linked entity is a non-product type). Inventory rows are **preserved** (`digitalProductId` nulled) — the real infrastructure stays as inventory attributed to its taxonomy node.
- **`discovery-runner.ts`** — runs reconcile after each promotion pass, so the portfolio self-heals from earlier over-promotion.
- Flipped the two tests that encoded the old buggy behavior.

## Live impact (applied to this install via the same reconcile logic)

| | Before | After |
|---|---|---|
| DigitalProduct rows | 54 | **16** (3 real `dpf-*` + 13 infra deps) |
| "Foundational" portfolio | 53 | 15 |
| InventoryEntity rows | 215 | 215 (all preserved as inventory) |

**38 network-noise products demoted, 0 inventory lost.**

## Tests

`76 passing` (policy + promotion + reconcile), `tsc` clean across `apps/web` + `packages/db`.

## Follow-up (not in this PR — needs your call)

13 infra-service products remain (postgres, qdrant, grafana, …), some of which are discovered-container duplicates of seeded reference products (e.g. `infra-postgres` "postgres" vs `infra-postgres-core` "PostgreSQL Database"). Deduping discovered-vs-seeded infra is a separate, judgment-dependent cleanup.

Refs: estate-accuracy goal; builds on BI-79307D22 (#1022)

🤖 Generated with [Claude Code](https://claude.com/claude-code)