### PR TITLE
feat(partner): capability-activation overlay + admin add-later surface (EP-PARTNER-CHANNEL Phase 1b)

### DIFF
--- a/apps/web/app/(shell)/storefront/settings/capabilities/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/capabilities/page.tsx
@@ -1,0 +1,84 @@
+import { prisma } from "@dpf/db";
+import {
+  CAPABILITY_REGISTRY,
+  getCapabilitySetupPrompt,
+  readActivationProfile,
+  type CapabilityKey,
+} from "@dpf/storefront-templates";
+import { CapabilityActivationToggle } from "@/components/storefront-admin/CapabilityActivationToggle";
+import { getEffectiveCapabilityActivations } from "@/lib/storefront/capability-activation";
+
+function labelFor(capabilityKey: string): string {
+  const entry = CAPABILITY_REGISTRY[capabilityKey as CapabilityKey];
+  if (entry) return entry.label;
+  return capabilityKey
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export default async function CapabilitiesSettingsPage() {
+  const [org, storefront] = await Promise.all([
+    prisma.organization.findFirst({ select: { id: true } }),
+    prisma.storefrontConfig.findFirst({
+      select: { archetype: { select: { activationProfile: true } } },
+    }),
+  ]);
+
+  const profile = readActivationProfile(storefront?.archetype?.activationProfile);
+  const derived =
+    profile?.capabilityActivations.map((capability) => ({
+      capabilityKey: capability.capabilityKey,
+      applicability: capability.applicability,
+    })) ?? [];
+
+  const effective = org ? await getEffectiveCapabilityActivations(org.id, derived) : [];
+
+  // Optional/recommended capabilities the org can turn on or off (the "add it
+  // later" surface). `required` capabilities are core to the business model and
+  // not toggled here; `not-applicable` ones have canEnableLater === false.
+  const togglable = effective.filter(
+    (capability) => capability.canEnableLater && capability.source !== "required",
+  );
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="mb-1 text-lg font-semibold text-[var(--dpf-text)]">Capabilities</h1>
+      <p className="mb-6 text-sm text-[var(--dpf-muted)]">
+        Optional capabilities for your business type. Turn one on whenever it applies — you
+        can change these at any time.
+      </p>
+
+      {togglable.length === 0 ? (
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          No optional capabilities for your business type yet.
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {togglable.map((capability) => {
+            const prompt = getCapabilitySetupPrompt(capability.capabilityKey);
+            return (
+              <li
+                key={capability.capabilityKey}
+                className="flex items-start justify-between gap-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-[var(--dpf-text)]">
+                    {prompt?.question ?? labelFor(capability.capabilityKey)}
+                  </div>
+                  {prompt?.helpText && (
+                    <div className="mt-1 text-xs text-[var(--dpf-muted)]">{prompt.helpText}</div>
+                  )}
+                </div>
+                <CapabilityActivationToggle
+                  capabilityKey={capability.capabilityKey}
+                  active={capability.active}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/storefront-admin/CapabilityActivationToggle.test.tsx
+++ b/apps/web/components/storefront-admin/CapabilityActivationToggle.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/capability-activation", () => ({
+  updateCapabilityActivation: vi.fn(),
+}));
+
+import { CapabilityActivationToggle } from "./CapabilityActivationToggle";
+
+describe("CapabilityActivationToggle", () => {
+  it("renders an on switch when active", () => {
+    const html = renderToStaticMarkup(
+      <CapabilityActivationToggle capabilityKey="partner-program" active />,
+    );
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('aria-checked="true"');
+  });
+
+  it("renders an off switch when inactive", () => {
+    const html = renderToStaticMarkup(
+      <CapabilityActivationToggle capabilityKey="partner-program" active={false} />,
+    );
+    expect(html).toContain('aria-checked="false"');
+  });
+});

--- a/apps/web/components/storefront-admin/CapabilityActivationToggle.tsx
+++ b/apps/web/components/storefront-admin/CapabilityActivationToggle.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CapabilityActivationChoice } from "@dpf/storefront-templates";
+import { updateCapabilityActivation } from "@/lib/actions/capability-activation";
+
+/**
+ * The admin "add it later" toggle for an offered capability (EP-PARTNER-CHANNEL
+ * Phase 1b). Flips the org's persisted OrganizationCapabilityActivation choice.
+ */
+export function CapabilityActivationToggle({
+  capabilityKey,
+  active,
+}: {
+  capabilityKey: string;
+  active: boolean;
+}) {
+  const [on, setOn] = useState(active);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function toggle() {
+    const next: CapabilityActivationChoice = on ? "disabled" : "enabled";
+    setError(null);
+    startTransition(async () => {
+      const result = await updateCapabilityActivation(capabilityKey, next);
+      if (result.ok) {
+        setOn(next === "enabled");
+      } else {
+        setError(result.error ?? "Could not update");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label={on ? "Turn off" : "Turn on"}
+        disabled={pending}
+        onClick={toggle}
+        className={[
+          "relative inline-flex h-6 w-11 items-center rounded-full border transition-colors",
+          on ? "bg-[var(--dpf-accent)] border-[var(--dpf-accent)]" : "bg-[var(--dpf-surface-2)] border-[var(--dpf-border)]",
+          pending ? "opacity-60" : "",
+        ].join(" ")}
+      >
+        <span
+          className={[
+            "inline-block h-4 w-4 transform rounded-full bg-[var(--dpf-surface-1)] transition-transform",
+            on ? "translate-x-6" : "translate-x-1",
+          ].join(" ")}
+        />
+      </button>
+      {error && <span className="text-[10px] text-[var(--dpf-muted)]">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/components/storefront-admin/StorefrontSettingsNav.tsx
+++ b/apps/web/components/storefront-admin/StorefrontSettingsNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const SETTINGS_TABS = [
   { label: "Portal", href: "/storefront/settings" },
   { label: "Your Business", href: "/storefront/settings/business" },
+  { label: "Capabilities", href: "/storefront/settings/capabilities" },
   { label: "Operating Hours", href: "/storefront/settings/operations" },
 ];
 

--- a/apps/web/lib/actions/capability-activation.ts
+++ b/apps/web/lib/actions/capability-activation.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { isCapabilityKey, type CapabilityActivationChoice } from "@dpf/storefront-templates";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { setCapabilityChoice } from "@/lib/storefront/capability-activation";
+
+async function requireManageBusinessModels(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_business_models")
+  ) {
+    throw new Error("Unauthorized");
+  }
+}
+
+/**
+ * Admin "add it later" path (EP-PARTNER-CHANNEL Phase 1b): records this org's
+ * enable/disable decision for an offered capability (e.g. partner-program) from
+ * the storefront settings surface. Same persistence the setup wizard writes,
+ * tagged decidedVia="admin".
+ */
+export async function updateCapabilityActivation(
+  capabilityKey: string,
+  choice: CapabilityActivationChoice,
+): Promise<{ ok: boolean; error?: string }> {
+  await requireManageBusinessModels();
+
+  if (!isCapabilityKey(capabilityKey)) {
+    return { ok: false, error: `Unknown capability: ${capabilityKey}` };
+  }
+  if (choice !== "enabled" && choice !== "disabled") {
+    return { ok: false, error: `Invalid choice: ${choice}` };
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return { ok: false, error: "No organization found" };
+  }
+
+  await setCapabilityChoice({
+    organizationId: org.id,
+    capabilityKey,
+    choice,
+    decidedVia: "admin",
+  });
+
+  revalidatePath("/storefront/settings/capabilities");
+  return { ok: true };
+}

--- a/apps/web/lib/storefront/capability-activation.test.ts
+++ b/apps/web/lib/storefront/capability-activation.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organizationCapabilityActivation: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import {
+  getEffectiveCapabilityActivations,
+  getOrgCapabilityChoices,
+  setCapabilityChoice,
+} from "./capability-activation";
+
+const findMany = prisma.organizationCapabilityActivation.findMany as ReturnType<typeof vi.fn>;
+const upsert = prisma.organizationCapabilityActivation.upsert as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  findMany.mockReset();
+  upsert.mockReset();
+});
+
+describe("getOrgCapabilityChoices", () => {
+  it("maps stored rows to a key→choice record and ignores malformed choices", async () => {
+    findMany.mockResolvedValue([
+      { capabilityKey: "partner-program", choice: "enabled" },
+      { capabilityKey: "point-of-sale", choice: "disabled" },
+      { capabilityKey: "garbage", choice: "maybe" },
+    ]);
+    const choices = await getOrgCapabilityChoices("org_1");
+    expect(choices).toEqual({ "partner-program": "enabled", "point-of-sale": "disabled" });
+  });
+});
+
+describe("getEffectiveCapabilityActivations", () => {
+  it("folds stored choices over derived applicabilities", async () => {
+    findMany.mockResolvedValue([{ capabilityKey: "partner-program", choice: "enabled" }]);
+    const effective = await getEffectiveCapabilityActivations("org_1", [
+      { capabilityKey: "partner-program", applicability: "recommended" },
+      { capabilityKey: "customer-accounts", applicability: "required" },
+    ]);
+    const byKey = Object.fromEntries(effective.map((e) => [e.capabilityKey, e]));
+    expect(byKey["partner-program"]).toMatchObject({ active: true, source: "org-choice" });
+    expect(byKey["customer-accounts"]).toMatchObject({ active: true, source: "required" });
+  });
+});
+
+describe("setCapabilityChoice", () => {
+  it("upserts the decision keyed by (organizationId, capabilityKey)", async () => {
+    upsert.mockResolvedValue({});
+    await setCapabilityChoice({
+      organizationId: "org_1",
+      capabilityKey: "partner-program",
+      choice: "enabled",
+      decidedVia: "setup-wizard",
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId_capabilityKey: { organizationId: "org_1", capabilityKey: "partner-program" } },
+        create: expect.objectContaining({ choice: "enabled", decidedVia: "setup-wizard" }),
+        update: { choice: "enabled", decidedVia: "setup-wizard" },
+      }),
+    );
+  });
+
+  it("rejects unknown capability keys before writing", async () => {
+    await expect(
+      setCapabilityChoice({
+        organizationId: "org_1",
+        capabilityKey: "not-a-capability",
+        choice: "enabled",
+        decidedVia: "admin",
+      }),
+    ).rejects.toThrow(/Unknown capability key/);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/storefront/capability-activation.ts
+++ b/apps/web/lib/storefront/capability-activation.ts
@@ -1,0 +1,88 @@
+import { prisma } from "@dpf/db";
+import {
+  isCapabilityKey,
+  resolveOrgCapabilityActivations,
+  type CapabilityActivationChoice,
+  type CapabilityApplicability,
+  type EffectiveCapabilityActivation,
+} from "@dpf/storefront-templates";
+
+/**
+ * Server data-access for the generic per-organization capability-activation
+ * overlay (EP-PARTNER-CHANNEL Phase 1b). The archetype derivation answers "is
+ * this capability applicable?"; these rows record "did this org turn it on?".
+ * Used by the setup wizard (decidedVia="setup-wizard") and the admin add-later
+ * toggle (decidedVia="admin"). Generic — partner-program is the first consumer.
+ *
+ * The pure fold lives in `resolveOrgCapabilityActivations` (@dpf/storefront-templates);
+ * this module is only the Prisma I/O + key validation around it.
+ */
+export type CapabilityDecisionVia = "setup-wizard" | "admin";
+
+function isChoice(value: string): value is CapabilityActivationChoice {
+  return value === "enabled" || value === "disabled";
+}
+
+/** Load this org's persisted capability opt-in choices as a key → choice map. */
+export async function getOrgCapabilityChoices(
+  organizationId: string,
+): Promise<Record<string, CapabilityActivationChoice>> {
+  const rows = await prisma.organizationCapabilityActivation.findMany({
+    where: { organizationId },
+    select: { capabilityKey: true, choice: true },
+  });
+  const choices: Record<string, CapabilityActivationChoice> = {};
+  for (const row of rows) {
+    if (isChoice(row.choice)) {
+      choices[row.capabilityKey] = row.choice;
+    }
+  }
+  return choices;
+}
+
+/**
+ * Fold this org's stored choices over the archetype-derived capability
+ * applicabilities, producing the effective per-capability activation the setup
+ * wizard, admin toggle, and route/UI gating all consume.
+ */
+export async function getEffectiveCapabilityActivations(
+  organizationId: string,
+  derived: ReadonlyArray<{ capabilityKey: string; applicability: CapabilityApplicability }>,
+): Promise<EffectiveCapabilityActivation[]> {
+  const choices = await getOrgCapabilityChoices(organizationId);
+  return resolveOrgCapabilityActivations(derived, choices);
+}
+
+/**
+ * Record an organization's enable/disable decision for a capability. Used at
+ * setup and from the admin "add it later" toggle. Rejects unknown capability
+ * keys so a typo can never persist an orphan activation row.
+ */
+export async function setCapabilityChoice(input: {
+  organizationId: string;
+  capabilityKey: string;
+  choice: CapabilityActivationChoice;
+  decidedVia: CapabilityDecisionVia;
+}): Promise<void> {
+  if (!isCapabilityKey(input.capabilityKey)) {
+    throw new Error(`Unknown capability key: ${input.capabilityKey}`);
+  }
+  await prisma.organizationCapabilityActivation.upsert({
+    where: {
+      organizationId_capabilityKey: {
+        organizationId: input.organizationId,
+        capabilityKey: input.capabilityKey,
+      },
+    },
+    create: {
+      organizationId: input.organizationId,
+      capabilityKey: input.capabilityKey,
+      choice: input.choice,
+      decidedVia: input.decidedVia,
+    },
+    update: {
+      choice: input.choice,
+      decidedVia: input.decidedVia,
+    },
+  });
+}

--- a/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
+++ b/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
@@ -1,95 +1,396 @@
-# Implementation Plan — Partner / Reseller Channel & Identity
+# Implementation Plan - Partner / Reseller Channel & Identity
 
 **Date:** 2026-06-04
+**Enterprise architecture review:** 2026-06-05
 **Spec:** [`docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md`](../specs/2026-06-04-partner-reseller-archetype-identity-design.md)
 **Epic:** `EP-PARTNER-CHANNEL`
-**Decision basis:** WWMD `principle_decide` (spec §7) — partner identity = `Principal.kind="partner"` + `partner_contact` alias; no parallel table.
+**Decision basis:** WWMD `principle_decide` (spec §7) - partner identity = `Principal.kind="partner"` + `partner_contact` alias; no parallel partner identity table.
 
-This plan turns the reviewed spec into ordered, gate-aware phases. Each phase names the files to touch, the migration (if any), and **which verification substrate** the build gate runs on — because a source-only worktree can verify `@dpf/storefront-templates` (pure TS) but **cannot** run `apps/web` tests or Prisma migrations (verified 2026-06-04: `react-dom/server` does not resolve; no DB). Runtime-bound gates run on the **canonical local install** or a **shared local-CI convergence sandbox lease** per AGENTS.md §5.
+This plan turns the reviewed spec into ordered, gate-aware implementation slices. It is intentionally strict about current repo truth, identity convergence, UI quality, and verification substrate: source-local package work can run in the worktree, but `apps/web`, migrations, auth, and UX gates run on the canonical local install or a `claim_nonprod_environment_lease(environmentKey="local-integration-ci")` sandbox per AGENTS.md §5.
 
-## Status legend
-`LANDED` merged to main · `OPEN-PR` pushed, in review · `TODO` not started.
+## Architecture Review Result
 
----
+Aligned with concerns addressed. The core direction is sound: partner support derives from archetype axes; partner humans converge through `Principal` / `PrincipalAlias`; partner organizations are account/domain records; the portal reads effective capability activation instead of raw `archetypeId`. The original plan needed tightening in five places:
 
-## Phase 0 — Archetype partner primitives — `LANDED` (#1454)
+- Status drift: PR #1454 and PR #1457 are now merged, while the live backlog still has several captured items that need status/evidence cleanup.
+- Phase 1b drift: setup-prompt metadata already exists in `@dpf/storefront-templates`; persistence and UI do not.
+- Identity risk: a local Partner credentials provider must not clone `CustomerContact.passwordHash` before the identity-edge or generic principal-credential decision.
+- UI under-specification: `/partners` needs an operational workbench contract, not just "use report-kit".
+- Refactoring budget: at least 20 percent of the implementation effort stays reserved for shared primitives exposed by this feature.
 
-`@dpf/storefront-templates`: `PartnerProgramProfile` (+ `PartnerType`/`PartnerTier`/`PartnerPortalMode`/`PartnerGraphMode`/`CapabilityActivationChoice`), `OwnershipScope+='partner-account'`, `CapabilityIsolation+='strict-partner-scope'`, `partner-program` capability, `derivePartnerProgramProfile`, `partner-channel-from-axes` rule, `NormalizedActivationProfile.partnerProgram`, and `resolveCapabilityActivation` (setup/add-later resolution). Pure TS; verified in-package.
+## Live Planning Context
 
-## Phase 1 — Target archetype catalog wiring — `OPEN-PR` (#1457, partial)
+Live DPF MCP reads on 2026-06-05 UTC:
 
-- **Landed:** `wholesale-distribution` archetype (retail-goods) deriving `partner-program=available`; catalog-level tests; `it-managed-services` already derives it.
-- **Remaining (TODO):**
-  1. `software-platform` axes (`platform:"yes-developer"`). **Coordinate with `BI-ARCH-4C1E90`** (Archetype Model V2 owns software-platform defaults) per PAR — propose the axis block to that item rather than committing a competing `activationProfile` here. Gate: package vitest.
-  2. Seed reconciliation + portal QA for `wholesale-distribution` on the **canonical install** — confirm the archetype upserts (`packages/db/src/seed-storefront-archetypes.ts` → `ARCHETYPE_SEED_DATA`) and renders in the setup picker. Gate: canonical install (UX).
-
-## Phase 1b — Setup question + add-later (persisted org choice) — `TODO`
-
-Delivers the founder requirement: **ask at setup, store the answer, allow adding later.** Generic across all `recommended`/`optional` capabilities; partner-program is the first consumer. Logic primitive (`resolveCapabilityActivation`) is already LANDED.
-
-1. **Schema — `packages/db/prisma/schema.prisma`** (migration `add-organization-capability-activation`):
-   ```prisma
-   model OrganizationCapabilityActivation {
-     id             String   @id @default(cuid())
-     organizationId String
-     capabilityKey  String   // matches @dpf/storefront-templates CapabilityKey
-     choice         String   // CapabilityActivationChoice: "enabled" | "disabled"
-     decidedAt      DateTime @default(now())
-     decidedVia     String   // "setup-wizard" | "admin"
-     organization   Organization @relation(fields: [organizationId], references: [id])
-     @@unique([organizationId, capabilityKey])
-     @@index([organizationId])
-   }
-   ```
-   Create with `pnpm --filter @dpf/db exec prisma migrate dev --name add-organization-capability-activation`. **Gate: canonical/sandbox (migration apply).**
-2. **Setup-prompt metadata — `@dpf/storefront-templates/capability-registry.ts`:** add optional `setupPrompt?: { question: string; helpText?: string }` to `CapabilityRegistryEntry`; set it on `partner-program` ("Do you sell through partners or resellers?"). Add `getCapabilitySetupPrompt(key)`. Gate: package vitest (verifiable in worktree).
-3. **Effective-activation read path — `apps/web/lib/storefront/`:** a server helper that loads an org's `OrganizationCapabilityActivation` rows and folds them through `resolveCapabilityActivation(derivedApplicability, choice)` to produce the effective capability set the UI/routes consult. Gate: canonical (typecheck + unit).
-4. **Setup wizard — `apps/web/components/storefront-admin/SetupWizard.tsx`:** for each capability where `resolveCapabilityActivation(...).promptAtSetup`, render the `setupPrompt` question; persist the answer to `OrganizationCapabilityActivation` (`decidedVia:"setup-wizard"`). Surface partner-program in `ArchetypeActivationSummary` (add `partner-program` to `SUMMARY_CAPABILITY_ORDER`; show the `partnerProgram` portal mode + partner types). Gate: canonical (UX).
-5. **Admin add-later toggle — `apps/web/app/(shell)/storefront/settings/...`:** a capability toggle for `canEnableLater` capabilities (writes `decidedVia:"admin"`). Gate: canonical (UX).
-6. **Archetype changeable post-setup:** add an API/action to update `StorefrontConfig.archetypeId` so applicability re-derives (today it is read-only). Gate: canonical (UX + ensure dependent capability rows reconcile).
-
-## Phase 2 — Partner identity + partner-org account — `TODO`
-
-1. **Schema audit decision (partner org):** choose `CustomerAccount.accountKind` discriminator vs a thin `PartnerAccount` vs explicit crosswalk (spec §6.2). Record the decision (WWMD `principle_decide` if non-obvious) before migrating. Bias: `PartnerAccount` if partner-specific fields (tier, agreement ref, margin policy, deal-registration ledger, partner graph) would pollute `CustomerAccount`.
-2. **Migration:** add the chosen partner-org model + (if needed) `Principal.kind` is free-string so `"partner"` needs no enum migration; add a `PartnerAccountPrincipal`/membership row keyed by `(partnerAccountId, principalId)` for delegated admin. Gate: canonical/sandbox (migration apply).
-3. **Principal linking — `apps/web/lib/identity/principal-linking.ts`:** add `syncPartnerPrincipal(partnerContactId)` mirroring `syncCustomerPrincipal`, kind `"partner"`, alias `partner_contact` (match the implemented snake_case alias vocabulary). Gate: canonical (unit).
-
-## Phase 2a — Identity/auth approach checkpoint — `TODO`
-
-Decide **identity-edge-first (OIDC via authentik) vs principal-local credentials** before writing a local Partner credentials provider, so Phase 3 doesn't build a throwaway. Reference the enterprise-auth spec's partner population. Output: a short ADR appended to the spec.
-
-## Phase 3 — Partner login + `/partners` shell — `TODO`
-
-1. **Auth — `apps/web/lib/govern/auth.ts`:** `UserType = "admin" | "customer" | "partner"`; Partner credentials provider mirroring the customer provider; session carries `partnerAccountId`, `partnerTier`, `partnerContactId`, and (moving toward convergence) `principalId`. Gate: canonical (auth flow UX).
-2. **Authorization — `apps/web/lib/identity/effective-auth-context.ts`:** partner scope resolving on the `Principal`, gated to `partner-account` ownership with `strict-partner-scope`; a partner cannot read another partner's or the operator's internal records (scope-guard tests). Gate: canonical (unit + UX).
-3. **Portal — `apps/web/app/partners/...`:** external partner workspace, gated by *active* `partner-program` (effective activation from Phase 1b), never raw `archetypeId`. Compose `report-kit` primitives (StatusBadge/DataTable/StatCard/FilterBar/ExportButton). First viewport: deal registrations, tier/agreement status, enablement, performance. Gate: canonical (UX).
-
-## Phase 4 — Deal registration, tiering, delegated admin — `TODO`
-
-Deal-registration ledger + partner tier records (prepared-not-prescribed — no payout/accounting execution yet); delegated partner-admin role (partner admin manages own contacts, partner-scoped); export paths with strict partner-account scope guards. Migration + canonical UX gates.
-
-## Phase 5 — Partner federation + SCIM — `TODO`
-
-OIDC/SAML against partner IdP + SCIM lifecycle as the partner-population projection of the authentik identity edge (enterprise-auth spec). No new auth stack. Canonical/sandbox gates.
-
----
-
-## Ordering & dependencies
-
-```
-Phase 0 (done) ─┬─ Phase 1 (PR) ──────────────┐
-                └─ Phase 1b (setup/add-later) ─┤
-                                               ├─ Phase 3 (login/portal) ─ Phase 4 ─ Phase 5
-            Phase 2 (identity) ─ Phase 2a ─────┘
-```
-
-- Phase 1b and Phase 2 are independent and can proceed in parallel; both block Phase 3.
-- Phase 2a (auth approach) must precede the Phase 3 auth provider.
-- Every `TODO` phase from 1b onward requires migration and/or `apps/web` runtime — run those build gates on the **canonical install** or a **`claim_nonprod_environment_lease(environmentKey="local-integration-ci")`** sandbox, not the worktree.
-
-## Verification matrix
-
-| Phase | Worktree-verifiable? | Build gate substrate |
+| Scope | Live state | Plan implication |
 | --- | --- | --- |
-| 0, 1 (catalog), 1b step 2 (registry) | yes (`@dpf/storefront-templates` vitest + tsc) | package |
-| 1 (seed/QA), 1b (model/wizard/admin), 2, 3, 4, 5 | no | canonical install / sandbox lease (migration + UX) |
+| `EP-PARTNER-CHANNEL` | In progress; six captured items. | Keep this plan tied to the partner epic; do not create a parallel epic. |
+| `BI-DE3FA72C` | Phase 0 partner primitives. | PR #1454 is merged; record/close after canonical evidence is attached. |
+| `BI-D4C550E1` | Phase 1 target archetype wiring. | PR #1457 is merged for `wholesale-distribution`; software-platform and canonical setup QA remain. |
+| `BI-66CF1AA4` | Phase 1b setup-time capability question + add-later toggle. | This is the next implementation slice. |
+| `BI-DE47EC0B` | Phase 2 partner identity + partner-org account. | Keep schema audit and identity convergence explicit before migration. |
+| `BI-00E69FBA` | Phase 3 partner login + `/partners` shell. | Blocked by Phase 1b and Phase 2/2a decisions. |
+| `BI-C47A568C` | Phases 4-5 deal registration, tiering, delegated admin, federation, SCIM. | Later capability slices; do not pull payout/accounting into early phases. |
+| `EP-ARCH-8D4F2A` / `BI-ARCH-4C1E90` | Archetype Model V2 owns setup/business-archetype unification and software-platform defaults. | Propose software-platform axes to that item instead of committing a competing activation profile here. |
+
+MCP `search_specs_and_plans` returned no indexed partner/reseller matches for the searched terms, even though the linked local spec exists in this branch. Treat the local spec path above as the source of truth until indexing catches up.
+
+## Current Repo Truth
+
+| Area | Verified state | Constraint |
+| --- | --- | --- |
+| Partner primitives | `PartnerProgramProfile`, partner types/tiers/modes, `partner-account`, `strict-partner-scope`, `partner-program`, `derivePartnerProgramProfile`, `readActivationProfile(...).partnerProgram`, and `resolveCapabilityActivation` exist under `packages/storefront-templates/src`. | Do not reimplement derivation in `apps/web`; consume the package contract. |
+| Setup prompt metadata | `CapabilityRegistryEntry.setupPrompt`, `partner-program` prompt copy, and `getCapabilitySetupPrompt()` already exist in `packages/storefront-templates/src/capability-registry.ts`. | Phase 1b should start from persistence and UI wiring, not repeat registry work. |
+| Catalog wiring | `it-managed-services` derives `partner-program=available`. PR #1457 added `wholesale-distribution` with catalog tests. `software-platform` still needs axes through `BI-ARCH-4C1E90`. | Phase 1 is merged but incomplete as a product outcome until software-platform and canonical setup QA are done. |
+| Setup UI | `SetupWizard` previews activation summaries and writes `StorefrontConfig` / `BusinessContext`; no org-level capability choice is persisted. | Add a generic org capability overlay shared by setup and admin. |
+| Admin settings | `/storefront/settings`, `/storefront/settings/business`, and `/storefront/settings/operations` exist. | Add capability activation to the existing settings IA, not a disconnected partner-only settings page. |
+| Auth/session | `apps/web/lib/govern/auth.ts` has `UserType = "admin" | "customer"` and workforce/customer credential providers. Session has customer account/contact fields but no partner fields and no canonical `principalId`. | Phase 3 must extend the session shape deliberately and preserve principal semantics. |
+| Principal spine | `Principal` / `PrincipalAlias` are live tables with free-string `kind` / `aliasType`; implementation uses snake_case aliases such as `customer_contact`. | Use `partner_contact` unless an alias-kind normalization lands first. |
+| Effective auth context | `apps/web/lib/identity/effective-auth-context.ts` currently resolves workforce/admin principal context only. | Partner-account scope needs a shared policy extension, not route-local checks. |
+| Account model | `CustomerAccount` is CRM/customer-heavy and has no `accountKind`. | Partner org modeling requires a real schema audit before migration. |
+| Report-kit | `StatusBadge`, `StatCard`, `DataTable`, `FilterBar`, `ExportButton`, `Chart`, and `statusColors` exist in `apps/web/components/ui/report-kit/`. | Partner reporting surfaces must extend report-kit/status intents instead of hand-rolling badges, KPI cards, tables, or color maps. |
+
+## Non-Negotiable Invariants
+
+1. **No raw archetype gating.** Feature code never checks `archetypeId === "software-platform"` to enable partners. It reads normalized partner-program applicability plus org activation.
+2. **Generic activation overlay.** `OrganizationCapabilityActivation` (or an equivalent name chosen during migration) is keyed by `(organizationId, capabilityKey)`, not partner-specific.
+3. **Principal convergence.** Partner humans are `Principal.kind="partner"` with a `PrincipalAlias.aliasType="partner_contact"`; no `PartnerContact` identity island.
+4. **Partner org is account data.** Use `PartnerAccount`, `CustomerAccount.accountKind`, or an explicit crosswalk only after auditing CRM/customer coupling.
+5. **No partner-only password table.** Decide identity-edge-first vs generic principal-local credentials before any local Partner credentials provider.
+6. **Strict partner scope.** `partner-account` ownership and `strict-partner-scope` must be enforced server-side for list, detail, mutation, and export paths.
+7. **Operational UI first.** `/partners` opens to work in progress: deal registrations, tier/agreement state, enablement, team, support, and performance. It is not a marketing landing page.
+8. **Theme-aware/report-kit UI.** Use `var(--dpf-*)` tokens and report-kit primitives; add status intents centrally.
+9. **Refactoring reserve.** Each implementation slice reserves at least 20 percent of effort for shared primitives: capability activation service, principal/session context, scope policy helpers, and report-kit/status intent coverage.
+
+## Standards Anchors
+
+Phase 5 federation/provisioning must follow standards, not vendor shorthand:
+
+- OIDC: [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0-final.html). Bind external identities to issuer + subject, not email.
+- SCIM: [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) core schema and [RFC 7644](https://datatracker.ietf.org/doc/rfc7644/) protocol. Use SCIM users/groups and PATCH semantics for lifecycle and membership where applicable.
+- SAML: [OASIS SAML 2.0 Technical Overview](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html). Treat SAML metadata/trust as identity-edge configuration, not DPF authorization policy.
+- DPF identity edge: `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md` keeps authentik as the protocol edge and DPF Authority Core as the authorization owner.
+- DPF UI: `docs/platform-usability-standards.md` and `apps/web/components/ui/report-kit/README.md` are the binding UI references. `search_design_intelligence` returned no results for partner/dashboard/reporting queries during this review, so local standards govern.
+
+## Phase 0 - Archetype Partner Primitives - MERGED (#1454)
+
+**Backlog:** `BI-DE3FA72C`
+
+Landed in [`#1454`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1454):
+
+- `@dpf/storefront-templates` partner primitives: `PartnerProgramProfile`, partner type/tier/mode types, `CapabilityActivationChoice`.
+- `OwnershipScope += "partner-account"` and `CapabilityIsolation += "strict-partner-scope"`.
+- `partner-program` capability and `partner-channel-from-axes` rule.
+- `derivePartnerProgramProfile` and `NormalizedActivationProfile.partnerProgram`.
+- `resolveCapabilityActivation` for setup/add-later semantics.
+- Source-local package tests.
+
+Follow-up: update live backlog/evidence once canonical evidence for the merged work is recorded.
+
+## Phase 1 - Target Archetype Catalog Wiring - MERGED PARTIAL (#1457)
+
+**Backlog:** `BI-D4C550E1`
+
+Landed in [`#1457`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1457):
+
+- New `wholesale-distribution` retail-goods archetype deriving `partner-program=available` from goods/business axes.
+- Catalog-level tests for partner derivation.
+- `it-managed-services` remains covered by existing MSP axes.
+
+Remaining:
+
+1. `software-platform` axes: set `platform: "yes-developer"` through `BI-ARCH-4C1E90` / Archetype Model V2, not as a competing activation profile in this partner branch.
+2. Seed reconciliation: confirm `packages/db/src/seed-storefront-archetypes.ts` upserts the new archetype into `StorefrontArchetype`.
+3. Canonical setup UX: verify `wholesale-distribution` appears in the setup picker and previews the partner-program summary on the canonical install or sandbox lease.
+
+Source-local gate: package vitest/tsc for the template package.
+Runtime gate: canonical install or shared local-CI sandbox for seed + setup UX.
+
+## Phase 1b - Setup Question + Add-Later Capability Activation - NEXT
+
+**Backlog:** `BI-66CF1AA4`
+
+Delivers the founder requirement: ask at setup, store the answer, allow adding later. This is generic across all `recommended` / `optional` capabilities; `partner-program` is the first consumer.
+
+### 1b.0 Refactor Checkpoint
+
+Before adding UI behavior, create/extend shared primitives so partner-program does not become a special case:
+
+- `apps/web/lib/storefront/effective-capability-activation.ts` (or equivalent): load derived capability applicability + org choices and return effective capability activation rows.
+- A pure mapper that converts `CapabilityActivationResolution` into UI-ready labels, status intent, prompt visibility, and admin toggle availability.
+- A central server action/API helper for writing capability choices with audit metadata.
+- Report-kit/status intent additions for capability status (`required`, `recommended`, `enabled`, `disabled`, `not-applicable`) if the settings UI needs badges.
+
+This checkpoint is the first 20 percent refactoring reserve for the slice.
+
+### 1b.1 Schema
+
+Add a generic org-capability overlay in `packages/db/prisma/schema.prisma` with migration `add-organization-capability-activation`:
+
+```prisma
+model OrganizationCapabilityActivation {
+  id                   String   @id @default(cuid())
+  organizationId       String
+  capabilityKey        String
+  choice               String
+  decidedVia           String
+  decidedByPrincipalId String?
+  decidedAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  organization         Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  decidedByPrincipal   Principal?   @relation(fields: [decidedByPrincipalId], references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, capabilityKey])
+  @@index([organizationId])
+  @@index([decidedByPrincipalId])
+}
+```
+
+Field rules:
+
+- `capabilityKey` matches `@dpf/storefront-templates` `CapabilityKey`.
+- `choice` is `CapabilityActivationChoice`: `enabled | disabled`.
+- `decidedVia` starts with `setup-wizard | admin`; keep this a typed string in app code.
+- `decidedByPrincipalId` is preferred over `userId` so the table is convergence-ready.
+- If Prisma relation naming collides with existing `Principal` relations, name the relation during implementation; do not drop the principal audit link.
+
+Create with `pnpm --filter @dpf/db exec prisma migrate dev --name add-organization-capability-activation`.
+Gate: canonical install or sandbox lease migration apply.
+
+### 1b.2 Registry Metadata - DONE IN BRANCH
+
+Already present:
+
+- `CapabilityRegistryEntry.setupPrompt`.
+- `partner-program` prompt: "Do you sell through partners or resellers?"
+- `getCapabilitySetupPrompt(key)`.
+- Registry tests.
+
+Do not re-add this. Only extend tests if the UI/API needs a new exported helper.
+
+### 1b.3 Effective Activation Read Path
+
+Add a server-side read path that:
+
+1. Loads the active org's `StorefrontConfig -> StorefrontArchetype.activationProfile`.
+2. Calls `readActivationProfile` / capability derivation from `@dpf/storefront-templates`.
+3. Loads `OrganizationCapabilityActivation` rows for the org.
+4. Resolves each capability through `resolveCapabilityActivation(applicability, choice)`.
+5. Returns a typed list used by setup, admin settings, and route guards.
+
+Rules:
+
+- Effective activation is the only input to `/partners` gating.
+- Unknown/stale capability keys are ignored but logged for cleanup.
+- A missing org choice is different from an explicit `disabled` choice.
+- Required capabilities may be confirmed/disabled only if the business rule allows it; the resolver remains the source of truth.
+
+Gate: source-local unit tests for pure helper; canonical `web` typecheck/build gate when app code is wired.
+
+### 1b.4 Setup Wizard
+
+Update `apps/web/components/storefront-admin/SetupWizard.tsx` and `/api/storefront/admin/setup` so:
+
+- The preview step renders setup prompts only for capabilities where `promptAtSetup === true` and `setupPrompt` exists.
+- The partner prompt answer persists to `OrganizationCapabilityActivation` with `decidedVia: "setup-wizard"`.
+- `ArchetypeActivationSummary` includes `partner-program` in `SUMMARY_CAPABILITY_ORDER` and shows partner portal mode / partner types without exposing raw JSON.
+- The form stays progressive: ask the yes/no partner question in setup; defer partner types, tiers, deal-registration rules, and federation to admin.
+- Copy says the capability can be added later when `canEnableLater === true`.
+
+UX gate: canonical install or sandbox lease, authenticated as `admin@dpf.local`, setup picker -> preview -> submit path.
+
+### 1b.5 Admin Add-Later Toggle
+
+Use the existing `/storefront/settings` IA:
+
+- Add a "Capabilities" section to `/storefront/settings` or `/storefront/settings/business` rather than a partner-only settings island.
+- Show capability status with report-kit primitives if status badges/tables are used.
+- Write through the same server action/API as setup with `decidedVia: "admin"`.
+- Require active org + admin session; record `decidedByPrincipalId` when available.
+- Do not show toggles for `not-applicable` / `hidden` capabilities.
+
+UX gate: canonical install or sandbox lease, settings path with partner-program off -> enable -> `/partners` route becomes available.
+
+### 1b.6 Archetype Change / Re-Derivation
+
+Current repo has reset helpers but not a polished operator-facing post-setup archetype-change workflow. For this slice:
+
+- Do not block partner add-later on a broad archetype migration UI.
+- Add the minimum re-derivation hook needed so when the active archetype changes, effective capability state recalculates from axes + stored org choices.
+- If a capability becomes `not-applicable`, leave the stored choice for audit but do not activate the route.
+- File a separate follow-up if full archetype-change UX is larger than the partner activation slice.
+
+## Phase 2 - Partner Account + Membership
+
+**Backlog:** `BI-DE47EC0B`
+
+Run the schema audit before choosing the partner-org model.
+
+Decision options:
+
+| Option | Use when | Watch-out |
+| --- | --- | --- |
+| `CustomerAccount.accountKind` | Partner accounts truly behave like CRM/customer accounts and share the same lifecycle safely. | Customer relations, invoices, customer sites, and opportunities may become semantically ambiguous. |
+| Thin `PartnerAccount` | Partner-specific tier, agreement, margin, deal-registration policy, delegated admin, or partner graph fields would pollute `CustomerAccount`. | Requires explicit crosswalk if the same company is also a customer. |
+| Explicit crosswalk | Same external org can be both customer and partner. | Do not merge by name/email; model the relationship. |
+
+Likely implementation shape if `PartnerAccount` is chosen:
+
+- `PartnerAccount` for partner org/program attributes.
+- `PartnerAccountMembership` (or `PartnerAccountPrincipal`) keyed by `(partnerAccountId, principalId)` with partner role/admin flags.
+- Optional crosswalk table between `PartnerAccount` and `CustomerAccount` for companies that are both.
+- No credential fields on partner account or membership rows.
+
+Gate: migration apply on canonical install/sandbox; schema tests for uniqueness and cascade behavior.
+
+## Phase 2a - Identity/Auth Approach Checkpoint
+
+This checkpoint must land before Phase 3 auth code.
+
+Decision: identity-edge-first vs generic principal-local credentials.
+
+Preferred direction:
+
+- If authentik/OIDC can be used for the partner population now, implement partner login through the identity edge.
+- If local credentials are unavoidable for an interim slice, first add a generic principal-local credential substrate that can later serve workforce/customer/partner, instead of adding `PartnerContact.passwordHash`.
+
+Required outputs:
+
+- Short ADR appended to the linked spec or a dedicated ADR file.
+- Chosen credential source and migration impact.
+- Session contract for `principalId`, `partnerAccountId`, `partnerMembershipId`, `partnerRole`, and `partnerTier`.
+- Alias helper in `apps/web/lib/identity/principal-linking.ts`: `syncPartnerPrincipal(...)` using `aliasType: "partner_contact"` unless alias-kind normalization lands first.
+- Tests mirroring `syncCustomerPrincipal` coverage.
+
+## Phase 3 - Partner Login + `/partners` Workbench
+
+**Backlog:** `BI-00E69FBA`
+
+Blocks: Phase 1b effective activation + Phase 2/2a identity/account decisions.
+
+### Auth And Session
+
+- Extend `UserType` to include `"partner"`.
+- Session carries canonical `principalId` and partner-specific fields.
+- Partner auth resolves to `Principal`, not directly to a domain contact row.
+- Social/OIDC account binding uses issuer + subject for federated identities, not email.
+
+### Authorization
+
+- Extend `apps/web/lib/identity/effective-auth-context.ts` for partner-account scope.
+- Add reusable server-side scope guards for list/detail/mutation/export.
+- Tests must cover cross-partner denial and operator-internal denial.
+- Partner admin is a partner-scoped role, not a platform role.
+
+### Route And UI Contract
+
+Route: `apps/web/app/partners/...`
+
+Gating:
+
+- Active session `type === "partner"`.
+- Effective `partner-program` activation is active for the operator org.
+- Partner membership is active.
+
+First viewport:
+
+- `StatCard`: open registrations, expiring registrations, tier/agreement state, onboarding completion.
+- Primary command: register deal.
+- Recent deal registrations table: `DataTable`, `StatusBadge`, `FilterBar`, CSV export when useful.
+- Enablement/next-action strip.
+- Team/admin entry when the signed-in partner has delegated admin rights.
+
+Tabs/subroutes:
+
+- Home
+- Deal Registrations
+- Enablement
+- Performance
+- Team
+- Settings
+
+UI rules:
+
+- No hero section, no marketing copy as the first screen.
+- No nested cards or hardcoded colors.
+- Use `StatusBadge` + central `statusColors` for deal/tier/agreement statuses.
+- Use `Chart` only for meaningful time-series performance, imported by subpath.
+- Empty states point to the next action.
+- No workforce nav or operator-only shortcuts.
+
+UX gate: canonical install or sandbox lease with a seeded partner account and one negative cross-partner test path.
+
+## Phase 4 - Deal Registration, Tiering, Delegated Admin
+
+**Backlog:** `BI-C47A568C`
+
+Prepared-not-prescribed channel operations:
+
+- Deal-registration ledger: status, owner partner account, expiry/renewal, conflict decision, audit notes.
+- Partner tier/program records: tier, agreement reference, entitlement flags, review cadence.
+- Delegated partner admin: invite/manage own partner members only.
+- Export/reporting paths with strict partner-account scope.
+
+Non-goals remain: payout execution, accounting sync, MDF, LMS, co-branded asset studios.
+
+Gate: migration apply, scope-guard tests, canonical UX.
+
+## Phase 5 - Partner Federation + SCIM
+
+**Backlog:** `BI-C47A568C`
+
+Federation is the partner-population projection of the enterprise-auth identity edge, not a new auth stack.
+
+- OIDC: bind issuer + subject to `PrincipalAlias`, surface provider/account metadata only as alias/protocol details.
+- SAML: configure trust/metadata at the identity edge; DPF consumes resolved principal context.
+- SCIM: provision users/groups/memberships into partner account membership through standards-compliant lifecycle flows.
+- DPF Authority Core owns roles, capabilities, partner scope, and audit semantics after authentication.
+
+Gate: canonical/sandbox auth flow, provisioning lifecycle tests, partner deprovisioning denial path.
+
+## Ordering And Dependencies
+
+```text
+Phase 0 merged
+  -> Phase 1 merged partial
+  -> Phase 1b setup/add-later
+       -> Phase 3 /partners route gating
+
+Phase 2 account/membership
+  -> Phase 2a auth approach checkpoint
+       -> Phase 3 partner login
+            -> Phase 4 deal/tier/admin
+                 -> Phase 5 federation/SCIM
+```
+
+- Phase 1b and Phase 2 can proceed in parallel.
+- Phase 3 cannot start until Phase 1b effective activation and Phase 2/2a identity/account decisions are complete.
+- Phase 4 can design records while Phase 3 runs, but cannot ship exports/mutations without partner scope guards.
+- Phase 5 waits for the identity-edge ADR and partner membership model.
+
+## Verification Matrix
+
+| Work | Worktree-verifiable? | Required substrate |
+| --- | --- | --- |
+| `@dpf/storefront-templates` pure rules/tests | Yes | Worktree package tests/typecheck |
+| Prisma migration creation | Partially | Generate in worktree; apply on canonical install or sandbox |
+| `apps/web` typecheck/build | No for source-only worktrees | Canonical local install or shared local-CI sandbox |
+| Setup wizard/admin settings UX | No | Canonical local install or shared local-CI sandbox |
+| Auth/login/session UX | No | Canonical local install or shared local-CI sandbox |
+| `/partners` UI and scope guards | Unit pieces source-local; UX runtime-bound | Source-local tests plus canonical/sandbox UX |
+
+Report the substrate every time. A worktree-only package test is not canonical-runtime evidence for migrations, `apps/web`, auth, or UX.
+
+## Completion Checklist
+
+- [ ] Phase 0 and Phase 1 merged work has backlog status/evidence reconciled.
+- [ ] `BI-66CF1AA4` implements generic org capability activation, not partner-only activation.
+- [ ] Setup wizard asks the partner question only when resolved activation says to ask.
+- [ ] Admin settings can enable partner-program later using the same resolver/write path.
+- [ ] `/partners` is gated by effective activation, partner session, and active partner membership.
+- [ ] Partner account schema audit is recorded before migration.
+- [ ] Auth ADR chooses identity edge or generic principal-local credentials before Partner credentials provider work.
+- [ ] Partner aliases use `partner_contact` unless alias-kind normalization lands first.
+- [ ] Partner UI uses report-kit, theme tokens, and operational workbench IA.
+- [ ] Canonical/sandbox verification evidence is captured for migration, build, setup UX, auth UX, and `/partners` UX.

--- a/packages/db/prisma/migrations/20260605034607_add_organization_capability_activation/migration.sql
+++ b/packages/db/prisma/migrations/20260605034607_add_organization_capability_activation/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "OrganizationCapabilityActivation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "capabilityKey" TEXT NOT NULL,
+    "choice" TEXT NOT NULL,
+    "decidedVia" TEXT NOT NULL,
+    "decidedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganizationCapabilityActivation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "OrganizationCapabilityActivation_organizationId_idx" ON "OrganizationCapabilityActivation"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationCapabilityActivation_organizationId_capabilityK_key" ON "OrganizationCapabilityActivation"("organizationId", "capabilityKey");
+
+-- AddForeignKey
+ALTER TABLE "OrganizationCapabilityActivation" ADD CONSTRAINT "OrganizationCapabilityActivation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2773,6 +2773,33 @@ model Organization {
   researchProposals             ResearchProposal[]
   integrationCoverageProviders  IntegrationCoverageProvider[]  @relation("OrgToCoverageProviders")
   integrationRoleCoverages      IntegrationRoleCoverage[]      @relation("OrgToCoverageCells")
+  capabilityActivations         OrganizationCapabilityActivation[]
+}
+
+// EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
+// the axis-derived capability applicability from @dpf/storefront-templates. The
+// derivation answers "is this capability applicable to the business model?"; this
+// row records "did this org turn it on?" — captured at setup (decidedVia="setup-wizard")
+// for capabilities that resolveCapabilityActivation() flags promptAtSetup, and
+// editable later from admin (decidedVia="admin"). Not partner-specific; partner-program
+// is the first consumer. Spec 2026-06-04-partner-reseller-archetype-identity §6.3.
+model OrganizationCapabilityActivation {
+  id             String       @id @default(cuid())
+  organizationId String
+  // Matches a @dpf/storefront-templates CapabilityKey (validated in app code via
+  // isCapabilityKey before write). Stored as String to avoid a DB enum that would
+  // need a migration every time the capability registry grows.
+  capabilityKey  String
+  // CapabilityActivationChoice: "enabled" | "disabled".
+  choice         String
+  // Provenance of the decision: "setup-wizard" | "admin".
+  decidedVia     String
+  decidedAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, capabilityKey])
+  @@index([organizationId])
 }
 
 model BusinessContext {

--- a/packages/storefront-templates/src/capability-activation.test.ts
+++ b/packages/storefront-templates/src/capability-activation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveCapabilityActivation } from "./capability-activation";
+import {
+  resolveCapabilityActivation,
+  resolveOrgCapabilityActivations,
+} from "./capability-activation";
 
 describe("resolveCapabilityActivation", () => {
   it("treats not-applicable / hidden capabilities as never active and never offered", () => {
@@ -68,5 +71,36 @@ describe("resolveCapabilityActivation", () => {
 
     // Pure channel/reseller archetype derives partner-program = required → on by default.
     expect(resolveCapabilityActivation("required").active).toBe(true);
+  });
+});
+
+describe("resolveOrgCapabilityActivations", () => {
+  const derived = [
+    { capabilityKey: "partner-program", applicability: "recommended" as const },
+    { capabilityKey: "customer-accounts", applicability: "required" as const },
+    { capabilityKey: "point-of-sale", applicability: "optional" as const },
+    { capabilityKey: "appointment-checkout", applicability: "not-applicable" as const },
+  ];
+
+  it("folds org choices over derived applicabilities into effective activations", () => {
+    const effective = resolveOrgCapabilityActivations(derived, {
+      "partner-program": "enabled",
+    });
+    const byKey = Object.fromEntries(effective.map((e) => [e.capabilityKey, e]));
+
+    // Org opted into the recommended partner program → active.
+    expect(byKey["partner-program"]).toMatchObject({ active: true, source: "org-choice" });
+    // Required stays on with no choice needed.
+    expect(byKey["customer-accounts"]).toMatchObject({ active: true, source: "required" });
+    // Optional with no choice → off but add-later.
+    expect(byKey["point-of-sale"]).toMatchObject({ active: false, canEnableLater: true });
+    // Not-applicable → never.
+    expect(byKey["appointment-checkout"]).toMatchObject({ active: false, canEnableLater: false });
+  });
+
+  it("defaults recommended capabilities off when the org has made no choice yet", () => {
+    const effective = resolveOrgCapabilityActivations(derived);
+    const partner = effective.find((e) => e.capabilityKey === "partner-program");
+    expect(partner).toMatchObject({ active: false, promptAtSetup: true, source: "default-off" });
   });
 });

--- a/packages/storefront-templates/src/capability-activation.ts
+++ b/packages/storefront-templates/src/capability-activation.ts
@@ -81,3 +81,29 @@ export function resolveCapabilityActivation(
     source: choice ? "org-choice" : "default-off",
   };
 }
+
+export interface EffectiveCapabilityActivation extends CapabilityActivationResolution {
+  capabilityKey: string;
+}
+
+/**
+ * Shared read-path primitive: folds an organization's persisted opt-in choices
+ * (from the `OrganizationCapabilityActivation` overlay) over the archetype-derived
+ * capability applicabilities, producing the effective per-capability activation
+ * for that org. The setup wizard, the admin "add it later" toggle, and route/UI
+ * gating all resolve through this one function so they cannot drift — invariant
+ * #2 of the partner-channel plan (generic activation overlay).
+ *
+ * @param derived  the org's archetype-derived capability activations (each carries a
+ *                 `capabilityKey` and `applicability`) — e.g. `NormalizedActivationProfile.capabilityActivations`.
+ * @param choices  map of `capabilityKey → CapabilityActivationChoice` for this org.
+ */
+export function resolveOrgCapabilityActivations(
+  derived: ReadonlyArray<{ capabilityKey: string; applicability: CapabilityApplicability }>,
+  choices: Readonly<Record<string, CapabilityActivationChoice>> = {},
+): EffectiveCapabilityActivation[] {
+  return derived.map(({ capabilityKey, applicability }) => ({
+    capabilityKey,
+    ...resolveCapabilityActivation(applicability, choices[capabilityKey] ?? null),
+  }));
+}


### PR DESCRIPTION
## What
Phase 1b of the partner channel: the generic per-org capability-activation overlay ("ask at setup, add it later") **and** the admin add-later vertical, end-to-end.

### Persistence + read path
- `OrganizationCapabilityActivation` model + migration `20260605034607` — keyed by `(organizationId, capabilityKey)`, `choice` (enabled|disabled) + `decidedVia` (setup-wizard|admin), cascade-deletes with the org. Generic; partner-program is the first consumer.
- `resolveOrgCapabilityActivations()` (@dpf/storefront-templates) — pure fold of org choices over derived applicability; one source of truth for wizard, admin, and route gating.

### Admin "add it later" surface (apps/web)
- `lib/storefront/capability-activation.ts` — server data-access (get choices, fold to effective, upsert with key validation).
- `updateCapabilityActivation` server action (guarded by `manage_business_models`).
- `/storefront/settings/capabilities` page + `CapabilityActivationToggle` + settings tab. Shows the org's offered capabilities with the partner setup question and a toggle; reads **effective activation, never raw archetypeId** (plan invariant #1). Theme tokens only.

### Plan
EA-reviewed implementation plan (9 invariants, standards anchors).

## Verification
- **Migration** (lease NPEL-2490FA086C, isolated throwaway DB): full chain + this migration apply clean from scratch; unique + FK cascade enforced. Canonical/dev DBs untouched.
- **apps/web full typecheck** (next typegen + tsc): clean.
- **Unit**: storefront-templates 44/44; server module 4/4 (prisma mocked); toggle render 2/2.
- **Functional round-trip vs a real fresh-migrated DB** (no mocks): create(enabled) → read → fold(active, source=org-choice) → upsert-update(disabled) → invalid-key rejected — all pass.

## Migration hygiene
Pre-existing main schema/migration drift (unrelated finance models) was kept OUT via a schema-to-schema diff; filed as **BI-3611ED6B**.

## Staged (next)
The setup-WIZARD question (the "ask at setup" half) + full browser click-through of the settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)