### PR TITLE
fix(discovery): cooperative event-loop yielding + liveness-aware healthcheck

### DIFF
--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -12,10 +12,13 @@ import { GET } from "./route";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Restore real timers and delete any threshold override between tests.
+  vi.useRealTimers();
+  delete process.env["EVENT_LOOP_LAG_THRESHOLD_MS"];
 });
 
 describe("GET /api/health", () => {
-  it("returns 200 status:ok only after the database check succeeds", async () => {
+  it("returns 200 status:ok when database is healthy and event loop is responsive", async () => {
     mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
 
     const res = await GET();
@@ -25,6 +28,8 @@ describe("GET /api/health", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("ok");
     expect(body.checks.database).toBe("ok");
+    expect(body.checks.eventLoop).toBe("ok");
+    expect(typeof body.lagMs).toBe("number");
     expect(typeof body.timestamp).toBe("string");
   });
 
@@ -37,6 +42,30 @@ describe("GET /api/health", () => {
     expect(res.status).toBe(503);
     expect(body.status).toBe("degraded");
     expect(body.checks.database).toBe("error");
+    expect(body.checks.eventLoop).toBe("ok");
     expect(body.error).toContain("connection refused");
+  });
+
+  it("returns 503 with eventLoop:lagging when lag exceeds threshold (BI-9F106818)", async () => {
+    // Override the threshold to 1ms so any lag triggers the check.
+    process.env["EVENT_LOOP_LAG_THRESHOLD_MS"] = "1";
+    mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
+
+    // Spin the CPU for 5ms synchronously so the setTimeout probe actually
+    // fires late. This is the simplest way to reliably produce real lag in
+    // a test without fake timers (which don't intercept a module's captured
+    // native setTimeout reference).
+    const spin = Date.now();
+    while (Date.now() - spin < 5) { /* busy-wait */ }
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.eventLoop).toBe("lagging");
+    expect(body.checks.database).toBe("unknown");
+    // DB query must NOT have been called — loop check is the first gate.
+    expect(mockQueryRaw).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -5,20 +5,73 @@
 // hard dependencies the portal cannot serve without — not merely prove the
 // Node process can answer. A failed dependency returns HTTP 503 so callers can
 // route around an unhealthy instance.
+//
+// BI-9F106818 Phase 0: also checks event-loop liveness. A background sweep
+// that monopolises the event loop makes the portal unresponsive while Docker
+// still reports "healthy" (its check only tests TCP + this route). A 2-second
+// setTimeout probe detects a wedged loop and returns 503 so Docker restarts
+// the container automatically rather than silently serving a hung process.
 
 import { prisma } from "@dpf/db";
 
+/** Measure event-loop lag by scheduling a zero-delay timer and recording
+ *  how late it actually fires. Healthy portals resolve in <50ms; a loop
+ *  wedged by a heavy discovery sweep takes seconds.
+ */
+function measureEventLoopLag(): Promise<number> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    setTimeout(() => resolve(Date.now() - start), 0);
+  });
+}
+
+// 2 000 ms: aggressive enough to catch a genuinely wedged loop, conservative
+// enough to never false-positive on a briefly busy-but-healthy process.
+// Override with EVENT_LOOP_LAG_THRESHOLD_MS for non-default environments.
+// Read per-request so tests and runtime config changes take effect immediately.
+function getEventLoopLagThreshold(): number {
+  return Number(process.env["EVENT_LOOP_LAG_THRESHOLD_MS"]) || 2000;
+}
+
 export async function GET() {
   const timestamp = new Date().toISOString();
+  const lagThresholdMs = getEventLoopLagThreshold();
+
+  // Check event-loop liveness FIRST (before the DB query, which would also
+  // block if the loop is wedged — making the probe itself unreliable).
+  const lagMs = await measureEventLoopLag();
+  if (lagMs >= lagThresholdMs) {
+    return Response.json(
+      {
+        status: "degraded",
+        checks: { database: "unknown", eventLoop: "lagging" },
+        error: `Event loop lag ${lagMs}ms exceeds threshold ${lagThresholdMs}ms`,
+        lagMs,
+        timestamp,
+      },
+      { status: 503 },
+    );
+  }
 
   try {
     // The one hard dependency every request path needs: the database.
     await prisma.$queryRaw`SELECT 1`;
-    return Response.json({ status: "ok", checks: { database: "ok" }, timestamp });
+    return Response.json({
+      status: "ok",
+      checks: { database: "ok", eventLoop: "ok" },
+      lagMs,
+      timestamp,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "database unreachable";
     return Response.json(
-      { status: "degraded", checks: { database: "error" }, error: message, timestamp },
+      {
+        status: "degraded",
+        checks: { database: "error", eventLoop: "ok" },
+        error: message,
+        lagMs,
+        timestamp,
+      },
       { status: 503 },
     );
   }

--- a/packages/db/src/discovery-runner.ts
+++ b/packages/db/src/discovery-runner.ts
@@ -68,6 +68,17 @@ export async function runBootstrapCollectors(
   return runLocalDiscoveryCollectors(collectors);
 }
 
+/**
+ * Yield the Node event loop so pending I/O (HTTP accept, timer callbacks) can
+ * run before the next CPU-bound pass. Used between major discovery phases so a
+ * long sweep cannot monopolise the event loop and starve HTTP serving.
+ * setImmediate fires after I/O callbacks but before timers — cooperative yield
+ * within a long synchronous-heavy pipeline (BI-9F106818 Phase 0).
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 export async function executeBootstrapDiscovery(
   db: BootstrapDiscoveryDb,
   options: BootstrapExecutionOptions = {},
@@ -90,8 +101,14 @@ export async function executeBootstrapDiscovery(
 
   const rawCollected = mergeCollectorOutputs([rawStaticOutput, connectionOutput]);
 
+  // Yield before CPU-bound inference/normalization passes so HTTP handling
+  // can proceed between phases (BI-9F106818 Phase 0).
+  await yieldToEventLoop();
+
   // Pass 1: Cross-collector relationship inference (host↔interfaces, target↔container)
   const collected = inferCrossCollectorRelationships(rawCollected);
+
+  await yieldToEventLoop();
 
   const taxonomyNodes = options.taxonomyNodes
     ?? (typeof (db as { taxonomyNode?: { findMany?: unknown } }).taxonomyNode?.findMany === "function"
@@ -122,6 +139,14 @@ export async function executeBootstrapDiscovery(
     trigger: options.trigger ?? "bootstrap",
   });
 
+  // Yield between every major pass (BI-9F106818 Phase 0): these passes are
+  // CPU-bound or fire many small DB/Neo4j awaits without naturally yielding
+  // between iterations, so a long sweep can starve the HTTP event loop.
+  // yieldToEventLoop() (setImmediate) lets pending HTTP accepts and timer
+  // callbacks run before we start the next pass.
+
+  await yieldToEventLoop();
+
   // Auto-promote high-confidence entities to DigitalProduct records
   try {
     const promotionSummary = await promoteInventoryEntities(db as never);
@@ -131,6 +156,8 @@ export async function executeBootstrapDiscovery(
   } catch (err) {
     console.error("[discovery] Promotion pass failed (non-fatal):", err);
   }
+
+  await yieldToEventLoop();
 
   // Reconcile: demote any previously-promoted infrastructure (host / NIC /
   // subnet / gateway) that the structural type-gate now rejects, so the
@@ -147,6 +174,8 @@ export async function executeBootstrapDiscovery(
     console.error("[discovery] Reconcile pass failed (non-fatal):", err);
   }
 
+  await yieldToEventLoop();
+
   // Pass 2 & 3: Product-to-infrastructure relationship inference
   try {
     const inferenceSummary = await inferProductDependencies(db as never);
@@ -159,6 +188,8 @@ export async function executeBootstrapDiscovery(
   } catch (err) {
     console.error("[discovery] Product inference pass failed (non-fatal):", err);
   }
+
+  await yieldToEventLoop();
 
   // Flag gateways that have no discovery connection configured
   try {


### PR DESCRIPTION
## What & why

**BI-9F106818 Phase 0** — immediate recurrence protection for the 2026-06-02 incident where the portal became unresponsive while Docker still reported "healthy."

Root cause: the hourly discovery sweep (`executeBootstrapDiscovery`) runs heavy CPU-bound passes and many small DB/Neo4j writes in the same Node process that serves HTTP, with no cooperative yield between phases. A large working set (maximal after a rebuild/fresh-seed) monopolised the event loop, filled the HTTP accept backlog, and produced timeouts — while the healthcheck, which runs on the same loop, kept reporting "healthy."

This PR adds two independent defences, neither of which waits on the full worker-container isolation (spec `2026-06-02-background-execution-isolation-design.md` Phase 1):

### 1. Cooperative yielding in `executeBootstrapDiscovery`

Adds `yieldToEventLoop()` (`setImmediate`-based) between every major pass in the sweep:
- post-collection cross-collector inference
- normalization + persistence
- entity promotion
- portfolio reconciliation
- product→infra edge inference
- gateway connection flagging

`setImmediate` fires after I/O callbacks but before timers — the right cooperative yield point within a heavy pipeline.

### 2. Liveness-aware `/api/health`

Adds a `setTimeout(0)` event-loop-lag probe as the **first** check, before the DB query (which would itself be unreliable on a wedged loop). If lag ≥ `EVENT_LOOP_LAG_THRESHOLD_MS` (default 2000ms, env-overridable):
- Returns **HTTP 503** with `checks.eventLoop: "lagging"`
- Skips the DB query entirely
- Docker marks the container **unhealthy** → automatic restart

This is the self-heal that would have recovered the incident without operator intervention. The `lagMs` field is surfaced in every response for monitoring/alerting.

## Changes

| File | Change |
|------|--------|
| `packages/db/src/discovery-runner.ts` | `yieldToEventLoop()` helper + 5 yield calls between phases of `executeBootstrapDiscovery` |
| `apps/web/app/api/health/route.ts` | Event-loop-lag probe (first gate), `checks.eventLoop` field, `lagMs` in response, `ENV_LOOP_LAG_THRESHOLD_MS` override |
| `apps/web/app/api/health/route.test.ts` | 3 updated/new tests covering: ok path (eventLoop:ok), DB error (eventLoop:ok), lagging loop (503, DB skipped) |

## Verification
- `vitest run` on both changed files → **12/12 pass**
- TypeScript: **0 new errors** vs baseline (35 pre-existing marketing errors on origin/main, unchanged)
- Pre-commit hooks: typecheck ok

## Note on concurrency
`fullDiscoverySweep` already has `concurrency: { limit: 1, scope: "fn" }` in its Inngest definition — overlapping runs are already prevented at the scheduler level. No advisory lock needed here (unlike `model-revalidation` which predates that cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)