### PR TITLE
feat(ai-ops-map): Stage D1 — preview canvas honors provider + A2A filters (BI-65B0D697)

### DIFF
--- a/apps/web/components/platform/A2aInteractionsPanel.tsx
+++ b/apps/web/components/platform/A2aInteractionsPanel.tsx
@@ -40,6 +40,7 @@ import {
   type A2aActorRole,
   type A2aAuthorityFilter,
 } from "./ai-operations-map-prefs";
+import type { A2aControlCriteria } from "./operations-control-filters";
 
 const AUTHORITY_OPTIONS: Array<{ id: A2aAuthorityFilter; label: string }> = [
   { id: "all", label: "All" },
@@ -54,9 +55,11 @@ type Props = {
   /** Shared replay playhead from the provider routing timeline (null = no sync). */
   replayTime?: number | null;
   replayRange?: A2aReplayRange | null;
+  /** Publish resolved A2A control filters up so the preview canvas mirrors this panel (Stage D). */
+  onFilterChange?: (criteria: A2aControlCriteria) => void;
 };
 
-export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTime, replayRange }: Props) {
+export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTime, replayRange, onFilterChange }: Props) {
   const defaults = getDefaultA2aFilterPreference();
   const [typeFilters, setTypeFilters] = useState<OperationsMapA2aEdgeKind[]>(defaults.types);
   const [stateFilters, setStateFilters] = useState<OperationsMapA2aInteractionState[]>(defaults.states);
@@ -82,6 +85,13 @@ export function A2aInteractionsPanel({ coworkers, a2aEdges, a2aLegend, replayTim
     if (!hydrated.current) return;
     saveA2aFilterPreference({ types: typeFilters, states: stateFilters, actorId, actorRole, authority });
   }, [typeFilters, stateFilters, actorId, actorRole, authority]);
+
+  // Publish resolved control filters up so the preview canvas (Stage D) mirrors
+  // this panel exactly. Stable parent handler (useCallback). Replay is layered
+  // by the canvas separately, so only the control criteria are published here.
+  useEffect(() => {
+    onFilterChange?.({ types: typeFilters, states: stateFilters, actorId, actorRole, authority });
+  }, [onFilterChange, typeFilters, stateFilters, actorId, actorRole, authority]);
 
   const labelByAgentId = useMemo(
     () => new Map(coworkers.map((coworker) => [coworker.agentId, coworker.label])),

--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -235,12 +235,28 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("{canvasPreview ? (");
     expect(source).toContain("data-canvas-preview");
     expect(source).toContain("<OperationsTopologyCanvas");
-    expect(source).toContain("topology={routingTopology}");
+    expect(source).toContain("topology={canvasTopology}");
     expect(source).toContain("dimension={dimension}");
     expect(source).toContain("replayTime={sharedReplay?.time ?? null}");
     expect(source).toContain("replayRange={sharedReplay?.range ?? null}");
 
     // Legacy panels remain the default authoritative surface + replay source.
-    expect(source).toContain("<RoutingTopologyPanel routingTopology={routingTopology} onReplayChange={handleReplayChange} />");
+    expect(source).toContain("onReplayChange={handleReplayChange}");
+  });
+
+  it("feeds the preview canvas a control-filtered topology the panels publish up (Stage D1)", () => {
+    const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
+
+    // Shared pure filter helpers (single source of truth for canvas + panels).
+    expect(source).toContain('from "./operations-control-filters"');
+    expect(source).toContain("applyRoutingControlFilters(routingTopology, routingControl)");
+    expect(source).toContain("applyA2aControlFilters(routingTopology.a2aEdges, a2aControl)");
+
+    // Panels publish their resolved criteria up (mirrors onReplayChange).
+    expect(source).toContain("onControlFilterChange={handleRoutingControlChange}");
+    expect(source).toContain("onFilterChange={handleA2aControlChange}");
+
+    // The canvas consumes the filtered topology, not the raw one.
+    expect(source).toContain("topology={canvasTopology}");
   });
 });

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -39,6 +39,16 @@ import { StalledTaskRecoveryActions } from "./StalledTaskRecoveryActions";
 import { A2aInteractionsPanel } from "./A2aInteractionsPanel";
 import { DeliberationLensPanel } from "./DeliberationLensPanel";
 import { OperationsTopologyCanvas } from "./OperationsTopologyCanvas";
+import {
+  applyRoutingControlFilters,
+  applyA2aControlFilters,
+  providerMatchesTypeFilter,
+  markerMatchesRouteFilter,
+  type RoutingRouteFilter,
+  type RoutingProviderTypeFilter,
+  type RoutingControlCriteria,
+  type A2aControlCriteria,
+} from "./operations-control-filters";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -88,7 +98,6 @@ const ROUTE_STATE_LABEL: Record<OperationsMapRoutingRouteState, string> = {
   historical: "Historical route",
 };
 
-type RoutingRouteFilter = "all" | OperationsMapRoutingRouteState;
 type RoutingTopologyRoute = OperationsMapRoutingTopology["routes"][number];
 type RoutingTopologyMarker = OperationsMapRoutingTopology["markers"][number];
 type RoutingTopologyProvider = OperationsMapRoutingTopology["providers"][number];
@@ -101,7 +110,6 @@ type DisplayRoutingRoute = RoutingTopologyRoute & {
   eventCount: number;
   sourceRouteIds: string[];
 };
-type RoutingProviderTypeFilter = "llm" | "mcp" | "all";
 
 const ROUTE_FILTER_OPTIONS: Array<{ id: RoutingRouteFilter; label: string }> = [
   { id: "all", label: "All" },
@@ -268,6 +276,40 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
   // explicitly temporary and is removed at cutover (spec §7 Stage D/E).
   const [canvasPreview, setCanvasPreview] = useState(false);
 
+  // Stage D1: the legacy panels own the filter UI and publish their resolved
+  // control criteria up (mirroring onReplayChange) so the preview canvas honours
+  // exactly what the operator selects. Defaults are permissive; each panel
+  // publishes its real criteria on mount, so the canvas converges within a tick.
+  // These same pure helpers back the unified control rail at Stage E.
+  const [routingControl, setRoutingControl] = useState<RoutingControlCriteria>({
+    routeFilter: "all",
+    providerTypeFilter: "llm",
+    providerFilter: "all",
+  });
+  const [a2aControl, setA2aControl] = useState<A2aControlCriteria>({
+    types: ["a2a-delegation", "a2a-handoff", "a2a-task-lineage", "a2a-deliberation"],
+    states: ["active", "completed", "failed", "blocked"],
+    actorId: "all",
+    actorRole: "either",
+    authority: "all",
+  });
+  const handleRoutingControlChange = useCallback(
+    (criteria: RoutingControlCriteria) => setRoutingControl(criteria),
+    [],
+  );
+  const handleA2aControlChange = useCallback(
+    (criteria: A2aControlCriteria) => setA2aControl(criteria),
+    [],
+  );
+
+  // Topology fed to the preview canvas: control-filtered routes/providers/markers
+  // and A2A edges. The canvas layers the shared replay window on top.
+  const canvasTopology = useMemo(() => {
+    const { routes, providers, markers } = applyRoutingControlFilters(routingTopology, routingControl);
+    const a2aEdges = applyA2aControlFilters(routingTopology.a2aEdges, a2aControl);
+    return { ...routingTopology, routes, providers, markers, a2aEdges };
+  }, [routingTopology, routingControl, a2aControl]);
+
   const selectedStation = selected.kind === "station"
     ? template.stations.find((station) => station.id === selected.id) ?? null
     : null;
@@ -340,7 +382,7 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
               Unified canvas · preview — verifying parity against the panels below
             </p>
             <OperationsTopologyCanvas
-              topology={routingTopology}
+              topology={canvasTopology}
               dimension={dimension}
               replayTime={sharedReplay?.time ?? null}
               replayRange={sharedReplay?.range ?? null}
@@ -349,7 +391,11 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
         ) : null}
 
         {showProvider ? (
-          <RoutingTopologyPanel routingTopology={routingTopology} onReplayChange={handleReplayChange} />
+          <RoutingTopologyPanel
+            routingTopology={routingTopology}
+            onReplayChange={handleReplayChange}
+            onControlFilterChange={handleRoutingControlChange}
+          />
         ) : null}
 
         {showA2a ? (
@@ -360,6 +406,7 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
               a2aLegend={routingTopology.a2aLegend}
               replayTime={showProvider ? sharedReplay?.time ?? null : null}
               replayRange={showProvider ? sharedReplay?.range ?? null : null}
+              onFilterChange={handleA2aControlChange}
             />
 
             <DeliberationLensPanel deliberations={routingTopology.deliberations} />
@@ -560,9 +607,11 @@ export function AiOperationsMap({ template, agents, projections, routingTopology
 function RoutingTopologyPanel({
   routingTopology,
   onReplayChange,
+  onControlFilterChange,
 }: {
   routingTopology: OperationsMapRoutingTopology;
   onReplayChange?: (selectedTime: number, range: RoutingTimelineRange) => void;
+  onControlFilterChange?: (criteria: RoutingControlCriteria) => void;
 }) {
   const mapShellRef = useRef<HTMLDivElement>(null);
   const pinnedMarkerRef = useRef<string | null>(null);
@@ -593,6 +642,12 @@ function RoutingTopologyPanel({
   useEffect(() => {
     onReplayChange?.(selectedReplayTime, timelineRange);
   }, [onReplayChange, selectedReplayTime, timelineRange]);
+
+  // Publish the resolved provider-side control filters so the preview canvas
+  // (Stage D) mirrors this panel exactly. Stable parent handler (useCallback).
+  useEffect(() => {
+    onControlFilterChange?.({ routeFilter, providerTypeFilter, providerFilter });
+  }, [onControlFilterChange, routeFilter, providerTypeFilter, providerFilter]);
 
   const providersById = useMemo(
     () => new Map(routingTopology.providers.map((provider) => [provider.providerId, provider])),
@@ -2151,21 +2206,6 @@ function summarizeVisibleRouting(routes: DisplayRoutingRoute[], providers: Routi
     totalCostUsd: providers.reduce((total, provider) => total + provider.costUsd, 0),
     totalTokens: providers.reduce((total, provider) => total + provider.tokenTotal, 0),
   };
-}
-
-function providerMatchesTypeFilter(
-  provider: RoutingTopologyProvider | undefined,
-  filter: RoutingProviderTypeFilter,
-): boolean {
-  if (!provider) return false;
-  return filter === "all" || provider.providerType === filter;
-}
-
-function markerMatchesRouteFilter(marker: RoutingTopologyMarker, filter: RoutingRouteFilter): boolean {
-  if (filter === "all") return true;
-  if (filter === "scheduled") return marker.type === "scheduled";
-  if (filter === "failover") return marker.type === "failover" || marker.type === "error";
-  return false;
 }
 
 function routeSymbolCaption(marker: RoutingTopologyMarker, coworkerLabel: string): string {

--- a/apps/web/components/platform/operations-control-filters.test.ts
+++ b/apps/web/components/platform/operations-control-filters.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRoutingControlFilters,
+  applyA2aControlFilters,
+  providerMatchesTypeFilter,
+  markerMatchesRouteFilter,
+  type A2aControlCriteria,
+  type RoutingControlCriteria,
+} from "./operations-control-filters";
+import { buildOperationsMapTopologyFixture } from "@/test-support/operations-map-fixture";
+import type {
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
+} from "@/lib/ai-operations-map/types";
+
+const ALL_TYPES: OperationsMapA2aEdgeKind[] = [
+  "a2a-delegation",
+  "a2a-handoff",
+  "a2a-task-lineage",
+  "a2a-deliberation",
+];
+const ALL_STATES: OperationsMapA2aInteractionState[] = ["active", "completed", "failed", "blocked"];
+
+const routing = (overrides: Partial<RoutingControlCriteria> = {}): RoutingControlCriteria => ({
+  routeFilter: "all",
+  providerTypeFilter: "all",
+  providerFilter: "all",
+  ...overrides,
+});
+const a2a = (overrides: Partial<A2aControlCriteria> = {}): A2aControlCriteria => ({
+  types: ALL_TYPES,
+  states: ALL_STATES,
+  actorId: "all",
+  actorRole: "either",
+  authority: "all",
+  ...overrides,
+});
+
+describe("applyRoutingControlFilters", () => {
+  const topology = buildOperationsMapTopologyFixture();
+
+  it("passes everything through with the default (all) criteria", () => {
+    const result = applyRoutingControlFilters(topology, routing());
+    expect(result.routes).toHaveLength(4);
+    expect(result.providers).toHaveLength(2);
+    expect(result.markers).toHaveLength(3);
+  });
+
+  it("filters routes by state (active)", () => {
+    const result = applyRoutingControlFilters(topology, routing({ routeFilter: "active" }));
+    expect(result.routes.map((r) => r.id)).toEqual(["route:active"]);
+    // markerMatchesRouteFilter only recognises all/scheduled/failover, so an
+    // "active" route filter hides every marker — matching panel behaviour.
+    expect(result.markers).toHaveLength(0);
+  });
+
+  it("keeps error/failover markers (and their route) under the failover filter", () => {
+    const result = applyRoutingControlFilters(topology, routing({ routeFilter: "failover" }));
+    expect(result.routes.map((r) => r.id)).toEqual(["route:failover"]);
+    expect(result.markers.map((m) => m.id)).toEqual(["marker:d2:error"]);
+  });
+
+  it("filters by provider type — mcp removes all-LLM topology", () => {
+    const result = applyRoutingControlFilters(topology, routing({ providerTypeFilter: "mcp" }));
+    expect(result.routes).toHaveLength(0);
+    expect(result.providers).toHaveLength(0);
+    expect(result.markers).toHaveLength(0);
+  });
+
+  it("filters by a specific provider, dropping other providers' routes and markers", () => {
+    const result = applyRoutingControlFilters(topology, routing({ providerFilter: "openai" }));
+    expect(result.routes.map((r) => r.id).sort()).toEqual(["route:failover", "route:historical"]);
+    expect(result.providers.map((p) => p.providerId)).toEqual(["openai"]);
+    // Only the openai-attributed marker survives; anthropic markers drop.
+    expect(result.markers.map((m) => m.id)).toEqual(["marker:d2:error"]);
+  });
+
+  it("drops a route-attached marker when its route is filtered out", () => {
+    // providerFilter anthropic keeps route:active (+ its marker:d1:decision)
+    // and route:scheduled; route:failover (openai) is gone so marker:d2:error drops.
+    const result = applyRoutingControlFilters(topology, routing({ providerFilter: "anthropic" }));
+    expect(result.routes.map((r) => r.id).sort()).toEqual(["route:active", "route:scheduled"]);
+    expect(result.markers.map((m) => m.id).sort()).toEqual(["marker:d1:decision", "marker:unattributed"]);
+  });
+});
+
+describe("applyA2aControlFilters", () => {
+  const { a2aEdges } = buildOperationsMapTopologyFixture();
+
+  it("passes every edge with default (all) criteria", () => {
+    expect(applyA2aControlFilters(a2aEdges, a2a())).toHaveLength(3);
+  });
+
+  it("filters by edge kind", () => {
+    const result = applyA2aControlFilters(a2aEdges, a2a({ types: ["a2a-delegation"] }));
+    expect(result.map((e) => e.id)).toEqual(["a2a:delegation:1"]);
+  });
+
+  it("filters by interaction state", () => {
+    const result = applyA2aControlFilters(a2aEdges, a2a({ states: ["completed"] }));
+    expect(result.map((e) => e.id)).toEqual(["a2a:handoff:1"]);
+  });
+
+  it("filters by actor with role 'to'", () => {
+    const result = applyA2aControlFilters(a2aEdges, a2a({ actorId: "brand-analyst", actorRole: "to" }));
+    expect(result.map((e) => e.id).sort()).toEqual(["a2a:delegation:1", "a2a:handoff:1"]);
+  });
+
+  it("filters by actor with role 'from' (none originate from brand-analyst)", () => {
+    const result = applyA2aControlFilters(a2aEdges, a2a({ actorId: "brand-analyst", actorRole: "from" }));
+    expect(result).toHaveLength(0);
+  });
+
+  it("partitions cleanly by authority (governed ∪ ungoverned === all)", () => {
+    const governed = applyA2aControlFilters(a2aEdges, a2a({ authority: "governed" }));
+    const ungoverned = applyA2aControlFilters(a2aEdges, a2a({ authority: "ungoverned" }));
+    expect(governed.length + ungoverned.length).toBe(a2aEdges.length);
+    const ids = new Set([...governed, ...ungoverned].map((e) => e.id));
+    expect(ids.size).toBe(a2aEdges.length);
+  });
+});
+
+describe("shared predicates", () => {
+  const { providers, markers } = buildOperationsMapTopologyFixture();
+
+  it("providerMatchesTypeFilter", () => {
+    expect(providerMatchesTypeFilter(providers[0], "all")).toBe(true);
+    expect(providerMatchesTypeFilter(providers[0], "llm")).toBe(true);
+    expect(providerMatchesTypeFilter(providers[0], "mcp")).toBe(false);
+    expect(providerMatchesTypeFilter(undefined, "all")).toBe(false);
+  });
+
+  it("markerMatchesRouteFilter", () => {
+    const decision = markers.find((m) => m.type === "decision")!;
+    const error = markers.find((m) => m.type === "error")!;
+    expect(markerMatchesRouteFilter(decision, "all")).toBe(true);
+    expect(markerMatchesRouteFilter(decision, "failover")).toBe(false);
+    expect(markerMatchesRouteFilter(error, "failover")).toBe(true);
+    expect(markerMatchesRouteFilter(decision, "scheduled")).toBe(false);
+  });
+});

--- a/apps/web/components/platform/operations-control-filters.ts
+++ b/apps/web/components/platform/operations-control-filters.ts
@@ -1,0 +1,140 @@
+// Pure control-filter helpers for the Operations Map.
+//
+// Single source of truth for "which routes / providers / markers / A2A edges
+// survive the operator's filter selections". Shared by the legacy
+// RoutingTopologyPanel and A2aInteractionsPanel (which own the filter UI today)
+// and by the unified OperationsTopologyCanvas (Stage D), so the canvas honours
+// exactly what the operator sets. These helpers are destined to back the single
+// control rail at Stage E cutover, when the legacy panels are deleted.
+//
+// Replay is intentionally NOT applied here. The shared replay window is layered
+// on top by the canvas (routeVisibleAtReplayTime / a2aEdgeVisibleAtReplayTime)
+// and by the panels, so control filtering and time scrubbing compose cleanly.
+
+import type {
+  OperationsMapRoutingTopology,
+  OperationsMapRoutingRoute,
+  OperationsMapRoutingProvider,
+  OperationsMapRoutingMarker,
+  OperationsMapRoutingRouteState,
+  OperationsMapA2aEdge,
+  OperationsMapA2aEdgeKind,
+  OperationsMapA2aInteractionState,
+} from "@/lib/ai-operations-map/types";
+import { a2aEdgeIsGoverned } from "./a2a-interaction-graph";
+
+export type RoutingRouteFilter = "all" | OperationsMapRoutingRouteState;
+export type RoutingProviderTypeFilter = "llm" | "mcp" | "all";
+
+/** Provider-side control filters owned by RoutingTopologyPanel. */
+export type RoutingControlCriteria = {
+  routeFilter: RoutingRouteFilter;
+  providerTypeFilter: RoutingProviderTypeFilter;
+  /** A specific providerId, or "all". */
+  providerFilter: string;
+};
+
+export type A2aActorRole = "either" | "from" | "to";
+export type A2aAuthorityFilter = "all" | "governed" | "ungoverned";
+
+/** A2A-side control filters owned by A2aInteractionsPanel. */
+export type A2aControlCriteria = {
+  types: OperationsMapA2aEdgeKind[];
+  states: OperationsMapA2aInteractionState[];
+  /** A specific coworker id, or "all". */
+  actorId: string;
+  actorRole: A2aActorRole;
+  authority: A2aAuthorityFilter;
+};
+
+export function providerMatchesTypeFilter(
+  provider: OperationsMapRoutingProvider | undefined,
+  filter: RoutingProviderTypeFilter,
+): boolean {
+  if (!provider) return false;
+  return filter === "all" || provider.providerType === filter;
+}
+
+export function markerMatchesRouteFilter(
+  marker: OperationsMapRoutingMarker,
+  filter: RoutingRouteFilter,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "scheduled") return marker.type === "scheduled";
+  if (filter === "failover") return marker.type === "failover" || marker.type === "error";
+  return false;
+}
+
+/**
+ * Apply the provider-side control filters to a topology, returning the routes,
+ * provider nodes, and markers that should be visible (before replay). Mirrors
+ * the predicate RoutingTopologyPanel computes internally so the canvas matches
+ * the panel exactly.
+ */
+export function applyRoutingControlFilters(
+  topology: Pick<OperationsMapRoutingTopology, "routes" | "providers" | "markers">,
+  criteria: RoutingControlCriteria,
+): {
+  routes: OperationsMapRoutingRoute[];
+  providers: OperationsMapRoutingProvider[];
+  markers: OperationsMapRoutingMarker[];
+} {
+  const { routeFilter, providerTypeFilter, providerFilter } = criteria;
+  const providersById = new Map(topology.providers.map((provider) => [provider.providerId, provider]));
+
+  const routes = topology.routes.filter((route) => {
+    const routeMatches = routeFilter === "all" || route.state === routeFilter;
+    const provider = providersById.get(route.providerId);
+    const providerMatches = providerFilter === "all"
+      ? providerMatchesTypeFilter(provider, providerTypeFilter)
+      : route.providerId === providerFilter;
+    return routeMatches && providerMatches;
+  });
+
+  const providers = topology.providers.filter((provider) => {
+    if (!providerMatchesTypeFilter(provider, providerTypeFilter)) return false;
+    return providerFilter === "all" || provider.providerId === providerFilter;
+  });
+
+  const survivingRouteIds = new Set(routes.map((route) => route.id));
+  const markers = topology.markers.filter((marker) => {
+    if (!markerMatchesRouteFilter(marker, routeFilter)) return false;
+    if (marker.providerId) {
+      if (providerFilter !== "all" && marker.providerId !== providerFilter) return false;
+      if (!providerMatchesTypeFilter(providersById.get(marker.providerId), providerTypeFilter)) return false;
+    }
+    // Route-attached markers only survive if their route survived the filters.
+    if (marker.routeId) return survivingRouteIds.has(marker.routeId);
+    return true;
+  });
+
+  return { routes, providers, markers };
+}
+
+/**
+ * Apply the A2A-side control filters to a set of edges (before replay). Mirrors
+ * the predicate A2aInteractionsPanel computes internally.
+ */
+export function applyA2aControlFilters(
+  edges: OperationsMapA2aEdge[],
+  criteria: A2aControlCriteria,
+): OperationsMapA2aEdge[] {
+  const { types, states, actorId, actorRole, authority } = criteria;
+  return edges.filter((edge) => {
+    if (!types.includes(edge.edgeKind)) return false;
+    if (!states.includes(edge.state)) return false;
+    if (actorId !== "all") {
+      const matchesFrom = edge.fromCoworkerId === actorId;
+      const matchesTo = edge.toCoworkerId === actorId;
+      if (actorRole === "from" && !matchesFrom) return false;
+      if (actorRole === "to" && !matchesTo) return false;
+      if (actorRole === "either" && !matchesFrom && !matchesTo) return false;
+    }
+    if (authority !== "all") {
+      const governed = a2aEdgeIsGoverned(edge);
+      if (authority === "governed" && !governed) return false;
+      if (authority === "ungoverned" && governed) return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
## What

**Stage D1** — the preview canvas now **honors the operator's filters**, closing the one known gap from the Stage D live verification. Before this, the canvas honored only dimension + replay and showed the full topology while the legacy panels filtered (visible as the canvas showing all 9 providers vs the panel's LLM-filtered 4).

Design: §7 Stage D. Plan: `docs/superpowers/plans/2026-06-05-three-band-stage-d-wiring-and-verification.md` (D1). Backlog: **BI-65B0D697**.

## How

- New pure module **`operations-control-filters.ts`** — the single source of truth for which **routes / providers / markers / A2A edges** survive the operator's filter selections. Replay is intentionally layered on top by the canvas, so control filtering and time scrubbing compose.
- Each legacy panel **publishes its resolved control criteria up** (mirroring the proven `onReplayChange` pattern): `RoutingTopologyPanel` → `{routeFilter, providerTypeFilter, providerFilter}`; `A2aInteractionsPanel` → `{types, states, actorId, actorRole, authority}`.
- The host applies the shared helpers to feed the canvas a **control-filtered topology**. Panels remain the authoritative control surface; the canvas mirrors them.
- **Dedup:** `providerMatchesTypeFilter` / `markerMatchesRouteFilter` and the routing filter types moved out of `AiOperationsMap` into the shared module (−22 lines there). These helpers are what the unified control rail will use at Stage E.

## Verification

- `pnpm --filter web test` — full suite **9789 passed, 0 failures**.
- `pnpm --filter web typecheck` — clean (re-verified after rebasing onto current `main`). CI is the binding gate.
- New helper tests: route-state / provider-type / specific-provider filtering + **route-attached marker survival**, and A2A type/state/actor-role/authority partitioning against the Stage 0 fixture (26 cases).

## Notes

- Additive; canvas still behind the temporary preview switch (default OFF). **Off clean `main`** (not stacked).
- Next: live drive on the portal (post self-upgrade) to confirm filters move the canvas in lockstep with the panels — then **Stage E** (default to canvas, delete legacy panels + the temporary switch + now-shared helpers' old call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
