### PR TITLE
feat(ea): Data Model aspect — live ERD tab + evolution timeline (EP-DATA-ARCH Phase 3, BI-759537CA)

### DIFF
--- a/apps/web/app/(shell)/ea/data-model/page.tsx
+++ b/apps/web/app/(shell)/ea/data-model/page.tsx
@@ -1,0 +1,137 @@
+// apps/web/app/(shell)/ea/data-model/page.tsx
+// EP-DATA-ARCH Phase 3 (BI-759537CA): the Data Model aspect of the EA home.
+// Surfaces the system-owned "Data Model" EaView (a live ERD mirrored from the
+// Prisma schema) via the existing /ea/views/[id] renderer, plus the EaSnapshot
+// evolution timeline. The viewpoint host is owned by EP-ARCH-NAV; this page
+// owns the data-model content surface.
+import Link from "next/link";
+import { prisma } from "@dpf/db";
+import { EaTabNav } from "@/components/ea/EaTabNav";
+
+const MIRROR_ISSUE_TYPE = "mirror-duplicate-source-key";
+
+export default async function EaDataModelPage() {
+  const view = await prisma.eaView.findFirst({
+    where: { scopeType: "data-model", scopeRef: "prisma" },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      createdAt: true,
+      notation: { select: { name: true } },
+      _count: { select: { viewElements: true } },
+    },
+  });
+
+  const snapshots = view
+    ? await prisma.eaSnapshot.findMany({
+        where: { viewId: view.id },
+        orderBy: { id: "desc" },
+        take: 8,
+        select: { id: true, changeSummary: true, elementCount: true, relationshipCount: true },
+      })
+    : [];
+
+  const openIssues = view
+    ? await prisma.eaConformanceIssue.findMany({
+        where: { viewId: view.id, issueType: MIRROR_ISSUE_TYPE, status: "open" },
+        select: { id: true, message: true },
+      })
+    : [];
+
+  const elementCount = view?._count.viewElements ?? 0;
+  const populated = view != null && elementCount > 0;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Enterprise Architecture</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Data Model — the logical data model mirrored from the Prisma schema as a live ERD, kept current by
+          the data-architecture mirror.
+        </p>
+      </div>
+
+      <EaTabNav />
+
+      {openIssues.length > 0 && (
+        <div className="mb-4 rounded-lg border border-[var(--dpf-error)] bg-[var(--dpf-surface-1)] p-3">
+          <p className="text-xs font-semibold text-[var(--dpf-error)]">
+            Mirror halted — {openIssues.length} duplicate source-key issue{openIssues.length !== 1 ? "s" : ""}
+          </p>
+          <p className="mt-1 text-[11px] text-[var(--dpf-muted)]">
+            The data-model mirror stopped to avoid creating duplicate elements. Showing the last successful
+            snapshot below until the conflict is resolved.
+          </p>
+        </div>
+      )}
+
+      {populated ? (
+        <>
+          <Link href={`/ea/views/${view!.id}`} style={{ textDecoration: "none" }}>
+            <div className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]">
+              <p className="mb-1 font-mono text-[9px] text-[var(--dpf-muted)]">
+                {view!.notation.name} · Live ERD
+              </p>
+              <p className="mb-1 text-sm font-semibold leading-tight text-[var(--dpf-text)]">{view!.name}</p>
+              {view!.description != null && (
+                <p className="mb-1.5 line-clamp-2 text-[10px] text-[var(--dpf-muted)]">{view!.description}</p>
+              )}
+              <div className="flex items-center gap-3 text-[10px] text-[var(--dpf-muted)]">
+                <span>
+                  {elementCount} data object{elementCount !== 1 ? "s" : ""}
+                </span>
+                <span>Open the ERD →</span>
+              </div>
+            </div>
+          </Link>
+
+          <div>
+            <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+              Evolution timeline
+            </h2>
+            {snapshots.length > 0 ? (
+              <ol className="space-y-2">
+                {snapshots.map((s) => (
+                  <li
+                    key={s.id}
+                    className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+                  >
+                    <p className="text-xs text-[var(--dpf-text)]">{s.changeSummary ?? "Mirror reconcile"}</p>
+                    <p className="mt-1 text-[10px] text-[var(--dpf-muted)]">
+                      {s.elementCount} element{s.elementCount !== 1 ? "s" : ""} · {s.relationshipCount} relationship
+                      {s.relationshipCount !== 1 ? "s" : ""}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="text-[11px] text-[var(--dpf-muted)]">
+                No snapshots yet — the next mirror reconcile with changes will record one.
+              </p>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6 text-center">
+          <p className="mb-2 text-sm font-medium text-[var(--dpf-text)]">
+            {view == null
+              ? "Data Model view has not been generated yet."
+              : "The Data Model view exists but has not been populated yet."}
+          </p>
+          <p className="mb-4 text-xs text-[var(--dpf-muted)]">
+            The live ERD is mirrored from the Prisma schema by the data-architecture mirror. It runs on schema
+            changes, on a schedule, and on demand. Once it has run, the data objects and their relationships
+            appear here as an interactive ERD with an evolution timeline.
+          </p>
+          <Link
+            href="/ea/views"
+            className="text-xs font-medium text-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
+          >
+            Browse all views &amp; viewpoints →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/ea/EaTabNav.test.tsx
+++ b/apps/web/components/ea/EaTabNav.test.tsx
@@ -19,10 +19,12 @@ describe("EaTabNav", () => {
 
     expect(html).toContain(">Capability Map<");
     expect(html).toContain(">Value Streams<");
+    expect(html).toContain(">Data Model<");
     expect(html).toContain(">Reference Models<");
     expect(html).not.toContain(">Agents<");
     expect(html).toContain('href="/ea/capabilities"');
     expect(html).toContain('href="/ea/value-streams"');
+    expect(html).toContain('href="/ea/data-model"');
     expect(html).toContain('href="/ea/views"');
     expect(html).toContain('href="/ea/models"');
   });

--- a/apps/web/components/ea/EaTabNav.tsx
+++ b/apps/web/components/ea/EaTabNav.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { label: "Overview", href: "/ea" },
   { label: "Capability Map", href: "/ea/capabilities" },
   { label: "Value Streams", href: "/ea/value-streams" },
+  { label: "Data Model", href: "/ea/data-model" },
   { label: "Views & Viewpoints", href: "/ea/views" },
   { label: "Reference Models", href: "/ea/models" },
 ];

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -671,6 +671,13 @@ async function seedEaViewpoints(): Promise<void> {
       elementSlugs: ["business_capability"],
       relSlugs: ["composed_of", "associated_with"],
     },
+    {
+      // EP-DATA-ARCH: live ERD mirrored from the Prisma schema (data objects).
+      name: "Data Model",
+      description: "Logical data model mirrored from the Prisma schema as a live ERD.",
+      elementSlugs: ["data_object"],
+      relSlugs: ["associated_with"],
+    },
   ];
 
   for (const vp of viewpoints) {
@@ -682,7 +689,7 @@ async function seedEaViewpoints(): Promise<void> {
       create: { name: vp.name, description: vp.description, allowedElementTypeSlugs, allowedRelTypeSlugs },
     });
   }
-  console.log("Seeded 4 viewpoint definitions");
+  console.log(`Seeded ${viewpoints.length} viewpoint definitions`);
 
   // ── BPMN 2.0 viewpoints ───────────────────────────────────────────────
   const bpmnNotation = await prisma.eaNotation.findUnique({
@@ -752,6 +759,10 @@ async function seedEaViews(): Promise<void> {
     where: { name: "Business Architecture" },
     select: { id: true },
   });
+  const dataModelVp = await prisma.viewpointDefinition.findUnique({
+    where: { name: "Data Model" },
+    select: { id: true },
+  });
   const views = [
     {
       name: "DPF Platform — Application Architecture",
@@ -768,6 +779,16 @@ async function seedEaViews(): Promise<void> {
       scopeType: "custom",
       scopeRef: null,
       viewpointId: bizVp?.id ?? null,
+    },
+    {
+      // EP-DATA-ARCH: system-owned host view; populated by the data-model mirror
+      // (reconcileDataModelMirror finds it by scopeType+scopeRef and reuses it).
+      name: "Data Model",
+      description: "Live ERD mirrored from the Prisma schema (system-owned).",
+      layoutType: "graph",
+      scopeType: "data-model",
+      scopeRef: "prisma",
+      viewpointId: dataModelVp?.id ?? null,
     },
   ];
   for (const v of views) {


### PR DESCRIPTION
EP-DATA-ARCH **Phase 3** — surfaces the data-model mirror in the converged EA home shipped by EP-ARCH-NAV (#1603). Per the coordination contract spelled out in that epic's IA spec — *EP-ARCH-NAV owns the viewpoint host; EP-DATA-ARCH owns the content* — promoting the Data Model viewpoint to a first-class tab is the one-line addition the spec invited.

## Changes
- **seed.ts** — seed the `Data Model` ViewpointDefinition (`data_object` / `associated_with`) + a system-owned `EaView` (`scopeType="data-model"`, `scopeRef="prisma"`). The Phase 2 reconcile (#1604) finds this view by `scopeType`+`scopeRef` and reuses it, so the aspect is populated on fresh install and stays consistent with the mirror.
- **EaTabNav** — add the "Data Model" tab (+ test).
- **/ea/data-model/page.tsx** — lists the data-model view (card → existing `/ea/views/[id]` ERD renderer, **zero new viewer code**) + the **EaSnapshot evolution timeline**, with honest empty states (not-generated / exists-but-empty) and a banner when the mirror is halted by duplicate-source-key conformance issues.

## Verification
- EaTabNav unit test asserts the new tab + href.
- **Typecheck clean** — validates the page's `eaView`/`eaSnapshot`/`eaConformanceIssue` queries against the real Prisma schema.
- Theme tokens only, no hardcoded colors.
- **Live UX verification follows post-merge** on the running `/ea` home: the page can't render in the live portal until merged + rebuilt. It is a close clone of the shipped, verified value-streams aspect; the empty-state path is the default until the Phase 6 mirror trigger runs.

## Sequence
Builds on #1603 (merged, the EA home), pairs with #1604 (Phase 2 mirror, open). Phase 6 wires the mirror trigger that populates the view; once it runs, this page shows the live ERD + a real evolution timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)