### PR TITLE
fix(test): green permissions tile-count after #1582 added the Workbooks tile

### DIFF
--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -68,11 +68,12 @@ describe("getWorkspaceTiles()", () => {
     expect(tiles).not.toContain("inventory");
   });
 
-  it("superuser gets all 13 top-level tiles regardless of role", () => {
+  it("superuser gets all 14 top-level tiles regardless of role", () => {
     const tiles = getWorkspaceTiles(superuser);
 
-    expect(tiles.length).toBe(13);
+    expect(tiles.length).toBe(14);
     expect(tiles.map((tile) => tile.key)).toContain("documents");
+    expect(tiles.map((tile) => tile.key)).toContain("workbooks");
   });
 });
 


### PR DESCRIPTION
## Urgent — main is red

#1582 (Universal Grid & Workbooks Phase 1) added the **Workbooks** workspace tile, so `getWorkspaceTiles()` now returns **14** tiles. The squash-merge of #1582 landed at a commit just before the matching test update, so `apps/web/lib/govern/permissions.test.ts` on `main` still asserts **13** → the **Unit Tests** job is red on `main`.

This one-line test fix restores green:
- `expect(tiles.length).toBe(14)` and asserts the `workbooks` key is present.

Verified: `pnpm --filter web exec vitest run lib/govern/permissions.test.ts` → 28/28 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)