### PR TITLE
feat(storefront): ask the partner question at setup + persist it (EP-PARTNER-CHANNEL Phase 1b, 'ask at setup' half)

### DIFF
--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -9,6 +9,7 @@ import {
   deriveRevenueModelFromActivationProfile,
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
+import { setCapabilityChoice } from "@/lib/storefront/capability-activation";
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -17,13 +18,14 @@ export async function POST(req: NextRequest) {
   }
 
   const {
-    archetypeId, tagline, heroImageUrl, orgName, orgSlug,
+    archetypeId, tagline, heroImageUrl, orgName, orgSlug, capabilityChoices,
   } = (await req.json()) as {
     archetypeId: string;
     tagline?: string;
     heroImageUrl?: string;
     orgName?: string;
     orgSlug: string;
+    capabilityChoices?: Array<{ capabilityKey: string; choice: "enabled" | "disabled" }>;
   };
 
   if (!orgSlug) {
@@ -137,6 +139,26 @@ export async function POST(req: NextRequest) {
       revenueModel,
     },
   });
+
+  // EP-PARTNER-CHANNEL Phase 1b: persist the operator's answers to the setup
+  // capability questions (e.g. "Do you sell through partners or resellers?").
+  // setCapabilityChoice validates the key; a bad/unknown key is skipped rather
+  // than failing the whole setup.
+  if (Array.isArray(capabilityChoices)) {
+    for (const entry of capabilityChoices) {
+      if (entry?.choice !== "enabled" && entry?.choice !== "disabled") continue;
+      try {
+        await setCapabilityChoice({
+          organizationId: org.id,
+          capabilityKey: entry.capabilityKey,
+          choice: entry.choice,
+          decidedVia: "setup-wizard",
+        });
+      } catch {
+        // Unknown capability key — skip without failing setup.
+      }
+    }
+  }
 
   await applyBusinessCapabilityPerspective(prisma, {
     archetypeId,

--- a/apps/web/components/storefront-admin/SetupWizard.tsx
+++ b/apps/web/components/storefront-admin/SetupWizard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { setupQuestionsFor } from "@/lib/storefront/setup-questions";
 import { ArchetypeActivationSummary } from "./ArchetypeActivationSummary";
 import { FinancialSetupStep } from "./FinancialSetupStep";
 import { seedOnboardingBrandOffer } from "@/lib/actions/seed-onboarding-brand-offer";
@@ -47,6 +48,7 @@ const CTA_OPTIONS = [
 ];
 
 
+
 export function SetupWizard({
   archetypes,
   orgNameFromDb,
@@ -67,6 +69,8 @@ export function SetupWizard({
   const [heroImageUrl, setHeroImageUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // EP-PARTNER-CHANNEL Phase 1b: per-capability setup answers (capabilityKey → enabled).
+  const [capabilityChoices, setCapabilityChoices] = useState<Record<string, boolean>>({});
 
   const displayPortalLabel = portalLabel ?? "Portal";
 
@@ -105,6 +109,11 @@ export function SetupWizard({
           orgSlug,
           tagline,
           heroImageUrl: heroImageUrl || null,
+          // Record the answer to each setup capability question (asked → decided).
+          capabilityChoices: setupQuestionsFor(selected!.activationProfile).map((q) => ({
+            capabilityKey: q.capabilityKey,
+            choice: capabilityChoices[q.capabilityKey] ? "enabled" : "disabled",
+          })),
         }),
       });
       if (!res.ok) {
@@ -428,6 +437,35 @@ export function SetupWizard({
           activationProfile={selected?.activationProfile}
           workspaceHomeActivation={selected?.workspaceHomeActivation}
         />
+        {(() => {
+          const questions = setupQuestionsFor(selected?.activationProfile);
+          if (questions.length === 0) return null;
+          return (
+            <div style={{ marginBottom: 16, display: "flex", flexDirection: "column", gap: 10 }}>
+              {questions.map((q) => (
+                <label
+                  key={q.capabilityKey}
+                  style={{ display: "flex", gap: 10, alignItems: "flex-start", border: "1px solid var(--dpf-border)", borderRadius: 8, background: "var(--dpf-surface-1)", padding: 12, cursor: "pointer" }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={capabilityChoices[q.capabilityKey] ?? false}
+                    onChange={(e) =>
+                      setCapabilityChoices((prev) => ({ ...prev, [q.capabilityKey]: e.target.checked }))
+                    }
+                    style={{ marginTop: 2 }}
+                  />
+                  <span style={{ minWidth: 0 }}>
+                    <span style={{ display: "block", fontSize: 13, fontWeight: 600, color: "var(--dpf-text)" }}>{q.question}</span>
+                    {q.helpText && (
+                      <span style={{ display: "block", fontSize: 12, color: "var(--dpf-muted)", marginTop: 2 }}>{q.helpText}</span>
+                    )}
+                  </span>
+                </label>
+              ))}
+            </div>
+          );
+        })()}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 24 }}>
           <div>
             <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 8 }}>Sections</div>

--- a/apps/web/lib/storefront/setup-questions.test.ts
+++ b/apps/web/lib/storefront/setup-questions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import { setupQuestionsFor } from "./setup-questions";
+
+function profileFor(archetypeId: string): unknown {
+  return ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId)?.activationProfile;
+}
+
+describe("setupQuestionsFor", () => {
+  it("asks the partner question for an archetype that recommends a partner program", () => {
+    const questions = setupQuestionsFor(profileFor("wholesale-distribution"));
+    const partner = questions.find((q) => q.capabilityKey === "partner-program");
+    expect(partner).toBeDefined();
+    expect(partner?.question).toBe("Do you sell through partners or resellers?");
+  });
+
+  it("asks no capability questions for a direct-to-consumer archetype", () => {
+    expect(setupQuestionsFor(profileFor("hair-salon"))).toEqual([]);
+  });
+
+  it("returns nothing when there is no activation profile", () => {
+    expect(setupQuestionsFor(undefined)).toEqual([]);
+    expect(setupQuestionsFor(null)).toEqual([]);
+  });
+});

--- a/apps/web/lib/storefront/setup-questions.ts
+++ b/apps/web/lib/storefront/setup-questions.ts
@@ -1,0 +1,33 @@
+import { getCapabilitySetupPrompt, readActivationProfile } from "@dpf/storefront-templates";
+
+export type CapabilitySetupQuestion = {
+  capabilityKey: string;
+  question: string;
+  helpText?: string;
+};
+
+/**
+ * The capability questions to ASK during setup for a given archetype
+ * (EP-PARTNER-CHANNEL Phase 1b). Only `recommended` capabilities that declare a
+ * setup prompt are asked (opt-in) — e.g. partner-program's "Do you sell through
+ * partners or resellers?". `required` capabilities are core to the business
+ * model (shown in the activation summary, not asked); `optional` ones are left to
+ * the admin settings "add it later" surface.
+ */
+export function setupQuestionsFor(activationProfile: unknown): CapabilitySetupQuestion[] {
+  const profile = readActivationProfile(activationProfile);
+  if (!profile) return [];
+
+  const questions: CapabilitySetupQuestion[] = [];
+  for (const capability of profile.capabilityActivations) {
+    if (capability.applicability !== "recommended") continue;
+    const prompt = getCapabilitySetupPrompt(capability.capabilityKey);
+    if (!prompt) continue;
+    questions.push({
+      capabilityKey: capability.capabilityKey,
+      question: prompt.question,
+      helpText: prompt.helpText,
+    });
+  }
+  return questions;
+}


### PR DESCRIPTION
## What
Completes Phase 1b — the **'ask at setup'** half (the admin 'add it later' half + persistence landed in #1468). When an archetype that recommends a partner channel is chosen during onboarding, the wizard asks *"Do you sell through partners or resellers?"* and stores the answer.

- **`lib/storefront/setup-questions.ts`** — `setupQuestionsFor(activationProfile)` derives the capabilities to ask about: only `recommended` ones with a setup prompt (partner-program). `required` is core (shown in the activation summary, not asked); `optional` lives in admin settings.
- **`SetupWizard` step 2** — renders the question(s) under the activation summary as opt-in checkboxes (theme tokens only); sends answers in the setup POST body.
- **setup route** — accepts `capabilityChoices` and persists each via `setCapabilityChoice` (`decidedVia='setup-wizard'`); unknown keys skipped without failing setup.

## Verification
- **apps/web full typecheck**: clean (against merged-#1468 main).
- **Unit**: `setup-questions` 3/3 — partner question asked for `wholesale-distribution`, none for `hair-salon`, empty for no profile.
- **Persistence path** (`setCapabilityChoice`, incl. `decidedVia='setup-wizard'`) was functionally proven against a real DB in #1468's round-trip; this PR reuses it.

## Remaining QA
Full browser click-through of the 9-step onboarding into a seeded runtime (the one gate a worktree can't host). With this PR, **both halves of 'ask at setup, add it later' are implemented and unit/typecheck/data-layer verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)