### PR TITLE
feat(backlog): scheduled auto-triage drain — make Scrum Master triage autonomous

### DIFF
--- a/apps/web/lib/operate/backlog-triage-drain.test.ts
+++ b/apps/web/lib/operate/backlog-triage-drain.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseTriageDecision,
+  autoApplyBuildSize,
+  runBacklogTriageDrain,
+  AUTO_TRIAGE_CONFIDENCE_THRESHOLD,
+  type TriageCandidate,
+} from "./backlog-triage-drain";
+
+describe("parseTriageDecision", () => {
+  it("parses a plain JSON object", () => {
+    const d = parseTriageDecision('{"outcome":"build","effortSize":"small","confidence":0.9,"rationale":"clear"}');
+    expect(d).toEqual({ outcome: "build", effortSize: "small", confidence: 0.9, rationale: "clear" });
+  });
+
+  it("tolerates markdown fences and surrounding prose", () => {
+    const d = parseTriageDecision('Here:\n```json\n{"outcome":"needs-human","confidence":0.4}\n```\nthanks');
+    expect(d?.outcome).toBe("needs-human");
+    expect(d?.confidence).toBe(0.4);
+  });
+
+  it("returns null on garbage or missing outcome", () => {
+    expect(parseTriageDecision("not json")).toBeNull();
+    expect(parseTriageDecision('{"effortSize":"small"}')).toBeNull();
+    expect(parseTriageDecision("")).toBeNull();
+  });
+});
+
+describe("autoApplyBuildSize (safety gate)", () => {
+  it("returns the size for a confident, well-formed build", () => {
+    expect(autoApplyBuildSize({ outcome: "build", effortSize: "medium", confidence: 0.85 })).toBe("medium");
+  });
+
+  it("rejects non-build outcomes", () => {
+    expect(autoApplyBuildSize({ outcome: "needs-human", effortSize: "small", confidence: 0.99 })).toBeNull();
+    expect(autoApplyBuildSize({ outcome: "discard", confidence: 0.99 })).toBeNull();
+  });
+
+  it("rejects low confidence", () => {
+    expect(
+      autoApplyBuildSize({ outcome: "build", effortSize: "small", confidence: AUTO_TRIAGE_CONFIDENCE_THRESHOLD - 0.01 }),
+    ).toBeNull();
+  });
+
+  it("rejects missing/invalid effort size", () => {
+    expect(autoApplyBuildSize({ outcome: "build", confidence: 0.99 })).toBeNull();
+    expect(autoApplyBuildSize({ outcome: "build", effortSize: "huge", confidence: 0.99 })).toBeNull();
+  });
+
+  it("rejects null decision", () => {
+    expect(autoApplyBuildSize(null)).toBeNull();
+  });
+});
+
+describe("runBacklogTriageDrain", () => {
+  const items: TriageCandidate[] = [
+    { itemId: "BI-A", title: "Clear build" },
+    { itemId: "BI-B", title: "Ambiguous" },
+    { itemId: "BI-C", title: "LLM error" },
+  ];
+
+  it("auto-applies only confident builds and leaves the rest for the operator", async () => {
+    const applyBuild = vi.fn(async () => {});
+    const decide = vi.fn(async (item: TriageCandidate) => {
+      if (item.itemId === "BI-A") return '{"outcome":"build","effortSize":"small","confidence":0.95,"rationale":"r"}';
+      if (item.itemId === "BI-B") return '{"outcome":"needs-human","confidence":0.5}';
+      throw new Error("llm down");
+    });
+
+    const result = await runBacklogTriageDrain({
+      getTriagingItems: async () => items,
+      decide,
+      applyBuild,
+    });
+
+    expect(result).toEqual({ considered: 3, autoBuilt: 1, leftForOperator: 2 });
+    expect(applyBuild).toHaveBeenCalledTimes(1);
+    expect(applyBuild).toHaveBeenCalledWith("BI-A", "small", expect.stringContaining("Auto-triaged by scheduled drain"));
+  });
+
+  it("counts an item as left-for-operator if applyBuild throws", async () => {
+    const result = await runBacklogTriageDrain({
+      getTriagingItems: async () => [{ itemId: "BI-X", title: "x" }],
+      decide: async () => '{"outcome":"build","effortSize":"medium","confidence":0.9}',
+      applyBuild: async () => {
+        throw new Error("db down");
+      },
+    });
+    expect(result).toEqual({ considered: 1, autoBuilt: 0, leftForOperator: 1 });
+  });
+
+  it("no-ops on an empty queue", async () => {
+    const decide = vi.fn();
+    const result = await runBacklogTriageDrain({
+      getTriagingItems: async () => [],
+      decide,
+      applyBuild: async () => {},
+    });
+    expect(result).toEqual({ considered: 0, autoBuilt: 0, leftForOperator: 0 });
+    expect(decide).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/operate/backlog-triage-drain.ts
+++ b/apps/web/lib/operate/backlog-triage-drain.ts
@@ -1,0 +1,157 @@
+// apps/web/lib/operate/backlog-triage-drain.ts
+//
+// Autonomous backlog triage drain — testable core logic.
+//
+// Why this exists (BI-5076EA95):
+//   Items captured into the backlog land in status="triaging" and sit there
+//   until someone decides their outcome. The Scrum Master coworker can now
+//   triage on request (it holds the backlog_triage grant), but nothing drains
+//   the queue on its own, so undecided items accumulate. This module is the
+//   scheduled drain: it asks an LLM to decide each triaging item and applies
+//   the SAFE decisions automatically.
+//
+// Safety posture (deliberately conservative):
+//   - Only "build" decisions are auto-applied. That outcome is reversible and
+//     non-destructive — it just moves the item into the open/build pool as
+//     real work. It never hides or removes anything.
+//   - defer / discard / duplicate / runbook / coworker-task, low-confidence
+//     decisions, and parse failures are LEFT in the triaging queue for a human
+//     (or the Scrum Master on request) to decide. An autonomous job must never
+//     silently bury work.
+//
+// The Inngest wrapper (apps/web/lib/queue/functions/backlog-triage-drain.ts)
+// supplies prisma + the LLM caller; this module stays pure and unit-testable.
+
+export const AUTO_TRIAGE_CONFIDENCE_THRESHOLD = 0.8;
+const VALID_EFFORT_SIZES = new Set(["small", "medium", "large", "xlarge"]);
+
+export type TriageCandidate = {
+  itemId: string;
+  title: string;
+  body?: string | null;
+  type?: string | null;
+  workType?: string | null;
+};
+
+export type TriageDecision = {
+  /** "build" is the only auto-applied outcome; anything else defers to a human. */
+  outcome: string;
+  effortSize?: string;
+  confidence?: number;
+  rationale?: string;
+};
+
+export type TriageDrainResult = {
+  considered: number;
+  autoBuilt: number;
+  leftForOperator: number;
+};
+
+export const TRIAGE_DRAIN_SYSTEM_PROMPT =
+  "You are a delivery-flow triage assistant draining a backlog's triaging queue. " +
+  "You only auto-decide items that are UNAMBIGUOUSLY real, scoped, buildable work. " +
+  "If an item is noise, a likely duplicate, stale, optional, vague, or you are at all unsure, " +
+  "you defer it to a human instead of guessing. Respond with ONLY a JSON object.";
+
+/** Build the per-item decision prompt. */
+export function buildTriageDrainPrompt(item: TriageCandidate): string {
+  const body = (item.body ?? "").toString().slice(0, 1200);
+  return `Decide how to triage this backlog item.
+
+ITEM: ${item.itemId}
+TITLE: ${item.title}
+TYPE: ${item.type ?? "unknown"} / ${item.workType ?? "unspecified"}
+${body ? `DETAIL:\n${body}\n` : ""}
+Return ONLY this JSON (no prose, no fences):
+{
+  "outcome": "build" | "needs-human",
+  "effortSize": "small" | "medium" | "large" | "xlarge",
+  "confidence": 0.0-1.0,
+  "rationale": "<one concise sentence>"
+}
+
+Choose "build" ONLY when the item is clearly real, scoped engineering/product work and you can size it confidently. For ANY noise, duplicate, stale/optional item, vague request, or uncertainty, choose "needs-human" (a human will decide defer/discard/duplicate). effortSize is required when outcome is "build".`;
+}
+
+/** Parse the model's JSON decision; tolerant of markdown fences. Returns null on failure. */
+export function parseTriageDecision(content: string): TriageDecision | null {
+  if (!content || typeof content !== "string") return null;
+  const stripped = content.trim().replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "").trim();
+  // Grab the first balanced-looking JSON object if there's surrounding text.
+  const start = stripped.indexOf("{");
+  const end = stripped.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(stripped.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (typeof obj.outcome !== "string") return null;
+  return {
+    outcome: obj.outcome,
+    effortSize: typeof obj.effortSize === "string" ? obj.effortSize : undefined,
+    confidence: typeof obj.confidence === "number" ? obj.confidence : undefined,
+    rationale: typeof obj.rationale === "string" ? obj.rationale : undefined,
+  };
+}
+
+/**
+ * The auto-apply gate. Returns the effortSize to apply when the decision is a
+ * confident, well-formed BUILD; otherwise null (leave for a human).
+ */
+export function autoApplyBuildSize(decision: TriageDecision | null): string | null {
+  if (!decision) return null;
+  if (decision.outcome !== "build") return null;
+  if (typeof decision.effortSize !== "string" || !VALID_EFFORT_SIZES.has(decision.effortSize)) return null;
+  if ((decision.confidence ?? 0) < AUTO_TRIAGE_CONFIDENCE_THRESHOLD) return null;
+  return decision.effortSize;
+}
+
+export type TriageDrainDeps = {
+  /** Fetch a bounded batch of items currently in the triaging queue. */
+  getTriagingItems: () => Promise<TriageCandidate[]>;
+  /** Ask the LLM for a decision; return raw text. Throwing is treated as "skip item". */
+  decide: (item: TriageCandidate) => Promise<string>;
+  /** Apply a confident build decision (status→open, triageOutcome=build, effortSize, resolution). */
+  applyBuild: (itemId: string, effortSize: string, rationale: string) => Promise<void>;
+};
+
+/**
+ * Drain the triaging queue: for each item, get a decision and auto-apply only
+ * confident BUILD outcomes. Everything else is left for a human. Never throws
+ * for a single bad item — it skips and continues.
+ */
+export async function runBacklogTriageDrain(deps: TriageDrainDeps): Promise<TriageDrainResult> {
+  const items = await deps.getTriagingItems();
+  if (items.length === 0) return { considered: 0, autoBuilt: 0, leftForOperator: 0 };
+
+  let autoBuilt = 0;
+  let leftForOperator = 0;
+
+  for (const item of items) {
+    let decision: TriageDecision | null = null;
+    try {
+      decision = parseTriageDecision(await deps.decide(item));
+    } catch {
+      decision = null;
+    }
+    const size = autoApplyBuildSize(decision);
+    if (size) {
+      try {
+        await deps.applyBuild(
+          item.itemId,
+          size,
+          `Auto-triaged by scheduled drain: ${(decision?.rationale ?? "confident build").slice(0, 400)}`,
+        );
+        autoBuilt++;
+      } catch {
+        leftForOperator++;
+      }
+    } else {
+      leftForOperator++;
+    }
+  }
+
+  return { considered: items.length, autoBuilt, leftForOperator };
+}

--- a/apps/web/lib/queue/functions/backlog-triage-drain.ts
+++ b/apps/web/lib/queue/functions/backlog-triage-drain.ts
@@ -1,0 +1,90 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+const MAX_PER_RUN = 25;
+
+/**
+ * Scheduled backlog triage drain (BI-5076EA95).
+ *
+ * Hourly, drains items sitting in status="triaging" by asking an LLM to decide
+ * each one and auto-applying only confident BUILD decisions (reversible,
+ * non-destructive). Everything else is left for the operator / Scrum Master.
+ * Core logic + safety gate live in lib/operate/backlog-triage-drain.ts (unit
+ * tested); this wrapper only wires prisma + the LLM caller.
+ *
+ * Gated by gateAtEntry (skips while the portal is draining for upgrade) and by
+ * the master DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED flag (it is registered in
+ * scheduledFunctions).
+ */
+export const backlogTriageDrain = inngest.createFunction(
+  { id: "ops/backlog-triage-drain", retries: 1, triggers: [cron("23 * * * *")] },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    const result = await step.run("drain-triaging-queue", async () => {
+      const { prisma } = await import("@dpf/db");
+      const {
+        runBacklogTriageDrain,
+        buildTriageDrainPrompt,
+        TRIAGE_DRAIN_SYSTEM_PROMPT,
+      } = await import("@/lib/operate/backlog-triage-drain");
+
+      // LLM caller — strong-enough model for triage judgment. If no model is
+      // available, every decide() throws → all items are left for the operator.
+      let routeAndCall:
+        | typeof import("@/lib/inference/routed-inference").routeAndCall
+        | undefined;
+      try {
+        ({ routeAndCall } = await import("@/lib/inference/routed-inference"));
+      } catch {
+        routeAndCall = undefined;
+      }
+
+      return runBacklogTriageDrain({
+        getTriagingItems: () =>
+          prisma.backlogItem.findMany({
+            where: { status: "triaging" },
+            orderBy: { createdAt: "asc" },
+            take: MAX_PER_RUN,
+            select: { itemId: true, title: true, body: true, type: true, workType: true },
+          }),
+
+        decide: async (item) => {
+          if (!routeAndCall) throw new Error("no-llm");
+          const resp = await routeAndCall(
+            [{ role: "user" as const, content: buildTriageDrainPrompt(item) }],
+            TRIAGE_DRAIN_SYSTEM_PROMPT,
+            "internal",
+            { taskType: "triage", budgetClass: "balanced", effort: "medium", persistDecision: false },
+          );
+          return resp.content;
+        },
+
+        applyBuild: async (itemId, effortSize, rationale) => {
+          await prisma.backlogItem.update({
+            where: { itemId },
+            data: {
+              status: "open",
+              triageOutcome: "build",
+              effortSize,
+              resolution: rationale,
+            },
+          });
+        },
+      });
+    });
+
+    await step.run("record-job-run", async () => {
+      const { recordJobRun } = await import("@/lib/operate/discovery-scheduler");
+      await recordJobRun("backlog-triage-drain", "ok");
+    });
+
+    console.log(
+      `[backlog-triage-drain] considered=${result.considered} ` +
+        `autoBuilt=${result.autoBuilt} leftForOperator=${result.leftForOperator}`,
+    );
+    return result;
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -6,6 +6,7 @@ import { mcpCatalogSync } from "./mcp-catalog-sync";
 import { codeGraphReconcileEvent, codeGraphReconcileScheduled } from "./code-graph-reconcile";
 import { routeWorkItem } from "./route-work-item";
 import { issueReportTriage } from "./issue-report-triage";
+import { backlogTriageDrain } from "./backlog-triage-drain";
 import { coworkerRegressionDetect } from "./coworker-regression-detect";
 import { agentTaskDispatch } from "./agent-task-dispatch";
 import { taskrunWatchdog } from "./taskrun-watchdog";
@@ -51,6 +52,7 @@ export const scheduledFunctions = [
   infraPrune,
   codeGraphReconcileScheduled,
   issueReportTriage,
+  backlogTriageDrain,
   coworkerRegressionDetect,
   agentTaskDispatch,
   taskrunWatchdog,


### PR DESCRIPTION
## Why
Follow-up to the backlog_triage grant (#1525). The Scrum Master can now triage *on request*, but nothing drains the triaging queue on its own, so undecided items accumulate (105 had piled up this week). This adds the autonomous drain — the piece that makes backlog triage a core, hands-off platform capability (BI-5076EA95).

## What
An hourly Inngest cron (`ops/backlog-triage-drain`) that, for each item in `status=triaging`, asks an LLM to decide it and **auto-applies only confident BUILD outcomes**.

### Safety posture (deliberately conservative)
- **BUILD-only auto-apply.** That outcome is reversible and non-destructive — it just moves the item into the open/build pool as real work. The job never hides or removes anything.
- **Everything else is left for a human** — defer / discard / duplicate, low-confidence (below 0.8), parse failures, and LLM/DB errors all stay in the triaging queue for the operator or the Scrum Master to decide. An autonomous job must never silently bury work.
- **Quiescence-gated** (`gateAtEntry` — skips while the portal drains for upgrade) and **master-flag gated** (registered in `scheduledFunctions`, governed by `DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED`).
- **Bounded** at 25 items/run.

## Architecture
Mirrors `issue-report-triage`: pure, unit-tested core in `lib/operate/backlog-triage-drain.ts` (prompt, tolerant JSON parse, the build-only/high-confidence gate, orchestrator) + a thin Inngest wrapper that wires prisma + `routeAndCall`.

## Tests
`lib/operate/backlog-triage-drain.test.ts` covers parse tolerance, the safety gate (rejects non-build / low-confidence / bad size / null), and the orchestrator (apply vs leave-for-operator, LLM-throw and DB-throw paths, empty queue).

Refs BI-5076EA95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
