### PR TITLE
fix(test): stop mcp-server-health stdio test racing vitest's 5s timeout

### DIFF
--- a/apps/web/lib/tak/mcp-server-health.test.ts
+++ b/apps/web/lib/tak/mcp-server-health.test.ts
@@ -97,15 +97,35 @@ describe("checkMcpServerHealth", () => {
 
     it("accepts a valid MCP runner basename even with absolute path", async () => {
       // The allowlist matches on basename, so a fully-qualified
-      // `/usr/local/bin/npx` is still accepted. We only assert that
-      // safeSpawn doesn't reject — the subsequent spawn is mocked
-      // upstream and won't actually run.
+      // `/usr/local/bin/npx` is still accepted (not rejected by safeSpawn).
+      // The mocked runner answers the initialize handshake immediately so the
+      // check resolves in milliseconds instead of waiting out the real 10s
+      // stdio timeout — which exceeds vitest's 5s default test timeout and
+      // made this test fail spuriously (timeout race, not an allowlist reject).
       const { spawn } = await import("child_process");
+      let onStdoutData: ((chunk: Buffer) => void) | undefined;
       vi.mocked(spawn).mockImplementation(
         () =>
           ({
-            stdout: { on: vi.fn() },
-            stdin: { write: vi.fn() },
+            stdout: {
+              on: (event: string, cb: (chunk: Buffer) => void) => {
+                if (event === "data") onStdoutData = cb;
+              },
+            },
+            stdin: {
+              write: () => {
+                // Simulate the server replying to the initialize request.
+                onStdoutData?.(
+                  Buffer.from(
+                    JSON.stringify({
+                      jsonrpc: "2.0",
+                      id: 1,
+                      result: { protocolVersion: "2024-11-05" },
+                    }) + "\n",
+                  ),
+                );
+              },
+            },
             on: vi.fn(),
             kill: vi.fn(),
           }) as unknown as ReturnType<typeof spawn>,
@@ -115,8 +135,10 @@ describe("checkMcpServerHealth", () => {
         command: "/usr/local/bin/npx",
         args: ["-y", "some-server"],
       });
-      // Timeout because no protocolVersion response, but NOT an allowlist reject.
+      // The valid basename is accepted (no allowlist rejection) and the
+      // handshake completes.
       expect(result.error ?? "").not.toMatch(/allowlist/);
+      expect(result.healthy).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What & why

`Unit Tests` is failing on **every open PR** (#1560, #1561, #1562, and others) on a single test — `lib/tak/mcp-server-health.test.ts > "accepts a valid MCP runner basename even with absolute path"`. This is a **pre-existing `main` breakage**, not caused by any of those PRs (it reproduces locally and on a doc-only branch).

**Root cause:** the test mocks `spawn` with a non-responding stdout, so `checkMcpServerHealth` runs to its real `STDIO_TIMEOUT_MS` (**10s**) — which exceeds vitest's **5000ms** default test timeout. The test times out before its assertion and fails deterministically (~5s).

## Fix
The mocked runner now answers the `initialize` handshake immediately, so the check resolves in ~ms. Still asserts the valid basename is **not** allowlist-rejected (the original intent), and additionally that the handshake completes (`healthy: true`). **Test-only** change — no production code touched.

## Verification
`pnpm --filter web exec vitest run lib/tak/mcp-server-health.test.ts` → **8/8 pass in ~0.3s** (was 5011ms + fail).

Unblocks `Unit Tests` for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)