### PR TITLE
fix(build-studio): advance phase to build after start_build confirms sandbox ready

### DIFF
--- a/apps/web/lib/integrate/build-on-plan-approval.ts
+++ b/apps/web/lib/integrate/build-on-plan-approval.ts
@@ -138,13 +138,21 @@ export async function dispatchBuildForApprovedPlan(params: {
       return { kind: "dispatched-failure", error: msg, durationMs: Date.now() - t0 };
     }
 
-    // Re-fetch to get the buildBranch now that start_build initialized it
+    // Re-fetch to get current phase. start_build initializes the branch but
+    // does NOT advance the phase — that happens in reviewBuildPlan's gate check.
+    // If the gate was previously blocked (e.g. sandbox unavailable), we advance
+    // the phase directly here since start_build has now confirmed sandbox readiness.
     const buildWithBranch = await prisma.featureBuild.findUnique({
       where: { buildId },
-      select: { phase: true },
+      select: { phase: true, buildBranch: true },
     });
-    if (buildWithBranch?.phase !== "build") {
-      await log(`Phase is ${buildWithBranch?.phase} after start_build — not in build, skipping orchestrator`);
+
+    if (buildWithBranch?.phase === "plan" && buildWithBranch.buildBranch) {
+      // start_build set the branch — advance phase to build manually
+      await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
+      await log("Phase advanced to build (start_build confirmed sandbox ready)");
+    } else if (buildWithBranch?.phase !== "build") {
+      await log(`Phase is ${buildWithBranch?.phase} after start_build — cannot advance, skipping orchestrator`);
       return { kind: "skipped-wrong-phase", reason: `phase=${buildWithBranch?.phase} after start_build` };
     }
 


### PR DESCRIPTION
Fixes the final build dispatch gap found during live testing on FB-5E20E793.

**Root cause**: start_build initializes the sandbox branch but does not advance phase from plan→build (that's reviewBuildPlan's gate job). When reviewBuildPlan's gate blocked (sandbox unavailable at review time), the phase stayed at 'plan'. After start_build ran and confirmed sandbox readiness, the phase-check in dispatchBuildForApprovedPlan was catching this and skipping.

**Fix**: after start_build succeeds and buildBranch is set, if the phase is still 'plan', explicitly advance to 'build' before running the orchestrator. This is safe: start_build confirmed the sandbox is ready, the branch is initialized, and we're past the reviewBuildPlan gate that requires a passing plan.

This is the last piece needed for the full autonomous pipeline to execute in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)