### PR TITLE
spec(workspace-home): roster references BI-B14D6CF6 as cross-cutting orchestrator dependency

### DIFF
--- a/docs/superpowers/specs/2026-06-04-workspace-home-contribution-roster-design.md
+++ b/docs/superpowers/specs/2026-06-04-workspace-home-contribution-roster-design.md
@@ -290,6 +290,24 @@ With the roster delivered:
 - **Runtime archetype change**: same substrate behavior; resolver re-runs per page load. No substrate change required.
 - **Per-archetype override deferral**: an archetype can opt into category-fallback for years; when evidence justifies the override, file (or pick up an already-filed) per-archetype BI, ship a contribution at the archetype level, and the resolver picks it on the next page load.
 
+### 9.1 Cross-cutting orchestrator — BI-B14D6CF6
+
+Resolver routing + activation-summary projection are automatic, but per the operator direction 2026-06-04:
+
+> "These differences are installed / established when the archetypes are chosen. The portal configuration needs to follow the needs of these business archetypes with little effort." — Mark Bodman
+
+…**install-time + runtime alignment of canonical data, signals, setup tasks, and empty-state behavior** with each contribution's `setupActivation` declarations is NOT yet implemented. The parent spec §5.5 promises that setup will "create setup tasks, seed safe demo records in test installs, or show honest empty states" from those declarations; no BI on main owns delivering that promise universally.
+
+**[BI-B14D6CF6](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-B14D6CF6)** — *Archetype-driven workspace-home setup activation orchestrator* — is filed as the cross-cutting BI that closes this gap. It extends the existing `StorefrontArchetype.activationProfile` activation pipeline to honor `WorkspaceHomeContribution.setupActivation` for every contribution. One orchestrator. Consumed by every BI in this roster.
+
+Universal, not per-archetype: every category-level + exact-archetype contribution gets archetype-driven setup-task generation, signal binding, empty-state coordination, and (on test installs only, gated by `DPF_SEED_DEMO_DATA=true`) declaration-derived demo-data seeding through the same code path. No per-BI orchestration code.
+
+Continuous tracking, not one-shot: activation runs at archetype selection, at archetype change, AND on a reconciliation cadence so the install's state stays aligned with the contribution's declarations over time. Drift surfaces as setup tasks the admin can act on.
+
+**Sequencing implication**: BI-B14D6CF6 is a hard dependency for "little-effort" archetype-driven install configuration. Every category-level BI in §7 implicitly consumes it. Once BI-B14D6CF6 ships, each consolidating BI's implementation simplifies — the orchestrator owns the setup-activation mechanics; the per-category BI ships the contribution literal + per-category vocabulary + slot composition only.
+
+**Dale HVAC plan (PR #1442) Phase 9 simplifies**: the orchestrator owns auto-seed; the plan's per-BI fixture file disappears. The same simplification applies to every other consolidating BI.
+
 ## 10. Standing rules audit
 
 - **Mirror, don't migrate.** Pure roster doc. No code, no schema, no migration.


### PR DESCRIPTION
## Summary

Follow-on to [PR #1460](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1460) (now merged). Adds §9.1 to the contribution roster naming **[BI-B14D6CF6](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues?q=BI-B14D6CF6)** — *Archetype-driven workspace-home setup activation orchestrator* — as the cross-cutting BI that closes the install-configuration-tracks-archetype-needs-with-little-effort gap.

## Operator direction this captures

> "These differences are installed / established when the archetypes are chosen. The portal configuration needs to follow the needs of these business archetypes with little effort." — Mark Bodman, 2026-06-04

HVAC is one of many archetypes that need this. The orchestrator is universal: one BI, consumed by every category-level + exact-archetype contribution under EP-REDUCTION-GEAR-ARCH.

## What the §9.1 amendment establishes

- The substrate (BI-1CCC6264, shipped) declares the contract via `WorkspaceHomeSetupActivation` (`requiredCanonicalData`, `requiredSignals`, `missingDataBehavior`).
- The parent spec §5.5 promises that setup will "create setup tasks, seed safe demo records in test installs, or show honest empty states" from those declarations.
- No BI on main owns delivering that promise. The Dale HVAC plan (PR #1442) Phase 9 was treating fixture seed as a one-off admin button — per-archetype-manual, the opposite of "little effort."
- **BI-B14D6CF6** is filed as the universal orchestrator that extends the existing `StorefrontArchetype.activationProfile` pipeline to honor every `WorkspaceHomeContribution.setupActivation`. Universal (not per-archetype) + continuous tracking (not one-shot at selection only).

## Sequencing implication

Every category-level BI implicitly consumes BI-B14D6CF6. Once it ships:

- Each consolidating BI's implementation simplifies — the orchestrator owns setup-activation mechanics; the per-category BI ships the contribution literal + per-category vocabulary + slot composition only.
- The Dale HVAC plan (PR #1442) Phase 9 simplifies — orchestrator owns auto-seed; the plan's per-BI fixture file disappears.
- Same simplification applies to all 8 new category-level BIs filed 2026-06-04 (BI-1F7731E5, BI-FE74CD4A, BI-25AFC2BC, BI-CB8EE2D0, BI-336FC845, BI-ED0153CA, BI-204CE2D6, BI-FA3294E0) + the 4 pre-existing (BI-EF03E915, BI-43A682A2, BI-96A3C7A9, BI-02845133) + BI-FE002675 (MSP exact) + BI-CE6AF925 (HVAC exact).

## Standing rules

- **DCO sign-off** on the commit.
- **Scoped commit** — `git commit --only` on the one roster file.
- **Rebased on current `origin/main`** (4d6854d4, which includes the merged PR #1460).
- **Overlap sweep** — clean.
- **Spec-then-BI alignment** — the orchestrator BI body (BI-B14D6CF6) and the roster §9.1 paragraph were written together so they reference each other coherently. Either can be read first.

## Test plan

- [ ] CI: DCO check
- [ ] CI: gitleaks
- [ ] Reviewer: confirm BI-B14D6CF6 is the right shape (universal cross-cutting orchestrator, not per-archetype code) — or override
- [ ] Reviewer: confirm the implication that Dale HVAC Phase 9 simplifies once the orchestrator ships — or override

🤖 Generated with [Claude Code](https://claude.com/claude-code)