### PR TITLE
feat(ai-ops-map): zoom controls on OperationsTopologyCanvas (Stage B2b) (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/OperationsTopologyCanvas.test.tsx
+++ b/apps/web/components/platform/OperationsTopologyCanvas.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { OperationsTopologyCanvas } from "./OperationsTopologyCanvas";
 import { buildOperationsMapTopologyFixture } from "@/test-support/operations-map-fixture";
 
@@ -125,5 +125,41 @@ describe("OperationsTopologyCanvas — shared replay scrubbing (Stage B2)", () =
     const states = [...container.querySelectorAll("[data-canvas-route]")].map((r) => r.getAttribute("data-route-state")).sort();
     expect(states).toEqual(["failover", "historical"]);
     expect(container.querySelectorAll("[data-canvas-a2a-arc]").length).toBe(2);
+  });
+});
+
+describe("OperationsTopologyCanvas — zoom controls (Stage B2b)", () => {
+  function findBtn(container: HTMLElement, name: string): HTMLButtonElement {
+    const b = [...container.querySelectorAll("button")].find((x) => x.getAttribute("aria-label") === name);
+    if (!b) throw new Error(`button "${name}" not found`);
+    return b as HTMLButtonElement;
+  }
+
+  it("renders zoom controls and zooms the viewBox in/out with a reset", () => {
+    const { container } = render(<OperationsTopologyCanvas topology={buildOperationsMapTopologyFixture()} />);
+    const svg = container.querySelector('svg[role="img"]') as SVGSVGElement;
+    const initial = svg.getAttribute("viewBox");
+    expect(initial?.startsWith("0 0 1040")).toBe(true); // 100% = full width from origin
+    expect(container.textContent).toContain("100%");
+
+    // Zoom in → viewBox narrows and recenters (no longer at origin).
+    fireEvent.click(findBtn(container, "Zoom in"));
+    const zoomed = container.querySelector('svg[role="img"]')?.getAttribute("viewBox");
+    expect(zoomed).not.toBe(initial);
+    expect(zoomed?.startsWith("0 0 1040")).toBe(false);
+    expect(container.textContent).toContain("125%");
+
+    // Reset → back to the default viewBox.
+    fireEvent.click(findBtn(container, "Reset zoom"));
+    expect(container.querySelector('svg[role="img"]')?.getAttribute("viewBox")).toBe(initial);
+  });
+
+  it("disables zoom-out at the minimum level and reset at the default", () => {
+    const { container } = render(<OperationsTopologyCanvas topology={buildOperationsMapTopologyFixture()} />);
+    // At default, reset is disabled.
+    expect(findBtn(container, "Reset zoom").disabled).toBe(true);
+    // Zoom out to the floor, then zoom-out is disabled.
+    fireEvent.click(findBtn(container, "Zoom out"));
+    expect(findBtn(container, "Zoom out").disabled).toBe(true);
   });
 });

--- a/apps/web/components/platform/OperationsTopologyCanvas.tsx
+++ b/apps/web/components/platform/OperationsTopologyCanvas.tsx
@@ -9,6 +9,10 @@
 //
 // Spec: docs/superpowers/specs/2026-06-05-ai-operations-map-three-band-cohesive-layout-design.md §7 Stage B
 
+"use client";
+
+import { useState } from "react";
+import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import { intentStyle } from "@/components/ui/report-kit";
 import type { OperationsMapRoutingTopology } from "@/lib/ai-operations-map/types";
 import {
@@ -53,6 +57,9 @@ const CANVAS = {
   nodeRadius: 8,
 };
 
+const ZOOM_LEVELS = [0.8, 1, 1.25, 1.5] as const;
+const DEFAULT_ZOOM_INDEX = 1;
+
 export function OperationsTopologyCanvas({
   topology,
   viewport = "desktop",
@@ -61,6 +68,8 @@ export function OperationsTopologyCanvas({
   replayTime = null,
   replayRange = null,
 }: Props) {
+  const [zoomIndex, setZoomIndex] = useState(DEFAULT_ZOOM_INDEX);
+  const zoomLevel = ZOOM_LEVELS[zoomIndex] ?? 1;
   const showProvider = dimension === "provider" || dimension === "both";
   const showA2a = dimension === "a2a" || dimension === "both";
 
@@ -99,19 +108,29 @@ export function OperationsTopologyCanvas({
       ? "Coworker spine with A2A interactions"
       : "Coworker spine with provider routing";
 
+  const canZoomOut = zoomIndex > 0;
+  const canZoomIn = zoomIndex < ZOOM_LEVELS.length - 1;
+
   return (
     <section
       aria-label="AI operations topology canvas"
       data-operations-topology-canvas
-      className="overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+      className="relative overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
     >
       {isEmpty ? (
         <p className="p-6 text-center text-sm text-[var(--dpf-muted)]">
           No provider routing or coworker activity in the current window.
         </p>
       ) : (
+        <>
+        <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5 rounded-full bg-[color-mix(in_srgb,var(--dpf-surface-1)_90%,transparent)] px-1.5 py-1 shadow-sm backdrop-blur">
+          <ZoomButton label="Zoom out" icon={ZoomOut} disabled={!canZoomOut} onClick={() => setZoomIndex((i) => Math.max(0, i - 1))} />
+          <span className="min-w-10 text-center text-[11px] font-medium text-[var(--dpf-text)]">{Math.round(zoomLevel * 100)}%</span>
+          <ZoomButton label="Zoom in" icon={ZoomIn} disabled={!canZoomIn} onClick={() => setZoomIndex((i) => Math.min(ZOOM_LEVELS.length - 1, i + 1))} />
+          <ZoomButton label="Reset zoom" icon={RotateCcw} disabled={zoomIndex === DEFAULT_ZOOM_INDEX} onClick={() => setZoomIndex(DEFAULT_ZOOM_INDEX)} />
+        </div>
         <svg
-          viewBox={`0 0 ${CANVAS.width} ${layout.height}`}
+          viewBox={zoomedViewBox(CANVAS.width, layout.height, zoomLevel)}
           role="img"
           aria-label={svgLabel}
           className="h-full w-full"
@@ -231,9 +250,48 @@ export function OperationsTopologyCanvas({
             </g>
           ))}
         </svg>
+        </>
       )}
     </section>
   );
+}
+
+function ZoomButton({
+  label,
+  icon: Icon,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: typeof ZoomIn;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]",
+        disabled
+          ? "cursor-not-allowed text-[var(--dpf-muted)] opacity-50"
+          : "text-[var(--dpf-text)] hover:bg-[var(--dpf-accent-soft)]",
+      ].join(" ")}
+    >
+      <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+    </button>
+  );
+}
+
+function zoomedViewBox(width: number, height: number, zoom: number): string {
+  const w = width / zoom;
+  const h = height / zoom;
+  const x = (width - w) / 2;
+  const y = (height - h) / 2;
+  return `${x} ${y} ${w} ${h}`;
 }
 
 function routePath(fromX: number, fromY: number, toX: number, toY: number, lane: number): string {


### PR DESCRIPTION
## What

**Stage B2b** of the cohesive three-band Operations Map: add **zoom controls** (in / out / reset) to the unified `OperationsTopologyCanvas`, closing another interactive-parity gap with the legacy provider panel before cutover. The canvas remains **off the operator route**.

Design: §7 Stage B. Backlog: **BI-65B0D697**.

## How

- Canvas becomes a client component with zoom state; viewBox scales around center across the same zoom levels (80/100/125/150%) the old panel uses.
- Token-styled zoom control overlay (lucide `ZoomIn`/`ZoomOut`/`RotateCcw`) with disabled states at the floor and at the default.

## Verification

- `pnpm --filter web test` — full suite green (9767 passed, 0 failures).
- `pnpm --filter web typecheck` — clean (regenerated the worktree Prisma client; stale vs `main`'s new models — harness, not code).
- New tests: zoom in/out/reset changes + restores the canvas viewBox; min-level and default disable the right controls.

## Notes

- Read-only, additive. **Stacked on #1524** — rebases clean as it merges.
- Remaining canvas parity = the marker popover; then **Stage D** (one unified control rail + inspector; wire the canvas onto the route behind the dimension toggle) and **Stage E** (cutover + delete old panels), each gated on a live functional verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
