### PR TITLE
fix(finance): respect resolved AI provider contracts

### DIFF
--- a/apps/web/lib/finance/ai-provider-finance.test.ts
+++ b/apps/web/lib/finance/ai-provider-finance.test.ts
@@ -138,6 +138,60 @@ describe("seedAiProviderFinanceBridge", () => {
     expect(mocks.workItemCreate).not.toHaveBeenCalled();
     expect(result.workItemId).toBe("existing-work");
   });
+
+  it("does not requeue plan-details asks when the existing contract already has resolved finance details", async () => {
+    mocks.contractFindFirst.mockResolvedValue({
+      id: "contract-chatgpt",
+      contractId: "AIC-CHATGPT",
+      monthlyCommittedAmount: 106.4,
+      usageUnit: "subscription_seat",
+      allowances: [
+        {
+          id: "allowance-chatgpt",
+          includedQuantity: 0,
+          usageUnit: "subscription_seat",
+        },
+      ],
+    });
+
+    const result = await seedAiProviderFinanceBridge({
+      providerId: "chatgpt",
+      providerName: "ChatGPT (OpenAI Subscription)",
+    });
+
+    expect(mocks.workItemFindFirst).not.toHaveBeenCalled();
+    expect(mocks.workItemCreate).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        contractId: "contract-chatgpt",
+        workItemId: null,
+      }),
+    );
+  });
+
+  it("treats zero-dollar included-access contracts as resolved when usage unit and allowance are known", async () => {
+    mocks.contractFindFirst.mockResolvedValue({
+      id: "contract-codex",
+      contractId: "AIC-CODEX",
+      monthlyCommittedAmount: 0,
+      usageUnit: "included_subscription_access",
+      allowances: [
+        {
+          id: "allowance-codex",
+          includedQuantity: 0,
+          usageUnit: "included_subscription_access",
+        },
+      ],
+    });
+
+    const result = await seedAiProviderFinanceBridge({
+      providerId: "codex",
+      providerName: "OpenAI Codex",
+    });
+
+    expect(mocks.workItemCreate).not.toHaveBeenCalled();
+    expect(result.workItemId).toBeNull();
+  });
 });
 
 describe("ensureFinanceCommitment", () => {

--- a/apps/web/lib/finance/ai-provider-finance.ts
+++ b/apps/web/lib/finance/ai-provider-finance.ts
@@ -66,6 +66,38 @@ function humanizeWorkItemType(value: string): string {
     .join(" ");
 }
 
+type ExistingAiProviderContractPlan = {
+  monthlyCommittedAmount?: number | Prisma.Decimal | null;
+  usageUnit?: string | null;
+  allowances?: Array<{
+    includedQuantity?: number | Prisma.Decimal | null;
+    usageUnit?: string | null;
+  }>;
+};
+
+function hasKnownNumber(value: number | Prisma.Decimal | null | undefined): boolean {
+  return value !== undefined && value !== null;
+}
+
+function getMissingAiProviderPlanFields(
+  input: SeedAiProviderFinanceBridgeInput,
+  existingContract?: ExistingAiProviderContractPlan | null,
+): string[] {
+  const existingAllowance = existingContract?.allowances?.find(
+    (allowance) => hasKnownNumber(allowance.includedQuantity) || Boolean(allowance.usageUnit),
+  );
+
+  return [
+    input.monthlyCommittedAmount === undefined && !hasKnownNumber(existingContract?.monthlyCommittedAmount)
+      ? "monthlyCommittedAmount"
+      : null,
+    input.includedQuantity === undefined && !hasKnownNumber(existingAllowance?.includedQuantity)
+      ? "includedQuantity"
+      : null,
+    !input.usageUnit && !existingContract?.usageUnit && !existingAllowance?.usageUnit ? "usageUnit" : null,
+  ].filter((field): field is string => Boolean(field));
+}
+
 async function ensureSupplier(input: SeedAiProviderFinanceBridgeInput) {
   const supplierName = input.supplierName ?? input.providerName;
   const existing = await prisma.supplier.findFirst({
@@ -154,7 +186,20 @@ export async function seedAiProviderFinanceBridge(input: SeedAiProviderFinanceBr
 
   const existingContract = await prisma.supplierContract.findFirst({
     where: { profileId: profile.id, status: { in: ["draft", "active"] } },
-    select: { id: true, contractId: true },
+    select: {
+      id: true,
+      contractId: true,
+      monthlyCommittedAmount: true,
+      usageUnit: true,
+      allowances: {
+        orderBy: { sortOrder: "asc" },
+        take: 1,
+        select: {
+          includedQuantity: true,
+          usageUnit: true,
+        },
+      },
+    },
     orderBy: { createdAt: "desc" },
   });
 
@@ -179,14 +224,23 @@ export async function seedAiProviderFinanceBridge(input: SeedAiProviderFinanceBr
       usageUrl: input.usageUrl ?? null,
       allowsOverage: false,
     },
-    select: { id: true, contractId: true },
+    select: {
+      id: true,
+      contractId: true,
+      monthlyCommittedAmount: true,
+      usageUnit: true,
+      allowances: {
+        orderBy: { sortOrder: "asc" },
+        take: 1,
+        select: {
+          includedQuantity: true,
+          usageUnit: true,
+        },
+      },
+    },
   });
 
-  const missingFields = [
-    input.monthlyCommittedAmount === undefined ? "monthlyCommittedAmount" : null,
-    input.includedQuantity === undefined ? "includedQuantity" : null,
-    !input.usageUnit ? "usageUnit" : null,
-  ].filter((field): field is string => Boolean(field));
+  const missingFields = getMissingAiProviderPlanFields(input, contract);
   const missingPlanDetails = missingFields.length > 0;
 
   const workItem = missingPlanDetails


### PR DESCRIPTION
## Summary
- Teach AI provider finance reconciliation to use existing resolved supplier-contract details before queuing `plan_details_needed` work items.
- Treat zero-dollar included-access contracts as resolved when amount, usage unit, and allowance evidence are present.
- Add regression coverage for browser-resolved ChatGPT subscription and Codex included-access contracts.

## Verification
- Worktree `D:\DPF-finance-reconcile-resolved-contracts`: `pnpm --filter web exec vitest run lib/finance/ai-provider-finance.test.ts` -> 9 passed.
- Worktree `D:\DPF-finance-reconcile-resolved-contracts`: `pnpm --filter web typecheck` -> passed, Next route types generated.
- Worktree `D:\DPF-finance-reconcile-resolved-contracts`: `pnpm --filter web exec next build` -> exit 0. Build emitted existing Turbopack warnings around Edge-runtime Node APIs and NFT tracing; no errors from this change.
- Canonical local database fallback check: active provider finance coverage is 10/10, missing active provider finance profiles is 0, total tracked monthly commitment is 107.50 USD, and the only remaining open finance work item is the real Claude Apple/iOS charge confirmation ask.

## Runtime data note
- Browser retrieval populated ChatGPT Pro billing at 106.40 USD/month with renewal on 2026-06-13, Codex as included in the ChatGPT subscription at 0 USD incremental monthly commitment, and `opendigitalproductfactory.com` GoDaddy domain registration at 13.19 USD/year amortized to 1.10 USD/month with renewal on 2027-03-08.
- Claude billing was visible as a Max plan subscribed through iOS, but the browser could not access the Apple invoice amount or renewal date; that unresolved evidence gap remains queued for Finance.