### PR TITLE
feat(ai-ops-map): authority/sensitivity filter facet on the A2A band (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/A2aInteractionsPanel.test.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.test.tsx
@@ -137,6 +137,29 @@ describe("A2aInteractionsPanel", () => {
     expect(inspector.textContent).toContain("brand-extract");
   });
 
+  it("narrows by authority (governed vs ungoverned)", () => {
+    const { container } = render(
+      <A2aInteractionsPanel
+        coworkers={COWORKERS}
+        a2aEdges={[
+          edge({ id: "gov", authorityScope: ["brand:read"] }),
+          edge({ id: "ungov", toCoworkerId: "reviewer", authorityScope: [], sensitivity: null, skillId: null }),
+        ]}
+        a2aLegend={LEGEND}
+      />,
+    );
+    expect(container.querySelectorAll("[data-a2a-edge]").length).toBe(2);
+
+    fireEvent.click(findButton(container, "Governed"));
+    expect(container.querySelectorAll("[data-a2a-edge]").length).toBe(1);
+
+    fireEvent.click(findButton(container, "Ungoverned"));
+    const remaining = container.querySelectorAll("[data-a2a-edge]");
+    expect(remaining.length).toBe(1);
+    // The remaining edge is the ungoverned one (different target coworker).
+    expect(remaining[0]?.getAttribute("aria-label")).toContain("Reviewer");
+  });
+
   it("scrubs in lock-step with the shared replay playhead", () => {
     const range = { start: 0, current: 60 * 60 * 1000, end: 100 * 60 * 1000 };
     const at = (min: number) => new Date(min * 60 * 1000).toISOString();

--- a/apps/web/components/platform/A2aInteractionsPanel.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.tsx
@@ -15,6 +15,7 @@ import {
   A2A_EDGE_KINDS,
   A2A_GRAPH_LAYOUT,
   A2A_STATES,
+  a2aEdgeIsGoverned,
   a2aEdgeSourceRecords,
   a2aEdgeVisibleAtReplayTime,
   a2aStateIntent,
@@ -37,7 +38,14 @@ import {
   loadA2aFilterPreference,
   saveA2aFilterPreference,
   type A2aActorRole,
+  type A2aAuthorityFilter,
 } from "./ai-operations-map-prefs";
+
+const AUTHORITY_OPTIONS: Array<{ id: A2aAuthorityFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "governed", label: "Governed" },
+  { id: "ungoverned", label: "Ungoverned" },
+];
 
 type Props = {
   coworkers: OperationsMapRoutingCoworker[];
@@ -54,6 +62,7 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
   const [stateFilters, setStateFilters] = useState<OperationsMapA2aInteractionState[]>(defaults.states);
   const [actorId, setActorId] = useState<string>(defaults.actorId);
   const [actorRole, setActorRole] = useState<A2aActorRole>(defaults.actorRole);
+  const [authority, setAuthority] = useState<A2aAuthorityFilter>(defaults.authority);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const hydrated = useRef(false);
 
@@ -65,13 +74,14 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
     setStateFilters(pref.states);
     setActorId(pref.actorId);
     setActorRole(pref.actorRole);
+    setAuthority(pref.authority);
     hydrated.current = true;
   }, []);
 
   useEffect(() => {
     if (!hydrated.current) return;
-    saveA2aFilterPreference({ types: typeFilters, states: stateFilters, actorId, actorRole });
-  }, [typeFilters, stateFilters, actorId, actorRole]);
+    saveA2aFilterPreference({ types: typeFilters, states: stateFilters, actorId, actorRole, authority });
+  }, [typeFilters, stateFilters, actorId, actorRole, authority]);
 
   const labelByAgentId = useMemo(
     () => new Map(coworkers.map((coworker) => [coworker.agentId, coworker.label])),
@@ -110,9 +120,14 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
         if (replayTime != null && replayRange != null && !a2aEdgeVisibleAtReplayTime(edge.occurredAt, replayTime, replayRange)) {
           return false;
         }
+        if (authority !== "all") {
+          const governed = a2aEdgeIsGoverned(edge);
+          if (authority === "governed" && !governed) return false;
+          if (authority === "ungoverned" && governed) return false;
+        }
         return true;
       }),
-    [a2aEdges, typeFilters, stateFilters, actorId, actorRole, replayTime, replayRange],
+    [a2aEdges, typeFilters, stateFilters, actorId, actorRole, authority, replayTime, replayRange],
   );
 
   const selectedEdge = filteredEdges.find((edge) => edge.id === selectedEdgeId) ?? null;
@@ -133,6 +148,7 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
     setStateFilters(reset.states);
     setActorId(reset.actorId);
     setActorRole(reset.actorRole);
+    setAuthority(reset.authority);
     setSelectedEdgeId(null);
     clearA2aFilterPreference();
   };
@@ -183,6 +199,16 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
             <ChipGroup label="State">
               {A2A_STATES.map((state) => (
                 <Chip key={state} active={stateFilters.includes(state)} label={STATE_LABEL[state]} onClick={() => toggleState(state)} />
+              ))}
+            </ChipGroup>
+            <ChipGroup label="Authority">
+              {AUTHORITY_OPTIONS.map((option) => (
+                <Chip
+                  key={option.id}
+                  active={authority === option.id}
+                  label={option.label}
+                  onClick={() => setAuthority(option.id)}
+                />
               ))}
             </ChipGroup>
             <div>

--- a/apps/web/components/platform/a2a-interaction-graph.test.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   A2A_GRAPH_LAYOUT,
+  a2aEdgeIsGoverned,
   a2aEdgeSourceRecords,
   a2aEdgeVisibleAtReplayTime,
   a2aStateIntent,
@@ -127,6 +128,14 @@ describe("a2a-interaction-graph helpers", () => {
     // Undated / unparseable interactions are always visible.
     expect(a2aEdgeVisibleAtReplayTime(null, t50, range)).toBe(true);
     expect(a2aEdgeVisibleAtReplayTime("not-a-date", t50, range)).toBe(true);
+  });
+
+  it("classifies governed (authority/sensitivity-bearing) interactions", () => {
+    expect(a2aEdgeIsGoverned({ authorityScope: ["brand:read"] })).toBe(true);
+    expect(a2aEdgeIsGoverned({ sensitivity: "confidential" })).toBe(true);
+    expect(a2aEdgeIsGoverned({ authorityScope: [], sensitivity: "" })).toBe(false);
+    expect(a2aEdgeIsGoverned({ authorityScope: [], sensitivity: "  " })).toBe(false);
+    expect(a2aEdgeIsGoverned({})).toBe(false);
   });
 
   it("clips long labels and titleizes ids", () => {

--- a/apps/web/components/platform/a2a-interaction-graph.ts
+++ b/apps/web/components/platform/a2a-interaction-graph.ts
@@ -184,6 +184,18 @@ export function a2aEdgeVisibleAtReplayTime(
   return selectedTime - ts <= a2aReplayWindow(range);
 }
 
+/**
+ * An interaction is "governed" when it carries a delegated authority scope or a
+ * sensitivity boundary — the audit-relevant subset for "who acted under what
+ * authority". Delegation edges carry authorityScope; sensitivity is populated
+ * where the source records it.
+ */
+export function a2aEdgeIsGoverned(edge: { authorityScope?: string[]; sensitivity?: string | null }): boolean {
+  const hasAuthority = Array.isArray(edge.authorityScope) && edge.authorityScope.length > 0;
+  const hasSensitivity = typeof edge.sensitivity === "string" && edge.sensitivity.trim() !== "";
+  return hasAuthority || hasSensitivity;
+}
+
 export function svgClip(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, Math.max(0, maxLength - 1))}…`;

--- a/apps/web/components/platform/ai-operations-map-prefs.test.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.test.ts
@@ -209,6 +209,7 @@ describe("AI operations map preferences", () => {
       states: ["failed", "blocked"],
       actorId: "brand-analyst",
       actorRole: "to",
+      authority: "governed",
     });
 
     expect(store.has(OPERATIONS_MAP_A2A_PREFERENCE_KEY)).toBe(true);
@@ -217,19 +218,21 @@ describe("AI operations map preferences", () => {
       states: ["failed", "blocked"],
       actorId: "brand-analyst",
       actorRole: "to",
+      authority: "governed",
     });
   });
 
   it("treats a stored empty A2A filter as show-all and drops unknown values", () => {
     store.set(
       OPERATIONS_MAP_A2A_PREFERENCE_KEY,
-      JSON.stringify({ types: ["bogus"], states: [], actorId: "x", actorRole: "sideways" }),
+      JSON.stringify({ types: ["bogus"], states: [], actorId: "x", actorRole: "sideways", authority: "nope" }),
     );
     const loaded = loadA2aFilterPreference();
     expect(loaded.types).toEqual(["a2a-delegation", "a2a-handoff", "a2a-task-lineage", "a2a-deliberation"]);
     expect(loaded.states).toEqual(["active", "completed", "failed", "blocked"]);
     expect(loaded.actorRole).toBe("either");
     expect(loaded.actorId).toBe("x");
+    expect(loaded.authority).toBe("all");
   });
 
   it("clears the A2A filter preference", () => {

--- a/apps/web/components/platform/ai-operations-map-prefs.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.ts
@@ -16,12 +16,14 @@ export const OPERATIONS_MAP_SAVED_VIEWS_KEY = "ai-operations-map:saved-views";
 export const OPERATIONS_MAP_A2A_PREFERENCE_KEY = "ai-operations-map:a2a";
 
 export type A2aActorRole = "either" | "from" | "to";
+export type A2aAuthorityFilter = "all" | "governed" | "ungoverned";
 
 export type OperationsMapA2aFilterPreference = {
   types: OperationsMapA2aEdgeKind[];
   states: OperationsMapA2aInteractionState[];
   actorId: string;
   actorRole: A2aActorRole;
+  authority: A2aAuthorityFilter;
 };
 
 const A2A_EDGE_KIND_VALUES: OperationsMapA2aEdgeKind[] = [
@@ -32,6 +34,7 @@ const A2A_EDGE_KIND_VALUES: OperationsMapA2aEdgeKind[] = [
 ];
 const A2A_STATE_VALUES: OperationsMapA2aInteractionState[] = ["active", "completed", "failed", "blocked"];
 const A2A_ACTOR_ROLES = new Set<A2aActorRole>(["either", "from", "to"]);
+const A2A_AUTHORITY_FILTERS = new Set<A2aAuthorityFilter>(["all", "governed", "ungoverned"]);
 const A2A_EDGE_KIND_SET = new Set<OperationsMapA2aEdgeKind>(A2A_EDGE_KIND_VALUES);
 const A2A_STATE_SET = new Set<OperationsMapA2aInteractionState>(A2A_STATE_VALUES);
 
@@ -41,6 +44,7 @@ export function getDefaultA2aFilterPreference(): OperationsMapA2aFilterPreferenc
     states: [...A2A_STATE_VALUES],
     actorId: "all",
     actorRole: "either",
+    authority: "all",
   };
 }
 
@@ -58,6 +62,7 @@ export function loadA2aFilterPreference(): OperationsMapA2aFilterPreference {
       : [];
     const actorRole = A2A_ACTOR_ROLES.has(parsed.actorRole as A2aActorRole) ? (parsed.actorRole as A2aActorRole) : "either";
     const actorId = typeof parsed.actorId === "string" && parsed.actorId.trim() !== "" ? parsed.actorId : "all";
+    const authority = A2A_AUTHORITY_FILTERS.has(parsed.authority as A2aAuthorityFilter) ? (parsed.authority as A2aAuthorityFilter) : "all";
 
     return {
       // Empty arrays mean "show all" rather than "hide everything" — a stored
@@ -66,6 +71,7 @@ export function loadA2aFilterPreference(): OperationsMapA2aFilterPreference {
       states: states.length > 0 ? states : [...A2A_STATE_VALUES],
       actorId,
       actorRole,
+      authority,
     };
   } catch {
     return getDefaultA2aFilterPreference();


### PR DESCRIPTION
## What

Slice 2B/3. Adds an **Authority** filter facet (All · Governed · Ungoverned) to the coworker-to-coworker interaction panel so an operator can isolate authority-bearing interactions for audit — "who acted under what delegated authority / sensitivity boundary".

Backlog: **BI-65B0D697** (EP-AI-OPSMAP).

## How

- **pure helper** `a2aEdgeIsGoverned` — an interaction is governed when it carries a non-empty `authorityScope` or a `sensitivity` value (delegation edges carry authority scope; sensitivity is populated where the source records it).
- **prefs** — extend the persisted A2A filter preference with `authority` (default `all`, validated on load).
- **A2aInteractionsPanel** — authority filter state (hydrate/save/reset) + an Authority chip group; the filter composes with the existing type / state / coworker(role) / shared-replay filters.

## Verification

- `pnpm --filter web test` — full suite green (9615 passed, 0 errors).
- `pnpm --filter web typecheck` — clean. CI is the binding gate.
- New tests: governed classification, prefs round-trip, panel narrowing by governed/ungoverned.

## Notes

- Read-only, additive. No new DB models or migrations.
- **Stacked on #1495** (shared replay window) since both touch the A2A panel + graph helper + prefs — this PR shows the replay commit too until #1495 merges; it then rebases to a clean single-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
