### PR TITLE
fix(verify): add TOOL_TO_GRANTS mapping for verify_live_install_readiness

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -259,6 +259,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   run_release_gate: ["release_gate_create"],
   schedule_release_bundle: ["release_plan_create"],
   get_release_status: ["release_plan_read"],
+  verify_live_install_readiness: ["release_plan_read"],
 
   // Discovery / Monitoring
   summarize_estate_posture: ["registry_read"],


### PR DESCRIPTION
## What & why

The `verify_live_install_readiness` MCP tool (added in merged [#1561](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1561)) landed in `PLATFORM_TOOLS` **without** a `TOOL_TO_GRANTS` entry. The **Routing Invariants Audit / INV-1** ("every `PLATFORM_TOOLS` entry has a `TOOL_TO_GRANTS` mapping") correctly flags it as a new violation — reddening the routing audit on `main` and on every PR branched after #1561 merged (#1562 etc.).

This is the second of the two failures on those PRs (the first, a `mcp-server-health` test timeout race, is [#1565](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1565)). It's my own slice-5 gap: typecheck + unit tests didn't cover grant mappings.

## Fix
Map it to `["release_plan_read"]` — a read-only deployment/release-readiness grant, matching its sibling `get_release_status`. One line.

## Verification
- INV-1 static check (PLATFORM_TOOLS − TOOL_TO_GRANTS) → **0 missing**
- `agent-grants.test.ts` → **102/102**
- `pnpm --filter web typecheck` → clean

Unblocks `Routing Invariants Audit` for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)