### PR TITLE
feat(workbooks): Finance (invoices) + Compliance (risks) platform-data grids (EP-GRID-WORKBOOKS Phase 1c)

### DIFF
--- a/apps/web/lib/workbooks/finance-compliance-adapters.test.ts
+++ b/apps/web/lib/workbooks/finance-compliance-adapters.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { INVOICE_COLUMNS, invoiceToGridRow } from "./invoice-adapter-mapping";
+import { RISK_COLUMNS, riskToGridRow, buildRiskInput } from "./risk-adapter-mapping";
+
+describe("invoice mapping", () => {
+  it("makes only status editable", () => {
+    const editable = INVOICE_COLUMNS.filter((c) => c.editable).map((c) => c.columnId);
+    expect(editable).toEqual(["status"]);
+  });
+
+  it("maps an invoice to a row keyed by column with numeric amounts", () => {
+    const row = invoiceToGridRow({
+      invoiceRef: "INV-2026-0001",
+      status: "sent",
+      accountName: "Acme",
+      totalAmount: 1200.5,
+      amountDue: 200.5,
+      currency: "GBP",
+      issueDate: new Date("2026-06-01T00:00:00.000Z"),
+      dueDate: new Date("2026-06-30T00:00:00.000Z"),
+      type: "standard",
+    });
+    expect(row.rowId).toBe("INV-2026-0001");
+    expect(row.cells.status).toBe("sent");
+    expect(row.cells.account).toBe("Acme");
+    expect(row.cells.totalAmount).toBe(1200.5);
+    expect(row.cells.dueDate).toBe("2026-06-30T00:00:00.000Z");
+  });
+});
+
+describe("risk mapping", () => {
+  it("marks identity/status/timestamp read-only and content editable", () => {
+    const byId = new Map(RISK_COLUMNS.map((c) => [c.columnId, c]));
+    expect(byId.get("assessmentId")?.editable).toBe(false);
+    expect(byId.get("status")?.editable).toBe(false);
+    expect(byId.get("assessedAt")?.editable).toBe(false);
+    expect(byId.get("title")?.editable).toBe(true);
+    expect(byId.get("severity")?.editable).toBe(true);
+  });
+
+  it("severity/likelihood/inherentRisk are selects with options", () => {
+    const sev = RISK_COLUMNS.find((c) => c.columnId === "severity");
+    expect(sev?.fieldType).toBe("select");
+    expect(sev?.config?.options?.map((o) => o.key)).toContain("catastrophic");
+  });
+
+  it("maps a risk to a row (null next-review -> null)", () => {
+    const row = riskToGridRow({
+      assessmentId: "RA-abc",
+      title: "Slip hazard",
+      hazard: "Wet floor",
+      likelihood: "possible",
+      severity: "moderate",
+      inherentRisk: "high",
+      residualRisk: null,
+      status: "active",
+      scope: null,
+      nextReviewDate: null,
+      notes: null,
+      assessedAt: new Date("2026-06-01T09:00:00.000Z"),
+    });
+    expect(row.rowId).toBe("RA-abc");
+    expect(row.cells.inherentRisk).toBe("high");
+    expect(row.cells.nextReviewDate).toBeNull();
+  });
+});
+
+describe("buildRiskInput", () => {
+  it("includes only the changed fields", () => {
+    const input = buildRiskInput({ severity: "major" });
+    expect(input).toEqual({ severity: "major" });
+  });
+
+  it("coerces an empty residualRisk/scope/notes to null", () => {
+    const input = buildRiskInput({ residualRisk: "", scope: "  ", notes: "" });
+    expect(input.residualRisk).toBeNull();
+    expect(input.scope).toBeNull();
+    expect(input.notes).toBeNull();
+  });
+
+  it("parses nextReviewDate to a Date and empty to null", () => {
+    const withDate = buildRiskInput({ nextReviewDate: "2026-12-01" });
+    expect(withDate.nextReviewDate).toBeInstanceOf(Date);
+    const cleared = buildRiskInput({ nextReviewDate: "" });
+    expect(cleared.nextReviewDate).toBeNull();
+  });
+
+  it("throws when title or hazard is cleared", () => {
+    expect(() => buildRiskInput({ title: "  " })).toThrow(/title/i);
+    expect(() => buildRiskInput({ hazard: "" })).toThrow(/hazard/i);
+  });
+
+  it("throws on an invalid next review date", () => {
+    expect(() => buildRiskInput({ nextReviewDate: "not-a-date" })).toThrow(/date/i);
+  });
+});

--- a/apps/web/lib/workbooks/invoice-adapter-mapping.ts
+++ b/apps/web/lib/workbooks/invoice-adapter-mapping.ts
@@ -1,0 +1,64 @@
+// Universal Grid & Workbooks — Invoice grid mapping (EP-GRID-WORKBOOKS, Phase 1c)
+// Pure (no server imports) column schema + row mapping for the Finance invoice grid.
+
+import { INVOICE_STATUSES } from "@/lib/finance/finance-validation";
+import type { ColumnDefinition, GridRow } from "./types";
+import { toOptions } from "./option-helpers";
+
+export const INVOICE_ENTITY_TYPE = "invoice";
+
+/**
+ * Invoice grid columns. Only `status` is editable in the grid (it routes through
+ * the validated updateInvoiceStatus action); amounts/dates/refs are read-only —
+ * editing those belongs to the invoice form / line-item flow.
+ */
+export const INVOICE_COLUMNS: ColumnDefinition[] = [
+  { columnId: "invoiceRef", name: "Invoice", fieldType: "text", position: 0, required: false, editable: false, width: 150 },
+  {
+    columnId: "status",
+    name: "Status",
+    fieldType: "select",
+    position: 1,
+    required: true,
+    editable: true,
+    width: 150,
+    groupable: true,
+    config: { options: toOptions(INVOICE_STATUSES) },
+  },
+  { columnId: "account", name: "Account", fieldType: "text", position: 2, required: false, editable: false, width: 220 },
+  { columnId: "totalAmount", name: "Total", fieldType: "number", position: 3, required: false, editable: false, width: 120 },
+  { columnId: "amountDue", name: "Due", fieldType: "number", position: 4, required: false, editable: false, width: 120 },
+  { columnId: "currency", name: "Currency", fieldType: "text", position: 5, required: false, editable: false, width: 90 },
+  { columnId: "issueDate", name: "Issued", fieldType: "date", position: 6, required: false, editable: false, width: 130 },
+  { columnId: "dueDate", name: "Due date", fieldType: "date", position: 7, required: false, editable: false, width: 130 },
+  { columnId: "type", name: "Type", fieldType: "text", position: 8, required: false, editable: false, width: 130 },
+];
+
+export interface InvoicePlain {
+  invoiceRef: string;
+  status: string;
+  accountName: string | null;
+  totalAmount: number;
+  amountDue: number;
+  currency: string;
+  issueDate: Date;
+  dueDate: Date;
+  type: string;
+}
+
+export function invoiceToGridRow(item: InvoicePlain): GridRow {
+  return {
+    rowId: item.invoiceRef,
+    cells: {
+      invoiceRef: item.invoiceRef,
+      status: item.status,
+      account: item.accountName,
+      totalAmount: item.totalAmount,
+      amountDue: item.amountDue,
+      currency: item.currency,
+      issueDate: item.issueDate.toISOString(),
+      dueDate: item.dueDate.toISOString(),
+      type: item.type,
+    },
+  };
+}

--- a/apps/web/lib/workbooks/invoice-adapter.ts
+++ b/apps/web/lib/workbooks/invoice-adapter.ts
@@ -1,0 +1,135 @@
+// Universal Grid & Workbooks — InvoiceAdapter (EP-GRID-WORKBOOKS, Phase 1c)
+// Finance invoices as a grid. Status edits route through the canonical
+// updateInvoiceStatus action (enforces manage_finance + status timestamps);
+// other fields are read-only here. No raw prisma writes.
+
+import { prisma } from "@dpf/db";
+import { updateInvoiceStatus } from "@/lib/actions/finance";
+import {
+  gridRegistry,
+  type DataSourceAdapter,
+  type AdapterContext,
+} from "./adapter";
+import {
+  INVOICE_ENTITY_TYPE,
+  INVOICE_COLUMNS,
+  invoiceToGridRow,
+  type InvoicePlain,
+} from "./invoice-adapter-mapping";
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type DataSourceFilter,
+  type SortSpec,
+  type Pagination,
+  type PagedRows,
+  type GridCapabilities,
+} from "./types";
+import { applyFilters, applySort, paginate } from "./grid-query";
+
+function decimalToNumber(d: unknown): number {
+  if (d == null) return 0;
+  return Number((d as { toString(): string }).toString());
+}
+
+const INVOICE_SELECT = {
+  invoiceRef: true,
+  status: true,
+  totalAmount: true,
+  amountDue: true,
+  currency: true,
+  issueDate: true,
+  dueDate: true,
+  type: true,
+  account: { select: { name: true } },
+} as const;
+
+function toPlain(inv: {
+  invoiceRef: string;
+  status: string;
+  totalAmount: unknown;
+  amountDue: unknown;
+  currency: string;
+  issueDate: Date;
+  dueDate: Date;
+  type: string;
+  account: { name: string } | null;
+}): InvoicePlain {
+  return {
+    invoiceRef: inv.invoiceRef,
+    status: inv.status,
+    accountName: inv.account?.name ?? null,
+    totalAmount: decimalToNumber(inv.totalAmount),
+    amountDue: decimalToNumber(inv.amountDue),
+    currency: inv.currency,
+    issueDate: inv.issueDate,
+    dueDate: inv.dueDate,
+    type: inv.type,
+  };
+}
+
+class InvoiceAdapter implements DataSourceAdapter {
+  readonly entityType = INVOICE_ENTITY_TYPE;
+
+  async getColumns(): Promise<ColumnDefinition[]> {
+    return INVOICE_COLUMNS;
+  }
+
+  async queryRows(
+    _entityType: string,
+    opts: { filters: DataSourceFilter; sort: SortSpec[]; pagination: Pagination },
+  ): Promise<PagedRows> {
+    const invoices = await prisma.invoice.findMany({
+      orderBy: { createdAt: "desc" },
+      select: INVOICE_SELECT,
+    });
+    const rows = invoices.map((i) => invoiceToGridRow(toPlain(i)));
+    const filtered = applyFilters(rows, opts.filters);
+    const sorted = applySort(filtered, opts.sort);
+    return paginate(sorted, opts.pagination.cursor, opts.pagination.limit);
+  }
+
+  async getRow(_entityType: string, rowId: string): Promise<GridRow | null> {
+    const inv = await prisma.invoice.findUnique({ where: { invoiceRef: rowId }, select: INVOICE_SELECT });
+    return inv ? invoiceToGridRow(toPlain(inv)) : null;
+  }
+
+  async updateCells(
+    _entityType: string,
+    rowId: string,
+    changes: Record<string, CellValue>,
+    _ctx: AdapterContext,
+  ): Promise<GridRow> {
+    const inv = await prisma.invoice.findUnique({ where: { invoiceRef: rowId }, select: { id: true } });
+    if (!inv) throw new Error("Invoice not found");
+
+    const keys = Object.keys(changes);
+    const nonStatus = keys.filter((k) => k !== "status");
+    if (nonStatus.length > 0) {
+      throw new Error("Only status is editable for invoices from the grid");
+    }
+    if ("status" in changes) {
+      const status = changes.status;
+      if (typeof status !== "string") throw new Error("Invalid invoice status");
+      // updateInvoiceStatus enforces manage_finance + status-driven timestamps.
+      await updateInvoiceStatus(inv.id, status as Parameters<typeof updateInvoiceStatus>[1]);
+    }
+
+    const updated = await this.getRow(_entityType, rowId);
+    if (!updated) throw new Error("Invoice updated but could not be read back");
+    return updated;
+  }
+
+  getCapabilities(ctx: AdapterContext): GridCapabilities {
+    return {
+      canAddRow: false,
+      canAddColumn: false,
+      canEditCell: ctx.canManage === true,
+      canDeleteRow: false,
+    };
+  }
+}
+
+export const invoiceAdapter = new InvoiceAdapter();
+gridRegistry.register(invoiceAdapter);

--- a/apps/web/lib/workbooks/option-helpers.ts
+++ b/apps/web/lib/workbooks/option-helpers.ts
@@ -1,0 +1,15 @@
+// Universal Grid & Workbooks — select-option helpers (EP-GRID-WORKBOOKS)
+// Shared by platform adapters to turn string-enum values into grid SelectOptions.
+
+import type { SelectOption } from "./types";
+
+export function humanizeKey(key: string): string {
+  return key
+    .split(/[-_]/)
+    .map((w) => (w.length ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
+export function toOptions(values: readonly string[]): SelectOption[] {
+  return values.map((v) => ({ key: v, label: humanizeKey(v) }));
+}

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -10,6 +10,8 @@ import { can } from "@/lib/permissions";
 import type { CapabilityKey } from "@/lib/govern/permissions";
 import { gridRegistry, type AdapterContext } from "./adapter";
 import "./backlog-adapter"; // self-register the backlog adapter
+import "./invoice-adapter"; // self-register the invoice adapter
+import "./risk-adapter"; // self-register the risk-assessment adapter
 import {
   type ColumnDefinition,
   type GridRow,
@@ -46,6 +48,20 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Every backlog item as an editable spreadsheet — same records as the backlog forms.",
     viewCapability: "view_operations",
     manageCapability: "manage_backlog",
+  },
+  {
+    entityType: "invoice",
+    label: "Invoices",
+    description: "Finance invoices as a grid — edit status inline; amounts/dates stay in the invoice form.",
+    viewCapability: "view_finance",
+    manageCapability: "manage_finance",
+  },
+  {
+    entityType: "risk_assessment",
+    label: "Risk assessments",
+    description: "Compliance risk register as an editable spreadsheet — same records as the risk forms.",
+    viewCapability: "view_compliance",
+    manageCapability: "manage_compliance",
   },
 ];
 

--- a/apps/web/lib/workbooks/risk-adapter-mapping.ts
+++ b/apps/web/lib/workbooks/risk-adapter-mapping.ts
@@ -1,0 +1,146 @@
+// Universal Grid & Workbooks — RiskAssessment grid mapping (EP-GRID-WORKBOOKS, Phase 1c)
+// Pure (no server imports) column schema, row mapping, and update-input builder
+// for the Compliance risk grid. The risk update action supports per-field edits,
+// so most fields are editable in the grid.
+
+import {
+  RISK_LIKELIHOODS,
+  RISK_SEVERITIES,
+  RISK_LEVELS,
+  type RiskAssessmentInput,
+} from "@/lib/govern/compliance-types";
+import type { ColumnDefinition, GridRow, CellValue } from "./types";
+import { toOptions } from "./option-helpers";
+
+export const RISK_ENTITY_TYPE = "risk_assessment";
+
+export const RISK_COLUMNS: ColumnDefinition[] = [
+  { columnId: "assessmentId", name: "ID", fieldType: "text", position: 0, required: false, editable: false, width: 120 },
+  { columnId: "title", name: "Title", fieldType: "text", position: 1, required: true, editable: true, width: 260 },
+  { columnId: "hazard", name: "Hazard", fieldType: "text", position: 2, required: true, editable: true, width: 220 },
+  {
+    columnId: "likelihood",
+    name: "Likelihood",
+    fieldType: "select",
+    position: 3,
+    required: true,
+    editable: true,
+    width: 140,
+    config: { options: toOptions(RISK_LIKELIHOODS) },
+  },
+  {
+    columnId: "severity",
+    name: "Severity",
+    fieldType: "select",
+    position: 4,
+    required: true,
+    editable: true,
+    width: 140,
+    config: { options: toOptions(RISK_SEVERITIES) },
+  },
+  {
+    columnId: "inherentRisk",
+    name: "Inherent risk",
+    fieldType: "select",
+    position: 5,
+    required: true,
+    editable: true,
+    width: 130,
+    groupable: true,
+    config: { options: toOptions(RISK_LEVELS) },
+  },
+  {
+    columnId: "residualRisk",
+    name: "Residual risk",
+    fieldType: "select",
+    position: 6,
+    required: false,
+    editable: true,
+    width: 130,
+    config: { options: toOptions(RISK_LEVELS) },
+  },
+  { columnId: "status", name: "Status", fieldType: "text", position: 7, required: false, editable: false, width: 110 },
+  { columnId: "scope", name: "Scope", fieldType: "text", position: 8, required: false, editable: true, width: 200 },
+  { columnId: "nextReviewDate", name: "Next review", fieldType: "date", position: 9, required: false, editable: true, width: 140 },
+  { columnId: "notes", name: "Notes", fieldType: "text", position: 10, required: false, editable: true, width: 300, config: { multiline: true } },
+  { columnId: "assessedAt", name: "Assessed", fieldType: "datetime", position: 11, required: false, editable: false, width: 160 },
+];
+
+export interface RiskPlain {
+  assessmentId: string;
+  title: string;
+  hazard: string;
+  likelihood: string;
+  severity: string;
+  inherentRisk: string;
+  residualRisk: string | null;
+  status: string;
+  scope: string | null;
+  nextReviewDate: Date | null;
+  notes: string | null;
+  assessedAt: Date;
+}
+
+export function riskToGridRow(item: RiskPlain): GridRow {
+  return {
+    rowId: item.assessmentId,
+    cells: {
+      assessmentId: item.assessmentId,
+      title: item.title,
+      hazard: item.hazard,
+      likelihood: item.likelihood,
+      severity: item.severity,
+      inherentRisk: item.inherentRisk,
+      residualRisk: item.residualRisk,
+      status: item.status,
+      scope: item.scope,
+      nextReviewDate: item.nextReviewDate ? item.nextReviewDate.toISOString() : null,
+      notes: item.notes,
+      assessedAt: item.assessedAt.toISOString(),
+    },
+  };
+}
+
+function str(v: CellValue): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+function strOrNull(v: CellValue): string | null {
+  const s = str(v).trim();
+  return s === "" ? null : s;
+}
+
+/**
+ * Build a Partial<RiskAssessmentInput> from grid changes (keyed by field name).
+ * Only includes fields actually present in `changes` — the update action applies
+ * a conditional spread, so undefined fields are left untouched.
+ */
+export function buildRiskInput(changes: Record<string, CellValue>): Partial<RiskAssessmentInput> {
+  const input: Partial<RiskAssessmentInput> = {};
+  if ("title" in changes) {
+    const t = str(changes.title).trim();
+    if (!t) throw new Error("Title cannot be empty");
+    input.title = t;
+  }
+  if ("hazard" in changes) {
+    const h = str(changes.hazard).trim();
+    if (!h) throw new Error("Hazard cannot be empty");
+    input.hazard = h;
+  }
+  if ("likelihood" in changes) input.likelihood = str(changes.likelihood);
+  if ("severity" in changes) input.severity = str(changes.severity);
+  if ("inherentRisk" in changes) input.inherentRisk = str(changes.inherentRisk);
+  if ("residualRisk" in changes) input.residualRisk = strOrNull(changes.residualRisk);
+  if ("scope" in changes) input.scope = strOrNull(changes.scope);
+  if ("notes" in changes) input.notes = strOrNull(changes.notes);
+  if ("nextReviewDate" in changes) {
+    const raw = changes.nextReviewDate;
+    if (raw == null || raw === "") {
+      input.nextReviewDate = null;
+    } else {
+      const d = new Date(typeof raw === "string" ? raw : String(raw));
+      if (Number.isNaN(d.getTime())) throw new Error("Invalid next review date");
+      input.nextReviewDate = d;
+    }
+  }
+  return input;
+}

--- a/apps/web/lib/workbooks/risk-adapter.ts
+++ b/apps/web/lib/workbooks/risk-adapter.ts
@@ -1,0 +1,122 @@
+// Universal Grid & Workbooks — RiskAssessmentAdapter (EP-GRID-WORKBOOKS, Phase 1c)
+// Compliance risk assessments as an editable grid. Edits route through the
+// canonical updateRiskAssessment action (enforces manage_compliance + audit log).
+// No raw prisma writes.
+
+import { prisma } from "@dpf/db";
+import { updateRiskAssessment } from "@/lib/actions/compliance";
+import {
+  gridRegistry,
+  type DataSourceAdapter,
+  type AdapterContext,
+} from "./adapter";
+import {
+  RISK_ENTITY_TYPE,
+  RISK_COLUMNS,
+  riskToGridRow,
+  buildRiskInput,
+  type RiskPlain,
+} from "./risk-adapter-mapping";
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type DataSourceFilter,
+  type SortSpec,
+  type Pagination,
+  type PagedRows,
+  type GridCapabilities,
+} from "./types";
+import { applyFilters, applySort, paginate } from "./grid-query";
+
+const RISK_SELECT = {
+  assessmentId: true,
+  title: true,
+  hazard: true,
+  likelihood: true,
+  severity: true,
+  inherentRisk: true,
+  residualRisk: true,
+  status: true,
+  scope: true,
+  nextReviewDate: true,
+  notes: true,
+  assessedAt: true,
+} as const;
+
+function toPlain(r: {
+  assessmentId: string;
+  title: string;
+  hazard: string;
+  likelihood: string;
+  severity: string;
+  inherentRisk: string;
+  residualRisk: string | null;
+  status: string;
+  scope: string | null;
+  nextReviewDate: Date | null;
+  notes: string | null;
+  assessedAt: Date;
+}): RiskPlain {
+  return { ...r };
+}
+
+class RiskAssessmentAdapter implements DataSourceAdapter {
+  readonly entityType = RISK_ENTITY_TYPE;
+
+  async getColumns(): Promise<ColumnDefinition[]> {
+    return RISK_COLUMNS;
+  }
+
+  async queryRows(
+    _entityType: string,
+    opts: { filters: DataSourceFilter; sort: SortSpec[]; pagination: Pagination },
+  ): Promise<PagedRows> {
+    const risks = await prisma.riskAssessment.findMany({
+      orderBy: { createdAt: "desc" },
+      select: RISK_SELECT,
+    });
+    const rows = risks.map((r) => riskToGridRow(toPlain(r)));
+    const filtered = applyFilters(rows, opts.filters);
+    const sorted = applySort(filtered, opts.sort);
+    return paginate(sorted, opts.pagination.cursor, opts.pagination.limit);
+  }
+
+  async getRow(_entityType: string, rowId: string): Promise<GridRow | null> {
+    const r = await prisma.riskAssessment.findUnique({ where: { assessmentId: rowId }, select: RISK_SELECT });
+    return r ? riskToGridRow(toPlain(r)) : null;
+  }
+
+  async updateCells(
+    _entityType: string,
+    rowId: string,
+    changes: Record<string, CellValue>,
+    _ctx: AdapterContext,
+  ): Promise<GridRow> {
+    const existing = await prisma.riskAssessment.findUnique({
+      where: { assessmentId: rowId },
+      select: { id: true },
+    });
+    if (!existing) throw new Error("Risk assessment not found");
+
+    const input = buildRiskInput(changes);
+    const res = await updateRiskAssessment(existing.id, input);
+    if (!res.ok) throw new Error(res.message);
+
+    const updated = await this.getRow(_entityType, rowId);
+    if (!updated) throw new Error("Risk assessment updated but could not be read back");
+    return updated;
+  }
+
+  getCapabilities(ctx: AdapterContext): GridCapabilities {
+    return {
+      canAddRow: false,
+      canAddColumn: false,
+      canEditCell: ctx.canManage === true,
+      canDeleteRow: false,
+    };
+  }
+}
+
+export const riskAssessmentAdapter = new RiskAssessmentAdapter();
+gridRegistry.register(riskAssessmentAdapter);


### PR DESCRIPTION
## What & why

Continues "the most logical interfaces in a spreadsheet paradigm." Phase 1b proved the pattern on Backlog; this adds **Finance invoices** and **Compliance risk assessments** as live, editable grids — each is **one adapter class + one registry row**, no new grid plumbing. Builds on EP-GRID-WORKBOOKS (#1582, #1593).

## Same data as the forms

- **`InvoiceAdapter`** — Finance invoices as a grid. **Status** is editable inline via the canonical `updateInvoiceStatus` (enforces `manage_finance` + status-driven timestamps). Amounts/dates/refs are read-only (they belong to the invoice/line-item form). Decimal amounts surfaced as numbers.
- **`RiskAssessmentAdapter`** — Compliance risk register as a grid. **Per-field edits** (title, hazard, likelihood, severity, inherent/residual risk, scope, next-review date, notes) route through `updateRiskAssessment` (enforces `manage_compliance` + audit log).
- **No raw prisma writes** in either — writes go through the existing validated actions, so a grid edit == a form edit on the same record.

## Discovery + access

Registered in `PLATFORM_TABLES`, so both auto-appear in the Workbooks hub **"Platform data"** catalog and at `/workbooks/system/[entityType]`. Gated by each domain's own capability: `view_finance`/`manage_finance`, `view_compliance`/`manage_compliance`. Viewers get a read-only grid.

## Verification (worktree)

- `vitest lib/workbooks/` → **43/43** (10 new invoice/risk mapping tests).
- `typecheck` clean; production `build` green; `/workbooks/system/[entityType]` intact.
- Live-portal UX functional verification runs after self-upgrade deploys this.

## Scope

Read + edit existing records (no row add/delete for platform data yet — `canAddRow`/`canDeleteRow` = false). Invoice editing is status-only by design until a general `updateInvoice` action exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)