### PR TITLE
feat(intake): auto-file CoworkerCapabilityNeed to the backlog (EP-INTAKE-UNIFY Phase 2)

### DIFF
--- a/apps/web/lib/coworker-self-assessment/assessment-service.test.ts
+++ b/apps/web/lib/coworker-self-assessment/assessment-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  capabilityNeedOriginId,
+  capabilityNeedToWorkType,
   linkNeedToBacklogItem,
   listCoworkerCapabilityNeeds,
   resolveCapabilityNeed,
@@ -22,6 +24,9 @@ function makeDeps() {
       listNeeds: vi.fn(async () => []),
       updateNeed: vi.fn(async (needId, data) => ({ needId, ...data })),
     },
+    fileBacklogItem: vi.fn(
+      async (n: { needId: string }): Promise<{ itemId: string } | null> => ({ itemId: `BI-${n.needId}` }),
+    ),
   };
 }
 
@@ -95,6 +100,92 @@ describe("submitCoworkerSelfAssessment", () => {
         status: "submitted",
       }),
     );
+  });
+
+  it("auto-files each need to the backlog and links it back", async () => {
+    const deps = makeDeps();
+
+    const result = await submitCoworkerSelfAssessment(
+      {
+        agentId: "marketing-strategist",
+        trigger: "tool-call",
+        routeContext: "/customer/marketing",
+        verdict: "gaps",
+        confidence: "medium",
+        rawPayload: {},
+        needs: [
+          {
+            kind: "tool",
+            severity: "important",
+            need: "Create publish-ready proof assets.",
+            blocks: "Cannot turn recommendations into assets.",
+          },
+        ],
+      },
+      deps,
+    );
+
+    // Filed through the front door with coworker + kind context.
+    expect(deps.fileBacklogItem).toHaveBeenCalledWith(
+      expect.objectContaining({ needId: "CWN-000001", agentId: "marketing-strategist", kind: "tool" }),
+    );
+    // Linked back + marked filed (no manual link step needed).
+    expect(deps.db.updateNeed).toHaveBeenCalledWith("CWN-000001", {
+      linkedBacklogItemId: "BI-CWN-000001",
+      status: "backlog-filed",
+    });
+    expect(result.backlogItemIds).toEqual(["BI-CWN-000001"]);
+  });
+
+  it("records the need even when the backlog projection fails (non-fatal)", async () => {
+    const deps = makeDeps();
+    deps.fileBacklogItem.mockResolvedValueOnce(null);
+
+    const result = await submitCoworkerSelfAssessment(
+      {
+        agentId: "ops-coordinator",
+        trigger: "tool-call",
+        routeContext: "/ops",
+        verdict: "gaps",
+        confidence: "low",
+        rawPayload: {},
+        needs: [{ kind: "skill", severity: "minor", need: "Need X.", blocks: "Blocks Y." }],
+      },
+      deps,
+    );
+
+    expect(deps.db.createNeed).toHaveBeenCalledOnce();
+    expect(deps.db.updateNeed).not.toHaveBeenCalled(); // no link when filing failed
+    expect(result.needIds).toEqual(["CWN-000001"]);
+    expect(result.backlogItemIds).toEqual([]);
+  });
+});
+
+describe("capabilityNeedToWorkType", () => {
+  it("carries the precise kinds through", () => {
+    expect(capabilityNeedToWorkType("tool")).toBe("tool");
+    expect(capabilityNeedToWorkType("skill")).toBe("skill");
+  });
+  it("maps prompt/convention to doc and grant/model/boundary to chore", () => {
+    expect(capabilityNeedToWorkType("prompt")).toBe("doc");
+    expect(capabilityNeedToWorkType("convention")).toBe("doc");
+    expect(capabilityNeedToWorkType("grant")).toBe("chore");
+    expect(capabilityNeedToWorkType("model")).toBe("chore");
+    expect(capabilityNeedToWorkType("boundary")).toBe("chore");
+  });
+  it("defaults the rest to feature", () => {
+    expect(capabilityNeedToWorkType("data")).toBe("feature");
+    expect(capabilityNeedToWorkType("ui_surface")).toBe("feature");
+    expect(capabilityNeedToWorkType("other")).toBe("feature");
+  });
+});
+
+describe("capabilityNeedOriginId", () => {
+  it("is stable across whitespace/case so re-surfaced gaps dedup to one item", () => {
+    const a = capabilityNeedOriginId("agent-1", "tool", "  Need   PUBLISH tools.  ");
+    const b = capabilityNeedOriginId("agent-1", "tool", "need publish tools.");
+    expect(a).toBe(b);
+    expect(a).toBe("agent-1:tool:need publish tools.");
   });
 });
 

--- a/apps/web/lib/coworker-self-assessment/assessment-service.ts
+++ b/apps/web/lib/coworker-self-assessment/assessment-service.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@dpf/db";
 import type { Prisma } from "@dpf/db";
+import { ingestBacklogItem } from "@/lib/operate/backlog-ingest";
+import type { BacklogWorkType } from "@/lib/explore/backlog";
 import type {
   CoworkerCapabilityNeedInput,
   CoworkerNeedFilters,
@@ -50,14 +52,86 @@ type CoworkerSelfAssessmentDb = {
   updateNeed(needId: string, data: NeedUpdateData): Promise<unknown>;
 };
 
+/** Files one capability need into the backlog. Returns the linked item id, or
+ *  null when the projection failed (non-fatal — the need is still recorded). */
+type FileCapabilityNeedFn = (input: {
+  needId: string;
+  agentId: string;
+  kind: string;
+  severity: string;
+  need: string;
+  blocks: string;
+}) => Promise<{ itemId: string } | null>;
+
 export type CoworkerSelfAssessmentDeps = {
   now: () => Date;
   createId: (prefix: "CWSA" | "CWN") => string;
   db: CoworkerSelfAssessmentDb;
+  fileBacklogItem: FileCapabilityNeedFn;
 };
 
 function defaultCreateId(prefix: "CWSA" | "CWN") {
   return `${prefix}-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+/**
+ * Map a capability-need kind to a backlog workType (advisory for triage). The
+ * precise ones (tool/skill) carry through; the rest pick the closest category.
+ */
+export function capabilityNeedToWorkType(kind: string): BacklogWorkType {
+  switch (kind) {
+    case "tool":
+      return "tool";
+    case "skill":
+      return "skill";
+    case "prompt":
+    case "convention":
+      return "doc";
+    case "grant":
+    case "model":
+    case "boundary":
+      return "chore";
+    // code, data, memory, ui_surface, other → feature
+    default:
+      return "feature";
+  }
+}
+
+/**
+ * Stable origin id for dedup: the same gap, re-surfaced by a later self-
+ * assessment (a new needId), touches one backlog item instead of spawning a
+ * duplicate. Keyed by coworker + kind + normalized need text.
+ */
+export function capabilityNeedOriginId(agentId: string, kind: string, need: string): string {
+  const slug = need.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 120);
+  return `${agentId}:${kind}:${slug}`;
+}
+
+function defaultFileBacklogItem(): FileCapabilityNeedFn {
+  return async (n) => {
+    try {
+      const res = await ingestBacklogItem({
+        title: `[${n.kind}] ${n.need}`.replace(/\s+/g, " ").trim().slice(0, 200),
+        body: [
+          n.need,
+          `Blocks: ${n.blocks}`,
+          `Kind: ${n.kind} | Severity: ${n.severity}`,
+          `Coworker: ${n.agentId}`,
+          `From capability need ${n.needId}`,
+        ].join("\n"),
+        workType: capabilityNeedToWorkType(n.kind),
+        source: "automated-detection",
+        itemIdPrefix: "CAP",
+        agentId: n.agentId,
+        origin: { kind: "capability-need", id: capabilityNeedOriginId(n.agentId, n.kind, n.need) },
+      });
+      return { itemId: res.itemId };
+    } catch (err) {
+      // Non-fatal: the need is still recorded even if the backlog projection fails.
+      console.error("[coworker-self-assessment] backlog auto-file failed", err);
+      return null;
+    }
+  };
 }
 
 function defined<T extends Record<string, unknown>>(value: T): T {
@@ -106,6 +180,7 @@ function depsOrDefault(deps?: Partial<CoworkerSelfAssessmentDeps>): CoworkerSelf
     now: deps?.now ?? (() => new Date()),
     createId: deps?.createId ?? defaultCreateId,
     db: deps?.db ?? defaultDb(),
+    fileBacklogItem: deps?.fileBacklogItem ?? defaultFileBacklogItem(),
   };
 }
 
@@ -134,7 +209,7 @@ function normalizeNeed(
 export async function submitCoworkerSelfAssessment(
   input: SubmitCoworkerSelfAssessmentInput,
   deps?: Partial<CoworkerSelfAssessmentDeps>,
-): Promise<{ assessmentId: string; needIds: string[] }> {
+): Promise<{ assessmentId: string; needIds: string[]; backlogItemIds: string[] }> {
   const resolved = depsOrDefault(deps);
   const createdAt = resolved.now();
   const assessmentId = resolved.createId("CWSA");
@@ -153,15 +228,36 @@ export async function submitCoworkerSelfAssessment(
   });
 
   const needIds: string[] = [];
+  const backlogItemIds: string[] = [];
   for (const need of input.needs) {
     const needId = resolved.createId("CWN");
     needIds.push(needId);
     await resolved.db.createNeed(
       normalizeNeed(need, assessmentId, input.agentId, needId, createdAt),
     );
+
+    // Consolidation (EP-INTAKE-UNIFY / BI-8CE36E65): file the need into the
+    // backlog the moment it is submitted, so the gap is visible and triageable
+    // there instead of waiting for a manual link that never happens. The need
+    // stays the evidence record; the BacklogItem is the work.
+    const filed = await resolved.fileBacklogItem({
+      needId,
+      agentId: input.agentId,
+      kind: need.kind,
+      severity: need.severity,
+      need: need.need.trim(),
+      blocks: need.blocks.trim(),
+    });
+    if (filed?.itemId) {
+      backlogItemIds.push(filed.itemId);
+      await resolved.db.updateNeed(needId, {
+        linkedBacklogItemId: filed.itemId,
+        status: "backlog-filed",
+      });
+    }
   }
 
-  return { assessmentId, needIds };
+  return { assessmentId, needIds, backlogItemIds };
 }
 
 export async function listCoworkerCapabilityNeeds(

--- a/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
+++ b/apps/web/lib/mcp-tools-coworker-self-assessment.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/lib/coworker-self-assessment/assessment-service", () => ({
   submitCoworkerSelfAssessment: vi.fn().mockResolvedValue({
     assessmentId: "CWSA-000001",
     needIds: ["CWN-000001"],
+    backlogItemIds: ["BI-CWN-000001"],
   }),
 }));
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -13495,7 +13495,7 @@ export async function executeTool(
       return {
         success: true,
         entityId: result.assessmentId,
-        message: `Submitted ${result.needIds.length} capability need${result.needIds.length === 1 ? "" : "s"} for review.`,
+        message: `Submitted ${result.needIds.length} capability need${result.needIds.length === 1 ? "" : "s"} and filed ${result.backlogItemIds?.length ?? 0} to the backlog for triage.`,
         data: result,
       };
     }


### PR DESCRIPTION
## Why

Phase 2 of the queue consolidation ([EP-INTAKE-UNIFY](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1584)). `CoworkerCapabilityNeed` was another hidden queue: a need only reached the backlog if an operator manually called `linkNeedToBacklogItem` for each one, so most sat at `status=submitted` indefinitely — coworkers' self-reported gaps never got prioritized.

## What

`submitCoworkerSelfAssessment` now files each need through the shared front door (`ingestBacklogItem`, landed in Phase 1) the moment it's submitted:

- **workType from kind** — `tool`/`skill` carry through; `prompt`/`convention` → `doc`; `grant`/`model`/`boundary` → `chore`; the rest → `feature`.
- **source** = `automated-detection` (the coworker observed its own gap).
- **dedup by content key** (`agent:kind:normalized-need`) so the same gap re-surfaced by a later self-assessment bumps occurrence instead of spawning duplicates.
- **linked back** via `linkedBacklogItemId` + status → `backlog-filed`; the need stays the evidence record, the `BacklogItem` is the work (per the EA guardrail: backlog is the work SSoT, no parallel lifecycle).
- **non-fatal**: filing is an injectable dep (`fileBacklogItem`); if projection fails the need is still recorded.

The `submit_coworker_capability_need` MCP response now reports how many needs landed in the backlog for triage.

## Verification

- `pnpm --filter web typecheck` — green (pre-commit ran it).
- `pnpm --filter web build` — green.
- Full web vitest — **10000 passed / 0 failed**. New tests cover the kind→workType map, the dedup origin key, the auto-file + link path, and the non-fatal-failure path. (The full-suite run also caught — and I fixed — a stale mock in `mcp-tools-coworker-self-assessment.test.ts` that didn't return the new `backlogItemIds`.)

## Next

Phase 3 — `ImprovementSignal` (BI-B716B387) — needs a schema migration for its back-link, so it'll be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)