### PR TITLE
feat(verify): fast static bundle-boundary guard (EP-VERIFY-PROC slice 4)

### DIFF
--- a/apps/web/lib/verify/bundle-boundary.guard.test.ts
+++ b/apps/web/lib/verify/bundle-boundary.guard.test.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HOST_ONLY_MATCHERS,
+  extractStaticImports,
+  findBoundaryViolations,
+  isHostOnlyModule,
+  type EntrypointImports,
+} from "./bundle-boundary";
+
+describe("extractStaticImports", () => {
+  it("includes static default, named, namespace, and bare imports", () => {
+    const src = `
+      import a from "mod-a";
+      import { b } from "mod-b";
+      import * as c from "mod-c";
+      import "mod-d";
+    `;
+    const specs = extractStaticImports(src);
+    expect(specs).toEqual(expect.arrayContaining(["mod-a", "mod-b", "mod-c", "mod-d"]));
+  });
+
+  it("includes re-exports (barrels)", () => {
+    expect(extractStaticImports(`export * from "./promoter";`)).toContain("./promoter");
+    expect(extractStaticImports(`export { runPromoter } from "./promoter";`)).toContain("./promoter");
+  });
+
+  it("EXCLUDES dynamic import() — the sanctioned lazy boundary", () => {
+    const src = `const p = await import("@/lib/self-upgrade/promoter");`;
+    expect(extractStaticImports(src)).not.toContain("@/lib/self-upgrade/promoter");
+  });
+
+  it("EXCLUDES import type / export type — erased at build", () => {
+    const src = `
+      import type { Foo } from "@/lib/self-upgrade/promoter";
+      export type { Bar } from "dockerode";
+    `;
+    expect(extractStaticImports(src)).toHaveLength(0);
+  });
+
+  it("includes a value import even with an inline type member", () => {
+    expect(extractStaticImports(`import { type A, b } from "mod-x";`)).toContain("mod-x");
+  });
+});
+
+describe("isHostOnlyModule", () => {
+  it("matches the promoter module and dockerode in any path form", () => {
+    expect(isHostOnlyModule("@/lib/self-upgrade/promoter")).toBe(true);
+    expect(isHostOnlyModule("../self-upgrade/promoter.ts")).toBe(true);
+    expect(isHostOnlyModule("dockerode")).toBe(true);
+  });
+  it("does not match pure siblings or the classifier", () => {
+    expect(isHostOnlyModule("@/lib/self-upgrade/build-failure-classifier")).toBe(false);
+    expect(isHostOnlyModule("@/lib/self-upgrade/config")).toBe(false);
+  });
+});
+
+describe("findBoundaryViolations", () => {
+  const entries: EntrypointImports[] = [
+    { path: "api/inngest/route.ts", imports: ["@/lib/self-upgrade/promoter", "react"] },
+    { path: "api/ok/route.ts", imports: ["@/lib/self-upgrade/config", "@/lib/self-upgrade"] },
+  ];
+
+  it("flags a direct host-only import", () => {
+    const v = findBoundaryViolations(entries);
+    expect(v).toContainEqual({
+      entrypoint: "api/inngest/route.ts",
+      specifier: "@/lib/self-upgrade/promoter",
+      via: "direct",
+    });
+  });
+
+  it("flags a barrel that re-exports a host-only module when its specifier is in the set", () => {
+    const v = findBoundaryViolations(entries, new Set(["@/lib/self-upgrade"]));
+    expect(v).toContainEqual({
+      entrypoint: "api/ok/route.ts",
+      specifier: "@/lib/self-upgrade",
+      via: "barrel",
+    });
+  });
+
+  it("passes a clean entrypoint set", () => {
+    const clean: EntrypointImports[] = [
+      { path: "api/x/route.ts", imports: ["@/lib/self-upgrade/config", "next/server"] },
+    ];
+    expect(findBoundaryViolations(clean)).toHaveLength(0);
+  });
+});
+
+// --- Real-tree regression guard: locks in the §2.1 fix and PR #1555 ---------
+const WEB_ROOT = join(__dirname, "..", "..");
+
+function collect(dir: string, match: (p: string) => boolean): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+  return entries
+    .map((e) => join(dir, e))
+    .filter((p) => match(p) && !p.endsWith(".test.ts") && !p.endsWith(".test.tsx"));
+}
+
+describe("server entrypoints do not statically import host-only modules (real tree)", () => {
+  it("no route.ts or Inngest function pulls the promoter/dockerode graph into the bundle", () => {
+    const routeFiles = collect(join(WEB_ROOT, "app", "api"), (p) => p.endsWith("route.ts"));
+    const inngestFiles = collect(join(WEB_ROOT, "lib", "queue", "functions"), (p) =>
+      p.endsWith(".ts"),
+    );
+    const files = [...routeFiles, ...inngestFiles];
+    // Sanity: the globs actually matched something (guards against a silently
+    // empty pass if the tree layout changes).
+    expect(files.length).toBeGreaterThan(0);
+
+    const entrypoints: EntrypointImports[] = files.map((path) => ({
+      path: path.slice(WEB_ROOT.length + 1).replace(/\\/g, "/"),
+      imports: extractStaticImports(readFileSync(path, "utf-8")),
+    }));
+
+    const violations = findBoundaryViolations(entrypoints, new Set(), DEFAULT_HOST_ONLY_MATCHERS);
+    expect(
+      violations,
+      `Host-only modules statically imported into the server bundle (use a dynamic import() boundary — see PR #1555):\n${violations
+        .map((v) => `  ${v.entrypoint} -> ${v.specifier} (${v.via})`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/web/lib/verify/bundle-boundary.ts
+++ b/apps/web/lib/verify/bundle-boundary.ts
@@ -1,0 +1,89 @@
+// Static bundle-boundary detector — catch the Docker-only build failure class in
+// seconds, source-local, instead of serially across 40-90s Docker builds.
+//
+// Spec: docs/superpowers/specs/2026-06-06-procedural-functional-verification-design.md (§3.3)
+// BI-98AF1066.
+//
+// The §2.1 trace's two bundle-boundary violations were found one-at-a-time across
+// two Docker builds: a route/Inngest entrypoint STATICALLY imported the promoter
+// (which spawns docker), dragging its host-only graph into the server bundle and
+// triggering a Turbopack duplicate-emitted-asset collision. A static import is the
+// problem; a dynamic `import()` (the fix) is fine. This module provides the pure
+// detectors; the guard test runs them over the real entrypoint set.
+
+/**
+ * Extract the specifiers a module pulls into the BUNDLE: top-level static
+ * `import ... from` and re-export `export ... from`. Deliberately excludes:
+ *  - `import type` / `export type` — erased at build, never in the bundle;
+ *  - dynamic `import("x")` — the sanctioned lazy boundary, not a bundle edge;
+ *  - bare side-effect `import "x"` IS included (it loads the module).
+ */
+export function extractStaticImports(source: string): string[] {
+  // Drop type-only import/export first (bounded at the `from "..."` terminator).
+  const noType = source.replace(
+    /\b(?:import|export)\s+type\b[\s\S]*?from\s*["'][^"']+["']/g,
+    "",
+  );
+  const specs = new Set<string>();
+  // import/export … from "spec" — default, named, namespace, multiline.
+  for (const m of noType.matchAll(/\bfrom\s*["']([^"']+)["']/g)) specs.add(m[1]);
+  // bare side-effect import "spec"
+  for (const m of noType.matchAll(/\bimport\s+["']([^"']+)["']/g)) specs.add(m[1]);
+  return [...specs];
+}
+
+/**
+ * Modules that must never be statically imported into a server-bundle entrypoint
+ * — they carry host-only/docker concerns and must be reached via dynamic import.
+ * Matched against the raw specifier string.
+ */
+export const DEFAULT_HOST_ONLY_MATCHERS: RegExp[] = [
+  /self-upgrade\/promoter(?:\.[tj]s)?$/, // spawns docker; lazy-load only
+  /(?:^|\/)dockerode$/, // docker SDK
+];
+
+export function isHostOnlyModule(
+  specifier: string,
+  matchers: RegExp[] = DEFAULT_HOST_ONLY_MATCHERS,
+): boolean {
+  return matchers.some((re) => re.test(specifier));
+}
+
+export type BoundaryViolation = {
+  /** The entrypoint that pulls a host-only module into the bundle. */
+  entrypoint: string;
+  /** The offending specifier. */
+  specifier: string;
+  /** "direct" — imported the host-only module itself; "barrel" — via a re-exporting barrel. */
+  via: "direct" | "barrel";
+};
+
+export type EntrypointImports = {
+  path: string;
+  /** Specifiers this entrypoint statically imports (from extractStaticImports). */
+  imports: string[];
+};
+
+/**
+ * Given each entrypoint's static imports, plus the set of barrel specifiers that
+ * are known to re-export a host-only module (resolved one level by the caller),
+ * return every boundary violation. Pure — all IO (glob/read/resolve) is the
+ * caller's job, so this is a truth table under test.
+ */
+export function findBoundaryViolations(
+  entrypoints: EntrypointImports[],
+  hostOnlyBarrelSpecifiers: Set<string> = new Set(),
+  matchers: RegExp[] = DEFAULT_HOST_ONLY_MATCHERS,
+): BoundaryViolation[] {
+  const violations: BoundaryViolation[] = [];
+  for (const entry of entrypoints) {
+    for (const spec of entry.imports) {
+      if (isHostOnlyModule(spec, matchers)) {
+        violations.push({ entrypoint: entry.path, specifier: spec, via: "direct" });
+      } else if (hostOnlyBarrelSpecifiers.has(spec)) {
+        violations.push({ entrypoint: entry.path, specifier: spec, via: "barrel" });
+      }
+    }
+  }
+  return violations;
+}


### PR DESCRIPTION
## What & why

Follow-on to [#1558](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1558) (merged), **Slice 4** of **EP-VERIFY-PROC**. Ships the fast static **bundle-boundary guard** (BI-98AF1066) so the Docker-only build-failure class surfaces in **seconds, source-local**, instead of one-at-a-time across 40–90s Docker builds.

The 22-minute trace in the design spec found its two bundle-boundary violations serially across two Docker builds because there was no fast check. This finds them all at once and locks in the fix from [#1555](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1555) as a regression guard.

## Changes
- **`apps/web/lib/verify/bundle-boundary.ts`** — pure detectors: `extractStaticImports()` (includes static imports + barrel re-exports; correctly **excludes** dynamic `import()` and `import type` — the sanctioned lazy boundary and erased types), `isHostOnlyModule()`, `findBoundaryViolations()`.
- **`bundle-boundary.guard.test.ts`** — synthetic truth table proving the detector ignores dynamic `import()`/`import type`, **plus a real-tree regression guard** asserting no `app/api` route or `lib/queue/functions` Inngest entry statically imports the promoter/dockerode graph. Runs in the existing **Unit Tests** CI job in milliseconds.

## Scope (no silent caps)
Direct host-only imports + barrel-set detection (pure). Deeper N-level transitive import-graph analysis and the triage doc's depcheck/knip undeclared-import check (Option B — needs a new dev dep + tool-eval) are explicit follow-on, not dropped.

## Verification
- `pnpm --filter web exec vitest run lib/verify/bundle-boundary.guard.test.ts` → **11/11**
- `pnpm --filter web typecheck` → clean
- Substrate: source-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
