### PR TITLE
fix(test): repair golden-decision baseline parser (broken Unit Tests on main)

### DIFF
--- a/apps/web/lib/decision/golden-decisions.test.ts
+++ b/apps/web/lib/decision/golden-decisions.test.ts
@@ -16,9 +16,9 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { parseWikiFrontmatter, type WikiPageFrontmatter } from "@dpf/db";
 import {
   GOLDEN_SCENARIOS,
+  parsePrinciplePage,
   scoreScenario,
   selectKernelCommandments,
   type ParsedPrinciplePage,
@@ -37,16 +37,10 @@ function loadCorpus(): ParsedPrinciplePage[] {
   const pages: ParsedPrinciplePage[] = [];
   for (const file of files) {
     const raw = readFileSync(`${PRINCIPLES_DIR}/${file}`, "utf8");
-    const { frontmatter } = parseWikiFrontmatter<WikiPageFrontmatter>(raw);
-    if (frontmatter.pageKind !== "principle") continue;
-    if (frontmatter.status && frontmatter.status !== "published") continue;
-    pages.push({
-      slug: file.replace(/\.md$/, ""),
-      principleTier: frontmatter.principleTier,
-      principleAppliesTo: frontmatter.principleAppliesTo,
-      principleDimensionVector: frontmatter.principleDimensionVector,
-      principleWeight: frontmatter.principleWeight,
-    });
+    const page = parsePrinciplePage(raw, file.replace(/\.md$/, ""));
+    if (page.pageKind !== "principle") continue;
+    if (page.status && page.status !== "published") continue;
+    pages.push(page);
   }
   return pages;
 }

--- a/apps/web/lib/decision/golden-decisions.ts
+++ b/apps/web/lib/decision/golden-decisions.ts
@@ -21,11 +21,61 @@ import { decide, type DecisionOption, type DecisionPrinciple, type DecisionResul
 // ─── Parsed-page shape (subset of WikiPage frontmatter we score against) ─────
 export type ParsedPrinciplePage = {
   slug: string;
+  pageKind?: string;
+  status?: string;
   principleTier?: string;
   principleAppliesTo?: string[];
   principleDimensionVector?: Record<string, number>;
   principleWeight?: number;
 };
+
+// ─── Minimal frontmatter parser ──────────────────────────────────────────────
+// Deterministic, self-contained parse of the SUBSET of principle frontmatter
+// this baseline scores against. Intentionally does NOT depend on the @dpf/db
+// `parseWikiFrontmatter` barrel — importing that heavy package barrel into an
+// apps/web vitest module resolves the named export to undefined under Vite's
+// SSR transform. The founder-kernel principle files use block-style lists and
+// single-line inline-JSON vectors, both handled here; mirrors the canonical
+// parser for these fields. Pure (string in, data out) — fs lives in the test.
+export function parsePrinciplePage(raw: string, slug: string): ParsedPrinciplePage {
+  const fmMatch = raw.replace(/\r\n/g, "\n").match(/^---\n([\s\S]*?)\n---/);
+  const fm = fmMatch ? fmMatch[1] : "";
+  const scalar = (key: string): string | undefined => {
+    const m = fm.match(new RegExp(`^${key}:(.*)$`, "m"));
+    if (!m) return undefined;
+    const v = m[1].trim().replace(/^["']|["']$/g, "");
+    return v.length ? v : undefined;
+  };
+  const blockList = (key: string): string[] => {
+    const lines = fm.split("\n");
+    const idx = lines.findIndex((l) => l === `${key}:` || l.startsWith(`${key}:`));
+    if (idx < 0) return [];
+    const inline = lines[idx].match(new RegExp(`^${key}:\\s*\\[(.*)\\]`));
+    if (inline) return inline[1].split(",").map((s) => s.trim().replace(/['"]/g, "")).filter(Boolean);
+    const out: string[] = [];
+    for (let j = idx + 1; j < lines.length; j++) {
+      const m = lines[j].match(/^\s+-\s+(.+?)\s*$/);
+      if (!m) { if (/^\S/.test(lines[j])) break; else continue; }
+      out.push(m[1].replace(/['"]/g, ""));
+    }
+    return out;
+  };
+  let principleDimensionVector: Record<string, number> | undefined;
+  const vecMatch = fm.match(/^principleDimensionVector:\s*(\{.*\})\s*$/m);
+  if (vecMatch) {
+    try { principleDimensionVector = JSON.parse(vecMatch[1]); } catch { /* leave undefined */ }
+  }
+  const weightStr = scalar("principleWeight");
+  return {
+    slug,
+    pageKind: scalar("pageKind"),
+    status: scalar("status"),
+    principleTier: scalar("principleTier"),
+    principleAppliesTo: blockList("principleAppliesTo"),
+    principleDimensionVector,
+    principleWeight: weightStr !== undefined ? Number(weightStr) : undefined,
+  };
+}
 
 const TIER_DEFAULT_WEIGHT: Record<string, number> = {
   commandment: 1.0,


### PR DESCRIPTION
## Urgent: fixes a broken Unit Tests gate on `main`

PR #1493 merged at its first commit, which imported `parseWikiFrontmatter` from the `@dpf/db` barrel. That barrel resolves the named export to `undefined` under vitest's Vite SSR transform, so `golden-decisions.test.ts` throws at collection time ("0 test") and **Unit Tests fails on main**. The fix commit landed on the branch *after* the merge, so it never reached main. This PR brings it in.

## Fix

- Replace the `@dpf/db` barrel import with a small, deterministic, self-contained frontmatter parser (`parsePrinciplePage`) for the subset of principle fields the baseline scores against — no cross-package barrel dependency.
- Fix scalar field extraction to `.trim()` the value (it was returning `" principle"`, failing the `pageKind` filter and loading 0 commandments).

## Verified against the real corpus (standalone, mirroring the committed parser)

```
commandments loaded: 20, proper-fix present: true, arch present: true
PASS quick-vs-proper-normal: winner=proper-seed-fix  [10.117, 8.182]  margin 1.935
PASS cheap-sound-vs-rebuild-guard: winner=cheap-sound-additive  [11.137, 10.196]  margin 0.941
```

(vitest itself runs in CI — `node_modules` is absent in the worktree. This PR's Unit Tests run is the real confirmation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
