### PR TITLE
feat(archetype): add trades capability perspective

### DIFF
--- a/packages/db/src/business-capability-perspectives.ts
+++ b/packages/db/src/business-capability-perspectives.ts
@@ -225,6 +225,77 @@ const BEAUTY_PERSONAL_CARE: BusinessCapabilityPerspective = {
   ],
 };
 
+const TRADES_MAINTENANCE: BusinessCapabilityPerspective = {
+  perspectiveId: "trades-maintenance",
+  label: "Trades And Maintenance",
+  source: "DPF trades/maintenance overlay informed by field-service dispatch, work-order lifecycle, customer ETA communications, truck stock, subcontractor/safety, and trades finance operating patterns",
+  capabilities: [
+    l1(
+      "trades-field-service-operations",
+      "Trades And Maintenance Operations",
+      100,
+      "Operate field-service work across inquiry intake, dispatch, technician readiness, work orders, customer updates, vehicle stock, subcontractors, and contract billing.",
+      ["consume", "operate"],
+    ),
+    l2(
+      "trades-job-intake-triage",
+      "trades-field-service-operations",
+      "Job Intake And Triage",
+      10,
+      "Capture job descriptions, urgency, property type, photos, notes, quote requests, emergency call-outs, and customer contact preferences.",
+      ["consume"],
+    ),
+    l2(
+      "trades-dispatch-technician-readiness",
+      "trades-field-service-operations",
+      "Dispatch And Technician Readiness",
+      20,
+      "Assign technicians or crews, schedule visits, check skills, tools, and parts readiness, and keep dispatcher queues current.",
+      ["operate"],
+    ),
+    l2(
+      "trades-work-order-lifecycle",
+      "trades-field-service-operations",
+      "Work Order Lifecycle",
+      30,
+      "Track planned maintenance, reactive repair, inspections, site notes, completion evidence, follow-up tasks, and status handoffs.",
+      ["operate"],
+    ),
+    l2(
+      "trades-customer-updates-eta",
+      "trades-field-service-operations",
+      "Customer Updates ETA And Exceptions",
+      40,
+      "Send appointment confirmations, on-my-way ETA updates, running-late notices, access instructions, and completion follow-ups across communication channels.",
+      ["integrate", "operate"],
+    ),
+    l2(
+      "trades-truck-stock-parts",
+      "trades-field-service-operations",
+      "Truck Stock Parts And Materials",
+      50,
+      "Track truck stock, parts usage, materials, tools, restock needs, purchasing, and job-to-inventory evidence.",
+      ["operate"],
+    ),
+    l2(
+      "trades-quotes-contracts-billing",
+      "trades-field-service-operations",
+      "Quotes Contracts And Billing Readiness",
+      60,
+      "Prepare quotes, maintenance contracts, labour and materials billing, purchase orders, deposits, VAT/tax posture, and collections evidence.",
+      ["consume", "operate", "integrate"],
+    ),
+    l2(
+      "trades-safety-compliance-subcontractors",
+      "trades-field-service-operations",
+      "Safety Compliance And Subcontractors",
+      70,
+      "Manage site safety, PPE, certificates, insurance, subcontractors, waste disposal, and regulated trade obligations.",
+      ["operate"],
+    ),
+  ],
+};
+
 function l1(
   key: string,
   name: string,
@@ -280,6 +351,10 @@ export function resolveBusinessCapabilityPerspective(
 
   if (input.category === "beauty-personal-care") {
     perspectives.push(BEAUTY_PERSONAL_CARE);
+  }
+
+  if (input.category === "trades-maintenance") {
+    perspectives.push(TRADES_MAINTENANCE);
   }
 
   return {

--- a/packages/db/test/business-capability-perspectives.test.ts
+++ b/packages/db/test/business-capability-perspectives.test.ts
@@ -62,6 +62,45 @@ describe("business capability perspectives", () => {
     expect(customSalon.capabilities.some((capability) => capability.key === "beauty-checkout-retail-payments")).toBe(true);
   });
 
+  it("adds a trades and maintenance category overlay for field-service work", () => {
+    const trades = resolveBusinessCapabilityPerspective({
+      archetypeId: "facilities-maintenance",
+      category: "trades-maintenance",
+    });
+
+    expect(trades.sourcePerspectiveIds).toEqual(["common-small-business", "trades-maintenance"]);
+    expect(trades.sources.map((source) => source.label)).toEqual(["Common Small Business", "Trades And Maintenance"]);
+    expect(trades.sources.map((source) => source.source)).toContain(
+      "DPF trades/maintenance overlay informed by field-service dispatch, work-order lifecycle, customer ETA communications, truck stock, subcontractor/safety, and trades finance operating patterns",
+    );
+    const keys = trades.capabilities.map((capability) => capability.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "trades-field-service-operations",
+        "trades-job-intake-triage",
+        "trades-dispatch-technician-readiness",
+        "trades-work-order-lifecycle",
+        "trades-customer-updates-eta",
+        "trades-truck-stock-parts",
+        "trades-quotes-contracts-billing",
+        "trades-safety-compliance-subcontractors",
+      ]),
+    );
+  });
+
+  it("applies trades category overlays even when the field-service leaf is custom", () => {
+    const customTrades = resolveBusinessCapabilityPerspective({
+      archetypeId: "hvac-contractor",
+      category: "trades-maintenance",
+    });
+
+    expect(customTrades.sourcePerspectiveIds).toEqual(["common-small-business", "trades-maintenance"]);
+    const keys = customTrades.capabilities.map((capability) => capability.key);
+    expect(keys).toContain("trades-truck-stock-parts");
+    expect(keys).not.toContain("beauty-service-operations");
+    expect(keys).not.toContain("msp-managed-customer-estate");
+  });
+
   it("projects capabilities with deterministic seed IDs and parent links", async () => {
     const upsert = vi.fn(async (args) => ({
       id: `db-${args.where.capabilityId}`,


### PR DESCRIPTION
## Summary
- Add a `trades-maintenance` business capability perspective overlay for field-service archetypes.
- Seed day-to-day capabilities for job intake, dispatch/technician readiness, work-order lifecycle, ETA/customer updates, truck stock/parts, quotes/contracts/billing, and safety/subcontractor obligations.
- Cover known and custom trades leaves so setup can load the category perspective even before every vertical leaf exists.

## Verification
- Worktree: `D:\DPF-bizcap-archetype-perspectives`
- `pnpm --filter @dpf/db exec vitest run test/business-capability-perspectives.test.ts` — passed after TDD red/green
- `pnpm --filter @dpf/db typecheck` — passed
- `pnpm --filter web exec vitest run components/portfolio/architecture/BusinessCapabilityMap.test.tsx` — passed
- `pnpm --filter web typecheck` — passed before rebase
- `pnpm --filter @dpf/db exec prisma generate` — refreshed generated Prisma client after rebasing onto #1496
- `pnpm --filter web exec next build` — passed source-local production build on the rebased branch; existing Turbopack Edge/NFT warnings remain

## Backlog context
- Live DPF MCP checked `EP-TRADES-FIELD-SERVICE`, `EP-ARCH-8D4F2A`, and portfolio context search before PR.
- Closest owning items are `BI-FS-001` and `BI-ARCH-4C1E90`; no new duplicate epic or backlog item was created.