### PR TITLE
feat(build-gate): surface Claude subscription CLI runner + one-click enable when disabled (BI-AD8955F9)

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -8,6 +8,8 @@ import { BuildStudio } from "@/components/build/BuildStudio";
 import { BuildStudioV2 } from "@/components/build-studio/BuildStudioV2";
 import { loadBuildStudioCapability } from "@/lib/build/build-studio-capability";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
+import { can } from "@/lib/govern/permissions";
+import { EnableRunnerButton } from "@/components/build/EnableRunnerButton";
 import Link from "next/link";
 import { execSync } from "child_process";
 
@@ -112,12 +114,27 @@ export default async function BuildPage({ searchParams }: PageProps) {
   const capability = await loadBuildStudioCapability();
   if (!capability.ok) {
     const isOnlyLocal = capability.reason === "only_local_provider_active";
-    const heading = isOnlyLocal
-      ? "Connect a code-capable AI runner to start building"
-      : "Build Studio needs a code-capable AI runner";
-    const body = isOnlyLocal
-      ? "Build Studio writes code and orchestrates tools for you. The local AI on this install can chat, but it is not the right runner for production code work yet. Connect a subscription CLI path or an API-key provider below, then the build flow opens up."
-      : "Build Studio needs an active runner that can write code and use tools at production quality. ChatGPT/OpenAI Codex can satisfy this through OAuth and Codex CLI; OpenAI and Anthropic API keys are separate pay-per-token licensing paths.";
+    // Inline-enable only makes sense for operators who can flip provider
+    // status; everyone else still gets the connect-a-provider link.
+    const canManageProviders = can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "manage_provider_connections",
+    );
+    const enableableRunners = canManageProviders ? capability.enableableRunners : [];
+    // Prefer Claude as the headline runner when present (matches the
+    // orchestrator's default subscription codegen path), else first available.
+    const primaryRunner =
+      enableableRunners.find((r) => r.shortLabel === "Claude") ?? enableableRunners[0];
+    const heading = primaryRunner
+      ? `${primaryRunner.shortLabel} is connected but turned off`
+      : isOnlyLocal
+        ? "Connect a code-capable AI runner to start building"
+        : "Build Studio needs a code-capable AI runner";
+    const body = primaryRunner
+      ? `${primaryRunner.shortLabel} is already set up on this install — it's just disabled. Enable it right here to start building; no trip to provider settings needed.`
+      : isOnlyLocal
+        ? "Build Studio writes code and orchestrates tools for you. The local AI on this install can chat, but it is not the right runner for production code work yet. Connect a subscription CLI path or an API-key provider below, then the build flow opens up."
+        : "Build Studio needs an active runner that can write code and use tools at production quality. ChatGPT/OpenAI Codex and Claude can both satisfy this through OAuth subscription CLI paths; OpenAI and Anthropic API keys are separate pay-per-token licensing paths.";
     return (
       <div className="flex items-start justify-center min-h-[60vh] px-6 py-10">
         <div className="max-w-2xl w-full space-y-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-8 shadow-sm">
@@ -131,7 +148,34 @@ export default async function BuildPage({ searchParams }: PageProps) {
             </div>
           </div>
 
-          <ul className="space-y-3 border-t border-[var(--dpf-border)] pt-5">
+          {enableableRunners.length > 0 ? (
+            <div className="space-y-3 border-t border-[var(--dpf-border)] pt-5">
+              {enableableRunners.map((runner) => (
+                <div
+                  key={runner.providerId}
+                  className="flex items-center justify-between gap-4 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3"
+                >
+                  <div className="space-y-0.5">
+                    <div className="text-sm font-medium text-[var(--dpf-text)]">{runner.name}</div>
+                    <div className="text-xs text-[var(--dpf-muted)]">
+                      Connected but turned off — enable to start building.
+                    </div>
+                  </div>
+                  <EnableRunnerButton providerId={runner.providerId} label={runner.shortLabel} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {enableableRunners.length > 0 ? (
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+              Or connect a different runner
+            </p>
+          ) : null}
+
+          <ul
+            className={`space-y-3 ${enableableRunners.length > 0 ? "pt-1" : "border-t border-[var(--dpf-border)] pt-5"}`}
+          >
             {capability.suggestedProviders.map((provider) => (
               <li key={provider.name} className="flex items-start gap-3">
                 <span
@@ -158,9 +202,13 @@ export default async function BuildPage({ searchParams }: PageProps) {
           <div className="flex flex-col gap-3 border-t border-[var(--dpf-border)] pt-5 sm:flex-row sm:items-center sm:justify-between">
             <Link
               href="/platform/ai/providers"
-              className="inline-block rounded px-5 py-2.5 text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+              className={`inline-block rounded px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90 ${
+                enableableRunners.length > 0
+                  ? "border border-[var(--dpf-border)] text-[var(--dpf-text)]"
+                  : "bg-[var(--dpf-accent)] text-white"
+              }`}
             >
-              Connect a provider &rarr;
+              {enableableRunners.length > 0 ? "Connect a different provider" : "Connect a provider"} &rarr;
             </Link>
             <span className="text-xs text-[var(--dpf-muted)]">
               {capability.activeProviderNames.length === 0

--- a/apps/web/components/build/EnableRunnerButton.tsx
+++ b/apps/web/components/build/EnableRunnerButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toggleProviderStatus } from "@/lib/actions/ai-providers";
+
+type Props = {
+  providerId: string;
+  /** Short label for the button, e.g. "Claude" / "Codex". */
+  label: string;
+};
+
+/**
+ * Inline "Enable" action for a configured-but-disabled code runner on the
+ * Build Studio capability gate. Flips ModelProvider.status inactive → active
+ * via toggleProviderStatus, then refreshes the route so the gate re-evaluates
+ * and the build flow opens — no navigation to /platform/ai/providers.
+ */
+export function EnableRunnerButton({ providerId, label }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function handleEnable() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await toggleProviderStatus(providerId);
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not enable this runner.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={handleEnable}
+        disabled={isPending}
+        className="inline-block rounded px-4 py-2 text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+      >
+        {isPending ? "Enabling…" : `Enable ${label}`}
+      </button>
+      {error ? (
+        <span role="alert" className="max-w-[16rem] text-right text-xs text-[var(--dpf-warning)]">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/build/build-studio-capability-db.test.ts
+++ b/apps/web/lib/build/build-studio-capability-db.test.ts
@@ -5,6 +5,9 @@ vi.mock("@dpf/db", () => ({
     modelProfile: {
       findMany: vi.fn(),
     },
+    modelProvider: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -12,10 +15,15 @@ import { prisma } from "@dpf/db";
 import { loadBuildStudioCapability } from "./build-studio-capability";
 
 const mockModelProfileFindMany = vi.mocked(prisma.modelProfile.findMany);
+const mockModelProviderFindMany = vi.mocked(prisma.modelProvider.findMany);
 
 describe("loadBuildStudioCapability", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: nothing merely disabled.
+    mockModelProviderFindMany.mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>,
+    );
   });
 
   it("queries active chat and code model profiles so Codex CLI can satisfy the Build Studio gate", async () => {
@@ -48,6 +56,29 @@ describe("loadBuildStudioCapability", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.satisfyingProviderNames).toEqual(["OpenAI Codex"]);
+    }
+  });
+
+  it("queries inactive CLI runners and surfaces them as enableable when the gate is closed", async () => {
+    mockModelProfileFindMany.mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof prisma.modelProfile.findMany>>,
+    );
+    mockModelProviderFindMany.mockResolvedValue([
+      { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", cliEngine: "claude" },
+    ] as unknown as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>);
+
+    const result = await loadBuildStudioCapability();
+
+    expect(mockModelProviderFindMany).toHaveBeenCalledWith({
+      where: { status: "inactive", cliEngine: { not: null } },
+      select: { providerId: true, name: true, cliEngine: true },
+      orderBy: { providerId: "asc" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.enableableRunners).toEqual([
+        { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", shortLabel: "Claude" },
+      ]);
     }
   });
 });

--- a/apps/web/lib/build/build-studio-capability.test.ts
+++ b/apps/web/lib/build/build-studio-capability.test.ts
@@ -35,6 +35,11 @@ describe("deriveBuildStudioCapability", () => {
         recommended: true,
       },
       {
+        name: "Claude - Subscription (CLI)",
+        description: "Recommended: sign in with your Claude (Anthropic) subscription via OAuth. Build Studio runs code generation through the Claude CLI path; no API key needed.",
+        recommended: true,
+      },
+      {
         name: "OpenAI API key",
         description: "Separate OpenAI platform billing. Use this when you want pay-per-token API usage instead of ChatGPT plan limits.",
       },
@@ -47,6 +52,12 @@ describe("deriveBuildStudioCapability", () => {
         description: "Useful for light or backup routing. Free-tier keys have lower quotas than paid API or subscription CLI paths.",
       },
     ]);
+  });
+
+  it("surfaces the Claude subscription CLI as a recommended runner", () => {
+    expect(
+      SUGGESTED_PROVIDERS.some((p) => p.name === "Claude - Subscription (CLI)" && p.recommended),
+    ).toBe(true);
   });
 
   it("returns only_local_provider_active when only Docker Model Runner has under-tier models", () => {
@@ -171,6 +182,73 @@ describe("deriveBuildStudioCapability", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.satisfyingProviderNames).toEqual(["Claude / Anthropic (OAuth Subscription)"]);
+    }
+  });
+
+  it("treats an enabled anthropic-sub as a code-capable runner so the gate opens", () => {
+    // The build orchestrator already runs codegen on the Claude subscription;
+    // the OAuth-subscription provider must satisfy the gate, not be filtered as local.
+    const result = deriveBuildStudioCapability([
+      model({
+        providerId: "anthropic-sub",
+        providerName: "Claude / Anthropic (OAuth Subscription)",
+        modelId: "claude-sonnet-4-6",
+      }),
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("surfaces configured-but-disabled CLI runners as enableable (inactive → one-click Enable)", () => {
+    const result = deriveBuildStudioCapability(
+      [
+        model({
+          providerId: "local",
+          providerName: "Docker Model Runner (local)",
+          modelId: "ai/qwen3:14B-Q6_K",
+          maxInputTokens: 32_768,
+        }),
+      ],
+      [
+        { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", cliEngine: "claude" },
+        { providerId: "codex", name: "OpenAI Codex", cliEngine: "codex" },
+      ],
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("only_local_provider_active");
+      expect(result.enableableRunners).toEqual([
+        { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", shortLabel: "Claude" },
+        { providerId: "codex", name: "OpenAI Codex", shortLabel: "Codex" },
+      ]);
+    }
+  });
+
+  it("surfaces enableable runners even when zero providers are active", () => {
+    const result = deriveBuildStudioCapability(
+      [],
+      [{ providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", cliEngine: "claude" }],
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("no_active_llm_providers");
+      expect(result.enableableRunners).toEqual([
+        { providerId: "anthropic-sub", name: "Claude / Anthropic (OAuth Subscription)", shortLabel: "Claude" },
+      ]);
+    }
+  });
+
+  it("returns empty enableableRunners when nothing is merely disabled", () => {
+    const result = deriveBuildStudioCapability([
+      model({
+        providerId: "local",
+        providerName: "Docker Model Runner (local)",
+        modelId: "ai/qwen3:14B-Q6_K",
+        maxInputTokens: 32_768,
+      }),
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.enableableRunners).toEqual([]);
     }
   });
 });

--- a/apps/web/lib/build/build-studio-capability.ts
+++ b/apps/web/lib/build/build-studio-capability.ts
@@ -33,6 +33,10 @@ export type BuildStudioCapability =
         | "no_strong_tier_model_available";
       activeProviderNames: string[];
       suggestedProviders: ReadonlyArray<SuggestedProvider>;
+      // Configured-but-disabled CLI code runners (e.g. anthropic-sub, codex)
+      // that the operator can switch on in place — no trip to
+      // /platform/ai/providers. Empty when nothing is merely turned off.
+      enableableRunners: ReadonlyArray<EnableableRunner>;
     };
 
 export interface ActiveProviderModel {
@@ -51,10 +55,43 @@ export interface SuggestedProvider {
   recommended?: boolean;
 }
 
+/**
+ * A code-capable CLI runner that exists in ModelProvider with status
+ * `inactive` — credentialed/configured but switched off. Surfaced on the
+ * build gate with an inline "Enable" action (toggleProviderStatus) so the
+ * operator never has to leave the screen for /platform/ai/providers.
+ */
+export interface EnableableRunner {
+  providerId: string;
+  /** Full provider display name, e.g. "Claude / Anthropic (OAuth Subscription)". */
+  name: string;
+  /** Short user-facing label for inline copy + the Enable button, e.g. "Claude" / "Codex". */
+  shortLabel: string;
+}
+
+/** Raw DB shape for a configured-but-disabled CLI runner, fed to the pure decision fn. */
+export interface ConfiguredInactiveRunner {
+  providerId: string;
+  name: string;
+  /** "claude" | "codex" | null — which CLI dispatch engine, drives the short label. */
+  cliEngine: string | null;
+}
+
+function shortRunnerLabel(runner: ConfiguredInactiveRunner): string {
+  if (runner.cliEngine === "claude") return "Claude";
+  if (runner.cliEngine === "codex") return "Codex";
+  return runner.name;
+}
+
 export const SUGGESTED_PROVIDERS: ReadonlyArray<SuggestedProvider> = [
   {
     name: "ChatGPT / OpenAI Codex - Subscription sign-in",
     description: "Recommended: sign in with OpenAI OAuth. Build Studio uses the Codex CLI path; no API key needed.",
+    recommended: true,
+  },
+  {
+    name: "Claude - Subscription (CLI)",
+    description: "Recommended: sign in with your Claude (Anthropic) subscription via OAuth. Build Studio runs code generation through the Claude CLI path; no API key needed.",
     recommended: true,
   },
   {
@@ -99,13 +136,23 @@ function isLocalProviderName(name: string): boolean {
  * sufficient" so a freshly connected REMOTE provider isn't blocked while
  * model discovery is still running in the background.
  */
-export function deriveBuildStudioCapability(models: ActiveProviderModel[]): BuildStudioCapability {
+export function deriveBuildStudioCapability(
+  models: ActiveProviderModel[],
+  inactiveRunners: ConfiguredInactiveRunner[] = [],
+): BuildStudioCapability {
+  const enableableRunners: EnableableRunner[] = inactiveRunners.map((r) => ({
+    providerId: r.providerId,
+    name: r.name,
+    shortLabel: shortRunnerLabel(r),
+  }));
+
   if (models.length === 0) {
     return {
       ok: false,
       reason: "no_active_llm_providers",
       activeProviderNames: [],
       suggestedProviders: SUGGESTED_PROVIDERS,
+      enableableRunners,
     };
   }
 
@@ -139,6 +186,7 @@ export function deriveBuildStudioCapability(models: ActiveProviderModel[]): Buil
     reason: onlyLocal ? "only_local_provider_active" : "no_strong_tier_model_available",
     activeProviderNames,
     suggestedProviders: SUGGESTED_PROVIDERS,
+    enableableRunners,
   };
 }
 
@@ -147,20 +195,32 @@ export function deriveBuildStudioCapability(models: ActiveProviderModel[]): Buil
  * calls the pure decision function. Used at /build page render time.
  */
 export async function loadBuildStudioCapability(): Promise<BuildStudioCapability> {
-  const profiles = await prisma.modelProfile.findMany({
-    where: {
-      modelClass: { in: ["chat", "code"] },
-      modelStatus: { in: ["active", "degraded"] },
-      provider: { status: "active" },
-    },
-    select: {
-      providerId: true,
-      modelId: true,
-      supportsToolUse: true,
-      maxInputTokens: true,
-      provider: { select: { name: true } },
-    },
-  });
+  const [profiles, inactiveProviders] = await Promise.all([
+    prisma.modelProfile.findMany({
+      where: {
+        modelClass: { in: ["chat", "code"] },
+        modelStatus: { in: ["active", "degraded"] },
+        provider: { status: "active" },
+      },
+      select: {
+        providerId: true,
+        modelId: true,
+        supportsToolUse: true,
+        maxInputTokens: true,
+        provider: { select: { name: true } },
+      },
+    }),
+    // Code runners that are configured/credentialed but switched off
+    // (status="inactive"). cliEngine!=null means it dispatches the Claude or
+    // Codex CLI path — exactly the runners the build orchestrator can drive.
+    // These get an inline Enable action on the gate; "unconfigured" providers
+    // (never set up) are intentionally excluded — they need the connect flow.
+    prisma.modelProvider.findMany({
+      where: { status: "inactive", cliEngine: { not: null } },
+      select: { providerId: true, name: true, cliEngine: true },
+      orderBy: { providerId: "asc" },
+    }),
+  ]);
 
   const models: ActiveProviderModel[] = profiles.map((p) => ({
     providerId: p.providerId,
@@ -170,7 +230,13 @@ export async function loadBuildStudioCapability(): Promise<BuildStudioCapability
     maxInputTokens: p.maxInputTokens,
   }));
 
-  return deriveBuildStudioCapability(models);
+  const inactiveRunners: ConfiguredInactiveRunner[] = inactiveProviders.map((p) => ({
+    providerId: p.providerId,
+    name: p.name,
+    cliEngine: p.cliEngine,
+  }));
+
+  return deriveBuildStudioCapability(models, inactiveRunners);
 }
 
 /**


### PR DESCRIPTION
## Summary

The Build Studio capability gate (G1, `apps/web/app/(shell)/build/page.tsx`) listed Codex CLI + three API-key providers as suggested runners but **omitted the Claude subscription (`anthropic-sub`) path** — even though the build orchestrator already runs codegen on it (`[claude-dispatch] … sonnet [Max Plan (OAuth)]`). Worse, when the Claude provider existed but was merely **disabled**, the operator had to leave the gate, go to `/platform/ai/providers`, and toggle it on before Build Studio would open.

This adds Claude as a first-class suggested runner and an **inline one-click Enable** for any code runner that's configured-but-disabled — no navigation away.

Relates to **BI-AD8955F9** (Claude-subscription code runner) — this is its UI/enablement facet.

## Changes

- **`build-studio-capability.ts`**
  - `SUGGESTED_PROVIDERS`: add `"Claude - Subscription (CLI)"`, recommended alongside the Codex CLI subscription path (both no-API-key code paths).
  - New `EnableableRunner` / `ConfiguredInactiveRunner` types + `enableableRunners` field on the closed-gate result.
  - `loadBuildStudioCapability` now also queries `ModelProvider` rows that are `status="inactive"` with `cliEngine != null` (configured/credentialed but switched off) and returns them as `enableableRunners`. `unconfigured` providers are intentionally excluded — they still need the connect flow.
  - The existing satisfying-logic already treats an enabled `anthropic-sub` as code-capable (OAuth-subscription is remote, never filtered as local); a regression test now locks that.
- **`EnableRunnerButton.tsx`** (new client component): calls `toggleProviderStatus(providerId)` → `router.refresh()`, flipping `inactive → active` so the gate re-evaluates in place.
- **`build/page.tsx`**: renders an inline Enable section for each disabled runner (gated on `manage_provider_connections`), with copy `"<runner> is connected but turned off — Enable to start building."`. Truly unconfigured/none-connected installs keep the `"Connect a provider →"` flow; the link becomes the secondary `"Connect a different provider →"` when an inline-enable option is present.

## Acceptance

- [x] Claude CLI/subscription appears as a suggested runner on the gate.
- [x] When `anthropic-sub` is `inactive`, one inline click enables it and the build flow opens with no navigation away.
- [x] An unconfigured provider still routes to the connect flow.
- [x] Capability assessment treats an enabled `anthropic-sub` as a code-capable runner (regression-tested).

## Verification

This branch was authored in a **source-only worktree** (no installed deps per AGENTS.md §5), so the runtime-bound gates — full `apps/web` vitest suite, `typecheck`, `next build` — run in **CI** on this PR rather than locally. Unit tests added/updated:

- `build-studio-capability.test.ts` — Claude in `SUGGESTED_PROVIDERS`; `enableableRunners` populated/empty cases; enabled `anthropic-sub` satisfies the gate.
- `build-studio-capability-db.test.ts` — `loadBuildStudioCapability` queries inactive CLI runners and surfaces them when the gate is closed.

Functional UX verification of the live gate (drive the disabled→Enable→build-opens path) should run on the canonical install after the governed self-upgrade deploys this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
