### PR TITLE
feat(estate): real-estate devices as Foundational Digital Products (provenance-aware)

### DIFF
--- a/packages/db/data/taxonomy_v3.json
+++ b/packages/db/data/taxonomy_v3.json
@@ -5754,5 +5754,65 @@
       "provisioningModel": "Account-based (role + entitlement)",
       "platformEcosystem": "Yes"
     }
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Building Management",
+    "level_2": "Security and Surveillance",
+    "level_3": "",
+    "definition": "Foundational digital products that monitor and secure the physical estate: IP cameras, NVR/DVR, video doorbells, alarm and intrusion sensors. Embedded software, network-connected, lifecycle-managed.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Building Management",
+    "level_2": "Climate Control",
+    "level_3": "",
+    "definition": "Foundational digital products that regulate environment: smart thermostats, HVAC controllers, environmental sensors.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Building Management",
+    "level_2": "Access Control",
+    "level_3": "",
+    "definition": "Foundational digital products governing physical access: smart locks, garage/gate controllers, entry remotes, intercoms.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Building Management",
+    "level_2": "Lighting and Energy Management",
+    "level_3": "",
+    "definition": "Foundational digital products for lighting and energy: smart switches, smart plugs, energy monitors, irrigation and pool controllers.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Building Management",
+    "level_2": "Connected Appliances",
+    "level_3": "",
+    "definition": "Foundational smart appliances with embedded software and APIs: ovens, washers/dryers, refrigerators, printers, and similar connected white-goods.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Client and End User Compute",
+    "level_3": "",
+    "definition": "Foundational client-compute digital products: laptops, desktops, tablets, smartphones, and wearables operated within the estate.",
+    "notes": "DPF estate extension — DPPM Foundational \"building management\" / \"client compute\" (The Open Group, Shift to Digital Product §4.3).",
+    "enrichment": {}
   }
 ]

--- a/packages/db/src/discovery-promotion-policy.test.ts
+++ b/packages/db/src/discovery-promotion-policy.test.ts
@@ -3,6 +3,7 @@ import {
   LEGACY_PROMOTABLE_TYPES,
   looksLikeRuntimeArtifact,
   isNonProductEntityType,
+  classifyEstateProvenance,
   resolvePromotionDecision,
 } from "./discovery-promotion-policy";
 
@@ -171,6 +172,66 @@ describe("looksLikeRuntimeArtifact", () => {
     ["Real Product Name", false],
   ])("classifies %s as runtime=%s", (name, expected) => {
     expect(looksLikeRuntimeArtifact(name)).toBe(expected);
+  });
+});
+
+describe("classifyEstateProvenance", () => {
+  it("classifies UniFi-discovered devices as real_estate", () => {
+    expect(classifyEstateProvenance({ discoveredVia: "unifi_clients_api", addressHint: "192.168.0.42" })).toBe("real_estate");
+    expect(classifyEstateProvenance({ discoveredVia: "unifi_api" })).toBe("real_estate");
+  });
+  it("classifies real-LAN IPs as real_estate", () => {
+    expect(classifyEstateProvenance({ addressHint: "192.168.0.59" })).toBe("real_estate");
+    expect(classifyEstateProvenance({ addressHint: "Doorbell Camera 192.168.0.7" })).toBe("real_estate");
+  });
+  it("classifies Docker-bridge IPs and platform sources as platform_internal", () => {
+    expect(classifyEstateProvenance({ discoveredVia: "arp_table", addressHint: "172.18.0.5" })).toBe("platform_internal");
+    expect(classifyEstateProvenance({ discoveredVia: "local_os" })).toBe("platform_internal");
+    expect(classifyEstateProvenance({ discoveredVia: "windows_exporter", addressHint: "172.20.0.1" })).toBe("platform_internal");
+  });
+  it("defaults unknown provenance to platform_internal (conservative)", () => {
+    expect(classifyEstateProvenance({})).toBe("platform_internal");
+    expect(classifyEstateProvenance({ discoveredVia: "mystery", addressHint: "8.8.8.8" })).toBe("platform_internal");
+  });
+  it("platform source wins over a real-LAN IP", () => {
+    expect(classifyEstateProvenance({ discoveredVia: "docker", addressHint: "192.168.0.1" })).toBe("platform_internal");
+  });
+});
+
+describe("resolvePromotionDecision — estate provenance", () => {
+  const node = { id: "tn_1", nodeId: "foundational/building_management/security_and_surveillance", governance: null };
+  const portfolio = { id: "p_1", slug: "foundational" };
+  const realDevice = {
+    entityType: "host", // would normally be blocked by the structural gate
+    name: "Reolink NVR",
+    attributionStatus: "attributed" as const,
+    attributionConfidence: 0.95,
+    digitalProductId: null,
+    taxonomyNodeId: "tn_1",
+  };
+
+  it("PROMOTES a real-estate host device (camera/NVR) despite host entityType", () => {
+    const d = resolvePromotionDecision({ ...realDevice, provenance: "real_estate" }, node, portfolio);
+    expect(d.decision).toBe("promote");
+    expect(d.evidence.source).toBe("real-estate-provenance");
+  });
+
+  it("still SKIPS a platform-internal host (Docker) via the structural gate", () => {
+    const d = resolvePromotionDecision({ ...realDevice, name: "LAN Host 172.18.0.5", provenance: "platform_internal" }, node, portfolio);
+    expect(d.decision).toBe("skip");
+    expect(d.reason).toBe("type_not_promotable");
+  });
+
+  it("treats omitted provenance as platform_internal (back-compat: host still skips)", () => {
+    const d = resolvePromotionDecision(realDevice, node, portfolio);
+    expect(d.decision).toBe("skip");
+    expect(d.reason).toBe("type_not_promotable");
+  });
+
+  it("real-estate provenance does not override the runtime-name gate", () => {
+    const d = resolvePromotionDecision({ ...realDevice, name: "dpf-redis-1", provenance: "real_estate" }, node, portfolio);
+    expect(d.decision).toBe("skip");
+    expect(d.reason).toBe("name_not_promotable");
   });
 });
 

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -85,6 +85,52 @@ export function isNonProductEntityType(entityType: string): boolean {
   return NON_PRODUCT_ENTITY_TYPES.has(entityType.trim().toLowerCase());
 }
 
+// ── Estate provenance ───────────────────────────────────────────────────────
+//
+// Distinguish the operator's REAL digital-product estate from the platform's
+// own black-box runtime. The reference standards (The Open Group, "The Shift
+// to Digital Product") classify IoT doorbells, cameras, smart appliances, and
+// connected devices as Digital Products in their own right — so a real-estate
+// `host`/`network_interface` (a Reolink NVR, a UniFi gateway) SHOULD become a
+// Foundational Digital Product, while the platform's own Docker containers /
+// local host (the bootstrap self-scan) are infrastructure plumbing the operator
+// treats as a black box. Operator direction: "the 192.168 range is the real
+// estate; the 172.18 Docker network is the platform black box."
+//
+// This provenance signal is what lets the structural entityType gate stay
+// correct for platform-internal infra (the 38 Docker rows it removed) WITHOUT
+// also blocking the operator's real connected devices.
+export type EstateProvenance = "real_estate" | "platform_internal";
+
+// Docker default bridge range (RFC1918 172.16/12) and the platform's own
+// self-scan collector sources.
+const DOCKER_BRIDGE_IP_RE = /(?:^|[^0-9])172\.(?:1[6-9]|2[0-9]|3[01])\./;
+const PLATFORM_SOURCE_RE = /docker|local_os|windows_exporter|node_exporter|prometheus|kubernetes|bootstrap|cadvisor/i;
+// Operator's real LAN (UniFi-discovered, or RFC1918 ranges that aren't the
+// Docker bridge).
+const REAL_ESTATE_SOURCE_RE = /unifi/i;
+const REAL_LAN_IP_RE = /(?:^|[^0-9])(?:192\.168|10)\./;
+
+export function classifyEstateProvenance(input: {
+  discoveredVia?: string | null;
+  /** An IP-bearing string for the entity (its address, or its name). */
+  addressHint?: string | null;
+}): EstateProvenance {
+  const via = input.discoveredVia ?? "";
+  const addr = input.addressHint ?? "";
+  // Platform signals win first: the platform's own containers/host can appear on
+  // odd ranges, so an explicit platform source or a Docker-bridge IP is decisive.
+  if (PLATFORM_SOURCE_RE.test(via)) return "platform_internal";
+  if (DOCKER_BRIDGE_IP_RE.test(addr)) return "platform_internal";
+  // Real-estate signals: discovered through the operator's network controller,
+  // or living on the operator's real LAN.
+  if (REAL_ESTATE_SOURCE_RE.test(via)) return "real_estate";
+  if (REAL_LAN_IP_RE.test(addr)) return "real_estate";
+  // Conservative default: treat unknown provenance as platform-internal so we
+  // never promote an unidentified infra row into the product portfolio.
+  return "platform_internal";
+}
+
 export const AUTO_PROMOTE_THRESHOLD = 0.9;
 
 export type PromotionSkipReason =
@@ -121,6 +167,11 @@ export interface PromotionEntityInput {
   attributionConfidence: number;
   digitalProductId: string | null;
   taxonomyNodeId: string | null;
+  // Estate provenance. When "real_estate", the structural entityType gate does
+  // NOT apply — a real connected device (camera, NVR, gateway) IS a Digital
+  // Product even though its entityType is host/network. Omitted/undefined keeps
+  // the prior conservative behaviour (treated as platform_internal).
+  provenance?: EstateProvenance;
 }
 
 export interface PromotionTaxonomyNodeInput {
@@ -209,14 +260,34 @@ export function resolvePromotionDecision(
   // into the portfolio. Same precedence rationale as the name-gate: structural
   // shape wins over taxonomy placement, because the alternative is letting an
   // over-broad taxonomy policy write bad product rows.
-  if (isNonProductEntityType(entity.entityType)) {
+  // ...EXCEPT for real-estate digital products. A camera / NVR / smart plug /
+  // gateway discovered on the operator's LAN (UniFi/arp) is a Digital Product
+  // in its own right (The Open Group, "The Shift to Digital Product") even
+  // though its entityType is host/network. The structural gate only suppresses
+  // the platform's own black-box runtime (its Docker containers / local host).
+  if (isNonProductEntityType(entity.entityType) && entity.provenance !== "real_estate") {
     return {
       decision: "skip",
       reason: "type_not_promotable",
       evidence: {
         source: "structural-type-gate",
         entityType: entity.entityType,
+        provenance: entity.provenance ?? "platform_internal",
       },
+    };
+  }
+
+  // Real-estate provenance: this is the operator's actual connected device, a
+  // Digital Product regardless of entityType or the taxonomy node's promotion
+  // policy. Gates 1-4 (taxonomy, confidence, portfolio, runtime-name) already
+  // passed, so promote it into its Foundational sub-portfolio.
+  if (entity.provenance === "real_estate") {
+    return {
+      decision: "promote",
+      ...(taxonomyNode.governance?.promotion?.classifyAs
+        ? { classifyAs: taxonomyNode.governance.promotion.classifyAs }
+        : {}),
+      evidence: { source: "real-estate-provenance" },
     };
   }
 

--- a/packages/db/src/discovery-promotion.ts
+++ b/packages/db/src/discovery-promotion.ts
@@ -13,6 +13,7 @@
 
 import {
   resolvePromotionDecision,
+  classifyEstateProvenance,
   type PromotionTaxonomyNodeInput,
 } from "./discovery-promotion-policy";
 import {
@@ -155,6 +156,20 @@ export async function promoteInventoryEntities(db: PromotionDb): Promise<Promoti
         ? { id: portfolioRow.id, slug: rootSlug }
         : null;
 
+      // Classify estate provenance from discovery evidence so the resolver can
+      // promote real-estate devices (UniFi/arp, 192.168) even when their
+      // entityType is host/network, while keeping the platform's own Docker
+      // self-scan (172.18) as a black box.
+      const props = (entity.properties ?? {}) as Record<string, unknown>;
+      const provenance = classifyEstateProvenance({
+        discoveredVia: typeof props.discoveredVia === "string" ? props.discoveredVia : null,
+        addressHint:
+          (typeof props.address === "string" && props.address) ||
+          (typeof props.ip === "string" && props.ip) ||
+          entity.name ||
+          null,
+      });
+
       // Delegate the promote/skip decision to the pure policy resolver.
       const decision = resolvePromotionDecision(
         {
@@ -166,6 +181,7 @@ export async function promoteInventoryEntities(db: PromotionDb): Promise<Promoti
           attributionConfidence: entity.attributionConfidence ?? 0,
           digitalProductId: entity.digitalProductId,
           taxonomyNodeId: entity.taxonomyNodeId,
+          provenance,
         },
         taxonomyNode,
         portfolio,

--- a/packages/db/src/discovery-reconcile.test.ts
+++ b/packages/db/src/discovery-reconcile.test.ts
@@ -4,17 +4,25 @@ import {
   reconcilePromotedProducts,
 } from "./discovery-reconcile";
 
+const INT = "platform_internal" as const;
+const REAL = "real_estate" as const;
+
 describe("isInfrastructureProduct", () => {
-  it("is true when every linked entity is an infra type", () => {
-    expect(isInfrastructureProduct(["host"])).toBe(true);
-    expect(isInfrastructureProduct(["network_interface", "subnet"])).toBe(true);
-    expect(isInfrastructureProduct(["gateway", "host", "docker_host"])).toBe(true);
+  it("is true when every linked entity is platform-internal infra", () => {
+    expect(isInfrastructureProduct([{ entityType: "host", provenance: INT }])).toBe(true);
+    expect(isInfrastructureProduct([{ entityType: "network_interface", provenance: INT }, { entityType: "subnet", provenance: INT }])).toBe(true);
   });
 
   it("is false when any linked entity is product-shaped", () => {
-    expect(isInfrastructureProduct(["host", "database"])).toBe(false);
-    expect(isInfrastructureProduct(["service"])).toBe(false);
-    expect(isInfrastructureProduct(["application"])).toBe(false);
+    expect(isInfrastructureProduct([{ entityType: "host", provenance: INT }, { entityType: "database", provenance: INT }])).toBe(false);
+    expect(isInfrastructureProduct([{ entityType: "service", provenance: INT }])).toBe(false);
+  });
+
+  it("is FALSE when an infra entity is real-estate provenance (a real device is kept)", () => {
+    // A camera/NVR/gateway on the operator's LAN is a Foundational Digital
+    // Product even though its entityType is host/network — never demoted.
+    expect(isInfrastructureProduct([{ entityType: "host", provenance: REAL }])).toBe(false);
+    expect(isInfrastructureProduct([{ entityType: "gateway", provenance: REAL }])).toBe(false);
   });
 
   it("is false when there are no linked entities (seed/registered product)", () => {
@@ -26,7 +34,7 @@ function makeDb(products: Array<{
   id: string;
   productId: string;
   name: string;
-  inventoryEntities: Array<{ id: string; entityType: string }>;
+  inventoryEntities: Array<{ id: string; entityType: string; name?: string | null; properties?: unknown }>;
 }>) {
   return {
     digitalProduct: {
@@ -73,6 +81,27 @@ describe("reconcilePromotedProducts", () => {
       where: { digitalProductId: "p_host" },
       data: { digitalProductId: null },
     });
+  });
+
+  it("KEEPS a real-estate device product (host-type but UniFi-discovered)", async () => {
+    // The 2026-06 estate fix: a Reolink NVR / UniFi gateway is a Foundational
+    // Digital Product. Its entityType is host/gateway, but its provenance is
+    // real-estate (192.168 / unifi), so reconcile must NOT demote it — while a
+    // Docker host on 172.18 IS demoted.
+    const db = makeDb([
+      { id: "p_real", productId: "dev-nvr", name: "Reolink NVR", inventoryEntities: [{ id: "e1", entityType: "host", name: "NVR 192.168.0.42", properties: { discoveredVia: "unifi_clients_api", address: "192.168.0.42" } }] },
+      { id: "p_docker", productId: "host-172", name: "LAN Host 172.18.0.5", inventoryEntities: [{ id: "e2", entityType: "host", name: "LAN Host 172.18.0.5", properties: { discoveredVia: "arp_table", address: "172.18.0.5" } }] },
+    ]);
+
+    const summary = await reconcilePromotedProducts(db as never);
+
+    expect(summary.demoted).toBe(1); // only the Docker host
+    expect(summary.kept).toBe(1); // the real-estate NVR
+    const deletedIds = db.digitalProduct.delete.mock.calls.map(
+      (c) => (c[0] as { where: { id: string } }).where.id,
+    );
+    expect(deletedIds).toContain("p_docker");
+    expect(deletedIds).not.toContain("p_real");
   });
 
   it("is idempotent — a clean estate demotes nothing", async () => {

--- a/packages/db/src/discovery-reconcile.ts
+++ b/packages/db/src/discovery-reconcile.ts
@@ -16,7 +16,11 @@
 // they simply stop being mislabeled as products (their digitalProductId is
 // nulled, so they remain attributed to their taxonomy node as inventory).
 
-import { isNonProductEntityType } from "./discovery-promotion-policy";
+import {
+  isNonProductEntityType,
+  classifyEstateProvenance,
+  type EstateProvenance,
+} from "./discovery-promotion-policy";
 
 export type ReconcileSummary = {
   /** DigitalProducts removed because they were infrastructure, not products. */
@@ -38,7 +42,7 @@ type ReconcileDb = {
       id: string;
       productId: string;
       name: string;
-      inventoryEntities: Array<{ id: string; entityType: string }>;
+      inventoryEntities: Array<{ id: string; entityType: string; name?: string | null; properties?: unknown }>;
     }>>;
     delete(args: { where: { id: string } }): Promise<unknown>;
   };
@@ -51,15 +55,23 @@ type ReconcileDb = {
 };
 
 /**
- * Decide whether a product is infrastructure that was wrongly promoted.
- * Pure — exported for unit testing.
+ * Decide whether a product is PLATFORM-INTERNAL infrastructure that was wrongly
+ * promoted (and should be demoted). Pure — exported for unit testing.
+ *
+ * A product is demoted only when every linked entity is BOTH an infra entityType
+ * AND platform-internal provenance (the platform's own Docker/local runtime).
+ * Real-estate devices (a camera/NVR/gateway on the operator's LAN) are kept —
+ * they are legitimate Foundational Digital Products even though their entityType
+ * is host/network.
  */
 export function isInfrastructureProduct(
-  linkedEntityTypes: readonly string[],
+  linkedEntities: ReadonlyArray<{ entityType: string; provenance: EstateProvenance }>,
 ): boolean {
   return (
-    linkedEntityTypes.length > 0 &&
-    linkedEntityTypes.every((t) => isNonProductEntityType(t))
+    linkedEntities.length > 0 &&
+    linkedEntities.every(
+      (e) => isNonProductEntityType(e.entityType) && e.provenance === "platform_internal",
+    )
   );
 }
 
@@ -82,13 +94,26 @@ export async function reconcilePromotedProducts(
       id: true,
       productId: true,
       name: true,
-      inventoryEntities: { select: { id: true, entityType: true } },
+      inventoryEntities: { select: { id: true, entityType: true, name: true, properties: true } },
     },
   });
 
   for (const product of products) {
-    const types = product.inventoryEntities.map((e) => e.entityType);
-    if (!isInfrastructureProduct(types)) {
+    const linked = product.inventoryEntities.map((e) => {
+      const props = (e.properties ?? {}) as Record<string, unknown>;
+      return {
+        entityType: e.entityType,
+        provenance: classifyEstateProvenance({
+          discoveredVia: typeof props.discoveredVia === "string" ? props.discoveredVia : null,
+          addressHint:
+            (typeof props.address === "string" && props.address) ||
+            (typeof props.ip === "string" && props.ip) ||
+            e.name ||
+            null,
+        }),
+      };
+    });
+    if (!isInfrastructureProduct(linked)) {
       summary.kept++;
       continue;
     }


### PR DESCRIPTION
## What

Completes the estate model so your real connected devices (cameras, NVRs, thermostats, smart plugs, gateways, endpoints, voice) are registered as **Foundational Digital Products** — while the platform's own Docker self-scan stays a black box.

Grounded in the reference standards (The Open Group, *"The Shift to Digital Product"* + *"Digital Product Portfolio Management"*): an IoT doorbell / smart appliance / camera **is a Digital Product**, and these belong in the **Foundational** portfolio (the paper names *"client compute, telephony, building management"* as Foundational examples).

## Two commits

1. **Foundational taxonomy** (seed): adds the `Building Management` subtree (Security & Surveillance, Climate, Access, Lighting & Energy, Connected Appliances) + `Compute > Client and End User Compute` — the homes the TBM taxonomy lacked.
2. **Provenance-aware promotion**: the #1445 structural type-gate correctly removed 38 Docker rows but also blocked the real devices. The fix distinguishes by **provenance, not entityType**:
   - `real_estate` = UniFi-discovered / operator LAN (192.168, 10.x) → promote as products
   - `platform_internal` = Docker self-scan (172.16/12, `local_os`, `*_exporter`, prometheus, k8s) → black box
   - Conservative default (unknown → internal), so nothing unidentified leaks in; the runtime-name gate still wins.
   - `reconcile` only demotes all-platform-internal-infra products — **real-estate device products are never demoted**.

## Live state (already done this session, via the DB)

Your **76/78 real devices are classified** into the new Foundational sub-portfolios (Lighting 27, Compute 11, Network 14, Voice 8, Security 7, Appliances 4, Climate 3, Access 2). On merge + next discovery pass, this code **promotes them to DigitalProduct records and keeps them**.

Also filed: improvement **IP-0DCAC** (Portfolio Analyst gains the DPPM-placement capability + override-driven improvement loop — so this stays automated).

## Tests
`87 passing` across policy + promotion + reconcile; `tsc` clean (apps/web + packages/db). Coverage includes: real-estate host promotes, Docker host still skips, omitted-provenance back-compat, reconcile keeps a UniFi NVR while demoting a 172.18 host.

Refs: estate-accuracy goal; builds on #1445 · cites `docs/Reference/shift_to_digital_product.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)