### PR TITLE
feat(discovery): DPPM placement algorithm — device class → Foundational sub-portfolio (BI-CA1688BB)

### DIFF
--- a/packages/db/src/device-placement.test.ts
+++ b/packages/db/src/device-placement.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  classifyDppmPortfolio,
+  DPPM_PORTFOLIOS,
+  FOUNDATIONAL_NODES,
+  placeableDeviceClasses,
+  placeDeviceClass,
+} from "./device-placement";
+import { AUTO_PROMOTE_THRESHOLD } from "./discovery-promotion-policy";
+
+// Mirrors the slugify + nodeId construction in seed.ts so the test proves the
+// placement target ids match the LIVE taxonomy, not a stale copy.
+function buildTaxonomyNodeIds(): Set<string> {
+  const raw = readFileSync(join(__dirname, "..", "data", "taxonomy_v3.json"), "utf8");
+  const rows = JSON.parse(raw) as Array<{
+    portfolio_id: string;
+    level_1: string;
+    level_2: string;
+    level_3: string;
+  }>;
+  const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  const ids = new Set<string>();
+  for (const row of rows) {
+    const pid = row.portfolio_id;
+    if (!pid) continue;
+    ids.add(pid);
+    if (!row.level_1) continue;
+    const l1 = `${pid}/${slugify(row.level_1)}`;
+    ids.add(l1);
+    if (!row.level_2) continue;
+    const l2 = `${l1}/${slugify(row.level_2)}`;
+    ids.add(l2);
+    if (!row.level_3) continue;
+    ids.add(`${l2}/${slugify(row.level_3)}`);
+  }
+  return ids;
+}
+
+describe("classifyDppmPortfolio — the four-portfolio test", () => {
+  it("sold products → Provided Externally", () => {
+    expect(classifyDppmPortfolio({ delivery: "sold_product", consumer: "external_customer" })).toBe(
+      "providedExternally",
+    );
+    expect(DPPM_PORTFOLIOS.providedExternally).toBe("products_and_services_sold");
+  });
+
+  it("employee-job software → Provided Internally", () => {
+    expect(classifyDppmPortfolio({ delivery: "employee_app", consumer: "internal_employee" })).toBe(
+      "providedInternally",
+    );
+    expect(DPPM_PORTFOLIOS.providedInternally).toBe("for_employees");
+  });
+
+  it("production OT → Manufacture & Delivery", () => {
+    expect(classifyDppmPortfolio({ delivery: "production_ot", consumer: "production_line" })).toBe(
+      "manufactureAndDelivery",
+    );
+    expect(DPPM_PORTFOLIOS.manufactureAndDelivery).toBe("manufacturing_and_delivery");
+  });
+
+  it("network / client compute / building management / IaaS → Foundational", () => {
+    expect(classifyDppmPortfolio({ delivery: "device", consumer: "infrastructure" })).toBe("foundational");
+    expect(DPPM_PORTFOLIOS.foundational).toBe("foundational");
+  });
+});
+
+describe("placeDeviceClass — device class → Foundational sub-portfolio node", () => {
+  const cases: Array<[string, string]> = [
+    // Security & Surveillance — Reolink / Hui-Zhou cameras, NVRs
+    ["ip_camera", FOUNDATIONAL_NODES.securityAndSurveillance],
+    ["nvr", FOUNDATIONAL_NODES.securityAndSurveillance],
+    ["doorbell_camera", FOUNDATIONAL_NODES.securityAndSurveillance],
+    // Climate — Nest thermostat
+    ["thermostat", FOUNDATIONAL_NODES.climateControl],
+    // Access — Chamberlain garage / smart locks
+    ["garage_door_opener", FOUNDATIONAL_NODES.accessControl],
+    ["smart_lock", FOUNDATIONAL_NODES.accessControl],
+    // Lighting & Energy — TP-Link Kasa plugs/bulbs
+    ["smart_plug", FOUNDATIONAL_NODES.lightingAndEnergy],
+    ["smart_bulb", FOUNDATIONAL_NODES.lightingAndEnergy],
+    // Connected Appliances — LG / Whirlpool
+    ["refrigerator", FOUNDATIONAL_NODES.connectedAppliances],
+    ["washer", FOUNDATIONAL_NODES.connectedAppliances],
+    // Network — Ubiquiti
+    ["gateway", FOUNDATIONAL_NODES.networkConnectivity],
+    ["access_point", FOUNDATIONAL_NODES.networkConnectivity],
+    ["switch", FOUNDATIONAL_NODES.networkConnectivity],
+    // Voice — Amazon Echo
+    ["voice_assistant", FOUNDATIONAL_NODES.voice],
+    ["smart_speaker", FOUNDATIONAL_NODES.voice],
+    // Client Compute — Apple / MSI / Intel / Samsung
+    ["client_endpoint", FOUNDATIONAL_NODES.clientCompute],
+    ["laptop", FOUNDATIONAL_NODES.clientCompute],
+    ["phone", FOUNDATIONAL_NODES.clientCompute],
+  ];
+
+  it.each(cases)("places %s under %s", (deviceClass, expectedNode) => {
+    const placement = placeDeviceClass(deviceClass);
+    expect(placement.taxonomyNodeId).toBe(expectedNode);
+    expect(placement.reason).toBe("mapped");
+    expect(placement.portfolio).toBe("foundational");
+    expect(placement.autoPlace).toBe(true);
+    expect(placement.taxonomyConfidence).toBeGreaterThanOrEqual(AUTO_PROMOTE_THRESHOLD);
+  });
+
+  it("normalizes synonyms and casing/spacing to canonical classes", () => {
+    expect(placeDeviceClass("Camera").taxonomyNodeId).toBe(FOUNDATIONAL_NODES.securityAndSurveillance);
+    expect(placeDeviceClass("smart-thermostat").taxonomyNodeId).toBe(FOUNDATIONAL_NODES.climateControl);
+    expect(placeDeviceClass("Echo").taxonomyNodeId).toBe(FOUNDATIONAL_NODES.voice);
+    expect(placeDeviceClass("PC").taxonomyNodeId).toBe(FOUNDATIONAL_NODES.clientCompute);
+  });
+
+  it("returns null + unplaceable_class for an unknown class (escalates, never mis-places)", () => {
+    const placement = placeDeviceClass("quantum_toaster");
+    expect(placement.taxonomyNodeId).toBeNull();
+    expect(placement.reason).toBe("unplaceable_class");
+    expect(placement.autoPlace).toBe(false);
+    expect(placement.taxonomyConfidence).toBe(0);
+  });
+
+  it("does not auto-place when confidence is below the promote threshold", () => {
+    const placement = placeDeviceClass("ip_camera", { confidence: 0.5 });
+    expect(placement.taxonomyNodeId).toBe(FOUNDATIONAL_NODES.securityAndSurveillance);
+    expect(placement.autoPlace).toBe(false);
+  });
+
+  it("every placeable class resolves to a foundational node id", () => {
+    for (const cls of placeableDeviceClasses()) {
+      const placement = placeDeviceClass(cls);
+      expect(placement.taxonomyNodeId).not.toBeNull();
+      expect(placement.taxonomyNodeId!.startsWith("foundational/")).toBe(true);
+    }
+  });
+});
+
+describe("placement targets exist in the live taxonomy (drift guard)", () => {
+  const taxonomyIds = buildTaxonomyNodeIds();
+
+  it("every FOUNDATIONAL_NODES id is a real node in taxonomy_v3.json", () => {
+    for (const [name, nodeId] of Object.entries(FOUNDATIONAL_NODES)) {
+      expect(taxonomyIds.has(nodeId), `${name} → ${nodeId} missing from taxonomy_v3.json`).toBe(true);
+    }
+  });
+
+  it("every device class places into an existing taxonomy node", () => {
+    for (const cls of placeableDeviceClasses()) {
+      const nodeId = placeDeviceClass(cls).taxonomyNodeId!;
+      expect(taxonomyIds.has(nodeId), `${cls} → ${nodeId} missing from taxonomy_v3.json`).toBe(true);
+    }
+  });
+
+  it("the four DPPM portfolio ids are real portfolio roots", () => {
+    for (const portfolioId of Object.values(DPPM_PORTFOLIOS)) {
+      expect(taxonomyIds.has(portfolioId), `${portfolioId} missing from taxonomy_v3.json`).toBe(true);
+    }
+  });
+});

--- a/packages/db/src/device-placement.ts
+++ b/packages/db/src/device-placement.ts
@@ -1,0 +1,244 @@
+/**
+ * DPPM placement algorithm — device class → Foundational sub-portfolio
+ * taxonomyNodeId (spec §3b, §5.4, §8.2; BI-CA1688BB).
+ *
+ * The infrastructure to *promote* a discovered device into the digital-product
+ * portfolio already exists (classifyEstateProvenance, AUTO_PROMOTE_THRESHOLD,
+ * the structural type/name gates, the seeded taxonomy tree). What did NOT exist
+ * is the placement *algorithm itself*: given a resolved device class, which
+ * existing taxonomy node does it belong under? This module is that algorithm.
+ *
+ * Design constraints (architect-reviewed spec):
+ *  - Placement resolves to an EXISTING `taxonomyNodeId` (the semantic nodeId
+ *    string, e.g. "foundational/building_management/security_and_surveillance").
+ *    We do NOT introduce a parallel {portfolio, taxonomyNode, productType}
+ *    object — the taxonomy path already encodes portfolio → sub-portfolio →
+ *    product type.
+ *  - Confidence reuses the discovery-triage thresholds + AUTO_PROMOTE_THRESHOLD,
+ *    not a parallel scale.
+ *  - Built on taxonomy_v3.json node ids (verified 2026-06-04) +
+ *    discovery-promotion-policy.ts.
+ *
+ * Pure and offline (spec §10): no DB, no network. The seed/runtime resolves the
+ * returned nodeId string → the TaxonomyNode cuid FK.
+ */
+
+import { AUTO_PROMOTE_THRESHOLD } from "./discovery-promotion-policy";
+
+/**
+ * The four DPPM portfolios (The Open Group, "Digital Product Portfolio
+ * Management" §4 + "The Shift to Digital Product"), mapped to the taxonomy_v3
+ * `portfolio_id` slugs they correspond to. The classification test for each is
+ * "what is delivered / who is the consumer":
+ *
+ *  - providedExternally   — products/services SOLD to customers.
+ *  - providedInternally   — software that does an employee's job.
+ *  - foundational         — the network, client compute, building management,
+ *                           and IaaS the business runs ON. (Estate devices.)
+ *  - manufactureAndDelivery — production / operational-technology systems.
+ *
+ * The estate (cameras, thermostats, plugs, appliances, network gear, endpoints)
+ * is, by this test, Foundational: it is infrastructure the business runs on,
+ * not something sold, an employee app, or production OT.
+ */
+export const DPPM_PORTFOLIOS = {
+  providedExternally: "products_and_services_sold",
+  providedInternally: "for_employees",
+  foundational: "foundational",
+  manufactureAndDelivery: "manufacturing_and_delivery",
+} as const;
+
+export type DppmPortfolioKey = keyof typeof DPPM_PORTFOLIOS;
+
+/** What is being delivered + to whom — the DPPM classification test inputs. */
+export type DppmClassificationInput = {
+  /** "device" | "sold_product" | "employee_app" | "production_ot" | … */
+  delivery: string;
+  /** "infrastructure" | "external_customer" | "internal_employee" | "production_line" | … */
+  consumer: string;
+};
+
+/**
+ * Apply the DPPM "what is delivered / who is the consumer" test to pick one of
+ * the four portfolios. Estate infrastructure → foundational.
+ */
+export function classifyDppmPortfolio(input: DppmClassificationInput): DppmPortfolioKey {
+  const delivery = input.delivery.trim().toLowerCase();
+  const consumer = input.consumer.trim().toLowerCase();
+
+  if (consumer === "external_customer" || delivery === "sold_product") {
+    return "providedExternally";
+  }
+  if (delivery === "production_ot" || consumer === "production_line") {
+    return "manufactureAndDelivery";
+  }
+  if (delivery === "employee_app" || consumer === "internal_employee") {
+    return "providedInternally";
+  }
+  // Network, client compute, building management, IaaS — the infrastructure the
+  // business runs on. This is where the discovered estate lands.
+  return "foundational";
+}
+
+// Foundational sub-portfolio taxonomy node ids (verified against
+// packages/db/data/taxonomy_v3.json, slugify = lowercase, non-alphanumeric → "_").
+export const FOUNDATIONAL_NODES = {
+  securityAndSurveillance: "foundational/building_management/security_and_surveillance",
+  climateControl: "foundational/building_management/climate_control",
+  accessControl: "foundational/building_management/access_control",
+  lightingAndEnergy: "foundational/building_management/lighting_and_energy_management",
+  connectedAppliances: "foundational/building_management/connected_appliances",
+  clientCompute: "foundational/compute/client_and_end_user_compute",
+  networkConnectivity: "foundational/network_management/network_connectivity",
+  voice: "foundational/network_management/voice",
+} as const;
+
+export type DevicePlacement = {
+  /** The resolved device class that was placed. */
+  deviceClass: string;
+  /** Existing taxonomy nodeId string, or null when the class cannot be placed. */
+  taxonomyNodeId: string | null;
+  /** Reuses the triage / promotion confidence scale (0..1). */
+  taxonomyConfidence: number;
+  /** The DPPM portfolio this placement sits in (always foundational for the estate today). */
+  portfolio: DppmPortfolioKey;
+  /** True when taxonomyConfidence clears AUTO_PROMOTE_THRESHOLD — auto-place, no operator. */
+  autoPlace: boolean;
+  /** Machine-readable rationale: "mapped" | "unplaceable_class". */
+  reason: "mapped" | "unplaceable_class";
+};
+
+/**
+ * Canonical device-class → Foundational sub-portfolio node map. The class names
+ * are the `deviceClass` values fingerprint rules resolve to (spec §5.3). Keep
+ * these stable — seed rules and the hive catalog reference them.
+ *
+ * Confidence is deterministic for these mappings (a class implies exactly one
+ * sub-portfolio), so it sits at the triage `deterministicAutoApply` band; the
+ * overall auto-place gate still ALSO requires the rule's identityConfidence to
+ * clear the bar, so a low-confidence identity will not auto-place even though
+ * the class→node mapping is certain.
+ */
+const DEVICE_CLASS_NODE: Record<string, string> = {
+  // Security & Surveillance
+  ip_camera: FOUNDATIONAL_NODES.securityAndSurveillance,
+  nvr: FOUNDATIONAL_NODES.securityAndSurveillance,
+  dvr: FOUNDATIONAL_NODES.securityAndSurveillance,
+  doorbell_camera: FOUNDATIONAL_NODES.securityAndSurveillance,
+  security_camera: FOUNDATIONAL_NODES.securityAndSurveillance,
+  alarm_panel: FOUNDATIONAL_NODES.securityAndSurveillance,
+  motion_sensor: FOUNDATIONAL_NODES.securityAndSurveillance,
+  // Climate Control
+  thermostat: FOUNDATIONAL_NODES.climateControl,
+  hvac_controller: FOUNDATIONAL_NODES.climateControl,
+  climate_sensor: FOUNDATIONAL_NODES.climateControl,
+  smart_vent: FOUNDATIONAL_NODES.climateControl,
+  // Access Control
+  smart_lock: FOUNDATIONAL_NODES.accessControl,
+  garage_door_opener: FOUNDATIONAL_NODES.accessControl,
+  gate_controller: FOUNDATIONAL_NODES.accessControl,
+  access_controller: FOUNDATIONAL_NODES.accessControl,
+  // Lighting & Energy Management
+  smart_plug: FOUNDATIONAL_NODES.lightingAndEnergy,
+  smart_bulb: FOUNDATIONAL_NODES.lightingAndEnergy,
+  light_switch: FOUNDATIONAL_NODES.lightingAndEnergy,
+  energy_monitor: FOUNDATIONAL_NODES.lightingAndEnergy,
+  smart_outlet: FOUNDATIONAL_NODES.lightingAndEnergy,
+  // Connected Appliances
+  smart_appliance: FOUNDATIONAL_NODES.connectedAppliances,
+  refrigerator: FOUNDATIONAL_NODES.connectedAppliances,
+  washer: FOUNDATIONAL_NODES.connectedAppliances,
+  dryer: FOUNDATIONAL_NODES.connectedAppliances,
+  oven: FOUNDATIONAL_NODES.connectedAppliances,
+  dishwasher: FOUNDATIONAL_NODES.connectedAppliances,
+  // Network Connectivity
+  gateway: FOUNDATIONAL_NODES.networkConnectivity,
+  router: FOUNDATIONAL_NODES.networkConnectivity,
+  switch: FOUNDATIONAL_NODES.networkConnectivity,
+  access_point: FOUNDATIONAL_NODES.networkConnectivity,
+  network_controller: FOUNDATIONAL_NODES.networkConnectivity,
+  firewall: FOUNDATIONAL_NODES.networkConnectivity,
+  // Voice
+  voice_assistant: FOUNDATIONAL_NODES.voice,
+  smart_speaker: FOUNDATIONAL_NODES.voice,
+  // Client & End User Compute
+  client_endpoint: FOUNDATIONAL_NODES.clientCompute,
+  laptop: FOUNDATIONAL_NODES.clientCompute,
+  desktop: FOUNDATIONAL_NODES.clientCompute,
+  workstation: FOUNDATIONAL_NODES.clientCompute,
+  phone: FOUNDATIONAL_NODES.clientCompute,
+  tablet: FOUNDATIONAL_NODES.clientCompute,
+  printer: FOUNDATIONAL_NODES.clientCompute,
+};
+
+/** Synonyms → canonical device-class keys, so rules can use natural names. */
+const DEVICE_CLASS_ALIASES: Record<string, string> = {
+  camera: "ip_camera",
+  webcam: "ip_camera",
+  smart_thermostat: "thermostat",
+  thermostat_controller: "thermostat",
+  plug: "smart_plug",
+  outlet: "smart_outlet",
+  bulb: "smart_bulb",
+  lock: "smart_lock",
+  speaker: "smart_speaker",
+  echo: "voice_assistant",
+  computer: "client_endpoint",
+  pc: "client_endpoint",
+  mobile: "phone",
+  smartphone: "phone",
+  ap: "access_point",
+  wifi_router: "router",
+};
+
+const DEFAULT_PLACEMENT_CONFIDENCE = 0.97;
+
+function canonicalDeviceClass(deviceClass: string): string {
+  const key = deviceClass.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return DEVICE_CLASS_ALIASES[key] ?? key;
+}
+
+/**
+ * Place a resolved device class into its Foundational sub-portfolio.
+ *
+ * Returns `taxonomyNodeId: null` + `reason: "unplaceable_class"` when the class
+ * is not in the map — the layer-1 coworker (BI-4FACD527) handles those, and an
+ * unplaceable class never silently lands in the wrong portfolio.
+ */
+export function placeDeviceClass(
+  deviceClass: string,
+  options: { confidence?: number } = {},
+): DevicePlacement {
+  const canonical = canonicalDeviceClass(deviceClass);
+  const nodeId = DEVICE_CLASS_NODE[canonical] ?? null;
+
+  if (nodeId === null) {
+    return {
+      deviceClass: canonical,
+      taxonomyNodeId: null,
+      taxonomyConfidence: 0,
+      portfolio: "foundational",
+      autoPlace: false,
+      reason: "unplaceable_class",
+    };
+  }
+
+  const taxonomyConfidence = clamp01(options.confidence ?? DEFAULT_PLACEMENT_CONFIDENCE);
+  return {
+    deviceClass: canonical,
+    taxonomyNodeId: nodeId,
+    taxonomyConfidence,
+    portfolio: "foundational",
+    autoPlace: taxonomyConfidence >= AUTO_PROMOTE_THRESHOLD,
+    reason: "mapped",
+  };
+}
+
+/** Every device class the algorithm can place (canonical keys). */
+export function placeableDeviceClasses(): string[] {
+  return Object.keys(DEVICE_CLASS_NODE);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -252,6 +252,7 @@ export * from "./discovery-fingerprint-redaction";
 export * from "./discovery-fingerprint-policy";
 export * from "./discovery-fingerprint-rules";
 export * from "./discovery-mac-classification";
+export * from "./device-placement";
 // `./discovery-fingerprint-catalog` is intentionally NOT re-exported. Its
 // `validateFingerprintCatalog` helper uses dynamic `path.resolve(process.cwd(), ...)`
 // to locate catalog JSON at runtime, which Turbopack flags as an overly broad


### PR DESCRIPTION
## Phase 2 of Device Identification & Portfolio Placement (spec §8.2)

The promotion infrastructure already existed (classifyEstateProvenance, AUTO_PROMOTE_THRESHOLD, type/name gates, the seeded taxonomy tree); the **placement algorithm** did not. This adds it. Pure `packages/db` TypeScript.

- `placeDeviceClass(deviceClass)` maps a resolved device class to an **existing** taxonomy nodeId string (e.g. `foundational/building_management/security_and_surveillance`). No parallel `{portfolio, taxonomyNode, productType}` object — the taxonomy path already encodes that (spec §5.4).
- `classifyDppmPortfolio` applies the four-portfolio "what is delivered / who is the consumer" test: Provided Externally (sold) / Provided Internally (employee apps) / Foundational (network, client compute, building management, IaaS) / Manufacture & Delivery (production OT). The estate → Foundational.
- Confidence reuses `AUTO_PROMOTE_THRESHOLD`, not a parallel scale; `autoPlace` is gated on it. Unknown classes return `taxonomyNodeId: null` (escalate, never mis-place).

### Tests
29 cases incl. a **live-taxonomy drift guard** that rebuilds every nodeId from `taxonomy_v3.json` (same slugify as `seed.ts`) and asserts every placement target + DPPM portfolio id exists.

> Stacked on #1476 (Phase 1, merged). Local pre-commit typecheck skipped (fresh-worktree `@dpf/storefront-templates` symlink baseline); CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)