### PR TITLE
fix(build): restore main Unit Tests gate — downgrade-gate fabrication retries + update #1572/#1573 tests

### DIFF
--- a/apps/web/lib/integrate/build-disciplines-integration.test.ts
+++ b/apps/web/lib/integrate/build-disciplines-integration.test.ts
@@ -241,8 +241,8 @@ describe("Build Disciplines — Full Flow Integration", () => {
         fileStructure: [{ path: "test.ts", action: "create", purpose: "test" }],
         tasks: [{ title: "task 1", testFirst: "write test", implement: "code", verify: "run" }],
       });
-      expect(prompt).toContain("test-first");
-      expect(prompt).toContain("bite-sized");
+      expect(prompt).toContain("TEST-FIRST");
+      expect(prompt).toContain("BITE-SIZED");
     });
   });
 });

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -97,13 +97,17 @@ describe("buildPlanReviewPrompt", () => {
     expect(prompt).toContain("Add filter");
   });
 
-  it("includes comprehensive review instruction to prevent whack-a-mole feedback", () => {
+  it("includes bounded, size-aware decision discipline to prevent whack-a-mole feedback", () => {
     const prompt = buildPlanReviewPrompt({
       fileStructure: [],
       tasks: [{ title: "Task 1", testFirst: "t", implement: "i", verify: "v" }],
     });
-    expect(prompt).toContain("MUST report ALL issues in a SINGLE response");
-    expect(prompt).toContain("ZERO surprise issues on a re-review");
+    // PR #1573 replaced the old "report ALL issues / ZERO surprise" instruction
+    // (which drove issue-volume + oscillation) with bounded, severity-disciplined,
+    // size-aware review. Assert the new contract.
+    expect(prompt).toContain("DECISION DISCIPLINE");
+    expect(prompt).toContain("do NOT pad the list to be exhaustive");
+    expect(prompt).toContain("SIZE-AWARENESS");
   });
 
   it("includes task count for reviewer context", () => {

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -1523,18 +1523,19 @@ describe("runAgenticLoop", () => {
 
   it("uses honest infra copy (not fabrication copy) for a downgraded build-route claim", async () => {
     const mockRoute = vi.mocked(routeAndCall);
-    // Two fabricated build claims → retry exhausted → final emission.
+    // BI-PIR-cc091267: a DOWNGRADED build-route turn gets 3 fabrication retries
+    // (to ride out a transient blip), so it takes 4 fabricated claims to exhaust
+    // them and reach the final honest-infra emission.
+    const downgradedFab = () => mockResult({
+      content: "Built and deployed the feature — implementation completed.",
+      downgraded: true,
+      downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
+    });
     mockRoute
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: true,
-        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: true,
-        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
-      }));
+      .mockResolvedValueOnce(downgradedFab())
+      .mockResolvedValueOnce(downgradedFab())
+      .mockResolvedValueOnce(downgradedFab())
+      .mockResolvedValueOnce(downgradedFab());
 
     const result = await runAgenticLoop({
       ...baseParams,

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1519,14 +1519,16 @@ export async function runAgenticLoop(params: {
           };
         }
 
-        // BI-PIR-cc091267 — a build-route fabrication signal (completion claim
-        // with zero tool calls) is most often a TRANSIENT provider downgrade:
-        // the preferred provider 529s, a weaker backup confabulates "done"
-        // without emitting the required tool call. A single retry can't ride out
-        // a blip that self-clears in ~30s, so give build routes a few attempts —
-        // each re-dispatches and can re-route to the recovered preferred
-        // provider. Conversational routes keep a single retry (unchanged).
-        const maxFabricationRetries = isBuildRoute ? 3 : 1;
+        // BI-PIR-cc091267 — extra retries are for a TRANSIENT provider
+        // downgrade only: the preferred provider 529s and a weaker backup
+        // confabulates "done" without the required tool call. A single retry
+        // can't ride out a blip that self-clears in ~30s, so a DOWNGRADED
+        // build-route turn gets a few attempts — each re-dispatches and can
+        // re-route to the recovered preferred provider. A HEALTHY false claim
+        // is genuine fabrication, not a blip — keep the single retry so the
+        // guard fires promptly (retrying a healthy model that just fabricated
+        // only wastes calls). Conversational routes always keep one retry.
+        const maxFabricationRetries = (isBuildRoute && result.downgraded) ? 3 : 1;
         if (fabricationRetries < maxFabricationRetries) {
           fabricationRetries++;
           console.warn(


### PR DESCRIPTION
## Problem
`main`'s **Unit Tests gate is red** — 6 tests failed because #1572 (fabrication-retry) and #1573 (bounded review) merged **without updating their tests** (the local suite was skipped). A red required gate blocks clean merge of *every* PR.

## Fixes
**1. Correctness improvement to #1572.** It made *all* build-route fabrication retry 3×, including a **healthy** false claim — but a healthy false claim is genuine fabrication, not a transient blip, so retrying it just wastes calls and delays the guard. Gate the extra retries on `result.downgraded`: a **downgraded** build-route turn gets 3 attempts (ride out a 529 blip); **healthy** + conversational keep one retry so the guard fires promptly. This matches what the agentic-loop tests encode.

**2. Tests updated to shipped behaviour:**
- `agentic-loop.test.ts` — the downgraded build-route test now exhausts 3 retries (4 fabricated claims); the 3 healthy tests are restored unchanged by the gate.
- `build-reviewers.test.ts` — assert the new bounded **DECISION DISCIPLINE / SIZE-AWARENESS** contract instead of the removed "report ALL issues / ZERO surprise".
- `build-disciplines-integration.test.ts` — match the new uppercase `TEST-FIRST`/`BITE-SIZED`.

Restores the Unit Tests gate so #1576/#1577 (and all PRs) can merge cleanly. (vitest isn't installable in the worktree; relying on CI as the binding evidence, with each retry-count reasoned.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)