### PR TITLE
doc(kernel): align build-gate examples to pnpm, drop residual npx

### DIFF
--- a/docs/founder-kernel/wiki/principles/do-the-work-dont-task-the-operator.md
+++ b/docs/founder-kernel/wiki/principles/do-the-work-dont-task-the-operator.md
@@ -59,7 +59,7 @@ If none of those four apply, the agent finishes the work.
 - **Positive:** An operator asks "did the build pass?" — the agent runs `pnpm --filter web build` in the sandbox, captures the output, and answers from real evidence. It does not say "please run the build and let me know."
 - **Positive:** An agent ships a Dockerfile fix. Instead of writing "operator step — please rebuild and verify", the agent stands up Postgres in the sandbox, applies migrations, runs the seed, builds the portal, starts the server, and curls the affected route. It reports the actual rendered output, then ships the PR with that evidence inline.
 - **Counterexample:** An agent ships a PR with `[ ] Post-merge: please run the seed and confirm X` in the test plan, when the sandbox has Postgres available and the agent could have run the seed itself. The hand-off was avoidable; the agent absorbed neither the work nor the verification.
-- **Counterexample:** An agent claims "all tests pass" based on unit tests against mocked Prisma clients, when the build gate (`npx next build`) was within reach and would have caught a real regression. The agent picked the easier work and tasked the operator with the rest.
+- **Counterexample:** An agent claims "all tests pass" based on unit tests against mocked Prisma clients, when the build gate (`pnpm --filter web build`) was within reach and would have caught a real regression. The agent picked the easier work and tasked the operator with the rest.
 
 ## When this does not apply
 

--- a/docs/founder-kernel/wiki/principles/test-in-the-portal-build.md
+++ b/docs/founder-kernel/wiki/principles/test-in-the-portal-build.md
@@ -29,7 +29,7 @@ Before claiming a feature works, exercise it through the portal build that opera
 
 ## Applies To
 
-In-platform coworkers and external coding agents. The build gate per AGENTS.md §5 is the platform's defined threshold for "done" — `cd apps/web && npx next build` plus the seed run plus a real DB query against the result. Agents must clear that gate themselves whenever the sandbox supports it; when it doesn't, they must name exactly what's missing rather than claim verification they did not perform.
+In-platform coworkers and external coding agents. The build gate per AGENTS.md §5 is the platform's defined threshold for "done" — `pnpm --filter web build` plus the seed run plus a real DB query against the result. Agents must clear that gate themselves whenever the sandbox supports it; when it doesn't, they must name exactly what's missing rather than claim verification they did not perform.
 
 ## Why
 
@@ -44,7 +44,7 @@ Before claiming a feature is complete:
 1. **Stand up the dependencies.** Postgres + Qdrant + embedding endpoint as the deployment uses them, or the closest in-sandbox equivalents.
 2. **Run the migrations.** `pnpm --filter @dpf/db exec prisma migrate deploy` against a fresh DB and again against one with prior data; both must apply cleanly.
 3. **Run the seed.** Confirm row counts match the source-of-truth markdown.
-4. **Build the portal.** `cd apps/web && npx next build`. Inspect the route manifest for the routes the feature ships.
+4. **Build the portal.** `pnpm --filter web build`. Inspect the route manifest for the routes the feature ships.
 5. **Start the production server.** `node .next/standalone/apps/web/server.js`, mint a session if needed, curl the affected routes, grep the rendered HTML for the content under test.
 6. **Report what you saw.** Status code, byte count, presence of the expected slugs / titles in the response.
 


### PR DESCRIPTION
@
Completes the `npx` -> `pnpm` gate-command realignment started in #1465 (AGENTS.md §5). A repo-wide sweep found two kernel principle pages still illustrating the build gate with `npx next build`.

## Why it matters

Kernel pages under `docs/founder-kernel/wiki/principles/` ship with every install and are cited as source of truth (retrievable via `wiki_query`). An `npx` example there contradicts:
- AGENTS.md §2 — "Use `pnpm --filter <pkg> exec <tool>`, never `npx <tool>` (npx ignores pinned versions)", and
- the canonical `build-gate-mandatory.md`, which already uses `pnpm --filter web build`.

## Changes (3 lines)

- `do-the-work-dont-task-the-operator.md`: `npx next build` -> `pnpm --filter web build`. Also makes the Counterexample consistent with the Positive example two lines above, which already used the pnpm form.
- `test-in-the-portal-build.md`: two sites (`cd apps/web && npx next build`) -> `pnpm --filter web build`.

## Verification

Docs-only. Pre-commit gate (gitleaks + typecheck) clean. These files are CRLF in-repo; edits preserved that, so the diff is the 3 logical hunks only — no line-ending churn. Sweep confirms no remaining `npx` in AGENTS.md, docs/testing/, or the kernel principles outside the §2/§30 rule lines that define the prohibition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@