### PR TITLE
feat: drive customer tabs from navigation model

### DIFF
--- a/apps/web/app/(shell)/customer/layout.tsx
+++ b/apps/web/app/(shell)/customer/layout.tsx
@@ -1,7 +1,7 @@
 // apps/web/app/(shell)/customer/layout.tsx
 import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
-import { can } from "@/lib/permissions";
+import { can, getAccessibleSectionNavEntries } from "@/lib/permissions";
 import { CustomerTabNav } from "@/components/customer/CustomerTabNav";
 
 export default async function CustomerLayout({
@@ -25,19 +25,10 @@ export default async function CustomerLayout({
     notFound();
   }
 
-  const tabs = [
-    ...(canViewCustomer
-      ? [
-          { label: "Accounts", href: "/customer" },
-          { label: "Engagements", href: "/customer/engagements" },
-          { label: "Pipeline", href: "/customer/opportunities" },
-          { label: "Quotes", href: "/customer/quotes" },
-          { label: "Orders", href: "/customer/sales-orders" },
-          { label: "Funnel", href: "/customer/funnel" },
-        ]
-      : []),
-    ...(canViewMarketing ? [{ label: "Marketing", href: "/customer/marketing" }] : []),
-  ];
+  const tabs = getAccessibleSectionNavEntries(access, "/customer").map((entry) => ({
+    label: entry.label,
+    href: entry.href,
+  }));
 
   return (
     <div>

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   can,
   canAccessEmployeeRecord,
+  getAccessibleSectionNavEntries,
   getShellNavSections,
   getWorkspaceSections,
   getWorkspaceTiles,
@@ -101,6 +102,30 @@ describe("getShellNavSections()", () => {
       "knowledge",
     ]);
     expect(sections.find((section) => section.key === "platform")).toBeUndefined();
+  });
+});
+
+describe("getAccessibleSectionNavEntries()", () => {
+  it("builds customer domain tabs from the canonical navigation model", () => {
+    const tabs = getAccessibleSectionNavEntries(hr000, "/customer");
+
+    expect(tabs.map((tab) => tab.label)).toEqual([
+      "Accounts",
+      "Engagements",
+      "Pipeline",
+      "Quotes",
+      "Orders",
+      "Funnel",
+      "Marketing",
+    ]);
+    expect(tabs.map((tab) => tab.href)).toContain("/customer/marketing");
+  });
+
+  it("keeps marketing reachable for marketing-only users without exposing CRM tabs", () => {
+    const tabs = getAccessibleSectionNavEntries(hr300, "/customer");
+
+    expect(tabs.map((tab) => tab.label)).toEqual(["Marketing"]);
+    expect(tabs[0]?.href).toBe("/customer/marketing");
   });
 });
 

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -4,6 +4,7 @@ import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context
 import { canAccessEmployeeScope } from "./manager-scope";
 import {
   getShellNavEntries,
+  getSectionNavEntries,
   type PortalShellSectionKey,
 } from "../navigation/portal-navigation-model";
 
@@ -124,6 +125,13 @@ export type ShellNavItem = {
   href: string;
   description: string;
   sectionKey: PortalShellSectionKey;
+  capabilityKey: CapabilityKey | null;
+};
+
+export type SectionNavItem = {
+  key: string;
+  label: string;
+  href: string;
   capabilityKey: CapabilityKey | null;
 };
 
@@ -249,6 +257,20 @@ export function getShellNavSections(user: UserContext): ShellNavSection[] {
     ...section,
     items: SHELL_ITEMS.filter((item) => item.sectionKey === section.key && isAllowed(user, item.capabilityKey)),
   })).filter((section) => section.items.length > 0);
+}
+
+export function getAccessibleSectionNavEntries(
+  user: UserContext,
+  path: string,
+): SectionNavItem[] {
+  return getSectionNavEntries(path)
+    .filter((entry) => isAllowed(user, entry.capabilityKey))
+    .map((entry) => ({
+      key: entry.key,
+      label: entry.label,
+      href: entry.path,
+      capabilityKey: entry.capabilityKey,
+    }));
 }
 
 export function getWorkspaceSections(user: UserContext): WorkspaceSection[] {

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -37,6 +37,7 @@ export type PortalNavRecord = {
   destinationKind: PortalDestinationKind;
   capabilityKey?: CapabilityKey | null;
   primaryOrder?: number;
+  sectionNavLabel?: string;
   shellNav?: {
     sectionKey: PortalShellSectionKey;
     label?: string;
@@ -101,6 +102,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   {
     key: "customer",
     label: "Customer",
+    sectionNavLabel: "Accounts",
     path: "/customer",
     parentPath: "/customer",
     domain: "business",
@@ -135,6 +137,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   {
     key: "customer-opportunities",
     label: "Opportunities",
+    sectionNavLabel: "Pipeline",
     path: "/customer/opportunities",
     parentPath: "/customer",
     domain: "customer",
@@ -155,6 +158,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   {
     key: "customer-sales-orders",
     label: "Sales Orders",
+    sectionNavLabel: "Orders",
     path: "/customer/sales-orders",
     parentPath: "/customer",
     domain: "customer",
@@ -771,6 +775,13 @@ function toEntry(route: PortalNavRecord): PortalNavEntry {
   };
 }
 
+function toSectionEntry(route: PortalNavRecord): PortalNavEntry {
+  return {
+    ...toEntry(route),
+    label: route.sectionNavLabel ?? route.label,
+  };
+}
+
 export function getRouteNavRecord(path: string): PortalNavRecord | undefined {
   return ROUTES_BY_PATH.get(normalizePath(path));
 }
@@ -798,7 +809,7 @@ export function getSectionNavEntries(path: string): PortalNavEntry[] {
     .map((siblingPath) => getRouteNavRecord(siblingPath))
     .filter((entry): entry is PortalNavRecord => entry !== undefined)
     .filter((entry) => entry.destinationKind !== "legacy-redirect")
-    .map(toEntry);
+    .map(toSectionEntry);
 }
 
 export function getShellNavEntries(): PortalShellNavEntry[] {

--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -2,12 +2,14 @@ import {
   PERMISSIONS as GOVERN_PERMISSIONS,
   can as governCan,
   canAccessEmployeeRecord,
+  getAccessibleSectionNavEntries,
   getDeniedCapabilities as governGetDeniedCapabilities,
   getGrantedCapabilities as governGetGrantedCapabilities,
   getShellNavSections,
   getWorkspaceSections,
   getWorkspaceTiles,
   type PlatformRoleId,
+  type SectionNavItem,
   type ShellNavItem,
   type ShellNavSection,
   type UserContext,
@@ -17,6 +19,7 @@ import {
 
 export type {
   PlatformRoleId,
+  SectionNavItem,
   ShellNavItem,
   ShellNavSection,
   UserContext,
@@ -52,6 +55,7 @@ export function can(user: UserContext, capability: CapabilityKey): boolean {
 
 export {
   canAccessEmployeeRecord,
+  getAccessibleSectionNavEntries,
   getShellNavSections,
   getWorkspaceSections,
   getWorkspaceTiles,


### PR DESCRIPTION
## Summary
- Drives the customer CRM tab bar from the canonical portal navigation model instead of a hand-built list in the customer shell layout.
- Adds section-specific labels so the user-facing tabs read as CRM work areas: Accounts, Engagements, Pipeline, Quotes, Orders, Funnel, Marketing.
- Reuses the existing permission gate for section navigation, so limited users only see the tabs they are allowed to use, including marketing-only access.

## UX / architecture notes
- This is the visible shell slice needed before the Pipedrive-inspired CRM/marketing/sales workflow can be used coherently.
- The customer workspace now has one canonical source for route inventory and section tabs, reducing future drift between routing, permissions, and UI navigation.

## Test plan
- [x] Worktree source-local: `pnpm --filter web exec vitest run lib/govern/permissions.test.ts` - 28 passed.
- [x] Worktree source-local: `pnpm --filter web exec vitest run components/customer/CustomerTabNav.test.tsx` - 4 passed.
- [x] Worktree source-local: `pnpm --filter web exec vitest run lib/navigation/portal-navigation-model.test.ts` - 7 passed.
- [x] Worktree source-local: `pnpm --filter web typecheck` - passed.
- [x] Shared local-CI convergence sandbox lease `NPEL-F323A83252`: `node scripts/local-integration-ci.mjs --candidate feat/portal-navigation-shell-model` passed.
- [x] Shared local-CI details: merge rehearsal onto `origin/main`, full web Vitest `1136 passed | 4 skipped`, web typecheck passed, Docker production build target completed.