### PR TITLE
feat(ea): deterministic Prisma→EA data-model mirror (EP-DATA-ARCH Phase 2, BI-2167A734)

### DIFF
--- a/apps/web/lib/ea/data-model-mirror-apply.test.ts
+++ b/apps/web/lib/ea/data-model-mirror-apply.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePrismaSchema } from "../integrate/code-graph/extractors/prisma-schema-adapter";
+import { reconcileDataModelMirror, type MirrorPrismaClient } from "./data-model-mirror-apply";
+import { modelSourceKey } from "./data-model-mirror";
+
+const SCHEMA = `
+model User {
+  id    String @id
+  posts Post[]
+}
+
+model Post {
+  id       String @id
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id])
+  @@index([authorId])
+}
+`;
+
+type Row = { id: string; properties: Record<string, unknown> };
+
+function matchesWhere(row: Row, where: Record<string, unknown> | undefined): boolean {
+  if (!where) return true;
+  if (typeof where.id === "string") return row.id === where.id;
+  const props = where.properties as { path?: string[]; string_starts_with?: string } | undefined;
+  if (props?.path?.[0] === "sourceKey" && typeof props.string_starts_with === "string") {
+    return String(row.properties.sourceKey ?? "").startsWith(props.string_starts_with);
+  }
+  return true;
+}
+
+/** In-memory MirrorPrismaClient backed by simple Maps. */
+function makeClient(seed?: { elements?: Row[]; relationships?: Row[] }) {
+  const elements = new Map<string, Row>((seed?.elements ?? []).map((r) => [r.id, r]));
+  const relationships = new Map<string, Row>((seed?.relationships ?? []).map((r) => [r.id, r]));
+  const viewElements: Array<{ viewId: string; elementId: string }> = [];
+  const snapshots: Array<Record<string, unknown>> = [];
+  const issues: Array<Record<string, unknown>> = [];
+  let seq = 0;
+  const nextId = (p: string) => `${p}-${++seq}`;
+
+  const elementStore = (map: Map<string, Row>, prefix: string) => ({
+    findMany: async (args: Record<string, unknown>) =>
+      [...map.values()]
+        .filter((r) => matchesWhere(r, args.where as Record<string, unknown>))
+        .map((r) => ({ id: r.id, properties: r.properties })),
+    create: async (args: Record<string, unknown>) => {
+      const data = args.data as Record<string, unknown>;
+      const id = nextId(prefix);
+      map.set(id, { id, properties: (data.properties ?? {}) as Record<string, unknown> });
+      return { id };
+    },
+    update: async (args: Record<string, unknown>) => {
+      const id = (args.where as { id: string }).id;
+      const data = args.data as Record<string, unknown>;
+      const row = map.get(id);
+      if (row && data.properties) row.properties = data.properties as Record<string, unknown>;
+      return { id };
+    },
+  });
+
+  const client: MirrorPrismaClient = {
+    eaNotation: { findUnique: async () => ({ id: "not-1", slug: "archimate4" }) },
+    eaElementType: { findUnique: async () => ({ id: "et-do", neoLabel: "ArchiMate__DataObject", slug: "data_object" }) },
+    eaRelationshipType: { findUnique: async () => ({ id: "rt-assoc", neoType: "ASSOCIATED_WITH", slug: "associated_with" }) },
+    viewpointDefinition: { upsert: async () => ({ id: "vp-1" }) },
+    eaView: {
+      findFirst: async () => null,
+      create: async () => ({ id: "view-1" }),
+    },
+    eaElement: elementStore(elements, "el"),
+    eaRelationship: elementStore(relationships, "rel"),
+    eaViewElement: {
+      findFirst: async (args: Record<string, unknown>) => {
+        const w = args.where as { viewId: string; elementId: string };
+        return viewElements.find((v) => v.viewId === w.viewId && v.elementId === w.elementId)
+          ? { id: "vm" }
+          : null;
+      },
+      create: async (args: Record<string, unknown>) => {
+        const data = args.data as { viewId: string; elementId: string };
+        viewElements.push({ viewId: data.viewId, elementId: data.elementId });
+        return { id: nextId("vm") };
+      },
+    },
+    eaSnapshot: {
+      create: async (args: Record<string, unknown>) => {
+        snapshots.push(args.data as Record<string, unknown>);
+        return { id: nextId("snap") };
+      },
+    },
+    eaConformanceIssue: {
+      findFirst: async () => null,
+      create: async (args: Record<string, unknown>) => {
+        issues.push(args.data as Record<string, unknown>);
+        return { id: nextId("issue") };
+      },
+    },
+  };
+
+  return { client, elements, relationships, viewElements, snapshots, issues };
+}
+
+const facts = parsePrismaSchema(SCHEMA);
+
+describe("reconcileDataModelMirror", () => {
+  it("first run creates data_object elements + relationships, view membership, and a snapshot", async () => {
+    const m = makeClient();
+    const result = await reconcileDataModelMirror({ prisma: m.client, facts });
+
+    expect(result.status).toBe("applied");
+    expect(result.snapshotWritten).toBe(true);
+    expect(result.summary.created).toBeGreaterThan(0);
+
+    // One element per model, keyed by stable source key.
+    const sourceKeys = [...m.elements.values()].map((r) => r.properties.sourceKey);
+    expect(sourceKeys).toEqual(expect.arrayContaining([modelSourceKey("User"), modelSourceKey("Post")]));
+    expect(m.relationships.size).toBeGreaterThanOrEqual(2);
+    expect(m.viewElements.length).toBe(2);
+    expect(m.snapshots).toHaveLength(1);
+  });
+
+  it("is idempotent end-to-end — a second reconcile is a noop with no snapshot", async () => {
+    const m = makeClient();
+    await reconcileDataModelMirror({ prisma: m.client, facts });
+    const elementsAfterFirst = m.elements.size;
+    const snapshotsAfterFirst = m.snapshots.length;
+
+    const second = await reconcileDataModelMirror({ prisma: m.client, facts });
+    expect(second.status).toBe("noop");
+    expect(second.snapshotWritten).toBe(false);
+    expect(m.elements.size).toBe(elementsAfterFirst);
+    expect(m.snapshots.length).toBe(snapshotsAfterFirst);
+  });
+
+  it("marks removed an element whose model left the schema", async () => {
+    const m = makeClient({
+      elements: [
+        {
+          id: "el-gone",
+          properties: { sourceKey: modelSourceKey("Gone"), descriptor: "x", mirrorRemoved: false },
+        },
+      ],
+    });
+    await reconcileDataModelMirror({ prisma: m.client, facts });
+    expect(m.elements.get("el-gone")?.properties.mirrorRemoved).toBe(true);
+  });
+
+  it("blocks and writes a conformance issue on a duplicate source key", async () => {
+    const dupKey = modelSourceKey("User");
+    const m = makeClient({
+      elements: [
+        { id: "dup-a", properties: { sourceKey: dupKey, descriptor: "a", mirrorRemoved: false } },
+        { id: "dup-b", properties: { sourceKey: dupKey, descriptor: "b", mirrorRemoved: false } },
+      ],
+    });
+    const result = await reconcileDataModelMirror({ prisma: m.client, facts });
+
+    expect(result.status).toBe("blocked");
+    expect(result.duplicateIssues).toBeGreaterThan(0);
+    expect(m.issues.length).toBeGreaterThan(0);
+    expect(m.issues[0].issueType).toBe("mirror-duplicate-source-key");
+    // No new elements created while blocked (only the two seeded duplicates remain).
+    expect(m.elements.size).toBe(2);
+    expect(m.snapshots).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/ea/data-model-mirror-apply.ts
+++ b/apps/web/lib/ea/data-model-mirror-apply.ts
@@ -1,0 +1,362 @@
+// Data-model mirror applier — EP-DATA-ARCH Phase 2 (BI-2167A734).
+//
+// Thin IO layer over the pure `planMirror` diff: resolves the EA context
+// (archimate4 notation, data_object element type, associated_with relationship
+// type), ensures the managed "Data Model" view exists, loads existing mirror
+// rows, applies the plan, writes an EaSnapshot on material delta, and (when a
+// source key is duplicated) writes a conformance issue and stops.
+//
+// Neo4j sync is optional and injected so the Postgres reconcile is testable
+// without a live graph.
+
+import {
+  planMirror,
+  summarizePlan,
+  describeChange,
+  DATA_MODEL_MIRROR_VERSION,
+  MODEL_SOURCE_KEY_PREFIX,
+  RELATION_SOURCE_KEY_PREFIX,
+  type DesiredElement,
+  type DesiredRelationship,
+  type ExistingMirrorRow,
+  type MirrorPlan,
+} from "./data-model-mirror";
+import type { Prisma } from "@dpf/db";
+import type { PrismaSchemaFacts } from "../integrate/code-graph/extractors/prisma-schema-adapter";
+
+const NOTATION_SLUG = "archimate4";
+const ELEMENT_TYPE_SLUG = "data_object";
+const RELATIONSHIP_TYPE_SLUG = "associated_with";
+const VIEWPOINT_NAME = "Data Model";
+const VIEW_SCOPE_TYPE = "data-model";
+const VIEW_SCOPE_REF = "prisma";
+const DUPLICATE_ISSUE_TYPE = "mirror-duplicate-source-key";
+
+// Narrow client surface (cast from the real prisma client, like state-store.ts).
+export type MirrorPrismaClient = {
+  eaNotation: { findUnique(args: Record<string, unknown>): Promise<{ id: string; slug: string } | null> };
+  eaElementType: { findUnique(args: Record<string, unknown>): Promise<{ id: string; neoLabel: string; slug: string } | null> };
+  eaRelationshipType: { findUnique(args: Record<string, unknown>): Promise<{ id: string; neoType: string; slug: string } | null> };
+  viewpointDefinition: { upsert(args: Record<string, unknown>): Promise<{ id: string }> };
+  eaView: {
+    findFirst(args: Record<string, unknown>): Promise<{ id: string } | null>;
+    create(args: Record<string, unknown>): Promise<{ id: string }>;
+  };
+  eaElement: {
+    findMany(args: Record<string, unknown>): Promise<Array<{ id: string; properties: unknown }>>;
+    create(args: Record<string, unknown>): Promise<{ id: string }>;
+    update(args: Record<string, unknown>): Promise<unknown>;
+  };
+  eaRelationship: {
+    findMany(args: Record<string, unknown>): Promise<Array<{ id: string; properties: unknown }>>;
+    create(args: Record<string, unknown>): Promise<{ id: string }>;
+    update(args: Record<string, unknown>): Promise<unknown>;
+  };
+  eaViewElement: {
+    findFirst(args: Record<string, unknown>): Promise<{ id: string } | null>;
+    create(args: Record<string, unknown>): Promise<{ id: string }>;
+  };
+  eaSnapshot: { create(args: Record<string, unknown>): Promise<{ id: string }> };
+  eaConformanceIssue: {
+    findFirst(args: Record<string, unknown>): Promise<{ id: string } | null>;
+    create(args: Record<string, unknown>): Promise<{ id: string }>;
+  };
+};
+
+export type MirrorContext = {
+  notationId: string;
+  notationSlug: string;
+  elementTypeId: string;
+  relationshipTypeId: string;
+  viewId: string;
+};
+
+export type MirrorResult = {
+  status: "applied" | "noop" | "blocked";
+  summary: ReturnType<typeof summarizePlan>;
+  snapshotWritten: boolean;
+  duplicateIssues: number;
+  viewId: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function toExistingRow(row: { id: string; properties: unknown }): ExistingMirrorRow {
+  const props = asRecord(row.properties);
+  return {
+    id: row.id,
+    sourceKey: String(props.sourceKey ?? ""),
+    descriptor: String(props.descriptor ?? ""),
+    removed: props.mirrorRemoved === true,
+  };
+}
+
+export async function resolveMirrorContext(prisma: MirrorPrismaClient): Promise<MirrorContext> {
+  const notation = await prisma.eaNotation.findUnique({ where: { slug: NOTATION_SLUG } });
+  if (!notation) throw new Error(`EA notation '${NOTATION_SLUG}' not found — seed the ArchiMate 4 notation first.`);
+
+  const elementType = await prisma.eaElementType.findUnique({
+    where: { notationId_slug: { notationId: notation.id, slug: ELEMENT_TYPE_SLUG } },
+  });
+  if (!elementType) throw new Error(`EA element type '${ELEMENT_TYPE_SLUG}' not found for notation '${NOTATION_SLUG}'.`);
+
+  const relationshipType = await prisma.eaRelationshipType.findUnique({
+    where: { notationId_slug: { notationId: notation.id, slug: RELATIONSHIP_TYPE_SLUG } },
+  });
+  if (!relationshipType) {
+    throw new Error(`EA relationship type '${RELATIONSHIP_TYPE_SLUG}' not found for notation '${NOTATION_SLUG}'.`);
+  }
+
+  const viewId = await ensureDataModelView(prisma, notation.id);
+
+  return {
+    notationId: notation.id,
+    notationSlug: notation.slug,
+    elementTypeId: elementType.id,
+    relationshipTypeId: relationshipType.id,
+    viewId,
+  };
+}
+
+export async function ensureDataModelView(prisma: MirrorPrismaClient, notationId: string): Promise<string> {
+  const viewpoint = await prisma.viewpointDefinition.upsert({
+    where: { name: VIEWPOINT_NAME },
+    update: {
+      description: "Logical data model mirrored from the Prisma schema.",
+      allowedElementTypeSlugs: [ELEMENT_TYPE_SLUG],
+      allowedRelTypeSlugs: [RELATIONSHIP_TYPE_SLUG],
+    },
+    create: {
+      name: VIEWPOINT_NAME,
+      description: "Logical data model mirrored from the Prisma schema.",
+      allowedElementTypeSlugs: [ELEMENT_TYPE_SLUG],
+      allowedRelTypeSlugs: [RELATIONSHIP_TYPE_SLUG],
+    },
+  });
+
+  const existing = await prisma.eaView.findFirst({
+    where: { scopeType: VIEW_SCOPE_TYPE, scopeRef: VIEW_SCOPE_REF },
+  });
+  if (existing) return existing.id;
+
+  const created = await prisma.eaView.create({
+    data: {
+      notationId,
+      name: "Data Model",
+      description: "Live ERD mirrored from the Prisma schema (system-owned).",
+      layoutType: "graph",
+      scopeType: VIEW_SCOPE_TYPE,
+      scopeRef: VIEW_SCOPE_REF,
+      viewpointId: viewpoint.id,
+      status: "draft",
+    },
+  });
+  return created.id;
+}
+
+export async function loadExistingMirror(prisma: MirrorPrismaClient): Promise<{
+  elements: ExistingMirrorRow[];
+  relationships: ExistingMirrorRow[];
+}> {
+  const elementRows = await prisma.eaElement.findMany({
+    where: { properties: { path: ["sourceKey"], string_starts_with: MODEL_SOURCE_KEY_PREFIX } },
+    select: { id: true, properties: true },
+  });
+  const relationshipRows = await prisma.eaRelationship.findMany({
+    where: { properties: { path: ["sourceKey"], string_starts_with: RELATION_SOURCE_KEY_PREFIX } },
+    select: { id: true, properties: true },
+  });
+  return {
+    elements: elementRows.map(toExistingRow),
+    relationships: relationshipRows.map(toExistingRow),
+  };
+}
+
+async function writeDuplicateIssues(
+  prisma: MirrorPrismaClient,
+  viewId: string,
+  plan: MirrorPlan,
+): Promise<number> {
+  let written = 0;
+  for (const conflict of plan.duplicates) {
+    const existing = await prisma.eaConformanceIssue.findFirst({
+      where: { issueType: DUPLICATE_ISSUE_TYPE, status: "open", viewId },
+    });
+    // One open umbrella issue per source key; skip if an identical open one exists.
+    if (existing) continue;
+    await prisma.eaConformanceIssue.create({
+      data: {
+        viewId,
+        issueType: DUPLICATE_ISSUE_TYPE,
+        severity: "error",
+        status: "open",
+        message: `Mirror source key '${conflict.sourceKey}' maps to ${conflict.ids.length} ${conflict.scope} rows; reconcile halted to avoid duplication.`,
+        detailsJson: { scope: conflict.scope, sourceKey: conflict.sourceKey, ids: conflict.ids },
+      },
+    });
+    written += 1;
+  }
+  return written;
+}
+
+export function elementCreateData(ctx: MirrorContext, desired: DesiredElement) {
+  return {
+    elementTypeId: ctx.elementTypeId,
+    name: desired.name,
+    lifecycleStage: "production",
+    lifecycleStatus: "active",
+    infraCiKey: desired.sourceKey,
+    properties: {
+      ...desired.properties,
+      descriptor: desired.descriptor,
+      mirrorRemoved: false,
+    } as Prisma.InputJsonValue,
+  };
+}
+
+export function relationshipCreateData(
+  ctx: MirrorContext,
+  desired: DesiredRelationship,
+  fromElementId: string,
+  toElementId: string,
+) {
+  return {
+    fromElementId,
+    toElementId,
+    relationshipTypeId: ctx.relationshipTypeId,
+    notationSlug: ctx.notationSlug,
+    properties: {
+      ...desired.properties,
+      descriptor: desired.descriptor,
+      mirrorRemoved: false,
+    } as Prisma.InputJsonValue,
+  };
+}
+
+/**
+ * Reconcile the Prisma data model into the EA substrate. Deterministic and
+ * idempotent: a no-delta run performs no writes and no snapshot.
+ */
+export async function reconcileDataModelMirror(deps: {
+  prisma: MirrorPrismaClient;
+  facts: PrismaSchemaFacts;
+  createdById?: string | null;
+  syncNeo4j?: (ctx: MirrorContext) => Promise<void>;
+}): Promise<MirrorResult> {
+  const { prisma, facts } = deps;
+  const ctx = await resolveMirrorContext(prisma);
+  const existing = await loadExistingMirror(prisma);
+  const plan = planMirror(facts, existing);
+  const summary = summarizePlan(plan);
+
+  if (plan.blocked) {
+    const duplicateIssues = await writeDuplicateIssues(prisma, ctx.viewId, plan);
+    return { status: "blocked", summary, snapshotWritten: false, duplicateIssues, viewId: ctx.viewId };
+  }
+
+  if (!plan.material) {
+    return { status: "noop", summary, snapshotWritten: false, duplicateIssues: 0, viewId: ctx.viewId };
+  }
+
+  // sourceKey -> elementId, seeded with existing rows then extended by creates.
+  const elementIdByKey = new Map<string, string>();
+  for (const row of existing.elements) elementIdByKey.set(row.sourceKey, row.id);
+
+  // 1) Elements first (relationships need their endpoint ids).
+  for (const op of plan.elementOps) {
+    if (op.kind === "create") {
+      const created = await prisma.eaElement.create({
+        data: { ...elementCreateData(ctx, op.desired), createdById: deps.createdById ?? null },
+      });
+      elementIdByKey.set(op.desired.sourceKey, created.id);
+      await ensureViewMembership(prisma, ctx.viewId, created.id);
+    } else if (op.kind === "update" || op.kind === "revive") {
+      await prisma.eaElement.update({
+        where: { id: op.id },
+        data: {
+          name: op.desired.name,
+          lifecycleStatus: "active",
+          properties: { ...op.desired.properties, descriptor: op.desired.descriptor, mirrorRemoved: false },
+        },
+      });
+      elementIdByKey.set(op.desired.sourceKey, op.id);
+      await ensureViewMembership(prisma, ctx.viewId, op.id);
+    } else if (op.kind === "remove") {
+      await markRemoved(prisma, "eaElement", op.id);
+    }
+  }
+
+  // 2) Relationships.
+  for (const op of plan.relationshipOps) {
+    if (op.kind === "create") {
+      const fromId = elementIdByKey.get(op.desired.fromSourceKey);
+      const toId = elementIdByKey.get(op.desired.toSourceKey);
+      if (!fromId || !toId) continue; // endpoint missing (defensive); skip.
+      await prisma.eaRelationship.create({
+        data: { ...relationshipCreateData(ctx, op.desired, fromId, toId), createdById: deps.createdById ?? null },
+      });
+    } else if (op.kind === "update" || op.kind === "revive") {
+      await prisma.eaRelationship.update({
+        where: { id: op.id },
+        data: { properties: { ...op.desired.properties, descriptor: op.desired.descriptor, mirrorRemoved: false } },
+      });
+    } else if (op.kind === "remove") {
+      await markRemoved(prisma, "eaRelationship", op.id);
+    }
+  }
+
+  // 3) Snapshot on material delta (evolution history).
+  const activeElements = facts.models.length;
+  const activeRelationships = plan.relationshipOps.length + existing.relationships.filter((r) => !r.removed).length;
+  await prisma.eaSnapshot.create({
+    data: {
+      viewId: ctx.viewId,
+      elementCount: activeElements,
+      relationshipCount: activeRelationships,
+      changeSummary: `Mirror reconcile: ${describeChange(summary)}.`,
+      graphJson: {
+        mirror: DATA_MODEL_MIRROR_VERSION,
+        summary,
+        models: facts.models.length,
+        relations: facts.relations.length,
+      },
+    },
+  });
+
+  if (deps.syncNeo4j) {
+    try {
+      await deps.syncNeo4j(ctx);
+    } catch {
+      // Neo4j projection is best-effort; Postgres remains the source of truth.
+    }
+  }
+
+  return { status: "applied", summary, snapshotWritten: true, duplicateIssues: 0, viewId: ctx.viewId };
+}
+
+async function ensureViewMembership(
+  prisma: MirrorPrismaClient,
+  viewId: string,
+  elementId: string,
+): Promise<void> {
+  const existing = await prisma.eaViewElement.findFirst({ where: { viewId, elementId } });
+  if (existing) return;
+  await prisma.eaViewElement.create({ data: { viewId, elementId, mode: "existing" } });
+}
+
+async function markRemoved(
+  prisma: MirrorPrismaClient,
+  model: "eaElement" | "eaRelationship",
+  id: string,
+): Promise<void> {
+  // Mark-removed via a JSON merge flag; never hard-delete (Never wipe to fix).
+  const client = prisma[model];
+  const current =
+    model === "eaElement"
+      ? await prisma.eaElement.findMany({ where: { id }, select: { id: true, properties: true } })
+      : await prisma.eaRelationship.findMany({ where: { id }, select: { id: true, properties: true } });
+  const props = asRecord(current[0]?.properties);
+  await client.update({ where: { id }, data: { properties: { ...props, mirrorRemoved: true } } });
+}

--- a/apps/web/lib/ea/data-model-mirror-apply.typecheck.ts
+++ b/apps/web/lib/ea/data-model-mirror-apply.typecheck.ts
@@ -1,0 +1,79 @@
+// Compile-time guard for EP-DATA-ARCH Phase 2 (BI-2167A734).
+//
+// The mirror applier writes through a narrow MirrorPrismaClient interface for
+// testability, which means `tsc` does NOT otherwise validate the create/update
+// payload field names against the real Prisma schema. This file passes the
+// exact payloads through the REAL prisma client types. It is never executed
+// (no DB connection) — it exists purely so `tsc --noEmit` fails if any EA
+// field name or shape drifts from the schema.
+
+import { prisma, type Prisma } from "@dpf/db";
+
+import { elementCreateData, relationshipCreateData, type MirrorContext } from "./data-model-mirror-apply";
+import type { DesiredElement, DesiredRelationship } from "./data-model-mirror";
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function __typecheckMirrorWrites(): Promise<void> {
+  // Guarded so this never runs even if accidentally imported at runtime.
+  if (process.env.__NEVER__ !== "1") return;
+
+  const ctx = {} as MirrorContext;
+  const el = {} as DesiredElement;
+  const rel = {} as DesiredRelationship;
+
+  await prisma.eaElement.create({ data: { ...elementCreateData(ctx, el), createdById: null } });
+  await prisma.eaElement.update({
+    where: { id: "x" },
+    data: { name: "n", lifecycleStatus: "active", properties: {} as Prisma.InputJsonValue },
+  });
+
+  await prisma.eaRelationship.create({
+    data: { ...relationshipCreateData(ctx, rel, "from", "to"), createdById: null },
+  });
+  await prisma.eaRelationship.update({
+    where: { id: "x" },
+    data: { properties: {} as Prisma.InputJsonValue },
+  });
+
+  await prisma.eaViewElement.create({ data: { viewId: "v", elementId: "e", mode: "existing" } });
+
+  await prisma.eaSnapshot.create({
+    data: {
+      viewId: "v",
+      elementCount: 1,
+      relationshipCount: 1,
+      changeSummary: "summary",
+      graphJson: {} as Prisma.InputJsonValue,
+    },
+  });
+
+  await prisma.eaConformanceIssue.create({
+    data: {
+      viewId: "v",
+      issueType: "mirror-duplicate-source-key",
+      severity: "error",
+      status: "open",
+      message: "m",
+      detailsJson: {} as Prisma.InputJsonValue,
+    },
+  });
+
+  await prisma.eaView.create({
+    data: {
+      notationId: "n",
+      name: "Data Model",
+      description: "d",
+      layoutType: "graph",
+      scopeType: "data-model",
+      scopeRef: "prisma",
+      viewpointId: "vp",
+      status: "draft",
+    },
+  });
+
+  await prisma.viewpointDefinition.upsert({
+    where: { name: "Data Model" },
+    update: { description: "d", allowedElementTypeSlugs: ["data_object"], allowedRelTypeSlugs: ["associated_with"] },
+    create: { name: "Data Model", description: "d", allowedElementTypeSlugs: ["data_object"], allowedRelTypeSlugs: ["associated_with"] },
+  });
+}

--- a/apps/web/lib/ea/data-model-mirror.test.ts
+++ b/apps/web/lib/ea/data-model-mirror.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePrismaSchema } from "../integrate/code-graph/extractors/prisma-schema-adapter";
+import {
+  buildDesiredState,
+  planMirror,
+  summarizePlan,
+  modelSourceKey,
+  type ExistingMirrorRow,
+} from "./data-model-mirror";
+
+const SCHEMA = `
+model User {
+  id    String @id
+  posts Post[]
+}
+
+model Post {
+  id       String @id
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id])
+  @@index([authorId])
+}
+`;
+
+const facts = parsePrismaSchema(SCHEMA);
+
+/** Build existing mirror rows that exactly match the desired state. */
+function existingMatching(): { elements: ExistingMirrorRow[]; relationships: ExistingMirrorRow[] } {
+  const desired = buildDesiredState(facts);
+  return {
+    elements: desired.elements.map((entry, i) => ({
+      id: `el-${i}`,
+      sourceKey: entry.sourceKey,
+      descriptor: entry.descriptor,
+      removed: false,
+    })),
+    relationships: desired.relationships.map((entry, i) => ({
+      id: `rel-${i}`,
+      sourceKey: entry.sourceKey,
+      descriptor: entry.descriptor,
+      removed: false,
+    })),
+  };
+}
+
+describe("planMirror", () => {
+  it("first run against an empty mirror creates everything (material)", () => {
+    const plan = planMirror(facts, { elements: [], relationships: [] });
+    expect(plan.blocked).toBe(false);
+    expect(plan.material).toBe(true);
+    expect(plan.elementOps.every((op) => op.kind === "create")).toBe(true);
+    expect(plan.elementOps).toHaveLength(2); // User, Post
+    expect(plan.relationshipOps.length).toBeGreaterThanOrEqual(2); // User->Post, Post->User
+    expect(plan.relationshipOps.every((op) => op.kind === "create")).toBe(true);
+  });
+
+  it("is idempotent — re-running against a matching mirror yields no ops and is not material", () => {
+    const plan = planMirror(facts, existingMatching());
+    expect(plan.elementOps).toHaveLength(0);
+    expect(plan.relationshipOps).toHaveLength(0);
+    expect(plan.material).toBe(false);
+    expect(plan.blocked).toBe(false);
+  });
+
+  it("creates only the newly-added model", () => {
+    const existing = existingMatching();
+    // Drop Post so it looks newly added.
+    const postKey = modelSourceKey("Post");
+    existing.elements = existing.elements.filter((e) => e.sourceKey !== postKey);
+    existing.relationships = existing.relationships.filter((r) => !r.sourceKey.includes(":Post:"));
+
+    const plan = planMirror(facts, existing);
+    const created = plan.elementOps.filter((op) => op.kind === "create");
+    expect(created).toHaveLength(1);
+    expect(created[0].kind === "create" && created[0].desired.name).toBe("Post");
+    expect(plan.material).toBe(true);
+  });
+
+  it("updates a model whose descriptor changed", () => {
+    const existing = existingMatching();
+    const userRow = existing.elements.find((e) => e.sourceKey === modelSourceKey("User"))!;
+    userRow.descriptor = "stale-descriptor";
+
+    const plan = planMirror(facts, existing);
+    const updates = plan.elementOps.filter((op) => op.kind === "update");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].kind === "update" && updates[0].id).toBe(userRow.id);
+  });
+
+  it("marks removed a mirror element no longer in the schema", () => {
+    const existing = existingMatching();
+    existing.elements.push({
+      id: "el-orphan",
+      sourceKey: modelSourceKey("DeletedModel"),
+      descriptor: "whatever",
+      removed: false,
+    });
+
+    const plan = planMirror(facts, existing);
+    const removals = plan.elementOps.filter((op) => op.kind === "remove");
+    expect(removals).toHaveLength(1);
+    expect(removals[0].kind === "remove" && removals[0].id).toBe("el-orphan");
+  });
+
+  it("revives a previously-removed element that reappears in the schema", () => {
+    const existing = existingMatching();
+    const userRow = existing.elements.find((e) => e.sourceKey === modelSourceKey("User"))!;
+    userRow.removed = true;
+
+    const plan = planMirror(facts, existing);
+    const revives = plan.elementOps.filter((op) => op.kind === "revive");
+    expect(revives).toHaveLength(1);
+    expect(revives[0].kind === "revive" && revives[0].id).toBe(userRow.id);
+  });
+
+  it("does not re-remove an already-removed orphan (idempotent removal)", () => {
+    const existing = existingMatching();
+    existing.elements.push({
+      id: "el-orphan",
+      sourceKey: modelSourceKey("DeletedModel"),
+      descriptor: "whatever",
+      removed: true,
+    });
+    const plan = planMirror(facts, existing);
+    expect(plan.elementOps.filter((op) => op.kind === "remove")).toHaveLength(0);
+    expect(plan.material).toBe(false);
+  });
+
+  it("blocks (no ops) when a source key maps to duplicate active rows", () => {
+    const existing = existingMatching();
+    const userRow = existing.elements.find((e) => e.sourceKey === modelSourceKey("User"))!;
+    existing.elements.push({ ...userRow, id: "el-dup" });
+
+    const plan = planMirror(facts, existing);
+    expect(plan.blocked).toBe(true);
+    expect(plan.elementOps).toHaveLength(0);
+    expect(plan.relationshipOps).toHaveLength(0);
+    expect(plan.material).toBe(false);
+    expect(plan.duplicates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ scope: "element", sourceKey: modelSourceKey("User") }),
+      ]),
+    );
+  });
+
+  it("summarizePlan counts ops by kind", () => {
+    const plan = planMirror(facts, { elements: [], relationships: [] });
+    const summary = summarizePlan(plan);
+    expect(summary.created).toBeGreaterThan(0);
+    expect(summary.updated).toBe(0);
+    expect(summary.removed).toBe(0);
+  });
+});

--- a/apps/web/lib/ea/data-model-mirror.ts
+++ b/apps/web/lib/ea/data-model-mirror.ts
@@ -1,0 +1,328 @@
+// Data-model mirror — EP-DATA-ARCH Phase 2 (BI-2167A734).
+//
+// Deterministic, idempotent projection of the Prisma data model into the EA
+// substrate: one `data_object` EaElement per model, one EaRelationship per
+// Prisma relation (carrying cardinality + FK metadata in `properties`). The
+// mirror owns factual structure; the Data Architect steward (Phase 4) adds
+// judgment on top without mutating mirror-owned rows.
+//
+// Identity is a stable source key stored in `properties.sourceKey` (and, for
+// elements, `infraCiKey`):
+//   element      prisma:model:<ModelName>
+//   relationship prisma:relation:<FromModel>:<fieldName>:<ToModel>
+//
+// The core diff (`planMirror`) is pure and fully unit-tested; DB/Neo4j writes
+// are a thin applier layered on top.
+
+import type {
+  PrismaSchemaFacts,
+  PrismaModelFact,
+  PrismaRelationFact,
+} from "../integrate/code-graph/extractors/prisma-schema-adapter";
+
+export const DATA_MODEL_MIRROR_VERSION = "data-model-mirror-v1";
+export const MODEL_SOURCE_KEY_PREFIX = "prisma:model:";
+export const RELATION_SOURCE_KEY_PREFIX = "prisma:relation:";
+
+export function modelSourceKey(modelName: string): string {
+  return `${MODEL_SOURCE_KEY_PREFIX}${modelName}`;
+}
+
+export function relationSourceKey(relation: {
+  fromModel: string;
+  fieldName: string;
+  toModel: string;
+}): string {
+  return `${RELATION_SOURCE_KEY_PREFIX}${relation.fromModel}:${relation.fieldName}:${relation.toModel}`;
+}
+
+// ---------------------------------------------------------------------------
+// Desired state (derived purely from parsed Prisma facts)
+// ---------------------------------------------------------------------------
+
+export type DesiredElement = {
+  sourceKey: string;
+  name: string;
+  properties: Record<string, unknown>;
+  /** Stable signature of mutable content; drives change detection. */
+  descriptor: string;
+};
+
+export type DesiredRelationship = {
+  sourceKey: string;
+  fromSourceKey: string;
+  toSourceKey: string;
+  properties: Record<string, unknown>;
+  descriptor: string;
+};
+
+function modelElementProperties(model: PrismaModelFact): Record<string, unknown> {
+  return {
+    sourceKey: modelSourceKey(model.name),
+    mirror: DATA_MODEL_MIRROR_VERSION,
+    model: model.name,
+    mappedTable: model.mappedTable,
+    isIgnored: model.isIgnored,
+    fieldCount: model.fields.length,
+    fields: model.fields.map((field) => ({
+      name: field.name,
+      type: field.rawType,
+      kind: field.kind,
+      isList: field.isList,
+      isRequired: field.isRequired,
+      isId: field.isId,
+      isUnique: field.isUnique,
+      mappedColumn: field.mappedColumn,
+    })),
+  };
+}
+
+function relationProperties(relation: PrismaRelationFact): Record<string, unknown> {
+  return {
+    sourceKey: relationSourceKey(relation),
+    mirror: DATA_MODEL_MIRROR_VERSION,
+    cardinality: relation.cardinality,
+    fieldName: relation.fieldName,
+    relationName: relation.relationName,
+    fkFields: relation.fkFields,
+    references: relation.references,
+    isFkIndexed: relation.isFkIndexed,
+  };
+}
+
+/** Stable, order-independent signature of a record's mutable content. */
+function signature(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.keys(val as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = (val as Record<string, unknown>)[key];
+          return acc;
+        }, {});
+    }
+    return val;
+  });
+}
+
+export function buildDesiredState(facts: PrismaSchemaFacts): {
+  elements: DesiredElement[];
+  relationships: DesiredRelationship[];
+} {
+  const elements: DesiredElement[] = facts.models.map((model) => {
+    const properties = modelElementProperties(model);
+    return {
+      sourceKey: modelSourceKey(model.name),
+      name: model.name,
+      properties,
+      descriptor: signature({ name: model.name, properties }),
+    };
+  });
+
+  const modelNames = new Set(facts.models.map((model) => model.name));
+  const relationships: DesiredRelationship[] = facts.relations
+    // Only mirror relations whose endpoints are both mirrored models.
+    .filter((relation) => modelNames.has(relation.fromModel) && modelNames.has(relation.toModel))
+    .map((relation) => {
+      const properties = relationProperties(relation);
+      return {
+        sourceKey: relationSourceKey(relation),
+        fromSourceKey: modelSourceKey(relation.fromModel),
+        toSourceKey: modelSourceKey(relation.toModel),
+        properties,
+        descriptor: signature(properties),
+      };
+    });
+
+  return { elements, relationships };
+}
+
+// ---------------------------------------------------------------------------
+// Existing state (read from the EA substrate, DB-agnostic shape)
+// ---------------------------------------------------------------------------
+
+export type ExistingMirrorRow = {
+  id: string;
+  sourceKey: string;
+  descriptor: string;
+  /** True once a row has been marked removed by a prior reconcile. */
+  removed: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+export type MirrorElementOp =
+  | { kind: "create"; desired: DesiredElement }
+  | { kind: "update"; id: string; desired: DesiredElement }
+  | { kind: "revive"; id: string; desired: DesiredElement }
+  | { kind: "remove"; id: string; sourceKey: string };
+
+export type MirrorRelationshipOp =
+  | { kind: "create"; desired: DesiredRelationship }
+  | { kind: "update"; id: string; desired: DesiredRelationship }
+  | { kind: "revive"; id: string; desired: DesiredRelationship }
+  | { kind: "remove"; id: string; sourceKey: string };
+
+export type DuplicateConflict = {
+  scope: "element" | "relationship";
+  sourceKey: string;
+  ids: string[];
+};
+
+export type MirrorPlan = {
+  elementOps: MirrorElementOp[];
+  relationshipOps: MirrorRelationshipOp[];
+  duplicates: DuplicateConflict[];
+  /** True when a duplicate source key blocks safe writes. */
+  blocked: boolean;
+  /** True when any structural change exists (drives snapshot-on-delta). */
+  material: boolean;
+};
+
+function indexBySourceKey(rows: ExistingMirrorRow[]): {
+  byKey: Map<string, ExistingMirrorRow>;
+  duplicates: Map<string, string[]>;
+} {
+  const grouped = new Map<string, ExistingMirrorRow[]>();
+  for (const row of rows) {
+    const list = grouped.get(row.sourceKey);
+    if (list) list.push(row);
+    else grouped.set(row.sourceKey, [row]);
+  }
+  const byKey = new Map<string, ExistingMirrorRow>();
+  const duplicates = new Map<string, string[]>();
+  for (const [sourceKey, list] of grouped) {
+    if (list.length > 1) {
+      duplicates.set(sourceKey, list.map((row) => row.id));
+    }
+    byKey.set(sourceKey, list[0]);
+  }
+  return { byKey, duplicates };
+}
+
+function diffElements(
+  desired: DesiredElement[],
+  existing: ExistingMirrorRow[],
+): { ops: MirrorElementOp[]; duplicates: DuplicateConflict[] } {
+  const { byKey, duplicates } = indexBySourceKey(existing);
+  const ops: MirrorElementOp[] = [];
+  const desiredKeys = new Set(desired.map((entry) => entry.sourceKey));
+
+  for (const entry of desired) {
+    const match = byKey.get(entry.sourceKey);
+    if (!match) {
+      ops.push({ kind: "create", desired: entry });
+    } else if (match.removed) {
+      ops.push({ kind: "revive", id: match.id, desired: entry });
+    } else if (match.descriptor !== entry.descriptor) {
+      ops.push({ kind: "update", id: match.id, desired: entry });
+    }
+  }
+
+  for (const row of existing) {
+    if (!desiredKeys.has(row.sourceKey) && !row.removed) {
+      ops.push({ kind: "remove", id: row.id, sourceKey: row.sourceKey });
+    }
+  }
+
+  const conflicts: DuplicateConflict[] = [...duplicates.entries()].map(([sourceKey, ids]) => ({
+    scope: "element",
+    sourceKey,
+    ids,
+  }));
+  return { ops, duplicates: conflicts };
+}
+
+function diffRelationships(
+  desired: DesiredRelationship[],
+  existing: ExistingMirrorRow[],
+): { ops: MirrorRelationshipOp[]; duplicates: DuplicateConflict[] } {
+  const { byKey, duplicates } = indexBySourceKey(existing);
+  const ops: MirrorRelationshipOp[] = [];
+  const desiredKeys = new Set(desired.map((entry) => entry.sourceKey));
+
+  for (const entry of desired) {
+    const match = byKey.get(entry.sourceKey);
+    if (!match) {
+      ops.push({ kind: "create", desired: entry });
+    } else if (match.removed) {
+      ops.push({ kind: "revive", id: match.id, desired: entry });
+    } else if (match.descriptor !== entry.descriptor) {
+      ops.push({ kind: "update", id: match.id, desired: entry });
+    }
+  }
+
+  for (const row of existing) {
+    if (!desiredKeys.has(row.sourceKey) && !row.removed) {
+      ops.push({ kind: "remove", id: row.id, sourceKey: row.sourceKey });
+    }
+  }
+
+  const conflicts: DuplicateConflict[] = [...duplicates.entries()].map(([sourceKey, ids]) => ({
+    scope: "relationship",
+    sourceKey,
+    ids,
+  }));
+  return { ops, duplicates: conflicts };
+}
+
+/**
+ * Pure reconcile diff. Given the desired state (from Prisma facts) and the
+ * existing mirror rows, produce the minimal set of create/update/revive/remove
+ * operations. Idempotent: re-running against an already-reconciled state yields
+ * an empty, non-material plan. If any source key maps to more than one active
+ * row, the plan is `blocked` (the applier writes a conformance issue and stops).
+ */
+export function planMirror(
+  facts: PrismaSchemaFacts,
+  existing: { elements: ExistingMirrorRow[]; relationships: ExistingMirrorRow[] },
+): MirrorPlan {
+  const desired = buildDesiredState(facts);
+  const elementDiff = diffElements(desired.elements, existing.elements);
+  const relationshipDiff = diffRelationships(desired.relationships, existing.relationships);
+
+  const duplicates = [...elementDiff.duplicates, ...relationshipDiff.duplicates];
+  const blocked = duplicates.length > 0;
+
+  const material =
+    !blocked && (elementDiff.ops.length > 0 || relationshipDiff.ops.length > 0);
+
+  return {
+    elementOps: blocked ? [] : elementDiff.ops,
+    relationshipOps: blocked ? [] : relationshipDiff.ops,
+    duplicates,
+    blocked,
+    material,
+  };
+}
+
+export type MirrorChangeSummary = {
+  created: number;
+  updated: number;
+  revived: number;
+  removed: number;
+};
+
+export function summarizePlan(plan: MirrorPlan): MirrorChangeSummary {
+  const count = (
+    ops: Array<{ kind: string }>,
+    kind: string,
+  ): number => ops.filter((op) => op.kind === kind).length;
+  return {
+    created: count(plan.elementOps, "create") + count(plan.relationshipOps, "create"),
+    updated: count(plan.elementOps, "update") + count(plan.relationshipOps, "update"),
+    revived: count(plan.elementOps, "revive") + count(plan.relationshipOps, "revive"),
+    removed: count(plan.elementOps, "remove") + count(plan.relationshipOps, "remove"),
+  };
+}
+
+export function describeChange(summary: MirrorChangeSummary): string {
+  return [
+    `${summary.created} added`,
+    `${summary.updated} updated`,
+    `${summary.revived} revived`,
+    `${summary.removed} removed`,
+  ].join(", ");
+}

--- a/packages/db/src/seed-ea-archimate4.ts
+++ b/packages/db/src/seed-ea-archimate4.ts
@@ -144,6 +144,8 @@ const RULES: RuleDef[] = [
   ["application_component", "application_component", "composed_of"],
   ["application_component", "application_service",   "serves"],
   ["application_component", "data_object",           "accesses"],
+  // Data model mirror (EP-DATA-ARCH): Prisma relations between logical data objects.
+  ["data_object",           "data_object",           "associated_with"],
   // Business internal
   ["business_actor",        "business_role",         "assigned_to"],
   ["business_capability",   "business_capability",   "associated_with"],


### PR DESCRIPTION
EP-DATA-ARCH **Phase 2** — deterministic, idempotent reconcile projecting the Prisma model into the EA substrate as `data_object` elements + relationships (with cardinality), the source of truth the Phase 3 ERD view renders. Builds on Phase 1 (#1601, merged): consumes `parsePrismaSchema`. Spec §6.2 · Plan Phase 2.

## Design — pure planner + thin IO applier
- **data-model-mirror.ts** (pure, fully tested): stable source keys (`prisma:model:<Name>`, `prisma:relation:<From>:<field>:<To>`), create/update/revive/remove diff, **duplicate-source-key detection** (blocks rather than duplicating), **materiality** (drives snapshot-on-delta).
- **data-model-mirror-apply.ts**: resolves `archimate4`/`data_object`/`associated_with`, ensures the system-owned **Data Model viewpoint + EaView**, maintains `EaViewElement` membership, writes an **EaSnapshot on material delta**, writes an **EaConformanceIssue + stops** on duplicate keys. **Mark-removed, never hard-delete.** Neo4j sync is an injected post-commit hook (wired in Phase 6).
- **seed-ea-archimate4.ts**: adds the `data_object → data_object` `associated_with` rule so mirrored relations are conformant.

## Decisions
- **No DB migration** — code-level duplicate guards + `properties.sourceKey`/`infraCiKey` identity (plan allowed deferring DB enforcement for this slice).
- **No new relationship type** — reuses `associated_with`; cardinality/FK metadata in `properties`.

## Verification
- **13 unit tests**: planner (first-run, **second-run noop/idempotent**, add/change/remove, revive, duplicate-stop, materiality) + applier end-to-end through an in-memory store (incl. second-run noop, mark-removed, blocked+conformance-issue).
- **Typecheck clean** — a typecheck-only guard passes **every EA create payload through the real Prisma client types**, so all field names are compiler-validated despite the narrow client interface used for testability.
- **Live run gated**: the worktree host can't reach the Dockerised Postgres, so the full 405-model mirror runs at **Phase 6 trigger** activation (sandbox/CI has DB access). Pure logic + compiler-validated writes + Phase 1's verified parse of the real 405-model schema cover the risk.

## Follow-on
Phase 3 (view, BI-759537CA) builds the ERD UI + snapshot timeline on the view this maintains; Phase 6 wires the trigger + Neo4j projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)