### PR TITLE
fix(nav): register /platform/schedule route record — green main after #1594

### DIFF
--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -62,6 +62,7 @@ export type PortalShellNavEntry = PortalNavEntry & {
 
 const platformSectionSiblings = [
   "/platform",
+  "/platform/schedule",
   "/platform/identity",
   "/platform/ai",
   "/platform/tools",
@@ -347,6 +348,17 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
       sectionKey: "platform",
       description: "Providers, integrations, services, and governance.",
     },
+    sectionSiblings: platformSectionSiblings,
+  },
+  {
+    key: "platform-schedule",
+    label: "Schedule",
+    path: "/platform/schedule",
+    parentPath: "/platform",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
     sectionSiblings: platformSectionSiblings,
   },
   {


### PR DESCRIPTION
## Urgent — main is red

#1594 (workspace redesign) added a **Schedule** nav item (`platform-nav.ts`) and the page `app/(shell)/platform/schedule/page.tsx`, but did not add a `PORTAL_NAV_ROUTES` record for `/platform/schedule`. `portal-navigation-model.test.ts` asserts every `PLATFORM_FAMILIES` href resolves via `getRouteNavRecord`, so **main's Unit Tests are red**: `/platform/schedule: expected undefined to be defined` (main CI failure at `e8d91869`).

This registers the missing route record (`view_platform`, `section-page` under `/platform`) and adds it to `platformSectionSiblings` so the **already-existing** page is reachable from the Platform section nav. Completes the omission rather than removing the nav item.

Verified: `vitest lib/navigation/portal-navigation-model.test.ts` → 7/7; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)