### PR TITLE
fix(grok): actually install + correctly invoke the Grok CLI in the build sandbox (EP-GROK-001)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -6,7 +6,9 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 # shell found" and silently degrading to static-analysis-only verification.
 # That broke the BS verification gate for every build dispatched into this
 # sandbox. SHELL is also exported so child processes inherit a known shell.
-RUN apk add --no-cache git postgresql16-client curl bubblewrap bash
+# gcompat + libstdc++/libgcc let the official (glibc-linked) Grok Build CLI binary run on
+# this Alpine/musl base. Verified: grok 0.2.32 loads and executes under gcompat here.
+RUN apk add --no-cache git postgresql16-client curl bubblewrap bash gcompat libstdc++ libgcc
 ENV SHELL=/bin/bash
 # Codex CLI: OpenAI's coding agent (like Claude Code but for OpenAI models).
 # Used by the Build Studio orchestrator to execute build tasks autonomously.
@@ -14,10 +16,15 @@ RUN npm install -g @openai/codex
 # Claude Code CLI: Anthropic's coding agent.
 # Used alongside Codex CLI for Build Studio task dispatch.
 RUN npm install -g @anthropic-ai/claude-code
-# Grok CLI (xAI): required for Build Studio "grok" dispatch engine (grok-dispatch.ts).
-# The exact global package name follows xAI releases (commonly results in `grok` binary).
-# --always-approve / --no-auto-update are the documented headless flags (see grok-dispatch.ts).
-RUN npm install -g @xai/grok-cli 2>/dev/null || echo "[sandbox] Grok CLI package not resolvable at image build time; ensure 'grok' binary is present for dispatch when provider=grok is selected"
+# Grok Build CLI (xAI): the official coding agent for the Build Studio "grok" dispatch
+# engine (grok-dispatch.ts). xAI ships it as a glibc-linked native binary via a curl
+# installer — there is NO npm package (the previous `@xai/grok-cli` line was a silent
+# no-op: that package does not exist, so provider=grok never actually worked). The binary
+# runs on this Alpine/musl base through the gcompat shim added above. The build-time
+# `grok --version` gate fails the image build loudly if the binary is missing or won't load.
+# Verified end-to-end: grok 0.2.32 installs under gcompat and reaches api.x.ai with XAI_API_KEY.
+RUN curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash \
+ && grok --version
 RUN git config --global user.email "sandbox@dpf.local" \
  && git config --global user.name "DPF Sandbox"
 # Codex CLI defaults: bypass internal sandbox (Docker IS the sandbox),

--- a/apps/web/lib/integrate/grok-dispatch.ts
+++ b/apps/web/lib/integrate/grok-dispatch.ts
@@ -157,9 +157,9 @@ Key patterns:
  * - Audit via recordBuildDispatchAttempt
  * - Graceful fallback for Grok CLI output format (text today; --json when supported)
  *
- * Grok uniques vs peers:
+ * Grok uniques vs peers (verified against grok 0.2.32):
  * - Auth: single XAI_API_KEY env (no auth.json dance, no OAuth refresh)
- * - Binary: `grok` (with -p for prompt, --dangerously-skip-permissions supported)
+ * - Binary: `grok` (official xAI Build CLI; --prompt-file + --always-approve for headless)
  * - Session: lighter (no persistent sessionId yet)
  */
 export async function dispatchGrokTask(params: {
@@ -251,7 +251,13 @@ export async function dispatchGrokTask(params: {
       "trap cleanup EXIT INT TERM",
       "cd /workspace",
       `export XAI_API_KEY=$(cat ${authKeyFile} 2>/dev/null || echo '')`,
-      `grok ${modelFlag} -p - --always-approve --no-auto-update < ${promptFile}`,
+      // Headless single-turn run, verified against grok 0.2.32:
+      //  --prompt-file  : read the prompt from a file. `-p/--single` takes a literal prompt
+      //                   ARGUMENT (not stdin), so the old `-p - < file` passed "-" as the
+      //                   prompt and ignored the file — it never worked.
+      //  --always-approve : auto-approve tool executions (unattended build mode).
+      // (`--no-auto-update` was removed: it is not a flag in current Grok Build and errored.)
+      `grok ${modelFlag} --prompt-file ${promptFile} --always-approve`,
       "cleanup",
     ].join("\n");
     const scriptB64 = Buffer.from(script).toString("base64");


### PR DESCRIPTION
## Summary
Follow-up to EP-GROK-001 (#1606). Selecting the **grok** Build Studio dispatch engine could not have worked: the sandbox install was a silent no-op and the dispatch command used flags the real CLI doesn't have. Both are fixed and **verified against the official binary (grok 0.2.32)** by building the image and driving the command end-to-end to `api.x.ai`.

## Root causes
1. **No binary in the sandbox.** `Dockerfile.sandbox` ran `npm install -g @xai/grok-cli 2>/dev/null || echo …` — but `@xai/grok-cli` returns **404 on npm** (it doesn't exist). The `|| echo` swallowed the failure, so the image shipped with **no `grok` binary** and `provider=grok` failed at dispatch with `grok: not found`.
2. **Wrong dispatch flags.** `grok-dispatch.ts` ran `grok -p - --always-approve --no-auto-update < promptFile`. Against the real CLI: `-p/--single` takes a literal prompt **argument, not stdin** (so `-` became the prompt and the file was ignored), and **`--no-auto-update` is not a flag** (errors).

## Fix
**Dockerfile.sandbox**
- Install the official Grok Build CLI via xAI's curl installer (`x.ai/cli/install.sh`) — it ships only as a glibc native binary, no npm package.
- Add `gcompat` + `libstdc++`/`libgcc` so the glibc binary runs on the Alpine/musl base.
- Add a build-time `grok --version` gate so a missing/broken binary **fails the image build** instead of silently shipping.

**grok-dispatch.ts**
- Use `--prompt-file <path>` (reads the file) instead of `-p - < file`.
- Drop the invalid `--no-auto-update`; keep `--always-approve`.

## Verification
- ✅ Full `docker build -f Dockerfile.sandbox` is **green**; the gate prints `grok 0.2.32 (5cb5dfeb8)`.
- ✅ In-container, `grok --prompt-file <f> --always-approve` reads the file, picks up `XAI_API_KEY`, and reaches `https://api.x.ai/v1/responses` (model `grok-build`). With a dummy key it returns a well-formed `400 invalid key` — proving the flag/auth/file-read path; a real key would complete the call.
- Local TS typecheck skipped (fresh worktree, no node_modules); the change is a string literal with no type impact — CI Typecheck gates the merge.

## Still gated
Full **functional** proof (an actual Build Studio build driven through Grok) needs a real `XAI_API_KEY` configured on a live install. This PR makes that possible; until then the grok runner stays at the `preview` tier.

## Related
- Epic EP-GROK-001 (#1606)
- A parallel thread is designing a **Build-Engine Provisioning** capability so engines like this are provisioned through a governed UX/MCP surface instead of hand-edited Dockerfiles — this fix becomes "recipe #1" there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)