### PR TITLE
fix(nav): register /platform/schedule nav record — unbreak main after #1594

### DIFF
--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -350,6 +350,16 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     sectionSiblings: platformSectionSiblings,
   },
   {
+    key: "platform-schedule",
+    label: "Schedule",
+    path: "/platform/schedule",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
     key: "platform-identity",
     label: "Identity & Access",
     path: "/platform/identity",


### PR DESCRIPTION
## Hotfix — unbreak `portal-navigation-model.test.ts` on main

PR #1594 squash-merged the main-portal redesign, which added a **Schedule** entry to `PLATFORM_FAMILIES` (`platform-nav.ts`) pointing at `/platform/schedule`. The matching `PortalNavRecord` fix landed in a follow-up commit on the PR branch that did **not** make it into the squash, so `main` now fails the navigation invariant:

```
lib/navigation/portal-navigation-model.test.ts › covers current platform family entries
AssertionError: /platform/schedule: expected undefined to be defined
```

The test asserts every platform-family nav href resolves to a `PortalNavRecord`. This registers `/platform/schedule` as a platform section-page (operator, `view_platform`), with no `shellNav` so it stays a sub-page reached via the platform tab nav, not the main rail.

Verified: `portal-navigation-model.test.ts` passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
