### PR TITLE
docs(install): mark macOS Apple Silicon GA + document voice (STT/TTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ iwr -UseBasicParsing https://raw.githubusercontent.com/OpenDigitalProductFactory
 powershell -ExecutionPolicy Bypass -File install-dpf.ps1
 ```
 
-### macOS Apple Silicon — Early access · [full guide](docs/install/macos.md)
+### macOS Apple Silicon — **GA** · [full guide](docs/install/macos.md)
 
-The Unix installer sources helper libraries from inside the repo, so you must clone first.
+Validated end-to-end on real Apple Silicon hardware (M-series, macOS 14+). The Unix installer sources helper libraries from inside the repo, so you must clone first.
 
 ```bash
 # Step 1 — clone the repo and enter it
@@ -70,6 +70,8 @@ cd opendigitalproductfactory
 # Step 2 — run the installer
 bash install-dpf.sh
 ```
+
+**Voice works on macOS.** Speech-to-text runs out of the box (bundled `speaches` / faster-whisper service — no GPU needed). For spoken output, Apple Silicon runs a native-host TTS sidecar (Docker can't reach the Neural Engine); enable it once with `bash scripts/tts/setup-chatterbox-tts-macos.sh`. See [Voice (STT + TTS)](docs/install/macos.md#voice-stt--tts).
 
 ### Linux (native Docker) — Early access · [full guide](docs/install/linux.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -461,7 +461,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         Expect 5&ndash;10 minutes for the platform itself, plus additional time for the initial AI model download. Login credentials are shown at the end of installation and saved to <code>.admin-credentials</code> in your install directory. After installation: <code>dpf-start</code> to start, <code>dpf-stop</code> to stop.
       </div>
       <div class="note" style="margin-top:14px;">
-        <strong>Other platforms (early access &mdash; pilots wanted):</strong> the macOS Apple Silicon, native Linux, and Cloud Single-VM (AWS / GCP / Azure, with Terraform modules) installers are code-complete on <code>main</code> with green CI. Real-hardware verification reports are what graduate them from Early Access to GA &mdash; see the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/README.md#quick-start">Quick Start table</a> and the dedicated install runbooks under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">docs/install/</a>.
+        <strong>macOS Apple Silicon (GA):</strong> validated end-to-end on real Apple Silicon hardware (M-series, macOS 14+), including the voice STT + native-host TTS path &mdash; see the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/install/macos.md">macOS install guide</a>.<br>
+        <strong>Other platforms (early access &mdash; pilots wanted):</strong> the native Linux and Cloud Single-VM (AWS / GCP / Azure, with Terraform modules) installers are code-complete on <code>main</code> with green CI. Real-hardware verification reports are what graduate them from Early Access to GA &mdash; see the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/README.md#quick-start">Quick Start table</a> and the dedicated install runbooks under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">docs/install/</a>.
       </div>
     </div>
   </section>
@@ -1552,8 +1553,8 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         </tr>
         <tr>
           <td><strong>macOS workstation</strong></td>
-          <td>Early access</td>
-          <td>The macOS Apple Silicon installer is code-complete on <code>main</code> with Docker Desktop and Docker Model Runner support. Real Apple Silicon install reports are needed before GA.</td>
+          <td><strong>GA</strong></td>
+          <td>The macOS Apple Silicon installer is validated end-to-end on real Apple Silicon hardware (M-series, macOS 14+) with Docker Desktop and Docker Model Runner, including the voice STT + native-host TTS sidecar path. Verification reports on additional Mac models / macOS versions remain welcome to widen the tested matrix.</td>
         </tr>
         <tr>
           <td><strong>Cloud single-VM (AWS / GCP / Azure)</strong></td>

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -3,21 +3,19 @@
 This is the end-user install guide for the Open Digital Product Factory
 on **Apple Silicon Macs** (M1 / M2 / M3 / M4).
 
-> **Status: Early access — please try it!**
+> **Status: GA — validated on real Apple Silicon hardware.**
 >
-> The macOS installer is code-complete and passes static CI gates.
-> What it hasn't seen yet is a real install on a real Apple Silicon
-> Mac in the wild — the `macos-14` GHA runner can't nest-virtualize
-> Docker Desktop, so CI only exercises the `--dry-run` path.
+> The macOS installer has been run end-to-end on a real Apple Silicon
+> Mac (M-series, macOS 14+) and troubleshot to a working portal,
+> including the voice (STT + native-host TTS) path. The findings from
+> that validation are folded into the steps and the
+> [Troubleshooting](#troubleshooting) section below.
 >
-> **If you have an Apple Silicon Mac, you can change that.** Follow
-> the steps below, then [tell us how it went](#help-us-graduate-to-ga)
-> — both success stories and "the installer hit a wall at step X"
-> reports are equally useful. A handful of community verification
-> reports is what we need to flip this guide from "early access" to
-> "GA."
->
-> The Windows installer remains the only GA install surface today.
+> CI still only exercises the `--dry-run` path (the `macos-14` GHA
+> runner can't nest-virtualize Docker Desktop), so additional
+> verification reports on other Mac models / macOS versions remain
+> welcome — see [Verify your install](#verify-your-install). Both
+> Windows and macOS Apple Silicon are GA install surfaces today.
 
 For the architectural background, see the
 [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
@@ -211,6 +209,60 @@ LLM_BASE_URL=https://api.example.com/v1
 DPF_LLM_PROVIDER=external
 ```
 
+## Voice (STT + TTS)
+
+DPF coworkers support both voice **input** (speech-to-text) and voice
+**output** (text-to-speech). On macOS the two halves are provisioned
+differently because Docker Desktop can't reach the Apple Neural Engine.
+
+**Speech-to-text (STT) — works out of the box.** A bundled `speaches`
+(faster-whisper / distil-whisper) service runs as the `dpf-stt`
+container. It's CPU-friendly and needs no GPU, so the mic button in the
+coworker panel works immediately after install — click it, speak, and
+your words land in the message box. STT is identical across macOS,
+Linux, and Windows.
+
+**Text-to-speech (TTS) — one-time native-host step on Apple Silicon.**
+Spoken output needs a synthesis engine with hardware acceleration.
+Docker Desktop can't expose the Mac's Neural Engine to a container, so
+on Apple Silicon the TTS engine runs as a **native-host sidecar** on
+the Mac instead of in Docker. The `docker-compose.macos.yml` overlay is
+already wired to talk to it (`TTS_PROVIDER=mlx`,
+`DPF_TTS_URL=http://host.docker.internal:8771`); you just provision the
+sidecar once:
+
+```bash
+bash scripts/tts/setup-chatterbox-tts-macos.sh
+```
+
+The script is idempotent (safe to re-run), installs a launch agent so
+the sidecar restarts at login, listens on port `8771`, and writes the
+matching `TTS_PROVIDER` / `DPF_TTS_URL` / `DPF_TTS_REFERENCE_HOST_ROOT`
+values into `.env`. A **founder seed voice** ships in the install seed
+(with a consent record), so spoken output works as soon as the sidecar
+is up — no voice recording required to get started.
+
+> **Contributor installs** run this provisioning automatically as part
+> of `scripts/setup.sh`. **Customer** installs (`bash install-dpf.sh`)
+> do not, so run the command above once if you want spoken output.
+> On Linux / Windows hosts TTS uses the bundled `dpf-tts` Docker
+> container instead and needs no host-side step.
+
+Once the sidecar is running, voice output features — per-profile
+speed / enthusiasm tuning and sentence-level streaming for low
+time-to-first-audio — are available in the coworker panel. Real-person
+voice cloning always requires an explicit consent record; voice never
+changes approval, confidence, or audit rules.
+
+**If the coworker transcribes but won't speak back**, the TTS sidecar
+isn't running. Re-run the setup script and confirm the agent loaded:
+
+```bash
+bash scripts/tts/setup-chatterbox-tts-macos.sh
+launchctl list | grep -E 'mlx-tts|chatterbox-tts'
+curl -fsS http://localhost:8771/health    # sidecar health
+```
+
 ## Autostart
 
 The installer registers a LaunchAgent at:
@@ -286,13 +338,14 @@ The portal is still running at `http://localhost:3000`.
 | `bash uninstall-dpf.sh --purge --keep-env` | Purge but retain `.env`. |
 | `bash uninstall-dpf.sh --purge --keep-state` | Purge but retain `~/.dpf` install history. |
 
-## Help us graduate to GA
+## Verify your install
 
-We can't run this installer on real Apple Silicon hardware from CI
-(the GHA `macos-14` runner can't nest-virtualize Docker Desktop), so
-the path from "early access" to "GA" runs through the community.
-If you ran the install above on a real Mac, **please file a quick
-report** — happy paths and failures are equally valuable.
+macOS Apple Silicon is GA, but CI still can't run the installer on real
+hardware (the GHA `macos-14` runner can't nest-virtualize Docker
+Desktop), so verification reports from additional Mac models / macOS
+versions remain valuable for widening the tested matrix. If you ran the
+install above, **a quick report is appreciated** — happy paths and
+failures are equally useful.
 
 **One-command report (fastest path):**
 

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -6,13 +6,15 @@
 > everything CI can't reach** — and you're the person who can close
 > those gaps.
 >
-> The macOS and Linux installers are code-complete and statically
-> CI-green. They graduate to GA when the community sends us
-> verification reports from real hardware. If you have an Apple
-> Silicon Mac, a non-Ubuntu Linux box, a TAPPaaS environment, or a
-> cloud VM you can spare for an hour, **please pick a section below
-> and run through it.** Both happy-path and failure reports are
-> valuable.
+> macOS Apple Silicon is **GA** — validated end-to-end on real
+> hardware. The Linux and cloud installers are code-complete and
+> statically CI-green and graduate to GA when the community sends us
+> verification reports from real hardware. Reports still widen the
+> tested matrix on every platform, including additional Mac models /
+> macOS versions. If you have an Apple Silicon Mac, a non-Ubuntu Linux
+> box, a TAPPaaS environment, or a cloud VM you can spare for an hour,
+> **please pick a section below and run through it.** Both happy-path
+> and failure reports are valuable.
 >
 > **How to report:** open an issue using the
 > [Install verification report template](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new?template=install_verification.md)


### PR DESCRIPTION
## What

macOS Apple Silicon has been validated end-to-end on real hardware (M-series, macOS 14+), including the voice path. This updates the public-facing docs to reflect GA status and documents the voice feature.

- **README**: macOS heading `Early access` → **GA**; added a voice note (STT works out of the box; native-host TTS sidecar is a one-time step on Apple Silicon).
- **docs/install/macos.md**: replaced the early-access banner with a GA/validated banner; added a **Voice (STT + TTS)** section explaining the bundled `speaches` STT service and the Apple-Silicon native-host Chatterbox/MLX TTS sidecar (`scripts/tts/setup-chatterbox-tts-macos.sh`, port 8771, `TTS_PROVIDER=mlx`); reframed *Help us graduate to GA* → **Verify your install**.
- **docs/index.html**: split macOS out of the "early access — pilots wanted" block (now its own GA line); flipped the macOS workstation deployment-status row to **GA**.
- **docs/install/verification-runbook.md**: macOS is GA; Linux/cloud remain pre-GA.

## Why

Issue [#656](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/656) (Verify: macOS Apple Silicon end-to-end install) is complete — the install was done and troubleshot to a working portal. Issue closed; this PR brings the docs in line.

## Accuracy notes

- **STT** (`speaches`/faster-whisper, `dpf-stt` container) is cross-platform and automatic.
- **TTS** on Apple Silicon runs as a **native-host sidecar** (Docker can't reach the Neural Engine). Provisioning auto-runs in *contributor* setup (`scripts/setup.sh`); the *customer* `install-dpf.sh` path does **not** invoke it, so the guide documents the one-time `setup-chatterbox-tts-macos.sh` command. Grounded in the actual installer/compose wiring, not invented steps.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)