### PR TITLE
fix(self-upgrade): force COMPOSE_BAKE=false in promoter build — unblock self-upgrade docker-build

### DIFF
--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -138,6 +138,13 @@ if [[ $_dry_run -eq 0 ]]; then
     exit 1
   fi
   export DPF_VERSION="$_built_sha"
+  # Force the classic BuildKit build path (via the docker daemon) instead of
+  # Compose Bake. The promoter image's Compose can default to Bake, which
+  # requires the buildx CLI plugin — absent in the promoter — and fails every
+  # self-upgrade at docker-build with "Docker Compose is configured to build
+  # using Bake, but buildx isn't installed". This matches the working manual
+  # `docker compose build` path. (Self-upgrade docker-build failures, 2026-06-06.)
+  export COMPOSE_BAKE=false
   docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
     "${_f_args[@]}" build portal
   # Capture the source content hash baked into the FRESHLY BUILT image. It is


### PR DESCRIPTION
## Problem
The platform **self-upgrade is failing**, not just disabled — `SelfUpgradeRun` history: **19 failed / 9 succeeded**, and **today 10 of the last 12 runs failed**. The current failure mode (most recent runs) is at the **docker-build** step:

> Docker Compose is configured to build using Bake, but buildx isn't installed

The promoter image's Compose selects **Bake**, which needs the **buildx CLI plugin** — absent in the promoter — so the build aborts every time. (The earlier `recovery-point-failed` runs were a *different*, earlier blocker; the recent runs get *past* recovery-point to docker-build, so that part now passes.)

This is why deploys have been done by **manual `docker compose build`** all along — the self-upgrade path itself is broken.

## Fix
Export `COMPOSE_BAKE=false` before the promoter's `docker compose build portal` (`scripts/promote.sh`) so it uses the classic BuildKit path via the daemon — the same path the **working manual build** uses. Plausibly the **last blocker** to an end-to-end self-upgrade.

## Verification
This fixes the identified cause. **Full verification requires a real, monitored self-upgrade run** (backups + tagged rollback ready) — that's the next step, not something this PR proves on its own.

Context: corrects my earlier overstatement that the "proper deploy path is restored" — re-enabling the flag didn't make the mechanism work; this addresses why it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)