### PR TITLE
Fix Windows local-integration Vitest blockers

### DIFF
--- a/apps/web/lib/invoice-pdf.test.ts
+++ b/apps/web/lib/invoice-pdf.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { generateInvoicePdf, getInvoicePdfFilename } from "./invoice-pdf";
+
+const PDF_TEST_TIMEOUT_MS = 20_000;
 
 const mockInvoice = {
   invoiceRef: "INV-2026-0001",
@@ -24,18 +26,24 @@ const mockInvoice = {
 };
 
 describe("generateInvoicePdf", () => {
-  it("returns a Buffer", async () => {
-    const result = await generateInvoicePdf(mockInvoice as never);
+  let standardPdf: Buffer;
+
+  beforeAll(async () => {
+    standardPdf = await generateInvoicePdf(mockInvoice as never);
+  }, PDF_TEST_TIMEOUT_MS);
+
+  it("returns a Buffer", () => {
+    const result = standardPdf;
     expect(Buffer.isBuffer(result)).toBe(true);
   });
 
-  it("returns a non-empty Buffer", async () => {
-    const result = await generateInvoicePdf(mockInvoice as never);
+  it("returns a non-empty Buffer", () => {
+    const result = standardPdf;
     expect(result.length).toBeGreaterThan(100);
   });
 
-  it("generates valid PDF (starts with %PDF)", async () => {
-    const result = await generateInvoicePdf(mockInvoice as never);
+  it("generates valid PDF (starts with %PDF)", () => {
+    const result = standardPdf;
     const header = result.subarray(0, 5).toString("ascii");
     expect(header).toBe("%PDF-");
   });
@@ -54,7 +62,7 @@ describe("generateInvoicePdf", () => {
     const result = await generateInvoicePdf(withIssuer as never);
     expect(result.subarray(0, 5).toString("ascii")).toBe("%PDF-");
     expect(result.length).toBeGreaterThan(100);
-  });
+  }, PDF_TEST_TIMEOUT_MS);
 });
 
 describe("getInvoicePdfFilename", () => {

--- a/apps/web/lib/self-upgrade/prepare-source-workspace.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source-workspace.integration.test.ts
@@ -12,21 +12,34 @@ import { prepareUpgradeSource, defaultGitRunner } from "./prepare-source";
 // and the upgrade must succeed anyway because the merge happens elsewhere.
 
 const GIT_AVAILABLE = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+const REAL_GIT_TEST_TIMEOUT_MS = 30_000;
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, {
     cwd,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "t",
-      GIT_AUTHOR_EMAIL: "t@t",
-      GIT_COMMITTER_NAME: "t",
-      GIT_COMMITTER_EMAIL: "t@t",
-      GIT_CONFIG_GLOBAL: "/dev/null",
-      GIT_CONFIG_SYSTEM: "/dev/null",
-    },
+    env: GIT_ENV,
   }).toString();
+}
+
+function gitExec(args: string[]): void {
+  execFileSync("git", args, { env: GIT_ENV });
+}
+
+function configureRepo(cwd: string): void {
+  git(cwd, "config", "core.autocrlf", "false");
+  git(cwd, "config", "core.eol", "lf");
+  git(cwd, "config", "commit.gpgsign", "false");
 }
 
 function commit(cwd: string, file: string, content: string, msg: string): void {
@@ -50,17 +63,17 @@ function makeWorld(): {
   const upstream = join(root, "upstream");
   const install = join(root, "install");
   const workspace = join(root, "install", ".upgrade-workspace");
-  execFileSync("git", ["init", "-b", "main", upstream]);
-  git(upstream, "config", "commit.gpgsign", "false");
+  gitExec(["init", "-b", "main", upstream]);
+  configureRepo(upstream);
   // Receive-pack would refuse to push to a checked-out main; for the test the
   // upstream is just a source we fetch FROM, not push to. Setting
   // receive.denyCurrentBranch=ignore keeps the upstream simple.
   git(upstream, "config", "receive.denyCurrentBranch", "ignore");
   commit(upstream, "base.txt", "v1\n", "base");
-  execFileSync("git", ["clone", "-q", upstream, install]);
+  gitExec(["-c", "core.autocrlf=false", "-c", "core.eol=lf", "clone", "-q", upstream, install]);
+  configureRepo(install);
   git(install, "config", "user.email", "t@t");
   git(install, "config", "user.name", "t");
-  git(install, "config", "commit.gpgsign", "false");
   // Install clones in dev typically have dpf/install checked out OR a feature
   // branch — receive-pack will refuse pushes to a checked-out branch unless
   // configured otherwise. The fix expects the workspace push to succeed when
@@ -73,7 +86,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
   const cleanup: string[] = [];
   beforeAll(() => {
     return () => cleanup.forEach((d) => rmSync(d, { recursive: true, force: true }));
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("does the upstream merge in the workspace, NOT in the install clone, even when install is dirty on a feature branch", async () => {
     const { upstream, install, workspace, root } = makeWorld();
@@ -140,7 +153,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     // block this push — dpf/install is not currently checked out.
     const installRefAfter = git(install, "rev-parse", "dpf/install").trim();
     expect(installRefAfter).toBe(wsHead);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("reuses an already-initialised workspace on subsequent runs (no second clone)", async () => {
     const { upstream, install, workspace, root } = makeWorld();
@@ -185,7 +198,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     expect(git(workspace, "rev-parse", "--git-dir").trim()).toBe(wsGitDirInodeBefore);
     expect(existsSync(join(workspace, "u1.txt"))).toBe(true);
     expect(existsSync(join(workspace, "u2.txt"))).toBe(true);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("workspace merge that conflicts aborts cleanly and surfaces conflict files (no install-clone mutation)", async () => {
     const { upstream, install, workspace, root } = makeWorld();
@@ -226,7 +239,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     // Operator's install clone is COMPLETELY untouched.
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("feat/whatever");
     expect(existsSync(join(install, "dirty.txt"))).toBe(true);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("captures stderr when merge fails with no conflict markers (e.g. unrelated histories) so failureLog is actionable", async () => {
     // Build a world where the install branch and upstream are unrelated
@@ -238,7 +251,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     // Reset the install branch to a freshly orphan-branched tree so it shares
     // NO history with upstream.
     git(install, "checkout", "--orphan", "dpf/install");
-    execFileSync("git", ["-C", install, "rm", "-rf", "--quiet", "."]);
+    git(install, "rm", "-rf", "--quiet", ".");
     commit(install, "alien.txt", "no shared history\n", "orphan install");
 
     const r = await prepareUpgradeSource(
@@ -262,7 +275,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     // is the canonical phrase on this code path.
     expect(r.message).toMatch(/no conflict markers/);
     expect(r.message.length).toBeGreaterThan("merge-conflict:".length);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("first-run with no install-branch on the install clone creates it from upstream tip", async () => {
     const { upstream, install, workspace, root } = makeWorld();
@@ -294,16 +307,16 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     // Install clone has dpf/install now (push-back created the ref).
     const installRef = git(install, "rev-parse", "dpf/install").trim();
     expect(installRef.length).toBe(40);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("refuses with a clear message when the install clone has no upstream remote", async () => {
     const root = mkdtempSync(join(tmpdir(), "dpf-upg-no-remote-"));
     cleanup.push(root);
     const install = join(root, "install");
-    execFileSync("git", ["init", "-b", "main", install]);
+    gitExec(["init", "-b", "main", install]);
+    configureRepo(install);
     git(install, "config", "user.email", "t@t");
     git(install, "config", "user.name", "t");
-    git(install, "config", "commit.gpgsign", "false");
     commit(install, "x.txt", "x\n", "x");
     const workspace = join(root, "ws");
 
@@ -322,5 +335,5 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — workspace-isolated (BI
     if (r.ok) return;
     expect(r.reason).toBe("prep-error");
     expect(r.message).toMatch(/no 'origin' remote/);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 });

--- a/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,21 +11,34 @@ import { prepareUpgradeSource, defaultGitRunner } from "./prepare-source";
 // a conflict is aborted to a clean tree rather than left mid-merge.
 
 const GIT_AVAILABLE = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+const REAL_GIT_TEST_TIMEOUT_MS = 30_000;
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, {
     cwd,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "t",
-      GIT_AUTHOR_EMAIL: "t@t",
-      GIT_COMMITTER_NAME: "t",
-      GIT_COMMITTER_EMAIL: "t@t",
-      GIT_CONFIG_GLOBAL: "/dev/null",
-      GIT_CONFIG_SYSTEM: "/dev/null",
-    },
+    env: GIT_ENV,
   }).toString();
+}
+
+function gitExec(args: string[]): void {
+  execFileSync("git", args, { env: GIT_ENV });
+}
+
+function configureRepo(cwd: string): void {
+  git(cwd, "config", "core.autocrlf", "false");
+  git(cwd, "config", "core.eol", "lf");
+  git(cwd, "config", "commit.gpgsign", "false");
 }
 
 function commit(cwd: string, file: string, content: string, msg: string): void {
@@ -39,14 +52,13 @@ function makeWorld(): { upstream: string; install: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "dpf-upg-"));
   const upstream = join(root, "upstream");
   const install = join(root, "install");
-  execFileSync("git", ["init", "-b", "main", upstream]);
-  // seed gpgsign off for the upstream too
-  git(upstream, "config", "commit.gpgsign", "false");
+  gitExec(["init", "-b", "main", upstream]);
+  configureRepo(upstream);
   commit(upstream, "base.txt", "v1\n", "base");
-  execFileSync("git", ["clone", "-q", upstream, install]);
+  gitExec(["-c", "core.autocrlf=false", "-c", "core.eol=lf", "clone", "-q", upstream, install]);
+  configureRepo(install);
   git(install, "config", "user.email", "t@t");
   git(install, "config", "user.name", "t");
-  git(install, "config", "commit.gpgsign", "false");
   return { upstream, install, root };
 }
 
@@ -54,7 +66,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
   const cleanup: string[] = [];
   beforeAll(() => {
     return () => cleanup.forEach((d) => rmSync(d, { recursive: true, force: true }));
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("merges upstream into the install branch, PRESERVING local commits", async () => {
     const { upstream, install, root } = makeWorld();
@@ -93,7 +105,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     // We are on the install branch, clean.
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
     expect(git(install, "status", "--porcelain").trim()).toBe("");
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("creates the install branch from HEAD on first run when it is absent", async () => {
     const { upstream, install, root } = makeWorld();
@@ -108,7 +120,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     expect(r.ok).toBe(true);
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
     expect(existsSync(join(install, "upstream.txt"))).toBe(true);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("ABORTS to a clean tree on a real conflict and reports the file", async () => {
     const { upstream, install, root } = makeWorld();
@@ -134,7 +146,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
     expect(git(install, "status", "--porcelain").trim()).toBe("");
     expect(git(install, "rev-parse", "HEAD").trim()).toBe(beforeHead);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("survives a hard-failing post-checkout hook (e.g. Git LFS hook with no git-lfs binary)", async () => {
     const { upstream, install, root } = makeWorld();
@@ -146,10 +158,10 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     // absent). Without hook-bypassing, `git checkout` returns non-zero and prep
     // would abort with prep-error even though the checkout itself succeeds.
     const hooksDir = join(install, ".dpf-hooks");
-    execFileSync("mkdir", ["-p", hooksDir]);
+    mkdirSync(hooksDir, { recursive: true });
     const hook = join(hooksDir, "post-checkout");
     writeFileSync(hook, "#!/bin/sh\necho 'git-lfs not found' >&2\nexit 2\n");
-    execFileSync("chmod", ["+x", hook]);
+    chmodSync(hook, 0o755);
     git(install, "config", "core.hooksPath", hooksDir);
 
     const r = await prepareUpgradeSource(
@@ -160,7 +172,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     expect(r.ok).toBe(true);
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("dpf/install");
     expect(existsSync(join(install, "upstream.txt"))).toBe(true);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("refuses up front on an uncommitted working tree (does not switch branch or merge)", async () => {
     const { upstream, install, root } = makeWorld();
@@ -187,7 +199,7 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     // the install branch, no merge in progress.
     expect(git(install, "rev-parse", "--abbrev-ref", "HEAD").trim()).toBe(startBranch);
     expect(existsSync(join(install, ".git", "MERGE_HEAD"))).toBe(false);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it("local mode stamps the working tree HEAD, with -dirty when uncommitted", async () => {
     const { install, root } = makeWorld();
@@ -207,5 +219,5 @@ describe.skipIf(!GIT_AVAILABLE)("prepareUpgradeSource — real git", () => {
     );
     expect(dirty.ok).toBe(true);
     if (dirty.ok) expect(dirty.stamp.endsWith("-dirty")).toBe(true);
-  });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
 });

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -256,6 +256,10 @@ async function initWorkspace(
   // beyond a fresh working tree). We do NOT pass --shared — that would make
   // the workspace fragile if the install clone is ever pruned mid-run.
   const clone = await run([
+    "-c",
+    "core.autocrlf=false",
+    "-c",
+    "core.eol=lf",
     "clone",
     "--no-tags",
     input.hostSourcePath,
@@ -270,6 +274,8 @@ async function initWorkspace(
   await run(["-C", input.workspacePath, "config", "user.email", "self-upgrade@dpf.local"]);
   await run(["-C", input.workspacePath, "config", "user.name", "DPF self-upgrade"]);
   await run(["-C", input.workspacePath, "config", "commit.gpgsign", "false"]);
+  await run(["-C", input.workspacePath, "config", "core.autocrlf", "false"]);
+  await run(["-C", input.workspacePath, "config", "core.eol", "lf"]);
   return { ok: true };
 }
 
@@ -457,6 +463,8 @@ async function prepareUpgradeSourceInWorkspace(
       ]);
       const conflictFiles = trim(conflicts.stdout).split("\n").map(trim).filter(Boolean);
       await run(["-C", input.workspacePath, "merge", "--abort"]);
+      await run(["-C", input.workspacePath, "reset", "--hard", "HEAD"]);
+      await run(["-C", input.workspacePath, "clean", "-fdx"]);
       // Capture stderr too so the operator-visible failureLog explains WHY
       // when conflictFiles is empty (e.g. refusing to merge unrelated
       // histories) — the legacy "merge-conflict: " trail with no files left

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -16,6 +16,7 @@ import { join, resolve } from "node:path";
 const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
 const BASH_OK = spawnSync("bash", ["--version"], { encoding: "utf8" }).status === 0;
 const GIT_OK = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+const PROMOTE_TEST_TIMEOUT_MS = 30_000;
 
 let bashDrivePrefix: string | undefined;
 
@@ -103,7 +104,7 @@ function runPromote(opts: {
       : []),
     ...(opts.dockerLog ? [`export DOCKER_LOG=${shellQuote(toBashPath(opts.dockerLog))}`] : []),
   ];
-  const r = spawnSync("bash", ["-lc", `${exports.join("\n")}\nexec ${shellQuote(toBashPath(SCRIPT))} --self-upgrade`], {
+  const r = spawnSync("bash", ["-lc", `${exports.join("\n")}\nexec bash ${shellQuote(toBashPath(SCRIPT))} --self-upgrade`], {
     encoding: "utf8",
   });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
@@ -133,7 +134,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, PROMOTE_TEST_TIMEOUT_MS);
 
   it("derives a -dirty stamp when the build source has uncommitted changes", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
@@ -145,7 +146,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, PROMOTE_TEST_TIMEOUT_MS);
 
   it("warns (does not silently mislabel) when the tree identity differs from the expected stamp", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
@@ -159,7 +160,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, PROMOTE_TEST_TIMEOUT_MS);
 
   it("passes the canonical install env file to docker compose when configured", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
@@ -181,5 +182,5 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, PROMOTE_TEST_TIMEOUT_MS);
 });

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -17,6 +17,28 @@ const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
 const BASH_OK = spawnSync("bash", ["--version"], { encoding: "utf8" }).status === 0;
 const GIT_OK = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
 
+let bashDrivePrefix: string | undefined;
+
+function toBashPath(value: string): string {
+  if (process.platform !== "win32") return value;
+  const normalized = value.replace(/\\/g, "/");
+  const drivePath = /^([A-Za-z]):\/(.*)$/.exec(normalized);
+  if (!drivePath) return normalized;
+
+  const drive = drivePath[1].toLowerCase();
+  const rest = drivePath[2];
+  if (bashDrivePrefix === undefined) {
+    const cwdDrive = /^([A-Za-z]):/.exec(process.cwd())?.[1]?.toLowerCase();
+    const pwd = spawnSync("bash", ["-lc", "pwd"], { encoding: "utf8" }).stdout.trim();
+    bashDrivePrefix = cwdDrive && pwd.startsWith(`/mnt/${cwdDrive}/`) ? "/mnt" : "";
+  }
+  return `${bashDrivePrefix}/${drive}/${rest}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function gitInit(dir: string): string {
   const env = {
     ...process.env,
@@ -28,6 +50,8 @@ function gitInit(dir: string): string {
     GIT_CONFIG_SYSTEM: "/dev/null",
   };
   execFileSync("git", ["init", "-b", "main", dir], { env });
+  execFileSync("git", ["-C", dir, "config", "core.autocrlf", "false"], { env });
+  execFileSync("git", ["-C", dir, "config", "core.eol", "lf"], { env });
   writeFileSync(join(dir, "Dockerfile"), "FROM scratch\n");
   writeFileSync(join(dir, "docker-compose.yml"), "services: {}\n");
   writeFileSync(join(dir, "docker-compose.macos.yml"), "services: {}\n");
@@ -39,7 +63,7 @@ function gitInit(dir: string): string {
 /** Fake `docker` and `curl` on PATH. */
 function makeFakeBin(root: string): string {
   const bin = join(root, "bin");
-  execFileSync("mkdir", ["-p", bin]);
+  mkdirSync(bin, { recursive: true });
   // docker: `build`/`up` are no-ops; any `cat /app/.dpf-source-content-hash`
   // (the content-verify guard — step 3 `docker run` and step 7
   // `docker compose exec`) returns a single stable hash so built==running.
@@ -67,21 +91,20 @@ function runPromote(opts: {
   composeEnvFile?: string;
   dockerLog?: string;
 }): { status: number | null; stdout: string; stderr: string } {
-  const r = spawnSync("bash", [SCRIPT, "--self-upgrade"], {
+  const exports = [
+    `export PATH=${shellQuote(toBashPath(opts.fakeBin))}:"$PATH"`,
+    `export PROMOTE_SOURCE=${shellQuote(toBashPath(opts.source))}`,
+    `export PROMOTE_TARGET_SHA=${shellQuote(opts.targetSha)}`,
+    `export PROMOTE_BACKUP_PATH=${shellQuote(toBashPath(opts.backup))}`,
+    "export PROMOTE_HEALTH_URL='http://127.0.0.1:9/api/health'",
+    "export PROMOTE_COMPOSE_PROJECT='dpf-functest'",
+    ...(opts.composeEnvFile
+      ? [`export PROMOTE_COMPOSE_ENV_FILE=${shellQuote(toBashPath(opts.composeEnvFile))}`]
+      : []),
+    ...(opts.dockerLog ? [`export DOCKER_LOG=${shellQuote(toBashPath(opts.dockerLog))}`] : []),
+  ];
+  const r = spawnSync("bash", ["-lc", `${exports.join("\n")}\nexec ${shellQuote(toBashPath(SCRIPT))} --self-upgrade`], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      PATH: `${opts.fakeBin}:${process.env.PATH}`,
-      PROMOTE_SOURCE: opts.source,
-      PROMOTE_TARGET_SHA: opts.targetSha,
-      // Backup path is OUTSIDE the source tree (as in production: /backups/...),
-      // so it never dirties the build source.
-      PROMOTE_BACKUP_PATH: opts.backup,
-      PROMOTE_HEALTH_URL: "http://127.0.0.1:9/api/health",
-      PROMOTE_COMPOSE_PROJECT: "dpf-functest",
-      ...(opts.composeEnvFile ? { PROMOTE_COMPOSE_ENV_FILE: opts.composeEnvFile } : {}),
-      ...(opts.dockerLog ? { DOCKER_LOG: opts.dockerLog } : {}),
-    },
   });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
@@ -90,7 +113,7 @@ function runPromote(opts: {
 function makeScratch(): { root: string; source: string; backup: string; fakeBin: string; head: string } {
   const root = mkdtempSync(join(tmpdir(), "dpf-promote-"));
   const source = join(root, "src");
-  execFileSync("mkdir", ["-p", source]);
+  mkdirSync(source, { recursive: true });
   const head = gitInit(source);
   const fakeBin = makeFakeBin(root);
   return { root, source, backup: join(root, "backup"), fakeBin, head };
@@ -149,7 +172,9 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
 
       expect(r.status).toBe(0);
       const log = readFileSync(dockerLog, "utf8");
-      expect(log).toContain(`compose --env-file ${envFile} --project-directory ${source}`);
+      expect(log).toContain(
+        `compose --env-file ${toBashPath(envFile)} --project-directory ${toBashPath(source)}`,
+      );
       expect(log).toContain("build portal");
       expect(log).toContain("up -d --no-deps --force-recreate portal");
       expect(log).toContain("exec -T portal cat /app/.dpf-source-content-hash");

--- a/apps/web/lib/voice-synthesis/adapters/mlx.ts
+++ b/apps/web/lib/voice-synthesis/adapters/mlx.ts
@@ -20,7 +20,7 @@
 //
 // Spec: docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md
 
-import path from "node:path"
+import { posix as posixPath } from "node:path"
 import type { VoiceSynthesisConfig } from "../types"
 import { VoiceSynthesisError, type RawSynthesisResult } from "./cartesia"
 
@@ -66,7 +66,9 @@ export interface MlxSynthesisConfig extends VoiceSynthesisConfig {
 export function resolveReferenceHostPath(providerVoiceId: string | undefined | null): string | null {
   const root = process.env.DPF_TTS_REFERENCE_HOST_ROOT
   if (!root || !providerVoiceId) return null
-  return path.join(root, providerVoiceId)
+  const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+$/, "") || "/"
+  const normalizedVoiceId = providerVoiceId.replace(/\\/g, "/").replace(/^\/+/, "")
+  return posixPath.join(normalizedRoot, normalizedVoiceId)
 }
 
 // CSM generation is stochastic: identical requests intermittently return empty


### PR DESCRIPTION
## Summary
- Stabilizes the Windows local-integration Vitest gate that blocked the portal navigation inventory PR.
- Makes real-Git upgrade tests hermetic against global `core.autocrlf=true` and replaces POSIX-only test shell calls with Node filesystem APIs.
- Hardens isolated self-upgrade workspace initialization/abort cleanup and normalizes MLX reference host paths to the POSIX sidecar contract.
- Refactors the invoice PDF test to render the standard PDF once and declares realistic timeouts for filesystem/PDF/real-script integration tests under full-suite contention.
- Runs `scripts/promote.sh` through Bash in the functional harness so Linux CI does not depend on the script file being executable in Git.

## Verification
- `pnpm --filter web exec vitest run` — passed in `D:\DPF-windows-local-integration-vitest` worktree after commit `0a1495e1`: 1124 test files passed, 9504 tests passed.
- `pnpm --filter web typecheck` — passed in `D:\DPF-windows-local-integration-vitest` worktree after commit `0a1495e1`.
- `pnpm --filter web build` — passed in `D:\DPF-windows-local-integration-vitest` worktree with existing Turbopack warnings.
- `node scripts/local-integration-ci.mjs --candidate fix/windows-local-integration-vitest --mode single-branch` — passed under local-integration-ci lease `NPEL-4B27EC20F0`; recorded evidence `cmq0bav8d05vd01qptu2kp1tz`.
- GitHub Actions for PR #1463 — passed after commit `0a1495e1`, including Unit Tests, Typecheck, Production Build, CodeQL, DCO, gitleaks, routing audits, and ADP Integration Tests.

Backlog: BI-15D84C42