### PR TITLE
fix(customer): bound CRM advisor guided prompts

### DIFF
--- a/apps/web/lib/crm/pipeline-inspector.test.ts
+++ b/apps/web/lib/crm/pipeline-inspector.test.ts
@@ -92,4 +92,48 @@ describe("pipeline inspector view model", () => {
       "follow-up-draft",
     ]);
   });
+
+  it("keeps opportunity advisor topics bounded to review and draft work", () => {
+    const view = buildPipelineInspectorView({
+      now,
+      opportunity: {
+        id: "opp-1",
+        opportunityId: "OPP-CODEX-001",
+        title: "Modernize revenue workflow",
+        stage: "proposal",
+        isDormant: false,
+        probability: 70,
+        expectedValue: 15000,
+        currency: "GBP",
+        expectedClose: new Date("2026-06-10T00:00:00.000Z"),
+        stageChangedAt: new Date("2026-05-06T12:00:00.000Z"),
+        notes: "Proposal sent after discovery.",
+        account: { id: "acct-1", name: "Acme Ops" },
+        contact: { email: "buyer@example.com", firstName: "Bea", lastName: "Buyer" },
+        engagement: {
+          id: "eng-1",
+          title: "Website pricing inquiry",
+          status: "qualified",
+          source: "web_inquiry",
+          sourceRefId: "inq-1",
+        },
+        quotes: [],
+        activities: [],
+      },
+    });
+
+    const combinedPrompt = view.aiTopics.map((topic) => topic.prompt).join("\n");
+
+    for (const topic of view.aiTopics) {
+      expect(topic.prompt).toContain("Do not create CRM records, update stages, send, or schedule anything.");
+    }
+    expect(combinedPrompt).not.toMatch(/\b(create|update)_opportunity\b/);
+    expect(combinedPrompt).not.toMatch(/\bsend_(email|marketing_email)\b/);
+    expect(combinedPrompt).not.toMatch(/\bschedule_(meeting|follow_up)\b/);
+    expect(view.aiTopics.map((topic) => topic.id)).toEqual([
+      "deal-summary",
+      "stale-stage-diagnosis",
+      "follow-up-draft",
+    ]);
+  });
 });

--- a/apps/web/lib/crm/pipeline-inspector.ts
+++ b/apps/web/lib/crm/pipeline-inspector.ts
@@ -48,6 +48,9 @@ const STAGE_EXIT_CRITERIA: Record<string, string[]> = {
   ],
 };
 
+const CRM_ADVISOR_BOUNDARY =
+  "Do not create CRM records, update stages, send, or schedule anything. Return review notes or draft copy for operator approval.";
+
 export const PIPELINE_STAGE_UPDATE_OPTIONS = OPEN_OPPORTUNITY_STAGES.map((stage) => ({
   value: stage,
   label: getOpportunityStageMeta(stage).label,
@@ -271,7 +274,8 @@ function buildAiTopics(input: {
       description: "Review account, activity, quote, and stage context.",
       prompt:
         `Summarize opportunity ${input.opportunityId}: ${input.title}. ` +
-        `${baseContext} Highlight current stage evidence, blockers, and the next best internal action.`,
+        `${baseContext} Highlight current stage evidence, blockers, and the next best internal action. ` +
+        CRM_ADVISOR_BOUNDARY,
       contextSummary: baseContext,
       expectedNextStep:
         "Customer Advisor should return a concise stage-aware deal summary without taking external action.",
@@ -282,7 +286,8 @@ function buildAiTopics(input: {
       description: "Inspect stage age, missing evidence, and what must happen next.",
       prompt:
         `Diagnose stage health for opportunity ${input.opportunityId}. ` +
-        `${baseContext} Suggested next action: ${input.suggestedNextAction}`,
+        `${baseContext} Suggested next action: ${input.suggestedNextAction}. ` +
+        CRM_ADVISOR_BOUNDARY,
       contextSummary: `${input.stageLabel}; ${input.stageAgeLabel}; next action: ${input.suggestedNextAction}`,
       expectedNextStep:
         "Customer Advisor should explain the stage posture and propose a governed follow-up task if needed.",
@@ -293,7 +298,7 @@ function buildAiTopics(input: {
       description: "Draft the next buyer-facing follow-up for review.",
       prompt:
         `Draft a buyer follow-up for opportunity ${input.opportunityId}. ` +
-        `${baseContext} Do not send or schedule anything; provide a draft for operator approval.`,
+        `${baseContext} ${CRM_ADVISOR_BOUNDARY}`,
       contextSummary: baseContext,
       expectedNextStep:
         "Customer Advisor should produce draft copy only; the operator decides whether to send it.",

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -114,6 +114,7 @@ describe("TOOL_TO_GRANTS — Marketing entries", () => {
     const tools = [
       "create_marketing_campaign_brief",
       "create_marketing_asset_task",
+      "draft_marketing_asset",
       "record_marketing_kpi_checkpoint",
       "create_marketing_automation_candidate",
     ];
@@ -423,6 +424,7 @@ describe("getToolGrantMapping reflects all entries", () => {
     expect(mapping["save_marketing_review"]).toEqual(["marketing_write"]);
     expect(mapping["create_marketing_campaign_brief"]).toEqual(["marketing_write"]);
     expect(mapping["create_marketing_asset_task"]).toEqual(["marketing_write"]);
+    expect(mapping["draft_marketing_asset"]).toEqual(["marketing_write"]);
     expect(mapping["record_marketing_kpi_checkpoint"]).toEqual(["marketing_write"]);
     expect(mapping["create_marketing_automation_candidate"]).toEqual(["marketing_write"]);
     expect(mapping["generate_custom_archetype"]).toEqual(["marketing_write"]);

--- a/docs/superpowers/plans/2026-06-06-pipedrive-crm-marketing-slice-5.md
+++ b/docs/superpowers/plans/2026-06-06-pipedrive-crm-marketing-slice-5.md
@@ -34,13 +34,13 @@ Out of scope for the first increment:
 
 ## Task 2: Sales Advisor Boundary Review
 
-- [ ] Keep existing opportunity deal summary, stage health, and follow-up draft topics.
-- [ ] Verify no sales launcher claims persistence through tools that do not exist.
+- [x] Keep existing opportunity deal summary, stage health, and follow-up draft topics.
+- [x] Verify no sales launcher claims persistence through tools that do not exist.
 - [ ] Add tests if future CRM governed-write tools are introduced.
 
 ## Task 3: Marketing Artifact Creation Flow
 
-- [ ] Confirm `marketing-specialist` prompts and grants can use `save_marketing_review`, `create_marketing_campaign_brief`, `create_marketing_asset_task`, `record_marketing_kpi_checkpoint`, `create_marketing_automation_candidate`, and `draft_marketing_asset`.
+- [x] Confirm `marketing-specialist` prompts and grants can use `save_marketing_review`, `create_marketing_campaign_brief`, `create_marketing_asset_task`, `record_marketing_kpi_checkpoint`, `create_marketing_automation_candidate`, and `draft_marketing_asset`.
 - [ ] Exercise a guided prompt that saves a recommendation or campaign artifact.
 - [ ] Verify the saved artifact appears on the relevant Customer Marketing route outside chat.
 


### PR DESCRIPTION
## Summary
- Add an explicit review/draft-only boundary to Customer Advisor opportunity launcher prompts.
- Add regression coverage that opportunity topics do not imply nonexistent CRM write tools or external send/schedule actions.
- Lock `draft_marketing_asset` into marketing write-tool grant coverage and update the Slice 5 plan status.

## Verification
- Worktree substrate: `D:\DPF-worktrees\crm-marketing-boundaries` (`compile-ready`).
- `pnpm --filter web exec vitest run lib/crm/pipeline-inspector.test.ts lib/tak/agent-grants.test.ts` — 2 files, 107 tests passed.
- `pnpm --filter web typecheck` — route types generated and `tsc --noEmit` passed.
- `pnpm --filter web build` — production build completed, 116 routes generated; existing Turbopack warning pattern remains at 256 warnings.
- `git diff --check` — clean.
- Hardcoded-color scan over touched source/test files — no matches.

## Notes
- No migrations.
- No UI styling changes.
- Canonical-runtime UX/artifact save verification remains the next Slice 5 task after this source-boundary increment.