### PR TITLE
fix(backups): write run trace to log.txt so admin "View log" isn't blank

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -567,7 +567,9 @@ export function BackupsClient({
                     color: "var(--dpf-text)",
                   }}
                 >
-                  {openLog.data.logTail ?? "(log empty)"}
+                  {openLog.data.logTail && openLog.data.logTail.trim().length > 0
+                    ? openLog.data.logTail
+                    : "(log empty)"}
                 </pre>
               </>
             )}

--- a/scripts/backup-neo4j.sh
+++ b/scripts/backup-neo4j.sh
@@ -28,7 +28,16 @@
 
 set -eu
 
-log() { printf '[backup-neo4j-trace] %s\n' "$*"; }
+# Emit each trace line to stdout (captured by the TS orchestrator) AND mirror it
+# into $LOG_FILE so the admin "View log" drawer shows the curated run trace, not
+# just raw docker output. LOG_FILE is set later; the guard tolerates the early
+# prereq window, and `|| true` keeps `set -e` from tripping on the mirror write.
+log() {
+  printf '[backup-neo4j-trace] %s\n' "$*"
+  if [ -n "${LOG_FILE:-}" ]; then
+    printf '[backup-neo4j-trace] %s\n' "$*" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+}
 fail() {
   log "failed: $1"
   exit "${2:-1}"
@@ -94,7 +103,9 @@ log "neo4j_image=$NEO4J_IMAGE"
 # Stop the running container so the database is offline for the dump.
 # 30-second grace period gives Neo4j time to flush + checkpoint.
 log "stopping Neo4j container"
-docker stop --timeout=30 "$NEO4J_CONTAINER" > "$LOG_FILE" 2>&1 || fail "could not stop $NEO4J_CONTAINER" 3
+# Append (>>) rather than truncate so the trace lines already mirrored into
+# log.txt (host path, image tag, "starting offline dump") are preserved.
+docker stop --timeout=30 "$NEO4J_CONTAINER" >> "$LOG_FILE" 2>&1 || fail "could not stop $NEO4J_CONTAINER" 3
 
 # Helper to restart the container on every exit path. Defined before the
 # dump so a dump failure still restarts Neo4j. We track success/fail of

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -31,7 +31,18 @@
 
 set -eu
 
-log() { printf '[backup-trace] %s\n' "$*"; }
+# Emit each trace line to stdout (captured by the TS orchestrator's console)
+# AND mirror it into $LOG_FILE so the admin "View log" drawer has meaningful
+# content. Without the file mirror, log.txt only ever held pg_dump's stderr —
+# which is empty on a successful dump, leaving the operator with a blank log.
+# LOG_FILE is set later; the guard tolerates the early prereq window before it
+# exists, and `|| true` keeps `set -e` from tripping on the mirror write.
+log() {
+  printf '[backup-trace] %s\n' "$*"
+  if [ -n "${LOG_FILE:-}" ]; then
+    printf '[backup-trace] %s\n' "$*" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+}
 fail() {
   log "failed: $1"
   exit "${2:-1}"
@@ -67,7 +78,9 @@ log "pg_version=$PG_VERSION"
 # Run pg_dump inside the postgres container; stream output to a host file.
 # Custom format (-Fc) is compressed, supports selective restore, and is what
 # the existing promoter script uses (scripts/promote.sh:157).
-if docker exec "$DB_CONTAINER" pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB" > "$DUMP_FILE" 2> "$LOG_FILE"; then
+# Append (2>>) rather than truncate so the [backup-trace] lines already mirrored
+# into log.txt survive; pg_dump's stderr (empty on success) is added after them.
+if docker exec "$DB_CONTAINER" pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB" > "$DUMP_FILE" 2>> "$LOG_FILE"; then
   log "pg_dump succeeded size=$(wc -c < "$DUMP_FILE")"
 else
   EXIT=$?

--- a/scripts/backup-qdrant.sh
+++ b/scripts/backup-qdrant.sh
@@ -20,7 +20,16 @@
 
 set -eu
 
-log() { printf '[backup-qdrant-trace] %s\n' "$*"; }
+# Emit each trace line to stdout (captured by the TS orchestrator) AND mirror it
+# into $LOG_FILE so the admin "View log" drawer shows the curated run trace, not
+# just raw curl output. LOG_FILE is set later; the guard tolerates the early
+# prereq window, and `|| true` keeps `set -e` from tripping on the mirror write.
+log() {
+  printf '[backup-qdrant-trace] %s\n' "$*"
+  if [ -n "${LOG_FILE:-}" ]; then
+    printf '[backup-qdrant-trace] %s\n' "$*" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+}
 fail() {
   log "failed: $1"
   exit "${2:-1}"


### PR DESCRIPTION
## Problem

On **Admin → Backups**, clicking **View log** opened the drawer fine (the manifest JSON rendered), but the **LOG (TAIL)** panel was always blank — for every backup, including healthy `OK` runs.

## Root cause

All three backup scripts emit their useful `[backup-trace]` progress lines to **stdout**, which the TS orchestrator captures to the portal console — *not* to the `log.txt` file the drawer reads. `log.txt` only ever captured the **underlying tool's** output:

- `scripts/backup-postgres.sh` redirected **only `pg_dump`'s stderr** into `log.txt` (`2> "$LOG_FILE"`). A successful `pg_dump` is silent, so `log.txt` was a **0-byte file** on every successful run → blank drawer.
- neo4j/qdrant captured some docker/curl output but still dropped the curated trace, and neo4j's first redirect (`> "$LOG_FILE"`) truncated anything written earlier.

## Fix

- **`backup-{postgres,neo4j,qdrant}.sh`**: `log()` now mirrors each trace line into `$LOG_FILE` as well as stdout (guarded for the early pre-`LOG_FILE` prereq window; `|| true` keeps `set -e` safe).
- Switched the truncating redirects to **appending** (`pg_dump 2>>`, neo4j `docker stop >>`) so captured tool output adds to the trace instead of erasing it.
- **`BackupsClient.tsx`**: an empty/whitespace `logTail` now renders `(log empty)` instead of a silent blank box.

## Caveats

1. This fixes **future** backups. The backups already on disk keep their empty logs — there is no content to recover (the tools never wrote any).
2. The scripts ship **inside the portal image**, so this takes effect on a live install only after the portal image is rebuilt and a fresh backup runs.

## Verification

- `sh -n` clean on all three scripts.
- Simulated a silent successful `pg_dump`: previously produced a 0-byte `log.txt`, now produces a populated trace.
- `pnpm --filter web exec vitest run lib/operate/backups` → 54 passed, 3 skipped.
- `pnpm --filter web typecheck` → clean. Pre-commit gitleaks + scoped typecheck passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
