### PR TITLE
chore(repo): add forward-only line-ending policy to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,32 @@
+# Line-ending policy — deterministic blobs across Windows, macOS, and Linux so
+# the same file produces the same bytes regardless of editor, tool, or host.
+# This prevents whole-file CRLF<->LF churn in diffs and blame (the failure mode
+# where one edit on a Windows box silently flips an entire file's line endings).
+#
+# Added forward-only: NO mass renormalize was run, so existing files normalize
+# to this policy the next time they are committed — one file at a time, when you
+# are already touching it. `text=auto` auto-detects binary files; the Git LFS
+# rules below still override for the listed asset types.
+# See docs/testing/pre-pr-gate.md and AGENTS.md §2.
+* text=auto eol=lf
+
+# Shell scripts run in Linux containers — LF required.
+docker-entrypoint.sh text eol=lf
+*.sh text eol=lf
+
+# Windows-native scripts — CRLF. Batch files are line-ending-sensitive, and the
+# PowerShell scripts here are authored and committed as CRLF. Overrides the LF
+# default above.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.ps1xml text eol=crlf
+
+# Binary assets via Git LFS — never treat as text.
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.xlsx filter=lfs diff=lfs merge=lfs -text
 *.docx filter=lfs diff=lfs merge=lfs -text
-docker-entrypoint.sh text eol=lf
-*.sh text eol=lf
 
 # Upstream Model Context Protocol spec — preserve LF line endings so the local
 # copy stays byte-identical to upstream and refresh diffs are clean.


### PR DESCRIPTION
@
Root-cause fix for the cross-machine drift behind the whole-file CRLF/LF churn seen this session (AGENTS.md silently flipped LF<->CRLF in `main`). Markdown and other text had **no** EOL policy, so the same file produced different blobs depending on editor/tool/host.

## Policy

- `* text=auto eol=lf` — default all text to LF, auto-detect binaries.
- Windows-native scripts pinned to **CRLF** (`*.bat`, `*.cmd`, `*.ps1`, `*.psm1`, `*.ps1xml`) — batch files are EOL-sensitive, and HEAD blobs confirm these are CRLF today, so **zero churn** for them.
- Existing rules preserved: container shell scripts LF, LFS binaries, MCP spec LF.

## Forward-only by design

**No `git add --renormalize` was run.** Existing files normalize to policy the next time each is individually committed — not in one large blame-disrupting diff. The only file in this PR is `.gitattributes` (+26/−2).

## Verification

- `git check-attr` resolves as intended: `.md`/`.json` → `eol=lf`; `.bat`/`.ps1` → `eol=crlf`; `.sh` → `eol=lf`; `.pdf` → binary.
- Staging `.gitattributes` cascaded to **no other file** (`git status` shows only `.gitattributes`).
- The `.gitattributes` blob itself committed as LF (policy self-applies on `add`).

Follow-up option (not in this PR, your call): a one-time repo-wide `git add --renormalize` in a dedicated quiet-window PR to converge all existing files at once instead of lazily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@