### PR TITLE
feat(ai-ops-map): coworker-to-coworker (A2A) interaction visibility (BI-65B0D697)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -17,6 +17,8 @@ vi.mock("@dpf/db", () => ({
     tokenUsage: { findMany: vi.fn() },
     scheduledAgentTask: { findMany: vi.fn() },
     scheduledJob: { findMany: vi.fn() },
+    delegationChain: { findMany: vi.fn() },
+    phaseHandoff: { findMany: vi.fn() },
   },
 }));
 
@@ -118,6 +120,8 @@ describe("AI operations map page", () => {
     vi.mocked(prisma.tokenUsage.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.scheduledAgentTask.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.scheduledJob.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.delegationChain.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([] as never);
 
     const { default: OperationsMapPage } = await import("./page");
     const element = await OperationsMapPage();

--- a/apps/web/components/platform/A2aInteractionsPanel.test.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { A2aInteractionsPanel } from "./A2aInteractionsPanel";
+import type {
+  OperationsMapA2aEdge,
+  OperationsMapA2aLegendItem,
+  OperationsMapRoutingCoworker,
+} from "@/lib/ai-operations-map/types";
+
+const COWORKERS: OperationsMapRoutingCoworker[] = [
+  { agentId: "ceo-coworker", label: "CEO Coworker", stationLabel: "Direct" },
+  { agentId: "brand-analyst", label: "Brand Analyst", stationLabel: "Brand" },
+  { agentId: "reviewer", label: "Reviewer", stationLabel: "Review" },
+];
+
+const LEGEND: OperationsMapA2aLegendItem[] = [
+  { edgeKind: "a2a-delegation", label: "Delegation", description: "Authority-bearing delegation." },
+  { edgeKind: "a2a-handoff", label: "Phase handoff", description: "Build phase handoff." },
+  { edgeKind: "a2a-task-lineage", label: "Task lineage", description: "Task lineage." },
+  { edgeKind: "a2a-deliberation", label: "Deliberation", description: "Peer review fan-out." },
+];
+
+function edge(overrides: Partial<OperationsMapA2aEdge> = {}): OperationsMapA2aEdge {
+  return {
+    id: "edge-1",
+    edgeKind: "a2a-delegation",
+    fromCoworkerId: "ceo-coworker",
+    toCoworkerId: "brand-analyst",
+    state: "active",
+    label: "Delegated brand-extract",
+    summary: "Delegated brand extraction work.",
+    occurredAt: "2026-06-04T10:00:00.000Z",
+    authorityScope: ["brand:read"],
+    skillId: "brand-extract",
+    refs: { delegationChainId: "del-1" },
+    weight: 2,
+    ...overrides,
+  };
+}
+
+function findButton(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === name,
+  );
+  if (!button) throw new Error(`button "${name}" not found`);
+  return button as HTMLButtonElement;
+}
+
+afterEach(() => {
+  cleanup();
+  // The panel now persists filter state; isolate localStorage between tests.
+  try {
+    localStorage.clear();
+  } catch {
+    // jsdom always provides localStorage; ignore if unavailable.
+  }
+});
+
+describe("A2aInteractionsPanel", () => {
+  it("renders an empty state when there are no A2A interactions", () => {
+    const { container } = render(
+      <A2aInteractionsPanel coworkers={COWORKERS} a2aEdges={[]} a2aLegend={LEGEND} />,
+    );
+    expect(container.textContent).toContain("No coworker-to-coworker interactions recorded");
+    expect(container.querySelectorAll("[data-a2a-edge]").length).toBe(0);
+  });
+
+  it("renders one edge per A2A interaction with its kind and state", () => {
+    const { container } = render(
+      <A2aInteractionsPanel
+        coworkers={COWORKERS}
+        a2aEdges={[
+          edge(),
+          edge({ id: "edge-2", edgeKind: "a2a-handoff", state: "completed", toCoworkerId: "reviewer" }),
+          edge({ id: "edge-3", edgeKind: "a2a-task-lineage", state: "failed", fromCoworkerId: "brand-analyst", toCoworkerId: "reviewer" }),
+        ]}
+        a2aLegend={LEGEND}
+      />,
+    );
+    const edges = container.querySelectorAll("[data-a2a-edge]");
+    expect(edges.length).toBe(3);
+    expect([...edges].map((el) => el.getAttribute("data-a2a-state")).sort()).toEqual([
+      "active",
+      "completed",
+      "failed",
+    ]);
+  });
+
+  it("narrows edges when a state filter is toggled off (troubleshooting view)", () => {
+    const { container } = render(
+      <A2aInteractionsPanel
+        coworkers={COWORKERS}
+        a2aEdges={[
+          edge({ id: "a", state: "active" }),
+          edge({ id: "b", state: "completed", toCoworkerId: "reviewer" }),
+        ]}
+        a2aLegend={LEGEND}
+      />,
+    );
+    expect(container.querySelectorAll("[data-a2a-edge]").length).toBe(2);
+    fireEvent.click(findButton(container, "Completed"));
+    const remaining = container.querySelectorAll("[data-a2a-edge]");
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.getAttribute("data-a2a-state")).toBe("active");
+  });
+
+  it("narrows edges by interaction type", () => {
+    const { container } = render(
+      <A2aInteractionsPanel
+        coworkers={COWORKERS}
+        a2aEdges={[
+          edge({ id: "a", edgeKind: "a2a-delegation" }),
+          edge({ id: "b", edgeKind: "a2a-handoff", toCoworkerId: "reviewer" }),
+        ]}
+        a2aLegend={LEGEND}
+      />,
+    );
+    fireEvent.click(findButton(container, "Phase handoff"));
+    const remaining = container.querySelectorAll("[data-a2a-edge]");
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.getAttribute("data-a2a-edge")).toBe("a2a-delegation");
+  });
+
+  it("shows the from→to coworkers and authority in the inspector when an edge is selected", () => {
+    const { container } = render(
+      <A2aInteractionsPanel coworkers={COWORKERS} a2aEdges={[edge()]} a2aLegend={LEGEND} />,
+    );
+    const inspector = container.querySelector('[aria-label="Interaction inspector"]') as HTMLElement;
+    expect(inspector.textContent).toContain("Select an interaction edge");
+
+    fireEvent.click(container.querySelector("[data-a2a-edge]") as Element);
+
+    expect(inspector.textContent).toContain("CEO Coworker");
+    expect(inspector.textContent).toContain("Brand Analyst");
+    expect(inspector.textContent).toContain("brand:read");
+    expect(inspector.textContent).toContain("brand-extract");
+  });
+});

--- a/apps/web/components/platform/A2aInteractionsPanel.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { StatCard, StatusBadge, intentStyle } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import type {
+  OperationsMapA2aEdge,
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
+  OperationsMapA2aLegendItem,
+  OperationsMapRoutingCoworker,
+} from "@/lib/ai-operations-map/types";
+import {
+  A2A_EDGE_KINDS,
+  A2A_GRAPH_LAYOUT,
+  A2A_STATES,
+  a2aEdgeSourceRecords,
+  a2aStateIntent,
+  columnPositions,
+  coworkerHref,
+  EDGE_KIND_LABEL,
+  edgeKindDash,
+  edgePath,
+  edgeStrokeWidth,
+  graphHeight,
+  orderedUnique,
+  STATE_LABEL,
+  svgClip,
+  titleize,
+} from "./a2a-interaction-graph";
+import {
+  clearA2aFilterPreference,
+  getDefaultA2aFilterPreference,
+  loadA2aFilterPreference,
+  saveA2aFilterPreference,
+  type A2aActorRole,
+} from "./ai-operations-map-prefs";
+
+type Props = {
+  coworkers: OperationsMapRoutingCoworker[];
+  a2aEdges: OperationsMapA2aEdge[];
+  a2aLegend: OperationsMapA2aLegendItem[];
+};
+
+export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend }: Props) {
+  const defaults = getDefaultA2aFilterPreference();
+  const [typeFilters, setTypeFilters] = useState<OperationsMapA2aEdgeKind[]>(defaults.types);
+  const [stateFilters, setStateFilters] = useState<OperationsMapA2aInteractionState[]>(defaults.states);
+  const [actorId, setActorId] = useState<string>(defaults.actorId);
+  const [actorRole, setActorRole] = useState<A2aActorRole>(defaults.actorRole);
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  const hydrated = useRef(false);
+
+  // Hydrate persisted filter state once on mount, then persist on change —
+  // mirrors the Operations Map view-preference pattern in AiOperationsMap.
+  useEffect(() => {
+    const pref = loadA2aFilterPreference();
+    setTypeFilters(pref.types);
+    setStateFilters(pref.states);
+    setActorId(pref.actorId);
+    setActorRole(pref.actorRole);
+    hydrated.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated.current) return;
+    saveA2aFilterPreference({ types: typeFilters, states: stateFilters, actorId, actorRole });
+  }, [typeFilters, stateFilters, actorId, actorRole]);
+
+  const labelByAgentId = useMemo(
+    () => new Map(coworkers.map((coworker) => [coworker.agentId, coworker.label])),
+    [coworkers],
+  );
+  const labelFor = useMemo(
+    () => (agentId: string) => labelByAgentId.get(agentId) ?? titleize(agentId),
+    [labelByAgentId],
+  );
+
+  const participantIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const edge of a2aEdges) {
+      ids.add(edge.fromCoworkerId);
+      ids.add(edge.toCoworkerId);
+    }
+    return orderedUnique([...ids], labelFor);
+  }, [a2aEdges, labelFor]);
+
+  const filteredEdges = useMemo(
+    () =>
+      a2aEdges.filter((edge) => {
+        if (!typeFilters.includes(edge.edgeKind)) return false;
+        if (!stateFilters.includes(edge.state)) return false;
+        if (actorId !== "all") {
+          const matchesFrom = edge.fromCoworkerId === actorId;
+          const matchesTo = edge.toCoworkerId === actorId;
+          if (actorRole === "from" && !matchesFrom) return false;
+          if (actorRole === "to" && !matchesTo) return false;
+          if (actorRole === "either" && !matchesFrom && !matchesTo) return false;
+        }
+        return true;
+      }),
+    [a2aEdges, typeFilters, stateFilters, actorId, actorRole],
+  );
+
+  const selectedEdge = filteredEdges.find((edge) => edge.id === selectedEdgeId) ?? null;
+
+  const stateCounts = useMemo(() => {
+    const counts: Record<OperationsMapA2aInteractionState, number> = { active: 0, completed: 0, failed: 0, blocked: 0 };
+    for (const edge of filteredEdges) counts[edge.state] += 1;
+    return counts;
+  }, [filteredEdges]);
+
+  const toggleType = (kind: OperationsMapA2aEdgeKind) =>
+    setTypeFilters((current) => toggleOption(current, kind, A2A_EDGE_KINDS));
+  const toggleState = (state: OperationsMapA2aInteractionState) =>
+    setStateFilters((current) => toggleOption(current, state, A2A_STATES));
+  const resetFilters = () => {
+    const reset = getDefaultA2aFilterPreference();
+    setTypeFilters(reset.types);
+    setStateFilters(reset.states);
+    setActorId(reset.actorId);
+    setActorRole(reset.actorRole);
+    setSelectedEdgeId(null);
+    clearA2aFilterPreference();
+  };
+
+  return (
+    <section
+      aria-label="Coworker interaction map"
+      className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <header className="space-y-3">
+        <div className="max-w-2xl">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Coworker-to-coworker interactions</h2>
+          <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+            After-the-fact A2A visibility: which coworker delegated, handed off, or spawned work to which other
+            coworker, under what authority, and how it resolved. Filter by interaction type, state, and coworker for
+            audit and troubleshooting.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <StatCard label="Interactions" value={filteredEdges.length} intent="accent" />
+          <StatCard label="Active" value={stateCounts.active} intent="accent" />
+          <StatCard label="Failed" value={stateCounts.failed} intent="danger" />
+          <StatCard label="Blocked" value={stateCounts.blocked} intent="warning" />
+        </div>
+      </header>
+
+      {a2aEdges.length === 0 ? (
+        <div className="rounded-md border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+          No coworker-to-coworker interactions recorded in the current window. Delegation, build phase-handoff, and
+          task-lineage interactions appear here as coworkers collaborate.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 lg:flex-row lg:flex-wrap lg:items-end lg:justify-between">
+            <ChipGroup label="Interaction type">
+              {A2A_EDGE_KINDS.map((kind) => (
+                <Chip key={kind} active={typeFilters.includes(kind)} label={EDGE_KIND_LABEL[kind]} onClick={() => toggleType(kind)} />
+              ))}
+            </ChipGroup>
+            <ChipGroup label="State">
+              {A2A_STATES.map((state) => (
+                <Chip key={state} active={stateFilters.includes(state)} label={STATE_LABEL[state]} onClick={() => toggleState(state)} />
+              ))}
+            </ChipGroup>
+            <div>
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Coworker</p>
+              <div className="flex flex-wrap items-center gap-2">
+                <label>
+                  <span className="sr-only">Filter by coworker</span>
+                  <select
+                    value={actorId}
+                    onChange={(event) => setActorId(event.target.value)}
+                    className="min-h-8 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1 text-xs text-[var(--dpf-text)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                  >
+                    <option value="all">All coworkers</option>
+                    {participantIds.map((id) => (
+                      <option key={id} value={id}>
+                        {labelFor(id)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className={actorId === "all" ? "opacity-50" : undefined}>
+                  <span className="sr-only">Coworker role</span>
+                  <select
+                    value={actorRole}
+                    disabled={actorId === "all"}
+                    onChange={(event) => setActorRole(event.target.value as A2aActorRole)}
+                    className="min-h-8 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1 text-xs text-[var(--dpf-text)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                  >
+                    <option value="either">as either</option>
+                    <option value="from">as source</option>
+                    <option value="to">as target</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={resetFilters}
+                  className="text-xs font-medium text-[var(--dpf-accent)] hover:underline focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <InteractionBand edges={filteredEdges} labelFor={labelFor} selectedEdgeId={selectedEdge?.id ?? null} onSelect={setSelectedEdgeId} />
+            <A2aEdgeInspector edge={selectedEdge} labelFor={labelFor} />
+          </div>
+
+          <A2aLegendRail legend={a2aLegend} />
+        </>
+      )}
+    </section>
+  );
+}
+
+function InteractionBand({
+  edges,
+  labelFor,
+  selectedEdgeId,
+  onSelect,
+}: {
+  edges: OperationsMapA2aEdge[];
+  labelFor: (agentId: string) => string;
+  selectedEdgeId: string | null;
+  onSelect: (edgeId: string) => void;
+}) {
+  const fromIds = useMemo(() => orderedUnique(edges.map((edge) => edge.fromCoworkerId), labelFor), [edges, labelFor]);
+  const toIds = useMemo(() => orderedUnique(edges.map((edge) => edge.toCoworkerId), labelFor), [edges, labelFor]);
+  const height = graphHeight(Math.max(fromIds.length, toIds.length, 1));
+  const fromY = columnPositions(fromIds, height);
+  const toY = columnPositions(toIds, height);
+
+  if (edges.length === 0) {
+    return (
+      <div className="flex min-h-44 items-center justify-center rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-6 text-sm text-[var(--dpf-muted)]">
+        No interactions match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]">
+      <svg
+        viewBox={`0 0 ${A2A_GRAPH_LAYOUT.width} ${height}`}
+        role="img"
+        aria-label="Coworker-to-coworker interaction edges"
+        className="h-full w-full"
+        style={{ minHeight: 220 }}
+      >
+        <defs>
+          {A2A_STATES.map((state) => (
+            <marker
+              key={state}
+              id={`a2a-arrow-${state}`}
+              viewBox="0 0 10 10"
+              refX="8"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill={intentStyle(a2aStateIntent(state)).fg} />
+            </marker>
+          ))}
+        </defs>
+
+        <text x={A2A_GRAPH_LAYOUT.fromX} y="22" textAnchor="middle" className="fill-[var(--dpf-muted)] text-[10px] uppercase tracking-[0.16em]">
+          From coworker
+        </text>
+        <text x={A2A_GRAPH_LAYOUT.toX} y="22" textAnchor="middle" className="fill-[var(--dpf-muted)] text-[10px] uppercase tracking-[0.16em]">
+          To coworker
+        </text>
+
+        {edges.map((edge, index) => {
+          const start = { x: A2A_GRAPH_LAYOUT.fromX, y: fromY.get(edge.fromCoworkerId) ?? height / 2 };
+          const end = { x: A2A_GRAPH_LAYOUT.toX, y: toY.get(edge.toCoworkerId) ?? height / 2 };
+          const isSelected = edge.id === selectedEdgeId;
+          const stroke = intentStyle(a2aStateIntent(edge.state)).fg;
+          return (
+            <path
+              key={edge.id}
+              data-a2a-edge={edge.edgeKind}
+              data-a2a-state={edge.state}
+              role="button"
+              tabIndex={0}
+              aria-label={`${labelFor(edge.fromCoworkerId)} → ${labelFor(edge.toCoworkerId)}: ${EDGE_KIND_LABEL[edge.edgeKind]} (${STATE_LABEL[edge.state]})`}
+              d={edgePath(start, end, index)}
+              fill="none"
+              stroke={stroke}
+              strokeWidth={edgeStrokeWidth(edge.weight, isSelected)}
+              strokeDasharray={edgeKindDash(edge.edgeKind)}
+              strokeOpacity={isSelected ? 1 : 0.85}
+              strokeLinecap="round"
+              markerEnd={`url(#a2a-arrow-${edge.state})`}
+              className="cursor-pointer focus:outline-none"
+              onClick={() => onSelect(edge.id)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(edge.id);
+                }
+              }}
+            >
+              <title>{`${labelFor(edge.fromCoworkerId)} → ${labelFor(edge.toCoworkerId)}: ${edge.label}`}</title>
+            </path>
+          );
+        })}
+
+        {fromIds.map((id) => (
+          <CoworkerNode key={`from-${id}`} x={A2A_GRAPH_LAYOUT.fromX} y={fromY.get(id) ?? height / 2} label={labelFor(id)} side="from" />
+        ))}
+        {toIds.map((id) => (
+          <CoworkerNode key={`to-${id}`} x={A2A_GRAPH_LAYOUT.toX} y={toY.get(id) ?? height / 2} label={labelFor(id)} side="to" />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function CoworkerNode({ x, y, label, side }: { x: number; y: number; label: string; side: "from" | "to" }) {
+  const textX = side === "from" ? x - A2A_GRAPH_LAYOUT.nodeRadius - 8 : x + A2A_GRAPH_LAYOUT.nodeRadius + 8;
+  const anchor = side === "from" ? "end" : "start";
+  return (
+    <g>
+      <circle cx={x} cy={y} r={A2A_GRAPH_LAYOUT.nodeRadius} fill="var(--dpf-surface-1)" stroke="var(--dpf-accent)" strokeWidth="2.2" />
+      <circle cx={x} cy={y} r="2.4" fill="var(--dpf-accent)" />
+      <text x={textX} y={y + 3.5} textAnchor={anchor} className="fill-[var(--dpf-text)] text-[10px] font-semibold">
+        {svgClip(label, 22)}
+      </text>
+    </g>
+  );
+}
+
+function A2aEdgeInspector({
+  edge,
+  labelFor,
+}: {
+  edge: OperationsMapA2aEdge | null;
+  labelFor: (agentId: string) => string;
+}) {
+  const sourceRecords = edge ? a2aEdgeSourceRecords(edge) : [];
+  return (
+    <aside aria-label="Interaction inspector" className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+      <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Inspector</h3>
+      {!edge ? (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          Select an interaction edge to inspect the coworkers, authority, and result behind it.
+        </p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          <div>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{EDGE_KIND_LABEL[edge.edgeKind]}</p>
+              <StatusBadge domain="a2aInteraction" status={edge.state} label={STATE_LABEL[edge.state]} variant="soft" />
+            </div>
+            <p className="mt-1 text-sm font-semibold text-[var(--dpf-text)]">
+              {labelFor(edge.fromCoworkerId)} → {labelFor(edge.toCoworkerId)}
+            </p>
+            <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{edge.summary}</p>
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[11px]">
+            <dt className="font-semibold text-[var(--dpf-muted)]">When</dt>
+            <dd className="min-w-0 break-words text-[var(--dpf-text)]">
+              <LocalTime value={edge.occurredAt} fallback="Unknown time" />
+            </dd>
+            {edge.skillId ? <Fact label="Skill" value={edge.skillId} /> : null}
+            {edge.gateResult ? <Fact label="Gate / consensus" value={edge.gateResult} /> : null}
+            {edge.authorityScope && edge.authorityScope.length > 0 ? (
+              <Fact label="Authority" value={edge.authorityScope.join(", ")} />
+            ) : null}
+            {edge.sensitivity ? <Fact label="Sensitivity" value={edge.sensitivity} /> : null}
+          </dl>
+          <div className="flex flex-wrap gap-2">
+            <Link href={coworkerHref(edge.fromCoworkerId)} className="text-xs text-[var(--dpf-accent)] hover:underline">
+              Open source coworker
+            </Link>
+            <Link href={coworkerHref(edge.toCoworkerId)} className="text-xs text-[var(--dpf-accent)] hover:underline">
+              Open target coworker
+            </Link>
+          </div>
+          <div>
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Source records</p>
+            {sourceRecords.length === 0 ? (
+              <p className="text-[11px] text-[var(--dpf-muted)]">No source record reference on this interaction.</p>
+            ) : (
+              <ul className="space-y-1">
+                {sourceRecords.map((record) => (
+                  <li key={`${record.label}:${record.value}`} className="flex flex-wrap items-center gap-1.5 text-[11px]">
+                    <span className="font-semibold text-[var(--dpf-muted)]">{record.label}:</span>
+                    {record.href ? (
+                      <Link href={record.href} className="break-all text-[var(--dpf-accent)] hover:underline">
+                        {record.value}
+                      </Link>
+                    ) : (
+                      <span className="break-all text-[var(--dpf-text)]" title="No detail page for this record type yet">
+                        {record.value}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function A2aLegendRail({ legend }: { legend: OperationsMapA2aLegendItem[] }) {
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 lg:flex-row lg:flex-wrap lg:items-center lg:justify-between">
+      <div aria-label="Interaction type key" className="flex flex-wrap items-center gap-3">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Types</span>
+        {legend.map((item) => (
+          <span key={item.edgeKind} title={item.description} className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[var(--dpf-text)]">
+            <svg width="34" height="8" aria-hidden="true">
+              <line x1="1" y1="4" x2="33" y2="4" stroke="var(--dpf-accent)" strokeWidth="2.2" strokeDasharray={edgeKindDash(item.edgeKind)} strokeLinecap="round" />
+            </svg>
+            {item.label}
+          </span>
+        ))}
+      </div>
+      <div aria-label="State key" className="flex flex-wrap items-center gap-3">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">States</span>
+        {A2A_STATES.map((state) => (
+          <span key={state} className="inline-flex items-center gap-1.5 text-[11px] font-medium text-[var(--dpf-text)]">
+            <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: intentStyle(a2aStateIntent(state)).fg }} />
+            {STATE_LABEL[state]}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Small presentational helpers ─────────────────────────────────────
+
+function ChipGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{label}</p>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={[
+        "min-h-7 rounded-full px-2.5 py-1 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]",
+        active
+          ? "bg-[var(--dpf-accent-soft)] text-[var(--dpf-text)]"
+          : "text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-1)] hover:text-[var(--dpf-text)]",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="font-semibold text-[var(--dpf-muted)]">{label}</dt>
+      <dd className="min-w-0 break-words text-[var(--dpf-text)]">{value}</dd>
+    </>
+  );
+}
+
+function toggleOption<T extends string>(current: T[], option: T, all: T[]): T[] {
+  if (current.includes(option)) {
+    const next = current.filter((candidate) => candidate !== option);
+    return next.length === 0 ? all : next;
+  }
+  return all.filter((candidate) => candidate === option || current.includes(candidate));
+}

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -32,6 +32,7 @@ import {
   type OperationsMapStoredQuickViewId,
 } from "./ai-operations-map-prefs";
 import { StalledTaskRecoveryActions } from "./StalledTaskRecoveryActions";
+import { A2aInteractionsPanel } from "./A2aInteractionsPanel";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -273,6 +274,12 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
         </header>
 
         <RoutingTopologyPanel routingTopology={routingTopology} />
+
+        <A2aInteractionsPanel
+          coworkers={routingTopology.coworkers}
+          a2aEdges={routingTopology.a2aEdges}
+          a2aLegend={routingTopology.a2aLegend}
+        />
       </section>
 
       <details

--- a/apps/web/components/platform/a2a-interaction-graph.test.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  A2A_GRAPH_LAYOUT,
+  a2aEdgeSourceRecords,
+  a2aStateIntent,
+  columnPositions,
+  coworkerHref,
+  edgeKindDash,
+  edgePath,
+  edgeStrokeWidth,
+  graphHeight,
+  orderedUnique,
+  svgClip,
+  titleize,
+} from "./a2a-interaction-graph";
+import type { OperationsMapA2aEdge } from "@/lib/ai-operations-map/types";
+
+function edge(overrides: Partial<OperationsMapA2aEdge> = {}): OperationsMapA2aEdge {
+  return {
+    id: "e1",
+    edgeKind: "a2a-delegation",
+    fromCoworkerId: "a",
+    toCoworkerId: "b",
+    state: "active",
+    label: "Delegated",
+    summary: "Summary",
+    occurredAt: "2026-06-04T10:00:00.000Z",
+    refs: {},
+    weight: 2,
+    ...overrides,
+  };
+}
+
+describe("a2a-interaction-graph helpers", () => {
+  it("maps interaction state to the shared report-kit intent", () => {
+    expect(a2aStateIntent("active")).toBe("accent");
+    expect(a2aStateIntent("completed")).toBe("success");
+    expect(a2aStateIntent("failed")).toBe("danger");
+    expect(a2aStateIntent("blocked")).toBe("warning");
+  });
+
+  it("gives each edge kind a distinct dash (non-colour channel)", () => {
+    const dashes = new Set([
+      String(edgeKindDash("a2a-delegation")),
+      edgeKindDash("a2a-handoff"),
+      edgeKindDash("a2a-task-lineage"),
+      edgeKindDash("a2a-deliberation"),
+    ]);
+    expect(dashes.size).toBe(4);
+    expect(edgeKindDash("a2a-delegation")).toBeUndefined();
+  });
+
+  it("scales stroke width with weight and thickens the selected edge", () => {
+    expect(edgeStrokeWidth(1, false)).toBeCloseTo(1.6);
+    expect(edgeStrokeWidth(100, false)).toBe(4); // clamped
+    expect(edgeStrokeWidth(2, true)).toBe(3.2);
+  });
+
+  it("orders unique ids by their resolved label", () => {
+    const labels: Record<string, string> = { a: "Zeta", b: "Alpha", c: "Mid" };
+    expect(orderedUnique(["a", "b", "c", "a"], (id) => labels[id] ?? id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("distributes column positions within the graph height", () => {
+    const height = graphHeight(3);
+    const positions = columnPositions(["x", "y", "z"], height);
+    const ys = [positions.get("x")!, positions.get("y")!, positions.get("z")!];
+    expect(ys[0]).toBeLessThan(ys[1]!);
+    expect(ys[1]).toBeLessThan(ys[2]!);
+    // Single-node column is centred within the usable band (between the top
+    // and bottom padding), not the raw SVG mid-height.
+    const solo = columnPositions(["only"], height);
+    const bandCentre = (A2A_GRAPH_LAYOUT.topPad + (height - A2A_GRAPH_LAYOUT.bottomPad)) / 2;
+    expect(solo.get("only")).toBeCloseTo(bandCentre, 0);
+  });
+
+  it("builds a cubic-bezier path between from and to nodes", () => {
+    const d = edgePath({ x: 150, y: 100 }, { x: 610, y: 200 }, 0);
+    expect(d.startsWith("M ")).toBe(true);
+    expect(d).toContain("C ");
+  });
+
+  it("builds an existing build deep-link and surfaces routeless records as plain text", () => {
+    const records = a2aEdgeSourceRecords(
+      edge({
+        buildId: "FB-9",
+        refs: { delegationChainId: "del-1", taskRunId: "TR-1", deliberationRunId: "delib-1" },
+      }),
+    );
+    const build = records.find((r) => r.label === "Build");
+    expect(build?.href).toBe("/build?buildId=FB-9");
+
+    // No fabricated routes for records without a page surface.
+    expect(records.find((r) => r.label === "Delegation chain")?.href).toBeUndefined();
+    expect(records.find((r) => r.label === "Task run")?.href).toBeUndefined();
+    expect(records.find((r) => r.label === "Deliberation run")?.href).toBeUndefined();
+    expect(records.find((r) => r.label === "Delegation chain")?.value).toBe("del-1");
+  });
+
+  it("returns no source records when an edge carries no refs or build", () => {
+    expect(a2aEdgeSourceRecords(edge())).toEqual([]);
+  });
+
+  it("builds coworker detail hrefs", () => {
+    expect(coworkerHref("brand-analyst")).toBe("/platform/ai/agent/brand-analyst");
+    expect(coworkerHref("a/b")).toBe("/platform/ai/agent/a%2Fb");
+  });
+
+  it("clips long labels and titleizes ids", () => {
+    expect(svgClip("short", 22)).toBe("short");
+    expect(svgClip("a-really-long-coworker-label", 10)).toHaveLength(10);
+    expect(titleize("brand-analyst")).toBe("Brand Analyst");
+  });
+});

--- a/apps/web/components/platform/a2a-interaction-graph.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.ts
@@ -1,0 +1,171 @@
+// Pure helpers for the AI Operations Map coworker-to-coworker (A2A)
+// interaction graph. Kept free of React and DOM so the layout math, edge
+// styling, state→intent mapping, and source-record link building are unit
+// testable in the default `node` vitest environment.
+//
+// State colour semantics flow through report-kit `statusColors`
+// (`a2aInteraction` domain) — there is intentionally no local colour map here.
+
+import { resolveIntent, type Intent } from "@/components/ui/report-kit/statusColors";
+import type {
+  OperationsMapA2aEdge,
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
+} from "@/lib/ai-operations-map/types";
+
+export const A2A_EDGE_KINDS: OperationsMapA2aEdgeKind[] = [
+  "a2a-delegation",
+  "a2a-handoff",
+  "a2a-task-lineage",
+  "a2a-deliberation",
+];
+
+export const A2A_STATES: OperationsMapA2aInteractionState[] = [
+  "active",
+  "completed",
+  "failed",
+  "blocked",
+];
+
+export const EDGE_KIND_LABEL: Record<OperationsMapA2aEdgeKind, string> = {
+  "a2a-delegation": "Delegation",
+  "a2a-handoff": "Phase handoff",
+  "a2a-task-lineage": "Task lineage",
+  "a2a-deliberation": "Deliberation",
+};
+
+export const STATE_LABEL: Record<OperationsMapA2aInteractionState, string> = {
+  active: "Active",
+  completed: "Completed",
+  failed: "Failed",
+  blocked: "Blocked",
+};
+
+export const A2A_GRAPH_LAYOUT = {
+  width: 760,
+  rowHeight: 56,
+  topPad: 40,
+  bottomPad: 28,
+  fromX: 150,
+  toX: 610,
+  nodeRadius: 7,
+};
+
+/** Resolve an A2A interaction state to a report-kit semantic intent. */
+export function a2aStateIntent(state: OperationsMapA2aInteractionState): Intent {
+  return resolveIntent("a2aInteraction", state);
+}
+
+/** Dash pattern per edge kind — the non-colour channel so kinds stay distinct. */
+export function edgeKindDash(kind: OperationsMapA2aEdgeKind): string | undefined {
+  switch (kind) {
+    case "a2a-delegation":
+      return undefined; // solid
+    case "a2a-handoff":
+      return "10 4";
+    case "a2a-task-lineage":
+      return "3 6";
+    case "a2a-deliberation":
+      return "1 6";
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
+  }
+}
+
+/** Stroke width grows with edge weight (chain depth / token budget bucket). */
+export function edgeStrokeWidth(weight: number, selected: boolean): number {
+  if (selected) return 3.2;
+  return Math.min(4, 1.2 + weight * 0.4);
+}
+
+export function orderedUnique(ids: string[], labelFor: (id: string) => string): string[] {
+  return [...new Set(ids)].sort((left, right) => labelFor(left).localeCompare(labelFor(right)));
+}
+
+/** Evenly distribute node ids down a column within the SVG height. */
+export function columnPositions(ids: string[], height: number): Map<string, number> {
+  const positions = new Map<string, number>();
+  const top = A2A_GRAPH_LAYOUT.topPad;
+  const bottom = height - A2A_GRAPH_LAYOUT.bottomPad;
+  const count = Math.max(ids.length, 1);
+  ids.forEach((id, index) => {
+    const y = count === 1 ? (top + bottom) / 2 : top + ((bottom - top) * index) / (count - 1);
+    positions.set(id, y);
+  });
+  return positions;
+}
+
+export function graphHeight(rowCount: number): number {
+  return A2A_GRAPH_LAYOUT.topPad + A2A_GRAPH_LAYOUT.bottomPad + Math.max(rowCount, 1) * A2A_GRAPH_LAYOUT.rowHeight;
+}
+
+/** Cubic-bezier path from a left (from) node to a right (to) node. */
+export function edgePath(start: { x: number; y: number }, end: { x: number; y: number }, index: number): string {
+  const bend = index % 2 === 0 ? 0 : 14;
+  const midX = (start.x + end.x) / 2;
+  const controlAY = start.y + (end.y - start.y) * 0.15 + bend;
+  const controlBY = start.y + (end.y - start.y) * 0.85 - bend;
+  const r = A2A_GRAPH_LAYOUT.nodeRadius;
+  return `M ${start.x + r} ${start.y} C ${midX} ${controlAY}, ${midX} ${controlBY}, ${end.x - r} ${end.y}`;
+}
+
+export function coworkerHref(agentId: string): string {
+  return `/platform/ai/agent/${encodeURIComponent(agentId)}`;
+}
+
+export type A2aSourceRecord = {
+  /** Human label for the kind of source record. */
+  label: string;
+  /** The record identifier shown to the operator. */
+  value: string;
+  /** Present only when a real page route exists for the record. */
+  href?: string;
+};
+
+/**
+ * Build the click-through source-record list for an A2A edge. Only records
+ * with an actual page route get an `href`; the rest are surfaced honestly as
+ * identifier text (no dead links). Routes verified 2026-06-05:
+ *   - Build Studio deep-links via `/build?buildId=<id>`.
+ *   - DelegationChain / PhaseHandoff / TaskRun / DeliberationRun have no
+ *     dedicated page route yet, so their ids are shown without a link.
+ */
+export function a2aEdgeSourceRecords(edge: OperationsMapA2aEdge): A2aSourceRecord[] {
+  const records: A2aSourceRecord[] = [];
+  if (edge.buildId) {
+    records.push({ label: "Build", value: edge.buildId, href: `/build?buildId=${encodeURIComponent(edge.buildId)}` });
+  }
+  if (edge.refs.delegationChainId) {
+    records.push({ label: "Delegation chain", value: edge.refs.delegationChainId });
+  }
+  if (edge.refs.phaseHandoffId) {
+    records.push({ label: "Phase handoff", value: edge.refs.phaseHandoffId });
+  }
+  if (edge.refs.taskRunId) {
+    records.push({ label: "Task run", value: edge.refs.taskRunId });
+  }
+  if (edge.refs.parentTaskRunId) {
+    records.push({ label: "Parent task run", value: edge.refs.parentTaskRunId });
+  }
+  if (edge.refs.deliberationRunId) {
+    records.push({ label: "Deliberation run", value: edge.refs.deliberationRunId });
+  }
+  return records;
+}
+
+export function svgClip(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+export function titleize(value: string): string {
+  return (
+    value
+      .split(/[-_:.\s]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || "Unknown"
+  );
+}

--- a/apps/web/components/platform/ai-operations-map-prefs.test.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { getOperationsMapQuickViewFilters } from "@/lib/ai-operations-map/project-events";
 import {
+  clearA2aFilterPreference,
   clearOperationsMapViewPreference,
   deleteOperationsMapSavedView,
+  getDefaultA2aFilterPreference,
+  loadA2aFilterPreference,
   loadOperationsMapViewPreference,
   loadOperationsMapSavedViews,
+  OPERATIONS_MAP_A2A_PREFERENCE_KEY,
   OPERATIONS_MAP_SAVED_VIEWS_KEY,
   OPERATIONS_MAP_VIEW_PREFERENCE_KEY,
+  saveA2aFilterPreference,
   saveOperationsMapViewPreference,
   upsertOperationsMapSavedView,
 } from "./ai-operations-map-prefs";
@@ -187,5 +192,45 @@ describe("AI operations map preferences", () => {
         },
       },
     ]);
+  });
+
+  it("defaults the A2A filter preference to all types and states", () => {
+    expect(loadA2aFilterPreference()).toEqual(getDefaultA2aFilterPreference());
+    expect(loadA2aFilterPreference().actorId).toBe("all");
+  });
+
+  it("round-trips the A2A filter preference through storage", () => {
+    saveA2aFilterPreference({
+      types: ["a2a-delegation", "a2a-handoff"],
+      states: ["failed", "blocked"],
+      actorId: "brand-analyst",
+      actorRole: "to",
+    });
+
+    expect(store.has(OPERATIONS_MAP_A2A_PREFERENCE_KEY)).toBe(true);
+    expect(loadA2aFilterPreference()).toEqual({
+      types: ["a2a-delegation", "a2a-handoff"],
+      states: ["failed", "blocked"],
+      actorId: "brand-analyst",
+      actorRole: "to",
+    });
+  });
+
+  it("treats a stored empty A2A filter as show-all and drops unknown values", () => {
+    store.set(
+      OPERATIONS_MAP_A2A_PREFERENCE_KEY,
+      JSON.stringify({ types: ["bogus"], states: [], actorId: "x", actorRole: "sideways" }),
+    );
+    const loaded = loadA2aFilterPreference();
+    expect(loaded.types).toEqual(["a2a-delegation", "a2a-handoff", "a2a-task-lineage", "a2a-deliberation"]);
+    expect(loaded.states).toEqual(["active", "completed", "failed", "blocked"]);
+    expect(loaded.actorRole).toBe("either");
+    expect(loaded.actorId).toBe("x");
+  });
+
+  it("clears the A2A filter preference", () => {
+    saveA2aFilterPreference(getDefaultA2aFilterPreference());
+    clearA2aFilterPreference();
+    expect(store.has(OPERATIONS_MAP_A2A_PREFERENCE_KEY)).toBe(false);
   });
 });

--- a/apps/web/components/platform/ai-operations-map-prefs.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.ts
@@ -3,6 +3,8 @@ import {
   OPERATIONS_MAP_QUICK_VIEWS,
 } from "@/lib/ai-operations-map/project-events";
 import type {
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
   OperationsMapProjectionFilters,
   OperationsMapProjectionSource,
   OperationsMapQuickViewId,
@@ -11,6 +13,80 @@ import type {
 
 export const OPERATIONS_MAP_VIEW_PREFERENCE_KEY = "ai-operations-map:view";
 export const OPERATIONS_MAP_SAVED_VIEWS_KEY = "ai-operations-map:saved-views";
+export const OPERATIONS_MAP_A2A_PREFERENCE_KEY = "ai-operations-map:a2a";
+
+export type A2aActorRole = "either" | "from" | "to";
+
+export type OperationsMapA2aFilterPreference = {
+  types: OperationsMapA2aEdgeKind[];
+  states: OperationsMapA2aInteractionState[];
+  actorId: string;
+  actorRole: A2aActorRole;
+};
+
+const A2A_EDGE_KIND_VALUES: OperationsMapA2aEdgeKind[] = [
+  "a2a-delegation",
+  "a2a-handoff",
+  "a2a-task-lineage",
+  "a2a-deliberation",
+];
+const A2A_STATE_VALUES: OperationsMapA2aInteractionState[] = ["active", "completed", "failed", "blocked"];
+const A2A_ACTOR_ROLES = new Set<A2aActorRole>(["either", "from", "to"]);
+const A2A_EDGE_KIND_SET = new Set<OperationsMapA2aEdgeKind>(A2A_EDGE_KIND_VALUES);
+const A2A_STATE_SET = new Set<OperationsMapA2aInteractionState>(A2A_STATE_VALUES);
+
+export function getDefaultA2aFilterPreference(): OperationsMapA2aFilterPreference {
+  return {
+    types: [...A2A_EDGE_KIND_VALUES],
+    states: [...A2A_STATE_VALUES],
+    actorId: "all",
+    actorRole: "either",
+  };
+}
+
+export function loadA2aFilterPreference(): OperationsMapA2aFilterPreference {
+  try {
+    const raw = localStorage.getItem(OPERATIONS_MAP_A2A_PREFERENCE_KEY);
+    if (!raw) return getDefaultA2aFilterPreference();
+
+    const parsed = JSON.parse(raw) as Partial<OperationsMapA2aFilterPreference>;
+    const types = Array.isArray(parsed.types)
+      ? parsed.types.filter((value): value is OperationsMapA2aEdgeKind => A2A_EDGE_KIND_SET.has(value as OperationsMapA2aEdgeKind))
+      : [];
+    const states = Array.isArray(parsed.states)
+      ? parsed.states.filter((value): value is OperationsMapA2aInteractionState => A2A_STATE_SET.has(value as OperationsMapA2aInteractionState))
+      : [];
+    const actorRole = A2A_ACTOR_ROLES.has(parsed.actorRole as A2aActorRole) ? (parsed.actorRole as A2aActorRole) : "either";
+    const actorId = typeof parsed.actorId === "string" && parsed.actorId.trim() !== "" ? parsed.actorId : "all";
+
+    return {
+      // Empty arrays mean "show all" rather than "hide everything" — a stored
+      // empty filter must never blank the panel.
+      types: types.length > 0 ? types : [...A2A_EDGE_KIND_VALUES],
+      states: states.length > 0 ? states : [...A2A_STATE_VALUES],
+      actorId,
+      actorRole,
+    };
+  } catch {
+    return getDefaultA2aFilterPreference();
+  }
+}
+
+export function saveA2aFilterPreference(preference: OperationsMapA2aFilterPreference): void {
+  try {
+    localStorage.setItem(OPERATIONS_MAP_A2A_PREFERENCE_KEY, JSON.stringify(preference));
+  } catch {
+    // localStorage can be unavailable or full; the panel remains usable without persistence.
+  }
+}
+
+export function clearA2aFilterPreference(): void {
+  try {
+    localStorage.removeItem(OPERATIONS_MAP_A2A_PREFERENCE_KEY);
+  } catch {
+    // localStorage can be unavailable; resetting in-memory state still keeps the panel usable.
+  }
+}
 
 export type OperationsMapStoredQuickViewId = OperationsMapQuickViewId | "custom";
 

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -145,6 +145,15 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     published: "success",
     archived: "neutral",
   },
+  // Coworker-to-coworker (A2A) interaction state on the AI Operations Map.
+  // Keeps the A2A panel's state→color semantics in the one shared registry
+  // instead of a private color map. See A2aInteractionsPanel.
+  a2aInteraction: {
+    active: "accent",
+    completed: "success",
+    failed: "danger",
+    blocked: "warning",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -47,6 +47,12 @@ vi.mock("@dpf/db", () => ({
     scheduledJob: {
       findMany: vi.fn(),
     },
+    delegationChain: {
+      findMany: vi.fn(),
+    },
+    phaseHandoff: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -59,6 +65,9 @@ describe("loadOperationsMapData", () => {
     vi.mocked(prisma.agentMessage.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.modelProfile.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.routeOutcome.findMany).mockResolvedValue([] as never);
+    // A2A interaction sources default to empty; individual tests override.
+    vi.mocked(prisma.delegationChain.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([] as never);
   });
 
   it("selects the map template from StorefrontConfig archetype truth", async () => {
@@ -409,6 +418,82 @@ describe("loadOperationsMapData", () => {
           summary: expect.stringContaining("auth"),
         }),
       ]),
+    );
+  });
+
+  it("projects coworker-to-coworker A2A interactions from delegation and phase-handoff substrate", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.agent.findMany).mockResolvedValue([
+      makeAgentRow(),
+      { ...makeAgentRow(), id: "agent-db-2", agentId: "brand-analyst", slugId: "brand-analyst", name: "Brand Analyst" },
+    ] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.routeDecisionLog.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.modelProvider.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.tokenUsage.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.scheduledAgentTask.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.scheduledJob.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.delegationChain.findMany).mockResolvedValue([
+      {
+        id: "del-1",
+        chainId: "chain-1",
+        depth: 0,
+        fromAgentId: "support-specialist",
+        toAgentId: "brand-analyst",
+        skillId: "brand-extract",
+        authorityScope: ["brand:read"],
+        status: "completed",
+        reason: "Delegated brand extraction",
+        startedAt: new Date("2026-06-04T10:00:00.000Z"),
+        completedAt: new Date("2026-06-04T10:05:00.000Z"),
+      },
+    ] as never);
+    vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([
+      {
+        id: "ph-1",
+        buildId: "FB-1",
+        fromPhase: "plan",
+        toPhase: "build",
+        fromAgentId: "support-specialist",
+        toAgentId: "brand-analyst",
+        summary: "Plan approved.",
+        gateResult: { passed: true, status: "advanced" },
+        tokenBudgetUsed: 4200,
+        createdAt: new Date("2026-06-04T11:00:00.000Z"),
+      },
+    ] as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(data.routingTopology.a2aEdges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          edgeKind: "a2a-delegation",
+          fromCoworkerId: "support-specialist",
+          toCoworkerId: "brand-analyst",
+          state: "completed",
+        }),
+        expect.objectContaining({
+          edgeKind: "a2a-handoff",
+          fromCoworkerId: "support-specialist",
+          toCoworkerId: "brand-analyst",
+          state: "completed",
+          buildId: "FB-1",
+        }),
+      ]),
+    );
+    expect(data.routingTopology.a2aLegend.map((item) => item.edgeKind)).toContain("a2a-delegation");
+    // Brand Analyst appears as a coworker node even though it only received work.
+    expect(data.routingTopology.coworkers.map((c) => c.agentId)).toContain("brand-analyst");
+    expect(prisma.delegationChain.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { startedAt: "desc" }, take: 40 }),
+    );
+    expect(prisma.phaseHandoff.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: "desc" }, take: 40 }),
     );
   });
 });

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -9,6 +9,12 @@ import {
   projectToolExecutionReceipt,
 } from "./project-events";
 import { projectRoutingTopology } from "./project-routing-topology";
+import {
+  projectA2aInteractions,
+  type A2aDelegationSourceRow,
+  type A2aPhaseHandoffSourceRow,
+  type A2aTaskLineageSourceRow,
+} from "./project-a2a-interactions";
 import type {
   OperationsMapRoutingTopology,
   OperationsMapAgent,
@@ -64,6 +70,9 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     routeOutcomes,
     scheduledAgentTasks,
     scheduledJobs,
+    delegationChains,
+    phaseHandoffs,
+    a2aTaskRuns,
   ] = await Promise.all([
     prisma.storefrontConfig.findFirst({
       include: {
@@ -338,6 +347,73 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
         lastStatus: true,
       },
     }),
+    // ── A2A interaction sources (BI-65B0D697) ──────────────────────────
+    // Coworker-to-coworker interactions projected migration-free from
+    // existing substrate. DelegationChain + PhaseHandoff carry explicit
+    // from/toAgentId; TaskRun lineage carries initiating/current/parent.
+    // Deliberation fan-out is deferred until branch-persona identity is
+    // captured (TaskNode has no agentId column today) — see Slice 4.
+    prisma.delegationChain.findMany({
+      orderBy: { startedAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        chainId: true,
+        depth: true,
+        fromAgentId: true,
+        toAgentId: true,
+        skillId: true,
+        authorityScope: true,
+        status: true,
+        reason: true,
+        startedAt: true,
+        completedAt: true,
+      },
+    }),
+    prisma.phaseHandoff.findMany({
+      orderBy: { createdAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        buildId: true,
+        fromPhase: true,
+        toPhase: true,
+        fromAgentId: true,
+        toAgentId: true,
+        summary: true,
+        gateResult: true,
+        tokenBudgetUsed: true,
+        createdAt: true,
+      },
+    }),
+    prisma.taskRun.findMany({
+      where: {
+        archivedAt: null,
+        OR: [
+          { parentTaskRunId: { not: null } },
+          {
+            AND: [
+              { initiatingAgentId: { not: null } },
+              { currentAgentId: { not: null } },
+            ],
+          },
+        ],
+      },
+      orderBy: { startedAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        taskRunId: true,
+        initiatingAgentId: true,
+        currentAgentId: true,
+        parentTaskRunId: true,
+        title: true,
+        objective: true,
+        status: true,
+        buildId: true,
+        startedAt: true,
+      },
+    }),
   ]);
 
   const routeDecisionAgentMessageIds = [
@@ -419,13 +495,130 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     scheduledJobs,
   });
 
+  // ── Compose coworker-to-coworker (A2A) interactions ──────────────────
+  // Project A2A edges from existing substrate and merge them into the
+  // provider routing topology. Coworker nodes contributed by A2A edges are
+  // unioned in so an agent that only ever *received* an interaction still
+  // appears. See project-a2a-interactions.ts + BI-65B0D697.
+  const a2aTaskRunAgentById = new Map<string, string | null>();
+  for (const row of a2aTaskRuns) {
+    a2aTaskRunAgentById.set(row.id, row.currentAgentId);
+    a2aTaskRunAgentById.set(row.taskRunId, row.currentAgentId);
+  }
+  const coworkerSourceRows = stationedAgents.map((agent) => ({
+    agentId: agent.agentId,
+    name: agent.name,
+    stationLabel: agent.stationLabel,
+  }));
+  const a2aProjection = projectA2aInteractions({
+    agents: coworkerSourceRows,
+    delegationChains: delegationChains.map((row): A2aDelegationSourceRow => ({
+      id: row.id,
+      chainId: row.chainId,
+      depth: row.depth,
+      fromAgentId: row.fromAgentId,
+      toAgentId: row.toAgentId,
+      skillId: row.skillId,
+      authorityScope: row.authorityScope,
+      status: row.status,
+      reason: row.reason,
+      startedAt: row.startedAt,
+      completedAt: row.completedAt,
+    })),
+    phaseHandoffs: phaseHandoffs.map((row): A2aPhaseHandoffSourceRow => {
+      const gate = resolveGateResult(row.gateResult);
+      return {
+        id: row.id,
+        buildId: row.buildId,
+        fromPhase: row.fromPhase,
+        toPhase: row.toPhase,
+        fromAgentId: row.fromAgentId,
+        toAgentId: row.toAgentId,
+        summary: row.summary,
+        gatePassed: gate.passed,
+        gateLabel: gate.label ?? `${row.fromPhase} → ${row.toPhase} gate`,
+        tokenBudgetUsed: row.tokenBudgetUsed,
+        createdAt: row.createdAt,
+      };
+    }),
+    taskLineage: a2aTaskRuns.map((row): A2aTaskLineageSourceRow => ({
+      id: row.id,
+      taskRunId: row.taskRunId,
+      initiatingAgentId: row.initiatingAgentId,
+      currentAgentId: row.currentAgentId,
+      parentTaskRunId: row.parentTaskRunId,
+      parentAgentId: row.parentTaskRunId
+        ? a2aTaskRunAgentById.get(row.parentTaskRunId) ?? null
+        : null,
+      title: row.title,
+      objective: row.objective,
+      status: row.status,
+      buildId: row.buildId,
+      startedAt: row.startedAt,
+    })),
+    // Deliberation fan-out deferred: TaskNode branch personas carry no
+    // agentId column yet. Wired once the A2A-capture thread records it.
+    deliberations: [],
+  });
+
+  const mergedCoworkers = mergeCoworkersById(routingTopology.coworkers, a2aProjection.coworkers);
+  const mergedTimeline = [...routingTopology.timeline, ...a2aProjection.timeline].sort(
+    (left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt),
+  );
+
   return {
     template,
     agents: stationedAgents,
     projections,
-    routingTopology,
+    routingTopology: {
+      ...routingTopology,
+      coworkers: mergedCoworkers,
+      a2aEdges: a2aProjection.a2aEdges,
+      timeline: mergedTimeline,
+    },
     recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} records per evidence source`,
   };
+}
+
+/**
+ * Resolve a PhaseHandoff.gateResult JSON blob into a pass/fail signal + a
+ * short label. Conservative: an explicit boolean wins; otherwise a status
+ * string is pattern-matched; otherwise the gate state is unknown (null).
+ */
+function resolveGateResult(value: unknown): { passed: boolean | null; label: string | null } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { passed: null, label: null };
+  }
+  const record = value as Record<string, unknown>;
+  const explicit = record.passed ?? record.allowed ?? record.advanced;
+  const statusText = [record.result, record.status, record.outcome, record.decision]
+    .find((entry): entry is string => typeof entry === "string");
+
+  let passed: boolean | null = null;
+  if (typeof explicit === "boolean") {
+    passed = explicit;
+  } else if (statusText) {
+    if (/pass|advanc|approv|ok|success/i.test(statusText)) passed = true;
+    else if (/fail|block|reject|deny|error/i.test(statusText)) passed = false;
+  }
+
+  return { passed, label: statusText ?? null };
+}
+
+/**
+ * Union two coworker-node lists by agentId, preserving the provider-topology
+ * entry when an agent appears in both. Keeps a stable label sort.
+ */
+function mergeCoworkersById<T extends { agentId: string; label: string }>(
+  primary: T[],
+  secondary: T[],
+): T[] {
+  const byId = new Map<string, T>();
+  for (const coworker of primary) byId.set(coworker.agentId, coworker);
+  for (const coworker of secondary) {
+    if (!byId.has(coworker.agentId)) byId.set(coworker.agentId, coworker);
+  }
+  return [...byId.values()].sort((left, right) => left.label.localeCompare(right.label));
 }
 
 function getActivationProfileType(value: unknown): string | null {

--- a/apps/web/lib/ai-operations-map/project-a2a-interactions.test.ts
+++ b/apps/web/lib/ai-operations-map/project-a2a-interactions.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectA2aInteractions,
+  type A2aDelegationSourceRow,
+  type A2aDeliberationSourceRow,
+  type A2aPhaseHandoffSourceRow,
+  type A2aTaskLineageSourceRow,
+} from "./project-a2a-interactions";
+import type { RoutingCoworkerSourceRow } from "./project-routing-topology";
+
+const AGENTS: RoutingCoworkerSourceRow[] = [
+  { agentId: "ceo-coworker", name: "CEO Coworker", stationLabel: "Direct" },
+  { agentId: "build-specialist", name: "Build Specialist", stationLabel: "Build" },
+  { agentId: "brand-analyst", name: "Brand Analyst", stationLabel: "Brand" },
+  { agentId: "reviewer", name: "Reviewer", stationLabel: "Review" },
+];
+
+function emptyInput() {
+  return {
+    agents: AGENTS,
+    delegationChains: [] as A2aDelegationSourceRow[],
+    phaseHandoffs: [] as A2aPhaseHandoffSourceRow[],
+    taskLineage: [] as A2aTaskLineageSourceRow[],
+    deliberations: [] as A2aDeliberationSourceRow[],
+  };
+}
+
+function makeDelegation(overrides: Partial<A2aDelegationSourceRow> = {}): A2aDelegationSourceRow {
+  return {
+    id: "del-1",
+    chainId: "chain-1",
+    depth: 0,
+    fromAgentId: "ceo-coworker",
+    toAgentId: "brand-analyst",
+    skillId: "brand-extract",
+    authorityScope: ["brand:read", "brand:write"],
+    status: "active",
+    reason: "Delegated brand extraction",
+    startedAt: new Date("2026-06-04T10:00:00.000Z"),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("A2A interaction projection", () => {
+  it("returns an empty projection with the legend when there is no A2A activity", () => {
+    const projection = projectA2aInteractions(emptyInput());
+    expect(projection.a2aEdges).toEqual([]);
+    expect(projection.coworkers).toEqual([]);
+    expect(projection.legend.map((item) => item.edgeKind)).toEqual([
+      "a2a-delegation",
+      "a2a-handoff",
+      "a2a-task-lineage",
+      "a2a-deliberation",
+    ]);
+  });
+
+  it("projects a delegation chain row into a coworker→coworker delegation edge", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      delegationChains: [makeDelegation()],
+    });
+
+    expect(projection.a2aEdges).toEqual([
+      expect.objectContaining({
+        edgeKind: "a2a-delegation",
+        fromCoworkerId: "ceo-coworker",
+        toCoworkerId: "brand-analyst",
+        state: "active",
+        skillId: "brand-extract",
+        authorityScope: ["brand:read", "brand:write"],
+        summary: "Delegated brand extraction",
+        refs: expect.objectContaining({ delegationChainId: "del-1" }),
+      }),
+    ]);
+    // Both endpoints become coworker nodes, even a pure target.
+    expect(projection.coworkers.map((c) => c.agentId).sort()).toEqual(["brand-analyst", "ceo-coworker"]);
+  });
+
+  it("maps delegation status into interaction state", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      delegationChains: [
+        makeDelegation({ id: "d-a", status: "completed" }),
+        makeDelegation({ id: "d-b", status: "failed", toAgentId: "reviewer" }),
+        makeDelegation({ id: "d-c", status: "blocked", toAgentId: "build-specialist" }),
+      ],
+    });
+    expect(projection.a2aEdges.map((e) => e.state)).toEqual(["completed", "failed", "blocked"]);
+  });
+
+  it("drops self-edges and rows missing an agent on either end", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      delegationChains: [
+        makeDelegation({ id: "self", fromAgentId: "ceo-coworker", toAgentId: "ceo-coworker" }),
+        makeDelegation({ id: "no-from", fromAgentId: "", toAgentId: "reviewer" }),
+        makeDelegation({ id: "no-to", fromAgentId: "ceo-coworker", toAgentId: "" }),
+      ],
+    });
+    expect(projection.a2aEdges).toEqual([]);
+  });
+
+  it("projects a build phase handoff edge with gate result", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      phaseHandoffs: [
+        {
+          id: "ph-1",
+          buildId: "FB-123",
+          fromPhase: "plan",
+          toPhase: "build",
+          fromAgentId: "build-specialist",
+          toAgentId: "reviewer",
+          summary: "Plan approved, advancing to build.",
+          gatePassed: true,
+          gateLabel: "plan gate passed",
+          tokenBudgetUsed: 4200,
+          createdAt: new Date("2026-06-04T11:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(projection.a2aEdges).toEqual([
+      expect.objectContaining({
+        edgeKind: "a2a-handoff",
+        fromCoworkerId: "build-specialist",
+        toCoworkerId: "reviewer",
+        state: "completed",
+        buildId: "FB-123",
+        gateResult: "plan gate passed",
+        refs: expect.objectContaining({ phaseHandoffId: "ph-1" }),
+      }),
+    ]);
+    expect(projection.a2aEdges[0]?.label).toContain("plan");
+    expect(projection.a2aEdges[0]?.label).toContain("build");
+  });
+
+  it("marks a handoff with a failed gate as blocked", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      phaseHandoffs: [
+        {
+          id: "ph-2",
+          buildId: "FB-9",
+          fromPhase: "build",
+          toPhase: "review",
+          fromAgentId: "build-specialist",
+          toAgentId: "reviewer",
+          summary: "Gate did not pass.",
+          gatePassed: false,
+          gateLabel: "review gate failed",
+          tokenBudgetUsed: 0,
+          createdAt: new Date("2026-06-04T11:30:00.000Z"),
+        },
+      ],
+    });
+    expect(projection.a2aEdges[0]?.state).toBe("blocked");
+  });
+
+  it("projects task lineage when the acting agent differs from the initiator", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      taskLineage: [
+        {
+          id: "tr-1",
+          taskRunId: "TR-1",
+          initiatingAgentId: "ceo-coworker",
+          currentAgentId: "build-specialist",
+          parentTaskRunId: null,
+          parentAgentId: null,
+          title: "Ship landing page",
+          objective: "Produce and ship the landing page",
+          status: "working",
+          buildId: null,
+          startedAt: new Date("2026-06-04T12:00:00.000Z"),
+        },
+      ],
+    });
+    expect(projection.a2aEdges).toEqual([
+      expect.objectContaining({
+        edgeKind: "a2a-task-lineage",
+        fromCoworkerId: "ceo-coworker",
+        toCoworkerId: "build-specialist",
+        state: "active",
+        refs: expect.objectContaining({ taskRunId: "TR-1" }),
+      }),
+    ]);
+  });
+
+  it("uses the resolved parent agent for child task lineage and skips same-agent tasks", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      taskLineage: [
+        {
+          id: "tr-child",
+          taskRunId: "TR-child",
+          initiatingAgentId: "build-specialist",
+          currentAgentId: "reviewer",
+          parentTaskRunId: "TR-parent",
+          parentAgentId: "ceo-coworker",
+          title: "Review child task",
+          objective: "Review the work",
+          status: "completed",
+          buildId: null,
+          startedAt: new Date("2026-06-04T12:10:00.000Z"),
+        },
+        {
+          id: "tr-same",
+          taskRunId: "TR-same",
+          initiatingAgentId: "reviewer",
+          currentAgentId: "reviewer",
+          parentTaskRunId: null,
+          parentAgentId: null,
+          title: "Self task",
+          objective: "No handoff",
+          status: "working",
+          buildId: null,
+          startedAt: new Date("2026-06-04T12:20:00.000Z"),
+        },
+      ],
+    });
+    expect(projection.a2aEdges).toHaveLength(1);
+    expect(projection.a2aEdges[0]).toEqual(
+      expect.objectContaining({
+        edgeKind: "a2a-task-lineage",
+        fromCoworkerId: "ceo-coworker",
+        toCoworkerId: "reviewer",
+        state: "completed",
+      }),
+    );
+  });
+
+  it("projects deliberation fan-out edges from coordinator to each branch persona", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      deliberations: [
+        {
+          id: "delib-1",
+          coordinatorAgentId: "ceo-coworker",
+          patternLabel: "Diversity review",
+          consensusState: "consensus",
+          taskRunId: "TR-7",
+          startedAt: new Date("2026-06-04T13:00:00.000Z"),
+          branches: [
+            { nodeId: "n1", agentId: "build-specialist", workerRole: "reviewer", status: "completed" },
+            { nodeId: "n2", agentId: "reviewer", workerRole: "skeptical_reviewer", status: "completed" },
+            { nodeId: "n3", agentId: "build-specialist", workerRole: "reviewer", status: "completed" },
+          ],
+        },
+      ],
+    });
+
+    const delibEdges = projection.a2aEdges.filter((e) => e.edgeKind === "a2a-deliberation");
+    // De-duped per (coordinator, branch agent): build-specialist appears once, weight reflects 2 branches.
+    expect(delibEdges.map((e) => e.toCoworkerId).sort()).toEqual(["build-specialist", "reviewer"]);
+    delibEdges.forEach((edge) => {
+      expect(edge.fromCoworkerId).toBe("ceo-coworker");
+      expect(edge.refs.deliberationRunId).toBe("delib-1");
+    });
+    const buildEdge = delibEdges.find((e) => e.toCoworkerId === "build-specialist");
+    expect(buildEdge?.weight).toBeGreaterThanOrEqual(2);
+  });
+
+  it("contributes timeline markers for each projected edge", () => {
+    const projection = projectA2aInteractions({
+      ...emptyInput(),
+      delegationChains: [makeDelegation()],
+    });
+    expect(projection.timeline).toHaveLength(1);
+    expect(projection.timeline[0]).toEqual(
+      expect.objectContaining({ occurredAt: "2026-06-04T10:00:00.000Z" }),
+    );
+  });
+});

--- a/apps/web/lib/ai-operations-map/project-a2a-interactions.ts
+++ b/apps/web/lib/ai-operations-map/project-a2a-interactions.ts
@@ -1,0 +1,406 @@
+import type {
+  OperationsMapA2aEdge,
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
+  OperationsMapA2aLegendItem,
+  OperationsMapRoutingCoworker,
+  OperationsMapRoutingMarkerType,
+  OperationsMapRoutingTimelineMarker,
+} from "./types";
+import type { RoutingCoworkerSourceRow } from "./project-routing-topology";
+
+/**
+ * Coworker-to-coworker (A2A) interaction projection.
+ *
+ * Pure function (no Prisma, no React) — same contract as
+ * `project-routing-topology.ts`. It reads rows from substrate that already
+ * exists today and maps them into typed A2A edges between two coworkers:
+ *
+ *   DelegationChain   → a2a-delegation   (fromAgentId → toAgentId)
+ *   PhaseHandoff      → a2a-handoff      (fromAgentId → toAgentId, build phase)
+ *   TaskRun lineage   → a2a-task-lineage (parent/initiating agent → current agent)
+ *   DeliberationRun   → a2a-deliberation (coordinator → each branch persona)
+ *
+ * No migration is required; the loader resolves the raw rows into the source
+ * DTOs below. See
+ * docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md
+ */
+
+export type A2aDelegationSourceRow = {
+  id: string;
+  chainId: string;
+  depth: number;
+  fromAgentId: string;
+  toAgentId: string;
+  skillId: string | null;
+  authorityScope: string[];
+  status: string;
+  reason: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+};
+
+export type A2aPhaseHandoffSourceRow = {
+  id: string;
+  buildId: string | null;
+  fromPhase: string;
+  toPhase: string;
+  fromAgentId: string;
+  toAgentId: string;
+  summary: string;
+  /** Loader-resolved from PhaseHandoff.gateResult JSON; null when unknown. */
+  gatePassed: boolean | null;
+  gateLabel: string | null;
+  tokenBudgetUsed: number;
+  createdAt: Date;
+};
+
+export type A2aTaskLineageSourceRow = {
+  id: string;
+  taskRunId: string;
+  initiatingAgentId: string | null;
+  currentAgentId: string | null;
+  parentTaskRunId: string | null;
+  /** Loader-resolved: parent task's currentAgentId ?? initiatingAgentId. */
+  parentAgentId: string | null;
+  title: string;
+  objective: string | null;
+  status: string;
+  buildId: string | null;
+  startedAt: Date;
+};
+
+export type A2aDeliberationBranchRow = {
+  nodeId: string;
+  agentId: string | null;
+  workerRole: string | null;
+  status: string | null;
+};
+
+export type A2aDeliberationSourceRow = {
+  id: string;
+  /** Loader-resolved from the parent TaskRun (current ?? initiating agent). */
+  coordinatorAgentId: string | null;
+  patternLabel: string | null;
+  consensusState: string;
+  taskRunId: string;
+  startedAt: Date;
+  branches: A2aDeliberationBranchRow[];
+};
+
+export type A2aInteractionInput = {
+  agents: RoutingCoworkerSourceRow[];
+  delegationChains: A2aDelegationSourceRow[];
+  phaseHandoffs: A2aPhaseHandoffSourceRow[];
+  taskLineage: A2aTaskLineageSourceRow[];
+  deliberations: A2aDeliberationSourceRow[];
+};
+
+export type A2aInteractionProjection = {
+  a2aEdges: OperationsMapA2aEdge[];
+  coworkers: OperationsMapRoutingCoworker[];
+  timeline: OperationsMapRoutingTimelineMarker[];
+  legend: OperationsMapA2aLegendItem[];
+};
+
+export const A2A_INTERACTION_LEGEND: OperationsMapA2aLegendItem[] = [
+  {
+    edgeKind: "a2a-delegation",
+    label: "Delegation",
+    description: "One coworker delegated authority-bearing work to another coworker.",
+  },
+  {
+    edgeKind: "a2a-handoff",
+    label: "Phase handoff",
+    description: "A build phase was handed from one coworker to the next, with a gate result.",
+  },
+  {
+    edgeKind: "a2a-task-lineage",
+    label: "Task lineage",
+    description: "A task was spawned or moved from an initiating/parent coworker to the acting coworker.",
+  },
+  {
+    edgeKind: "a2a-deliberation",
+    label: "Deliberation",
+    description: "A coordinating coworker fanned a decision out to branch personas for peer review.",
+  },
+];
+
+export function projectA2aInteractions(input: A2aInteractionInput): A2aInteractionProjection {
+  const sourceCoworkerById = new Map(input.agents.map((agent) => [agent.agentId, agent]));
+  const coworkers: OperationsMapRoutingCoworker[] = [];
+  const coworkerById = new Map<string, OperationsMapRoutingCoworker>();
+  const a2aEdges: OperationsMapA2aEdge[] = [];
+  const timeline: OperationsMapRoutingTimelineMarker[] = [];
+
+  const pushEdge = (edge: OperationsMapA2aEdge | null) => {
+    if (!edge) return;
+    ensureCoworker(coworkers, coworkerById, edge.fromCoworkerId, sourceCoworkerById);
+    ensureCoworker(coworkers, coworkerById, edge.toCoworkerId, sourceCoworkerById);
+    a2aEdges.push(edge);
+    timeline.push({
+      id: `timeline:a2a:${edge.id}`,
+      lane: "history",
+      label: edge.label,
+      occurredAt: edge.occurredAt ?? new Date(0).toISOString(),
+      markerType: timelineMarkerType(edge),
+    });
+  };
+
+  for (const row of input.delegationChains) {
+    pushEdge(projectDelegation(row));
+  }
+  for (const row of input.phaseHandoffs) {
+    pushEdge(projectPhaseHandoff(row));
+  }
+  for (const row of input.taskLineage) {
+    pushEdge(projectTaskLineage(row));
+  }
+  for (const edge of projectDeliberations(input.deliberations)) {
+    pushEdge(edge);
+  }
+
+  return {
+    a2aEdges,
+    coworkers: sortByLabel(coworkers),
+    timeline,
+    legend: A2A_INTERACTION_LEGEND,
+  };
+}
+
+function projectDelegation(row: A2aDelegationSourceRow): OperationsMapA2aEdge | null {
+  const from = normalizeAgentId(row.fromAgentId);
+  const to = normalizeAgentId(row.toAgentId);
+  if (!isDistinctPair(from, to)) return null;
+
+  return {
+    id: `a2a:delegation:${row.id}`,
+    edgeKind: "a2a-delegation",
+    fromCoworkerId: from,
+    toCoworkerId: to,
+    state: mapDelegationState(row.status),
+    label: row.skillId ? `Delegated ${row.skillId}` : "Delegation",
+    summary: row.reason ?? "Coworker delegation",
+    occurredAt: row.startedAt.toISOString(),
+    authorityScope: row.authorityScope,
+    skillId: row.skillId,
+    refs: { delegationChainId: row.id },
+    weight: clampWeight(row.authorityScope.length || 1),
+  };
+}
+
+function projectPhaseHandoff(row: A2aPhaseHandoffSourceRow): OperationsMapA2aEdge | null {
+  const from = normalizeAgentId(row.fromAgentId);
+  const to = normalizeAgentId(row.toAgentId);
+  if (!isDistinctPair(from, to)) return null;
+
+  return {
+    id: `a2a:handoff:${row.id}`,
+    edgeKind: "a2a-handoff",
+    fromCoworkerId: from,
+    toCoworkerId: to,
+    // A recorded handoff already occurred; treat it as completed unless the
+    // gate explicitly did not pass, in which case it is a blocked transition.
+    state: row.gatePassed === false ? "blocked" : "completed",
+    label: `Handoff ${row.fromPhase} → ${row.toPhase}`,
+    summary: row.summary,
+    occurredAt: row.createdAt.toISOString(),
+    buildId: row.buildId,
+    gateResult: row.gateLabel,
+    refs: { phaseHandoffId: row.id },
+    weight: tokenBudgetWeight(row.tokenBudgetUsed),
+  };
+}
+
+function projectTaskLineage(row: A2aTaskLineageSourceRow): OperationsMapA2aEdge | null {
+  const current = normalizeAgentId(row.currentAgentId ?? "");
+  // Prefer the resolved parent agent (child task handoff); otherwise the
+  // initiating agent (within-task initiator → actor transition).
+  const from = row.parentTaskRunId && row.parentAgentId
+    ? normalizeAgentId(row.parentAgentId)
+    : normalizeAgentId(row.initiatingAgentId ?? "");
+  if (!isDistinctPair(from, current)) return null;
+
+  return {
+    id: `a2a:lineage:${row.id}`,
+    edgeKind: "a2a-task-lineage",
+    fromCoworkerId: from,
+    toCoworkerId: current,
+    state: mapTaskState(row.status),
+    label: row.title || "Task lineage",
+    summary: row.objective ?? row.title ?? "Task handoff",
+    occurredAt: row.startedAt.toISOString(),
+    buildId: row.buildId,
+    refs: { taskRunId: row.taskRunId, parentTaskRunId: row.parentTaskRunId },
+    weight: 2,
+  };
+}
+
+function projectDeliberations(rows: A2aDeliberationSourceRow[]): OperationsMapA2aEdge[] {
+  const edges: OperationsMapA2aEdge[] = [];
+  for (const run of rows) {
+    const coordinator = normalizeAgentId(run.coordinatorAgentId ?? "");
+    if (!coordinator) continue;
+
+    // Aggregate branches per distinct branch agent so a deliberation that
+    // assigned several branches to the same persona renders as one weighted
+    // edge rather than a cluttered fan.
+    const branchesByAgent = new Map<string, A2aDeliberationBranchRow[]>();
+    for (const branch of run.branches) {
+      const agentId = normalizeAgentId(branch.agentId ?? "");
+      if (!isDistinctPair(coordinator, agentId)) continue;
+      const list = branchesByAgent.get(agentId) ?? [];
+      list.push(branch);
+      branchesByAgent.set(agentId, list);
+    }
+
+    for (const [agentId, branches] of branchesByAgent) {
+      edges.push({
+        id: `a2a:deliberation:${run.id}:${agentId}`,
+        edgeKind: "a2a-deliberation",
+        fromCoworkerId: coordinator,
+        toCoworkerId: agentId,
+        state: mapDeliberationState(run.consensusState, branches),
+        label: run.patternLabel ? `Deliberation: ${run.patternLabel}` : "Deliberation",
+        summary: branchRoleSummary(branches),
+        occurredAt: run.startedAt.toISOString(),
+        gateResult: run.consensusState,
+        refs: { deliberationRunId: run.id, taskRunId: run.taskRunId },
+        weight: clampWeight(branches.length),
+      });
+    }
+  }
+  return edges;
+}
+
+// ─── State mapping ────────────────────────────────────────────────────
+
+function mapDelegationState(status: string): OperationsMapA2aInteractionState {
+  switch (status.trim().toLowerCase()) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "blocked":
+      return "blocked";
+    default:
+      return "active";
+  }
+}
+
+function mapTaskState(status: string): OperationsMapA2aInteractionState {
+  switch (status.trim().toLowerCase()) {
+    case "completed":
+    case "archived":
+      return "completed";
+    case "failed":
+    case "rejected":
+      return "failed";
+    case "canceled":
+    case "cancelled":
+      return "blocked";
+    default:
+      // submitted | working | input-required | auth-required
+      return "active";
+  }
+}
+
+function mapDeliberationState(
+  consensusState: string,
+  branches: A2aDeliberationBranchRow[],
+): OperationsMapA2aInteractionState {
+  // A failed/blocked branch dominates the per-agent edge state.
+  if (branches.some((branch) => branchFailed(branch.status))) return "failed";
+  switch (consensusState.trim().toLowerCase()) {
+    case "consensus":
+    case "partial-consensus":
+      return "completed";
+    case "no-consensus":
+    case "insufficient-evidence":
+      return "failed";
+    default:
+      return "active";
+  }
+}
+
+function branchFailed(status: string | null): boolean {
+  const value = (status ?? "").trim().toLowerCase();
+  return value === "failed" || value === "cancelled" || value === "canceled";
+}
+
+function branchRoleSummary(branches: A2aDeliberationBranchRow[]): string {
+  const roles = branches
+    .map((branch) => branch.workerRole)
+    .filter((role): role is string => Boolean(role));
+  if (roles.length === 0) return "Deliberation branch review";
+  return `Branch roles: ${[...new Set(roles)].join(", ")}`;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function normalizeAgentId(agentId: string): string {
+  const normalized = agentId.trim();
+  if (!normalized || /^unknown$/i.test(normalized)) return "";
+  return normalized;
+}
+
+function isDistinctPair(from: string, to: string): boolean {
+  return Boolean(from) && Boolean(to) && from !== to;
+}
+
+function clampWeight(value: number): number {
+  return Math.min(5, Math.max(1, Math.round(value)));
+}
+
+function tokenBudgetWeight(tokens: number): number {
+  if (tokens >= 100_000) return 5;
+  if (tokens >= 25_000) return 4;
+  if (tokens >= 5_000) return 3;
+  if (tokens >= 500) return 2;
+  return 1;
+}
+
+function timelineMarkerType(edge: OperationsMapA2aEdge): OperationsMapRoutingMarkerType {
+  if (edge.state === "failed" || edge.state === "blocked") return "error";
+  if (edge.edgeKind === "a2a-deliberation") return "governance";
+  return "decision";
+}
+
+function ensureCoworker(
+  coworkers: OperationsMapRoutingCoworker[],
+  coworkerById: Map<string, OperationsMapRoutingCoworker>,
+  agentId: string,
+  sourceCoworkerById: Map<string, RoutingCoworkerSourceRow>,
+) {
+  if (!agentId || coworkerById.has(agentId)) return;
+  const source = sourceCoworkerById.get(agentId);
+  const coworker: OperationsMapRoutingCoworker = {
+    agentId,
+    label: source?.name ?? titleize(agentId),
+    stationLabel: source?.stationLabel ?? null,
+  };
+  coworkers.push(coworker);
+  coworkerById.set(agentId, coworker);
+}
+
+function sortByLabel<T extends { label: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function titleize(value: string): string {
+  return (
+    value
+      .split(/[-_:.\s]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || "Unknown"
+  );
+}
+
+const _edgeKindGuard: Record<OperationsMapA2aEdgeKind, true> = {
+  "a2a-delegation": true,
+  "a2a-handoff": true,
+  "a2a-task-lineage": true,
+  "a2a-deliberation": true,
+};
+void _edgeKindGuard;

--- a/apps/web/lib/ai-operations-map/project-routing-topology.ts
+++ b/apps/web/lib/ai-operations-map/project-routing-topology.ts
@@ -9,6 +9,7 @@ import type {
   OperationsMapRoutingTimelineMarker,
   OperationsMapRoutingTopology,
 } from "./types";
+import { A2A_INTERACTION_LEGEND } from "./project-a2a-interactions";
 
 export type RoutingCoworkerSourceRow = {
   agentId: string;
@@ -442,9 +443,14 @@ export function projectRoutingTopology(input: RoutingTopologyInput): OperationsM
     coworkers: sortByLabel(coworkers),
     providers,
     routes,
+    // A2A interaction edges are contributed by `projectA2aInteractions` and
+    // merged in `load-map-data.ts`. Default to empty here so the topology
+    // shape is stable when only provider routing is projected.
+    a2aEdges: [],
     markers,
     timeline: timeline.sort((left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt)),
     legend: ROUTING_TOPOLOGY_LEGEND,
+    a2aLegend: A2A_INTERACTION_LEGEND,
   };
 }
 

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -222,13 +222,70 @@ export type OperationsMapRoutingLegendItem = {
   description: string;
 };
 
+// ─── Typed-node / typed-edge graph (A2A re-architecture) ───────────────
+//
+// The topology was originally a two-lane bipartite graph: every edge ran
+// coworker → provider. To surface coworker-to-coworker (A2A) interactions
+// — delegation, build phase-handoff, task spawn/lineage, deliberation
+// fan-out — the model is generalized so an edge declares its kind. Provider
+// routes remain `OperationsMapRoutingRoute` (the `provider-route` variant);
+// A2A interactions are `OperationsMapA2aEdge` and connect two coworkers.
+// See docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md
+
+export type OperationsMapNodeKind = "coworker" | "provider";
+
+export type OperationsMapEdgeKind =
+  | "provider-route"
+  | "a2a-delegation"
+  | "a2a-handoff"
+  | "a2a-task-lineage"
+  | "a2a-deliberation";
+
+export type OperationsMapA2aEdgeKind = Exclude<OperationsMapEdgeKind, "provider-route">;
+
+export type OperationsMapA2aInteractionState = "active" | "completed" | "failed" | "blocked";
+
+export type OperationsMapA2aEdge = {
+  id: string;
+  edgeKind: OperationsMapA2aEdgeKind;
+  fromCoworkerId: string;
+  toCoworkerId: string;
+  state: OperationsMapA2aInteractionState;
+  label: string;
+  summary: string;
+  occurredAt: string | null;
+  // Audit / troubleshooting envelope — populated where the source row carries it.
+  authorityScope?: string[];
+  sensitivity?: string | null;
+  skillId?: string | null;
+  buildId?: string | null;
+  gateResult?: string | null;
+  // Source-record references for click-through audit.
+  refs: {
+    delegationChainId?: string | null;
+    phaseHandoffId?: string | null;
+    taskRunId?: string | null;
+    parentTaskRunId?: string | null;
+    deliberationRunId?: string | null;
+  };
+  weight: number;
+};
+
+export type OperationsMapA2aLegendItem = {
+  edgeKind: OperationsMapA2aEdgeKind;
+  label: string;
+  description: string;
+};
+
 export type OperationsMapRoutingTopology = {
   coworkers: OperationsMapRoutingCoworker[];
   providers: OperationsMapRoutingProvider[];
   routes: OperationsMapRoutingRoute[];
+  a2aEdges: OperationsMapA2aEdge[];
   markers: OperationsMapRoutingMarker[];
   timeline: OperationsMapRoutingTimelineMarker[];
   legend: OperationsMapRoutingLegendItem[];
+  a2aLegend: OperationsMapA2aLegendItem[];
 };
 
 export type OperationsMapQuickViewId = "all" | "exceptions" | "evidence" | "tool-runs";

--- a/docs/superpowers/plans/2026-06-04-ai-operations-map-a2a-interaction-visibility.md
+++ b/docs/superpowers/plans/2026-06-04-ai-operations-map-a2a-interaction-visibility.md
@@ -1,0 +1,138 @@
+# AI Operations Map — A2A Interaction Visibility — Implementation Plan
+
+> **For agentic workers:** Execute task-by-task with TDD. Steps use checkbox (`- [ ]`) syntax for tracking. Backlog item: `BI-65B0D697` (epic `EP-AI-OPSMAP`). Design: `docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md`.
+
+**Goal:** Re-architect `/platform/ai/operations-map` to render coworker-to-coworker (A2A) interactions — delegation, build phase-handoff, task spawn/lineage, deliberation fan-out — as first-class typed edges alongside the existing coworker→provider routing, with audit/troubleshooting filtering and an enriched inspector.
+
+**Architecture:** Generalize the existing `apps/web/lib/ai-operations-map/` projection layer from an implicit two-lane bipartite model to a typed-node / typed-edge graph. Add a second pure projector that reads **existing** A2A substrate (`DelegationChain`, `PhaseHandoff`, `TaskRun` lineage, `DeliberationRun`) — **no migration**. Compose both projectors in the loader. Re-architect `AiOperationsMap.tsx` rendering into three bands (coworker interaction band, provider routing band, shared replay timeline) and extend filtering + inspector.
+
+**Tech Stack:** Next.js App Router, Prisma via `@dpf/db`, React/SVG, Vitest, `lucide-react`, DPF `--dpf-*` theme tokens.
+
+**Coordination:** Parallel A2A-capture thread owns the write path (`EP-A2A`, `BI-9DB7C332`). This plan is read-only + migration-free + additive to avoid collision. Re-sweep open PRs + recent `main` before every push.
+
+---
+
+## File Structure
+
+- Modify `apps/web/lib/ai-operations-map/types.ts` — add `OperationsMapNodeKind`, `OperationsMapEdgeKind`, `OperationsMapA2aInteractionState`, `OperationsMapA2aEdge`, `OperationsMapA2aLegendItem`; add `a2aEdges` + `a2aLegend` to `OperationsMapRoutingTopology`.
+- Create `apps/web/lib/ai-operations-map/project-a2a-interactions.ts` — pure projector: A2A source rows → `OperationsMapA2aEdge[]` + contributed coworker nodes + timeline markers.
+- Create `apps/web/lib/ai-operations-map/project-a2a-interactions.test.ts` — TDD coverage per edge kind, state mapping, self-edge/missing-agent handling, aggregation.
+- Modify `apps/web/lib/ai-operations-map/load-map-data.ts` — fetch the four A2A sources in the existing `Promise.all`; compose A2A edges into `routingTopology`.
+- Modify `apps/web/lib/ai-operations-map/load-map-data.test.ts` — assert the new source queries and merged `a2aEdges`.
+- Modify `apps/web/lib/ai-operations-map/project-routing-topology.ts` — emit `a2aEdges: []` + `a2aLegend` defaults so the topology shape is stable when the A2A projector is absent (keeps existing tests green during Slice 1).
+- Modify `apps/web/components/platform/AiOperationsMap.tsx` — three-band layout, A2A edge rendering + legend, interaction-dimension filters, A2A inspector detail.
+- Modify `apps/web/components/platform/AiOperationsMap.test.tsx` — A2A edges render, filters narrow, inspector shows from→to + click-through, empty-state.
+- Modify `apps/web/components/platform/ai-operations-map-prefs.ts` (+ test) — persist the new interaction-dimension + A2A filter state.
+
+---
+
+## Phase / Slice 1 — Data model + A2A projector (migration-free, TDD) — ✅ DONE (2026-06-04)
+
+> No rendering change. Independently verifiable via vitest. This is the foundational re-architecture; everything else builds on it. **Status: complete — 51 `lib/ai-operations-map` tests pass, `typecheck` clean.** Deliberation projection is supported + unit-tested but left unwired in the loader (TaskNode carries no branch-persona `agentId` yet) → Slice 4.
+
+### Task 1.1: Generalize the topology type model
+
+- [ ] Add `OperationsMapNodeKind = "coworker" | "provider"`.
+- [ ] Add `OperationsMapEdgeKind = "provider-route" | "a2a-delegation" | "a2a-handoff" | "a2a-task-lineage" | "a2a-deliberation"`.
+- [ ] Add `OperationsMapA2aInteractionState = "active" | "completed" | "failed" | "blocked"`.
+- [ ] Add `OperationsMapA2aEdge` (from/to coworker, edgeKind, state, label, summary, occurredAt, authorityScope?, sensitivity?, skillId?, buildId?, gateResult?, refs{}, weight) per spec §4.2.
+- [ ] Add `OperationsMapA2aLegendItem` (edgeKind, label, description).
+- [ ] Add `a2aEdges: OperationsMapA2aEdge[]` and `a2aLegend: OperationsMapA2aLegendItem[]` to `OperationsMapRoutingTopology`.
+- [ ] Keep `OperationsMapRoutingRoute` unchanged (it IS the `provider-route` variant) for backward compatibility.
+
+### Task 1.2: A2A projector tests (write first, expect red)
+
+- [ ] `DelegationChain` row → one `a2a-delegation` edge `fromAgentId`→`toAgentId`; state mapped from `status`; `authorityScope`/`skillId`/`reason` carried; refs.delegationChainId set.
+- [ ] `PhaseHandoff` row → one `a2a-handoff` edge with `fromPhase→toPhase` label, `gateResult` carried, refs.phaseHandoffId/buildId set.
+- [ ] `TaskRun` with `parentTaskRunId` set OR `initiatingAgentId ≠ currentAgentId` → one `a2a-task-lineage` edge; rows where initiating==current and no parent yield no edge.
+- [ ] `DeliberationRun` + branch `TaskNode`s → coordinator→branch `a2a-deliberation` edges, aggregated per run.
+- [ ] Self-edge (`from === to`) dropped; row missing an agent on either end skipped.
+- [ ] Coworkers referenced only as a delegation *target* still appear in contributed coworker nodes.
+- [ ] Run `pnpm --filter web exec vitest run lib/ai-operations-map/project-a2a-interactions.test.ts` and confirm it fails for the missing module.
+
+### Task 1.3: Implement `project-a2a-interactions.ts`
+
+- [ ] Pure function `projectA2aInteractions(input)` — no Prisma, no React imports (mirror `project-routing-topology.ts`).
+- [ ] Define source-row DTO types for the four sources.
+- [ ] Map each source per spec §4.3 table; conservative defaults (unknown status → `active`).
+- [ ] Contribute coworker nodes via an `ensureCoworker`-style helper; return `{ a2aEdges, coworkers, timeline }`.
+- [ ] Aggregate deliberation branch edges per run to avoid clutter.
+- [ ] Re-run tests to green; keep existing `project-routing-topology.test.ts` passing.
+
+### Task 1.4: Compose in the loader
+
+- [ ] Add `a2aLegend` constant + `a2aEdges: []` defaults to `projectRoutingTopology` output so the topology shape is stable.
+- [ ] In `load-map-data.ts`, add to the existing `Promise.all`: recent `delegationChain`, `phaseHandoff`, `taskRun` (lineage subset), `deliberationRun` (+ branch nodes) fetches, bounded by `RECENT_TOOL_LIMIT`.
+- [ ] Call `projectA2aInteractions`, merge its coworker nodes into the topology coworker set, set `topology.a2aEdges`, and merge timeline markers.
+- [ ] Update `load-map-data.test.ts` to assert the new queries issue and `a2aEdges` is populated.
+
+### Task 1.5: Verify Slice 1
+
+- [ ] `pnpm --filter web exec vitest run lib/ai-operations-map`
+- [ ] `pnpm --filter web typecheck`
+- [ ] Confirm no rendering regression (component still compiles against the extended topology with `a2aEdges` unused).
+
+---
+
+## Phase / Slice 2 — Rendering band — ✅ FIRST INCREMENT DONE (2026-06-04)
+
+> Implemented as an isolated, tested `A2aInteractionsPanel.tsx` component rendered below the provider routing panel, rather than re-cutting the 2599-line provider SVG in place — this delivers operator-facing A2A visibility now without destabilizing the working provider view. It renders a from→to coworker interaction band (typed per-kind line styles + per-state colors + arrowheads + legend), the interaction-type / state / coworker(role) filters (Slice 3 scope, folded in here), and a click-through inspector. 5 behavioral render tests pass. The fully-merged three-band orbital SVG layout (spec §5.1) — sharing coworker Y-positions with the provider band — remains the polish target for a later increment.
+
+### Task 2.1: Banded layout
+
+- [ ] Replace fixed two-lane `ROUTING_LAYOUT` assumptions with a banded layout computing coworker Y-positions once and reusing them across the interaction band and provider band.
+- [ ] Add a coworker interaction band that draws A2A edges between coworker nodes.
+
+### Task 2.2: A2A edge visual grammar
+
+- [ ] Per-`edgeKind` line treatment + symbol + legend entry (spec §5.2); color via `--dpf-*` only; state conveyed by shape+dash+label, never color alone.
+- [ ] Aggregate deliberation fan-out visually; expandable in inspector.
+- [ ] Add an empty-state for the interaction band when `a2aEdges` is empty.
+
+### Task 2.3: Verify Slice 2
+
+- [ ] `pnpm --filter web exec vitest run components/platform/AiOperationsMap`
+- [ ] `pnpm --filter web build`
+- [ ] Visual check at desktop + mobile widths.
+
+---
+
+## Phase / Slice 3 — Filtering + inspector — ✅ LARGELY DONE (2026-06-05, post-review)
+
+> After the 2026-06-05 architecture/UI review, this slice was advanced alongside the report-kit refactoring allocation (spec §8):
+> - **report-kit / token alignment:** A2A state→colour now flows through the shared `statusColors` `a2aInteraction` domain (no local colour map); inspector state uses `StatusBadge`; KPI counts use `StatCard`; timestamps use `LocalTime` (no `Intl.DateTimeFormat` in the leaf).
+> - **Pure helpers extracted + tested:** layout math, edge styling, state intent, and source-record link building moved to [a2a-interaction-graph.ts](apps/web/components/platform/a2a-interaction-graph.ts) with full vitest coverage.
+> - **Honest source-record click-through:** `/build?buildId=` deep-link verified and used; `DelegationChain`/`PhaseHandoff`/`TaskRun`/`DeliberationRun` shown as identifier text (no dead links) since they have no page route.
+> - **Persisted filters:** A2A type/state/coworker(role) filter state persists via `ai-operations-map-prefs` (`loadA2aFilterPreference`/`saveA2aFilterPreference`/`clearA2aFilterPreference`), round-trip unit-tested.
+>
+> Verified: 87 `lib/ai-operations-map` + `components/platform` tests pass, `typecheck` clean.
+> **Remaining (Slice 2B/3 polish):** top-level `Provider routes · A2A · Both` dimension toggle, authority/sensitivity filter facet, shared replay-window composition across both bands, saved-view integration that includes A2A filters, and the cohesive three-band layout.
+
+### Task 3.1: Interaction-dimension filtering
+
+- [ ] Dimension toggle: Provider routes · A2A interactions · Both (default Both).
+- [ ] A2A type filter (delegation/handoff/lineage/deliberation, multi-select).
+- [ ] Actor filter (single coworker as source/target/either).
+- [ ] State filter (active/completed/failed/blocked) — the troubleshooting entry point.
+- [ ] Authority/sensitivity filter where edges carry it.
+- [ ] Compose all with the existing replay-time window.
+- [ ] Persist new keys via `ai-operations-map-prefs` (+ test).
+
+### Task 3.2: A2A inspector detail
+
+- [ ] Extend the symbol/edge detail popover for A2A edges: from→to coworker, edge kind, state, reason/summary, authority scope + sensitivity, gate/consensus result, click-through links to source record (delegation chain, build, task run, deliberation).
+
+### Task 3.3: Verify Slice 3 + functional sign-off
+
+- [ ] Full vitest + typecheck + build gates.
+- [ ] Functional: drive `/platform/ai/operations-map` on the live install; confirm A2A edges render between correct coworkers, filters narrow as specified, inspector shows from→to + authority + click-through, timeline scrubs A2A markers. Record as a dynamic-analysis narrative naming the substrate (per structural-≠-functional commandment). If no A2A rows exist yet, drive a Build Studio run to produce `PhaseHandoff` rows, or verify empty-state and defer live-edge sign-off honestly.
+
+---
+
+## Non-Goals
+
+- No writes to delegation/handoff/task/deliberation state (read-only map).
+- No new database models or migrations in v1.
+- No dependency on the parallel A2A-capture thread shipping first.
+- No live-SSE animation in v1 (reuse the existing static replay timeline).
+- No new permissions or theme tokens.

--- a/docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md
@@ -1,0 +1,432 @@
+# AI Operations Map - Coworker-to-Coworker (A2A) Interaction Visibility - Design
+
+| Field | Value |
+|-------|-------|
+| **Status** | Reviewed and implementation-aligned (2026-06-05) |
+| **Created** | 2026-06-04 |
+| **Last review** | 2026-06-05 architecture/UI/spec pass |
+| **Owner** | Platform / AI Operations |
+| **Surface** | `/platform/ai/operations-map`, `apps/web/lib/ai-operations-map/*`, `apps/web/components/platform/AiOperationsMap.tsx`, `apps/web/components/platform/A2aInteractionsPanel.tsx` |
+| **Parent epic / item** | `EP-AI-OPSMAP`; `BI-65B0D697` ("AI Operations Map - coworker-to-coworker (A2A) interaction visibility re-architecture") |
+| **Related live work** | `EP-A2A`; `BI-9DB7C332` ("Multi-agent collaboration & visibility - user-facing handoff/summon + pattern lens") owns the runtime/capture side |
+| **Related specs/plans** | `docs/superpowers/specs/2026-04-23-a2a-aligned-coworker-runtime-design.md`, `docs/superpowers/specs/2026-05-10-ai-coworker-visual-control-surface-design.md`, `docs/specs/routing-resilience-and-failure-observability-spec.md`, `docs/superpowers/plans/2026-05-13-ai-routing-topology-map.md`, `docs/superpowers/plans/2026-06-04-ai-operations-map-a2a-interaction-visibility.md` |
+| **Backlog posture** | Live MCP check on 2026-06-05: do not file a duplicate. `BI-65B0D697` is already open under `EP-AI-OPSMAP`; `BI-9DB7C332` is in progress under `EP-A2A` and should remain the coordination point for capture/runtime enrichment. |
+
+## 0. Architecture Review Summary
+
+The current direction is architecturally sound: A2A visibility belongs in the existing AI Operations Map as a read/projection/render slice, not as a new route or a new database subsystem. The important correction is scope honesty. The first implementation increment already landed a migration-free typed-edge substrate and a separate A2A panel, but it has not yet completed the original three-band shared layout, replay-window composition, persisted A2A filter preferences, source-record click-through for every edge type, or live-edge verification on the canonical runtime.
+
+This spec therefore treats the work as a staged re-architecture:
+
+| Layer | Current repo truth | Target contract |
+|---|---|---|
+| Topology data model | `types.ts` now has `OperationsMapA2aEdge`, `OperationsMapA2aEdgeKind`, `a2aEdges`, and `a2aLegend`; provider routes remain `OperationsMapRoutingRoute`. | Keep provider routes stable while making A2A edges first-class typed coworker-to-coworker edges. |
+| Projection | `project-a2a-interactions.ts` exists and is pure; `load-map-data.ts` wires `DelegationChain`, `PhaseHandoff`, and `TaskRun` lineage. Deliberation projection exists as a pure function path, but the loader passes `deliberations: []` because `TaskNode` currently has branch role/status but no branch agent id. | Compose every stable A2A source without a migration. Wire deliberation fan-out only when branch-persona agent identity exists or an equivalent runtime event source lands. |
+| Rendering | `A2aInteractionsPanel.tsx` renders a separate coworker-to-coworker interaction panel below the provider routing panel. It has type/state/coworker filters and an inspector. | Evolve toward a cohesive operations view: A2A interaction band, provider-routing band, shared timeline, shared filter state, and consistent inspector behavior. |
+| UI system | The first panel uses DPF tokens, keyboard-selectable SVG paths, and readable empty states. It still uses local `Stat`/chip primitives, local state-color mapping, and `Intl.DateTimeFormat` directly. | Reserve refactoring capacity to fold status/count/filter/time display onto report-kit/status intent/`LocalTime` patterns where they fit, while keeping the custom SVG graph for the interaction topology. |
+
+The governing decision remains: compose existing substrate before adding tables. This protects the parallel `EP-A2A` capture thread and keeps v1 implementation narrow, reviewable, and truthful.
+
+## 1. Problem
+
+The Operations Map can already explain provider routing: which coworker routed to which provider, which provider failed, what fallback occurred, and what the recent routing window looked like. It does not yet answer the A2A operational questions:
+
+- Which coworker delegated work to another coworker, and why?
+- Which Build Studio phase was handed from one coworker to the next, and what gate result governed it?
+- Which task run spawned or shifted work from an initiating/parent coworker to the acting coworker?
+- Which deliberation fanned work out to peer-review personas, and which branch roles participated?
+- For any of those interactions, what authority, status, source record, and evidence can the operator inspect after the fact?
+
+This is not just a missing filter. The provider-routing topology was originally a two-lane bipartite graph: coworker nodes on one side, provider nodes on the other, and every path shaped as coworker -> provider. A2A edges have two coworker endpoints, so they require an explicit typed-edge model and a rendering grammar that does not pretend every edge has a provider.
+
+## 2. Current Repo and Substrate Truth
+
+### 2.1 Rendering and Projection Surfaces
+
+Verified in `claude/admiring-wescoff-cd6a30` on 2026-06-05:
+
+| Surface | Current truth |
+|---|---|
+| `apps/web/components/platform/AiOperationsMap.tsx` | 2605 lines. Renders the existing `RoutingTopologyPanel`, then the new `A2aInteractionsPanel`. Provider-routing layout is still preserved. |
+| `apps/web/components/platform/A2aInteractionsPanel.tsx` | 585 lines. New client component for visible A2A interactions, local filters, local summary counts, SVG edge band, and inspector. |
+| `apps/web/lib/ai-operations-map/types.ts` | Extended with A2A edge/legend types and `a2aEdges`/`a2aLegend` on `OperationsMapRoutingTopology`. |
+| `apps/web/lib/ai-operations-map/project-a2a-interactions.ts` | Pure projector for delegation, handoff, task lineage, and deliberation-shaped input DTOs. No Prisma or React imports. |
+| `apps/web/lib/ai-operations-map/load-map-data.ts` | Fetches `DelegationChain`, `PhaseHandoff`, and lineage-relevant `TaskRun` rows, then merges the A2A projection into the existing routing topology. Deliberation wiring is intentionally deferred. |
+| `apps/web/components/ui/report-kit/README.md` | Canonical reporting/data-display palette: `StatusBadge`, `StatCard`, `FilterBar`, `DataTable`, `ExportButton`, `Chart`, `statusColors`, and `LocalTime` guidance. |
+
+### 2.2 A2A Substrate
+
+The platform already persists enough data to render useful A2A visibility without a migration. The table below separates what is wired now from what is future-ready.
+
+| Model | A2A-relevant fields | Edge yielded | Loader status |
+|---|---|---|---|
+| `DelegationChain` | `fromAgentId`, `toAgentId`, `skillId`, `status`, `reason`, `chainId`, `depth`, `parentLinkId`, `authorityScope[]`, `originUserId`, `originAuthority[]`, `startedAt`, `completedAt` | `a2a-delegation`: explicit coworker -> coworker delegation with authority envelope and status. | Wired in `load-map-data.ts`. |
+| `PhaseHandoff` | `fromAgentId`, `toAgentId`, `fromPhase`, `toPhase`, `summary`, `buildId`, `gateResult`, `tokenBudgetUsed`, `iterationCount`, `createdAt` | `a2a-handoff`: Build Studio phase handoff with gate context. | Wired in `load-map-data.ts`; explicit gate failure maps to `blocked`, otherwise recorded handoffs map to `completed`. |
+| `TaskRun` | `initiatingAgentId`, `currentAgentId`, `parentTaskRunId`, `a2aMetadata`, `source`, `status`, `contextId`, `threadId`, `buildId`, `title`, `objective`, `startedAt`, `completedAt` | `a2a-task-lineage`: initiating/parent coworker -> current coworker when distinct. | Wired in `load-map-data.ts`; parent agent is resolved from the fetched task-run set when available. |
+| `DeliberationRun` + `TaskNode` | `DeliberationRun.taskRunId`, `consensusState`, `diversityMode`, `adjudicationMode`; branch `TaskNode.workerRole`, `influenceLevel`, `status` | Target `a2a-deliberation`: coordinator -> branch persona. | Not loader-wired yet. `TaskNode` has branch role/status but no branch-persona `agentId`, so rendering this as agent-to-agent would currently fabricate identity. |
+| `AgentThread` | `parentThreadId`, `childCount`, `cancelledAt` | Secondary corroboration for thread spawning lineage. | Not a primary v1 edge source; agent attribution should come through `TaskRun` or future capture events. |
+
+Conclusion: v1 remains migration-free, but the definition of "v1" must not promise deliberation fan-out until branch identity exists. This is an architecture integrity constraint, not a UI nicety.
+
+### 2.3 Boundary With the A2A Capture Thread
+
+`EP-A2A` / `BI-9DB7C332` owns richer capture semantics: handoff/summon UX, runtime event enrichment, A2A metadata, and any future event rows. This spec owns the read/projection/render path for Operations Map visibility.
+
+Rules:
+
+- This slice must not add a parallel A2A event table unless the capture thread explicitly establishes it as the canonical source.
+- `a2aMetadata` is a forward-compatible enrichment slot, not a required v1 dependency.
+- When the capture thread lands richer events, add one projector input path. Do not replace `DelegationChain`, `PhaseHandoff`, and `TaskRun` projections unless the new source is declared authoritative.
+- Before push/PR, re-sweep `origin/main`, open PRs, `EP-AI-OPSMAP`, and `EP-A2A` for overlap.
+
+## 3. Research and Benchmarking
+
+### 3.1 A2A Protocol
+
+Primary sources:
+
+- [A2A latest specification](https://a2a-protocol.org/latest/specification/)
+- [A2A upstream specification repository](https://github.com/a2aproject/A2A/blob/main/docs/specification.md)
+
+Relevant standard pressure:
+
+- A2A defines task-native communication around `Task`, `Message`, `Artifact`, `Part`, status updates, artifact updates, task lookup, task cancellation, and task subscription.
+- The current spec supports blocking and non-blocking send behavior; async callers are expected to poll, subscribe, or receive push notifications.
+- `Message` and `Artifact` are distinct payload concepts. DPF should not collapse coworker interaction visibility into chat text or provider logs.
+
+Adopted for this spec:
+
+- DPF maps A2A-like work identity to `TaskRun`, not to a new map-only concept.
+- DPF maps interaction outputs/evidence to existing record refs first and future `TaskArtifact` / event rows later.
+- The Operations Map visualizes A2A-shaped task history; it does not claim public A2A endpoint conformance.
+
+Rejected for v1:
+
+- No public `AgentCard`, `SendMessage`, or `SubscribeToTask` implementation as part of this slice.
+- No live streaming animation in the map until the runtime/capture contract provides stable event semantics.
+
+### 3.2 Observability Standards
+
+Primary sources:
+
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [W3C Trace Context Recommendation](https://www.w3.org/TR/trace-context/)
+
+Relevant standard pressure:
+
+- OpenTelemetry separates traces, logs, metrics, events, and resources. The Operations Map should preserve source-record references and correlation ids instead of replacing them with a screenshot-only dashboard.
+- W3C Trace Context gives a portable correlation model, and its privacy guidance warns against putting personally identifiable information into trace state.
+
+Adopted for this spec:
+
+- A2A edges carry `refs` to authoritative DPF rows and may later carry trace/span correlation fields when those exist.
+- Timeline markers should be projections of source records, not handcrafted display-only events.
+- Future correlation fields must be opaque ids or stable internal references, not free-form human/user data.
+
+### 3.3 DPF UI Standards
+
+Primary sources:
+
+- `AGENTS.md` section 12: no hardcoded colors; use theme tokens.
+- `docs/platform-usability-standards.md`: WCAG 2.2 AA, token-backed surfaces/text/borders/focus.
+- `apps/web/components/ui/report-kit/README.md`: reporting/data-display primitives and status intent registry.
+
+Adopted:
+
+- Custom SVG is acceptable for the interaction graph because report-kit `Chart` is not a graph-topology primitive.
+- Status pills, KPI counts, filter rows, tables, and exports must use report-kit primitives when the primitive fits.
+- Status and severity color semantics should flow through `statusColors` or token-backed semantic intent, not a per-panel color map.
+- Timestamps in React UI should use shared time rendering (`LocalTime`) rather than direct `Intl.DateTimeFormat` in leaf components.
+
+## 4. Goals and Non-Goals
+
+### Goals
+
+1. Render coworker-to-coworker interactions as first-class edges for delegation, phase handoff, and task lineage in the current v1 slice.
+2. Keep deliberation fan-out as a supported typed-edge concept, but wire it only when branch agent identity is present.
+3. Preserve existing provider-routing functionality and tests.
+4. Give operators audit/troubleshooting controls by interaction type, actor role, state, and eventually authority/sensitivity.
+5. Provide an inspector that explains from coworker, to coworker, edge kind, state, reason/summary, authority/gate context, and source-record refs.
+6. Stay migration-free until the capture thread establishes a canonical new write path.
+7. Reserve about 20% of remaining implementation effort for refactoring the A2A panel into established DPF UI/reporting primitives and smaller pure helpers.
+
+### Non-Goals
+
+- No writes to delegation, handoff, task, deliberation, or thread state.
+- No new database models or migrations in v1.
+- No public A2A server/client protocol implementation.
+- No live-SSE animation in v1.
+- No separate `/platform/ai/a2a-map` route.
+- No fabricated deliberation branch-agent edges while the schema lacks branch agent identity.
+
+## 5. Design - Typed-Edge Topology Model
+
+### 5.1 Node Model
+
+Coworkers and providers remain separate node kinds. Coworkers can be both a source and target of A2A edges, so they are not merely a left lane.
+
+```ts
+export type OperationsMapNodeKind = "coworker" | "provider";
+```
+
+The current implementation preserves `OperationsMapRoutingCoworker` and `OperationsMapRoutingProvider`. A discriminator can be added later if a generic graph renderer replaces the current separate provider and A2A panels.
+
+### 5.2 Edge Model
+
+Provider routes stay backward-compatible as `OperationsMapRoutingRoute`. A2A interactions are their own discriminated edge type:
+
+```ts
+export type OperationsMapEdgeKind =
+  | "provider-route"
+  | "a2a-delegation"
+  | "a2a-handoff"
+  | "a2a-task-lineage"
+  | "a2a-deliberation";
+
+export type OperationsMapA2aEdgeKind = Exclude<
+  OperationsMapEdgeKind,
+  "provider-route"
+>;
+
+export type OperationsMapA2aInteractionState =
+  | "active"
+  | "completed"
+  | "failed"
+  | "blocked";
+```
+
+`OperationsMapA2aEdge` carries the minimum audit envelope:
+
+```ts
+export type OperationsMapA2aEdge = {
+  id: string;
+  edgeKind: OperationsMapA2aEdgeKind;
+  fromCoworkerId: string;
+  toCoworkerId: string;
+  state: OperationsMapA2aInteractionState;
+  label: string;
+  summary: string;
+  occurredAt: string | null;
+  authorityScope?: string[];
+  sensitivity?: string | null;
+  skillId?: string | null;
+  buildId?: string | null;
+  gateResult?: string | null;
+  refs: {
+    delegationChainId?: string | null;
+    phaseHandoffId?: string | null;
+    taskRunId?: string | null;
+    parentTaskRunId?: string | null;
+    deliberationRunId?: string | null;
+  };
+  weight: number;
+};
+```
+
+`OperationsMapRoutingTopology` includes:
+
+```ts
+export type OperationsMapRoutingTopology = {
+  coworkers: OperationsMapRoutingCoworker[];
+  providers: OperationsMapRoutingProvider[];
+  routes: OperationsMapRoutingRoute[];
+  a2aEdges: OperationsMapA2aEdge[];
+  markers: OperationsMapRoutingMarker[];
+  timeline: OperationsMapRoutingTimelineMarker[];
+  legend: OperationsMapRoutingLegendItem[];
+  a2aLegend: OperationsMapA2aLegendItem[];
+};
+```
+
+`a2aEdges` defaults to `[]`. Empty A2A data must never break the provider topology.
+
+## 6. Design - A2A Projection
+
+`project-a2a-interactions.ts` is the correct architectural boundary: pure in, pure out, no Prisma, no React. `load-map-data.ts` owns database reads and DTO shaping.
+
+| Source | Edge kind | State mapping | Required guardrails |
+|---|---|---|---|
+| `DelegationChain` | `a2a-delegation` | `completed`, `failed`, `blocked`; all else `active`. | Drop self-edges and rows missing either agent. Preserve `authorityScope`, `skillId`, and `reason`. |
+| `PhaseHandoff` | `a2a-handoff` | Explicit gate failure -> `blocked`; otherwise a recorded handoff -> `completed`. | Preserve `buildId`, `gateResult` label, phase labels, and token-weight bucket. |
+| `TaskRun` lineage | `a2a-task-lineage` | `completed`/`archived` -> `completed`; `failed`/`rejected` -> `failed`; `canceled` -> `blocked`; all else `active`. | Prefer parent agent for child task runs; otherwise initiating agent. Drop initiating==current self-edges. |
+| `DeliberationRun` + branches | `a2a-deliberation` | Consensus/branch status. | Do not wire in loader until branch-persona agent identity exists. Pure projector support is fine; runtime projection without identity is not. |
+
+Composition requirements:
+
+- Merge A2A-contributed coworker nodes into provider-topology coworker nodes by `agentId`, preserving provider topology labels when duplicated.
+- Merge provider and A2A timeline markers chronologically.
+- Keep A2A source fetch limits bounded by the existing recent-window discipline until the map has URL/date-range controls.
+- Do not turn missing source rows into synthetic "example" interactions.
+
+## 7. Design - Rendering and Interaction
+
+### 7.1 Current Increment
+
+The current visible increment is a separate `A2aInteractionsPanel` rendered under the provider routing panel. This is acceptable as a stabilization slice because it:
+
+- avoids destabilizing the 2605-line provider topology component,
+- proves the A2A projection creates renderable operator value,
+- gives tests a focused component boundary, and
+- preserves existing provider routing UX.
+
+It is not the final visual architecture. The final v1 UX should feel like one operations surface rather than two unrelated panels.
+
+### 7.2 Target Layout
+
+The target layout is a cohesive operations map with three coordinated bands:
+
+1. **Coworker interaction band:** directional A2A edges between coworkers.
+2. **Provider routing band:** existing coworker -> provider routing paths.
+3. **Shared timeline:** one replay window that can scrub provider and A2A events together.
+
+Coworker labels and vertical positioning should converge where possible so an operator can visually connect "this coworker delegated to another coworker" and "this coworker routed to this provider" without relearning the map twice.
+
+### 7.3 A2A Visual Grammar
+
+| Edge kind | Line treatment | Meaning |
+|---|---|---|
+| `a2a-delegation` | Solid | Authority-bearing delegation between coworkers. |
+| `a2a-handoff` | Long dash | Build-phase handoff with gate result. |
+| `a2a-task-lineage` | Short dash | Parent/initiating coworker to acting coworker task lineage. |
+| `a2a-deliberation` | Dotted/fan | Coordinator to branch personas once branch identity is available. |
+
+State uses semantic tokens plus explicit text:
+
+- `active`: active/accent intent
+- `completed`: success intent
+- `failed`: danger/error intent
+- `blocked`: warning intent
+
+Color is never the only channel. State must also appear as text in the inspector and the graph must vary dash/shape/labels by edge kind.
+
+### 7.4 Filters
+
+Current first increment:
+
+- A2A type filter
+- state filter
+- coworker actor filter with `either` / `from` / `to`
+- reset action local to the panel
+
+Remaining target:
+
+- top-level dimension toggle: `Provider routes`, `A2A interactions`, `Both`
+- authority/sensitivity filter when data exists
+- shared replay-window filter across provider and A2A markers
+- persisted A2A filter state through the existing Operations Map preference mechanism
+- saved operator views that include A2A filter state
+
+### 7.5 Inspector and Click-Through
+
+Current first increment:
+
+- Shows edge kind, from coworker, to coworker, summary, state, time, skill/gate/authority/build when available.
+- Links to source/target coworker and build when `buildId` exists.
+
+Remaining target:
+
+- Link to authoritative source records for delegation chain, phase handoff/build, task run, and deliberation outcome when route surfaces exist.
+- Use stable href builders rather than inline route construction inside the graph component.
+- Render timestamps through shared time display.
+- Surface "source record unavailable" honestly rather than hiding missing links.
+
+## 8. UI, Accessibility, and Refactoring Requirements
+
+This is an operational dashboard, not a landing page. It should be dense, quiet, scannable, and built for repeated troubleshooting.
+
+Mandatory UI rules:
+
+- Use `--dpf-*` tokens for text, surfaces, borders, accents, success/warning/error, and focus rings.
+- Do not add local raw hex colors or a local status color registry.
+- Use report-kit primitives where they fit:
+  - `StatCard` or a report-kit equivalent for KPI counts.
+  - `StatusBadge` / `statusColors` for status and severity semantics.
+  - `FilterBar` where filters become reusable facets.
+  - `LocalTime` for timestamp display.
+- Custom SVG remains acceptable for the A2A graph because report-kit `Chart` does not model directed coworker interaction topology.
+- Keyboard users must be able to select each rendered edge and reset/narrow filters.
+- SVG paths need accessible names that include from coworker, to coworker, edge kind, and state.
+- Text must fit on desktop and mobile; long coworker labels should truncate inside SVG and be fully visible in the inspector.
+- Avoid nested card visual hierarchy. A panel can be a bounded tool surface, but repeated items should not become cards inside cards.
+
+Refactoring allocation:
+
+Reserve about 20% of remaining implementation effort for targeted cleanup that improves durability without expanding scope:
+
+- Extract graph layout math and edge style mapping into pure helpers with tests.
+- Replace local count/status/filter primitives with report-kit primitives where the API fits.
+- Move A2A state-to-intent mapping into a shared status intent path instead of keeping a private `stateStroke` map.
+- Replace direct timestamp formatting in `A2aInteractionsPanel` with shared time rendering.
+- Keep the first panel extraction if it protects the provider map, but avoid a permanent forked design language.
+
+## 9. Verification Plan
+
+Source-local gates in the worktree:
+
+- `pnpm --filter web exec vitest run lib/ai-operations-map`
+- `pnpm --filter web exec vitest run components/platform/A2aInteractionsPanel.test.tsx`
+- `pnpm --filter web exec vitest run components/platform/AiOperationsMap.test.tsx`
+- `pnpm --filter web typecheck`
+- `pnpm --filter web build`
+
+Functional gate on canonical runtime or shared local-CI convergence sandbox:
+
+- Drive `/platform/ai/operations-map`.
+- Confirm provider routing remains intact.
+- Confirm the A2A panel renders real `DelegationChain`, `PhaseHandoff`, or `TaskRun` lineage edges when rows exist.
+- Confirm filters narrow by type/state/coworker role.
+- Confirm inspector shows from/to, state, summary, authority/gate/build context, and honest source links.
+- Confirm empty state when no A2A rows exist in the selected window.
+- Record dynamic-analysis evidence naming the substrate. Do not claim UX complete from source-local tests alone.
+
+If the install has no A2A rows:
+
+- Prefer generating a real phase handoff through an existing Build Studio or coworker flow.
+- If that is not feasible in the verification window, record source-local green plus canonical empty-state UX only, and leave live-edge verification open.
+
+## 10. Backlog and Coordination
+
+Live MCP state on 2026-06-05:
+
+- `EP-AI-OPSMAP` remains the parent epic for the Operations Map visibility work.
+- `BI-65B0D697` is the existing backlog item for this work. Do not create another.
+- `EP-A2A` / `BI-9DB7C332` is the capture/runtime coordination point.
+
+Before PR:
+
+- Update `BI-65B0D697` with implementation evidence and any deferred live-edge verification caveat.
+- Cross-link the PR and the implementation plan.
+- Re-check open PRs and recent `main` for changes to `AiOperationsMap.tsx`, `load-map-data.ts`, `TaskRun`, `PhaseHandoff`, `DelegationChain`, and deliberation runtime files.
+
+## 11. Sequencing
+
+1. **Slice 1 - data model + A2A projector (done in current worktree, verify before PR).** Typed A2A edge model, pure projector, loader composition for delegation/handoff/task-lineage, and tests.
+2. **Slice 2A - separate visible A2A panel (done in current worktree, verify before PR).** Separate panel below provider routing with A2A SVG, local filters, legend, empty state, and inspector.
+3. **Slice 2B - cohesive map layout (remaining polish).** Move from "separate panel" toward coordinated coworker/provider/timeline bands without destabilizing provider routing.
+4. **Slice 3 - shared filters, inspector, preferences (partially done).** Add top-level dimension toggle, authority/sensitivity filtering, persisted A2A filter state, saved-view integration, and source-record href builders.
+5. **Slice 4 - deliberation identity/capture integration (later).** Wire `a2a-deliberation` only after branch persona agent identity is captured by schema/runtime or an authoritative event source.
+6. **Slice 5 - live/correlation enrichment (later).** Consume stable A2A event rows, task artifacts, or trace/correlation ids when the runtime/capture contract exists.
+
+## 12. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The UI claims deliberation agent-to-agent visibility without agent identity. | Keep deliberation as a future typed edge; do not wire loader projection until branch agent identity exists. |
+| The first panel becomes a permanent forked design system. | Allocate refactoring time to report-kit/status intent/LocalTime adoption and pure layout helpers. |
+| A2A map work collides with `EP-A2A` capture work. | Keep this slice read-only and migration-free; coordinate through `BI-65B0D697` and `BI-9DB7C332`; re-sweep before push. |
+| Sparse A2A data makes the surface look empty. | Render a clear empty state; verify with real generated rows when possible; never ship fake examples as live data. |
+| Reworking a large SVG map destabilizes provider routing. | Keep provider panel stable while introducing A2A in an isolated component, then converge layout in smaller tested slices. |
+| Local tests pass but live UX is broken. | Treat source-local gates as necessary but insufficient; canonical-runtime UX evidence is required before claiming completion. |
+
+## 13. Definition of Done
+
+For this backlog item to be complete:
+
+- The map shows real coworker-to-coworker A2A edges for delegation, phase handoff, and task lineage from existing substrate with no migration.
+- Deliberation is either wired from a truthful branch-agent source or explicitly left as a later slice; no fabricated branch-persona edges.
+- Existing provider routing remains intact.
+- Operators can filter A2A interactions by type, state, and coworker actor role; final v1 also persists filter state and composes with the replay window.
+- The inspector shows from/to coworker, state, summary, authority/gate/build context, and honest source-record links.
+- UI uses DPF theme tokens and report-kit/status/time primitives where appropriate.
+- Source-local tests, typecheck, and build pass on the worktree.
+- Functional verification is run on the canonical local install or shared local-CI convergence sandbox, with substrate named in the evidence.


### PR DESCRIPTION
@
## What

Re-architects `/platform/ai/operations-map` from a two-lane coworker→provider bipartite graph into a typed-node / typed-edge model so **coworker-to-coworker (A2A) interactions** — delegation, build phase-handoff, task spawn/lineage — are first-class. Migration-free; reads existing substrate only.

Backlog: **BI-65B0D697** (EP-AI-OPSMAP). Coordinates with the EP-A2A capture thread (BI-9DB7C332), which owns the write path — this PR is read/projection/render only.

Spec: `docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md`
Plan: `docs/superpowers/plans/2026-06-04-ai-operations-map-a2a-interaction-visibility.md`

## How

- **Data model** (`types.ts`): `OperationsMapA2aEdge` / `edgeKind` / `a2aEdges` / `a2aLegend`; provider routes unchanged.
- **Projector** (`project-a2a-interactions.ts`, pure): delegation, phase-handoff, task-lineage wired; deliberation supported but **loader-deferred** until `TaskNode` carries a branch-persona agent id. Composed in `load-map-data.ts` from existing `DelegationChain` / `PhaseHandoff` / `TaskRun` — **no migration**.
- **Rendering** (`A2aInteractionsPanel.tsx`): isolated panel below the provider routing panel (keeps the 2.6k-line provider SVG stable) — from→to interaction band (typed per-kind dashes + per-state colors + arrowheads + legend), type/state/coworker(role) filters, click-through inspector, empty state.
- **UI alignment**: `a2aInteraction` domain added to report-kit `statusColors` (no local color map); `StatusBadge` / `StatCard` / `intentStyle` / `LocalTime` adopted; pure graph helpers extracted to `a2a-interaction-graph.ts`; honest source-record links (`/build?buildId=` verified; routeless records shown as id text, no dead links).
- **Persistence**: A2A filter state via `ai-operations-map-prefs`.

## Verification

- `pnpm --filter web test` — full suite green (9534 passed; the operations-map page test mock was updated for the new Prisma sources).
- `pnpm --filter web typecheck` — clean. Worktree `next build` — clean (CI is the binding gate).
- **Deferred (open):** live-edge functional sign-off on the running portal. Substrate check: Live DB has 60 `PhaseHandoff` rows (Dev 5); `DelegationChain` and `TaskRun`-lineage are 0, so only `a2a-handoff` has live data today. Per spec §9, deferred to post-merge on the Live portal.

## Notes

- Read-only, additive, migration-free. No new DB models.
- Overlap-swept against `origin/main` + open PRs (2026-06-05): only #1459 touched a shared file (`statusColors.ts`); resolved by keeping both `marketing` and `a2aInteraction` domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@