### PR TITLE
doc(verify): point living docs at the procedural verification entry point (EP-VERIFY-PROC)

### DIFF
--- a/docs/operations/dpf-production-runtime.md
+++ b/docs/operations/dpf-production-runtime.md
@@ -18,6 +18,7 @@ This install runs three local runtime roles:
 - The **Build runtime** is the agent execution surface; humans see it through Build Studio's in-canvas preview (the footer "Open live preview" button) rather than treating it as a developer scratch surface.
 - The **Contributor preview** is opt-in via the `dev` compose profile. A plain `docker compose up -d` does not start it, and customer installs do not ship it by default.
 - Promote changes through branch → PR → merge → `/ops/self-upgrade` / governed promoter → Live portal verification rather than treating the Live portal as a scratch environment.
+- **Step zero for Live portal verification:** run `pnpm verify:preflight` (or the `verify_live_install_readiness` MCP tool / the `dpf-verify-on-live-install` skill) for a deterministic `CAN-TEST` / `MUST-ADVANCE` / `BLOCKED` verdict before driving a feature's happy path — instead of hand-comparing the served SHA. A `BLOCKED` verdict caused by an unrelated defect is a stop-and-file-a-BI condition, not a cue to refresh the portal by hand. Canonical procedure: [`2026-06-06-procedural-functional-verification-design.md`](../superpowers/specs/2026-06-06-procedural-functional-verification-design.md).
 
 ## Why this matters
 

--- a/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
+++ b/docs/superpowers/plans/2026-05-26-local-redeploy-helper.md
@@ -1,5 +1,7 @@
 # Local Redeploy Helper Implementation Plan
 
+> **Superseded scope note (2026-06-06).** `scripts/redeploy-portal.{ps1,sh}` is a **recovery / bootstrap** primitive only. It is **not** the feature-verification refresh path: AGENTS.md §5 and [`image-identity-equals-bytes`](../../founder-kernel/wiki/principles/image-identity-equals-bytes.md) reserve live-portal advancement for the governed self-upgrade pipeline (`/ops/self-upgrade`). Task 1's "update version-check drift guidance to point to the new helper" was **reversed** — `scripts/portal-version-check.{sh,ps1}` now point at the governed path, and the canonical entry point for verifying a feature on the live install is the preflight + `dpf-verify-on-live-install` skill ([`2026-06-06-procedural-functional-verification-design.md`](../specs/2026-06-06-procedural-functional-verification-design.md)). This historical plan is retained as the record of how the helper was built.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add one local redeploy helper per shell that builds and recreates `portal-init` and `portal` together so manual rebuilds cannot leave the init image behind the app image.


### PR DESCRIPTION
## What & why

Keeps the **living** docs current after the procedural-verification work landed (merged [#1558](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1558)), so `docs/` keeps disambiguating "what's current" across iterations — per your standing ask.

Scoped deliberately: `docs/README.md` already separates *living current-state* trees (`operations/`, `architecture/`, `user-guide/`, `install/`, `founder-kernel/`) from *dated historical* trees (`superpowers/specs|plans|audits`, `triage`) which are append-only. So this **does not rewrite history** — it updates the one living doc and adds a superseded *note* (not a rewrite) to the one historical plan that originated guidance my Slice 1 reversed.

## Changes
- **`docs/operations/dpf-production-runtime.md`** — new Rules line: "step zero for Live portal verification" names `pnpm verify:preflight` / the `verify_live_install_readiness` MCP tool / the `dpf-verify-on-live-install` skill + the BLOCKED stop-rule, linking the canonical spec. (The doc's existing rules were already current; this links policy → executable.)
- **`docs/superpowers/plans/2026-05-26-local-redeploy-helper.md`** — superseded scope note: `redeploy-portal` is recovery/bootstrap only; its "point version-check drift at the helper" task was reversed (the version-check scripts now point at the governed self-upgrade path). Plan retained as the build record.

## On the systemic question
A doc-freshness mechanism already exists — **`EP-DOCS-6B9F2A`** + **`BI-DOCS-GUARD`** (automated route/claim-drift checks, not yet implemented). Not duplicating it; this PR is the targeted content fix for the verification epic. The "drift tool pointing at forbidden remediation" class is a good concrete case for `BI-DOCS-GUARD` to eventually catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
