### PR TITLE
feat(hive): unified Hive Contributions consent surface — Admin → Hive (BI-1B7E352A)

### DIFF
--- a/apps/web/app/(shell)/admin/hive/page.tsx
+++ b/apps/web/app/(shell)/admin/hive/page.tsx
@@ -1,0 +1,94 @@
+import { AdminTabNav } from "@/components/admin/AdminTabNav";
+import { HiveContributionsPanel } from "@/components/admin/HiveContributionsPanel";
+import { getHiveContributionsView } from "@/lib/actions/hive-contributions";
+
+const STATUS_COLORS: Record<string, string> = {
+  submitted: "var(--dpf-muted)",
+  curating: "var(--dpf-accent)",
+  accepted: "var(--dpf-success, #15803d)",
+  rejected: "var(--dpf-warning, #b45309)",
+  withdrawn: "var(--dpf-muted)",
+};
+
+export default async function AdminHiveContributionsPage() {
+  const view = await getHiveContributionsView();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Admin</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">Hive Contributions</p>
+      </div>
+      <AdminTabNav />
+
+      <div className="mt-6 space-y-8">
+        <section>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">What you share with the hive</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mb-4">
+            One place to govern everything that flows to the hive. Device fingerprints are PII-free and default on — every
+            install&apos;s discoveries make every install smarter. Opt out anytime; it&apos;s honored immediately.
+          </p>
+          <HiveContributionsPanel view={view} />
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Contributor identity</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mb-3">
+            One stable, obfuscated pseudonym used across every contribution type — attributable without being personally
+            identifying.
+          </p>
+          <div
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-mono text-sm"
+            style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", color: "var(--dpf-text)" }}
+          >
+            {view.contributor ?? "not yet generated"}
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Contribution ledger</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mb-3">
+            What was shared, when, and its curation status.
+          </p>
+          {view.ledger.length === 0 ? (
+            <div
+              className="p-6 text-sm text-[var(--dpf-muted)] rounded-lg text-center"
+              style={{ background: "var(--dpf-surface-1)", border: "1px dashed var(--dpf-border)" }}
+            >
+              Nothing contributed yet. When the platform shares a device fingerprint or improvement, it appears here.
+            </div>
+          ) : (
+            <div className="rounded-lg overflow-hidden" style={{ border: "1px solid var(--dpf-border)" }}>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr style={{ background: "var(--dpf-surface-1)" }} className="text-left text-xs text-[var(--dpf-muted)]">
+                    <th className="px-3 py-2 font-medium">Type</th>
+                    <th className="px-3 py-2 font-medium">Summary</th>
+                    <th className="px-3 py-2 font-medium">Redaction</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 font-medium">When</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {view.ledger.map((e) => (
+                    <tr key={e.id} className="border-t" style={{ borderColor: "var(--dpf-border)" }}>
+                      <td className="px-3 py-2 text-[var(--dpf-text)] whitespace-nowrap">{e.contributionType}</td>
+                      <td className="px-3 py-2 text-[var(--dpf-text)]">{e.summary}</td>
+                      <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">{e.redactionStatus ?? "—"}</td>
+                      <td className="px-3 py-2 whitespace-nowrap" style={{ color: STATUS_COLORS[e.status] ?? "var(--dpf-muted)" }}>
+                        {e.status}
+                      </td>
+                      <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">
+                        {new Date(e.createdAt).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/admin/HiveContributionsPanel.tsx
+++ b/apps/web/components/admin/HiveContributionsPanel.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  setDeviceFingerprintOptIn,
+  setHiveContributionsPaused,
+  type HiveContributionsView,
+} from "@/lib/actions/hive-contributions";
+
+const TYPE_LABELS: Record<string, string> = {
+  device_fingerprint: "Device fingerprints",
+  source: "Source & improvements",
+  improvement: "Improvement proposals",
+};
+
+function Toggle({
+  checked,
+  disabled,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50"
+      style={{ background: checked ? "var(--dpf-accent)" : "var(--dpf-border)" }}
+    >
+      <span
+        className="inline-block h-5 w-5 transform rounded-full bg-white transition-transform"
+        style={{ transform: checked ? "translateX(22px)" : "translateX(2px)" }}
+      />
+    </button>
+  );
+}
+
+export function HiveContributionsPanel({ view }: { view: HiveContributionsView }) {
+  const [config, setConfig] = useState(view.config);
+  const [statuses, setStatuses] = useState(view.statuses);
+  const [isPending, startTransition] = useTransition();
+
+  function recompute(next: typeof config) {
+    setStatuses((prev) =>
+      prev.map((s) => {
+        const optedIn = s.type === "device_fingerprint" ? next.deviceFingerprintOptIn : s.optedIn;
+        return { ...s, optedIn, enabled: !next.hiveContributionsPaused && optedIn };
+      }),
+    );
+  }
+
+  function onPause(next: boolean) {
+    const nextConfig = { ...config, hiveContributionsPaused: next };
+    setConfig(nextConfig);
+    recompute(nextConfig);
+    startTransition(() => void setHiveContributionsPaused(next));
+  }
+
+  function onFingerprintOptIn(next: boolean) {
+    const nextConfig = { ...config, deviceFingerprintOptIn: next };
+    setConfig(nextConfig);
+    recompute(nextConfig);
+    startTransition(() => void setDeviceFingerprintOptIn(next));
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Master pause */}
+      <div
+        className="flex items-center justify-between p-4 rounded-lg border-l-4"
+        style={{
+          background: "var(--dpf-surface-1)",
+          borderLeftColor: config.hiveContributionsPaused ? "var(--dpf-warning, #b45309)" : "var(--dpf-border)",
+        }}
+      >
+        <div>
+          <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Pause all contributions</h3>
+          <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+            Immediately stops every contribution type from leaving this install. Already-curated rules remain in the
+            shared catalog.
+          </p>
+        </div>
+        <Toggle
+          checked={config.hiveContributionsPaused}
+          disabled={isPending}
+          onChange={onPause}
+          label="Pause all contributions"
+        />
+      </div>
+
+      {/* Per-type toggles */}
+      <div className="rounded-lg" style={{ background: "var(--dpf-surface-1)" }}>
+        {statuses.map((s) => {
+          const isFingerprint = s.type === "device_fingerprint";
+          return (
+            <div
+              key={s.type}
+              className="flex items-start justify-between gap-4 p-4 border-b last:border-b-0"
+              style={{ borderColor: "var(--dpf-border)" }}
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
+                    {TYPE_LABELS[s.type] ?? s.type}
+                  </h3>
+                  {isFingerprint && (
+                    <span
+                      className="text-[10px] px-2 py-0.5 rounded-full"
+                      style={{ background: "color-mix(in srgb, var(--dpf-accent) 13%, transparent)", color: "var(--dpf-accent)" }}
+                    >
+                      default on · PII-free
+                    </span>
+                  )}
+                  {config.hiveContributionsPaused && (
+                    <span className="text-[10px] px-2 py-0.5 rounded-full" style={{ background: "var(--dpf-border)", color: "var(--dpf-muted)" }}>
+                      paused
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-[var(--dpf-muted)] mt-1">{s.description}</p>
+              </div>
+              {isFingerprint ? (
+                <Toggle
+                  checked={s.optedIn}
+                  disabled={isPending || config.hiveContributionsPaused}
+                  onChange={onFingerprintOptIn}
+                  label="Device fingerprint contributions"
+                />
+              ) : (
+                <span className="text-xs text-[var(--dpf-muted)] whitespace-nowrap">
+                  {s.optedIn ? "On" : "Off"} · via contribution mode
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/admin/admin-nav.ts
+++ b/apps/web/components/admin/admin-nav.ts
@@ -63,9 +63,11 @@ export const ADMIN_FAMILIES: AdminFamily[] = [
       "/admin/diagnostics",
       "/admin/backups",
       "/admin/cockpit",
+      "/admin/hive",
     ],
     subItems: [
       { label: "Platform Development", href: "/admin/platform-development" },
+      { label: "Hive Contributions", href: "/admin/hive" },
       { label: "Issue Reports", href: "/admin/issue-reports" },
       { label: "Diagnostics", href: "/admin/diagnostics" },
       { label: "Backups", href: "/admin/backups" },

--- a/apps/web/lib/actions/hive-contributions.ts
+++ b/apps/web/lib/actions/hive-contributions.ts
@@ -1,0 +1,111 @@
+"use server";
+
+import {
+  prisma,
+  resolveHiveContributionStatuses,
+  type HiveContributionConfig,
+  type HiveContributionTypeStatus,
+} from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getDisplayPseudonym } from "@/lib/integrate/identity-privacy";
+import { revalidatePath } from "next/cache";
+
+async function requireManagePlatform(): Promise<string> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_platform")) {
+    throw new Error("Unauthorized");
+  }
+  return user.id!;
+}
+
+const HIVE_PATH = "/admin/hive";
+
+const DEFAULT_CONFIG: HiveContributionConfig = {
+  deviceFingerprintOptIn: true,
+  hiveContributionsPaused: false,
+  contributionMode: "selective",
+};
+
+export type HiveContributionsView = {
+  config: HiveContributionConfig;
+  statuses: HiveContributionTypeStatus[];
+  contributor: string | null;
+  ledger: Array<{
+    id: string;
+    contributionType: string;
+    contributor: string;
+    ruleKey: string | null;
+    summary: string;
+    status: string;
+    redactionStatus: string | null;
+    createdAt: string;
+  }>;
+};
+
+export async function getHiveContributionsView(): Promise<HiveContributionsView> {
+  const row = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { deviceFingerprintOptIn: true, hiveContributionsPaused: true, contributionMode: true },
+  });
+  const config: HiveContributionConfig = {
+    deviceFingerprintOptIn: row?.deviceFingerprintOptIn ?? DEFAULT_CONFIG.deviceFingerprintOptIn,
+    hiveContributionsPaused: row?.hiveContributionsPaused ?? DEFAULT_CONFIG.hiveContributionsPaused,
+    contributionMode: row?.contributionMode ?? DEFAULT_CONFIG.contributionMode,
+  };
+
+  const contributor = await getDisplayPseudonym().catch(() => null);
+
+  const ledgerRows = await prisma.hiveContributionLedger.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  type LedgerRow = {
+    id: string;
+    contributionType: string;
+    contributor: string;
+    ruleKey: string | null;
+    summary: string;
+    status: string;
+    redactionStatus: string | null;
+    createdAt: Date;
+  };
+
+  return {
+    config,
+    statuses: resolveHiveContributionStatuses(config),
+    contributor,
+    ledger: (ledgerRows as LedgerRow[]).map((r: LedgerRow) => ({
+      id: r.id,
+      contributionType: r.contributionType,
+      contributor: r.contributor,
+      ruleKey: r.ruleKey,
+      summary: r.summary,
+      status: r.status,
+      redactionStatus: r.redactionStatus,
+      createdAt: r.createdAt.toISOString(),
+    })),
+  };
+}
+
+export async function setDeviceFingerprintOptIn(enabled: boolean): Promise<void> {
+  const userId = await requireManagePlatform();
+  await prisma.platformDevConfig.upsert({
+    where: { id: "singleton" },
+    update: { deviceFingerprintOptIn: enabled, configuredAt: new Date(), configuredById: userId },
+    create: { id: "singleton", deviceFingerprintOptIn: enabled, configuredById: userId },
+  });
+  revalidatePath(HIVE_PATH);
+}
+
+export async function setHiveContributionsPaused(paused: boolean): Promise<void> {
+  const userId = await requireManagePlatform();
+  await prisma.platformDevConfig.upsert({
+    where: { id: "singleton" },
+    update: { hiveContributionsPaused: paused, configuredAt: new Date(), configuredById: userId },
+    create: { id: "singleton", hiveContributionsPaused: paused, configuredById: userId },
+  });
+  revalidatePath(HIVE_PATH);
+}

--- a/apps/web/lib/hive/contribute-fingerprint.ts
+++ b/apps/web/lib/hive/contribute-fingerprint.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import {
+  prisma,
+  buildFingerprintContribution,
+  buildLedgerEntry,
+  isContributionEnabled,
+  type ContributableRule,
+  type HiveContributionConfig,
+} from "@dpf/db";
+import { getDisplayPseudonym } from "@/lib/integrate/identity-privacy";
+
+/**
+ * The single entry point that contributes a resolved device fingerprint to the
+ * hive — honoring the §6.1 consent surface (the device-fingerprint opt-in + the
+ * master pause) and recording the contribution in the one ledger.
+ *
+ * Fail-closed: redaction runs inside buildFingerprintContribution; any
+ * blocked_sensitive aborts. The actual cross-install transport
+ * (contribute_to_hive) is driven by the curation pipeline; this records the
+ * vetted, PII-free intent + ledger entry that the pipeline picks up.
+ */
+export type ContributeFingerprintResult = {
+  contributed: boolean;
+  reason: string;
+  ledgerId?: string;
+};
+
+export async function contributeDeviceFingerprint(rule: ContributableRule): Promise<ContributeFingerprintResult> {
+  const row = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: { deviceFingerprintOptIn: true, hiveContributionsPaused: true, contributionMode: true },
+  });
+  const config: HiveContributionConfig = {
+    deviceFingerprintOptIn: row?.deviceFingerprintOptIn ?? true,
+    hiveContributionsPaused: row?.hiveContributionsPaused ?? false,
+    contributionMode: row?.contributionMode ?? "selective",
+  };
+
+  if (!isContributionEnabled("device_fingerprint", config)) {
+    return { contributed: false, reason: "contribution_disabled" };
+  }
+
+  const contributor = await getDisplayPseudonym().catch(() => "dpf-anon");
+  const result = buildFingerprintContribution(rule, { optIn: true, contributor });
+  if (result.status !== "ready") {
+    return { contributed: false, reason: result.status };
+  }
+
+  const payloadHash = createHash("sha256").update(JSON.stringify(result.payload)).digest("hex").slice(0, 16);
+  const entry = await prisma.hiveContributionLedger.create({
+    data: buildLedgerEntry({
+      contributionType: "device_fingerprint",
+      contributor,
+      ruleKey: rule.ruleKey,
+      summary: `${result.payload.resolvedIdentity.name} → ${result.payload.taxonomyNodeId ?? "unplaced"}`,
+      payloadHash,
+      redactionStatus: result.redactedFields.length > 0 ? "redacted" : "not_required",
+    }),
+  });
+
+  return { contributed: true, reason: "ready", ledgerId: entry.id };
+}

--- a/packages/db/prisma/migrations/20260605060000_hive_contributions_surface/migration.sql
+++ b/packages/db/prisma/migrations/20260605060000_hive_contributions_surface/migration.sql
@@ -1,0 +1,26 @@
+-- Hive Contributions consent surface (spec §6.1)
+
+-- PlatformDevConfig: device-fingerprint opt-in (default ON, PII-free) + master pause.
+ALTER TABLE "PlatformDevConfig" ADD COLUMN "deviceFingerprintOptIn" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "PlatformDevConfig" ADD COLUMN "hiveContributionsPaused" BOOLEAN NOT NULL DEFAULT false;
+
+-- One contribution ledger for every type that flows to the hive.
+CREATE TABLE "HiveContributionLedger" (
+    "id" TEXT NOT NULL,
+    "contributionType" TEXT NOT NULL,
+    "contributor" TEXT NOT NULL,
+    "ruleKey" TEXT,
+    "summary" TEXT NOT NULL,
+    "payloadHash" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "redactionStatus" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HiveContributionLedger_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "HiveContributionLedger_contributionType_idx" ON "HiveContributionLedger"("contributionType");
+CREATE INDEX "HiveContributionLedger_status_idx" ON "HiveContributionLedger"("status");
+CREATE INDEX "HiveContributionLedger_contributor_idx" ON "HiveContributionLedger"("contributor");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5363,6 +5363,36 @@ model PlatformDevConfig {
   forkVerifiedAt         DateTime?
   backlogTeeUpDailyCap   Int       @default(3)
   governedBacklogEnabled Boolean   @default(false)
+  // Hive Contributions consent (spec §6.1). Device-fingerprint contribution is
+  // opt-in, DEFAULTED ON because outbound fingerprints are PII-free
+  // (redactFingerprintEvidence, fail-closed). The master pause halts ALL
+  // contribution types immediately.
+  deviceFingerprintOptIn   Boolean @default(true)
+  hiveContributionsPaused  Boolean @default(false)
+}
+
+// One ledger for everything that flows to the hive — what was shared, when,
+// its type, and its curation status (spec §6.1: "one contribution ledger").
+model HiveContributionLedger {
+  id               String   @id @default(cuid())
+  // "device_fingerprint" | "source" | "improvement" (extensible).
+  contributionType String
+  // The stable obfuscated contributor pseudonym used across all types.
+  contributor      String
+  // For device-fingerprint contributions: the rule key shared.
+  ruleKey          String?
+  summary          String
+  // Hash of the contributed payload for dedup/audit without storing PII.
+  payloadHash      String?
+  // submitted | curating | accepted | rejected | withdrawn
+  status           String   @default("submitted")
+  redactionStatus  String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([contributionType])
+  @@index([status])
+  @@index([contributor])
 }
 
 model EaNotation {

--- a/packages/db/src/hive-contribution-settings.test.ts
+++ b/packages/db/src/hive-contribution-settings.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLedgerEntry,
+  HIVE_CONTRIBUTION_TYPES,
+  isContributionEnabled,
+  isTypeOptedIn,
+  resolveHiveContributionStatuses,
+  type HiveContributionConfig,
+} from "./hive-contribution-settings";
+
+const base: HiveContributionConfig = {
+  deviceFingerprintOptIn: true,
+  hiveContributionsPaused: false,
+  contributionMode: "selective",
+};
+
+describe("device fingerprint opt-in (default-on)", () => {
+  it("is enabled by default", () => {
+    expect(isContributionEnabled("device_fingerprint", base)).toBe(true);
+  });
+
+  it("is disabled when opted out", () => {
+    expect(isContributionEnabled("device_fingerprint", { ...base, deviceFingerprintOptIn: false })).toBe(false);
+  });
+});
+
+describe("source/improvement follows contributionMode", () => {
+  it("enabled for selective / contribute_all", () => {
+    expect(isTypeOptedIn("source", { ...base, contributionMode: "selective" })).toBe(true);
+    expect(isTypeOptedIn("improvement", { ...base, contributionMode: "contribute_all" })).toBe(true);
+  });
+  it("disabled for fork_only", () => {
+    expect(isTypeOptedIn("source", { ...base, contributionMode: "fork_only" })).toBe(false);
+  });
+});
+
+describe("master pause overrides every type", () => {
+  it("disables all types regardless of per-type opt-in", () => {
+    const paused = { ...base, hiveContributionsPaused: true };
+    for (const type of HIVE_CONTRIBUTION_TYPES) {
+      expect(isContributionEnabled(type, paused), type).toBe(false);
+    }
+  });
+
+  it("preserves the per-type opt-in state under pause (optedIn vs enabled)", () => {
+    const statuses = resolveHiveContributionStatuses({ ...base, hiveContributionsPaused: true });
+    const fp = statuses.find((s) => s.type === "device_fingerprint")!;
+    expect(fp.optedIn).toBe(true); // preference retained
+    expect(fp.enabled).toBe(false); // but paused
+  });
+});
+
+describe("resolveHiveContributionStatuses", () => {
+  it("returns one status per type with a plain-language description", () => {
+    const statuses = resolveHiveContributionStatuses(base);
+    expect(statuses).toHaveLength(HIVE_CONTRIBUTION_TYPES.length);
+    const fp = statuses.find((s) => s.type === "device_fingerprint")!;
+    expect(fp.description).toMatch(/Never your MAC/);
+  });
+});
+
+describe("buildLedgerEntry", () => {
+  it("shapes a ledger row starting at submitted", () => {
+    const entry = buildLedgerEntry({
+      contributionType: "device_fingerprint",
+      contributor: "dpf-pseudo-1",
+      ruleKey: "estate:reolink-camera",
+      summary: "Reolink IP camera → Security & Surveillance",
+      redactionStatus: "not_required",
+    });
+    expect(entry.status).toBe("submitted");
+    expect(entry.contributionType).toBe("device_fingerprint");
+    expect(entry.ruleKey).toBe("estate:reolink-camera");
+  });
+});

--- a/packages/db/src/hive-contribution-settings.ts
+++ b/packages/db/src/hive-contribution-settings.ts
@@ -89,8 +89,19 @@ export type HiveLedgerEntryInput = {
   redactionStatus?: string | null;
 };
 
+/** Concrete ledger-row data shape (assignable to the Prisma create input). */
+export type HiveLedgerEntryData = {
+  contributionType: HiveContributionType;
+  contributor: string;
+  ruleKey: string | null;
+  summary: string;
+  payloadHash: string | null;
+  redactionStatus: string | null;
+  status: string;
+};
+
 /** Shape a ledger row payload (status starts "submitted"). */
-export function buildLedgerEntry(input: HiveLedgerEntryInput): Record<string, unknown> {
+export function buildLedgerEntry(input: HiveLedgerEntryInput): HiveLedgerEntryData {
   return {
     contributionType: input.contributionType,
     contributor: input.contributor,

--- a/packages/db/src/hive-contribution-settings.ts
+++ b/packages/db/src/hive-contribution-settings.ts
@@ -1,0 +1,103 @@
+/**
+ * Hive contribution consent resolution (spec §6.1).
+ *
+ * One surface governs every contribution type. This module is the pure logic
+ * behind it: given the persisted PlatformDevConfig flags, decide whether a given
+ * contribution type may currently flow to the hive. The master pause overrides
+ * everything; per-type opt-ins gate the rest.
+ *
+ * Device fingerprints are opt-in DEFAULTED ON (PII-free, redaction fail-closed).
+ * Source/improvement contributions follow the existing contributionMode policy
+ * (fork_only = off; selective | contribute_all = on).
+ *
+ * Pure/testable — the server actions + the Phase-6 contribution path call this
+ * so the toggle is honored in exactly one place.
+ */
+
+export type HiveContributionType = "device_fingerprint" | "source" | "improvement";
+
+export const HIVE_CONTRIBUTION_TYPES: readonly HiveContributionType[] = [
+  "device_fingerprint",
+  "source",
+  "improvement",
+];
+
+/** The persisted consent inputs (a subset of PlatformDevConfig). */
+export type HiveContributionConfig = {
+  deviceFingerprintOptIn: boolean;
+  hiveContributionsPaused: boolean;
+  /** "fork_only" | "selective" | "contribute_all" */
+  contributionMode: string;
+};
+
+export type HiveContributionTypeStatus = {
+  type: HiveContributionType;
+  /** The per-type preference, ignoring the master pause. */
+  optedIn: boolean;
+  /** The effective decision: opted in AND not master-paused. */
+  enabled: boolean;
+  /** Plain-language statement of exactly what leaves the install. */
+  description: string;
+};
+
+const DESCRIPTIONS: Record<HiveContributionType, string> = {
+  device_fingerprint:
+    "PII-stripped device fingerprint → identity → portfolio placement. Never your MAC, IP, hostname, or SSID.",
+  source: "Code, builds, and improvement proposals contributed via pull request with DCO sign-off.",
+  improvement: "Improvement proposals and platform learnings shared back to the hive.",
+};
+
+/** Per-type opt-in, before the master pause is applied. */
+export function isTypeOptedIn(type: HiveContributionType, config: HiveContributionConfig): boolean {
+  switch (type) {
+    case "device_fingerprint":
+      return config.deviceFingerprintOptIn;
+    case "source":
+    case "improvement":
+      // Existing source/improvement policy: anything other than fork-only is opted in.
+      return config.contributionMode !== "fork_only";
+  }
+}
+
+/**
+ * The effective decision for a type: opted in AND the master pause is off.
+ * This is the single gate the contribution paths must consult.
+ */
+export function isContributionEnabled(type: HiveContributionType, config: HiveContributionConfig): boolean {
+  if (config.hiveContributionsPaused) {
+    return false;
+  }
+  return isTypeOptedIn(type, config);
+}
+
+/** Full per-type status list for the consent UI. */
+export function resolveHiveContributionStatuses(config: HiveContributionConfig): HiveContributionTypeStatus[] {
+  return HIVE_CONTRIBUTION_TYPES.map((type) => ({
+    type,
+    optedIn: isTypeOptedIn(type, config),
+    enabled: isContributionEnabled(type, config),
+    description: DESCRIPTIONS[type],
+  }));
+}
+
+export type HiveLedgerEntryInput = {
+  contributionType: HiveContributionType;
+  contributor: string;
+  ruleKey?: string | null;
+  summary: string;
+  payloadHash?: string | null;
+  redactionStatus?: string | null;
+};
+
+/** Shape a ledger row payload (status starts "submitted"). */
+export function buildLedgerEntry(input: HiveLedgerEntryInput): Record<string, unknown> {
+  return {
+    contributionType: input.contributionType,
+    contributor: input.contributor,
+    ruleKey: input.ruleKey ?? null,
+    summary: input.summary,
+    payloadHash: input.payloadHash ?? null,
+    redactionStatus: input.redactionStatus ?? null,
+    status: "submitted",
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -256,6 +256,7 @@ export * from "./discovery-fingerprint-observation";
 export * from "./device-placement";
 export * from "./device-investigation";
 export * from "./device-fingerprint-contribution";
+export * from "./hive-contribution-settings";
 // `./discovery-fingerprint-catalog` is intentionally NOT re-exported. Its
 // `validateFingerprintCatalog` helper uses dynamic `path.resolve(process.cwd(), ...)`
 // to locate catalog JSON at runtime, which Turbopack flags as an overly broad


### PR DESCRIPTION
## Phase 5 — unified Hive Contributions consent surface (spec §6.1 / §8.5)

One Admin → Hive page governs everything that flows to the hive, with the device-fingerprint contribution path wired to honor it.

### Schema (migration `20260605060000_hive_contributions_surface`)
- `PlatformDevConfig` += `deviceFingerprintOptIn` (default **true** — PII-free) + `hiveContributionsPaused` (master pause).
- New `HiveContributionLedger` model — one ledger for every contribution type.

### Logic (`packages/db`, pure + tested)
`isContributionEnabled` (per-type opt-in **AND** not master-paused), `resolveHiveContributionStatuses`, `buildLedgerEntry`. Device fingerprints default-on; source/improvements follow the existing `contributionMode`.

### UI (`apps/web`)
- `/admin/hive`: per-type toggles (Device fingerprints *default-on · PII-free*; Source & improvements via contribution mode), the obfuscated contributor pseudonym, the contribution ledger, and a master **pause all**.
- Toggles are optimistic (`useTransition`); server actions gated by `can(..., "manage_platform")`, honored immediately.
- `admin-nav`: "Hive Contributions" under Advanced.

### Wiring (the §6.1 "wire each path" requirement)
`lib/hive/contribute-fingerprint.ts` — the single entry point: resolves the effective opt-in, runs the **fail-closed** `buildFingerprintContribution`, records the ledger entry. Opt-out / master pause halts it immediately.

### Tests
8 settings cases (default-on, opt-out, contributionMode mapping, master pause overrides every type, ledger shaping).

> The migration applies via `prisma migrate deploy` on the portal's next start. Local web typecheck isn't runnable in this fresh worktree (`@dpf/db` symlink absent — environmental); **CI Typecheck gates this merge** and I'll confirm it green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)