### PR TITLE
feat(operate): self-diagnosing coworker regressions — detector + diagnosis + Issue Reports UI (BI-47443B67)

### DIFF
--- a/apps/web/components/admin/IssueReportPanel.test.tsx
+++ b/apps/web/components/admin/IssueReportPanel.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 vi.mock("@/lib/actions/quality", () => ({
   updateIssueReportStatus: vi.fn(),
+  sendIssueReportToBuildStudioAsFix: vi.fn(),
 }));
 
 import { IssueReportPanel } from "./IssueReportPanel";
@@ -19,6 +20,7 @@ const reports = [
     routeContext: "/build",
     errorStack: null,
     source: "agentic-loop-guard",
+    triggerKind: null,
     createdAt: "2026-05-25T21:34:43.000Z",
     reportedBy: null,
   },
@@ -33,10 +35,28 @@ const reports = [
     routeContext: null,
     errorStack: null,
     source: "warmup",
+    triggerKind: null,
     createdAt: "2026-05-25T19:58:01.000Z",
     reportedBy: null,
   },
 ];
+
+const coworkerRegressionReport = {
+  id: "db-3",
+  reportId: "PIR-COWORKER-REGRESSION",
+  type: "runtime_error",
+  severity: "high",
+  status: "open",
+  title: "Coworker latency regression: support-specialist on /platform/ai",
+  description:
+    "Diagnosis: slow-provider-dispatch\nRecent p95: 9000ms\nBaseline p95: 2000ms\nRatio: 4.5\nDispatches: 3\nNudges: 1\nTools attached: true\nExecuted tools: 0\nProvider: anthropic\nModel: claude-sonnet\nProbable cause: slow-provider-dispatch",
+  routeContext: "/platform/ai",
+  errorStack: null,
+  source: "coworker-regression-detector",
+  triggerKind: "latency-regression",
+  createdAt: "2026-06-05T10:05:00.000Z",
+  reportedBy: null,
+};
 
 const stats = {
   byStatus: { open: 1, acknowledged: 1 },
@@ -67,5 +87,32 @@ describe("IssueReportPanel", () => {
     expect(html).toContain("Ask System Admin");
     expect(html).toContain("Suppress");
     expect(html).not.toContain("Acknowledge");
+  });
+
+  it("renders a structured coworker-regression diagnosis with a send-to-fix action", () => {
+    const html = renderToStaticMarkup(
+      <IssueReportPanel
+        items={[coworkerRegressionReport]}
+        total={1}
+        stats={{
+          ...stats,
+          queueSummary: {
+            actionable: 1,
+            processGuard: 0,
+            warmupNoise: 0,
+            triaged: 0,
+            resolved: 0,
+            suppressed: 0,
+          },
+        }}
+      />,
+    );
+
+    // The platform explains the regression, scannable in Admin > Issue Reports.
+    expect(html).toContain("Coworker regression");
+    expect(html).toContain("slow-provider-dispatch");
+    expect(html).toContain("Recent p95");
+    // Operator can act: send the PIR to Build Studio as a fix.
+    expect(html).toContain("Send to Build Studio as a fix");
   });
 });

--- a/apps/web/components/admin/IssueReportPanel.tsx
+++ b/apps/web/components/admin/IssueReportPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 import { Archive, Bot, CheckCircle2, Filter, ShieldAlert, Wrench } from "lucide-react";
 import { updateIssueReportStatus, sendIssueReportToBuildStudioAsFix } from "@/lib/actions/quality";
+import { StatCard, StatusBadge } from "@/components/ui/report-kit";
 import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "@/lib/quality/issue-report-status";
 import {
   classifyIssueReport,
@@ -23,6 +24,7 @@ interface ReportRow {
   routeContext: string | null;
   errorStack: string | null;
   source: string;
+  triggerKind: string | null;
   createdAt: string;
   reportedBy: { id: string; name: string | null; email: string | null } | null;
 }
@@ -122,11 +124,11 @@ export function IssueReportPanel({
   return (
     <div className="space-y-5">
       <section className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
-        <StatCard label="Needs action" value={queueSummary.actionable} tone="var(--dpf-error)" />
-        <StatCard label="Process guard" value={queueSummary.processGuard} tone="var(--dpf-accent)" />
-        <StatCard label="Warmup noise" value={queueSummary.warmupNoise} tone="var(--dpf-warning)" />
-        <StatCard label="Triaged" value={queueSummary.triaged} tone="var(--dpf-warning)" />
-        <StatCard label="Resolved" value={queueSummary.resolved} tone="var(--dpf-success)" />
+        <StatCard label="Needs action" value={queueSummary.actionable} intent="danger" />
+        <StatCard label="Process guard" value={queueSummary.processGuard} intent="accent" />
+        <StatCard label="Warmup noise" value={queueSummary.warmupNoise} intent="warning" />
+        <StatCard label="Triaged" value={queueSummary.triaged} intent="warning" />
+        <StatCard label="Resolved" value={queueSummary.resolved} intent="success" />
         <StatCard label="Total" value={total} />
       </section>
 
@@ -175,18 +177,16 @@ export function IssueReportPanel({
 
       {Object.keys(stats.bySeverity).length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {Object.entries(stats.bySeverity).map(([severity, count]) => {
-            const tone = toneForSeverity(severity);
-            return (
-              <span
-                key={severity}
-                className="rounded-md border px-2 py-1 text-xs"
-                style={{ color: tone, borderColor: tone }}
-              >
-                {severity}: {count}
-              </span>
-            );
-          })}
+          {Object.entries(stats.bySeverity).map(([severity, count]) => (
+            <StatusBadge
+              key={severity}
+              domain="issueSeverity"
+              status={severity}
+              label={`${severity}: ${count}`}
+              uppercase={false}
+              size="md"
+            />
+          ))}
         </div>
       )}
 
@@ -262,25 +262,30 @@ function IssueReportRow({
 }) {
   const classification = classifyIssueReport(report);
   const status = normalizeIssueReportStatus(report.status);
-  const severityTone = toneForSeverity(report.severity);
-  const statusTone = toneForStatusBucket(status.bucket);
+  const isCoworkerRegression = report.source === "coworker-regression-detector";
+  const diagnosis = isCoworkerRegression ? parseCoworkerDiagnosis(report.description) : null;
 
   return (
     <article className="bg-[var(--dpf-surface-1)]">
       <div className="grid gap-3 p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
         <button type="button" onClick={onToggle} className="min-w-0 text-left">
           <div className="flex min-w-0 items-center gap-3">
-            <span
-              className="h-2.5 w-2.5 shrink-0 rounded-full"
-              style={{ backgroundColor: severityTone }}
-              title={report.severity}
+            <StatusBadge
+              domain="issueSeverity"
+              status={report.severity}
+              variant="soft"
+              size="sm"
+              className="shrink-0"
             />
             <span className="truncate font-mono text-xs text-[var(--dpf-muted)]">{report.reportId}</span>
             <span className="truncate text-sm font-medium text-[var(--dpf-text)]">{report.title}</span>
           </div>
-          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--dpf-muted)]">
-            <Badge label={classification.categoryLabel} />
-            <Badge label={status.label} tone={statusTone} />
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[var(--dpf-muted)]">
+            <StatusBadge intent="neutral" label={classification.categoryLabel} size="sm" />
+            <StatusBadge domain="issueStatus" status={status.bucket} label={status.label} size="sm" />
+            {isCoworkerRegression && (
+              <StatusBadge intent="accent" label="Coworker regression" size="sm" />
+            )}
             <span>{report.source}</span>
             {report.routeContext && <span className="font-mono">{report.routeContext}</span>}
             <span>{new Date(report.createdAt).toLocaleString()}</span>
@@ -335,6 +340,30 @@ function IssueReportRow({
 
       {expanded && (
         <div className="space-y-3 border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+          {diagnosis && (
+            <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusBadge intent="accent" label="Coworker regression" size="sm" />
+                {diagnosis.probableCause && (
+                  <StatusBadge intent="danger" label={diagnosis.probableCause} size="sm" uppercase={false} />
+                )}
+              </div>
+              {diagnosis.summary && (
+                <p className="mt-2 text-xs leading-5 text-[var(--dpf-text)]">{diagnosis.summary}</p>
+              )}
+              {diagnosis.metrics.length > 0 && (
+                <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 sm:grid-cols-4">
+                  {diagnosis.metrics.map(({ label, value }) => (
+                    <div key={label} className="min-w-0">
+                      <dt className="text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">{label}</dt>
+                      <dd className="truncate font-mono text-xs text-[var(--dpf-text)]">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </div>
+          )}
+
           {report.description && (
             <div>
               <h4 className="mb-1 text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">Description</h4>
@@ -375,17 +404,6 @@ function IssueReportRow({
   );
 }
 
-function StatCard({ label, value, tone }: { label: string; value: number; tone?: string }) {
-  return (
-    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
-      <p className="text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">{label}</p>
-      <p className="text-xl font-bold text-[var(--dpf-text)]" style={tone ? { color: tone } : undefined}>
-        {value}
-      </p>
-    </div>
-  );
-}
-
 function PostureBlock({ label, value, detail }: { label: string; value: number; detail: string }) {
   return (
     <div>
@@ -396,40 +414,51 @@ function PostureBlock({ label, value, detail }: { label: string; value: number; 
   );
 }
 
-function Badge({ label, tone }: { label: string; tone?: string }) {
-  return (
-    <span
-      className="rounded-md border border-[var(--dpf-border)] px-1.5 py-0.5 font-semibold uppercase"
-      style={tone ? { color: tone, borderColor: tone } : undefined}
-    >
-      {label}
-    </span>
-  );
-}
+type CoworkerDiagnosis = {
+  probableCause: string | null;
+  summary: string | null;
+  metrics: Array<{ label: string; value: string }>;
+};
 
-function toneForSeverity(severity: string): string {
-  switch (severity) {
-    case "critical":
-    case "high":
-      return "var(--dpf-error)";
-    case "medium":
-      return "var(--dpf-warning)";
-    default:
-      return "var(--dpf-muted)";
-  }
-}
+// Parse the deterministic diagnosis block the detector writes into
+// PlatformIssueReport.description (see coworker-regression-diagnosis.ts). The
+// description is a stable "Key: value" line format; we surface a scannable
+// subset as operator evidence and leave the full text in the Description panel.
+function parseCoworkerDiagnosis(description: string | null): CoworkerDiagnosis | null {
+  if (!description) return null;
 
-function toneForStatusBucket(bucket: string): string {
-  switch (bucket) {
-    case "needs_action":
-      return "var(--dpf-error)";
-    case "resolved":
-      return "var(--dpf-success)";
-    case "suppressed":
-      return "var(--dpf-muted)";
-    default:
-      return "var(--dpf-warning)";
+  const fields = new Map<string, string>();
+  for (const line of description.split("\n")) {
+    const sep = line.indexOf(":");
+    if (sep === -1) continue;
+    const key = line.slice(0, sep).trim().toLowerCase();
+    const value = line.slice(sep + 1).trim();
+    if (key && value && !fields.has(key)) fields.set(key, value);
   }
+
+  const probableCause = fields.get("probable cause") ?? fields.get("diagnosis") ?? null;
+  const summary = fields.get("summary") ?? null;
+
+  const metricSpecs: Array<{ key: string; label: string }> = [
+    { key: "recent p95", label: "Recent p95" },
+    { key: "baseline p95", label: "Baseline p95" },
+    { key: "ratio", label: "Ratio" },
+    { key: "recent nudge rate", label: "Recent nudge rate" },
+    { key: "baseline nudge rate", label: "Baseline nudge rate" },
+    { key: "dispatches", label: "Dispatches" },
+    { key: "nudges", label: "Nudges" },
+    { key: "tools attached", label: "Tools attached" },
+    { key: "executed tools", label: "Executed tools" },
+    { key: "provider", label: "Provider" },
+    { key: "model", label: "Model" },
+  ];
+
+  const metrics = metricSpecs
+    .filter((spec) => fields.has(spec.key))
+    .map((spec) => ({ label: spec.label, value: fields.get(spec.key) as string }));
+
+  if (!probableCause && !summary && metrics.length === 0) return null;
+  return { probableCause, summary, metrics };
 }
 
 function buildAdminPrompt(report: ReportRow, category: IssueReportCategory): string {

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -162,6 +162,23 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     "insufficient-evidence": "warning",
     pending: "accent",
   },
+  // Platform issue-report severity (Admin > Issue Reports). Mirrors the
+  // operator-facing severity semantics where an unbreached high is already
+  // danger-tier, distinct from the generic `severity` ramp below.
+  issueSeverity: {
+    info: "info",
+    low: "neutral",
+    medium: "warning",
+    high: "danger",
+    critical: "danger",
+  },
+  // Platform issue-report lifecycle bucket (needs_action/triaged/resolved/...).
+  issueStatus: {
+    needs_action: "danger",
+    triaged: "warning",
+    resolved: "success",
+    suppressed: "neutral",
+  },
   // Generic severity ramp, reusable by any surface that has none of its own.
   severity: {
     info: "info",

--- a/apps/web/lib/operate/coworker-regression-detector.test.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeP95,
+  groupDispatchRowsIntoTurns,
+  shouldFileLatencyRegression,
+} from "./coworker-regression-detector";
+
+describe("coworker latency regression detector", () => {
+  it("groups dispatch rows by threadId and agentMessageId and sums durationMs", () => {
+    const turns = groupDispatchRowsIntoTurns([
+      {
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        taskType: "conversation",
+        durationMs: 1200,
+        startedAt: new Date("2026-06-05T10:00:00Z"),
+      },
+      {
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        taskType: "conversation",
+        durationMs: 800,
+        startedAt: new Date("2026-06-05T10:00:02Z"),
+      },
+      {
+        threadId: null,
+        agentMessageId: "msg-2",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        taskType: "conversation",
+        durationMs: 999,
+        startedAt: new Date("2026-06-05T10:00:03Z"),
+      },
+    ]);
+
+    expect(turns).toEqual([
+      expect.objectContaining({
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        totalMs: 2000,
+      }),
+    ]);
+  });
+
+  it("uses the earliest startedAt as the turn timestamp", () => {
+    const turns = groupDispatchRowsIntoTurns([
+      {
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: 500,
+        startedAt: new Date("2026-06-05T10:00:05Z"),
+      },
+      {
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: 500,
+        startedAt: new Date("2026-06-05T10:00:01Z"),
+      },
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].startedAt).toEqual(new Date("2026-06-05T10:00:01Z"));
+    expect(turns[0].totalMs).toBe(1000);
+  });
+
+  it("skips rows missing threadId, agentMessageId, or a positive durationMs", () => {
+    const turns = groupDispatchRowsIntoTurns([
+      // missing threadId
+      {
+        threadId: null,
+        agentMessageId: "msg-a",
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: 1000,
+        startedAt: new Date("2026-06-05T10:00:00Z"),
+      },
+      // missing agentMessageId
+      {
+        threadId: "thr-x",
+        agentMessageId: null,
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: 1000,
+        startedAt: new Date("2026-06-05T10:00:00Z"),
+      },
+      // zero/null durationMs
+      {
+        threadId: "thr-y",
+        agentMessageId: "msg-y",
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: 0,
+        startedAt: new Date("2026-06-05T10:00:00Z"),
+      },
+      {
+        threadId: "thr-z",
+        agentMessageId: "msg-z",
+        agentId: "a",
+        routeContext: "/r",
+        taskType: null,
+        durationMs: null,
+        startedAt: new Date("2026-06-05T10:00:00Z"),
+      },
+    ]);
+    expect(turns).toEqual([]);
+  });
+
+  describe("computeP95", () => {
+    it("returns null for an empty array", () => {
+      expect(computeP95([])).toBeNull();
+    });
+
+    it("returns the p95 value", () => {
+      expect(computeP95([1000, 1100, 1200, 9000])).toBe(9000);
+    });
+
+    it("returns the single value for one sample", () => {
+      expect(computeP95([4242])).toBe(4242);
+    });
+  });
+
+  describe("shouldFileLatencyRegression", () => {
+    it("files only when sample size and p95 ratio both clear the threshold", () => {
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: 9000,
+          baselineP95Ms: 2000,
+          recentSampleCount: 12,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: true, ratio: 4.5 });
+    });
+
+    it("does not file when sample count is below minSamples", () => {
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: 9000,
+          baselineP95Ms: 2000,
+          recentSampleCount: 5,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: false, ratio: 4.5 });
+    });
+
+    it("does not file when the ratio is under the factor", () => {
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: 4000,
+          baselineP95Ms: 2000,
+          recentSampleCount: 20,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: false, ratio: 2 });
+    });
+
+    it("does not file when a window p95 is null", () => {
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: null,
+          baselineP95Ms: 2000,
+          recentSampleCount: 20,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: false, ratio: null });
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: 9000,
+          baselineP95Ms: null,
+          recentSampleCount: 20,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: false, ratio: null });
+    });
+
+    it("does not file when baseline p95 is zero", () => {
+      expect(
+        shouldFileLatencyRegression({
+          recentP95Ms: 9000,
+          baselineP95Ms: 0,
+          recentSampleCount: 20,
+          minSamples: 10,
+          factor: 3,
+        }),
+      ).toEqual({ file: false, ratio: null });
+    });
+  });
+});

--- a/apps/web/lib/operate/coworker-regression-detector.test.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.test.ts
@@ -1,9 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  computeNudgeShare,
   computeP95,
+  detectCoworkerNudgeRateRegressions,
   groupDispatchRowsIntoTurns,
   shouldFileLatencyRegression,
+  shouldFileNudgeRateRegression,
+  type CoworkerTurnMetricRow,
 } from "./coworker-regression-detector";
+
+function metricRow(
+  overrides: Partial<CoworkerTurnMetricRow> & {
+    threadId: string;
+    agentMessageId: string;
+    nudges: number;
+  },
+): CoworkerTurnMetricRow {
+  return {
+    agentId: "support-specialist",
+    routeContext: "/platform/ai",
+    taskType: "conversation",
+    createdAt: new Date("2026-06-05T10:00:00Z"),
+    ...overrides,
+  };
+}
 
 describe("coworker latency regression detector", () => {
   it("groups dispatch rows by threadId and agentMessageId and sums durationMs", () => {
@@ -201,6 +221,181 @@ describe("coworker latency regression detector", () => {
           factor: 3,
         }),
       ).toEqual({ file: false, ratio: null });
+    });
+  });
+});
+
+describe("coworker nudge-rate regression detector", () => {
+  describe("computeNudgeShare", () => {
+    it("returns null for an empty window", () => {
+      expect(computeNudgeShare([])).toBeNull();
+    });
+
+    it("returns the share of turns with at least one nudge", () => {
+      const rows = [
+        metricRow({ threadId: "t1", agentMessageId: "m1", nudges: 0 }),
+        metricRow({ threadId: "t2", agentMessageId: "m2", nudges: 1 }),
+        metricRow({ threadId: "t3", agentMessageId: "m3", nudges: 3 }),
+        metricRow({ threadId: "t4", agentMessageId: "m4", nudges: 0 }),
+      ];
+      expect(computeNudgeShare(rows)).toBe(0.5);
+    });
+  });
+
+  describe("shouldFileNudgeRateRegression", () => {
+    it("files when recent share is >= factor x a positive baseline", () => {
+      const result = shouldFileNudgeRateRegression({
+        recentShare: 0.6,
+        baselineShare: 0.1,
+        recentSampleCount: 12,
+        minSamples: 10,
+        factor: 3,
+        minNudgeRate: 0.2,
+      });
+      expect(result.file).toBe(true);
+      expect(result.ratio).toBeCloseTo(6, 10);
+    });
+
+    it("does not file when recent share is under factor x baseline", () => {
+      expect(
+        shouldFileNudgeRateRegression({
+          recentShare: 0.2,
+          baselineShare: 0.1,
+          recentSampleCount: 12,
+          minSamples: 10,
+          factor: 3,
+          minNudgeRate: 0.2,
+        }),
+      ).toEqual({ file: false, ratio: 2 });
+    });
+
+    it("files on zero baseline when recent share clears the absolute floor", () => {
+      expect(
+        shouldFileNudgeRateRegression({
+          recentShare: 0.25,
+          baselineShare: 0,
+          recentSampleCount: 12,
+          minSamples: 10,
+          factor: 3,
+          minNudgeRate: 0.2,
+        }),
+      ).toEqual({ file: true, ratio: null });
+    });
+
+    it("does not file on zero baseline below the absolute floor", () => {
+      expect(
+        shouldFileNudgeRateRegression({
+          recentShare: 0.1,
+          baselineShare: 0,
+          recentSampleCount: 12,
+          minSamples: 10,
+          factor: 3,
+          minNudgeRate: 0.2,
+        }),
+      ).toEqual({ file: false, ratio: null });
+    });
+
+    it("does not file when the sample count is below minSamples", () => {
+      expect(
+        shouldFileNudgeRateRegression({
+          recentShare: 1,
+          baselineShare: 0,
+          recentSampleCount: 3,
+          minSamples: 10,
+          factor: 3,
+          minNudgeRate: 0.2,
+        }),
+      ).toEqual({ file: false, ratio: null });
+    });
+
+    it("does not file when the recent window is empty", () => {
+      expect(
+        shouldFileNudgeRateRegression({
+          recentShare: null,
+          baselineShare: 0.1,
+          recentSampleCount: 0,
+          minSamples: 10,
+          factor: 3,
+          minNudgeRate: 0.2,
+        }),
+      ).toEqual({ file: false, ratio: null });
+    });
+  });
+
+  describe("detectCoworkerNudgeRateRegressions orchestration", () => {
+    const now = () => new Date("2026-06-05T12:00:00Z");
+
+    function buildRows(count: number, nudgedCount: number, prefix: string) {
+      const rows: CoworkerTurnMetricRow[] = [];
+      for (let i = 0; i < count; i++) {
+        rows.push(
+          metricRow({
+            threadId: `${prefix}-t${i}`,
+            agentMessageId: `${prefix}-m${i}`,
+            nudges: i < nudgedCount ? 2 : 0,
+          }),
+        );
+      }
+      return rows;
+    }
+
+    it("files a nudge-rate PIR when the recent share spikes against a zero baseline", async () => {
+      const fileReport = vi.fn(async () => {});
+      const result = await detectCoworkerNudgeRateRegressions({
+        now,
+        // recent: 12 turns, 6 nudged -> 0.5 share; baseline: all clean -> 0.
+        fetchTurnMetrics: async (from) =>
+          from.getTime() >= now().getTime() - 60 * 60 * 1000
+            ? buildRows(12, 6, "recent")
+            : buildRows(20, 0, "base"),
+        hasOpenDuplicate: async () => false,
+        fileReport,
+      });
+
+      expect(result.filed).toBe(1);
+      expect(fileReport).toHaveBeenCalledTimes(1);
+      const arg = fileReport.mock.calls[0][0];
+      expect(arg.title).toContain("nudge-rate regression");
+      expect(arg.title).toContain("support-specialist");
+      expect(arg.agentId).toBe("support-specialist");
+      expect(arg.routeContext).toBe("/platform/ai");
+      // Exemplar is one of the nudged turns.
+      expect(arg.threadId).toMatch(/^recent-t/);
+      expect(arg.severity).toBe("high"); // 0.5 share
+    });
+
+    it("skips filing when an open duplicate PIR already exists", async () => {
+      const fileReport = vi.fn(async () => {});
+      const result = await detectCoworkerNudgeRateRegressions({
+        now,
+        fetchTurnMetrics: async (from) =>
+          from.getTime() >= now().getTime() - 60 * 60 * 1000
+            ? buildRows(12, 6, "recent")
+            : buildRows(20, 0, "base"),
+        hasOpenDuplicate: async () => true,
+        fileReport,
+      });
+
+      expect(result.filed).toBe(0);
+      expect(result.skippedDuplicates).toBe(1);
+      expect(fileReport).not.toHaveBeenCalled();
+    });
+
+    it("does not file when the recent nudge share is below threshold", async () => {
+      const fileReport = vi.fn(async () => {});
+      const result = await detectCoworkerNudgeRateRegressions({
+        now,
+        // recent share 1/12 ~= 0.083, below the 0.2 zero-baseline floor.
+        fetchTurnMetrics: async (from) =>
+          from.getTime() >= now().getTime() - 60 * 60 * 1000
+            ? buildRows(12, 1, "recent")
+            : buildRows(20, 0, "base"),
+        hasOpenDuplicate: async () => false,
+        fileReport,
+      });
+
+      expect(result.filed).toBe(0);
+      expect(fileReport).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/lib/operate/coworker-regression-detector.test.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.test.ts
@@ -349,6 +349,7 @@ describe("coworker nudge-rate regression detector", () => {
             ? buildRows(12, 6, "recent")
             : buildRows(20, 0, "base"),
         hasOpenDuplicate: async () => false,
+        fetchExemplarTurnMetric: async () => null,
         fileReport,
       });
 
@@ -362,6 +363,10 @@ describe("coworker nudge-rate regression detector", () => {
       // Exemplar is one of the nudged turns.
       expect(arg.threadId).toMatch(/^recent-t/);
       expect(arg.severity).toBe("high"); // 0.5 share
+      // Diagnosis block is embedded. With no persisted exemplar metric and the
+      // exemplar carrying nudges but no dispatch count, the deterministic rules
+      // cannot confirm a redispatch loop, so it degrades to insufficient-evidence.
+      expect(arg.description).toContain("Diagnosis:");
     });
 
     it("skips filing when an open duplicate PIR already exists", async () => {

--- a/apps/web/lib/operate/coworker-regression-detector.test.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.test.ts
@@ -340,7 +340,16 @@ describe("coworker nudge-rate regression detector", () => {
     }
 
     it("files a nudge-rate PIR when the recent share spikes against a zero baseline", async () => {
-      const fileReport = vi.fn(async () => {});
+      const fileReport = vi.fn(
+        async (_input: {
+          title: string;
+          description: string;
+          severity: string;
+          routeContext: string | null;
+          threadId: string | null;
+          agentId: string | null;
+        }) => {},
+      );
       const result = await detectCoworkerNudgeRateRegressions({
         now,
         // recent: 12 turns, 6 nudged -> 0.5 share; baseline: all clean -> 0.

--- a/apps/web/lib/operate/coworker-regression-detector.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.ts
@@ -134,15 +134,85 @@ export function shouldFileLatencyRegression(input: {
   return { file, ratio };
 }
 
+// ── Nudge-rate pure helpers ──────────────────────────────────────────────
+
+/**
+ * One persisted `CoworkerTurnMetric` row, shaped for the nudge-rate detector.
+ * Only the fields the nudge-rate path reads are modeled here.
+ */
+export type CoworkerTurnMetricRow = {
+  threadId: string;
+  agentMessageId: string;
+  agentId: string | null;
+  routeContext: string | null;
+  taskType: string | null;
+  nudges: number;
+  createdAt: Date;
+};
+
+/**
+ * Share of turns in a window that incurred at least one continuation nudge.
+ * Returns null for an empty window so callers can distinguish "no data" from
+ * "no nudges".
+ */
+export function computeNudgeShare(rows: CoworkerTurnMetricRow[]): number | null {
+  if (rows.length === 0) return null;
+  const nudged = rows.reduce((n, r) => (r.nudges > 0 ? n + 1 : n), 0);
+  return nudged / rows.length;
+}
+
+/**
+ * Anti-flap gate for nudge-rate regressions. Files only when the recent window
+ * has enough samples AND either:
+ *  - the baseline nudge share is > 0 and the recent share is at least
+ *    `factor`x the baseline share; or
+ *  - the baseline share is 0 (or absent) and the recent share is at least
+ *    `minNudgeRate` (so one isolated nudge on a small sample does not alert).
+ *
+ * `ratio` is reported only when the baseline share is positive; it is null in
+ * the zero-baseline case where a multiplicative ratio is undefined.
+ */
+export function shouldFileNudgeRateRegression(input: {
+  recentShare: number | null;
+  baselineShare: number | null;
+  recentSampleCount: number;
+  minSamples: number;
+  factor: number;
+  minNudgeRate: number;
+}): { file: boolean; ratio: number | null } {
+  const {
+    recentShare,
+    baselineShare,
+    recentSampleCount,
+    minSamples,
+    factor,
+    minNudgeRate,
+  } = input;
+
+  if (recentShare == null || recentSampleCount < minSamples) {
+    return { file: false, ratio: null };
+  }
+
+  if (baselineShare != null && baselineShare > 0) {
+    const ratio = recentShare / baselineShare;
+    return { file: ratio >= factor, ratio };
+  }
+
+  // Zero (or absent) baseline: alert on an absolute floor only.
+  return { file: recentShare >= minNudgeRate, ratio: null };
+}
+
 // ── Orchestration ────────────────────────────────────────────────────────
 
 const DEFAULT_RECENT_WINDOW_MS = 60 * 60 * 1000;
 const DEFAULT_BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_MIN_SAMPLES = 10;
 const DEFAULT_FACTOR = 3;
+const DEFAULT_MIN_NUDGE_RATE = 0.2;
 
 const DETECTOR_SOURCE = "coworker-regression-detector";
 const LATENCY_TRIGGER_KIND = "latency-regression";
+const NUDGE_RATE_TRIGGER_KIND = "nudge-rate-regression";
 
 /** Null/empty attribution collapses to this key only — never persisted. */
 function bucketKeyPart(value: string | null): string {
@@ -317,6 +387,186 @@ function bucketByAgentRoute(
   return buckets;
 }
 
+function bucketMetricsByAgentRoute(
+  rows: CoworkerTurnMetricRow[],
+): Map<string, CoworkerTurnMetricRow[]> {
+  const buckets = new Map<string, CoworkerTurnMetricRow[]>();
+  for (const row of rows) {
+    const key = `${bucketKeyPart(row.agentId)}::${bucketKeyPart(
+      row.routeContext,
+    )}`;
+    const list = buckets.get(key);
+    if (list) list.push(row);
+    else buckets.set(key, [row]);
+  }
+  return buckets;
+}
+
+// ── Nudge-rate orchestration ─────────────────────────────────────────────
+
+export type DetectNudgeRateDeps = {
+  now?: () => Date;
+  recentWindowMs?: number;
+  baselineWindowMs?: number;
+  minSamples?: number;
+  factor?: number;
+  minNudgeRate?: number;
+  /** Fetch persisted turn metrics with `createdAt` in [from, to). */
+  fetchTurnMetrics: (
+    from: Date,
+    to: Date,
+  ) => Promise<CoworkerTurnMetricRow[]>;
+  /**
+   * Returns true if an OPEN PIR already exists for this
+   * source/trigger/agent/route tuple.
+   */
+  hasOpenDuplicate: (input: {
+    agentId: string | null;
+    routeContext: string | null;
+  }) => Promise<boolean>;
+  /** Files a PIR via the single server-side writer. */
+  fileReport: (input: {
+    title: string;
+    description: string;
+    severity: string;
+    routeContext: string | null;
+    threadId: string | null;
+    agentId: string | null;
+  }) => Promise<void>;
+};
+
+export type DetectNudgeRateResult = {
+  bucketsEvaluated: number;
+  filed: number;
+  skippedDuplicates: number;
+};
+
+/**
+ * Map nudge share to a severity. Conservative: a marginal nudge uptick should
+ * not page; a turn that nudges on the majority of attempts should.
+ */
+function nudgeSeverityFor(recentShare: number): string {
+  if (recentShare >= 0.75) return "critical";
+  if (recentShare >= 0.5) return "high";
+  return "medium";
+}
+
+/**
+ * Detect coworker nudge-rate regressions over persisted `CoworkerTurnMetric`
+ * rows and file deduplicated PIRs.
+ *
+ * Deps are injected so the orchestration is testable without a live database;
+ * the Inngest entry point binds them to Prisma + `createPlatformIssueReport`.
+ */
+export async function detectCoworkerNudgeRateRegressions(
+  deps?: Partial<DetectNudgeRateDeps>,
+): Promise<DetectNudgeRateResult> {
+  const resolved = await resolveNudgeRateDeps(deps);
+  const {
+    now,
+    recentWindowMs,
+    baselineWindowMs,
+    minSamples,
+    factor,
+    minNudgeRate,
+    fetchTurnMetrics,
+    hasOpenDuplicate,
+    fileReport,
+  } = resolved;
+
+  const nowDate = now();
+  const recentFrom = new Date(nowDate.getTime() - recentWindowMs);
+  const baselineFrom = new Date(nowDate.getTime() - baselineWindowMs);
+
+  const [recentRows, baselineRows] = await Promise.all([
+    fetchTurnMetrics(recentFrom, nowDate),
+    // Baseline window ends where the recent window begins so they do not overlap.
+    fetchTurnMetrics(baselineFrom, recentFrom),
+  ]);
+
+  const recentBuckets = bucketMetricsByAgentRoute(recentRows);
+  const baselineBuckets = bucketMetricsByAgentRoute(baselineRows);
+
+  let filed = 0;
+  let skippedDuplicates = 0;
+  let bucketsEvaluated = 0;
+
+  for (const [key, recent] of recentBuckets) {
+    bucketsEvaluated++;
+    const baseline = baselineBuckets.get(key) ?? [];
+
+    const recentShare = computeNudgeShare(recent);
+    const baselineShare = computeNudgeShare(baseline);
+
+    const decision = shouldFileNudgeRateRegression({
+      recentShare,
+      baselineShare,
+      recentSampleCount: recent.length,
+      minSamples,
+      factor,
+      minNudgeRate,
+    });
+
+    if (!decision.file || recentShare == null) continue;
+
+    const agentId = recent[0].agentId;
+    const routeContext = recent[0].routeContext;
+    // Worst exemplar: the most-nudged turn in the recent bucket.
+    const exemplar = recent.reduce((worst, r) =>
+      r.nudges > worst.nudges ? r : worst,
+    );
+
+    if (await hasOpenDuplicate({ agentId, routeContext })) {
+      skippedDuplicates++;
+      continue;
+    }
+
+    const severity = nudgeSeverityFor(recentShare);
+    const agentLabel = agentId ?? "unknown-agent";
+    const routeLabel = routeContext ?? "unknown-route";
+    const recentPct = (recentShare * 100).toFixed(1);
+    const baselineLabel =
+      baselineShare == null
+        ? "n/a"
+        : `${(baselineShare * 100).toFixed(1)}% (n=${baseline.length})`;
+    const ratioLabel =
+      decision.ratio == null ? "n/a (zero baseline)" : `${decision.ratio.toFixed(2)}x`;
+
+    const description = [
+      `Coworker nudge-rate regression detected.`,
+      ``,
+      `Agent: ${agentLabel}`,
+      `Route: ${routeLabel}`,
+      `Recent nudge rate: ${recentPct}% (n=${recent.length})`,
+      `Baseline nudge rate: ${baselineLabel}`,
+      `Ratio: ${ratioLabel} (factor threshold ${factor}x, zero-baseline floor ${(
+        minNudgeRate * 100
+      ).toFixed(0)}%)`,
+      `Window: last ${Math.round(recentWindowMs / 60000)}m vs prior ${Math.round(
+        baselineWindowMs / (24 * 60 * 60 * 1000),
+      )}d`,
+      ``,
+      `Worst exemplar turn:`,
+      `  thread: ${exemplar.threadId}`,
+      `  agentMessage: ${exemplar.agentMessageId}`,
+      `  nudges: ${exemplar.nudges}`,
+      `  taskType: ${exemplar.taskType ?? "unknown"}`,
+    ].join("\n");
+
+    await fileReport({
+      title: `Coworker nudge-rate regression: ${agentLabel} on ${routeLabel}`,
+      description,
+      severity,
+      routeContext,
+      threadId: exemplar.threadId,
+      agentId,
+    });
+    filed++;
+  }
+
+  return { bucketsEvaluated, filed, skippedDuplicates };
+}
+
 /**
  * Bind detector deps to live substrate (Prisma + the single PIR writer) for
  * any caller that does not inject its own. Prisma and the route/task join are
@@ -429,6 +679,100 @@ async function resolveDeps(
     minSamples,
     factor,
     fetchDispatchRows,
+    hasOpenDuplicate,
+    fileReport,
+  };
+}
+
+/**
+ * Bind nudge-rate detector deps to live substrate (Prisma + the single PIR
+ * writer). Prisma is imported lazily so the pure helpers stay importable in
+ * tests without pulling the database client into the module graph.
+ */
+async function resolveNudgeRateDeps(
+  deps?: Partial<DetectNudgeRateDeps>,
+): Promise<Required<DetectNudgeRateDeps>> {
+  const now = deps?.now ?? (() => new Date());
+  const recentWindowMs = deps?.recentWindowMs ?? DEFAULT_RECENT_WINDOW_MS;
+  const baselineWindowMs = deps?.baselineWindowMs ?? DEFAULT_BASELINE_WINDOW_MS;
+  const minSamples = deps?.minSamples ?? DEFAULT_MIN_SAMPLES;
+  const factor = deps?.factor ?? DEFAULT_FACTOR;
+  const minNudgeRate = deps?.minNudgeRate ?? DEFAULT_MIN_NUDGE_RATE;
+
+  const fetchTurnMetrics =
+    deps?.fetchTurnMetrics ??
+    (async (from: Date, to: Date) => {
+      const { prisma } = await import("@dpf/db");
+      const rows = await prisma.coworkerTurnMetric.findMany({
+        where: { createdAt: { gte: from, lt: to } },
+        select: {
+          threadId: true,
+          agentMessageId: true,
+          agentId: true,
+          routeContext: true,
+          taskType: true,
+          nudges: true,
+          createdAt: true,
+        },
+      });
+      return rows.map(
+        (r) =>
+          ({
+            threadId: r.threadId,
+            agentMessageId: r.agentMessageId,
+            agentId: r.agentId,
+            routeContext: r.routeContext,
+            taskType: r.taskType,
+            nudges: r.nudges,
+            createdAt: r.createdAt,
+          }) satisfies CoworkerTurnMetricRow,
+      );
+    });
+
+  const hasOpenDuplicate =
+    deps?.hasOpenDuplicate ??
+    (async ({ agentId, routeContext }) => {
+      const { prisma } = await import("@dpf/db");
+      const existing = await prisma.platformIssueReport.findFirst({
+        where: {
+          status: ISSUE_REPORT_STATUS.OPEN,
+          source: DETECTOR_SOURCE,
+          triggerKind: NUDGE_RATE_TRIGGER_KIND,
+          agentId: agentId ?? null,
+          routeContext: routeContext ?? null,
+        },
+        select: { id: true },
+      });
+      return existing != null;
+    });
+
+  const fileReport =
+    deps?.fileReport ??
+    (async ({ title, description, severity, routeContext, threadId, agentId }) => {
+      const { createPlatformIssueReport } = await import(
+        "@/lib/quality/platform-issue-reports"
+      );
+      await createPlatformIssueReport({
+        type: "regression",
+        source: DETECTOR_SOURCE,
+        triggerKind: NUDGE_RATE_TRIGGER_KIND,
+        title,
+        description,
+        severity,
+        routeContext,
+        threadId,
+        agentId,
+      });
+    });
+
+  return {
+    now,
+    recentWindowMs,
+    baselineWindowMs,
+    minSamples,
+    factor,
+    minNudgeRate,
+    fetchTurnMetrics,
     hasOpenDuplicate,
     fileReport,
   };

--- a/apps/web/lib/operate/coworker-regression-detector.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.ts
@@ -1,0 +1,435 @@
+/**
+ * Coworker regression detector — Task 1: latency detection over existing
+ * `AdapterRunTelemetry`.
+ *
+ * Pure helpers (`groupDispatchRowsIntoTurns`, `computeP95`,
+ * `shouldFileLatencyRegression`) are framework-free and unit-tested. The
+ * orchestrator `detectCoworkerLatencyRegressions` reads recent + baseline
+ * dispatch telemetry, recovers route/task via the `AgentMessage` join,
+ * buckets by `(agentId, routeContext)`, compares trailing-window p95, and
+ * files a deduplicated `PlatformIssueReport` through the single server-side
+ * PIR writer.
+ *
+ * Architecture grounding (see
+ * docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md):
+ *  - Latency source of truth is `AdapterRunTelemetry.durationMs` (there is no
+ *    `inferenceMs` on that model).
+ *  - PIRs are written only via `createPlatformIssueReport()` — never a direct
+ *    `prisma.platformIssueReport.create`.
+ *  - The existing 15-minute issue-report triage job promotes open PIRs to bug
+ *    backlog items; this detector only files PIRs.
+ */
+
+import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
+
+// ── Pure helper contracts ────────────────────────────────────────────────
+
+export type AdapterTurnDispatchRow = {
+  threadId: string | null;
+  agentMessageId: string | null;
+  agentId: string | null;
+  routeContext: string | null;
+  taskType: string | null;
+  durationMs: number | null;
+  startedAt: Date;
+};
+
+export type CoworkerTurnSample = {
+  threadId: string;
+  agentMessageId: string;
+  agentId: string | null;
+  routeContext: string | null;
+  taskType: string | null;
+  totalMs: number;
+  startedAt: Date;
+};
+
+/**
+ * Group per-dispatch telemetry rows into one sample per coworker turn.
+ *
+ * Rules (per plan Step 3):
+ *  - Skip rows missing `threadId`, missing `agentMessageId`, or lacking a
+ *    positive `durationMs`.
+ *  - Group by `threadId::agentMessageId`; sum `durationMs` into `totalMs`.
+ *  - Use the earliest `startedAt` as the turn timestamp.
+ *  - Attribution fields (`agentId`, `routeContext`, `taskType`) are taken
+ *    from the first surviving row in the group and never coerced to
+ *    `"unknown"` placeholders here.
+ */
+export function groupDispatchRowsIntoTurns(
+  rows: AdapterTurnDispatchRow[],
+): CoworkerTurnSample[] {
+  const byTurn = new Map<string, CoworkerTurnSample>();
+
+  for (const row of rows) {
+    if (!row.threadId || !row.agentMessageId) continue;
+    if (row.durationMs == null || row.durationMs <= 0) continue;
+
+    const key = `${row.threadId}::${row.agentMessageId}`;
+    const existing = byTurn.get(key);
+
+    if (!existing) {
+      byTurn.set(key, {
+        threadId: row.threadId,
+        agentMessageId: row.agentMessageId,
+        agentId: row.agentId,
+        routeContext: row.routeContext,
+        taskType: row.taskType,
+        totalMs: row.durationMs,
+        startedAt: row.startedAt,
+      });
+      continue;
+    }
+
+    existing.totalMs += row.durationMs;
+    if (row.startedAt < existing.startedAt) {
+      existing.startedAt = row.startedAt;
+    }
+    // Backfill attribution from later rows if the first surviving row lacked it.
+    existing.agentId ??= row.agentId;
+    existing.routeContext ??= row.routeContext;
+    existing.taskType ??= row.taskType;
+  }
+
+  return [...byTurn.values()];
+}
+
+/**
+ * Linear-interpolation-free p95: nearest-rank on the sorted values.
+ * Returns null for an empty input.
+ */
+export function computeP95(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  // Nearest-rank index for the 95th percentile.
+  const rank = Math.ceil(0.95 * sorted.length);
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[index];
+}
+
+/**
+ * Anti-flap gate: file only when the recent window has enough samples AND its
+ * p95 exceeds the trailing baseline p95 by at least `factor`.
+ *
+ * `ratio` is reported whenever both p95 values are present and the baseline is
+ * positive, so callers can surface it even when not filing; it is null when the
+ * ratio is undefined (missing p95 or zero baseline).
+ */
+export function shouldFileLatencyRegression(input: {
+  recentP95Ms: number | null;
+  baselineP95Ms: number | null;
+  recentSampleCount: number;
+  minSamples: number;
+  factor: number;
+}): { file: boolean; ratio: number | null } {
+  const { recentP95Ms, baselineP95Ms, recentSampleCount, minSamples, factor } =
+    input;
+
+  if (recentP95Ms == null || baselineP95Ms == null || baselineP95Ms <= 0) {
+    return { file: false, ratio: null };
+  }
+
+  const ratio = recentP95Ms / baselineP95Ms;
+  const file = recentSampleCount >= minSamples && ratio >= factor;
+  return { file, ratio };
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────
+
+const DEFAULT_RECENT_WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_MIN_SAMPLES = 10;
+const DEFAULT_FACTOR = 3;
+
+const DETECTOR_SOURCE = "coworker-regression-detector";
+const LATENCY_TRIGGER_KIND = "latency-regression";
+
+/** Null/empty attribution collapses to this key only — never persisted. */
+function bucketKeyPart(value: string | null): string {
+  return value && value.trim().length > 0 ? value : "unknown";
+}
+
+export type DetectLatencyDeps = {
+  now?: () => Date;
+  recentWindowMs?: number;
+  baselineWindowMs?: number;
+  minSamples?: number;
+  factor?: number;
+  /** Fetch dispatch rows with `startedAt` in [from, to). */
+  fetchDispatchRows: (
+    from: Date,
+    to: Date,
+  ) => Promise<AdapterTurnDispatchRow[]>;
+  /**
+   * Returns true if an OPEN PIR already exists for this
+   * source/trigger/agent/route tuple.
+   */
+  hasOpenDuplicate: (input: {
+    agentId: string | null;
+    routeContext: string | null;
+  }) => Promise<boolean>;
+  /** Files a PIR via the single server-side writer. */
+  fileReport: (input: {
+    title: string;
+    description: string;
+    severity: string;
+    routeContext: string | null;
+    threadId: string | null;
+    agentId: string | null;
+  }) => Promise<void>;
+};
+
+export type DetectLatencyResult = {
+  bucketsEvaluated: number;
+  filed: number;
+  skippedDuplicates: number;
+};
+
+/**
+ * Map ratio + absolute recent p95 to a severity. Deliberately conservative:
+ * the detector should not page on a marginal regression.
+ */
+function severityFor(ratio: number, recentP95Ms: number): string {
+  if (ratio >= 6 || recentP95Ms >= 60_000) return "critical";
+  if (ratio >= 4 || recentP95Ms >= 30_000) return "high";
+  return "medium";
+}
+
+/**
+ * Detect coworker latency regressions and file deduplicated PIRs.
+ *
+ * Deps are injected so the orchestration is testable without a live database;
+ * the Inngest entry point binds them to Prisma + `createPlatformIssueReport`.
+ */
+export async function detectCoworkerLatencyRegressions(
+  deps?: Partial<DetectLatencyDeps>,
+): Promise<DetectLatencyResult> {
+  const resolved = await resolveDeps(deps);
+  const {
+    now,
+    recentWindowMs,
+    baselineWindowMs,
+    minSamples,
+    factor,
+    fetchDispatchRows,
+    hasOpenDuplicate,
+    fileReport,
+  } = resolved;
+
+  const nowDate = now();
+  const recentFrom = new Date(nowDate.getTime() - recentWindowMs);
+  const baselineFrom = new Date(nowDate.getTime() - baselineWindowMs);
+
+  const [recentRows, baselineRows] = await Promise.all([
+    fetchDispatchRows(recentFrom, nowDate),
+    // Baseline window ends where the recent window begins so the two do not overlap.
+    fetchDispatchRows(baselineFrom, recentFrom),
+  ]);
+
+  const recentTurns = groupDispatchRowsIntoTurns(recentRows);
+  const baselineTurns = groupDispatchRowsIntoTurns(baselineRows);
+
+  const recentBuckets = bucketByAgentRoute(recentTurns);
+  const baselineBuckets = bucketByAgentRoute(baselineTurns);
+
+  let filed = 0;
+  let skippedDuplicates = 0;
+  let bucketsEvaluated = 0;
+
+  for (const [key, recent] of recentBuckets) {
+    bucketsEvaluated++;
+    const baseline = baselineBuckets.get(key) ?? [];
+
+    const recentP95 = computeP95(recent.map((t) => t.totalMs));
+    const baselineP95 = computeP95(baseline.map((t) => t.totalMs));
+
+    const decision = shouldFileLatencyRegression({
+      recentP95Ms: recentP95,
+      baselineP95Ms: baselineP95,
+      recentSampleCount: recent.length,
+      minSamples,
+      factor,
+    });
+
+    if (!decision.file || decision.ratio == null || recentP95 == null) continue;
+
+    // Representative attribution + worst exemplar come from the recent bucket.
+    const agentId = recent[0].agentId;
+    const routeContext = recent[0].routeContext;
+    const exemplar = recent.reduce((worst, t) =>
+      t.totalMs > worst.totalMs ? t : worst,
+    );
+
+    if (await hasOpenDuplicate({ agentId, routeContext })) {
+      skippedDuplicates++;
+      continue;
+    }
+
+    const severity = severityFor(decision.ratio, recentP95);
+    const agentLabel = agentId ?? "unknown-agent";
+    const routeLabel = routeContext ?? "unknown-route";
+
+    const description = [
+      `Coworker turn latency regression detected.`,
+      ``,
+      `Agent: ${agentLabel}`,
+      `Route: ${routeLabel}`,
+      `Recent p95: ${recentP95}ms (n=${recent.length})`,
+      `Baseline p95: ${baselineP95}ms (n=${baseline.length})`,
+      `Ratio: ${decision.ratio.toFixed(2)}x (threshold ${factor}x)`,
+      `Window: last ${Math.round(recentWindowMs / 60000)}m vs prior ${Math.round(
+        baselineWindowMs / (24 * 60 * 60 * 1000),
+      )}d`,
+      ``,
+      `Worst exemplar turn:`,
+      `  thread: ${exemplar.threadId}`,
+      `  agentMessage: ${exemplar.agentMessageId}`,
+      `  totalMs: ${exemplar.totalMs}`,
+      `  taskType: ${exemplar.taskType ?? "unknown"}`,
+    ].join("\n");
+
+    await fileReport({
+      title: `Coworker latency regression: ${agentLabel} on ${routeLabel}`,
+      description,
+      severity,
+      routeContext,
+      threadId: exemplar.threadId,
+      agentId,
+    });
+    filed++;
+  }
+
+  return { bucketsEvaluated, filed, skippedDuplicates };
+}
+
+function bucketByAgentRoute(
+  turns: CoworkerTurnSample[],
+): Map<string, CoworkerTurnSample[]> {
+  const buckets = new Map<string, CoworkerTurnSample[]>();
+  for (const turn of turns) {
+    const key = `${bucketKeyPart(turn.agentId)}::${bucketKeyPart(
+      turn.routeContext,
+    )}`;
+    const list = buckets.get(key);
+    if (list) list.push(turn);
+    else buckets.set(key, [turn]);
+  }
+  return buckets;
+}
+
+/**
+ * Bind detector deps to live substrate (Prisma + the single PIR writer) for
+ * any caller that does not inject its own. Prisma and the route/task join are
+ * imported lazily so the pure helpers stay importable in tests without pulling
+ * the database client into the module graph.
+ */
+async function resolveDeps(
+  deps?: Partial<DetectLatencyDeps>,
+): Promise<Required<DetectLatencyDeps>> {
+  const now = deps?.now ?? (() => new Date());
+  const recentWindowMs = deps?.recentWindowMs ?? DEFAULT_RECENT_WINDOW_MS;
+  const baselineWindowMs = deps?.baselineWindowMs ?? DEFAULT_BASELINE_WINDOW_MS;
+  const minSamples = deps?.minSamples ?? DEFAULT_MIN_SAMPLES;
+  const factor = deps?.factor ?? DEFAULT_FACTOR;
+
+  const fetchDispatchRows =
+    deps?.fetchDispatchRows ??
+    (async (from: Date, to: Date) => {
+      const { prisma } = await import("@dpf/db");
+      // Pull dispatch telemetry for coworker turns in the window, then recover
+      // route/task by joining AgentMessage on agentMessageId.
+      const rows = await prisma.adapterRunTelemetry.findMany({
+        where: {
+          startedAt: { gte: from, lt: to },
+          threadId: { not: null },
+          agentMessageId: { not: null },
+          durationMs: { gt: 0 },
+        },
+        select: {
+          threadId: true,
+          agentMessageId: true,
+          agentId: true,
+          durationMs: true,
+          startedAt: true,
+        },
+      });
+
+      const messageIds = [
+        ...new Set(
+          rows
+            .map((r) => r.agentMessageId)
+            .filter((id): id is string => id != null),
+        ),
+      ];
+
+      const messages = messageIds.length
+        ? await prisma.agentMessage.findMany({
+            where: { id: { in: messageIds } },
+            select: { id: true, routeContext: true, taskType: true },
+          })
+        : [];
+      const byMessageId = new Map(messages.map((m) => [m.id, m]));
+
+      return rows.map((r) => {
+        const msg = r.agentMessageId
+          ? byMessageId.get(r.agentMessageId)
+          : undefined;
+        return {
+          threadId: r.threadId,
+          agentMessageId: r.agentMessageId,
+          agentId: r.agentId,
+          routeContext: msg?.routeContext ?? null,
+          taskType: msg?.taskType ?? null,
+          durationMs: r.durationMs,
+          startedAt: r.startedAt,
+        } satisfies AdapterTurnDispatchRow;
+      });
+    });
+
+  const hasOpenDuplicate =
+    deps?.hasOpenDuplicate ??
+    (async ({ agentId, routeContext }) => {
+      const { prisma } = await import("@dpf/db");
+      const existing = await prisma.platformIssueReport.findFirst({
+        where: {
+          status: ISSUE_REPORT_STATUS.OPEN,
+          source: DETECTOR_SOURCE,
+          triggerKind: LATENCY_TRIGGER_KIND,
+          agentId: agentId ?? null,
+          routeContext: routeContext ?? null,
+        },
+        select: { id: true },
+      });
+      return existing != null;
+    });
+
+  const fileReport =
+    deps?.fileReport ??
+    (async ({ title, description, severity, routeContext, threadId, agentId }) => {
+      const { createPlatformIssueReport } = await import(
+        "@/lib/quality/platform-issue-reports"
+      );
+      await createPlatformIssueReport({
+        type: "regression",
+        source: DETECTOR_SOURCE,
+        triggerKind: LATENCY_TRIGGER_KIND,
+        title,
+        description,
+        severity,
+        routeContext,
+        threadId,
+        agentId,
+      });
+    });
+
+  return {
+    now,
+    recentWindowMs,
+    baselineWindowMs,
+    minSamples,
+    factor,
+    fetchDispatchRows,
+    hasOpenDuplicate,
+    fileReport,
+  };
+}

--- a/apps/web/lib/operate/coworker-regression-detector.ts
+++ b/apps/web/lib/operate/coworker-regression-detector.ts
@@ -21,6 +21,47 @@
  */
 
 import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
+import {
+  buildCoworkerRegressionDiagnosis,
+  type CoworkerRegressionDiagnosis,
+} from "./coworker-regression-diagnosis";
+
+/**
+ * Full per-turn metric row for the exemplar turn, used to enrich a PIR with a
+ * deterministic diagnosis. Looked up by `(threadId, agentMessageId)` through an
+ * injectable dep; when absent the detector passes minimal input so the
+ * diagnosis yields `insufficient-evidence` rather than throwing.
+ */
+export type ExemplarTurnMetric = {
+  dispatches: number | null;
+  nudges: number | null;
+  toolsAttached: boolean | null;
+  executedTools: number | null;
+  totalMs: number | null;
+  taskType: string | null;
+  providerId: string | null;
+  modelId: string | null;
+};
+
+/**
+ * Render a diagnosis as a compact, description-safe block for a PIR. Kept here
+ * (not in the pure module) because it is detector-presentation, not diagnosis
+ * logic. The `Diagnosis:` first line is what the operator UI keys on.
+ */
+function diagnosisBlock(diagnosis: CoworkerRegressionDiagnosis): string {
+  const m = diagnosis.metrics;
+  return [
+    `Diagnosis: ${diagnosis.probableCause}`,
+    diagnosis.summary,
+    ``,
+    `Dispatches: ${m.dispatches ?? "n/a"}`,
+    `Nudges: ${m.nudges ?? "n/a"}`,
+    `Tools attached: ${m.toolsAttached ?? "n/a"}`,
+    `Executed tools: ${m.executedTools ?? "n/a"}`,
+    `Provider: ${m.providerId ?? "n/a"}`,
+    `Model: ${m.modelId ?? "n/a"}`,
+  ].join("\n");
+}
 
 // ── Pure helper contracts ────────────────────────────────────────────────
 
@@ -238,6 +279,16 @@ export type DetectLatencyDeps = {
     agentId: string | null;
     routeContext: string | null;
   }) => Promise<boolean>;
+  /**
+   * Look up the persisted turn metric for the exemplar turn so the PIR can
+   * carry a deterministic diagnosis. Returns null when the turn was never
+   * persisted (e.g. metrics writer disabled / fail-open), in which case the
+   * diagnosis degrades to `insufficient-evidence`.
+   */
+  fetchExemplarTurnMetric: (key: {
+    threadId: string;
+    agentMessageId: string;
+  }) => Promise<ExemplarTurnMetric | null>;
   /** Files a PIR via the single server-side writer. */
   fileReport: (input: {
     title: string;
@@ -283,6 +334,7 @@ export async function detectCoworkerLatencyRegressions(
     factor,
     fetchDispatchRows,
     hasOpenDuplicate,
+    fetchExemplarTurnMetric,
     fileReport,
   } = resolved;
 
@@ -339,6 +391,26 @@ export async function detectCoworkerLatencyRegressions(
     const agentLabel = agentId ?? "unknown-agent";
     const routeLabel = routeContext ?? "unknown-route";
 
+    // Enrich with a deterministic diagnosis from the exemplar's persisted turn
+    // metric. The exemplar's summed adapter duration (`totalMs`) is the
+    // dispatch time; the metric row carries the wall-clock turn duration.
+    const exemplarMetric = await fetchExemplarTurnMetric({
+      threadId: exemplar.threadId,
+      agentMessageId: exemplar.agentMessageId,
+    });
+    const diagnosis = buildCoworkerRegressionDiagnosis({
+      routeContext,
+      taskType: exemplarMetric?.taskType ?? exemplar.taskType,
+      dispatches: exemplarMetric?.dispatches ?? null,
+      nudges: exemplarMetric?.nudges ?? null,
+      toolsAttached: exemplarMetric?.toolsAttached ?? null,
+      executedTools: exemplarMetric?.executedTools ?? null,
+      totalMs: exemplarMetric?.totalMs ?? null,
+      dispatchMs: exemplar.totalMs,
+      providerId: exemplarMetric?.providerId ?? null,
+      modelId: exemplarMetric?.modelId ?? null,
+    });
+
     const description = [
       `Coworker turn latency regression detected.`,
       ``,
@@ -356,6 +428,8 @@ export async function detectCoworkerLatencyRegressions(
       `  agentMessage: ${exemplar.agentMessageId}`,
       `  totalMs: ${exemplar.totalMs}`,
       `  taskType: ${exemplar.taskType ?? "unknown"}`,
+      ``,
+      diagnosisBlock(diagnosis),
     ].join("\n");
 
     await fileReport({
@@ -424,6 +498,15 @@ export type DetectNudgeRateDeps = {
     agentId: string | null;
     routeContext: string | null;
   }) => Promise<boolean>;
+  /**
+   * Look up the persisted turn metric for the exemplar turn so the PIR can
+   * carry a deterministic diagnosis. Returns null when the turn was never
+   * persisted, in which case the diagnosis degrades to `insufficient-evidence`.
+   */
+  fetchExemplarTurnMetric: (key: {
+    threadId: string;
+    agentMessageId: string;
+  }) => Promise<ExemplarTurnMetric | null>;
   /** Files a PIR via the single server-side writer. */
   fileReport: (input: {
     title: string;
@@ -471,6 +554,7 @@ export async function detectCoworkerNudgeRateRegressions(
     minNudgeRate,
     fetchTurnMetrics,
     hasOpenDuplicate,
+    fetchExemplarTurnMetric,
     fileReport,
   } = resolved;
 
@@ -532,6 +616,26 @@ export async function detectCoworkerNudgeRateRegressions(
     const ratioLabel =
       decision.ratio == null ? "n/a (zero baseline)" : `${decision.ratio.toFixed(2)}x`;
 
+    // Enrich with a deterministic diagnosis from the exemplar's persisted turn
+    // metric. The nudge-rate path has no per-turn dispatch duration, so
+    // `dispatchMs` is left null and duration-shape rules cannot fire.
+    const exemplarMetric = await fetchExemplarTurnMetric({
+      threadId: exemplar.threadId,
+      agentMessageId: exemplar.agentMessageId,
+    });
+    const diagnosis = buildCoworkerRegressionDiagnosis({
+      routeContext,
+      taskType: exemplarMetric?.taskType ?? exemplar.taskType,
+      dispatches: exemplarMetric?.dispatches ?? null,
+      nudges: exemplarMetric?.nudges ?? exemplar.nudges,
+      toolsAttached: exemplarMetric?.toolsAttached ?? null,
+      executedTools: exemplarMetric?.executedTools ?? null,
+      totalMs: exemplarMetric?.totalMs ?? null,
+      dispatchMs: null,
+      providerId: exemplarMetric?.providerId ?? null,
+      modelId: exemplarMetric?.modelId ?? null,
+    });
+
     const description = [
       `Coworker nudge-rate regression detected.`,
       ``,
@@ -551,6 +655,8 @@ export async function detectCoworkerNudgeRateRegressions(
       `  agentMessage: ${exemplar.agentMessageId}`,
       `  nudges: ${exemplar.nudges}`,
       `  taskType: ${exemplar.taskType ?? "unknown"}`,
+      ``,
+      diagnosisBlock(diagnosis),
     ].join("\n");
 
     await fileReport({
@@ -653,6 +759,9 @@ async function resolveDeps(
       return existing != null;
     });
 
+  const fetchExemplarTurnMetric =
+    deps?.fetchExemplarTurnMetric ?? defaultFetchExemplarTurnMetric;
+
   const fileReport =
     deps?.fileReport ??
     (async ({ title, description, severity, routeContext, threadId, agentId }) => {
@@ -680,7 +789,49 @@ async function resolveDeps(
     factor,
     fetchDispatchRows,
     hasOpenDuplicate,
+    fetchExemplarTurnMetric,
     fileReport,
+  };
+}
+
+/**
+ * Live binding for the exemplar turn-metric lookup. Imports Prisma lazily so
+ * the detector module stays importable in client-free tests. Returns null when
+ * the exemplar turn has no persisted `CoworkerTurnMetric` row.
+ */
+async function defaultFetchExemplarTurnMetric(key: {
+  threadId: string;
+  agentMessageId: string;
+}): Promise<ExemplarTurnMetric | null> {
+  const { prisma } = await import("@dpf/db");
+  const row = await prisma.coworkerTurnMetric.findUnique({
+    where: {
+      threadId_agentMessageId: {
+        threadId: key.threadId,
+        agentMessageId: key.agentMessageId,
+      },
+    },
+    select: {
+      dispatches: true,
+      nudges: true,
+      toolsAttached: true,
+      executedTools: true,
+      totalMs: true,
+      taskType: true,
+      providerId: true,
+      modelId: true,
+    },
+  });
+  if (!row) return null;
+  return {
+    dispatches: row.dispatches,
+    nudges: row.nudges,
+    toolsAttached: row.toolsAttached,
+    executedTools: row.executedTools,
+    totalMs: row.totalMs,
+    taskType: row.taskType,
+    providerId: row.providerId,
+    modelId: row.modelId,
   };
 }
 
@@ -746,6 +897,9 @@ async function resolveNudgeRateDeps(
       return existing != null;
     });
 
+  const fetchExemplarTurnMetric =
+    deps?.fetchExemplarTurnMetric ?? defaultFetchExemplarTurnMetric;
+
   const fileReport =
     deps?.fileReport ??
     (async ({ title, description, severity, routeContext, threadId, agentId }) => {
@@ -774,6 +928,7 @@ async function resolveNudgeRateDeps(
     minNudgeRate,
     fetchTurnMetrics,
     hasOpenDuplicate,
+    fetchExemplarTurnMetric,
     fileReport,
   };
 }

--- a/apps/web/lib/operate/coworker-regression-diagnosis.test.ts
+++ b/apps/web/lib/operate/coworker-regression-diagnosis.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCoworkerRegressionDiagnosis,
+  type CoworkerRegressionDiagnosisInput,
+} from "./coworker-regression-diagnosis";
+
+/** A fully-populated, benign turn; override per case to trigger one rule. */
+function baseInput(
+  overrides: Partial<CoworkerRegressionDiagnosisInput> = {},
+): CoworkerRegressionDiagnosisInput {
+  return {
+    routeContext: "/platform/ai",
+    taskType: "conversation",
+    dispatches: 1,
+    nudges: 0,
+    toolsAttached: false,
+    executedTools: 0,
+    totalMs: 5000,
+    dispatchMs: 1000,
+    providerId: "anthropic",
+    modelId: "claude-x",
+    ...overrides,
+  };
+}
+
+describe("buildCoworkerRegressionDiagnosis", () => {
+  describe("nudge-redispatch-loop", () => {
+    it("fires when nudges > 0 and dispatches > 1", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({ nudges: 2, dispatches: 3 }),
+      );
+      expect(diagnosis.probableCause).toBe("nudge-redispatch-loop");
+      expect(diagnosis.summary).toContain("nudge-redispatch-loop");
+      expect(diagnosis.metrics.nudges).toBe(2);
+      expect(diagnosis.metrics.dispatches).toBe(3);
+    });
+
+    it("wins over the tool-surface rule when both would match", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          nudges: 1,
+          dispatches: 2,
+          toolsAttached: true,
+          executedTools: 0,
+        }),
+      );
+      expect(diagnosis.probableCause).toBe("nudge-redispatch-loop");
+    });
+
+    it("does not fire on a single dispatch even with a nudge", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({ nudges: 1, dispatches: 1, dispatchMs: 4500 }),
+      );
+      expect(diagnosis.probableCause).not.toBe("nudge-redispatch-loop");
+    });
+  });
+
+  describe("full-tool-surface-on-conversational-turn", () => {
+    it("fires when tools attached, none executed, conversational, non-/build route", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          toolsAttached: true,
+          executedTools: 0,
+          taskType: "conversation",
+          routeContext: "/platform/ai",
+        }),
+      );
+      expect(diagnosis.probableCause).toBe(
+        "full-tool-surface-on-conversational-turn",
+      );
+      expect(diagnosis.summary).toContain(
+        "full-tool-surface-on-conversational-turn",
+      );
+    });
+
+    it("fires when taskType is missing (null) on a non-/build route", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          toolsAttached: true,
+          executedTools: 0,
+          taskType: null,
+          routeContext: "/platform/ai",
+        }),
+      );
+      expect(diagnosis.probableCause).toBe(
+        "full-tool-surface-on-conversational-turn",
+      );
+    });
+
+    it("does NOT fire on a /build route (tools expected there)", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          toolsAttached: true,
+          executedTools: 0,
+          taskType: "conversation",
+          routeContext: "/build/123",
+          dispatchMs: 1000,
+        }),
+      );
+      expect(diagnosis.probableCause).not.toBe(
+        "full-tool-surface-on-conversational-turn",
+      );
+    });
+
+    it("does NOT fire when a tool actually executed", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          toolsAttached: true,
+          executedTools: 1,
+          taskType: "conversation",
+        }),
+      );
+      expect(diagnosis.probableCause).not.toBe(
+        "full-tool-surface-on-conversational-turn",
+      );
+    });
+  });
+
+  describe("slow-provider-dispatch", () => {
+    it("fires when dispatch dominates the turn duration and provider is known", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          totalMs: 10000,
+          dispatchMs: 9000,
+          providerId: "anthropic",
+          modelId: "claude-x",
+        }),
+      );
+      expect(diagnosis.probableCause).toBe("slow-provider-dispatch");
+      expect(diagnosis.summary).toContain("slow-provider-dispatch");
+      expect(diagnosis.summary).toContain("anthropic/claude-x");
+    });
+
+    it("does NOT fire when dispatch is not dominant", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({ totalMs: 10000, dispatchMs: 2000, executedTools: 0 }),
+      );
+      expect(diagnosis.probableCause).not.toBe("slow-provider-dispatch");
+    });
+  });
+
+  describe("tool-call-exploration", () => {
+    it("fires when executedTools is high and dispatch is not dominant", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          executedTools: 5,
+          toolsAttached: true,
+          totalMs: 10000,
+          dispatchMs: 2000,
+        }),
+      );
+      expect(diagnosis.probableCause).toBe("tool-call-exploration");
+      expect(diagnosis.summary).toContain("tool-call-exploration");
+      expect(diagnosis.metrics.executedTools).toBe(5);
+    });
+
+    it("yields slow-provider-dispatch (not tool-call-exploration) when dispatch dominates despite many tools", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          executedTools: 5,
+          toolsAttached: true,
+          totalMs: 10000,
+          dispatchMs: 9000,
+        }),
+      );
+      expect(diagnosis.probableCause).toBe("slow-provider-dispatch");
+    });
+  });
+
+  describe("insufficient-evidence", () => {
+    it("fires when the core turn surface is entirely missing", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis({
+        routeContext: null,
+        taskType: null,
+        dispatches: null,
+        nudges: null,
+        toolsAttached: null,
+        executedTools: null,
+        totalMs: null,
+        dispatchMs: null,
+        providerId: null,
+        modelId: null,
+      });
+      expect(diagnosis.probableCause).toBe("insufficient-evidence");
+      expect(diagnosis.summary).toContain("Insufficient evidence");
+      expect(diagnosis.metrics.dispatches).toBeNull();
+    });
+
+    it("fires as a fallthrough when facts exist but no positive rule matches", () => {
+      const diagnosis = buildCoworkerRegressionDiagnosis(
+        baseInput({
+          dispatches: 1,
+          nudges: 0,
+          toolsAttached: false,
+          executedTools: 0,
+          totalMs: 10000,
+          dispatchMs: 2000, // not dominant
+          providerId: "anthropic",
+          modelId: "claude-x",
+        }),
+      );
+      expect(diagnosis.probableCause).toBe("insufficient-evidence");
+    });
+  });
+
+  it("always echoes the provided metrics regardless of cause", () => {
+    const diagnosis = buildCoworkerRegressionDiagnosis(
+      baseInput({ nudges: 2, dispatches: 3 }),
+    );
+    expect(diagnosis.metrics).toEqual({
+      dispatches: 3,
+      nudges: 2,
+      toolsAttached: false,
+      executedTools: 0,
+      totalMs: 5000,
+      taskType: "conversation",
+      providerId: "anthropic",
+      modelId: "claude-x",
+    });
+  });
+});

--- a/apps/web/lib/operate/coworker-regression-diagnosis.ts
+++ b/apps/web/lib/operate/coworker-regression-diagnosis.ts
@@ -1,0 +1,229 @@
+/**
+ * Coworker regression diagnosis — Task 3: deterministic probable-cause
+ * assembly for a regressed coworker turn.
+ *
+ * This module is intentionally PURE: no Prisma import, no I/O, no clock. It
+ * takes the per-turn facts the detector already has (or can look up from a
+ * `CoworkerTurnMetric` row by `(threadId, agentMessageId)`) and maps them to a
+ * single deterministic `probableCause` plus a short, description-safe summary.
+ *
+ * Keeping it framework-free means its unit test loads in this worktree even
+ * though there is no generated Prisma client, and it can be composed into the
+ * detector's PIR-filing path without dragging the database into the diagnosis
+ * decision.
+ *
+ * Architecture grounding (see
+ * docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md):
+ *  - Deterministic rules only in this BI. No LLM narrative.
+ *  - The summary must be safe for `PlatformIssueReport.description`: short,
+ *    single-paragraph, no untrusted free text.
+ */
+
+export type CoworkerRegressionDiagnosisProbableCause =
+  | "nudge-redispatch-loop"
+  | "full-tool-surface-on-conversational-turn"
+  | "slow-provider-dispatch"
+  | "tool-call-exploration"
+  | "insufficient-evidence";
+
+export type CoworkerRegressionDiagnosis = {
+  probableCause: CoworkerRegressionDiagnosisProbableCause;
+  summary: string;
+  metrics: {
+    dispatches: number | null;
+    nudges: number | null;
+    toolsAttached: boolean | null;
+    executedTools: number | null;
+    totalMs: number | null;
+    taskType: string | null;
+    providerId: string | null;
+    modelId: string | null;
+  };
+};
+
+/**
+ * Per-turn facts the diagnosis consumes. All fields are nullable because the
+ * exemplar turn may have no persisted `CoworkerTurnMetric` row, in which case
+ * the detector passes minimal input and we yield `insufficient-evidence`
+ * rather than throwing.
+ *
+ * `dispatchMs` is the summed adapter dispatch duration for the turn (from
+ * `AdapterRunTelemetry.durationMs`); `totalMs` is the wall-clock turn duration
+ * from the turn metric. They differ when wall time is dominated by something
+ * other than provider dispatch (e.g. tool execution), which is what separates
+ * `slow-provider-dispatch` from `tool-call-exploration`.
+ */
+export type CoworkerRegressionDiagnosisInput = {
+  routeContext: string | null;
+  taskType: string | null;
+  dispatches: number | null;
+  nudges: number | null;
+  toolsAttached: boolean | null;
+  executedTools: number | null;
+  totalMs: number | null;
+  dispatchMs: number | null;
+  providerId: string | null;
+  modelId: string | null;
+};
+
+/**
+ * Fraction of wall-clock turn time consumed by provider dispatch above which we
+ * call the dispatch "dominant". Conservative: most of the turn must be the LLM
+ * call, not tool round-trips.
+ */
+const DISPATCH_DOMINANCE_FRACTION = 0.7;
+
+/**
+ * `executedTools` count at or above which tool-call exploration is "high"
+ * enough to be the probable cause when dispatch is not dominant.
+ */
+const HIGH_EXECUTED_TOOLS = 3;
+
+/**
+ * True when the turn carries enough signal to diagnose at all. We require at
+ * least the dispatch/nudge/tool surface to be present; a turn metric row with
+ * only ids is not diagnosable.
+ */
+function hasSufficientEvidence(input: CoworkerRegressionDiagnosisInput): boolean {
+  return (
+    input.dispatches != null ||
+    input.nudges != null ||
+    input.toolsAttached != null ||
+    input.executedTools != null
+  );
+}
+
+/** True when the route is the `/build` surface (tools are expected there). */
+function isBuildRoute(routeContext: string | null): boolean {
+  return routeContext != null && routeContext.startsWith("/build");
+}
+
+/** True when dispatch duration dominates the wall-clock turn time. */
+function dispatchIsDominant(
+  dispatchMs: number | null,
+  totalMs: number | null,
+): boolean {
+  if (dispatchMs == null || totalMs == null || totalMs <= 0) return false;
+  return dispatchMs / totalMs >= DISPATCH_DOMINANCE_FRACTION;
+}
+
+/**
+ * Build a deterministic diagnosis for a regressed coworker turn.
+ *
+ * PRECEDENCE (evaluated top-to-bottom; first match wins, deterministic):
+ *
+ *   0. insufficient-evidence — guard. If the turn lacks the core dispatch/
+ *      nudge/tool surface, we cannot diagnose, so this short-circuits before
+ *      any positive rule. (A turn with the surface present never lands here.)
+ *   1. nudge-redispatch-loop — nudges > 0 AND dispatches > 1. A re-ask /
+ *      continuation loop is the most actionable and most specific signal, so
+ *      it wins over the others even if tools were also attached.
+ *   2. full-tool-surface-on-conversational-turn — toolsAttached = true,
+ *      executedTools = 0, and the turn is conversational (taskType
+ *      "conversation" or missing) on a non-/build route. Attaching the whole
+ *      tool surface to a chat turn that used none of it is a concrete,
+ *      mechanical cost we rank above the duration-shape rules.
+ *   3. slow-provider-dispatch — provider dispatch duration dominates the turn
+ *      (dispatchMs / totalMs >= 0.7) and a provider/model is known. When the
+ *      LLM call itself is the wall-clock cost, that is the cause.
+ *   4. tool-call-exploration — executedTools is high (>= 3) and dispatch is
+ *      NOT dominant, i.e. the turn spent its time round-tripping tools.
+ *   5. (fallthrough) — evidence exists but matches no positive rule, which we
+ *      treat as insufficient-evidence: we have facts but no confident cause.
+ *
+ * Why this order: 1 and 2 are specific structural defects (loop, mis-attached
+ * surface) that are directly fixable; 3 and 4 are duration-shape explanations
+ * that are mutually exclusive by construction (dominant vs. not dominant). The
+ * loop rule precedes the tool-surface rule because a nudge loop is both more
+ * severe and a superset signal (it re-dispatches regardless of tool state).
+ */
+export function buildCoworkerRegressionDiagnosis(
+  input: CoworkerRegressionDiagnosisInput,
+): CoworkerRegressionDiagnosis {
+  const metrics = {
+    dispatches: input.dispatches,
+    nudges: input.nudges,
+    toolsAttached: input.toolsAttached,
+    executedTools: input.executedTools,
+    totalMs: input.totalMs,
+    taskType: input.taskType,
+    providerId: input.providerId,
+    modelId: input.modelId,
+  };
+
+  // 0. Evidence guard.
+  if (!hasSufficientEvidence(input)) {
+    return {
+      probableCause: "insufficient-evidence",
+      summary:
+        "Insufficient evidence: no persisted turn metrics for the exemplar turn, so the probable cause cannot be determined deterministically.",
+      metrics,
+    };
+  }
+
+  const nudges = input.nudges ?? 0;
+  const dispatches = input.dispatches ?? 0;
+  const executedTools = input.executedTools ?? 0;
+  const toolsAttached = input.toolsAttached === true;
+
+  // 1. nudge-redispatch-loop
+  if (nudges > 0 && dispatches > 1) {
+    return {
+      probableCause: "nudge-redispatch-loop",
+      summary: `Probable cause: nudge-redispatch-loop. The turn issued ${dispatches} provider dispatches with ${nudges} continuation nudge(s), indicating a re-ask/redispatch loop rather than a single completion.`,
+      metrics,
+    };
+  }
+
+  // 2. full-tool-surface-on-conversational-turn
+  const isConversational =
+    input.taskType === "conversation" || input.taskType == null;
+  if (
+    toolsAttached &&
+    executedTools === 0 &&
+    isConversational &&
+    !isBuildRoute(input.routeContext)
+  ) {
+    return {
+      probableCause: "full-tool-surface-on-conversational-turn",
+      summary:
+        "Probable cause: full-tool-surface-on-conversational-turn. The full tool surface was attached to a conversational turn that executed no tools, inflating prompt size and latency without benefit.",
+      metrics,
+    };
+  }
+
+  // 3. slow-provider-dispatch
+  if (
+    dispatchIsDominant(input.dispatchMs, input.totalMs) &&
+    (input.providerId != null || input.modelId != null)
+  ) {
+    const providerLabel = [input.providerId, input.modelId]
+      .filter((v): v is string => v != null && v.length > 0)
+      .join("/");
+    return {
+      probableCause: "slow-provider-dispatch",
+      summary: `Probable cause: slow-provider-dispatch. Provider dispatch (${providerLabel || "unknown provider"}) dominated the turn duration, so the latency is in the model call itself rather than tool work or a loop.`,
+      metrics,
+    };
+  }
+
+  // 4. tool-call-exploration
+  if (
+    executedTools >= HIGH_EXECUTED_TOOLS &&
+    !dispatchIsDominant(input.dispatchMs, input.totalMs)
+  ) {
+    return {
+      probableCause: "tool-call-exploration",
+      summary: `Probable cause: tool-call-exploration. The turn executed ${executedTools} tools and dispatch did not dominate the duration, so the latency is in tool round-trips rather than the model call.`,
+      metrics,
+    };
+  }
+
+  // 5. Fallthrough: facts exist but no rule fired confidently.
+  return {
+    probableCause: "insufficient-evidence",
+    summary:
+      "Insufficient evidence: turn metrics are present but match no deterministic regression pattern, so no confident probable cause can be assigned.",
+    metrics,
+  };
+}

--- a/apps/web/lib/operate/coworker-turn-metrics.test.ts
+++ b/apps/web/lib/operate/coworker-turn-metrics.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  recordCoworkerTurnMetric,
+  type CoworkerTurnMetricUpserter,
+} from "./coworker-turn-metrics";
+
+function makeDelegate(impl?: CoworkerTurnMetricUpserter["upsert"]) {
+  const upsert = vi.fn(impl ?? (async () => ({})));
+  const delegate: CoworkerTurnMetricUpserter = { upsert };
+  return { delegate, upsert, getDelegate: async () => delegate };
+}
+
+describe("recordCoworkerTurnMetric", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("upserts by the (threadId, agentMessageId) natural key", async () => {
+    const { upsert, getDelegate } = makeDelegate();
+
+    await recordCoworkerTurnMetric(
+      {
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        taskType: "conversation",
+        providerId: "anthropic-sub",
+        modelId: "claude-haiku-4-5",
+        dispatches: 3,
+        nudges: 2,
+        toolsAttached: true,
+        executedTools: 1,
+        totalMs: 9000,
+      },
+      { getDelegate },
+    );
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.where).toEqual({
+      threadId_agentMessageId: { threadId: "thr-1", agentMessageId: "msg-1" },
+    });
+    expect(arg.create).toMatchObject({
+      threadId: "thr-1",
+      agentMessageId: "msg-1",
+      agentId: "support-specialist",
+      routeContext: "/platform/ai",
+      taskType: "conversation",
+      providerId: "anthropic-sub",
+      modelId: "claude-haiku-4-5",
+      dispatches: 3,
+      nudges: 2,
+      toolsAttached: true,
+      executedTools: 1,
+      totalMs: 9000,
+    });
+    // Update payload mirrors create minus the key fields.
+    expect(arg.update).toMatchObject({ nudges: 2, dispatches: 3, totalMs: 9000 });
+    expect(arg.update.threadId).toBeUndefined();
+  });
+
+  it("stores null for absent optional values rather than placeholders", async () => {
+    const { upsert, getDelegate } = makeDelegate();
+
+    await recordCoworkerTurnMetric(
+      { threadId: "thr-2", agentMessageId: "msg-2" },
+      { getDelegate },
+    );
+
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.create).toMatchObject({
+      agentId: null,
+      routeContext: null,
+      taskType: null,
+      providerId: null,
+      modelId: null,
+      totalMs: null,
+      // numeric counters default to 0, toolsAttached to false
+      dispatches: 0,
+      nudges: 0,
+      executedTools: 0,
+      toolsAttached: false,
+    });
+  });
+
+  it("does not write when threadId is missing", async () => {
+    const { upsert, getDelegate } = makeDelegate();
+    await recordCoworkerTurnMetric(
+      { threadId: null, agentMessageId: "msg-3" },
+      { getDelegate },
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("does not write when agentMessageId is missing", async () => {
+    const { upsert, getDelegate } = makeDelegate();
+    await recordCoworkerTurnMetric(
+      { threadId: "thr-3", agentMessageId: null },
+      { getDelegate },
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("fails open: suppresses Prisma errors and never throws", async () => {
+    const { getDelegate, upsert } = makeDelegate(async () => {
+      throw new Error("connection refused");
+    });
+
+    await expect(
+      recordCoworkerTurnMetric(
+        { threadId: "thr-4", agentMessageId: "msg-4" },
+        { getDelegate },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("fails open when delegate resolution itself throws", async () => {
+    await expect(
+      recordCoworkerTurnMetric(
+        { threadId: "thr-5", agentMessageId: "msg-5" },
+        {
+          getDelegate: async () => {
+            throw new Error("client unavailable");
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/operate/coworker-turn-metrics.ts
+++ b/apps/web/lib/operate/coworker-turn-metrics.ts
@@ -1,0 +1,123 @@
+/**
+ * Coworker turn-metric writer — Task 2: persist one durable rollup per coworker
+ * turn so the regression detector can compute nudge-rate windows without
+ * re-parsing console `[turn]` logs.
+ *
+ * `recordCoworkerTurnMetric` is the single fire-and-forget writer. It is called
+ * from `agentic-loop.ts` at the existing `logTurnSummary()` point as
+ * `void recordCoworkerTurnMetric({...})` and MUST NEVER throw or reject in a way
+ * that disturbs the turn — failures are caught and logged via `console.warn`.
+ *
+ * Architecture grounding (see
+ * docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md):
+ *  - Upsert by the natural key `(threadId, agentMessageId)` so a duplicated
+ *    `logTurnSummary()` call does not duplicate a turn row.
+ *  - Store `null` for absent provider/model/route/agent/task values — never a
+ *    synthetic `"unknown"` placeholder; bucketing collapses null to a key part
+ *    in the detector, not in storage.
+ *  - The Prisma client is imported lazily (and is dependency-injectable) so this
+ *    module — and any unit test importing it — does not pull the generated
+ *    `@dpf/db` client into the module graph at load time. This mirrors the DI
+ *    pattern in `coworker-regression-detector.ts`.
+ */
+
+export type RecordCoworkerTurnMetricInput = {
+  threadId: string | null;
+  agentMessageId: string | null;
+  agentId?: string | null;
+  routeContext?: string | null;
+  taskType?: string | null;
+  providerId?: string | null;
+  modelId?: string | null;
+  dispatches?: number | null;
+  nudges?: number | null;
+  toolsAttached?: boolean | null;
+  executedTools?: number | null;
+  totalMs?: number | null;
+};
+
+/**
+ * Minimal structural contract for the Prisma delegate this writer touches.
+ * Declared locally so the module never has to import the generated client type.
+ */
+export type CoworkerTurnMetricUpserter = {
+  upsert: (args: {
+    where: { threadId_agentMessageId: { threadId: string; agentMessageId: string } };
+    create: Record<string, unknown>;
+    update: Record<string, unknown>;
+  }) => Promise<unknown>;
+};
+
+export type RecordCoworkerTurnMetricDeps = {
+  /** Injectable for tests; defaults to the lazily-imported `@dpf/db` delegate. */
+  getDelegate?: () => Promise<CoworkerTurnMetricUpserter>;
+};
+
+/** Coerce an optional numeric to a stored value, defaulting absent to 0. */
+function intOrZero(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** Coerce an optional numeric to a nullable stored value (totalMs). */
+function intOrNull(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Normalize an absent string field to `null` — never a placeholder. */
+function strOrNull(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+async function defaultGetDelegate(): Promise<CoworkerTurnMetricUpserter> {
+  const { prisma } = await import("@dpf/db");
+  return prisma.coworkerTurnMetric as unknown as CoworkerTurnMetricUpserter;
+}
+
+/**
+ * Persist (upsert) one turn rollup. Fire-and-forget safe: on any failure —
+ * including a missing key or a Prisma error — it catches, warns, and resolves
+ * without throwing.
+ */
+export async function recordCoworkerTurnMetric(
+  input: RecordCoworkerTurnMetricInput,
+  deps?: RecordCoworkerTurnMetricDeps,
+): Promise<void> {
+  try {
+    const threadId = strOrNull(input.threadId);
+    const agentMessageId = strOrNull(input.agentMessageId);
+
+    // The natural key requires both correlation fields; without either there is
+    // no stable row identity, so skip the write rather than insert an
+    // un-joinable orphan.
+    if (!threadId || !agentMessageId) return;
+
+    const getDelegate = deps?.getDelegate ?? defaultGetDelegate;
+    const delegate = await getDelegate();
+
+    const data = {
+      agentId: strOrNull(input.agentId),
+      routeContext: strOrNull(input.routeContext),
+      taskType: strOrNull(input.taskType),
+      providerId: strOrNull(input.providerId),
+      modelId: strOrNull(input.modelId),
+      dispatches: intOrZero(input.dispatches),
+      nudges: intOrZero(input.nudges),
+      toolsAttached: Boolean(input.toolsAttached),
+      executedTools: intOrZero(input.executedTools),
+      totalMs: intOrNull(input.totalMs),
+    };
+
+    await delegate.upsert({
+      where: { threadId_agentMessageId: { threadId, agentMessageId } },
+      create: { threadId, agentMessageId, ...data },
+      update: data,
+    });
+  } catch (err) {
+    // Fire-and-forget: turn observability must never break a coworker turn.
+    console.warn(
+      `[coworker-turn-metrics] failed to record turn metric: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -67,6 +67,7 @@ export interface CreatePlatformIssueReportInput {
   threadId?: string | null;
   taskRunId?: string | null;
   featureBuildId?: string | null;
+  agentId?: string | null;
 
   // Ownership — resolved automatically if not provided
   portfolioId?: string | null;
@@ -137,6 +138,7 @@ export async function createPlatformIssueReport(
       supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
       reportedById: input.reportedById ?? null,
       threadId: input.threadId ?? null,
+      agentId: input.agentId ?? null,
       taskRunId: input.taskRunId ?? null,
       featureBuildId: input.featureBuildId ?? null,
       source: input.source.slice(0, LIMITS.source),

--- a/apps/web/lib/queue/functions/coworker-regression-detect.ts
+++ b/apps/web/lib/queue/functions/coworker-regression-detect.ts
@@ -1,0 +1,31 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+/**
+ * quality/coworker-regression-detect — runs every 15 minutes alongside the
+ * issue-report triage job. Detects coworker turn latency regressions over
+ * existing `AdapterRunTelemetry` and files deduplicated `PlatformIssueReport`
+ * rows, which the existing triage path then promotes to bug backlog items.
+ *
+ * Mirrors the cron pattern in `issue-report-triage.ts`: same retries, same
+ * quiescence gate, Prisma/detector imported lazily inside the step.
+ */
+export const coworkerRegressionDetect = inngest.createFunction(
+  {
+    id: "quality/coworker-regression-detect",
+    retries: 2,
+    triggers: [cron("*/15 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("detect-coworker-regressions", async () => {
+      const { detectCoworkerLatencyRegressions } = await import(
+        "@/lib/operate/coworker-regression-detector"
+      );
+      return detectCoworkerLatencyRegressions();
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -6,6 +6,7 @@ import { mcpCatalogSync } from "./mcp-catalog-sync";
 import { codeGraphReconcileEvent, codeGraphReconcileScheduled } from "./code-graph-reconcile";
 import { routeWorkItem } from "./route-work-item";
 import { issueReportTriage } from "./issue-report-triage";
+import { coworkerRegressionDetect } from "./coworker-regression-detect";
 import { agentTaskDispatch } from "./agent-task-dispatch";
 import { taskrunWatchdog } from "./taskrun-watchdog";
 import { evalBackground, probeBackground } from "./eval-background";
@@ -50,6 +51,7 @@ export const scheduledFunctions = [
   infraPrune,
   codeGraphReconcileScheduled,
   issueReportTriage,
+  coworkerRegressionDetect,
   agentTaskDispatch,
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -26,6 +26,9 @@ vi.mock("@dpf/db", () => ({
     platformIssueReport: {
       create: vi.fn(),
     },
+    coworkerTurnMetric: {
+      upsert: vi.fn(),
+    },
   },
 }));
 vi.mock("@/lib/routed-inference", () => ({

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -8,6 +8,7 @@ import { isRedundantReaskQuestion } from "@/lib/tak/conversation-intent";
 import { PLATFORM_TOOLS, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { sanitizeForLog } from "@/lib/security/safe-log";
+import { recordCoworkerTurnMetric } from "@/lib/operate/coworker-turn-metrics";
 import type { ChatMessage } from "@/lib/ai-inference";
 import { prisma } from "@dpf/db";
 import { agentEventBus } from "./agent-event-bus";
@@ -1006,6 +1007,22 @@ export async function runAgenticLoop(params: {
         `totalMs=${Date.now() - startTime}`,
       ),
     );
+    // BI-47443B67: persist the same rollup durably so the regression detector
+    // can compute nudge-rate windows. Fire-and-forget — the writer never throws.
+    void recordCoworkerTurnMetric({
+      threadId,
+      agentMessageId: agentMessageId ?? null,
+      agentId,
+      routeContext,
+      taskType: taskType ?? null,
+      providerId: provider,
+      modelId: model,
+      dispatches: inferenceCallCount,
+      nudges: continuationNudges,
+      toolsAttached: toolsAttachedForTurn,
+      executedTools: executedTools.length,
+      totalMs: Date.now() - startTime,
+    });
   };
 
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {

--- a/docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md
+++ b/docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md
@@ -1,0 +1,527 @@
+# Self-Diagnosing Coworker Regressions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**BI:** `BI-47443B67` under `EP-COST-001`
+
+**Goal:** DPF detects coworker latency and nudge-loop regressions, files a `PlatformIssueReport`, promotes it through the existing PIR-to-BI triage path, and shows operators a structured diagnosis without a human stitching logs.
+
+**Architecture:** Reuse `PlatformIssueReport`, `AdapterRunTelemetry`, `RouteDecisionLog`, and the existing 15-minute issue-report triage function. Add one focused turn-rollup persistence model only for metrics that do not exist durably today, then enrich PIR descriptions with deterministic diagnosis facts. Do not build a parallel incident system.
+
+**Tech Stack:** Next.js 16, Prisma 7, PostgreSQL, Inngest cron functions, Vitest, DPF report-kit UI primitives.
+
+---
+
+## Chief Architect Review
+
+This plan is approved with required corrections. The original direction was right, but it had three architecture risks:
+
+1. It named `AdapterRunTelemetry.inferenceMs`, which does not exist. Use `AdapterRunTelemetry.durationMs` for dispatch latency. `TokenUsage.inferenceMs` exists, but it lacks the same `threadId` and `agentMessageId` correlation and should not drive the thread-diagnosis path.
+2. It left Phase 2 undecided between extending `AdapterRunTelemetry` and adding `CoworkerTurnMetric`. Choose `CoworkerTurnMetric`. A turn rollup is not a provider dispatch attempt; storing nudge counts on every adapter call would duplicate aggregate state and make nudge-rate windows harder to query.
+3. It treated the operator UI as a verification afterthought. The result must be visible in Admin > Issue Reports using report-kit/theme-aware primitives where touched, because the product value is "the platform explains the regression", not merely "a row exists".
+
+## Live Backlog And Repo Grounding
+
+Live MCP state on 2026-06-05:
+
+- `BI-47443B67` exists under `EP-COST-001`, status `triaging`, type `product`, workType `feature`, source `user-request`.
+- Related same-epic items exist and should enrich, not block, this work: `BI-AFF0F06F` (routing-decision trace) and `BI-3AFA7A4F` (persisted per-call latency).
+- MCP `search_specs_and_plans` did not find another active plan/spec for `BI-47443B67`, so this file is the implementation handoff artifact.
+
+Repo facts verified in the worktree:
+
+| Need | Current substrate | Where |
+|---|---|---|
+| Auto-detection to backlog pattern | `checkForSpike` creates `BI-PIR-SPIKE-*` bug backlog items from runtime issue volume | `apps/web/lib/operate/issue-report-triage.ts` |
+| PIR writer | `createPlatformIssueReport` is the single server-side writer, applies length limits, and links `threadId`, `agentId`, `routeContext`, `triggerKind`, `source` | `apps/web/lib/quality/platform-issue-reports.ts` |
+| PIR triage cadence | `quality/issue-report-triage` runs every 15 minutes, processes open PIRs, and runs spike detection | `apps/web/lib/queue/functions/issue-report-triage.ts` |
+| Per-dispatch telemetry | `AdapterRunTelemetry` stores `threadId`, `agentMessageId`, `agentId`, `providerId`, `modelId`, `durationMs`, token counts, status, and error fields | `packages/db/prisma/schema.prisma` |
+| Route/task attribution | `AdapterRunTelemetry.agentMessageId` joins to `AgentMessage.id`; `AgentMessage` carries `routeContext` and `taskType` | `packages/db/prisma/schema.prisma` |
+| Turn summary | `[turn]` log includes `thread`, `agent`, `route`, `provider`, `model`, `dispatches`, `nudges`, `toolsAttached`, `executedTools`, `totalMs`, but is console-only | `apps/web/lib/tak/agentic-loop.ts` |
+| Routing-decision enrichment | `RouteDecisionLog` is persisted with `agentMessageId`; use it when present | `apps/web/lib/routing/loader.ts`, `packages/db/prisma/schema.prisma` |
+| Operator surface | Admin Issue Reports exists but has local reporting widgets and inline tone styling in touched areas | `apps/web/components/admin/IssueReportPanel.tsx` |
+
+## Standards Adopted
+
+- OpenTelemetry GenAI semantic conventions use operation duration and token-usage metrics for AI calls. DPF does not need to adopt OTel in this slice, but the data names should stay compatible: operation duration = `durationMs`, token usage = input/output/cached tokens.
+- OpenTelemetry Metrics guidance treats metrics as runtime measurements consumed by a backend; this plan keeps detector data bounded, numeric, and aggregatable rather than parsing prose logs.
+- Google SRE alerting guidance favors symptom-based alerts and anti-flap controls. The detector alerts on user-visible coworker turn latency/nudge symptoms and requires sample thresholds, a trailing baseline, and deduplication.
+
+References:
+
+- OpenTelemetry GenAI metrics: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+- OpenTelemetry metrics concepts: https://opentelemetry.io/docs/concepts/signals/metrics/
+- Google SRE practical alerting: https://sre.google/sre-book/practical-alerting/
+
+## Architectural Rules For Implementation
+
+- **Reuse first:** `PlatformIssueReport` remains the canonical issue record. The detector creates PIRs; the existing triage job promotes open PIRs to bug backlog items.
+- **No hidden direct DB write workaround:** if MCP evidence capture or backlog writes need scope escalation, stop and surface the needed scope. Do not bypass write-scope controls with ad hoc SQL.
+- **One additive model only:** `CoworkerTurnMetric` is the single new persistence shape, because nudge and dispatch summaries are turn-level facts.
+- **No LLM diagnosis in this BI:** deterministic rules first. LLM narratives are a later enhancement only after rule accuracy is proven.
+- **Operator-facing UI matters:** any touched Issue Reports reporting UI must use `apps/web/components/ui/report-kit/` and DPF CSS variables. Do not add new local status color maps, inline color styles, or hand-rolled tables/badges.
+- **Refactoring budget:** spend about 20% of implementation effort on focused refactoring that reduces future churn: shared detector math, a shared PIR filing helper, and report-kit migration for touched Issue Reports widgets. Do not spend this budget on broad renames or unrelated cleanup.
+
+## File Structure
+
+Create:
+
+- `apps/web/lib/operate/coworker-regression-detector.ts` — pure detector math plus orchestration for latency and nudge-rate checks.
+- `apps/web/lib/operate/coworker-regression-diagnosis.ts` — deterministic diagnosis assembly from turn metrics, adapter telemetry, and route decisions.
+- `apps/web/lib/operate/coworker-turn-metrics.ts` — fire-and-forget writer and read helpers for turn metrics.
+- `apps/web/lib/operate/coworker-regression-detector.test.ts` — detector threshold, p95, dedup, exemplar, and severity tests.
+- `apps/web/lib/operate/coworker-regression-diagnosis.test.ts` — deterministic probable-cause tests.
+- `apps/web/lib/operate/coworker-turn-metrics.test.ts` — writer shape and fail-open tests.
+- `apps/web/lib/queue/functions/coworker-regression-detect.ts` — Inngest cron entry point.
+- `packages/db/prisma/migrations/<timestamp>_add_coworker_turn_metric/migration.sql` — additive migration.
+
+Modify:
+
+- `packages/db/prisma/schema.prisma` — add `CoworkerTurnMetric` and indexes.
+- `apps/web/lib/tak/agentic-loop.ts` — call `recordCoworkerTurnMetric()` where `logTurnSummary()` fires.
+- `apps/web/lib/queue/functions/index.ts` — export/register the new Inngest function.
+- `apps/web/lib/queue/functions/issue-report-triage.ts` only if a shared PIR/backlog helper is extracted; otherwise leave the existing triage cadence unchanged.
+- `apps/web/components/admin/IssueReportPanel.tsx` — add `triggerKind` to `ReportRow`, show structured diagnosis, and migrate touched reporting widgets to report-kit primitives.
+- `apps/web/components/admin/IssueReportPanel.test.tsx` — assert diagnosis visibility and report-kit-safe rendering.
+
+## Task 1: Latency Detector Over Existing Telemetry
+
+**Files:**
+
+- Create: `apps/web/lib/operate/coworker-regression-detector.ts`
+- Create: `apps/web/lib/operate/coworker-regression-detector.test.ts`
+- Create: `apps/web/lib/queue/functions/coworker-regression-detect.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+
+- [ ] **Step 1: Write p95 and baseline tests**
+
+Add tests that use in-memory rows shaped like `AdapterRunTelemetry`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  computeP95,
+  groupDispatchRowsIntoTurns,
+  shouldFileLatencyRegression,
+} from "./coworker-regression-detector";
+
+describe("coworker latency regression detector", () => {
+  it("groups dispatch rows by threadId and agentMessageId and sums durationMs", () => {
+    const turns = groupDispatchRowsIntoTurns([
+      { threadId: "thr-1", agentMessageId: "msg-1", agentId: "support-specialist", routeContext: "/platform/ai", taskType: "conversation", durationMs: 1200, startedAt: new Date("2026-06-05T10:00:00Z") },
+      { threadId: "thr-1", agentMessageId: "msg-1", agentId: "support-specialist", routeContext: "/platform/ai", taskType: "conversation", durationMs: 800, startedAt: new Date("2026-06-05T10:00:02Z") },
+      { threadId: null, agentMessageId: "msg-2", agentId: "support-specialist", routeContext: "/platform/ai", taskType: "conversation", durationMs: 999, startedAt: new Date("2026-06-05T10:00:03Z") },
+    ]);
+
+    expect(turns).toEqual([
+      expect.objectContaining({
+        threadId: "thr-1",
+        agentMessageId: "msg-1",
+        agentId: "support-specialist",
+        routeContext: "/platform/ai",
+        totalMs: 2000,
+      }),
+    ]);
+  });
+
+  it("files only when sample size and p95 ratio both clear the threshold", () => {
+    expect(computeP95([1000, 1100, 1200, 9000])).toBe(9000);
+    expect(
+      shouldFileLatencyRegression({
+        recentP95Ms: 9000,
+        baselineP95Ms: 2000,
+        recentSampleCount: 12,
+        minSamples: 10,
+        factor: 3,
+      }),
+    ).toEqual({ file: true, ratio: 4.5 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing detector tests**
+
+Run from the worktree:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-regression-detector.test.ts
+```
+
+Expected: fail because the detector module does not exist.
+
+- [ ] **Step 3: Implement pure detector helpers**
+
+Create helpers with these contracts:
+
+```ts
+export type AdapterTurnDispatchRow = {
+  threadId: string | null;
+  agentMessageId: string | null;
+  agentId: string | null;
+  routeContext: string | null;
+  taskType: string | null;
+  durationMs: number | null;
+  startedAt: Date;
+};
+
+export type CoworkerTurnSample = {
+  threadId: string;
+  agentMessageId: string;
+  agentId: string | null;
+  routeContext: string | null;
+  taskType: string | null;
+  totalMs: number;
+  startedAt: Date;
+};
+
+export function groupDispatchRowsIntoTurns(rows: AdapterTurnDispatchRow[]): CoworkerTurnSample[];
+export function computeP95(values: number[]): number | null;
+export function shouldFileLatencyRegression(input: {
+  recentP95Ms: number | null;
+  baselineP95Ms: number | null;
+  recentSampleCount: number;
+  minSamples: number;
+  factor: number;
+}): { file: boolean; ratio: number | null };
+```
+
+Rules:
+
+- Skip rows missing `threadId`, missing `agentMessageId`, or lacking a positive `durationMs`.
+- Group by `threadId::agentMessageId`.
+- Use the earliest `startedAt` as the turn timestamp.
+- For `(agentId, routeContext)` buckets, treat null values as `"unknown"` only inside grouping keys; do not persist `"unknown"` placeholders.
+
+- [ ] **Step 4: Add detector orchestration**
+
+Add `detectCoworkerLatencyRegressions(deps)` that:
+
+- reads recent rows for the last 60 minutes and baseline rows for the prior 7 days;
+- joins `AgentMessage` by `agentMessageId` to recover `routeContext` and `taskType`;
+- groups rows into turns;
+- buckets by `(agentId, routeContext)`;
+- computes p95 for recent and baseline windows;
+- requires `MIN_SAMPLES` and `p95 >= baseline * FACTOR`;
+- picks the worst recent turn as exemplar;
+- checks for an existing open PIR with `source="coworker-regression-detector"`, `triggerKind="latency-regression"`, same `agentId`, and same `routeContext`;
+- files a PIR with `createPlatformIssueReport()` if no duplicate exists.
+
+Use conservative defaults:
+
+```ts
+const DEFAULT_RECENT_WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_MIN_SAMPLES = 10;
+const DEFAULT_FACTOR = 3;
+```
+
+- [ ] **Step 5: Register the Inngest cron**
+
+Create `apps/web/lib/queue/functions/coworker-regression-detect.ts`:
+
+```ts
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export const coworkerRegressionDetect = inngest.createFunction(
+  { id: "quality/coworker-regression-detect", retries: 2, triggers: [cron("*/15 * * * *")] },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("detect-coworker-regressions", async () => {
+      const { detectCoworkerLatencyRegressions } = await import("@/lib/operate/coworker-regression-detector");
+      return detectCoworkerLatencyRegressions();
+    });
+  },
+);
+```
+
+Export it from `apps/web/lib/queue/functions/index.ts`.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-regression-detector.test.ts apps/web/lib/queue/functions/index.test.ts
+```
+
+Expected: pass in the worktree.
+
+## Task 2: Persist Turn Metrics For Nudge Detection
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_coworker_turn_metric/migration.sql`
+- Create: `apps/web/lib/operate/coworker-turn-metrics.ts`
+- Create: `apps/web/lib/operate/coworker-turn-metrics.test.ts`
+- Modify: `apps/web/lib/tak/agentic-loop.ts`
+- Modify: `apps/web/lib/tak/agentic-loop.test.ts`
+
+- [ ] **Step 1: Add the Prisma model**
+
+Add:
+
+```prisma
+model CoworkerTurnMetric {
+  id              String   @id @default(cuid())
+  threadId        String
+  agentMessageId  String
+  agentId         String?
+  routeContext    String?
+  taskType        String?
+  providerId      String?
+  modelId         String?
+  dispatches      Int      @default(0)
+  nudges          Int      @default(0)
+  toolsAttached   Boolean  @default(false)
+  executedTools   Int      @default(0)
+  totalMs         Int?
+  createdAt       DateTime @default(now())
+
+  @@unique([threadId, agentMessageId])
+  @@index([agentId, routeContext, createdAt])
+  @@index([threadId, createdAt])
+}
+```
+
+Migration SQL must be additive only. Do not backfill from logs.
+
+- [ ] **Step 2: Write the fail-open writer tests**
+
+Test that `recordCoworkerTurnMetric()` upserts by `(threadId, agentMessageId)`, does not write without either key, and suppresses Prisma errors.
+
+- [ ] **Step 3: Implement the writer**
+
+Create `recordCoworkerTurnMetric(input)` in `apps/web/lib/operate/coworker-turn-metrics.ts`.
+
+Requirements:
+
+- It must be fire-and-forget safe: catch and `console.warn`, never throw.
+- It must upsert by `(threadId, agentMessageId)` so duplicate `logTurnSummary()` calls do not duplicate turn rows.
+- It must store null for absent provider/model/route/agent values rather than synthetic placeholders.
+
+- [ ] **Step 4: Wire the writer at the existing turn summary point**
+
+In `apps/web/lib/tak/agentic-loop.ts`, update `logTurnSummary(provider, model)` to also call:
+
+```ts
+void recordCoworkerTurnMetric({
+  threadId,
+  agentMessageId: agentMessageId ?? null,
+  agentId,
+  routeContext,
+  taskType: taskType ?? null,
+  providerId: provider,
+  modelId: model,
+  dispatches: inferenceCallCount,
+  nudges: continuationNudges,
+  toolsAttached: toolsAttachedForTurn,
+  executedTools: executedTools.length,
+  totalMs: Date.now() - startTime,
+});
+```
+
+Keep the existing console log for immediate operator debugging until the new PIR flow is proven.
+
+- [ ] **Step 5: Extend detector for nudge-rate regression**
+
+Add a detector path that reads `CoworkerTurnMetric`, buckets by `(agentId, routeContext)`, and files a `triggerKind="nudge-rate-regression"` PIR when sample thresholds pass and either:
+
+- the baseline share is greater than zero and the recent share of turns with `nudges > 0` is at least `DEFAULT_FACTOR` times the baseline share; or
+- the baseline share is zero and the recent share is at least `DEFAULT_MIN_NUDGE_RATE`.
+
+Use `DEFAULT_MIN_NUDGE_RATE = 0.2` for the zero-baseline case so one isolated nudge does not alert on a small sample.
+
+Dedup uses the same source/trigger/agent/route/status predicate as latency.
+
+- [ ] **Step 6: Run tests and migration check**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-turn-metrics.test.ts apps/web/lib/operate/coworker-regression-detector.test.ts apps/web/lib/tak/agentic-loop.test.ts
+pnpm --filter @dpf/db exec prisma validate
+```
+
+Expected: tests pass and Prisma schema validates in the worktree.
+
+## Task 3: Deterministic Diagnosis Enrichment
+
+**Files:**
+
+- Create: `apps/web/lib/operate/coworker-regression-diagnosis.ts`
+- Create: `apps/web/lib/operate/coworker-regression-diagnosis.test.ts`
+- Modify: `apps/web/lib/operate/coworker-regression-detector.ts`
+
+- [ ] **Step 1: Write diagnosis tests**
+
+Cover these cause tags:
+
+- `nudge-redispatch-loop` when `nudges > 0` and `dispatches > 1`;
+- `full-tool-surface-on-conversational-turn` when `toolsAttached=true`, `executedTools=0`, and `taskType` is `conversation` or missing on a non-`/build` route;
+- `slow-provider-dispatch` when one provider/model dominates duration;
+- `tool-call-exploration` when `executedTools` is high and dispatch duration is not dominant;
+- `insufficient-evidence` when required rows are missing.
+
+- [ ] **Step 2: Implement diagnosis assembly**
+
+`buildCoworkerRegressionDiagnosis(input)` should return:
+
+```ts
+export type CoworkerRegressionDiagnosis = {
+  probableCause:
+    | "nudge-redispatch-loop"
+    | "full-tool-surface-on-conversational-turn"
+    | "slow-provider-dispatch"
+    | "tool-call-exploration"
+    | "insufficient-evidence";
+  summary: string;
+  metrics: {
+    dispatches: number | null;
+    nudges: number | null;
+    toolsAttached: boolean | null;
+    executedTools: number | null;
+    totalMs: number | null;
+    taskType: string | null;
+    providerId: string | null;
+    modelId: string | null;
+  };
+};
+```
+
+The summary must be deterministic, short, and suitable for `PlatformIssueReport.description`.
+
+- [ ] **Step 3: Enrich PIR filing**
+
+When the detector files a PIR, include:
+
+- report title with trigger and bucket, for example `Coworker latency regression: support-specialist on /platform/ai`;
+- description with baseline p95, recent p95, ratio, exemplar thread, agent message, and diagnosis block;
+- `source="coworker-regression-detector"`;
+- `triggerKind="latency-regression"` or `triggerKind="nudge-rate-regression"`;
+- `threadId` of the worst exemplar;
+- `agentId` and `routeContext` where available;
+- `severity` as `medium`, `high`, or `critical` based on ratio and absolute latency.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-regression-diagnosis.test.ts apps/web/lib/operate/coworker-regression-detector.test.ts
+```
+
+Expected: pass in the worktree.
+
+## Task 4: Operator UI In Admin Issue Reports
+
+**Files:**
+
+- Modify: `apps/web/components/admin/IssueReportPanel.tsx`
+- Modify: `apps/web/components/admin/IssueReportPanel.test.tsx`
+- Modify if needed: `apps/web/components/ui/report-kit/statusColors.ts`
+
+- [ ] **Step 1: Add a diagnosis rendering test**
+
+Add a report fixture with:
+
+```ts
+{
+  source: "coworker-regression-detector",
+  triggerKind: "latency-regression",
+  description: "Diagnosis: slow-provider-dispatch\nRecent p95: 9000ms\nBaseline p95: 2000ms\nDispatches: 3\nNudges: 1\nTools attached: true\nProbable cause: slow-provider-dispatch",
+}
+```
+
+Assert that the rendered panel shows:
+
+- `Coworker regression`;
+- `slow-provider-dispatch`;
+- `Recent p95`;
+- an action to send the PIR to Build Studio as a fix.
+
+- [ ] **Step 2: Migrate touched reporting widgets to report-kit**
+
+Add `triggerKind: string | null` to the component's `ReportRow` type. `getIssueReports()` already returns full `PlatformIssueReport` rows, so this is a component contract fix, not a query rewrite.
+
+Replace local `StatCard`, local severity chips, and inline tone styles in touched areas with:
+
+- `StatCard` from `@/components/ui/report-kit`;
+- `StatusBadge` for severity/status/trigger;
+- `resolveIntent` or `STATUS_INTENT` additions in `statusColors.ts` if a new domain mapping is needed.
+
+Do not introduce raw hex, `text-gray-*`, `bg-white`, `text-black`, or inline color styles.
+
+- [ ] **Step 3: Render diagnosis as scannable operator evidence**
+
+Keep the expanded report layout compact:
+
+- title and status row;
+- `Coworker regression` badge when `source === "coworker-regression-detector"`;
+- diagnosis summary;
+- compact metric rows for `recent p95`, `baseline p95`, `ratio`, `dispatches`, `nudges`, `toolsAttached`, `provider`, `model`;
+- existing actions preserved.
+
+- [ ] **Step 4: Run UI tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/admin/IssueReportPanel.test.tsx
+```
+
+Expected: pass in the worktree.
+
+## Task 5: Functional Evidence And Build Gate
+
+**Files:**
+
+- No new source files unless test utilities need small fixtures.
+
+- [ ] **Step 1: Run source-local tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/operate/coworker-regression-detector.test.ts apps/web/lib/operate/coworker-regression-diagnosis.test.ts apps/web/lib/operate/coworker-turn-metrics.test.ts apps/web/lib/tak/agentic-loop.test.ts apps/web/components/admin/IssueReportPanel.test.tsx
+pnpm --filter web typecheck
+```
+
+Expected: pass in the worktree. This is source-local evidence only.
+
+- [ ] **Step 2: Run migration apply check on the canonical runtime or shared local-CI sandbox**
+
+Use the canonical local install or `local-integration-ci` lease. Do not treat a worktree-only Prisma check as migration evidence.
+
+Expected: migration applies cleanly and leaves existing PIR/telemetry rows intact.
+
+- [ ] **Step 3: Run production build on the canonical runtime or shared local-CI sandbox**
+
+Run the build gate on the canonical substrate named in `AGENTS.md`.
+
+Expected: production build succeeds with zero errors.
+
+- [ ] **Step 4: Functional UX verification**
+
+On the canonical local install:
+
+1. Create or seed correlated `AdapterRunTelemetry` rows with the same `threadId` and `agentMessageId`, recent p95 above threshold, and baseline rows below threshold.
+2. Run `quality/coworker-regression-detect`.
+3. Confirm one open PIR exists with `source="coworker-regression-detector"`, `triggerKind="latency-regression"`, exemplar `threadId`, and structured diagnosis in `description`.
+4. Run or wait for `quality/issue-report-triage`.
+5. Confirm a bug backlog item is created through the existing PIR triage path.
+6. Open Admin > Issue Reports and confirm the regression diagnosis is visible, scannable, and action-ready.
+
+Expected: the platform produces the same diagnosis an operator would otherwise assemble manually.
+
+## Definition Of Done
+
+- A slow or nudge-looping coworker turn on the canonical local install causes a deduplicated PIR to be auto-filed.
+- The PIR carries structured diagnosis: dispatches, nudges, toolsAttached, executedTools, provider, model, totalMs, baseline, recent p95 or nudge rate, and probable cause.
+- The existing issue-report triage path promotes the PIR to a bug backlog item without a parallel incident pipeline.
+- Admin > Issue Reports displays the diagnosis with theme-aware report-kit UI and no new hardcoded color/status logic.
+- Source-local tests pass in the worktree; production build, UX verification, and migration apply are recorded with their canonical substrate.

--- a/packages/db/prisma/migrations/20260605180000_add_coworker_turn_metric/migration.sql
+++ b/packages/db/prisma/migrations/20260605180000_add_coworker_turn_metric/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "CoworkerTurnMetric" (
+    "id" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "agentMessageId" TEXT NOT NULL,
+    "agentId" TEXT,
+    "routeContext" TEXT,
+    "taskType" TEXT,
+    "providerId" TEXT,
+    "modelId" TEXT,
+    "dispatches" INTEGER NOT NULL DEFAULT 0,
+    "nudges" INTEGER NOT NULL DEFAULT 0,
+    "toolsAttached" BOOLEAN NOT NULL DEFAULT false,
+    "executedTools" INTEGER NOT NULL DEFAULT 0,
+    "totalMs" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CoworkerTurnMetric_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CoworkerTurnMetric_threadId_agentMessageId_key" ON "CoworkerTurnMetric"("threadId", "agentMessageId");
+
+-- CreateIndex
+CREATE INDEX "CoworkerTurnMetric_agentId_routeContext_createdAt_idx" ON "CoworkerTurnMetric"("agentId", "routeContext", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CoworkerTurnMetric_threadId_createdAt_idx" ON "CoworkerTurnMetric"("threadId", "createdAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10015,3 +10015,24 @@ model ResearchProposal {
   @@index([organizationId, status])
   @@index([status])
 }
+
+model CoworkerTurnMetric {
+  id              String   @id @default(cuid())
+  threadId        String
+  agentMessageId  String
+  agentId         String?
+  routeContext    String?
+  taskType        String?
+  providerId      String?
+  modelId         String?
+  dispatches      Int      @default(0)
+  nudges          Int      @default(0)
+  toolsAttached   Boolean  @default(false)
+  executedTools   Int      @default(0)
+  totalMs         Int?
+  createdAt       DateTime @default(now())
+
+  @@unique([threadId, agentMessageId])
+  @@index([agentId, routeContext, createdAt])
+  @@index([threadId, createdAt])
+}


### PR DESCRIPTION
Implements **BI-47443B67** (EP-COST-001) per the chief-architect-reviewed plan `docs/superpowers/plans/2026-06-05-self-diagnosing-coworker-regressions.md`. The platform detects and **explains** its own coworker latency / nudge-loop regressions instead of a human stitching logs. Builds on the per-turn `[turn]` telemetry from #1479 (now in main).

## What it does
- **Task 1 — latency detector (no new schema).** A `*/15` Inngest cron mirrors the existing `checkForSpike` pattern: groups `AdapterRunTelemetry` (`durationMs`, `threadId`, `agentMessageId`) into turns, buckets by `(agentId, routeContext)`, compares recent p95 to a trailing 7-day baseline (`MIN_SAMPLES`, `p95 ≥ baseline×FACTOR`), dedups against open PIRs, and files via the single `createPlatformIssueReport` writer → the existing PIR→BI triage path promotes it.
- **Task 2 — `CoworkerTurnMetric` (additive model + migration).** Fire-and-forget upsert at the existing `logTurnSummary` point persists per-turn `nudges`/`dispatches`/`toolsAttached`/`totalMs`; detector gains a nudge-rate path.
- **Task 3 — deterministic diagnosis.** Pure rules map metrics to a probable cause (`nudge-redispatch-loop`, `full-tool-surface-on-conversational-turn`, `slow-provider-dispatch`, `tool-call-exploration`, `insufficient-evidence`) — no LLM — folded into the PIR description.
- **Task 4 — Admin > Issue Reports UI.** A "Coworker regression" badge + scannable evidence block (recent/baseline p95, ratio, dispatches, nudges, toolsAttached, provider, model), migrated onto report-kit `StatCard`/`StatusBadge` with `--dpf-*` tokens (no raw hex / inline color).

## Architectural notes (from the review)
- Reuses `PlatformIssueReport` + the existing 15-min triage cadence — no parallel incident system.
- One additive model only (`CoworkerTurnMetric`); migration timestamped after the latest existing migration; schema-regression guard passed.
- PIRs written only through `createPlatformIssueReport` (extended additively with `agentId`, which the column already had and the dedup predicate needs) — no direct prisma writes.
- Detector/writer use dependency injection so unit tests run client-free; diagnosis module is import-pure.

## Verification
- **Source-local (done):** 122 tests across the 5 touched/new files + 34 blast-radius tests pass; **full `apps/web` typecheck: 0 errors** (pre-commit typecheck gate passed without skip).
- **Canonical substrate (pending — Task 5 Steps 2-4):** migration apply, production build, and the end-to-end functional UX (seed correlated telemetry → run the cron → confirm an auto-filed, deduplicated PIR carrying the diagnosis → triage promotes it to a BI → visible in Admin > Issue Reports). These require the canonical runtime / image rebuild and are not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
