### PR TITLE
fix: suppress backlog MCP test teardown logs

### DIFF
--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.spyOn(console, "log").mockImplementation(() => undefined);
+vi.spyOn(console, "info").mockImplementation(() => undefined);
+
 const { mockPrisma, mockInngest } = vi.hoisted(() => ({
   mockPrisma: {
     backlogItem: {


### PR DESCRIPTION
## Summary
- Suppresses noisy MCP trace console output inside `mcp-tools-backlog.test.ts` so Vitest does not fail during worker teardown after passing assertions.
- Keeps production MCP logging unchanged; this is a test harness fix for the backlog tool suite.

## Test plan
- [x] Clean-main reproduction before fix: `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts` failed after 15 passing tests with `EnvironmentTeardownError`.
- [x] Worktree source-local: `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts` - 15 passed, no teardown error.
- [x] Worktree source-local: `pnpm --filter web typecheck` - passed.
- [x] Shared local-CI convergence sandbox lease `NPEL-7CA1DB1496`: `node scripts/local-integration-ci.mjs --candidate fix/mcp-backlog-vitest-teardown` passed; evidence `cmq0yum7z0h9m01li4j0eicvu`.
- [x] Shared local-CI details: merge rehearsal onto `origin/main`, full web Vitest `1136 passed | 4 skipped`, web typecheck passed, Docker production build target completed.