### PR TITLE
feat(verify): MCP tool verify_live_install_readiness (EP-VERIFY-PROC slice 5)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1108,6 +1108,25 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: false,
   },
   {
+    name: "verify_live_install_readiness",
+    description:
+      "Preflight a feature against the live install before driving its happy path. Returns the same deterministic verdict as `pnpm verify:preflight` — CAN-TEST (served bytes contain the feature commit), MUST-ADVANCE (behind/unprovable → advance via the governed self-upgrade path), or BLOCKED (no testable runtime → file a BI and stop) — plus one next action. Surface-agnostic: identical verdict logic for CLI and in-portal/Build Studio. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        featureSha: {
+          type: "string",
+          description:
+            "The commit the feature under test requires — a PR/BI merge SHA or a build's commit. Compared against the live install's served image identity.",
+        },
+      },
+      required: ["featureSha"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
     name: "record_execution_evidence",
     description: "Attach an evidence record to a backlog item (test pass/fail, build pass/fail, ux verification, spec review, manual check, external link). Writes an evidence activity row; the cross-cutting audit lives in ToolExecution. Side-effecting.",
     inputSchema: {
@@ -6343,6 +6362,23 @@ export async function executeTool(
         success: true,
         message: `Found ${results.length} match(es).`,
         data: { results },
+      };
+    }
+
+    case "verify_live_install_readiness": {
+      const featureSha = String(params["featureSha"] ?? "").trim();
+      if (!featureSha)
+        return {
+          success: false,
+          error: "missing_feature_sha",
+          message: "featureSha is required (a PR/BI merge SHA or a build's commit).",
+        };
+      const { resolveLiveInstallReadiness } = await import("@/lib/verify/preflight-service");
+      const verdict = await resolveLiveInstallReadiness({ featureSha });
+      return {
+        success: true,
+        message: `${verdict.verdict}: ${verdict.reason}`,
+        data: verdict,
       };
     }
 

--- a/apps/web/lib/verify/preflight-service.test.ts
+++ b/apps/web/lib/verify/preflight-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { ImageVersion } from "@/lib/platform/image-version";
+import {
+  resolveLiveInstallReadiness,
+  type ReadinessDeps,
+} from "./preflight-service";
+
+const FEATURE = "a".repeat(40);
+const SERVED = "b".repeat(40);
+
+function deps(over: Partial<ReadinessDeps>): ReadinessDeps {
+  return {
+    readImage: async (): Promise<ImageVersion | null> => ({ raw: SERVED, source: "git-sha" }),
+    isAncestor: async () => null,
+    ...over,
+  };
+}
+
+describe("resolveLiveInstallReadiness", () => {
+  it("CAN-TEST when the served git-sha image contains the feature commit", async () => {
+    const r = await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({ isAncestor: async () => true }),
+    );
+    expect(r.verdict).toBe("CAN-TEST");
+    expect(r.nextAction.kind).toBe("drive-happy-path");
+  });
+
+  it("MUST-ADVANCE when the served git-sha image does not contain the feature commit", async () => {
+    const r = await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({ isAncestor: async () => false }),
+    );
+    expect(r.verdict).toBe("MUST-ADVANCE");
+  });
+
+  it("BLOCKED when ancestry is uncomputable (git unavailable in-portal)", async () => {
+    const r = await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({ isAncestor: async () => null }),
+    );
+    expect(r.verdict).toBe("BLOCKED");
+  });
+
+  it("MUST-ADVANCE when the served identity is a content-hash (not comparable)", async () => {
+    const r = await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({ readImage: async () => ({ raw: "c".repeat(64), source: "content-hash" }) }),
+    );
+    expect(r.verdict).toBe("MUST-ADVANCE");
+  });
+
+  it("BLOCKED when there is no image marker (not a built image)", async () => {
+    const r = await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({ readImage: async () => null }),
+    );
+    expect(r.verdict).toBe("BLOCKED");
+    expect(r.nextAction.kind).toBe("file-blocker-bi");
+  });
+
+  it("does not call ancestry when the image is not a git-sha", async () => {
+    let called = false;
+    await resolveLiveInstallReadiness(
+      { featureSha: FEATURE },
+      deps({
+        readImage: async () => ({ raw: "c".repeat(64), source: "content-hash" }),
+        isAncestor: async () => {
+          called = true;
+          return null;
+        },
+      }),
+    );
+    expect(called).toBe(false);
+  });
+});

--- a/apps/web/lib/verify/preflight-service.ts
+++ b/apps/web/lib/verify/preflight-service.ts
@@ -1,0 +1,77 @@
+// Server-side preflight service — the IO behind the verify_live_install_readiness
+// MCP tool, so Build Studio and in-portal coworkers hit the IDENTICAL verdict the
+// CLI surfaces (pnpm verify:preflight) use.
+//
+// Spec: docs/superpowers/specs/2026-06-06-procedural-functional-verification-design.md (§3.1, §6 slice 5)
+// BI-85433710 (surface-agnostic).
+//
+// The verdict logic stays single-sourced in computePreflightVerdict; this only
+// supplies the IO: the portal's own served identity (readImageVersion, same
+// process) and best-effort git ancestry. Dependencies are injected so the
+// orchestration is unit-testable without fs/git.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readImageVersion, type ImageVersion } from "@/lib/platform/image-version";
+import {
+  computePreflightVerdict,
+  type PreflightResult,
+} from "@/lib/verify/preflight";
+
+const execFileAsync = promisify(execFile);
+
+export type ReadinessDeps = {
+  /** The live install's served identity (the portal's own image marker). */
+  readImage: () => Promise<ImageVersion | null>;
+  /**
+   * Whether `feature` is contained in (ancestor-or-equal of) `served`. Returns
+   * null when it cannot be computed (git unavailable, commit not present).
+   */
+  isAncestor: (feature: string, served: string) => Promise<boolean | null>;
+};
+
+/** Real ancestry check; never throws — returns null on any failure. */
+export async function gitAncestry(
+  feature: string,
+  served: string,
+): Promise<boolean | null> {
+  if (feature.toLowerCase() === served.toLowerCase()) return true; // equal ⇒ contained
+  try {
+    await execFileAsync("git", ["merge-base", "--is-ancestor", feature, served]);
+    return true; // exit 0 ⇒ ancestor
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    return code === 1 ? false : null; // 1 ⇒ not ancestor; else uncomputable
+  }
+}
+
+export const defaultReadinessDeps: ReadinessDeps = {
+  readImage: () => readImageVersion(),
+  isAncestor: gitAncestry,
+};
+
+/**
+ * Resolve the live-install readiness verdict for a feature commit. Pure
+ * orchestration over injected IO — the verdict itself comes from the shared
+ * computePreflightVerdict so every surface is identical.
+ */
+export async function resolveLiveInstallReadiness(
+  params: { featureSha: string },
+  deps: ReadinessDeps = defaultReadinessDeps,
+): Promise<PreflightResult> {
+  const servedImage = await deps.readImage();
+  // This code runs inside the portal, so the install is reachable by definition;
+  // a null image means "not a built image" (dev/test), which the core maps to
+  // BLOCKED.
+  const featureContainedInServed =
+    servedImage && servedImage.source === "git-sha"
+      ? await deps.isAncestor(params.featureSha, servedImage.raw)
+      : null;
+
+  return computePreflightVerdict({
+    portalReachable: true,
+    servedImage,
+    featureSha: params.featureSha,
+    featureContainedInServed,
+  });
+}


### PR DESCRIPTION
## What & why

Follow-on to merged [#1558](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1558), **Slice 5** of **EP-VERIFY-PROC** — the last planned slice. Closes **surface-agnosticism**: Build Studio and in-portal coworkers now hit the *identical* preflight verdict the CLI surfaces (`pnpm verify:preflight`) use, via the shared `computePreflightVerdict` core. No second implementation — exactly what makes the three delivery surfaces interchangeable per the Unified Delivery Surfaces contract.

## Changes
- **`apps/web/lib/verify/preflight-service.ts`** — `resolveLiveInstallReadiness()`: the server-side IO behind the tool. Reads the portal's own served identity (`readImageVersion`, same process) and best-effort git ancestry, with dependencies **injected** so the orchestration is unit-testable without fs/git. The verdict itself stays single-sourced in `computePreflightVerdict`.
- **`preflight-service.test.ts`** — 6 cases over mocked deps.
- **`mcp-tools.ts`** — `verify_live_install_readiness` tool (read-only, `view_operations`, immediate): `featureSha` in → the structured `CAN-TEST`/`MUST-ADVANCE`/`BLOCKED` verdict out.

## Verification
- `vitest preflight-service` → **6/6**; preflight + tool-definition tests green
- `pnpm --filter web typecheck` → clean
- Substrate: source-local.

## Epic status
With this, all planned slices (1–5) and all six filed BIs of EP-VERIFY-PROC are implemented. Slices 1–3 merged in #1558; Slice 4 in [#1560](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1560); Slice 5 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
