### PR TITLE
feat(customer): add marketing agentic operation topics

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/page.test.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.test.tsx
@@ -1,0 +1,140 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getMarketingWorkspaceSnapshot } = vi.hoisted(() => ({
+  getMarketingWorkspaceSnapshot: vi.fn(),
+}));
+
+vi.mock("@/lib/marketing", () => ({
+  formatMarketingDate: (value: Date | string | null | undefined) =>
+    value ? new Date(value).toISOString().slice(0, 10) : "No date",
+  formatMarketingGap: (value: string) => `Gap: ${value}`,
+  formatMarketingLabel: (value: string) =>
+    value
+      .split(/[-_]/g)
+      .map((part) => part[0]?.toUpperCase() + part.slice(1))
+      .join(" "),
+  getMarketingWorkspaceSnapshot,
+}));
+
+vi.mock("@/components/agent/AgentWorkLauncher", () => ({
+  AgentWorkLauncher: ({
+    primaryActionLabel,
+    routeContext,
+    topics,
+  }: {
+    primaryActionLabel: string;
+    routeContext?: string;
+    topics: Array<{ id: string; label: string; prompt: string }>;
+  }) => (
+    <section data-route-context={routeContext} data-testid="agent-work-launcher">
+      <p>{primaryActionLabel}</p>
+      {topics.map((topic) => (
+        <article key={topic.id} data-topic-id={topic.id}>
+          <h2>{topic.label}</h2>
+          <p>{topic.prompt}</p>
+        </article>
+      ))}
+    </section>
+  ),
+}));
+
+vi.mock("@/components/customer-marketing/MarketingStrategyOverview", () => ({
+  MarketingStrategyOverview: () => <section data-testid="strategy-overview" />,
+}));
+
+vi.mock("@/components/customer-marketing/ApprovalQueuePanel", () => ({
+  ApprovalQueuePanel: () => <section data-testid="approval-queue" />,
+}));
+
+import CustomerMarketingPage from "./page";
+
+const now = new Date("2026-06-06T12:00:00.000Z");
+
+function snapshot() {
+  return {
+    organization: {
+      id: "org-1",
+      name: "DPF Demo",
+      website: "https://example.test",
+      addressSummary: "Austin, TX",
+    },
+    storefront: {
+      id: "storefront-1",
+      archetypeId: "expert-services",
+      archetypeName: "Expert Services",
+      tagline: "Proof-led growth",
+      description: "Operational advice",
+      ctaType: "inquiry",
+    },
+    strategy: {
+      strategyId: "strategy-1",
+      status: "active",
+      primaryGoal: "Generate qualified founder inquiries",
+      routeToMarket: "inbound",
+      localityModel: "national",
+      geographicScope: "United States",
+      primaryChannels: ["linkedin", "email"],
+      secondaryChannels: ["content-seo"],
+      differentiators: ["operational proof"],
+      reviewCadence: "weekly",
+      lastReviewedAt: now,
+      nextReviewAt: new Date("2026-06-13T12:00:00.000Z"),
+      sourceSummary: "Seeded test context",
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Founder operators", description: "Hands-on CEOs" }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [{ type: "case-study", label: "Founder case study" }],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: {
+      reviewType: "ad-hoc",
+      summary: "Prioritize founder proof.",
+      createdAt: now,
+      suggestedActions: [
+        { description: "Collect one proof asset before outbound work." },
+      ],
+      recommendation: {
+        primaryChannels: ["linkedin", "email"],
+        skippedChannels: ["paid-social"],
+        cadence: "weekly",
+        kpis: ["qualified replies"],
+      },
+    },
+    workProducts: {
+      campaignBriefs: [],
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: ["linkedin-personal-social"],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+}
+
+describe("CustomerMarketingPage", () => {
+  beforeEach(() => {
+    getMarketingWorkspaceSnapshot.mockResolvedValue(snapshot());
+  });
+
+  it("offers Slice 5 agentic operations topics in the marketing route context", async () => {
+    const html = renderToStaticMarkup(await CustomerMarketingPage());
+
+    expect(html).toContain('data-route-context="/customer/marketing"');
+    expect(html).toContain("Start marketing review");
+    expect(html).toContain('data-topic-id="signal-review"');
+    expect(html).toContain('data-topic-id="campaign-brief"');
+    expect(html).toContain('data-topic-id="automation-candidates"');
+    expect(html).toContain('data-topic-id="integration-recommendations"');
+    expect(html).toContain("save_marketing_review");
+    expect(html).not.toContain('data-topic-id="strategy-review"');
+    expect(html).not.toContain('data-topic-id="campaign-directions"');
+    expect(html).not.toContain('data-topic-id="proof-plan"');
+  });
+});

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -7,6 +7,10 @@ import {
 import { AgentWorkLauncher } from "@/components/agent/AgentWorkLauncher";
 import { ApprovalQueuePanel } from "@/components/customer-marketing/ApprovalQueuePanel";
 import { MarketingStrategyOverview } from "@/components/customer-marketing/MarketingStrategyOverview";
+import {
+  MARKETING_AGENTIC_OPERATIONS_ROUTE,
+  buildMarketingAgenticOperationTopics,
+} from "@/lib/marketing/agentic-operations";
 
 export default async function CustomerMarketingPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -56,35 +60,17 @@ export default async function CustomerMarketingPage() {
   const kpiStack = latestRecommendation?.kpis.length
     ? latestRecommendation.kpis.join(", ")
     : "No saved KPI stack yet";
-  const launcherTopics = [
-    {
-      id: "strategy-review",
-      label: "Strategy review",
-      description: "Have the strategist translate the current assumptions into plain language and ask the next useful question.",
-      prompt:
-        "Run a marketing review for this business. Use the current business, storefront, customer, and strategy context. Start by telling me what you think the first marketing decision should be, then ask me one focused question before recommending campaigns.",
-      contextSummary: `Market: ${marketFocus}. Buyer: ${audienceFocus}. Motion: ${routeFocus}.`,
-      expectedNextStep: "The strategist will ask one focused question before suggesting campaigns.",
-    },
-    {
-      id: "campaign-directions",
-      label: "Campaign ideas",
-      description: "Turn the current focus into practical campaign options for email, LinkedIn, events, outbound, or content.",
-      prompt:
-        "Suggest 3 practical campaign directions for this business based on the current strategy. Make them specific to the audience, market, route to market, and likely proof assets. Include the first step I should approve or change.",
-      contextSummary: `Channels: ${primaryChannels}. Proof: ${proofFocus}.`,
-      expectedNextStep: "The strategist will propose options and ask what you want to shape first.",
-    },
-    {
-      id: "proof-plan",
-      label: "Proof of expertise",
-      description: "Identify the proof, examples, or authority signals needed before we ask the market to act.",
-      prompt:
-        "Help me build a proof-of-expertise plan for this business. Identify the testimonials, case studies, outcomes, credentials, examples, or FAQs that would make campaigns more credible, and tell me what to collect first.",
-      contextSummary: `Current proof: ${proofFocus}. Buyer: ${audienceFocus}.`,
-      expectedNextStep: "The strategist will recommend the first proof asset to collect or draft.",
-    },
-  ];
+  const launcherTopics = buildMarketingAgenticOperationTopics({
+    marketFocus,
+    audienceFocus,
+    routeFocus,
+    primaryChannels,
+    recommendedChannels,
+    skippedChannels,
+    proofFocus,
+    kpiStack,
+    suggestions,
+  });
 
   return (
     <div className="space-y-6">
@@ -116,6 +102,7 @@ export default async function CustomerMarketingPage() {
         agentName="Marketing Strategist"
         primaryActionLabel="Start marketing review"
         topics={launcherTopics}
+        routeContext={MARKETING_AGENTIC_OPERATIONS_ROUTE}
       />
 
       <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">

--- a/apps/web/lib/marketing/agentic-operations.test.ts
+++ b/apps/web/lib/marketing/agentic-operations.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXTERNAL_MARKETING_SIDE_EFFECT_TOOLS,
+  MARKETING_AGENTIC_OPERATIONS_ROUTE,
+  buildMarketingAgenticOperationTopics,
+} from "./agentic-operations";
+
+const context = {
+  marketFocus: "Focused on the United States",
+  audienceFocus: "Founder operators",
+  routeFocus: "Inbound",
+  primaryChannels: "LinkedIn, Email",
+  recommendedChannels: "LinkedIn, Email",
+  skippedChannels: "Paid social",
+  proofFocus: "Founder case study",
+  kpiStack: "Qualified replies, demo requests",
+  suggestions: [
+    "Confirm the first audience before launching campaigns.",
+    "Collect one proof asset before outbound work.",
+  ],
+};
+
+describe("marketing agentic operations topics", () => {
+  it("builds the Slice 5 guided-work topic set", () => {
+    const topics = buildMarketingAgenticOperationTopics(context);
+
+    expect(topics.map((topic) => topic.id)).toEqual([
+      "signal-review",
+      "campaign-brief",
+      "automation-candidates",
+      "integration-recommendations",
+    ]);
+    expect(topics.map((topic) => topic.label)).toEqual([
+      "Signal review",
+      "Campaign brief",
+      "Automation candidates",
+      "Integration fit",
+    ]);
+  });
+
+  it("grounds prompts in current marketing context and governed internal artifact tools", () => {
+    const topics = buildMarketingAgenticOperationTopics(context);
+    const combinedPrompt = topics.map((topic) => topic.prompt).join("\n");
+
+    expect(MARKETING_AGENTIC_OPERATIONS_ROUTE).toBe("/customer/marketing");
+    expect(topics[0]?.contextSummary).toContain("Founder operators");
+    expect(topics[1]?.contextSummary).toContain("LinkedIn, Email");
+    expect(combinedPrompt).toContain("save_marketing_review");
+    expect(combinedPrompt).toContain("create_marketing_campaign_brief");
+    expect(combinedPrompt).toContain("create_marketing_asset_task");
+    expect(combinedPrompt).toContain("record_marketing_kpi_checkpoint");
+    expect(combinedPrompt).toContain("create_marketing_automation_candidate");
+  });
+
+  it("keeps external channel side effects out of launcher prompts", () => {
+    const topics = buildMarketingAgenticOperationTopics(context);
+
+    for (const topic of topics) {
+      for (const toolName of EXTERNAL_MARKETING_SIDE_EFFECT_TOOLS) {
+        expect(topic.prompt).not.toContain(toolName);
+      }
+      expect(topic.prompt).toContain("Do not publish, send, schedule, place ads, or change autopilot policy");
+      expect(topic.expectedNextStep).not.toMatch(/publish|send|schedule|spend/i);
+    }
+  });
+});

--- a/apps/web/lib/marketing/agentic-operations.ts
+++ b/apps/web/lib/marketing/agentic-operations.ts
@@ -1,0 +1,116 @@
+export type MarketingAgenticOperationContext = {
+  marketFocus: string;
+  audienceFocus: string;
+  routeFocus: string;
+  primaryChannels: string;
+  recommendedChannels: string;
+  skippedChannels: string;
+  proofFocus: string;
+  kpiStack: string;
+  suggestions: string[];
+};
+
+export type MarketingAgenticOperationTopic = {
+  id: string;
+  label: string;
+  description: string;
+  prompt: string;
+  contextSummary: string;
+  expectedNextStep: string;
+};
+
+export const MARKETING_AGENTIC_OPERATIONS_ROUTE = "/customer/marketing";
+
+export const EXTERNAL_MARKETING_SIDE_EFFECT_TOOLS = [
+  "publish_to_linkedin",
+  "send_marketing_email",
+  "place_linkedin_ad",
+  "tick_marketing_scheduler",
+  "plan_upcoming_marketing_drafts",
+  "set_marketing_autopilot_policy",
+] as const;
+
+const SIDE_EFFECT_BOUNDARY =
+  "Do not publish, send, schedule, place ads, or change autopilot policy.";
+
+function suggestionBrief(suggestions: string[]): string {
+  return suggestions.length > 0
+    ? suggestions.slice(0, 3).join(" ")
+    : "No specific gaps are currently flagged.";
+}
+
+export function buildMarketingAgenticOperationTopics(
+  context: MarketingAgenticOperationContext,
+): MarketingAgenticOperationTopic[] {
+  const strategyContext =
+    `Market: ${context.marketFocus}. Buyer: ${context.audienceFocus}. ` +
+    `Motion: ${context.routeFocus}.`;
+  const channelContext =
+    `Channels: ${context.primaryChannels}. Recommended: ${context.recommendedChannels}. ` +
+    `Skipped: ${context.skippedChannels}.`;
+  const proofContext =
+    `Proof: ${context.proofFocus}. KPIs: ${context.kpiStack}.`;
+  const gapContext = suggestionBrief(context.suggestions);
+
+  return [
+    {
+      id: "signal-review",
+      label: "Signal review",
+      description:
+        "Review acquisition signals, stale assumptions, and the next useful marketing decision.",
+      prompt:
+        "Review the current customer acquisition signals and marketing assumptions. " +
+        `${strategyContext} ${channelContext} Current gaps: ${gapContext} ` +
+        "If you name a concrete channel, cadence, audience, KPI, proof asset, or next step, " +
+        "persist the recommendation with save_marketing_review and record KPI evidence with record_marketing_kpi_checkpoint when useful. " +
+        `${SIDE_EFFECT_BOUNDARY}`,
+      contextSummary: `${strategyContext} ${channelContext}`,
+      expectedNextStep:
+        "Marketing Strategist should save the internal recommendation and ask one focused follow-up question.",
+    },
+    {
+      id: "campaign-brief",
+      label: "Campaign brief",
+      description:
+        "Turn the current strategy into a campaign brief and the first asset task.",
+      prompt:
+        "Create the next internal campaign work product for this business. " +
+        `${strategyContext} ${channelContext} ${proofContext} ` +
+        "Use create_marketing_campaign_brief for the campaign plan, create_marketing_asset_task for the first concrete asset, " +
+        "and draft_marketing_asset only after the asset task exists and the draft can stay in the approval queue. " +
+        `${SIDE_EFFECT_BOUNDARY}`,
+      contextSummary: `${context.audienceFocus}; ${context.primaryChannels}; ${context.proofFocus}`,
+      expectedNextStep:
+        "Marketing Strategist should create a reviewable campaign brief and first asset task.",
+    },
+    {
+      id: "automation-candidates",
+      label: "Automation candidates",
+      description:
+        "Identify repeated follow-up or campaign work that could become a governed proposal.",
+      prompt:
+        "Look for repeated marketing or sales-support actions that could become internal automation candidates. " +
+        `${strategyContext} ${channelContext} Current gaps: ${gapContext} ` +
+        "Create proposal-only candidates with create_marketing_automation_candidate, including trigger, action, rationale, and why human approval is required. " +
+        `${SIDE_EFFECT_BOUNDARY}`,
+      contextSummary: `${channelContext} ${gapContext}`,
+      expectedNextStep:
+        "Marketing Strategist should save proposal-only candidates with human approval posture.",
+    },
+    {
+      id: "integration-recommendations",
+      label: "Integration fit",
+      description:
+        "Recommend which connected or candidate integration should feed marketing evidence next.",
+      prompt:
+        "Recommend the next integration or signal source that should strengthen this customer acquisition system. " +
+        `${strategyContext} ${channelContext} ${proofContext} ` +
+        "Use get_marketing_summary, suggest_campaign_ideas, or analyze_seo_opportunity for read-only evidence where useful. " +
+        "If the recommendation is concrete, save it with save_marketing_review instead of leaving it only in chat. " +
+        `${SIDE_EFFECT_BOUNDARY}`,
+      contextSummary: `${strategyContext} ${proofContext}`,
+      expectedNextStep:
+        "Marketing Strategist should save the internal recommendation and name the evidence gap it addresses.",
+    },
+  ];
+}

--- a/docs/superpowers/plans/2026-06-06-pipedrive-crm-marketing-slice-5.md
+++ b/docs/superpowers/plans/2026-06-06-pipedrive-crm-marketing-slice-5.md
@@ -1,0 +1,63 @@
+# Pipedrive CRM Marketing Slice 5 Implementation Plan
+
+> **For agentic workers:** Execute incrementally with TDD. Keep all entry points inside Business > Customer. Use governed marketing tools for internal work product, and keep external publish, send, schedule, ad spend, and autopilot policy changes behind explicit approval.
+
+**Backlog item:** `BI-D8E00326` - CRM marketing Slice 5: agentic sales and marketing operations.
+
+**Goal:** Turn `/customer` and `/customer/marketing` from read-only orientation plus ad hoc coworker prompts into a maintainable guided-work surface where sales and marketing coworkers create durable internal artifacts instead of chat-only advice.
+
+**Architecture:** Keep the route family under `/customer`. Use `AgentWorkLauncher` for explicit preview and confirmation. Put reusable guided-work topic construction in source-local helpers instead of page-local prompt arrays. Use the existing marketing work-product tools and visible routes (`/customer/marketing/campaigns`, `/customer/marketing/funnel`, `/customer/marketing/automation`) before adding any new schema.
+
+## Scope
+
+Deliver in small PRs:
+
+- Sales advisor deal summary and follow-up drafting prompts stay on opportunity routes.
+- Marketing strategist guided starts cover signal review, campaign brief creation, automation candidates, and integration recommendations.
+- Internal artifacts are saved through governed marketing tools.
+- Saved artifacts remain visible outside chat on the existing Customer Marketing routes.
+- External side effects stay approval-gated.
+
+Out of scope for the first increment:
+
+- New CRM write tools.
+- New database tables.
+- External publish/send/schedule/ad-spend execution.
+- Moving Customer Marketing into global navigation, `/portal`, or `/storefront`.
+
+## Task 1: Guided Marketing Topic Source of Truth
+
+- [x] Add a pure `buildMarketingAgenticOperationTopics()` helper.
+- [x] Replace page-local `/customer/marketing` prompt arrays with the helper.
+- [x] Pass explicit `/customer/marketing` route context into `AgentWorkLauncher`.
+- [x] Test that launcher topics cover Slice 5 and exclude external side-effect tool names.
+
+## Task 2: Sales Advisor Boundary Review
+
+- [ ] Keep existing opportunity deal summary, stage health, and follow-up draft topics.
+- [ ] Verify no sales launcher claims persistence through tools that do not exist.
+- [ ] Add tests if future CRM governed-write tools are introduced.
+
+## Task 3: Marketing Artifact Creation Flow
+
+- [ ] Confirm `marketing-specialist` prompts and grants can use `save_marketing_review`, `create_marketing_campaign_brief`, `create_marketing_asset_task`, `record_marketing_kpi_checkpoint`, `create_marketing_automation_candidate`, and `draft_marketing_asset`.
+- [ ] Exercise a guided prompt that saves a recommendation or campaign artifact.
+- [ ] Verify the saved artifact appears on the relevant Customer Marketing route outside chat.
+
+## Task 4: Approval Boundary Evidence
+
+- [ ] Verify pending drafts appear in the approval queue before any external action.
+- [ ] Verify approved drafts require a visible publish/send button and connected integration.
+- [ ] Verify automation candidates remain proposals until a governed workflow adds enablement controls.
+
+## Task 5: UX Verification
+
+- [ ] Re-run authenticated desktop crawl for `/customer`, `/customer/opportunities`, and all `/customer/marketing/*` routes after promotion to a canonical runtime or shared local-CI lease.
+- [ ] Re-run mobile viewport inspection for clipped text and launcher overlap.
+- [ ] Record evidence on `BI-D8E00326` once write-scoped MCP evidence is available.
+
+## Verification for This Increment
+
+- `pnpm --filter web exec vitest run lib/marketing/agentic-operations.test.ts 'app/(shell)/customer/marketing/page.test.tsx' lib/marketing/subroutes.test.ts components/agent/AgentWorkLauncher.test.tsx components/customer-marketing/MarketingTabNav.test.tsx`
+- `pnpm --filter web typecheck`
+- `pnpm --filter web build`

--- a/docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md
+++ b/docs/superpowers/specs/2026-05-26-pipedrive-inspired-crm-marketing-operations-design.md
@@ -47,7 +47,7 @@ Live DB fallback found an existing in-progress epic:
 - 9 backlog items are linked.
 - Statuses include `done`, `in-progress`, and two existing `triaging` rows.
 
-Live MCP state on 2026-06-06 shows `BI-D8E00326` open for CRM marketing Slice 5: agentic sales and marketing operations, under `EP-CRM-MKT-OPS`. Use that item for the next product slice rather than reopening the historical Slice 1 checklist.
+Live MCP state on 2026-06-06 shows `BI-D8E00326` open for CRM marketing Slice 5: agentic sales and marketing operations, under `EP-CRM-MKT-OPS`. Use that item for the next product slice rather than reopening the historical Slice 1 checklist. The implementation plan is `docs/superpowers/plans/2026-06-06-pipedrive-crm-marketing-slice-5.md`.
 
 ## 4. Research and Benchmarking
 


### PR DESCRIPTION
## Summary
- adds a pure Slice 5 marketing agentic-operations topic builder for signal review, campaign briefs, automation candidates, and integration fit
- wires `/customer/marketing` to the shared topic builder and explicit `/customer/marketing` route context
- adds focused tests plus a Slice 5 implementation plan linked from the owning spec

## Verification
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: `pnpm --filter web exec vitest run lib/marketing/agentic-operations.test.ts` (red first: missing module)
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: `pnpm --filter web exec vitest run lib/marketing/agentic-operations.test.ts 'app/(shell)/customer/marketing/page.test.tsx' lib/marketing/subroutes.test.ts components/agent/AgentWorkLauncher.test.tsx components/customer-marketing/MarketingTabNav.test.tsx`
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: `pnpm --filter web typecheck`
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: `pnpm --filter web build` (passes; existing Turbopack Edge/NFT warnings remain)
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: `git diff --check`
- Worktree `D:\DPF-worktrees\crm-marketing-slice-5`: hardcoded-color scan over touched TS/TSX files

## Notes
- This is the first increment of `BI-D8E00326`; no new schema, no external publish/send/schedule/ad-spend behavior.
- Canonical-runtime UX crawl remains a follow-up after this source reaches a governed runtime promotion path.