### PR TITLE
fix(coworker): give coworkers their page data + read-only baseline (docs/source/code-graph) (BI-FD7E4D72)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -989,6 +989,9 @@ export async function sendMessage(input: {
 
   // Get ALL platform tools (no mode filtering — we filter the merged set below)
   const { getAvailableTools, toolsToOpenAIFormat } = await import("@/lib/mcp-tools");
+  // Every coworker holds a read-only baseline (page coordination data, docs,
+  // source, code graph) on top of its agent-specific grants — BI-FD7E4D72.
+  const { COWORKER_READ_BASELINE_GRANTS } = await import("@/lib/tak/agent-grants");
   const toolUserContext = {
     platformRole: user.platformRole,
     isSuperuser: user.isSuperuser,
@@ -998,6 +1001,7 @@ export async function sendMessage(input: {
     // Skip mode filtering here — applied to merged set
     unifiedMode: useUnified,
     agentId: agent.agentId,
+    additionalGrants: COWORKER_READ_BASELINE_GRANTS,
   });
 
   // Get page-specific actions
@@ -1049,6 +1053,7 @@ export async function sendMessage(input: {
       externalAccessEnabled: true,
       unifiedMode: useUnified,
       agentId: agent.agentId,
+      additionalGrants: COWORKER_READ_BASELINE_GRANTS,
     });
     disabledExternalTools = getExternalAccessToolSummaries(
       filterToolsForCoworkerRuntime(externalEnabledPlatformTools, {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4652,7 +4652,20 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
 
 export async function getAvailableTools(
   userContext: UserContext,
-  options?: { externalAccessEnabled?: boolean; mode?: "advise" | "act"; unifiedMode?: boolean; agentId?: string },
+  options?: {
+    externalAccessEnabled?: boolean;
+    mode?: "advise" | "act";
+    unifiedMode?: boolean;
+    agentId?: string;
+    /**
+     * Extra grants to union with the agent's own grants before tool gating.
+     * Used by the coworker path to apply COWORKER_READ_BASELINE_GRANTS so every
+     * coworker can read its page data, docs, source, and the code graph
+     * (BI-FD7E4D72). Read-only by construction; the user-capability check above
+     * still bounds what the human operator may see.
+     */
+    additionalGrants?: readonly string[];
+  },
 ): Promise<ToolDefinition[]> {
   let platformTools = PLATFORM_TOOLS.filter(
     (tool) =>
@@ -4669,6 +4682,14 @@ export async function getAvailableTools(
   let agentGrants: string[] = [];
   if (options?.agentId) {
     agentGrants = await getAgentToolGrantsAsync(options.agentId);
+    // Union the agent's own grants with any baseline read grants (the coworker
+    // path passes COWORKER_READ_BASELINE_GRANTS). Done here so the merged set is
+    // also used by the discovered-MCP-tool gating below. The merge only widens
+    // toward read-only tools; agents that hold no grants AND get no baseline are
+    // left ungated exactly as before (length-0 → no filtering).
+    if (options.additionalGrants?.length) {
+      agentGrants = Array.from(new Set([...agentGrants, ...options.additionalGrants]));
+    }
     if (agentGrants.length > 0) {
       platformTools = platformTools.filter((tool) => isToolAllowedByGrants(tool.name, agentGrants));
     }

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -5,6 +5,7 @@ import {
   isToolAllowedByGrants,
   getAgentToolGrants,
   getToolGrantMapping,
+  COWORKER_READ_BASELINE_GRANTS,
 } from "./agent-grants";
 
 describe("TOOL_TO_GRANTS — Build / Sandbox entries", () => {
@@ -737,5 +738,75 @@ describe("TOOL_TO_GRANTS — Browser-driving entries (EP-BROWSER-DRIVE, Verdict 
     const map = getToolGrantMapping();
     expect(map["mcp-browser-use__browse_act"]).toEqual(["browser_drive"]);
     expect(map["mcp-browser-use__browse_open"]).toEqual(["browser_read"]);
+  });
+});
+
+// BI-FD7E4D72 — every coworker gets a read-only baseline so it can see its
+// page's coordination data and read the docs, source, and code graph. The
+// coworker path (agent-coworker.ts) unions this set with the agent's own grants
+// before tool gating in getAvailableTools.
+describe("COWORKER_READ_BASELINE_GRANTS — page visibility + docs/source/code-graph reads", () => {
+  it("is read-only: only *_read grants plus file_read", () => {
+    for (const g of COWORKER_READ_BASELINE_GRANTS) {
+      expect(g === "file_read" || g.endsWith("_read")).toBe(true);
+    }
+  });
+
+  it("unlocks the page coordination, docs, source, and code-graph read tools", () => {
+    const baseline = [...COWORKER_READ_BASELINE_GRANTS];
+    // The exact tools the operator's Dev Loop question needed:
+    expect(isToolAllowedByGrants("get_runtime_coordination_map", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("list_nonprod_environment_leases", baseline)).toBe(true);
+    // Documentation:
+    expect(isToolAllowedByGrants("doc_search", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("doc_load", baseline)).toBe(true);
+    // Source code:
+    expect(isToolAllowedByGrants("read_project_file", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("search_project_files", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("read_source_at_version", baseline)).toBe(true);
+    // Code graph ("the code graph especially"):
+    expect(isToolAllowedByGrants("search_code_graph", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("trace_code_surface", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("find_related_tests", baseline)).toBe(true);
+    // Knowledge / wiki:
+    expect(isToolAllowedByGrants("search_knowledge", baseline)).toBe(true);
+    expect(isToolAllowedByGrants("wiki_query", baseline)).toBe(true);
+  });
+
+  it("does NOT unlock any write, sandbox, deploy, or admin authority", () => {
+    const baseline = [...COWORKER_READ_BASELINE_GRANTS];
+    expect(isToolAllowedByGrants("create_backlog_item", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("update_backlog_item", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("write_sandbox_file", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("launch_sandbox", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("claim_nonprod_environment_lease", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("register_runtime_target", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("execute_promotion", baseline)).toBe(false);
+    expect(isToolAllowedByGrants("admin_run_command", baseline)).toBe(false);
+  });
+
+  it("lifts the ops coordinator (AGT-WS-OPS) from backlog-only to page-visible when unioned", () => {
+    const opsGrants = getAgentToolGrants("AGT-WS-OPS") ?? [];
+    // Before: the backlog-scoped agent (backlog_read/backlog_write/registry_read)
+    // cannot see the runtime coordination map, the code graph, or the source.
+    // (Note: doc_search/doc_load are already reachable via its registry_read —
+    // TOOL_TO_GRANTS is ANY-of — so the docs were never the gap; the page's own
+    // coordination data and the code graph were.)
+    expect(isToolAllowedByGrants("get_runtime_coordination_map", opsGrants)).toBe(false);
+    expect(isToolAllowedByGrants("list_nonprod_environment_leases", opsGrants)).toBe(false);
+    expect(isToolAllowedByGrants("search_code_graph", opsGrants)).toBe(false);
+    expect(isToolAllowedByGrants("trace_code_surface", opsGrants)).toBe(false);
+    expect(isToolAllowedByGrants("read_project_file", opsGrants)).toBe(false);
+
+    // After: union with the coworker read baseline (what getAvailableTools does).
+    const merged = Array.from(new Set([...opsGrants, ...COWORKER_READ_BASELINE_GRANTS]));
+    expect(isToolAllowedByGrants("get_runtime_coordination_map", merged)).toBe(true);
+    expect(isToolAllowedByGrants("list_nonprod_environment_leases", merged)).toBe(true);
+    expect(isToolAllowedByGrants("search_code_graph", merged)).toBe(true);
+    expect(isToolAllowedByGrants("trace_code_surface", merged)).toBe(true);
+    expect(isToolAllowedByGrants("read_project_file", merged)).toBe(true);
+    expect(isToolAllowedByGrants("doc_search", merged)).toBe(true);
+    // But its own backlog-write authority is preserved, not lost.
+    expect(isToolAllowedByGrants("create_backlog_item", merged)).toBe(true);
   });
 });

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -52,6 +52,39 @@ export function expandGrants(grants: readonly string[]): string[] {
 }
 
 /**
+ * Read-only baseline every coworker holds, regardless of its agent-specific
+ * grants. Encodes the platform design criterion (operator, 2026-06-06,
+ * BI-FD7E4D72): a coworker must have complete visibility of the page it is on
+ * plus read access to the documentation, the source code, and the code graph
+ * for "how it works and the rest of the portal". Without this the page-scoped
+ * agents (e.g. AGT-WS-OPS, granted only backlog_*) could neither see their
+ * page's coordination data nor look anything up — making them, in the
+ * operator's words, "rather useless".
+ *
+ * Every grant here is READ-ONLY. The user-capability check in getAvailableTools
+ * (`can(userContext, requiredCapability)`) still applies on top, so this never
+ * escalates a coworker beyond what its human operator may see. Merged into the
+ * agent's grants at coworker tool-resolution time (see getAvailableTools'
+ * `additionalGrants` option) rather than hand-stamped onto every agent entry —
+ * one durable rule that new agents inherit automatically, and which sidesteps
+ * the DB-vs-JSON grant-sync problem since it is applied in code at runtime.
+ *
+ *  - registry_read     → knowledge base, wiki, portfolio context
+ *  - file_read         → read/search project source code
+ *  - document_read     → platform documentation (doc_search / doc_load)
+ *  - code_graph_read   → the code graph (search_code_graph / trace_code_surface)
+ *  - work_capsule_read → page coordination data (runtime targets, leases,
+ *                        build progress) — the data pages like /ops/dev-loop render
+ */
+export const COWORKER_READ_BASELINE_GRANTS: readonly string[] = [
+  "registry_read",
+  "file_read",
+  "document_read",
+  "code_graph_read",
+  "work_capsule_read",
+];
+
+/**
  * Maps platform tool names to agent grant categories.
  * A tool is allowed if the agent has ANY of the grants it maps to —
  * directly OR via GRANT_IMPLICATIONS expansion (see expandGrants).

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -497,6 +497,45 @@ export const ROUTE_CONTEXT_MAP: Record<string, RouteContextDef> = {
     ],
   },
 
+  "/ops/dev-loop": {
+    routePrefix: "/ops/dev-loop",
+    domain: "Dev Loop — Runtime Coordination",
+    sensitivity: "internal",
+    domainContext:
+      "This page is the Dev Loop runtime coordination map. It shows governed RuntimeTargets (root portal, dev portal, build sandboxes, promotion sandboxes) grouped by lifecycle status, the active non-prod environment leases, and the runtimeTargetJanitor rules (BI-AD949172). It is NOT the delivery backlog. Use the PAGE DATA block as ground truth for what is currently deployed where. Multiple targets can legitimately share a status and even a URL/port at once — each build sandbox registers its own target on the shared sandbox port, and a 'running' target whose lastHeartbeat is stale simply has not been swept to 'expired' yet (janitor: running + no heartbeat for 2h → expired). Always reconcile a target's status against its lastHeartbeat before treating it as live, and prefer get_runtime_coordination_map for the full live record.",
+    domainTools: [
+      "get_runtime_coordination_map",
+      "list_nonprod_environment_leases",
+      "search_code_graph",
+      "trace_code_surface",
+      "doc_search",
+      "search_knowledge",
+    ],
+    docsPath: "/docs/operations/index",
+    skills: [
+      {
+        label: "Explain the runtime map",
+        description: "Summarize what is deployed where and flag anything stale",
+        capability: "view_platform",
+        taskType: "analysis",
+        prompt: "Look at the PAGE DATA for this Dev Loop page. Summarize the active runtime targets and leases in plain language, and flag any 'running' target whose lastHeartbeat is old enough that the janitor should sweep it to expired. Explain why duplicates on the same port can be normal. Don't call tools unless the page data is missing something you need from get_runtime_coordination_map.",
+      },
+      {
+        label: "Why is this here?",
+        description: "Trace a runtime target or janitor rule back to the code that creates it",
+        capability: "view_platform",
+        taskType: "analysis",
+        prompt: "I'll name a runtime target, lease, or janitor behavior on this page. Use search_code_graph / trace_code_surface and read_project_file to find the code that registers or sweeps it, and the docs that describe it, then explain how it works and why this entry exists.",
+      },
+      {
+        label: "Report an issue",
+        description: "Report a bug or give feedback",
+        capability: null,
+        prompt: "I'd like to report an issue or give feedback about this page.",
+      },
+    ],
+  },
+
   "/ops": {
     routePrefix: "/ops",
     domain: "Operations",

--- a/apps/web/lib/tak/route-context.test.ts
+++ b/apps/web/lib/tak/route-context.test.ts
@@ -28,6 +28,8 @@ const {
     taxRemittanceRun: { count: vi.fn() },
     taxObligationPeriod: { count: vi.fn() },
     taxJurisdictionReference: { findMany: vi.fn() },
+    runtimeTarget: { findMany: vi.fn() },
+    nonProductionEnvironmentLease: { findMany: vi.fn() },
   },
   mockGetPlaybook: vi.fn(),
   mockGetVocabulary: vi.fn(),
@@ -140,6 +142,10 @@ beforeEach(() => {
   mockPrisma.taxRemittanceRun.count.mockResolvedValue(0);
   mockPrisma.taxObligationPeriod.count.mockResolvedValue(0);
   mockPrisma.taxJurisdictionReference.findMany.mockResolvedValue([]);
+  mockPrisma.runtimeTarget.findMany.mockReset();
+  mockPrisma.nonProductionEnvironmentLease.findMany.mockReset();
+  mockPrisma.runtimeTarget.findMany.mockResolvedValue([]);
+  mockPrisma.nonProductionEnvironmentLease.findMany.mockResolvedValue([]);
 
   mockGetPlaybook.mockReturnValue({
     primaryGoal: "Build authority pipeline through expertise demonstration and client nurture",
@@ -272,5 +278,63 @@ describe("getRouteDataContext", () => {
     expect(context).toContain("DPF tax processing proposal required");
     expect(context).toContain("Likely DPF/Texas research focus");
     expect(context).toContain("Texas Comptroller");
+  });
+
+  it("gives /ops/dev-loop its own runtime-coordination page data, not the backlog (BI-FD7E4D72)", async () => {
+    const now = Date.now();
+    mockPrisma.runtimeTarget.findMany.mockResolvedValue([
+      {
+        targetId: "RT-ROOT-PORTAL",
+        kind: "root-portal",
+        status: "running",
+        hostUrl: "http://localhost:3000",
+        lastHeartbeatAt: new Date(now - 5 * 60_000),
+        expiresAt: null,
+        updatedAt: new Date(now - 5 * 60_000),
+        workCapsule: null,
+        featureBuild: null,
+      },
+      {
+        targetId: "RT-BUILD-SANDBOX-9E4FA6DE",
+        kind: "build-sandbox",
+        status: "running",
+        hostUrl: "http://localhost:3035",
+        // stale: heartbeat is days old, janitor should have swept it
+        lastHeartbeatAt: new Date(now - 11 * 24 * 3_600_000),
+        expiresAt: null,
+        updatedAt: new Date(now - 11 * 24 * 3_600_000),
+        workCapsule: { headBranch: "fix/some-branch" },
+        featureBuild: { buildId: "FB-12345678" },
+      },
+    ]);
+    mockPrisma.nonProductionEnvironmentLease.findMany.mockResolvedValue([
+      {
+        leaseId: "LEASE-1",
+        environmentKey: "local-integration-ci",
+        status: "active",
+        ownerProvider: "codex",
+        purpose: "Validate self-upgrade backup script path repair",
+        branchName: "fix/self-upgrade-backup-script-path",
+        worktreePath: "/work/abc",
+        expiresAt: new Date(now + 3 * 3_600_000),
+        releasedAt: null,
+      },
+    ]);
+
+    const context = await getRouteDataContext("/ops/dev-loop", "user-1");
+
+    expect(context).toContain("PAGE DATA — Dev Loop (runtime coordination map):");
+    // The runtime targets the page renders must be present...
+    expect(context).toContain("RT-ROOT-PORTAL");
+    expect(context).toContain("RT-BUILD-SANDBOX-9E4FA6DE");
+    expect(context).toContain("ACTIVE RUNTIME TARGETS (2)");
+    expect(context).toContain("ACTIVE NON-PROD LEASES (1)");
+    expect(context).toContain("local-integration-ci");
+    // ...and it must explain stale-vs-live + same-port duplicates (the operator's question).
+    expect(context).toContain("no heartbeat for 2h");
+    expect(context).toMatch(/lastHeartbeat=.*h ago/);
+    // It must NOT have fallen back to the /ops backlog provider.
+    expect(context).not.toContain("PAGE DATA — Operations Backlog:");
+    expect(mockPrisma.runtimeTarget.findMany).toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/tak/route-context.ts
+++ b/apps/web/lib/tak/route-context.ts
@@ -17,6 +17,11 @@ const ROUTE_CONTEXT_PROVIDERS: Record<string, (userId: string, routeContext: str
   "/platform/ai": getAiWorkforceContext,
   "/platform/ai/providers": getProvidersContext,
   "/platform/tools/discovery": getDiscoveryOperationsContext,
+  // /ops/dev-loop renders the runtime coordination map (targets + leases), NOT
+  // the backlog. Without its own provider it fell back to /ops → getOpsContext
+  // and the coworker only saw backlog items + epics (BI-FD7E4D72). More-specific
+  // prefix wins via longest-match below, so this must precede "/ops".
+  "/ops/dev-loop": getDevLoopContext,
   "/ops": getOpsContext,
   "/compliance/licensing": getLicensingReadinessContext,
   "/compliance": getComplianceContext,
@@ -394,6 +399,92 @@ async function getOpsContext(): Promise<string> {
     "",
     "ALL BACKLOG ITEMS:",
     ...itemLines,
+  ].join("\n");
+}
+
+// /ops/dev-loop — the runtime coordination map. Mirrors the data the page
+// renders (apps/web/app/(shell)/ops/dev-loop/page.tsx getData): RuntimeTargets
+// grouped by lifecycle + active NonProductionEnvironmentLeases, plus the janitor
+// rules so the coworker can reason about staleness (e.g. why several targets
+// show "running" on the same port — stale ones await the 2h-no-heartbeat sweep).
+// BI-FD7E4D72 / BI-AD949172.
+async function getDevLoopContext(): Promise<string> {
+  const [targets, leases] = await Promise.all([
+    prisma.runtimeTarget.findMany({
+      orderBy: { updatedAt: "desc" },
+      take: 50,
+      select: {
+        targetId: true,
+        kind: true,
+        status: true,
+        hostUrl: true,
+        lastHeartbeatAt: true,
+        expiresAt: true,
+        updatedAt: true,
+        workCapsule: { select: { headBranch: true } },
+        featureBuild: { select: { buildId: true } },
+      },
+    }),
+    prisma.nonProductionEnvironmentLease.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 30,
+      select: {
+        leaseId: true,
+        environmentKey: true,
+        status: true,
+        ownerProvider: true,
+        purpose: true,
+        branchName: true,
+        worktreePath: true,
+        expiresAt: true,
+        releasedAt: true,
+      },
+    }),
+  ]);
+
+  const now = Date.now();
+  const ageHours = (d: Date | null): string =>
+    d ? `${Math.round(((now - d.getTime()) / 3_600_000) * 10) / 10}h ago` : "never";
+
+  const ACTIVE = ["running", "starting", "verifying", "assigned"];
+  const STALE = ["expired", "failed"];
+  const INACTIVE = ["planned", "verified", "released"];
+
+  const fmtTarget = (t: (typeof targets)[number]): string => {
+    const branch = t.workCapsule?.headBranch ? ` branch=${t.workCapsule.headBranch}` : "";
+    const build = t.featureBuild?.buildId ? ` build=${t.featureBuild.buildId}` : "";
+    const url = t.hostUrl ? ` url=${t.hostUrl}` : "";
+    return `- ${t.targetId} [${t.kind}/${t.status}]${url} lastHeartbeat=${ageHours(t.lastHeartbeatAt)}${branch}${build}`;
+  };
+
+  const active = targets.filter((t) => ACTIVE.includes(t.status));
+  const stale = targets.filter((t) => STALE.includes(t.status));
+  const inactive = targets.filter((t) => INACTIVE.includes(t.status));
+  const activeLeases = leases.filter((l) => l.status === "active" && !l.releasedAt);
+
+  const leaseLines = activeLeases.map(
+    (l) =>
+      `- ${l.environmentKey} (${l.leaseId}) provider=${l.ownerProvider}` +
+      `${l.branchName ? ` branch=${l.branchName}` : ""} purpose="${l.purpose}" expires=${ageHours(l.expiresAt).replace(" ago", " from update")}`,
+  );
+
+  return [
+    "\nPAGE DATA — Dev Loop (runtime coordination map):",
+    "This page shows governed RuntimeTargets and non-prod environment leases, not the backlog.",
+    "",
+    `ACTIVE RUNTIME TARGETS (${active.length}) — status in running/starting/verifying/assigned:`,
+    ...(active.length ? active.map(fmtTarget) : ["- (none)"]),
+    "",
+    `STALE / FAILED TARGETS (${stale.length}) — status expired/failed:`,
+    ...(stale.length ? stale.map(fmtTarget) : ["- (none)"]),
+    "",
+    `INACTIVE TARGETS (${inactive.length}) — status planned/verified/released:`,
+    ...(inactive.length ? inactive.map(fmtTarget) : ["- (none)"]),
+    "",
+    `ACTIVE NON-PROD LEASES (${activeLeases.length}):`,
+    ...(leaseLines.length ? leaseLines : ["- (none)"]),
+    "",
+    "JANITOR RULES (runtimeTargetJanitor, BI-AD949172): running/starting + no heartbeat for 2h → expired; planned + no consumer for 7 days → released; lease past expiresAt → expired. So several targets can show the SAME status (e.g. running) and even the same URL/port concurrently — multiple build sandboxes register their own target on the shared sandbox port; a 'running' target whose lastHeartbeat is hours/days old is stale and simply has not been swept to 'expired' yet. Cross-check status against lastHeartbeat before assuming a target is live. Use get_runtime_coordination_map for the full live record (verifications, capsule/build linkage).",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Why

On **/ops/dev-loop** ("Dev Loop"), the attached coworker could not answer a question about the runtime targets its own page renders — it replied that it only had backlog items and epics. Coworkers are supposed to have complete visibility of the page they're on, plus read access to docs, source, and the code graph (a stated design criterion). Reported by the operator 2026-06-06 (BI-FD7E4D72).

This is a **coverage gap, not a regression** — both gaps have existed since `/ops/dev-loop` shipped in #1443 (BI-AD949172, 2026-06-03).

## Root cause (two compounding gaps)

1. **Page data** — `route-context.ts` had no `/ops/dev-loop` provider, so longest-prefix match fell back to `/ops` → `getOpsContext`, which loads only backlog items + epics. The coworker never received the runtime targets/leases on screen. This affected **5 of 6 `/ops` tabs** (Improvements, Changes, Promotions, Self-upgrade, Dev Loop), all inheriting the `/ops` domain context that says "this page shows the delivery backlog."
2. **Tool grants** — `AGT-WS-OPS` holds only `backlog_read`/`backlog_write`/`registry_read`, so it couldn't look the data up either: no `work_capsule_read` (runtime map), `code_graph_read` (code graph), or `file_read` (source).

## What changed

- **`getDevLoopContext` + `/ops/dev-loop` provider** — surfaces runtime targets, leases, and the janitor rules (mirrors the page's own query), including stale-vs-live and same-port reasoning so the coworker can answer "why are there 4 running targets on the same port?"
- **`/ops/dev-loop` entry in `ROUTE_CONTEXT_MAP`** — accurate `domainContext` + `domainTools` (`get_runtime_coordination_map`, `list_nonprod_environment_leases`, `search_code_graph`, `trace_code_surface`, `doc_search`, …), no longer described as the backlog.
- **`COWORKER_READ_BASELINE_GRANTS`** — a read-only baseline (`registry_read`, `file_read`, `document_read`, `code_graph_read`, `work_capsule_read`) unioned into coworker tool resolution via a new `getAvailableTools({ additionalGrants })` option. **One durable, principle-based rule** so *every* coworker can see its page's coordination data and read the docs, source, and code graph by default. Read-only by construction; the per-tool `requiredCapability` check still bounds what the human operator may see. Applied in code, so it needs no per-agent seed edits and sidesteps the DB-vs-JSON grant-sync problem.

## Tests

- `route-context.test.ts` — `/ops/dev-loop` returns its own runtime-coordination page data and **must not** fall back to the backlog provider.
- `agent-grants.test.ts` — baseline is read-only, unlocks the page/docs/source/code-graph read tools, grants no write/sandbox/deploy/admin authority, and lifts `AGT-WS-OPS` from backlog-only to page-visible when unioned (preserving its own backlog-write).

**Verification:** 143/143 targeted tests pass; `web` typecheck clean. The 4 unrelated failures in `agentic-loop.test.ts` (fabrication-guard / build-route) are **pre-existing on `main`** — confirmed by stashing this PR's edits and re-running that file on the clean tree (same 4 failures). Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
