### PR TITLE
fix(ops): one portal-update surface + kill phantom EOL-conflict merge

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -5,7 +5,6 @@ import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
 import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
 import { McpTokenManager } from "@/components/admin/McpTokenManager";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
-import { PlatformUpdateApplyPanel } from "@/components/admin/PlatformUpdateApplyPanel";
 import TokenExpiryBanner from "@/components/admin/TokenExpiryBanner";
 import {
   getGitHubConnectedState,
@@ -51,10 +50,10 @@ export default async function AdminPlatformDevelopmentPage() {
       <AdminTabNav />
       <TokenExpiryBanner />
       <LegacyTokenOverrideBanner />
-      <PlatformUpdateApplyPanel
-        updatePending={config?.updatePending ?? false}
-        pendingVersion={config?.pendingVersion ?? null}
-      />
+      {/* BI-D43EB266: the source-merge "Apply update" control moved to the
+          single operator update surface at Ops -> Self-Upgrade. This page keeps
+          contribution policy + identity config; the update banner now deep-links
+          to /ops/self-upgrade. */}
       <ForkSetupPanel
         enabled={isContributionModelEnabled()}
         contributionModel={config?.contributionModel ?? null}

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -7,8 +7,23 @@ vi.mock("@/lib/actions/promotions", () => ({
   listSelfUpgradeRuns: vi.fn(),
 }));
 
+vi.mock("@/lib/actions/platform-dev-config", () => ({
+  getPlatformDevConfig: vi.fn(),
+}));
+
 vi.mock("@/components/ops/OpsTabNav", () => ({
   OpsTabNav: () => <div data-testid="ops-tab-nav" />,
+}));
+
+// BI-D43EB266: the source-merge sub-step is folded into the Self-Upgrade page.
+vi.mock("@/components/admin/PlatformUpdateApplyPanel", () => ({
+  PlatformUpdateApplyPanel: (props: { updatePending: boolean; pendingVersion: string | null }) => (
+    <div
+      data-testid="platform-update-apply-panel"
+      data-update-pending={String(props.updatePending)}
+      data-pending-version={props.pendingVersion ?? ""}
+    />
+  ),
 }));
 
 vi.mock("@/components/ops/SelfUpgradeClient", () => ({
@@ -36,10 +51,13 @@ vi.mock("@/components/ops/SelfUpgradeClient", () => ({
 }));
 
 import { getSelfUpgradeStatus, listSelfUpgradeRuns } from "@/lib/actions/promotions";
+import { getPlatformDevConfig } from "@/lib/actions/platform-dev-config";
 import SelfUpgradePage from "./page";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: install does not customise source — panel stays dormant.
+  vi.mocked(getPlatformDevConfig).mockResolvedValue(null as never);
 });
 
 const baseStatus = {
@@ -138,5 +156,29 @@ describe("SelfUpgradePage", () => {
 
     expect(html).toContain('data-platform-version="1.0.0"');
     expect(html).toContain('data-platform-git-sha="abc1234"');
+  });
+
+  it("renders the source-merge sub-step with the install's pending update state (BI-D43EB266)", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+    vi.mocked(getPlatformDevConfig).mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v9c92036a",
+    } as never);
+
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+
+    expect(html).toContain('data-testid="platform-update-apply-panel"');
+    expect(html).toContain('data-update-pending="true"');
+    expect(html).toContain('data-pending-version="v9c92036a"');
+  });
+
+  it("leaves the source-merge sub-step dormant when the install does not customise source", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+
+    expect(html).toContain('data-update-pending="false"');
   });
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -1,11 +1,19 @@
 import { getSelfUpgradeStatus, listSelfUpgradeRuns } from "@/lib/actions/promotions";
+import { getPlatformDevConfig } from "@/lib/actions/platform-dev-config";
 import SelfUpgradeClient from "@/components/ops/SelfUpgradeClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { PlatformUpdateApplyPanel } from "@/components/admin/PlatformUpdateApplyPanel";
 
 export default async function SelfUpgradePage() {
-  const [status, { runs, nextCursor }] = await Promise.all([
+  // BI-D43EB266: Self-Upgrade is the single operator entry point for "update
+  // the portal". The image/SHA deploy controls (SelfUpgradeClient) are the
+  // primary path; the source-merge sub-step (PlatformUpdateApplyPanel) is
+  // folded in below and surfaces only when the install customises source
+  // (updatePending). getPlatformDevConfig can be null on a fresh install.
+  const [status, { runs, nextCursor }, devConfig] = await Promise.all([
     getSelfUpgradeStatus(),
     listSelfUpgradeRuns(),
+    getPlatformDevConfig(),
   ]);
 
   const clientProps = JSON.parse(
@@ -24,6 +32,11 @@ export default async function SelfUpgradePage() {
       <OpsTabNav />
 
       <SelfUpgradeClient {...clientProps} />
+
+      <PlatformUpdateApplyPanel
+        updatePending={devConfig?.updatePending ?? false}
+        pendingVersion={devConfig?.pendingVersion ?? null}
+      />
     </div>
   );
 }

--- a/apps/web/components/admin/PlatformUpdateApplyPanel.tsx
+++ b/apps/web/components/admin/PlatformUpdateApplyPanel.tsx
@@ -2,16 +2,18 @@
 
 // apps/web/components/admin/PlatformUpdateApplyPanel.tsx
 //
-// 2026-05-23 BI-9B77E247: The UpdatePendingBanner directs operators to
-// /admin/platform-development to apply the queued platform update, but
-// before this panel existed the destination route had no Apply control —
-// the merge logic was only reachable from a coworker turn via the
-// apply_platform_update MCP tool. When the System Admin coworker fell
-// back to the local model (provider-routing degraded state, BI-FF180422)
-// it could not reliably invoke that tool, leaving operators with no path
-// to apply queued updates.
+// 2026-05-23 BI-9B77E247: gives operators an in-portal Apply control for a
+// queued platform source-merge — the merge logic was previously only
+// reachable from a coworker turn via the apply_platform_update MCP tool,
+// which the System Admin coworker could not reliably invoke when routing
+// fell back to the local model (BI-FF180422).
 //
-// This panel renders an Apply control directly on the destination route.
+// 2026-06-05 BI-D43EB266: this panel is the source-merge SUB-STEP of the
+// single operator update surface at Ops -> Self-Upgrade. It is rendered on
+// /ops/self-upgrade beneath the image/SHA deploy controls and surfaces only
+// when the install customises source (updatePending). It no longer lives on
+// /admin/platform-development; the update banner deep-links to Ops.
+//
 // It invokes the shared applyPlatformUpdate server action (single source
 // of truth shared with the MCP tool case), and surfaces the structured
 // result inline — clean merge summary on success, or a per-file conflict

--- a/apps/web/components/shell/UpdatePendingBannerClient.test.tsx
+++ b/apps/web/components/shell/UpdatePendingBannerClient.test.tsx
@@ -17,9 +17,11 @@ describe("UpdatePendingBannerClient", () => {
     render(<UpdatePendingBannerClient pendingVersion="v1.2.3" />);
 
     expect(screen.getByRole("status")).toHaveAttribute("data-overlay-banner", "true");
-    expect(screen.getByRole("link", { name: /review in admin/i })).toHaveAttribute(
+    // BI-D43EB266: the banner deep-links to the single operator update surface
+    // (Ops -> Self-Upgrade), not the Admin source-merge destination.
+    expect(screen.getByRole("link", { name: /review in self-upgrade/i })).toHaveAttribute(
       "href",
-      "/admin/platform-development",
+      "/ops/self-upgrade",
     );
     expect(screen.getByRole("button", { name: /collapse platform update banner/i })).toBeInTheDocument();
   });

--- a/apps/web/components/shell/UpdatePendingBannerClient.tsx
+++ b/apps/web/components/shell/UpdatePendingBannerClient.tsx
@@ -61,10 +61,10 @@ export function UpdatePendingBannerClient({ pendingVersion }: Props) {
           <span className="font-medium">Platform update {versionLabel} is ready.</span>{" "}
           <span className="text-[var(--dpf-muted)]">Your customisations are preserved.</span>{" "}
           <Link
-            href="/admin/platform-development"
+            href="/ops/self-upgrade"
             className="font-medium text-[var(--dpf-accent)] underline underline-offset-2"
           >
-            Review in Admin - Platform Development
+            Review in Self-Upgrade
           </Link>
         </div>
         <button

--- a/apps/web/lib/actions/platform-dev-config.apply.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.apply.test.ts
@@ -237,6 +237,74 @@ describe("applyPlatformUpdate", () => {
     expect(mockExec.mock.calls[1]?.[0]).toBe("git diff --name-only --diff-filter=U");
   });
 
+  it("short-circuits a redundant same-version apply with zero conflicts (BI-4112378F)", async () => {
+    // The install is already on the pending version: the .dpf-version sentinel
+    // matches pendingVersion. Re-running the merge would only re-derive the
+    // phantom CRLF↔LF conflicts, so the apply must be a clean no-op — no merge
+    // is attempted, the pending flag clears, and zero files are reported.
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v9c92036a",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    // No merge in progress; the version sentinel exists and matches.
+    mockExistsSync.mockImplementation((path: string) => path.endsWith(".dpf-version"));
+    mockReadFileSync.mockImplementation((path: string) =>
+      path.endsWith(".dpf-version") ? "v9c92036a\n" : "",
+    );
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    if (result.kind === "clean-merge") {
+      expect(result.version).toBe("v9c92036a");
+      expect(result.filesUpdated).toBe(0);
+    }
+    const commands = mockExec.mock.calls.map(([cmd]) => String(cmd));
+    // The defining assertion: zero conflicts because no merge was ever run.
+    expect(commands.some((cmd) => cmd.includes("merge"))).toBe(false);
+    expect(commands).not.toContain("rm -rf apps/web packages");
+    expect(mockPrisma.platformDevConfig.update).toHaveBeenCalledWith({
+      where: { id: "singleton" },
+      data: { updatePending: false, pendingVersion: null },
+    });
+  });
+
+  it("merges with CR-at-EOL tolerance and declares the LF normalisation policy (BI-4112378F)", async () => {
+    // A genuine cross-version apply must still neutralise the snapshot-vs-source
+    // CRLF↔LF mismatch: the merge runs hookless with -X ignore-cr-at-eol, and
+    // the durable `.gitattributes` policy is staged on the upstream refresh.
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      updatePending: true,
+      pendingVersion: "v1.2.3",
+    });
+    mockPrisma.platformDevConfig.update.mockResolvedValue({});
+    mockExistsSync.mockReturnValue(false); // no merge in progress, no sentinel
+
+    mockExec.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, value: { stdout: string; stderr: string }) => void) => {
+      if (!cb) return;
+      if (cmd.includes("--diff-filter=U")) cb(null, { stdout: "", stderr: "" });
+      else if (cmd === "git diff --cached --stat") cb(null, { stdout: " 7 files changed, 21 insertions(+)", stderr: "" });
+      else cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await applyPlatformUpdate();
+
+    expect(result.kind).toBe("clean-merge");
+    const commands = mockExec.mock.calls.map(([cmd]) => String(cmd));
+    expect(commands).toContain(
+      "git -c core.hooksPath=/dev/null merge -X ignore-cr-at-eol dpf-upstream --no-commit --no-ff",
+    );
+    expect(commands).toContain("git add .gitattributes");
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/workspace/.gitattributes",
+      "* text=auto eol=lf\n",
+      "utf-8",
+    );
+    // The plain (conflict-prone) merge invocation must no longer be issued.
+    expect(commands).not.toContain("git merge dpf-upstream --no-commit --no-ff");
+  });
+
   it("returns clean-merge after a successful no-conflict merge and clears the pending flag", async () => {
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       updatePending: true,

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -736,6 +736,20 @@ const UPDATE_WORK_BRANCH = "my-changes";
 const HOOKLESS_GIT = "git -c core.hooksPath=/dev/null";
 const PLATFORM_UPDATE_SOURCE_PATHS = ["apps/web", "packages"] as const;
 const STALE_GIT_INDEX_LOCK_MS = 30_000;
+const VERSION_SENTINEL_FILE = ".dpf-version";
+
+// BI-4112378F: the image-sync snapshot path that builds `my-changes` and the
+// source-copy path that builds `dpf-upstream` normalise line endings
+// differently, so two trees that are byte-identical modulo CRLF↔LF diverge
+// wholesale (verified: 4,186 files, ~99.96% of which collapse when CR-at-EOL
+// is ignored). `-X ignore-cr-at-eol` makes the merge compare content the way
+// the clean-check guards already do (see gitDiffHasRealChanges), neutralising
+// the phantom conflicts at merge time. The `.gitattributes` policy below
+// declares the durable normalisation contract so future commits on both
+// branches converge on LF.
+const MERGE_EOL_TOLERANT_OPTS = "-X ignore-cr-at-eol";
+const GIT_ATTRIBUTES_FILE = ".gitattributes";
+const GIT_ATTRIBUTES_POLICY = "* text=auto eol=lf\n";
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -750,6 +764,52 @@ async function ensureWorkspaceSafeDirectory(
     `git config --global --add safe.directory ${shellQuote(workspace)} >/dev/null 2>&1 || true`,
     gitOpts,
   );
+}
+
+/**
+ * Read the installed-version sentinel (`.dpf-version`) written by the last
+ * successful apply. Returns the trimmed contents, or null when the sentinel
+ * is absent / unreadable (e.g. a freshly bootstrapped workspace).
+ *
+ * Used to short-circuit a redundant same-version apply: if the install is
+ * already on `pendingVersion`, re-running the merge would only surface the
+ * BI-4112378F phantom EOL conflicts, so we treat it as a no-op instead.
+ */
+function readInstalledVersion(
+  workspace: string,
+  resolvePath: (...parts: string[]) => string,
+): string | null {
+  const { existsSync, readFileSync } = lazyFs();
+  const sentinel = resolvePath(workspace, VERSION_SENTINEL_FILE);
+  if (!existsSync(sentinel)) return null;
+  try {
+    const raw = readFileSync(sentinel, "utf-8");
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure the durable line-ending normalisation policy (`.gitattributes`
+ * `* text=auto eol=lf`) is present in the workspace and staged. Idempotent —
+ * skips the write/add when the policy already matches. Declaring this on the
+ * `dpf-upstream` refresh lands it on both managed branches once merged, so the
+ * snapshot and source-copy population paths converge on LF going forward.
+ */
+async function ensureLineEndingPolicy(
+  execUpdate: ExecUpdate,
+  gitOpts: ExecUpdateOptions,
+  workspace: string,
+  resolvePath: (...parts: string[]) => string,
+): Promise<void> {
+  const { existsSync, readFileSync, writeFileSync } = lazyFs();
+  const target = resolvePath(workspace, GIT_ATTRIBUTES_FILE);
+  const current = existsSync(target) ? readFileSync(target, "utf-8") : "";
+  if (current === GIT_ATTRIBUTES_POLICY) return;
+  writeFileSync(target, GIT_ATTRIBUTES_POLICY, "utf-8");
+  await execUpdate(`git add ${GIT_ATTRIBUTES_FILE}`, gitOpts);
 }
 
 function recoverStaleGitIndexLock(
@@ -1033,7 +1093,33 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
     await ensureWorkspaceSafeDirectory(execUpdate, gitOpts, workspace);
     recoverStaleGitIndexLock(workspace, resolvePath);
 
-    if (existsSync(resolvePath(workspace, ".git", "MERGE_HEAD"))) {
+    const mergeInProgress = existsSync(resolvePath(workspace, ".git", "MERGE_HEAD"));
+
+    // BI-4112378F: short-circuit a redundant same-version apply. When the
+    // install is already on `pendingVersion` (no merge mid-flight), there is
+    // nothing to merge — proceeding would only re-derive the phantom EOL
+    // conflicts between the snapshot-built and source-copied trees. Treat it
+    // as a clean no-op: clear the pending flag and report zero files changed.
+    if (!mergeInProgress) {
+      const installedVersion = readInstalledVersion(workspace, resolvePath);
+      if (installedVersion !== null && installedVersion === pendingVersion) {
+        await prisma.platformDevConfig.update({
+          where: { id: "singleton" },
+          data: { updatePending: false, pendingVersion: null },
+        });
+        revalidatePath("/admin/platform-development");
+        revalidatePath("/ops/self-upgrade");
+        revalidatePath("/", "layout"); // banner lives in shell layout
+        return {
+          kind: "clean-merge",
+          message: `Already on v${pendingVersion}. No changes to merge.`,
+          version: pendingVersion,
+          filesUpdated: 0,
+        };
+      }
+    }
+
+    if (mergeInProgress) {
       const conflicts = await collectPlatformUpdateConflicts(
         execUpdate,
         gitOpts,
@@ -1063,6 +1149,7 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
 
     // Step 1-3: Refresh dpf-upstream branch with new source
     await checkoutManagedUpdateBranch(execUpdate, gitOpts, UPDATE_UPSTREAM_BRANCH);
+    await ensureLineEndingPolicy(execUpdate, gitOpts, workspace, resolvePath);
     await execUpdate("rm -rf apps/web packages", gitOpts);
     await execUpdate("cp -r /app/apps/web-src/. apps/web/", gitOpts);
     await execUpdate("cp -r /app/packages-src/. packages/", gitOpts);
@@ -1080,10 +1167,16 @@ export async function applyPlatformUpdate(): Promise<ApplyPlatformUpdateResult> 
       );
     }
 
-    // Step 4: Merge into my-changes
+    // Step 4: Merge into my-changes. `-X ignore-cr-at-eol` (BI-4112378F)
+    // prevents the snapshot-vs-source CRLF↔LF mismatch from manufacturing
+    // conflicts on otherwise-identical files. HOOKLESS_GIT keeps host
+    // checkout/commit hooks (git-lfs, pre-commit) out of the merge.
     await checkoutManagedUpdateBranch(execUpdate, gitOpts, UPDATE_WORK_BRANCH);
     try {
-      await execUpdate(`git merge ${UPDATE_UPSTREAM_BRANCH} --no-commit --no-ff`, gitOpts);
+      await execUpdate(
+        `${HOOKLESS_GIT} merge ${MERGE_EOL_TOLERANT_OPTS} ${UPDATE_UPSTREAM_BRANCH} --no-commit --no-ff`,
+        gitOpts,
+      );
     } catch {
       // Merge conflicts surface as a non-zero exit — expected, handled below
     }

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -779,12 +779,13 @@ function readInstalledVersion(
   workspace: string,
   resolvePath: (...parts: string[]) => string,
 ): string | null {
-  const { existsSync, readFileSync } = lazyFs();
+  const { readFileSync } = lazyFs();
   const sentinel = resolvePath(workspace, VERSION_SENTINEL_FILE);
-  if (!existsSync(sentinel)) return null;
+  // Read directly and treat any failure (absent / unreadable) as "no sentinel".
+  // Reading-then-catching rather than exists-then-read avoids a check-to-use
+  // TOCTOU race (CodeQL js/file-system-race).
   try {
-    const raw = readFileSync(sentinel, "utf-8");
-    const trimmed = raw.trim();
+    const trimmed = readFileSync(sentinel, "utf-8").trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
     return null;
@@ -804,9 +805,17 @@ async function ensureLineEndingPolicy(
   workspace: string,
   resolvePath: (...parts: string[]) => string,
 ): Promise<void> {
-  const { existsSync, readFileSync, writeFileSync } = lazyFs();
+  const { readFileSync, writeFileSync } = lazyFs();
   const target = resolvePath(workspace, GIT_ATTRIBUTES_FILE);
-  const current = existsSync(target) ? readFileSync(target, "utf-8") : "";
+  // Read-or-default rather than exists-then-read — avoids a check-to-use
+  // TOCTOU race (CodeQL js/file-system-race). A missing/unreadable file just
+  // means the policy isn't present yet, so we write it.
+  let current = "";
+  try {
+    current = readFileSync(target, "utf-8");
+  } catch {
+    current = "";
+  }
   if (current === GIT_ATTRIBUTES_POLICY) return;
   writeFileSync(target, GIT_ATTRIBUTES_POLICY, "utf-8");
   await execUpdate(`git add ${GIT_ATTRIBUTES_FILE}`, gitOpts);

--- a/docs/superpowers/plans/2026-06-05-reconcile-portal-update-surfaces-and-fix-phantom-conflict-merge.md
+++ b/docs/superpowers/plans/2026-06-05-reconcile-portal-update-surfaces-and-fix-phantom-conflict-merge.md
@@ -1,0 +1,112 @@
+---
+title: Reconcile portal self-upgrade surfaces + fix phantom-conflict merge
+date: 2026-06-05
+backlog_items:
+  - BI-D43EB266   # IA: two portal-update surfaces confuse operators; banner mis-routes
+  - BI-4112378F   # phantom 802-conflict same-version merge (CRLF↔LF)
+epic: EP-INSTALL-HARDENING-2026-05-23
+status: implemented
+---
+
+# Reconcile portal update surfaces + fix phantom-conflict merge
+
+## Problem
+
+Two separate "update the portal" surfaces confused operators, and one was
+broken:
+
+1. **`/ops/self-upgrade`** (Ops tab) — governed-upgrade orchestrator that
+   deploys a prebuilt portal image/SHA (`deployedSha → targetSha`),
+   maintenance windows, run history, recovery points + rollback. The
+   operator's primary path; works.
+2. **`/admin/platform-development`** (Admin tab) — `applyPlatformUpdate`
+   merges upstream source into the install's `my-changes` branch in the
+   `/workspace` git repo. The "update available" banner deep-linked *here*,
+   not to the Ops surface the operator uses.
+
+**Problem A (BI-D43EB266) — IA fragmentation.** Both surfaces independently
+advertised "update available" with their own apply controls in different nav
+areas; the shell banner routed to the Admin source-merge surface.
+
+**Problem B (BI-4112378F) — phantom 802-conflict merge.** `applyPlatformUpdate`
+merged local branch `dpf-upstream` into `my-changes`. The two branches carried
+the same version label (`v9c92036a`) but diverged by 4,186 files / ~687k lines;
+~99.96% of that collapsed when CR-at-EOL was ignored — a CRLF↔LF normalization
+mismatch between the image-sync snapshot path (`my-changes`) and the source-copy
+path (`dpf-upstream`). A redundant same-version apply phantom-conflicted, and a
+real future bundle would too.
+
+## Substrate verified
+
+- `apps/web/lib/actions/platform-dev-config.ts` — `applyPlatformUpdate`; the
+  merge at the work-branch step used a plain `git merge … --no-commit --no-ff`
+  with no EOL tolerance and no same-version guard. The clean-check guards
+  already used `--ignore-cr-at-eol` (precedent).
+- `apps/web/lib/mcp-tools.ts` `apply_platform_update` case **delegates** to the
+  same server action — single source of truth, so one fix covers UI + coworker.
+- `apps/web/components/shell/UpdatePendingBanner{,Client}.tsx` — banner derived
+  from `platformDevConfig.updatePending/pendingVersion`, linked to
+  `/admin/platform-development`.
+- `apps/web/components/admin/PlatformUpdateApplyPanel.tsx` — self-hides when
+  `!updatePending` (so gating on `updatePending` == "install customizes source
+  and has a pending merge").
+- `/ops/self-upgrade` page fetched only promotions status; `/admin/platform-
+  development` hosted the apply panel + contribution policy.
+
+## Changes
+
+### Part B — merge bug (BI-4112378F), `platform-dev-config.ts`
+
+1. **Same-version short-circuit.** Before any merge work (and only when no
+   merge is mid-flight), read the `.dpf-version` sentinel via a new
+   `readInstalledVersion`. If it equals `pendingVersion`, clear the pending
+   flag and return a clean no-op (`filesUpdated: 0`) — **zero conflicts**,
+   no `git merge` invoked. This is the acceptance test.
+2. **EOL-tolerant merge.** The work-branch merge now runs hookless with
+   `-X ignore-cr-at-eol`, matching the verified root cause (the diff collapses
+   when CR-at-EOL is ignored). Prevents phantom conflicts on genuine
+   cross-version applies too.
+3. **Durable normalization policy.** `ensureLineEndingPolicy` writes/stages
+   `.gitattributes` (`* text=auto eol=lf`) on the `dpf-upstream` refresh, so it
+   lands on both managed branches once merged and future snapshots converge on
+   LF (BI fix direction #1).
+
+> No-remote note (BI fix direction #2): `dpf-upstream` is a local branch with
+> no remote. The action already tolerates a missing `origin/main`
+> (`assertBranchRepairCanUseCurrentHead` returns early). Giving `dpf-upstream`
+> a real upstream base is a larger change deferred as follow-up; the
+> short-circuit + EOL tolerance fully resolve the phantom-conflict acceptance
+> criterion without it.
+
+### Part A — IA reconciliation (BI-D43EB266)
+
+1. **Banner re-point.** `UpdatePendingBannerClient` now links to
+   `/ops/self-upgrade` ("Review in Self-Upgrade").
+2. **Fold source-merge into Self-Upgrade.** `/ops/self-upgrade` now also
+   fetches `getPlatformDevConfig()` and renders `PlatformUpdateApplyPanel`
+   beneath the image/SHA deploy controls — surfaced only when the install
+   customizes source (`updatePending`).
+3. **Remove the duplicate Admin destination.** The apply panel is removed from
+   `/admin/platform-development` (which keeps contribution policy + identity).
+   "Update available" is now asserted on one operator surface.
+
+## Tests
+
+- `platform-dev-config.apply.test.ts` (node env, ran locally — 19/19 pass):
+  - new: same-version apply short-circuits with **zero conflicts**, no merge,
+    pending flag cleared.
+  - new: merge runs `-X ignore-cr-at-eol` hookless and stages the
+    `.gitattributes` policy; asserts the plain conflict-prone merge is gone.
+- `ops/self-upgrade/page.test.tsx` (ran locally — pass): panel receives the
+  install's pending state; dormant when source isn't customized.
+- `UpdatePendingBannerClient.test.tsx`: asserts the `/ops/self-upgrade`
+  deep-link. (Local run blocked only by a duplicate-React artifact from the
+  worktree's incomplete `node_modules`; validated in CI.)
+
+## Acceptance
+
+- [x] One operator "update the portal" surface; banner deep-links to it.
+- [x] Same-version apply produces 0 conflicts — covered by a test.
+- [x] Genuine source conflicts reviewable inside the self-upgrade flow, not a
+      separate Admin destination.
+- [x] Recovery-point/rollback behavior preserved (promotions path untouched).


### PR DESCRIPTION
Reconciles the two portal "update" surfaces and fixes the same-version merge that blocked every self-upgrade. Closes the two cold-install dogfood findings under `EP-INSTALL-HARDENING-2026-05-23`.

## BI-D43EB266 — one operator update surface
Two surfaces independently advertised "update available" with their own apply controls in different nav areas, and the shell banner deep-linked to the *Admin* source-merge surface rather than the *Ops* surface operators actually use.

- **Banner re-point** — `UpdatePendingBannerClient` now links to `/ops/self-upgrade` ("Review in Self-Upgrade").
- **Fold source-merge into Self-Upgrade** — `/ops/self-upgrade` now also fetches `getPlatformDevConfig()` and renders `PlatformUpdateApplyPanel` beneath the image/SHA deploy controls, surfaced **only when the install customizes source** (`updatePending`).
- **Remove the duplicate Admin destination** — the apply panel is gone from `/admin/platform-development`, which keeps contribution policy + identity. "Update available" is now asserted on one surface.

## BI-4112378F — phantom 802-conflict merge
`my-changes` (image-sync snapshots) and `dpf-upstream` (source copy) carried the same version label but diverged by 4,186 files — ~99.96% of which collapsed when CR-at-EOL was ignored. A pure CRLF↔LF normalization mismatch; a redundant same-version apply phantom-conflicted, and real bundles would too.

- **Same-version short-circuit** — when `.dpf-version` already equals `pendingVersion` (no merge mid-flight), the apply is a clean no-op: **zero conflicts, no `git merge` invoked**, pending flag cleared.
- **EOL-tolerant merge** — the work-branch merge runs hookless with `-X ignore-cr-at-eol` (matches the verified root cause; also protects genuine cross-version applies).
- **Durable normalization** — stages `.gitattributes` (`* text=auto eol=lf`) on the `dpf-upstream` refresh so both managed branches converge on LF going forward.

The `apply_platform_update` MCP tool delegates to the same `applyPlatformUpdate` server action, so the fix covers both the in-portal UI and the coworker path. **Recovery-point/rollback (promotions) untouched.**

> No-remote follow-up (BI fix direction #2): `dpf-upstream` is a local branch with no remote; the action already tolerates a missing `origin/main`. Giving it a real upstream base is deferred — the short-circuit + EOL tolerance fully resolve the phantom-conflict criterion without it.

## Acceptance
- [x] One operator "update the portal" surface; banner deep-links to it.
- [x] Same-version apply produces 0 conflicts — covered by a test.
- [x] Genuine source conflicts reviewable inside the self-upgrade flow, not a separate Admin destination.
- [x] Recovery-point/rollback behavior preserved.

## Tests
- `platform-dev-config.apply.test.ts` (node env, ran locally — **19/19 pass**): new same-version-zero-conflict test + new `-X ignore-cr-at-eol` / `.gitattributes` merge test.
- `ops/self-upgrade/page.test.tsx` (ran locally — pass): folded sub-step receives the install's pending state; dormant when source isn't customized.
- `UpdatePendingBannerClient.test.tsx`: asserts the `/ops/self-upgrade` deep-link (local run blocked only by a duplicate-React artifact from the worktree's incomplete `node_modules`; CI validates).

Plan: `docs/superpowers/plans/2026-06-05-reconcile-portal-update-surfaces-and-fix-phantom-conflict-merge.md`

> Note: pre-commit typecheck was skipped via the sanctioned `DPF_SKIP_TYPECHECK=1` because `next`/`@dpf/db` aren't resolvable in this worktree (incomplete `node_modules`); a scoped `tsc` run showed no type errors in the changed code beyond that environmental resolution. CI gates the merge.

Refs: BI-D43EB266, BI-4112378F · Epic: EP-INSTALL-HARDENING-2026-05-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)