### PR TITLE
feat(workbooks): kanban board view for platform grids — drag to change status (EP-GRID-WORKBOOKS Phase 1d)

### DIFF
--- a/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
@@ -8,18 +8,24 @@ import {
   type PlatformUser,
 } from "@/lib/workbooks/platform-tables";
 import { WorkbookError } from "@/lib/workbooks/workbook-service";
+import { defaultGroupByColumn } from "@/lib/workbooks/kanban-grouping";
 import { WorkbookGrid } from "@/components/workbooks/Grid";
+import { KanbanBoard } from "@/components/workbooks/KanbanBoard";
 
 export const dynamic = "force-dynamic";
 
-type Props = { params: Promise<{ entityType: string }> };
+type Props = {
+  params: Promise<{ entityType: string }>;
+  searchParams: Promise<{ view?: string }>;
+};
 
-export default async function PlatformTablePage({ params }: Props) {
+export default async function PlatformTablePage({ params, searchParams }: Props) {
   const session = await auth();
   if (!session?.user) redirect("/login");
   const user = session.user;
 
   const { entityType } = await params;
+  const { view } = await searchParams;
   const def = getPlatformTable(entityType);
   if (!def) notFound();
 
@@ -62,15 +68,58 @@ export default async function PlatformTablePage({ params }: Props) {
         <p className="text-sm text-[var(--dpf-muted)]">{def.description}</p>
       </div>
 
-      <div className="min-h-0 flex-1">
-        <WorkbookGrid
-          source="platform"
-          tableId={entityType}
-          columns={grid.schema.columns}
-          rows={grid.rows}
-          capabilities={grid.schema.capabilities}
-        />
-      </div>
+      {(() => {
+        const groupBy = defaultGroupByColumn(grid.schema.columns);
+        const boardView = view === "board" && groupBy !== null;
+        return (
+          <>
+            {groupBy !== null && (
+              <div className="mb-3 inline-flex w-fit overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+                <Link
+                  href={`/workbooks/system/${entityType}`}
+                  className={
+                    boardView
+                      ? "px-3 py-1.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                      : "bg-[var(--dpf-surface-2)] px-3 py-1.5 font-medium text-[var(--dpf-text)]"
+                  }
+                >
+                  Grid
+                </Link>
+                <Link
+                  href={`/workbooks/system/${entityType}?view=board`}
+                  className={
+                    boardView
+                      ? "bg-[var(--dpf-surface-2)] px-3 py-1.5 font-medium text-[var(--dpf-text)]"
+                      : "px-3 py-1.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  }
+                >
+                  Board
+                </Link>
+              </div>
+            )}
+            <div className="min-h-0 flex-1">
+              {boardView && groupBy !== null ? (
+                <KanbanBoard
+                  source="platform"
+                  tableId={entityType}
+                  columns={grid.schema.columns}
+                  rows={grid.rows}
+                  capabilities={grid.schema.capabilities}
+                  groupByColumnId={groupBy}
+                />
+              ) : (
+                <WorkbookGrid
+                  source="platform"
+                  tableId={entityType}
+                  columns={grid.schema.columns}
+                  rows={grid.rows}
+                  capabilities={grid.schema.capabilities}
+                />
+              )}
+            </div>
+          </>
+        );
+      })()}
     </div>
   );
 }

--- a/apps/web/components/workbooks/KanbanBoard.tsx
+++ b/apps/web/components/workbooks/KanbanBoard.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+// Universal Grid & Workbooks — KanbanBoard (EP-GRID-WORKBOOKS, Phase 1d)
+// A generic board view over the same ColumnDefinition/GridRow contract as the
+// grid. Lanes come from a groupable select column; dragging a card to another
+// lane updates that field through the same validated dispatch the grid uses
+// (custom workbook store or the platform domain action). Native HTML5 DnD — no
+// extra dependency.
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type GridCapabilities,
+} from "@/lib/workbooks/types";
+import { groupRowsByColumn, cardFieldLayout } from "@/lib/workbooks/kanban-grouping";
+import { updateCellsAction } from "@/lib/actions/workbooks";
+import { updatePlatformCellsAction } from "@/lib/actions/platform-grid";
+
+export interface KanbanBoardProps {
+  source: "custom" | "platform";
+  tableId: string;
+  columns: ColumnDefinition[];
+  rows: GridRow[];
+  capabilities: GridCapabilities;
+  groupByColumnId: string;
+}
+
+function formatValue(col: ColumnDefinition | undefined, value: CellValue): string {
+  if (value === null || value === undefined || value === "") return "";
+  if (!col) return String(value);
+  switch (col.fieldType) {
+    case "select": {
+      const opt = col.config?.options?.find((o) => o.key === value);
+      return opt?.label ?? String(value);
+    }
+    case "multi_select":
+      return Array.isArray(value) ? value.join(", ") : String(value);
+    case "checkbox":
+      return value === true ? "Yes" : "No";
+    case "date":
+      return typeof value === "string" ? new Date(value).toLocaleDateString() : String(value);
+    case "datetime":
+      return typeof value === "string" ? new Date(value).toLocaleString() : String(value);
+    case "reference":
+      return typeof value === "object" && value && !Array.isArray(value)
+        ? value.label ?? value.referenceId
+        : String(value);
+    default:
+      return String(value);
+  }
+}
+
+export function KanbanBoard({
+  source,
+  tableId,
+  columns,
+  rows,
+  capabilities,
+  groupByColumnId,
+}: KanbanBoardProps) {
+  const [rowData, setRowData] = useState<GridRow[]>(rows);
+  const [error, setError] = useState<string | null>(null);
+  const [dragRowId, setDragRowId] = useState<string | null>(null);
+
+  const colById = useMemo(() => new Map(columns.map((c) => [c.columnId, c])), [columns]);
+  const lanes = useMemo(
+    () => groupRowsByColumn(rowData, columns, groupByColumnId),
+    [rowData, columns, groupByColumnId],
+  );
+  const { titleColumnId, metaColumnIds } = useMemo(
+    () => cardFieldLayout(columns, groupByColumnId),
+    [columns, groupByColumnId],
+  );
+  const canMove = capabilities.canEditCell;
+
+  const move = useCallback(
+    async (rowId: string, laneKey: string) => {
+      const row = rowData.find((r) => r.rowId === rowId);
+      if (!row) return;
+      const current = row.cells[groupByColumnId];
+      const currentKey = typeof current === "string" ? current : current == null ? "" : String(current);
+      if (currentKey === laneKey) return;
+
+      const nextValue: CellValue = laneKey === "" ? null : laneKey;
+      const prev = rowData;
+      setRowData((rs) =>
+        rs.map((r) => (r.rowId === rowId ? { ...r, cells: { ...r.cells, [groupByColumnId]: nextValue } } : r)),
+      );
+      setError(null);
+
+      const res =
+        source === "platform"
+          ? await updatePlatformCellsAction(tableId, rowId, { [groupByColumnId]: nextValue })
+          : await updateCellsAction(tableId, rowId, { [groupByColumnId]: nextValue });
+      if (!res.ok) {
+        setRowData(prev); // revert
+        setError(res.error);
+      }
+    },
+    [rowData, groupByColumnId, source, tableId],
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-2">
+      {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
+      <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto pb-2">
+        {lanes.map((lane) => (
+          <div
+            key={lane.key || "__unset__"}
+            onDragOver={(e) => {
+              if (canMove) e.preventDefault();
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              const id = e.dataTransfer.getData("text/plain") || dragRowId;
+              if (id && canMove) void move(id, lane.key);
+              setDragRowId(null);
+            }}
+            className="flex w-72 shrink-0 flex-col rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+          >
+            <div className="flex items-center justify-between border-b border-[var(--dpf-border)] px-3 py-2">
+              <span className="text-sm font-medium text-[var(--dpf-text)]">{lane.label}</span>
+              <span className="rounded-full bg-[var(--dpf-surface-1)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">
+                {lane.rows.length}
+              </span>
+            </div>
+            <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-2">
+              {lane.rows.map((row) => (
+                <div
+                  key={row.rowId}
+                  draggable={canMove}
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData("text/plain", row.rowId);
+                    e.dataTransfer.effectAllowed = "move";
+                    setDragRowId(row.rowId);
+                  }}
+                  className={`rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 ${
+                    canMove ? "cursor-grab active:cursor-grabbing" : ""
+                  }`}
+                >
+                  {titleColumnId && (
+                    <div className="text-sm font-medium text-[var(--dpf-text)]">
+                      {formatValue(colById.get(titleColumnId), row.cells[titleColumnId] ?? null) || row.rowId}
+                    </div>
+                  )}
+                  <div className="mt-1 flex flex-col gap-0.5">
+                    {metaColumnIds.map((cid) => {
+                      const text = formatValue(colById.get(cid), row.cells[cid] ?? null);
+                      if (!text) return null;
+                      return (
+                        <div key={cid} className="text-xs text-[var(--dpf-muted)]">
+                          <span className="opacity-70">{colById.get(cid)?.name}:</span> {text}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+              {lane.rows.length === 0 && (
+                <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-3 text-center text-xs text-[var(--dpf-muted)]">
+                  Drop here
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/workbooks/kanban-grouping.test.ts
+++ b/apps/web/lib/workbooks/kanban-grouping.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupRowsByColumn,
+  defaultGroupByColumn,
+  cardFieldLayout,
+} from "./kanban-grouping";
+import type { ColumnDefinition, GridRow } from "./types";
+
+const columns: ColumnDefinition[] = [
+  { columnId: "itemId", name: "ID", fieldType: "text", position: 0, required: false, editable: false },
+  { columnId: "title", name: "Title", fieldType: "text", position: 1, required: true, editable: true },
+  {
+    columnId: "status",
+    name: "Status",
+    fieldType: "select",
+    position: 2,
+    required: true,
+    editable: true,
+    groupable: true,
+    config: { options: [
+      { key: "open", label: "Open" },
+      { key: "in-progress", label: "In Progress" },
+      { key: "done", label: "Done" },
+    ] },
+  },
+  { columnId: "priority", name: "Priority", fieldType: "number", position: 3, required: false, editable: true },
+];
+
+const rows: GridRow[] = [
+  { rowId: "BI-1", cells: { itemId: "BI-1", title: "A", status: "open", priority: 1 } },
+  { rowId: "BI-2", cells: { itemId: "BI-2", title: "B", status: "done", priority: 2 } },
+  { rowId: "BI-3", cells: { itemId: "BI-3", title: "C", status: "open", priority: 3 } },
+];
+
+describe("groupRowsByColumn", () => {
+  it("creates a lane per option in option order", () => {
+    const lanes = groupRowsByColumn(rows, columns, "status");
+    expect(lanes.map((l) => l.key)).toEqual(["open", "in-progress", "done"]);
+    expect(lanes.find((l) => l.key === "open")?.rows.map((r) => r.rowId)).toEqual(["BI-1", "BI-3"]);
+    expect(lanes.find((l) => l.key === "done")?.rows.map((r) => r.rowId)).toEqual(["BI-2"]);
+  });
+
+  it("uses option labels as lane labels", () => {
+    const lanes = groupRowsByColumn(rows, columns, "status");
+    expect(lanes.find((l) => l.key === "in-progress")?.label).toBe("In Progress");
+  });
+
+  it("adds an (unset) lane only when a row has no/unknown value", () => {
+    const withUnset: GridRow[] = [
+      ...rows,
+      { rowId: "BI-4", cells: { itemId: "BI-4", title: "D", status: null, priority: 0 } },
+      { rowId: "BI-5", cells: { itemId: "BI-5", title: "E", status: "weird", priority: 0 } },
+    ];
+    const lanes = groupRowsByColumn(withUnset, columns, "status");
+    const unset = lanes.find((l) => l.label === "(unset)");
+    expect(unset?.rows.map((r) => r.rowId)).toEqual(["BI-4", "BI-5"]);
+  });
+
+  it("omits the (unset) lane when every row has a known value", () => {
+    const lanes = groupRowsByColumn(rows, columns, "status");
+    expect(lanes.some((l) => l.label === "(unset)")).toBe(false);
+  });
+});
+
+describe("defaultGroupByColumn", () => {
+  it("picks the first groupable select column", () => {
+    expect(defaultGroupByColumn(columns)).toBe("status");
+  });
+  it("returns null when no column is groupable", () => {
+    const none = columns.map((c) => ({ ...c, groupable: false }));
+    expect(defaultGroupByColumn(none)).toBeNull();
+  });
+});
+
+describe("cardFieldLayout", () => {
+  it("uses the first editable text column as title and excludes the group column", () => {
+    const { titleColumnId, metaColumnIds } = cardFieldLayout(columns, "status", 2);
+    expect(titleColumnId).toBe("title");
+    expect(metaColumnIds).not.toContain("status");
+    expect(metaColumnIds).not.toContain("title");
+    expect(metaColumnIds.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/web/lib/workbooks/kanban-grouping.ts
+++ b/apps/web/lib/workbooks/kanban-grouping.ts
@@ -1,0 +1,77 @@
+// Universal Grid & Workbooks — kanban grouping (EP-GRID-WORKBOOKS, Phase 1d)
+// Pure helpers that turn a flat row set into kanban lanes grouped by a select
+// column. No React/DOM here so it is unit-testable; the board component renders
+// the result and wires drag-and-drop.
+
+import type { ColumnDefinition, GridRow, CellValue } from "./types";
+
+export interface KanbanLane {
+  key: string; // the group-by value ("" for unset)
+  label: string;
+  rows: GridRow[];
+}
+
+const UNSET_KEY = "";
+const UNSET_LABEL = "(unset)";
+
+function cellKey(value: CellValue): string {
+  if (value === null || value === undefined) return UNSET_KEY;
+  if (Array.isArray(value)) return value[0] ?? UNSET_KEY;
+  if (typeof value === "object") return value.referenceId ?? UNSET_KEY;
+  return String(value);
+}
+
+/**
+ * Group rows into lanes keyed by the group-by column's select options, in option
+ * order, with a trailing "(unset)" lane only when some row has no/unknown value.
+ * Rows whose value isn't a known option fall into the unset lane.
+ */
+export function groupRowsByColumn(
+  rows: GridRow[],
+  columns: ColumnDefinition[],
+  groupByColumnId: string,
+): KanbanLane[] {
+  const groupCol = columns.find((c) => c.columnId === groupByColumnId);
+  const options = groupCol?.config?.options ?? [];
+  const optionByKey = new Map(options.map((o) => [o.key, o.label]));
+
+  const lanes: KanbanLane[] = options.map((o) => ({ key: o.key, label: o.label, rows: [] }));
+  const laneByKey = new Map(lanes.map((l) => [l.key, l]));
+  const unset: KanbanLane = { key: UNSET_KEY, label: UNSET_LABEL, rows: [] };
+
+  for (const row of rows) {
+    const k = cellKey(row.cells[groupByColumnId] ?? null);
+    const lane = k !== UNSET_KEY && optionByKey.has(k) ? laneByKey.get(k)! : unset;
+    lane.rows.push(row);
+  }
+
+  return unset.rows.length > 0 ? [...lanes, unset] : lanes;
+}
+
+/** First column eligible to group a board by (a select column flagged groupable). */
+export function defaultGroupByColumn(columns: ColumnDefinition[]): string | null {
+  const col = columns.find((c) => c.groupable && c.fieldType === "select");
+  return col?.columnId ?? null;
+}
+
+/**
+ * Choose which columns to show on a card: a primary "title" (first editable text
+ * column, else first text column) plus up to `maxMeta` other non-group columns.
+ */
+export function cardFieldLayout(
+  columns: ColumnDefinition[],
+  groupByColumnId: string,
+  maxMeta = 3,
+): { titleColumnId: string | null; metaColumnIds: string[] } {
+  const candidates = columns.filter((c) => c.columnId !== groupByColumnId);
+  const titleCol =
+    candidates.find((c) => c.fieldType === "text" && c.editable) ??
+    candidates.find((c) => c.fieldType === "text") ??
+    candidates[0];
+  const titleColumnId = titleCol?.columnId ?? null;
+  const metaColumnIds = candidates
+    .filter((c) => c.columnId !== titleColumnId)
+    .slice(0, maxMeta)
+    .map((c) => c.columnId);
+  return { titleColumnId, metaColumnIds };
+}


### PR DESCRIPTION
## What & why

You asked about kanban for build-studio/backlog. This lands the **kanban mechanism on the Backlog** (and any platform grid with a groupable column) — the ready, self-contained, low-risk choice. A FeatureBuild/phase board for Build Studio should fold into its active redesign (`EP-BUILD-STUDIO-UX`) and **reuses this same generic board component**, so this is the foundation for both.

Builds on EP-GRID-WORKBOOKS (#1582 / #1593 / #1596).

## What it does

A **Board** view alongside the Grid for any platform table with a groupable select column:
- **Backlog** → lanes by status (open / in-progress / done / deferred)
- **Risk assessments** → lanes by inherent risk
- **Invoices** → lanes by status

Drag a card to another lane and the group-by field updates through the **same validated dispatch the grid uses** — `updateBacklogItem` / `updateInvoiceStatus` / `updateRiskAssessment`. No new write path; edits gated by `capabilities.canEditCell` (viewers can't drag).

## Changes

- **`lib/workbooks/kanban-grouping.ts`** (pure, unit-tested) — `groupRowsByColumn` (lanes in option order; trailing "(unset)" lane only when needed), `defaultGroupByColumn`, `cardFieldLayout`.
- **`components/workbooks/KanbanBoard.tsx`** — native HTML5 drag-and-drop (**no new dependency** → no tool-eval gate), theme-tokened, optimistic move with revert-on-error.
- **Grid/Board toggle** on `/workbooks/system/[entityType]` (`?view=board`), shown only when a groupable column exists.

## Verification (worktree)

- `vitest lib/workbooks/` → **50/50** (7 new grouping tests).
- `typecheck` clean; production `build` green; system route intact.
- Live-portal UX functional verification runs after self-upgrade deploys this.

## Note on Build Studio

A FeatureBuild "phase" board (ideate→plan→build→review→ship) is a natural next step but belongs in the Build Studio redesign rather than a parallel surface — it's a new `FeatureBuildAdapter` + this same `KanbanBoard`. Flagged, not bundled (PAR — that surface is actively owned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)