### PR TITLE
fix(test): unbreak red main — update build-route fabrication tests for #1572's 3-retry budget (BI-E1861A80)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -1298,20 +1298,17 @@ describe("runAgenticLoop", () => {
     const mockRoute = vi.mocked(routeAndCall);
     const mockExecuteTool = vi.mocked(executeTool);
 
-    mockRoute
-      .mockResolvedValueOnce(mockResult({
-        content: "Checking the existing Build Studio workflow files.",
-        toolCalls: [{ id: "toolu_read_1", name: "search_project_files", arguments: { query: "BuildStudio workflow actions" } }],
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "",
-      }));
+    // Dispatch 1 runs the read-only tool; every subsequent dispatch repeats the
+    // unpersisted plan-ready claim so the build-route fabrication-retry budget
+    // (3, per BI-PIR-cc091267 / #1572) exhausts and the guard blocks it — rather
+    // than the mock running out and returning undefined.
+    mockRoute.mockResolvedValueOnce(mockResult({
+      content: "Checking the existing Build Studio workflow files.",
+      toolCalls: [{ id: "toolu_read_1", name: "search_project_files", arguments: { query: "BuildStudio workflow actions" } }],
+    }));
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
+    }));
 
     mockExecuteTool.mockResolvedValueOnce({ success: true, message: "Found Build Studio workflow files." });
 
@@ -1387,13 +1384,13 @@ describe("runAgenticLoop", () => {
   it("blocks a repeated fabricated plan-ready reply instead of surfacing it to the user", async () => {
     const mockRoute = vi.mocked(routeAndCall);
 
-    mockRoute
-      .mockResolvedValueOnce(mockResult({
-        content: "Plan ready — 5 tasks across 4 files. Building now.",
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Plan ready — 5 tasks across 4 files. Building now.",
-      }));
+    // BI-PIR-cc091267 (#1572) raised the build-route fabrication-retry budget to
+    // 3 (up to 4 dispatches). Return the fabricated reply for every dispatch so
+    // the budget exhausts and the guard emits its final message, instead of the
+    // mock running out and returning undefined on the 3rd call.
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Plan ready — 5 tasks across 4 files. Building now.",
+    }));
 
     const result = await runAgenticLoop({
       ...baseParams,
@@ -1523,18 +1520,13 @@ describe("runAgenticLoop", () => {
 
   it("uses honest infra copy (not fabrication copy) for a downgraded build-route claim", async () => {
     const mockRoute = vi.mocked(routeAndCall);
-    // Two fabricated build claims → retry exhausted → final emission.
-    mockRoute
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: true,
-        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: true,
-        downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
-      }));
+    // Fabricated downgraded build claim on every dispatch → build-route retry
+    // budget (3, per BI-PIR-cc091267 / #1572) exhausts → final emission.
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Built and deployed the feature — implementation completed.",
+      downgraded: true,
+      downgradeMessage: "Switched to Claude after the preferred endpoint was unavailable.",
+    }));
 
     const result = await runAgenticLoop({
       ...baseParams,
@@ -1551,16 +1543,12 @@ describe("runAgenticLoop", () => {
 
   it("STILL fires the fabrication guard on a healthy (non-downgraded) false claim", async () => {
     const mockRoute = vi.mocked(routeAndCall);
-    // Healthy provider, repeated fabricated claim → fabrication copy must win.
-    mockRoute
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: false,
-      }))
-      .mockResolvedValueOnce(mockResult({
-        content: "Built and deployed the feature — implementation completed.",
-        downgraded: false,
-      }));
+    // Healthy provider, repeated fabricated claim on every dispatch → build-route
+    // retry budget (3, per BI-PIR-cc091267 / #1572) exhausts → fabrication copy wins.
+    mockRoute.mockResolvedValue(mockResult({
+      content: "Built and deployed the feature — implementation completed.",
+      downgraded: false,
+    }));
 
     const result = await runAgenticLoop({
       ...baseParams,


### PR DESCRIPTION
## What
`main` is red: 4 tests in `apps/web/lib/tak/agentic-loop.test.ts` fail with `TypeError: Cannot read properties of undefined (reading 'responseId')` at `agentic-loop.ts:1294`.

- "does not allow plan-ready claims after read-only tool use without build-plan persistence"
- "blocks a repeated fabricated plan-ready reply instead of surfacing it to the user"
- "uses honest infra copy (not fabrication copy) for a downgraded build-route claim"
- "STILL fires the fabrication guard on a healthy (non-downgraded) false claim"

## Root cause — real regression on main
PR #1572 (`7237d714`, BI-PIR-cc091267) changed `agentic-loop.ts:1529` to `maxFabricationRetries = isBuildRoute ? 3 : 1`. Build routes now make up to **4** `routeAndCall` dispatches before the fabrication guard emits. These 4 tests still queued only 2 (or 3) `mockResolvedValueOnce` responses. Once the queue is exhausted the mock returns `undefined`, and `result.responseId` dereferences undefined.

#1572 changed **only** `agentic-loop.ts` (16 lines) and never updated the test file. Its "Unit Tests" CI check concluded **FAILURE** (2026-06-06 19:39:39Z) but the PR was merged 4 min later (19:43:06Z) with the check red — so main has been red since.

## Fix — in the tests, not the runtime
`routeAndCall` always returns a `RoutedInferenceResult` or throws (caught at line 1277); it never returns `undefined` in production. A `result?.responseId` guard would only **mask a contract violation**, so it was deliberately not added.

Instead, the 4 build-route fabrication tests now use a persistent `.mockResolvedValue(...)` for the repeated-fabrication dispatches (dispatch 1 stays `.mockResolvedValueOnce` where it carries a tool call). This exhausts the retry budget and reaches the guard's final emission regardless of the exact retry count, so the tests survive future budget tuning.

## Verification
- `pnpm --filter web exec vitest run lib/tak/agentic-loop.test.ts` → **79 passed** (was 4 failed).
- Scoped typecheck (pre-commit) passed.
- Full `apps/web` vitest run showed only unrelated `Test timed out in 5000ms` flakiness with a run-to-run-varying failure set (load-induced locally; those files pass in CI).

## Follow-up (separate)
Governance gap: a red required "Unit Tests" check should block merge. Captured in BI-E1861A80.

Backlog: BI-E1861A80

🤖 Generated with [Claude Code](https://claude.com/claude-code)