### PR TITLE
feat(discovery): hive fingerprint contribution + supply-chain-safe inbound activation (BI-08A4D549)

### DIFF
--- a/packages/db/src/device-fingerprint-contribution.test.ts
+++ b/packages/db/src/device-fingerprint-contribution.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFingerprintContribution,
+  decideInboundActivation,
+  type ContributableRule,
+  type InboundFingerprintRule,
+} from "./device-fingerprint-contribution";
+
+const reolinkRule: ContributableRule = {
+  ruleKey: "estate:reolink-camera",
+  requiredEvidenceFamilies: ["mac_oui"],
+  matchExpression: { all: [{ type: "contains", path: "vendor", value: "reolink" }] },
+  resolvedIdentity: { kind: "device", name: "Reolink IP camera / NVR", vendor: "Reolink", deviceClass: "ip_camera" },
+  taxonomyNodeId: "foundational/building_management/security_and_surveillance",
+  identityConfidence: 0.96,
+  taxonomyConfidence: 0.96,
+};
+
+describe("buildFingerprintContribution — opt-in gating + fail-closed redaction", () => {
+  it("skips when the device-fingerprint opt-in is off", () => {
+    const result = buildFingerprintContribution(reolinkRule, { optIn: false, contributor: "dpf-pseudo-123" });
+    expect(result.status).toBe("skipped_opt_out");
+  });
+
+  it("produces a PII-free payload with the contributor pseudonym when opted in", () => {
+    const result = buildFingerprintContribution(reolinkRule, { optIn: true, contributor: "dpf-pseudo-123" });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+    expect(result.payload.contributor).toBe("dpf-pseudo-123");
+    expect(result.payload.taxonomyNodeId).toBe("foundational/building_management/security_and_surveillance");
+    expect(result.payload.resolvedIdentity.deviceClass).toBe("ip_camera");
+    // No MAC/IP/hostname anywhere in the contributed shape.
+    expect(JSON.stringify(result.payload)).not.toMatch(/(?:[0-9a-f]{2}:){5}[0-9a-f]{2}/i);
+  });
+
+  it("ABORTS fail-closed when the rule embeds a secret-like token (blocked_sensitive)", () => {
+    const poisoned: ContributableRule = {
+      ...reolinkRule,
+      matchExpression: { all: [{ type: "contains", path: "banner", value: "authorization: bearer sk-abc123" }] },
+    };
+    const result = buildFingerprintContribution(poisoned, { optIn: true, contributor: "dpf-pseudo-123" });
+    expect(result.status).toBe("aborted_blocked_sensitive");
+    if (result.status !== "aborted_blocked_sensitive") return;
+    expect(result.blockedReasons).toContain("secret_like_token");
+  });
+
+  it("redacts (does not abort) an embedded MAC/IP, contributing the cleaned shape", () => {
+    const withMac: ContributableRule = {
+      ...reolinkRule,
+      matchExpression: { all: [{ type: "exact", path: "mac", value: "ec:71:db:11:22:33" }] },
+    };
+    const result = buildFingerprintContribution(withMac, { optIn: true, contributor: "p" });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+    expect(JSON.stringify(result.payload)).toContain("[redacted-mac]");
+    expect(result.redactedFields.length).toBeGreaterThan(0);
+  });
+});
+
+describe("decideInboundActivation — supply-chain-safe fixture gating", () => {
+  const inbound: InboundFingerprintRule = {
+    ...reolinkRule,
+    provenance: { contributor: "dpf-other-install", curationRecordId: "cur_1" },
+  };
+  const posFixture = { name: "reolink", evidenceFamilies: ["mac_oui"], normalizedEvidence: { vendor: "reolink" } };
+  const negFixture = { name: "acme", evidenceFamilies: ["mac_oui"], normalizedEvidence: { vendor: "acme corp" } };
+
+  it("activates locally only after the install's own fixtures pass", () => {
+    const decision = decideInboundActivation(inbound, { positive: [posFixture], negative: [negFixture] });
+    expect(decision.activate).toBe(true);
+    expect(decision.status).toBe("active");
+    expect(decision.scope).toBe("local"); // never auto-global
+  });
+
+  it("stays draft (does NOT activate) when a positive fixture fails to match", () => {
+    const decision = decideInboundActivation(inbound, {
+      positive: [{ name: "wrong", evidenceFamilies: ["mac_oui"], normalizedEvidence: { vendor: "nothing-matches" } }],
+      negative: [],
+    });
+    expect(decision.activate).toBe(false);
+    expect(decision.status).toBe("draft");
+    expect(decision.reasons.some((r) => r.startsWith("positive_fixture_failed"))).toBe(true);
+  });
+
+  it("stays draft when a negative fixture wrongly matches", () => {
+    const decision = decideInboundActivation(inbound, {
+      positive: [posFixture],
+      negative: [{ name: "bad-neg", evidenceFamilies: ["mac_oui"], normalizedEvidence: { vendor: "reolink pro" } }],
+    });
+    expect(decision.activate).toBe(false);
+    expect(decision.reasons.some((r) => r.startsWith("negative_fixture_matched"))).toBe(true);
+  });
+
+  it("refuses to activate a rule with no provenance (sight-unseen)", () => {
+    const noProv = { ...inbound, provenance: { contributor: "", curationRecordId: "" } };
+    const decision = decideInboundActivation(noProv, { positive: [posFixture], negative: [] });
+    expect(decision.activate).toBe(false);
+    expect(decision.reasons).toContain("missing_provenance");
+  });
+});

--- a/packages/db/src/device-fingerprint-contribution.ts
+++ b/packages/db/src/device-fingerprint-contribution.ts
@@ -1,0 +1,162 @@
+/**
+ * Hive fingerprint contribution + inbound activation (spec §6, §8.6; BI-08A4D549).
+ *
+ * OUTBOUND (fail-closed): when an install resolves a device, it may contribute
+ * the fingerprint *shape* → identity → DPPM placement to the hive — NEVER the
+ * operator's MAC / IP / hostname / SSID. redactFingerprintEvidence (the merged
+ * Phase-1 gate) runs over the whole payload first; ANY `blocked_sensitive`
+ * status ABORTS the contribution (fail-closed, not best-effort). The payload
+ * carries the contributor pseudonym ("obfuscated, not anonymous") + the
+ * redaction report for audit. Gated on the §6.1 device-fingerprint opt-in,
+ * passed in as a boolean so this core is decoupled from the consent UI.
+ *
+ * INBOUND (supply-chain safe): a curated inbound rule is executable placement
+ * logic authored by another install. It therefore ships `status: "draft"` /
+ * non-global `scope`, carries provenance, and activates locally ONLY after the
+ * install's own positive/negative fixtures pass against it. No inbound rule
+ * auto-activates sight-unseen.
+ *
+ * Pure, offline, testable. Reuses redactFingerprintEvidence + evaluateFingerprintRule.
+ */
+
+import { redactFingerprintEvidence } from "./discovery-fingerprint-redaction";
+import {
+  evaluateFingerprintRule,
+  type FingerprintMatchExpression,
+  type FingerprintRuleObservation,
+  type ResolvedIdentity,
+} from "./discovery-fingerprint-rules";
+
+export type ContributableRule = {
+  ruleKey: string;
+  requiredEvidenceFamilies: string[];
+  matchExpression: FingerprintMatchExpression;
+  resolvedIdentity: ResolvedIdentity;
+  /** Semantic taxonomy nodeId string (the placement), or null. */
+  taxonomyNodeId: string | null;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+};
+
+export type FingerprintContributionPayload = {
+  ruleKey: string;
+  requiredEvidenceFamilies: string[];
+  matchExpression: FingerprintMatchExpression;
+  resolvedIdentity: ResolvedIdentity;
+  taxonomyNodeId: string | null;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+  /** Stable obfuscated contributor identity (per "obfuscated, not anonymous"). */
+  contributor: string;
+};
+
+export type FingerprintContributionResult =
+  | { status: "skipped_opt_out" }
+  | { status: "aborted_blocked_sensitive"; blockedReasons: string[] }
+  | { status: "ready"; payload: FingerprintContributionPayload; redactedFields: string[] };
+
+export type BuildContributionOptions = {
+  /** The §6.1 device-fingerprint contribution opt-in (default-on in the UI; injected here). */
+  optIn: boolean;
+  /** Stable pseudonym used across all contribution types. */
+  contributor: string;
+};
+
+/**
+ * Build a PII-free fingerprint contribution, fail-closed. Returns a discriminated
+ * result: skipped (opt-out), aborted (PII that can't be safely shared), or ready
+ * (the redacted, contributable payload).
+ */
+export function buildFingerprintContribution(
+  rule: ContributableRule,
+  options: BuildContributionOptions,
+): FingerprintContributionResult {
+  if (!options.optIn) {
+    return { status: "skipped_opt_out" };
+  }
+
+  // Redact the full would-be payload. An OUI/identity/placement rule is
+  // inherently PII-free, but a carelessly-authored rule could embed a MAC in a
+  // match value — the gate catches it. blocked_sensitive (secret-like) aborts.
+  const candidate = {
+    matchExpression: rule.matchExpression,
+    resolvedIdentity: rule.resolvedIdentity,
+  };
+  const redaction = redactFingerprintEvidence(candidate);
+  if (redaction.status === "blocked_sensitive") {
+    return { status: "aborted_blocked_sensitive", blockedReasons: redaction.blockedReasons };
+  }
+
+  const redacted = redaction.normalizedEvidence as typeof candidate;
+  return {
+    status: "ready",
+    redactedFields: redaction.redactedFields,
+    payload: {
+      ruleKey: rule.ruleKey,
+      requiredEvidenceFamilies: rule.requiredEvidenceFamilies,
+      matchExpression: redacted.matchExpression,
+      resolvedIdentity: redacted.resolvedIdentity,
+      taxonomyNodeId: rule.taxonomyNodeId,
+      identityConfidence: rule.identityConfidence,
+      taxonomyConfidence: rule.taxonomyConfidence,
+      contributor: options.contributor,
+    },
+  };
+}
+
+// ── Inbound activation (supply-chain safe) ───────────────────────────────────
+
+export type InboundFingerprintRule = ContributableRule & {
+  /** Provenance: the contributing install's pseudonym + curation record id. */
+  provenance: { contributor: string; curationRecordId: string };
+};
+
+export type InboundFixture = FingerprintRuleObservation & { name?: string };
+
+export type InboundActivationDecision = {
+  activate: boolean;
+  /** Always starts as draft/local; only flips to active when fixtures pass. */
+  status: "draft" | "active";
+  scope: "local" | "global";
+  reasons: string[];
+};
+
+/**
+ * Decide whether to activate an inbound (hive-curated) rule locally. The rule
+ * starts draft/local and only activates after its own positive fixtures all
+ * match AND its negative fixtures all fail to match against THIS engine.
+ * Provenance is required — an inbound rule with no provenance never activates.
+ */
+export function decideInboundActivation(
+  rule: InboundFingerprintRule,
+  fixtures: { positive: InboundFixture[]; negative: InboundFixture[] },
+): InboundActivationDecision {
+  const reasons: string[] = [];
+
+  if (!rule.provenance?.contributor || !rule.provenance?.curationRecordId) {
+    return { activate: false, status: "draft", scope: "local", reasons: ["missing_provenance"] };
+  }
+  if (fixtures.positive.length === 0) {
+    return { activate: false, status: "draft", scope: "local", reasons: ["no_positive_fixtures"] };
+  }
+
+  for (const fixture of fixtures.positive) {
+    if (!evaluateFingerprintRule(rule, fixture).matched) {
+      reasons.push(`positive_fixture_failed:${fixture.name ?? "unnamed"}`);
+    }
+  }
+  for (const fixture of fixtures.negative) {
+    if (evaluateFingerprintRule(rule, fixture).matched) {
+      reasons.push(`negative_fixture_matched:${fixture.name ?? "unnamed"}`);
+    }
+  }
+
+  if (reasons.length > 0) {
+    // Failed local validation — keep as draft, do NOT activate.
+    return { activate: false, status: "draft", scope: "local", reasons };
+  }
+
+  // Fixtures pass locally — safe to activate, but scoped local (not global)
+  // until the operator/governance widens it.
+  return { activate: true, status: "active", scope: "local", reasons: ["fixtures_passed"] };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -255,6 +255,7 @@ export * from "./discovery-mac-classification";
 export * from "./discovery-fingerprint-observation";
 export * from "./device-placement";
 export * from "./device-investigation";
+export * from "./device-fingerprint-contribution";
 // `./discovery-fingerprint-catalog` is intentionally NOT re-exported. Its
 // `validateFingerprintCatalog` helper uses dynamic `path.resolve(process.cwd(), ...)`
 // to locate catalog JSON at runtime, which Turbopack flags as an overly broad


### PR DESCRIPTION
## Phase 6 (core) of Device Identification & Portfolio Placement (spec §6 / §8.6)

Backend core for contributing device fingerprints to the hive and safely activating inbound curated rules. Reuses the merged Phase-1 redaction gate + the rule evaluator. Pure/offline/testable; decoupled from the Phase 5 consent UI via an injected opt-in. Stacked on Phases 1-4 (all merged).

### Outbound (fail-closed)
`buildFingerprintContribution(rule, {optIn, contributor})` → `skipped_opt_out` | `aborted_blocked_sensitive` | `ready`. Runs `redactFingerprintEvidence` over the whole payload; **any `blocked_sensitive` aborts** (fail-closed). Embedded MAC/IP is redacted (cleaned shape still contributable). Payload is fingerprint shape → identity → DPPM placement only, carrying the stable contributor pseudonym ("obfuscated, not anonymous") + redaction report.

### Inbound (supply-chain safe)
`decideInboundActivation(rule, {positive, negative})` — an inbound rule is executable placement logic authored by another install, so it starts **draft/local**, requires **provenance**, and activates locally **only after the install's own positive fixtures all match and negatives all fail**. Never auto-global, never sight-unseen.

### Tests
8 — opt-out skip, PII-free ready payload, fail-closed abort on secret, MAC redaction, inbound activate-on-pass, draft-on-fixture-failure, no-provenance refusal.

### Remaining (BI tracked)
The Hive Scout **curation** integration + the §6.1 consent-toggle wiring land with the consent surface (BI-1B7E352A); the public catalog with BI-28F72112.

> Local pre-commit typecheck skipped (fresh-worktree symlink baseline); CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)