### PR TITLE
fix(backlog): grant Scrum Master the backlog_triage capability so it can triage the queue

### DIFF
--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -352,14 +352,16 @@ HEURISTICS:
 - Scope control: what can be deferred without losing value?
 - WIP limits: how much work in progress is too much? Flag overcommitment
 - Epic health: which epics are stalled, which are progressing?
+- Triage: every newly-captured item sits in "triaging" until you decide its outcome. Drain that queue — for each item decide build / runbook / coworker-task / defer / duplicate / discard (assign an effort size when the outcome is build), so nothing sits undecided. Discard pure noise/telemetry artifacts, consolidate duplicates, defer genuinely stale or optional work, and route real work to build.
 
-INTERPRETIVE MODEL: You optimize for delivery velocity and predictability. A healthy backlog has clear priorities, no bottlenecks, steady throughput, and no item sitting in "open" for too long.
+INTERPRETIVE MODEL: You optimize for delivery velocity and predictability. A healthy backlog has clear priorities, no bottlenecks, steady throughput, an empty triaging queue, and no item sitting in "open" for too long.
 
-ON THIS PAGE: The user sees the backlog with items, epics, priorities, and statuses. You can create and update backlog items.`,
+ON THIS PAGE: The user sees the backlog with items, epics, priorities, and statuses. You can create, update, AND triage backlog items (apply the triage decision + effort size on items in the triaging queue).`,
     skills: [
       { label: "Create item", description: "Add a new backlog item", capability: "manage_backlog", prompt: "Help me create a new backlog item" },
       { label: "Epic progress", description: "How are the epics progressing?", capability: "view_operations", prompt: "Give me a status report on the current epics" },
       { label: "Prioritize", description: "Help order items by value", capability: "manage_backlog", prompt: "Help me prioritize the open backlog items" },
+      { label: "Triage queue", description: "Decide outcomes for items awaiting triage", capability: "manage_backlog", prompt: "Process the triaging queue: for each item in 'triaging' status apply a triage decision with your triage tool — discard noise, consolidate duplicates, defer stale/optional work, and triage real work as build with an effort size. Work in batches and report what you decided." },
       { label: "Find blockers", description: "What's blocking delivery?", capability: "view_operations", prompt: "What's currently blocking delivery flow?" },
       { label: "Report an issue", description: "Report a bug or give feedback", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1175,7 +1175,7 @@ async function seedCoworkerAgents(): Promise<void> {
     "customer-advisor":     ["consumer_read", "registry_read", "backlog_read", "backlog_write", "marketing_read"],
     "marketing-specialist": ["marketing_read", "marketing_write", "consumer_read", "registry_read"],
     "storefront-advisor":   ["consumer_read", "registry_read", "backlog_read", "backlog_write", "marketing_read", "marketing_write", "web_search"],
-    "ops-coordinator":      ["backlog_read", "backlog_write", "registry_read", "portfolio_read"],
+    "ops-coordinator":      ["backlog_read", "backlog_write", "backlog_triage", "registry_read", "portfolio_read"],
     "platform-engineer":    ["agent_control_read", "admin_read", "admin_write", "registry_read", "telemetry_read"],
     "build-specialist":     ["file_read", "code_graph_read", "backlog_read", "backlog_write", "architecture_read", "build_plan_write", "registry_read", "sandbox_execute", "deployment_plan_create", "iac_execute", "release_gate_create", "release_plan_create", "release_plan_read", "coworker_screen_read", "coworker_screen_drive"],
     "data-architect":       ["file_read", "sandbox_execute", "architecture_read", "registry_read"],


### PR DESCRIPTION
## Problem
The /ops **Scrum Master** coworker (`ops-coordinator`) — whose entire role is backlog/delivery-flow management — was granted `backlog_read`/`backlog_write` but **not `backlog_triage`** ([seed.ts:1178](packages/db/src/seed.ts)). Since `triage_backlog_item` and `size_backlog_item` require the `backlog_triage` grant ([agent-grants.ts](apps/web/lib/tak/agent-grants.ts)), those tools were never attached — so when asked to triage, the coworker either hung with zero tool calls or fabricated a 'complete' without persisting. Backlog triage had to be done by a privileged external MCP token instead of the coworker itself.

## Fix
- **`packages/db/src/seed.ts`** — add `backlog_triage` to `ops-coordinator` in `HARDCODED_COWORKER_GRANTS` (the DB grant source for hardcoded coworkers).
- **`apps/web/lib/tak/agent-routing.ts`** — the /ops Scrum Master system prompt now covers draining the `triaging` queue (decide build / runbook / coworker-task / defer / duplicate / discard + assign effort size), and a discoverable **"Triage queue"** skill button triggers it.

## Verification (live)
With the grant applied and the in-memory grant cache cleared (portal restart), the Scrum Master triaged **BI-5076EA95** to **build / medium** via `triage_backlog_item` through the portal UX — kernel-gate `verdict=allow tool=triage_backlog_item` + DB persisted (`open | build | medium`).

## Follow-ups (tracked in BI-5076EA95)
- Strong-tier model requirement for the triage skill so bulk triage doesn't stall on a weak model.
- Scheduled / intake-triggered **auto-drain** of the `triaging` queue (confidence-gated; ambiguous items flagged for operator review) so the queue never accumulates.

Refs BI-5076EA95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)