### PR TITLE
fix(self-upgrade): hold trigger feedback + make impact summary resolve on real installs

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -334,6 +334,24 @@ describe("SelfUpgradeClient – loading", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
     expect(html).toContain('aria-busy="true"');
   });
+
+  it("shows the 'starting' hint while busy and no run is running yet", () => {
+    // The manual trigger only queues the upgrade; the worker takes a few seconds
+    // to flip the run to running. The hint reassures the operator so they don't
+    // re-click thinking it's broken.
+    shared.isPending = true;
+    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
+    expect(html).toContain('data-upgrade-starting="true"');
+    expect(html).toContain("No need to click again");
+  });
+
+  it("does not show the 'starting' hint once a run is already running", () => {
+    shared.isPending = false;
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} />,
+    );
+    expect(html).not.toContain('data-upgrade-starting="true"');
+  });
 });
 
 // ─── Success feedback ─────────────────────────────────────────────────────────

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { rollbackSelfUpgrade, triggerSelfUpgrade } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
@@ -193,6 +193,7 @@ export default function SelfUpgradeClient({
   const [isPending, startTransition] = useTransition();
   const [isRollbackPending, startRollbackTransition] = useTransition();
   const [override, setOverride] = useState(false);
+  const [justQueued, setJustQueued] = useState(false);
   const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(null);
   const [rollbackConfirmation, setRollbackConfirmation] = useState("");
   const [rollbackResult, setRollbackResult] = useState<{
@@ -215,12 +216,43 @@ export default function SelfUpgradeClient({
   const showActivity =
     draining || cooldownActive || (!!deferredRun && (quiescence?.blockers.length ?? 0) > 0);
 
+  // True once the worker has actually picked the upgrade up — the run is running
+  // or the portal is draining/swapping for the swap.
+  const upgradeInFlight = latestRun?.status === "running" || draining;
+
+  // The manual trigger only *queues* an upgrade: the server action returns
+  // `{ queued: true }` in well under a second, but the Inngest worker still has
+  // to fetch + compare SHAs before the run flips to "running". Without a held
+  // state the button would snap straight back to "Upgrade now" while nothing
+  // visibly happened — which reads as "broken" and invites repeat clicks (each
+  // one firing another upgrade event). We hold a "Starting…" state until the run
+  // actually appears, poll so progress shows up on its own, and time out as a
+  // safety net if the queued event never materialises (e.g. skipped for cooldown).
+  useEffect(() => {
+    if (justQueued && upgradeInFlight) setJustQueued(false);
+  }, [justQueued, upgradeInFlight]);
+
+  useEffect(() => {
+    if (!justQueued) return;
+    const timeout = setTimeout(() => setJustQueued(false), 45_000);
+    return () => clearTimeout(timeout);
+  }, [justQueued]);
+
+  useEffect(() => {
+    if (!justQueued && !upgradeInFlight) return;
+    const interval = setInterval(() => router.refresh(), 4_000);
+    return () => clearInterval(interval);
+  }, [justQueued, upgradeInFlight, router]);
+
+  const triggerBusy = isPending || justQueued;
+
   function handleTrigger() {
     setTriggerResult(null);
     const force = override;
     startTransition(async () => {
       const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
       setTriggerResult(result);
+      if (result.queued) setJustQueued(true);
       router.refresh();
     });
   }
@@ -278,17 +310,34 @@ export default function SelfUpgradeClient({
             <button
               type="button"
               onClick={handleTrigger}
-              disabled={isPending || latestRun?.status === "running"}
-              aria-busy={isPending}
+              disabled={triggerBusy || latestRun?.status === "running"}
+              aria-busy={triggerBusy}
               aria-label="Upgrade now"
               data-override={override ? "true" : "false"}
               className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
             >
-              {isPending ? "Upgrading..." : override ? "Force upgrade now" : "Upgrade now"}
+              {isPending
+                ? "Upgrading..."
+                : justQueued
+                  ? "Starting…"
+                  : override
+                    ? "Force upgrade now"
+                    : "Upgrade now"}
             </button>
           </div>
         )}
       </div>
+
+      {enabled && triggerBusy && latestRun?.status !== "running" && (
+        <div
+          className="text-xs text-[var(--dpf-muted)]"
+          data-upgrade-starting="true"
+          aria-live="polite"
+        >
+          Upgrade starting — the worker is checking for a new build. This can take
+          a few seconds; progress will appear below. No need to click again.
+        </div>
+      )}
 
       {!enabled && (
         <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-sm text-[var(--dpf-muted)]">

--- a/apps/web/lib/self-upgrade/impact/index.test.ts
+++ b/apps/web/lib/self-upgrade/impact/index.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@/lib/self-upgrade/run-store", () => ({
+  getLatestSucceededRun: vi.fn(),
+}));
+vi.mock("@/lib/self-upgrade/completion", () => ({
+  getDeployedSha: vi.fn(),
+}));
+
 import { summarizeUpgradeImpact } from "./index";
 import { _resetCacheForTest } from "./cache";
+import { getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import type { InstallSignals, RawCommit } from "./types";
 
 afterEach(() => {
@@ -123,6 +132,38 @@ describe("summarizeUpgradeImpact — orchestrator", () => {
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
     if (second.ok) expect(second.summary.fromCache).toBe(true);
+  });
+
+  it("falls back to the deployed git SHA as the baseline when no succeeded run exists", async () => {
+    // A never-upgraded but CI-stamped ("labeled") install: no succeeded run, but
+    // the image identity IS a git SHA, so we can still summarize since-install.
+    vi.mocked(getLatestSucceededRun).mockResolvedValue(null as never);
+    vi.mocked(getDeployedSha).mockResolvedValue("c".repeat(40));
+    const out = await summarizeUpgradeImpact({ skipPhrasing: true }, {
+      // loadCurrentLineageSha intentionally NOT injected → exercises the default
+      // fallback chain (succeeded-run marker → deployed git SHA → null).
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [rawCommit("feat: x", [], "1".repeat(40))],
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out.ok).toBe(true);
+  });
+
+  it("stays no-lineage when neither a succeeded run nor a git-SHA image identity exists", async () => {
+    // A local/content-hash build: image identity is a 64-char content hash, not a
+    // git SHA, so there is genuinely no comparable baseline.
+    vi.mocked(getLatestSucceededRun).mockResolvedValue(null as never);
+    vi.mocked(getDeployedSha).mockResolvedValue("e".repeat(64));
+    const out = await summarizeUpgradeImpact({}, {
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [],
+      enrichPrs: async () => ({ reachable: false, enriched: 0, byPr: new Map() }),
+      phraseSummary: async () => null,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "no-lineage" });
   });
 
   it("refresh=true bypasses the cache and reruns the change-set collector", async () => {

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -11,6 +11,8 @@
 //   4. Otherwise: collect change set -> classify -> score -> phrase -> cache.
 
 import { getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { getDeployedSha } from "@/lib/self-upgrade/completion";
+import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha } from "@/lib/self-upgrade/version";
 import { cacheKey, getCached, setCached } from "./cache";
 import { collectChangeSet } from "./change-set";
@@ -47,16 +49,23 @@ export type SummarizeDeps = {
   phraseSummary?: typeof phraseSummary;
 };
 
+const GIT_SHA_RE = /^[0-9a-f]{40}$/i;
+
 async function defaultLoadCurrentLineageSha(): Promise<string | null> {
   const run = await getLatestSucceededRun();
   // The upstream lineage marker is the targetSha of the latest succeeded run
   // (the upstream commit absorbed into the running build) — NOT deployedSha,
   // which in merge mode is the merge-commit identity (see run-store.ts).
-  return run?.targetSha ?? null;
-}
+  if (run?.targetSha && GIT_SHA_RE.test(run.targetSha)) return run.targetSha;
 
-async function defaultLoadTargetSha(): Promise<string | null> {
-  return resolveTargetSha("operator-impact-summary");
+  // No succeeded self-upgrade yet (a never-upgraded install). Fall back to the
+  // commit THIS install was built from, so a CI-stamped ("labeled") production
+  // build can still summarize everything between install and the upstream
+  // target. A local/content-hash build has no git-SHA identity, so this stays
+  // null and the panel honestly reports "no lineage" rather than a wall of hex.
+  const deployed = await getDeployedSha();
+  if (deployed && GIT_SHA_RE.test(deployed)) return deployed;
+  return null;
 }
 
 /**
@@ -68,10 +77,27 @@ export async function summarizeUpgradeImpact(
   options: SummarizeOptions = {},
   deps: SummarizeDeps = {},
 ): Promise<SummaryResult> {
+  // The self-upgrade config carries the host clone path + remote/branch the git
+  // reads must use. getSelfUpgradeStatus threads this into resolveTargetSha; the
+  // impact summary historically did NOT, so both the target resolve and the
+  // change-set `git log` ran against the wrong default path (`/workspace`) and
+  // the panel could never produce output on any real install. Load it once and
+  // pass it through (only when the caller hasn't injected its own loaders).
+  const needsConfig = !deps.loadTargetSha || !deps.loadChangeSet;
+  const config = needsConfig ? await getSelfUpgradeConfig() : null;
+
   const loadCurrentLineageSha = deps.loadCurrentLineageSha ?? defaultLoadCurrentLineageSha;
-  const loadTargetSha = deps.loadTargetSha ?? defaultLoadTargetSha;
+  const loadTargetSha =
+    deps.loadTargetSha ??
+    (() => resolveTargetSha("operator-impact-summary", config ?? {}));
   const loadInstallSignals = deps.loadInstallSignals ?? (() => collectInstallSignals());
-  const loadChangeSet = deps.loadChangeSet ?? ((input) => collectChangeSet(input));
+  const loadChangeSet =
+    deps.loadChangeSet ??
+    ((input) =>
+      collectChangeSet({
+        ...input,
+        config: { hostSourcePath: config?.hostSourceMountPath },
+      }));
   const enrich = deps.enrichPrs ?? enrichPrs;
   const phrase = deps.phraseSummary ?? phraseSummary;
 


### PR DESCRIPTION
## What & why

Two operator-facing defects on **/ops/self-upgrade**, both reported from a live install.

### 1. "Upgrade now" gave no lasting feedback → repeated clicking
The trigger action only *queues* an Inngest event and returns in under a second. The worker then fetches + compares SHAs before the run flips to `running` (several seconds). The button left its transient "Upgrading…" state the instant the event was queued and snapped back to "Upgrade now" while nothing visibly changed — reading as broken and inviting repeat clicks, each firing another upgrade event.

**Fix:** hold a disabled **"Starting…"** state until the run actually appears (or the portal starts draining), an inline *"no need to click again"* hint, a 4s auto-poll so progress (status badge, drain activity) surfaces on its own, and a 45s safety timeout so a queued-but-skipped event (e.g. cooldown) can never leave the button stuck.

### 2. "What's in this update?" never produced output
The impact orchestrator called `resolveTargetSha()` **and** `collectChangeSet()` with **no config**, so both git reads ran against the wrong default host path (`/workspace`) instead of the install's configured `hostSourceMountPath` — the same config `getSelfUpgradeStatus` already threads into `resolveTargetSha`. Target resolution failed with *"Could not resolve the upstream target SHA"* (the message seen on the live install), and the change-set `git log` would have failed the same way.

**Fix:**
- Thread the self-upgrade `config` into both git reads so they use the same host clone the status panel resolves against.
- Fall back to the deployed git SHA as the **since-install baseline** when no succeeded run exists yet, so a CI-stamped ("labeled") production build summarizes on first view. A local/content-hash build (no git identity) still reports `no-lineage` honestly rather than rendering a hex blob.

## Test plan
- `apps/web` vitest: 137 tests pass across affected files (+18 `SelfUpgradeClient`, +2 impact orchestrator).
- `pnpm --filter web typecheck` (next typegen + `tsc --noEmit`) clean.
- Pre-commit secret scan + scoped typecheck passed.

Unit + type verified; functional verification on a live install to follow (the impact path depends on the real host clone + config, which a worktree can't fully reproduce).

## Files
- `apps/web/components/ops/SelfUpgradeClient.tsx` (+ test)
- `apps/web/lib/self-upgrade/impact/index.ts` (+ test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
