### PR TITLE
fix(customer): add quote detail route

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUnique, notFound } = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error("not-found");
+  }),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    quote: {
+      findUnique,
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound,
+}));
+
+import QuoteDetailPage from "./page";
+
+describe("QuoteDetailPage", () => {
+  beforeEach(() => {
+    findUnique.mockResolvedValue({
+      id: "quote-1",
+      quoteNumber: "QUO-2026-0007",
+      version: 2,
+      status: "sent",
+      validFrom: new Date("2026-06-01T10:00:00.000Z"),
+      validUntil: new Date("2026-06-30T10:00:00.000Z"),
+      subtotal: 1200,
+      discountType: "percentage",
+      discountValue: 10,
+      taxAmount: 216,
+      totalAmount: 1296,
+      currency: "USD",
+      terms: "Net 14",
+      notes: "Includes implementation support.",
+      sentAt: new Date("2026-06-02T10:00:00.000Z"),
+      acceptedAt: null,
+      rejectedAt: null,
+      createdAt: new Date("2026-06-01T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-02T10:00:00.000Z"),
+      createdBy: { email: "seller@example.test" },
+      account: {
+        id: "acct-1",
+        accountId: "ACCT-001",
+        name: "Founder Ops Ltd",
+      },
+      opportunity: {
+        id: "opp-1",
+        opportunityId: "OPP-001",
+        title: "Revenue workflow refactor",
+        stage: "proposal",
+      },
+      lineItems: [
+        {
+          id: "line-1",
+          description: "Discovery workshop",
+          quantity: 2,
+          unitPrice: 300,
+          discountPercent: 0,
+          taxPercent: 20,
+          lineTotal: 600,
+          sortOrder: 1,
+          product: null,
+        },
+        {
+          id: "line-2",
+          description: "Implementation sprint",
+          quantity: 1,
+          unitPrice: 600,
+          discountPercent: 0,
+          taxPercent: 20,
+          lineTotal: 600,
+          sortOrder: 2,
+          product: { name: "Delivery Accelerator" },
+        },
+      ],
+      salesOrder: {
+        id: "so-1",
+        orderRef: "SO-2026-0004",
+        status: "confirmed",
+        totalAmount: 1296,
+        currency: "USD",
+      },
+    });
+  });
+
+  it("renders the quote detail reached from quote links", async () => {
+    const html = renderToStaticMarkup(
+      await QuoteDetailPage({ params: Promise.resolve({ id: "quote-1" }) }),
+    );
+
+    expect(findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "quote-1" },
+      }),
+    );
+    expect(html).toContain("QUO-2026-0007");
+    expect(html).toContain("Founder Ops Ltd");
+    expect(html).toContain("Revenue workflow refactor");
+    expect(html).toContain("Discovery workshop");
+    expect(html).toContain("Implementation sprint");
+    expect(html).toContain("Delivery Accelerator");
+    expect(html).toContain("USD 1,296");
+    expect(html).toContain("SO-2026-0004");
+    expect(html).toContain('href="/customer/quotes"');
+    expect(html).toContain('href="/customer/opportunities?opportunity=opp-1"');
+    expect(html).toContain("var(--dpf-");
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("returns not found for a missing quote", async () => {
+    findUnique.mockResolvedValue(null);
+
+    await expect(
+      QuoteDetailPage({ params: Promise.resolve({ id: "missing" }) }),
+    ).rejects.toThrow("not-found");
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.tsx
@@ -1,0 +1,297 @@
+// apps/web/app/(shell)/customer/quotes/[id]/page.tsx
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  CRM_TONE_CLASSES,
+  getOpportunityStageMeta,
+  getQuoteStatusMeta,
+} from "@/lib/crm/presentation";
+
+type QuoteDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+function formatMoney(currency: string, value: unknown) {
+  return `${currency} ${Number(value ?? 0).toLocaleString()}`;
+}
+
+function formatDiscount(
+  currency: string,
+  discountType: string,
+  discountValue: unknown,
+) {
+  const value = Number(discountValue ?? 0);
+  if (value === 0) return "None";
+  return discountType === "percentage"
+    ? `${value.toLocaleString()}%`
+    : formatMoney(currency, value);
+}
+
+export default async function QuoteDetailPage({ params }: QuoteDetailPageProps) {
+  const { id } = await params;
+  const quote = await prisma.quote.findUnique({
+    where: { id },
+    include: {
+      account: { select: { id: true, accountId: true, name: true } },
+      opportunity: {
+        select: { id: true, opportunityId: true, title: true, stage: true },
+      },
+      createdBy: { select: { email: true } },
+      lineItems: {
+        orderBy: { sortOrder: "asc" },
+        include: { product: { select: { name: true } } },
+      },
+      salesOrder: {
+        select: {
+          id: true,
+          orderRef: true,
+          status: true,
+          totalAmount: true,
+          currency: true,
+        },
+      },
+    },
+  });
+
+  if (!quote) notFound();
+
+  const statusMeta = getQuoteStatusMeta(quote.status);
+  const stageMeta = getOpportunityStageMeta(quote.opportunity.stage);
+  const stageToneClasses = CRM_TONE_CLASSES[stageMeta.tone];
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <Link
+            href="/customer/quotes"
+            className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            Back to quotes
+          </Link>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-bold text-[var(--dpf-text)]">
+              {quote.quoteNumber}
+            </h1>
+            <span className="text-[10px] text-[var(--dpf-muted)]">
+              v{quote.version}
+            </span>
+            <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
+          </div>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            {quote.account.name} / {quote.opportunity.title}
+          </p>
+        </div>
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3 md:text-right">
+          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Total
+          </p>
+          <p className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">
+            {formatMoney(quote.currency, quote.totalAmount)}
+          </p>
+          <p className="mt-1 text-[10px] text-[var(--dpf-muted)]">
+            Valid until <LocalTime value={quote.validUntil} utc />
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="space-y-4">
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                Line items
+              </h2>
+              <span className="text-xs text-[var(--dpf-muted)]">
+                {quote.lineItems.length} item{quote.lineItems.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              {quote.lineItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 md:grid-cols-[minmax(0,1fr)_7rem_8rem]"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[var(--dpf-text)]">
+                      {item.description}
+                    </p>
+                    {item.product ? (
+                      <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                        {item.product.name}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="text-xs text-[var(--dpf-muted)] md:text-right">
+                    {item.quantity} x {formatMoney(quote.currency, item.unitPrice)}
+                  </div>
+                  <div className="text-sm font-semibold text-[var(--dpf-text)] md:text-right">
+                    {formatMoney(quote.currency, item.lineTotal)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Terms and notes
+            </h2>
+            <dl className="mt-4 grid gap-4 md:grid-cols-2">
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                  Terms
+                </dt>
+                <dd className="mt-1 text-sm text-[var(--dpf-text)]">
+                  {quote.terms || "No terms recorded."}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                  Notes
+                </dt>
+                <dd className="mt-1 text-sm text-[var(--dpf-text)]">
+                  {quote.notes || "No notes recorded."}
+                </dd>
+              </div>
+            </dl>
+          </section>
+        </div>
+
+        <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Quote summary
+            </h2>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Subtotal</dt>
+                <dd className="font-medium text-[var(--dpf-text)]">
+                  {formatMoney(quote.currency, quote.subtotal)}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Discount</dt>
+                <dd className="font-medium text-[var(--dpf-text)]">
+                  {formatDiscount(
+                    quote.currency,
+                    quote.discountType,
+                    quote.discountValue,
+                  )}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Tax</dt>
+                <dd className="font-medium text-[var(--dpf-text)]">
+                  {formatMoney(quote.currency, quote.taxAmount)}
+                </dd>
+              </div>
+              <div className="border-t border-[var(--dpf-border)] pt-3">
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="text-[var(--dpf-muted)]">Total</dt>
+                  <dd className="font-semibold text-[var(--dpf-text)]">
+                    {formatMoney(quote.currency, quote.totalAmount)}
+                  </dd>
+                </div>
+              </div>
+            </dl>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Related opportunity
+            </h2>
+            <div className="mt-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+              <Link
+                href={`/customer/opportunities?opportunity=${quote.opportunity.id}`}
+                className="text-sm font-semibold text-[var(--dpf-text)] hover:text-[var(--dpf-accent)]"
+              >
+                {quote.opportunity.title}
+              </Link>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                {quote.opportunity.opportunityId}
+              </p>
+              <div className="mt-3 flex items-center justify-between gap-2">
+                <span
+                  className={[
+                    "border-b-2 pb-1 text-xs font-semibold text-[var(--dpf-text)]",
+                    stageToneClasses.border,
+                  ].join(" ")}
+                >
+                  {stageMeta.label}
+                </span>
+                <span className="text-xs text-[var(--dpf-muted)]">
+                  {quote.account.accountId}
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Timeline
+            </h2>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div>
+                <dt className="text-[var(--dpf-muted)]">Created</dt>
+                <dd className="mt-1 text-[var(--dpf-text)]">
+                  <LocalTime value={quote.createdAt} utc />
+                  {quote.createdBy?.email ? ` by ${quote.createdBy.email}` : ""}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[var(--dpf-muted)]">Updated</dt>
+                <dd className="mt-1 text-[var(--dpf-text)]">
+                  <LocalTime value={quote.updatedAt} utc />
+                </dd>
+              </div>
+              {quote.sentAt ? (
+                <div>
+                  <dt className="text-[var(--dpf-muted)]">Sent</dt>
+                  <dd className="mt-1 text-[var(--dpf-text)]">
+                    <LocalTime value={quote.sentAt} utc />
+                  </dd>
+                </div>
+              ) : null}
+              {quote.acceptedAt ? (
+                <div>
+                  <dt className="text-[var(--dpf-muted)]">Accepted</dt>
+                  <dd className="mt-1 text-[var(--dpf-text)]">
+                    <LocalTime value={quote.acceptedAt} utc />
+                  </dd>
+                </div>
+              ) : null}
+              {quote.rejectedAt ? (
+                <div>
+                  <dt className="text-[var(--dpf-muted)]">Rejected</dt>
+                  <dd className="mt-1 text-[var(--dpf-text)]">
+                    <LocalTime value={quote.rejectedAt} utc />
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          </section>
+
+          {quote.salesOrder ? (
+            <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+              <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                Sales order
+              </h2>
+              <p className="mt-2 text-sm font-mono text-[var(--dpf-text)]">
+                {quote.salesOrder.orderRef}
+              </p>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                {quote.salesOrder.status} /{" "}
+                {formatMoney(quote.salesOrder.currency, quote.salesOrder.totalAmount)}
+              </p>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add the missing internal `/customer/quotes/[id]` shell route so quote links from the quote list and pipeline inspector no longer land on 404.
- Render quote context, line items, totals, related opportunity, timeline, and sales order using DPF theme tokens.
- Add a page test covering detail rendering, route links, not-found behavior, and tokenized styling.

## Verification
- `pnpm --filter web exec vitest run "app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx"`
- `pnpm --filter web exec vitest run "app/(shell)/customer/(crm)/quotes/[id]/page.test.tsx" "app/(shell)/customer/(crm)/opportunities/page.test.tsx" "components/customer/PipelineStageInspector.test.tsx"`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passes; existing Turbopack Edge/NFT warnings remain)
- `git diff --check`
- Theme-token scan on new files: no hardcoded hex or Tailwind color classes found
- Local-CI lease `NPEL-CAAACD8843` on `http://127.0.0.1:3010`: rebuilt `local-ci-portal`, health ok, quote-list/detail Playwright proof passed, no bad `/customer/quotes/<id>` responses, mobile quote detail overflow check passed

## Follow-up Captured
- Background `/api/platform/metrics/alerts` 503 console noise remains outside this CRM route fix and was recorded as `BI-B671E47A`.