### PR TITLE
fix(security): grant-gate discovered MCP tools (close authority bypass)

### DIFF
--- a/apps/web/components/platform/EffectivePermissionsPanel.tsx
+++ b/apps/web/components/platform/EffectivePermissionsPanel.tsx
@@ -52,8 +52,21 @@ type EffectivePermissionsProps = {
 /**
  * Maps platform tool names to agent grant categories.
  * Mirrors TOOL_TO_GRANTS from agent-grants.ts for client-side evaluation.
+ *
+ * NOTE: this is a hand-maintained mirror and drifts from the server map. It is
+ * display-only — enforcement is server-side via getAvailableTools /
+ * isToolAllowedByGrants. Collapsing this onto a single shared/generated grant
+ * map is tracked as architect-review Slice 0 item 5 (EP-BROWSER-DRIVE). Until
+ * then, add new grant mappings here in the same change as agent-grants.ts.
  */
 const TOOL_TO_GRANTS: Record<string, string[]> = {
+  // Browser-driving (namespaced MCP) — EP-BROWSER-DRIVE, spec 2026-06-05 §8.2.
+  "mcp-browser-use__browse_open": ["browser_read"],
+  "mcp-browser-use__browse_extract": ["browser_read"],
+  "mcp-browser-use__browse_screenshot": ["browser_read"],
+  "mcp-browser-use__browse_close": ["browser_read"],
+  "mcp-browser-use__browse_run_tests": ["browser_read"],
+  "mcp-browser-use__browse_act": ["browser_drive"],
   create_backlog_item: ["backlog_write"],
   update_backlog_item: ["backlog_write"],
   query_backlog: ["backlog_read"],

--- a/apps/web/lib/mcp-tools-mcp-server.test.ts
+++ b/apps/web/lib/mcp-tools-mcp-server.test.ts
@@ -47,6 +47,28 @@ describe("getAvailableTools with MCP server tools", () => {
     const mcpTool = tools.find((t) => t.name === "stripe__create_payment");
     expect(mcpTool).toBeDefined();
   });
+
+  it("grant-gates discovered browser-driving tools but not unmapped MCP tools (EP-BROWSER-DRIVE Verdict 5)", async () => {
+    // browse_act + browse_open carry TOOL_TO_GRANTS entries; stripe__create_payment
+    // does not. With no agent grants (grantless context) the mapped browser tools
+    // must be filtered out even though External Access is on — the gap Verdict 5
+    // closes — while the unmapped tool still passes through unchanged.
+    vi.mocked(getMcpServerTools).mockResolvedValue([
+      { name: "mcp-browser-use__browse_act", description: "drive", inputSchema: { type: "object" }, requiredCapability: null, requiresExternalAccess: true, sideEffect: true },
+      { name: "mcp-browser-use__browse_open", description: "open", inputSchema: { type: "object" }, requiredCapability: null, requiresExternalAccess: true, sideEffect: true },
+      { name: "stripe__create_payment", description: "pay", inputSchema: { type: "object" }, requiredCapability: null, requiresExternalAccess: true, sideEffect: true },
+    ]);
+
+    const tools = await getAvailableTools(
+      { platformRole: "admin", isSuperuser: true },
+      { externalAccessEnabled: true },
+    );
+    const names = tools.map((t) => t.name);
+
+    expect(names).not.toContain("mcp-browser-use__browse_act");
+    expect(names).not.toContain("mcp-browser-use__browse_open");
+    expect(names).toContain("stripe__create_payment");
+  });
 });
 
 describe("executeTool with namespaced MCP server tools", () => {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4620,9 +4620,11 @@ export async function getAvailableTools(
   // Agent-scoped filtering: intersection of user capabilities and agent tool grants.
   // EP-AI-WORKFORCE-001: use the async DB-first resolver so grants written via
   // the DB (e.g. via seed or Admin UI) take precedence over the JSON fallback.
+  const { getAgentToolGrantsAsync, isToolAllowedByGrants, getToolGrantMapping } =
+    await import("./agent-grants");
+  let agentGrants: string[] = [];
   if (options?.agentId) {
-    const { getAgentToolGrantsAsync, isToolAllowedByGrants } = await import("./agent-grants");
-    const agentGrants = await getAgentToolGrantsAsync(options.agentId);
+    agentGrants = await getAgentToolGrantsAsync(options.agentId);
     if (agentGrants.length > 0) {
       platformTools = platformTools.filter((tool) => isToolAllowedByGrants(tool.name, agentGrants));
     }
@@ -4632,8 +4634,22 @@ export async function getAvailableTools(
     try {
       const { getMcpServerTools } = await import("./mcp-server-tools");
       const mcpTools = await getMcpServerTools();
-      const filtered = options?.mode === "advise" ? [] : mcpTools;
-      return [...platformTools, ...filtered];
+      const modeFiltered = options?.mode === "advise" ? [] : mcpTools;
+      // Grant-gate discovered MCP tools, closing the Verdict 5 authority gap
+      // (EP-BROWSER-DRIVE, spec 2026-06-05 §8.2). Previously every discovered
+      // MCP tool was appended ungated whenever External Access was on — so a
+      // side-effecting browser tool was ambiently callable. Now a discovered
+      // tool that carries a TOOL_TO_GRANTS entry (the namespaced browser-driving
+      // tools) is denied unless the agent holds the grant; this denies them even
+      // for an agent with no grants at all (empty agentGrants → false). Discovered
+      // tools WITHOUT a mapping retain prior behavior so other MCP servers are not
+      // regressed — tightening those to default-deny is tracked separately
+      // (architect review Slice 0 item 4, the discovered-tool policy overlay).
+      const grantMap = getToolGrantMapping();
+      const grantFiltered = modeFiltered.filter((tool) =>
+        grantMap[tool.name] ? isToolAllowedByGrants(tool.name, agentGrants) : true,
+      );
+      return [...platformTools, ...grantFiltered];
     } catch {
       // MCP server tools unavailable — return platform tools only
     }

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -685,3 +685,44 @@ describe("Existing coworkers — no behavior regression from the refactor", () =
     expect(isToolAllowedByGrants("promote_to_build_studio", cooGrants)).toBe(false);
   });
 });
+
+describe("TOOL_TO_GRANTS — Browser-driving entries (EP-BROWSER-DRIVE, Verdict 5)", () => {
+  it("browse_act (side-effecting) requires browser_drive, not browser_read", () => {
+    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["browser_drive"])).toBe(true);
+    // browser_read alone is NOT enough to drive — the whole point of the split.
+    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["browser_read"])).toBe(false);
+    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", [])).toBe(false);
+    expect(isToolAllowedByGrants("mcp-browser-use__browse_act", ["backlog_write"])).toBe(false);
+  });
+
+  it("read tools require browser_read, and browser_drive satisfies them via implication", () => {
+    for (const tool of [
+      "mcp-browser-use__browse_open",
+      "mcp-browser-use__browse_extract",
+      "mcp-browser-use__browse_screenshot",
+      "mcp-browser-use__browse_close",
+      "mcp-browser-use__browse_run_tests",
+    ]) {
+      expect(isToolAllowedByGrants(tool, ["browser_read"])).toBe(true);
+      // browser_drive implies browser_read, so a driver can also read.
+      expect(isToolAllowedByGrants(tool, ["browser_drive"])).toBe(true);
+      expect(isToolAllowedByGrants(tool, [])).toBe(false);
+    }
+  });
+
+  it("browse_run_tests stays QA-scoped on browser_read, never browser_drive", () => {
+    expect(isToolAllowedByGrants("mcp-browser-use__browse_run_tests", ["browser_read"])).toBe(true);
+  });
+
+  it("GRANT_IMPLICATIONS is one-way: browser_drive implies browser_read, not the reverse", () => {
+    expect(GRANT_IMPLICATIONS["browser_drive"]).toEqual(["browser_read"]);
+    expect(expandGrants(["browser_drive"])).toContain("browser_read");
+    expect(expandGrants(["browser_read"])).not.toContain("browser_drive");
+  });
+
+  it("the namespaced browser tools are present in the grant mapping (so they don't default-deny)", () => {
+    const map = getToolGrantMapping();
+    expect(map["mcp-browser-use__browse_act"]).toEqual(["browser_drive"]);
+    expect(map["mcp-browser-use__browse_open"]).toEqual(["browser_read"]);
+  });
+});

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -28,6 +28,11 @@ export const GRANT_IMPLICATIONS: Readonly<Record<string, readonly string[]>> = {
   // `build_promote` was the legacy promotion grant; `build_lifecycle` is the
   // broader Pseudo-User Contract grant covering reopen + cancel + promote.
   build_promote: ["build_lifecycle"],
+  // Browser-driving (EP-BROWSER-DRIVE, spec 2026-06-05 §8.2, Verdict 5):
+  // holding `browser_drive` (side-effecting browser actions) implies
+  // `browser_read` (navigate / extract / screenshot). One-way, as ever —
+  // `browser_read` alone never implies the drive grant.
+  browser_drive: ["browser_read"],
 };
 
 /** Expand a list of held grants by applying GRANT_IMPLICATIONS one-way.
@@ -53,6 +58,22 @@ export function expandGrants(grants: readonly string[]): string[] {
  * Tools not in this map are DENIED by default — every tool must have an entry.
  */
 const TOOL_TO_GRANTS: Record<string, string[]> = {
+  // Browser-driving (namespaced MCP, server slug `mcp-browser-use`) —
+  // EP-BROWSER-DRIVE, spec 2026-06-05 §8.2 (Verdict 5). These are the
+  // platform-visible `<serverId>__<toolName>` names (see mcp-server-tools.ts
+  // `namespaceTool`), because that is the form that enters the coworker tool
+  // list. Read tools require `browser_read`; the side-effecting `browse_act`
+  // requires `browser_drive` (which implies `browser_read`). `browse_run_tests`
+  // stays QA-scoped on `browser_read`, never `browser_drive`. Without an entry
+  // here these tools were appended ungated under External Access — the gap this
+  // closes (see getAvailableTools in apps/web/lib/mcp-tools.ts).
+  "mcp-browser-use__browse_open": ["browser_read"],
+  "mcp-browser-use__browse_extract": ["browser_read"],
+  "mcp-browser-use__browse_screenshot": ["browser_read"],
+  "mcp-browser-use__browse_close": ["browser_read"],
+  "mcp-browser-use__browse_run_tests": ["browser_read"],
+  "mcp-browser-use__browse_act": ["browser_drive"],
+
   // Backlog
   create_backlog_item: ["backlog_write"],
   update_backlog_item: ["backlog_write"],


### PR DESCRIPTION
## What

Closes a pre-existing authority gap: `getAvailableTools()` appended **discovered MCP server tools ungated** whenever External Access was on, so an agent could see/call a side-effecting external tool without holding any agent grant for it. Confirmed at `apps/web/lib/mcp-tools.ts` — discovered tools from `getMcpServerTools()` were returned as `[...platformTools, ...mcpTools]` while only `platformTools` passed through `isToolAllowedByGrants()`.

## Change

- `agent-grants.ts`: add `browser_read` / `browser_drive` grant keys; map the namespaced `mcp-browser-use__*` tools in `TOOL_TO_GRANTS` (read tools → `browser_read`; `browse_act` → `browser_drive`; `browse_run_tests` stays QA-scoped on `browser_read`); add the one-way `GRANT_IMPLICATIONS` edge `browser_drive → [browser_read]`.
- `mcp-tools.ts`: grant-filter discovered MCP tools. A discovered tool that carries a `TOOL_TO_GRANTS` entry is denied unless the agent holds the grant — **denied even for a grantless agent**. Discovered tools *without* a mapping retain prior behavior, so other MCP servers are not regressed (tightening those to default-deny is tracked separately as the discovered-tool policy overlay).
- `EffectivePermissionsPanel.tsx`: add the browser entries to the client mirror; note the shared-map follow-up.

## Why standalone

This is the independently-valuable security hardening that the browser-driving epic (EP-BROWSER-DRIVE, BI-2AED4F15) surfaced — it closes a live grant-bypass regardless of the rest of the substrate, so it ships on its own. No coworker is seeded `browser_drive` here; this only makes the tools un-callable without the grant.

## Verification

Verified against current `main`: 104 vitest pass across `agent-grants.test.ts` (gate logic, implication, default-deny) and `mcp-tools-mcp-server.test.ts` (an ungranted agent does not see `mcp-browser-use__*` even with External Access on; unmapped tools still pass through). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)