### PR TITLE
feat(customer): reconcile CRM marketing UX

### DIFF
--- a/apps/web/components/customer/CustomerMetricTile.test.tsx
+++ b/apps/web/components/customer/CustomerMetricTile.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { CustomerMetricTile } from "./CustomerMetricTile";
 
 describe("CustomerMetricTile", () => {
-  it("renders a linked metric with DPF theme classes", () => {
+  it("renders a linked metric through the shared report-kit StatCard", () => {
     const html = renderToStaticMarkup(
       <CustomerMetricTile
         href="/customer/opportunities"
@@ -18,7 +18,8 @@ describe("CustomerMetricTile", () => {
     expect(html).toContain(">Pipeline<");
     expect(html).toContain(">3<");
     expect(html).toContain("£6,000 open");
-    expect(html).toContain("border-[var(--dpf-accent)]");
+    expect(html).toContain("border-left-color:var(--dpf-accent)");
+    expect(html).not.toContain("border-[var(--dpf-accent)]");
     expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
   });
 });

--- a/apps/web/components/customer/CustomerMetricTile.tsx
+++ b/apps/web/components/customer/CustomerMetricTile.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import type { CrmTone } from "@/lib/crm/presentation";
-import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+import { StatCard } from "@/components/ui/report-kit";
+import { CRM_TONE_INTENT } from "./crmToneIntent";
 
 type CustomerMetricTileProps = {
   href: string;
@@ -17,23 +17,14 @@ export function CustomerMetricTile({
   detail,
   tone,
 }: CustomerMetricTileProps) {
-  const toneClasses = CRM_TONE_CLASSES[tone];
-
   return (
-    <Link
+    <StatCard
       href={href}
-      className={[
-        "block rounded-lg border-l-2 bg-[var(--dpf-surface-1)] p-3 transition-colors hover:bg-[var(--dpf-surface-2)]",
-        toneClasses.border,
-      ].join(" ")}
-    >
-      <p className="text-[10px] uppercase tracking-wider text-[var(--dpf-muted)]">
-        {label}
-      </p>
-      <p className="mt-1 text-lg font-bold text-[var(--dpf-text)]">{value}</p>
-      <p className={["mt-1 text-[10px]", toneClasses.text].join(" ")}>
-        {detail}
-      </p>
-    </Link>
+      label={label}
+      value={value}
+      hint={detail}
+      intent={CRM_TONE_INTENT[tone]}
+      className="h-full"
+    />
   );
 }

--- a/apps/web/components/customer/CustomerStatusBadge.test.tsx
+++ b/apps/web/components/customer/CustomerStatusBadge.test.tsx
@@ -3,14 +3,15 @@ import { describe, expect, it } from "vitest";
 import { CustomerStatusBadge } from "./CustomerStatusBadge";
 
 describe("CustomerStatusBadge", () => {
-  it("renders the label and theme-aware tone classes", () => {
+  it("renders the label through the shared report-kit StatusBadge", () => {
     const html = renderToStaticMarkup(
       <CustomerStatusBadge label="Dormant" tone="warning" />,
     );
 
     expect(html).toContain(">Dormant<");
-    expect(html).toContain("border-[var(--dpf-border)]");
-    expect(html).toContain("text-[var(--dpf-text)]");
+    expect(html).toContain('data-intent="warning"');
+    expect(html).toContain("border-color:var(--dpf-warning)");
+    expect(html).not.toContain("border-[var(--dpf-border)]");
     expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
   });
 });

--- a/apps/web/components/customer/CustomerStatusBadge.tsx
+++ b/apps/web/components/customer/CustomerStatusBadge.tsx
@@ -1,5 +1,6 @@
 import type { CrmTone } from "@/lib/crm/presentation";
-import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+import { StatusBadge } from "@/components/ui/report-kit";
+import { CRM_TONE_INTENT } from "./crmToneIntent";
 
 type CustomerStatusBadgeProps = {
   label: string;
@@ -13,16 +14,11 @@ export function CustomerStatusBadge({
   className = "",
 }: CustomerStatusBadgeProps) {
   return (
-    <span
-      className={[
-        "shrink-0 rounded-full border px-1.5 py-0.5 text-[9px]",
-        CRM_TONE_CLASSES[tone].badge,
-        className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
-    >
-      {label}
-    </span>
+    <StatusBadge
+      intent={CRM_TONE_INTENT[tone]}
+      label={label}
+      uppercase={false}
+      className={["shrink-0", className].filter(Boolean).join(" ")}
+    />
   );
 }

--- a/apps/web/components/customer/RevenueCockpit.test.tsx
+++ b/apps/web/components/customer/RevenueCockpit.test.tsx
@@ -33,6 +33,7 @@ describe("RevenueCockpit", () => {
     expect(html).toContain("Pipeline");
     expect(html).toContain("2 stale opportunities need a next action");
     expect(html).toContain('href="/customer/opportunities"');
+    expect(html).toContain('data-intent="warning"');
   });
 
   it("renders a calm empty attention state", () => {

--- a/apps/web/components/customer/RevenueCockpit.tsx
+++ b/apps/web/components/customer/RevenueCockpit.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { CustomerMetricTile } from "./CustomerMetricTile";
 import type { RevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
-import { CRM_TONE_CLASSES } from "@/lib/crm/presentation";
+import { StatusBadge } from "@/components/ui/report-kit";
+import { CRM_TONE_INTENT } from "./crmToneIntent";
 
 type RevenueCockpitProps = {
   summary: RevenueCockpitSummary;
@@ -46,12 +47,14 @@ export function RevenueCockpit({ summary }: RevenueCockpitProps) {
             <Link
               key={item.id}
               href={item.href}
-              className={[
-                "rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-[var(--dpf-surface-2)]",
-                CRM_TONE_CLASSES[item.tone].badge,
-              ].join(" ")}
+              className="inline-flex max-w-full rounded transition-opacity hover:opacity-80"
             >
-              {item.label}
+              <StatusBadge
+                intent={CRM_TONE_INTENT[item.tone]}
+                label={item.label}
+                uppercase={false}
+                size="md"
+              />
             </Link>
           ))
         ) : (

--- a/apps/web/components/customer/crmToneIntent.ts
+++ b/apps/web/components/customer/crmToneIntent.ts
@@ -1,0 +1,12 @@
+import type { Intent } from "@/components/ui/report-kit";
+import type { CrmTone } from "@/lib/crm/presentation";
+
+export const CRM_TONE_INTENT: Record<CrmTone, Intent> = {
+  accent: "accent",
+  attention: "accent",
+  danger: "danger",
+  info: "info",
+  neutral: "neutral",
+  success: "success",
+  warning: "warning",
+};

--- a/docs/superpowers/audits/2026-05-26-pipedrive-crm-marketing-ux-fit-review.md
+++ b/docs/superpowers/audits/2026-05-26-pipedrive-crm-marketing-ux-fit-review.md
@@ -82,3 +82,18 @@ Expected behavior:
 - Store the output as a design artifact or plan section so review does not depend on chat memory.
 
 This is now implemented as `packages/dpf-skill-pack/skills/dpf-ux-fit-review/SKILL.md`. Use the skill before incoming UI plans add routes, tabs, dashboard bands, metric tiles, status badges, empty states, or coworker launchers.
+
+## 6. 2026-06-06 Reconciliation Note
+
+The original Slice 1 fit review remains the right guardrail, but the implementation state has moved on. The current audit is `docs/superpowers/audits/2026-06-06-customer-crm-marketing-ux-reconciliation.md`.
+
+Current `origin/main` evidence shows:
+
+- Slice 1 CRM presentation metadata, revenue cockpit, Customer metric/status wrappers, and color cleanup are present.
+- Slice 2 pipeline inspector is present.
+- Slice 3 acquisition signal routing is present.
+- Slice 4 marketing Campaigns/Funnel/Automation routes are present and no longer phase placeholders.
+- `CustomerMetricTile` and `CustomerStatusBadge` now compose `report-kit` primitives through a CRM tone adapter.
+- Remaining product work is Slice 5, tracked as `BI-D8E00326`.
+
+The authenticated canonical browser crawl was blocked by a login-submit runtime/auth failure on 2026-06-06, so future Slice 5 verification must re-run the crawl after that blocker is resolved.

--- a/docs/superpowers/audits/2026-06-06-customer-crm-marketing-ux-reconciliation.md
+++ b/docs/superpowers/audits/2026-06-06-customer-crm-marketing-ux-reconciliation.md
@@ -1,0 +1,88 @@
+# Customer CRM Marketing UX Reconciliation
+
+| Field | Value |
+| ----- | ----- |
+| Date | 2026-06-06 |
+| Status | Current-state reconciliation and UX fit review |
+| Branch | `feat/customer-crm-ux-reconcile` |
+| Related plan | `docs/superpowers/plans/2026-05-26-pipedrive-crm-marketing-slice-1.md` |
+| Related spec | `docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md` |
+| Live backlog | `BI-D8E00326` - CRM marketing Slice 5: agentic sales and marketing operations |
+
+## 1. Verdict
+
+The Customer CRM and Marketing route family now fits the portal simplification direction as a Business > Customer surface. The older Slice 1 plan should not be executed task-by-task anymore: its core work has landed on `origin/main`.
+
+The remaining product gap is Slice 5, not Slice 1:
+
+- sales advisor and marketing strategist actions that create durable internal artifacts
+- approval-gated external send, publish, schedule, or spend actions
+- saved artifact visibility outside chat
+- UX verification after the canonical auth path is healthy
+
+## 2. Current-State Map
+
+| Surface | Current home | Evidence | UX assessment |
+| ------- | ------------ | -------- | ------------- |
+| `/customer` | Business > Customer section home | `RevenueCockpit`, `CustomerMetricTile`, `CustomerStatusBadge`, `buildRevenueCockpitSummary` | Fits as a scan-first local decision surface. It should remain a Customer section home, not a global dashboard. |
+| `/customer/opportunities` | Customer pipeline working surface | `PipelineStageInspector`, `AgentWorkLauncher`, shared CRM status metadata | Fits as the working view for stale deals and next actions. Coworker work remains preview + confirmation. |
+| `/customer/engagements` | Customer acquisition workflow | `AcquisitionSignalRouter`, `Engagement.source`, `sourceRefId` | Fits as signal-to-engagement routing without introducing a separate Lead table. |
+| `/customer/marketing` | Customer Marketing overview | `AgentWorkLauncher`, saved marketing strategy and work-product panels | Fits as strategy-first marketing context. Avoid turning it into another global campaign dashboard. |
+| `/customer/marketing/campaigns` | Customer Marketing subroute | real route and `MarketingRoutePrimitives` | Fits because the route is now backed by read-only campaign brief/task data. |
+| `/customer/marketing/funnel` | Customer Marketing subroute | real route and `MarketingRoutePrimitives` | Fits because the route reads source/channel/stage evidence instead of showing a phase placeholder. |
+| `/customer/marketing/automation` | Customer Marketing subroute | real route and `MarketingRoutePrimitives` | Fits because the route reads automation candidates and approval posture. |
+
+## 3. Findings
+
+### Fixed In This Reconciliation
+
+- The Slice 1 implementation plan was stale and still looked executable even though the work is already on `origin/main`.
+- `CustomerMetricTile` and `CustomerStatusBadge` still owned their own visual shell. They now compose `report-kit` `StatCard` and `StatusBadge` through a small CRM-tone adapter, preserving Customer CRM vocabulary while converging reporting UI.
+- The target Customer CRM route family has no `STATUS_COLOURS`, `STAGE_COLOURS`, raw hex, or raw Tailwind color classes in the audited paths.
+
+### Remaining Guardrails
+
+- Keep Slice 5 inside Business > Customer. Do not promote sales/marketing AI work to global AppRail, Workspace cards, Platform nav, `/portal`, or `/storefront`.
+- Metric tiles, tabs, and topic choices navigate or select only. They must not send coworker prompts.
+- Coworker-starting actions stay inside `AgentWorkLauncher` with prompt preview, context summary, expected next step, and explicit confirmation.
+- External send, publish, schedule, or ad-spend actions remain approval-gated and must preserve consent and provenance.
+- Future generic reporting surfaces should use `report-kit` directly; Customer wrappers are acceptable only as thin vocabulary adapters.
+
+### Runtime Evidence Limitation
+
+The canonical portal responded at `http://127.0.0.1:3000/welcome` and `/login`, and the Docker `dpf-portal-1` container was healthy. Authenticated route crawl was blocked because submitting the admin login form produced the app fallback text "This page couldn't load". No useful matching portal log appeared in the recent tail.
+
+Therefore this audit uses source-local route/component evidence plus focused tests for the code change. Authenticated browser screenshots for `/customer` and `/customer/marketing/*` remain unrun and should be repeated after the auth/runtime blocker is cleared.
+
+## 4. UX Fit Review - Customer CRM Marketing Reconciliation
+
+- Decision: fits-with-guardrails
+- Owning area: Business > Customer
+- Route family: `/customer`, `/customer/opportunities`, `/customer/engagements`, `/customer/funnel`, `/customer/marketing`, `/customer/marketing/campaigns`, `/customer/marketing/funnel`, `/customer/marketing/automation`
+- Primary persona: founder/operator managing customer acquisition, revenue attention, and marketing work without remembering scattered route names
+- Navigation layer touched: section navigation plus local page links only
+- Reuse/convergence: Customer CRM vocabulary wrappers now compose `report-kit` `StatCard` and `StatusBadge`; marketing subroutes use `MarketingRoutePrimitives` and report-kit primitives
+- Source truth: existing CRM models, marketing work-product models, `apps/web/lib/crm/presentation.ts`, `apps/web/lib/crm/revenue-cockpit.ts`, and marketing route read models
+- Empty/failure behavior: current route code contains calm empty states; Slice 5 should keep empty states outcome-oriented and avoid tutorial-heavy walls of copy
+- AI boundary: no prompt send from metric/tab clicks; coworker work requires `AgentWorkLauncher` preview and explicit confirmation
+- Required plan/spec edits:
+  - Mark the old Slice 1 implementation plan as historical/current-main reconciled
+  - Point remaining product work at `BI-D8E00326`
+  - Record the canonical auth-crawl blocker so route screenshots are not overclaimed
+- Evidence before merge:
+  - source-local focused component tests for Customer wrappers and `RevenueCockpit`
+  - hardcoded-color scan over Customer CRM/Marketing route family
+  - typecheck and production build
+  - authenticated browser crawl after login/runtime is healthy
+- Captured in: this audit, the Slice 1 plan status block, and the Pipedrive CRM/Marketing spec runtime grounding
+
+## 5. Next Slice
+
+Proceed with `BI-D8E00326` as Slice 5 only after this reconciliation lands. The implementation should focus on agentic sales and marketing operations:
+
+1. keep all entry points inside Business > Customer
+2. use `AgentWorkLauncher` or a successor with the same preview/confirmation boundary
+3. save internal artifacts through governed tools
+4. show saved artifacts on the relevant Customer/Marketing route, not only in chat
+5. gate external side effects behind explicit approval
+6. re-run authenticated desktop and mobile browser crawls after the auth blocker is resolved

--- a/docs/superpowers/plans/2026-05-26-pipedrive-crm-marketing-slice-1.md
+++ b/docs/superpowers/plans/2026-05-26-pipedrive-crm-marketing-slice-1.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **2026-06-06 reconciliation status:** Do not execute this plan task-by-task from the unchecked boxes below. `origin/main` already contains the Slice 1 substrate and follow-on customer CRM/marketing surfaces: CRM presentation metadata, `RevenueCockpit`, `CustomerMetricTile`, `CustomerStatusBadge`, pipeline inspector, acquisition signal routing, real marketing Campaigns/Funnel/Automation subroutes, and guided coworker launch boundaries. The current reconciliation artifact is `docs/superpowers/audits/2026-06-06-customer-crm-marketing-ux-reconciliation.md`. Remaining product work is tracked as `BI-D8E00326` (CRM marketing Slice 5: agentic sales and marketing operations).
+
 **Goal:** Build the first Pipedrive-inspired CRM and marketing operations slice: a scan-first revenue cockpit on `/customer`, theme-aware CRM presentation metadata, shared summary components, and a cleaned marketing tab nav with no phase-locked placeholders.
 
 **Architecture:** Keep the first slice on existing CRM and marketing models. Extract pure CRM presentation and summary logic into small tested modules, render reusable customer summary components from server pages, and hide marketing subroutes until real read-only routes are implemented in a later slice. Do not add database tables or external integration writes in this slice.
@@ -18,7 +20,7 @@ It must also respect the binding UX-governance rules in `docs/superpowers/specs/
 
 It must also pass `dpf-ux-fit-review` before code edits. The feature belongs to Business > Customer and must not add global AppRail entries, Workspace cards, Platform nav entries, or vendor-branded user-facing language. "Pipedrive-inspired" is research language only; visible product copy should use DPF-native labels such as "Today in revenue", "Pipeline", "Engagements", "Quotes", "Orders", and "Marketing".
 
-PR strategy: Slice 1 is theme-aware refactor + dead-code removal + shared-helper extraction. It qualifies as a Claude-led maintenance PR per the `feedback_no_manual_prs` rule and does NOT need to flow through Build Studio. Slices 2–5 from the design spec are feature work and must be filed as backlog items, promoted, and run through Build Studio.
+PR strategy: Slice 1 was theme-aware refactor + dead-code removal + shared-helper extraction. It qualified as a Claude-led maintenance PR per the `feedback_no_manual_prs` rule and did NOT need to flow through Build Studio. Follow-on feature slices are no longer represented by this historical checklist; use current backlog state and `BI-D8E00326` for Slice 5.
 
 Included:
 
@@ -30,24 +32,24 @@ Included:
 - removal of visible "Phase 2" / "Phase 3" marketing tabs
 - focused unit/component tests
 
-Excluded:
+Historical exclusions at Slice 1 start:
 
 - new Prisma models
 - drag-and-drop opportunity movement
 - signal-to-engagement creation
 - external publish/send/schedule actions
-- real `/customer/marketing/campaigns`, `/customer/marketing/funnel`, or `/customer/marketing/automation` routes
+- real `/customer/marketing/campaigns`, `/customer/marketing/funnel`, or `/customer/marketing/automation` routes, which have since landed
 - PR creation before verification
 
 Implementation must happen in a new git worktree branched from `origin/main` (see Task 0). The doc branch `doc/pipedrive-crm-marketing` remains the research and planning branch.
 
-Files left as known refactor debt after Slice 1 (deferred to Slice 1b — file a tracked backlog item before Slice 2 starts):
+Files originally left as known refactor debt after Slice 1 (now reconciled on `origin/main`):
 
 - `apps/web/app/(shell)/customer/(crm)/[id]/page.tsx` — STATUS_COLOURS
 - `apps/web/app/(shell)/customer/(crm)/quotes/page.tsx` — STATUS_COLOURS
 - `apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx` — STATUS_COLOURS
 
-These three are intentionally out of Slice 1 to keep the touched-file surface small, but the shared `presentation.ts` helper this slice introduces is what they will consume.
+These three now consume shared Customer CRM status presentation via `CustomerStatusBadge` and `apps/web/lib/crm/presentation.ts`.
 
 ## File Structure
 

--- a/docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md
+++ b/docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Date | 2026-05-26 |
-| Status | Draft for operator review |
+| Status | Runtime-current through Slice 4; Slice 5 queued as `BI-D8E00326` |
 | Owners | Mark Bodman, Codex |
 | Scope | Customer CRM, pipeline, marketing workspace, acquisition integrations, AI coworker use cases |
 | Related specs | `2026-03-20-crm-research-synthesis.md`, `2026-03-20-crm-sales-pipeline-design.md`, `2026-04-24-customer-marketing-workspace-design.md`, `2026-04-11-marketing-specialist-skills-design.md` |
@@ -28,10 +28,12 @@ The current repo already has the substrate needed for a first implementation sli
 - Pipeline data already includes `Opportunity.stage`, `probability`, `expectedValue`, and `stageChangedAt`.
 - `Engagement` already has `source` and `sourceRefId`, which are suitable for first-slice lead and market signal routing.
 - Marketing work products already exist: `MarketingStrategy`, `MarketingReview`, `MarketingCampaignBrief`, `MarketingAssetTask`, `MarketingKpiCheckpoint`, and `MarketingAutomationCandidate`.
-- `/customer/marketing` now exists as the internal marketing workspace and resolves to `marketing-specialist`.
+- `/customer/marketing` exists as the internal marketing workspace and resolves to `marketing-specialist`.
 - The marketing agent already persists durable work via MCP tools such as `save_marketing_review`, `create_marketing_campaign_brief`, `create_marketing_asset_task`, `record_marketing_kpi_checkpoint`, and `create_marketing_automation_candidate`.
-- The `MarketingTabNav` still exposes disabled Campaigns, Funnel, and Automation tabs with "Phase 2" / "Phase 3" labels. This creates visible product debt on a customer-facing operations surface.
-- The CRM pages under `/customer` still use hardcoded status and stage colors plus inline style objects. This violates the DPF theme-aware UI standard and should be cleaned up as part of the first product slice.
+- `MarketingTabNav` now exposes real Overview, Strategy, Campaigns, Funnel, and Automation routes. The visible "Phase 2" / "Phase 3" placeholder pattern has been removed.
+- The CRM pages under `/customer` now centralize stage/status labels in `apps/web/lib/crm/presentation.ts`, use `apps/web/lib/crm/revenue-cockpit.ts` for summary math, and render Customer CRM metric/status wrappers that compose the shared `report-kit` palette.
+- Pipeline inspector, acquisition signal routing, marketing subroutes, and guided coworker launch boundaries have landed on `origin/main`; see `docs/superpowers/audits/2026-06-06-customer-crm-marketing-ux-reconciliation.md`.
+- Authenticated browser crawl against the canonical portal was attempted on 2026-06-06, but login submit produced the app fallback text "This page couldn't load". Browser route screenshots remain pending until that runtime/auth blocker is cleared.
 - The native integration catalogue already includes HubSpot CRM and Marketing, Google Marketing Intelligence, Facebook Lead Ads, Google Business Profile, and Mailchimp Marketing.
 - The integration coverage matrix already says Facebook Lead Ads should land in CRM and sales workflow, and Mailchimp writeback requires consent and customer-record boundaries.
 
@@ -45,7 +47,7 @@ Live DB fallback found an existing in-progress epic:
 - 9 backlog items are linked.
 - Statuses include `done`, `in-progress`, and two existing `triaging` rows.
 
-This design should extend the existing marketing epic or spawn a tightly scoped CRM/marketing operations epic after operator approval. It should not mutate backlog statuses in this thread, especially because `triaging` exists in live data while AGENTS.md lists canonical backlog statuses as `open`, `in-progress`, `done`, and `deferred`.
+Live MCP state on 2026-06-06 shows `BI-D8E00326` open for CRM marketing Slice 5: agentic sales and marketing operations, under `EP-CRM-MKT-OPS`. Use that item for the next product slice rather than reopening the historical Slice 1 checklist.
 
 ## 4. Research and Benchmarking
 


### PR DESCRIPTION
## Summary

- Reconciles the historical Pipedrive-inspired CRM/marketing slice docs against current `origin/main` and live backlog item `BI-D8E00326`.
- Adds a Customer CRM tone adapter so `CustomerMetricTile`, `CustomerStatusBadge`, and Revenue Cockpit attention badges compose the shared report-kit intent system instead of maintaining local badge/card styling maps.
- Adds the 2026-06-06 Customer CRM/Marketing UX reconciliation audit and records the canonical auth-crawl blocker rather than overstating UX evidence.

## Verification

- [x] Worktree source-local: `pnpm --filter web exec vitest run components/customer/CustomerMetricTile.test.tsx components/customer/CustomerStatusBadge.test.tsx components/customer/RevenueCockpit.test.tsx components/customer-marketing/MarketingTabNav.test.tsx components/agent/AgentWorkLauncher.test.tsx components/customer/PipelineStageInspector.test.tsx components/customer/AcquisitionSignalRouter.test.tsx lib/crm/presentation.test.ts lib/crm/revenue-cockpit.test.ts "app/(shell)/customer/(crm)/opportunities/page.test.tsx"` — 10 files / 28 tests passed.
- [x] Worktree source-local: `pnpm --filter web typecheck` — passed, including route type generation.
- [x] Worktree source-local: `pnpm --filter web build` — passed and generated 116 routes; existing Turbopack Edge/NFT warning family remains.
- [x] Worktree source-local: `git diff --check` — passed.
- [x] Worktree source-local: Customer route-family hardcoded color scan — no matches.
- [!] Canonical portal runtime: `/welcome` and `/login` were reachable, but admin login submit produced the app fallback text “This page couldn’t load”; authenticated Customer route crawl remains unrun and is documented in the audit/spec.
- [!] DPF MCP `evaluate_page` returned a JSON-RPC deserialize error on the Customer routes; fallback evidence is source-local plus Playwright reachability/auth probe.