### PR TITLE
fix(coworker): recover from hung clearConversation so the panel can't wedge on "Sending…" (BI-63906D5D)

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -776,9 +776,36 @@ export function AgentCoworkerPanel({
     setClearConfirmOpen(false);
 
     startClearing(async () => {
-      const result = await clearConversation({ threadId });
+      // BI-63906D5D — coworker panel wedge: useTransition keeps `isClearing`
+      // true until this async resolves, and `isClearing` disables the input
+      // (placeholder "Sending..."). clearConversation can hang server-side
+      // (observed after an aborted/ghost-called coworker turn left the thread
+      // mid-flight), which left the panel permanently wedged — surviving a
+      // page reload and a portal restart, with no operator recovery. Race the
+      // call against a timeout so the transition — and therefore the input —
+      // always recovers, then reset local state best-effort so the operator can
+      // keep working even if the server side never confirmed the clear.
+      const CLEAR_TIMEOUT_MS = 10_000;
+      let timedOut = false;
+      const result = await Promise.race([
+        clearConversation({ threadId }),
+        new Promise<{ error: string }>((resolve) =>
+          setTimeout(() => {
+            timedOut = true;
+            resolve({ error: "clearConversation timed out" });
+          }, CLEAR_TIMEOUT_MS),
+        ),
+      ]);
       if ("error" in result) {
         console.warn("clearConversation error:", result.error);
+        if (timedOut) {
+          // Best-effort local reset so a hung server action doesn't strand the
+          // operator. The input re-enables as soon as this async returns.
+          setMessages([]);
+          setBuildTasks(new Map());
+          setBuildProgress(null);
+          onConversationCleared?.();
+        }
         return;
       }
       setMessages([]);


### PR DESCRIPTION
## Problem
The Build Studio coworker panel can wedge **permanently** at placeholder "Sending…", surviving page reload **and** a portal restart, with no operator recovery. This blocks the plan-revision loop and was a dominant "Build Studio doesn't work as intended" surface this session.

## Root cause
`AgentMessageInput` is disabled when `disabled = isClearing || !threadId` (placeholder "Sending…"). `handleConfirmClear` runs `clearConversation` inside `useTransition`'s `startClearing` with **no timeout** — so if the server action hangs (observed after an aborted/ghost-called coworker turn left the thread mid-flight), `isClearing` stays `true` forever and the input is dead. Unlike `isBusy` (healed by the existing 15s recovery poll), `isClearing` had no recovery path.

## Fix
Race `clearConversation` against a 10s timeout so the transition — and thus the input — always recovers, and reset local conversation state best-effort on timeout so the operator is never stranded. Localized to `handleConfirmClear`; no behavior change on the success path.

## Context
Found while driving FB-F4D77326 end-to-end (the build that proved the Build Studio pipeline works after the BI-BA67108A crash fix). Part of **EP-VERIFY-PROC** (deterministic coworker-turn lifecycle). The server-side companion — emit a terminal SSE/turn-status on every abort path so the client never depends on this fallback — remains in BI-63906D5D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)