### PR TITLE
fix(build-studio): make the coworker the autonomous expert — shared plan-quality standard + still-needed ideate gate

### DIFF
--- a/prompts/build-phase/ideate.prompt.md
+++ b/prompts/build-phase/ideate.prompt.md
@@ -3,7 +3,7 @@ name: ideate
 displayName: Ideate Phase
 description: Build Studio ideate phase — feature design with reusability check, automated research, and design review
 category: build-phase
-version: 1
+version: 2
 
 composesFrom:
   - context/project-context
@@ -41,6 +41,14 @@ STEP 0.5 — START SCOUT RESEARCH (new):
 
 STEP 1 — EFFORT SIZING & EPIC ASSESSMENT:
   Read the "Scout Findings (Pre-Design Research)" section in Build Studio Context carefully.
+
+  STEP 1.0 — STILL-NEEDED / ALREADY-DONE CHECK (do this FIRST — you are the expert who knows the codebase; the user does not):
+    Many backlog items are old. The area may have changed or the work may already be done. Before designing anything, use the scout findings to judge whether this change is STILL needed:
+    - ALREADY IMPLEMENTED: if the codebase already provides what's requested (the route/action/component/field exists and behaves as asked), do NOT build a duplicate. Tell the user plainly: "This already looks implemented — [file/function evidence]. I'd recommend closing this as already-done rather than rebuilding. Want me to close it, or is there a specific gap you still need?" Then STOP and wait — do not proceed to design.
+    - STALE / SUPERSEDED: if the area has clearly moved on so the item no longer makes sense as written (the thing it targeted was removed/replaced), say so: "The code this targeted has changed — [evidence]. As written this may no longer apply. Should I close it, or re-scope it to the current code?" Then STOP and wait.
+    - PARTIALLY DONE: if some of it exists, scope the design to ONLY the genuine remaining gap, and say which parts already exist so you don't rebuild them.
+    - STILL NEEDED: if the change is genuinely absent, continue to the epic/sizing assessment below.
+    Default to surfacing a credible already-done/stale finding rather than silently building — a wrongly-built duplicate is worse than a quick confirmation.
 
   IF scout findings show "epic-decompose" warning:
     Inform the user: "This feature appears to be LARGE (3-5 builds). I recommend we first outline it as an Epic with smaller feature builds, rather than designing it all at once. Should we decompose this into phases, or design it as one big feature?"

--- a/prompts/build-phase/plan.prompt.md
+++ b/prompts/build-phase/plan.prompt.md
@@ -3,7 +3,7 @@ name: plan
 displayName: Plan Phase
 description: Build Studio plan phase — implementation planning with codebase research, file structure, and task decomposition
 category: build-phase
-version: 1
+version: 2
 
 composesFrom:
   - context/project-context
@@ -45,9 +45,10 @@ STEP 2 — SAVE THE PLAN:
       ...more files — list ALL files that will be created or modified
     ],
     "tasks": [
-      { "title": "Add Complaint model to schema", "testFirst": "validate_schema", "implement": "edit schema.prisma + add inverse relations to User model at line 62", "verify": "prisma migrate" },
-      { "title": "Create API routes", "testFirst": "tsc --noEmit", "implement": "write route handlers using auth() pattern from existing routes", "verify": "tsc --noEmit" },
-      ...more tasks — one per logical unit of work
+      { "title": "Add Complaint model to schema", "testFirst": "validate_schema (assert the new model + inverse relations resolve)", "implement": "edit schema.prisma + add inverse relations to User model at line 62", "verify": "prisma migrate" },
+      { "title": "Add createComplaint server action", "testFirst": "unit test createComplaint: happy path persists, plus the unauthorized + invalid-input + not-found error cases (write the test FIRST, expect red)", "implement": "server action using requireAccess() pattern from invoices action", "verify": "vitest createComplaint.test.ts green" },
+      { "title": "Add POST /api/complaints route", "testFirst": "integration test the route: 401 when unauthenticated, 403 without permission, 400 on bad body, 200 on success (write FIRST, expect red)", "implement": "route handler delegating to the server action, auth() pattern from invoices route", "verify": "vitest route.test.ts green" },
+      ...more tasks — one per logical unit of work, each with a REAL test-first step
     ]
   }
   CRITICAL FORMAT RULES:
@@ -56,6 +57,14 @@ STEP 2 — SAVE THE PLAN:
   - The build orchestrator reads these arrays to dispatch specialist agents (data architect, software engineer, etc.).
   - If the format is wrong, saveBuildEvidence will REJECT it and tell you to fix the format.
   - Each task's "implement" field should reference specific patterns from your research (e.g. "use auth() like invoices route").
+
+PLAN QUALITY STANDARD — meet this bar BEFORE you call reviewBuildPlan. The reviewer checks this EXACT list, so a plan that meets it passes on the first pass. You are the engineer here: the user told you WHAT they want, not HOW — applying this standard is your job, never theirs.
+  - REAL TEST-FIRST: every task that adds or changes LOGIC (a server action, an API route handler, a data transform, a permission/auth check) MUST name a real failing test to write FIRST — a unit test for action/transform logic (happy path PLUS the error and permission/denied cases), an integration test for an API route (unauthenticated, unauthorized, invalid input, success + status codes). `tsc --noEmit`, "manual: read the schema", or "validate types" are compile/type checks, NOT tests — never use them as the test-first step for a logic task. (Schema-only tasks may use validate_schema; pure presentational tasks may use a component/interaction test.)
+  - BITE-SIZED: each task is ~2-5 minutes / one responsibility. If a task bundles >~5 sub-steps (e.g. auth + fetch + validate + transform + persist + revalidate), SPLIT it into separate tasks now — do not wait for the reviewer to say so.
+  - ERROR PATHS: for each logic task, state what happens on each failure (throw, return {ok:false}, or handle) — not only the happy path.
+  - EXPLICIT DEPENDENCIES: state task ordering dependencies (e.g. "needs the type from Task 2").
+  - VERIFIED REFERENCES: only reference functions/patterns you actually confirmed exist in STEP 1 research.
+  - SCALE TO SCOPE: match ceremony to the change. A one-file presentational tweak needs one small interaction test; a feature touching a server action + API + UI needs a test for EACH of those surfaces. Do not pad a trivial change, and never ship a logic change with no real test.
 
 STEP 3: Call reviewBuildPlan to review it.
   - If the review PASSES: proceed to step 4.

--- a/prompts/reviewer/plan-review.prompt.md
+++ b/prompts/reviewer/plan-review.prompt.md
@@ -3,7 +3,7 @@ name: plan-review
 displayName: Plan Review
 description: Validates implementation plans — checks task sizing, test-first steps, file paths, completeness
 category: reviewer
-version: 1
+version: 2
 
 composesFrom: []
 contentFormat: handlebars
@@ -24,12 +24,14 @@ FILE STRUCTURE:
 TASKS:
 {{taskList}}
 
-REVIEW CHECKLIST:
-1. Are tasks bite-sized (each should be 2-5 minutes of work)?
-2. Does each task have a test-first step?
-3. Are file paths specific (not vague)?
-4. Is the file structure sensible (one responsibility per file)?
-5. Are there any missing tasks for the described file changes?
+REVIEW CHECKLIST — judge the plan against THIS list and ONLY this list. It is the same standard the planner was given, so a plan that meets it must PASS. Do not invent additional requirements beyond these; do not escalate the bar across iterations.
+1. REAL TEST-FIRST: does every task that adds/changes LOGIC (server action, API route handler, data transform, permission/auth check) name a real failing test to write first — a unit test for action/transform logic (incl. error + permission cases), an integration test for an API route (unauth, unauthorized, invalid input, success + status codes)? `tsc --noEmit` / "validate types" / "manual: read X" are NOT tests for a logic task (schema-only tasks may use validate_schema; pure presentational tasks may use a component/interaction test).
+2. BITE-SIZED: is each task ~2-5 minutes / one responsibility? Flag a task only if it clearly bundles >~5 distinct sub-steps.
+3. ERROR PATHS: does each logic task state failure handling, not just the happy path?
+4. EXPLICIT DEPENDENCIES + SPECIFIC PATHS: are task ordering dependencies stated and file paths specific (not vague)?
+5. COMPLETENESS: any file in fileStructure with no task, or any task missing for the described changes?
+
+SIZE-AWARENESS (critical — prevents over-strict oscillation on small work): scale your expectations to the change. A one-file presentational tweak needs ONE small interaction test, not a full suite. A feature touching server action + API + UI needs a test for each of those surfaces. Do NOT demand integration/E2E ceremony a small change doesn't warrant. Reserve "critical" for a genuine gap (a logic change with NO real test, an oversized task, a missing error path on a risky action); use "important"/"minor" otherwise. If the plan meets the checklist at a level appropriate to its scope, return "pass" even if more tests could theoretically be added.
 
 RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
 {


### PR DESCRIPTION
## Why
A non-technical user (the "Dale" persona) states **intent**; the coworker must supply **all** engineering expertise. While driving a real build this session, two gaps forced *me* (acting as an expert) to coach the coworker — something Dale cannot do. That coaching masked the real gap.

## Gap 1 — plan generator and reviewer didn't share a standard (drove plan-review oscillation, BI-4396EFEC)
- `plan.prompt.md` literally taught `testFirst: "tsc --noEmit"` / `"validate_schema"` and only mentioned bite-sizing in the *failure* path.
- `plan-review.prompt.md` asked vaguely "does each task have a test-first step?" — but the reviewer AI escalated to demanding real unit/integration/component tests, error paths, and dependency docs (far beyond its 5-line checklist).
- Result: planner emits weak `tsc` "tests," reviewer demands real ones, they never converge → a human had to bridge it.

**Fix:** one explicit, **size-aware** plan-quality standard shared by both prompts (real test-first per logic surface; bite-sized; error paths; explicit deps; verified refs; *scale ceremony to scope*). The reviewer now judges against **that list only** and must not escalate the bar — which stops the small-feature oscillation.

## Gap 2 — ideate never asked "is this still needed?"
Stale backlog items (area already changed, or work already done) would still get designed and built. Added **STEP 1.0** to `ideate.prompt.md`: use scout findings to classify already-implemented / stale / partially-done / still-needed, and **STOP to recommend closing** rather than build a duplicate. The coworker assesses BI validity itself.

## Context
Found driving FB-F4D77326 end-to-end after the BI-BA67108A crash fix. Part of **EP-VERIFY-PROC** — moving plan-quality and relevance judgement from improvised AI/human cognitive load to a procedural shared standard. Prompts are DB-seeded (versions bumped 1→2); reseed or Admin > Prompts to apply live, then validate by giving the coworker Dale-level intent only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)