### PR TITLE
feat: unlock CRM marketing subroutes

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/automation/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/automation/page.tsx
@@ -1,0 +1,105 @@
+import {
+  MarketingEmptyState,
+  MarketingIntentBadge,
+  MarketingLifecycleBadge,
+  MarketingMetricGrid,
+  MarketingPageHeader,
+  MarketingRecordCard,
+  MarketingSection,
+} from "@/components/customer-marketing/MarketingRoutePrimitives";
+import { getMarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { buildMarketingAutomationView } from "@/lib/marketing/subroutes";
+
+export default async function CustomerMarketingAutomationPage() {
+  const snapshot = await getMarketingWorkspaceSnapshot();
+
+  if (!snapshot) {
+    return (
+      <MarketingEmptyState
+        title="Automation candidates are waiting for organization setup"
+        description="Governed automation ideas become available once the organization workspace has been initialized."
+      />
+    );
+  }
+
+  const view = buildMarketingAutomationView(snapshot);
+
+  return (
+    <div className="space-y-6">
+      <MarketingPageHeader
+        eyebrow="Customer Marketing"
+        title="Automation candidates"
+        description="Review suggested marketing automations, triggers, and approval posture before any workflow is enabled."
+        actionHref="/customer/marketing"
+        actionLabel="Back to overview"
+      />
+
+      <MarketingMetricGrid metrics={view.metrics} />
+
+      <MarketingSection
+        title="Candidate workflows"
+        description="This route is read-only in Slice 4. Approval, scheduling, and policy controls stay governed by later execution work."
+      >
+        {view.candidates.length === 0 ? (
+          <MarketingEmptyState
+            title="No automation candidates saved"
+            description="Ask the Marketing Strategist to identify repetitive follow-up or campaign work that could become an approval-gated automation."
+            actionHref="/customer/marketing"
+            actionLabel="Open strategist workspace"
+          />
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {view.candidates.map((candidate) => (
+              <MarketingRecordCard key={candidate.id}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                      {candidate.title}
+                    </h2>
+                    <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                      {candidate.rationale}
+                    </p>
+                  </div>
+                  <MarketingLifecycleBadge status={candidate.status} />
+                </div>
+
+                <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Trigger
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{candidate.trigger}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Action
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{candidate.action}</dd>
+                  </div>
+                </dl>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <MarketingIntentBadge
+                    intent={candidate.intent}
+                    label={candidate.approvalLabel}
+                  />
+                  <MarketingIntentBadge intent="neutral" label={candidate.safetyLabel} />
+                </div>
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+
+      <MarketingSection title="Guardrail">
+        <MarketingRecordCard>
+          <p className="text-sm text-[var(--dpf-text)]">
+            Automation candidates shown here are proposals. They do not publish,
+            send, schedule, or mutate CRM data until a governed workflow adds the
+            appropriate approval and audit path.
+          </p>
+        </MarketingRecordCard>
+      </MarketingSection>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
@@ -1,0 +1,160 @@
+import {
+  MarketingDate,
+  MarketingEmptyState,
+  MarketingLifecycleBadge,
+  MarketingMetricGrid,
+  MarketingPageHeader,
+  MarketingRecordCard,
+  MarketingSection,
+} from "@/components/customer-marketing/MarketingRoutePrimitives";
+import { formatMarketingLabel, getMarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { buildMarketingCampaignsView } from "@/lib/marketing/subroutes";
+
+export default async function CustomerMarketingCampaignsPage() {
+  const snapshot = await getMarketingWorkspaceSnapshot();
+
+  if (!snapshot) {
+    return (
+      <MarketingEmptyState
+        title="Campaign work is waiting for organization setup"
+        description="Campaign briefs and asset tasks become available once the organization workspace has been initialized."
+      />
+    );
+  }
+
+  const view = buildMarketingCampaignsView(snapshot);
+
+  return (
+    <div className="space-y-6">
+      <MarketingPageHeader
+        eyebrow="Customer Marketing"
+        title="Campaign work"
+        description="Read the campaign briefs, proof assets, asset tasks, and approval posture the strategist has already saved."
+        actionHref="/customer/marketing/strategy"
+        actionLabel="Review strategy"
+      />
+
+      <MarketingMetricGrid metrics={view.metrics} />
+
+      <MarketingSection
+        title="Campaign briefs"
+        description="Briefs define the audience, channel mix, proof, and measurable outcome before individual assets are drafted."
+      >
+        {view.campaigns.length === 0 ? (
+          <MarketingEmptyState
+            title="No campaign briefs saved yet"
+            description="Ask the Marketing Strategist to turn the current acquisition assumptions into a campaign brief before assets are drafted."
+            actionHref="/customer/marketing"
+            actionLabel="Open strategist workspace"
+          />
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {view.campaigns.map((campaign) => (
+              <MarketingRecordCard key={campaign.id}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                      {campaign.title}
+                    </h2>
+                    <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                      {campaign.objective}
+                    </p>
+                  </div>
+                  <MarketingLifecycleBadge status={campaign.status} />
+                </div>
+
+                <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Audience
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{campaign.audience}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Channels
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">
+                      {campaign.channelsLabel}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Asset progress
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">
+                      {campaign.taskCount} task{campaign.taskCount === 1 ? "" : "s"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Next work
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">
+                      {campaign.nextWorkLabel}
+                    </dd>
+                  </div>
+                </dl>
+
+                {campaign.kpis.length > 0 ? (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {campaign.kpis.map((kpi) => (
+                      <span
+                        key={kpi}
+                        className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-[11px] text-[var(--dpf-text)]"
+                      >
+                        {kpi}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+
+      <MarketingSection
+        title="Asset tasks"
+        description="Asset tasks are the concrete pieces of work that can become approval-gated drafts."
+      >
+        {view.assetTasks.length === 0 ? (
+          <MarketingEmptyState
+            title="No asset tasks queued"
+            description="Once the strategist saves a task, it will appear here with its channel, due window, and draft posture."
+          />
+        ) : (
+          <div className="grid gap-3 lg:grid-cols-2">
+            {view.assetTasks.map((task) => (
+              <MarketingRecordCard key={task.id}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+                      {task.title}
+                    </h2>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      {formatMarketingLabel(task.assetType)} on {task.channelLabel}
+                    </p>
+                  </div>
+                  <MarketingLifecycleBadge status={task.status} />
+                </div>
+                <p className="mt-3 text-sm text-[var(--dpf-text)]">{task.brief}</p>
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                  <span className="text-[var(--dpf-muted)]">{task.dueWindow}</span>
+                  <span className="text-[var(--dpf-muted)]">/</span>
+                  <span className="font-medium text-[var(--dpf-text)]">
+                    {task.draftStatusLabel}
+                  </span>
+                </div>
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+
+      <p className="text-xs text-[var(--dpf-muted)]">
+        Last strategy review: <MarketingDate value={snapshot.strategy.lastReviewedAt} />
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/customer/marketing/funnel/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/funnel/page.tsx
@@ -1,0 +1,221 @@
+import { prisma } from "@dpf/db";
+
+import {
+  MarketingEmptyState,
+  MarketingLifecycleBadge,
+  MarketingMetricGrid,
+  MarketingPageHeader,
+  MarketingRecordCard,
+  MarketingSection,
+} from "@/components/customer-marketing/MarketingRoutePrimitives";
+import { getMarketingWorkspaceSnapshot } from "@/lib/marketing";
+import {
+  buildMarketingFunnelView,
+  type MarketingFunnelEvidenceInput,
+} from "@/lib/marketing/subroutes";
+
+async function getMarketingFunnelEvidence(): Promise<MarketingFunnelEvidenceInput> {
+  const [engagementGroups, opportunities] = await Promise.all([
+    prisma.engagement.groupBy({
+      by: ["source", "status"],
+      _count: true,
+    }),
+    prisma.opportunity.findMany({
+      select: {
+        stage: true,
+        expectedValue: true,
+        engagementId: true,
+      },
+    }),
+  ]);
+
+  const engagementIds = [
+    ...new Set(
+      opportunities
+        .map((opportunity) => opportunity.engagementId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  const sourceRows =
+    engagementIds.length > 0
+      ? await prisma.engagement.findMany({
+          where: { id: { in: engagementIds } },
+          select: { id: true, source: true },
+        })
+      : [];
+  const sourceByEngagementId = new Map(
+    sourceRows.map((engagement) => [engagement.id, engagement.source]),
+  );
+
+  return {
+    engagements: engagementGroups.map((row) => ({
+      source: row.source,
+      status: row.status,
+      count: row._count,
+    })),
+    opportunities: opportunities.map((opportunity) => ({
+      source: opportunity.engagementId
+        ? sourceByEngagementId.get(opportunity.engagementId) ?? null
+        : null,
+      stage: opportunity.stage,
+      expectedValue: Number(opportunity.expectedValue ?? 0),
+    })),
+  };
+}
+
+export default async function CustomerMarketingFunnelPage() {
+  const [snapshot, evidence] = await Promise.all([
+    getMarketingWorkspaceSnapshot(),
+    getMarketingFunnelEvidence(),
+  ]);
+
+  if (!snapshot) {
+    return (
+      <MarketingEmptyState
+        title="Marketing funnel is waiting for organization setup"
+        description="Source and stage evidence becomes available once the organization workspace has been initialized."
+      />
+    );
+  }
+
+  const view = buildMarketingFunnelView(snapshot, evidence);
+
+  return (
+    <div className="space-y-6">
+      <MarketingPageHeader
+        eyebrow="Customer Marketing"
+        title="Source and funnel evidence"
+        description="Compare acquisition sources, CRM engagements, and opportunity stages without overstating campaign attribution."
+        actionHref="/customer/engagements"
+        actionLabel="Review signals"
+      />
+
+      <MarketingMetricGrid metrics={view.metrics} />
+
+      <MarketingSection
+        title="Source evidence"
+        description="Rows show the source recorded on CRM engagements and converted opportunities. This is evidence, not a full multi-touch attribution model."
+      >
+        {view.sourceRows.length === 0 ? (
+          <MarketingEmptyState
+            title="No source evidence yet"
+            description="Route storefront or integration signals into engagements to start building marketing source evidence."
+            actionHref="/customer/engagements"
+            actionLabel="Open engagements"
+          />
+        ) : (
+          <div className="grid gap-3 xl:grid-cols-2">
+            {view.sourceRows.map((row) => (
+              <MarketingRecordCard key={row.source}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                      {row.source}
+                    </h2>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      {row.evidenceLabel}
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-[var(--dpf-accent)]">
+                    {row.pipelineValueLabel}
+                  </span>
+                </div>
+                <dl className="mt-4 grid grid-cols-2 gap-3 text-sm lg:grid-cols-4">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Engagements
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{row.engagementCount}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Opportunities
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{row.opportunityCount}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Open
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">
+                      {row.openOpportunityCount}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+                      Won
+                    </dt>
+                    <dd className="mt-1 text-[var(--dpf-text)]">{row.wonCount}</dd>
+                  </div>
+                </dl>
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+
+      <MarketingSection
+        title="Opportunity stages"
+        description="Stage evidence shows where sourced opportunities sit in the sales workflow."
+      >
+        {view.stageRows.length === 0 ? (
+          <MarketingEmptyState
+            title="No opportunity stage evidence"
+            description="Converted engagements will populate this stage view once opportunities exist."
+          />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {view.stageRows.map((row) => (
+              <MarketingRecordCard key={row.stage}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+                      {row.stageLabel}
+                    </h2>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      {row.count} opportunit{row.count === 1 ? "y" : "ies"}
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-[var(--dpf-accent)]">
+                    {row.pipelineValueLabel}
+                  </span>
+                </div>
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+
+      <MarketingSection
+        title="KPI checkpoints"
+        description="Saved strategist KPI checkpoints keep campaign evidence visible while the funnel matures."
+      >
+        {view.kpiRows.length === 0 ? (
+          <MarketingEmptyState
+            title="No KPI checkpoints saved"
+            description="Ask the strategist to save the first target metric for the campaign or channel under review."
+          />
+        ) : (
+          <div className="grid gap-3 lg:grid-cols-2">
+            {view.kpiRows.map((row) => (
+              <MarketingRecordCard key={row.id}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+                      {row.metric}
+                    </h2>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      {row.target} / {row.cadence}
+                    </p>
+                  </div>
+                  <MarketingLifecycleBadge status={row.status} />
+                </div>
+                <p className="mt-3 text-sm text-[var(--dpf-text)]">{row.notes}</p>
+              </MarketingRecordCard>
+            ))}
+          </div>
+        )}
+      </MarketingSection>
+    </div>
+  );
+}

--- a/apps/web/components/customer-marketing/MarketingRoutePrimitives.tsx
+++ b/apps/web/components/customer-marketing/MarketingRoutePrimitives.tsx
@@ -1,0 +1,179 @@
+import Link from "next/link";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { StatCard, StatusBadge } from "@/components/ui/report-kit";
+import type { Intent } from "@/components/ui/report-kit";
+import { formatMarketingLabel } from "@/lib/marketing";
+import type { MarketingMetric } from "@/lib/marketing/subroutes";
+
+export function MarketingPageHeader({
+  eyebrow,
+  title,
+  description,
+  actionHref,
+  actionLabel,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  actionHref?: string;
+  actionLabel?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <p className="text-xs uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
+          {eyebrow}
+        </p>
+        <h1 className="mt-2 text-2xl font-bold text-[var(--dpf-text)]">{title}</h1>
+        <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
+          {description}
+        </p>
+      </div>
+      {actionHref && actionLabel ? (
+        <Link
+          href={actionHref}
+          className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-2 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]"
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function MarketingMetricGrid({ metrics }: { metrics: MarketingMetric[] }) {
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      {metrics.map((metric) => (
+        <StatCard
+          key={metric.label}
+          label={metric.label}
+          value={metric.value}
+          hint={metric.hint}
+          intent={metric.intent}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function MarketingSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-base font-semibold text-[var(--dpf-text)]">{title}</h2>
+        {description ? (
+          <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function MarketingEmptyState({
+  title,
+  description,
+  actionHref,
+  actionLabel,
+}: {
+  title: string;
+  description: string;
+  actionHref?: string;
+  actionLabel?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)]">{title}</h2>
+      <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">{description}</p>
+      {actionHref && actionLabel ? (
+        <Link
+          href={actionHref}
+          className="mt-4 inline-flex rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function MarketingRecordCard({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <article
+      className={[
+        "rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </article>
+  );
+}
+
+export function MarketingLifecycleBadge({
+  status,
+  label,
+}: {
+  status: string;
+  label?: string;
+}) {
+  return (
+    <StatusBadge
+      domain="marketing"
+      status={status}
+      label={label ?? formatMarketingLabel(status)}
+      uppercase={false}
+      variant="soft"
+    />
+  );
+}
+
+export function MarketingIntentBadge({
+  intent,
+  label,
+}: {
+  intent: Intent;
+  label: string;
+}) {
+  return (
+    <StatusBadge intent={intent} label={label} uppercase={false} variant="soft" />
+  );
+}
+
+export function MarketingDate({
+  value,
+  fallback = "No date",
+}: {
+  value: Date | string | null | undefined;
+  fallback?: string;
+}) {
+  return (
+    <LocalTime
+      value={value}
+      mode="date"
+      utc
+      fallback={fallback}
+      className="text-[var(--dpf-muted)]"
+    />
+  );
+}

--- a/apps/web/components/customer-marketing/MarketingTabNav.test.tsx
+++ b/apps/web/components/customer-marketing/MarketingTabNav.test.tsx
@@ -26,15 +26,18 @@ vi.mock("next/link", () => ({
 import { MarketingTabNav } from "./MarketingTabNav";
 
 describe("MarketingTabNav", () => {
-  it("renders only implemented marketing routes", () => {
+  it("renders every implemented marketing route", () => {
     pathname = "/customer/marketing";
     const html = renderToStaticMarkup(<MarketingTabNav />);
 
     expect(html).toContain('href="/customer/marketing"');
     expect(html).toContain('href="/customer/marketing/strategy"');
-    expect(html).not.toContain("Campaigns");
-    expect(html).not.toContain("Funnel");
-    expect(html).not.toContain("Automation");
+    expect(html).toContain('href="/customer/marketing/campaigns"');
+    expect(html).toContain('href="/customer/marketing/funnel"');
+    expect(html).toContain('href="/customer/marketing/automation"');
+    expect(html).toContain("Campaigns");
+    expect(html).toContain("Funnel");
+    expect(html).toContain("Automation");
     expect(html).not.toContain("Phase 2");
     expect(html).not.toContain("Phase 3");
   });
@@ -43,6 +46,14 @@ describe("MarketingTabNav", () => {
     pathname = "/customer/marketing/strategy";
     const html = renderToStaticMarkup(<MarketingTabNav />);
 
+    expect(html).toContain("border-[var(--dpf-accent)]");
+  });
+
+  it("keeps Campaigns active for nested campaign routes", () => {
+    pathname = "/customer/marketing/campaigns/briefs";
+    const html = renderToStaticMarkup(<MarketingTabNav />);
+
+    expect(html).toContain('href="/customer/marketing/campaigns"');
     expect(html).toContain("border-[var(--dpf-accent)]");
   });
 });

--- a/apps/web/components/customer-marketing/MarketingTabNav.tsx
+++ b/apps/web/components/customer-marketing/MarketingTabNav.tsx
@@ -6,6 +6,9 @@ import { usePathname } from "next/navigation";
 const TABS = [
   { label: "Overview", href: "/customer/marketing" },
   { label: "Strategy", href: "/customer/marketing/strategy" },
+  { label: "Campaigns", href: "/customer/marketing/campaigns" },
+  { label: "Funnel", href: "/customer/marketing/funnel" },
+  { label: "Automation", href: "/customer/marketing/automation" },
 ] as const;
 
 export function MarketingTabNav() {

--- a/apps/web/components/customer/CustomerTabNav.test.tsx
+++ b/apps/web/components/customer/CustomerTabNav.test.tsx
@@ -70,4 +70,23 @@ describe("CustomerTabNav", () => {
     expect(html).toContain('href="/customer/marketing"');
     expect(html).toContain("border-[var(--dpf-accent)]");
   });
+
+  it("allows many customer tabs to wrap on narrow screens", () => {
+    pathname = "/customer/marketing/campaigns";
+    const html = renderToStaticMarkup(
+      <CustomerTabNav
+        tabs={[
+          { label: "Accounts", href: "/customer" },
+          { label: "Opportunities", href: "/customer/opportunities" },
+          { label: "Engagements", href: "/customer/engagements" },
+          { label: "Quotes", href: "/customer/quotes" },
+          { label: "Orders", href: "/customer/sales-orders" },
+          { label: "Funnel", href: "/customer/funnel" },
+          { label: "Marketing", href: "/customer/marketing" },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("flex-wrap");
+  });
 });

--- a/apps/web/components/customer/CustomerTabNav.tsx
+++ b/apps/web/components/customer/CustomerTabNav.tsx
@@ -23,7 +23,7 @@ export function CustomerTabNav({ tabs }: Props) {
   if (tabs.length === 0) return null;
 
   return (
-    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
+    <div className="mb-6 flex flex-wrap gap-x-1 gap-y-2 border-b border-[var(--dpf-border)]">
       {tabs.map((t) => (
         <Link
           key={t.href}

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -51,4 +51,11 @@ describe("statusColors", () => {
     expect(resolveIntent("complaintSeverity", "critical")).toBe("danger");
     expect(resolveIntent("complaintStatus", "resolved")).toBe("success");
   });
+
+  it("maps marketing lifecycle statuses to operational intents", () => {
+    expect(resolveIntent("marketing", "draft")).toBe("neutral");
+    expect(resolveIntent("marketing", "pending-review")).toBe("warning");
+    expect(resolveIntent("marketing", "approved")).toBe("success");
+    expect(resolveIntent("marketing", "rejected")).toBe("danger");
+  });
 });

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -131,6 +131,20 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     active: "success",
     inactive: "danger",
   },
+  // Marketing strategy/work-product lifecycle.
+  marketing: {
+    draft: "neutral",
+    ready: "info",
+    active: "success",
+    pending: "warning",
+    "pending-review": "warning",
+    "needs-changes": "warning",
+    approved: "success",
+    rejected: "danger",
+    stale: "warning",
+    published: "success",
+    archived: "neutral",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",

--- a/apps/web/lib/marketing/subroutes.test.ts
+++ b/apps/web/lib/marketing/subroutes.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import {
+  buildMarketingAutomationView,
+  buildMarketingCampaignsView,
+  buildMarketingFunnelView,
+} from "./subroutes";
+
+const now = new Date("2026-06-04T12:00:00.000Z");
+
+function snapshot(
+  overrides: Partial<MarketingWorkspaceSnapshot> = {},
+): MarketingWorkspaceSnapshot {
+  const base: MarketingWorkspaceSnapshot = {
+    organization: {
+      id: "org-1",
+      name: "DPF Demo",
+      website: "https://example.test",
+      addressSummary: "Austin, TX",
+    },
+    storefront: {
+      id: "storefront-1",
+      archetypeId: "expert-services",
+      archetypeName: "Expert Services",
+      tagline: "Proof-led growth",
+      description: "Operational advice",
+      ctaType: "inquiry",
+    },
+    strategy: {
+      strategyId: "strategy-1",
+      status: "active",
+      primaryGoal: "Generate qualified founder inquiries",
+      routeToMarket: "inbound",
+      localityModel: "national",
+      geographicScope: "United States",
+      primaryChannels: ["linkedin", "email"],
+      secondaryChannels: ["content-seo"],
+      differentiators: ["operational proof"],
+      reviewCadence: "weekly",
+      lastReviewedAt: now,
+      nextReviewAt: new Date("2026-06-11T12:00:00.000Z"),
+      sourceSummary: "Seeded test context",
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Founder operators", description: "Hands-on CEOs" }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: null,
+    workProducts: {
+      campaignBriefs: [
+        {
+          briefId: "brief-1",
+          title: "Founder trust sequence",
+          objective: "Create qualified sales conversations",
+          audience: "Founder operators",
+          channels: ["linkedin", "email"],
+          cta: "Book a fit call",
+          proofAssets: ["case study"],
+          kpis: ["qualified replies"],
+          notes: "Keep it founder-led.",
+          status: "draft",
+          createdAt: now,
+        },
+      ],
+      assetTasks: [
+        {
+          taskId: "task-1",
+          title: "Draft LinkedIn proof post",
+          assetType: "linkedin-post",
+          channel: "linkedin",
+          dueWindow: "this week",
+          brief: "Use the founder trust sequence.",
+          status: "draft",
+          createdAt: now,
+        },
+        {
+          taskId: "task-2",
+          title: "Write nurture email",
+          assetType: "email",
+          channel: "email",
+          dueWindow: "next week",
+          brief: "Follow up after the proof post.",
+          status: "ready",
+          createdAt: now,
+        },
+      ],
+      kpiCheckpoints: [
+        {
+          checkpointId: "kpi-1",
+          metric: "qualified replies",
+          target: "5 per month",
+          cadence: "weekly",
+          notes: "Baseline after first send.",
+          status: "active",
+          createdAt: now,
+        },
+      ],
+      automationCandidates: [
+        {
+          candidateId: "auto-1",
+          title: "Reply follow-up reminder",
+          trigger: "Qualified reply received",
+          action: "Create CRM follow-up task",
+          approvalRequired: true,
+          rationale: "Protects response SLA.",
+          status: "draft",
+          createdAt: now,
+        },
+      ],
+    },
+    pendingDrafts: [
+      {
+        draftId: "draft-1",
+        sourceType: "marketing-asset-task",
+        sourceId: "task-1",
+        assetTaskTitle: "Draft LinkedIn proof post",
+        channelId: "linkedin",
+        assetType: "linkedin-post",
+        status: "pending-review",
+        body: "Post body",
+        bodyFormat: "markdown",
+        createdByAgentId: "AGT-WS-MARKETING",
+        createdAt: now,
+      },
+    ],
+    approvedDrafts: [],
+    connectedChannels: ["linkedin-personal-social"],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+
+  return { ...base, ...overrides };
+}
+
+describe("marketing subroute view models", () => {
+  it("builds campaign rows with asset task and draft posture", () => {
+    const view = buildMarketingCampaignsView(snapshot());
+
+    expect(view.metrics).toEqual([
+      { label: "Campaign briefs", value: "1", hint: "1 active work plan", intent: "accent" },
+      { label: "Asset tasks", value: "2", hint: "1 waiting for review", intent: "info" },
+      { label: "Ready to publish", value: "0", hint: "approval-gated", intent: "success" },
+    ]);
+    expect(view.campaigns[0]).toMatchObject({
+      title: "Founder trust sequence",
+      channelsLabel: "LinkedIn, Email",
+      taskCount: 2,
+      pendingDraftCount: 1,
+      nextWorkLabel: "1 draft waiting for review",
+    });
+    expect(view.assetTasks[0]).toMatchObject({
+      title: "Draft LinkedIn proof post",
+      draftStatusLabel: "Pending review",
+    });
+  });
+
+  it("aggregates funnel evidence without overstating attribution", () => {
+    const view = buildMarketingFunnelView(snapshot(), {
+      engagements: [
+        { source: "storefront", status: "new", count: 3 },
+        { source: "facebook-lead-ads", status: "qualified", count: 2 },
+      ],
+      opportunities: [
+        { source: "storefront", stage: "qualification", expectedValue: 5000 },
+        { source: "storefront", stage: "closed_won", expectedValue: 7000 },
+        { source: null, stage: "proposal", expectedValue: 2500 },
+      ],
+    });
+
+    expect(view.sourceRows[0]).toMatchObject({
+      source: "Storefront",
+      engagementCount: 3,
+      opportunityCount: 2,
+      pipelineValueLabel: "GBP 12,000",
+      evidenceLabel: "Source evidence, not full attribution",
+    });
+    expect(view.sourceRows.map((row) => row.source)).toContain("Facebook Lead Ads");
+    expect(view.stageRows.map((row) => row.stageLabel)).toEqual([
+      "Qualification",
+      "Proposal",
+      "Won",
+    ]);
+  });
+
+  it("summarizes automation approval posture", () => {
+    const view = buildMarketingAutomationView(snapshot());
+
+    expect(view.metrics[0]).toMatchObject({
+      label: "Automation candidates",
+      value: "1",
+      intent: "warning",
+    });
+    expect(view.candidates[0]).toMatchObject({
+      title: "Reply follow-up reminder",
+      approvalLabel: "Approval required",
+      safetyLabel: "Human approval before this can run",
+    });
+  });
+});

--- a/apps/web/lib/marketing/subroutes.ts
+++ b/apps/web/lib/marketing/subroutes.ts
@@ -1,0 +1,434 @@
+import type { Intent } from "@/components/ui/report-kit";
+import {
+  formatMarketingLabel,
+  type MarketingWorkspaceSnapshot,
+  type OutboundDraftRow,
+} from "@/lib/marketing";
+import {
+  getOpportunityStageMeta,
+  isOpenOpportunityStage,
+  OPEN_OPPORTUNITY_STAGES,
+} from "@/lib/crm/presentation";
+
+export type MarketingMetric = {
+  label: string;
+  value: string;
+  hint: string;
+  intent: Intent;
+};
+
+export type MarketingCampaignRow = {
+  id: string;
+  title: string;
+  objective: string;
+  audience: string;
+  channels: string[];
+  channelsLabel: string;
+  status: string;
+  createdAt: Date;
+  taskCount: number;
+  pendingDraftCount: number;
+  approvedDraftCount: number;
+  nextWorkLabel: string;
+  kpis: string[];
+};
+
+export type MarketingAssetTaskRow = {
+  id: string;
+  title: string;
+  assetType: string;
+  channelLabel: string;
+  dueWindow: string;
+  status: string;
+  draftStatusLabel: string;
+  brief: string;
+};
+
+export type MarketingCampaignsView = {
+  metrics: MarketingMetric[];
+  campaigns: MarketingCampaignRow[];
+  assetTasks: MarketingAssetTaskRow[];
+  hasWork: boolean;
+};
+
+export type MarketingFunnelEngagementInput = {
+  source: string | null;
+  status: string;
+  count: number;
+};
+
+export type MarketingFunnelOpportunityInput = {
+  source: string | null;
+  stage: string;
+  expectedValue: number | null;
+};
+
+export type MarketingFunnelEvidenceInput = {
+  engagements: MarketingFunnelEngagementInput[];
+  opportunities: MarketingFunnelOpportunityInput[];
+};
+
+export type MarketingFunnelSourceRow = {
+  source: string;
+  engagementCount: number;
+  opportunityCount: number;
+  openOpportunityCount: number;
+  wonCount: number;
+  pipelineValue: number;
+  pipelineValueLabel: string;
+  evidenceLabel: string;
+};
+
+export type MarketingFunnelStageRow = {
+  stage: string;
+  stageLabel: string;
+  count: number;
+  pipelineValue: number;
+  pipelineValueLabel: string;
+};
+
+export type MarketingFunnelView = {
+  metrics: MarketingMetric[];
+  sourceRows: MarketingFunnelSourceRow[];
+  stageRows: MarketingFunnelStageRow[];
+  kpiRows: Array<{
+    id: string;
+    metric: string;
+    target: string;
+    cadence: string;
+    status: string;
+    notes: string;
+  }>;
+  hasEvidence: boolean;
+};
+
+export type MarketingAutomationCandidateRow = {
+  id: string;
+  title: string;
+  trigger: string;
+  action: string;
+  rationale: string;
+  status: string;
+  approvalLabel: string;
+  safetyLabel: string;
+  intent: Intent;
+};
+
+export type MarketingAutomationView = {
+  metrics: MarketingMetric[];
+  candidates: MarketingAutomationCandidateRow[];
+  hasCandidates: boolean;
+};
+
+const STAGE_ORDER = [...OPEN_OPPORTUNITY_STAGES, "closed_won", "closed_lost"];
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`;
+}
+
+function nonEmpty(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+function channelLabel(channel: string | null | undefined): string {
+  return channel ? formatMarketingLabel(channel) : "Unassigned channel";
+}
+
+function joinLabels(values: string[], fallback: string): string {
+  return values.length > 0 ? values.map(formatMarketingLabel).join(", ") : fallback;
+}
+
+function sourceLabel(source: string | null | undefined): string {
+  if (!source) return "Unattributed";
+  if (source === "facebook-lead-ads") return "Facebook Lead Ads";
+  return formatMarketingLabel(source);
+}
+
+function moneyLabel(value: number): string {
+  return `GBP ${Math.round(value).toLocaleString("en-GB")}`;
+}
+
+function draftForTask(taskId: string, drafts: OutboundDraftRow[]): OutboundDraftRow | null {
+  return (
+    drafts.find(
+      (draft) =>
+        draft.sourceType === "marketing-asset-task" && draft.sourceId === taskId,
+    ) ?? null
+  );
+}
+
+function draftLifecycleLabel(status: string): string {
+  if (status === "pending-review") return "Pending review";
+  if (status === "needs-changes") return "Needs changes";
+  return formatMarketingLabel(status);
+}
+
+function draftStatusLabel(taskId: string, snapshot: MarketingWorkspaceSnapshot): string {
+  const pending = draftForTask(taskId, snapshot.pendingDrafts);
+  if (pending) return draftLifecycleLabel(pending.status);
+  const approved = draftForTask(taskId, snapshot.approvedDrafts);
+  if (approved) return "Approved";
+  return "Not drafted";
+}
+
+function taskMatchesBrief(
+  task: MarketingWorkspaceSnapshot["workProducts"]["assetTasks"][number],
+  brief: MarketingWorkspaceSnapshot["workProducts"]["campaignBriefs"][number],
+): boolean {
+  if (task.channel && brief.channels.includes(task.channel)) return true;
+  const taskText = `${task.title} ${task.brief ?? ""}`.toLowerCase();
+  return taskText.includes(brief.title.toLowerCase());
+}
+
+export function buildMarketingCampaignsView(
+  snapshot: MarketingWorkspaceSnapshot,
+): MarketingCampaignsView {
+  const briefs = snapshot.workProducts.campaignBriefs;
+  const tasks = snapshot.workProducts.assetTasks;
+  const pendingReviewCount = snapshot.pendingDrafts.length;
+  const approvedCount = snapshot.approvedDrafts.length;
+
+  const campaigns = briefs.map((brief) => {
+    const matchedTasks = tasks.filter((task) => taskMatchesBrief(task, brief));
+    const pendingDraftCount = matchedTasks.filter((task) =>
+      Boolean(draftForTask(task.taskId, snapshot.pendingDrafts)),
+    ).length;
+    const approvedDraftCount = matchedTasks.filter((task) =>
+      Boolean(draftForTask(task.taskId, snapshot.approvedDrafts)),
+    ).length;
+    const undraftedCount = Math.max(0, matchedTasks.length - pendingDraftCount - approvedDraftCount);
+    const nextWorkLabel =
+      pendingDraftCount > 0
+        ? `${plural(pendingDraftCount, "draft")} waiting for review`
+        : undraftedCount > 0
+          ? `${plural(undraftedCount, "asset task")} needs a draft`
+          : approvedDraftCount > 0
+            ? `${plural(approvedDraftCount, "draft")} ready to publish`
+            : "No asset tasks yet";
+
+    return {
+      id: brief.briefId,
+      title: brief.title,
+      objective: brief.objective,
+      audience: nonEmpty(brief.audience, "Audience not specified"),
+      channels: brief.channels,
+      channelsLabel: joinLabels(brief.channels, "Channels not selected"),
+      status: brief.status,
+      createdAt: brief.createdAt,
+      taskCount: matchedTasks.length,
+      pendingDraftCount,
+      approvedDraftCount,
+      nextWorkLabel,
+      kpis: brief.kpis,
+    };
+  });
+
+  const assetTasks = tasks.map((task) => ({
+    id: task.taskId,
+    title: task.title,
+    assetType: task.assetType,
+    channelLabel: channelLabel(task.channel),
+    dueWindow: nonEmpty(task.dueWindow, "No due window"),
+    status: task.status,
+    draftStatusLabel: draftStatusLabel(task.taskId, snapshot),
+    brief: nonEmpty(task.brief, "No saved brief"),
+  }));
+
+  return {
+    metrics: [
+      {
+        label: "Campaign briefs",
+        value: String(briefs.length),
+        hint: plural(briefs.length, "active work plan"),
+        intent: "accent",
+      },
+      {
+        label: "Asset tasks",
+        value: String(tasks.length),
+        hint:
+          pendingReviewCount > 0
+            ? `${pendingReviewCount} waiting for review`
+            : "draft queue clear",
+        intent: "info",
+      },
+      {
+        label: "Ready to publish",
+        value: String(approvedCount),
+        hint: "approval-gated",
+        intent: "success",
+      },
+    ],
+    campaigns,
+    assetTasks,
+    hasWork: briefs.length > 0 || tasks.length > 0,
+  };
+}
+
+export function buildMarketingFunnelView(
+  snapshot: MarketingWorkspaceSnapshot,
+  evidence: MarketingFunnelEvidenceInput,
+): MarketingFunnelView {
+  const bySource = new Map<string, MarketingFunnelSourceRow>();
+  const byStage = new Map<string, MarketingFunnelStageRow>();
+
+  function ensureSource(source: string | null | undefined): MarketingFunnelSourceRow {
+    const key = source ?? "__unattributed";
+    const existing = bySource.get(key);
+    if (existing) return existing;
+    const row: MarketingFunnelSourceRow = {
+      source: sourceLabel(source),
+      engagementCount: 0,
+      opportunityCount: 0,
+      openOpportunityCount: 0,
+      wonCount: 0,
+      pipelineValue: 0,
+      pipelineValueLabel: moneyLabel(0),
+      evidenceLabel: "Source evidence, not full attribution",
+    };
+    bySource.set(key, row);
+    return row;
+  }
+
+  for (const engagement of evidence.engagements) {
+    ensureSource(engagement.source).engagementCount += engagement.count;
+  }
+
+  for (const opportunity of evidence.opportunities) {
+    const source = ensureSource(opportunity.source);
+    const value = opportunity.expectedValue ?? 0;
+    source.opportunityCount += 1;
+    source.pipelineValue += value;
+    if (isOpenOpportunityStage(opportunity.stage)) {
+      source.openOpportunityCount += 1;
+    }
+    if (opportunity.stage === "closed_won") {
+      source.wonCount += 1;
+    }
+
+    const stageMeta = getOpportunityStageMeta(opportunity.stage);
+    const stageRow = byStage.get(opportunity.stage) ?? {
+      stage: opportunity.stage,
+      stageLabel: stageMeta.label,
+      count: 0,
+      pipelineValue: 0,
+      pipelineValueLabel: moneyLabel(0),
+    };
+    stageRow.count += 1;
+    stageRow.pipelineValue += value;
+    byStage.set(opportunity.stage, stageRow);
+  }
+
+  const sourceRows = [...bySource.values()]
+    .map((row) => ({
+      ...row,
+      pipelineValueLabel: moneyLabel(row.pipelineValue),
+    }))
+    .sort((a, b) => b.opportunityCount - a.opportunityCount || b.engagementCount - a.engagementCount);
+  const stageRows = [...byStage.values()]
+    .map((row) => ({
+      ...row,
+      pipelineValueLabel: moneyLabel(row.pipelineValue),
+    }))
+    .sort((a, b) => {
+      const ai = STAGE_ORDER.indexOf(a.stage as (typeof STAGE_ORDER)[number]);
+      const bi = STAGE_ORDER.indexOf(b.stage as (typeof STAGE_ORDER)[number]);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+
+  const totalEngagements = evidence.engagements.reduce((sum, row) => sum + row.count, 0);
+  const totalOpportunities = evidence.opportunities.length;
+  const openOpportunities = evidence.opportunities.filter((row) =>
+    isOpenOpportunityStage(row.stage),
+  ).length;
+
+  return {
+    metrics: [
+      {
+        label: "Source signals",
+        value: String(totalEngagements),
+        hint: plural(sourceRows.length, "source"),
+        intent: "accent",
+      },
+      {
+        label: "Opportunities",
+        value: String(totalOpportunities),
+        hint: `${openOpportunities} open`,
+        intent: "info",
+      },
+      {
+        label: "KPI checkpoints",
+        value: String(snapshot.workProducts.kpiCheckpoints.length),
+        hint: "strategist evidence",
+        intent: "success",
+      },
+    ],
+    sourceRows,
+    stageRows,
+    kpiRows: snapshot.workProducts.kpiCheckpoints.map((checkpoint) => ({
+      id: checkpoint.checkpointId,
+      metric: checkpoint.metric,
+      target: nonEmpty(checkpoint.target, "No target"),
+      cadence: checkpoint.cadence ? formatMarketingLabel(checkpoint.cadence) : "No cadence",
+      status: checkpoint.status,
+      notes: nonEmpty(checkpoint.notes, "No notes"),
+    })),
+    hasEvidence: totalEngagements > 0 || totalOpportunities > 0,
+  };
+}
+
+export function buildMarketingAutomationView(
+  snapshot: MarketingWorkspaceSnapshot,
+): MarketingAutomationView {
+  const candidates = snapshot.workProducts.automationCandidates.map((candidate) => {
+    const approvalLabel = candidate.approvalRequired
+      ? "Approval required"
+      : "Review before enabling";
+    const intent: Intent = candidate.approvalRequired ? "warning" : "info";
+    return {
+      id: candidate.candidateId,
+      title: candidate.title,
+      trigger: candidate.trigger,
+      action: candidate.action,
+      rationale: nonEmpty(candidate.rationale, "No rationale recorded"),
+      status: candidate.status,
+      approvalLabel,
+      safetyLabel: candidate.approvalRequired
+        ? "Human approval before this can run"
+        : "Keep disabled until reviewed",
+      intent,
+    };
+  });
+
+  const approvalRequiredCount = candidates.filter(
+    (candidate) => candidate.approvalLabel === "Approval required",
+  ).length;
+
+  return {
+    metrics: [
+      {
+        label: "Automation candidates",
+        value: String(candidates.length),
+        hint:
+          approvalRequiredCount > 0
+            ? `${approvalRequiredCount} approval-gated`
+            : "no approvals waiting",
+        intent: "warning",
+      },
+      {
+        label: "Connected channels",
+        value: String(snapshot.connectedChannels.length),
+        hint: "available to marketing",
+        intent: "info",
+      },
+      {
+        label: "Pending drafts",
+        value: String(snapshot.pendingDrafts.length),
+        hint: "review before external action",
+        intent: "accent",
+      },
+    ],
+    candidates,
+    hasCandidates: candidates.length > 0,
+  };
+}

--- a/docs/superpowers/plans/2026-06-04-pipedrive-crm-marketing-slice-4.md
+++ b/docs/superpowers/plans/2026-06-04-pipedrive-crm-marketing-slice-4.md
@@ -1,0 +1,94 @@
+# Pipedrive CRM Marketing Slice 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unlock real read-only marketing subroutes for campaign work, marketing funnel evidence, and automation candidates under `/customer/marketing`.
+
+**Architecture:** Reuse the existing marketing strategy/work-product substrate and CRM engagement/opportunity evidence. Add a small marketing route read-model module so page files stay mostly presentation and route navigation only exposes implemented routes.
+
+**Tech Stack:** Next.js app router server pages, React server/client components, Prisma via `@dpf/db`, Vitest, DPF theme tokens, report-kit status/data primitives where useful.
+
+---
+
+## Scope
+
+This plan implements `BI-F40F447C` in `EP-CRM-MKT-OPS`.
+
+Deliver:
+- `/customer/marketing/campaigns`
+- `/customer/marketing/funnel`
+- `/customer/marketing/automation`
+- marketing tab nav with only real routes
+- useful empty states backed by actual substrate checks
+
+Out of scope:
+- new database tables
+- external publish/send behavior
+- AI agent autonomous writes
+- Build Studio promotion
+
+## File Map
+
+- Modify `apps/web/components/customer-marketing/MarketingTabNav.tsx` to expose the three newly implemented routes.
+- Modify `apps/web/components/customer-marketing/MarketingTabNav.test.tsx` to assert all visible tabs are real routes and nested routes activate correctly.
+- Create `apps/web/lib/marketing/subroutes.ts` for pure route view models: campaigns, funnel, automation, labels, counts, and status intent mapping.
+- Create `apps/web/lib/marketing/subroutes.test.ts` with red/green coverage for campaign task grouping, funnel evidence, and automation approval posture.
+- Create `apps/web/components/customer-marketing/MarketingRoutePrimitives.tsx` for shared section shell, empty state, metric tiles, and compact status treatment.
+- Create `apps/web/app/(shell)/customer/marketing/campaigns/page.tsx`.
+- Create `apps/web/app/(shell)/customer/marketing/funnel/page.tsx`.
+- Create `apps/web/app/(shell)/customer/marketing/automation/page.tsx`.
+- Extend `apps/web/components/ui/report-kit/statusColors.ts` with marketing lifecycle intents if `StatusBadge` is used for marketing status.
+
+## Implementation Tasks
+
+### Task 1: Route Nav Contract
+
+- [ ] Write a failing `MarketingTabNav` test that expects Campaigns, Funnel, and Automation links.
+- [ ] Run `pnpm --filter web exec vitest run components/customer-marketing/MarketingTabNav.test.tsx` and confirm the new expectation fails.
+- [ ] Update `MarketingTabNav.tsx` to expose only implemented routes.
+- [ ] Re-run the nav test and confirm it passes.
+
+### Task 2: Route View Models
+
+- [ ] Write failing tests in `apps/web/lib/marketing/subroutes.test.ts` for:
+  - campaign briefs with asset-task progress
+  - funnel source rows combining engagement source and opportunity stage evidence
+  - automation candidate approval posture
+- [ ] Run `pnpm --filter web exec vitest run lib/marketing/subroutes.test.ts` and confirm the tests fail because the module is absent.
+- [ ] Implement `apps/web/lib/marketing/subroutes.ts` with pure helpers and no database calls.
+- [ ] Re-run the subroute tests and confirm they pass.
+
+### Task 3: Shared Presentation Refactor
+
+- [ ] Create `MarketingRoutePrimitives.tsx` for the repeated section, metric, empty-state, and status elements used by the new routes.
+- [ ] Use DPF theme variables only. Avoid hardcoded colors and one-off badge maps.
+- [ ] Keep page files as data assembly plus composition, not status/formatting logic.
+
+### Task 4: Campaigns Route
+
+- [ ] Create `/customer/marketing/campaigns`.
+- [ ] Read `getMarketingWorkspaceSnapshot()`.
+- [ ] Render campaign briefs, related asset tasks, approval/draft posture, channels, KPIs, and useful empty state.
+- [ ] Link back to `/customer/marketing/strategy` when strategy context is missing.
+
+### Task 5: Funnel Route
+
+- [ ] Create `/customer/marketing/funnel`.
+- [ ] Read `getMarketingWorkspaceSnapshot()` plus CRM engagement/opportunity grouped evidence from existing models.
+- [ ] Render source/channel rows, stage counts, conversion hints, and KPI checkpoints.
+- [ ] Avoid implying attribution when only source evidence exists.
+
+### Task 6: Automation Route
+
+- [ ] Create `/customer/marketing/automation`.
+- [ ] Read `getMarketingWorkspaceSnapshot()`.
+- [ ] Render automation candidates with approval posture, trigger, action, rationale, and safety copy.
+- [ ] Keep all write/policy controls out of scope for Slice 4.
+
+### Task 7: Verification
+
+- [ ] Run focused Vitest for new/changed tests.
+- [ ] Run `pnpm --filter web typecheck` in the worktree.
+- [ ] Run production build on the canonical runtime surface or CI path required by AGENTS.md.
+- [ ] Exercise `/customer/marketing`, `/customer/marketing/campaigns`, `/customer/marketing/funnel`, and `/customer/marketing/automation` with UX evidence.
+- [ ] Push, open a ready PR, wait for CI, merge, and mark `BI-F40F447C` done only after evidence is recorded.


### PR DESCRIPTION
## Summary
- Unlock read-only CRM marketing subroutes for campaigns, funnel evidence, and automation candidates.
- Add shared marketing route primitives and pure subroute view models for campaign/funnel/automation pages.
- Extend marketing lifecycle status intents through report-kit and wrap the customer tab nav to remove mobile horizontal overflow.
- Add the Slice 4 implementation plan artifact for BI-F40F447C.

## Verification
- Worktree `D:\DPF-crm-marketing-slice-4`: `pnpm --filter web exec vitest run components/customer/CustomerTabNav.test.tsx components/customer-marketing/MarketingTabNav.test.tsx lib/marketing/subroutes.test.ts components/ui/report-kit/statusColors.test.ts` -> passed, 4 files / 16 tests.
- Worktree `D:\DPF-crm-marketing-slice-4`: `pnpm --filter web typecheck` -> passed, `next typegen` and `tsc --noEmit`.
- Worktree `D:\DPF-crm-marketing-slice-4`: `pnpm --filter web build` -> passed. Existing Turbopack Edge/NFT warning family remains.
- Leased shared local-CI convergence sandbox `NPEL-B3C751CA18` at `http://localhost:3001`: Playwright checked `/customer/marketing`, `/customer/marketing/campaigns`, `/customer/marketing/funnel`, and `/customer/marketing/automation` at 1440x1000 and 390x844. All expected headings/copy/nav links were present, with no horizontal overflow.

## Evidence
- DPF external evidence: `cmq08a2qp031b01qp7gguyrqf`.
- Final commit: `aa75046101981e4dc1a296cc5bf6d6ef64ad4c69`.

## Notes
- No migration added.
- Preview container mutates generated Windows `node_modules/@dpf` reparse links; links were repaired after UX verification with `pnpm install --frozen-lockfile`.
