### PR TITLE
feat(workbooks): reveal platform grids in-place per surface + demote the standalone hub (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/app/(shell)/compliance/risks/page.tsx
+++ b/apps/web/app/(shell)/compliance/risks/page.tsx
@@ -3,11 +3,14 @@ import { RISK_LEVELS } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateRiskAssessmentForm } from "@/components/compliance/CreateRiskAssessmentForm";
 import { StatusBadge } from "@/components/ui/report-kit";
+import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
+import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 
-type Props = { searchParams: Promise<{ inherentRisk?: string; status?: string }> };
+type Props = { searchParams: Promise<{ inherentRisk?: string; status?: string; view?: string }> };
 
 export default async function RisksPage({ searchParams }: Props) {
   const sp = await searchParams;
+  const view = sp.view === "grid" || sp.view === "board" ? sp.view : null;
   const filters = {
     ...(sp.inherentRisk && { inherentRisk: sp.inherentRisk }),
     ...(sp.status && { status: sp.status }),
@@ -24,6 +27,12 @@ export default async function RisksPage({ searchParams }: Props) {
         <CreateRiskAssessmentForm />
       </div>
 
+      <SurfaceViewSwitcher entityType="risk_assessment" current={view ?? "list"} />
+
+      {view ? (
+        <SurfacePlatformGrid entityType="risk_assessment" view={view} />
+      ) : (
+        <>
       {/* Filter bar */}
       <form className="flex flex-wrap gap-3 mb-6">
         <select name="inherentRisk" defaultValue={sp.inherentRisk ?? ""}
@@ -80,6 +89,8 @@ export default async function RisksPage({ searchParams }: Props) {
             </Link>
           ))}
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/finance/invoices/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/page.tsx
@@ -5,6 +5,8 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import Link from "next/link";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
+import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -26,10 +28,11 @@ const ALL_STATUSES = [
   "paid",
 ];
 
-type Props = { searchParams: Promise<{ status?: string }> };
+type Props = { searchParams: Promise<{ status?: string; view?: string }> };
 
 export default async function InvoicesPage({ searchParams }: Props) {
-  const { status } = await searchParams;
+  const { status, view: viewParam } = await searchParams;
+  const view = viewParam === "grid" || viewParam === "board" ? viewParam : null;
 
   const [invoices, statusCounts, orgSettings] = await Promise.all([
     prisma.invoice.findMany({
@@ -87,6 +90,12 @@ export default async function InvoicesPage({ searchParams }: Props) {
 
       <FinanceTabNav />
 
+      <SurfaceViewSwitcher entityType="invoice" current={view ?? "list"} />
+
+      {view ? (
+        <SurfacePlatformGrid entityType="invoice" view={view} />
+      ) : (
+        <>
       {/* Status filter pills */}
       <div className="flex flex-wrap gap-2 mb-6">
         <Link
@@ -194,6 +203,8 @@ export default async function InvoicesPage({ searchParams }: Props) {
             </tbody>
           </table>
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -2,15 +2,19 @@
 import { getBacklogItems, getDigitalProductsForSelect, getTaxonomyNodesFlat, getEpics, getPortfoliosForSelect } from "@/lib/backlog-data";
 import { OpsClient } from "@/components/ops/OpsClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
+import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 
 export const dynamic = "force-dynamic";
 
 type Props = {
-  searchParams?: Promise<{ itemId?: string }>;
+  searchParams?: Promise<{ itemId?: string; view?: string }>;
 };
 
 export default async function OpsPage({ searchParams }: Props) {
   const sp = await searchParams;
+  const rawView = sp?.view;
+  const view = rawView === "grid" || rawView === "board" ? rawView : null;
   const [items, digitalProducts, taxonomyNodes, epics, portfolios] = await Promise.all([
     getBacklogItems(),
     getDigitalProductsForSelect(),
@@ -30,14 +34,20 @@ export default async function OpsPage({ searchParams }: Props) {
 
       <OpsTabNav />
 
-      <OpsClient
-        items={items}
-        digitalProducts={digitalProducts}
-        taxonomyNodes={taxonomyNodes}
-        epics={epics}
-        portfolios={portfolios}
-        focusedItemId={sp?.itemId}
-      />
+      <SurfaceViewSwitcher entityType="backlog_item" current={view ?? "list"} />
+
+      {view ? (
+        <SurfacePlatformGrid entityType="backlog_item" view={view} />
+      ) : (
+        <OpsClient
+          items={items}
+          digitalProducts={digitalProducts}
+          taxonomyNodes={taxonomyNodes}
+          epics={epics}
+          portfolios={portfolios}
+          focusedItemId={sp?.itemId}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/(shell)/workbooks/page.tsx
+++ b/apps/web/app/(shell)/workbooks/page.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Table2, Database } from "lucide-react";
+import { Table2 } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { listWorkbooks } from "@/lib/workbooks/workbook-service";
-import { listPlatformTablesForUser } from "@/lib/workbooks/platform-tables";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { CreateWorkbookButton } from "@/components/workbooks/CreateWorkbookButton";
 
@@ -19,11 +18,6 @@ export default async function WorkbooksHubPage() {
   }
 
   const workbooks = await listWorkbooks({ id: user.id, isSuperuser: user.isSuperuser });
-  const platformTables = listPlatformTablesForUser({
-    id: user.id,
-    platformRole: user.platformRole,
-    isSuperuser: user.isSuperuser,
-  });
   const canManage = can(
     { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
     "manage_workbooks",
@@ -76,31 +70,6 @@ export default async function WorkbooksHubPage() {
             </li>
           ))}
         </ul>
-      )}
-
-      {platformTables.length > 0 && (
-        <section className="mt-10">
-          <h2 className="mb-1 text-lg font-semibold text-[var(--dpf-text)]">Platform data</h2>
-          <p className="mb-3 text-sm text-[var(--dpf-muted)]">
-            Existing platform records, opened as live spreadsheets. Edits here are the same data as the forms.
-          </p>
-          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {platformTables.map((t) => (
-              <li key={t.entityType}>
-                <Link
-                  href={`/workbooks/system/${t.entityType}`}
-                  className="block rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition hover:bg-[var(--dpf-surface-2)]"
-                >
-                  <div className="flex items-center gap-2">
-                    <Database className="h-4 w-4 text-[var(--dpf-muted)]" />
-                    <span className="font-medium text-[var(--dpf-text)]">{t.label}</span>
-                  </div>
-                  <p className="mt-1 line-clamp-2 text-sm text-[var(--dpf-muted)]">{t.description}</p>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </section>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx
@@ -47,10 +47,10 @@ export default async function PlatformTablePage({ params, searchParams }: Props)
   return (
     <div className="mx-auto flex h-full w-full max-w-6xl flex-col p-6">
       <Link
-        href="/workbooks"
+        href={def.homeSurface.path}
         className="mb-2 inline-flex items-center gap-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
       >
-        <ChevronLeft className="h-4 w-4" /> Workbooks
+        <ChevronLeft className="h-4 w-4" /> {def.homeSurface.label}
       </Link>
 
       <div className="mb-4">

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -27,6 +27,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
     subItems: [
       { label: "Platform Hub", href: "/platform" },
       { label: "Schedule", href: "/platform/schedule" },
+      { label: "Workbooks", href: "/workbooks" },
     ],
   },
   {

--- a/apps/web/components/workbooks/SurfacePlatformGrid.tsx
+++ b/apps/web/components/workbooks/SurfacePlatformGrid.tsx
@@ -1,0 +1,67 @@
+// apps/web/components/workbooks/SurfacePlatformGrid.tsx
+// Renders a platform-data grid (the same records a form edits) embedded in its
+// home domain surface (EP-GRID-WORKBOOKS per-surface integration). Reuses the
+// existing getPlatformTableGridData + WorkbookGrid/KanbanBoard substrate — no new
+// grid code. Capability is enforced by getPlatformTableGridData (domain view/manage).
+import { auth } from "@/lib/auth";
+import {
+  getPlatformTableGridData,
+  type PlatformUser,
+} from "@/lib/workbooks/platform-tables";
+import { WorkbookError } from "@/lib/workbooks/workbook-service";
+import { defaultGroupByColumn } from "@/lib/workbooks/kanban-grouping";
+import { WorkbookGrid } from "@/components/workbooks/Grid";
+import { KanbanBoard } from "@/components/workbooks/KanbanBoard";
+
+export async function SurfacePlatformGrid({
+  entityType,
+  view,
+}: {
+  entityType: string;
+  view: "grid" | "board";
+}) {
+  const session = await auth();
+  if (!session?.user) return null;
+  const user = session.user;
+  const svcUser: PlatformUser = {
+    id: user.id,
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
+
+  let grid;
+  try {
+    grid = await getPlatformTableGridData(svcUser, entityType);
+  } catch (e) {
+    if (e instanceof WorkbookError) {
+      return <p className="text-sm text-[var(--dpf-muted)]">{e.message}</p>;
+    }
+    throw e;
+  }
+
+  const groupBy = defaultGroupByColumn(grid.schema.columns);
+  const boardView = view === "board" && groupBy !== null;
+
+  return (
+    <div className="min-h-0 flex-1">
+      {boardView && groupBy !== null ? (
+        <KanbanBoard
+          source="platform"
+          tableId={entityType}
+          columns={grid.schema.columns}
+          rows={grid.rows}
+          capabilities={grid.schema.capabilities}
+          groupByColumnId={groupBy}
+        />
+      ) : (
+        <WorkbookGrid
+          source="platform"
+          tableId={entityType}
+          columns={grid.schema.columns}
+          rows={grid.rows}
+          capabilities={grid.schema.capabilities}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
+++ b/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
@@ -1,0 +1,48 @@
+// apps/web/components/workbooks/SurfaceViewSwitcher.tsx
+// Consistent List / Grid / Board switch revealed on a domain surface (Finance,
+// Compliance, Ops). Registry-driven (EP-GRID-WORKBOOKS per-surface integration):
+// every platform table gets the identical affordance for free. Mirrors the
+// existing /workbooks/system toggle styling. Theme tokens only.
+import Link from "next/link";
+
+import { getHomeSurfaceForEntity } from "@/lib/workbooks/platform-tables";
+
+export type SurfaceView = "list" | "grid" | "board";
+
+export function SurfaceViewSwitcher({
+  entityType,
+  current,
+}: {
+  entityType: string;
+  current: SurfaceView;
+}) {
+  const home = getHomeSurfaceForEntity(entityType);
+  if (!home) return null;
+
+  const tabs: Array<{ key: SurfaceView; label: string; href: string }> = [
+    { key: "list", label: "List", href: home.path },
+    { key: "grid", label: "Grid", href: `${home.path}?view=grid` },
+  ];
+  if (home.board) {
+    tabs.push({ key: "board", label: "Board", href: `${home.path}?view=board` });
+  }
+
+  return (
+    <div className="mb-4 inline-flex w-fit overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+      {tabs.map((t) => (
+        <Link
+          key={t.key}
+          href={t.href}
+          aria-current={current === t.key ? "page" : undefined}
+          className={
+            current === t.key
+              ? "bg-[var(--dpf-surface-2)] px-3 py-1.5 font-medium text-[var(--dpf-text)]"
+              : "px-3 py-1.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          }
+        >
+          {t.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -68,12 +68,13 @@ describe("getWorkspaceTiles()", () => {
     expect(tiles).not.toContain("inventory");
   });
 
-  it("superuser gets all 14 top-level tiles regardless of role", () => {
+  it("superuser gets all 13 top-level tiles regardless of role", () => {
     const tiles = getWorkspaceTiles(superuser);
 
-    expect(tiles.length).toBe(14);
+    expect(tiles.length).toBe(13);
     expect(tiles.map((tile) => tile.key)).toContain("documents");
-    expect(tiles.map((tile) => tile.key)).toContain("workbooks");
+    // Workbooks is demoted under Platform Hub (EP-GRID-WORKBOOKS) — no longer a top-level tile.
+    expect(tiles.map((tile) => tile.key)).not.toContain("workbooks");
   });
 });
 

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -161,7 +161,6 @@ const ALL_TILES: WorkspaceTile[] = [
   { key: "ai_workforce", label: "AI Workforce",  route: "/platform/ai",  capabilityKey: "view_platform",    accentColor: "var(--dpf-info)" },
   { key: "build",       label: "Build Studio", route: "/build",       capabilityKey: "view_platform",    accentColor: "var(--dpf-success)" },
   { key: "documents",   label: "Documents",    route: "/workspace/documents", capabilityKey: "view_platform", accentColor: "var(--dpf-accent)" },
-  { key: "workbooks",   label: "Workbooks",    route: "/workbooks",   capabilityKey: "view_workbooks",   accentColor: "var(--dpf-info)" },
   { key: "portfolio",  label: "Portfolio",  route: "/portfolio", capabilityKey: "view_portfolio",   accentColor: "var(--dpf-success)" },
   { key: "employee",   label: "Employee",   route: "/employee",  capabilityKey: "view_employee",    accentColor: "var(--dpf-info)" },
   { key: "customer",   label: "Customer",   route: "/customer",  capabilityKey: "view_customer",    accentColor: "var(--dpf-accent)" },
@@ -226,7 +225,7 @@ const WORKSPACE_SECTION_BLUEPRINTS: Array<{
     key: "product-oversight",
     label: "Shape products",
     description: "Move work from strategy to delivery while keeping estate context inside the product flow.",
-    tileKeys: ["portfolio", "backlog", "ea_modeler", "workbooks"],
+    tileKeys: ["portfolio", "backlog", "ea_modeler"],
   },
   {
     key: "business-operations",

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -108,11 +108,9 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     audienceModes: ["worker", "operator"],
     destinationKind: "domain-home",
     capabilityKey: "view_workbooks",
-    primaryOrder: 15,
-    shellNav: {
-      sectionKey: "workspace",
-      description: "Spreadsheet-style grids for your own tables and platform data.",
-    },
+    // Demoted from the primary Workspace nav (EP-GRID-WORKBOOKS): the platform-data
+    // grids now live in-place on their domain surfaces; the user-tables hub is
+    // surfaced under Platform Hub (see platform-nav.ts). Record kept so links resolve.
     sectionSiblings: ["/workbooks"],
   },
   {

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -32,12 +32,25 @@ export interface PlatformUser {
   isSuperuser: boolean;
 }
 
+/**
+ * Where a platform grid lives in the portal IA. Each platform dataset is revealed
+ * in-place on its own domain surface (EP-GRID-WORKBOOKS per-surface integration),
+ * not on a standalone Workbooks hub. `board` marks whether the grid has a groupable
+ * column suitable for a Kanban Board view.
+ */
+export interface PlatformTableHomeSurface {
+  path: string;
+  label: string;
+  board: boolean;
+}
+
 export interface PlatformTableDef {
   entityType: string;
   label: string;
   description: string;
   viewCapability: CapabilityKey;
   manageCapability: CapabilityKey;
+  homeSurface: PlatformTableHomeSurface;
 }
 
 /** The registry of platform datasets available as grids. Add a row per adapter. */
@@ -48,6 +61,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Every backlog item as an editable spreadsheet — same records as the backlog forms.",
     viewCapability: "view_operations",
     manageCapability: "manage_backlog",
+    homeSurface: { path: "/ops", label: "Operations", board: true },
   },
   {
     entityType: "invoice",
@@ -55,6 +69,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Finance invoices as a grid — edit status inline; amounts/dates stay in the invoice form.",
     viewCapability: "view_finance",
     manageCapability: "manage_finance",
+    homeSurface: { path: "/finance/invoices", label: "Invoices", board: true },
   },
   {
     entityType: "risk_assessment",
@@ -62,6 +77,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance risk register as an editable spreadsheet — same records as the risk forms.",
     viewCapability: "view_compliance",
     manageCapability: "manage_compliance",
+    homeSurface: { path: "/compliance/risks", label: "Risk assessments", board: true },
   },
 ];
 
@@ -71,6 +87,12 @@ function userCtx(user: PlatformUser) {
 
 export function getPlatformTable(entityType: string): PlatformTableDef | undefined {
   return PLATFORM_TABLES.find((t) => t.entityType === entityType);
+}
+
+export function getHomeSurfaceForEntity(
+  entityType: string,
+): PlatformTableHomeSurface | undefined {
+  return getPlatformTable(entityType)?.homeSurface;
 }
 
 export function listPlatformTablesForUser(user: PlatformUser): PlatformTableDef[] {

--- a/docs/superpowers/specs/2026-06-06-workbooks-per-surface-integration-design.md
+++ b/docs/superpowers/specs/2026-06-06-workbooks-per-surface-integration-design.md
@@ -1,0 +1,119 @@
+# Workbooks Per-Surface Integration — Design
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft — substrate-verified 2026-06-06 |
+| Date | 2026-06-06 |
+| Epic | EP-GRID-WORKBOOKS — Universal Grid & Workbooks |
+| Live backlog | MCP 2026-06-06: BI-09D945C5 (feature, large — per-surface integration), BI-DFD98A2D (feature, medium — demote/relocate hub). Both `open`/`build`. |
+| WWMD | `principle_decide` 2026-06-06 (external_coding_agent) → `in-place-view-toggle`, composite 11.80 vs 11.10 / 7.66, margin 0.70, high confidence, no commandment conflict |
+| Operator direction | 2026-06-06: integrate the platform-data grids into each domain surface (not a standalone all-spreadsheets hub); demote the top-level Workbooks nav. AskUserQuestion → demoted hub lands **Under Platform Hub**. |
+
+## 1. Problem
+
+`/workbooks` is a top-level Workspace destination that presents everything as spreadsheets: a user-defined custom-tables section **plus** a "Platform data" section that lists Finance invoices, Compliance risk assessments, and Ops backlog items as grid cards linking to `/workbooks/system/[entityType]`.
+
+Operator feedback: a standalone all-spreadsheets surface is the wrong home for the platform-data grids. The invoice grid belongs **in Finance**, the risk grid **in Compliance**, the backlog grid **in Ops** — revealed in the topic the worksheet is *for*, as integrated as possible. The top-level Workbooks entry is also too prominent for what (after the platform grids move out) is a personal power-user tool.
+
+This is not a missing-capability problem. The grids exist and work. The gap is **placement and a consistent reveal pattern**.
+
+## 2. Goals
+
+1. Reveal each platform-data grid in its own domain surface, in the topic context, via one consistent pattern.
+2. Make the pattern registry-driven so it's identical across surfaces and free for any future platform table.
+3. Demote the standalone Workbooks: remove the top-level Workspace chip; relocate the user-tables hub under Platform Hub; the platform-data section leaves the hub.
+4. Reuse the existing grid substrate; add no second grid implementation.
+5. No hardcoded colors; report-kit / DPF theme tokens.
+
+## 3. Verified Substrate
+
+| Capability | Current substrate (verified 2026-06-06) | Design implication |
+| --- | --- | --- |
+| Platform-table registry | `apps/web/lib/workbooks/platform-tables.ts` — `PLATFORM_TABLES`: `{entityType,label,description,viewCapability,manageCapability}` for `invoice`, `risk_assessment`, `backlog_item`. | Extend with a `homeSurface` mapping; it becomes the integration seam. |
+| Grid data fn | `getPlatformTableGridData(user, entityType)` returns schema+columns+rows+capabilities. | Call directly from each surface page — no new query code. |
+| Grid components | `WorkbookGrid` / `KanbanBoard` (`apps/web/components/workbooks/`), parameterized by `source`/`tableId`/`columns`/`rows`/`capabilities`. | Embed in surface pages. The `/workbooks/system/[entityType]` page is already just a thin wrapper around these. |
+| Grid/Board toggle | The system page already implements a Grid↔Board switch via `?view=board` + `defaultGroupByColumn`. | Generalize into a shared `<SurfaceViewSwitcher>`. |
+| Surface targets | `/finance/invoices/page.tsx`, `/compliance/risks/page.tsx`, `/ops/page.tsx` all exist as server components with native list views + searchParams. | Add the switcher to each; native view is the default. |
+| Workspace nav | `portal-navigation-model.ts` key `workbooks`, section `workspace`, `primaryOrder: 15`. | Remove the primary chip (drop `shellNav`+`primaryOrder`). |
+| Platform Hub nav | `apps/web/components/platform/platform-nav.ts` (`PLATFORM_FAMILIES`). | Add a Workbooks subitem under the Overview family. |
+| Capability gating | each platform table gates on its **domain** capability (`view_finance`/`view_compliance`/`view_operations`). | Per-surface grids are already correctly gated — no change. |
+
+## 4. Decision (WWMD)
+
+`principle_decide` (external_coding_agent, `mark-dpf-platform`, 20 commandments, strong structured coverage):
+
+| Option | Composite | Verdict |
+| --- | --- | --- |
+| **in-place-view-toggle** | **11.80** | **Recommended — high confidence, margin 0.70** |
+| dedicated-grid-subroute | 11.10 | Viable runner-up |
+| crosslink-keep-hub | 7.66 | Rejected |
+
+Top contributors: Research & Use Standards (0.91), No Hardcoded Colors (0.92), Single Source of Truth (0.83), Ship Real Functionality (0.75). No commandment conflict.
+
+- **`in-place-view-toggle`** keeps the user in the topic — the spreadsheet is a *view mode* of the same page — which is exactly "as integrated in the topic as possible." Highest reuse and lowest cognitive load.
+- **`dedicated-grid-subroute`** scored close but adds a navigation hop and a sub-route per surface; kept as the fallback if a surface can't host an in-place mode cleanly.
+- **`crosslink-keep-hub`** is the "here, not there" the operator explicitly rejected; lowest on Proper-Fix and maintainability.
+
+## 5. Design
+
+### 5.1 The consistent reveal pattern
+
+Extend the registry with a `homeSurface` per entity (`{ path, label, board }`) and embed, on each surface page, a shared pair of server components:
+
+- **`SurfaceViewSwitcher`** — a segmented control **List · Grid · Board** that mirrors the existing system-page toggle styling, links to `?view=grid|board`, and only offers Board when the registry marks the table groupable. Drop-in above the surface content.
+- **`SurfacePlatformGrid`** — fetches `getPlatformTableGridData(user, entityType)` and renders `WorkbookGrid` (or `KanbanBoard` for `view=board`, via `defaultGroupByColumn`). Rendered only when `?view` is set.
+
+Each surface page adds two lines: render the switcher, and when `?view` is set render `SurfacePlatformGrid` instead of its native list (List remains the default — no regression). Because both read the registry, **every current and future platform table gets the identical affordance for free** — that is the "consistent" mechanism.
+
+Targets: `invoice`→`/finance/invoices`, `risk_assessment`→`/compliance/risks`, `backlog_item`→`/ops`.
+
+### 5.2 Nav demotion (→ Platform Hub)
+
+- Remove the `workbooks` **primary** chip from the Workspace section (`portal-navigation-model.ts`: drop `primaryOrder` + `shellNav`; the route record stays so links still resolve).
+- Add a Workbooks subitem under **Platform Hub** (`platform-nav.ts`, Overview family). The user-defined custom-tables hub lives here as power-user tooling.
+- Strip the "Platform data" section from `apps/web/app/(shell)/workbooks/page.tsx` — those grids now live on the surfaces.
+- Point the `/workbooks/system/[entityType]` back-link at the registry `homeSurface` so a grid reached from a surface returns to that surface.
+
+### 5.3 What stays
+
+The `/workbooks/system/[entityType]` route and the user-defined workbook routes remain functional (deep-links, MCP, shares). Additive placement + a nav move, not a teardown of the grid engine.
+
+## 6. Decomposition
+
+| BI | Size | Scope |
+| --- | --- | --- |
+| BI-09D945C5 | large | Registry `homeSurface`, `SurfaceViewSwitcher` + `SurfacePlatformGrid`, integration into the three surfaces. |
+| BI-DFD98A2D | medium | Remove the Workspace chip, add the hub under Platform Hub, strip the hub's Platform-data section, fix the system-grid back-link. |
+
+Both ship together here (the demotion must not strip the hub's platform-data section until the per-surface grids are live).
+
+## 7. Research & Benchmarking
+
+- **Airtable / Notion / Smartsheet** — a dataset has one home; grid/board/calendar are *view modes* of that dataset via an in-context switcher, never a separate destination per view. Adopted: view-mode toggle in place.
+- **Linear / Jira** — the same issue list toggles list↔board in place via a header control; users stay in project context. This is the `SurfaceViewSwitcher` model.
+- **Salesforce / ServiceNow** — records appear as grids *within* their object/module, gated by that module's permissions — matching DPF's per-table domain-capability gating.
+- **DPF precedent** — EP-ARCH-NAV (2026-06-06): a cross-cutting capability surfaced as a view within each topic rather than a standalone destination. Same doctrine, reused for grids.
+
+## 8. UX Fit
+
+Decision: `fits-with-guardrails`.
+
+- Owning areas: Finance, Compliance, Ops (grid views) + Platform Hub (demoted hub). No new top-level nav; one chip removed.
+- Reuse: `getPlatformTableGridData`, `WorkbookGrid`/`KanbanBoard`, existing toggle markup; two new shared server components.
+- Default view per surface unchanged (native list); Grid/Board are opt-in → no regression.
+- Theme: tokens only.
+
+## 9. Verification
+
+- **Unit:** registry `homeSurface` resolution; switcher renders List/Grid/Board (Board gated on registry flag); nav model — `workbooks` no longer a primary/shell entry, present under Platform Hub; nav invariants (unique path, sectionSiblings ⊂ parentPath, every shell + platform-family href resolves).
+- **Typecheck / Build:** `pnpm --filter web typecheck` + `build` (CI / canonical install / shared sandbox).
+- **Functional (live install):** the switcher toggles native↔Grid↔Board in place on each surface; grid edits persist to the same records; the Workspace chip is gone; the hub is under Platform Hub showing only user tables; deep-links still work and breadcrumb to the home surface.
+- **UX:** desktop + mobile; no hardcoded colors; honest empty states.
+
+## 10. Risks
+
+- **Surface page heterogeneity** — switcher is additive (native list default); fall back to `dedicated-grid-subroute` for any surface that can't host an in-place mode.
+- **Capability widening** — keep each grid gated by the registry's existing domain capability; no widening.
+- **Hub link rot** — sweep internal `/workbooks` links when relocating; the system back-link derives from the registry.
+- **Ordering** — don't strip the hub's Platform-data section until per-surface grids are live (same PR keeps them coupled).
+- **Runtime-bound verification** — worktree is source-control only; build + UX evidence from CI / canonical install / shared sandbox.


### PR DESCRIPTION
## EP-GRID-WORKBOOKS — per-surface integration + demote the standalone hub

Operator feedback (2026-06-06): the standalone `/workbooks` all-spreadsheets surface is the wrong home for the platform-data grids — the invoice grid belongs **in Finance**, risks **in Compliance**, backlog **in Ops**, revealed in the topic the worksheet is *for*; and the top-level Workbooks entry should be demoted. IA approach run through WWMD `principle_decide` → **in-place-view-toggle** (composite 11.80 vs 11.10 / 7.66, margin 0.70, high confidence, no commandment conflict). Demoted-hub placement confirmed by operator → **Under Platform Hub**.

Spec: [`docs/superpowers/specs/2026-06-06-workbooks-per-surface-integration-design.md`](docs/superpowers/specs/2026-06-06-workbooks-per-surface-integration-design.md) (on this branch).

### BI-09D945C5 — per-surface integration
- Extend `PLATFORM_TABLES` with a `homeSurface` mapping (`invoice`→`/finance/invoices`, `risk_assessment`→`/compliance/risks`, `backlog_item`→`/ops`) + `getHomeSurfaceForEntity`.
- Two shared server components: `SurfaceViewSwitcher` (List · Grid · Board) and `SurfacePlatformGrid` (reuses the existing `getPlatformTableGridData` + `WorkbookGrid`/`KanbanBoard` — **no new grid code**).
- Wired into the three surfaces via `?view=`; the native list stays the default (no regression). Registry-driven, so any future platform table gets the identical affordance for free.

### BI-DFD98A2D — demote / relocate hub
- Removed the Workbooks chip from the primary Workspace nav (`shellNav`/`primaryOrder`) **and** the Workspace home tiles.
- Surfaced the user-tables hub under **Platform Hub** (`platform-nav.ts` Overview family).
- Stripped the "Platform data" section from the `/workbooks` hub (now lives on the surfaces); pointed the `/workbooks/system/[entityType]` back-link at the registry `homeSurface`.
- Updated the workspace-tiles test (14→13; workbooks no longer top-level).

Both BIs filed under EP-GRID-WORKBOOKS, triaged `build`, linked to the epic.

### Verification
- **Local gates could not run** (source-only worktree, no toolchain); `DPF_SKIP_TYPECHECK=1` used per the documented pattern — **CI gates typecheck + build + unit tests.**
- Nav invariants reviewed by construction: `getShellNavEntries` filters on `shellNav` (chip cleanly dropped); `/workbooks` record retained so `getRouteNavRecord` still resolves for the Platform-Hub entry; updated `permissions.test.ts` for the tile count. No hardcoded colors.
- **UX verification** of the live toggles requires merge + governed self-upgrade (the live portal can't be rebuilt from a worktree). Recommend exercising List↔Grid↔Board on `/finance/invoices`, `/compliance/risks`, `/ops`, the Platform-Hub Workbooks entry, and the stripped hub post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)