### PR TITLE
feat: add portal navigation inventory

### DIFF
--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -2,6 +2,10 @@
 import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
 
 import { canAccessEmployeeScope } from "./manager-scope";
+import {
+  getShellNavEntries,
+  type PortalShellSectionKey,
+} from "../navigation/portal-navigation-model";
 
 export type PlatformRoleId =
   | "HR-000" | "HR-100" | "HR-200"
@@ -119,12 +123,12 @@ export type ShellNavItem = {
   label: string;
   href: string;
   description: string;
-  sectionKey: "workspace" | "business" | "products" | "platform" | "knowledge";
+  sectionKey: PortalShellSectionKey;
   capabilityKey: CapabilityKey | null;
 };
 
 export type ShellNavSection = {
-  key: "workspace" | "business" | "products" | "platform" | "knowledge";
+  key: PortalShellSectionKey;
   label: string;
   description: string;
   items: ShellNavItem[];
@@ -181,144 +185,14 @@ const SHELL_SECTIONS: Array<Pick<ShellNavSection, "key" | "label" | "description
   },
 ];
 
-const SHELL_ITEMS: ShellNavItem[] = [
-  {
-    key: "workspace",
-    label: "Workspace",
-    href: "/workspace",
-    description: "See what needs attention next.",
-    sectionKey: "workspace",
-    capabilityKey: null,
-  },
-  {
-    key: "documents",
-    label: "Documents",
-    href: "/workspace/documents",
-    description: "Search, open, publish, and trace managed documents.",
-    sectionKey: "workspace",
-    capabilityKey: "view_platform",
-  },
-  {
-    key: "customer",
-    label: "Customer",
-    href: "/customer",
-    description: "Accounts, pipeline, quotes, and orders.",
-    sectionKey: "business",
-    capabilityKey: "view_customer",
-  },
-  {
-    key: "employee",
-    label: "People",
-    href: "/employee",
-    description: "Human users, contractors, and workforce records.",
-    sectionKey: "business",
-    capabilityKey: "view_employee",
-  },
-  {
-    key: "finance",
-    label: "Finance",
-    href: "/finance",
-    description: "Cashflow, receivables, payables, and close.",
-    sectionKey: "business",
-    capabilityKey: "view_finance",
-  },
-  {
-    key: "compliance",
-    label: "Compliance",
-    href: "/compliance",
-    description: "Controls, risk, obligations, and posture.",
-    sectionKey: "business",
-    capabilityKey: "view_compliance",
-  },
-  {
-    key: "storefront",
-    label: "Portal",
-    href: "/storefront",
-    description: "Customer-facing portal experience and setup.",
-    sectionKey: "business",
-    capabilityKey: "view_storefront",
-  },
-  {
-    key: "portfolio",
-    label: "Portfolio",
-    href: "/portfolio",
-    description: "Digital products and their lifecycle homes.",
-    sectionKey: "products",
-    capabilityKey: "view_portfolio",
-  },
-  {
-    key: "backlog",
-    label: "Backlog",
-    href: "/ops",
-    description: "Cross-cutting work queues and improvements.",
-    sectionKey: "products",
-    capabilityKey: "view_operations",
-  },
-  {
-    key: "ea_modeler",
-    label: "Architecture",
-    href: "/portfolio/architecture",
-    description: "Reference models, capabilities, and structure.",
-    sectionKey: "products",
-    capabilityKey: "view_ea_modeler",
-  },
-  {
-    key: "ai_workforce",
-    label: "AI Workforce",
-    href: "/platform/ai",
-    description: "Oversee AI specialists and their authority.",
-    sectionKey: "platform",
-    capabilityKey: "view_platform",
-  },
-  {
-    key: "build",
-    label: "Build Studio",
-    href: "/build",
-    description: "Create and ship new capability with AI help.",
-    sectionKey: "platform",
-    capabilityKey: "view_platform",
-  },
-  {
-    key: "platform",
-    label: "Platform Hub",
-    href: "/platform",
-    description: "Providers, integrations, services, and governance.",
-    sectionKey: "platform",
-    capabilityKey: "view_platform",
-  },
-  {
-    key: "admin",
-    label: "Admin",
-    href: "/admin",
-    description: "Core platform configuration and access.",
-    sectionKey: "platform",
-    capabilityKey: "view_admin",
-  },
-  {
-    key: "knowledge",
-    label: "Knowledge",
-    href: "/knowledge",
-    description: "Shared operational and product knowledge.",
-    sectionKey: "knowledge",
-    capabilityKey: null,
-  },
-  {
-    key: "wiki",
-    label: "Wiki",
-    href: "/wiki",
-    description: "Founder kernel and per-org overlay — stances, heuristics, decisions.",
-    sectionKey: "knowledge",
-    capabilityKey: null,
-  },
-  {
-    key: "docs",
-    label: "Docs",
-    href: "/docs",
-    description: "Reference documentation and specs.",
-    sectionKey: "knowledge",
-    capabilityKey: null,
-  },
-];
+const SHELL_ITEMS: ShellNavItem[] = getShellNavEntries().map((entry) => ({
+  key: entry.key,
+  label: entry.label,
+  href: entry.path,
+  description: entry.description,
+  sectionKey: entry.sectionKey,
+  capabilityKey: entry.capabilityKey,
+}));
 
 const WORKSPACE_SECTION_BLUEPRINTS: Array<{
   key: WorkspaceSection["key"];

--- a/apps/web/lib/navigation/portal-navigation-model.test.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { PLATFORM_FAMILIES } from "@/components/platform/platform-nav";
+import { getShellNavSections } from "@/lib/govern/permissions";
+
+import {
+  PORTAL_NAV_ROUTES,
+  getPrimaryNavEntries,
+  getRouteNavRecord,
+  getSectionNavEntries,
+} from "./portal-navigation-model";
+
+const adminUser = { platformRole: "HR-000", isSuperuser: false };
+
+describe("portal navigation model", () => {
+  it("has one unique route record per path", () => {
+    const paths = PORTAL_NAV_ROUTES.map((route) => route.path);
+
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("keeps section navigation inside its parent domain", () => {
+    for (const route of PORTAL_NAV_ROUTES) {
+      for (const item of route.sectionSiblings ?? []) {
+        expect(item.startsWith(route.parentPath)).toBe(true);
+      }
+    }
+  });
+
+  it("does not expose Admin as a Platform family sibling", () => {
+    const platformTabs = getSectionNavEntries("/platform").map((entry) => entry.path);
+
+    expect(platformTabs).not.toContain("/admin");
+  });
+
+  it("keeps worker and operator primary entries separately addressable", () => {
+    const workerKeys = getPrimaryNavEntries("worker").map((entry) => entry.key);
+    const operatorKeys = getPrimaryNavEntries("operator").map((entry) => entry.key);
+
+    expect(workerKeys).toContain("workspace");
+    expect(operatorKeys).toContain("platform");
+    expect(workerKeys).not.toContain("admin");
+  });
+
+  it("classifies legacy redirect destinations as redirects, not primary nav", () => {
+    expect(getRouteNavRecord("/admin/storefront")?.destinationKind).toBe(
+      "legacy-redirect",
+    );
+    expect(getPrimaryNavEntries("operator").map((entry) => entry.path)).not.toContain(
+      "/admin/storefront",
+    );
+  });
+
+  it("covers current shell navigation entries without changing visible routes", () => {
+    const shellHrefs = getShellNavSections(adminUser)
+      .flatMap((section) => section.items)
+      .map((item) => item.href);
+
+    expect(shellHrefs).toContain("/platform");
+    expect(shellHrefs).toContain("/admin");
+
+    for (const href of shellHrefs) {
+      expect(getRouteNavRecord(href), href).toBeDefined();
+    }
+  });
+
+  it("covers current platform family entries without keeping Admin inside Platform", () => {
+    const platformFamilyHrefs = PLATFORM_FAMILIES.flatMap((family) => [
+      family.href,
+      ...family.subItems.map((item) => item.href),
+    ]);
+
+    expect(platformFamilyHrefs).toContain("/admin");
+    expect(getSectionNavEntries("/platform").map((entry) => entry.path)).not.toContain(
+      "/admin",
+    );
+
+    for (const href of platformFamilyHrefs) {
+      expect(getRouteNavRecord(href), href).toBeDefined();
+    }
+  });
+});

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -1,0 +1,813 @@
+import type { CapabilityKey } from "@/lib/govern/permissions";
+
+export type PortalAudienceMode = "worker" | "operator" | "customer" | "diagnostic";
+
+export type PortalDestinationKind =
+  | "domain-home"
+  | "section-page"
+  | "detail"
+  | "workflow-step"
+  | "settings"
+  | "contextual-action"
+  | "legacy-redirect";
+
+export type PortalDomain =
+  | "workspace"
+  | "business"
+  | "delivery"
+  | "platform"
+  | "admin"
+  | "knowledge"
+  | "customer";
+
+export type PortalShellSectionKey =
+  | "workspace"
+  | "business"
+  | "products"
+  | "platform"
+  | "knowledge";
+
+export type PortalNavRecord = {
+  key: string;
+  label: string;
+  path: string;
+  parentPath: string;
+  domain: PortalDomain;
+  audienceModes: readonly PortalAudienceMode[];
+  destinationKind: PortalDestinationKind;
+  capabilityKey?: CapabilityKey | null;
+  primaryOrder?: number;
+  shellNav?: {
+    sectionKey: PortalShellSectionKey;
+    label?: string;
+    description: string;
+  };
+  sectionSiblings?: readonly string[];
+};
+
+export type PortalNavEntry = Pick<
+  PortalNavRecord,
+  "key" | "label" | "path" | "parentPath" | "domain" | "destinationKind"
+> & {
+  capabilityKey: CapabilityKey | null;
+  audienceModes: readonly PortalAudienceMode[];
+};
+
+export type PortalShellNavEntry = PortalNavEntry & {
+  label: string;
+  description: string;
+  sectionKey: PortalShellSectionKey;
+};
+
+const platformSectionSiblings = [
+  "/platform",
+  "/platform/identity",
+  "/platform/ai",
+  "/platform/tools",
+  "/platform/audit",
+] as const;
+
+export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
+  {
+    key: "workspace",
+    label: "Workspace",
+    path: "/workspace",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: null,
+    primaryOrder: 10,
+    shellNav: {
+      sectionKey: "workspace",
+      description: "See what needs attention next.",
+    },
+    sectionSiblings: ["/workspace", "/workspace/documents"],
+  },
+  {
+    key: "documents",
+    label: "Documents",
+    path: "/workspace/documents",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+    shellNav: {
+      sectionKey: "workspace",
+      description: "Search, open, publish, and trace managed documents.",
+    },
+  },
+  {
+    key: "customer",
+    label: "Customer",
+    path: "/customer",
+    parentPath: "/customer",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_customer",
+    primaryOrder: 20,
+    shellNav: {
+      sectionKey: "business",
+      description: "Accounts, pipeline, quotes, and orders.",
+    },
+    sectionSiblings: [
+      "/customer",
+      "/customer/engagements",
+      "/customer/opportunities",
+      "/customer/quotes",
+      "/customer/sales-orders",
+      "/customer/funnel",
+      "/customer/marketing",
+    ],
+  },
+  {
+    key: "customer-engagements",
+    label: "Engagements",
+    path: "/customer/engagements",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_customer",
+  },
+  {
+    key: "customer-opportunities",
+    label: "Opportunities",
+    path: "/customer/opportunities",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_customer",
+  },
+  {
+    key: "customer-quotes",
+    label: "Quotes",
+    path: "/customer/quotes",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_customer",
+  },
+  {
+    key: "customer-sales-orders",
+    label: "Sales Orders",
+    path: "/customer/sales-orders",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_customer",
+  },
+  {
+    key: "customer-funnel",
+    label: "Funnel",
+    path: "/customer/funnel",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_customer",
+  },
+  {
+    key: "customer-marketing",
+    label: "Marketing",
+    path: "/customer/marketing",
+    parentPath: "/customer",
+    domain: "customer",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_marketing",
+  },
+  {
+    key: "employee",
+    label: "People",
+    path: "/employee",
+    parentPath: "/employee",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_employee",
+    shellNav: {
+      sectionKey: "business",
+      description: "Human users, contractors, and workforce records.",
+    },
+  },
+  {
+    key: "finance",
+    label: "Finance",
+    path: "/finance",
+    parentPath: "/finance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_finance",
+    primaryOrder: 30,
+    shellNav: {
+      sectionKey: "business",
+      description: "Cashflow, receivables, payables, and close.",
+    },
+  },
+  {
+    key: "compliance",
+    label: "Compliance",
+    path: "/compliance",
+    parentPath: "/compliance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_compliance",
+    primaryOrder: 40,
+    shellNav: {
+      sectionKey: "business",
+      description: "Controls, risk, obligations, and posture.",
+    },
+  },
+  {
+    key: "storefront",
+    label: "Portal",
+    path: "/storefront",
+    parentPath: "/storefront",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_storefront",
+    primaryOrder: 50,
+    shellNav: {
+      sectionKey: "business",
+      description: "Customer-facing portal experience and setup.",
+    },
+  },
+  {
+    key: "portfolio",
+    label: "Portfolio",
+    path: "/portfolio",
+    parentPath: "/portfolio",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_portfolio",
+    shellNav: {
+      sectionKey: "products",
+      description: "Digital products and their lifecycle homes.",
+    },
+  },
+  {
+    key: "backlog",
+    label: "Backlog",
+    path: "/ops",
+    parentPath: "/ops",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_operations",
+    primaryOrder: 60,
+    shellNav: {
+      sectionKey: "products",
+      description: "Cross-cutting work queues and improvements.",
+    },
+  },
+  {
+    key: "ea_modeler",
+    label: "Architecture",
+    path: "/portfolio/architecture",
+    parentPath: "/portfolio",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_ea_modeler",
+    shellNav: {
+      sectionKey: "products",
+      description: "Reference models, capabilities, and structure.",
+    },
+  },
+  {
+    key: "ai_workforce",
+    label: "AI Workforce",
+    path: "/platform/ai",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+    shellNav: {
+      sectionKey: "platform",
+      description: "Oversee AI specialists and their authority.",
+    },
+  },
+  {
+    key: "build",
+    label: "Build Studio",
+    path: "/build",
+    parentPath: "/build",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_platform",
+    primaryOrder: 70,
+    shellNav: {
+      sectionKey: "platform",
+      description: "Create and ship new capability with AI help.",
+    },
+  },
+  {
+    key: "platform",
+    label: "Platform Hub",
+    path: "/platform",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_platform",
+    primaryOrder: 80,
+    shellNav: {
+      sectionKey: "platform",
+      description: "Providers, integrations, services, and governance.",
+    },
+    sectionSiblings: platformSectionSiblings,
+  },
+  {
+    key: "platform-identity",
+    label: "Identity & Access",
+    path: "/platform/identity",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+    sectionSiblings: [
+      "/platform/identity",
+      "/platform/identity/principals",
+      "/platform/identity/groups",
+      "/platform/identity/directory",
+      "/platform/identity/federation",
+      "/platform/identity/applications",
+      "/platform/identity/authorization",
+      "/platform/identity/agents",
+    ],
+  },
+  {
+    key: "platform-identity-principals",
+    label: "Principals",
+    path: "/platform/identity/principals",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-groups",
+    label: "Groups",
+    path: "/platform/identity/groups",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-directory",
+    label: "Directory",
+    path: "/platform/identity/directory",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-federation",
+    label: "Federation",
+    path: "/platform/identity/federation",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-applications",
+    label: "Applications",
+    path: "/platform/identity/applications",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-authorization",
+    label: "Authorization",
+    path: "/platform/identity/authorization",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-identity-agents",
+    label: "Agents",
+    path: "/platform/identity/agents",
+    parentPath: "/platform/identity",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-operations-map",
+    label: "Operations Map",
+    path: "/platform/ai/operations-map",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-capacity-continuity",
+    label: "Capacity Continuity",
+    path: "/platform/ai/capacity-continuity",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-assignments",
+    label: "Assignments",
+    path: "/platform/ai/assignments",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-prompts",
+    label: "Prompts",
+    path: "/platform/ai/prompts",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-skills",
+    label: "Skills",
+    path: "/platform/ai/skills",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-capability-needs",
+    label: "Capability Needs",
+    path: "/platform/ai/capability-needs",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-providers",
+    label: "Providers & Routing",
+    path: "/platform/ai/providers",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-ai-build-studio",
+    label: "Build Runtime",
+    path: "/platform/ai/build-studio",
+    parentPath: "/platform/ai",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "settings",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools",
+    label: "Tools & Services",
+    path: "/platform/tools",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+    sectionSiblings: [
+      "/platform/tools",
+      "/platform/tools/catalog",
+      "/platform/tools/services",
+      "/platform/tools/integrations",
+      "/platform/tools/built-ins",
+      "/platform/tools/discovery",
+      "/platform/tools/inventory",
+    ],
+  },
+  {
+    key: "platform-tools-catalog",
+    label: "MCP Catalog",
+    path: "/platform/tools/catalog",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools-services",
+    label: "MCP Services",
+    path: "/platform/tools/services",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools-integrations",
+    label: "Native Integrations",
+    path: "/platform/tools/integrations",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools-built-ins",
+    label: "Built-in Tools",
+    path: "/platform/tools/built-ins",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools-discovery",
+    label: "Estate Discovery",
+    path: "/platform/tools/discovery",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-tools-inventory",
+    label: "Capability Inventory",
+    path: "/platform/tools/inventory",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit",
+    label: "Governance & Audit",
+    path: "/platform/audit",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+    sectionSiblings: [
+      "/platform/audit",
+      "/platform/audit/ledger",
+      "/platform/audit/journal",
+      "/platform/audit/routes",
+      "/platform/audit/operations",
+      "/platform/audit/authority",
+      "/platform/audit/metrics",
+    ],
+  },
+  {
+    key: "platform-audit-ledger",
+    label: "Ledger",
+    path: "/platform/audit/ledger",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit-journal",
+    label: "Journal",
+    path: "/platform/audit/journal",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit-routes",
+    label: "Routes",
+    path: "/platform/audit/routes",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit-operations",
+    label: "Operations",
+    path: "/platform/audit/operations",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit-authority",
+    label: "Authority",
+    path: "/platform/audit/authority",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "platform-audit-metrics",
+    label: "Metrics",
+    path: "/platform/audit/metrics",
+    parentPath: "/platform/audit",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    key: "admin",
+    label: "Admin",
+    path: "/admin",
+    parentPath: "/admin",
+    domain: "admin",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_admin",
+    primaryOrder: 90,
+    shellNav: {
+      sectionKey: "platform",
+      description: "Core platform configuration and access.",
+    },
+  },
+  {
+    key: "admin-storefront-redirect",
+    label: "Storefront Admin Redirect",
+    path: "/admin/storefront",
+    parentPath: "/admin",
+    domain: "admin",
+    audienceModes: ["operator"],
+    destinationKind: "legacy-redirect",
+    capabilityKey: "view_admin",
+  },
+  {
+    key: "admin-business-context-redirect",
+    label: "Business Context Redirect",
+    path: "/admin/business-context",
+    parentPath: "/admin",
+    domain: "admin",
+    audienceModes: ["operator"],
+    destinationKind: "legacy-redirect",
+    capabilityKey: "view_admin",
+  },
+  {
+    key: "admin-operating-hours-redirect",
+    label: "Operating Hours Redirect",
+    path: "/admin/operating-hours",
+    parentPath: "/admin",
+    domain: "admin",
+    audienceModes: ["operator"],
+    destinationKind: "legacy-redirect",
+    capabilityKey: "view_admin",
+  },
+  {
+    key: "knowledge",
+    label: "Knowledge",
+    path: "/knowledge",
+    parentPath: "/knowledge",
+    domain: "knowledge",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: null,
+    primaryOrder: 100,
+    shellNav: {
+      sectionKey: "knowledge",
+      description: "Shared operational and product knowledge.",
+    },
+  },
+  {
+    key: "wiki",
+    label: "Wiki",
+    path: "/wiki",
+    parentPath: "/wiki",
+    domain: "knowledge",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: null,
+    shellNav: {
+      sectionKey: "knowledge",
+      description: "Founder kernel and per-org overlay - stances, heuristics, decisions.",
+    },
+  },
+  {
+    key: "docs",
+    label: "Docs",
+    path: "/docs",
+    parentPath: "/docs",
+    domain: "knowledge",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: null,
+    shellNav: {
+      sectionKey: "knowledge",
+      description: "Reference documentation and specs.",
+    },
+  },
+] as const;
+
+const ROUTES_BY_PATH = new Map(
+  PORTAL_NAV_ROUTES.map((route) => [normalizePath(route.path), route] as const),
+);
+
+function normalizePath(path: string): string {
+  if (path.length > 1 && path.endsWith("/")) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+function toEntry(route: PortalNavRecord): PortalNavEntry {
+  return {
+    key: route.key,
+    label: route.label,
+    path: route.path,
+    parentPath: route.parentPath,
+    domain: route.domain,
+    audienceModes: route.audienceModes,
+    destinationKind: route.destinationKind,
+    capabilityKey: route.capabilityKey ?? null,
+  };
+}
+
+export function getRouteNavRecord(path: string): PortalNavRecord | undefined {
+  return ROUTES_BY_PATH.get(normalizePath(path));
+}
+
+export function getPrimaryNavEntries(audienceMode: PortalAudienceMode): PortalNavEntry[] {
+  return PORTAL_NAV_ROUTES
+    .filter((route) =>
+      route.primaryOrder !== undefined &&
+      route.destinationKind !== "legacy-redirect" &&
+      route.audienceModes.includes(audienceMode)
+    )
+    .sort((left, right) => (left.primaryOrder ?? 0) - (right.primaryOrder ?? 0))
+    .map(toEntry);
+}
+
+export function getSectionNavEntries(path: string): PortalNavEntry[] {
+  const route = getRouteNavRecord(path);
+  const owner = route?.sectionSiblings
+    ? route
+    : route?.parentPath
+      ? getRouteNavRecord(route.parentPath)
+      : undefined;
+
+  return (owner?.sectionSiblings ?? [])
+    .map((siblingPath) => getRouteNavRecord(siblingPath))
+    .filter((entry): entry is PortalNavRecord => entry !== undefined)
+    .filter((entry) => entry.destinationKind !== "legacy-redirect")
+    .map(toEntry);
+}
+
+export function getShellNavEntries(): PortalShellNavEntry[] {
+  return PORTAL_NAV_ROUTES
+    .filter((route) => route.shellNav !== undefined)
+    .map((route) => ({
+      ...toEntry(route),
+      label: route.shellNav?.label ?? route.label,
+      description: route.shellNav?.description ?? "",
+      sectionKey: route.shellNav?.sectionKey ?? "knowledge",
+    }));
+}

--- a/docs/superpowers/plans/2026-06-05-portal-navigation-archetype-ia.md
+++ b/docs/superpowers/plans/2026-06-05-portal-navigation-archetype-ia.md
@@ -1,0 +1,910 @@
+# Portal Navigation Archetype IA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make internal portal navigation easier for humans by separating worker-mode archetype navigation from platform-operator navigation, consolidating duplicated setup/control surfaces, and centralizing route ownership.
+
+**Tracking item:** `BI-CD6EE9D8` under `EP-REDUCTION-GEAR-ARCH` owns Slice 1: canonical navigation inventory.
+
+**Architecture:** Add a typed route/navigation model first, then migrate shell and section nav to consume that model. Keep route paths stable in early slices; change labels, layout ownership, and contextual actions before any route retirement. Extend workspace-home resolution later so archetype contributions can shape the AppRail.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Prisma 7, pnpm workspaces, Vitest, DPF CSS variables, report-kit for data-display surfaces.
+
+---
+
+## Source Spec
+
+Implement against:
+
+- `docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md`
+- `docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md`
+- `docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md`
+- `docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md`
+
+## Worktree And Verification Rules
+
+- Work in a topic worktree, not the root checkout.
+- Do not change route paths in Tasks 1-5 unless a task explicitly says to update redirects.
+- UI styling must use `var(--dpf-*)` tokens. No raw hex or `text-gray-*`.
+- Use `pnpm --filter web exec vitest run <target tests>` for source-local tests.
+- Run `pnpm --filter web typecheck` before handoff.
+- Runtime UX verification must use the Live portal (`http://localhost:3000`) or a governed local-CI lease. Do not verify final UX on a worktree-local dev server.
+
+## File Structure
+
+New files:
+
+- `apps/web/lib/navigation/portal-navigation-model.ts` - canonical route family, audience mode, destination kind, and label metadata.
+- `apps/web/lib/navigation/portal-navigation-model.test.ts` - structural tests for route ownership, duplicates, and cross-domain tab rules.
+- `apps/web/lib/navigation/legacy-redirects.ts` - documented legacy redirect table used by tests and route docs.
+- `apps/web/lib/navigation/legacy-redirects.test.ts` - redirect inventory tests.
+- `apps/web/components/shell/use-resolved-shell-nav.ts` - client helper or server adapter for mode-aware AppRail sections after Task 6.
+
+Modified files:
+
+- `apps/web/lib/govern/permissions.ts` - derive shell nav items from the new navigation model while preserving role gates.
+- `apps/web/components/shell/Header.tsx` - remove "Internal cockpit" copy and accept mode-aware header copy.
+- `apps/web/components/shell/AppRail.tsx` - render mode-aware labels and optional compact group descriptions.
+- `apps/web/components/platform/platform-nav.ts` - remove `/admin` as a Platform family tab in Phase 1.
+- `apps/web/components/platform/PlatformTabNav.tsx` - consume the Platform family model without cross-domain Admin.
+- `apps/web/components/admin/AdminTabNav.tsx` and `apps/web/app/(shell)/admin/layout.tsx` - move Admin nav to layout-level.
+- `apps/web/components/finance/FinanceTabNav.tsx` and `apps/web/app/(shell)/finance/layout.tsx` - move Finance nav to layout-level.
+- `apps/web/components/compliance/ComplianceTabNav.tsx` - move family definitions into shared nav model or local typed model.
+- `apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx` - visible label cleanup only.
+- `apps/web/components/storefront-admin/StorefrontSettingsNav.tsx` - "Portal" label cleanup.
+- `apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.tsx` - point setup CTA at the most specific setup path.
+- `apps/web/lib/workspace-home/types.ts` and `apps/web/lib/workspace-home/registry.ts` - later Task 6 shell context extension.
+
+---
+
+### Task 1: Add Canonical Navigation Inventory
+
+**Files:**
+
+- Create: `apps/web/lib/navigation/portal-navigation-model.ts`
+- Create: `apps/web/lib/navigation/portal-navigation-model.test.ts`
+
+- [x] **Step 1: Create the failing structural tests**
+
+Create `apps/web/lib/navigation/portal-navigation-model.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  PORTAL_NAV_ROUTES,
+  getPrimaryNavEntries,
+  getSectionNavEntries,
+  getRouteNavRecord,
+} from "./portal-navigation-model";
+
+describe("portal navigation model", () => {
+  it("has one unique route record per path", () => {
+    const paths = PORTAL_NAV_ROUTES.map((route) => route.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("keeps section navigation inside its parent domain", () => {
+    for (const route of PORTAL_NAV_ROUTES) {
+      for (const item of route.sectionSiblings ?? []) {
+        expect(item.startsWith(route.parentPath)).toBe(true);
+      }
+    }
+  });
+
+  it("does not expose Admin as a Platform family sibling", () => {
+    const platformTabs = getSectionNavEntries("/platform").map((entry) => entry.path);
+    expect(platformTabs).not.toContain("/admin");
+  });
+
+  it("keeps worker and operator primary entries separately addressable", () => {
+    expect(getPrimaryNavEntries("worker").map((entry) => entry.key)).toContain("workspace");
+    expect(getPrimaryNavEntries("operator").map((entry) => entry.key)).toContain("platform");
+    expect(getPrimaryNavEntries("worker").map((entry) => entry.key)).not.toContain("admin");
+  });
+
+  it("classifies legacy redirect destinations as redirects, not primary nav", () => {
+    expect(getRouteNavRecord("/admin/storefront")?.destinationKind).toBe("legacy-redirect");
+    expect(getPrimaryNavEntries("operator").map((entry) => entry.path)).not.toContain("/admin/storefront");
+  });
+});
+```
+
+- [x] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/navigation/portal-navigation-model.test.ts
+```
+
+Expected: fail because `portal-navigation-model.ts` does not exist.
+
+- [x] **Step 3: Implement the minimal navigation model**
+
+Create `apps/web/lib/navigation/portal-navigation-model.ts`:
+
+```ts
+export type PortalAudienceMode = "worker" | "operator" | "customer" | "diagnostic";
+
+export type PortalDestinationKind =
+  | "domain-home"
+  | "section-page"
+  | "detail"
+  | "workflow-step"
+  | "settings"
+  | "contextual-action"
+  | "legacy-redirect";
+
+export type PortalNavRecord = {
+  key: string;
+  label: string;
+  path: string;
+  parentPath: string;
+  domain: "workspace" | "business" | "delivery" | "platform" | "admin" | "knowledge" | "customer";
+  audienceModes: PortalAudienceMode[];
+  destinationKind: PortalDestinationKind;
+  sectionSiblings?: string[];
+};
+
+export const PORTAL_NAV_ROUTES: PortalNavRecord[] = [
+  {
+    key: "workspace",
+    label: "Workspace",
+    path: "/workspace",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    sectionSiblings: ["/workspace", "/workspace/documents"],
+  },
+  {
+    key: "documents",
+    label: "Documents",
+    path: "/workspace/documents",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+  },
+  {
+    key: "customer",
+    label: "Customer",
+    path: "/customer",
+    parentPath: "/customer",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    sectionSiblings: [
+      "/customer",
+      "/customer/engagements",
+      "/customer/opportunities",
+      "/customer/quotes",
+      "/customer/sales-orders",
+      "/customer/funnel",
+      "/customer/marketing",
+    ],
+  },
+  {
+    key: "finance",
+    label: "Money",
+    path: "/finance",
+    parentPath: "/finance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "compliance",
+    label: "Compliance",
+    path: "/compliance",
+    parentPath: "/compliance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "customer-portal",
+    label: "Customer Portal",
+    path: "/storefront",
+    parentPath: "/storefront",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "delivery",
+    label: "Delivery",
+    path: "/ops",
+    parentPath: "/ops",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "build",
+    label: "Build Studio",
+    path: "/build",
+    parentPath: "/build",
+    domain: "delivery",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "platform",
+    label: "Platform",
+    path: "/platform",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    sectionSiblings: [
+      "/platform",
+      "/platform/identity",
+      "/platform/ai",
+      "/platform/tools",
+      "/platform/audit",
+    ],
+  },
+  {
+    key: "admin",
+    label: "Admin",
+    path: "/admin",
+    parentPath: "/admin",
+    domain: "admin",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "knowledge",
+    label: "Knowledge",
+    path: "/knowledge",
+    parentPath: "/knowledge",
+    domain: "knowledge",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+  },
+  {
+    key: "admin-storefront-redirect",
+    label: "Legacy storefront admin redirect",
+    path: "/admin/storefront",
+    parentPath: "/storefront",
+    domain: "business",
+    audienceModes: ["diagnostic"],
+    destinationKind: "legacy-redirect",
+  },
+];
+
+export function getRouteNavRecord(path: string): PortalNavRecord | undefined {
+  return PORTAL_NAV_ROUTES.find((route) => route.path === path);
+}
+
+export function getPrimaryNavEntries(mode: PortalAudienceMode): PortalNavRecord[] {
+  return PORTAL_NAV_ROUTES.filter(
+    (route) =>
+      route.destinationKind === "domain-home" &&
+      route.audienceModes.includes(mode),
+  );
+}
+
+export function getSectionNavEntries(parentPath: string): PortalNavRecord[] {
+  const parent = getRouteNavRecord(parentPath);
+  if (!parent?.sectionSiblings) return [];
+  return parent.sectionSiblings
+    .map((path) => getRouteNavRecord(path) ?? {
+      key: path,
+      label: path.replace(`${parentPath}/`, ""),
+      path,
+      parentPath,
+      domain: parent.domain,
+      audienceModes: parent.audienceModes,
+      destinationKind: "section-page" as const,
+    })
+    .filter((route) => route.parentPath === parentPath);
+}
+```
+
+- [ ] **Step 4: Run the navigation model test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/navigation/portal-navigation-model.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add apps/web/lib/navigation/portal-navigation-model.ts apps/web/lib/navigation/portal-navigation-model.test.ts
+git commit -s -m "feat: add portal navigation inventory model"
+```
+
+---
+
+### Task 2: Remove Cross-Domain Admin From Platform Tabs
+
+**Files:**
+
+- Modify: `apps/web/components/platform/platform-nav.ts`
+- Modify: `apps/web/components/platform/PlatformTabNav.test.tsx`
+
+- [ ] **Step 1: Add/adjust the failing Platform nav test**
+
+In `apps/web/components/platform/PlatformTabNav.test.tsx`, ensure this test exists:
+
+```ts
+it("does not render Core Admin as a platform family tab", () => {
+  pathname = "/platform";
+  const html = renderToStaticMarkup(<PlatformTabNav />);
+  expect(html).toContain("Identity &amp; Access");
+  expect(html).toContain("AI Operations");
+  expect(html).not.toContain("Core Admin");
+  expect(html).not.toContain('href="/admin"');
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/platform/PlatformTabNav.test.tsx
+```
+
+Expected: fail while `Core Admin` is still a Platform family.
+
+- [ ] **Step 3: Remove the Admin family from Platform nav**
+
+In `apps/web/components/platform/platform-nav.ts`:
+
+- Remove `"admin"` from `PlatformFamilyKey`.
+- Remove the family object with `key: "admin"`.
+- Keep `/admin` reachable from the global operator rail and contextual cards.
+
+The resulting union starts:
+
+```ts
+export type PlatformFamilyKey =
+  | "overview"
+  | "identity"
+  | "ai"
+  | "tools"
+  | "audit";
+```
+
+- [ ] **Step 4: Run the Platform nav test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/platform/PlatformTabNav.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add apps/web/components/platform/platform-nav.ts apps/web/components/platform/PlatformTabNav.test.tsx
+git commit -s -m "fix: keep admin out of platform family tabs"
+```
+
+---
+
+### Task 3: Fix First-Touch Labels And Setup CTA
+
+**Files:**
+
+- Modify: `apps/web/components/shell/Header.tsx`
+- Modify: `apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.tsx`
+- Modify: `apps/web/lib/govern/permissions.ts`
+- Test: existing shell/header/nav tests plus new focused tests if absent
+
+- [ ] **Step 1: Add assertions for copy**
+
+If no tests exist for these components, create focused tests:
+
+- `apps/web/components/shell/Header.test.tsx`
+- `apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.test.tsx`
+
+Header test:
+
+```tsx
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Header } from "./Header";
+
+describe("Header", () => {
+  it("does not use cockpit copy in the worker-facing shell header", () => {
+    const html = renderToStaticMarkup(
+      <Header
+        platformRole="HR-000"
+        brandName="Digital Product Factory"
+        brandLogoUrl={null}
+        userId="user-1"
+      />,
+    );
+
+    expect(html).not.toContain("Internal cockpit");
+    expect(html).toContain("Workspace");
+  });
+});
+```
+
+Unconfigured notice test:
+
+```tsx
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { UnconfiguredWorkspaceHomeNotice } from "./UnconfiguredWorkspaceHomeNotice";
+
+describe("UnconfiguredWorkspaceHomeNotice", () => {
+  it("points users to the setup route instead of the storefront dashboard", () => {
+    const html = renderToStaticMarkup(<UnconfiguredWorkspaceHomeNotice />);
+    expect(html).toContain('href="/storefront/setup"');
+    expect(html).not.toContain('href="/storefront"');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and confirm failures**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/shell/Header.test.tsx apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.test.tsx
+```
+
+Expected: header test fails until copy is changed; notice test fails if CTA still points to `/storefront`.
+
+- [ ] **Step 3: Update copy and route**
+
+Update `Header.tsx`:
+
+```tsx
+<span className="rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
+  Workspace
+</span>
+```
+
+Update the subtitle to:
+
+```tsx
+<p className="mt-0.5 truncate text-xs text-[var(--dpf-muted)]">
+  Work, handoffs, and governed AI coworkers in one place
+</p>
+```
+
+Update `UnconfiguredWorkspaceHomeNotice.tsx` CTA href to `/storefront/setup`.
+
+Update `apps/web/lib/govern/permissions.ts` visible label for `/storefront`:
+
+```ts
+{
+  key: "storefront",
+  label: "Customer Portal",
+  href: "/storefront",
+  description: "Customer-facing portal experience and setup.",
+  sectionKey: "business",
+  capabilityKey: "view_storefront",
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/shell/Header.test.tsx apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.test.tsx apps/web/components/shell/AppRail.test.tsx
+```
+
+Expected: pass. If `AppRail.test.tsx` does not exist, run the existing permissions/nav tests instead.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add apps/web/components/shell/Header.tsx apps/web/components/shell/Header.test.tsx apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.tsx apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.test.tsx apps/web/lib/govern/permissions.ts
+git commit -s -m "fix: clarify workspace and customer portal navigation labels"
+```
+
+---
+
+### Task 4: Layout-Level Admin And Finance Section Nav
+
+**Files:**
+
+- Modify: `apps/web/app/(shell)/admin/layout.tsx`
+- Modify: `apps/web/app/(shell)/finance/layout.tsx` or create it if absent
+- Modify: admin pages that manually render `<AdminTabNav />`
+- Modify: finance pages that manually render `<FinanceTabNav />`
+- Tests: existing AdminTabNav and FinanceTabNav tests
+
+- [ ] **Step 1: Move Admin nav to the Admin layout**
+
+Update `apps/web/app/(shell)/admin/layout.tsx` to render `AdminTabNav` once:
+
+```tsx
+import { AdminTabNav } from "@/components/admin/AdminTabNav";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { notFound } from "next/navigation";
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_admin",
+    )
+  ) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <AdminTabNav />
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Remove manual AdminTabNav imports from child pages**
+
+Remove `<AdminTabNav />` and the import from pages under `apps/web/app/(shell)/admin/**/page.tsx` that are wrapped by the layout.
+
+- [ ] **Step 3: Add or update Finance layout**
+
+Create or update `apps/web/app/(shell)/finance/layout.tsx`:
+
+```tsx
+import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+
+export default function FinanceLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <FinanceTabNav />
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Remove manual FinanceTabNav imports from child pages**
+
+Remove `<FinanceTabNav />` and import statements from finance pages wrapped by the new layout.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/admin/AdminTabNav.test.tsx apps/web/components/finance/FinanceTabNav.test.tsx
+pnpm --filter web typecheck
+```
+
+Expected: tests and typecheck pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add apps/web/app/(shell)/admin apps/web/app/(shell)/finance apps/web/components/admin apps/web/components/finance
+git commit -s -m "refactor: move admin and finance nav to layouts"
+```
+
+---
+
+### Task 5: Add Legacy Redirect Inventory Tests
+
+**Files:**
+
+- Create: `apps/web/lib/navigation/legacy-redirects.ts`
+- Create: `apps/web/lib/navigation/legacy-redirects.test.ts`
+
+- [ ] **Step 1: Create redirect inventory**
+
+Create `legacy-redirects.ts`:
+
+```ts
+export type LegacyRedirectRecord = {
+  from: string;
+  to: string;
+  owner: "storefront" | "ops" | "platform-ai" | "platform-tools" | "platform-audit";
+  status: "permanent-compat" | "temporary-compat";
+};
+
+export const LEGACY_REDIRECTS: LegacyRedirectRecord[] = [
+  { from: "/admin/storefront", to: "/storefront", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/storefront/inbox", to: "/storefront/inbox", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/storefront/items", to: "/storefront/items", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/storefront/settings", to: "/storefront/settings", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/business-context", to: "/storefront/settings/business", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/operating-hours", to: "/storefront/settings/operations", owner: "storefront", status: "permanent-compat" },
+  { from: "/admin/backlog", to: "/ops", owner: "ops", status: "permanent-compat" },
+  { from: "/admin/prompts", to: "/platform/ai/prompts", owner: "platform-ai", status: "permanent-compat" },
+  { from: "/admin/skills", to: "/platform/ai/skills", owner: "platform-ai", status: "permanent-compat" },
+  { from: "/platform/integrations", to: "/platform/tools/catalog", owner: "platform-tools", status: "permanent-compat" },
+  { from: "/platform/services", to: "/platform/tools/services", owner: "platform-tools", status: "permanent-compat" },
+  { from: "/platform/ai/routing", to: "/platform/ai/providers", owner: "platform-ai", status: "permanent-compat" },
+  { from: "/platform/ai/history", to: "/platform/audit/ledger", owner: "platform-audit", status: "permanent-compat" },
+];
+```
+
+- [ ] **Step 2: Add structural tests**
+
+Create `legacy-redirects.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { LEGACY_REDIRECTS } from "./legacy-redirects";
+
+describe("legacy redirects", () => {
+  it("has unique source paths", () => {
+    const sources = LEGACY_REDIRECTS.map((redirect) => redirect.from);
+    expect(new Set(sources).size).toBe(sources.length);
+  });
+
+  it("does not redirect a path to itself", () => {
+    for (const redirect of LEGACY_REDIRECTS) {
+      expect(redirect.from).not.toBe(redirect.to);
+    }
+  });
+
+  it("keeps admin storefront redirects owned by storefront", () => {
+    expect(
+      LEGACY_REDIRECTS.filter((redirect) => redirect.from.startsWith("/admin/storefront"))
+        .every((redirect) => redirect.owner === "storefront"),
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/navigation/legacy-redirects.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```powershell
+git add apps/web/lib/navigation/legacy-redirects.ts apps/web/lib/navigation/legacy-redirects.test.ts
+git commit -s -m "test: document legacy navigation redirects"
+```
+
+---
+
+### Task 6: Add Workspace Shell Context To Workspace-Home Resolution
+
+**Files:**
+
+- Modify: `apps/web/lib/workspace-home/types.ts`
+- Modify: `apps/web/lib/workspace-home/registry.ts`
+- Modify: `apps/web/app/(shell)/workspace/page.tsx`
+- Modify: `apps/web/components/shell/AppRail.tsx`
+- Test: `apps/web/lib/workspace-home/registry.test.ts`
+
+- [ ] **Step 1: Add shell context tests**
+
+In `apps/web/lib/workspace-home/registry.test.ts`, add:
+
+```ts
+it("returns platform operator shell context for platform fallback", () => {
+  const resolution = resolveWorkspaceHomeContribution({
+    archetypeId: null,
+    archetypeCategory: null,
+  });
+
+  expect(resolution.shell.mode).toBe("platform-operator");
+  expect(resolution.shell.primaryLabel).toBe("Workspace");
+  expect(resolution.shell.showOperatorSwitch).toBe(false);
+});
+
+it("returns worker shell context for a resolved archetype contribution", () => {
+  const resolution = resolveWorkspaceHomeContribution({
+    archetypeId: "it-managed-services",
+    archetypeCategory: "professional-services",
+  });
+
+  if (resolution.kind === "platform-fallback") {
+    throw new Error("expected an archetype contribution fixture for it-managed-services");
+  }
+
+  expect(resolution.shell.mode).toBe("worker");
+  expect(resolution.shell.primaryLabel.length).toBeGreaterThan(0);
+  expect(resolution.shell.navGroups.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/workspace-home/registry.test.ts
+```
+
+Expected: fail because `shell` does not exist on resolution.
+
+- [ ] **Step 3: Extend workspace-home types**
+
+Add to `apps/web/lib/workspace-home/types.ts`:
+
+```ts
+export type WorkspaceShellMode = "worker" | "platform-operator";
+
+export type WorkspaceNavItem = {
+  key: string;
+  label: string;
+  href: string;
+  description?: string;
+};
+
+export type WorkspaceNavGroup = {
+  key: string;
+  label: string;
+  items: WorkspaceNavItem[];
+};
+
+export type WorkspaceShellContext = {
+  mode: WorkspaceShellMode;
+  primaryLabel: string;
+  subtitle?: string;
+  navGroups: WorkspaceNavGroup[];
+  showOperatorSwitch: boolean;
+};
+```
+
+Attach `shell: WorkspaceShellContext` to the existing resolution type rather than creating a parallel resolver union.
+
+- [ ] **Step 4: Populate shell context in registry**
+
+In `registry.ts`, add a platform fallback shell and a contribution shell. Use archetype labels from the contribution where available:
+
+```ts
+const PLATFORM_OPERATOR_SHELL: WorkspaceShellContext = {
+  mode: "platform-operator",
+  primaryLabel: "Workspace",
+  subtitle: "Work, handoffs, and governed AI coworkers in one place",
+  showOperatorSwitch: false,
+  navGroups: [],
+};
+```
+
+For resolved contributions, return:
+
+```ts
+shell: {
+  mode: "worker",
+  primaryLabel: contribution.displayName,
+  subtitle: contribution.primaryOperatingQuestion,
+  showOperatorSwitch: true,
+  navGroups: contribution.navGroups ?? [],
+}
+```
+
+If `displayName`, `primaryOperatingQuestion`, or `navGroups` are not yet in the contribution type, add them as optional fields and provide defaults.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/workspace-home/registry.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add apps/web/lib/workspace-home apps/web/app/(shell)/workspace/page.tsx apps/web/components/shell/AppRail.tsx
+git commit -s -m "feat: add workspace shell context for archetype navigation"
+```
+
+---
+
+### Task 7: Live UX Verification
+
+**Files:**
+
+- Modify if needed: `tests/e2e/platform-qa-plan.md`
+- Evidence only: record results through governed evidence path if available
+
+- [ ] **Step 1: Run source-local checks**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/navigation/portal-navigation-model.test.ts apps/web/lib/navigation/legacy-redirects.test.ts apps/web/components/platform/PlatformTabNav.test.tsx apps/web/components/admin/AdminTabNav.test.tsx apps/web/components/finance/FinanceTabNav.test.tsx apps/web/lib/workspace-home/registry.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: all pass in the topic worktree.
+
+- [ ] **Step 2: Rebuild and verify on Live portal**
+
+Use the canonical runtime path from AGENTS. Rebuild and run the Docker-served Live portal from the integration substrate, not a random dev server:
+
+```powershell
+docker compose build --no-cache portal portal-init sandbox
+docker compose up -d
+```
+
+Expected: `dpf-portal-1` healthy and `http://localhost:3000/api/health` returns 200.
+
+- [ ] **Step 3: Drive desktop verification**
+
+In the browser, log in at `http://localhost:3000/login` as `admin@dpf.local`, then verify:
+
+- `/workspace` no longer says "Internal cockpit".
+- `/workspace` setup CTA opens `/storefront/setup` when no worker home is configured.
+- AppRail visible label for `/storefront` is "Customer Portal" or the chosen approved label.
+- `/platform` family tabs do not include "Core Admin".
+- `/admin` still appears in operator primary navigation for a superuser.
+- `/storefront/settings` retains Dashboard, Sections, Items, Team, Inbox, Settings plus settings subnav.
+- `/finance` still shows Finance family navigation once, not repeated by every page body.
+
+- [ ] **Step 4: Drive mobile verification**
+
+Use a mobile viewport and verify:
+
+- AppRail/primary navigation remains usable without text overlap.
+- Section tabs wrap or scroll without occluding page content.
+- `/workspace`, `/storefront/settings`, `/platform`, and `/finance` remain navigable.
+
+- [ ] **Step 5: Record verification summary**
+
+Add a short verification note to the PR body or evidence system:
+
+```md
+Verification substrate: Live portal at http://localhost:3000.
+Source-local tests: <command> -> pass.
+Typecheck: <command> -> pass.
+UX: drove /workspace, /storefront/settings, /platform, /admin, /finance on desktop and mobile. Observed no cockpit copy, no Core Admin Platform tab, setup CTA points to /storefront/setup, and section nav remains usable.
+```
+
+- [ ] **Step 6: Commit final docs/test updates**
+
+Run:
+
+```powershell
+git add tests/e2e/platform-qa-plan.md docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md docs/superpowers/plans/2026-06-05-portal-navigation-archetype-ia.md
+git commit -s -m "docs: plan portal navigation archetype IA rollout"
+```
+
+## Acceptance Checklist
+
+- [ ] Navigation model tests pass.
+- [ ] Legacy redirect inventory tests pass.
+- [ ] Platform tabs no longer include Admin as a sibling.
+- [ ] First-touch labels separate Workspace, Customer Portal, Customer Account, and Live portal concepts.
+- [ ] Admin and Finance nav are layout-owned instead of repeated per page.
+- [ ] Workspace-home resolution can return shell context for worker/operator modes.
+- [ ] Source-local tests pass in the topic worktree.
+- [ ] Typecheck passes in the topic worktree.
+- [ ] Live portal UX verification is complete on desktop and mobile.
+- [ ] Any unresolved route-retirement decisions are left as documented follow-up BIs, not hidden code changes.

--- a/docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md
+++ b/docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md
@@ -1,0 +1,547 @@
+# Portal Navigation And Archetype IA Design
+
+| Field | Value |
+| --- | --- |
+| Status | Draft audit - ready for founder/architect review |
+| Date | 2026-06-05 |
+| Owner | Mark Bodman |
+| Author | Codex |
+| Scope | Internal portal navigation, route hierarchy, human task discovery, archetype-aware workspace entry, consolidation/refactor plan |
+| Out of scope | Implementing code changes in this pass, deleting routes, changing permissions, changing external customer `/portal` authentication behavior |
+| Primary epic alignment | `EP-REDUCTION-GEAR-ARCH` for archetype-aware workspace and primitive reuse |
+| Related backlog | `BI-CD6EE9D8`, `BI-FE002675`, `BI-5B8FE5C1`, `BI-89C19AAF`, `BI-1CCC6264`, `BI-3E8D2CF5`, `BI-CE6AF925`, `BI-FS-001`, `BI-ARCH-4C1E90` |
+| Anchor specs/docs | `docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md`, `docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md`, `docs/superpowers/plans/2026-05-31-archetype-aware-workspace.md`, `docs/user-guide/market-archetypes.md`, `docs/user-guide/storefront/index.md` |
+
+## Executive Verdict
+
+DPF has the right ingredients for a scalable portal: a global shell, domain tabs, role permissions, archetype records, workspace-home contributions, and redirect shims for legacy routes. The current human experience still feels hard to use because these pieces are arranged as platform modules first and jobs-to-be-done second.
+
+The visible result is a portal where one admin user sees 17 global rail destinations, many pages repeat the same sibling links as tabs and cards, and `/workspace` acts as a cross-domain launchpad instead of the archetype-specific daily work surface described in the docs. This is not a single broken component. It is an information architecture problem.
+
+The recommended direction is:
+
+1. Keep the current global shell but make it role- and mode-aware.
+2. Make `/workspace` the default archetype worker home when an active archetype has a contribution; keep the platform home as an explicit operator mode.
+3. Consolidate top-level navigation around durable user jobs, not implementation packages.
+4. Convert cross-domain shortcuts into contextual actions and health drill-downs.
+5. Move legacy Admin, Storefront, Finance setup, Platform runtime, and Build Studio configuration overlaps into a single route ownership model.
+6. Reserve 20% of implementation capacity for refactoring the navigation substrate, matching the workspace-home standards.
+
+## Evidence Gathered
+
+### Live Runtime Sample
+
+Live portal evidence was collected on the canonical install at `http://localhost:3000` after logging in as `admin@dpf.local`.
+
+Observed pages:
+
+- `/workspace`
+- `/storefront`
+- `/storefront/settings`
+- `/customer`
+- `/customer/marketing`
+- `/finance`
+- `/compliance`
+- `/ops`
+- `/platform`
+- `/platform/ai`
+- `/platform/tools`
+- `/platform/audit`
+- `/admin`
+- `/build`
+
+Key live observations:
+
+- `/workspace` shows a 17-link primary AppRail: Workspace, Documents, Customer, People, Finance, Compliance, Portal, Portfolio, Backlog, Architecture, AI Workforce, Build Studio, Platform Hub, Admin, Knowledge, Wiki, Docs.
+- `/workspace` main content exposed 118 links in the sampled DOM. Many links drill across domains from a health/status matrix: `Connections -> /platform/tools/integrations`, `Capabilities -> /platform/ai`, `Containment -> /platform/ai/authority`, `Context -> /wiki`.
+- `/workspace` shows "Workspace home is using the standard view" and sends users to `/storefront` with "Review business setup", even though the setup purpose is worker-home activation.
+- The shell header still says "Internal cockpit", which conflicts with the reserved cockpit language in the vertical workspace-home spec.
+- `/storefront/settings` shows two stacked navigation layers: the storefront tab row and a settings sub-row. The model is understandable, but the parent label "Portal" is ambiguous because `/portal` is the external customer account surface.
+- `/customer/marketing` has customer tabs plus marketing tabs, then includes a literal platform integration path link (`/platform/tools/integrations/email-postmark`) inside a business workflow.
+- `/platform`, `/platform/tools`, `/platform/audit`, and `/platform/ai` repeat Platform family tabs and then render cards that link to the same families again.
+- `/platform` includes "Core Admin" as a Platform family, while `/admin` has its own Admin family navigation. This creates a cross-context jump disguised as a sibling tab.
+- `/finance` exposes setup, overview, family tabs, hub cards, and many sublinks in one screen. It is useful for an accountant, but it is too large to be a first-touch generic Business nav item.
+- `/ops` is labeled "Backlog" in the global rail, but the page title is "Operations" and the section tabs include Backlog, Improvements, Changes, Promotions, Self-upgrade, and Dev Loop.
+- `/build` preserves the global rail while presenting its own work-control surface and live preview link to `localhost:3035`. This is correct for platform contributors, but a customer-operator should not need to reason about the preview substrate from primary nav.
+
+### Source Evidence
+
+Current navigation and route ownership are mostly code-owned:
+
+- `apps/web/lib/govern/permissions.ts` defines `SHELL_ITEMS` and `SHELL_SECTIONS`, including 17 global rail entries for a superuser.
+- `apps/web/components/shell/AppRail.tsx` renders every permitted shell item as a persistent primary rail.
+- `apps/web/components/platform/platform-nav.ts` defines Platform families and includes `Core Admin -> /admin` as a Platform peer.
+- `apps/web/components/platform/PlatformTabNav.tsx` renders Platform family tabs and active-family subitems.
+- `apps/web/app/(shell)/platform/ai/layout.tsx`, `platform/tools/layout.tsx`, `platform/audit/layout.tsx`, and `platform/identity/layout.tsx` each inject `PlatformTabNav`, while `apps/web/app/(shell)/platform/page.tsx` imports it manually.
+- `apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx` renders Dashboard, Sections, Items, Team, Inbox, Settings.
+- `apps/web/components/storefront-admin/StorefrontSettingsNav.tsx` renders Portal, Your Business, Operating Hours inside Settings.
+- `apps/web/components/finance/finance-nav.ts` defines five Finance families and many subitems.
+- `apps/web/components/compliance/ComplianceTabNav.tsx` defines Compliance families and subitems inline rather than in a shared nav model.
+- `apps/web/components/ops/OpsTabNav.tsx` labels `/ops` as Backlog even though the route title is Operations.
+- Redirect shims exist for legacy and migrated routes, including `/admin/storefront -> /storefront`, `/admin/business-context -> /storefront/settings/business`, `/admin/operating-hours -> /storefront/settings/operations`, `/admin/backlog -> /ops`, `/admin/prompts -> /platform/ai/prompts`, `/admin/skills -> /platform/ai/skills`, `/platform/integrations -> /platform/tools/catalog`, `/platform/services -> /platform/tools/services`, `/platform/ai/routing -> /platform/ai/providers`, and `/platform/ai/history -> /platform/audit/ledger`.
+
+### Backlog And Spec Evidence
+
+Live MCP backlog review found relevant existing work rather than a need for a brand-new epic:
+
+- `EP-REDUCTION-GEAR-ARCH` is open and owns the workspace-home substrate direction.
+- `BI-CD6EE9D8` tracks Slice 1: canonical navigation inventory under `EP-REDUCTION-GEAR-ARCH`.
+- `BI-FE002675` is the MSP workspace-home research/design item.
+- `BI-5B8FE5C1` is the vertical workspace primitive library item.
+- `BI-89C19AAF` is the vertical workspace home design item.
+- `BI-1CCC6264`, `BI-3E8D2CF5`, and `BI-CE6AF925` are the shared workspace resolver/projection/HVAC follow-ons named by existing specs.
+- `EP-TRADES-FIELD-SERVICE` and `BI-FS-001` cover field-service/HVAC archetype work.
+
+MCP `search_specs_and_plans` did not find an existing broad portal-navigation IA spec for "navigation portal storefront archetype business setup information architecture." Existing workspace-home specs cover `/workspace`, but not the whole portal navigation consolidation.
+
+### External Standards
+
+This audit follows these external UX standards and benchmarks:
+
+- Material Design: navigation drawers are appropriate for apps with five or more top-level destinations, two or more hierarchy levels, or unrelated destinations. It also cautions against competing primary navigation components. Source: [Material Design Navigation Drawer](https://m2.material.io/components/navigation-drawer).
+- NN/g menu design checklist: use clear, familiar labels; avoid internal jargon; communicate current location; provide local navigation for closely related content. Source: [NN/g Menu Design Checklist PDF](https://media.nngroup.com/media/articles/attachments/PDF_Menu-Design-Checklist.pdf).
+- GOV.UK service design: map the user's whole problem and design around the journey from the user's perspective. Source: [GOV.UK Map a User's Whole Problem](https://www.gov.uk/service-manual/design/map-a-users-whole-problem).
+- GOV.UK service standard: make services simple to use so users can complete the thing they came to do with minimal help. Source: [GOV.UK Service Standard Point 4](https://www.gov.uk/service-manual/service-standard/point-4-make-the-service-simple-to-use/).
+
+## Current-State Map
+
+### Global Shell Today
+
+The AppRail is grouped as:
+
+| Group | Entries |
+| --- | --- |
+| Workspace | Workspace, Documents |
+| Business | Customer, People, Finance, Compliance, Portal |
+| Products | Portfolio, Backlog, Architecture |
+| Platform | AI Workforce, Build Studio, Platform Hub, Admin |
+| Knowledge | Knowledge, Wiki, Docs |
+
+This is a reasonable superuser map for a platform operator. It is not the right default mental model for a clinic scheduler, HVAC dispatcher, MSP service coordinator, retail merchandiser, or restaurant manager.
+
+### Section Navigation Today
+
+| Section | Current navigation model | Issue |
+| --- | --- | --- |
+| Workspace | No local section nav; command center links everywhere | Cross-domain launchpad, not an archetype work home |
+| Storefront | Dashboard, Sections, Items, Team, Inbox, Settings; Settings subnav | Useful, but "Portal" label collides with external `/portal` |
+| Customer | Accounts, Engagements, Pipeline, Quotes, Orders, Funnel, Marketing; Marketing has Overview/Strategy | Good sibling model, but marketing also points to platform integrations |
+| Finance | Overview, Revenue, Spend, Close, Configuration with many subitems | Strong internal model, but too broad for primary global discovery |
+| Compliance | Overview, Licensing, Library, Controls, Assurance, Risk, Operations | Good family model, but "Operations" inside Compliance competes with `/ops` |
+| Ops | Backlog, Improvements, Changes, Promotions, Self-upgrade, Dev Loop | Mixed backlog, release, runtime, and contributor workflow |
+| Platform | Overview, Identity, AI, Tools, Audit, Core Admin | Crosses into Admin as if Admin is a Platform sibling |
+| Admin | Access, Organization, Configuration, Advanced | Still contains surfaces that have moved into Platform or Storefront |
+| Build | Custom work-control surface | Correct as a specialized workspace, but too prominent for every business operator |
+
+### Route Ownership Problems
+
+The current route set has three kinds of overlap:
+
+1. **Legacy route overlap:** old Admin routes redirect into Storefront, Ops, Platform AI, and Platform Audit.
+2. **Concept overlap:** Storefront setup, Business Context, Finance setup, and archetype setup all describe business shape from different places.
+3. **Control-plane overlap:** Platform AI, Audit, Admin Advanced, Build Studio, Ops Dev Loop, and Platform Development all expose pieces of the same contributor/runtime control plane.
+
+## Severity-Ranked Findings
+
+### Critical: Default Navigation Is Platform-Module First, Not Archetype-Work First
+
+The docs say the archetype should shape the customer portal, worker home, coworker emphasis, vocabulary, marketing posture, and contribution applicability. The live global rail still leads with modules. A business operator must translate "Platform Hub", "AI Workforce", "Backlog", "Architecture", and "Portal" into their work.
+
+This violates the market-archetype premise. It also weakens the workspace-home specs because the user can be dropped into an archetype-aware `/workspace` while the surrounding chrome still shouts "platform".
+
+Required direction: `/workspace` resolves the active archetype and its worker-mode navigation. Platform/operator surfaces remain available through an explicit operator switch for authorized users.
+
+### Critical: The Workspace Is A Cross-Domain Launchpad Instead Of A Job Home
+
+The sampled `/workspace` had 118 main links. The command center is useful for platform operations but overloads worker discovery. It links status matrix cells into Wiki, Platform Tools, AI, Authority, Ops, Customer, Finance, Compliance, and Build.
+
+Required direction: worker homes should show the top operating question for the selected archetype. Cross-domain status drilldowns remain available only in platform-operator mode or diagnostic panels.
+
+### High: Global, Section, Local, And Action Navigation Are Blended
+
+Cards and table cells often behave like navigation. Some are legitimate shortcuts; others are status facts that become cross-domain jumps. This makes it unclear whether a user is selecting a sibling page, drilling into a fact, taking an action, or leaving the current work context.
+
+Required direction: each layer gets one job:
+
+- Global rail: durable product/work domains.
+- Section tabs: siblings inside one domain.
+- Local nav: filters, views, anchors, drawers, or drill-down controls inside one page.
+- Contextual actions: create, configure, send, review, open live preview.
+
+### High: Platform And Admin Boundaries Are Blurred
+
+`/platform` lists "Core Admin" as a family tab that links to `/admin`, while `/admin` has its own tab family. Legacy redirects also move Admin pages into Storefront and Platform AI. The result is not wrong technically, but it feels like a nav jump rather than a sibling section.
+
+Required direction: "Admin" should either be a Platform settings family or a separate global operator area, not both. If kept separate, Platform pages should link to Admin as a contextual configuration action, not a Platform family tab.
+
+### High: Setup Is Split Across Storefront, Business, Finance, And Admin
+
+The `/workspace` setup notice points to `/storefront`. Storefront Settings includes "Your Business" and "Operating Hours." Finance has its own setup profile derived from the storefront archetype. Admin Business Context redirects into Storefront settings.
+
+The domain model split is correct: `BusinessContext`, `StorefrontArchetype`, `StorefrontConfig`, and `BusinessModel` are distinct. The UX journey is fragmented.
+
+Required direction: one "Business Setup" journey owns archetype activation, public portal shape, internal workspace activation, finance profile, operating hours, and setup gaps. Domain settings remain as lightweight return/edit surfaces.
+
+### High: Naming Collides Across Audiences
+
+The word "Portal" currently means at least three things:
+
+- `/storefront`: internal admin for the customer-facing public experience.
+- `/portal`: external customer account area.
+- "Live portal": production-served runtime from topology docs.
+
+The shell header says "Internal cockpit", while workspace-home specs reserve "cockpit" for a platform diagnostic concept.
+
+Required direction:
+
+- Rename internal `/storefront` visible label to "Customer Portal" or "Public Portal".
+- Keep `/portal` copy as "Customer Account" or "Customer Portal sign-in".
+- Keep runtime docs using "Live portal".
+- Replace "Internal cockpit" in the shell header with "Work hub", "Workspace", or archetype-specific worker-home labels.
+
+### Medium: Section Nav Implementation Is Inconsistent
+
+Platform section nav is layout-based for nested areas and manually imported on `/platform`. Finance nav is manually imported into many pages. Compliance nav is layout-based. Admin nav is manually imported into pages. Storefront nav is layout-based.
+
+Required direction: each route family should have one layout-level nav injection. Manual per-page nav imports should be retired except for specialized embedded workflows.
+
+### Medium: Detail Routes Need Breadcrumb Discipline
+
+Many detail routes have local back links, which is good. The global rail still remains fully visible, so a detail page can feel like it is at the same hierarchy depth as a global domain. This matters most for compliance records, finance records, agent details, product details, and Build Studio work capsules.
+
+Required direction: detail pages use breadcrumbs for depth and keep only the parent section active. They should not introduce new global entry points.
+
+### Medium: Build Studio Is Both A Global Domain And A Platform AI Configuration Area
+
+Build Studio appears globally as `/build`, while Build Runtime configuration appears under `/platform/ai/build-studio`. That split is defensible, but the labels must stay clear:
+
+- Build Studio: the work surface for creating/reviewing builds.
+- Build Runtime settings: configuration of providers, gates, and runtime policy.
+
+Required direction: keep `/build` global only for users whose work involves platform development. For business operators, Build Studio is a contextual "request improvement" path from the archetype workspace, not a primary rail item.
+
+## Target-State Navigation Model
+
+### Operating Modes
+
+The portal needs two primary internal modes:
+
+| Mode | Audience | Default for | Navigation emphasis |
+| --- | --- | --- | --- |
+| Worker mode | Business users doing daily work | Any install with an active archetype contribution | Archetype work board, customer work, schedule/queue, money, team, portal, coworker handoffs |
+| Platform operator mode | Superusers, contributors, platform admins | Authorized operators and unconfigured installs | Build, AI workforce, runtime, tools, audit, admin, docs |
+
+Mode is not only role. A founder/admin in an HVAC install should be able to switch between "Dispatcher home" and "Platform home". Ordinary workers should default to the archetype home and not see platform-heavy chrome.
+
+### Proposed Global Rail
+
+For worker mode:
+
+| Group | Entries | Notes |
+| --- | --- | --- |
+| Work | Home, My Queue | Home is archetype-resolved; My Queue is personal/coworker handoff work |
+| Business | Customers, Money, Team | Labels adapt by archetype where useful |
+| Operations | Schedule/Jobs/Orders/Inventory | Contribution chooses 2-4 visible destinations |
+| Growth | Public Portal, Marketing | Only when relevant to role/archetype |
+| Support | Knowledge, Help | Docs/Wiki hidden from non-technical workers unless relevant |
+
+For platform operator mode:
+
+| Group | Entries | Notes |
+| --- | --- | --- |
+| Work | Workspace, Documents | Platform fallback home |
+| Delivery | Backlog, Build Studio, Promotions | Consolidates `/ops` and `/build` mental model |
+| Platform | AI Workforce, Tools, Runtime, Audit | Runtime includes self-upgrade/dev-loop concepts |
+| Business Admin | Customer Portal, Finance, Compliance, People | Operational domains still available |
+| Admin | Access, Organization, Configuration | Not duplicated as a Platform family tab |
+| Knowledge | Knowledge, Wiki, Docs | Contributor/operator docs |
+
+The current superuser rail can remain during transition, but the product direction is mode-resolved primary navigation.
+
+### Section Navigation Rules
+
+1. A section tab row may only list sibling pages under the same route family.
+2. A tab row may not link to a different global domain. Example: Platform tabs should not include `/admin`.
+3. If a card opens a sibling page, it can be a shortcut but should not duplicate every tab.
+4. If a card starts work, use a button/action label rather than making the whole card a nav item.
+5. If a status cell drills into diagnostics, keep it in platform-operator mode or make it an explicit "Inspect" action.
+6. Settings/configuration should live under the domain they configure, but first-run setup should remain one guided Business Setup journey.
+7. Detail pages use breadcrumbs and parent section active state; they are not global destinations.
+
+## Archetype Navigation Objectives
+
+Navigation should be generated from the same archetype activation profile that shapes the workspace home. The active `StorefrontConfig -> StorefrontArchetype` determines the worker-mode global entries and their vocabulary.
+
+### MSP / IT Managed Services
+
+Market objective: keep client environments healthy, renew agreements, resolve tickets, manage assets, and protect margin.
+
+Primary worker nav:
+
+- Service Desk
+- Customers / Sites
+- Assets
+- Agreements
+- Service Health
+- Money
+- Customer Portal
+
+Consolidation implications:
+
+- Customer sites and managed assets should not be buried under generic Customer or Inventory.
+- Tools/integrations that matter to service health should surface as setup gaps or health-board drilldowns, not primary Platform nav.
+- Licensing/compliance should appear as a client/service readiness concern when it blocks service delivery.
+
+### Field Service / HVAC / Trades
+
+Market objective: dispatch jobs, manage technician load, prevent missed customer updates, and keep truck/part readiness visible.
+
+Primary worker nav:
+
+- Dispatch
+- Jobs
+- Customers / Sites
+- Schedule
+- Inventory / Trucks
+- Money
+- Customer Portal
+
+Consolidation implications:
+
+- `/workspace` should lead with today's dispatch board, not platform command center.
+- Storefront inquiries, jobs, schedule, notifications, and inventory should be one flow.
+- Finance setup matters as invoice/payment defaults, not as a separate first-touch domain.
+
+### Healthcare / Wellness Clinic
+
+Market objective: keep appointments ready, forms complete, practitioners balanced, and patient follow-ups reliable.
+
+Primary worker nav:
+
+- Schedule
+- Patients
+- Readiness
+- Follow-ups
+- Billing
+- Compliance
+- Customer Portal
+
+Consolidation implications:
+
+- Compliance and customer communication need to be contextual to appointment readiness.
+- Marketing should not be first-touch unless the role is owner/growth.
+
+### Retail / Goods
+
+Market objective: keep orders moving, stock visible, returns handled, and demand signals actionable.
+
+Primary worker nav:
+
+- Orders
+- Stock
+- Customers
+- Receiving
+- Returns
+- Marketing
+- Money
+
+Consolidation implications:
+
+- Inventory, customer, and finance are not separate mental worlds for a merchandiser.
+- Marketing belongs to growth/demand and should reuse customer data without jumping to platform integrations.
+
+### Software Platform
+
+Market objective: ship product improvements, support customers, monitor runtime health, and manage subscription/revenue signals.
+
+Primary worker nav:
+
+- Build / Delivery
+- Customers
+- Support
+- Runtime Health
+- Revenue
+- AI Coworkers
+- Knowledge
+
+Consolidation implications:
+
+- This archetype legitimately sees more platform/contributor surfaces.
+- It still needs a clear distinction between "run my software business" and "administer DPF internals".
+
+## Consolidation Opportunities
+
+### Business Setup Spine
+
+Consolidate:
+
+- `/storefront/setup`
+- `/storefront/settings/business`
+- `/storefront/settings/operations`
+- `/finance/settings/setup`
+- legacy `/admin/business-context`
+- legacy `/admin/operating-hours`
+- workspace-home activation summaries
+
+Target: one Business Setup journey with domain-specific edit surfaces after completion.
+
+### Customer Growth Surface
+
+Consolidate:
+
+- `/customer`
+- `/customer/marketing`
+- `/storefront/inbox`
+- public portal setup gaps
+- marketing integrations setup prompts
+
+Target: Customer/Growth flows stay in business context. Platform integration pages remain setup/configuration destinations behind explicit actions.
+
+### Delivery And Change Operations
+
+Consolidate:
+
+- `/ops` backlog
+- `/ops/improvements`
+- `/ops/changes`
+- `/ops/promotions`
+- `/build`
+- `/platform/audit/operations`
+- `/ops/dev-loop`
+- `/ops/self-upgrade`
+
+Target: separate "Delivery" from "Runtime Operations". Backlog and Build Studio are delivery; self-upgrade/dev-loop/runtime targets are platform runtime operations.
+
+### Platform Control Plane
+
+Consolidate:
+
+- `/platform/ai`
+- `/platform/tools`
+- `/platform/audit`
+- `/admin/platform-development`
+- `/admin/diagnostics`
+- `/admin/backups`
+- `/platform/edge-nodes`
+
+Target: Platform owns AI workforce, tools/services, runtime, audit, and diagnostics. Admin owns access/org/configuration.
+
+### Finance And Compliance Setup
+
+Consolidate:
+
+- Finance setup profile derived from archetype
+- Compliance licensing/onboard setup
+- Business archetype activation
+
+Target: domain pages show setup gaps, but setup decisions flow through Business Setup and carry archetype context.
+
+## Migration Plan
+
+### Phase 0 - Route And Nav Inventory Gate
+
+Create a code-owned route/nav inventory and test that every visible route has:
+
+- one parent domain
+- one section family if applicable
+- one audience mode (`worker`, `operator`, `customer`, or `diagnostic`)
+- one destination kind (`domain-home`, `section-page`, `detail`, `workflow-step`, `settings`, `contextual-action`, `legacy-redirect`)
+
+This phase is read-mostly and should not change user-facing navigation except test-safe metadata.
+
+### Phase 1 - Low-Risk Naming And Context Fixes
+
+Make the easiest changes that reduce confusion without changing route behavior:
+
+- Replace shell "Internal cockpit" copy with "Workspace" or mode-aware text.
+- Rename visible `/storefront` global label from "Portal" to "Customer Portal" or "Public Portal".
+- Change `/workspace` setup CTA from `/storefront` to the correct setup/business path.
+- Remove `/admin` from Platform family tabs; represent it as an admin/configuration action instead.
+- Rename `/ops` global label from "Backlog" to "Delivery" or split backlog from runtime operations.
+- Replace literal path links in business workflows with human action labels.
+- Add tests that legacy redirects still work.
+
+### Phase 2 - Centralize Section Navigation
+
+Refactor section nav into one canonical model:
+
+- Move Finance nav injection to a layout or shared family shell.
+- Move Admin nav injection to layout-level.
+- Keep Platform nav layout-level across Platform families.
+- Move Compliance family definitions into a shared model, matching Finance/Platform patterns.
+- Remove duplicated tab/card link sets where cards only mirror tabs.
+
+This is the first meaningful refactor slice.
+
+### Phase 3 - Archetype Worker Navigation
+
+Extend workspace-home resolution to return a `WorkspaceShellContext`:
+
+- `mode`
+- `primaryLabel`
+- `subtitle`
+- `navGroups`
+- `showOperatorSwitch`
+- `setupGaps`
+
+The global AppRail consumes this context when `/workspace` resolves a vertical contribution. The platform rail remains for operator mode and unconfigured fallback.
+
+### Phase 4 - Consolidate Setup
+
+Create the Business Setup spine:
+
+- archetype selection
+- public portal activation
+- worker-home activation summary
+- finance defaults
+- operating hours
+- customer/contact baseline
+- required integrations/setup gaps
+
+Domain settings pages become return/edit surfaces. They should not each restart the same setup concept.
+
+### Phase 5 - Route Retirement And Redirect Review
+
+After Phase 1-4 settle, classify all redirects:
+
+- keep permanent compatibility redirects
+- keep temporary redirects with removal release
+- remove dead internal links
+- add telemetry for redirects that still receive traffic
+
+Do not delete routes until telemetry shows the link is not used or the redirect has a documented replacement.
+
+## Refactoring Allocation
+
+At least 20% of implementation capacity should be reserved for refactoring. For this effort, refactoring is not polish; it is the main debt reducer.
+
+Required refactor targets:
+
+1. A typed navigation model that owns global, section, and local route metadata.
+2. Layout-level section nav injection for Finance, Admin, Platform, Compliance, Storefront, Customer, and Ops/Delivery.
+3. Worker-mode AppRail context returned by workspace-home resolution.
+4. A redirect inventory test so legacy routes stay intentional.
+5. Common nav primitives with consistent theme-aware styling.
+6. Removal of manually duplicated tab rows where route layouts can own them.
+
+## Acceptance Criteria
+
+- Every major page has exactly one primary home in the route/nav inventory.
+- The primary rail has an operator mode and a worker/archetype mode.
+- `/workspace` no longer defaults every configured business to a platform command center.
+- Storefront/Public Portal/Customer Account/Live Portal terminology is separated.
+- Platform and Admin are no longer sibling tabs inside one Platform family unless Admin is formally absorbed into Platform settings.
+- Business setup is one journey with domain edit surfaces, not several competing setup paths.
+- Section tabs list only sibling routes.
+- Cross-domain actions are labeled as actions, not ambiguous nav siblings.
+- Existing legacy redirects are tested and classified.
+- UI uses DPF theme tokens and existing nav visual patterns.
+- Live portal UX verification covers desktop and mobile for at least one configured archetype and one platform-operator fallback.
+
+## Open Decisions
+
+1. Should the first worker-mode nav prove with MSP or HVAC? Recommendation: MSP if the current install remains `software-platform`/DPF customer-zero; HVAC if `BI-FS-001` lands first and Dale replay is the acceptance path.
+2. Should `/ops` become "Delivery" globally, with runtime operations moved into Platform Runtime? Recommendation: yes, but only after redirect and backlog telemetry are captured.
+3. Should Admin be absorbed into Platform Settings or remain a separate global operator domain? Recommendation: keep Admin separate for now; remove it from Platform family tabs.
+4. Should Marketing remain under Customer or move to Growth? Recommendation: keep route under Customer initially, but label the user-facing family as Growth/Customer Growth where archetypes need it.
+5. Should `/storefront` route be renamed technically? Recommendation: no in this effort. Change visible label first; technical route rename has too much migration risk for too little gain.


### PR DESCRIPTION
## Summary
- Adds a typed `PORTAL_NAV_ROUTES` inventory for portal route ownership, audience modes, destination kinds, shell entries, and section siblings.
- Adds structural Vitest coverage so shell navigation and Platform family routes stay represented without treating `/admin` as a Platform sibling.
- Adds the portal navigation/archetype IA spec and implementation plan for the follow-on mode-aware shell and section-nav migration.

Tracking: `BI-CD6EE9D8` under `EP-REDUCTION-GEAR-ARCH`.

## Test plan
- [x] Worktree source-local: `pnpm exec vitest run lib/navigation/portal-navigation-model.test.ts` — 1 file, 7 tests passed.
- [x] Worktree source-local: `pnpm --filter web typecheck` — `next typegen && tsc --noEmit` passed after regenerating Prisma client for the rebased mainline schema.
- [x] Shared local-CI convergence sandbox lease `NPEL-61885983B0`: `node scripts/local-integration-ci.mjs --candidate feat/portal-navigation-inventory` passed; evidence `cmq0xy9hs0gay01liq7str054`.
- [x] Shared local-CI details: merge rehearsal onto `origin/main`, full web Vitest `1136 passed | 4 skipped`, web typecheck passed, Docker production build target completed.
- [x] UX verification: n/a for this slice; no route/component rendering change, this adds the canonical model and docs needed before visible AppRail migration.

## Operator notes
- Overlap sweep: no open PRs for this navigation slice; only open PR observed was unrelated docs feedback-closure work (#1484).
- Follow-on visible slice: consume `PORTAL_NAV_ROUTES` from shell/AppRail and section nav so the CRM/marketing/customer routes become reachable through the consolidated model.