### PR TITLE
fix(backups): raise View-log drawer above the coworker rail (z-index)

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -512,7 +512,12 @@ export function BackupsClient({
       {/* ─── Log drawer ──────────────────────────────────────────────────── */}
       {openLog && (
         <div
-          className="fixed inset-0 z-40 flex justify-end"
+          // z-[80] so the drawer sits ABOVE the persistent AI coworker rail
+          // (z-50). At z-40 the rail painted over the right ~380px of the
+          // 480px drawer, hiding the manifest + log entirely — the drawer
+          // opened but its content was unreadable. Matches the app's
+          // top-overlay convention (z-[80]/[85]/[90]).
+          className="fixed inset-0 z-[80] flex justify-end"
           onClick={() => setOpenLog(null)}
           style={{ background: "rgba(0, 0, 0, 0.5)" }}
         >


### PR DESCRIPTION
## Problem

On **Admin → Backups**, clicking **View log** opened the drawer, but its contents were **unreadable** — the AI coworker rail covered them. This is the actual "I can't see them" the user reported.

## Root cause

The log drawer is a right-anchored panel at **`z-40`**; the persistent AI coworker rail sits at **`z-50`**. So the rail painted over the right ~380px of the 480px drawer — exactly where the manifest and log tail render. The drawer *opened*, but its content sat behind the coworker panel.

(The earlier fix — populating `log.txt` — was necessary but invisible, because the panel itself was never on top.)

Confirmed via live DOM inspection: drawer overlay `z-40`, coworker rail fixed ancestor `z-50`, `elementFromPoint` at the drawer's right-center resolved to the coworker rail.

## Fix

Raise the drawer overlay to **`z-[80]`** so it sits above the coworker rail, matching the app's existing top-overlay convention (`z-[80]`/`[85]`/`[90]`). One-line change in `BackupsClient.tsx`.

## Verification

- Reproduced live: bumped the open drawer to `z-80` in the DOM → manifest + `[backup-trace]` log became fully visible and readable above the coworker rail (screenshot evidence captured during review).
- `pnpm --filter web exec vitest run app/(shell)/admin/backups lib/operate/backups` → 54 passed, 3 skipped.
- `pnpm --filter web typecheck` → clean. Pre-commit gitleaks + scoped typecheck passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
