### PR TITLE
feat(intake): project persistent ImprovementSignals into the backlog (EP-INTAKE-UNIFY Phase 3)

### DIFF
--- a/apps/web/lib/improvement-flywheel/signals.test.ts
+++ b/apps/web/lib/improvement-flywheel/signals.test.ts
@@ -12,7 +12,20 @@ vi.mock("@dpf/db", () => ({
   },
 }));
 
-import { createOrTouchImprovementSignal } from "./signals";
+import {
+  SIGNAL_BACKLOG_THRESHOLD,
+  createOrTouchImprovementSignal,
+  signalSourceTypeToWorkType,
+} from "./signals";
+
+describe("signalSourceTypeToWorkType", () => {
+  it("maps skill/curation, tool, doc, and defaults the rest to bug", () => {
+    expect(signalSourceTypeToWorkType("skill_curation")).toBe("skill");
+    expect(signalSourceTypeToWorkType("tool_failure")).toBe("tool");
+    expect(signalSourceTypeToWorkType("doc_gap")).toBe("doc");
+    expect(signalSourceTypeToWorkType("user_correction")).toBe("bug");
+  });
+});
 
 describe("createOrTouchImprovementSignal", () => {
   beforeEach(() => {
@@ -84,5 +97,58 @@ describe("createOrTouchImprovementSignal", () => {
 
     const updateCall = update.mock.calls[0]?.[0] as { data: Record<string, unknown> };
     expect(updateCall.data).not.toHaveProperty("evidence");
+  });
+
+  it("files once when recurrence reaches the threshold and back-links the signal", async () => {
+    findUnique.mockResolvedValue({ signalId: "IS-EXISTING" });
+    update
+      .mockResolvedValueOnce({ recurrenceCount: SIGNAL_BACKLOG_THRESHOLD, backlogItemId: null })
+      .mockResolvedValueOnce({});
+    const fileBacklogItem = vi.fn(async () => ({ itemId: "BI-SIG-1" }));
+
+    const result = await createOrTouchImprovementSignal(
+      { sourceType: "platform_issue_report", sourceId: "PIR-AB12C", title: "Persistent friction" },
+      { fileBacklogItem },
+    );
+
+    expect(fileBacklogItem).toHaveBeenCalledWith(
+      expect.objectContaining({ signalId: "IS-EXISTING", recurrenceCount: SIGNAL_BACKLOG_THRESHOLD }),
+    );
+    expect(result).toEqual({ signalId: "IS-EXISTING", isNew: false, backlogItemId: "BI-SIG-1" });
+    // Second update persists the back-link.
+    expect(update).toHaveBeenNthCalledWith(2, expect.objectContaining({ data: { backlogItemId: "BI-SIG-1" } }));
+  });
+
+  it("does not re-file a signal that already has a backlog item", async () => {
+    findUnique.mockResolvedValue({ signalId: "IS-EXISTING" });
+    update.mockResolvedValue({
+      recurrenceCount: SIGNAL_BACKLOG_THRESHOLD + 5,
+      backlogItemId: "BI-SIG-EXISTING",
+    });
+    const fileBacklogItem = vi.fn();
+
+    const result = await createOrTouchImprovementSignal(
+      { sourceType: "platform_issue_report", sourceId: "PIR-AB12C", title: "Already filed" },
+      { fileBacklogItem },
+    );
+
+    expect(fileBacklogItem).not.toHaveBeenCalled();
+    expect(result.backlogItemId).toBe("BI-SIG-EXISTING");
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays non-fatal when projection fails — signal recorded, no back-link", async () => {
+    findUnique.mockResolvedValue({ signalId: "IS-EXISTING" });
+    update.mockResolvedValue({ recurrenceCount: SIGNAL_BACKLOG_THRESHOLD, backlogItemId: null });
+    const fileBacklogItem = vi.fn(async () => null);
+
+    const result = await createOrTouchImprovementSignal(
+      { sourceType: "platform_issue_report", sourceId: "PIR-AB12C", title: "Projection fails" },
+      { fileBacklogItem },
+    );
+
+    expect(fileBacklogItem).toHaveBeenCalledOnce();
+    expect(result).toEqual({ signalId: "IS-EXISTING", isNew: false });
+    expect(update).toHaveBeenCalledTimes(1); // no link write
   });
 });

--- a/apps/web/lib/improvement-flywheel/signals.ts
+++ b/apps/web/lib/improvement-flywheel/signals.ts
@@ -1,18 +1,33 @@
-// Minimal ImprovementSignal writer for the governed Hermes-style learning loop.
+// ImprovementSignal writer for the governed Hermes-style learning loop.
 //
 // `2026-04-05-continuous-improvement-flywheel-design.md` owns the full
-// signal-routing and prioritization pipeline. This module is a thin writer
-// the reflection plane uses to emit governed evidence — it does NOT make
-// prioritization decisions or implement the top-3 selection logic. The
-// schema (PR #623) carries the columns; this module preserves the
-// (sourceType, sourceId) dedupe contract so a re-fired reflection over the
-// same PlatformIssueReport increments recurrenceCount instead of producing
+// signal-routing and prioritization (top-N ranking) pipeline. This module
+// preserves the (sourceType, sourceId) dedupe contract so a re-fired reflection
+// over the same source increments recurrenceCount instead of producing
 // duplicate rows.
+//
+// EP-INTAKE-UNIFY / BI-B716B387: it also closes the signal→backlog gap. A
+// signal that becomes PERSISTENT (recurs to SIGNAL_BACKLOG_THRESHOLD) is filed
+// once through the shared backlog front door and back-linked via
+// ImprovementSignal.backlogItemId. One-off signals stay evidence-only, so the
+// backlog stays low-noise without a scheduled evaluation. The backlog's own
+// triage does prioritization — this is intake, not ranking.
 
 import { randomUUID } from "crypto";
 
 import type { Prisma } from "@dpf/db";
 import { prisma } from "@dpf/db";
+
+import { ingestBacklogItem } from "@/lib/operate/backlog-ingest";
+import type { BacklogWorkType } from "@/lib/explore/backlog";
+
+/**
+ * A signal that has recurred this many times is worth a BacklogItem. Recurrence
+ * is the only persistence signal the schema carries (there is no severity), so
+ * it is the gate. Tunable; the flywheel design may later replace this with a
+ * ranked top-N evaluation.
+ */
+export const SIGNAL_BACKLOG_THRESHOLD = 3;
 
 export type CreateOrTouchImprovementSignalInput = {
   /** Source vocabulary (e.g. "platform_issue_report", "user_correction"). */
@@ -34,39 +49,132 @@ export type CreateOrTouchImprovementSignalInput = {
 export type CreateOrTouchImprovementSignalResult = {
   signalId: string;
   isNew: boolean;
+  /** Set when this call projected (or found) the signal's BacklogItem. */
+  backlogItemId?: string;
+};
+
+/** Files a persistent signal into the backlog. Returns the item id, or null when
+ *  projection failed (non-fatal — the signal is still recorded). */
+export type FileSignalBacklogItemFn = (input: {
+  signalId: string;
+  sourceType: string;
+  sourceId: string;
+  title: string;
+  description?: string | null;
+  suspectedRootCause?: string | null;
+  objectiveImpactHypothesis?: string | null;
+  recurrenceCount: number;
+  routeContext?: string | null;
+  agentId?: string | null;
+}) => Promise<{ itemId: string } | null>;
+
+export type ImprovementSignalDeps = {
+  fileBacklogItem?: FileSignalBacklogItemFn;
 };
 
 function makeSignalId(): string {
   return `IS-${randomUUID().slice(0, 8).toUpperCase()}`;
 }
 
+/** Map a signal source vocabulary to a backlog workType (advisory for triage). */
+export function signalSourceTypeToWorkType(sourceType: string): BacklogWorkType {
+  const s = sourceType.toLowerCase();
+  if (s.includes("skill") || s.includes("curation")) return "skill";
+  if (s.includes("tool")) return "tool";
+  if (s.includes("doc")) return "doc";
+  // Reflection / issue-report / correction friction is defect-class by default.
+  return "bug";
+}
+
+function defaultFileSignalBacklogItem(): FileSignalBacklogItemFn {
+  return async (s) => {
+    try {
+      const res = await ingestBacklogItem({
+        title: s.title,
+        body: [
+          s.description ?? null,
+          s.suspectedRootCause ? `Suspected root cause: ${s.suspectedRootCause}` : null,
+          s.objectiveImpactHypothesis ? `Impact hypothesis: ${s.objectiveImpactHypothesis}` : null,
+          `Signal ${s.signalId} (${s.sourceType}:${s.sourceId})`,
+          `Recurrence: ${s.recurrenceCount}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        workType: signalSourceTypeToWorkType(s.sourceType),
+        source: "automated-detection",
+        itemIdPrefix: "SIG",
+        agentId: s.agentId ?? null,
+        origin: { kind: "improvement-signal", id: s.signalId },
+      });
+      return { itemId: res.itemId };
+    } catch (err) {
+      // Non-fatal: the signal is still recorded even if the projection fails.
+      console.error("[improvement-flywheel] signal backlog projection failed", err);
+      return null;
+    }
+  };
+}
+
 /**
- * Insert a fresh ImprovementSignal row for `(sourceType, sourceId)` or, if
- * one already exists, bump its `recurrenceCount` and refresh `lastSeenAt`
- * without overwriting the original evidence. Returns the public `signalId`
- * and an `isNew` flag the caller can use for log/notification copy.
+ * Insert a fresh ImprovementSignal row for `(sourceType, sourceId)` or, if one
+ * already exists, bump its `recurrenceCount` and refresh `lastSeenAt` without
+ * overwriting the original evidence. When the (post-increment) recurrence count
+ * reaches SIGNAL_BACKLOG_THRESHOLD and the signal has not already been filed, it
+ * is projected once into the backlog and back-linked.
  *
- * Dedupe lives on the schema's `@@unique([sourceType, sourceId])`. Callers
- * MUST supply a stable, source-derived `sourceId` (e.g. the PlatformIssueReport's
- * public reportId) — otherwise dedupe degrades to per-row inserts.
+ * Dedupe lives on the schema's `@@unique([sourceType, sourceId])`. Callers MUST
+ * supply a stable, source-derived `sourceId` — otherwise dedupe degrades to
+ * per-row inserts.
  */
 export async function createOrTouchImprovementSignal(
   input: CreateOrTouchImprovementSignalInput,
+  deps?: ImprovementSignalDeps,
 ): Promise<CreateOrTouchImprovementSignalResult> {
+  const fileBacklogItem = deps?.fileBacklogItem ?? defaultFileSignalBacklogItem();
+  const where = {
+    sourceType_sourceId: { sourceType: input.sourceType, sourceId: input.sourceId },
+  };
+
   const existing = await prisma.improvementSignal.findUnique({
-    where: { sourceType_sourceId: { sourceType: input.sourceType, sourceId: input.sourceId } },
+    where,
     select: { signalId: true },
   });
 
   if (existing) {
-    await prisma.improvementSignal.update({
-      where: { sourceType_sourceId: { sourceType: input.sourceType, sourceId: input.sourceId } },
+    const updated = await prisma.improvementSignal.update({
+      where,
       data: {
         recurrenceCount: { increment: 1 },
         lastSeenAt: new Date(),
       },
+      select: { recurrenceCount: true, backlogItemId: true },
     });
-    return { signalId: existing.signalId, isNew: false };
+
+    let backlogItemId = updated.backlogItemId ?? undefined;
+    if (!backlogItemId && updated.recurrenceCount >= SIGNAL_BACKLOG_THRESHOLD) {
+      const filed = await fileBacklogItem({
+        signalId: existing.signalId,
+        sourceType: input.sourceType,
+        sourceId: input.sourceId,
+        title: input.title,
+        description: input.description ?? null,
+        suspectedRootCause: input.suspectedRootCause ?? null,
+        objectiveImpactHypothesis: input.objectiveImpactHypothesis ?? null,
+        recurrenceCount: updated.recurrenceCount,
+        routeContext: input.routeContext ?? null,
+        agentId: input.agentId ?? null,
+      });
+      if (filed?.itemId) {
+        backlogItemId = filed.itemId;
+        await prisma.improvementSignal.update({ where, data: { backlogItemId: filed.itemId } });
+      }
+    }
+
+    return {
+      signalId: existing.signalId,
+      isNew: false,
+      ...(backlogItemId ? { backlogItemId } : {}),
+    };
   }
 
   const signalId = makeSignalId();
@@ -87,5 +195,6 @@ export async function createOrTouchImprovementSignal(
       objectiveImpactHypothesis: input.objectiveImpactHypothesis ?? null,
     },
   });
+  // A brand-new signal (recurrenceCount=1) is below threshold — evidence only.
   return { signalId, isNew: true };
 }

--- a/packages/db/prisma/migrations/20260606010000_improvement_signal_backlog_link/migration.sql
+++ b/packages/db/prisma/migrations/20260606010000_improvement_signal_backlog_link/migration.sql
@@ -1,0 +1,7 @@
+-- EP-INTAKE-UNIFY / BI-B716B387: back-link an ImprovementSignal to the
+-- BacklogItem it was projected into once it becomes persistent. Additive,
+-- nullable column — no backfill needed (existing signals stay unlinked until
+-- they next cross the recurrence threshold).
+ALTER TABLE "ImprovementSignal" ADD COLUMN "backlogItemId" TEXT;
+
+CREATE INDEX "ImprovementSignal_backlogItemId_idx" ON "ImprovementSignal"("backlogItemId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4451,6 +4451,10 @@ model ImprovementSignal {
   objectiveImpactHypothesis String?
   graphNodeRefs             String[] @default([])
   graphEdgeRefs             String[] @default([])
+  // EP-INTAKE-UNIFY / BI-B716B387: back-link to the BacklogItem a persistent
+  // signal was projected into (semantic itemId, BI-…). Null until the signal
+  // crosses the recurrence threshold and is filed through the shared front door.
+  backlogItemId             String?
   createdAt                 DateTime @default(now())
   updatedAt                 DateTime @updatedAt
   lastSeenAt                DateTime @default(now())
@@ -4460,6 +4464,7 @@ model ImprovementSignal {
   @@index([routeContext, createdAt(sort: Desc)])
   @@index([agentId, createdAt(sort: Desc)])
   @@index([toolName, createdAt(sort: Desc)])
+  @@index([backlogItemId])
 }
 
 model ExternalEvidenceRecord {


### PR DESCRIPTION
## Why

Phase 3 of the queue consolidation ([EP-INTAKE-UNIFY](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1584)). `ImprovementSignal` had **no path to the backlog at all** — the continuous-improvement flywheel's intended top-N promotion was never implemented, so reflection/curation signals accumulated invisibly with no `backlogItemId` field.

## What

`createOrTouchImprovementSignal` now projects a signal into the backlog through the shared front door (from Phase 1) once it becomes **persistent** — `recurrenceCount` reaches `SIGNAL_BACKLOG_THRESHOLD` (3) — exactly once, back-linked via the new `ImprovementSignal.backlogItemId`:

- **Low-noise by design** — one-off signals stay evidence-only; only recurring friction earns a BacklogItem. No scheduled job; the backlog's own triage does prioritization (the flywheel design still owns ranking — this is intake, not ranking).
- **workType from sourceType** — skill/curation → `skill`, tool → `tool`, doc → `doc`, else `bug`.
- `source=automated-detection`, deduped by `signalId`; filing is injectable and **non-fatal** (the signal is still recorded if projection fails).
- The two callers (`curator.ts`, `reflection-triggers.ts`) need no changes — they get the behavior through the single writer.

**Schema:** additive nullable `ImprovementSignal.backlogItemId` + index; migration `20260606010000_improvement_signal_backlog_link` (no backfill — existing signals link on their next threshold crossing).

## Verification

- `pnpm --filter web typecheck` — green (pre-commit ran it). `pnpm --filter web build` — green.
- Full web vitest — **9962 passed / 0 failed**. Signals suite extended: threshold gate, file-once, no-re-file, non-fatal projection, and the sourceType→workType map (kept the existing create/increment/evidence-preservation tests).
- The `@dpf/db` model-integration tests need a live Postgres (they run in CI); this additive nullable column doesn't touch them.

## Next

Phase 4 — `PlatformIssueReport` synchronous projection (BI-EDFBE081), which also retires the 15-min triage cron and folds `/admin/issue-reports` into a `workType=bug` view (the 2026-05-30 spec's Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)