### PR TITLE
feat(ai-ops-map): Provider/A2A/Both dimension toggle (Slice 2B) (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -182,4 +182,26 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("Reset time scale");
     expect(source).toContain("zoomLabel");
   });
+
+  it("offers a Provider/A2A/Both dimension toggle that focuses the map and persists", () => {
+    const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
+
+    // Toggle control + options.
+    expect(source).toContain("DimensionToggle");
+    expect(source).toContain("DIMENSION_OPTIONS");
+    expect(source).toContain("aria-label=\"Operations map dimension\"");
+    expect(source).toContain("Provider routes");
+    expect(source).toContain("A2A interactions");
+    // Conditional rendering of the provider band vs the A2A panels.
+    expect(source).toContain("showProvider");
+    expect(source).toContain("showA2a");
+    expect(source).toContain("showProvider ? <RoutingTopologyPanel");
+    expect(source).toContain("showA2a ? (");
+    expect(source).toContain("<A2aInteractionsPanel");
+    expect(source).toContain("<DeliberationLensPanel");
+    // Persistence wiring.
+    expect(source).toContain("loadOperationsMapDimension");
+    expect(source).toContain("saveOperationsMapDimension");
+    expect(source).toContain("dimensionHydrated");
+  });
 });

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -29,6 +29,10 @@ import {
   clearOperationsMapViewPreference,
   loadOperationsMapViewPreference,
   saveOperationsMapViewPreference,
+  getDefaultOperationsMapDimension,
+  loadOperationsMapDimension,
+  saveOperationsMapDimension,
+  type OperationsMapDimension,
   type OperationsMapStoredQuickViewId,
 } from "./ai-operations-map-prefs";
 import { StalledTaskRecoveryActions } from "./StalledTaskRecoveryActions";
@@ -208,6 +212,8 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
   const [severityFilters, setSeverityFilters] = useState<OperationsMapSeverity[]>(
     DEFAULT_QUICK_VIEW_FILTERS.severities,
   );
+  const [dimension, setDimension] = useState<OperationsMapDimension>(getDefaultOperationsMapDimension());
+  const dimensionHydrated = useRef(false);
   const preferenceHydrated = useRef(false);
   const filteredProjections = useMemo(
     () => filterOperationsMapProjections(projections, { sources: sourceFilters, severities: severityFilters }),
@@ -232,6 +238,19 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
       },
     });
   }, [activeQuickViewId, sourceFilters, severityFilters]);
+
+  useEffect(() => {
+    setDimension(loadOperationsMapDimension());
+    dimensionHydrated.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!dimensionHydrated.current) return;
+    saveOperationsMapDimension(dimension);
+  }, [dimension]);
+
+  const showProvider = dimension === "provider" || dimension === "both";
+  const showA2a = dimension === "a2a" || dimension === "both";
 
   const selectedStation = selected.kind === "station"
     ? template.stations.find((station) => station.id === selected.id) ?? null
@@ -274,15 +293,21 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
           </p>
         </header>
 
-        <RoutingTopologyPanel routingTopology={routingTopology} />
+        <DimensionToggle dimension={dimension} onChange={setDimension} />
 
-        <A2aInteractionsPanel
-          coworkers={routingTopology.coworkers}
-          a2aEdges={routingTopology.a2aEdges}
-          a2aLegend={routingTopology.a2aLegend}
-        />
+        {showProvider ? <RoutingTopologyPanel routingTopology={routingTopology} /> : null}
 
-        <DeliberationLensPanel deliberations={routingTopology.deliberations} />
+        {showA2a ? (
+          <>
+            <A2aInteractionsPanel
+              coworkers={routingTopology.coworkers}
+              a2aEdges={routingTopology.a2aEdges}
+              a2aLegend={routingTopology.a2aLegend}
+            />
+
+            <DeliberationLensPanel deliberations={routingTopology.deliberations} />
+          </>
+        ) : null}
       </section>
 
       <details
@@ -2402,6 +2427,53 @@ function routingViewBox(zoomLevel: number): string {
 function svgLabel(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+const DIMENSION_OPTIONS: Array<{ id: OperationsMapDimension; label: string; hint: string }> = [
+  { id: "both", label: "Both", hint: "Provider routing + coworker interactions" },
+  { id: "provider", label: "Provider routes", hint: "Provider routing only" },
+  { id: "a2a", label: "A2A interactions", hint: "Coworker-to-coworker interactions only" },
+];
+
+function DimensionToggle({
+  dimension,
+  onChange,
+}: {
+  dimension: OperationsMapDimension;
+  onChange: (dimension: OperationsMapDimension) => void;
+}) {
+  const active = DIMENSION_OPTIONS.find((option) => option.id === dimension) ?? DIMENSION_OPTIONS[0];
+  return (
+    <div
+      role="group"
+      aria-label="Operations map dimension"
+      className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2"
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+        Dimension
+      </span>
+      <div className="inline-flex rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-0.5">
+        {DIMENSION_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={dimension === option.id}
+            title={option.hint}
+            onClick={() => onChange(option.id)}
+            className={[
+              "min-h-7 rounded-full px-3 py-1 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]",
+              dimension === option.id
+                ? "bg-[var(--dpf-accent-soft)] font-medium text-[var(--dpf-text)]"
+                : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+            ].join(" ")}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <span className="text-xs text-[var(--dpf-muted)]">{active.hint}</span>
+    </div>
+  );
 }
 
 function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {

--- a/apps/web/components/platform/ai-operations-map-prefs.test.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.test.ts
@@ -2,16 +2,20 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getOperationsMapQuickViewFilters } from "@/lib/ai-operations-map/project-events";
 import {
   clearA2aFilterPreference,
+  clearOperationsMapDimension,
   clearOperationsMapViewPreference,
   deleteOperationsMapSavedView,
   getDefaultA2aFilterPreference,
   loadA2aFilterPreference,
+  loadOperationsMapDimension,
   loadOperationsMapViewPreference,
   loadOperationsMapSavedViews,
   OPERATIONS_MAP_A2A_PREFERENCE_KEY,
+  OPERATIONS_MAP_DIMENSION_KEY,
   OPERATIONS_MAP_SAVED_VIEWS_KEY,
   OPERATIONS_MAP_VIEW_PREFERENCE_KEY,
   saveA2aFilterPreference,
+  saveOperationsMapDimension,
   saveOperationsMapViewPreference,
   upsertOperationsMapSavedView,
 } from "./ai-operations-map-prefs";
@@ -232,5 +236,22 @@ describe("AI operations map preferences", () => {
     saveA2aFilterPreference(getDefaultA2aFilterPreference());
     clearA2aFilterPreference();
     expect(store.has(OPERATIONS_MAP_A2A_PREFERENCE_KEY)).toBe(false);
+  });
+
+  it("defaults the dimension to both and round-trips a stored choice", () => {
+    expect(loadOperationsMapDimension()).toBe("both");
+    saveOperationsMapDimension("a2a");
+    expect(store.has(OPERATIONS_MAP_DIMENSION_KEY)).toBe(true);
+    expect(loadOperationsMapDimension()).toBe("a2a");
+    saveOperationsMapDimension("provider");
+    expect(loadOperationsMapDimension()).toBe("provider");
+  });
+
+  it("falls back to both for an unknown stored dimension and clears cleanly", () => {
+    store.set(OPERATIONS_MAP_DIMENSION_KEY, "bogus");
+    expect(loadOperationsMapDimension()).toBe("both");
+    saveOperationsMapDimension("a2a");
+    clearOperationsMapDimension();
+    expect(store.has(OPERATIONS_MAP_DIMENSION_KEY)).toBe(false);
   });
 });

--- a/apps/web/components/platform/ai-operations-map-prefs.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.ts
@@ -88,6 +88,47 @@ export function clearA2aFilterPreference(): void {
   }
 }
 
+// ─── Operations Map dimension toggle (Provider routes · A2A · Both) ───────
+// Lets the operator focus the map on provider routing, coworker-to-coworker
+// (A2A) interactions, or both. Defaults to "both" (the full surface).
+
+export const OPERATIONS_MAP_DIMENSION_KEY = "ai-operations-map:dimension";
+
+export type OperationsMapDimension = "provider" | "a2a" | "both";
+
+const OPERATIONS_MAP_DIMENSIONS = new Set<OperationsMapDimension>(["provider", "a2a", "both"]);
+
+export function getDefaultOperationsMapDimension(): OperationsMapDimension {
+  return "both";
+}
+
+export function loadOperationsMapDimension(): OperationsMapDimension {
+  try {
+    const raw = localStorage.getItem(OPERATIONS_MAP_DIMENSION_KEY);
+    return OPERATIONS_MAP_DIMENSIONS.has(raw as OperationsMapDimension)
+      ? (raw as OperationsMapDimension)
+      : getDefaultOperationsMapDimension();
+  } catch {
+    return getDefaultOperationsMapDimension();
+  }
+}
+
+export function saveOperationsMapDimension(dimension: OperationsMapDimension): void {
+  try {
+    localStorage.setItem(OPERATIONS_MAP_DIMENSION_KEY, dimension);
+  } catch {
+    // localStorage can be unavailable or full; the map remains usable without persistence.
+  }
+}
+
+export function clearOperationsMapDimension(): void {
+  try {
+    localStorage.removeItem(OPERATIONS_MAP_DIMENSION_KEY);
+  } catch {
+    // localStorage can be unavailable; resetting in-memory state still keeps the map usable.
+  }
+}
+
 export type OperationsMapStoredQuickViewId = OperationsMapQuickViewId | "custom";
 
 export type OperationsMapViewPreference = {


### PR DESCRIPTION
## What

Slice 2B (first increment). Adds a top-level **Provider routes · A2A interactions · Both** dimension toggle to the AI Operations Map so an operator can focus the surface — provider routing only, coworker-to-coworker (A2A) interactions only, or both (default). A step toward the "one cohesive operations surface" target in the design.

Backlog: **BI-65B0D697** (EP-AI-OPSMAP), Slice 2B.

## How

- **prefs** — `load/save/clearOperationsMapDimension` (`provider` | `a2a` | `both`, default `both`) with validation.
- **AiOperationsMap** — `DimensionToggle` segmented control; `showProvider` / `showA2a` conditionally render the provider routing band vs the A2A interaction panel + deliberation lens; choice hydrates/persists via the dimension preference.
- **tests** — dimension prefs round-trip; AiOperationsMap source-assertion for the toggle, options, conditional render, and persistence wiring.

## Verification

- `pnpm --filter web test` — 9557 passed, 0 test failures. (The run reports 1 pre-existing unrelated unhandled-rejection flake in `lib/actions/build-governed.test.ts` — already flagged for hardening; not from this change.)
- `pnpm --filter web typecheck` — clean (after regenerating the worktree Prisma client, which was stale vs main; a harness concern, not a code change). CI is the binding gate.

## Notes

- Read-only, additive. No new DB models or migrations.
- **Stacked on #1473** (deliberation lens) so the toggle can govern all three panels — this PR shows the deliberation commit too until #1473 merges. Merge #1473 first; this then rebases to a clean single-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
