### PR TITLE
feat(ai-ops-map): shared replay window across provider routing + A2A band (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/A2aInteractionsPanel.test.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.test.tsx
@@ -136,4 +136,30 @@ describe("A2aInteractionsPanel", () => {
     expect(inspector.textContent).toContain("brand:read");
     expect(inspector.textContent).toContain("brand-extract");
   });
+
+  it("scrubs in lock-step with the shared replay playhead", () => {
+    const range = { start: 0, current: 60 * 60 * 1000, end: 100 * 60 * 1000 };
+    const at = (min: number) => new Date(min * 60 * 1000).toISOString();
+    const edges = [
+      edge({ id: "early", occurredAt: at(40) }),
+      edge({ id: "late", occurredAt: at(58), toCoworkerId: "reviewer" }),
+    ];
+
+    // Playhead at "current" → both visible, no synced banner.
+    const atNow = render(
+      <A2aInteractionsPanel coworkers={COWORKERS} a2aEdges={edges} a2aLegend={LEGEND} replayTime={range.current} replayRange={range} />,
+    );
+    expect(atNow.container.querySelectorAll("[data-a2a-edge]").length).toBe(2);
+    expect(atNow.container.querySelector("[data-a2a-replay-synced]")).toBeNull();
+    cleanup();
+
+    // Scrubbed back to 50min → only the edge at 40min has occurred; the 58min
+    // edge is in the future and hidden, and the synced banner appears.
+    const scrubbed = render(
+      <A2aInteractionsPanel coworkers={COWORKERS} a2aEdges={edges} a2aLegend={LEGEND} replayTime={50 * 60 * 1000} replayRange={range} />,
+    );
+    const visible = scrubbed.container.querySelectorAll("[data-a2a-edge]");
+    expect(visible.length).toBe(1);
+    expect(scrubbed.container.querySelector("[data-a2a-replay-synced]")).not.toBeNull();
+  });
 });

--- a/apps/web/components/platform/A2aInteractionsPanel.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.tsx
@@ -16,7 +16,9 @@ import {
   A2A_GRAPH_LAYOUT,
   A2A_STATES,
   a2aEdgeSourceRecords,
+  a2aEdgeVisibleAtReplayTime,
   a2aStateIntent,
+  type A2aReplayRange,
   columnPositions,
   coworkerHref,
   EDGE_KIND_LABEL,
@@ -41,9 +43,12 @@ type Props = {
   coworkers: OperationsMapRoutingCoworker[];
   a2aEdges: OperationsMapA2aEdge[];
   a2aLegend: OperationsMapA2aLegendItem[];
+  /** Shared replay playhead from the provider routing timeline (null = no sync). */
+  replayTime?: number | null;
+  replayRange?: A2aReplayRange | null;
 };
 
-export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend }: Props) {
+export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTime, replayRange }: Props) {
   const defaults = getDefaultA2aFilterPreference();
   const [typeFilters, setTypeFilters] = useState<OperationsMapA2aEdgeKind[]>(defaults.types);
   const [stateFilters, setStateFilters] = useState<OperationsMapA2aInteractionState[]>(defaults.states);
@@ -86,6 +91,10 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend }: Props) 
     return orderedUnique([...ids], labelFor);
   }, [a2aEdges, labelFor]);
 
+  // Active only while the provider routing timeline has been scrubbed back from
+  // "now"; at the default playhead position every recent interaction stays visible.
+  const replaySynced = replayTime != null && replayRange != null && replayTime < replayRange.current;
+
   const filteredEdges = useMemo(
     () =>
       a2aEdges.filter((edge) => {
@@ -98,9 +107,12 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend }: Props) 
           if (actorRole === "to" && !matchesTo) return false;
           if (actorRole === "either" && !matchesFrom && !matchesTo) return false;
         }
+        if (replayTime != null && replayRange != null && !a2aEdgeVisibleAtReplayTime(edge.occurredAt, replayTime, replayRange)) {
+          return false;
+        }
         return true;
       }),
-    [a2aEdges, typeFilters, stateFilters, actorId, actorRole],
+    [a2aEdges, typeFilters, stateFilters, actorId, actorRole, replayTime, replayRange],
   );
 
   const selectedEdge = filteredEdges.find((edge) => edge.id === selectedEdgeId) ?? null;
@@ -138,6 +150,14 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend }: Props) 
             coworker, under what authority, and how it resolved. Filter by interaction type, state, and coworker for
             audit and troubleshooting.
           </p>
+          {replaySynced ? (
+            <p
+              data-a2a-replay-synced
+              className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-[var(--dpf-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--dpf-text)]"
+            >
+              Synced to the routing replay timeline — showing interactions up to the selected time.
+            </p>
+          ) : null}
         </div>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <StatCard label="Interactions" value={filteredEdges.length} intent="accent" />

--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -195,7 +195,8 @@ describe("AiOperationsMap", () => {
     // Conditional rendering of the provider band vs the A2A panels.
     expect(source).toContain("showProvider");
     expect(source).toContain("showA2a");
-    expect(source).toContain("showProvider ? <RoutingTopologyPanel");
+    expect(source).toContain("showProvider ? (");
+    expect(source).toContain("<RoutingTopologyPanel");
     expect(source).toContain("showA2a ? (");
     expect(source).toContain("<A2aInteractionsPanel");
     expect(source).toContain("<DeliberationLensPanel");
@@ -203,5 +204,19 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("loadOperationsMapDimension");
     expect(source).toContain("saveOperationsMapDimension");
     expect(source).toContain("dimensionHydrated");
+  });
+
+  it("shares the replay playhead between the provider timeline and the A2A band", () => {
+    const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
+
+    // Provider panel publishes the playhead up via a stable callback.
+    expect(source).toContain("onReplayChange");
+    expect(source).toContain("onReplayChange?.(selectedReplayTime, timelineRange)");
+    expect(source).toContain("handleReplayChange");
+    expect(source).toContain("useCallback");
+    expect(source).toContain("setSharedReplay");
+    // A2A band receives the shared replay window.
+    expect(source).toContain("replayTime={showProvider ? sharedReplay?.time ?? null : null}");
+    expect(source).toContain("replayRange={showProvider ? sharedReplay?.range ?? null : null}");
   });
 });

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type SyntheticEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import {
   RotateCcw,
@@ -252,6 +252,14 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
   const showProvider = dimension === "provider" || dimension === "both";
   const showA2a = dimension === "a2a" || dimension === "both";
 
+  // Shared replay window: the provider routing panel owns the timeline and
+  // publishes its playhead here so the A2A interaction band scrubs in step.
+  const [sharedReplay, setSharedReplay] = useState<{ time: number; range: RoutingTimelineRange } | null>(null);
+  const handleReplayChange = useCallback(
+    (time: number, range: RoutingTimelineRange) => setSharedReplay({ time, range }),
+    [],
+  );
+
   const selectedStation = selected.kind === "station"
     ? template.stations.find((station) => station.id === selected.id) ?? null
     : null;
@@ -295,7 +303,9 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
 
         <DimensionToggle dimension={dimension} onChange={setDimension} />
 
-        {showProvider ? <RoutingTopologyPanel routingTopology={routingTopology} /> : null}
+        {showProvider ? (
+          <RoutingTopologyPanel routingTopology={routingTopology} onReplayChange={handleReplayChange} />
+        ) : null}
 
         {showA2a ? (
           <>
@@ -303,6 +313,8 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
               coworkers={routingTopology.coworkers}
               a2aEdges={routingTopology.a2aEdges}
               a2aLegend={routingTopology.a2aLegend}
+              replayTime={showProvider ? sharedReplay?.time ?? null : null}
+              replayRange={showProvider ? sharedReplay?.range ?? null : null}
             />
 
             <DeliberationLensPanel deliberations={routingTopology.deliberations} />
@@ -500,7 +512,13 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
   );
 }
 
-function RoutingTopologyPanel({ routingTopology }: { routingTopology: OperationsMapRoutingTopology }) {
+function RoutingTopologyPanel({
+  routingTopology,
+  onReplayChange,
+}: {
+  routingTopology: OperationsMapRoutingTopology;
+  onReplayChange?: (selectedTime: number, range: RoutingTimelineRange) => void;
+}) {
   const mapShellRef = useRef<HTMLDivElement>(null);
   const pinnedMarkerRef = useRef<string | null>(null);
   const [routeFilter, setRouteFilter] = useState<RoutingRouteFilter>("all");
@@ -523,6 +541,14 @@ function RoutingTopologyPanel({ routingTopology }: { routingTopology: Operations
     [baseTimelineRange, timelineWindowAnchor, timelineZoomLevel],
   );
   const selectedTimelinePercent = timelineMarkerPosition(selectedReplayTime, timelineRange);
+
+  // Publish the replay playhead so the A2A interaction band can scrub in
+  // lock-step (shared replay window). Fires only when the playhead or window
+  // actually changes; the parent's handler is stable (useCallback).
+  useEffect(() => {
+    onReplayChange?.(selectedReplayTime, timelineRange);
+  }, [onReplayChange, selectedReplayTime, timelineRange]);
+
   const providersById = useMemo(
     () => new Map(routingTopology.providers.map((provider) => [provider.providerId, provider])),
     [routingTopology.providers],

--- a/apps/web/components/platform/a2a-interaction-graph.test.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   A2A_GRAPH_LAYOUT,
   a2aEdgeSourceRecords,
+  a2aEdgeVisibleAtReplayTime,
   a2aStateIntent,
   columnPositions,
   coworkerHref,
@@ -104,6 +105,28 @@ describe("a2a-interaction-graph helpers", () => {
   it("builds coworker detail hrefs", () => {
     expect(coworkerHref("brand-analyst")).toBe("/platform/ai/agent/brand-analyst");
     expect(coworkerHref("a/b")).toBe("/platform/ai/agent/a%2Fb");
+  });
+
+  it("shares the replay playhead with the provider timeline", () => {
+    // span = 100 min → window = max(45min, 20%*100min=20min) = 45min.
+    const range = { start: 0, current: 60 * 60 * 1000, end: 100 * 60 * 1000 };
+    const at = (min: number) => new Date(min * 60 * 1000).toISOString();
+
+    // Playhead at/after "current" → everything recent is visible.
+    expect(a2aEdgeVisibleAtReplayTime(at(10), range.current, range)).toBe(true);
+    expect(a2aEdgeVisibleAtReplayTime(at(90), range.current + 5, range)).toBe(true);
+
+    // Scrubbed back to t=50min: an edge at 48min is within the 45min window and
+    // has already occurred → visible; an edge at 55min hasn't occurred yet → hidden.
+    const t50 = 50 * 60 * 1000;
+    expect(a2aEdgeVisibleAtReplayTime(at(48), t50, range)).toBe(true);
+    expect(a2aEdgeVisibleAtReplayTime(at(55), t50, range)).toBe(false);
+    // An edge at 2min is older than the 45min look-back from t=50 → hidden.
+    expect(a2aEdgeVisibleAtReplayTime(at(2), t50, range)).toBe(false);
+
+    // Undated / unparseable interactions are always visible.
+    expect(a2aEdgeVisibleAtReplayTime(null, t50, range)).toBe(true);
+    expect(a2aEdgeVisibleAtReplayTime("not-a-date", t50, range)).toBe(true);
   });
 
   it("clips long labels and titleizes ids", () => {

--- a/apps/web/components/platform/a2a-interaction-graph.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.ts
@@ -155,6 +155,35 @@ export function a2aEdgeSourceRecords(edge: OperationsMapA2aEdge): A2aSourceRecor
   return records;
 }
 
+// ─── Shared replay window ─────────────────────────────────────────────
+// Lets the A2A interaction band scrub in lock-step with the provider routing
+// replay timeline. Mirrors AiOperationsMap's routeVisibleAtReplayTime so both
+// dimensions share one playhead: at/after "current" everything recent shows;
+// scrubbing back reveals only interactions that had occurred by the playhead.
+
+export type A2aReplayRange = { start: number; current: number; end: number };
+
+/** Look-back window around the playhead — max(45min, 20% of the visible span). */
+export function a2aReplayWindow(range: A2aReplayRange): number {
+  return Math.max(1000 * 60 * 45, (range.end - range.start) * 0.2);
+}
+
+export function a2aEdgeVisibleAtReplayTime(
+  occurredAt: string | null,
+  selectedTime: number,
+  range: A2aReplayRange,
+): boolean {
+  if (!occurredAt) return true; // undated interactions are always visible
+  const ts = Date.parse(occurredAt);
+  if (!Number.isFinite(ts)) return true;
+  // Playhead at or ahead of "now" → show all recent interactions (default).
+  if (selectedTime >= range.current) return true;
+  // Scrubbed back in time → only interactions that had occurred by the
+  // playhead, and only within the look-back window.
+  if (selectedTime < ts) return false;
+  return selectedTime - ts <= a2aReplayWindow(range);
+}
+
 export function svgClip(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, Math.max(0, maxLength - 1))}…`;


### PR DESCRIPTION
## What

Slice 2B. Makes the coworker-to-coworker (A2A) interaction band scrub **in lock-step with the provider routing replay timeline** — one playhead now governs both dimensions of the Operations Map, a major step toward the "one cohesive surface" target.

Backlog: **BI-65B0D697** (EP-AI-OPSMAP), Slice 2B.

## How

- **pure helper** `a2aEdgeVisibleAtReplayTime` (mirrors `routeVisibleAtReplayTime`): playhead at/after "current" shows all recent interactions; scrubbing back reveals only interactions that had occurred by the playhead within the look-back window; undated edges stay visible.
- **RoutingTopologyPanel** publishes its playhead up via a stable `onReplayChange(selectedTime, range)` callback (fires only when the selected time/window changes — no render loop).
- **AiOperationsMap** holds the shared replay state (`useCallback` handler) and feeds `replayTime`/`replayRange` to `A2aInteractionsPanel` — only while the provider band is visible (the dimension toggle can hide it).
- **A2aInteractionsPanel** filters edges by the shared playhead and shows a "synced to the routing replay timeline" hint when scrubbed back; the interaction count narrows live as you scrub.

## Verification

- `pnpm --filter web test` — full suite green (9613 passed, 0 errors).
- `pnpm --filter web typecheck` — clean. CI is the binding gate.
- New tests: helper visibility logic, panel replay narrowing + banner, AiOperationsMap source assertions for the callback wiring.

## Notes

- Read-only, additive. No new DB models or migrations.
- Default behavior is unchanged: at the default playhead position every recent interaction stays visible; the shared filtering only engages as the operator scrubs the timeline back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
