### PR TITLE
docs(workspace): redesign the default /workspace home as the company day-to-day surface

### DIFF
--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -1,9 +1,11 @@
 import { prisma } from "@dpf/db";
 import { PlatformTabNav } from "@/components/platform/PlatformTabNav";
 import { PlatformSummaryCard } from "@/components/platform/PlatformSummaryCard";
+import { PlatformReadinessMatrix } from "@/components/workspace/PlatformReadinessMatrix";
 import { getProposalStats } from "@/lib/evaluate/proposal-data";
 import { getToolExecutionStats } from "@/lib/tool-execution-data";
 import { buildAuthoritySummaryMetrics, getPlatformAuthoritySummary } from "@/lib/platform-authority-summary";
+import { loadWorkspaceCommandCenter } from "@/lib/workspace/command-center";
 
 export default async function PlatformPage() {
   const [
@@ -18,6 +20,7 @@ export default async function PlatformPage() {
     userCount,
     roleCount,
     capabilityCount,
+    commandCenter,
   ] = await Promise.all([
     prisma.agent.count(),
     prisma.modelProvider.count({ where: { status: "active" } }),
@@ -30,6 +33,7 @@ export default async function PlatformPage() {
     prisma.user.count(),
     prisma.platformRole.count(),
     prisma.platformCapability.count(),
+    loadWorkspaceCommandCenter(prisma),
   ]);
   const authorityMetrics = buildAuthoritySummaryMetrics(authoritySummary);
 
@@ -105,6 +109,18 @@ export default async function PlatformPage() {
           <p className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{toolStats.failed}</p>
         </div>
       </div>
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Operations</h2>
+        <a
+          href="/platform/schedule"
+          className="inline-flex items-center rounded-md border border-[var(--dpf-border)] px-3 py-2 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+        >
+          Platform schedule →
+        </a>
+      </div>
+
+      <PlatformReadinessMatrix readiness={commandCenter.commandCenter.readiness} />
     </div>
   );
 }

--- a/apps/web/app/(shell)/platform/schedule/page.tsx
+++ b/apps/web/app/(shell)/platform/schedule/page.tsx
@@ -1,0 +1,48 @@
+// apps/web/app/(shell)/platform/schedule/page.tsx
+//
+// The operator schedule — "everything the portal is scheduled to do." This is
+// the full multi-source calendar: business events PLUS the platform/ops minutia
+// (scheduled cron jobs and recurring digests, deployment windows, blackouts,
+// change requests, and AI coworker task runs) that were deliberately kept off
+// the business workspace home. See
+// docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md §6.2.
+
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { PlatformTabNav } from "@/components/platform/PlatformTabNav";
+import { WorkspaceCalendar } from "@/components/workspace/WorkspaceCalendar";
+import { getCalendarEvents } from "@/lib/calendar-data";
+import { can } from "@/lib/govern/permissions";
+
+export default async function PlatformSchedulePage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+  if (!can(session.user, "view_platform")) redirect("/workspace");
+
+  const now = new Date();
+  const rangeStart = new Date(now.getFullYear(), now.getMonth(), -7);
+  const rangeEnd = new Date(now.getFullYear(), now.getMonth() + 1, 7);
+  const events = await getCalendarEvents(rangeStart, rangeEnd);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Platform schedule</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Everything the portal is scheduled to do — scheduled jobs and recurring digests,
+          deployment windows and blackouts, change requests, and AI coworker task runs, alongside
+          business events. The business{" "}
+          <a href="/workspace/calendar" className="text-[var(--dpf-accent)] hover:underline">
+            day-to-day calendar
+          </a>{" "}
+          hides this platform detail.
+        </p>
+      </div>
+
+      <PlatformTabNav />
+
+      <WorkspaceCalendar events={events} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/workspace/calendar/page.tsx
+++ b/apps/web/app/(shell)/workspace/calendar/page.tsx
@@ -1,0 +1,46 @@
+// apps/web/app/(shell)/workspace/calendar/page.tsx
+//
+// The full BUSINESS calendar — the "open full calendar" target from the
+// workspace home's Today & Next agenda. It defaults to business-context
+// sources (bookings, money due, providers, CRM, compliance) and hides the
+// platform/ops minutia (cron digests, deployment windows, AI task runs), which
+// live on the operator schedule at /platform/schedule. All filters remain
+// available, so a user can opt the platform sources back in.
+
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { WorkspaceCalendar } from "@/components/workspace/WorkspaceCalendar";
+import { getCalendarEvents } from "@/lib/calendar-data";
+
+export default async function WorkspaceCalendarPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const now = new Date();
+  const rangeStart = new Date(now.getFullYear(), now.getMonth(), -7);
+  const rangeEnd = new Date(now.getFullYear(), now.getMonth() + 1, 7);
+  const events = await getCalendarEvents(rangeStart, rangeEnd);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Business calendar</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Bookings, money due, customer deadlines, and team availability. Platform and operations
+          schedules live on the{" "}
+          <a href="/platform/schedule" className="text-[var(--dpf-accent)] hover:underline">
+            platform schedule
+          </a>
+          .
+        </p>
+      </div>
+
+      <WorkspaceCalendar
+        events={events}
+        defaultHiddenCategories={["platform", "operations"]}
+        defaultHiddenSources={["scheduled-jobs", "change-mgmt", "agent-tasks"]}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -24,7 +24,10 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
     href: "/platform",
     description: "Supervise platform operations from a small number of workflow hubs.",
     matchPrefixes: ["/platform"],
-    subItems: [{ label: "Platform Hub", href: "/platform" }],
+    subItems: [
+      { label: "Platform Hub", href: "/platform" },
+      { label: "Schedule", href: "/platform/schedule" },
+    ],
   },
   {
     key: "identity",

--- a/apps/web/components/workspace-home/PlatformWorkspaceHome.test.tsx
+++ b/apps/web/components/workspace-home/PlatformWorkspaceHome.test.tsx
@@ -77,12 +77,22 @@ const fixtureData: Omit<PlatformWorkspaceHomeData, "storefrontConfig"> = {
 };
 
 describe("PlatformWorkspaceHome", () => {
-  it("keeps the first render focused on the command center before work-area launchers", () => {
+  it("leads with day-to-day work (needs attention + today's agenda) before work-area launchers", () => {
     const html = renderToStaticMarkup(<PlatformWorkspaceHome data={fixtureData} />);
 
-    expect(html.indexOf("Command Center")).toBeLessThan(html.indexOf("Work areas"));
+    // Critical strip and the business agenda come before the demoted launcher.
+    expect(html.indexOf("Needs attention")).toBeLessThan(html.indexOf("Work areas"));
+    expect(html).toContain("Today &amp; next");
     expect(html).toContain("Show areas");
+    // Launcher stays collapsed: its tiles/links are not in the first render.
     expect(html).not.toContain("AI Workforce");
     expect(html).not.toContain('href="/platform/ai"');
+  });
+
+  it("does not render the platform readiness matrix on the business home", () => {
+    const html = renderToStaticMarkup(<PlatformWorkspaceHome data={fixtureData} />);
+
+    expect(html).not.toContain("Domain readiness");
+    expect(html).not.toContain("Command Center");
   });
 });

--- a/apps/web/components/workspace-home/PlatformWorkspaceHome.tsx
+++ b/apps/web/components/workspace-home/PlatformWorkspaceHome.tsx
@@ -1,8 +1,6 @@
-import { Suspense } from "react";
-
 import { ActivityFeed } from "@/components/workspace/ActivityFeed";
+import { BusinessAgenda } from "@/components/workspace/BusinessAgenda";
 import { BusinessCommandCenter } from "@/components/workspace/BusinessCommandCenter";
-import { WorkspaceCalendar } from "@/components/workspace/WorkspaceCalendar";
 import { WorkspaceAreaLauncher } from "@/components/workspace-home/WorkspaceAreaLauncher";
 import type { PlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
 
@@ -15,7 +13,6 @@ export function PlatformWorkspaceHome({ data }: PlatformWorkspaceHomeProps) {
     workspaceSections,
     workspaceCommandCenter,
     calendarEvents,
-    archetypeCategory,
     feedItems,
   } = data;
 
@@ -24,21 +21,14 @@ export function PlatformWorkspaceHome({ data }: PlatformWorkspaceHomeProps) {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-[var(--dpf-text)]">Workspace</h1>
         <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-          Today's work, schedule, handoffs, and activity in one place.
+          Your day at a glance — what needs doing now and next.
         </p>
       </div>
 
       <BusinessCommandCenter view={workspaceCommandCenter.commandCenter} />
 
       <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div>
-          <p className="mb-3 text-xs uppercase tracking-widest text-[var(--dpf-muted)]">
-            Calendar
-          </p>
-          <Suspense fallback={null}>
-            <WorkspaceCalendar events={calendarEvents} archetypeCategory={archetypeCategory} />
-          </Suspense>
-        </div>
+        <BusinessAgenda events={calendarEvents} />
         <div>
           <p className="mb-3 text-xs uppercase tracking-widest text-[var(--dpf-muted)]">
             Activity

--- a/apps/web/components/workspace/ActivityFeed.tsx
+++ b/apps/web/components/workspace/ActivityFeed.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
 import type { FeedItem } from "@/lib/activity-feed-data";
 
 const SECTION_CONFIG = {
@@ -78,7 +80,8 @@ export function ActivityFeed({ items }: Props) {
                     <div className="flex-1 min-w-0">
                       <p className="text-xs text-[var(--dpf-text)] truncate">{item.title}</p>
                       <p className="text-[10px] text-[var(--dpf-muted)] mt-0.5">
-                        {item.person ? `${item.person} · ` : ""}{new Date(item.date).toLocaleDateString()}
+                        {item.person ? `${item.person} · ` : ""}
+                        <LocalTime value={item.date} mode="date" />
                       </p>
                     </div>
                     {item.status && item.statusColor && (

--- a/apps/web/components/workspace/BusinessAgenda.test.tsx
+++ b/apps/web/components/workspace/BusinessAgenda.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BusinessAgenda, isBusinessAgendaEvent } from "./BusinessAgenda";
+import type { CalendarEventView } from "@/lib/calendar-data";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+
+function ev(partial: Partial<CalendarEventView> & Pick<CalendarEventView, "id" | "title" | "start" | "category" | "eventType">): CalendarEventView {
+  return {
+    end: null,
+    allDay: false,
+    color: "#14b8a6",
+    editable: false,
+    sourceType: "projected",
+    ...partial,
+  };
+}
+
+const events: CalendarEventView[] = [
+  ev({ id: "b1", title: "Patel booking", start: "2026-06-10T15:00:00.000Z", category: "business", eventType: "booking" }),
+  ev({ id: "f1", title: "Acme invoice due", start: "2026-06-11T00:00:00.000Z", category: "finance", eventType: "invoice", allDay: true }),
+  // platform/ops minutia — must never appear on the business agenda
+  ev({ id: "p1", title: "Nightly backup digest", start: "2026-06-10T13:00:00.000Z", category: "platform", eventType: "recurring-digest" }),
+  ev({ id: "p2", title: "Deploy window", start: "2026-06-10T20:00:00.000Z", category: "operations", eventType: "deployment-window" }),
+  ev({ id: "a1", title: "Coworker task run", start: "2026-06-10T14:00:00.000Z", category: "platform", eventType: "agent-task" }),
+  // past event — before today's cutoff
+  ev({ id: "old", title: "Last week booking", start: "2026-06-01T15:00:00.000Z", category: "business", eventType: "booking" }),
+];
+
+describe("isBusinessAgendaEvent", () => {
+  it("keeps business-context events and rejects platform/ops minutia", () => {
+    expect(isBusinessAgendaEvent({ category: "business", eventType: "booking" })).toBe(true);
+    expect(isBusinessAgendaEvent({ category: "finance", eventType: "invoice" })).toBe(true);
+    expect(isBusinessAgendaEvent({ category: "platform", eventType: "recurring-digest" })).toBe(false);
+    expect(isBusinessAgendaEvent({ category: "operations", eventType: "deployment-window" })).toBe(false);
+    expect(isBusinessAgendaEvent({ category: "platform", eventType: "agent-task" })).toBe(false);
+    expect(isBusinessAgendaEvent({ category: "business", eventType: "operating-hours" })).toBe(false);
+  });
+});
+
+describe("BusinessAgenda", () => {
+  it("shows upcoming business events and excludes platform/ops events", () => {
+    const html = renderToStaticMarkup(<BusinessAgenda events={events} now={NOW} />);
+
+    expect(html).toContain("Today &amp; next");
+    expect(html).toContain("Patel booking");
+    expect(html).toContain("Acme invoice due");
+    // platform minutia and past events are absent
+    expect(html).not.toContain("Nightly backup digest");
+    expect(html).not.toContain("Deploy window");
+    expect(html).not.toContain("Coworker task run");
+    expect(html).not.toContain("Last week booking");
+  });
+
+  it("renders an empty state (no synthesized rows) when there are no business events", () => {
+    const html = renderToStaticMarkup(<BusinessAgenda events={[]} now={NOW} />);
+
+    expect(html).toContain("Nothing scheduled for the business right now.");
+  });
+
+  it("renders an empty state when only platform events exist", () => {
+    const onlyPlatform = events.filter((e) => e.category === "platform" || e.category === "operations");
+    const html = renderToStaticMarkup(<BusinessAgenda events={onlyPlatform} now={NOW} />);
+
+    expect(html).toContain("Nothing scheduled for the business right now.");
+  });
+});

--- a/apps/web/components/workspace/BusinessAgenda.tsx
+++ b/apps/web/components/workspace/BusinessAgenda.tsx
@@ -1,0 +1,146 @@
+// apps/web/components/workspace/BusinessAgenda.tsx
+//
+// "Today & Next" — the purposed business schedule for the default workspace
+// home. It shows only business-context events (bookings, money due, provider
+// availability, customer/CRM deadlines, capacity-relevant people events,
+// compliance deadlines) drawn from the SAME calendar projection the full
+// calendar uses — never platform cron digests, deployment windows, blackouts,
+// or AI task runs. Those live on the operator schedule (/platform/schedule).
+//
+// Server component. Real data only: it renders whatever upcoming business
+// events the loader returns and shows an empty state when there are none — it
+// never synthesizes rows.
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type { CalendarEventView } from "@/lib/calendar-data";
+
+/** Categories that belong to the operator schedule, never the business home. */
+const PLATFORM_CATEGORIES = new Set(["platform", "operations"]);
+/** Event types that are platform/ops minutia, never the business home. */
+const PLATFORM_EVENT_TYPES = new Set([
+  "recurring-digest",
+  "maintenance",
+  "deployment-window",
+  "blackout",
+  "change-request",
+  "agent-task",
+]);
+
+const CATEGORY_BADGE: Record<string, { intent: Intent; label: string }> = {
+  business: { intent: "accent", label: "Business" },
+  finance: { intent: "warning", label: "Money" },
+  compliance: { intent: "danger", label: "Compliance" },
+  hr: { intent: "info", label: "People" },
+  personal: { intent: "neutral", label: "Personal" },
+};
+
+export function isBusinessAgendaEvent(e: Pick<CalendarEventView, "category" | "eventType">): boolean {
+  if (PLATFORM_CATEGORIES.has(e.category)) return false;
+  if (PLATFORM_EVENT_TYPES.has(e.eventType)) return false;
+  // Operating-hours render as a translucent background tint on the full
+  // calendar; they are not agenda items.
+  if (e.eventType === "operating-hours") return false;
+  return true;
+}
+
+function dayKey(iso: string): string {
+  // Group by calendar day using the ISO date prefix (stable across server/client).
+  return iso.slice(0, 10);
+}
+
+type Props = {
+  events: CalendarEventView[];
+  /** Reference instant; defaults to now. Injectable for deterministic tests. */
+  now?: Date;
+  /** Max agenda rows to show before linking to the full calendar. */
+  limit?: number;
+  /** Where "Open full calendar" points. */
+  fullCalendarHref?: string;
+};
+
+export function BusinessAgenda({
+  events,
+  now = new Date(),
+  limit = 10,
+  fullCalendarHref = "/workspace/calendar",
+}: Props) {
+  const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+
+  const upcoming = events
+    .filter(isBusinessAgendaEvent)
+    .filter((e) => {
+      const ends = new Date(e.end ?? e.start).getTime();
+      return Number.isFinite(ends) && ends >= cutoff;
+    })
+    .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
+    .slice(0, limit);
+
+  const groups: { key: string; items: CalendarEventView[] }[] = [];
+  for (const ev of upcoming) {
+    const key = dayKey(ev.start);
+    const last = groups[groups.length - 1];
+    if (last && last.key === key) last.items.push(ev);
+    else groups.push({ key, items: [ev] });
+  }
+
+  return (
+    <section
+      aria-labelledby="business-agenda-title"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+    >
+      <div className="flex items-center justify-between border-b border-[var(--dpf-border)] px-4 py-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+            Today &amp; next
+          </p>
+          <h2 id="business-agenda-title" className="mt-0.5 text-sm font-semibold text-[var(--dpf-text)]">
+            What&apos;s on for the business
+          </h2>
+        </div>
+        <a
+          href={fullCalendarHref}
+          className="text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+        >
+          Open full calendar →
+        </a>
+      </div>
+
+      {groups.length === 0 ? (
+        <div className="px-4 py-8 text-center text-sm text-[var(--dpf-muted)]">
+          Nothing scheduled for the business right now.
+          <br />
+          <a href={fullCalendarHref} className="text-[var(--dpf-accent)] hover:underline">
+            Add a booking, invoice, or appointment
+          </a>{" "}
+          to see it here.
+        </div>
+      ) : (
+        <ul className="divide-y divide-[var(--dpf-border)]">
+          {groups.map((group) => (
+            <li key={group.key} className="px-4 py-3">
+              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                <LocalTime value={`${group.key}T00:00:00.000Z`} mode="date" utc />
+              </p>
+              <ul className="space-y-2">
+                {group.items.map((ev) => {
+                  const badge = CATEGORY_BADGE[ev.category] ?? { intent: "neutral" as Intent, label: ev.category };
+                  return (
+                    <li key={ev.id} className="flex items-center gap-3">
+                      <span className="w-16 shrink-0 text-xs tabular-nums text-[var(--dpf-muted)]">
+                        {ev.allDay ? "All day" : <LocalTime value={ev.start} mode="time" />}
+                      </span>
+                      <StatusBadge intent={badge.intent} label={badge.label} variant="soft" />
+                      <span className="min-w-0 flex-1 truncate text-sm text-[var(--dpf-text)]">{ev.title}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/workspace/BusinessCommandCenter.test.tsx
+++ b/apps/web/components/workspace/BusinessCommandCenter.test.tsx
@@ -8,63 +8,25 @@ const fixtureView: WorkspaceCommandCenterView = {
     {
       id: "cmd-1",
       label: "Approval required",
-      description: "2 proposals are waiting for containment review",
+      description: "2 proposals are waiting for review",
       severity: "warning",
-      href: "/platform/ai/authority",
+      href: "/ops/improvements",
     },
   ],
   snapshot: [
     { id: "ai", label: "AI coworkers", value: 4, href: "/platform/ai" },
     { id: "work", label: "Open work", value: 7, href: "/ops" },
   ],
+  // Readiness is still present on the view (the loader builds it) but the
+  // business command center must NOT render it — it relocated to the platform
+  // surface (PlatformReadinessMatrix).
   readiness: [
     {
       id: "ai",
       label: "AI workforce",
       href: "/platform/ai/operations-map",
       cells: [
-        {
-          key: "context",
-          label: "Context",
-          description: "Evidence, docs, and operating knowledge",
-          state: "good",
-          href: "/wiki",
-        },
-        {
-          key: "connections",
-          label: "Connections",
-          description: "Provider, integration, and customer-system links",
-          state: "attention",
-          href: "/platform/tools/integrations",
-        },
-        {
-          key: "capabilities",
-          label: "Capabilities",
-          description: "People and AI coworkers able to act",
-          state: "good",
-          href: "/platform/ai",
-        },
-        {
-          key: "cadence",
-          label: "Cadence",
-          description: "Scheduled work, reviews, and follow-up rhythm",
-          state: "good",
-          href: "/workspace",
-        },
-        {
-          key: "confidence",
-          label: "Confidence",
-          description: "Recent receipts and low-risk signals",
-          state: "attention",
-          href: "/platform/ai/operations-map",
-        },
-        {
-          key: "containment",
-          label: "Containment",
-          description: "Approvals, route scope, and side-effect controls",
-          state: "blocked",
-          href: "/platform/ai/authority",
-        },
+        { key: "context", label: "Context", description: "Evidence and operating knowledge", state: "good", href: "/wiki" },
       ],
     },
   ],
@@ -80,33 +42,25 @@ const fixtureView: WorkspaceCommandCenterView = {
 };
 
 describe("BusinessCommandCenter", () => {
-  it("renders the command center, six-C labels, work in motion, and AI Operations link", () => {
+  it("renders the critical strip, snapshot, and work in motion", () => {
     const html = renderToStaticMarkup(<BusinessCommandCenter view={fixtureView} />);
 
-    expect(html).toContain("Command Center");
+    expect(html).toContain("Needs attention");
     expect(html).toContain("Approval required");
-    expect(html).toContain("Context");
-    expect(html).toContain("Connections");
-    expect(html).toContain("Capabilities");
-    expect(html).toContain("Cadence");
-    expect(html).toContain("Confidence");
-    expect(html).toContain("Containment");
+    expect(html).toContain("AI coworkers");
+    expect(html).toContain("Open work");
+    expect(html).toContain("Work in motion");
     expect(html).toContain("Reconcile overdue invoices");
-    expect(html).toContain("AI Operations Map");
   });
 
-  it("puts six-C descriptions into cell titles without adding another visible text tier", () => {
+  it("does NOT render the six-C readiness matrix (it moved to the platform surface)", () => {
     const html = renderToStaticMarkup(<BusinessCommandCenter view={fixtureView} />);
 
-    expect(html).toContain("Context: Good - Evidence, docs, and operating knowledge");
-  });
-
-  it("renders readiness cells as explanatory status instead of duplicate navigation links", () => {
-    const html = renderToStaticMarkup(<BusinessCommandCenter view={fixtureView} />);
-
-    expect(html).toContain('href="/platform/ai/operations-map"');
+    expect(html).not.toContain("Domain readiness");
+    expect(html).not.toContain("Containment");
+    // No deep platform-meta drill links leak onto the business home.
     expect(html).not.toContain('href="/wiki"');
-    expect(html).not.toContain('href="/platform/tools/integrations"');
+    expect(html).not.toContain("AI Operations Map");
   });
 
   it("uses DPF theme tokens instead of hardcoded neutral color classes", () => {

--- a/apps/web/components/workspace/BusinessCommandCenter.tsx
+++ b/apps/web/components/workspace/BusinessCommandCenter.tsx
@@ -1,9 +1,17 @@
-import type {
-  CommandSeverity,
-  ReadinessCell,
-  ReadinessState,
-  WorkspaceCommandCenterView,
-} from "@/lib/workspace/command-center";
+// apps/web/components/workspace/BusinessCommandCenter.tsx
+//
+// The business day-to-day surface for the default workspace home: the
+// "needs attention" critical strip, an at-a-glance StatCard snapshot, and the
+// human + AI "work in motion" list. The 6×6 Six-Cs readiness matrix that used
+// to live here is an operator/governance view and now renders on the platform
+// surface (see PlatformReadinessMatrix and
+// docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md §7).
+//
+// Real data only — every block renders from the command-center loader and shows
+// an empty state when there is nothing, never synthesized rows.
+
+import { StatCard } from "@/components/ui/report-kit";
+import type { CommandSeverity, WorkspaceCommandCenterView } from "@/lib/workspace/command-center";
 
 type Props = {
   view: WorkspaceCommandCenterView;
@@ -15,54 +23,14 @@ const severityClass: Record<CommandSeverity, string> = {
   info: "border-[var(--dpf-info)] text-[var(--dpf-info)]",
 };
 
-const stateClass: Record<ReadinessState, string> = {
-  good: "border-[var(--dpf-success)] text-[var(--dpf-success)]",
-  attention: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
-  blocked: "border-[var(--dpf-error)] text-[var(--dpf-error)]",
-  unknown: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
-};
-
-const stateLabel: Record<ReadinessState, string> = {
-  good: "Good",
-  attention: "Attention",
-  blocked: "Blocked",
-  unknown: "Unknown",
-};
-
-function readinessTitle(cell: ReadinessCell) {
-  return `${cell.label}: ${stateLabel[cell.state]} - ${cell.description}`;
-}
-
-function ReadinessStatusPill({ cell, className = "" }: { cell: ReadinessCell; className?: string }) {
-  return (
-    <span
-      className={`${className} ${stateClass[cell.state]}`}
-      title={readinessTitle(cell)}
-      aria-label={readinessTitle(cell)}
-    >
-      {stateLabel[cell.state]}
-    </span>
-  );
-}
-
 export function BusinessCommandCenter({ view }: Props) {
   return (
-    <section aria-labelledby="business-command-center-title" className="mb-6 space-y-4">
-      <div className="flex flex-col gap-3 border-b border-[var(--dpf-border)] pb-4 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Workspace home</p>
-          <h2 id="business-command-center-title" className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">
-            Command Center
-          </h2>
-        </div>
-        <a
-          href="/platform/ai/operations-map"
-          className="inline-flex w-fit items-center rounded-md border border-[var(--dpf-border)] px-3 py-2 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
-        >
-          AI Operations Map
-        </a>
-      </div>
+    <section aria-labelledby="business-command-center-title" className="space-y-4">
+      <h2 id="business-command-center-title" className="sr-only">
+        Needs attention and at-a-glance
+      </h2>
 
+      {/* Critical strip — exceptions that need action now */}
       <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
         <div className="border-b border-[var(--dpf-border)] px-4 py-3">
           <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Needs attention</p>
@@ -86,102 +54,44 @@ export function BusinessCommandCenter({ view }: Props) {
             ))
           ) : (
             <div className="px-4 py-6 text-sm text-[var(--dpf-muted)]">
-              No urgent command-center items right now.
+              Nothing needs your attention right now.
             </div>
           )}
         </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
-        {view.snapshot.map((item) => (
-          <a
-            key={item.id}
-            href={item.href}
-            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3 hover:bg-[var(--dpf-surface-2)]"
-          >
-            <p className="text-[11px] font-semibold uppercase text-[var(--dpf-muted)]">{item.label}</p>
-            <p className="mt-2 text-2xl font-semibold tabular-nums text-[var(--dpf-text)]">{item.value}</p>
-          </a>
-        ))}
-      </div>
-
-      <div className="grid gap-3 md:hidden">
-        {view.readiness.map((row) => (
-          <section key={row.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-            <a href={row.href} className="text-sm font-semibold text-[var(--dpf-text)] hover:text-[var(--dpf-accent)]">
-              {row.label}
-            </a>
-            <div className="mt-3 grid grid-cols-2 gap-2">
-              {row.cells.map((cell) => (
-                <div
-                  key={`${row.id}-${cell.key}`}
-                  className={`flex min-h-16 flex-col justify-between rounded-md border px-3 py-2 text-xs ${stateClass[cell.state]}`}
-                  title={readinessTitle(cell)}
-                  aria-label={readinessTitle(cell)}
-                >
-                  <span className="font-semibold text-[var(--dpf-muted)]">{cell.label}</span>
-                  <span className="font-semibold">{stateLabel[cell.state]}</span>
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
-
-      <div className="hidden overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] md:block">
-        <table className="w-full min-w-[760px] table-fixed text-left text-sm">
-          <thead>
-            <tr className="border-b border-[var(--dpf-border)]">
-              <th className="w-44 px-4 py-3 text-xs font-semibold uppercase text-[var(--dpf-muted)]">Domain</th>
-              {view.readiness[0]?.cells.map((cell) => (
-                <th key={cell.key} className="px-3 py-3 text-xs font-semibold uppercase text-[var(--dpf-muted)]">
-                  {cell.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {view.readiness.map((row) => (
-              <tr key={row.id} className="border-b border-[var(--dpf-border)] last:border-b-0">
-                <th className="px-4 py-3 align-middle font-medium text-[var(--dpf-text)]">
-                  <a href={row.href} className="hover:text-[var(--dpf-accent)]">
-                    {row.label}
-                  </a>
-                </th>
-                {row.cells.map((cell) => (
-                  <td key={`${row.id}-${cell.key}`} className="px-3 py-3 align-middle">
-                    <ReadinessStatusPill
-                      cell={cell}
-                      className="inline-flex min-w-20 justify-center rounded-full border px-2 py-1 text-[11px] font-semibold"
-                    />
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-        <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-          <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Human and AI work in motion</p>
-        </div>
-        <div className="grid gap-0 md:grid-cols-2 xl:grid-cols-3">
-          {view.workInMotion.map((item) => (
-            <a
-              key={item.id}
-              href={item.href}
-              className="min-h-20 border-b border-[var(--dpf-border)] px-4 py-3 hover:bg-[var(--dpf-surface-2)] md:border-r xl:last:border-r-0"
-            >
-              <p className="text-sm font-semibold text-[var(--dpf-text)]">{item.label}</p>
-              <p className="mt-1 text-xs text-[var(--dpf-muted)]">{item.actor}</p>
-              <span className="mt-2 inline-flex rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-[11px] font-medium text-[var(--dpf-muted)]">
-                {item.status}
-              </span>
-            </a>
+      {/* At-a-glance snapshot — report-kit StatCards */}
+      {view.snapshot.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          {view.snapshot.map((item) => (
+            <StatCard key={item.id} label={item.label} value={item.value} href={item.href} />
           ))}
         </div>
-      </div>
+      )}
+
+      {/* Human + AI work in motion */}
+      {view.workInMotion.length > 0 && (
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+          <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+            <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Work in motion</p>
+          </div>
+          <div className="grid gap-0 md:grid-cols-2 xl:grid-cols-3">
+            {view.workInMotion.map((item) => (
+              <a
+                key={item.id}
+                href={item.href}
+                className="min-h-20 border-b border-[var(--dpf-border)] px-4 py-3 hover:bg-[var(--dpf-surface-2)] md:border-r xl:last:border-r-0"
+              >
+                <p className="text-sm font-semibold text-[var(--dpf-text)]">{item.label}</p>
+                <p className="mt-1 text-xs text-[var(--dpf-muted)]">{item.actor}</p>
+                <span className="mt-2 inline-flex rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-[11px] font-medium text-[var(--dpf-muted)]">
+                  {item.status}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/components/workspace/PlatformReadinessMatrix.test.tsx
+++ b/apps/web/components/workspace/PlatformReadinessMatrix.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PlatformReadinessMatrix } from "./PlatformReadinessMatrix";
+import type { BusinessDomainReadiness } from "@/lib/workspace/command-center";
+
+const readiness: BusinessDomainReadiness[] = [
+  {
+    id: "ai",
+    label: "AI workforce",
+    href: "/platform/ai/operations-map",
+    cells: [
+      { key: "context", label: "Context", description: "Evidence and operating knowledge", state: "good", href: "/wiki" },
+      { key: "connections", label: "Connections", description: "Provider and integration links", state: "attention", href: "/platform/tools/integrations" },
+      { key: "capabilities", label: "Capabilities", description: "People and AI coworkers able to act", state: "good", href: "/platform/ai" },
+      { key: "cadence", label: "Cadence", description: "Scheduled work and follow-up rhythm", state: "good", href: "/workspace" },
+      { key: "confidence", label: "Confidence", description: "Recent receipts and low-risk signals", state: "attention", href: "/platform/ai/operations-map" },
+      { key: "containment", label: "Containment", description: "Approvals and side-effect controls", state: "blocked", href: "/platform/ai/authority" },
+    ],
+  },
+];
+
+describe("PlatformReadinessMatrix", () => {
+  it("renders the six-C labels and domain heading", () => {
+    const html = renderToStaticMarkup(<PlatformReadinessMatrix readiness={readiness} />);
+
+    expect(html).toContain("Domain readiness");
+    for (const label of ["Context", "Connections", "Capabilities", "Cadence", "Confidence", "Containment"]) {
+      expect(html).toContain(label);
+    }
+    // Cell descriptions ride in titles, not as a separate visible tier.
+    expect(html).toContain("Context: Good - Evidence and operating knowledge");
+  });
+
+  it("renders nothing for an empty matrix", () => {
+    const html = renderToStaticMarkup(<PlatformReadinessMatrix readiness={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("uses DPF theme tokens, not hardcoded colors", () => {
+    const html = renderToStaticMarkup(<PlatformReadinessMatrix readiness={readiness} />);
+    expect(html).toContain("var(--dpf-");
+    expect(html).not.toMatch(/text-gray-|bg-gray-|border-gray-|text-white|text-black|bg-white|#[0-9a-fA-F]{3,6}/);
+  });
+});

--- a/apps/web/components/workspace/PlatformReadinessMatrix.tsx
+++ b/apps/web/components/workspace/PlatformReadinessMatrix.tsx
@@ -1,0 +1,120 @@
+// apps/web/components/workspace/PlatformReadinessMatrix.tsx
+//
+// The 6×6 "Six-Cs" domain-readiness matrix. This is a platform-maturity /
+// governance view — context, connections, capabilities, cadence, confidence,
+// containment across the business domains. It is an OPERATOR concern and lives
+// on the platform surface, not on the business day-to-day workspace home
+// (see docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md §7).
+//
+// Extracted verbatim from BusinessCommandCenter so the worker home no longer
+// renders it. Server component, pure.
+
+import type { BusinessDomainReadiness, ReadinessCell, ReadinessState } from "@/lib/workspace/command-center";
+
+const stateClass: Record<ReadinessState, string> = {
+  good: "border-[var(--dpf-success)] text-[var(--dpf-success)]",
+  attention: "border-[var(--dpf-warning)] text-[var(--dpf-warning)]",
+  blocked: "border-[var(--dpf-error)] text-[var(--dpf-error)]",
+  unknown: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
+};
+
+const stateLabel: Record<ReadinessState, string> = {
+  good: "Good",
+  attention: "Attention",
+  blocked: "Blocked",
+  unknown: "Unknown",
+};
+
+function readinessTitle(cell: ReadinessCell) {
+  return `${cell.label}: ${stateLabel[cell.state]} - ${cell.description}`;
+}
+
+function ReadinessStatusPill({ cell, className = "" }: { cell: ReadinessCell; className?: string }) {
+  return (
+    <span
+      className={`${className} ${stateClass[cell.state]}`}
+      title={readinessTitle(cell)}
+      aria-label={readinessTitle(cell)}
+    >
+      {stateLabel[cell.state]}
+    </span>
+  );
+}
+
+type Props = {
+  readiness: BusinessDomainReadiness[];
+};
+
+export function PlatformReadinessMatrix({ readiness }: Props) {
+  if (readiness.length === 0) return null;
+
+  return (
+    <section aria-labelledby="platform-readiness-title" className="space-y-3">
+      <div>
+        <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Platform readiness</p>
+        <h2 id="platform-readiness-title" className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">
+          Domain readiness
+        </h2>
+      </div>
+
+      {/* Mobile: stacked cards */}
+      <div className="grid gap-3 md:hidden">
+        {readiness.map((row) => (
+          <section key={row.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <a href={row.href} className="text-sm font-semibold text-[var(--dpf-text)] hover:text-[var(--dpf-accent)]">
+              {row.label}
+            </a>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              {row.cells.map((cell) => (
+                <div
+                  key={`${row.id}-${cell.key}`}
+                  className={`flex min-h-16 flex-col justify-between rounded-md border px-3 py-2 text-xs ${stateClass[cell.state]}`}
+                  title={readinessTitle(cell)}
+                  aria-label={readinessTitle(cell)}
+                >
+                  <span className="font-semibold text-[var(--dpf-muted)]">{cell.label}</span>
+                  <span className="font-semibold">{stateLabel[cell.state]}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {/* Desktop: matrix table */}
+      <div className="hidden overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] md:block">
+        <table className="w-full min-w-[760px] table-fixed text-left text-sm">
+          <thead>
+            <tr className="border-b border-[var(--dpf-border)]">
+              <th className="w-44 px-4 py-3 text-xs font-semibold uppercase text-[var(--dpf-muted)]">Domain</th>
+              {readiness[0]?.cells.map((cell) => (
+                <th key={cell.key} className="px-3 py-3 text-xs font-semibold uppercase text-[var(--dpf-muted)]">
+                  {cell.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {readiness.map((row) => (
+              <tr key={row.id} className="border-b border-[var(--dpf-border)] last:border-b-0">
+                <th className="px-4 py-3 align-middle font-medium text-[var(--dpf-text)]">
+                  <a href={row.href} className="hover:text-[var(--dpf-accent)]">
+                    {row.label}
+                  </a>
+                </th>
+                {row.cells.map((cell) => (
+                  <td key={`${row.id}-${cell.key}`} className="px-3 py-3 align-middle">
+                    <ReadinessStatusPill
+                      cell={cell}
+                      className="inline-flex min-w-20 justify-center rounded-full border px-2 py-1 text-[11px] font-semibold"
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/workspace/WorkspaceCalendar.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.tsx
@@ -50,9 +50,18 @@ const ARCHETYPE_DEFAULT_HIDDEN: Record<string, string[]> = {
 type Props = {
   events: CalendarEventView[];
   archetypeCategory?: string | null;
+  /** Categories hidden on first load when no `hidden` URL param is set. */
+  defaultHiddenCategories?: string[];
+  /** Source filters hidden on first load when no `sourceHidden` URL param is set. */
+  defaultHiddenSources?: string[];
 };
 
-export function WorkspaceCalendar({ events: initialEvents, archetypeCategory }: Props) {
+export function WorkspaceCalendar({
+  events: initialEvents,
+  archetypeCategory,
+  defaultHiddenCategories,
+  defaultHiddenSources,
+}: Props) {
   const calendarRef = useRef<FullCalendar>(null);
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -61,18 +70,20 @@ export function WorkspaceCalendar({ events: initialEvents, archetypeCategory }: 
   // Restore hidden categories from URL on mount
   const hiddenCategories = useMemo(() => {
     const param = searchParams.get("hidden");
-    return param ? new Set(param.split(",")) : new Set<string>();
-  }, [searchParams]);
+    if (param) return new Set(param.split(","));
+    return defaultHiddenCategories ? new Set(defaultHiddenCategories) : new Set<string>();
+  }, [searchParams, defaultHiddenCategories]);
 
-  // Restore hidden source filters from URL — fall back to archetype defaults on first load
+  // Restore hidden source filters from URL — fall back to explicit defaults, then archetype defaults
   const hiddenSources = useMemo(() => {
     const param = searchParams.get("sourceHidden");
     if (param) return new Set(param.split(","));
+    if (defaultHiddenSources) return new Set(defaultHiddenSources);
     const defaults = archetypeCategory
       ? ARCHETYPE_DEFAULT_HIDDEN[archetypeCategory]
       : undefined;
     return defaults ? new Set(defaults) : new Set<string>();
-  }, [searchParams, archetypeCategory]);
+  }, [searchParams, archetypeCategory, defaultHiddenSources]);
 
   const [createPopover, setCreatePopover] = useState<{ date: string; endDate?: string } | null>(null);
   const [agentScheduler, setAgentScheduler] = useState<{ date: string } | null>(null);

--- a/docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md
+++ b/docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED: Use `superpowers:executing-plans` when running this plan end-to-end. This plan is a product-behavior walkthrough, not a build-system verification plan. Use the already-available sandbox/main build selected by the operator; do not turn failed access into a self-upgrade or deployment investigation unless the task is explicitly rescoped.
 
+> **Tied to the portal-redesign effort (2026-06-06).** This plan is the founder's clean-install acceptance vehicle for the main-portal redesign. Its **§3 "Employee Work View"** is the direct acceptance test for the [Main Portal Workspace Home Redesign](../specs/2026-06-06-main-portal-workspace-home-redesign-design.md) and the [Archetype Portal Screen Prototypes](../specs/2026-06-06-archetype-portal-screen-prototypes-design.md): §3's fail condition ("worker-facing UX still reads like platform operator tooling") is exactly the default-home defect the redesign removes. All three docs ship together on the same branch / PR under `EP-REDUCTION-GEAR-ARCH` so the test plan is not lost from the design it validates.
+
 **Goal:** Confirm that selecting a business archetype produces a coherent DPF experience across setup, business capabilities, employee work, customer/storefront flows, finance, integrations, AI coworkers, and portfolio/product/backlog surfaces.
 
 **Architecture:** Exercise a representative archetype coverage set rather than every vertical exhaustively. Each walkthrough follows the same surface checklist so repeated failures become cross-cutting backlog items instead of many duplicate vertical bugs.

--- a/docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md
+++ b/docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md
@@ -1,0 +1,246 @@
+# Archetype Acceptance Test Plan
+
+> **For agentic workers:** REQUIRED: Use `superpowers:executing-plans` when running this plan end-to-end. This plan is a product-behavior walkthrough, not a build-system verification plan. Use the already-available sandbox/main build selected by the operator; do not turn failed access into a self-upgrade or deployment investigation unless the task is explicitly rescoped.
+
+**Goal:** Confirm that selecting a business archetype produces a coherent DPF experience across setup, business capabilities, employee work, customer/storefront flows, finance, integrations, AI coworkers, and portfolio/product/backlog surfaces.
+
+**Architecture:** Exercise a representative archetype coverage set rather than every vertical exhaustively. Each walkthrough follows the same surface checklist so repeated failures become cross-cutting backlog items instead of many duplicate vertical bugs.
+
+**Tech Stack:** DPF portal, `StorefrontConfig -> StorefrontArchetype`, business capability perspectives, workspace home resolver, storefront templates, finance setup, integration catalog, AI coworker registry, live backlog.
+
+---
+
+## Scope
+
+This plan answers: "Does the archetype-driven experience work well enough across the main different parts?"
+
+It intentionally separates product UX confidence from build/deploy validation. If the app is already available, test the product. If the app cannot be reached or the selected install is stale, record that as an environment blocker and stop the walkthrough; do not spend this test pass debugging the build pipeline.
+
+## Baseline To Reconcile
+
+Before execution, reconcile the live install inventory with this baseline:
+
+- Live archetype inventory observed on 2026-06-06: 46 storefront archetypes across 12 categories.
+- Business capability seed observed on 2026-06-06: 28 active generic capability rows, with archetype-specific behavior layered through perspectives/provenance.
+- Known roster drift to watch: `wholesale-distribution` exists in live data and should be included in retail/goods coverage.
+- Existing related work: business capability and employee work taxonomy, workspace-home contribution roster, vertical workspace-home substrate, portal navigation archetype IA, QuickBooks parity, integration benchmark work.
+
+If the live count differs, update the evidence notes before judging coverage.
+
+## Representative Coverage Set
+
+Run this first batch before trying to cover every archetype:
+
+| Archetype | Category | Why It Is In The Batch |
+| --- | --- | --- |
+| `software-platform` | `software-platform` | Platform/operator behavior, portfolio/product surfaces, AI coworker coordination, and intentional platform fallback. |
+| `it-managed-services` | `professional-services` | Rich professional-services setup, service delivery, customer support, security/compliance, Microsoft 365-style integration anchors. |
+| `hair-salon` or `beauty-spa` | `beauty-personal-care` | Appointment/service business, employee scheduling, customer intake, local marketing. |
+| `wholesale-distribution` | `retail-goods` | Goods, B2B customers, inventory/procurement, and the newer archetype that exposed roster drift. |
+| `plumber` or `electrician` | `trades-maintenance` | Field-service workflow, dispatch-style work, estimates, jobs, customer requests. |
+| `restaurant` | `food-hospitality` | Food/hospitality vocabulary, menu/offer structure, customer-facing portal language. |
+| `dental-practice` | `healthcare-wellness` | Healthcare-style service delivery, intake, compliance posture, patient/customer wording. |
+| `property-management-company` | `hoa-property-management` | Owners/tenants, requests, property obligations, recurring work. |
+| `charity` or `animal-shelter` | `nonprofit-community` | Donation, volunteer, community-service, and support vocabulary. |
+| `tutoring` | `education-training` | Sessions, scheduling, students/customers, learning-service workflow. |
+| `gym` or `yoga-studio` | `fitness-recreation` | Membership/service hybrid and recurring customer engagement. |
+| `pet-grooming` or `pet-boarding` | `pet-services` | Appointment plus pet/asset-style customer-subject workflows. |
+
+This set covers platform, professional service, appointment service, goods/inventory, field service, food, healthcare, property, nonprofit, education, fitness, and pet service operating models.
+
+## Per-Archetype Walkthrough
+
+Use the same sequence for each archetype.
+
+### 1. Setup Selection
+
+- Select the archetype in setup or reset the configured archetype through the available admin path.
+- Confirm the selected archetype persists after saving, navigating away, and returning.
+- Confirm `StorefrontConfig` is the source of truth for the selected archetype, not a stale `Organization.industry` or generic business context field.
+- Confirm business context language, setup summary, and next steps reflect the selected business type.
+- Fail if setup reverts, persists the wrong archetype, or claims a tailored experience where only a generic fallback is available.
+
+### 2. Business Capabilities
+
+- Open the business capability/taxonomy surface, currently surfaced through portfolio architecture and related capability views.
+- Confirm the capability page is not empty.
+- Confirm the capability tree covers day-to-day work: setup, finance, revenue/customer growth, customer operations/support, people/admin, work communications, compliance/risk, portfolio/product, and inventory/procurement/assets where relevant.
+- Confirm commercial market/product references from the spreadsheet/taxonomy seed are visible or traceable in UX where they matter, especially for integrations and buy-vs-build posture.
+- Confirm the capability perspective/provenance reflects the selected archetype or clearly reports that only the generic baseline is active.
+- Fail if capabilities are blank, only technical, disconnected from the selected business model, or hide the market/product context needed for integration planning.
+
+### 3. Employee Work View
+
+- Open the main workspace and any role/work queue views.
+- Confirm the workspace reflects the employees who would actually use the business: owner/operator, bookkeeper/accountant, sales/business development, marketing, operations/service delivery, customer support, HR/payroll/admin, inventory/procurement, and IT/security/compliance where relevant.
+- Confirm the first screen gives useful work cues for that archetype rather than platform administration noise.
+- Confirm missing vertical workspace-home contributions are honest fallbacks, not misleading tailored promises.
+- Fail if worker-facing UX still reads like platform operator tooling for ordinary business employees.
+
+### 4. Customer / Storefront / Portal
+
+- Open the internal storefront management surface and the public customer/storefront surface.
+- Confirm labels, calls to action, sections, item templates, and forms match the archetype.
+- Exercise the natural customer action for the archetype: book, inquire, order, donate, request service, register, or contact.
+- Confirm resulting inbox/order/booking/donation records appear in the management surface where applicable.
+- Fail if the CTA type is wrong, customer copy is generic in a confusing way, or the action does not route back into the business workspace.
+
+### 5. Finance
+
+- Open finance setup and finance work surfaces.
+- Confirm finance posture fits the archetype:
+  - invoices and customers for service businesses
+  - bills, vendors, and expenses for operators
+  - purchasing, stock, and assets for goods businesses
+  - donations or grants for nonprofits where relevant
+  - reporting, close, and reconciliation posture for QuickBooks parity
+- Confirm QuickBooks and Stripe are presented as integration anchors where appropriate.
+- Confirm the posture is clear: native DPF, integration-led, hybrid, eventual replacement, or not applicable yet.
+- Fail if finance setup is missing, misleading, or treats materially different business models as identical.
+
+### 6. Integrations
+
+- Check whether relevant integration anchors appear for the archetype:
+  - QuickBooks
+  - Stripe
+  - HubSpot or CRM
+  - ADP/payroll
+  - Microsoft 365 or communications
+  - Mailchimp
+  - Google Business Profile
+  - social and communications channels
+- Confirm each visible integration has an understandable role in the business workflow.
+- Confirm missing integrations are framed as gaps or future work rather than silent omissions.
+- Fail if expected integrations are absent from the taxonomy/UX for an archetype where they are central to the business.
+
+### 7. AI Coworkers
+
+- Confirm relevant coworkers are suggested or implied by the work:
+  - bookkeeper/accountant
+  - sales assistant
+  - marketing assistant
+  - service coordinator
+  - customer support
+  - setup/business analyst
+  - compliance/security helper
+  - procurement/inventory helper where relevant
+- Confirm coworker handoffs map to real employee jobs instead of generic agent chatter.
+- Note missing coworkers as backlog candidates.
+- Fail if coworker support is generic and disconnected from the selected business model.
+
+### 8. Portfolio / Product / Backlog Surface
+
+- Confirm portfolio/product language works for `software-platform`.
+- Confirm non-software archetypes are framed around business capabilities and employee work, not forced into software product-management vocabulary.
+- Confirm backlog item naming and body templates can carry archetype, employee role, business capability, DPF surface, integration anchor, and posture.
+- Fail if every business is forced into platform/product vocabulary or if missing capability work cannot be captured as small backlog slices.
+
+### 9. UX And Performance Smoke
+
+- Check desktop and mobile-width layouts for obvious overlap, clipped text, unreadable cards, and confusing navigation.
+- Check that page headings, tabs, actions, and empty states are business-appropriate.
+- Confirm the test path does not require the user to understand internal architecture terms.
+- Fail if the main workflow is visually broken, unreadable, or too jargon-heavy for the target employee.
+
+## Pass / Warn / Fail Rules
+
+Use consistent verdicts:
+
+- `Pass`: the archetype produces coherent setup, useful capabilities, sensible customer flow, and relevant integration/work context.
+- `Warn`: the archetype works but relies on generic fallback, thin copy, missing exact workspace-home contribution, or incomplete integration depth.
+- `Fail`: empty capabilities, wrong archetype persistence, broken setup, wrong CTA, misleading tailored claims, missing central integration anchors, or platform/admin vocabulary leaking into worker UX.
+- `Blocked`: app unavailable, auth/setup unavailable, database unavailable, or environment/build state prevents the walkthrough.
+
+## Evidence Template
+
+Capture one record per archetype:
+
+```text
+Archetype:
+Category:
+Why tested:
+Install/build used:
+Setup result:
+Capability result:
+Employee/work result:
+Customer/storefront result:
+Finance result:
+Integration result:
+AI coworker result:
+Portfolio/product/backlog result:
+UX/performance issues:
+Verdict: Pass / Warn / Fail / Blocked
+Follow-up backlog item:
+```
+
+## Cross-Cutting Failure Rules
+
+- If the first archetype in a category cannot be selected or persisted, stop that category and file one category setup blocker.
+- If the same problem appears across three or more categories, file one cross-cutting backlog item instead of one item per archetype.
+- If only vocabulary or copy is weak but the workflow functions, mark `Warn` and group the issue into a content/taxonomy improvement item.
+- If capabilities are empty anywhere, mark `Fail`; empty capability UX breaks the core purpose of this work.
+- If an archetype has no exact vertical workspace-home contribution, do not fail automatically. Fail only if the UI claims exact tailoring or the fallback is unusable.
+
+## Done-Enough Criteria
+
+The product is ready for broader testing when:
+
+- All 12 representative archetypes have been walked.
+- No business capability page is empty.
+- At least one service, goods, nonprofit, property, platform, healthcare, food, education, fitness, and pet-service archetype has passed or has a clear backlog item.
+- At least one each of inquiry, booking, order/purchase, and donation-style customer actions has been exercised where applicable.
+- QuickBooks, Stripe, CRM, payroll, communications, marketing, and local-presence integration posture is visible where expected.
+- Employee work views are understandable for real business roles.
+- Platform/product vocabulary does not leak into every vertical.
+- No open P0/P1 failures remain; P2/P3 issues have backlog items.
+
+## Likely Backlog Batch
+
+Check for duplicates before creating any items. The first likely batch from this plan is:
+
+1. **Archetype QA: acceptance matrix and walkthrough harness for live business archetypes**
+   - Type: `product`
+   - Work type: `tool`
+   - Scope: Provide a reusable matrix/harness that tracks category, archetype, employee roles, customer CTA, finance posture, integration anchors, workspace-home mode, and verdict.
+
+2. **Business capability UX: expose commercial market/product references from taxonomy seed**
+   - Type: `product`
+   - Work type: `feature`
+   - Scope: Show the common commercial products and market anchors that are already present in the source spreadsheet/taxonomy data, tied to capabilities and integration posture.
+
+3. **Business capability perspectives: fill high-value archetype-specific gaps**
+   - Type: `product`
+   - Work type: `feature`
+   - Scope: Add or refine perspectives for the representative archetype batch, starting with `it-managed-services`, `wholesale-distribution`, `hair-salon`, `plumber/electrician`, and `dental-practice`.
+
+4. **Employee work taxonomy: category-level role and queue expectations**
+   - Type: `product`
+   - Work type: `feature`
+   - Scope: Define expected employee roles, work queues, coworker handoffs, and first-screen cues for each archetype category.
+
+5. **Integration posture cards by archetype category**
+   - Type: `product`
+   - Work type: `feature`
+   - Scope: For each category, declare whether QuickBooks, Stripe, CRM, payroll, communications, marketing, local presence, inventory/procurement, and compliance tools are native DPF, integration-led, hybrid, eventual replacement, or not applicable.
+
+6. **Archetype inventory reconciliation for `wholesale-distribution` and roster docs**
+   - Type: `product`
+   - Work type: `doc`
+   - Scope: Reconcile live archetype count and retail/goods roster references so planning docs, acceptance plans, and live data agree.
+
+## Recommended Execution Order
+
+1. `software-platform`
+2. `it-managed-services`
+3. `hair-salon` or `beauty-spa`
+4. `wholesale-distribution`
+5. `plumber` or `electrician`
+6. `restaurant`
+7. `dental-practice`
+8. `property-management-company`
+9. `charity` or `animal-shelter`
+10. `tutoring`
+11. `gym` or `yoga-studio`
+12. `pet-grooming` or `pet-boarding`
+
+This order starts with platform/operator behavior, then tests the richest known profile, then covers appointment service, goods/inventory, field service, and the remaining category families.

--- a/docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md
+++ b/docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md
@@ -1,0 +1,1193 @@
+---
+title: Archetype Portal Screen Prototypes
+date: 2026-06-06
+status: draft - ready for critique
+owner: Mark Bodman
+author: Codex
+scope: Text mockups and review criteria for archetype-specific main portal and worker-home screens
+out_of_scope:
+  - Runtime implementation
+  - Live portal verification
+  - Deployment or self-upgrade validation
+related_plans:
+  - docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md
+  - docs/superpowers/plans/2026-05-17-business-capability-employee-work-taxonomy.md
+related_specs:
+  - docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md
+  - docs/superpowers/specs/2026-06-04-workspace-home-contribution-roster-design.md
+  - docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md
+primary_epics:
+  - EP-REDUCTION-GEAR-ARCH
+  - EP-BIZ-CAP
+---
+
+# Archetype Portal Screen Prototypes
+
+## 1. Purpose
+
+This spec captures low-fidelity text mockups for the archetype-specific DPF portal screens that need critique before implementation. It is intended for another agent, designer, architect, or operator to review for:
+
+- critical content
+- form and tone
+- layout
+- function
+- business capability coverage
+- employee role fit
+- native vs integration-led posture
+
+It does not implement any UI. It makes the target screens concrete enough that Build Studio or another agent can critique the design before writing code.
+
+## 2. Direct Answer: Is Main Portal Screen Configuration Mapped To This Work?
+
+Yes. The main portal and worker-home configuration ability is already architecturally mapped to this work, but the target screens are not fully specified or implemented yet.
+
+### Current Configuration Plumbing
+
+The current source already carries these archetype-controlled inputs:
+
+| Configurable input | Current source/surface | What it can influence |
+| --- | --- | --- |
+| Active archetype | `StorefrontConfig -> StorefrontArchetype` | The install's business type and semantic archetype. |
+| Category | `StorefrontArchetype.category` | Vocabulary, finance setup profile, category-level worker-home fallback, and item suggestions. |
+| CTA type | `StorefrontArchetype.ctaType` | Customer action: booking, purchase, inquiry, or donation. |
+| Item templates | `StorefrontArchetype.itemTemplates` | Public portal offerings and item-management defaults. |
+| Section templates | `StorefrontArchetype.sectionTemplates` | Public portal page sections. |
+| Custom vocabulary | `StorefrontArchetype.customVocabulary` | Labels for items, stakeholders, team, inbox, and portal. |
+| Activation profile | `StorefrontArchetype.activationProfile` | Required/recommended capabilities, billing profile, customer-scope isolation, and setup prompts. |
+| Workspace-home activation summary | `buildWorkspaceHomeActivationSummaries()` | Setup preview for worker-home mode, primary operating question, primitives, required data, and missing-data behavior. |
+| Finance setup profile | `financeProfileSlugFromCategory()` | Payment pattern, recurring billing applicability, invoices, currency, tax defaults. |
+| Capability toggles | `/storefront/settings/capabilities` | Add-later toggles for recommended capabilities. |
+| Public portal admin tabs | `/storefront` | Dashboard, sections, items, team, inbox, settings, with archetype vocabulary. |
+| Main worker home resolver | `resolveWorkspaceHomeContribution()` | Exact archetype contribution, category fallback, or platform fallback. |
+
+### Current Gap
+
+The main `/workspace` route currently resolves the contribution state but still renders `PlatformWorkspaceHome`. The `defaultWorkspaceHomeRegistry` is empty, so worker homes fall back to the standard platform view unless a future contribution is registered.
+
+The gap is not a lack of architectural hooks. The gap is a missing set of reviewable contribution prototypes and implementation-ready manifests for each category and high-value exact archetype.
+
+This spec fills the prototype gap.
+
+### Target Configuration Model
+
+The target portal configuration should resolve these values from the chosen archetype and present them in setup before commit:
+
+| Target setting | Derived from | Used by |
+| --- | --- | --- |
+| `workerHomeMode` | Workspace-home resolver | Main `/workspace` first viewport. |
+| `workerHomeContributionId` | Exact or category contribution | Slot/component manifest and setup activation. |
+| `primaryOperatingQuestion` | Workspace-home contribution | Setup preview, worker-home page title/subtitle, review criteria. |
+| `workerChromeMode` | `WorkspaceHomeResolution.mode` plus role | Global rail and shell language. |
+| `customerPortalTemplate` | `sectionTemplates`, `itemTemplates`, `ctaType`, vocabulary | Public/customer portal and `/storefront` admin. |
+| `financeProfileSlug` | `financeProfileSlugFromCategory(category)` | Finance setup and accounting/payment readiness. |
+| `integrationPostureCards` | Category + activation profile + capability taxonomy | Setup preview, platform tools, capability pages. |
+| `employeeRoleLanes` | Category prototype + activation profile | Team setup, work queues, coworker handoffs. |
+| `capabilityMarketEnrichment` | Business capability taxonomy and spreadsheet-derived commercial market/product fields | Capability review, integration posture, backlog capture. |
+
+The setup experience should therefore preview five downstream screens:
+
+```text
+[Worker home] [Customer portal] [Money setup] [Integrations] [Team/coworkers]
+```
+
+The current DPF code can already support the first four inputs in pieces. The prototype work decides the missing screen semantics, especially `workerHomeContributionId`, `employeeRoleLanes`, and `capabilityMarketEnrichment`.
+
+## 3. Design And Research Benchmarks
+
+### Standards And Architecture References
+
+- ServiceNow CSDM treats business services, technical services, applications, and capabilities as relationship-rich data that should be implemented progressively rather than all at once. Adopted for DPF: use clear relationships between business capability, employee work, product surface, integration, and worker-home contribution. Source: https://www.servicenow.com/docs/r/servicenow-platform/common-service-data-model-csdm/csdm-conceptual-model.html
+- The Open Group IT4IT uses value streams and digital products to manage digital product delivery at scale. Adopted for DPF: use IT4IT-like structure for the `software-platform` archetype and portfolio/product/backlog surfaces, but do not force software-product vocabulary onto every SMB archetype. Source: https://www.opengroup.org/it4it
+- BIAN's Service Landscape organizes banking service domains and business capabilities. Adopted for DPF: when a vertical has a strong external taxonomy such as banking, use it structurally as a vertical capability reference, not as a direct implementation requirement for every small business. Source: https://bian.org/deliverables/bian-standards/bian-service-landscape-5-0/
+
+### Product Benchmarks
+
+- Odoo documents a broad suite across Finance, Sales, Websites, Supply Chain, HR, Marketing, Services, Productivity, and Studio. Adopted for DPF: archetype homes should combine cross-suite work into one role-specific first screen rather than making a small-business user navigate every module. Source: https://www.odoo.com/documentation/latest/applications.html
+- ERPNext covers ERP-style business domains including accounting, inventory, CRM, HR, retail, healthcare, and education. Adopted for DPF: archetype-specific screens should lean on operational records and industry modules, but DPF should keep its AI coworker and backlog/governance layer as a differentiator. Source: https://docs.erpnext.com/
+- Microsoft Dynamics 365 industry solutions use industry data models, including healthcare data models based on FHIR. Adopted for DPF: regulated or domain-specific verticals should have vertical data-model awareness, but DPF should surface that as posture and setup guidance until the implementation is ready. Source: https://learn.microsoft.com/en-us/dynamics365/industry/
+- QuickBooks anchors small-business finance around income, expenses, invoices, bills, payments, bank reconciliation, reports, and tax readiness. Adopted for DPF: every archetype prototype must state whether finance is native DPF, QuickBooks-led, Stripe-led, or hybrid. Source: https://quickbooks.intuit.com/accounting/
+
+## 4. Prototype Method
+
+The prototypes use a category-first, exact-override model:
+
+- Category prototype: one full screen shape per archetype category.
+- Exact archetype delta: each archetype lists the content, form, layout, and function that differs from the category prototype.
+- Main portal mapping: each prototype declares the public/customer portal shape, worker-home shape, finance/integration posture, and employee/coworker focus.
+
+This matches the existing resolver: exact archetype -> category fallback -> unconfigured platform fallback.
+
+## 5. Common Screen Skeleton
+
+Every worker-home prototype uses the same reviewable skeleton:
+
+```text
+Header:
+  [Business label] [Archetype/status chip] [Primary setup/integration gap]
+
+Critical strip:
+  Exceptions that must be handled before the business day goes sideways.
+
+Primary zone:
+  The answer to the worker's first operating question.
+
+Secondary zone:
+  Supporting business context: money, customer, inventory, compliance, or capacity.
+
+Briefing zone:
+  AI coworker handoffs, employee queues, approvals, and communication exceptions.
+
+Setup/integration rail:
+  QuickBooks, Stripe, CRM, payroll, Microsoft 365, marketing, local presence,
+  inventory, compliance, or vertical-specific connectors.
+```
+
+Every prototype also declares:
+
+```text
+Critical content:
+Form/tone:
+Layout intent:
+Primary function:
+Employee lanes:
+Customer portal posture:
+Finance posture:
+Integration anchors:
+AI coworker fit:
+Prototype risks:
+```
+
+### 5.1 First-Viewport Layout Rule
+
+Desktop first viewport must show:
+
+1. Header with business label, archetype/status chip, and one setup/integration gap.
+2. Critical strip with at least one actionable row, not just count chips.
+3. Primary board answering the operating question.
+4. Setup/integration rail with the next configuration action and 2-4 integration anchors.
+
+Mobile order must be:
+
+```text
+Critical strip
+Current/next item
+Primary queue
+One setup/integration gap
+Briefing/coworker handoffs
+Secondary analytics and supporting context
+```
+
+Secondary cards can move below the fold. The setup gap cannot disappear below the fold while the install is incomplete.
+
+### 5.2 Worker-Facing Copy Rule
+
+The mockup itself uses employee language. Architecture notes can use canonical terms.
+
+| Architecture term | Worker-facing copy |
+| --- | --- |
+| Billing readiness | Ready to invoice / payment setup |
+| Lifecycle review queues | Reviews due / renewals due / follow-up checks |
+| Capability toggles | Add-on features / optional business tools |
+| Coworker drafts | AI-prepared replies / AI-prepared notes |
+| Required canonical data | Missing setup data |
+| Required signals | Alerts this screen needs |
+| Workspace contribution | Worker home |
+
+### 5.3 Critical Strip Row Format
+
+Each critical strip must include an object, time or urgency, owner, state, and next action:
+
+```text
+[Time/urgency] [Object/customer/person] - [problem state] - [owner] - [next action]
+```
+
+Examples:
+
+| Prototype | Actionable critical row |
+| --- | --- |
+| Software Platform | `Now BI-4025EF5F build review - blocked on evidence - build operator - open review packet` |
+| Professional Services | `Today Acme renewal - proposal unsent - account manager - send for client review` |
+| Trades And Maintenance | `10:30 Johnson repair - confirmation failed - dispatcher - call customer` |
+| Healthcare And Wellness | `09:20 Room 2 appointment - intake missing - front desk - collect form` |
+| Beauty And Personal Care | `11:00 Emma color service - patch note missing - front desk - confirm before chair` |
+| Education And Training | `16:00 Patel tutoring - exam plan behind - instructor - update progress note` |
+| Food And Hospitality | `Dinner prep - salmon stock low - kitchen lead - approve supplier run` |
+| Retail And Goods | `Order 1048 - picking delayed - store manager - assign fulfillment` |
+| Fitness And Recreation | `18:00 yoga class - waitlist full - front desk - confirm room capacity` |
+| Nonprofit And Community | `Urgent intake - volunteer cover missing - program lead - assign shift` |
+| Pet Services | `14:30 Bailey groom - owner pickup note missing - groomer - send update` |
+| HOA And Property Management | `Unit 4B leak - vendor overdue - property manager - escalate repair` |
+
+### 5.4 Contribution Manifest Stub Format
+
+Every category or exact screen must eventually become a workspace-home contribution manifest. The prototype critique should verify these stubs before implementation:
+
+```text
+contributionId:
+match: category | exact | platform-operator-mode
+primaryOperatingQuestion:
+slots:
+  - slotId: today-now | exceptions-needs-review | coworker-handoffs | custom
+    zone: critical-strip | primary | secondary | briefing | setup
+    primitiveKey:
+    componentKey:
+    title:
+    dataRefs:
+primaryRoutes:
+setupActivation:
+  requiredCanonicalData:
+  requiredSignals:
+  missingDataBehavior:
+emptyState:
+```
+
+Prototype-level stubs:
+
+| Prototype | Match | Primary primitive/component stub | Primary routes/actions | Required data/signals | Empty state |
+| --- | --- | --- | --- | --- | --- |
+| Software Platform | `platform-operator-mode` | Platform command center, existing `PlatformWorkspaceHome` | `/workspace`, `/ops`, `/build`, `/platform/ai/authority` | Backlog, builds, runtime health, tool evidence | Preserve platform home; no registered vertical contribution until architect approves. |
+| Professional Services | category + MSP exact | `case-board` / `customer-callbacks`; MSP adds `health-board` | `/customer`, `/customer/engagements`, `/finance/invoices`, `/storefront/inbox` | Customers, opportunities, work items, invoices, communication attempts | Render client-work empty state with setup link. |
+| Trades And Maintenance | category | `decision-queue` / `today-schedule`, `capacity-lanes` / `technician-load` | `/workspace/my-queue`, `/storefront/inbox`, `/customer`, `/finance/purchase-orders` | WorkItem, CalendarEvent, customer/site, communication attempts | Render empty job board with service-request setup. |
+| Healthcare And Wellness | category | `appointment-schedule` / `patient-queue`, `capacity-lanes` / `shift-summary` | `/storefront/inbox`, `/customer`, `/compliance/licensing`, `/finance/payments` | Bookings, customer/patient record, provider schedule, reminder attempts | Render empty appointment schedule; do not imply clinical record ownership. |
+| Beauty And Personal Care | category | `appointment-schedule` / `today-schedule`, `inventory-watch` / `inventory-alerts` | `/storefront/inbox`, `/storefront/team`, `/storefront/items`, `/finance/payments` | Bookings, providers, services, supplies/payment state | Render empty booking board with services/team setup links. |
+| Education And Training | category | `appointment-schedule` / `today-schedule`, `case-board` / `customer-callbacks` | `/storefront/inbox`, `/customer`, `/storefront/items`, `/finance/payments` | Sessions/bookings, learners/accounts, instructors, messages | Render empty lesson/cohort board. |
+| Food And Hospitality | category | `service-period-board` / `shift-summary`, `inventory-watch` / `inventory-alerts` | `/storefront/inbox`, `/storefront/items`, `/finance/suppliers`, `/finance/purchase-orders` | Bookings/orders, menu/items, stock, staff schedule | Render empty service period; keep stock setup visible. |
+| Retail And Goods | category + wholesale exact | `decision-queue` / `retail-replenishment`, `inventory-watch` / `inventory-alerts` | `/storefront/items`, `/storefront/inbox`, `/finance/purchase-orders`, `/customer` | Products, orders/inquiries, stock, suppliers, customer accounts | Render empty products/orders board; trade exact shows account setup. |
+| Fitness And Recreation | category | `appointment-schedule` / `today-schedule`, `case-board` / `customer-callbacks` | `/storefront/inbox`, `/storefront/items`, `/customer`, `/finance/payments` | Classes/bookings, members, instructors, payment attempts | Render empty class/member board. |
+| Nonprofit And Community | category + animal-care exact | `case-board` / `customer-callbacks`, `volunteer-program-board` / `shift-summary` | `/storefront/inbox`, `/storefront/items`, `/customer/marketing`, `/finance/reports` | Programs/cases, donations, volunteers, communication attempts | Render empty program board with donation/volunteer setup. |
+| Pet Services | category | `appointment-schedule` / `today-schedule`, `case-board` / `customer-callbacks` | `/storefront/inbox`, `/storefront/team`, `/storefront/items`, `/finance/payments` | Pets/owners, bookings, care notes, staff capacity | Render empty animal schedule with service/team setup. |
+| HOA And Property Management | category | `case-board` / `customer-callbacks`, `decision-queue` / `unassigned-work` | `/customer`, `/storefront/inbox`, `/finance/invoices`, `/compliance/licensing` | Requests, owners/residents, vendors, notices, finance records | Render empty request board with community portal setup. |
+
+### 5.5 Setup/Integration Rail Content
+
+Every prototype's right rail should show one active setup gap and the integration posture most likely to matter:
+
+| Prototype | Rail content |
+| --- | --- |
+| Software Platform | `Open review evidence`; anchors: GitHub, OpenAI/Codex, Stripe, QuickBooks, runtime tools. |
+| Professional Services | `Connect books or client email`; anchors: QuickBooks, Stripe, HubSpot, Microsoft 365. |
+| Trades And Maintenance | `Finish service request and crew setup`; anchors: QuickBooks, Stripe, Microsoft 365/SMS, Google Business Profile. |
+| Healthcare And Wellness | `Finish appointment reminders and compliance setup`; anchors: Stripe, QuickBooks, Microsoft 365, EHR/practice system later. |
+| Beauty And Personal Care | `Add team availability and services`; anchors: Stripe, QuickBooks, Mailchimp, Google Business Profile. |
+| Education And Training | `Add instructors and course/session catalog`; anchors: Stripe, QuickBooks, HubSpot, Microsoft 365. |
+| Food And Hospitality | `Add menu/service period and stock vendors`; anchors: Stripe/POS, QuickBooks, Google Business Profile, social channels. |
+| Retail And Goods | `Add products, stock, and order handling`; anchors: Stripe/POS, QuickBooks, HubSpot, inventory/ecommerce provider later. |
+| Fitness And Recreation | `Add classes, instructors, and membership/payment setup`; anchors: Stripe, QuickBooks, Mailchimp, Google Business Profile. |
+| Nonprofit And Community | `Add donation/volunteer/program setup`; anchors: Stripe, QuickBooks, Mailchimp, Microsoft 365. |
+| Pet Services | `Add services, staff capacity, and pet intake fields`; anchors: Stripe, QuickBooks, Google Business Profile, communications. |
+| HOA And Property Management | `Add request categories, vendors, and assessment/payment setup`; anchors: QuickBooks, Stripe/payment portal, Microsoft 365, property-management provider later. |
+
+### 5.6 Capability And Role Wiring
+
+The current `CAPABILITY_REGISTRY` is activation-profile oriented and does not yet contain every business capability from `EP-BIZ-CAP`. Use registry keys where they exist; otherwise use the business capability taxonomy row rather than inventing keys.
+
+| Prototype | Employee roles | Registry keys where applicable | Business capability focus | Integration posture |
+| --- | --- | --- | --- | --- |
+| Software Platform | owner/operator, product lead, build operator, support | `project-work`, `lifecycle-review-queues`, `billing-readiness` | portfolio/product/backlog operations, runtime governance | native DPF with selected integrations |
+| Professional Services | owner/operator, practitioner, sales/BD, admin, bookkeeper | `customer-accounts`, `project-work`, `billing-readiness`, MSP adds `customer-estate`, `service-agreements`, `remote-support` | client work, pipeline, billing, service delivery | hybrid |
+| Trades And Maintenance | dispatcher, technician/crew, service admin, owner, bookkeeper | `customer-accounts`, `customer-sites`, `billing-readiness`, `appointment-checkout` where booking applies | service delivery, dispatch, customer support, procurement | hybrid |
+| Healthcare And Wellness | front desk, practitioner, admin, compliance, bookkeeper | `appointment-checkout`, `customer-accounts`, `billing-readiness` | appointments, intake, compliance, follow-up | integration-led for clinical, hybrid for operations |
+| Beauty And Personal Care | front desk, stylist/tech/trainer, owner, marketing, bookkeeper | `appointment-checkout`, `point-of-sale`, `billing-readiness` | bookings, capacity, rebooking, supplies | hybrid |
+| Education And Training | instructor, admin, enrolment, owner, bookkeeper | `appointment-checkout`, `project-work`, `billing-readiness` | sessions, learner progress, enrolment | hybrid |
+| Food And Hospitality | manager, kitchen/production, front-of-house, owner, bookkeeper | `point-of-sale`, `customer-accounts`, `billing-readiness` | service period, orders, stock, purchasing | integration-led for POS, hybrid for operations |
+| Retail And Goods | store manager, fulfillment, procurement, sales, bookkeeper | `point-of-sale`, `customer-accounts`, `partner-program`, `billing-readiness` | orders, inventory, procurement, customer/trade accounts | hybrid |
+| Fitness And Recreation | front desk, instructor/trainer, owner, marketing, bookkeeper | `appointment-checkout`, `point-of-sale`, `billing-readiness` | classes, memberships, retention | hybrid |
+| Nonprofit And Community | program manager, volunteer coordinator, fundraiser, admin, bookkeeper | `customer-accounts`, `billing-readiness` | programs, donors, volunteers, cases | hybrid |
+| Pet Services | groomer/carer/walker, front desk, owner, customer support | `appointment-checkout`, `customer-accounts`, `billing-readiness` | animal care, bookings, capacity, owner updates | hybrid |
+| HOA And Property Management | property manager, board/admin, vendor coordinator, bookkeeper | `customer-accounts`, `customer-sites`, `billing-readiness` | requests, vendors, assessments, notices | hybrid |
+
+### 5.7 Public Portal CTA Route And Record Mapping
+
+Every archetype has a public customer/storefront shape through `/s/[slug]` and an internal management shape through `/storefront`. The external customer account surface `/portal` remains separate.
+
+| CTA type | Public route shape | Internal record/work surface | Notes for prototype review |
+| --- | --- | --- | --- |
+| `booking` | `/s/[slug]/book/[itemId]` | `StorefrontBooking`, visible in `/storefront/inbox` | Must show date/time, provider/resource, customer, service, confirmation state. |
+| `purchase` | `/s/[slug]/order/[itemId]` then checkout/confirmation | `StorefrontOrder`, visible in `/storefront/inbox` | Must show item, quantity, price/payment state, pickup/shipping if relevant. |
+| `inquiry` | `/s/[slug]/inquire` or `/s/[slug]/inquire/[itemId]` | `StorefrontInquiry`, visible in `/storefront/inbox` | Must show request, customer, desired outcome, owner, next response. |
+| `donation` | `/s/[slug]/donate` | `StorefrontDonation`, visible in `/storefront/inbox` | Must show donor/supporter, amount/campaign, acknowledgement status. |
+
+Review rule: if the prototype's customer action does not match the archetype's `ctaType`, mark the prototype `Fail` unless the exact archetype intentionally overrides the item CTA in its item template.
+
+## 6. Configuration Preview Screen
+
+The setup flow needs a reviewable preview that connects all downstream screens before the operator commits the archetype.
+
+```text
+Business setup: Choose your business type
+
+[Search archetypes.....................................]
+
+Selected: Wholesale Distribution
+Category: Retail and goods
+Customer action: Inquiry / trade account
+
+Activation preview
++----------------------------------------------------------+
+| Worker home: Trade operations board                      |
+| The worker arrives asking: What orders, stock, and       |
+| customer account requests need attention today?          |
+|                                                          |
+| Required data: customers, products, inventory, orders    |
+| Optional: QuickBooks, Stripe, HubSpot, Microsoft 365     |
+|                                                          |
+| Capabilities: customer accounts, inventory, purchase,    |
+| billing readiness, lifecycle review queues               |
++----------------------------------------------------------+
+
+Screens this will configure
+[Worker home] [Customer portal] [Money setup] [Integrations] [Team/coworkers]
+
+Next step:
+  Configure public portal and finance profile
+```
+
+Review goal: the operator should understand what will change in the main worker home, public portal, finance profile, capability toggles, and integrations before saving.
+
+## 7. Category Prototypes
+
+### 7.1 Software Platform
+
+Representative archetype: `software-platform`
+
+Primary operating question: "What needs to ship, recover, or be governed today?"
+
+Architecture posture: preserve `PlatformWorkspaceHome` as platform-operator mode unless a later architect decision explicitly registers `software-platform` as a `WorkspaceHomeContribution`. This prototype is an operator target screen, not evidence that every business archetype should inherit platform chrome.
+
+```text
+Open Digital Product Factory - Platform Operator Home
+
+Critical strip
+[Failed checks 2] [Open incidents 1] [Blocked builds 3] [Unreviewed AI actions 5]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Delivery board            | | Runtime health            |
+| Ready to review: 4        | | Main portal: healthy      |
+| In build: 3               | | MCP: degraded             |
+| Waiting on human: 2       | | Local CI lease: busy      |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Roadmap and backlog       | | Product/customer signals  |
+| EPs with open items       | | Customer feedback         |
+| Next recommended work     | | Storefront inquiries      |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Build Studio handoffs] [Governance approvals] [AI coworker capability gaps]
+```
+
+Critical content: releases, builds, self-upgrade health, backlog, incidents, AI authority, product/customer signals.
+
+Form/tone: platform-operator language is acceptable here. This is the one archetype where Build Studio, backlog, product, and runtime vocabulary belongs in the first viewport.
+
+Layout intent: command center plus delivery health. Keep customer/operator data visible but secondary.
+
+Primary function: help the platform operator decide what to ship, unblock, or govern next.
+
+Employee lanes: owner/operator, product lead, build/release operator, platform admin, support.
+
+Customer portal posture: public product inquiry and customer portal remain separate from operator home.
+
+Finance posture: hybrid. Stripe and QuickBooks matter for platform billing/accounting but should not dominate first viewport.
+
+Integration anchors: GitHub, OpenAI/Codex, Microsoft 365, Stripe, QuickBooks, HubSpot, Mailchimp, monitoring/runtime connectors.
+
+AI coworker fit: portfolio advisor, build specialist, platform engineer, support analyst, finance controller.
+
+Prototype risks: if this screen becomes the default for non-platform archetypes, every SMB vertical will feel like internal DPF administration.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `software-platform` | Keep platform/operator home. Do not use this as the generic worker-home fallback for ordinary businesses once category contributions exist. |
+
+### 7.2 Professional Services
+
+Representative archetypes: `it-managed-services`, `accounting`, `legal-services`, `consulting`, `marketing-agency`
+
+Primary operating question: "Which clients, engagements, and deadlines need attention today?"
+
+```text
+Professional Services - Client Work Home
+
+Critical strip
+[Due today 6] [Client risks 2] [Unsent proposals 3] [Invoice holds 1]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Client work board         | | Capacity by role          |
+| Matters/projects          | | Partner/manager load      |
+| Next client action        | | Staff availability        |
+| Due dates                 | | Overbooked work           |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Pipeline and proposals    | | Billing readiness         |
+| Leads, quotes, renewals   | | WIP, retainers, invoices  |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Client follow-ups] [Coworker drafts] [Contract/accountant review] [Email failures]
+```
+
+Critical content: clients, matters/projects, deadlines, proposals, billing readiness, capacity, follow-ups.
+
+Form/tone: client-service language. Avoid "product backlog" unless the firm is delivering software/product work.
+
+Layout intent: case-board-led for legal/accounting; project-deliverable-led for consulting/marketing; health-board-led for MSP.
+
+Primary function: make client work, deadlines, proposals, and billing visible in one worker screen.
+
+Employee lanes: owner/operator, account manager, consultant, practitioner, sales/BD, bookkeeper/accountant, support/admin.
+
+Customer portal posture: client portal for inquiries, onboarding forms, documents, and project/status requests.
+
+Finance posture: hybrid. QuickBooks for accounting, Stripe for payments, DPF for client work and billing readiness.
+
+Integration anchors: QuickBooks, Stripe, HubSpot, Microsoft 365, Mailchimp, Google Business Profile, service desk/RMM for MSP.
+
+AI coworker fit: client engagement assistant, sales assistant, bookkeeper/accountant, service coordinator, security/compliance helper for MSP.
+
+Prototype risks: MSP is materially different from non-MSP professional services and should keep exact-override treatment.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `it-managed-services` | Replace generic client work board with customer estate health, open tickets, SLA risk, device/security posture, recurring agreements, and remote-support handoffs. |
+| `accounting` | Emphasize client deadlines, books/tax/close work, document requests, accountant collaboration, and QuickBooks posture. |
+| `legal-services` | Emphasize matters, deadlines, document review, conflict checks, retainers, and client communications. |
+| `consulting` | Emphasize engagements, deliverables, milestones, workshops, account growth, and proposal pipeline. |
+| `marketing-agency` | Emphasize campaigns, approvals, content calendar, lead sources, client reporting, Mailchimp/HubSpot/Google posture. |
+
+### 7.3 Trades And Maintenance
+
+Representative archetypes: `plumber`, `electrician`, `facilities-maintenance`, `cleaning-service`, `landscaping`
+
+Primary operating question: "What is on the board today, who is blocked, and who needs an update?"
+
+```text
+Trades and Maintenance - Dispatch Home
+
+Critical strip
+[Emergency jobs 2] [Unassigned 4] [Parts blocked 3] [Customer update failed 1]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Today's job board         | | Crew load                 |
+| Job, site, window, status | | Technician/crew capacity  |
+| Next stop / late risk     | | Overloaded routes         |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Site map / routes         | | Parts and purchase needs  |
+| Open sites, ETA, distance | | Truck stock, PO gaps      |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Dispatcher approvals] [Customer callbacks] [Quote follow-ups] [Safety/compliance gaps]
+```
+
+Critical content: jobs, sites, crew, emergency priority, parts, ETA/customer communications, quotes.
+
+Form/tone: operational and plain. Use "jobs", "sites", "crew", "service calls", not platform language.
+
+Layout intent: dispatch-first. Map and parts are supporting unless the exact archetype makes them primary.
+
+Primary function: keep service work moving and reduce missed appointments or unhandled emergencies.
+
+Employee lanes: owner/operator, dispatcher, technician/crew, service admin, bookkeeper, customer support.
+
+Customer portal posture: service request portal with quote/request forms and status updates.
+
+Finance posture: hybrid. DPF can own jobs, quotes, and service requests; QuickBooks/Stripe own accounting/payments until maturity increases.
+
+Integration anchors: QuickBooks, Stripe, Microsoft 365, Google Business Profile, communications/SMS, field-service/service-desk providers later.
+
+AI coworker fit: dispatcher/service coordinator, sales estimator, customer support, bookkeeper, procurement assistant.
+
+Prototype risks: cleaning and landscaping may need route density over parts; electrician may need permits and safety; facilities maintenance may need asset/site health.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `plumber` | Put emergency jobs and customer ETA updates in the critical strip; parts inventory remains prominent. |
+| `electrician` | Add permits, safety/compliance, certifications, and inspection reminders. |
+| `facilities-maintenance` | Add site/asset health board and recurring planned maintenance. |
+| `cleaning-service` | Emphasize route density, crew assignments, recurring contracts, and supply checklists. |
+| `landscaping` | Add weather risk, route planning, seasonal service windows, and equipment readiness. |
+
+### 7.4 Healthcare And Wellness
+
+Representative archetypes: `dental-practice`, `physiotherapy`, `counselling`, `optician`, `veterinary-clinic`
+
+Primary operating question: "Who is coming in today, what is missing before the visit, and what needs follow-up?"
+
+```text
+Healthcare and Wellness - Practice Home
+
+Critical strip
+[Missing forms 4] [No-show risk 2] [Lab/result wait 3] [Urgent follow-up 1]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Today's appointments      | | Provider/room capacity    |
+| Patient, time, provider   | | Rooms/chairs/practitioners|
+| Visit prep status         | | Gaps and overbooking      |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Care/case follow-ups      | | Billing and claims/admin  |
+| Plans, recalls, tasks     | | Payments, invoices, gaps  |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Front desk handoffs] [Patient reminders] [Compliance/licensing alerts] [Coworker notes]
+```
+
+Critical content: appointments, patient/customer preparation, room/provider capacity, reminders, compliance/licensing, billing readiness.
+
+Form/tone: careful, privacy-aware, and operational. If PHI/EHR depth is not implemented, the screen must not imply clinical system-of-record ownership.
+
+Layout intent: appointment schedule plus readiness strip. Case-board becomes stronger for multi-visit care.
+
+Primary function: keep the day running while surfacing intake, reminder, and follow-up gaps.
+
+Employee lanes: owner/operator, front desk/admin, practitioner, customer support, bookkeeper, compliance/admin.
+
+Customer portal posture: patient/client portal for booking, intake, reminders, and communication. EHR/clinical record remains external unless implemented.
+
+Finance posture: hybrid. DPF can support service billing and payments; regulated claims/EHR/banking are integration-led.
+
+Integration anchors: QuickBooks, Stripe, Microsoft 365, Google Business Profile, communications, EHR/practice-management systems later.
+
+AI coworker fit: front-desk assistant, scheduler, customer support, bookkeeper, compliance/licensing helper.
+
+Prototype risks: healthcare screens must be explicit about what DPF does not own yet.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `dental-practice` | Add chair/room schedule, hygiene recalls, treatment plan follow-ups, payment estimate gaps. |
+| `physiotherapy` | Add care-plan progress, multi-visit packages, exercise-plan follow-ups. |
+| `counselling` | Use risk-sensitive tone, protected handoffs, session continuity, and minimal public detail. |
+| `optician` | Add lab order status, eyewear/product pickup, retail replenishment. |
+| `veterinary-clinic` | Replace patient language with animal/pet owner where appropriate; add species, boarding overlap, vaccination reminders. |
+
+### 7.5 Beauty And Personal Care
+
+Representative archetypes: `hair-salon`, `barber-shop`, `nail-salon`, `beauty-spa`, `personal-trainer`
+
+Primary operating question: "Who is next, who is waiting, and what do we need to deliver today's services?"
+
+```text
+Beauty and Personal Care - Booking Home
+
+Critical strip
+[Late arrivals 2] [Walk-ins waiting 4] [Supplies low 3] [Rebooking gaps 5]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Appointment board         | | Staff/station capacity    |
+| Client, service, stylist  | | Chair/room/tech load      |
+| Next and late risk        | | Open slots                |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Client follow-ups         | | Products and supplies     |
+| Rebooking, reminders      | | Color, tools, retail      |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Front desk handoffs] [Marketing offers] [Payment holds] [Review requests]
+```
+
+Critical content: bookings, staff capacity, stations/rooms, client communication, supplies, rebooking, retail add-ons.
+
+Form/tone: warm, concise, client-service oriented.
+
+Layout intent: schedule-first with supply and rebooking support.
+
+Primary function: improve daily service throughput and client follow-up without making staff manage back-office modules.
+
+Employee lanes: owner/operator, front desk, stylist/technician/trainer, marketing, bookkeeper.
+
+Customer portal posture: booking portal with services, packages, intake notes, and rebooking.
+
+Finance posture: Stripe-led for checkout/payments; QuickBooks-led for books; DPF hybrid for bookings, packages, and retail readiness.
+
+Integration anchors: Stripe, QuickBooks, Mailchimp, Google Business Profile, Facebook/Instagram, Microsoft 365/communications.
+
+AI coworker fit: client engagement assistant, scheduler, marketing assistant, inventory assistant, bookkeeper.
+
+Prototype risks: personal training behaves more like one-to-one coaching than a chair/station business.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `hair-salon` | Emphasize stylist/chair schedule, color inventory, rebooking, retail products. |
+| `barber-shop` | Shift critical strip toward walk-ins, queue, chair turnover, and memberships/packages. |
+| `nail-salon` | Add technician/station supply readiness and service duration balancing. |
+| `beauty-spa` | Replace chair capacity with room/equipment capacity; add intake/consent reminders. |
+| `personal-trainer` | Emphasize client programs, session packages, progress follow-up, and retention cases. |
+
+### 7.6 Education And Training
+
+Representative archetypes: `tutoring`, `music-school`, `corporate-training`, `driving-school`
+
+Primary operating question: "Which learners or cohorts need attention, and what sessions or outcomes are at risk?"
+
+```text
+Education and Training - Learning Operations Home
+
+Critical strip
+[Session prep gaps 3] [Learners behind 5] [Instructor conflict 1] [Parent/client reply needed 4]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Today's lessons/cohorts   | | Instructor capacity       |
+| Learner, instructor, time | | Room/car/coach load       |
+| Prep and attendance       | | Conflicts                 |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Progress and outcomes     | | Enrolment pipeline        |
+| Milestones, exams, risks  | | Leads, trials, packages   |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Parent/client updates] [Certification approvals] [Payment/package gaps] [Coworker drafts]
+```
+
+Critical content: sessions, learners/cohorts, instructors, progress, communication, enrolment, packages.
+
+Form/tone: learner-focused, progress-aware, not school-district heavy unless exact archetype needs it.
+
+Layout intent: schedule plus progress/case board.
+
+Primary function: connect daily sessions to learner/customer outcomes and follow-up work.
+
+Employee lanes: owner/operator, instructor, admin, sales/enrolment, marketing, bookkeeper.
+
+Customer portal posture: academy portal for booking, courses, enrolment, documents, and parent/client communication.
+
+Finance posture: Stripe-led for packages/enrolment payments; QuickBooks-led for accounting; DPF hybrid for sessions and learner progress.
+
+Integration anchors: Stripe, QuickBooks, HubSpot, Mailchimp, Google Business Profile, Microsoft 365.
+
+AI coworker fit: enrolment assistant, scheduler, instructor-support assistant, marketing assistant, bookkeeper.
+
+Prototype risks: driving school needs route/car capacity; corporate training needs cohort/account delivery rather than individual learner focus.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `tutoring` | Emphasize one-to-one sessions, learner progress, parent updates, exam prep. |
+| `music-school` | Add instrument/room scheduling, recital/service-period board, lesson packages. |
+| `corporate-training` | Emphasize cohorts, employer accounts, certification completion, trainer utilization. |
+| `driving-school` | Add car/instructor capacity, road-test readiness, route/location constraints. |
+
+### 7.7 Food And Hospitality
+
+Representative archetypes: `restaurant`, `bakery`, `catering`
+
+Primary operating question: "What service period, prep, order, or guest issue needs attention now?"
+
+```text
+Food and Hospitality - Service Period Home
+
+Critical strip
+[Prep behind 3] [Reservation issue 2] [Allergen flag 1] [Stock low 4]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Service period board      | | Staff/station capacity    |
+| Lunch/dinner/event status | | Kitchen/FOH load          |
+| Prep, orders, guests      | | Coverage gaps             |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Orders and bookings       | | Stock and purchasing      |
+| Reservations, catering    | | Ingredients, vendor gaps  |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Guest replies] [Vendor follow-up] [Shift notes] [Review/social follow-up]
+```
+
+Critical content: service periods, reservations/orders, prep, staff, ingredients, allergens, vendor/purchase needs.
+
+Form/tone: fast operational language. The screen should support repeated glance use.
+
+Layout intent: service-period board first, inventory and booking/order support second.
+
+Primary function: keep the current service window and prep work under control.
+
+Employee lanes: owner/operator, manager, kitchen/production, front-of-house, events/catering coordinator, bookkeeper.
+
+Customer portal posture: venue portal for menus, bookings, inquiries, orders, or event requests depending on archetype.
+
+Finance posture: Stripe/POS-led for payments; QuickBooks-led for accounting; DPF hybrid for service operations and purchasing posture.
+
+Integration anchors: Stripe, QuickBooks, Google Business Profile, social channels, reservations/POS later, Microsoft 365.
+
+AI coworker fit: venue manager, booking assistant, procurement helper, marketing assistant, bookkeeper.
+
+Prototype risks: restaurant, bakery, and catering have very different service periods, so exact deltas matter.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `restaurant` | Emphasize reservations, service windows, table/guest issues, allergen flags. |
+| `bakery` | Replace reservations with bake schedule, wholesale/retail orders, production batches. |
+| `catering` | Emphasize event pipeline, proposal/quote status, delivery logistics, staffing by event. |
+
+### 7.8 Retail And Goods
+
+Representative archetypes: `retail-goods`, `artisan-goods`, `florist`, `wholesale-distribution`
+
+Primary operating question: "What is selling, what is out, and what needs to ship or be approved?"
+
+```text
+Retail and Goods - Commerce Operations Home
+
+Critical strip
+[Stock-out risk 5] [Orders delayed 3] [Return issue 2] [Trade account request 4]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Orders and fulfillment    | | Inventory watch           |
+| New, picking, pickup      | | SKU, threshold, vendor    |
+| Returns and exceptions    | | Reorder status            |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Customer/account pipeline | | Purchasing and vendors    |
+| Leads, trade accounts     | | POs, bills, receipts      |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Manager approvals] [Customer updates] [Supplier follow-up] [Marketing/product recommendations]
+```
+
+Critical content: orders, products/SKUs, inventory, fulfillment, returns, customers/accounts, suppliers, purchase orders.
+
+Form/tone: goods and operations language. Avoid service-only terminology.
+
+Layout intent: orders and inventory side by side.
+
+Primary function: connect customer demand, stock, fulfillment, purchasing, and money.
+
+Employee lanes: owner/operator, store manager, fulfillment/ops, procurement/inventory admin, sales/BD, marketing, bookkeeper.
+
+Customer portal posture: storefront for products or trade inquiries, with exact CTA differences for B2C vs B2B.
+
+Finance posture: hybrid. QuickBooks for books, Stripe/POS for payments, DPF for inventory/procurement context until deeper system-of-record gates are met.
+
+Integration anchors: QuickBooks, Stripe, HubSpot, Mailchimp, Google Business Profile, inventory/POS/ecommerce providers later.
+
+AI coworker fit: inventory/procurement assistant, sales assistant, marketing assistant, bookkeeper, customer support.
+
+Prototype risks: wholesale distribution is B2B and inquiry-led; it should not look like a consumer product shop.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `retail-goods` | Default B2C products, orders, pickup/shipping, returns, inventory. |
+| `artisan-goods` | Add custom commissions, production queue, workshops, bespoke-order case board. |
+| `florist` | Add perishables, delivery routes, event/wedding inquiries, sympathy order sensitivity. |
+| `wholesale-distribution` | Replace consumer checkout with trade accounts, case/pallet pricing, stockist/distributor pipeline, credit terms, high-volume quote workflow. |
+
+### 7.9 Fitness And Recreation
+
+Representative archetypes: `gym`, `yoga-studio`, `dance-studio`
+
+Primary operating question: "Who is coming in, what is at capacity, and which members need attention?"
+
+```text
+Fitness and Recreation - Member Operations Home
+
+Critical strip
+[Class waitlist 3] [Instructor conflict 1] [Retention risk 8] [Payment failed 4]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Today's classes/sessions  | | Capacity and coverage     |
+| Class, instructor, room   | | Room, instructor, limit   |
+| Attendance and waitlist   | | Peak load                 |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Member cases              | | Membership and payments   |
+| Retention, goals, outreach| | Packages, failed payments |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Front desk handoffs] [Trainer notes] [Campaign suggestions] [Renewal reminders]
+```
+
+Critical content: classes/sessions, instructors, rooms, member capacity, waitlists, retention, memberships/payments.
+
+Form/tone: member-first and energetic, without marketing-page bloat.
+
+Layout intent: class schedule plus retention/member cases.
+
+Primary function: keep daily programming, capacity, and member engagement healthy.
+
+Employee lanes: owner/operator, front desk, instructor/trainer, marketing, bookkeeper.
+
+Customer portal posture: member portal for classes, memberships, passes, bookings, and renewals.
+
+Finance posture: Stripe-led for memberships/packages; QuickBooks for accounting; DPF hybrid for member operations.
+
+Integration anchors: Stripe, QuickBooks, Mailchimp, Google Business Profile, social channels, Microsoft 365.
+
+AI coworker fit: member engagement assistant, scheduler, marketing assistant, bookkeeper.
+
+Prototype risks: dance studios need event/recital cycles; gyms need membership churn; yoga studios need class waitlists and package sales.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `gym` | Emphasize membership churn, capacity peaks, trainer sessions, failed payments. |
+| `yoga-studio` | Emphasize class waitlists, instructor schedule, class packs, retreats/workshops. |
+| `dance-studio` | Add recital/service-period board, class levels, rehearsals, family billing. |
+
+### 7.10 Nonprofit And Community
+
+Representative archetypes: `charity`, `community-shelter`, `animal-shelter`, `pet-rescue`, `sports-club`
+
+Primary operating question: "Which programs, people, donors, or volunteers need attention today?"
+
+```text
+Nonprofit and Community - Program Home
+
+Critical strip
+[Urgent cases 3] [Volunteer gap 5] [Donation follow-up 7] [Program capacity risk 2]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Program/case board        | | Volunteer and staff cover |
+| People, cases, programs   | | Shifts, roles, gaps       |
+| Urgency and next action   | | Training/compliance       |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Donor/supporter pipeline  | | Campaigns and outreach    |
+| Gifts, pledges, thanks    | | Appeals, events, sponsors |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Volunteer handoffs] [Donor replies] [Grant/admin tasks] [Safeguarding/compliance gaps]
+```
+
+Critical content: programs, cases/clients, volunteers, donations, campaigns, outreach, compliance.
+
+Form/tone: mission-aware and respectful. Avoid sales-heavy wording for vulnerable populations.
+
+Layout intent: program/case board plus volunteer coverage.
+
+Primary function: coordinate mission delivery, supporter engagement, and staffing gaps.
+
+Employee lanes: owner/operator/executive director, program manager, volunteer coordinator, fundraiser/marketing, admin/bookkeeper, support.
+
+Customer portal posture: supporter hub for donations, volunteer sign-up, events, and inquiries; animal-focused variants need adoption/sponsor language.
+
+Finance posture: hybrid. QuickBooks/accounting for books, Stripe/donation payments, DPF for program/donor/volunteer operations.
+
+Integration anchors: Stripe, QuickBooks, Mailchimp, Google Business Profile, Microsoft 365, social channels, donor/grant systems later.
+
+AI coworker fit: community manager, volunteer coordinator, donor/fundraising assistant, case support assistant, bookkeeper.
+
+Prototype risks: sports club is membership/purchase-heavy; animal rescue shares patterns with pet services.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `charity` | Emphasize donor pipeline, appeals, campaigns, gift acknowledgements, corporate giving. |
+| `community-shelter` | Emphasize urgent cases, bed/program capacity, volunteer gaps, supply donations. |
+| `animal-shelter` | Emphasize animals, foster/adoption, shelter capacity, supplies, volunteer shifts. |
+| `pet-rescue` | Emphasize rescue cases, foster homes, adoption pipeline, animal-care handoffs. |
+| `sports-club` | Emphasize memberships, fixtures/events, family billing, volunteer coaches, ticketing. |
+
+### 7.11 Pet Services
+
+Representative archetypes: `pet-grooming`, `pet-boarding`, `dog-walking`
+
+Primary operating question: "Which animals are coming in or out today, and who needs care or owner updates?"
+
+```text
+Pet Services - Animal Care Home
+
+Critical strip
+[Owner update needed 4] [Care note missing 2] [Capacity full 1] [Route conflict 3]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Animal schedule           | | Staff/capacity lanes      |
+| Pet, owner, service, time | | Groomer/carer/walker load |
+| Prep, pickup, care notes  | | Room/kennel/route limits  |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Care/case notes           | | Supplies and payments     |
+| Preferences, meds, risks  | | Food, products, invoices  |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Owner messages] [Care handoffs] [Rebooking reminders] [Incident/compliance notes]
+```
+
+Critical content: animals, owners, bookings, care notes, capacity, staff, owner communications, supplies.
+
+Form/tone: pet-owner friendly, operational, and trust-building.
+
+Layout intent: animal schedule first, capacity and care notes close beside it.
+
+Primary function: coordinate appointments, care capacity, and owner communication.
+
+Employee lanes: owner/operator, groomer/carer/walker, front desk, customer support, bookkeeper.
+
+Customer portal posture: booking portal for pet owners, with pet profile/intake details.
+
+Finance posture: Stripe-led for appointment/package payments; QuickBooks for books; DPF hybrid for scheduling/care operations.
+
+Integration anchors: Stripe, QuickBooks, Google Business Profile, Mailchimp, communications/SMS, Microsoft 365.
+
+AI coworker fit: booking assistant, care coordinator, customer support, marketing assistant, bookkeeper.
+
+Prototype risks: dog walking needs route-map prominence; pet boarding needs occupancy/care capacity over appointment slots.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `pet-grooming` | Emphasize grooming appointments, pet prep notes, owner pickup, rebooking. |
+| `pet-boarding` | Emphasize occupancy, kennel/room capacity, care schedule, feeding/medication notes. |
+| `dog-walking` | Emphasize routes, walker capacity, owner updates, recurring schedule. |
+
+### 7.12 HOA And Property Management
+
+Representative archetypes: `property-management-company`, `homeowners-association`, `condo-association`
+
+Primary operating question: "What resident, owner, board, vendor, or property issue needs action today?"
+
+```text
+HOA and Property Management - Community Operations Home
+
+Critical strip
+[Urgent requests 4] [Board approvals 3] [Vendor overdue 2] [Owner notice failed 1]
+
+Primary zone
++---------------------------+ +---------------------------+
+| Requests and cases        | | Properties and vendors    |
+| Owner/resident, issue     | | Unit/site, vendor status  |
+| Violation/maintenance     | | Work order progress       |
++---------------------------+ +---------------------------+
+
+Secondary zone
++---------------------------+ +---------------------------+
+| Board and compliance      | | Money and assessments     |
+| Approvals, meetings, docs | | Dues, invoices, arrears   |
++---------------------------+ +---------------------------+
+
+Briefing zone
+[Board handoffs] [Vendor follow-up] [Owner communications] [Compliance/licensing gaps]
+```
+
+Critical content: owner/resident requests, violations, vendors, board approvals, properties/units, notices, dues/assessments.
+
+Form/tone: calm, accountable, community-service oriented.
+
+Layout intent: case/request board plus vendor/property status.
+
+Primary function: coordinate community requests, vendors, board work, and money.
+
+Employee lanes: owner/operator/property manager, board/admin, vendor coordinator, bookkeeper, customer/resident support.
+
+Customer portal posture: community portal for requests, documents, notices, assessments, and owner/resident communication.
+
+Finance posture: QuickBooks/accounting-led for books; DPF hybrid for requests, vendors, notices, board tasks, and assessment readiness.
+
+Integration anchors: QuickBooks, Stripe/payment portal, Microsoft 365, communications, Google Business Profile where relevant, property-management systems later.
+
+AI coworker fit: community manager, vendor coordinator, support assistant, bookkeeper, compliance helper.
+
+Prototype risks: property-management-company is tenant/lease/vendor heavy; HOA/condo are board/owner/community heavy.
+
+Exact archetype deltas:
+
+| Archetype | Delta |
+| --- | --- |
+| `property-management-company` | Add leases, tenants, rent/arrears, move-in/out, vendor work orders. |
+| `homeowners-association` | Emphasize homeowners, violations, dues, board approvals, community notices. |
+| `condo-association` | Emphasize unit-level issues, common-area maintenance, board packets, owner communications. |
+
+## 8. All-Archetype Coverage And Exact-Screen Decisions
+
+Decision values:
+
+- `exact now`: needs its own prototype before implementation critique is complete.
+- `delta only`: category prototype is acceptable if the listed delta is reviewed.
+- `category fallback ok`: category prototype is enough for the first build slice.
+
+| Category | Archetype | CTA | Decision | Reason |
+| --- | --- | --- | --- | --- |
+| `software-platform` | `software-platform` | inquiry | exact now | Platform operator mode is unique and must not leak to SMB worker homes. |
+| `professional-services` | `it-managed-services` | inquiry | exact now | MSP estate health, SLAs, security posture, and recurring agreements diverge from generic client work. |
+| `professional-services` | `accounting` | inquiry | delta only | Client deadline and QuickBooks/accountant focus can start from professional-services case board. |
+| `professional-services` | `consulting` | inquiry | category fallback ok | Engagement/deliverable work fits category board initially. |
+| `professional-services` | `legal-services` | inquiry | delta only | Matter/deadline/retainer language needs review but layout can reuse category board. |
+| `professional-services` | `marketing-agency` | inquiry | delta only | Campaign approvals and client reporting need stronger copy, but layout can reuse project work. |
+| `trades-maintenance` | `cleaning-service` | inquiry | delta only | Route density and recurring contracts differ; category dispatch still works. |
+| `trades-maintenance` | `electrician` | inquiry | delta only | Permits, safety, and certification rows need review. |
+| `trades-maintenance` | `facilities-maintenance` | inquiry | delta only | Asset/site health should be stronger than generic trades. |
+| `trades-maintenance` | `landscaping` | inquiry | delta only | Weather and seasonal service windows need review. |
+| `trades-maintenance` | `plumber` | inquiry | category fallback ok | Emergency jobs and parts fit category dispatch board. |
+| `healthcare-wellness` | `counselling` | booking | exact now | Risk-sensitive tone, privacy, and session continuity require separate review. |
+| `healthcare-wellness` | `dental-practice` | booking | category fallback ok | Appointment/provider/room board fits first slice. |
+| `healthcare-wellness` | `optician` | booking | delta only | Retail/lab-status hybrid needs reviewed delta. |
+| `healthcare-wellness` | `physiotherapy` | booking | delta only | Multi-visit progress cases need reviewed delta. |
+| `healthcare-wellness` | `veterinary-clinic` | booking | exact now | Animal/pet-owner language and boarding/medical overlap diverge enough for exact review. |
+| `beauty-personal-care` | `barber-shop` | booking | delta only | Walk-in queue can be a reviewed delta. |
+| `beauty-personal-care` | `beauty-spa` | booking | delta only | Room/equipment and intake requirements need reviewed delta. |
+| `beauty-personal-care` | `hair-salon` | booking | category fallback ok | Chair/stylist schedule fits category prototype. |
+| `beauty-personal-care` | `nail-salon` | booking | category fallback ok | Technician/station capacity fits category prototype. |
+| `beauty-personal-care` | `personal-trainer` | booking | exact now | One-to-one programs and retention/case work differ from salon chair/station model. |
+| `education-training` | `corporate-training` | inquiry | exact now | Employer accounts, cohorts, certifications, and trainer utilization diverge from tutoring. |
+| `education-training` | `driving-school` | purchase | exact now | Car/instructor/road-test routing and purchase+booking mix need exact review. |
+| `education-training` | `music-school` | booking | delta only | Recital/event cycle needs reviewed delta. |
+| `education-training` | `tutoring` | booking | category fallback ok | Learner/session/progress board fits category prototype. |
+| `food-hospitality` | `bakery` | purchase | delta only | Production/bake schedule needs reviewed delta. |
+| `food-hospitality` | `catering` | inquiry | exact now | Event pipeline, quoting, delivery, and staffing diverge from restaurant service period. |
+| `food-hospitality` | `restaurant` | booking | category fallback ok | Service period and reservation board fits category prototype. |
+| `retail-goods` | `artisan-goods` | purchase | delta only | Bespoke commissions and production queue need reviewed delta. |
+| `retail-goods` | `florist` | purchase | delta only | Perishables, delivery, and event/sympathy sensitivity need reviewed delta. |
+| `retail-goods` | `retail-goods` | purchase | category fallback ok | Orders/inventory/fulfillment board fits category prototype. |
+| `retail-goods` | `wholesale-distribution` | inquiry | exact now | B2B trade accounts, pallet/case pricing, credit terms, and distributor pipeline diverge from retail. |
+| `fitness-recreation` | `dance-studio` | purchase | delta only | Recital/service-period cycle needs reviewed delta. |
+| `fitness-recreation` | `gym` | purchase | category fallback ok | Classes/memberships/retention board fits category prototype. |
+| `fitness-recreation` | `yoga-studio` | purchase | category fallback ok | Class waitlist and packages fit category prototype. |
+| `nonprofit-community` | `animal-shelter` | donation | exact now | Animal-care, adoption/foster, and shelter capacity diverge from general nonprofit. |
+| `nonprofit-community` | `charity` | donation | category fallback ok | Donations/programs/volunteers fit category prototype. |
+| `nonprofit-community` | `community-shelter` | donation | delta only | Urgent service and vulnerable-client tone need reviewed delta. |
+| `nonprofit-community` | `pet-rescue` | donation | exact now | Rescue/foster/adoption overlaps pet care and needs exact review. |
+| `nonprofit-community` | `sports-club` | purchase | exact now | Membership/ticketing/fixture model diverges from donation-led nonprofit. |
+| `pet-services` | `dog-walking` | booking | exact now | Route map and recurring walker capacity need exact layout. |
+| `pet-services` | `pet-boarding` | booking | exact now | Occupancy, care schedule, feeding/medication notes need exact layout. |
+| `pet-services` | `pet-grooming` | booking | category fallback ok | Booking/care-note board fits category prototype. |
+| `hoa-property-management` | `condo-association` | inquiry | delta only | Unit/common-area focus needs reviewed delta. |
+| `hoa-property-management` | `homeowners-association` | inquiry | category fallback ok | Requests/violations/board approvals fit category prototype. |
+| `hoa-property-management` | `property-management-company` | inquiry | exact now | Leases, tenants, rent, move-in/out, and vendor work orders diverge from HOA board model. |
+
+Exact-now backlog follow-up group:
+
+```text
+software-platform
+it-managed-services
+wholesale-distribution
+counselling
+veterinary-clinic
+catering
+dog-walking
+pet-boarding
+property-management-company
+corporate-training
+driving-school
+personal-trainer
+sports-club
+animal-shelter
+pet-rescue
+```
+
+## 9. Backlog Mapping
+
+This spec should not create a new replacement epic. It maps to existing work:
+
+| Work area | Existing owner |
+| --- | --- |
+| Workspace-home resolver, primitive registry, contribution sequencing | `EP-REDUCTION-GEAR-ARCH` |
+| Archetype-driven setup activation orchestrator | `BI-B14D6CF6` |
+| Worker-mode shell/chrome switch | `BI-8D9CA348` |
+| Business capability and employee-work taxonomy | `EP-BIZ-CAP` |
+| Integration/provider parity and benchmarks | `EP-INT-2E7C1A` |
+| Archetype model/setup unification | `EP-ARCH-8D4F2A` |
+| QuickBooks parity | `EP-INT-2E7C1A` |
+
+Known category or exact workspace-home backlog anchors:
+
+| Prototype category | Backlog anchor |
+| --- | --- |
+| Software Platform | `BI-02845133` plus platform/operator shell work |
+| Professional Services | `BI-FA3294E0` for non-MSP, `BI-FE002675` for MSP |
+| Trades And Maintenance | `BI-1F7731E5` for non-HVAC trades, `BI-CE6AF925` for HVAC proving install |
+| Healthcare And Wellness | `BI-FE74CD4A` |
+| Beauty And Personal Care | `BI-25AFC2BC` |
+| Education And Training | `BI-CB8EE2D0` |
+| Food And Hospitality | `BI-336FC845` |
+| Retail And Goods | `BI-ED0153CA` |
+| Fitness And Recreation | `BI-204CE2D6` |
+| Nonprofit And Community | `BI-EF03E915` |
+| Pet Services | `BI-43A682A2` |
+| HOA And Property Management | `BI-96A3C7A9` |
+
+Likely backlog items to create or update after review:
+
+1. Archetype prototype review: critique category-level worker-home mockups for critical content, form, layout, and function.
+2. Main portal setup preview: show worker home, customer portal, finance, integrations, team/coworker impact before archetype commit.
+3. Workspace-home contribution manifests: category-level contributions for the 11 non-platform categories.
+4. Exact archetype prototypes: MSP, wholesale distribution, counselling, veterinary clinic, catering, dog walking, property management, and software platform operator.
+5. Business capability UX: expose commercial market/product references inside capability review and setup preview.
+
+## 10. Review Prompt For Another Agent
+
+Use this prompt to critique the spec:
+
+```text
+Review docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md.
+
+Do not implement code.
+
+Critique the prototype set for:
+1. Critical content: does each first viewport include the facts a real employee needs?
+2. Form and tone: does the language fit the archetype and avoid platform jargon?
+3. Layout: does the hierarchy make sense across critical strip, primary zone, secondary zone, briefing zone, and setup/integration rail?
+4. Function: are the actions tied to current DPF surfaces, canonical records, or clearly named integration anchors?
+5. Coverage: do all 46 archetypes have enough prototype coverage, and which need exact screens rather than category fallback?
+6. Architecture: does the proposal fit StorefrontConfig -> StorefrontArchetype, workspace-home contributions, capability taxonomy, and integration posture?
+
+Return findings ordered by severity with file/section references. Prefer concrete changes to vague opinions.
+```
+
+## 11. Acceptance Criteria
+
+The prototype spec is acceptable when:
+
+- Every current archetype is mapped to a category prototype and exact delta.
+- The main portal screen configuration path is explicitly mapped to setup, public portal, finance, capabilities, integrations, and worker-home contribution mechanics.
+- Reviewers can evaluate critical content, form, layout, and function without running the portal.
+- The spec does not imply that DPF owns regulated finance, payroll, clinical, banking, or payment execution before integration-led maturity gates are met.
+- Category prototypes are small enough to become backlog slices rather than a giant replacement project.
+- Commercial market/product references are called out as required UX context, not buried only in spreadsheet-derived seed data.

--- a/docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md
+++ b/docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md
@@ -1,9 +1,10 @@
 ---
 title: Archetype Portal Screen Prototypes
 date: 2026-06-06
-status: draft - ready for critique
+status: draft — architect-reviewed 2026-06-06 (default-home gap resolved); ready for founder review
 owner: Mark Bodman
 author: Codex
+reviewer: Enterprise Architect persona (Claude) — review folded 2026-06-06
 scope: Text mockups and review criteria for archetype-specific main portal and worker-home screens
 out_of_scope:
   - Runtime implementation
@@ -16,6 +17,7 @@ related_specs:
   - docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md
   - docs/superpowers/specs/2026-06-04-workspace-home-contribution-roster-design.md
   - docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md
+  - docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md
 primary_epics:
   - EP-REDUCTION-GEAR-ARCH
   - EP-BIZ-CAP
@@ -36,6 +38,16 @@ This spec captures low-fidelity text mockups for the archetype-specific DPF port
 - native vs integration-led posture
 
 It does not implement any UI. It makes the target screens concrete enough that Build Studio or another agent can critique the design before writing code.
+
+## 1a. Enterprise Architect Review (2026-06-06)
+
+**Verdict: keep the per-archetype prototype set; close the one gap it leaves open — the default home.** The category prototypes (§7), the worker-facing copy rule (§5.2), the critical-strip row format (§5.3), the contribution-manifest stubs (§5.4), and the all-archetype coverage decisions (§8) are sound and align with the canonical substrate ([vertical-workspace-home](2026-05-24-vertical-workspace-home-design.md), [archetype-aware-workspace](2026-05-31-archetype-aware-workspace-design.md)). They need no structural change.
+
+**The gap:** §7.1 treats the platform/operator home as the default and says only "preserve `PlatformWorkspaceHome`." But that platform-operator composition — a 6×6 Six-Cs *readiness maturity matrix*, a cross-domain tile launchpad, and a firehose calendar mixing customer bookings with platform cron digests and deployment windows — **is what every install lands on today**, because `defaultWorkspaceHomeRegistry` is empty and most archetypes have no registered contribution yet. That default home is *not* a business day-to-day surface; it is internal platform minutia occupying the company's prime screen (the same defect the [IA audit](2026-06-05-portal-navigation-archetype-ia-design.md) named).
+
+**Resolution (folded in):** the default/fallback `/workspace` home is now redesigned in a dedicated sibling spec — [Main Portal Workspace Home Redesign](2026-06-06-main-portal-workspace-home-redesign-design.md). It makes the default home answer "what is the immediate and next-up work for this business?" using the **report-kit** palette, wired to **real loaders** (no fabricated data), with the **full platform schedule moved to an operator admin surface** and replaced by a purposed business "Today & Next" agenda. The Six-Cs readiness matrix relocates to the operator surface, where it is the `software-platform` install's legitimate day-to-day. §7.1 below is updated to reference that redesign rather than implying operator chrome is an acceptable default for ordinary businesses.
+
+This prototype spec (the per-archetype mockups) and the default-home redesign together cover both halves of the main portal: the configured-vertical homes *and* the default home every business sees first.
 
 ## 2. Direct Answer: Is Main Portal Screen Configuration Mapped To This Work?
 
@@ -352,7 +364,7 @@ Representative archetype: `software-platform`
 
 Primary operating question: "What needs to ship, recover, or be governed today?"
 
-Architecture posture: preserve `PlatformWorkspaceHome` as platform-operator mode unless a later architect decision explicitly registers `software-platform` as a `WorkspaceHomeContribution`. This prototype is an operator target screen, not evidence that every business archetype should inherit platform chrome.
+Architecture posture: `PlatformWorkspaceHome` is the **platform-operator mode** and the legitimate day-to-day home for the `software-platform` (DPF-on-DPF) install only. It is **not** the acceptable default for ordinary businesses. The composition described here (readiness matrix, command center, full platform schedule) is the *operator* surface; ordinary installs that have no registered vertical contribution get the redesigned business default home instead — see [Main Portal Workspace Home Redesign](2026-06-06-main-portal-workspace-home-redesign-design.md), which moves the 6×6 readiness matrix and the full platform/cron schedule here (to the operator surface) and gives the default home a business "Today & Next" agenda + work queue wired to real data with report-kit. This prototype is an operator target screen, not evidence that every business archetype should inherit platform chrome.
 
 ```text
 Open Digital Product Factory - Platform Operator Home

--- a/docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md
@@ -222,6 +222,8 @@ No new epic. This is the default-home slice of the existing workspace-home work.
 
 ## 12. Verification Plan
 
+**Acceptance vehicle:** this redesign is verified through **§3 "Employee Work View"** of the [Archetype Acceptance Test Plan](../plans/2026-06-06-archetype-acceptance-test-plan.md), exercised on a clean install across the 12 representative archetypes. §3's fail condition — *"worker-facing UX still reads like platform operator tooling for ordinary business employees"* — is the exact defect this spec removes, so a §3 `Pass` on a non-`software-platform` archetype is the redesign's acceptance signal. The steps below are the focused redesign smoke that feeds that walkthrough.
+
 1. Drive `/workspace` on the Live install as a non-platform user; confirm first viewport = header + critical strip + Today&Next + work queue; confirm no readiness matrix, no cron/deployment events.
 2. Drive the operator `/platform/schedule` surface; confirm cron digests, deployment windows, blackouts, and agent-task runs are present there.
 3. Resize to mobile; confirm the §4.2 order.

--- a/docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md
@@ -1,0 +1,230 @@
+---
+title: Main Portal Workspace Home Redesign — the company's day-to-day at-a-glance surface
+date: 2026-06-06
+status: draft — architect-authored, ready for founder review
+owner: Mark Bodman (CEO)
+author: Enterprise Architect persona (Claude, taking over the Codex effort)
+scope: Redesign of the DEFAULT/fallback `/workspace` home (the surface every install lands on before — or instead of — a registered vertical contribution). Re-architects the command center, splits the schedule, and wires every zone to real loaders using the report-kit palette.
+out_of_scope:
+  - The per-archetype vertical worker homes (owned by the contribution roster + Dale visual specs; this spec is their default-mode sibling)
+  - New schema / new dashboard-widget substrate
+  - The external customer `/portal` surface
+anchor_specs:
+  - docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md
+  - docs/superpowers/specs/2026-05-24-vertical-workspace-home-design.md
+  - docs/superpowers/specs/2026-05-24-workspace-home-primitive-registry-design.md
+  - docs/superpowers/specs/2026-06-05-portal-navigation-archetype-ia-design.md
+related_specs:
+  - docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md
+  - docs/superpowers/specs/2026-05-24-dales-ac-repair-workspace-home-visual-design.md
+  - docs/specs/reporting-ux-primitives-spec.md
+primary_epics:
+  - EP-REDUCTION-GEAR-ARCH
+related_backlog:
+  - BI-1CCC6264
+  - BI-02845133
+  - BI-5B8FE5C1
+---
+
+# Main Portal Workspace Home Redesign
+
+## 1. Architect Verdict
+
+**The vertical-home lineage fixed the wrong half of the screen first.** The whole `EP-REDUCTION-GEAR-ARCH` body of work — the resolver, the 11-primitive registry, the Dale HVAC visual anchor, the archetype-aware layering spec, the contribution roster — makes the *configured vertical* home excellent. But every install today renders the **default** home (`PlatformWorkspaceHome`), because `defaultWorkspaceHomeRegistry` is empty by design and most archetypes have no registered contribution yet. That default home is the screen Mark is looking at, and it is **not the company's day-to-day**. It is a platform-operator command center: a six-dimension readiness *maturity matrix*, a cross-domain tile launchpad, and a firehose calendar that mixes a customer's bookings with the platform's own cron digests and deployment windows.
+
+This is the same defect the navigation/IA audit named on 2026-06-05: *"`/workspace` acts as a cross-domain launchpad instead of the archetype-specific daily work surface... 118 links in the sampled DOM... a health/status matrix [drilling] across domains."* ([portal-navigation-archetype-ia-design §Executive Verdict](2026-06-05-portal-navigation-archetype-ia-design.md)).
+
+**Verdict:** the default `/workspace` home must be redesigned to answer one question — *"What is the immediate and next-up work for this business, in one compelling place?"* — using the **report-kit** palette we already shipped, wired to **real** loaders (no fabricated data), with the **full platform schedule moved off this page to an admin surface** and replaced by a *purposed* business schedule. The archetype-prototype spec ([2026-06-06](2026-06-06-archetype-portal-screen-prototypes-design.md)) left §7.1 as "preserve `PlatformWorkspaceHome`"; this spec closes that gap by redesigning the default home itself so it is a worthy at-a-glance surface for *any* business, including before a vertical contribution is registered.
+
+This is the **default-mode sibling** of the archetype-aware spec, not a competitor. When a vertical contribution resolves, the archetype home wins (per [archetype-aware §Proposed IA](2026-05-31-archetype-aware-workspace-design.md)). When it does not — the common case today — the user gets *this* redesigned default home instead of operator chrome.
+
+## 2. Problem Statement — what is wrong with the current default home
+
+Current composition ([`apps/web/components/workspace-home/PlatformWorkspaceHome.tsx`](../../../apps/web/components/workspace-home/PlatformWorkspaceHome.tsx)):
+
+1. **`BusinessCommandCenter`** ([`apps/web/components/workspace/BusinessCommandCenter.tsx`](../../../apps/web/components/workspace/BusinessCommandCenter.tsx)) renders, in order: a command strip, a 6-tile snapshot, a **6×6 "readiness matrix"** (AI workforce / customers / finance / compliance / people / platform-delivery × the *Six Cs* context/connections/capabilities/cadence/confidence/containment), and a work-in-motion grid. The readiness matrix is a **platform-maturity meta-view**. A bakery owner does not arrive asking "what is my AI-workforce containment posture?" — that is internal platform minutia.
+2. **`WorkspaceCalendar`** ([`apps/web/components/workspace/WorkspaceCalendar.tsx`](../../../apps/web/components/workspace/WorkspaceCalendar.tsx)) renders a full `FullCalendar` with **10 source filters across 8 categories**, including `platform` cron `recurring-digest` jobs, `maintenance` events, `deployment-window`/`blackout` change-management, and `agent-task` runs. This is "everything the portal is scheduled to do" — the right data for an operator, the wrong altitude for a daily business home.
+3. **`WorkspaceAreaLauncher`** ([`apps/web/components/workspace-home/WorkspaceAreaLauncher.tsx`](../../../apps/web/components/workspace-home/WorkspaceAreaLauncher.tsx)) is the cross-domain tile launchpad the IA audit flagged.
+4. The **activity feed** ([`apps/web/components/workspace/ActivityFeed.tsx`](../../../apps/web/components/workspace/ActivityFeed.tsx)) is HR-centric (timesheets, leave, onboarding) rather than whole-business.
+
+None of this is *wrong data* — it is **mis-prioritized altitude**. The redesign keeps every real signal but re-sorts it so the business's own immediate work is the first viewport and platform/operator concerns move to where operators look for them.
+
+## 3. Design Goal & Principles
+
+**Goal:** the default `/workspace` first viewport answers, at a glance, *what needs doing now and next* for the business — work, tasks, schedule, and activity — in one compact, compelling surface, built from reusable components and real data.
+
+Principles (inherited from [archetype-aware §Design Principles](2026-05-31-archetype-aware-workspace-design.md); restated for the default home):
+
+1. **Day-to-day first, platform-meta last.** The first viewport is the business's immediate + next-up work. Platform readiness/maturity is an operator concern, reachable but not resident here.
+2. **Real data only — no fabrication.** Every tile, list, row, and schedule item binds to an existing loader. Zero placeholder/mock content. An empty real state renders a positive-empty or setup-action state (per [archetype-aware §Degraded and Missing-Data Behavior](2026-05-31-archetype-aware-workspace-design.md)), never invented rows.
+3. **Compose report-kit, don't hand-roll.** KPI tiles use `StatCard`; lists use `DataTable`; status uses `StatusBadge`/`statusColors`; filters use `FilterBar`; trend charts use `Chart`. No local color maps, no bespoke `<table>` markup ([report-kit README](../../../apps/web/components/ui/report-kit/README.md)).
+4. **Purposed schedule, not the firehose.** The home schedule shows business context only. The full multi-source schedule becomes an admin surface (§6).
+5. **No second substrate.** Extend the workspace-home loaders, the command-center builder, the calendar projector, and report-kit. No new `Dashboard`/`Widget` table.
+6. **Theme-aware.** `var(--dpf-*)` tokens and report-kit intent helpers only.
+
+## 4. Redesigned First-Viewport Layout
+
+The default home re-uses the canonical zone vocabulary from [archetype-aware §Proposed IA](2026-05-31-archetype-aware-workspace-design.md) (`critical-strip` / `primary` / `secondary` / `briefing` / `setup`) so the default home and vertical homes are structurally consistent.
+
+```text
+Workspace — <Business name>                       [Today · <weekday>, <date>]   [+ New ▾]
+
+CRITICAL STRIP  (actionable rows, not just counts)
+  [⚠ now]  Invoice #1048 overdue 12d · Acme Co · → /finance/invoices/1048
+  [⚠ 10:30] Booking unconfirmed · J. Patel · → /storefront/inbox/...
+  [• today] 2 approvals waiting on you · → /ops/improvements
+
+PRIMARY ZONE  — "What needs doing now and next"
++-------------------------------+ +-------------------------------+
+| Today & Next                  | | My / team work queue          |
+| (purposed business schedule)  | | open + in-progress, by owner  |
+|  09:00 Booking — Patel        | |  ⬤ Draft proposal — you       |
+|  11:30 Invoice due — Acme     | |  ⬤ Follow-up call — A. Lee    |
+|  14:00 Provider: Sam off      | |  ⬤ Review timesheet — (mgr)   |
+|  → open full business calendar| |  → /ops  · → /workspace/my-queue|
++-------------------------------+ +-------------------------------+
+
+SECONDARY ZONE  — at-a-glance business health (StatCards, real metrics)
+[ Open work N ] [ Outstanding $X ] [ Customers N ] [ Bookings today N ] [ Overdue N ]
+
+BRIEFING ZONE  — AI coworker handoffs + activity
++-------------------------------+ +-------------------------------+
+| Coworker handoffs (PAR)       | | Recent activity               |
+| AI-prepared replies/notes     | | what changed, who, when       |
+| waiting for your go-ahead     | | (whole-business, role-scoped) |
++-------------------------------+ +-------------------------------+
+
+SETUP RAIL (only while incomplete)
+  Finish business setup · connect QuickBooks/Stripe · register worker home
+```
+
+### 4.1 First-viewport rule
+
+Desktop first viewport (1366×768 floor, per the Dale density budget) must show: operating header, critical strip with ≥1 actionable row, the **Today & Next** business schedule, and the **work queue**. Secondary StatCards, briefing, and setup rail may sit below the fold — except the setup gap, which stays visible while the install is incomplete.
+
+### 4.2 Mobile order
+
+```text
+Critical strip → Today & Next → Work queue → one setup gap → Coworker handoffs → Secondary StatCards → Recent activity
+```
+
+## 5. Zone → Component → Data Wiring (real, no fake data)
+
+Every zone binds to a loader that already exists. The "Source today" column proves the data is real and wired; the "Component" column is the reusable primitive that renders it.
+
+| Zone | What it shows | Component (reusable) | Real data source (existing) |
+| --- | --- | --- | --- |
+| Critical strip | Actionable exception rows (overdue money, unconfirmed/at-risk bookings, blocked work, approvals on you) | repurposed `BusinessCommandCenter` command strip + `StatusBadge` | `buildCommandStrip()` in [`command-center.ts`](../../../apps/web/lib/workspace/command-center.ts) — re-scoped to business exceptions (finance overdue, compliance, pending proposals); platform-only items (AI containment, broken providers, failed task runs) move to the admin operator view (§7) |
+| Primary — Today & Next | Purposed **business** schedule: bookings, invoices/bills due, provider availability, CRM activity/pipeline deadlines, capacity-relevant HR (leave) | `DataTable` (compact agenda list) **or** a slimmed `WorkspaceCalendar` agenda view; `StatusBadge` for state; `LocalTime` for times | `getCalendarEvents()` in [`calendar-data.ts`](../../../apps/web/lib/workforce/calendar-data.ts), **filtered to business categories/sources** (§6.1). Same loader, narrowed projection — no new query |
+| Primary — Work queue | Open + in-progress work the user (and, for managers, the team) must action | `DataTable` + `StatusBadge` | Backlog/work-item counts already loaded by `loadWorkspaceCommandCenter()` (`openBacklogCount`, `inProgressBacklogCount`); itemized rows via the existing `/ops` + `/workspace/my-queue` loaders |
+| Secondary — health StatCards | ≤6 KPI tiles: open work, outstanding $, customers, bookings today, overdue items | `StatCard` (report-kit) | `WorkspaceMetrics` from [`command-center.ts`](../../../apps/web/lib/workspace/command-center.ts) — the same 6-tile snapshot, re-expressed as `StatCard`s with drill-down `href` and optional `delta` |
+| Briefing — coworker handoffs | AI-prepared replies/notes/proposals waiting for the user (PAR acknowledge/reassign) | existing handoff rendering; `StatusBadge` | `CoworkerActionEnvelope` projection (per [archetype-aware §WWWD and Coworker Integration](2026-05-31-archetype-aware-workspace-design.md)); work-in-motion from `loadWorkspaceCommandCenter().commandCenter.workInMotion` |
+| Briefing — recent activity | Whole-business recent changes, role-scoped | `ActivityFeed` (kept; broadened beyond HR where data exists) | `getActivityFeed()` in [`activity-feed-data.ts`](../../../apps/web/lib/activity-feed-data.ts) |
+| Setup rail | One active setup gap + integration anchors | `StatCard`/notice + links | `buildAttentionItems()` + storefront/setup-activation state already loaded by `loadPlatformWorkspaceHomeData()` |
+
+**No-fake-data rule (enforced):** components render only from these loaders. Where a loader returns zero rows, the component shows its declared empty/setup state — it must not synthesize illustrative rows. Tests assert that with empty inputs the rendered output contains no row content (only the empty-state copy).
+
+## 6. The Schedule Split
+
+Mark's instruction: *"The full schedule view is too much on this page... a better admin surface to see everything the portal is scheduled to do. A purposed schedule is needed here with the main business context, not internal platform minutia."*
+
+The split runs along the calendar's **existing** `category`/`sourceType` axis ([`WorkspaceCalendar.tsx` `CATEGORY_CONFIG` / `SOURCE_FILTER_CONFIG`](../../../apps/web/components/workspace/WorkspaceCalendar.tsx)). No new event types, no new projector — just two bounded views over one loader.
+
+### 6.1 Home — "Today & Next" (business context)
+
+Default-home schedule shows **business** altitude only:
+
+| Keep on home | Calendar category | Source filter | Event types |
+| --- | --- | --- | --- |
+| Bookings / appointments | `business` | `bookings` | `booking` |
+| Customer activity & deadlines | `business` | `crm` | `crm-activity`, `pipeline-deadline` |
+| Provider availability | `business` | `providers` | `provider-schedule` |
+| Operating hours | `business` | `op-hours` | `operating-hours` |
+| Money due | `finance` | `finance` | `invoice`, `bill`, `recurring-invoice` |
+| Capacity-relevant people events | `hr` | (native/leave) | `leave` (coverage-affecting only) |
+| Compliance deadlines | `compliance` | `compliance` | `compliance-deadline`, `audit`, `regulatory` |
+| User-created events | `business`/`personal` | `native` | native |
+
+Presented as a **compact agenda** (today + the next few days), not the month grid, so it earns its first-viewport slot. "Open full business calendar" links to the full month/week view *still scoped to these business sources*.
+
+### 6.2 Admin — "Platform schedule" (everything the portal is scheduled to do)
+
+Operator/platform altitude moves to a dedicated admin surface:
+
+| Move to admin | Calendar category | Source filter | Event types |
+| --- | --- | --- | --- |
+| Scheduled platform jobs / cron digests | `platform` | `scheduled-jobs` | `recurring-digest`, `maintenance` |
+| Deployment windows, blackouts, change requests | `operations` | `change-mgmt` | `deployment-window`, `blackout`, `change-request` |
+| AI coworker scheduled task runs | `platform` | `agent-tasks` | `agent-task` |
+
+**Route (architect default):** `/platform/schedule` — the platform family is the operator surface per the [IA route-ownership model](2026-06-05-portal-navigation-archetype-ia-design.md); `/ops` is the alternative if the implementer finds change-management already lives there. Whichever wins, the rule is one: *"everything the portal is scheduled to do"* lands under an operator route, gated by `view_platform`/`manage_platform`, and is reachable from the home only via an operator switch (per [archetype-aware §Resolved Review Q5](2026-05-31-archetype-aware-workspace-design.md)), not resident on the worker home.
+
+**Reuse:** the admin surface renders the **same** `WorkspaceCalendar` component with the source/category set defaulted to the platform/ops subset — the calendar is already filter-driven, so this is configuration, not a fork.
+
+## 7. Re-architecture of Existing Components
+
+Nothing is thrown away — each current piece is repurposed to its correct altitude.
+
+| Current component | Disposition | Where it goes |
+| --- | --- | --- |
+| `BusinessCommandCenter` **command strip** | **Keep, re-scope** to business exceptions | Critical strip on home |
+| `BusinessCommandCenter` **snapshot (6 tiles)** | **Re-express as `StatCard`s** | Secondary zone on home |
+| `BusinessCommandCenter` **readiness matrix (6×6 Six-Cs)** | **Move to operator surface** | A "Platform readiness" panel on `/platform` (or the operator-mode home), not the worker home. It is a maturity/governance view — exactly the platform minutia Mark flagged |
+| `BusinessCommandCenter` **work-in-motion** | **Keep** | Briefing zone (handoffs/activity) |
+| `WorkspaceCalendar` (full, 10 sources) | **Split** (§6) | Business subset → home agenda; full set → `/platform/schedule` admin |
+| `WorkspaceAreaLauncher` (tile launchpad) | **Demote** | Moves below the fold / into the global rail per the IA audit's "convert cross-domain shortcuts into contextual actions" direction; it is navigation, not day-to-day work, so it must not outrank the work queue |
+| `ActivityFeed` | **Keep, broaden** | Briefing zone; widen beyond HR where whole-business activity data exists |
+
+The 6×6 readiness matrix relocation is the single most important change: it is the clearest instance of "internal platform minutia" occupying prime real estate on the business's daily screen.
+
+## 8. Relationship to the Vertical-Home Lineage
+
+| Surface | Owner spec | This spec's relationship |
+| --- | --- | --- |
+| Vertical archetype homes (HVAC dispatch board, clinic, retail, MSP…) | [vertical-workspace-home](2026-05-24-vertical-workspace-home-design.md), [Dale visual](2026-05-24-dales-ac-repair-workspace-home-visual-design.md), [contribution roster](2026-06-04-workspace-home-contribution-roster-design.md) | When a contribution resolves, the vertical home wins. This spec does not touch them. |
+| Configuration layering, zones, report-kit rule, slot covenant | [archetype-aware-workspace](2026-05-31-archetype-aware-workspace-design.md) | This spec **conforms** to it — same zones, same report-kit mandate, same no-second-substrate rule, same `LocalTime`/banned-copy lint. |
+| **Default/fallback `/workspace` home** | *(gap)* | **This spec.** It is the `configured-fallback` + `unconfigured` first-screen behavior, redesigned from operator-chrome into a real business day-to-day surface. |
+| Per-category text prototypes | [archetype-portal-screen-prototypes](2026-06-06-archetype-portal-screen-prototypes-design.md) §7 | This spec resolves that spec's §7.1 default-home gap (see the review folded into that file). |
+
+`software-platform` (the DPF-on-DPF install) is the one archetype that legitimately wants the operator command center as its day-to-day — for it, the relocated readiness matrix + platform schedule *are* the business ([contribution roster §3](2026-06-04-workspace-home-contribution-roster-design.md)). The operator view therefore is not deleted; it becomes the explicit operator mode and the `software-platform` home.
+
+## 9. Non-Goals / Guardrails
+
+- No new `Dashboard`/`Widget`/`PageBuilder` table; no drag-and-drop builder.
+- No new calendar event types or projector forks — the split is filter configuration over the existing projection.
+- No local color/status maps or hand-rolled tables — report-kit only.
+- No fabricated/sample data in any state — empty real data renders empty/setup states.
+- Banned-copy lint (`gear`, `ring`, `slip`, `cockpit`, `reduction-gear`, etc.) applies to all worker-facing strings ([archetype-aware §UI/UX Behavior](2026-05-31-archetype-aware-workspace-design.md)).
+
+## 10. Acceptance Criteria
+
+- Default `/workspace` first viewport shows, above the fold on 1366×768: operating header, critical strip with ≥1 actionable row, the **Today & Next** business agenda, and the **work queue** — and does **not** show the 6×6 readiness matrix or platform cron/deployment events.
+- The **Today & Next** schedule renders only business-category/source events (§6.1); platform/ops/agent-task events are absent from the home and present on the operator `/platform/schedule` surface (§6.2).
+- All KPI tiles are `StatCard`s; all status pills are `StatusBadge`; any tabular list is `DataTable`; any filter is `FilterBar` — verified by grep showing no new bespoke table/color-map markup in the redesigned components.
+- Every rendered zone is bound to a real loader from §5; with empty inputs, no synthesized rows appear (unit-tested).
+- The relocated readiness matrix renders on the operator surface and is reachable from the worker home only via an operator switch gated by `view_platform`/`manage_platform`.
+- Banned-copy lint and `LocalTime` usage pass; tokens only, no raw hex.
+- UX verification drives the Live portal at `http://localhost:3000/workspace` (desktop + mobile) and the operator schedule surface, reported as a structured dynamic-analysis narrative (drove X → observed Y → signed off Z), per the founder's "functional, not structural" standard.
+- `pnpm typecheck` + web unit tests + production build pass before implementation is considered complete.
+
+## 11. Backlog Mapping
+
+No new epic. This is the default-home slice of the existing workspace-home work.
+
+| Work area | Existing owner |
+| --- | --- |
+| Default-home redesign (zones, report-kit recomposition, command-strip re-scope) | `BI-1CCC6264` (resolver/registry/platform-fallback) — extend its platform-fallback rendering |
+| Schedule split (business agenda on home; `/platform/schedule` admin) | new BI under `EP-REDUCTION-GEAR-ARCH` if not absorbed by `BI-1CCC6264` — "purposed business schedule + platform schedule admin surface" |
+| Readiness-matrix relocation to operator surface | `BI-02845133` (software-platform / platform operator home) |
+| report-kit recomposition of snapshot → StatCards | `BI-5B8FE5C1` (primitive library) reuse; no new primitive needed |
+
+**Likely new BI to file** (gap proven not to fit an existing body): *"Default workspace-home redesign — business day-to-day surface + schedule split"*, scoped to the platform-fallback path so it lands independently of any single vertical contribution.
+
+## 12. Verification Plan
+
+1. Drive `/workspace` on the Live install as a non-platform user; confirm first viewport = header + critical strip + Today&Next + work queue; confirm no readiness matrix, no cron/deployment events.
+2. Drive the operator `/platform/schedule` surface; confirm cron digests, deployment windows, blackouts, and agent-task runs are present there.
+3. Resize to mobile; confirm the §4.2 order.
+4. Confirm empty-state behavior with a freshly-seeded install (no bookings/invoices) renders setup/positive-empty states, not fabricated rows.
+5. Confirm report-kit composition by source inspection and the unit-test assertions in §10.
+6. Capture the dynamic-analysis report and turn it over to the founder for assurance.


### PR DESCRIPTION
## What & why

Takes over the Codex portal-redesign effort as enterprise architect — **design + implementation + functional verification**.

The `EP-REDUCTION-GEAR-ARCH` lineage perfected the per-archetype *vertical* homes but left the **default** `/workspace` home — what every install lands on, since `defaultWorkspaceHomeRegistry` is empty — as platform-operator chrome: a 6×6 Six-Cs *readiness maturity matrix*, a cross-domain tile launchpad, and a firehose calendar mixing customer bookings with the platform's own cron digests and deployment windows. That is internal platform minutia on the company's prime daily screen (the defect the 2026-06-05 IA audit named, and the §3 fail condition of the archetype acceptance test plan).

## Design docs

- **[Main Portal Workspace Home Redesign](docs/superpowers/specs/2026-06-06-main-portal-workspace-home-redesign-design.md)** — the redesign spec.
- Architect review folded into **[Archetype Portal Screen Prototypes](docs/superpowers/specs/2026-06-06-archetype-portal-screen-prototypes-design.md)** (resolves its §7.1 default-home gap) and **[Archetype Acceptance Test Plan](docs/superpowers/plans/2026-06-06-archetype-acceptance-test-plan.md)** (cross-linked — its §3 is this redesign's acceptance test). Codex's original commits carried over with authorship.

## Implementation

- Default `/workspace` home leads with day-to-day work: **Needs attention** critical strip, **report-kit StatCard** snapshot, **work in motion**, and a new **Today & Next** business agenda (`BusinessAgenda`) beside the activity feed.
- `BusinessAgenda` shows only business-context events (bookings, money due, providers, CRM, compliance) from the existing calendar projection — **real data only**, empty state renders (no synthesized rows). Platform cron digests, deployment windows, blackouts, and AI task runs never appear.
- **Schedule split** along the existing `category`/`sourceType` axis (no new substrate): `/workspace/calendar` = full business calendar (platform sources hidden by default); `/platform/schedule` = operator "everything scheduled" view.
- **Relocated the 6×6 Six-Cs readiness matrix** off the business home to `/platform` (`PlatformReadinessMatrix`).
- Fixed a pre-existing `ActivityFeed` hydration mismatch (raw locale date → shared `LocalTime`).

## Verification (contributor preview `:3001`, live DB)

Drove all four surfaces functionally:
- `/workspace` — redesigned home renders; no readiness matrix; StatCards + business agenda present; **no hydration errors**.
- `/workspace/calendar` — business calendar; Platform/Operations filters hidden by default; cron jobs absent.
- `/platform` — readiness matrix renders here; "Platform schedule →".
- `/platform/schedule` — full firehose (cron digests, sweeps, deploys, agent tasks).

Web typecheck + affected vitest suites green pre-change; CI runs the authoritative typecheck/build/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
