### PR TITLE
fix(build): build-route fabrication retries ride out transient provider downgrades (BI-PIR-cc091267)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1046,7 +1046,7 @@ export async function runAgenticLoop(params: {
   const executedTools: AgenticResult["executedTools"] = [];
   let lastResult: RoutedInferenceResult | null = null;
   let continuationNudges = 0;
-  let fabricationRetried = false;
+  let fabricationRetries = 0;
   let frustrationCount = 0;
   let bestPreNudgeContent = ""; // Preserve best text from before nudge
   const startTime = Date.now();
@@ -1519,10 +1519,18 @@ export async function runAgenticLoop(params: {
           };
         }
 
-        if (!fabricationRetried) {
-          fabricationRetried = true;
+        // BI-PIR-cc091267 — a build-route fabrication signal (completion claim
+        // with zero tool calls) is most often a TRANSIENT provider downgrade:
+        // the preferred provider 529s, a weaker backup confabulates "done"
+        // without emitting the required tool call. A single retry can't ride out
+        // a blip that self-clears in ~30s, so give build routes a few attempts —
+        // each re-dispatches and can re-route to the recovered preferred
+        // provider. Conversational routes keep a single retry (unchanged).
+        const maxFabricationRetries = isBuildRoute ? 3 : 1;
+        if (fabricationRetries < maxFabricationRetries) {
+          fabricationRetries++;
           console.warn(
-            "[agentic-loop] fabrication detected: claimed completion without the required tool-backed evidence. Retrying.",
+            `[agentic-loop] fabrication detected: claimed completion without the required tool-backed evidence. Retrying (${fabricationRetries}/${maxFabricationRetries}).`,
           );
           messages = [
             ...messages,


### PR DESCRIPTION
## Problem
The build-specialist intermittently aborts a plan/build turn with "the underlying work wasn't recorded" — a zero-tool-call completion claim. Found while validating a Dale-level build: the coworker produced a real 9-task plan when the provider was healthy, but other turns failed. Root cause: on a build route, a fabrication signal is most often a **transient provider downgrade** (preferred provider 529s → weaker backup confabulates "done" without the required tool call), and the guard retried only **once** — not enough to ride out a blip that self-clears in ~30s.

## Fix
Route-aware fabrication-retry budget in `agentic-loop.ts`: build routes get up to **3** attempts (each re-dispatches and can re-route to the recovered preferred provider); conversational routes keep the single retry. Contained to the fabrication error path — happy path and non-build routes unaffected.

## Scope
Transient-downgrade half of **BI-PIR-cc091267**. Fuller fix (explicit re-escalation to preferred provider + short backoff) is follow-up. Please let CI (`agentic-loop.test.ts`) validate and deploy via the proper path — this is hot agentic-loop code, not for a manual rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)