### PR TITLE
feat(intake): shared backlog-ingest front door + auto-file improvement proposals (EP-INTAKE-UNIFY)

### DIFF
--- a/apps/web/lib/actions/improvements.ts
+++ b/apps/web/lib/actions/improvements.ts
@@ -4,7 +4,7 @@
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
-import * as crypto from "crypto";
+import { ingestBacklogItem, improvementCategoryToWorkType } from "@/lib/operate/backlog-ingest";
 
 // ─── Allowed transitions ─────────────────────────────────────────────────────
 
@@ -59,30 +59,44 @@ export async function prioritizeImprovement(proposalId: string) {
   if (!proposal) return { error: "Not found" };
   if (proposal.status !== "reviewed") return { error: `Cannot prioritize from "${proposal.status}"` };
 
-  // Create a linked backlog item
-  const itemId = `BI-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
-  await prisma.backlogItem.create({
-    data: {
-      itemId,
+  // The backlog item is normally created when the proposal is filed
+  // (EP-INTAKE-UNIFY auto-file). Reuse it; only file one for legacy proposals
+  // that predate auto-filing. Route any creation through the shared front door
+  // so the item carries a workType (the historical defect was a workType-less,
+  // triage-skipping direct create here).
+  let backlogItemId = proposal.backlogItemId;
+  if (!backlogItemId) {
+    const ingest = await ingestBacklogItem({
       title: proposal.title,
-      type: "product",
-      status: "open",
-      body: `${proposal.description}\n\n---\nFrom improvement proposal ${proposal.proposalId}\nCategory: ${proposal.category} | Severity: ${proposal.severity}\nObserved: ${proposal.observedFriction ?? "N/A"}`,
-    },
-  });
+      body: [
+        proposal.description,
+        proposal.observedFriction ? `Observed friction: ${proposal.observedFriction}` : null,
+        `Category: ${proposal.category} | Severity: ${proposal.severity}`,
+        `From improvement proposal ${proposal.proposalId}`,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      workType: improvementCategoryToWorkType(proposal.category),
+      source: "automated-detection",
+      itemIdPrefix: "IMP",
+      submittedById: session.user.id,
+      origin: { kind: "improvement", id: proposal.proposalId },
+    });
+    backlogItemId = ingest.itemId;
+  }
 
   await prisma.improvementProposal.update({
     where: { proposalId },
     data: {
       status: "prioritized",
       prioritizedAt: new Date(),
-      backlogItemId: itemId,
+      backlogItemId,
     },
   });
 
   revalidatePath("/ops/improvements");
   revalidatePath("/ops");
-  return { success: true, backlogItemId: itemId };
+  return { success: true, backlogItemId };
 }
 
 export async function startImprovement(proposalId: string) {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -11658,12 +11658,13 @@ export async function executeTool(
         }
       }
 
+      const category = String(params["category"] ?? "missing_feature");
       const proposal = await prisma.improvementProposal.create({
         data: {
           proposalId,
           title: String(params["title"] ?? "Untitled improvement"),
           description: String(params["description"] ?? ""),
-          category: String(params["category"] ?? "missing_feature"),
+          category,
           severity: String(params["severity"] ?? "medium"),
           observedFriction: typeof params["observedFriction"] === "string" ? params["observedFriction"] : null,
           conversationExcerpt,
@@ -11673,20 +11674,63 @@ export async function executeTool(
           threadId: context?.threadId ?? null,
         },
       });
+
+      // Consolidation (EP-INTAKE-UNIFY / BI-7541AB88): file the work into the
+      // backlog the moment the proposal exists, so it is visible and triageable
+      // without the old manual Review→Prioritize promotion that never happened.
+      // The proposal stays the evidence record; the BacklogItem is the work.
+      let backlogItemId: string | null = null;
+      try {
+        const { ingestBacklogItem, improvementCategoryToWorkType } = await import(
+          "@/lib/operate/backlog-ingest"
+        );
+        const ingest = await ingestBacklogItem({
+          title: proposal.title,
+          body: [
+            proposal.description,
+            proposal.observedFriction ? `Observed friction: ${proposal.observedFriction}` : null,
+            `Category: ${category} | Severity: ${proposal.severity}`,
+            `From improvement proposal ${proposal.proposalId}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          workType: improvementCategoryToWorkType(category),
+          source: "automated-detection",
+          itemIdPrefix: "IMP",
+          submittedById: userId,
+          agentId: context?.agentId ?? null,
+          origin: { kind: "improvement", id: proposal.proposalId },
+        });
+        backlogItemId = ingest.itemId;
+        await prisma.improvementProposal.update({
+          where: { proposalId: proposal.proposalId },
+          data: { backlogItemId },
+        });
+      } catch (err) {
+        // Non-fatal: the proposal is still recorded even if the backlog projection fails.
+        console.error("[propose_improvement] backlog auto-file failed", err);
+      }
+
+      // Index the proposal in platform knowledge (was previously unreachable
+      // dead code after the return).
+      import("@/lib/semantic-memory")
+        .then(({ storePlatformKnowledge }) =>
+          storePlatformKnowledge({
+            entityId: proposal.proposalId,
+            entityType: "improvement",
+            title: proposal.title,
+            content: String(params["description"] ?? ""),
+          }),
+        )
+        .catch(() => {});
+
       return {
         success: true,
         entityId: proposal.proposalId,
-        message: `Improvement proposal ${proposal.proposalId} created: "${proposal.title}". It will be reviewed by a manager.`,
+        message: backlogItemId
+          ? `Improvement proposal ${proposal.proposalId} created and filed to the backlog as ${backlogItemId} for triage.`
+          : `Improvement proposal ${proposal.proposalId} created: "${proposal.title}".`,
       };
-      // Index in platform knowledge
-      import("@/lib/semantic-memory").then(({ storePlatformKnowledge }) =>
-        storePlatformKnowledge({
-          entityId: proposal.proposalId,
-          entityType: "improvement",
-          title: proposal.title,
-          content: String(params["description"] ?? ""),
-        })
-      ).catch(() => {});
     }
 
     case "propose_skill_improvement": {

--- a/apps/web/lib/operate/backlog-ingest.test.ts
+++ b/apps/web/lib/operate/backlog-ingest.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  backlogOriginMarker,
+  composeIngestBody,
+  generateBacklogItemId,
+  improvementCategoryToWorkType,
+  ingestBacklogItem,
+  validateIngestStatus,
+  type IngestBacklogStore,
+} from "./backlog-ingest";
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+describe("backlogOriginMarker", () => {
+  it("builds a stable, queryable marker", () => {
+    expect(backlogOriginMarker("improvement", "IP-6F240")).toBe("[origin:improvement:IP-6F240]");
+  });
+});
+
+describe("generateBacklogItemId", () => {
+  it("uses BI- with an 8-char hex suffix when no prefix", () => {
+    expect(generateBacklogItemId()).toMatch(/^BI-[0-9A-F]{8}$/);
+  });
+  it("inserts an uppercased prefix", () => {
+    expect(generateBacklogItemId("imp")).toMatch(/^BI-IMP-[0-9A-F]{8}$/);
+  });
+});
+
+describe("composeIngestBody", () => {
+  it("returns the marker alone when there is no body", () => {
+    expect(composeIngestBody(null, "[origin:x:1]")).toBe("[origin:x:1]");
+  });
+  it("appends the marker on its own paragraph", () => {
+    expect(composeIngestBody("hello", "[origin:x:1]")).toBe("hello\n\n[origin:x:1]");
+  });
+  it("is idempotent — never double-appends an existing marker", () => {
+    const once = composeIngestBody("hello", "[origin:x:1]");
+    expect(composeIngestBody(once, "[origin:x:1]")).toBe(once);
+  });
+  it("returns the body unchanged when there is no marker", () => {
+    expect(composeIngestBody("hello", null)).toBe("hello");
+  });
+  it("returns null when neither body nor marker", () => {
+    expect(composeIngestBody("   ", null)).toBeNull();
+  });
+});
+
+describe("improvementCategoryToWorkType", () => {
+  it("maps skill", () => expect(improvementCategoryToWorkType("skill")).toBe("skill"));
+  it("maps bug-ish categories to bug", () => {
+    expect(improvementCategoryToWorkType("bug")).toBe("bug");
+    expect(improvementCategoryToWorkType("broken_feature")).toBe("bug");
+  });
+  it("maps doc and tool", () => {
+    expect(improvementCategoryToWorkType("doc-gap")).toBe("doc");
+    expect(improvementCategoryToWorkType("missing_tool")).toBe("tool");
+  });
+  it("defaults missing_feature to feature", () => {
+    expect(improvementCategoryToWorkType("missing_feature")).toBe("feature");
+    expect(improvementCategoryToWorkType(null)).toBe("feature");
+  });
+});
+
+describe("validateIngestStatus", () => {
+  it("allows triaging with no outcome", () => expect(validateIngestStatus("triaging", null, null)).toBeNull());
+  it("rejects non-triaging without an outcome", () =>
+    expect(validateIngestStatus("open", null, null)).toMatch(/triageOutcome is required/));
+  it("rejects triaging with an outcome", () =>
+    expect(validateIngestStatus("triaging", "build", null)).toMatch(/must not be set/));
+  it("requires effortSize for build", () =>
+    expect(validateIngestStatus("open", "build", null)).toMatch(/effortSize is required/));
+  it("accepts build with effortSize", () =>
+    expect(validateIngestStatus("open", "build", "medium")).toBeNull());
+});
+
+// ─── Orchestrator (fake store, no DB) ─────────────────────────────────────────
+
+function makeStore(overrides: Partial<IngestBacklogStore> = {}): {
+  store: IngestBacklogStore;
+  created: Array<Record<string, unknown>>;
+  updated: Array<Record<string, unknown>>;
+} {
+  const created: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const store: IngestBacklogStore = {
+    backlogItem: {
+      findFirst: async () => null,
+      update: async (args) => {
+        updated.push((args as { data: Record<string, unknown> }).data);
+        return {};
+      },
+      create: async (args) => {
+        const data = (args as { data: Record<string, unknown> }).data;
+        created.push(data);
+        return { itemId: data.itemId as string };
+      },
+      ...(overrides.backlogItem ?? {}),
+    },
+    epic: {
+      findFirst: async () => null,
+      ...(overrides.epic ?? {}),
+    },
+  };
+  return { store, created, updated };
+}
+
+describe("ingestBacklogItem", () => {
+  it("creates a triaging item by default, with workType/source and the origin marker in the body", async () => {
+    const { store, created } = makeStore();
+    const indexKnowledge = vi.fn();
+
+    const result = await ingestBacklogItem(
+      {
+        title: "Auto-investigate unknown devices",
+        body: "Two devices could not be classified.",
+        workType: "feature",
+        source: "automated-detection",
+        itemIdPrefix: "IMP",
+        origin: { kind: "improvement", id: "IP-6F240" },
+      },
+      { store, indexKnowledge },
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.itemId).toMatch(/^BI-IMP-/);
+    expect(created).toHaveLength(1);
+    expect(created[0]).toMatchObject({
+      status: "triaging",
+      workType: "feature",
+      source: "automated-detection",
+      type: "portfolio",
+    });
+    expect(created[0].body).toContain("[origin:improvement:IP-6F240]");
+    expect(created[0].triageOutcome).toBeUndefined();
+    expect(indexKnowledge).toHaveBeenCalledOnce();
+  });
+
+  it("dedupes on the origin marker — bumps occurrence instead of creating a duplicate", async () => {
+    const { store, created, updated } = makeStore({
+      backlogItem: {
+        findFirst: async () => ({ id: "cuid1", itemId: "BI-IMP-EXISTING" }),
+        update: async () => ({}),
+        create: async () => {
+          throw new Error("should not create on dedup hit");
+        },
+      },
+    });
+
+    const result = await ingestBacklogItem(
+      {
+        title: "Same friction again",
+        workType: "feature",
+        source: "automated-detection",
+        origin: { kind: "improvement", id: "IP-6F240" },
+      },
+      { store, indexKnowledge: () => {} },
+    );
+
+    expect(result).toEqual({ itemId: "BI-IMP-EXISTING", created: false });
+    expect(created).toHaveLength(0);
+    expect(updated).toHaveLength(0); // create path's update recorder unused; dedup update is in the override
+  });
+
+  it("resolves a semantic epic id to its cuid FK", async () => {
+    const { store, created } = makeStore({
+      epic: { findFirst: async () => ({ id: "epic-cuid-123" }) },
+    });
+
+    await ingestBacklogItem(
+      {
+        title: "Linked to an epic",
+        workType: "feature",
+        source: "user-request",
+        epicId: "EP-INTAKE-UNIFY",
+      },
+      { store, indexKnowledge: () => {} },
+    );
+
+    expect(created[0].epicId).toBe("epic-cuid-123");
+  });
+
+  it("throws on an invalid status/outcome pairing rather than writing a bad row", async () => {
+    const { store, created } = makeStore();
+    await expect(
+      ingestBacklogItem(
+        { title: "bad", workType: "bug", source: "user-request", status: "open" },
+        { store, indexKnowledge: () => {} },
+      ),
+    ).rejects.toThrow(/triageOutcome is required/);
+    expect(created).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/operate/backlog-ingest.ts
+++ b/apps/web/lib/operate/backlog-ingest.ts
@@ -1,0 +1,239 @@
+// ─── Shared Backlog-Ingest Front Door ───────────────────────────────────────
+// One path every detector / queue files portal-dev work through, so work lands
+// in the backlog (BacklogItem) the instant it is detected — no manual promotion
+// step, no parallel queue. Generalizes the process-observer-triage pattern
+// (pure builder + dedup + injectable deps) and gives it an origin back-link.
+//
+// See docs/superpowers/specs/2026-06-06-work-intake-unification-design.md
+// (EP-INTAKE-UNIFY, BI-2BB06F90).
+
+import { randomUUID } from "crypto";
+
+import { prisma as defaultPrisma } from "@dpf/db";
+
+import type {
+  BacklogWorkType,
+  BacklogSource,
+  BacklogTriageOutcome,
+  BacklogEffortSize,
+} from "@/lib/explore/backlog";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface BacklogIngestInput {
+  title: string;
+  body?: string | null;
+  /** The WHAT (closed enum) — required on every item per the workType spec. */
+  workType: BacklogWorkType;
+  /** The ORIGIN (closed enum) — how the work arrived. */
+  source: BacklogSource;
+  /** Ownership axis. Defaults to "portfolio" (platform-level work). */
+  type?: "product" | "portfolio";
+  /** Lifecycle status. Defaults to "triaging" so the item enters normal triage. */
+  status?: "triaging" | "open" | "in-progress";
+  triageOutcome?: BacklogTriageOutcome;
+  effortSize?: BacklogEffortSize;
+  priority?: number;
+  /** Semantic (EP-…) or cuid epic id; resolved to the FK in the orchestrator. */
+  epicId?: string;
+  digitalProductId?: string | null;
+  taxonomyNodeId?: string | null;
+  submittedById?: string | null;
+  agentId?: string | null;
+  /** Optional itemId prefix, e.g. "IMP" → BI-IMP-XXXXXXXX. */
+  itemIdPrefix?: string;
+  /** Provenance back-link to the origin record (e.g. {kind:"improvement", id:"IP-6F240"}). */
+  origin?: { kind: string; id: string };
+}
+
+export interface BacklogIngestResult {
+  itemId: string;
+  /** false = matched an existing non-terminal item (deduped, occurrence bumped). */
+  created: boolean;
+}
+
+/**
+ * Minimal structural view of the BacklogItem/Epic stores the front door touches.
+ * Lets tests inject a fake without standing up a Prisma client.
+ */
+export interface IngestBacklogStore {
+  backlogItem: {
+    findFirst(args: unknown): Promise<{ id: string; itemId: string } | null>;
+    update(args: unknown): Promise<unknown>;
+    create(args: unknown): Promise<{ itemId: string }>;
+  };
+  epic: {
+    findFirst(args: unknown): Promise<{ id: string } | null>;
+  };
+}
+
+export interface BacklogIngestDeps {
+  store?: IngestBacklogStore;
+  /** Override knowledge indexing (default: fire-and-forget semantic-memory store). */
+  indexKnowledge?: (args: { entityId: string; title: string; content: string }) => void;
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/** Stable, queryable, human-readable provenance marker embedded in the body. */
+export function backlogOriginMarker(kind: string, id: string): string {
+  return `[origin:${kind}:${id}]`;
+}
+
+export function generateBacklogItemId(prefix?: string): string {
+  const suffix = randomUUID().slice(0, 8).toUpperCase();
+  const trimmed = prefix?.trim();
+  return trimmed ? `BI-${trimmed.toUpperCase()}-${suffix}` : `BI-${suffix}`;
+}
+
+/** Append the marker on its own line, idempotently (never double-appends). */
+export function composeIngestBody(
+  body: string | null | undefined,
+  marker: string | null,
+): string | null {
+  const base = typeof body === "string" && body.trim() ? body.trimEnd() : null;
+  if (!marker) return base;
+  if (base && base.includes(marker)) return base;
+  return base ? `${base}\n\n${marker}` : marker;
+}
+
+/**
+ * Map an ImprovementProposal category to a backlog workType. Mirrors the
+ * create_backlog_item required-field contract so auto-filed items are never
+ * workType-less (the historical prioritizeImprovement defect).
+ */
+export function improvementCategoryToWorkType(
+  category: string | null | undefined,
+): BacklogWorkType {
+  const c = (category ?? "").toLowerCase();
+  if (c === "skill") return "skill";
+  if (c.includes("bug") || c.includes("defect") || c.includes("error") || c.includes("broken")) {
+    return "bug";
+  }
+  if (c.includes("doc")) return "doc";
+  if (c.includes("tool")) return "tool";
+  if (c.includes("refactor") || c.includes("debt") || c.includes("cleanup")) return "refactor";
+  if (c.includes("chore")) return "chore";
+  return "feature";
+}
+
+/**
+ * Enforce the same status/triageOutcome pairing rules as create_backlog_item.
+ * Returns an error message, or null when valid.
+ */
+export function validateIngestStatus(
+  status: string,
+  triageOutcome: string | null,
+  effortSize: string | null,
+): string | null {
+  if (status !== "triaging" && !triageOutcome) {
+    return "triageOutcome is required when status is not 'triaging'";
+  }
+  if (status === "triaging" && triageOutcome) {
+    return "triageOutcome must not be set when status='triaging'";
+  }
+  if (triageOutcome === "build" && !effortSize) {
+    return "effortSize is required when triageOutcome='build'";
+  }
+  return null;
+}
+
+// ─── Default knowledge indexing (fire-and-forget) ─────────────────────────────
+
+function defaultIndexKnowledge(args: { entityId: string; title: string; content: string }): void {
+  import("@/lib/semantic-memory")
+    .then(({ storePlatformKnowledge }) =>
+      storePlatformKnowledge({
+        entityId: args.entityId,
+        entityType: "backlog",
+        title: args.title,
+        content: args.content,
+      }),
+    )
+    .catch(() => {});
+}
+
+// ─── Orchestrator ─────────────────────────────────────────────────────────────
+
+/**
+ * File (or dedupe) a BacklogItem for portal-dev work. Every detector/queue
+ * routes through here so the backlog is the single source of truth for the work
+ * while the origin record stays the evidence.
+ *
+ * Dedup: when `origin` is supplied and a non-terminal item already carries its
+ * marker, the existing item's occurrenceCount is bumped and no duplicate is
+ * created — so a recurring signal touches one item.
+ */
+export async function ingestBacklogItem(
+  input: BacklogIngestInput,
+  deps: BacklogIngestDeps = {},
+): Promise<BacklogIngestResult> {
+  const store = deps.store ?? (defaultPrisma as unknown as IngestBacklogStore);
+  const indexKnowledge = deps.indexKnowledge ?? defaultIndexKnowledge;
+
+  const status = input.status ?? "triaging";
+  const triageOutcome = input.triageOutcome ?? null;
+  const effortSize = input.effortSize ?? null;
+
+  const validationError = validateIngestStatus(status, triageOutcome, effortSize);
+  if (validationError) {
+    throw new Error(`[backlog-ingest] ${validationError}`);
+  }
+
+  const marker = input.origin ? backlogOriginMarker(input.origin.kind, input.origin.id) : null;
+
+  // Dedup by origin marker against non-terminal items.
+  if (marker) {
+    const existing = await store.backlogItem.findFirst({
+      where: { body: { contains: marker }, status: { notIn: ["done", "deferred"] } },
+      select: { id: true, itemId: true },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existing) {
+      await store.backlogItem.update({
+        where: { id: existing.id },
+        data: { occurrenceCount: { increment: 1 }, lastSeenAt: new Date() },
+      });
+      return { itemId: existing.itemId, created: false };
+    }
+  }
+
+  // Resolve epic semantic id → cuid FK.
+  let epicCuid: string | null = null;
+  if (input.epicId && input.epicId.trim()) {
+    const raw = input.epicId.trim();
+    const epicRow = await store.epic.findFirst({
+      where: { OR: [{ epicId: raw }, { id: raw }] },
+      select: { id: true },
+    });
+    epicCuid = epicRow?.id ?? null;
+  }
+
+  const itemId = generateBacklogItemId(input.itemIdPrefix);
+  const body = composeIngestBody(input.body, marker);
+
+  const item = await store.backlogItem.create({
+    data: {
+      itemId,
+      title: input.title || "Untitled",
+      type: input.type ?? "portfolio",
+      status,
+      workType: input.workType,
+      source: input.source,
+      lastSeenAt: new Date(),
+      ...(body !== null ? { body } : {}),
+      ...(triageOutcome ? { triageOutcome } : {}),
+      ...(effortSize ? { effortSize } : {}),
+      ...(typeof input.priority === "number" ? { priority: input.priority } : {}),
+      ...(epicCuid ? { epicId: epicCuid } : {}),
+      ...(input.digitalProductId ? { digitalProductId: input.digitalProductId } : {}),
+      ...(input.taxonomyNodeId ? { taxonomyNodeId: input.taxonomyNodeId } : {}),
+      ...(input.submittedById ? { submittedById: input.submittedById } : {}),
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+    },
+  });
+
+  indexKnowledge({ entityId: item.itemId, title: input.title, content: input.body ?? "" });
+
+  return { itemId: item.itemId, created: true };
+}

--- a/docs/superpowers/specs/2026-06-06-work-intake-unification-design.md
+++ b/docs/superpowers/specs/2026-06-06-work-intake-unification-design.md
@@ -1,0 +1,114 @@
+# Work Intake Unification — One Front Door for Portal-Dev Work
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft |
+| Date | 2026-06-06 |
+| Epic | [`EP-INTAKE-UNIFY`](#) — "Single front door for work intake — consolidate isolated queues into the backlog" |
+| Backlog items | BI-2BB06F90 (shared front door — foundation), BI-7541AB88 (auto-file ImprovementProposal — this slice), BI-B716B387 (ImprovementSignal), BI-8CE36E65 (CoworkerCapabilityNeed), BI-EDFBE081 (PlatformIssueReport sync projection), BI-353702E8 (audit ledgers), BI-196693D6 (UI fold) |
+| Related substrate | [`apps/web/lib/operate/process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts) (the pattern this generalizes); [`apps/web/lib/explore/backlog.ts`](../../../apps/web/lib/explore/backlog.ts) (enums); [`apps/web/lib/mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts) (`create_backlog_item`, `propose_improvement`); [`apps/web/lib/actions/improvements.ts`](../../../apps/web/lib/actions/improvements.ts); [`apps/web/lib/skills/proposals.ts`](../../../apps/web/lib/skills/proposals.ts); `BacklogItem`, `ImprovementProposal`, `ImprovementSignal`, `CoworkerCapabilityNeed`, `PlatformIssueReport` |
+| Related specs | [Unified backlog + workType (2026-05-30)](2026-05-30-unified-backlog-worktype-design.md) — landed; this spec is the broader sibling it deferred. |
+| Scope | Build ONE shared backlog-ingest helper (`ingestBacklogItem`) that every detector/queue files through; auto-project the isolated portal-dev queues into `BacklogItem` at the moment their origin record is created, back-linked, deduped — so work is visible in the backlog the instant it's detected, with no manual promotion step. Phase 1 (this slice): the shared front door + auto-file `ImprovementProposal` (the visible symptom) + fix the no-`workType` defect in `prioritizeImprovement`. Phases 2-5: the remaining queues + the UI fold, one BI each. |
+| Out of scope | Operational / human work queues (customer inquiries, bookings, marketing tasks, leave requests, onboarding tasks, customer-estate triage) — those are a SEPARATE mechanism (the collaborative `WorkQueue`/`WorkItem` substrate), not the portal-dev backlog. Skill-content proposals (`category="skill"`, governed approve/rollback in `skills/proposals.ts`) — they have their own revision-governance lifecycle and are not generic backlog work. Domain audit ledgers (`TaxIssue`, `LicenseReadinessIssue`, `PortfolioQualityIssue`, `EaConformanceIssue`) stay audit surfaces; only their platform-dev *remediation* files a BI (Phase 5). |
+
+---
+
+## 1. Problem
+
+Operator (Mark) flagged hidden queues: portal-dev work captured in their own tables/pages, never landing in the backlog, so it is invisible and never prioritized. The visible symptom: Operations → Improvements (`ImprovementProposal`), where `IP-6F240` ("Estate Specialist: auto-investigate unknown devices") sits at `proposed` indefinitely.
+
+### 1.1 The improvement queue only reaches the backlog through two manual clicks
+
+`propose_improvement` ([`mcp-tools.ts:11641`](../../../apps/web/lib/mcp-tools.ts)) creates an `ImprovementProposal` at `status="proposed"` and **no** `BacklogItem`. A `BacklogItem` is only born inside `prioritizeImprovement` ([`improvements.ts:54`](../../../apps/web/lib/actions/improvements.ts)), which requires an operator to first click **Mark Reviewed** (`proposed → reviewed`) and then **Prioritize** (`reviewed → prioritized`). Those clicks never happen, so the proposed work is lost. Two further defects in that path:
+
+- The `BacklogItem` it creates has **no `workType`** (it writes `prisma.backlogItem.create` directly, bypassing the `create_backlog_item` required-field guard) — the exact failure the 2026-05-30 workType spec set out to prevent.
+- It skips triage entirely (`status="open"` with no `triageOutcome`), so the item lands in the "ready" pool without ever being triaged.
+
+There is also dead code: the semantic-memory indexing in `propose_improvement` sits **after** the `return` ([`mcp-tools.ts:11681-11689`](../../../apps/web/lib/mcp-tools.ts)) and never runs.
+
+### 1.2 Every queue rolls its own intake
+
+Audit found these distinct `BacklogItem` birth points, each with its own shape and drift: `create_backlog_item` MCP + `createBacklogItem` server action; issue-report triage; process-observer triage (`buildBacklogItemData`); `sendIssueReportToBuildStudioAsFix`; `prioritizeImprovement`; `createBacklogItemFromFinding`. There is **no shared promote-to-backlog helper**, so each path diverges (the `workType` defect above is one symptom). Sibling queues that never reliably reach the backlog at all: `ImprovementSignal` (no link field), `CoworkerCapabilityNeed` (manual link only), `PlatformIssueReport` (15-min cron, parallel queue).
+
+## 2. Current Repo Truth
+
+| Area | Verified behavior | Implication |
+| ---- | ----------------- | ----------- |
+| `BacklogItem` columns | Has `workType String?`, `source String?`, `occurrenceCount Int @default(1)`, `lastSeenAt DateTime?`, `status`, `type`, `triageOutcome` ([`schema.prisma:950`](../../../packages/db/prisma/schema.prisma)). | The dedup/recurrence columns already exist — the front door can bump `occurrenceCount`/`lastSeenAt` instead of creating a duplicate. |
+| Enums | `BACKLOG_WORK_TYPE_VALUES`, `BACKLOG_SOURCE_VALUES`, `BACKLOG_STATUS_VALUES`, `BACKLOG_TRIAGE_OUTCOMES` in [`backlog.ts`](../../../apps/web/lib/explore/backlog.ts). | The front door types its inputs against these; no new enums. |
+| Canonical create | `create_backlog_item` ([`mcp-tools.ts:5301`](../../../apps/web/lib/mcp-tools.ts)): itemId gen, status/triageOutcome pairing rules, epic semantic→cuid resolve, semantic index. | The front door extracts this logic so the MCP tool and every detector share one implementation. |
+| Generalizable pattern | `buildBacklogItemData` + `isDuplicate` + `triageAndFile` ([`process-observer-triage.ts`](../../../apps/web/lib/operate/process-observer-triage.ts)) — pure builder + dedup + injectable-deps filing, already unit-tested. | The front door is this pattern, promoted to the canonical home and given an origin back-link. |
+| `ImprovementProposal` | `backlogItemId String?` link field exists; created at `status="proposed"` with no BI. | Auto-file at creation, set `backlogItemId`. |
+| Skill proposals | `category="skill"` proposals run a governed approve/rollback that mutates `SkillDefinition.skillMdContent` ([`skills/proposals.ts`](../../../apps/web/lib/skills/proposals.ts)). | Excluded from auto-file — different lifecycle. |
+
+## 3. Design
+
+### 3.1 The shared front door — `ingestBacklogItem`
+
+New module `apps/web/lib/operate/backlog-ingest.ts`. Split into pure planning (unit-testable, no DB) and a thin async orchestrator (mirrors `process-observer-triage.ts`).
+
+**Contract:**
+
+```ts
+export interface BacklogIngestInput {
+  title: string;
+  body?: string | null;
+  workType: BacklogWorkType;          // the WHAT (closed enum)
+  source: BacklogSource;              // the ORIGIN (closed enum)
+  type?: "product" | "portfolio";     // default "portfolio"
+  status?: "triaging" | "open" | "in-progress"; // default "triaging"
+  triageOutcome?: BacklogTriageOutcome;
+  effortSize?: BacklogEffortSize;
+  priority?: number;
+  epicId?: string;                    // semantic (EP-…) or cuid; resolved in the orchestrator
+  digitalProductId?: string | null;
+  taxonomyNodeId?: string | null;
+  submittedById?: string | null;
+  agentId?: string | null;
+  itemIdPrefix?: string;              // e.g. "IMP" → BI-IMP-XXXXXXXX
+  /** Provenance back-link to the origin record (e.g. {kind:"improvement", id:"IP-6F240"}). */
+  origin?: { kind: string; id: string };
+}
+
+export interface BacklogIngestResult { itemId: string; created: boolean; }
+```
+
+**Behavior:**
+
+1. **Provenance marker.** When `origin` is given, append a stable machine- and human-readable line to the body: `[origin:<kind>:<id>]`. This makes the link queryable without a schema change (the same "embed the source id in the body" pattern `quality.ts` and `improvements.ts` already use, now standardized). Callers that own a typed FK field (`ImprovementProposal.backlogItemId`, `CoworkerCapabilityNeed.linkedBacklogItemId`) **also** set it from the returned `itemId`.
+2. **Dedup by origin.** Before creating, if `origin` is set, look for a non-terminal (`status NOT IN (done, deferred)`) `BacklogItem` whose body contains the marker. On hit: bump `occurrenceCount` + set `lastSeenAt = now()`, return `{ itemId, created: false }`. This is what "whatever created these items still needs to create them, but they should land in backlog" requires — a recurring signal touches one item, not N.
+3. **Create.** Otherwise create the `BacklogItem` reusing the validated `create_backlog_item` rules (itemId gen with optional prefix, status/triageOutcome pairing, epic resolve), default `status="triaging"` so the item enters the normal triage queue, index in semantic memory. Return `{ itemId, created: true }`.
+
+**Why `status="triaging"` by default:** the consolidation makes work *visible and prioritizable*, it does not pre-decide the work. New auto-filed items land where every hand-filed item lands — the triage queue — and the existing scheduled triage drain / operator triages them. No queue gets to inject `status="open"` work that skips triage (closing the `prioritizeImprovement` defect by construction).
+
+The front door deliberately extracts the *same* validated rules `create_backlog_item` already enforces (itemId gen, status/triageOutcome pairing, epic resolve). Migrating the existing call sites onto it — `create_backlog_item` (which returns structured `{success:false}` errors to MCP callers rather than throwing), issue-report triage, process-observer, assurance, `sendIssueReportToBuildStudioAsFix` — is a fast-follow, one reviewable diff each, so this slice does not change the MCP error contract while standing up the shared path.
+
+### 3.2 Auto-file `ImprovementProposal` (this slice)
+
+`propose_improvement` ([`mcp-tools.ts:11641`](../../../apps/web/lib/mcp-tools.ts)): after creating the proposal, call `ingestBacklogItem` with `origin={kind:"improvement", id:proposalId}`, `source="automated-detection"` (a coworker observed the friction), `workType` derived from `category` (`category==="skill"` never reaches here; map `bug`-ish categories to `bug`, else `feature`), `itemIdPrefix="IMP"`, status `triaging`. Set `ImprovementProposal.backlogItemId` from the result. Move the (currently dead) semantic-index call before the `return`.
+
+`prioritizeImprovement` ([`improvements.ts:54`](../../../apps/web/lib/actions/improvements.ts)): no longer the *only* path to a BI. If `proposal.backlogItemId` is already set (the normal case now), reuse it — do **not** create a second item. For legacy proposals created before this change with no link, ingest one through the front door (fixing the no-`workType` defect). The proposal's own status transitions are unchanged; the backlog is now the source of truth for the *work*, the proposal is the *evidence*.
+
+The `/ops/improvements` page stays in this slice (its full fold into a filtered backlog view is BI-196693D6). It already shows the proposal lifecycle; a follow-up adds a "see backlog item" link.
+
+### 3.3 The remaining phases (one BI each, not this slice)
+
+| Phase | BI | Change |
+| ----- | -- | ------ |
+| 2 | BI-B716B387 | `ImprovementSignal`: flywheel evaluation files recurring/high-impact signals via the front door, deduped by `signalId`. |
+| 3 | BI-8CE36E65 | `CoworkerCapabilityNeed`: auto-file on submission (`workType=skill|tool`), back-link `linkedBacklogItemId`. |
+| 4 | BI-EDFBE081 | `PlatformIssueReport`: synchronous projection via the front door, retire the 15-min cron, fold `/admin/issue-reports` into a `workType=bug` view (the 2026-05-30 spec's Phase 2). |
+| 5 | BI-353702E8 | Audit ledgers (`AssuranceFinding` already auto-files — migrate it onto the front door; others gain a rule/operator "file to backlog" affordance). |
+| 6 | BI-196693D6 | UI fold: the former queue pages become evidence views; `/ops` is the one place to see and prioritize portal-dev work. |
+
+## 4. Verification Gates (this slice)
+
+| Layer | What to run / show |
+| ----- | ------------------ |
+| Unit | `pnpm --filter web exec vitest run` — new `backlog-ingest.test.ts`: marker compose (idempotent, no double-append), itemId gen with/without prefix, dedup decision (marker hit bumps vs. miss creates), workType derivation from improvement category, status default. Existing `process-observer-triage` / `mcp-tools-backlog` suites stay green. |
+| Typecheck / build | `pnpm --filter web typecheck`; `cd apps/web && pnpm exec next build` — zero errors. |
+| Functional (live install) | Drive `propose_improvement` (a coworker proposes an improvement) → confirm a `triaging` `BacklogItem` appears in `/ops` immediately, linked back, with a real `workType` — no manual Review/Prioritize needed. Re-propose the same origin → `occurrenceCount` bumps, no duplicate. This is the structural→functional step required before claiming the symptom fixed. |
+
+## 5. Next Step After Sign-Off
+
+Implement Phase 1 directly on this worktree (Build Studio stabilization in progress; direct DCO PR is the current ship path), DCO-signed PR off `origin/main`, full build gate, then functionally verify on the live install. Phases 2-6 proceed one BI at a time, each migrating one queue onto the shared front door.


### PR DESCRIPTION
## Why

Operator flagged **hidden queues of portal-dev work** that never land in the backlog, so the work is invisible and never prioritized. The visible symptom: Operations → Improvements (`ImprovementProposal`), where a proposal only becomes a `BacklogItem` after a human clicks **Mark Reviewed** then **Prioritize** — two steps that never happen, so proposed work is lost. That manual path also created a `BacklogItem` with **no `workType`** and **skipped triage**.

This is the first slice of **EP-INTAKE-UNIFY** — one front door so every detector files portal-dev work into the one backlog, with the origin record kept as evidence.

## What

- **`apps/web/lib/operate/backlog-ingest.ts` (new)** — the shared `ingestBacklogItem()` front door: pure planning helpers (origin marker, itemId gen, body compose, workType derivation, status/outcome validation) + a thin orchestrator with an injectable store. Defaults to `status=triaging` (work enters normal triage), embeds a queryable `[origin:kind:id]` back-link, and **dedupes by origin** — a recurring signal bumps `occurrenceCount` instead of creating duplicates. (BI-2BB06F90)
- **`propose_improvement`** — auto-files a triaging `BacklogItem` the moment a proposal exists, back-linked via `ImprovementProposal.backlogItemId`. Also restores a previously-unreachable semantic-index call (dead code after `return`). (BI-7541AB88)
- **`prioritizeImprovement`** — reuses the linked item (no double-create) and routes any legacy creation through the front door, fixing the `workType`-less direct create.
- **Spec** — `docs/superpowers/specs/2026-06-06-work-intake-unification-design.md` (Phases 2–6 cover ImprovementSignal, CoworkerCapabilityNeed, PlatformIssueReport, audit ledgers, UI fold — each its own BI under EP-INTAKE-UNIFY).

## Scope

Portal-dev queues only. Operational/human queues (customer inquiries, bookings, leave, onboarding, estate triage) are explicitly a **separate** mechanism. Skill-content proposals (`category=skill`, governed approve/rollback) and domain audit ledgers stay as-is.

## Verification

- `pnpm --filter web typecheck` — green (pre-commit hook also ran it).
- `pnpm --filter web build` (`next build`) — green.
- New `backlog-ingest.test.ts` — 26 specs (helpers + orchestrator dedup/create/epic-resolve/validation), green.
- Full web vitest — green **except 6 pre-existing failures** in `build-reviewers`/`build-disciplines`/`agentic-loop`, confirmed present on `origin/main` (#1573) with this branch's changes stashed — unrelated to this PR.
- Functional check on the live install (drive `propose_improvement` → triaging BI appears in `/ops` immediately, linked, with a real workType; re-propose → occurrence bumps, no duplicate) is the post-merge dogfood step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)