### PR TITLE
fix(grants): map TOOL_TO_GRANTS for the Workbooks MCP tools (INV-1 hotfix)

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -115,6 +115,19 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   query_backlog: ["backlog_read"],
   report_quality_issue: ["backlog_write"],
 
+  // Workbooks / Universal Grid (EP-GRID-WORKBOOKS, #1582). These MCP tools
+  // shipped without a grant mapping, so every tool was default-deny (INV-1) and
+  // unreachable from any coworker. The handler's capability split is
+  // view_workbooks (read) / manage_workbooks (write); mirror it as read/write
+  // grant categories. Held by no agent yet — workbook tools stay coworker-deny
+  // until a role grants them, which is the correct conservative default for a
+  // user-facing grid feature.
+  workbook_list_tables: ["workbook_read"],
+  workbook_get_schema: ["workbook_read"],
+  workbook_query_rows: ["workbook_read"],
+  workbook_create_row: ["workbook_write"],
+  workbook_update_cells: ["workbook_write"],
+
   // Governed MCP backlog surface (spec 2026-04-25)
   create_epic: ["backlog_write"],
   update_epic: ["backlog_write"],

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -1282,6 +1282,29 @@
         "start_scout_research"
       ],
       "implies": []
+    },
+    {
+      "key": "workbook_read",
+      "description": "Read user-defined Workbook / Universal Grid tables: list tables, read schema, and query rows (EP-GRID-WORKBOOKS).",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "workbook_get_schema",
+        "workbook_list_tables",
+        "workbook_query_rows"
+      ],
+      "implies": []
+    },
+    {
+      "key": "workbook_write",
+      "description": "Create and update rows and cells in user-defined Workbook / Universal Grid tables (EP-GRID-WORKBOOKS).",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "workbook_create_row",
+        "workbook_update_cells"
+      ],
+      "implies": []
     }
   ]
 }


### PR DESCRIPTION
## Why

The **Routing Invariants Audit** (`INV-1`) is failing on every PR's merge result with:

> [INV-1] 5 PLATFORM_TOOLS entries have no TOOL_TO_GRANTS mapping

[#1582](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1582) (Universal Grid & Workbooks) shipped 5 MCP tools — `workbook_list_tables`, `workbook_get_schema`, `workbook_query_rows`, `workbook_create_row`, `workbook_update_cells` — without a `TOOL_TO_GRANTS` entry. By the agent-grants default-deny policy that makes them unreachable from any coworker, and the violation isn't in the audit baseline, so it blocks **all** open PRs.

## What

Add the mapping in `apps/web/lib/tak/agent-grants.ts`, mirroring the handler's documented capability split (`view_workbooks` / `manage_workbooks`):

- read → `workbook_read`: `workbook_list_tables`, `workbook_get_schema`, `workbook_query_rows`
- write → `workbook_write`: `workbook_create_row`, `workbook_update_cells`

These are new grant categories held by no agent yet, so the tools stay coworker-deny until a role explicitly grants them — the correct conservative default for a user-facing grid feature, and enough to satisfy INV-1.

## Verification

- INV-1 audit: 5 missing → 0 missing.
- `apps/web/lib/tak/agent-grants.test.ts` — 106 tests green.
- `pnpm --filter web typecheck` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)