### PR TITLE
feat(ai-ops-map): replay-aware OperationsTopologyCanvas (Stage B2) (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/OperationsTopologyCanvas.test.tsx
+++ b/apps/web/components/platform/OperationsTopologyCanvas.test.tsx
@@ -93,3 +93,37 @@ describe("OperationsTopologyCanvas — A2A arc half (Stage C)", () => {
     expect(container.querySelectorAll("[data-canvas-marker]").length).toBe(0);
   });
 });
+
+describe("OperationsTopologyCanvas — shared replay scrubbing (Stage B2)", () => {
+  // Fixture timestamps: T0=10:00, T1=10:05, T2=10:10, T3=10:15.
+  const ms = (iso: string) => Date.parse(iso);
+  const range = {
+    start: ms("2026-06-05T10:00:00.000Z"),
+    current: ms("2026-06-05T10:10:00.000Z"),
+    end: ms("2026-06-05T10:15:00.000Z"),
+  };
+
+  it("shows everything at the default (current) playhead", () => {
+    const { container } = render(
+      <OperationsTopologyCanvas topology={buildOperationsMapTopologyFixture()} replayTime={range.current} replayRange={range} />,
+    );
+    expect(container.querySelectorAll("[data-canvas-route]").length).toBe(4);
+    expect(container.querySelectorAll("[data-canvas-a2a-arc]").length).toBe(3);
+  });
+
+  it("hides future routes and arcs when the playhead is scrubbed back", () => {
+    // Scrub to T1 (10:05): future active route (T2) + scheduled (T3) hide; past
+    // failover (T1) + historical (T0) stay. A2A lineage (T2) hides; delegation
+    // (T0) + handoff (T1) stay.
+    const { container } = render(
+      <OperationsTopologyCanvas
+        topology={buildOperationsMapTopologyFixture()}
+        replayTime={ms("2026-06-05T10:05:00.000Z")}
+        replayRange={range}
+      />,
+    );
+    const states = [...container.querySelectorAll("[data-canvas-route]")].map((r) => r.getAttribute("data-route-state")).sort();
+    expect(states).toEqual(["failover", "historical"]);
+    expect(container.querySelectorAll("[data-canvas-a2a-arc]").length).toBe(2);
+  });
+});

--- a/apps/web/components/platform/OperationsTopologyCanvas.tsx
+++ b/apps/web/components/platform/OperationsTopologyCanvas.tsx
@@ -21,13 +21,16 @@ import {
   routeStateDash,
   routeStateOpacity,
   routeStateStroke,
+  routeVisibleAtReplayTime,
   routeWidth,
 } from "./operations-topology-style";
 import {
+  a2aEdgeVisibleAtReplayTime,
   a2aStateIntent,
   edgeKindDash,
   EDGE_KIND_LABEL,
   STATE_LABEL,
+  type A2aReplayRange,
 } from "./a2a-interaction-graph";
 
 export type TopologyDimension = "provider" | "a2a" | "both";
@@ -38,6 +41,9 @@ type Props = {
   selectedCoworkerId?: string | null;
   /** Which halves to render — mirrors the Provider/A2A/Both dimension toggle. */
   dimension?: TopologyDimension;
+  /** Shared replay playhead — when set, both halves scrub in lock-step. */
+  replayTime?: number | null;
+  replayRange?: A2aReplayRange | null;
 };
 
 const CANVAS = {
@@ -52,17 +58,30 @@ export function OperationsTopologyCanvas({
   viewport = "desktop",
   selectedCoworkerId = null,
   dimension = "both",
+  replayTime = null,
+  replayRange = null,
 }: Props) {
   const showProvider = dimension === "provider" || dimension === "both";
   const showA2a = dimension === "a2a" || dimension === "both";
+
+  // Shared replay window: filter both halves by the playhead before layout so
+  // the spine, routes, and arcs all reflect the same point in time. At the
+  // default playhead (>= "current") everything recent stays visible.
+  const replayActive = replayTime != null && replayRange != null;
+  const visibleRoutes = showProvider
+    ? (replayActive ? topology.routes.filter((route) => routeVisibleAtReplayTime(route, replayTime, replayRange)) : topology.routes)
+    : [];
+  const visibleA2aEdges = showA2a
+    ? (replayActive ? topology.a2aEdges.filter((edge) => a2aEdgeVisibleAtReplayTime(edge.occurredAt, replayTime, replayRange)) : topology.a2aEdges)
+    : [];
 
   // The spine is the union of the visible halves: provider-routing coworkers
   // and/or A2A participants. Each half is suppressed in single-dimension mode.
   const layout = buildOperationsTopologyLayout({
     coworkers: topology.coworkers,
     providers: showProvider ? topology.providers : [],
-    routes: showProvider ? topology.routes : [],
-    a2aEdges: showA2a ? topology.a2aEdges : [],
+    routes: visibleRoutes,
+    a2aEdges: visibleA2aEdges,
     markers: showProvider ? topology.markers : [],
     selectedCoworkerId,
     viewport,

--- a/apps/web/components/platform/operations-topology-style.test.ts
+++ b/apps/web/components/platform/operations-topology-style.test.ts
@@ -5,6 +5,7 @@ import {
   routeStateDash,
   routeStateOpacity,
   routeStateStroke,
+  routeVisibleAtReplayTime,
   routeWidth,
 } from "./operations-topology-style";
 
@@ -38,5 +39,22 @@ describe("operations topology style", () => {
     expect(markerTypeStroke("error")).toBe("var(--dpf-error)");
     expect(markerTypeStroke("decision")).toBe("var(--dpf-accent)");
     expect(Object.keys(ROUTE_STATE_LABEL)).toHaveLength(5);
+  });
+
+  it("scrubs routes with the shared replay playhead", () => {
+    const min = (m: number) => m * 60 * 1000;
+    const range = { start: 0, current: min(60), end: min(100) }; // window = 45min
+    const at = (m: number) => new Date(min(m)).toISOString();
+
+    // Playhead at/after current → active route visible.
+    expect(routeVisibleAtReplayTime({ state: "active", occurredAt: at(10) }, range.current, range)).toBe(true);
+    // Scrubbed back to t=50: a future active route is hidden, a past one within window is shown.
+    expect(routeVisibleAtReplayTime({ state: "active", occurredAt: at(55) }, min(50), range)).toBe(false);
+    expect(routeVisibleAtReplayTime({ state: "active", occurredAt: at(48) }, min(50), range)).toBe(true);
+    // Scheduled is only visible once the playhead reaches "current".
+    expect(routeVisibleAtReplayTime({ state: "scheduled", occurredAt: at(70) }, min(50), range)).toBe(false);
+    expect(routeVisibleAtReplayTime({ state: "scheduled", occurredAt: at(70) }, range.current, range)).toBe(true);
+    // Undated routes are always visible.
+    expect(routeVisibleAtReplayTime({ state: "active", occurredAt: null }, min(50), range)).toBe(true);
   });
 });

--- a/apps/web/components/platform/operations-topology-style.ts
+++ b/apps/web/components/platform/operations-topology-style.ts
@@ -11,6 +11,33 @@ import type {
   OperationsMapRoutingMarkerType,
   OperationsMapRoutingRouteState,
 } from "@/lib/ai-operations-map/types";
+import { a2aReplayWindow, type A2aReplayRange } from "./a2a-interaction-graph";
+
+/**
+ * Whether a provider route is visible at the shared replay playhead. Mirrors
+ * AiOperationsMap's routeVisibleAtReplayTime so the unified canvas scrubs
+ * identically to the legacy panel, and reuses the same look-back window as the
+ * A2A band so both halves share one playhead.
+ */
+export function routeVisibleAtReplayTime(
+  route: { state: OperationsMapRoutingRouteState; occurredAt: string | null },
+  selectedTime: number,
+  range: A2aReplayRange,
+): boolean {
+  if (!route.occurredAt) return true;
+  const occurredAt = Date.parse(route.occurredAt);
+  if (!Number.isFinite(occurredAt)) return true;
+  const window = a2aReplayWindow(range);
+
+  if (route.state === "scheduled") {
+    return selectedTime >= range.current && selectedTime <= occurredAt + window;
+  }
+  if (selectedTime < occurredAt) return false;
+  if (route.state === "active" || route.state === "secondary" || route.state === "failover") {
+    return selectedTime >= range.current || selectedTime - occurredAt <= window;
+  }
+  return selectedTime - occurredAt <= window;
+}
 
 export function routeStateStroke(state: OperationsMapRoutingRouteState): string {
   switch (state) {


### PR DESCRIPTION
## What

**Stage B2** of the cohesive three-band Operations Map: both halves of the unified `OperationsTopologyCanvas` now **scrub in lock-step with one shared replay window** — the spine, provider routes, and A2A arcs all reflect the same point in time. Still off the operator route (parity-gated).

Design: §7 Stage B. Backlog: **BI-65B0D697**.

## How

- `routeVisibleAtReplayTime` — pure helper mirroring `AiOperationsMap`'s route replay semantics (active/secondary/failover/scheduled/historical), reusing the A2A look-back window so routes and arcs share one playhead.
- `OperationsTopologyCanvas` accepts `replayTime`/`replayRange` and replay-filters both routes and A2A edges before layout. At the default playhead everything recent stays visible; scrubbing back hides future activity.

## Verification

- `pnpm --filter web test` — full suite green (9715 passed, 0 failures).
- `pnpm --filter web typecheck` — clean. CI is the binding gate.
- New tests: route replay-visibility logic; canvas shows-all at current playhead and narrows routes + arcs when scrubbed back.

## Notes

- Read-only, additive, migration-free. **Stacked on #1523/#1521/#1519** — rebases clean as they merge.
- Heads-up: the full suite intermittently flakes on `lib/mcp-tools-*.test.ts` **5000ms timeouts under parallel load** (unrelated to this change — those files pass fast in isolation, and the suite is green on retry). Same class as the previously-flagged `build-governed.test.ts` flake.
- Remaining: **Stage D** (one unified control rail + inspector; wire the canvas onto the route behind the dimension toggle) and **Stage E** (cutover + delete old panels), plus zoom/marker-popover reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
