### PR TITLE
fix(build-studio): rename 'New' CTA to 'Start a new build' (BI-950FE085)

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -510,6 +510,9 @@ export function BuildStudio({
                 rows={3}
                 className="w-full px-3 py-2 text-sm bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded-md text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)] resize-y min-h-[72px] max-h-[200px] leading-snug"
               />
+              {/* BI-950FE085 (D??): the prior "New" label gave Dale no signal
+                  about what he was creating. "Start a new build" is explicit —
+                  it names the action, the artifact, and the intent. */}
               <div className="flex items-center justify-between mt-2 gap-2">
                 <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
                   Press Cmd/Ctrl+Enter to start.
@@ -521,7 +524,7 @@ export function BuildStudio({
                   className="px-4 py-2 text-sm font-semibold bg-[var(--dpf-accent)] text-white border-none rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:opacity-90 transition-opacity flex items-center gap-1.5"
                 >
                   {creating && <span className="w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin" />}
-                  {creating ? "Creating..." : "New"}
+                  {creating ? "Starting…" : "Start a new build"}
                 </button>
               </div>
             </div>
@@ -770,7 +773,7 @@ export function BuildStudio({
                 <div className="text-left bg-[var(--dpf-surface-2)] rounded-lg border border-[var(--dpf-border)] p-4 shadow-dpf-md">
                   <p className="text-xs font-semibold text-[var(--dpf-text)] mb-3 uppercase tracking-wider">How it works</p>
                   <div className="flex flex-col gap-2.5">
-                    <Step n={1} text="Type a feature name in the sidebar and click New" />
+                    <Step n={1} text={'Type a feature name in the sidebar and click “Start a new build”'} />
                     <Step n={2} text="Your AI Coworker will open and guide you through the process" />
                     <Step n={3} text="Review the live preview as it builds" />
                     <Step n={4} text="Approve and deploy when you're happy" />
@@ -1285,7 +1288,7 @@ function FleetRailZone({
           <div className="text-3xl mb-3 opacity-20">&#128161;</div>
           <p className="text-sm text-[var(--dpf-muted)] mb-2">No builds yet</p>
           <p className="text-xs text-[var(--dpf-muted)] opacity-70">
-            Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
+            Type a feature name above and click "Start a new build" to start.
           </p>
         </div>
       </div>
@@ -1348,7 +1351,7 @@ function FleetRailZone({
         ))}
         {activeEpicRollups.length === 0 && activeEntries.length === 0 && (
           <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
-            No active builds. Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
+            No active builds. Type a feature name above and click "Start a new build" to start.
           </li>
         )}
         {completedItemCount > 0 && (

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -211,6 +211,22 @@ function makeEpicRollup(overrides: Partial<EpicRollupView> = {}): EpicRollupView
 }
 
 describe("BuildStudio active-build header layout", () => {
+  it("intake CTA is labelled 'Start a new build' not just 'New' (BI-950FE085)", () => {
+    // Regression guard: Dale had no idea what "New" created. The CTA must
+    // name the action + artifact so it's discoverable without training.
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+    expect(html).toContain("Start a new build");
+    expect(html).not.toContain(">New<");
+  });
+
   it("renders the empty state instead of crashing when server data arrays are missing", () => {
     const html = renderToStaticMarkup(
       <BuildStudio


### PR DESCRIPTION
## Summary

Fixes the discoverability gap in the Build Studio intake form. The button labelled **"New"** gave Dale no indication of what artifact it creates. Renaming it to **"Start a new build"** makes the action explicit.

Closes `BI-950FE085` (the discoverability half — the multiline textarea was already delivered as D12 in PR #1070).

## What changed

| Location | Before | After |
|---|---|---|
| Submit button | `New` | `Start a new build` |
| In-progress state | `Creating...` | `Starting…` |
| How-it-works step 1 | `...and click New` | `...and click "Start a new build"` |
| Empty-state hint (no builds) | `...press New to start` | `...click "Start a new build" to start` |
| Empty-state hint (no active build) | `...press New to start` | `...click "Start a new build" to start` |

All five occurrences updated consistently so the copy doesn't contradict itself.

## Why the multiline textarea is already done

BI-950FE085 has two sub-items:
1. Multiline description field — shipped as **D12 in PR #1070** (`apps/web/components/build/BuildStudio.tsx` lines 492-527, comment explicitly calls it out).
2. Discoverable CTA — **this PR**.

## Tests

1 new regression guard in `BuildStudioHeaderLayout.test.tsx`:
- Asserts the static HTML contains `"Start a new build"`
- Asserts it does NOT contain `">New<"` (guards against future renames reverting the change)

17/17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)