### PR TITLE
feat(workbooks): platform-data grids — Backlog as an editable spreadsheet (EP-GRID-WORKBOOKS Phase 1b)

### DIFF
--- a/apps/web/app/(shell)/workbooks/page.tsx
+++ b/apps/web/app/(shell)/workbooks/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Table2 } from "lucide-react";
+import { Table2, Database } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { listWorkbooks } from "@/lib/workbooks/workbook-service";
+import { listPlatformTablesForUser } from "@/lib/workbooks/platform-tables";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { CreateWorkbookButton } from "@/components/workbooks/CreateWorkbookButton";
 
@@ -18,6 +19,11 @@ export default async function WorkbooksHubPage() {
   }
 
   const workbooks = await listWorkbooks({ id: user.id, isSuperuser: user.isSuperuser });
+  const platformTables = listPlatformTablesForUser({
+    id: user.id,
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  });
   const canManage = can(
     { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
     "manage_workbooks",
@@ -70,6 +76,31 @@ export default async function WorkbooksHubPage() {
             </li>
           ))}
         </ul>
+      )}
+
+      {platformTables.length > 0 && (
+        <section className="mt-10">
+          <h2 className="mb-1 text-lg font-semibold text-[var(--dpf-text)]">Platform data</h2>
+          <p className="mb-3 text-sm text-[var(--dpf-muted)]">
+            Existing platform records, opened as live spreadsheets. Edits here are the same data as the forms.
+          </p>
+          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {platformTables.map((t) => (
+              <li key={t.entityType}>
+                <Link
+                  href={`/workbooks/system/${t.entityType}`}
+                  className="block rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition hover:bg-[var(--dpf-surface-2)]"
+                >
+                  <div className="flex items-center gap-2">
+                    <Database className="h-4 w-4 text-[var(--dpf-muted)]" />
+                    <span className="font-medium text-[var(--dpf-text)]">{t.label}</span>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-sm text-[var(--dpf-muted)]">{t.description}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/lib/auth";
+import {
+  getPlatformTable,
+  getPlatformTableGridData,
+  type PlatformUser,
+} from "@/lib/workbooks/platform-tables";
+import { WorkbookError } from "@/lib/workbooks/workbook-service";
+import { WorkbookGrid } from "@/components/workbooks/Grid";
+
+export const dynamic = "force-dynamic";
+
+type Props = { params: Promise<{ entityType: string }> };
+
+export default async function PlatformTablePage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+  const user = session.user;
+
+  const { entityType } = await params;
+  const def = getPlatformTable(entityType);
+  if (!def) notFound();
+
+  const svcUser: PlatformUser = {
+    id: user.id,
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
+
+  let grid;
+  try {
+    grid = await getPlatformTableGridData(svcUser, entityType);
+  } catch (e) {
+    if (e instanceof WorkbookError && e.status === 403) redirect("/workbooks");
+    if (e instanceof WorkbookError && e.status === 404) notFound();
+    throw e;
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-6xl flex-col p-6">
+      <Link
+        href="/workbooks"
+        className="mb-2 inline-flex items-center gap-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+      >
+        <ChevronLeft className="h-4 w-4" /> Workbooks
+      </Link>
+
+      <div className="mb-4">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold text-[var(--dpf-text)]">{def.label}</h1>
+          <span className="rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">
+            platform data
+          </span>
+          {!grid.schema.capabilities.canEditCell && (
+            <span className="rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">
+              read-only
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-[var(--dpf-muted)]">{def.description}</p>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <WorkbookGrid
+          source="platform"
+          tableId={entityType}
+          columns={grid.schema.columns}
+          rows={grid.rows}
+          capabilities={grid.schema.capabilities}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -41,12 +41,20 @@ import {
   updateCellsAction,
   deleteRowAction,
 } from "@/lib/actions/workbooks";
+import { updatePlatformCellsAction } from "@/lib/actions/platform-grid";
 
 export interface WorkbookGridProps {
+  /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
   tableId: string;
   columns: ColumnDefinition[];
   rows: GridRow[];
   capabilities: GridCapabilities;
+  /**
+   * "custom" = user-defined WorkbookTable (default).
+   * "platform" = a live grid over platform records (e.g. backlog); edits route
+   * through the domain's validated update action, not the workbook store.
+   */
+  source?: "custom" | "platform";
 }
 
 function toRowData(rows: GridRow[]): GridRowData[] {
@@ -130,7 +138,13 @@ function compareValues(a: CellValue, b: CellValue): number {
   return av < bv ? -1 : 1;
 }
 
-export function WorkbookGrid({ tableId, columns, rows, capabilities }: WorkbookGridProps) {
+export function WorkbookGrid({
+  tableId,
+  columns,
+  rows,
+  capabilities,
+  source = "custom",
+}: WorkbookGridProps) {
   const [rowData, setRowData] = useState<GridRowData[]>(() => toRowData(rows));
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
   const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
@@ -158,10 +172,13 @@ export function WorkbookGrid({ tableId, columns, rows, capabilities }: WorkbookG
   const persistCell = useCallback(
     async (rowId: string, columnId: string, value: CellValue) => {
       setError(null);
-      const res = await updateCellsAction(tableId, rowId, { [columnId]: value });
+      const res =
+        source === "platform"
+          ? await updatePlatformCellsAction(tableId, rowId, { [columnId]: value })
+          : await updateCellsAction(tableId, rowId, { [columnId]: value });
       if (!res.ok) setError(res.error);
     },
-    [tableId],
+    [tableId, source],
   );
 
   const onRowsChange = useCallback(

--- a/apps/web/lib/actions/platform-grid.ts
+++ b/apps/web/lib/actions/platform-grid.ts
@@ -1,0 +1,36 @@
+"use server";
+
+// Universal Grid & Workbooks — platform-data grid server actions (EP-GRID-WORKBOOKS, Phase 1b)
+// Edits to platform records (e.g. backlog) made from a grid. Auth here; the
+// underlying domain update action re-enforces its own capability + validation.
+
+import { auth } from "@/lib/auth";
+import { updatePlatformCells } from "@/lib/workbooks/platform-tables";
+import { WorkbookError } from "@/lib/workbooks/workbook-service";
+import type { CellValue } from "@/lib/workbooks/types";
+
+export type PlatformGridResult =
+  | { ok: true; data: { rowId: string } }
+  | { ok: false; error: string };
+
+export async function updatePlatformCellsAction(
+  entityType: string,
+  rowId: string,
+  changes: Record<string, CellValue>,
+): Promise<PlatformGridResult> {
+  try {
+    const session = await auth();
+    const user = session?.user;
+    if (!user?.id) throw new WorkbookError("Not authenticated", 401);
+    const row = await updatePlatformCells(
+      { id: user.id, platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      entityType,
+      rowId,
+      changes,
+    );
+    return { ok: true, data: { rowId: row.rowId } };
+  } catch (e) {
+    if (e instanceof WorkbookError) return { ok: false, error: e.message };
+    return { ok: false, error: e instanceof Error ? e.message : "Unexpected error" };
+  }
+}

--- a/apps/web/lib/workbooks/adapter.ts
+++ b/apps/web/lib/workbooks/adapter.ts
@@ -20,6 +20,12 @@ export interface AdapterContext {
   userId: string;
   /** workbook-level role for the current user, when the table belongs to a workbook */
   workbookRole?: "owner" | "editor" | "viewer";
+  /**
+   * For platform-data adapters (not backed by a WorkbookShare): whether the user
+   * holds the domain's manage capability (e.g. manage_backlog). The service
+   * resolves it from the domain permission and passes it in.
+   */
+  canManage?: boolean;
 }
 
 export interface ReferenceResolution {

--- a/apps/web/lib/workbooks/backlog-adapter-mapping.test.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-mapping.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  BACKLOG_COLUMNS,
+  backlogItemToGridRow,
+  buildBacklogInput,
+  type BacklogEditableExisting,
+} from "./backlog-adapter-mapping";
+
+describe("BACKLOG_COLUMNS", () => {
+  it("exposes the expected columns keyed by field name", () => {
+    const keys = BACKLOG_COLUMNS.map((c) => c.columnId);
+    expect(keys).toEqual(
+      expect.arrayContaining(["itemId", "title", "status", "priority", "type", "workType", "source", "body", "updatedAt"]),
+    );
+  });
+
+  it("marks identity/timestamp columns read-only and content columns editable", () => {
+    const byId = new Map(BACKLOG_COLUMNS.map((c) => [c.columnId, c]));
+    expect(byId.get("itemId")?.editable).toBe(false);
+    expect(byId.get("updatedAt")?.editable).toBe(false);
+    expect(byId.get("title")?.editable).toBe(true);
+    expect(byId.get("status")?.editable).toBe(true);
+  });
+
+  it("status is a select with options and excludes triaging", () => {
+    const status = BACKLOG_COLUMNS.find((c) => c.columnId === "status");
+    expect(status?.fieldType).toBe("select");
+    const optionKeys = status?.config?.options?.map((o) => o.key) ?? [];
+    expect(optionKeys).toContain("open");
+    expect(optionKeys).toContain("done");
+    expect(optionKeys).not.toContain("triaging");
+  });
+});
+
+describe("backlogItemToGridRow", () => {
+  it("maps a record to a row keyed by field name with ISO date", () => {
+    const row = backlogItemToGridRow({
+      itemId: "BI-1",
+      title: "Fix login",
+      status: "open",
+      type: "product",
+      workType: "bug",
+      source: "user-request",
+      priority: 3,
+      epicId: "EP-X",
+      body: "details",
+      updatedAt: new Date("2026-06-06T10:00:00.000Z"),
+    });
+    expect(row.rowId).toBe("BI-1");
+    expect(row.cells.title).toBe("Fix login");
+    expect(row.cells.status).toBe("open");
+    expect(row.cells.priority).toBe(3);
+    expect(row.cells.updatedAt).toBe("2026-06-06T10:00:00.000Z");
+  });
+});
+
+describe("buildBacklogInput", () => {
+  const existing: BacklogEditableExisting = {
+    title: "Old title",
+    type: "product",
+    status: "open",
+    workType: "bug",
+    source: "user-request",
+    priority: 2,
+    body: "old body",
+    epicId: "EP-1",
+    digitalProductId: "dp-1",
+    taxonomyNodeId: null,
+  };
+
+  it("overlays a single changed field and preserves the rest", () => {
+    const input = buildBacklogInput(existing, { status: "done" });
+    expect(input.status).toBe("done");
+    expect(input.title).toBe("Old title");
+    expect(input.workType).toBe("bug");
+    expect(input.type).toBe("product");
+    expect(input.digitalProductId).toBe("dp-1");
+    expect(input.epicId).toBe("EP-1");
+  });
+
+  it("coerces a numeric-string priority to a number", () => {
+    const input = buildBacklogInput(existing, { priority: "5" });
+    expect(input.priority).toBe(5);
+  });
+
+  it("throws when required workType is missing and not supplied", () => {
+    const noWorkType = { ...existing, workType: null };
+    expect(() => buildBacklogInput(noWorkType, { status: "done" })).toThrow(/work type/i);
+  });
+
+  it("accepts a supplied workType for an item that was missing one", () => {
+    const noWorkType = { ...existing, workType: null };
+    const input = buildBacklogInput(noWorkType, { workType: "chore" });
+    expect(input.workType).toBe("chore");
+  });
+
+  it("throws when title is cleared", () => {
+    expect(() => buildBacklogInput(existing, { title: "  " })).toThrow(/title/i);
+  });
+});

--- a/apps/web/lib/workbooks/backlog-adapter-mapping.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-mapping.ts
@@ -1,0 +1,180 @@
+// Universal Grid & Workbooks — BacklogItem grid mapping (EP-GRID-WORKBOOKS, Phase 1b)
+//
+// Pure (no server imports) mapping between BacklogItem records and the grid's
+// ColumnDefinition / GridRow contract. Isolated here so it is unit-testable
+// without pulling in prisma or the "use server" update action. The adapter
+// (backlog-adapter.ts) composes these with the data layer.
+
+import {
+  BACKLOG_STATUS_VALUES,
+  BACKLOG_WORK_TYPE_VALUES,
+  BACKLOG_SOURCE_VALUES,
+  type BacklogItemInput,
+  type BacklogStatus,
+  type BacklogWorkType,
+  type BacklogSource,
+} from "@/lib/explore/backlog";
+import type { ColumnDefinition, GridRow, CellValue, SelectOption } from "./types";
+
+export const BACKLOG_ENTITY_TYPE = "backlog_item";
+
+function humanize(key: string): string {
+  return key
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function options(values: readonly string[]): SelectOption[] {
+  return values.map((v) => ({ key: v, label: humanize(v) }));
+}
+
+// Status options offered for editing — omit "triaging" (an intake-only state).
+const EDITABLE_STATUS = BACKLOG_STATUS_VALUES.filter((s) => s !== "triaging");
+
+/** Fixed column schema for the Backlog grid. columnId == BacklogItem field name. */
+export const BACKLOG_COLUMNS: ColumnDefinition[] = [
+  { columnId: "itemId", name: "ID", fieldType: "text", position: 0, required: false, editable: false, width: 130 },
+  { columnId: "title", name: "Title", fieldType: "text", position: 1, required: true, editable: true, width: 320 },
+  {
+    columnId: "status",
+    name: "Status",
+    fieldType: "select",
+    position: 2,
+    required: true,
+    editable: true,
+    width: 130,
+    groupable: true,
+    config: { options: options(EDITABLE_STATUS) },
+  },
+  { columnId: "priority", name: "Priority", fieldType: "number", position: 3, required: false, editable: true, width: 90 },
+  {
+    columnId: "type",
+    name: "Type",
+    fieldType: "select",
+    position: 4,
+    required: true,
+    editable: true,
+    width: 120,
+    config: { options: options(["product", "portfolio"]) },
+  },
+  {
+    columnId: "workType",
+    name: "Work type",
+    fieldType: "select",
+    position: 5,
+    required: true,
+    editable: true,
+    width: 120,
+    config: { options: options(BACKLOG_WORK_TYPE_VALUES) },
+  },
+  {
+    columnId: "source",
+    name: "Source",
+    fieldType: "select",
+    position: 6,
+    required: false,
+    editable: true,
+    width: 150,
+    config: { options: options(BACKLOG_SOURCE_VALUES) },
+  },
+  { columnId: "epicId", name: "Epic", fieldType: "text", position: 7, required: false, editable: false, width: 160 },
+  { columnId: "body", name: "Details", fieldType: "text", position: 8, required: false, editable: true, width: 360, config: { multiline: true } },
+  { columnId: "updatedAt", name: "Updated", fieldType: "datetime", position: 9, required: false, editable: false, width: 170 },
+];
+
+/** The subset of BacklogItem fields needed to build a complete update payload. */
+export interface BacklogEditableExisting {
+  title: string;
+  type: string;
+  status: string;
+  workType: string | null;
+  source: string | null;
+  priority: number | null;
+  body: string | null;
+  epicId: string | null;
+  digitalProductId: string | null;
+  taxonomyNodeId: string | null;
+}
+
+/** Map a backlog record (list/detail shape) into a grid row keyed by field name. */
+export function backlogItemToGridRow(item: {
+  itemId: string;
+  title: string;
+  status: string;
+  type: string;
+  workType: string | null;
+  source: string | null;
+  priority: number | null;
+  epicId: string | null;
+  body: string | null;
+  updatedAt: Date;
+}): GridRow {
+  return {
+    rowId: item.itemId,
+    cells: {
+      itemId: item.itemId,
+      title: item.title,
+      status: item.status,
+      priority: item.priority,
+      type: item.type,
+      workType: item.workType,
+      source: item.source,
+      epicId: item.epicId,
+      body: item.body,
+      updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : String(item.updatedAt),
+    },
+  };
+}
+
+function asNumberOrUndef(v: CellValue | undefined): number | undefined {
+  if (typeof v === "number") return v;
+  if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) return Number(v);
+  return undefined;
+}
+
+function asStringOrUndef(v: CellValue | undefined): string | undefined {
+  return typeof v === "string" && v !== "" ? v : undefined;
+}
+
+/**
+ * Build a complete BacklogItemInput by overlaying grid changes (keyed by field
+ * name) onto the existing record. Throws if a required field would be empty —
+ * we never silently invent a workType/type/title.
+ */
+export function buildBacklogInput(
+  existing: BacklogEditableExisting,
+  changes: Record<string, CellValue>,
+): BacklogItemInput {
+  const pick = <T>(field: string, fallback: T): CellValue | T =>
+    field in changes ? changes[field] : fallback;
+
+  const title = String(pick("title", existing.title) ?? "").trim();
+  if (!title) throw new Error("Title cannot be empty");
+
+  const type = String(pick("type", existing.type)) as "product" | "portfolio";
+
+  const workTypeRaw = pick("workType", existing.workType);
+  const workType = (typeof workTypeRaw === "string" ? workTypeRaw : "") as BacklogWorkType;
+  if (!workType) {
+    throw new Error("This item is missing a work type — set it in the backlog form first");
+  }
+
+  const status = String(pick("status", existing.status)) as BacklogStatus;
+
+  const sourceRaw = pick("source", existing.source ?? undefined);
+  const source = (asStringOrUndef(sourceRaw) as BacklogSource | undefined) ?? undefined;
+
+  return {
+    title,
+    type,
+    workType,
+    status,
+    source,
+    priority: asNumberOrUndef(pick("priority", existing.priority ?? undefined)),
+    body: asStringOrUndef(pick("body", existing.body ?? undefined)),
+    epicId: existing.epicId ?? undefined,
+    digitalProductId: existing.digitalProductId ?? undefined,
+    taxonomyNodeId: existing.taxonomyNodeId ?? undefined,
+  };
+}

--- a/apps/web/lib/workbooks/backlog-adapter.ts
+++ b/apps/web/lib/workbooks/backlog-adapter.ts
@@ -1,0 +1,139 @@
+// Universal Grid & Workbooks — BacklogItemAdapter (EP-GRID-WORKBOOKS, Phase 1b)
+//
+// Renders real BacklogItem records as an editable grid. This is the first
+// platform-data adapter: the grid is a live view over the same records the
+// backlog forms edit, NOT a copy. Writes route through the canonical
+// updateBacklogItem server action (which itself enforces manage_backlog and all
+// status/validation rules) — never a raw prisma write.
+
+import { prisma } from "@dpf/db";
+import { updateBacklogItem } from "@/lib/actions/backlog";
+import { getBacklogItems } from "@/lib/explore/backlog-data";
+import {
+  gridRegistry,
+  type DataSourceAdapter,
+  type AdapterContext,
+} from "./adapter";
+import {
+  BACKLOG_ENTITY_TYPE,
+  BACKLOG_COLUMNS,
+  backlogItemToGridRow,
+  buildBacklogInput,
+  type BacklogEditableExisting,
+} from "./backlog-adapter-mapping";
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type DataSourceFilter,
+  type SortSpec,
+  type Pagination,
+  type PagedRows,
+  type GridCapabilities,
+} from "./types";
+import { applyFilters, applySort, paginate } from "./grid-query";
+
+async function readGridRow(itemId: string): Promise<GridRow | null> {
+  const item = await prisma.backlogItem.findUnique({
+    where: { itemId },
+    select: {
+      itemId: true,
+      title: true,
+      status: true,
+      type: true,
+      workType: true,
+      source: true,
+      priority: true,
+      epicId: true,
+      body: true,
+      updatedAt: true,
+    },
+  });
+  return item ? backlogItemToGridRow(item) : null;
+}
+
+class BacklogItemAdapter implements DataSourceAdapter {
+  readonly entityType = BACKLOG_ENTITY_TYPE;
+
+  async getColumns(): Promise<ColumnDefinition[]> {
+    return BACKLOG_COLUMNS;
+  }
+
+  async queryRows(
+    _entityType: string,
+    opts: { filters: DataSourceFilter; sort: SortSpec[]; pagination: Pagination },
+  ): Promise<PagedRows> {
+    const items = await getBacklogItems();
+    const rows = items.map(backlogItemToGridRow);
+    const filtered = applyFilters(rows, opts.filters);
+    const sorted = applySort(filtered, opts.sort);
+    return paginate(sorted, opts.pagination.cursor, opts.pagination.limit);
+  }
+
+  async getRow(_entityType: string, rowId: string): Promise<GridRow | null> {
+    return readGridRow(rowId);
+  }
+
+  async updateCells(
+    _entityType: string,
+    rowId: string,
+    changes: Record<string, CellValue>,
+    _ctx: AdapterContext,
+  ): Promise<GridRow> {
+    const existing = await prisma.backlogItem.findUnique({
+      where: { itemId: rowId },
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        status: true,
+        workType: true,
+        source: true,
+        priority: true,
+        body: true,
+        epicId: true,
+        digitalProductId: true,
+        taxonomyNodeId: true,
+      },
+    });
+    if (!existing) throw new Error("Backlog item not found");
+
+    const editable: BacklogEditableExisting = {
+      title: existing.title,
+      type: existing.type,
+      status: existing.status,
+      workType: existing.workType,
+      source: existing.source,
+      priority: existing.priority,
+      body: existing.body,
+      epicId: existing.epicId,
+      digitalProductId: existing.digitalProductId,
+      taxonomyNodeId: existing.taxonomyNodeId,
+    };
+
+    const input = buildBacklogInput(editable, changes);
+    // Canonical, fully-validated + authorized update path (enforces manage_backlog).
+    await updateBacklogItem(existing.id, input);
+
+    const updated = await readGridRow(rowId);
+    if (!updated) throw new Error("Item updated but could not be read back");
+    return updated;
+  }
+
+  getCapabilities(ctx: AdapterContext): GridCapabilities {
+    const canEdit = ctx.canManage === true;
+    return {
+      // Platform data: read + edit existing records in Phase 1b.
+      // Row creation/deletion stay in the domain's own forms for now.
+      canAddRow: false,
+      canAddColumn: false,
+      canEditCell: canEdit,
+      canDeleteRow: false,
+    };
+  }
+}
+
+export const backlogItemAdapter = new BacklogItemAdapter();
+
+// Self-register on module load.
+gridRegistry.register(backlogItemAdapter);

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -1,0 +1,134 @@
+// Universal Grid & Workbooks — platform-data tables (EP-GRID-WORKBOOKS, Phase 1b)
+//
+// Exposes existing platform datasets as grids without requiring a user-created
+// Workbook. Each entry maps a registered adapter to its domain capabilities, so
+// the same record a form edits can be viewed/edited as a spreadsheet. Access is
+// gated by the domain's own capability (view to see, manage to edit); the
+// canonical update action enforces it again on write.
+
+import { can } from "@/lib/permissions";
+import type { CapabilityKey } from "@/lib/govern/permissions";
+import { gridRegistry, type AdapterContext } from "./adapter";
+import "./backlog-adapter"; // self-register the backlog adapter
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type GridCapabilities,
+  type DataSourceFilter,
+  type SortSpec,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  emptyViewConfig,
+  type ViewConfig,
+} from "./types";
+import { WorkbookError } from "./workbook-service";
+
+export interface PlatformUser {
+  id: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+}
+
+export interface PlatformTableDef {
+  entityType: string;
+  label: string;
+  description: string;
+  viewCapability: CapabilityKey;
+  manageCapability: CapabilityKey;
+}
+
+/** The registry of platform datasets available as grids. Add a row per adapter. */
+export const PLATFORM_TABLES: PlatformTableDef[] = [
+  {
+    entityType: "backlog_item",
+    label: "Backlog",
+    description: "Every backlog item as an editable spreadsheet — same records as the backlog forms.",
+    viewCapability: "view_operations",
+    manageCapability: "manage_backlog",
+  },
+];
+
+function userCtx(user: PlatformUser) {
+  return { platformRole: user.platformRole, isSuperuser: user.isSuperuser };
+}
+
+export function getPlatformTable(entityType: string): PlatformTableDef | undefined {
+  return PLATFORM_TABLES.find((t) => t.entityType === entityType);
+}
+
+export function listPlatformTablesForUser(user: PlatformUser): PlatformTableDef[] {
+  return PLATFORM_TABLES.filter((t) => can(userCtx(user), t.viewCapability));
+}
+
+function requireTable(user: PlatformUser, entityType: string): PlatformTableDef {
+  const def = getPlatformTable(entityType);
+  if (!def) throw new WorkbookError("Unknown platform table", 404);
+  if (!can(userCtx(user), def.viewCapability)) {
+    throw new WorkbookError("You do not have access to this data", 403);
+  }
+  return def;
+}
+
+export interface PlatformGridData {
+  schema: {
+    tableId: string;
+    name: string;
+    dataSource: string;
+    columns: ColumnDefinition[];
+    capabilities: GridCapabilities;
+  };
+  rows: GridRow[];
+  nextCursor: string | null;
+  view: ViewConfig;
+}
+
+export async function getPlatformTableGridData(
+  user: PlatformUser,
+  entityType: string,
+  opts: { filters?: DataSourceFilter; sort?: SortSpec[]; cursor?: string | null; limit?: number } = {},
+): Promise<PlatformGridData> {
+  const def = requireTable(user, entityType);
+  const adapter = gridRegistry.require(entityType);
+  const ctx: AdapterContext = {
+    userId: user.id,
+    canManage: can(userCtx(user), def.manageCapability),
+  };
+  const limit = Math.min(Math.max(opts.limit ?? DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+  const columns = await adapter.getColumns(entityType);
+  const { data, nextCursor } = await adapter.queryRows(entityType, {
+    filters: opts.filters ?? { conditions: [], logic: "and" },
+    sort: opts.sort ?? [],
+    pagination: { cursor: opts.cursor ?? null, limit },
+  });
+  return {
+    schema: {
+      tableId: entityType,
+      name: def.label,
+      dataSource: entityType,
+      columns,
+      capabilities: adapter.getCapabilities(ctx),
+    },
+    rows: data,
+    nextCursor,
+    view: emptyViewConfig(columns),
+  };
+}
+
+export async function updatePlatformCells(
+  user: PlatformUser,
+  entityType: string,
+  rowId: string,
+  changes: Record<string, CellValue>,
+): Promise<GridRow> {
+  const def = requireTable(user, entityType);
+  if (!can(userCtx(user), def.manageCapability)) {
+    throw new WorkbookError(`You do not have permission to edit ${def.label}`, 403);
+  }
+  const adapter = gridRegistry.require(entityType);
+  if (!adapter.updateCells) throw new WorkbookError("This data source is read-only", 400);
+  return adapter.updateCells(entityType, rowId, changes, {
+    userId: user.id,
+    canManage: true,
+  });
+}


### PR DESCRIPTION
## What & why

Phase 1 shipped user-defined workbooks. This **Phase 1b** delivers the operator's actual ask — *"certain interfaces should allow working in a spreadsheet paradigm; this is missing for the most logical interfaces."* It makes a grid a **live view/editor over real platform records**, not a separate copy. First dataset: **Backlog**.

Builds on EP-GRID-WORKBOOKS (Phase 1, #1582).

## How it stays "the same data as the forms"

`BacklogItemAdapter` reads real `BacklogItem` records and **writes through the canonical `updateBacklogItem` server action** — which re-enforces `manage_backlog` and all status/validation/epic-completion rules. **No raw prisma writes.** So a grid edit and a form edit hit the identical validated path on the identical record.

## Changes

- **`lib/workbooks/backlog-adapter.ts`** — the adapter. Pure field↔column mapping isolated in **`backlog-adapter-mapping.ts`** (unit-tested), so building the update payload (merge changes over existing, refuse to invent a required field) is verifiable.
- **`lib/workbooks/platform-tables.ts`** — registry + service exposing registered adapters as grids **without** a user Workbook; gated by the domain's own capability (`view_operations` to see, `manage_backlog` to edit). New dataset = one registry row.
- **`AdapterContext.canManage`** for platform adapters.
- **Grid** dispatches edits by `source`: `"custom"` → workbook store, `"platform"` → `updatePlatformCellsAction` → domain update action.
- **New surface** `/workbooks/system/[entityType]` renders the platform grid; the Workbooks hub gains a **"Platform data"** catalog section.

## Scope

Phase 1b = **read + edit** existing records (status, priority, title, type, workType, source, body). Row add/delete stay in the domain forms for now (`canAddRow`/`canDeleteRow` = false — spec's "false for platform data initially"). Next datasets (Finance invoices, Compliance risks) are one adapter each.

## Verification (worktree)

- `vitest lib/workbooks/` → **33/33** (9 new backlog-mapping tests).
- `typecheck` clean; production `build` green with `/workbooks/system/[entityType]` registered.
- Live-portal UX functional verification runs after self-upgrade deploys this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)