### PR TITLE
feat(ai-ops-map): deliberation lens (Option B, no migration) (BI-8DF5E740)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@dpf/db", () => ({
     scheduledJob: { findMany: vi.fn() },
     delegationChain: { findMany: vi.fn() },
     phaseHandoff: { findMany: vi.fn() },
+    deliberationRun: { findMany: vi.fn() },
   },
 }));
 
@@ -122,6 +123,7 @@ describe("AI operations map page", () => {
     vi.mocked(prisma.scheduledJob.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.delegationChain.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.deliberationRun.findMany).mockResolvedValue([] as never);
 
     const { default: OperationsMapPage } = await import("./page");
     const element = await OperationsMapPage();

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -33,6 +33,7 @@ import {
 } from "./ai-operations-map-prefs";
 import { StalledTaskRecoveryActions } from "./StalledTaskRecoveryActions";
 import { A2aInteractionsPanel } from "./A2aInteractionsPanel";
+import { DeliberationLensPanel } from "./DeliberationLensPanel";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -280,6 +281,8 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
           a2aEdges={routingTopology.a2aEdges}
           a2aLegend={routingTopology.a2aLegend}
         />
+
+        <DeliberationLensPanel deliberations={routingTopology.deliberations} />
       </section>
 
       <details

--- a/apps/web/components/platform/DeliberationLensPanel.test.tsx
+++ b/apps/web/components/platform/DeliberationLensPanel.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DeliberationLensPanel } from "./DeliberationLensPanel";
+import type { OperationsMapDeliberation } from "@/lib/ai-operations-map/types";
+
+function deliberation(overrides: Partial<OperationsMapDeliberation> = {}): OperationsMapDeliberation {
+  return {
+    id: "delib-1",
+    coordinatorCoworkerId: "ceo-coworker",
+    coordinatorLabel: "CEO Coworker",
+    pattern: "Diversity review",
+    diversityMode: "multi-provider-heterogeneous",
+    consensusState: "partial-consensus",
+    occurredAt: "2026-06-05T10:00:00.000Z",
+    branches: [
+      { nodeId: "n1", role: "reviewer", modelId: "claude-sonnet", providerId: "anthropic", status: "completed" },
+      { nodeId: "n2", role: "skeptical_reviewer", modelId: "gpt-5", providerId: "openai", status: "completed" },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("DeliberationLensPanel", () => {
+  it("renders an empty state when there are no deliberations", () => {
+    const { container } = render(<DeliberationLensPanel deliberations={[]} />);
+    expect(container.textContent).toContain("No deliberations recorded");
+    expect(container.querySelectorAll("[data-deliberation]").length).toBe(0);
+  });
+
+  it("renders one card per deliberation with coordinator, consensus, and branch roster", () => {
+    const { container } = render(
+      <DeliberationLensPanel deliberations={[deliberation(), deliberation({ id: "delib-2" })]} />,
+    );
+    expect(container.querySelectorAll("[data-deliberation]").length).toBe(2);
+    // First card: coordinator + branches.
+    expect(container.textContent).toContain("CEO Coworker");
+    expect(container.querySelectorAll("[data-deliberation-branch]").length).toBe(4); // 2 branches x 2 cards
+  });
+
+  it("shows branch model/provider for diverse runs and consensus state", () => {
+    const { container } = render(<DeliberationLensPanel deliberations={[deliberation()]} />);
+    expect(container.textContent).toContain("anthropic / claude-sonnet");
+    expect(container.textContent).toContain("openai / gpt-5");
+    expect(container.textContent?.toLowerCase()).toContain("partial");
+  });
+
+  it("does not invent model/provider text for role-only branches", () => {
+    const { container } = render(
+      <DeliberationLensPanel
+        deliberations={[
+          deliberation({
+            diversityMode: "single-model-multi-persona",
+            branches: [{ nodeId: "n1", role: "reviewer", modelId: null, providerId: null, status: "running" }],
+          }),
+        ]}
+      />,
+    );
+    const branch = container.querySelector("[data-deliberation-branch]") as HTMLElement;
+    expect(branch.textContent).toContain("Reviewer");
+    expect(branch.textContent).not.toContain("/"); // no provider/model separator fabricated
+  });
+});

--- a/apps/web/components/platform/DeliberationLensPanel.tsx
+++ b/apps/web/components/platform/DeliberationLensPanel.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import type {
+  OperationsMapDeliberation,
+  OperationsMapDeliberationBranch,
+} from "@/lib/ai-operations-map/types";
+
+type Props = {
+  deliberations: OperationsMapDeliberation[];
+};
+
+/**
+ * Deliberation lens (Option B). A deliberation is a coordinating coworker
+ * fanning a decision out to N review branches. Those branches are NOT distinct
+ * coworkers today, so this renders a coordinator-side summary (role + model/
+ * provider) rather than coworker↔coworker edges — never fabricating identity.
+ * See docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md
+ */
+export function DeliberationLensPanel({ deliberations }: Props) {
+  return (
+    <section
+      aria-label="Deliberation lens"
+      className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="max-w-2xl">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Deliberations</h2>
+          <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+            Internal review fans: a coordinating coworker deliberated across review branches (by role, and where the
+            run is diverse, by model/provider). Branches are review facets of the coordinator, not separate coworkers.
+          </p>
+        </div>
+        <span className="inline-flex items-center rounded-full bg-[var(--dpf-surface-2)] px-2.5 py-1">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">Runs</span>
+          <span className="ml-2 text-xs font-semibold text-[var(--dpf-text)]">{deliberations.length}</span>
+        </span>
+      </header>
+
+      {deliberations.length === 0 ? (
+        <div className="rounded-md border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+          No deliberations recorded in the current window. Multi-branch reviews appear here as coworkers deliberate.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {deliberations.map((deliberation) => (
+            <li
+              key={deliberation.id}
+              data-deliberation={deliberation.id}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-[var(--dpf-text)]">{deliberation.coordinatorLabel}</p>
+                  <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+                    {deliberation.pattern ?? "Deliberation"} · {diversityModeLabel(deliberation.diversityMode)} ·{" "}
+                    {deliberation.branches.length} branch{deliberation.branches.length === 1 ? "" : "es"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <StatusBadge
+                    domain="deliberationConsensus"
+                    status={deliberation.consensusState}
+                    label={consensusLabel(deliberation.consensusState)}
+                    variant="soft"
+                  />
+                  <LocalTime
+                    value={deliberation.occurredAt}
+                    className="text-[10px] text-[var(--dpf-muted)]"
+                    fallback="Unknown time"
+                  />
+                </div>
+              </div>
+
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {deliberation.branches.map((branch) => (
+                  <li
+                    key={branch.nodeId}
+                    data-deliberation-branch={branch.nodeId}
+                    className="inline-flex items-center gap-1.5 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[11px]"
+                    title={branchTitle(branch)}
+                  >
+                    <span className="font-medium text-[var(--dpf-text)]">{humanize(branch.role) || "Branch"}</span>
+                    {branch.modelId ? (
+                      <span className="text-[var(--dpf-muted)]">
+                        {branch.providerId ? `${branch.providerId} / ${branch.modelId}` : branch.modelId}
+                      </span>
+                    ) : null}
+                    {branch.status ? (
+                      <span className="text-[var(--dpf-muted)]">· {humanize(branch.status)}</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function branchTitle(branch: OperationsMapDeliberationBranch): string {
+  const parts = [humanize(branch.role) || "Branch"];
+  if (branch.modelId) parts.push(branch.providerId ? `${branch.providerId} / ${branch.modelId}` : branch.modelId);
+  if (branch.status) parts.push(humanize(branch.status));
+  return parts.join(" · ");
+}
+
+function diversityModeLabel(mode: string): string {
+  switch (mode) {
+    case "single-model-multi-persona":
+      return "Single model · multi-persona";
+    case "multi-model-same-provider":
+      return "Multi-model · same provider";
+    case "multi-provider-heterogeneous":
+      return "Multi-provider";
+    default:
+      return humanize(mode);
+  }
+}
+
+function consensusLabel(state: string): string {
+  return humanize(state);
+}
+
+function humanize(value: string | null): string {
+  if (!value) return "";
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part, index) => (index === 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -154,6 +154,14 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     failed: "danger",
     blocked: "warning",
   },
+  // Deliberation consensus outcome on the AI Operations Map deliberation lens.
+  deliberationConsensus: {
+    consensus: "success",
+    "partial-consensus": "warning",
+    "no-consensus": "danger",
+    "insufficient-evidence": "warning",
+    pending: "accent",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -53,6 +53,9 @@ vi.mock("@dpf/db", () => ({
     phaseHandoff: {
       findMany: vi.fn(),
     },
+    deliberationRun: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -68,6 +71,7 @@ describe("loadOperationsMapData", () => {
     // A2A interaction sources default to empty; individual tests override.
     vi.mocked(prisma.delegationChain.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.phaseHandoff.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.deliberationRun.findMany).mockResolvedValue([] as never);
   });
 
   it("selects the map template from StorefrontConfig archetype truth", async () => {
@@ -494,6 +498,65 @@ describe("loadOperationsMapData", () => {
     );
     expect(prisma.phaseHandoff.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ orderBy: { createdAt: "desc" }, take: 40 }),
+    );
+  });
+
+  it("projects the deliberation lens with coordinator + branch model/provider from routeDecision", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.agent.findMany).mockResolvedValue([makeAgentRow()] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.routeDecisionLog.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.modelProvider.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.tokenUsage.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.scheduledAgentTask.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.scheduledJob.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.deliberationRun.findMany).mockResolvedValue([
+      {
+        id: "delib-1",
+        diversityMode: "multi-provider-heterogeneous",
+        consensusState: "partial-consensus",
+        startedAt: new Date("2026-06-05T10:00:00.000Z"),
+        taskRun: { currentAgentId: "support-specialist", initiatingAgentId: null },
+        pattern: { name: "Diversity review" },
+        branchNodes: [
+          {
+            id: "n1",
+            workerRole: "reviewer",
+            status: "completed",
+            routeDecision: { selectedModelId: "claude-sonnet", selectedEndpoint: "anthropic:claude-sonnet" },
+          },
+          {
+            id: "n2",
+            workerRole: "skeptical_reviewer",
+            status: "completed",
+            routeDecision: { selectedModelId: "gpt-5", providerId: "openai" },
+          },
+        ],
+      },
+    ] as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(data.routingTopology.deliberations).toEqual([
+      expect.objectContaining({
+        id: "delib-1",
+        coordinatorCoworkerId: "support-specialist",
+        coordinatorLabel: "Support Specialist",
+        pattern: "Diversity review",
+        diversityMode: "multi-provider-heterogeneous",
+        consensusState: "partial-consensus",
+      }),
+    ]);
+    expect(data.routingTopology.deliberations[0].branches).toEqual([
+      { nodeId: "n1", role: "reviewer", modelId: "claude-sonnet", providerId: "anthropic", status: "completed" },
+      { nodeId: "n2", role: "skeptical_reviewer", modelId: "gpt-5", providerId: "openai", status: "completed" },
+    ]);
+    expect(prisma.deliberationRun.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { startedAt: "desc" }, take: 40 }),
     );
   });
 });

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -15,6 +15,10 @@ import {
   type A2aPhaseHandoffSourceRow,
   type A2aTaskLineageSourceRow,
 } from "./project-a2a-interactions";
+import {
+  projectDeliberations,
+  type DeliberationSourceRow,
+} from "./project-deliberations";
 import type {
   OperationsMapRoutingTopology,
   OperationsMapAgent,
@@ -73,6 +77,7 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     delegationChains,
     phaseHandoffs,
     a2aTaskRuns,
+    deliberationRuns,
   ] = await Promise.all([
     prisma.storefrontConfig.findFirst({
       include: {
@@ -414,6 +419,25 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
         startedAt: true,
       },
     }),
+    // Deliberation lens (Option B): coordinator-internal fan. Branches are not
+    // distinct coworkers, so we render a coordinator-side summary (role + model/
+    // provider from each branch's routeDecision) rather than A2A edges. The
+    // coordinator is the parent TaskRun's current/initiating agent.
+    prisma.deliberationRun.findMany({
+      orderBy: { startedAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        diversityMode: true,
+        consensusState: true,
+        startedAt: true,
+        taskRun: { select: { currentAgentId: true, initiatingAgentId: true } },
+        pattern: { select: { name: true } },
+        branchNodes: {
+          select: { id: true, workerRole: true, status: true, routeDecision: true },
+        },
+      },
+    }),
   ]);
 
   const routeDecisionAgentMessageIds = [
@@ -566,6 +590,30 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     (left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt),
   );
 
+  // Deliberation lens (Option B). Coordinator = parent TaskRun's current/
+  // initiating agent; per-branch model/provider recovered from routeDecision.
+  const deliberations = projectDeliberations({
+    agents: coworkerSourceRows,
+    deliberations: deliberationRuns.map((run): DeliberationSourceRow => ({
+      id: run.id,
+      coordinatorAgentId: run.taskRun?.currentAgentId ?? run.taskRun?.initiatingAgentId ?? null,
+      pattern: run.pattern?.name ?? null,
+      diversityMode: run.diversityMode,
+      consensusState: run.consensusState,
+      startedAt: run.startedAt,
+      branches: run.branchNodes.map((node) => {
+        const { modelId, providerId } = extractBranchModelProvider(node.routeDecision);
+        return {
+          nodeId: node.id,
+          role: node.workerRole,
+          modelId,
+          providerId,
+          status: node.status,
+        };
+      }),
+    })),
+  });
+
   return {
     template,
     agents: stationedAgents,
@@ -574,10 +622,40 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       ...routingTopology,
       coworkers: mergedCoworkers,
       a2aEdges: a2aProjection.a2aEdges,
+      deliberations,
       timeline: mergedTimeline,
     },
     recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} records per evidence source`,
   };
+}
+
+/**
+ * Recover a deliberation branch's model/provider from its persisted
+ * `TaskNode.routeDecision` JSON. Provider falls back to the endpoint-id prefix
+ * ("provider:model") when not stored explicitly — consistent with the routing
+ * topology projector's provider resolution. Returns nulls for non-diverse runs
+ * (single-model-multi-persona branches share one model and may carry neither).
+ */
+function extractBranchModelProvider(value: unknown): { modelId: string | null; providerId: string | null } {
+  const parsed = typeof value === "string" ? safeJsonObject(value) : value;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { modelId: null, providerId: null };
+  }
+  const record = parsed as Record<string, unknown>;
+  const modelId = typeof record.selectedModelId === "string" ? record.selectedModelId : null;
+  let providerId = typeof record.providerId === "string" ? record.providerId : null;
+  if (!providerId && typeof record.selectedEndpoint === "string" && record.selectedEndpoint.includes(":")) {
+    providerId = record.selectedEndpoint.split(":")[0] || null;
+  }
+  return { modelId, providerId };
+}
+
+function safeJsonObject(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/web/lib/ai-operations-map/project-deliberations.test.ts
+++ b/apps/web/lib/ai-operations-map/project-deliberations.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectDeliberations,
+  type DeliberationSourceRow,
+} from "./project-deliberations";
+import type { RoutingCoworkerSourceRow } from "./project-routing-topology";
+
+const AGENTS: RoutingCoworkerSourceRow[] = [
+  { agentId: "ceo-coworker", name: "CEO Coworker", stationLabel: "Direct" },
+  { agentId: "ea-architect", name: "EA Architect", stationLabel: "Integrate" },
+];
+
+function run(overrides: Partial<DeliberationSourceRow> = {}): DeliberationSourceRow {
+  return {
+    id: "delib-1",
+    coordinatorAgentId: "ceo-coworker",
+    pattern: "Diversity review",
+    diversityMode: "multi-provider-heterogeneous",
+    consensusState: "consensus",
+    startedAt: new Date("2026-06-05T10:00:00.000Z"),
+    branches: [
+      { nodeId: "n1", role: "reviewer", modelId: "claude-sonnet", providerId: "anthropic", status: "completed" },
+      { nodeId: "n2", role: "skeptical_reviewer", modelId: "gpt-5", providerId: "openai", status: "completed" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("deliberation lens projection", () => {
+  it("returns an empty list when there are no deliberations", () => {
+    expect(projectDeliberations({ agents: AGENTS, deliberations: [] })).toEqual([]);
+  });
+
+  it("projects a deliberation with its coordinator label and branch roster", () => {
+    const [delib] = projectDeliberations({ agents: AGENTS, deliberations: [run()] });
+    expect(delib).toEqual(
+      expect.objectContaining({
+        id: "delib-1",
+        coordinatorCoworkerId: "ceo-coworker",
+        coordinatorLabel: "CEO Coworker",
+        pattern: "Diversity review",
+        diversityMode: "multi-provider-heterogeneous",
+        consensusState: "consensus",
+        occurredAt: "2026-06-05T10:00:00.000Z",
+      }),
+    );
+    expect(delib.branches).toEqual([
+      { nodeId: "n1", role: "reviewer", modelId: "claude-sonnet", providerId: "anthropic", status: "completed" },
+      { nodeId: "n2", role: "skeptical_reviewer", modelId: "gpt-5", providerId: "openai", status: "completed" },
+    ]);
+  });
+
+  it("titleizes an unknown coordinator id rather than dropping the run", () => {
+    const [delib] = projectDeliberations({
+      agents: AGENTS,
+      deliberations: [run({ coordinatorAgentId: "hive-scout" })],
+    });
+    expect(delib.coordinatorCoworkerId).toBe("hive-scout");
+    expect(delib.coordinatorLabel).toBe("Hive Scout");
+  });
+
+  it("keeps a coordinator-less run but marks it unattributed (never fabricates a coworker)", () => {
+    const [delib] = projectDeliberations({
+      agents: AGENTS,
+      deliberations: [run({ coordinatorAgentId: null })],
+    });
+    expect(delib.coordinatorCoworkerId).toBeNull();
+    expect(delib.coordinatorLabel).toBe("Unattributed coordinator");
+  });
+
+  it("preserves role-only branches for single-model-multi-persona runs (no model/provider)", () => {
+    const [delib] = projectDeliberations({
+      agents: AGENTS,
+      deliberations: [
+        run({
+          diversityMode: "single-model-multi-persona",
+          branches: [
+            { nodeId: "n1", role: "reviewer", modelId: null, providerId: null, status: "completed" },
+            { nodeId: "n2", role: "skeptical_reviewer", modelId: null, providerId: null, status: "running" },
+          ],
+        }),
+      ],
+    });
+    expect(delib.branches.map((b) => b.role)).toEqual(["reviewer", "skeptical_reviewer"]);
+    expect(delib.branches.every((b) => b.modelId === null && b.providerId === null)).toBe(true);
+  });
+
+  it("sorts deliberations newest-first", () => {
+    const list = projectDeliberations({
+      agents: AGENTS,
+      deliberations: [
+        run({ id: "old", startedAt: new Date("2026-06-05T08:00:00.000Z") }),
+        run({ id: "new", startedAt: new Date("2026-06-05T12:00:00.000Z") }),
+      ],
+    });
+    expect(list.map((d) => d.id)).toEqual(["new", "old"]);
+  });
+});

--- a/apps/web/lib/ai-operations-map/project-deliberations.ts
+++ b/apps/web/lib/ai-operations-map/project-deliberations.ts
@@ -1,0 +1,93 @@
+import type {
+  OperationsMapDeliberation,
+  OperationsMapDeliberationBranch,
+} from "./types";
+import type { RoutingCoworkerSourceRow } from "./project-routing-topology";
+
+/**
+ * Deliberation lens projection (Option B — coordinator-internal fan).
+ *
+ * Pure function (no Prisma, no React). A deliberation branch is NOT a distinct
+ * registered coworker today, so this projector deliberately produces a
+ * coordinator-side summary (coordinator coworker + branch roster by role and,
+ * where the run is diverse, model/provider) rather than coworker↔coworker A2A
+ * edges. It never fabricates a coworker identity for a branch.
+ *
+ * See docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md
+ */
+
+export type DeliberationBranchSourceRow = {
+  nodeId: string;
+  role: string | null;
+  modelId: string | null;
+  providerId: string | null;
+  status: string | null;
+};
+
+export type DeliberationSourceRow = {
+  id: string;
+  /** Loader-resolved from the parent TaskRun (current ?? initiating agent). */
+  coordinatorAgentId: string | null;
+  pattern: string | null;
+  diversityMode: string;
+  consensusState: string;
+  startedAt: Date;
+  branches: DeliberationBranchSourceRow[];
+};
+
+export type DeliberationProjectionInput = {
+  agents: RoutingCoworkerSourceRow[];
+  deliberations: DeliberationSourceRow[];
+};
+
+export function projectDeliberations(input: DeliberationProjectionInput): OperationsMapDeliberation[] {
+  const labelByAgentId = new Map(input.agents.map((agent) => [agent.agentId, agent.name]));
+
+  return input.deliberations
+    .map((run): OperationsMapDeliberation => {
+      const coordinatorId = normalizeAgentId(run.coordinatorAgentId ?? "");
+      const branches: OperationsMapDeliberationBranch[] = run.branches.map((branch) => ({
+        nodeId: branch.nodeId,
+        role: branch.role,
+        modelId: branch.modelId,
+        providerId: branch.providerId,
+        status: branch.status,
+      }));
+
+      return {
+        id: run.id,
+        coordinatorCoworkerId: coordinatorId || null,
+        coordinatorLabel: coordinatorId
+          ? labelByAgentId.get(coordinatorId) ?? titleize(coordinatorId)
+          : "Unattributed coordinator",
+        pattern: run.pattern,
+        diversityMode: run.diversityMode,
+        consensusState: run.consensusState,
+        occurredAt: run.startedAt.toISOString(),
+        branches,
+      };
+    })
+    .sort((left, right) => occurredAtMs(right.occurredAt) - occurredAtMs(left.occurredAt));
+}
+
+function normalizeAgentId(agentId: string): string {
+  const normalized = agentId.trim();
+  if (!normalized || /^unknown$/i.test(normalized)) return "";
+  return normalized;
+}
+
+function occurredAtMs(value: string | null): number {
+  if (!value) return 0;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function titleize(value: string): string {
+  return (
+    value
+      .split(/[-_:.\s]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || "Unknown"
+  );
+}

--- a/apps/web/lib/ai-operations-map/project-routing-topology.ts
+++ b/apps/web/lib/ai-operations-map/project-routing-topology.ts
@@ -447,6 +447,10 @@ export function projectRoutingTopology(input: RoutingTopologyInput): OperationsM
     // merged in `load-map-data.ts`. Default to empty here so the topology
     // shape is stable when only provider routing is projected.
     a2aEdges: [],
+    // Deliberation summaries are contributed by `projectDeliberations` and
+    // merged in `load-map-data.ts`; default empty when only provider routing
+    // is projected.
+    deliberations: [],
     markers,
     timeline: timeline.sort((left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt)),
     legend: ROUTING_TOPOLOGY_LEGEND,

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -277,11 +277,41 @@ export type OperationsMapA2aLegendItem = {
   description: string;
 };
 
+// ─── Deliberation lens (Option B — coordinator-internal fan, no fabricated
+// coworker identity) ────────────────────────────────────────────────────
+//
+// A deliberation is a coordinator coworker fanning a decision out to N branch
+// review personas. Today those branches are NOT distinct registered coworkers
+// (see docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md),
+// so they are rendered as a coordinator-side lens — role + (where the run is
+// diverse) model/provider pulled from TaskNode.routeDecision — rather than as
+// coworker↔coworker A2A edges.
+
+export type OperationsMapDeliberationBranch = {
+  nodeId: string;
+  role: string | null;
+  modelId: string | null;
+  providerId: string | null;
+  status: string | null;
+};
+
+export type OperationsMapDeliberation = {
+  id: string;
+  coordinatorCoworkerId: string | null;
+  coordinatorLabel: string;
+  pattern: string | null;
+  diversityMode: string;
+  consensusState: string;
+  occurredAt: string | null;
+  branches: OperationsMapDeliberationBranch[];
+};
+
 export type OperationsMapRoutingTopology = {
   coworkers: OperationsMapRoutingCoworker[];
   providers: OperationsMapRoutingProvider[];
   routes: OperationsMapRoutingRoute[];
   a2aEdges: OperationsMapA2aEdge[];
+  deliberations: OperationsMapDeliberation[];
   markers: OperationsMapRoutingMarker[];
   timeline: OperationsMapRoutingTimelineMarker[];
   legend: OperationsMapRoutingLegendItem[];

--- a/docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md
+++ b/docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md
@@ -1,0 +1,99 @@
+# Deliberation Branch Identity for A2A Operations-Map Edges — Design / Coordination Note
+
+| Field | Value |
+|-------|-------|
+| **Status** | Coordination proposal (PAR: proposed, awaiting capture-thread acknowledgement) |
+| **Created** | 2026-06-05 |
+| **Owner (this note)** | AI Operations Map (read/projection/render) — `BI-65B0D697` / `EP-AI-OPSMAP` |
+| **Acknowledging owner** | Multi-agent collaboration & visibility capture thread — `BI-9DB7C332` / `EP-A2A` (branch `claude/sleepy-khorana-197ea7`) |
+| **Surface** | `apps/web/lib/ai-operations-map/project-a2a-interactions.ts`, `load-map-data.ts`, `apps/web/components/platform/A2aInteractionsPanel.tsx`; `packages/db/prisma/schema.prisma` (`TaskNode`, `DeliberationRun`) |
+| **Related** | `docs/superpowers/specs/2026-06-04-ai-operations-map-a2a-interaction-visibility-design.md`, `docs/superpowers/specs/2026-06-04-multi-agent-collaboration-visibility-design.md`, `docs/superpowers/specs/2026-04-21-deliberation-pattern-framework-design.md` |
+
+## 0. Why this note exists
+
+The A2A Operations Map (`BI-65B0D697`, PR #1467) ships a typed-edge interaction model that already renders **delegation**, **phase-handoff**, and **task-lineage** coworker↔coworker edges from existing substrate. The fourth edge kind — **`a2a-deliberation`** (coordinator → branch persona) — is implemented in the pure projector and unit-tested, but the loader deliberately passes `deliberations: []` because **no stable branch-persona identity is persisted**. This note (a) verifies that gap precisely, (b) frames the product decision it forces, (c) defines the data contract the projector needs so identity is never fabricated, and (d) flags a **direct overlap** with the capture thread's planned Operations-Map work so the two threads converge instead of duplicating.
+
+This is a **proposal**. The capture thread (`BI-9DB7C332`) owns the write path / migration; it should acknowledge or amend before any schema change.
+
+## 1. Substrate truth (verified 2026-06-05)
+
+A deliberation is a `DeliberationRun` (`schema.prisma` ~9028) with branch `TaskNode` rows linked by `TaskNode.deliberationRunId` (~5199). Findings:
+
+- **`TaskNode` has no `agentId` / persona-identity column.** Branch nodes carry `workerRole` (string: `reviewer` | `skeptical_reviewer` | `researcher` | …) and `status` only.
+- **Branch dispatch** (`apps/web/lib/queue/functions/deliberation-run.ts:221-228`) writes `status`, `completedAt`, and `routeDecision` (JSON) to each branch node. It does **not** persist a clean per-branch executor identity.
+- **Per-branch provider/model are computed but not first-classed.** `deliberation-run.ts:176-179` derives `providerId`/`modelId` per branch and pushes them to `priorProviderIds`/`priorModelIds` for *diversity tracking* only. However, the full `decision` (incl. `selectedEndpoint` / `selectedModelId`) **is** persisted in `TaskNode.routeDecision` — so the per-branch **model/provider** is recoverable from JSON for the diverse modes.
+- **`DeliberationOutcome.branchRoster`** (`synthesizer.ts:84-89`, schema ~9072) is `[{ branchNodeId, role, completed, failureReason? }]` — **no** agent/provider/model id.
+- **The coordinator IS resolvable**: `DeliberationRun.taskRunId` → `TaskRun.currentAgentId ?? initiatingAgentId`. My projector already resolves coordinator this way.
+
+### The nuance that makes this a decision, not a column add
+
+Branch identity depends on `DeliberationRun.diversityMode`:
+
+| diversityMode | What distinguishes a branch | Is the branch a distinct *coworker*? |
+|---|---|---|
+| `single-model-multi-persona` | **role only** (same model, same provider) | **No** — it is the same coworker wearing different review hats |
+| `multi-model-same-provider` | role + **model** (recoverable from `routeDecision`) | No — different model, same coworker/provider |
+| `multi-provider-heterogeneous` | role + **provider/model** (recoverable from `routeDecision`) | Debatable — different executor, still not a registered `Agent` |
+
+So a deliberation branch is, in today's runtime, **the coordinator running an internal review branch under a role** — not a separate registered coworker `Agent`. Rendering `a2a-deliberation` as coworker→coworker would **fabricate coworker identity** unless the capture thread elevates branch personas to first-class `Agent`s. The A2A spec's own non-goal forbids that fabrication.
+
+## 2. The product decision (capture thread to make)
+
+**Are deliberation branch personas distinct coworkers, or internal review facets of one coworker?**
+
+- **Option A — Personas are distinct coworkers.** The capture thread registers/binds an `Agent` per deliberation persona (or per persona+model) and records its `agentId` on the branch node. Then `a2a-deliberation` renders as genuine coworker→coworker fan-out. Cost: a migration (`TaskNode.agentId`) + a persona→Agent mapping policy.
+- **Option B — Personas are internal facets (recommended default).** Deliberation stays a coordinator-internal self-fan. The Operations Map renders it **not** as coworker↔coworker but as a coordinator self-loop / distinct "deliberation" affordance (e.g., a badge or a small fan glyph on the coordinator node, or a dedicated lens), differentiated by role and — where diverse — by model/provider pulled from `TaskNode.routeDecision`. **No migration; no fabricated coworker identity.**
+
+Recommendation: **Option B** unless the capture thread has a concrete product reason to treat reviewers as distinct coworkers. It is truthful to the runtime, needs no migration, and still surfaces "this coworker deliberated across N roles/models."
+
+## 3. Data contract the projector needs (either option)
+
+To keep the Operations Map honest, extend `A2aDeliberationBranchRow` (in `project-a2a-interactions.ts`) so identity carries its **kind**, and the renderer decides representation:
+
+```ts
+type A2aDeliberationBranchRow = {
+  nodeId: string;
+  role: string | null;            // workerRole (always present)
+  status: string | null;
+  // identity + its kind — projector never fabricates a coworker:
+  identityKind: "agent" | "model" | "role";   // agent only when a real Agent.agentId exists
+  agentId: string | null;          // populated ONLY when identityKind === "agent"
+  modelId: string | null;          // from TaskNode.routeDecision (diverse modes)
+  providerId: string | null;       // from TaskNode.routeDecision (diverse modes)
+};
+```
+
+- **Option A** populates `identityKind:"agent"` + `agentId` → loader wires `a2a-deliberation` coworker→coworker edges.
+- **Option B** populates `identityKind:"role"|"model"` → loader keeps `deliberations: []` for the coworker band and (optionally, follow-up) renders a coordinator-side deliberation affordance from `modelId`/`role`. The projector's deliberation path stays guarded so it only emits coworker edges when `identityKind === "agent"`.
+
+The `model`/`provider` fields are **recoverable today with no migration** from `TaskNode.routeDecision`, so an Option-B deliberation affordance is buildable now without the capture thread.
+
+## 4. Overlap reconciliation (important)
+
+`BI-9DB7C332` Slice 2 (per its backlog body) plans: *"delegatesTo/escalatesTo enforcement + DelegationChain hops; **Operations Map transfer overlay + collaboration-graph inspector**."* That intersects PR #1467 directly:
+
+- The capture thread **writes** `DelegationChain` hops and `TaskRun.parentTaskRunId` / `a2aMetadata` (role/tier/enteredVia). PR #1467 **already projects** those into `a2a-delegation` and `a2a-task-lineage` edges and renders them in `A2aInteractionsPanel`.
+- Both threads otherwise risk building **two parallel Operations-Map overlays** for the same coworker↔coworker concept.
+
+**Proposal:** the typed-edge substrate from PR #1467 — `OperationsMapA2aEdge` / `a2aEdges` on the topology + `A2aInteractionsPanel` + `project-a2a-interactions.ts` — becomes the **shared render/projection substrate**. The capture thread's "collaboration-graph inspector" projects into that model (add inputs to the projector) rather than adding a second overlay. Division of ownership:
+
+| Concern | Owner |
+|---|---|
+| Writing collaboration substrate (AgentEvent bus, `DelegationChain`, `a2aMetadata`, branch identity) | Capture thread (`BI-9DB7C332`) |
+| Typed-edge topology model + Operations-Map render/projection/filter/inspector | Ops-Map thread (`BI-65B0D697`) |
+| Deliberation branch identity decision + capture (§2) | Capture thread, per this note |
+
+## 5. Minimal capture change (only if Option A is chosen)
+
+| Model | Field | Type | Written at | Notes |
+|---|---|---|---|---|
+| `TaskNode` | `agentId` (or `personaAgentId`) | `String?` | `deliberation-run.ts:221-228` (alongside `routeDecision`) | Nullable; populated only for deliberation branches once a persona→`Agent` binding exists. Requires a persona→Agent registration/mapping policy. |
+
+If Option B is chosen, **no migration**; the Ops-Map thread builds the coordinator-side deliberation affordance from `TaskNode.routeDecision` + `workerRole` as a follow-up slice.
+
+## 6. Asks of the capture thread (acknowledgement)
+
+1. Decide §2 Option A vs B.
+2. If A: add `TaskNode.agentId` + persona→Agent mapping, and emit `identityKind:"agent"` rows (§3).
+3. Adopt the §4 division of ownership so the "collaboration-graph inspector" composes the PR #1467 typed-edge substrate instead of a parallel overlay.
+4. Coordinate before either thread pushes further Operations-Map render changes (continuous overlap sweep).


### PR DESCRIPTION
## What

Follow-up to #1467. Renders **deliberation** activity on the AI Operations Map without fabricating coworker identity. A deliberation branch is the coordinator running an internal review hat (a role; and where the run is diverse, a model/provider) — **not** a distinct registered coworker — so it is shown as a **coordinator-side lens**, not as coworker-to-coworker A2A edges.

Backlog: **BI-8DF5E740** (EP-A2A). Coordination/design note: `docs/superpowers/specs/2026-06-05-deliberation-branch-identity-for-a2a-ops-map-design.md`.

## How

- **types** — `OperationsMapDeliberation(+Branch)` + `deliberations` on the topology.
- **projector** — pure `project-deliberations.ts`: coordinator + branch roster; never fabricates a coworker for a branch.
- **loader** — fetch `DeliberationRun` + branch `TaskNode`s; coordinator = parent `TaskRun.currentAgentId ?? initiatingAgentId`; per-branch **model/provider recovered from `TaskNode.routeDecision`** — **no migration**.
- **render** — `DeliberationLensPanel`: coordinator, pattern, diversity mode, consensus `StatusBadge` (new `deliberationConsensus` `statusColors` domain), branch roster, `LocalTime`, empty state.

## Verification

- `pnpm --filter web test` — full suite green (9545 passed) for this slice; targeted `lib/ai-operations-map` + component tests green on the rebased tree; `typecheck` clean. CI is the binding gate.

## Notes

- Read-only, migration-free, additive.
- **Option A** — elevating deliberation branch personas to distinct registered coworker `Agent`s (a `TaskNode.agentId` migration) so deliberation renders as genuine coworker-to-coworker fan-out — remains the capture thread decision (`BI-9DB7C332`). Option B here does not preempt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
