### PR TITLE
fix(routing): honest tool-use failure message + plain-language issue reports (BI-23E0714C, BI-E42C0B7E)

### DIFF
--- a/apps/web/components/admin/IssueReportPanel.tsx
+++ b/apps/web/components/admin/IssueReportPanel.tsx
@@ -7,6 +7,7 @@ import { StatCard, StatusBadge } from "@/components/ui/report-kit";
 import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "@/lib/quality/issue-report-status";
 import {
   classifyIssueReport,
+  explainIssueReport,
   normalizeIssueReportStatus,
   summarizeIssueReportQueue,
   type IssueReportCategory,
@@ -261,6 +262,7 @@ function IssueReportRow({
   isPending: boolean;
 }) {
   const classification = classifyIssueReport(report);
+  const explanation = explainIssueReport(report);
   const status = normalizeIssueReportStatus(report.status);
   const isCoworkerRegression = report.source === "coworker-regression-detector";
   const diagnosis = isCoworkerRegression ? parseCoworkerDiagnosis(report.description) : null;
@@ -340,6 +342,15 @@ function IssueReportRow({
 
       {expanded && (
         <div className="space-y-3 border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+          {/* Plain-language explanation for non-technical operators (BI-E42C0B7E).
+              Shown first so a founder understands the report without reading a stack trace. */}
+          <div className="rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3">
+            <h4 className="mb-1 text-[10px] font-semibold uppercase text-[var(--dpf-accent)]">What this means</h4>
+            <p className="text-xs leading-5 text-[var(--dpf-text)]">{explanation.meaning}</p>
+            <h4 className="mb-1 mt-3 text-[10px] font-semibold uppercase text-[var(--dpf-accent)]">What you can do</h4>
+            <p className="text-xs leading-5 text-[var(--dpf-text)]">{explanation.whatToDo}</p>
+          </div>
+
           {diagnosis && (
             <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
               <div className="flex flex-wrap items-center gap-2">
@@ -372,12 +383,14 @@ function IssueReportRow({
           )}
 
           {report.errorStack && (
-            <div>
-              <h4 className="mb-1 text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">Stack trace</h4>
-              <pre className="max-h-48 overflow-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] leading-relaxed text-[var(--dpf-muted)]">
+            <details>
+              <summary className="cursor-pointer text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">
+                Technical detail (stack trace)
+              </summary>
+              <pre className="mt-1 max-h-48 overflow-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[10px] leading-relaxed text-[var(--dpf-muted)]">
                 {report.errorStack}
               </pre>
-            </div>
+            </details>
           )}
 
           {report.reportedBy && (

--- a/apps/web/lib/quality/issue-report-queue.test.ts
+++ b/apps/web/lib/quality/issue-report-queue.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyIssueReport,
+  explainIssueReport,
   normalizeIssueReportStatus,
   summarizeIssueReportQueue,
 } from "./issue-report-queue";
@@ -84,5 +85,56 @@ describe("issue-report queue helpers", () => {
     expect(summary.processGuard).toBe(1);
     expect(summary.warmupNoise).toBe(1);
     expect(summary.resolved).toBe(1);
+  });
+});
+
+describe("explainIssueReport (plain-language for non-technical operators)", () => {
+  it("explains a zero-tool-call guard report as a transient local-model fallback", () => {
+    const explanation = explainIssueReport({
+      ...baseReport,
+      reportId: "coworker-process-1-zero-tool-call",
+      title: "[coworker-process] zero-tool-call on phase=ideate",
+      source: "agentic-loop-guard",
+    });
+
+    expect(explanation.meaning).toContain("without calling any");
+    expect(explanation.meaning).toContain("bundled local model");
+    expect(explanation.whatToDo).toContain("Providers & Routing");
+    // Must not imply the operator misconfigured something.
+    expect(explanation.whatToDo.toLowerCase()).toContain("clears itself");
+  });
+
+  it("explains a tool-capability / provider-outage report without blaming config", () => {
+    const explanation = explainIssueReport({
+      ...baseReport,
+      title: "No tool-use-capable AI provider is available for this coworker",
+      type: "runtime_error",
+    });
+
+    expect(explanation.meaning).toContain("tool-capable AI provider");
+    expect(explanation.whatToDo).toContain("No setup change is usually needed");
+  });
+
+  it("marks warmup noise as safe to suppress", () => {
+    const explanation = explainIssueReport({
+      ...baseReport,
+      title: "Model warmup ping",
+      source: "warmup",
+    });
+
+    expect(explanation.meaning).toContain("health check");
+    expect(explanation.whatToDo).toContain("suppress");
+  });
+
+  it("gives a runtime crash a human framing and an action", () => {
+    const explanation = explainIssueReport({
+      ...baseReport,
+      title: "Cannot read properties of undefined (reading 'toLowerCase')",
+      type: "runtime_error",
+      description: "TypeError at renderPage",
+    });
+
+    expect(explanation.meaning).toContain("unexpected error");
+    expect(explanation.whatToDo).toContain("Ask System Admin");
   });
 });

--- a/apps/web/lib/quality/issue-report-queue.ts
+++ b/apps/web/lib/quality/issue-report-queue.ts
@@ -106,6 +106,93 @@ export function classifyIssueReport(report: IssueReportQueueInput): IssueReportC
   };
 }
 
+/**
+ * Plain-language explanation of an issue report for a NON-TECHNICAL operator
+ * (BI-E42C0B7E). The raw title / stack trace are written for engineers; this
+ * turns each report into "what this means" + "what you can do" so a founder can
+ * act without reading a stack trace.
+ *
+ * High-signal patterns (tool-capability / provider outage / zero-tool-call) are
+ * matched first because those are the reports operators hit most and the ones
+ * the raw text explains worst.
+ */
+export type IssueReportExplanation = {
+  meaning: string;
+  whatToDo: string;
+};
+
+export function explainIssueReport(
+  report: IssueReportQueueInput & { description?: string | null },
+): IssueReportExplanation {
+  const category = detectCategory(report);
+  const haystack = `${report.title} ${report.description ?? ""}`.toLowerCase();
+
+  const mentionsTool = /tool/.test(haystack);
+  const isZeroToolCall = /zero-tool-call|no tool call|without (?:calling|using) (?:a |any )?tool/.test(haystack);
+  const isToolCapability =
+    /tool-use-capable|supports tools|exceeds threshold|skipped local fallback|tool-capable/.test(haystack);
+  const isProviderOutage =
+    /rate.?limit|overload|provider (?:unavailable|temporarily|status)|all endpoints failed|\b429\b|\b529\b/.test(
+      haystack,
+    );
+
+  if (isZeroToolCall || (category === "process_guard" && mentionsTool)) {
+    return {
+      meaning:
+        "A coworker was expected to use its tools to do real work but finished a turn without calling any. " +
+        "This usually means it was running on the small bundled local model — because your paid AI providers were " +
+        "briefly unavailable — and that model can't reliably drive a large set of tools.",
+      whatToDo:
+        "This normally clears itself once your paid AI providers (Claude / GPT) are available again. " +
+        "If it keeps happening, open Platform > AI > Providers & Routing and confirm a paid, tool-capable provider is active.",
+    };
+  }
+
+  if (isToolCapability || isProviderOutage) {
+    return {
+      meaning:
+        "The platform briefly had no powerful, tool-capable AI provider available — usually because your paid " +
+        "providers (Claude / GPT) were rate-limited for a short period, leaving only the small bundled local model.",
+      whatToDo:
+        "No setup change is usually needed; this clears on its own within a minute or two. " +
+        "If it persists, open Platform > AI > Providers & Routing to confirm a paid provider is connected and active.",
+    };
+  }
+
+  switch (category) {
+    case "warmup_noise":
+      return {
+        meaning: "A routine internal health check, not a real problem.",
+        whatToDo: "Safe to suppress — it's background noise from the platform checking itself.",
+      };
+    case "runtime":
+      return {
+        meaning:
+          "The app hit an unexpected error while a page or action was running. The technical detail below is for " +
+          "engineers; the key fact is that a screen or action failed.",
+        whatToDo:
+          'If you can reproduce it, note what you clicked. Use "Ask System Admin" to investigate, or ' +
+          '"Send to Build Studio as a fix" to queue a repair.',
+      };
+    case "user_feedback":
+      return {
+        meaning: "Feedback or a problem reported by a person using the platform.",
+        whatToDo: "Review the description and decide whether it needs a fix or a follow-up.",
+      };
+    case "process_guard":
+      return {
+        meaning:
+          "An automated guard noticed a coworker's work session behaved abnormally (for example, stalling or looping).",
+        whatToDo: 'Use "Ask System Admin" to investigate the cause, then triage.',
+      };
+    default:
+      return {
+        meaning: "An issue the platform recorded for review.",
+        whatToDo: 'Use "Ask System Admin" to investigate, then triage or resolve.',
+      };
+  }
+}
+
 export function summarizeIssueReportQueue(reports: IssueReportQueueInput[]): IssueReportQueueSummary {
   return reports.reduce<IssueReportQueueSummary>((summary, report) => {
     const classification = classifyIssueReport(report);

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -447,7 +447,7 @@ describe("runAgenticLoop", () => {
     threadId: "thread-1",
   };
 
-  it("explains missing tool-use capacity instead of masking it as a temporary outage", async () => {
+  it("points to the real provider surface when no tool-capable endpoint is active", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockRejectedValueOnce(new Error(
       "No eligible endpoints for task 'unknown': No endpoint satisfies agent capability floor (EP-AGENT-CAP-002). Missing: toolUse.",
@@ -459,13 +459,15 @@ describe("runAgenticLoop", () => {
       agentId: "admin-assistant",
     });
 
-    expect(result.content).toContain("No tool-use-capable AI provider is available");
-    expect(result.content).toContain("Platform > AI > Model Assignment");
+    // Genuine config gap → name the REAL surface, not the old "Model Assignment".
+    expect(result.content).toContain("No AI model that supports tools is active");
+    expect(result.content).toContain("Providers & Routing");
+    expect(result.content).not.toContain("Model Assignment");
     expect(result.providerId).toBe("unknown");
     expect(result.modelId).toBe("unknown");
   });
 
-  it("explains exhausted tool-using endpoint failures instead of masking them as temporary", async () => {
+  it("explains a transient paid outage + local tool cap instead of blaming config", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockRejectedValueOnce(new Error(
       'All endpoints failed for onboarding. Attempts: [{"endpointId":"local","error":"Network error calling local: fetch failed"},{"endpointId":"local","error":"skipped local fallback: 58 tools exceeds threshold for small local models"}]',
@@ -477,10 +479,30 @@ describe("runAgenticLoop", () => {
       agentId: "admin-assistant",
     });
 
-    expect(result.content).toContain("No tool-use-capable AI provider is available");
-    expect(result.content).toContain("Platform > AI > Model Assignment");
+    // The bundled local model was bypassed for tool count while paid providers
+    // were down — nothing is misconfigured, so do NOT send the operator to settings.
+    expect(result.content).toContain("briefly unavailable");
+    expect(result.content).toContain("58 of them");
+    expect(result.content).toContain("Nothing is misconfigured");
+    expect(result.content).not.toContain("Model Assignment");
     expect(result.providerId).toBe("unknown");
     expect(result.modelId).toBe("unknown");
+  });
+
+  it("treats a generic all-endpoints-failed as a transient retry, not a config error", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockRejectedValueOnce(new Error(
+      'All endpoints failed for conversation. Attempts: [{"endpointId":"anthropic-sub","error":"429 rate limited"}]',
+    ));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/admin/issue-reports",
+      agentId: "admin-assistant",
+    });
+
+    expect(result.content).toContain("try again in about 30 seconds");
+    expect(result.content).not.toContain("Model Assignment");
   });
 
   it("executes tools through the governed lifecycle path", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -53,6 +53,71 @@ const MAX_TEXT_MESSAGE_CHARS = 4_000;
 const COMPLETION_CLAIM_PATTERN =
   /\b(built|deployed|shipped|created|implemented|saved|configured|tested|fixed|completed|installed|launched|starting up|initializing|applying|generating)\b|tests?\s+pass|plan(?:ning)?\s+(?:is\s+done|ready)|building\s+now|start\s+implementation/i;
 
+/**
+ * Build a plain-language, non-technical explanation when an agent turn fails
+ * because routing could not complete a tool-using call (BI-23E0714C).
+ *
+ * The old behavior lumped every tool-route failure into one message that told
+ * the operator to "Configure an active model that supports tools in
+ * Platform > AI > Model Assignment" — which is wrong and a dead end whenever a
+ * tool-capable provider IS already configured (the common case). This classifier
+ * distinguishes the real situations so we never send a non-technical operator to
+ * fix config that is already correct:
+ *
+ *  - REQUEST_TOO_LARGE  → context overflow; start a new thread.
+ *  - local bypassed for tool count + paid providers down → the bundled local
+ *    model can't drive this coworker's large tool set and paid providers are
+ *    briefly unavailable (usually a short rate-limit). Nothing is misconfigured.
+ *  - genuinely no tool-capable endpoint active → point to the REAL surface.
+ *  - other endpoint failures → transient; retry shortly.
+ */
+export function describeToolRouteFailure(
+  errorMessage: string,
+  toolCount: number,
+): string {
+  const msg = errorMessage ?? "";
+
+  if (msg.startsWith("REQUEST_TOO_LARGE:")) {
+    return "Your conversation is too long for this AI provider. Please start a new thread to continue.";
+  }
+
+  // Most common real cause: the bundled local model was bypassed because this
+  // coworker exposes more tools than a small local model can reliably handle,
+  // and no paid provider was available to take the work. This is NOT a
+  // misconfiguration, so do not point the operator at a settings page.
+  if (/exceeds threshold|skipped local fallback/i.test(msg)) {
+    // Prefer the exact count the router reported ("58 tools exceeds threshold");
+    // fall back to the tool count we were handed.
+    const reported = msg.match(/(\d+)\s+tools?\s+exceeds threshold/i);
+    const count = reported ? Number(reported[1]) : toolCount;
+    const tools = count > 0 ? `${count} of them` : "many";
+    return (
+      "Your paid AI providers (such as Claude or GPT) are briefly unavailable right now — " +
+      "usually a short rate-limit that clears within a minute — and this coworker uses too many " +
+      `tools (${tools}) for the bundled local model to run on its own. Nothing is misconfigured. ` +
+      "Please wait a moment and try again."
+    );
+  }
+
+  // Genuine config gap: routing found no active model that supports tools at all.
+  if (/No eligible endpoints/i.test(msg) && /toolUse/i.test(msg)) {
+    return (
+      "No AI model that supports tools is active right now. Open Platform > AI > " +
+      "Providers & Routing to activate a tool-capable provider, then try again."
+    );
+  }
+
+  // Endpoints exist but all transiently failed (rate-limit / overload / network).
+  if (/All endpoints failed/i.test(msg)) {
+    return (
+      "The AI providers are momentarily busy (usually rate-limited or overloaded). " +
+      "Please try again in about 30 seconds — no setup change is needed."
+    );
+  }
+
+  return "The AI provider is temporarily unavailable. Please try again in about 30 seconds.";
+}
+
 // Narration patterns: agent describes code or announces intent instead of calling tools.
 // Includes preamble narration ("Let me check", "I need to fix") and intent announcements
 // ("I'd like to generate...", "I would like to call...") that precede but do not replace tool use.
@@ -1212,19 +1277,9 @@ export async function runAgenticLoop(params: {
     } catch (routeErr) {
       const msg = routeErr instanceof Error ? routeErr.message : String(routeErr);
       console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
-      const isTooLarge = msg.startsWith("REQUEST_TOO_LARGE:");
-      const isMissingToolUseCapacity =
-        /No eligible endpoints/i.test(msg) && /toolUse/i.test(msg);
-      const isToolUsingEndpointFailure =
-        Boolean(routeOptions.tools && routeOptions.tools.length > 0) &&
-        (/All endpoints failed/i.test(msg) || /tools exceeds threshold/i.test(msg));
       logTurnSummary("unknown", "unknown");
       return {
-        content: isTooLarge
-          ? "Your conversation is too long for this AI provider. Please start a new thread to continue."
-          : isMissingToolUseCapacity || isToolUsingEndpointFailure
-            ? "No tool-use-capable AI provider is available for this coworker. Configure an active model that supports tools in Platform > AI > Model Assignment, then retry this task."
-          : "The AI provider is temporarily unavailable. Please try again in about 30 seconds.",
+        content: describeToolRouteFailure(msg, routeOptions.tools?.length ?? 0),
         providerId: "unknown",
         modelId: "unknown",
         downgraded: false,


### PR DESCRIPTION
## Why

A coworker (observed: **System Admin / `admin-assistant`** triaging an issue report, 2026-06-06 17:47) returned:

> No tool-use-capable AI provider is available for this coworker. Configure an active model that supports tools in Platform > AI > Model Assignment, then retry this task.

…and the next turn said it *"ran on the bundled local model because configured paid providers were unavailable."* The two messages are contradictory and the first is **factually wrong** — and a dead end for a non-technical operator.

### Evidence-grounded root cause (from the live install)
- `anthropic-sub` (Claude) and `codex` (GPT-5.4) are configured, active, and tool-capable. Local `gemma4` is active with `supportsToolUse=true`, `toolFidelity=100`. **A tool-capable provider IS configured** — so "go configure a model" sends the operator on a dead-end path.
- Real trigger: paid providers were briefly rate-limited → router fell back to local → [`fallback.ts:211`](apps/web/lib/routing/fallback.ts) caps local fallback at `LOCAL_FALLBACK_MAX_TOOLS = 15` and **skips** local when the coworker exposes >15 tools (these coworkers expose 26–58). With paid down and local skipped, [`agentic-loop.ts`](apps/web/lib/tak/agentic-loop.ts) emitted the misleading config message.
- `RouteDecisionLog` confirms `admin-assistant` was routed to `gemma4` (local) 7× in ~30s — the spin the tool cap is meant to prevent.

## What changed

**Commit 1 — honest, actionable routing message (BI-23E0714C)**
Replaces the single lumped message with `describeToolRouteFailure()`, which classifies the failure from the error contract and returns plain-language guidance:
- `REQUEST_TOO_LARGE` → start a new thread
- local bypassed for tool count → *paid providers briefly unavailable + local can't drive N tools; nothing is misconfigured; retry* (extracts the real N from the error string)
- genuinely no tool-capable endpoint active → points to the **real** surface, **Platform > AI > Providers & Routing** (not the old "Model Assignment")
- other endpoint failures → transient; retry in ~30s

**Commit 2 — plain-language issue reports (BI-E42C0B7E, slice 1)**
Adds `explainIssueReport()` (pure, unit-tested) producing *"What this means" + "What you can do"* for each report, keyed off category + high-signal patterns (tool-capability / provider-outage / zero-tool-call matched first). Rendered as a panel atop the expanded report; the raw stack trace is collapsed behind a "Technical detail" disclosure.

## Scope notes
- `routed-inference.ts` still references "Model Assignment" for a **different, narrower** path (genuine capability-floor / model-assignment). Its `NoEligibleEndpointsError` propagates up into the new classifier (case "no tool-capable endpoint"), so the user-facing message stays consistent. Left as-is to keep this PR focused.
- **Deferred (captured in the BIs):** graceful degradation on call-time fallback failure (auto-retry when paid capacity returns / route a relevance-ranked tool subset to local); dedup/grouping of identical reports; surfacing the auto-triage verdict on the report (ties into **EP-PROACTIVE-OPS**).

## Tests
- `apps/web/lib/tak/agentic-loop.test.ts` — rewrote the 2 tests asserting the old message; added a generic-transient case.
- `apps/web/lib/quality/issue-report-queue.test.ts` — 4 new cases for `explainIssueReport`.
- Both files green (87 tests); `tsc --noEmit` clean; pre-commit scoped typecheck passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
