### PR TITLE
fix: make health lag test deterministic

### DIFF
--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -47,16 +47,10 @@ describe("GET /api/health", () => {
   });
 
   it("returns 503 with eventLoop:lagging when lag exceeds threshold (BI-9F106818)", async () => {
-    // Override the threshold to 1ms so any lag triggers the check.
-    process.env["EVENT_LOOP_LAG_THRESHOLD_MS"] = "1";
+    // Force the event-loop guard branch without relying on host timer
+    // granularity. A 0ms timeout can resolve with either 0ms or 1ms lag.
+    process.env["EVENT_LOOP_LAG_THRESHOLD_MS"] = "-1";
     mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
-
-    // Spin the CPU for 5ms synchronously so the setTimeout probe actually
-    // fires late. This is the simplest way to reliably produce real lag in
-    // a test without fake timers (which don't intercept a module's captured
-    // native setTimeout reference).
-    const spin = Date.now();
-    while (Date.now() - spin < 5) { /* busy-wait */ }
 
     const res = await GET();
     const body = await res.json();


### PR DESCRIPTION
## Summary
- Makes the health-route event-loop lag test deterministic by forcing the guard branch through the existing threshold override.
- Removes the busy-wait/timer-granularity dependency that can pass locally but fail in the full Vitest suite when the measured lag is 0ms.
- Leaves production `/api/health` behavior unchanged.

## Test plan
- [x] Worktree source-local: `pnpm --filter web exec vitest run app/api/health/route.test.ts` - 3 passed.
- [x] Worktree source-local: five-run PowerShell loop around `pnpm --filter web exec vitest run app/api/health/route.test.ts` - all passed.
- [x] Worktree source-local: `pnpm --filter web typecheck` - passed.
- [x] Shared local-CI convergence sandbox lease `NPEL-19DCBAE055`: `node scripts/local-integration-ci.mjs --candidate fix/health-event-loop-test-determinism` passed.
- [x] Shared local-CI details: merge rehearsal onto `origin/main`, full web Vitest `1136 passed | 4 skipped`, web typecheck passed, Docker production build target completed.