### PR TITLE
feat(code-graph): DMMF-grade Prisma extractor — fields, types, relations, cardinality (EP-DATA-ARCH Phase 1, BI-8579FB2D)

### DIFF
--- a/apps/web/lib/integrate/code-graph/extractors/prisma-schema-adapter.test.ts
+++ b/apps/web/lib/integrate/code-graph/extractors/prisma-schema-adapter.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePrismaSchema, type PrismaRelationFact } from "./prisma-schema-adapter";
+
+const FIXTURE = `
+enum Role {
+  admin
+  member
+}
+
+model User {
+  id      String  @id @default(cuid())
+  email   String  @unique @map("email_address")
+  role    Role    @default(member)
+  posts   Post[]
+  profile Profile?
+  legacy  String? @ignore
+  @@map("users")
+}
+
+model Profile {
+  id     String  @id
+  bio    String?
+  userId String  @unique
+  user   User    @relation(fields: [userId], references: [id])
+}
+
+model Post {
+  id       String    @id
+  title    String
+  authorId String
+  author   User      @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  tags     Tag[]
+  comments Comment[]
+  @@index([authorId])
+}
+
+model Tag {
+  id    String @id
+  name  String
+  posts Post[]
+  @@ignore
+}
+
+model Comment {
+  id     String @id
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
+}
+`;
+
+function relation(
+  relations: PrismaRelationFact[],
+  fromModel: string,
+  fieldName: string,
+): PrismaRelationFact {
+  const found = relations.find((r) => r.fromModel === fromModel && r.fieldName === fieldName);
+  if (!found) throw new Error(`relation ${fromModel}.${fieldName} not found`);
+  return found;
+}
+
+describe("parsePrismaSchema", () => {
+  const facts = parsePrismaSchema(FIXTURE);
+
+  it("parses models and mapped table names", () => {
+    const names = facts.models.map((m) => m.name).sort();
+    expect(names).toEqual(["Comment", "Post", "Profile", "Tag", "User"]);
+    expect(facts.models.find((m) => m.name === "User")?.mappedTable).toBe("users");
+  });
+
+  it("parses enums and their values", () => {
+    const role = facts.enums.find((e) => e.name === "Role");
+    expect(role?.values).toEqual(["admin", "member"]);
+  });
+
+  it("classifies field kinds, flags, and mapped columns", () => {
+    const user = facts.models.find((m) => m.name === "User")!;
+    const id = user.fields.find((f) => f.name === "id")!;
+    expect(id).toMatchObject({ kind: "scalar", isId: true, hasDefault: true, isRequired: true });
+
+    const email = user.fields.find((f) => f.name === "email")!;
+    expect(email).toMatchObject({ kind: "scalar", isUnique: true, mappedColumn: "email_address" });
+
+    const role = user.fields.find((f) => f.name === "role")!;
+    expect(role.kind).toBe("enum");
+
+    const posts = user.fields.find((f) => f.name === "posts")!;
+    expect(posts).toMatchObject({ kind: "relation", isList: true });
+  });
+
+  it("marks field-level and model-level @ignore", () => {
+    const user = facts.models.find((m) => m.name === "User")!;
+    expect(user.fields.find((f) => f.name === "legacy")?.isIgnored).toBe(true);
+    expect(facts.models.find((m) => m.name === "Tag")?.isIgnored).toBe(true);
+  });
+
+  it("derives one-to-many / many-to-one cardinality", () => {
+    expect(relation(facts.relations, "User", "posts").cardinality).toBe("one-to-many");
+    expect(relation(facts.relations, "Post", "author").cardinality).toBe("many-to-one");
+  });
+
+  it("derives one-to-one cardinality", () => {
+    expect(relation(facts.relations, "User", "profile").cardinality).toBe("one-to-one");
+    expect(relation(facts.relations, "Profile", "user").cardinality).toBe("one-to-one");
+  });
+
+  it("derives many-to-many cardinality (implicit)", () => {
+    expect(relation(facts.relations, "Post", "tags").cardinality).toBe("many-to-many");
+    expect(relation(facts.relations, "Tag", "posts").cardinality).toBe("many-to-many");
+  });
+
+  it("captures FK fields and references on the owning side", () => {
+    const author = relation(facts.relations, "Post", "author");
+    expect(author.fkFields).toEqual(["authorId"]);
+    expect(author.references).toEqual(["id"]);
+  });
+
+  it("detects FK index coverage (@@index, @unique) and FK-without-index", () => {
+    // authorId is covered by @@index([authorId]).
+    expect(relation(facts.relations, "Post", "author").isFkIndexed).toBe(true);
+    // userId is covered because it is @unique.
+    expect(relation(facts.relations, "Profile", "user").isFkIndexed).toBe(true);
+    // postId has no index and is not unique -> FK without index.
+    expect(relation(facts.relations, "Comment", "post").isFkIndexed).toBe(false);
+  });
+
+  it("records line anchors for models and fields", () => {
+    const user = facts.models.find((m) => m.name === "User")!;
+    expect(user.startLine).toBeGreaterThan(0);
+    expect(user.endLine).toBeGreaterThan(user.startLine);
+    expect(user.fields.every((f) => f.line >= user.startLine)).toBe(true);
+  });
+
+  it("is robust to an empty schema", () => {
+    expect(parsePrismaSchema("")).toEqual({ models: [], enums: [], relations: [] });
+  });
+});

--- a/apps/web/lib/integrate/code-graph/extractors/prisma-schema-adapter.ts
+++ b/apps/web/lib/integrate/code-graph/extractors/prisma-schema-adapter.ts
@@ -1,0 +1,426 @@
+// Prisma schema adapter — EP-DATA-ARCH Phase 1 (BI-8579FB2D).
+//
+// Parses a Prisma schema into a rich, typed fact structure: models with
+// fields, types, mapped names, indexes, and relations carrying derived
+// cardinality + FK-index coverage. This is the structured source consumed by
+// (a) the code-graph Prisma extractor (graph nodes/edges) and (b) the EA
+// data-model mirror (EP-DATA-ARCH Phase 2).
+//
+// Design note (spec docs/superpowers/specs/2026-06-06-data-architecture-self-maintenance-design.md §4/§6.1):
+// This is a self-contained parser, NOT a dependency on `@prisma/internals`.
+// The repo pins Prisma 7.8.0 and does not ship `@prisma/internals`; `getDMMF`
+// is not a stable public schema API under Prisma 7. The adapter exposes a
+// stable interface (`parsePrismaSchema`) so the implementation can be swapped
+// for a DMMF/manifest-backed one later without touching consumers.
+
+export type PrismaFieldKind = "scalar" | "enum" | "relation" | "unsupported";
+
+export type RelationCardinality =
+  | "one-to-one"
+  | "one-to-many"
+  | "many-to-one"
+  | "many-to-many";
+
+const PRISMA_SCALAR_TYPES = new Set([
+  "String",
+  "Boolean",
+  "Int",
+  "BigInt",
+  "Float",
+  "Decimal",
+  "DateTime",
+  "Json",
+  "Bytes",
+]);
+
+export type PrismaRelationAttribute = {
+  name: string | null;
+  fields: string[];
+  references: string[];
+  onDelete: string | null;
+  onUpdate: string | null;
+};
+
+export type PrismaFieldFact = {
+  name: string;
+  /** Column name from `@map(...)`, else null. */
+  mappedColumn: string | null;
+  /** Declared type with `[]`/`?` stripped, e.g. `User`, `String`. */
+  rawType: string;
+  kind: PrismaFieldKind;
+  isList: boolean;
+  isRequired: boolean;
+  isId: boolean;
+  isUnique: boolean;
+  hasDefault: boolean;
+  isUpdatedAt: boolean;
+  isIgnored: boolean;
+  /** Present when kind === "relation". */
+  relation: PrismaRelationAttribute | null;
+  line: number;
+};
+
+export type PrismaBlockIndexKind = "index" | "unique" | "id";
+
+export type PrismaBlockIndex = {
+  kind: PrismaBlockIndexKind;
+  fields: string[];
+  line: number;
+};
+
+export type PrismaModelFact = {
+  name: string;
+  /** Table name from `@@map(...)`, else null. */
+  mappedTable: string | null;
+  isIgnored: boolean;
+  startLine: number;
+  endLine: number;
+  fields: PrismaFieldFact[];
+  blockIndexes: PrismaBlockIndex[];
+};
+
+export type PrismaEnumFact = {
+  name: string;
+  values: string[];
+  line: number;
+};
+
+export type PrismaRelationFact = {
+  /** Model that declares the relation field. */
+  fromModel: string;
+  /** Referenced model (the relation field's type). */
+  toModel: string;
+  fieldName: string;
+  relationName: string | null;
+  /** Cardinality as seen from fromModel -> toModel. */
+  cardinality: RelationCardinality;
+  /** Local scalar FK fields (only on the owning side; may be empty). */
+  fkFields: string[];
+  references: string[];
+  /** True when fkFields are covered by an index/unique/id (FK-without-index check). */
+  isFkIndexed: boolean;
+  line: number;
+};
+
+export type PrismaSchemaFacts = {
+  models: PrismaModelFact[];
+  enums: PrismaEnumFact[];
+  relations: PrismaRelationFact[];
+};
+
+type RawBlock = {
+  blockType: "model" | "enum" | "type";
+  name: string;
+  startLine: number;
+  endLine: number;
+  body: Array<{ text: string; line: number }>;
+};
+
+/** Strip line/doc comments outside of quoted strings. */
+function stripComment(line: string): string {
+  let inString = false;
+  for (let i = 0; i < line.length - 1; i++) {
+    const ch = line[i];
+    if (ch === '"') inString = !inString;
+    if (!inString && ch === "/" && line[i + 1] === "/") {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+function tokenizeBlocks(sourceText: string): RawBlock[] {
+  const blocks: RawBlock[] = [];
+  const lines = sourceText.split("\n");
+  const blockHead = /^\s*(model|enum|type)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/;
+
+  let current: RawBlock | null = null;
+  for (let index = 0; index < lines.length; index++) {
+    const rawLine = lines[index];
+    const lineNumber = index + 1;
+    const line = stripComment(rawLine);
+
+    if (!current) {
+      const head = blockHead.exec(line);
+      if (head) {
+        current = {
+          blockType: head[1] as RawBlock["blockType"],
+          name: head[2],
+          startLine: lineNumber,
+          endLine: lineNumber,
+          body: [],
+        };
+      }
+      continue;
+    }
+
+    if (/^\s*\}\s*$/.test(line)) {
+      current.endLine = lineNumber;
+      blocks.push(current);
+      current = null;
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      current.body.push({ text: trimmed, line: lineNumber });
+    }
+  }
+
+  return blocks;
+}
+
+function parseBracketList(source: string, key: string): string[] {
+  // Matches `key: [a, b]` capturing the inner list.
+  const pattern = new RegExp(`${key}\\s*:\\s*\\[([^\\]]*)\\]`);
+  const match = pattern.exec(source);
+  if (!match) return [];
+  return match[1]
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseNamedArg(source: string, key: string): string | null {
+  const pattern = new RegExp(`${key}\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*)`);
+  const match = pattern.exec(source);
+  return match ? match[1] : null;
+}
+
+function parseRelationAttribute(fieldText: string): PrismaRelationAttribute | null {
+  const relationStart = fieldText.indexOf("@relation");
+  if (relationStart === -1) return null;
+  // Extract the parenthesised argument list (handles nested brackets simply).
+  const open = fieldText.indexOf("(", relationStart);
+  if (open === -1) {
+    return { name: null, fields: [], references: [], onDelete: null, onUpdate: null };
+  }
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < fieldText.length; i++) {
+    if (fieldText[i] === "(") depth++;
+    else if (fieldText[i] === ")") {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  const args = close === -1 ? fieldText.slice(open + 1) : fieldText.slice(open + 1, close);
+
+  const quotedName = /^\s*"([^"]*)"/.exec(args);
+  const namedName = /name\s*:\s*"([^"]*)"/.exec(args);
+  const name = namedName?.[1] ?? quotedName?.[1] ?? null;
+
+  return {
+    name,
+    fields: parseBracketList(args, "fields"),
+    references: parseBracketList(args, "references"),
+    onDelete: parseNamedArg(args, "onDelete"),
+    onUpdate: parseNamedArg(args, "onUpdate"),
+  };
+}
+
+function parseMapValue(fieldText: string): string | null {
+  const match = /@map\s*\(\s*"([^"]*)"\s*\)/.exec(fieldText);
+  return match ? match[1] : null;
+}
+
+function classifyType(
+  rawType: string,
+  enumNames: Set<string>,
+  modelNames: Set<string>,
+): PrismaFieldKind {
+  if (PRISMA_SCALAR_TYPES.has(rawType)) return "scalar";
+  if (enumNames.has(rawType)) return "enum";
+  if (modelNames.has(rawType)) return "relation";
+  return "unsupported";
+}
+
+function parseFieldLine(
+  text: string,
+  line: number,
+  enumNames: Set<string>,
+  modelNames: Set<string>,
+): PrismaFieldFact | null {
+  // A field line: `name Type<modifiers> @attr...`. Skip block attributes.
+  const match = /^([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_."()]*(?:\[\])?\??)/.exec(text);
+  if (!match) return null;
+
+  const name = match[1];
+  let typeToken = match[2];
+  const isList = typeToken.endsWith("[]");
+  if (isList) typeToken = typeToken.slice(0, -2);
+  const isOptional = typeToken.endsWith("?");
+  if (isOptional) typeToken = typeToken.slice(0, -1);
+  const rawType = typeToken;
+
+  const kind = classifyType(rawType, enumNames, modelNames);
+  const relation = kind === "relation" ? parseRelationAttribute(text) : null;
+
+  return {
+    name,
+    mappedColumn: parseMapValue(text),
+    rawType,
+    kind,
+    isList,
+    isRequired: !isOptional && !isList,
+    isId: /@id\b/.test(text),
+    isUnique: /@unique\b/.test(text),
+    hasDefault: /@default\s*\(/.test(text),
+    isUpdatedAt: /@updatedAt\b/.test(text),
+    isIgnored: /@ignore\b/.test(text),
+    relation,
+    line,
+  };
+}
+
+function parseBlockIndex(text: string, line: number): PrismaBlockIndex | null {
+  const head = /^@@(id|unique|index)\b/.exec(text);
+  if (!head) return null;
+  const kind = head[1] as PrismaBlockIndexKind;
+  // Fields can be `[a, b]` or a single `field`. `@@id([a])` / `@@index([a, b])`.
+  const listMatch = /\[([^\]]*)\]/.exec(text);
+  const fields = listMatch
+    ? listMatch[1]
+        .split(",")
+        .map((entry) => entry.trim().replace(/\(.*$/, "").trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+  return { kind, fields, line };
+}
+
+function parseModelBlock(
+  block: RawBlock,
+  enumNames: Set<string>,
+  modelNames: Set<string>,
+): PrismaModelFact {
+  const fields: PrismaFieldFact[] = [];
+  const blockIndexes: PrismaBlockIndex[] = [];
+  let mappedTable: string | null = null;
+  let isIgnored = false;
+
+  for (const { text, line } of block.body) {
+    if (text.startsWith("@@")) {
+      const mapMatch = /^@@map\s*\(\s*"([^"]*)"\s*\)/.exec(text);
+      if (mapMatch) {
+        mappedTable = mapMatch[1];
+        continue;
+      }
+      if (/^@@ignore\b/.test(text)) {
+        isIgnored = true;
+        continue;
+      }
+      const blockIndex = parseBlockIndex(text, line);
+      if (blockIndex) blockIndexes.push(blockIndex);
+      continue;
+    }
+    const field = parseFieldLine(text, line, enumNames, modelNames);
+    if (field) fields.push(field);
+  }
+
+  return {
+    name: block.name,
+    mappedTable,
+    isIgnored,
+    startLine: block.startLine,
+    endLine: block.endLine,
+    fields,
+    blockIndexes,
+  };
+}
+
+function fieldsCoveredByIndex(fkFields: string[], model: PrismaModelFact): boolean {
+  if (fkFields.length === 0) return false;
+  // Single FK field is covered if it is @id/@unique on the field itself.
+  if (fkFields.length === 1) {
+    const owning = model.fields.find((field) => field.name === fkFields[0]);
+    if (owning && (owning.isId || owning.isUnique)) return true;
+  }
+  // Covered if a block index's leading fields match the FK fields (prefix match).
+  return model.blockIndexes.some((index) => {
+    if (index.fields.length < fkFields.length) return false;
+    return fkFields.every((field, position) => index.fields[position] === field);
+  });
+}
+
+function deriveCardinality(thisIsList: boolean, inverseIsList: boolean): RelationCardinality {
+  if (thisIsList && inverseIsList) return "many-to-many";
+  if (thisIsList && !inverseIsList) return "one-to-many";
+  if (!thisIsList && inverseIsList) return "many-to-one";
+  return "one-to-one";
+}
+
+function deriveRelations(models: PrismaModelFact[]): PrismaRelationFact[] {
+  const modelByName = new Map(models.map((model) => [model.name, model]));
+  const relations: PrismaRelationFact[] = [];
+
+  for (const model of models) {
+    for (const field of model.fields) {
+      if (field.kind !== "relation") continue;
+      const target = modelByName.get(field.rawType);
+      if (!target) continue;
+
+      // Find the inverse relation field on the target model.
+      const inverse = target.fields.find((candidate) => {
+        if (candidate.kind !== "relation" || candidate.rawType !== model.name) return false;
+        const thisName = field.relation?.name ?? null;
+        const candidateName = candidate.relation?.name ?? null;
+        if (thisName || candidateName) return thisName === candidateName;
+        return true;
+      });
+
+      const inverseIsList = inverse?.isList ?? false;
+      const fkFields = field.relation?.fields ?? [];
+
+      relations.push({
+        fromModel: model.name,
+        toModel: target.name,
+        fieldName: field.name,
+        relationName: field.relation?.name ?? null,
+        cardinality: deriveCardinality(field.isList, inverseIsList),
+        fkFields,
+        references: field.relation?.references ?? [],
+        isFkIndexed: fieldsCoveredByIndex(fkFields, model),
+        line: field.line,
+      });
+    }
+  }
+
+  return relations;
+}
+
+/**
+ * Parse a Prisma schema source into rich, typed facts.
+ * Pure and deterministic — safe to call at build time and in tests.
+ */
+export function parsePrismaSchema(sourceText: string): PrismaSchemaFacts {
+  const blocks = tokenizeBlocks(sourceText);
+  const modelNames = new Set(
+    blocks.filter((block) => block.blockType === "model").map((block) => block.name),
+  );
+  const enumBlocks = blocks.filter((block) => block.blockType === "enum");
+  const enumNames = new Set(enumBlocks.map((block) => block.name));
+
+  const enums: PrismaEnumFact[] = enumBlocks.map((block) => ({
+    name: block.name,
+    values: block.body
+      .map((entry) => entry.text)
+      .filter((text) => !text.startsWith("@@"))
+      .map((text) => text.split(/\s+/)[0])
+      .filter((value) => value.length > 0),
+    line: block.startLine,
+  }));
+
+  const models = blocks
+    .filter((block) => block.blockType === "model")
+    .map((block) => parseModelBlock(block, enumNames, modelNames));
+
+  const relations = deriveRelations(models);
+
+  return { models, enums, relations };
+}
+
+/** Adapter version — bump when the parsing contract changes. */
+export const PRISMA_SCHEMA_ADAPTER_VERSION = "prisma-schema-adapter-v1";

--- a/apps/web/lib/integrate/code-graph/extractors/prisma.test.ts
+++ b/apps/web/lib/integrate/code-graph/extractors/prisma.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from "vitest";
 import { CODE_GRAPH_EXTRACTORS } from ".";
 import { extractPrismaFacts, prismaExtractor } from "./prisma";
 
+const SCHEMA = `
+model User {
+  id    String @id
+  posts Post[]
+}
+
+model Post {
+  id       String @id
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id])
+  @@index([authorId])
+}
+`;
+
 describe("extractPrismaFacts", () => {
   it("extracts Prisma model declarations", () => {
     const result = extractPrismaFacts({
@@ -14,6 +28,62 @@ describe("extractPrismaFacts", () => {
     expect(result.nodes).toEqual(expect.arrayContaining([
       expect.objectContaining({ kind: "PrismaModel", name: "FeatureBuild" }),
     ]));
+  });
+
+  it("emits PrismaField nodes with type/flag attributes", () => {
+    const result = extractPrismaFacts({
+      graphKey: "source-code",
+      filePath: "packages/db/prisma/schema.prisma",
+      sourceText: SCHEMA,
+    });
+
+    const authorId = result.nodes.find(
+      (n) => n.kind === "PrismaField" && n.key.endsWith("Post.authorId"),
+    );
+    expect(authorId).toBeDefined();
+    expect(authorId?.attributes).toMatchObject({ model: "Post", fieldKind: "scalar", rawType: "String" });
+  });
+
+  it("emits HAS_FIELD edges from model to field", () => {
+    const result = extractPrismaFacts({
+      graphKey: "source-code",
+      filePath: "packages/db/prisma/schema.prisma",
+      sourceText: SCHEMA,
+    });
+
+    const hasField = result.edges.find(
+      (e) => e.kind === "HAS_FIELD" && e.toKey.endsWith("Post.authorId"),
+    );
+    expect(hasField).toBeDefined();
+    expect(hasField?.fromKey).toContain("prisma-model:Post");
+  });
+
+  it("emits RELATES_TO edges carrying derived cardinality and FK index status", () => {
+    const result = extractPrismaFacts({
+      graphKey: "source-code",
+      filePath: "packages/db/prisma/schema.prisma",
+      sourceText: SCHEMA,
+    });
+
+    const relatesTo = result.edges.filter((e) => e.kind === "RELATES_TO");
+    const postToUser = relatesTo.find(
+      (e) => e.fromKey.endsWith("prisma-model:Post") && e.toKey.endsWith("prisma-model:User"),
+    );
+    expect(postToUser?.attributes).toMatchObject({ cardinality: "many-to-one", isFkIndexed: true });
+
+    const userToPost = relatesTo.find(
+      (e) => e.fromKey.endsWith("prisma-model:User") && e.toKey.endsWith("prisma-model:Post"),
+    );
+    expect(userToPost?.attributes).toMatchObject({ cardinality: "one-to-many" });
+  });
+
+  it("keeps the DEFINES edge for backward compatibility", () => {
+    const result = extractPrismaFacts({
+      graphKey: "source-code",
+      filePath: "packages/db/prisma/schema.prisma",
+      sourceText: SCHEMA,
+    });
+    expect(result.edges.some((e) => e.kind === "DEFINES")).toBe(true);
   });
 
   it("is registered for projection", () => {

--- a/apps/web/lib/integrate/code-graph/extractors/prisma.ts
+++ b/apps/web/lib/integrate/code-graph/extractors/prisma.ts
@@ -1,30 +1,52 @@
-import type { CodeGraphExtraction, CodeGraphExtractor, CodeGraphExtractorInput } from "../types";
+import type {
+  CodeGraphAttributes,
+  CodeGraphExtraction,
+  CodeGraphExtractor,
+  CodeGraphExtractorInput,
+} from "../types";
+import {
+  parsePrismaSchema,
+  PRISMA_SCHEMA_ADAPTER_VERSION,
+  type PrismaModelFact,
+} from "./prisma-schema-adapter";
 
-const EXTRACTOR = "prisma-line-v1";
+const EXTRACTOR = "prisma-dmmf-v2";
 
-function lineFor(text: string, index: number): number {
-  return text.slice(0, index).split("\n").length;
+function modelKey(graphKey: string, modelName: string): string {
+  return `${graphKey}:prisma-model:${modelName}`;
+}
+
+function fieldKey(graphKey: string, modelName: string, fieldName: string): string {
+  return `${graphKey}:prisma-field:${modelName}.${fieldName}`;
+}
+
+function modelAttributes(model: PrismaModelFact): CodeGraphAttributes {
+  const attributes: CodeGraphAttributes = {
+    fieldCount: model.fields.length,
+    isIgnored: model.isIgnored,
+  };
+  if (model.mappedTable) attributes.mappedTable = model.mappedTable;
+  return attributes;
 }
 
 export function extractPrismaFacts(input: CodeGraphExtractorInput): CodeGraphExtraction {
   const nodes: CodeGraphExtraction["nodes"] = [];
   const edges: CodeGraphExtraction["edges"] = [];
-  const modelPattern = /^\s*model\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/gm;
-  let match: RegExpExecArray | null;
 
-  while ((match = modelPattern.exec(input.sourceText)) != null) {
-    const name = match[1];
-    const startLine = lineFor(input.sourceText, match.index);
-    const key = `${input.graphKey}:prisma-model:${name}`;
+  const facts = parsePrismaSchema(input.sourceText);
+
+  for (const model of facts.models) {
+    const key = modelKey(input.graphKey, model.name);
     nodes.push({
       graphKey: input.graphKey,
       kind: "PrismaModel",
       key,
-      name,
+      name: model.name,
       filePath: input.filePath,
-      startLine,
-      endLine: startLine,
+      startLine: model.startLine,
+      endLine: model.endLine,
       extractor: EXTRACTOR,
+      attributes: modelAttributes(model),
     });
     edges.push({
       graphKey: input.graphKey,
@@ -32,10 +54,74 @@ export function extractPrismaFacts(input: CodeGraphExtractorInput): CodeGraphExt
       fromKey: `${input.graphKey}:${input.filePath}`,
       toKey: key,
       filePath: input.filePath,
-      startLine,
-      endLine: startLine,
+      startLine: model.startLine,
+      endLine: model.startLine,
       confidence: "exact",
       extractor: EXTRACTOR,
+    });
+
+    for (const field of model.fields) {
+      const fKey = fieldKey(input.graphKey, model.name, field.name);
+      const fieldAttributes: CodeGraphAttributes = {
+        model: model.name,
+        fieldKind: field.kind,
+        rawType: field.rawType,
+        isList: field.isList,
+        isRequired: field.isRequired,
+        isId: field.isId,
+        isUnique: field.isUnique,
+        hasDefault: field.hasDefault,
+        isUpdatedAt: field.isUpdatedAt,
+        isIgnored: field.isIgnored,
+      };
+      if (field.mappedColumn) fieldAttributes.mappedColumn = field.mappedColumn;
+
+      nodes.push({
+        graphKey: input.graphKey,
+        kind: "PrismaField",
+        key: fKey,
+        name: field.name,
+        filePath: input.filePath,
+        startLine: field.line,
+        endLine: field.line,
+        extractor: EXTRACTOR,
+        attributes: fieldAttributes,
+      });
+      edges.push({
+        graphKey: input.graphKey,
+        kind: "HAS_FIELD",
+        fromKey: key,
+        toKey: fKey,
+        filePath: input.filePath,
+        startLine: field.line,
+        endLine: field.line,
+        confidence: "exact",
+        extractor: EXTRACTOR,
+      });
+    }
+  }
+
+  for (const relation of facts.relations) {
+    const relationAttributes: CodeGraphAttributes = {
+      cardinality: relation.cardinality,
+      fieldName: relation.fieldName,
+      isFkIndexed: relation.isFkIndexed,
+    };
+    if (relation.relationName) relationAttributes.relationName = relation.relationName;
+    if (relation.fkFields.length > 0) relationAttributes.fkFields = relation.fkFields.join(",");
+    if (relation.references.length > 0) relationAttributes.references = relation.references.join(",");
+
+    edges.push({
+      graphKey: input.graphKey,
+      kind: "RELATES_TO",
+      fromKey: modelKey(input.graphKey, relation.fromModel),
+      toKey: modelKey(input.graphKey, relation.toModel),
+      filePath: input.filePath,
+      startLine: relation.line,
+      endLine: relation.line,
+      confidence: "exact",
+      extractor: EXTRACTOR,
+      attributes: relationAttributes,
     });
   }
 
@@ -44,7 +130,7 @@ export function extractPrismaFacts(input: CodeGraphExtractorInput): CodeGraphExt
 
 export const prismaExtractor: CodeGraphExtractor = {
   name: "prisma",
-  version: "v1",
+  version: PRISMA_SCHEMA_ADAPTER_VERSION,
   matches(filePath) {
     return filePath.replace(/\\/g, "/").endsWith(".prisma");
   },

--- a/apps/web/lib/integrate/code-graph/neo4j-projection.ts
+++ b/apps/web/lib/integrate/code-graph/neo4j-projection.ts
@@ -23,6 +23,7 @@ const STRUCTURAL_NODE_LABELS = [
   "CodeRoute",
   "CodeTool",
   "PrismaModel",
+  "PrismaField",
   "PromptTemplateSource",
   "TestFile",
   "ExternalModule",
@@ -62,6 +63,7 @@ export async function ensureCodeGraphNeo4jSchema(): Promise<void> {
     "CREATE CONSTRAINT cr_routeKey IF NOT EXISTS FOR (n:CodeRoute) REQUIRE n.codeRouteKey IS UNIQUE",
     "CREATE CONSTRAINT ct_toolKey IF NOT EXISTS FOR (n:CodeTool) REQUIRE n.codeToolKey IS UNIQUE",
     "CREATE CONSTRAINT pm_modelKey IF NOT EXISTS FOR (n:PrismaModel) REQUIRE n.prismaModelKey IS UNIQUE",
+    "CREATE CONSTRAINT pf_fieldKey IF NOT EXISTS FOR (n:PrismaField) REQUIRE n.prismaFieldKey IS UNIQUE",
     "CREATE CONSTRAINT pts_promptKey IF NOT EXISTS FOR (n:PromptTemplateSource) REQUIRE n.promptTemplateSourceKey IS UNIQUE",
     "CREATE CONSTRAINT tf_testFileKey IF NOT EXISTS FOR (n:TestFile) REQUIRE n.testFileKey IS UNIQUE",
     "CREATE CONSTRAINT em_moduleKey IF NOT EXISTS FOR (n:ExternalModule) REQUIRE n.externalModuleKey IS UNIQUE",
@@ -71,6 +73,7 @@ export async function ensureCodeGraphNeo4jSchema(): Promise<void> {
     "CREATE INDEX cr_graphKey IF NOT EXISTS FOR (n:CodeRoute) ON (n.graphKey)",
     "CREATE INDEX ct_graphKey IF NOT EXISTS FOR (n:CodeTool) ON (n.graphKey)",
     "CREATE INDEX pm_graphKey IF NOT EXISTS FOR (n:PrismaModel) ON (n.graphKey)",
+    "CREATE INDEX pf_graphKey IF NOT EXISTS FOR (n:PrismaField) ON (n.graphKey)",
     "CREATE INDEX pts_graphKey IF NOT EXISTS FOR (n:PromptTemplateSource) ON (n.graphKey)",
     "CREATE INDEX tf_graphKey IF NOT EXISTS FOR (n:TestFile) ON (n.graphKey)",
     "CREATE INDEX em_graphKey IF NOT EXISTS FOR (n:ExternalModule) ON (n.graphKey)",
@@ -113,6 +116,7 @@ function endpointForKey(graphKey: string, key: string): NodeEndpointProjection |
     { prefix: `${graphKey}:route:`, label: "CodeRoute" },
     { prefix: `${graphKey}:tool:`, label: "CodeTool" },
     { prefix: `${graphKey}:prisma-model:`, label: "PrismaModel" },
+    { prefix: `${graphKey}:prisma-field:`, label: "PrismaField" },
     { prefix: `${graphKey}:test:`, label: "TestFile" },
     { prefix: `${graphKey}:module:`, label: "ExternalModule" },
   ];
@@ -141,6 +145,13 @@ function chunks<T>(items: T[], size: number): T[][] {
     result.push(items.slice(index, index + size));
   }
   return result;
+}
+
+// `SET n += map` requires a non-null map; default missing attributes to {}.
+function withAttributeDefaults<T extends { attributes?: Record<string, unknown> }>(
+  facts: T[],
+): Array<T & { attributes: Record<string, unknown> }> {
+  return facts.map((fact) => ({ ...fact, attributes: fact.attributes ?? {} }));
 }
 
 async function projectCodeFileFacts(files: CodeFileProjection[]): Promise<void> {
@@ -179,9 +190,10 @@ async function projectNodeFacts(label: CodeGraphNodeKind, facts: CodeGraphNodeFa
         "    n.path = fact.filePath,",
         "    n.startLine = fact.startLine,",
         "    n.endLine = fact.endLine,",
-        "    n.extractor = fact.extractor",
+        "    n.extractor = fact.extractor,",
+        "    n += fact.attributes",
       ].join("\n"),
-      { facts: batch },
+      { facts: withAttributeDefaults(batch) },
     );
   }
 }
@@ -204,9 +216,10 @@ async function projectTypedEdgeFacts(
         "    r.startLine = fact.startLine,",
         "    r.endLine = fact.endLine,",
         "    r.confidence = fact.confidence,",
-        "    r.extractor = fact.extractor",
+        "    r.extractor = fact.extractor,",
+        "    r += fact.attributes",
       ].join("\n"),
-      { facts: batch },
+      { facts: withAttributeDefaults(batch) },
     );
   }
 }
@@ -226,9 +239,10 @@ async function projectGenericEdgeFacts(kind: CodeGraphEdgeKind, facts: CodeGraph
         "    r.startLine = fact.startLine,",
         "    r.endLine = fact.endLine,",
         "    r.confidence = fact.confidence,",
-        "    r.extractor = fact.extractor",
+        "    r.extractor = fact.extractor,",
+        "    r += fact.attributes",
       ].join("\n"),
-      { facts: batch },
+      { facts: withAttributeDefaults(batch) },
     );
   }
 }

--- a/apps/web/lib/integrate/code-graph/types.ts
+++ b/apps/web/lib/integrate/code-graph/types.ts
@@ -4,6 +4,7 @@ export type CodeGraphNodeKind =
   | "CodeRoute"
   | "CodeTool"
   | "PrismaModel"
+  | "PrismaField"
   | "PromptTemplateSource"
   | "TestFile"
   | "ExternalModule";
@@ -16,9 +17,17 @@ export type CodeGraphEdgeKind =
   | "EXPOSES_TOOL"
   | "USES_MODEL"
   | "USES_PROMPT"
-  | "TESTED_BY";
+  | "TESTED_BY"
+  | "HAS_FIELD"
+  | "RELATES_TO";
 
 export type CodeGraphConfidence = "exact" | "heuristic";
+
+/**
+ * Optional primitive metadata projected onto a node/edge (Neo4j `SET n += map`).
+ * Values are limited to primitives so they map cleanly to graph properties.
+ */
+export type CodeGraphAttributes = Record<string, string | number | boolean>;
 
 export type CodeGraphNodeFact = {
   graphKey: string;
@@ -29,6 +38,8 @@ export type CodeGraphNodeFact = {
   startLine: number | null;
   endLine: number | null;
   extractor: string;
+  /** Optional primitive metadata (e.g. Prisma field type/flags). */
+  attributes?: CodeGraphAttributes;
 };
 
 export type CodeGraphEdgeFact = {
@@ -41,6 +52,8 @@ export type CodeGraphEdgeFact = {
   endLine: number | null;
   confidence: CodeGraphConfidence;
   extractor: string;
+  /** Optional primitive metadata (e.g. relation cardinality / FK info). */
+  attributes?: CodeGraphAttributes;
 };
 
 export type CodeGraphExtraction = {


### PR DESCRIPTION
## What

EP-DATA-ARCH **Phase 1** — enrich the Prisma code-graph extractor so it captures field- and relation-level detail (not just model names). This is the structured source the EA data-model mirror (Phase 2) and the Data Architect steward (Phase 4) consume.

Spec: `docs/superpowers/specs/2026-06-06-data-architecture-self-maintenance-design.md` §6.1 · Plan: `docs/superpowers/plans/2026-06-06-data-architecture-self-maintenance.md` Phase 1 (design landing in #1580).

## Why in-session (not Build Studio)

Build Studio is currently degraded — the promoted Phase 1 build (FB-9B904F86) failed Ideate dispatch on a sandbox CLI auth error (filed BI-7CA11F9A, BI-1291B677, BI-42582965). Operator authorized the standing in-session fallback.

## Approach

Self-contained, fixture-tested schema parser behind a **stable adapter interface** (`parsePrismaSchema`) — **no `@prisma/internals` dependency**. The repo pins Prisma 7.8.0 and does not ship `@prisma/internals`; `getDMMF` is not a stable public schema API under Prisma 7 (spec §4). The adapter's implementation can swap to a DMMF/manifest-backed one later without touching callers.

## Changes

- **`prisma-schema-adapter.ts`** (new) — parses models (mapped table, `@@ignore`), fields (type kind, mapped column, `@id`/`@unique`/`@default`/`@updatedAt`/`@ignore`/list/optional), block indexes, and relations with **derived cardinality** (one/many-to-one/-many, many-to-many) + **FK-without-index detection**.
- **`prisma.ts`** — consumes the adapter; emits `PrismaModel` + `PrismaField` nodes and `HAS_FIELD` + `RELATES_TO` edges; `DEFINES` kept for back-compat; version `prisma-dmmf-v2`.
- **`types.ts`** — add `PrismaField` node kind, `HAS_FIELD`/`RELATES_TO` edge kinds, optional primitive `attributes` bag.
- **`neo4j-projection.ts`** — register `PrismaField` (label, key prefix, constraint, index) and project the `attributes` bag via `SET += ` (default empty; backward-compatible for existing extractors).

## Verification

- **Unit:** 10 adapter + 7 extractor tests; full code-graph suite **62 passed**. Fixtures cover mapped names, `@ignore`, 1:1 / 1:N / N:M, and indexed vs unindexed FK.
- **Typecheck:** clean (scoped pre-commit + full `--filter web typecheck`).
- **Functional (real input):** parses the production `schema.prisma` → **405 models, 1,196 relations** with cardinality, **0 unsupported fields**, and **120 FK-without-index** findings (the signal the steward will act on).
- `next build` left to CI (isolated extractor logic + additive types).

## Follow-on

Phase 2 (mirror, BI-2167A734) consumes `parsePrismaSchema` directly to project `data_object` `EaElement`s + relationships into the EA substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
