### PR TITLE
fix: resolve managed backup scripts in self-upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,13 @@ RUN NODE_OPTIONS="--max-old-space-size=4096" NEXT_TELEMETRY_DISABLED=1 NEXT_TURB
 FROM deps AS init
 COPY pnpm-workspace.yaml tsconfig.base.json .gitignore ./
 COPY scripts/set-hooks-path.mjs ./scripts/
+COPY scripts/backup-postgres.sh ./scripts/
+COPY scripts/backup-neo4j.sh ./scripts/
+COPY scripts/backup-qdrant.sh ./scripts/
+COPY scripts/restore-postgres.sh ./scripts/
+COPY scripts/restore-neo4j.sh ./scripts/
+COPY scripts/restore-qdrant.sh ./scripts/
+COPY scripts/postgres-trial-restore.sh ./scripts/
 COPY apps/web/ ./apps/web/
 COPY packages/ ./packages/
 COPY prompts/ ./prompts/

--- a/apps/web/lib/operate/backups/backups-host-path-relocation.test.ts
+++ b/apps/web/lib/operate/backups/backups-host-path-relocation.test.ts
@@ -79,6 +79,26 @@ describe("DPF_BACKUPS_HOST_PATH relocation (BI-8004BCD8)", () => {
   });
 
   describe("TypeScript runners", () => {
+    const dockerfile = read("Dockerfile");
+    const managedScripts = [
+      "backup-postgres.sh",
+      "backup-neo4j.sh",
+      "backup-qdrant.sh",
+      "restore-postgres.sh",
+      "restore-neo4j.sh",
+      "restore-qdrant.sh",
+      "postgres-trial-restore.sh",
+    ];
+
+    it("runtime image packages the managed backup and restore scripts", () => {
+      for (const script of managedScripts) {
+        expect(dockerfile, `${script} must be copied into /app/scripts`).toContain(
+          `scripts/${script}`,
+        );
+      }
+      expect(dockerfile).toContain("COPY --from=init /app/scripts ./scripts");
+    });
+
     it("neo4j-backup-runner.ts forwards DPF_BACKUPS_HOST_PATH explicitly", () => {
       const body = read("apps/web/lib/operate/backups/neo4j-backup-runner.ts");
       expect(body).toContain('DPF_BACKUPS_HOST_PATH: process.env.DPF_BACKUPS_HOST_PATH ?? ""');

--- a/apps/web/lib/operate/backups/managed-script-path.test.ts
+++ b/apps/web/lib/operate/backups/managed-script-path.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  managedScriptRootCandidates,
+  resolveManagedScriptPath,
+} from "./managed-script-path";
+
+const SCRIPT = "backup-postgres.sh";
+
+function existsOnly(paths: string[]) {
+  const available = new Set(paths);
+  return (candidate: string) => available.has(candidate);
+}
+
+describe("managed backup script path resolution", () => {
+  it("prefers the bundled production script when /workspace is incomplete", () => {
+    const path = resolveManagedScriptPath(SCRIPT, {
+      env: { PROJECT_ROOT: "/workspace" },
+      existsSync: existsOnly([`/app/scripts/${SCRIPT}`]),
+    });
+
+    expect(path).toBe(`/app/scripts/${SCRIPT}`);
+  });
+
+  it("falls back to the mounted install source when the image does not carry the script", () => {
+    const path = resolveManagedScriptPath(SCRIPT, {
+      env: { PROJECT_ROOT: "/workspace" },
+      existsSync: existsOnly([`/host-dpf/scripts/${SCRIPT}`]),
+    });
+
+    expect(path).toBe(`/host-dpf/scripts/${SCRIPT}`);
+  });
+
+  it("honors an explicit script root override before bundled defaults", () => {
+    const path = resolveManagedScriptPath(SCRIPT, {
+      env: {
+        DPF_MANAGED_SCRIPT_DIR: "/custom/scripts",
+        PROJECT_ROOT: "/workspace",
+      },
+      existsSync: existsOnly([`/custom/scripts/${SCRIPT}`, `/app/scripts/${SCRIPT}`]),
+    });
+
+    expect(path).toBe(`/custom/scripts/${SCRIPT}`);
+  });
+
+  it("keeps root candidates stable and duplicate-free", () => {
+    expect(
+      managedScriptRootCandidates({
+        DPF_MANAGED_SCRIPT_DIR: "/custom/scripts",
+        PROJECT_ROOT: "/workspace",
+      }),
+    ).toEqual([
+      "/custom/scripts",
+      "/app/scripts",
+      "/workspace/scripts",
+      "/host-dpf/scripts",
+    ]);
+  });
+});

--- a/apps/web/lib/operate/backups/managed-script-path.ts
+++ b/apps/web/lib/operate/backups/managed-script-path.ts
@@ -1,0 +1,52 @@
+import { existsSync as nodeExistsSync } from "node:fs";
+import path from "node:path";
+
+interface EnvLike {
+  [key: string]: string | undefined;
+  DPF_MANAGED_SCRIPT_DIR?: string;
+  PROJECT_ROOT?: string;
+}
+
+interface ResolveManagedScriptPathOptions {
+  env?: EnvLike;
+  existsSync?: (candidate: string) => boolean;
+}
+
+function normalizeRoot(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function pushUnique(roots: string[], candidate: string | null): void {
+  if (!candidate || roots.includes(candidate)) return;
+  roots.push(candidate);
+}
+
+export function managedScriptRootCandidates(env: EnvLike = process.env): string[] {
+  const roots: string[] = [];
+  const projectRoot = normalizeRoot(env.PROJECT_ROOT) ?? "/workspace";
+
+  pushUnique(roots, normalizeRoot(env.DPF_MANAGED_SCRIPT_DIR));
+  pushUnique(roots, "/app/scripts");
+  pushUnique(roots, path.posix.join(projectRoot, "scripts"));
+  pushUnique(roots, "/workspace/scripts");
+  pushUnique(roots, "/host-dpf/scripts");
+
+  return roots;
+}
+
+export function resolveManagedScriptPath(
+  scriptName: string,
+  options?: ResolveManagedScriptPathOptions,
+): string {
+  const roots = managedScriptRootCandidates(options?.env ?? process.env);
+  const existsSync = options?.existsSync ?? nodeExistsSync;
+
+  for (const root of roots) {
+    const candidate = path.posix.join(root, scriptName);
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return path.posix.join(roots[0] ?? "/app/scripts", scriptName);
+}

--- a/apps/web/lib/operate/backups/neo4j-backup-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-backup-runner.ts
@@ -47,12 +47,13 @@ import {
   type BackupRetentionPolicy,
   type BackupTrigger,
 } from "./types";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
 const NEO4J_SUBDIR = "neo4j";
-const SCRIPT_PATH = "/workspace/scripts/backup-neo4j.sh";
+const SCRIPT_NAME = "backup-neo4j.sh";
 const RUNNER_TIMEOUT_MS = 10 * 60 * 1000; // 10-minute hard cap (Neo4j stop+dump+start)
 
 export interface RunNeo4jBackupArgs {
@@ -157,7 +158,7 @@ export async function runNeo4jBackup(
   const trigger = args.trigger;
   const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(SCRIPT_NAME);
   const composeProject = args.composeProject ?? process.env.COMPOSE_PROJECT_NAME ?? "dpf";
   const containerName =
     process.env.DPF_NEO4J_CONTAINER ?? `${composeProject}-neo4j-1`;

--- a/apps/web/lib/operate/backups/neo4j-restore-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-restore-runner.ts
@@ -31,11 +31,12 @@ import {
   RestoreIntegrityError,
 } from "./postgres-restore-runner";
 import { runNeo4jBackup } from "./neo4j-backup-runner";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
-const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-neo4j.sh";
+const RESTORE_SCRIPT_NAME = "restore-neo4j.sh";
 const RUNNER_TIMEOUT_MS = 10 * 60 * 1000;
 
 export interface Neo4jRestoreArgs {
@@ -115,7 +116,7 @@ export async function runNeo4jRestore(
 ): Promise<{ restoreId: string; status: "ok" | "failed" }> {
   const now = args.now ?? (() => new Date());
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(RESTORE_SCRIPT_NAME);
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
   const release = args.acquireLock === false

--- a/apps/web/lib/operate/backups/postgres-backup-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-backup-runner.ts
@@ -39,12 +39,13 @@ import {
   type BackupRetentionPolicy,
   type BackupTrigger,
 } from "./types";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
 const POSTGRES_SUBDIR = "postgres";
-const SCRIPT_PATH = "/workspace/scripts/backup-postgres.sh";
+const SCRIPT_NAME = "backup-postgres.sh";
 const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // 30-minute hard cap
 
 export interface RunBackupArgs {
@@ -174,7 +175,7 @@ export async function runPostgresBackup(
   const trigger = args.trigger;
   const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(SCRIPT_NAME);
   const composeProject = args.composeProject ?? process.env.COMPOSE_PROJECT_NAME ?? "dpf";
   const containerName =
     process.env.DPF_PRODUCTION_DB_CONTAINER ?? `${composeProject}-postgres-1`;

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -33,11 +33,12 @@ import {
 } from "@/lib/operate/metrics";
 
 import { runPostgresBackup } from "./postgres-backup-runner";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
-const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-postgres.sh";
+const RESTORE_SCRIPT_NAME = "restore-postgres.sh";
 const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // mirror backup runner
 
 /** Module-scoped portal mutex. Single Next.js server = single source of truth. */
@@ -217,7 +218,7 @@ export async function runPostgresRestore(
 ): Promise<{ restoreId: string; status: "ok" | "failed" }> {
   const now = args.now ?? (() => new Date());
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(RESTORE_SCRIPT_NAME);
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
   const release = args.acquireLock === false

--- a/apps/web/lib/operate/backups/postgres-trial-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-trial-restore-runner.ts
@@ -31,11 +31,12 @@ import {
   TRIAL_RESTORE_DEFAULT_ASSERT_TABLES,
   TRIAL_RESTORE_TRIGGER,
 } from "./constants";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
-const TRIAL_RESTORE_SCRIPT_PATH = "/workspace/scripts/postgres-trial-restore.sh";
+const TRIAL_RESTORE_SCRIPT_NAME = "postgres-trial-restore.sh";
 const RUNNER_TIMEOUT_MS = 10 * 60 * 1000; // 10-minute hard cap
 
 export interface RunPostgresTrialRestoreArgs {
@@ -188,7 +189,7 @@ export async function runPostgresTrialRestore(
   const now = args.now ?? (() => new Date());
   const startedAt = now();
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? TRIAL_RESTORE_SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(TRIAL_RESTORE_SCRIPT_NAME);
   const assertTables = args.assertTables ?? TRIAL_RESTORE_DEFAULT_ASSERT_TABLES;
   const runScript = args.runScript ?? defaultRunScript;
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;

--- a/apps/web/lib/operate/backups/qdrant-backup-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-backup-runner.ts
@@ -40,12 +40,13 @@ import {
   type BackupRetentionPolicy,
   type BackupTrigger,
 } from "./types";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
 const QDRANT_SUBDIR = "qdrant";
-const SCRIPT_PATH = "/workspace/scripts/backup-qdrant.sh";
+const SCRIPT_NAME = "backup-qdrant.sh";
 const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // 30-minute hard cap
 
 export interface RunQdrantBackupArgs {
@@ -147,7 +148,7 @@ export async function runQdrantBackup(
   const trigger = args.trigger;
   const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(SCRIPT_NAME);
 
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 

--- a/apps/web/lib/operate/backups/qdrant-restore-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-restore-runner.ts
@@ -30,11 +30,12 @@ import {
   RestoreIntegrityError,
 } from "./postgres-restore-runner";
 import { runQdrantBackup } from "./qdrant-backup-runner";
+import { resolveManagedScriptPath } from "./managed-script-path";
 
 const execFileAsync = promisify(execFile);
 
 const BACKUPS_ROOT = "/backups";
-const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-qdrant.sh";
+const RESTORE_SCRIPT_NAME = "restore-qdrant.sh";
 const RUNNER_TIMEOUT_MS = 30 * 60 * 1000;
 
 export interface QdrantRestoreArgs {
@@ -113,7 +114,7 @@ export async function runQdrantRestore(
 ): Promise<{ restoreId: string; status: "ok" | "failed" }> {
   const now = args.now ?? (() => new Date());
   const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
-  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const scriptPath = args.scriptPath ?? resolveManagedScriptPath(RESTORE_SCRIPT_NAME);
   const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
 
   const release = args.acquireLock === false


### PR DESCRIPTION
## Summary
- package the managed backup/restore scripts into the production runner image
- route backup, restore, and trial-restore runners through a shared managed script resolver
- allow production images to use bundled scripts while retaining `/workspace/scripts` for dev and `/host-dpf/scripts` as install-source fallback

## Root cause
The live self-upgrade attempt `SUR-C290C009` failed safely during pre-upgrade recovery because all backup runners tried to execute `/workspace/scripts/backup-*.sh`. In the current live container, `/workspace/scripts` only had `set-hooks-path.mjs`; the full backup scripts were present on `/host-dpf/scripts`, but the runners had no fallback.

## Validation
- Worktree: `D:\DPF-self-upgrade-backup-script-path`
- `pnpm --filter web exec vitest run lib/operate/backups/managed-script-path.test.ts lib/operate/backups/backups-host-path-relocation.test.ts lib/operate/backups/postgres-restore-runner.test.ts lib/operate/backups/postgres-trial-restore-runner.test.ts lib/operate/backups/retention.test.ts` -> 5 files, 53 tests passed
- `pnpm --filter web typecheck` -> passed
- `pnpm --filter web build` -> passed source-local production build; emitted existing Turbopack/Edge-runtime warnings
- `git diff --check` -> passed

## Runtime note
I did not rebuild the live main portal directly. The live self-upgrade path was triggered through `/ops/self-upgrade`; it failed before swap at the recovery-point gate, so no runtime replacement occurred.