### PR TITLE
feat(archetype): partner/reseller program primitives + partner identity design (EP-PARTNER-CHANNEL Phase 0)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
@@ -1,0 +1,187 @@
+# Partner / Reseller Archetype Extension And Partner Identity Design
+
+**Date:** 2026-06-04
+**Status:** Draft
+**Author:** Claude (Opus 4.8) with founder direction
+**Decision basis:** WWMD `principle_decide` (recorded §7); governing profile `mark-dpf-platform`
+**Related specs:**
+- `docs/superpowers/specs/2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md` (operating-model axes + capability derivation — the substrate this extends)
+- `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md` (Principal convergence — the binding identity rule)
+- `docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md`
+**Related epics:** `EP-ARCH-8D4F2A` (Archetype Model V2), `EP-EDGE-NODE`, the enterprise-auth identity track
+
+---
+
+## 1. Problem Statement
+
+Some business archetypes sell **through** other businesses, not only direct to end customers. A SaaS platform has referral, reseller, and technology partners. An IT managed-service provider is itself a channel partner of its vendors and may sub-contract. A goods brand sells wholesale through distributors and resellers. These businesses need to onboard, tier, enable, and pay a **partner/reseller network** — and those partners need to **log in** to a surface that is *not* the customer storefront and *not* the internal workforce console.
+
+Today DPF models exactly two external-facing operating assumptions and exactly two human identity kinds:
+
+- **Archetype layer.** `OperatingModelAxes.primaryConsumer` already enumerates `"channel-partner"`, and the MSP spec acknowledges that an MSP's "products sold" portfolio is "largely a resale" — but **no archetype activates a partner channel**, and there is no typed contract describing the partner operating model the way `BillingPatternProfile` describes the billing model.
+- **Identity layer.** Login is a strict binary: `User` (workforce, session `type:"admin"`) vs `CustomerContact` (storefront customer, session `type:"customer"`). A partner is *neither* — it is an external organization that transacts on its own paper, sees margin/deal-registration data a customer never should, and is governed by a partner agreement rather than an employment relationship or a purchase.
+
+This design extends the archetype substrate to **derive** a partner program from operating-model axes (so partner support is a function of an archetype's axes, not a hand-authored flag), and specifies the **partner identity and login** as a third principal kind under the platform's binding Principal-convergence rule.
+
+## 2. Live Backlog Context
+
+Live DPF MCP reads on 2026-06-04 (no DB fallback). Relevant state:
+
+- `EP-ARCH-8D4F2A` — *Archetype Model V2: Unified Business Archetypes* (in-progress) is the natural epic home for the archetype-layer primitives.
+- `EP-EDGE-NODE`, `EP-SITE-7C4D2B`, and the MSP segmentation spec already landed the axes + portfolio + capability-derivation substrate this design plugs into (`packages/storefront-templates/src/{capability-registry,applicability-rules,activation-profile}.ts`).
+- The enterprise-auth-directory-federation spec (2026-04-22) + its 2026-05-09 Principal-convergence addendum are the binding identity contract; the partner login slice is an extension of that track, **not** a new auth stack.
+
+No existing spec, epic, or backlog item covers partner/reseller support — verified by `search_specs_and_plans`, `search_knowledge`, and a repo-wide grep. This design is the first.
+
+## 3. Research & Benchmarking
+
+### 3.1 Channel / partner taxonomy (Partner Relationship Management)
+
+The channel-sales industry has a stable, well-documented partner taxonomy. The platform adopts these names verbatim so the classification stays aligned with how customers already think about their channel.
+
+| Partner type | What they do | Distinguishing need |
+| --- | --- | --- |
+| Referral | Introduce a lead; paid on close; never take title | Tracking links, commission/payout |
+| Affiliate | Marketing partner driving tracked traffic | Tracking links, payout automation |
+| Reseller / VAR | Buy-to-resell; transact on their own paper | Deal registration, quoting, sales enablement |
+| Distributor | Sell to downstream resellers | Tiered access, inventory visibility |
+| Managed service provider | Deliver + resell under their own brand | Sub-customer estate, recurring agreements |
+| Technology / ISV | Co-built or co-marketed integration | Joint solution docs, co-marketing |
+| Franchise | Operate the brand under licensed territory | Territory scoping, brand controls |
+| Agent / broker | Sell on commission without taking title | Commission tracking |
+
+**Deal registration** is the canonical channel-conflict-management mechanism: a partner registers a lead and gets time-boxed "first dibs" before it reopens to other partners. **Partner tiering** (registered → authorized → silver/gold/platinum) incentivizes performance and gates margin and portal entitlements. A **partner portal** is the distinct login surface where partners reach deal registration, enablement content, and performance analytics.
+
+Sources:
+- Impartner — *20 Common Types of Channel Partners*: https://impartner.com/resources/blog/types-of-channel-partners
+- Kiflo — *Reseller vs Referral: Choosing the Right Type of Partner*: https://www.kiflo.com/blog/reseller-vs-referral-partner
+- Channeltivity — *Deal Registration Best Practices*: https://www.channeltivity.com/blog/prm-best-practices-deal-registration/
+- Magentrix — *What is PRM (Partner Relationship Management)?*: https://www.magentrix.com/glossary/prm
+- Gartner — *Partner Relationship Management Applications* (market definition): https://www.gartner.com/reviews/market/partner-relationship-management-applications
+
+Adopted patterns: the 8-type partner taxonomy; deal registration; tier ladder; a dedicated partner portal surface.
+Rejected patterns: cloning a full PRM (MDF management, LMS, co-branded asset studios) in the first slice; vendor-specific deal-registration workflows hard-coded into the platform.
+
+### 3.2 Partner identity (B2B / Partner IAM)
+
+The identity industry treats **partner/B2B access as a third population**, distinct from both workforce (internal) and consumer/customer (B2C) login. Partner IAM emphasizes invitation-based onboarding, federated login (SAML/OIDC) against the partner's own IdP, delegated administration (a partner admin manages their own users), scoped RBAC, multi-org separation, and SCIM lifecycle provisioning.
+
+Sources:
+- Microsoft Entra — *What is B2B collaboration?* / *External ID overview*: https://learn.microsoft.com/en-us/entra/external-id/what-is-b2b , https://learn.microsoft.com/en-us/entra/external-id/external-identities-overview
+- LoginRadius — *B2B vs B2C Authentication* / *What is Partner IAM?*: https://www.loginradius.com/blog/identity/b2b-vs-b2c-authentication , https://www.loginradius.com/blog/identity/what-is-partner-iam
+- SecureAuth — *B2B and Partners Access Management*: https://docs.secureauth.com/ciam/en/b2b-and-partners-access-management.html
+
+Adopted patterns: partner login is its own population (not overloaded onto customer auth); federated OIDC/SAML; delegated partner-admin; SCIM provisioning; per-partner-org policy isolation.
+Why this fits DPF cleanly: the enterprise-auth spec **already chose** an authentik identity edge with OIDC/SAML + SCIM and a DPF authority core. Partner login is the partner-population projection of that same edge — no new protocol stack. Rejected pattern: a parallel partner auth stack (see §7 WWMD and §11 doctrine).
+
+## 4. Design Goals
+
+1. Make a partner/reseller channel **derive from operating-model axes**, so adding partner support to an archetype is a function of its axes — not a per-archetype boolean (matches the MSP spec's anti-flag-sprawl architecture).
+2. Provide a typed `PartnerProgramProfile` contract describing the partner operating model (types, tiers, deal registration, downstream projection), parallel to `BillingPatternProfile`.
+3. Activate partner support for the archetypes that **typically** have it (SaaS/software-platform, IT managed-services, retail wholesale/distribution) without forcing it on direct-to-consumer archetypes (salon, healthcare, HOA).
+4. Model partner login/identity as a **third principal kind** under the binding Principal-convergence rule — not a parallel identity table, and not overloaded onto `CustomerContact`.
+5. Give partners a distinct portal surface (`/partners`) with strict partner-account isolation, delegated partner administration, and partner-only data (margin, deal registration, downstream sub-customers).
+6. Reuse the existing external-account substrate and the already-chosen identity edge; introduce the minimum new substrate.
+
+## 5. Non-Goals
+
+- A full PRM (MDF, partner LMS, co-branded asset generation, channel-incentive engines) in the first slice.
+- Multi-tenant partner-operated DPF installs. Partners are strict partner-account scopes inside the operator's org, mirroring the MSP customer-estate decision (§8 of the MSP spec).
+- Customer→partner identity merge/split rules (a shared-email person who is both) — deferred to the convergence open-questions list.
+- Replacing customer social login or workforce auth.
+- Commission/payout execution and accounting sync in the first slice (prepared-not-prescribed, like MSP billing).
+
+## 6. Core Architecture — Two Layers
+
+### 6.1 Layer A — Archetype operating model (LANDED in this change)
+
+Partner support plugs into the existing `axes → capability-registry → applicability-rules → activation-profile` derivation chain exactly as MSP customer-estate does.
+
+**Primitives added (`packages/storefront-templates/src/`):**
+
+- `types.ts`
+  - `PartnerType` — the 8-type PRM taxonomy (§3.1).
+  - `PartnerTier` — `registered | authorized | silver | gold | platinum`.
+  - `PartnerPortalMode` — `none | available | primary`.
+  - `PartnerGraphMode` — `none | separate-partner-projection` (mirrors `CustomerGraphMode`).
+  - `PartnerProgramProfile` — `{ portalMode, partnerTypes, tiers, dealRegistration, partnerGraph }`.
+  - `OwnershipScope` extended with `"partner-account"`; `CapabilityIsolation` extended with `"strict-partner-scope"`.
+- `capability-registry.ts` — new capability `partner-program` (portfolio `productsAndServicesSold`, default scope `partner-account`, isolation `strict-partner-scope`, surfaces `["partners","partner-portal"]`).
+- `applicability-rules.ts`
+  - `derivePartnerProgramProfile(axes, portfolios)` — pure derivation, precedence: channel-partner primaryConsumer → `primary`; platform/ecosystem → `available`; MSP (business + recurring-agreement + primary delivery) → `available`; wholesale (goods + business) → `available`; else `none`.
+  - `partner-channel-from-axes` rule — sets `partner-program` to `required` when `portalMode==="primary"`, `recommended` when `"available"`, leaves `not-applicable` otherwise.
+- `activation-profile.ts` — `NormalizedActivationProfile.partnerProgram` computed in `readActivationProfile`, alongside `billingProfile`.
+
+**Derivation matrix (rendered view of the rules; the rules are the source of truth):**
+
+| Archetype example | primaryConsumer | platform | form / commercial | `partner-program` | portalMode |
+| --- | --- | --- | --- | --- | --- |
+| Software platform / SaaS | business | yes-developer | services / subscription | recommended | available |
+| IT managed services (MSP) | business | no | services / recurring-agreement | recommended | available |
+| Retail wholesale / distribution | business | no | goods / transactional | recommended | available |
+| Pure channel/reseller business | channel-partner | — | — | required | primary |
+| Hair salon / beauty | individual | no | services / appointment-checkout | not-applicable | none |
+| Healthcare, HOA, nonprofit | individual/household | no | services / recurring-agreement | not-applicable | none |
+
+Adding the 50th archetype to a partner channel is a matter of its axis values, not a new rule.
+
+### 6.2 Layer B — Partner identity & login (DESIGNED here; staged for the gated slice)
+
+Per AGENTS.md §11 and the enterprise-auth 2026-05-09 convergence addendum (**binding**): any identity-bearing entity introduced after 2026-05-09 must be a `PrincipalAlias` linked to a `Principal`, not a parallel identity table. Therefore:
+
+- **Partner contact (the human who logs in)** → `Principal.kind = "partner"` + `PrincipalAlias.aliasType = "partner-contact"`. Authorization resolves on the `Principal`; the alias kind tells the platform the request authenticated through the partner surface. This is the "not exactly customer, not exactly employee" third kind, expressed the way the convergence model already expresses workforce vs customer vs agent vs edge-node.
+- **Partner organization (the reseller company)** → an external account record. Schema-audit first (§11): reuse `CustomerAccount` with an `accountKind` discriminator (`customer | partner`) if its shape fits, OR a thin `PartnerAccount` if partner-specific fields (tier, agreement, margin terms, deal-registration ledger) justify separation. The partner *org* is account data; only the partner *contact* is identity-bearing and bound by convergence. Decision deferred to the schema-audit task in the plan.
+- **Auth surface** → extend `UserType = "admin" | "customer"` to `"admin" | "customer" | "partner"`; add a Partner credentials provider mirroring the existing Customer provider in `apps/web/lib/govern/auth.ts`; session carries `partnerAccountId`, `partnerTier`, `partnerContactId`. Federated partner login (OIDC/SAML against a partner IdP) and SCIM provisioning are the authentik-edge projection per the enterprise-auth spec — partner is simply that spec's partner population.
+- **Authorization** → partner capabilities resolve through the same effective-auth-context evaluator, gated to `partner-account` ownership scope with `strict-partner-scope` isolation. A partner sees only their own partner-account records (deal registrations, margin, downstream sub-customers); never another partner's, never the operator's internal estate, never raw customer PII beyond what the partner agreement permits. Delegated partner-admin (a partner admin manages their own contacts) is a partner-scoped role.
+- **Portal route** → `/partners` (external partner experience), distinct from `/storefront` (internal management) and `/portal` (customer). The `partner-program` capability's `surfaces: ["partners","partner-portal"]` gate the route — visible only when the normalized profile's `partner-program` applicability is `required`/`recommended`, never by comparing raw `archetypeId`.
+
+## 7. WWMD Verification
+
+`principle_decide` (population `external_coding_agent`, surface `partner-archetype-design`, governing profile `mark-dpf-platform`) scored three partner-identity options:
+
+| Option | Composite | Verdict |
+| --- | --- | --- |
+| **A. `Principal.kind="partner"` + alias, reuse account substrate, derive from axes** | **1.280** | **Recommended** |
+| C. Parallel `Partner`/`PartnerContact` identity table + own auth stack | 1.192 | Rejected |
+| B. Reuse `CustomerContact` with a partner role flag | 1.186 | Rejected |
+
+Top contributor for A: **Principal Convergence** (alignment 0.78), followed by Verify-substrate-before-proposing-new and Organization-as-canonical-identity. No commandment conflict. The margin (0.087) fell below the 0.2 tie threshold → flagged low-confidence/human-review; that flag is a **semantic artifact** (commandments supplied no structured features, so the three options scored close on the core principles alone). The tie is resolved **decisively by the binding written rule**: the convergence addendum *prohibits* Option C (parallel table) for any identity entity created after 2026-05-09, and the convergence model explicitly separates identity *kinds* rather than overloading one (`CustomerContact`), which disqualifies Option B. Option A is therefore both the kernel recommendation and the doctrine-mandated path. Human-review flag is satisfied: this design is the founder-directed artifact.
+
+## 8. Data Model Direction
+
+First (landed) slice — archetype layer:
+- Pure TypeScript in `@dpf/storefront-templates`. No DB table, no migration. Partner program is derived JSON on the normalized profile, exactly like `billingProfile`.
+
+Identity slice (staged, gated):
+- Add `Principal.kind` value `"partner"` and `PrincipalAlias` kind `"partner-contact"` (no new identity table — convergence-compliant).
+- Schema-audit decision: `CustomerAccount.accountKind` discriminator vs a thin `PartnerAccount` for partner-org fields (tier, agreement ref, deal-registration ledger, margin terms).
+- `UserType` + Partner credentials provider + session shape (`partnerAccountId`, `partnerTier`).
+- Migration applies cleanly + UX verification on the canonical install (build gate §5) — this is why the identity slice is staged behind the pure-TS primitive slice.
+
+## 9. Acceptance Criteria
+
+1. `derivePartnerProgramProfile` produces `primary` for channel-partner axes, `available` for platform/MSP/wholesale axes, and `none` for direct-to-consumer axes — from axis values alone, no per-archetype hand-edits. *(Met — `applicability-rules.test.ts`.)*
+2. The `partner-program` capability is `required` for channel-partner, `recommended` for platform/MSP/wholesale, `not-applicable` otherwise, with `partner-account` ownership and `strict-partner-scope` isolation. *(Met.)*
+3. `NormalizedActivationProfile.partnerProgram` is populated by `readActivationProfile`. *(Met.)*
+4. Package typecheck + vitest green. *(Met — 32/32 tests, tsc clean.)*
+5. (Identity slice) Partner login resolves to a `Principal.kind="partner"` via a `partner-contact` alias; authorization resolves on the Principal; `/partners` is gated by `partner-program` applicability, never by raw archetype id; a partner cannot see another partner's or the operator's internal records. *(Staged.)*
+6. (Identity slice) No parallel partner identity table is introduced; migration applies cleanly; UX verified on the canonical install. *(Staged.)*
+
+## 10. Phases
+
+- **Phase 0 (landed in this change):** archetype-layer partner primitives + derivation + tests.
+- **Phase 1:** wire the target archetypes' `activationProfile.axes` so `software-platform`, `it-managed-services`, and a retail wholesale archetype activate the partner program; assert the §6.1 matrix from the rules; QA on canonical install.
+- **Phase 2:** schema-audit the partner-org account (reuse `CustomerAccount` vs thin `PartnerAccount`); add `Principal.kind="partner"` + `partner-contact` alias + sync function in `principal-linking.ts`; migration.
+- **Phase 3:** `UserType="partner"` + Partner credentials provider + session shape; effective-auth-context partner scope; `/partners` portal shell gated by `partner-program`.
+- **Phase 4:** deal registration + tiering records (prepared-not-prescribed); delegated partner-admin role.
+- **Phase 5:** partner federation (OIDC/SAML) + SCIM via the authentik edge, per the enterprise-auth spec's partner population.
+
+## 11. Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Partner identity becomes a parallel island | Binding Principal-convergence: `Principal.kind="partner"` + alias, authorization on the Principal. |
+| Partner data bleeds across partners or into customer/operator views | `strict-partner-scope` isolation, partner-account ownership, server-side scope guards, tests. |
+| Per-archetype partner flags proliferate | Partner program derives from axes; no archetype-id conditionals in feature code. |
+| Overloading customer auth with partners | Distinct `UserType="partner"`, distinct `/partners` surface, partner-only entitlements. |
+| Overbuilding PRM | Prepared-not-prescribed deal registration/tiering first; defer MDF/LMS/co-branding. |

--- a/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
@@ -135,6 +135,23 @@ Per AGENTS.md §11 and the enterprise-auth 2026-05-09 convergence addendum (**bi
 - **Authorization** → partner capabilities resolve through the same effective-auth-context evaluator, gated to `partner-account` ownership scope with `strict-partner-scope` isolation. A partner sees only their own partner-account records (deal registrations, margin, downstream sub-customers); never another partner's, never the operator's internal estate, never raw customer PII beyond what the partner agreement permits. Delegated partner-admin (a partner admin manages their own contacts) is a partner-scoped role.
 - **Portal route** → `/partners` (external partner experience), distinct from `/storefront` (internal management) and `/portal` (customer). The `partner-program` capability's `surfaces: ["partners","partner-portal"]` gate the route — visible only when the normalized profile's `partner-program` applicability is `required`/`recommended`, never by comparing raw `archetypeId`.
 
+### 6.3 Setup-time activation & "add it later" (persisted org choice)
+
+**The derivation answers "is a partner channel applicable to this business model?" — it does not answer "did this org opt in, and can they turn it on later?"** Today, capability applicability is purely derived from axes and silently applied: there is no setup-time question, no persisted per-org choice, and no admin toggle (verified 2026-06-04 — `apps/web/lib/storefront/archetype-activation.ts`, `StorefrontConfig`, `BusinessContext` carry no org-level capability-activation state). That is a gap for *every* `recommended`/`optional` capability; partner-program is the first to need it, so it is solved generically here.
+
+**Model: a persisted org-choice overlay on top of the derived applicability.** The derivation says how strongly a capability is offered; the org's stored `CapabilityActivationChoice` (`enabled | disabled`, default unset) says whether this org turned it on. Both the setup wizard and the admin toggle resolve through one function, `resolveCapabilityActivation(applicability, choice?)` (`capability-activation.ts`, landed in this change), so "ask at setup" and "add it later" share a single source of truth:
+
+| Derived applicability | Setup wizard | Default state | Add later (admin)? |
+| --- | --- | --- | --- |
+| `required` (channel-partner archetype) | confirmed (informed) | **on** (core to the model) | yes (re-enable if opted out) |
+| `recommended` (SaaS / MSP / wholesale) | **asked** — "Do you sell through partners/resellers?" | off until opt-in | **yes** |
+| `optional` | not surfaced (keeps wizard clean) | off | **yes** |
+| `not-applicable` / `hidden` | never | off | no |
+
+So: when an archetype whose axes derive `partner-program = recommended` is chosen at setup, the wizard **asks** whether the partner channel applies; the answer is stored; and if the org declines (or the model changes), the partner channel can be **enabled later** from admin. A pure-channel/reseller archetype (`primaryConsumer = channel-partner`, derived `required`) is on by default but still confirmed.
+
+**Staged substrate (needs migration + runtime gates):** a persisted `OrganizationCapabilityActivation` overlay keyed by `(organizationId, capabilityKey) → CapabilityActivationChoice` (generic — not partner-specific), the setup-wizard question for `promptAtSetup` capabilities, and the admin capability toggle for `canEnableLater` capabilities. The resolution logic primitive is landed; the persistence + UI are Phase 1b/3 (build-gated on the canonical install). The archetype must also be changeable post-setup (re-deriving applicability) for the add-later path to be complete — currently it is not.
+
 ## 7. WWMD Verification
 
 `principle_decide` (population `external_coding_agent`, surface `partner-archetype-design`, governing profile `mark-dpf-platform`) scored three partner-identity options:
@@ -163,14 +180,17 @@ Identity slice (staged, gated):
 1. `derivePartnerProgramProfile` produces `primary` for channel-partner axes, `available` for platform/MSP/wholesale axes, and `none` for direct-to-consumer axes — from axis values alone, no per-archetype hand-edits. *(Met — `applicability-rules.test.ts`.)*
 2. The `partner-program` capability is `required` for channel-partner, `recommended` for platform/MSP/wholesale, `not-applicable` otherwise, with `partner-account` ownership and `strict-partner-scope` isolation. *(Met.)*
 3. `NormalizedActivationProfile.partnerProgram` is populated by `readActivationProfile`. *(Met.)*
-4. Package typecheck + vitest green. *(Met — 32/32 tests, tsc clean.)*
-5. (Identity slice) Partner login resolves to a `Principal.kind="partner"` via a `partner-contact` alias; authorization resolves on the Principal; `/partners` is gated by `partner-program` applicability, never by raw archetype id; a partner cannot see another partner's or the operator's internal records. *(Staged.)*
-6. (Identity slice) No parallel partner identity table is introduced; migration applies cleanly; UX verified on the canonical install. *(Staged.)*
+4. `resolveCapabilityActivation` makes `recommended` capabilities ask at setup + opt-in + add-later, `required` on-by-default, `optional` add-later-only, `not-applicable`/`hidden` never. *(Met — `capability-activation.test.ts`.)*
+5. Package typecheck + vitest green. *(Met — 38/38 tests, tsc clean.)*
+6. (Phase 1b) When a `recommended` partner archetype is chosen at setup the wizard asks "Do you sell through partners/resellers?"; the answer persists; a declining org can enable it later from admin; the archetype is changeable post-setup. *(Staged.)*
+7. (Identity slice) Partner login resolves to a `Principal.kind="partner"` via a `partner-contact` alias; authorization resolves on the Principal; `/partners` is gated by `partner-program` applicability, never by raw archetype id; a partner cannot see another partner's or the operator's internal records. *(Staged.)*
+8. (Identity slice) No parallel partner identity table is introduced; migration applies cleanly; UX verified on the canonical install. *(Staged.)*
 
 ## 10. Phases
 
-- **Phase 0 (landed in this change):** archetype-layer partner primitives + derivation + tests.
+- **Phase 0 (landed in this change):** archetype-layer partner primitives + derivation + the `resolveCapabilityActivation` setup/add-later resolution logic + tests.
 - **Phase 1:** wire the target archetypes' `activationProfile.axes` so `software-platform`, `it-managed-services`, and a retail wholesale archetype activate the partner program; assert the §6.1 matrix from the rules; QA on canonical install.
+- **Phase 1b (setup question + add-later):** persisted generic `OrganizationCapabilityActivation` overlay `(organizationId, capabilityKey) → CapabilityActivationChoice`; wire the setup wizard to **ask** about `promptAtSetup` capabilities (partner-program first); admin capability toggle for `canEnableLater`; make the archetype changeable post-setup so applicability re-derives. Migration + UX gates. (§6.3)
 - **Phase 2:** schema-audit the partner-org account (reuse `CustomerAccount` vs thin `PartnerAccount`); add `Principal.kind="partner"` + `partner-contact` alias + sync function in `principal-linking.ts`; migration.
 - **Phase 3:** `UserType="partner"` + Partner credentials provider + session shape; effective-auth-context partner scope; `/partners` portal shell gated by `partner-program`.
 - **Phase 4:** deal registration + tiering records (prepared-not-prescribed); delegated partner-admin role.

--- a/packages/storefront-templates/src/activation-profile.ts
+++ b/packages/storefront-templates/src/activation-profile.ts
@@ -1,6 +1,7 @@
 import {
   deriveBillingPatternProfile,
   deriveCapabilityApplicability,
+  derivePartnerProgramProfile,
 } from "./applicability-rules";
 import {
   isCapabilityKey,
@@ -21,6 +22,7 @@ import type {
   OperatingModelAxes,
   OperatingModelDelivery,
   OperatingModelForm,
+  PartnerProgramProfile,
   PlatformEcosystem,
   PortfolioDecomposition,
   PortfolioScope,
@@ -106,6 +108,7 @@ export interface NormalizedActivationProfile extends ActivationProfile {
   portfolios: PortfolioDecomposition;
   capabilityOverrides: CapabilityOverride[];
   billingProfile: BillingPatternProfile;
+  partnerProgram: PartnerProgramProfile;
   capabilityActivations: CapabilityActivation[];
 }
 
@@ -331,6 +334,7 @@ export function readActivationProfile(raw: unknown): NormalizedActivationProfile
 
   const capabilityMap = deriveCapabilityApplicability(axes, portfolios, capabilityOverrides);
   const billingProfile = deriveBillingPatternProfile(axes);
+  const partnerProgram = derivePartnerProgramProfile(axes, portfolios);
 
   return {
     ...legacyShape,
@@ -338,6 +342,7 @@ export function readActivationProfile(raw: unknown): NormalizedActivationProfile
     portfolios,
     capabilityOverrides,
     billingProfile,
+    partnerProgram,
     capabilityActivations: Array.from(capabilityMap.values()),
     ...(raw.seededServiceCategories !== undefined && isStringArray(raw.seededServiceCategories)
       ? { seededServiceCategories: raw.seededServiceCategories }

--- a/packages/storefront-templates/src/applicability-rules.test.ts
+++ b/packages/storefront-templates/src/applicability-rules.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveBillingPatternProfile,
   deriveCapabilityApplicability,
+  derivePartnerProgramProfile,
 } from "./applicability-rules";
 import type {
   CapabilityActivation,
@@ -79,6 +80,36 @@ const hoaAxes: OperatingModelAxes = {
   platform: "no",
 };
 
+const platformAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "digital",
+  primaryConsumer: "business",
+  consumptionChannel: "api-portal-cli",
+  commercialModel: "subscription",
+  provisioning: "account-and-entitlement",
+  platform: "yes-developer",
+};
+
+const channelPartnerAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "hybrid",
+  primaryConsumer: "channel-partner",
+  consumptionChannel: "portal-api",
+  commercialModel: "recurring-agreement",
+  provisioning: "account-and-entitlement",
+  platform: "no",
+};
+
+const wholesaleAxes: OperatingModelAxes = {
+  form: "goods",
+  delivery: "physical",
+  primaryConsumer: "business",
+  consumptionChannel: "sales-assisted",
+  commercialModel: "transactional",
+  provisioning: "account-with-billing",
+  platform: "no",
+};
+
 describe("deriveCapabilityApplicability", () => {
   it("derives MSP capabilities from axes and portfolios, with only remote support overridden", () => {
     const overrides: CapabilityOverride[] = [
@@ -147,5 +178,63 @@ describe("deriveBillingPatternProfile", () => {
       recurringBillingApplicability: "optional",
       invoiceExecutionMode: "manual",
     });
+  });
+});
+
+describe("derivePartnerProgramProfile", () => {
+  it("makes the partner portal primary when the primary consumer is a channel partner", () => {
+    expect(derivePartnerProgramProfile(channelPartnerAxes, mspPortfolios)).toMatchObject({
+      portalMode: "primary",
+      dealRegistration: true,
+      partnerGraph: "separate-partner-projection",
+    });
+  });
+
+  it("offers an available partner program for platform/ecosystem (SaaS) archetypes", () => {
+    const program = derivePartnerProgramProfile(platformAxes, mspPortfolios);
+    expect(program.portalMode).toBe("available");
+    expect(program.partnerTypes).toContain("technology");
+    expect(program.dealRegistration).toBe(true);
+  });
+
+  it("offers an available partner program for managed service providers", () => {
+    expect(derivePartnerProgramProfile(mspAxes, mspPortfolios)).toMatchObject({
+      portalMode: "available",
+      partnerTypes: ["managed-service-provider", "technology"],
+    });
+  });
+
+  it("offers an available partner program for wholesale/distribution (goods sold to business)", () => {
+    expect(derivePartnerProgramProfile(wholesaleAxes, salonPortfolios)).toMatchObject({
+      portalMode: "available",
+      partnerTypes: ["reseller", "distributor"],
+    });
+  });
+
+  it("activates no partner channel for direct-to-consumer archetypes", () => {
+    expect(derivePartnerProgramProfile(salonAxes, salonPortfolios).portalMode).toBe("none");
+    expect(derivePartnerProgramProfile(retailAxes, salonPortfolios).portalMode).toBe("none");
+    expect(derivePartnerProgramProfile(hoaAxes, salonPortfolios).portalMode).toBe("none");
+  });
+});
+
+describe("partner-program capability derivation", () => {
+  it("requires the partner program when selling through channel partners", () => {
+    const capabilities = deriveCapabilityApplicability(channelPartnerAxes, mspPortfolios);
+    expect(getCapability(capabilities, "partner-program")).toMatchObject({
+      applicability: "required",
+      ownershipScopes: ["partner-account"],
+      isolation: "strict-partner-scope",
+    });
+  });
+
+  it("recommends the partner program for platform/MSP/wholesale models", () => {
+    expect(getCapability(deriveCapabilityApplicability(platformAxes, mspPortfolios), "partner-program").applicability).toBe("recommended");
+    expect(getCapability(deriveCapabilityApplicability(mspAxes, mspPortfolios), "partner-program").applicability).toBe("recommended");
+    expect(getCapability(deriveCapabilityApplicability(wholesaleAxes, salonPortfolios), "partner-program").applicability).toBe("recommended");
+  });
+
+  it("leaves the partner program not-applicable for direct-to-consumer archetypes", () => {
+    expect(getCapability(deriveCapabilityApplicability(salonAxes, salonPortfolios), "partner-program").applicability).toBe("not-applicable");
   });
 });

--- a/packages/storefront-templates/src/applicability-rules.ts
+++ b/packages/storefront-templates/src/applicability-rules.ts
@@ -11,6 +11,7 @@ import type {
   CapabilityOverride,
   CommercialModel,
   OperatingModelAxes,
+  PartnerProgramProfile,
   PortfolioDecomposition,
 } from "./types";
 
@@ -382,6 +383,26 @@ const RULES: ApplicabilityRule[] = [
       ];
     },
   },
+  {
+    name: "partner-channel-from-axes",
+    evaluate: (axes, portfolios) => {
+      const program = derivePartnerProgramProfile(axes, portfolios);
+      if (program.portalMode === "none") return [];
+
+      return [
+        {
+          key: "partner-program",
+          applicability: program.portalMode === "primary" ? "required" : "recommended",
+          reason:
+            program.portalMode === "primary"
+              ? "A channel-partner primary consumer sells through a partner/reseller network."
+              : "Platform/ecosystem, managed-service, and wholesale models commonly run a partner channel alongside direct sales.",
+          ownershipScopes: ["partner-account"],
+          isolation: "strict-partner-scope",
+        },
+      ];
+    },
+  },
 ];
 
 function applyOverrides(map: CapabilityMap, overrides: CapabilityOverride[]): void {
@@ -493,4 +514,79 @@ function supportedPatternsForCommercialModel(commercialModel: CommercialModel): 
 
 export function deriveBillingPatternProfile(axes: OperatingModelAxes): BillingPatternProfile {
   return supportedPatternsForCommercialModel(axes.commercialModel);
+}
+
+const NO_PARTNER_PROGRAM: PartnerProgramProfile = {
+  portalMode: "none",
+  partnerTypes: [],
+  tiers: [],
+  dealRegistration: false,
+  partnerGraph: "none",
+};
+
+/**
+ * Derives the partner/reseller operating model from the operating-model axes,
+ * the same way {@link deriveBillingPatternProfile} derives billing from
+ * `commercialModel`. Partner support is therefore a function of an archetype's
+ * axis values, not a hand-authored per-archetype flag — adding the 50th
+ * archetype to a partner channel is a matter of its axes, not a new rule.
+ *
+ * Precedence (first match wins):
+ *  1. `primaryConsumer === "channel-partner"` — selling *through* partners is the
+ *     primary motion → partner portal is primary, downstream projection on.
+ *  2. platform/ecosystem play (`platform !== "no"`) — SaaS/marketplace partner
+ *     program alongside direct sales.
+ *  3. managed service provider (B2B + recurring-agreement + primary delivery) —
+ *     MSPs are themselves channel partners and may sub-contract.
+ *  4. wholesale/distribution (physical goods sold to business buyers who resell).
+ */
+export function derivePartnerProgramProfile(
+  axes: OperatingModelAxes,
+  portfolios: PortfolioDecomposition,
+): PartnerProgramProfile {
+  if (axes.primaryConsumer === "channel-partner") {
+    return {
+      portalMode: "primary",
+      partnerTypes: ["reseller", "distributor", "managed-service-provider"],
+      tiers: ["registered", "authorized", "silver", "gold", "platinum"],
+      dealRegistration: true,
+      partnerGraph: "separate-partner-projection",
+    };
+  }
+
+  if (axes.platform === "yes-marketplace" || axes.platform === "yes-developer") {
+    return {
+      portalMode: "available",
+      partnerTypes: ["referral", "reseller", "technology"],
+      tiers: ["registered", "silver", "gold", "platinum"],
+      dealRegistration: true,
+      partnerGraph: "separate-partner-projection",
+    };
+  }
+
+  if (
+    axes.primaryConsumer === "business" &&
+    axes.commercialModel === "recurring-agreement" &&
+    portfolios.manufactureAndDeliver.scope === "primary"
+  ) {
+    return {
+      portalMode: "available",
+      partnerTypes: ["managed-service-provider", "technology"],
+      tiers: ["registered", "authorized"],
+      dealRegistration: true,
+      partnerGraph: "none",
+    };
+  }
+
+  if (axes.form === "goods" && axes.primaryConsumer === "business") {
+    return {
+      portalMode: "available",
+      partnerTypes: ["reseller", "distributor"],
+      tiers: ["registered", "authorized"],
+      dealRegistration: false,
+      partnerGraph: "separate-partner-projection",
+    };
+  }
+
+  return NO_PARTNER_PROGRAM;
 }

--- a/packages/storefront-templates/src/capability-activation.test.ts
+++ b/packages/storefront-templates/src/capability-activation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCapabilityActivation } from "./capability-activation";
+
+describe("resolveCapabilityActivation", () => {
+  it("treats not-applicable / hidden capabilities as never active and never offered", () => {
+    for (const applicability of ["not-applicable", "hidden"] as const) {
+      expect(resolveCapabilityActivation(applicability)).toEqual({
+        active: false,
+        promptAtSetup: false,
+        canEnableLater: false,
+        source: "not-applicable",
+      });
+    }
+  });
+
+  it("turns required capabilities on by default but still confirms them at setup", () => {
+    expect(resolveCapabilityActivation("required")).toMatchObject({
+      active: true,
+      promptAtSetup: true,
+      canEnableLater: true,
+      source: "required",
+    });
+  });
+
+  it("honors an explicit org opt-out of a required capability", () => {
+    expect(resolveCapabilityActivation("required", "disabled")).toMatchObject({
+      active: false,
+      source: "org-choice",
+      canEnableLater: true,
+    });
+  });
+
+  it("asks at setup for recommended capabilities and keeps them off until the org opts in", () => {
+    // No stored choice yet → offered at setup, not yet active.
+    expect(resolveCapabilityActivation("recommended")).toMatchObject({
+      active: false,
+      promptAtSetup: true,
+      canEnableLater: true,
+      source: "default-off",
+    });
+    // Org said yes (at setup or later).
+    expect(resolveCapabilityActivation("recommended", "enabled")).toMatchObject({
+      active: true,
+      source: "org-choice",
+    });
+  });
+
+  it("keeps optional capabilities off and out of the setup wizard but available to add later", () => {
+    expect(resolveCapabilityActivation("optional")).toMatchObject({
+      active: false,
+      promptAtSetup: false,
+      canEnableLater: true,
+      source: "default-off",
+    });
+    expect(resolveCapabilityActivation("optional", "enabled").active).toBe(true);
+  });
+
+  it("supports the partner-program flow: recommended archetype asks, off until opt-in, addable later", () => {
+    // SaaS/MSP/wholesale derive partner-program = recommended.
+    const atSetup = resolveCapabilityActivation("recommended");
+    expect(atSetup.promptAtSetup).toBe(true); // "Do you sell through partners/resellers?"
+    expect(atSetup.active).toBe(false); // not on until they say yes
+    expect(atSetup.canEnableLater).toBe(true); // add-later provision
+
+    // Org declined at setup, then enables it later from admin.
+    expect(resolveCapabilityActivation("recommended", "enabled").active).toBe(true);
+
+    // Pure channel/reseller archetype derives partner-program = required → on by default.
+    expect(resolveCapabilityActivation("required").active).toBe(true);
+  });
+});

--- a/packages/storefront-templates/src/capability-activation.ts
+++ b/packages/storefront-templates/src/capability-activation.ts
@@ -1,0 +1,83 @@
+import type { CapabilityActivationChoice, CapabilityApplicability } from "./types";
+
+/**
+ * Why a capability resolved to its current active/inactive state.
+ * - `required`: core to the chosen business model; on by default, no org opt-in needed.
+ * - `org-choice`: the org made an explicit enabled/disabled decision.
+ * - `default-off`: offered (recommended/optional) but the org has not opted in yet.
+ * - `not-applicable`: the business model does not support this capability.
+ */
+export type CapabilityActivationSource =
+  | "required"
+  | "org-choice"
+  | "default-off"
+  | "not-applicable";
+
+export interface CapabilityActivationResolution {
+  /** Is the capability effectively active for this organization right now? */
+  active: boolean;
+  /**
+   * Should the setup wizard ask the user about this capability during initial
+   * onboarding? True for `required` (informed/confirmed) and `recommended`
+   * (asked). `optional` capabilities are not surfaced at setup to keep the
+   * wizard uncluttered — they are reachable via {@link CapabilityActivationResolution.canEnableLater}.
+   */
+  promptAtSetup: boolean;
+  /**
+   * Can the org enable this capability later from admin even when it is off now?
+   * True for anything the business model supports (`required`/`recommended`/`optional`).
+   * This is the "add it later" provision.
+   */
+  canEnableLater: boolean;
+  source: CapabilityActivationSource;
+}
+
+/**
+ * Resolves the *effective* activation of a capability for one organization by
+ * overlaying that org's persisted opt-in {@link CapabilityActivationChoice} on
+ * top of the derived {@link CapabilityApplicability}.
+ *
+ * The derivation (from operating-model axes) says how strongly a capability is
+ * offered; this function says whether *this* org has it on, whether to ask at
+ * setup, and whether it can be turned on later. Both the setup wizard and the
+ * admin capability toggle resolve through this single function so "ask at setup"
+ * and "add it later" share one source of truth.
+ *
+ * Semantics:
+ * - `not-applicable` / `hidden` → never active, never prompted, cannot enable later.
+ * - `required` → active unless the org explicitly disabled it; confirmed (not
+ *   silently applied) at setup; can be re-enabled later.
+ * - `recommended` → opt-in: off until the org enables it; **asked at setup**; can
+ *   be enabled later.
+ * - `optional` → opt-in: off until enabled; not surfaced at setup; **can be added later**.
+ */
+export function resolveCapabilityActivation(
+  applicability: CapabilityApplicability,
+  choice?: CapabilityActivationChoice | null,
+): CapabilityActivationResolution {
+  if (applicability === "not-applicable" || applicability === "hidden") {
+    return {
+      active: false,
+      promptAtSetup: false,
+      canEnableLater: false,
+      source: "not-applicable",
+    };
+  }
+
+  if (applicability === "required") {
+    return {
+      active: choice !== "disabled",
+      promptAtSetup: true,
+      canEnableLater: true,
+      source: choice ? "org-choice" : "required",
+    };
+  }
+
+  // recommended | optional → opt-in; off until the org turns it on.
+  return {
+    active: choice === "enabled",
+    promptAtSetup: applicability === "recommended",
+    canEnableLater: true,
+    source: choice ? "org-choice" : "default-off",
+  };
+}

--- a/packages/storefront-templates/src/capability-registry.test.ts
+++ b/packages/storefront-templates/src/capability-registry.test.ts
@@ -24,6 +24,7 @@ describe("capability registry", () => {
       "project-work",
       "lifecycle-review-queues",
       "remote-support",
+      "partner-program",
     ]);
   });
 

--- a/packages/storefront-templates/src/capability-registry.ts
+++ b/packages/storefront-templates/src/capability-registry.ts
@@ -128,6 +128,13 @@ export const CAPABILITY_REGISTRY = {
     defaultIsolation: "strict-customer-scope",
     surfaces: ["remote-support", "customers"],
   },
+  "partner-program": {
+    label: "Partner Program",
+    portfolio: "productsAndServicesSold",
+    defaultOwnershipScope: "partner-account",
+    defaultIsolation: "strict-partner-scope",
+    surfaces: ["partners", "partner-portal"],
+  },
 } as const satisfies Record<string, CapabilityRegistryEntry>;
 
 export type CapabilityKey = keyof typeof CAPABILITY_REGISTRY;

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -2,5 +2,6 @@ export * from "./types";
 export * from "./capability-registry";
 export * from "./applicability-rules";
 export * from "./activation-profile";
+export * from "./capability-activation";
 export * from "./archetypes/index";
 export * from "./sections/schemas";

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -309,6 +309,17 @@ export type PartnerPortalMode = "none" | "available" | "primary";
 export type PartnerGraphMode = "none" | "separate-partner-projection";
 
 /**
+ * An organization's stored decision about an offered (recommended/optional)
+ * capability. This is the *persisted opt-in overlay* that sits on top of the
+ * derived {@link CapabilityApplicability}: the derivation answers "is this
+ * applicable to the business model?"; the choice answers "did this org turn it
+ * on?". Captured at setup when a capability is `recommended`, and editable later
+ * from admin (the "add it later" path). Resolution lives in
+ * `resolveCapabilityActivation` (capability-activation.ts).
+ */
+export type CapabilityActivationChoice = "enabled" | "disabled";
+
+/**
  * The partner/reseller operating model an archetype activates. Derived from the
  * {@link OperatingModelAxes} (platform, primaryConsumer, form, commercialModel)
  * the same way {@link BillingPatternProfile} is derived from `commercialModel`,

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -164,7 +164,8 @@ export type OwnershipScope =
   | "customer-account"
   | "customer-site"
   | "configuration-item"
-  | "edge-node";
+  | "edge-node"
+  | "partner-account";
 
 export type TransactionContext =
   | "service-agreement"
@@ -174,7 +175,11 @@ export type TransactionContext =
   | "billing-period"
   | "episode-of-care";
 
-export type CapabilityIsolation = "organization-scope" | "strict-customer-scope" | "shared";
+export type CapabilityIsolation =
+  | "organization-scope"
+  | "strict-customer-scope"
+  | "shared"
+  | "strict-partner-scope";
 
 export type PaymentPattern =
   | "point-of-sale"
@@ -250,6 +255,73 @@ export interface BillingPatternProfile {
   supportedPaymentPatterns: PaymentPattern[];
   invoiceExecutionMode: InvoiceExecutionMode;
   recurringBillingApplicability: Exclude<CapabilityApplicability, "hidden">;
+}
+
+/**
+ * Channel-partner / reseller archetypes. Names follow the established
+ * Partner Relationship Management (PRM) taxonomy so the platform classification
+ * stays aligned with how the channel-sales industry already segments partners
+ * (see docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md §3).
+ *
+ * - `referral` / `affiliate`: introduce or market leads; paid on close, never take title.
+ * - `reseller`: buys-to-resell / value-added reseller (VAR); transacts under their own paper.
+ * - `distributor`: sells to downstream resellers; needs tiered access and inventory visibility.
+ * - `managed-service-provider`: delivers and resells the offer under their own brand.
+ * - `technology`: ISV / integration / alliance partner; co-built or co-marketed solutions.
+ * - `franchise`: operates the brand under a licensed territory.
+ * - `agent-broker`: sells on commission without taking title to goods or contracts.
+ */
+export type PartnerType =
+  | "referral"
+  | "affiliate"
+  | "reseller"
+  | "distributor"
+  | "managed-service-provider"
+  | "technology"
+  | "franchise"
+  | "agent-broker";
+
+/**
+ * Partner program tier ladder. Empty tier list means a flat, untiered program.
+ * Tier governs deal-registration priority, margin, and portal entitlements.
+ */
+export type PartnerTier =
+  | "registered"
+  | "authorized"
+  | "silver"
+  | "gold"
+  | "platinum";
+
+/**
+ * How prominent the partner channel is for this archetype.
+ * - `none`: no partner channel; the partner portal route stays hidden.
+ * - `available`: partner channel runs alongside direct sales (platform/SaaS, MSP, wholesale).
+ * - `primary`: the business sells *through* partners as its main go-to-market motion.
+ */
+export type PartnerPortalMode = "none" | "available" | "primary";
+
+/**
+ * Whether partners get an isolated downstream projection of their own
+ * sub-customers / managed estate, mirroring {@link CustomerGraphMode} for the
+ * customer side. `separate-partner-projection` means a partner's records are
+ * scoped to the partner account under strict isolation.
+ */
+export type PartnerGraphMode = "none" | "separate-partner-projection";
+
+/**
+ * The partner/reseller operating model an archetype activates. Derived from the
+ * {@link OperatingModelAxes} (platform, primaryConsumer, form, commercialModel)
+ * the same way {@link BillingPatternProfile} is derived from `commercialModel`,
+ * so adding partner support to an archetype is a function of its axis values —
+ * not a hand-authored per-archetype flag.
+ */
+export interface PartnerProgramProfile {
+  portalMode: PartnerPortalMode;
+  partnerTypes: PartnerType[];
+  tiers: PartnerTier[];
+  /** Deal-registration / channel-conflict protection applies. */
+  dealRegistration: boolean;
+  partnerGraph: PartnerGraphMode;
 }
 
 export interface SeededConfigurationItemType {


### PR DESCRIPTION
## What

Research-first extension of DPF archetypes for **partners/resellers**, with the partner program **derived from operating-model axes** (no per-archetype flag — same pattern as MSP customer-estate). Plus the design + WWMD verification + staged phases for a **partner identity/login** that is 'not exactly a customer, not exactly an employee'.

### Landed (Phase 0 — pure TS, verified)
`@dpf/storefront-templates`:
- `PartnerType` (8-type PRM taxonomy), `PartnerTier`, `PartnerPortalMode`, `PartnerGraphMode`, `PartnerProgramProfile`
- `OwnershipScope += 'partner-account'`, `CapabilityIsolation += 'strict-partner-scope'`
- `partner-program` capability (capability-registry)
- `derivePartnerProgramProfile(axes, portfolios)` + `partner-channel-from-axes` rule (applicability-rules)
- `NormalizedActivationProfile.partnerProgram` (activation-profile)

Derivation: channel-partner primaryConsumer → `primary`; platform/MSP/wholesale → `available`; direct-to-consumer → `none`.

### Designed + staged (spec + backlog)
`docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md` — research & benchmarking (PRM + Partner IAM, cited), WWMD ledger, and the partner identity/login design: `Principal.kind='partner'` + `partner-contact` alias (Principal-convergence compliant — **not** a parallel table, **not** overloaded onto `CustomerContact`), `UserType='partner'`, `/partners` portal. Staged as **EP-PARTNER-CHANNEL** Phases 1–5 (5 BIs filed).

## WWMD
`principle_decide` recommended `Principal.kind='partner'` (top contributor: Principal Convergence). No commandment conflict. Low margin is a semantic artifact; the binding §11 convergence rule decisively breaks the tie. Full ledger in spec §7.

## Verification
- `vitest run`: **32/32 pass** (new partner-program coverage included)
- `tsc --noEmit`: **clean**
- Substrate: root-clone toolchain against worktree source (pure-TS leaf package, no runtime/DB coupling)

## Scope
Phase 0 is self-contained and additive — no behavior change to existing archetypes (none set partner-activating axes yet; that's Phase 1, behind the build gate). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)