### PR TITLE
feat(catalog): public device-identification catalog — read API + browsable page (BI-28F72112)

### DIFF
--- a/apps/web/app/(shell)/platform/device-catalog/page.tsx
+++ b/apps/web/app/(shell)/platform/device-catalog/page.tsx
@@ -1,0 +1,115 @@
+import {
+  prisma,
+  buildPublicDeviceCatalog,
+  type PublicCatalogRuleInput,
+  type FingerprintMatchExpression,
+  type ResolvedIdentity,
+} from "@dpf/db";
+
+export const metadata = {
+  title: "Device Catalog",
+};
+
+type RuleRow = {
+  ruleKey: string;
+  status: string;
+  scope: string;
+  matchExpression: unknown;
+  requiredEvidenceFamilies: string[];
+  resolvedIdentity: unknown;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+  taxonomyNode: { nodeId: string } | null;
+};
+
+export default async function DeviceCatalogPage() {
+  const rules = (await prisma.discoveryFingerprintRule.findMany({
+    where: { status: "active", scope: "global" },
+    select: {
+      ruleKey: true,
+      status: true,
+      scope: true,
+      matchExpression: true,
+      requiredEvidenceFamilies: true,
+      resolvedIdentity: true,
+      identityConfidence: true,
+      taxonomyConfidence: true,
+      taxonomyNode: { select: { nodeId: true } },
+    },
+  })) as RuleRow[];
+
+  const input: PublicCatalogRuleInput[] = rules.map((r) => ({
+    ruleKey: r.ruleKey,
+    status: r.status,
+    scope: r.scope,
+    matchExpression: r.matchExpression as FingerprintMatchExpression,
+    requiredEvidenceFamilies: r.requiredEvidenceFamilies,
+    resolvedIdentity: (r.resolvedIdentity ?? {}) as ResolvedIdentity,
+    taxonomyNodeId: r.taxonomyNode?.nodeId ?? null,
+    identityConfidence: r.identityConfidence,
+    taxonomyConfidence: r.taxonomyConfidence,
+  }));
+
+  const catalog = buildPublicDeviceCatalog(input);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Device Catalog</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-1 max-w-2xl">
+          The open, <strong>portfolio-aware</strong> device-identification database. Fingerbank tells you <em>what</em> a
+          device is; DPF tells you what <strong>and</strong> where it belongs in your digital-product estate. PII-free,
+          versioned, and served read-only at{" "}
+          <code className="text-xs">/api/v1/device-catalog</code>.
+        </p>
+        <div className="flex gap-4 mt-3 text-xs text-[var(--dpf-muted)]">
+          <span>schema v{catalog.schemaVersion}</span>
+          <span>catalog v{catalog.version}</span>
+          <span>{catalog.count} identified device classes</span>
+        </div>
+      </div>
+
+      {catalog.entries.length === 0 ? (
+        <div
+          className="p-6 text-sm text-[var(--dpf-muted)] rounded-lg text-center"
+          style={{ background: "var(--dpf-surface-1)", border: "1px dashed var(--dpf-border)" }}
+        >
+          No published device fingerprints yet. As the seed catalog and hive-curated rules activate, they appear here.
+        </div>
+      ) : (
+        <div className="rounded-lg overflow-hidden" style={{ border: "1px solid var(--dpf-border)" }}>
+          <table className="w-full text-sm">
+            <thead>
+              <tr style={{ background: "var(--dpf-surface-1)" }} className="text-left text-xs text-[var(--dpf-muted)]">
+                <th className="px-3 py-2 font-medium">Device</th>
+                <th className="px-3 py-2 font-medium">Vendor</th>
+                <th className="px-3 py-2 font-medium">Class</th>
+                <th className="px-3 py-2 font-medium">Fingerprint</th>
+                <th className="px-3 py-2 font-medium">Portfolio placement</th>
+                <th className="px-3 py-2 font-medium">Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {catalog.entries.map((e) => (
+                <tr key={e.ruleKey} className="border-t align-top" style={{ borderColor: "var(--dpf-border)" }}>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{e.identity.name}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">{e.identity.vendor ?? "—"}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">{e.identity.deviceClass ?? "—"}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)]">
+                    {e.signals.map((s) => `${s.signal} "${s.match}"`).join(", ")}
+                  </td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">
+                    {e.placement.path.length > 0 ? e.placement.path.join(" › ") : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">
+                    {Math.round(Math.min(e.identityConfidence, e.taxonomyConfidence) * 100)}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/api/v1/device-catalog/route.ts
+++ b/apps/web/app/api/v1/device-catalog/route.ts
@@ -1,0 +1,62 @@
+// GET /api/v1/device-catalog — the public, PII-free device-identification
+// catalog (spec §7): fingerprint → identity → DPPM placement, versioned with
+// the catalog schemaVersion. Read-only, unauthenticated, cacheable.
+
+import { NextResponse } from "next/server";
+import {
+  prisma,
+  buildPublicDeviceCatalog,
+  type PublicCatalogRuleInput,
+  type FingerprintMatchExpression,
+  type ResolvedIdentity,
+} from "@dpf/db";
+
+export async function GET() {
+  try {
+    const rules = await prisma.discoveryFingerprintRule.findMany({
+      where: { status: "active", scope: "global" },
+      select: {
+        ruleKey: true,
+        status: true,
+        scope: true,
+        matchExpression: true,
+        requiredEvidenceFamilies: true,
+        resolvedIdentity: true,
+        identityConfidence: true,
+        taxonomyConfidence: true,
+        taxonomyNode: { select: { nodeId: true } },
+      },
+    });
+
+    const input: PublicCatalogRuleInput[] = rules.map(
+      (r: {
+        ruleKey: string;
+        status: string;
+        scope: string;
+        matchExpression: unknown;
+        requiredEvidenceFamilies: string[];
+        resolvedIdentity: unknown;
+        identityConfidence: number;
+        taxonomyConfidence: number;
+        taxonomyNode: { nodeId: string } | null;
+      }) => ({
+        ruleKey: r.ruleKey,
+        status: r.status,
+        scope: r.scope,
+        matchExpression: r.matchExpression as FingerprintMatchExpression,
+        requiredEvidenceFamilies: r.requiredEvidenceFamilies,
+        resolvedIdentity: (r.resolvedIdentity ?? {}) as ResolvedIdentity,
+        taxonomyNodeId: r.taxonomyNode?.nodeId ?? null,
+        identityConfidence: r.identityConfidence,
+        taxonomyConfidence: r.taxonomyConfidence,
+      }),
+    );
+
+    const catalog = buildPublicDeviceCatalog(input);
+    return NextResponse.json(catalog, {
+      headers: { "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=600" },
+    });
+  } catch {
+    return NextResponse.json({ code: "INTERNAL_ERROR", message: "Failed to build device catalog" }, { status: 500 });
+  }
+}

--- a/packages/db/src/device-catalog.test.ts
+++ b/packages/db/src/device-catalog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPublicDeviceCatalog,
+  projectPublicCatalogEntry,
+  type PublicCatalogRuleInput,
+} from "./device-catalog";
+
+const reolink: PublicCatalogRuleInput = {
+  ruleKey: "estate:reolink-camera",
+  status: "active",
+  scope: "global",
+  matchExpression: { all: [{ type: "contains", path: "vendor", value: "reolink" }] },
+  requiredEvidenceFamilies: ["mac_oui"],
+  resolvedIdentity: { kind: "device", name: "Reolink IP camera / NVR", vendor: "Reolink", deviceClass: "ip_camera" },
+  taxonomyNodeId: "foundational/building_management/security_and_surveillance",
+  identityConfidence: 0.96,
+  taxonomyConfidence: 0.96,
+};
+
+describe("projectPublicCatalogEntry", () => {
+  it("projects an active global rule into a placement-aware entry", () => {
+    const entry = projectPublicCatalogEntry(reolink)!;
+    expect(entry.identity).toEqual({ name: "Reolink IP camera / NVR", vendor: "Reolink", deviceClass: "ip_camera" });
+    expect(entry.placement.taxonomyNodeId).toBe("foundational/building_management/security_and_surveillance");
+    expect(entry.placement.portfolio).toBe("foundational");
+    expect(entry.placement.path).toEqual(["Foundational", "Building Management", "Security And Surveillance"]);
+    expect(entry.signals).toEqual([{ signal: "vendor contains", match: "reolink" }]);
+  });
+
+  it("excludes non-active or non-global rules", () => {
+    expect(projectPublicCatalogEntry({ ...reolink, status: "draft" })).toBeNull();
+    expect(projectPublicCatalogEntry({ ...reolink, scope: "local" })).toBeNull();
+  });
+
+  it("drops an entry whose projected shape would leak a secret (fail-closed)", () => {
+    const poisoned: PublicCatalogRuleInput = {
+      ...reolink,
+      matchExpression: { all: [{ type: "contains", path: "banner", value: "authorization: bearer sk-xyz" }] },
+    };
+    expect(projectPublicCatalogEntry(poisoned)).toBeNull();
+  });
+});
+
+describe("buildPublicDeviceCatalog", () => {
+  it("builds a versioned, sorted, count-bearing catalog of publishable entries", () => {
+    const catalog = buildPublicDeviceCatalog(
+      [
+        reolink,
+        { ...reolink, ruleKey: "estate:amazon-voice", resolvedIdentity: { kind: "device", name: "Amazon Echo", vendor: "Amazon", deviceClass: "voice_assistant" }, taxonomyNodeId: "foundational/network_management/voice" },
+        { ...reolink, ruleKey: "estate:draft-thing", status: "draft" },
+      ],
+      { version: "1.2.3" },
+    );
+    expect(catalog.schemaVersion).toBe("2");
+    expect(catalog.version).toBe("1.2.3");
+    expect(catalog.count).toBe(2); // draft excluded
+    expect(catalog.entries.map((e) => e.ruleKey)).toEqual(["estate:amazon-voice", "estate:reolink-camera"]);
+  });
+
+  it("never includes PII fields (no MAC/IP) in published entries", () => {
+    const catalog = buildPublicDeviceCatalog([reolink]);
+    expect(JSON.stringify(catalog)).not.toMatch(/(?:[0-9a-f]{2}:){5}[0-9a-f]{2}/i);
+  });
+});

--- a/packages/db/src/device-catalog.ts
+++ b/packages/db/src/device-catalog.ts
@@ -1,0 +1,133 @@
+/**
+ * Public device-identification catalog projection (spec §7, §8.7).
+ *
+ * DPF's portfolio-aware Fingerbank: the curated, PII-free
+ * fingerprint → identity → DPPM-placement mappings, safe to publish. This
+ * module projects active, global fingerprint rules into the public catalog
+ * shape and is pure/testable; the API route queries the rules and calls it.
+ *
+ * Differentiator (spec §7): Fingerbank tells you WHAT a device is; DPF tells you
+ * what AND where it belongs in your digital-product estate — the placement layer
+ * is the value.
+ *
+ * PII-safety: entries are derived from rule SHAPES (already PII-free), and each
+ * entry is run through redactFingerprintEvidence as a fail-closed net — any
+ * blocked_sensitive entry is dropped from the public catalog rather than leaked.
+ */
+
+import { redactFingerprintEvidence } from "./discovery-fingerprint-redaction";
+import type { FingerprintMatchClause, FingerprintMatchExpression, ResolvedIdentity } from "./discovery-fingerprint-rules";
+
+export type PublicCatalogRuleInput = {
+  ruleKey: string;
+  status: string;
+  scope: string;
+  matchExpression: FingerprintMatchExpression;
+  requiredEvidenceFamilies: string[];
+  resolvedIdentity: ResolvedIdentity;
+  /** Semantic taxonomy nodeId string (the placement), or null. */
+  taxonomyNodeId: string | null;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+};
+
+export type PublicCatalogSignal = { signal: string; match: string };
+
+export type PublicCatalogEntry = {
+  ruleKey: string;
+  identity: { name: string; vendor: string | null; deviceClass: string | null };
+  placement: {
+    taxonomyNodeId: string | null;
+    portfolio: string | null;
+    path: string[];
+  };
+  signals: PublicCatalogSignal[];
+  evidenceFamilies: string[];
+  identityConfidence: number;
+  taxonomyConfidence: number;
+};
+
+export type PublicDeviceCatalog = {
+  catalogKey: string;
+  schemaVersion: string;
+  version: string;
+  count: number;
+  entries: PublicCatalogEntry[];
+};
+
+function clausesOf(expression: FingerprintMatchExpression): FingerprintMatchClause[] {
+  return "all" in expression ? expression.all : expression.any;
+}
+
+/** A human-readable, value-bearing summary of one match clause (PII-free for OUI/identity rules). */
+function summarizeClause(clause: FingerprintMatchClause): PublicCatalogSignal {
+  const value =
+    "value" in clause
+      ? Array.isArray(clause.value)
+        ? clause.value.join(",")
+        : String(clause.value)
+      : "pattern" in clause
+        ? clause.pattern
+        : "";
+  return { signal: `${clause.path} ${clause.type}`, match: value };
+}
+
+function humanizePlacement(nodeId: string | null): { portfolio: string | null; path: string[] } {
+  if (!nodeId) {
+    return { portfolio: null, path: [] };
+  }
+  const segments = nodeId.split("/");
+  const titleize = (s: string) => s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return { portfolio: segments[0] ?? null, path: segments.map(titleize) };
+}
+
+/** Project one rule into a public catalog entry, or null if it must not be published. */
+export function projectPublicCatalogEntry(rule: PublicCatalogRuleInput): PublicCatalogEntry | null {
+  // Only active, global rules are public.
+  if (rule.status !== "active" || rule.scope !== "global") {
+    return null;
+  }
+
+  const signals = clausesOf(rule.matchExpression).map(summarizeClause);
+  const identity = {
+    name: rule.resolvedIdentity.name,
+    vendor: rule.resolvedIdentity.vendor ?? null,
+    deviceClass: rule.resolvedIdentity.deviceClass ?? null,
+  };
+
+  // Fail-closed PII net: if the projected, value-bearing entry contains
+  // anything redaction flags as blocked_sensitive, do not publish it.
+  const redaction = redactFingerprintEvidence({ identity, signals });
+  if (redaction.status === "blocked_sensitive") {
+    return null;
+  }
+
+  const placement = humanizePlacement(rule.taxonomyNodeId);
+  return {
+    ruleKey: rule.ruleKey,
+    identity,
+    placement: { taxonomyNodeId: rule.taxonomyNodeId, ...placement },
+    signals,
+    evidenceFamilies: rule.requiredEvidenceFamilies,
+    identityConfidence: rule.identityConfidence,
+    taxonomyConfidence: rule.taxonomyConfidence,
+  };
+}
+
+export function buildPublicDeviceCatalog(
+  rules: PublicCatalogRuleInput[],
+  meta: { catalogKey?: string; schemaVersion?: string; version?: string } = {},
+): PublicDeviceCatalog {
+  const entries = rules
+    .map(projectPublicCatalogEntry)
+    .filter((e): e is PublicCatalogEntry => e !== null)
+    .sort((a, b) => a.ruleKey.localeCompare(b.ruleKey));
+
+  return {
+    catalogKey: meta.catalogKey ?? "dpf-public-device-catalog",
+    schemaVersion: meta.schemaVersion ?? "2",
+    version: meta.version ?? "0.1.0",
+    count: entries.length,
+    entries,
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -257,6 +257,7 @@ export * from "./device-placement";
 export * from "./device-investigation";
 export * from "./device-fingerprint-contribution";
 export * from "./hive-contribution-settings";
+export * from "./device-catalog";
 // `./discovery-fingerprint-catalog` is intentionally NOT re-exported. Its
 // `validateFingerprintCatalog` helper uses dynamic `path.resolve(process.cwd(), ...)`
 // to locate catalog JSON at runtime, which Turbopack flags as an overly broad


### PR DESCRIPTION
## Phase 7 — public device-identification catalog (spec §7 / §8.7)

DPF's portfolio-aware Fingerbank: the curated, PII-free fingerprint → identity → DPPM placement DB, versioned with the catalog schemaVersion.

- **`device-catalog.ts`** (`packages/db`, pure + tested): `projectPublicCatalogEntry` + `buildPublicDeviceCatalog` project active **global** rules into public entries — identity, the fingerprint signals (value-bearing but PII-free), and the human-readable portfolio placement path. **Fail-closed PII net**: any entry whose projected shape trips `redactFingerprintEvidence` is dropped.
- **`GET /api/v1/device-catalog`** — read-only, unauthenticated, cacheable.
- **`/platform/device-catalog`** — browsable page; the differentiated positioning (Fingerbank tells you *what*; DPF tells you what **and** where it belongs), schema + catalog version, and an identity → fingerprint → placement table.

### Tests
5 — projection, active/global gating, fail-closed secret drop, versioned/sorted/counted catalog, and a no-PII assertion.

> Local web typecheck not runnable (fresh-worktree `@dpf/db` symlink absent); CI Typecheck gates this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)