### PR TITLE
feat(install): auto-start dpf-tts on NVIDIA-GPU Linux/Windows installs (BI-3C812E4E)

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -237,6 +237,35 @@ DPF_LLM_PROVIDER=external
 The Linux overlay still defines the `ollama` service, but you can stop
 it with `docker compose stop ollama` if you don't want it running.
 
+## Voice (STT + TTS)
+
+DPF coworkers support voice **input** (speech-to-text) and voice
+**output** (text-to-speech).
+
+**Speech-to-text (STT) — works out of the box.** The bundled `dpf-stt`
+container (faster-whisper) is profile-free, so it starts on a plain
+install and the coworker mic button works immediately. CPU-friendly; no
+GPU required.
+
+**Text-to-speech (TTS) — automatic on an NVIDIA GPU.** Spoken output
+uses the bundled `dpf-tts` container (Chatterbox — self-hosted, no API
+key, data stays on the Docker network). It needs hardware acceleration,
+so the installer starts it **automatically when it detects an NVIDIA GPU
+with ≥ 6 GB VRAM** — no manual `--profile tts` step. The portal is
+already wired to reach it (`TTS_PROVIDER=chatterbox`,
+`DPF_TTS_URL=http://dpf-tts:8000`), so spoken output just works.
+
+**No NVIDIA GPU?** The installer skips `dpf-tts` — its GPU reservation
+can't start on a GPU-less host, and the self-hosted CPU tier is
+~10–30× slower. STT still works. For spoken output without a GPU, route
+to a managed TTS API: set `TTS_PROVIDER=cartesia` or
+`TTS_PROVIDER=fish-audio` (plus the provider's API key) in `.env` and
+re-run the installer. (A GPU-reservation-free CPU-tier default is
+tracked as a follow-up.)
+
+> macOS Apple Silicon uses a native-host sidecar instead of `dpf-tts` —
+> see the [macOS guide](macos.md#voice-stt--tts).
+
 ## Autostart
 
 The installer registers a systemd **user** unit at:

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -142,6 +142,33 @@ LLM_BASE_URL=https://api.example.com/v1
 DPF_LLM_PROVIDER=external
 ```
 
+## Voice (STT + TTS)
+
+DPF coworkers support voice **input** (speech-to-text) and voice
+**output** (text-to-speech).
+
+**Speech-to-text (STT) — works out of the box.** The bundled `dpf-stt`
+container (faster-whisper) is profile-free, so it starts on a plain
+install and the coworker mic button works immediately. CPU-friendly; no
+GPU required.
+
+**Text-to-speech (TTS) — automatic on an NVIDIA GPU.** Spoken output
+uses the bundled `dpf-tts` container (Chatterbox — self-hosted, no API
+key). It needs hardware acceleration, so the installer starts it
+**automatically when it detects an NVIDIA GPU with ≥ 6 GB VRAM** — no
+manual `--profile tts` step. The portal is already wired to reach it
+(`TTS_PROVIDER=chatterbox`, `DPF_TTS_URL=http://dpf-tts:8000`). GPU
+passthrough requires Docker Desktop on the WSL2 backend with current
+NVIDIA drivers installed on the Windows host.
+
+**No NVIDIA GPU?** The installer skips `dpf-tts` — its GPU reservation
+can't start on a GPU-less host, and the self-hosted CPU tier is
+~10–30× slower. STT still works. For spoken output without a GPU, route
+to a managed TTS API: set `TTS_PROVIDER=cartesia` or
+`TTS_PROVIDER=fish-audio` (plus the provider's API key) in `.env` and
+re-run the installer. (A GPU-reservation-free CPU-tier default is
+tracked as a follow-up.)
+
 ## Autostart
 
 The installer registers a Windows **Scheduled Task** that starts the

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1839,6 +1839,34 @@ if (-not (Test-StepDone "started")) {
     docker compose @coreComposeArgs up -d
     $ErrorActionPreference = $oldEAP
 
+    # Voice / TTS sidecar. Spoken output uses the bundled dpf-tts container, but
+    # it's behind the `tts` compose profile (and carries an NVIDIA deploy
+    # reservation), so a plain `up` never starts it -- leaving voice silent out
+    # of the box. Start it here so a fresh install speaks, per
+    # bundled-services-active-by-default. Only enabled when an NVIDIA GPU with
+    # >=6 GB VRAM is detected (the deploy reservation would fail on a GPU-less
+    # host; the CPU tier is ~10-30x slower). Non-fatal: a GPU-runtime hiccup
+    # must not abort the install.
+    $ttsVram = 0.0
+    if (Test-Path "$DPF_DIR\.host-profile.json") {
+        try { $ttsVram = [double]((Get-Content "$DPF_DIR\.host-profile.json" -Raw | ConvertFrom-Json).gpuVramGB) } catch { $ttsVram = 0.0 }
+    }
+    if ($ttsVram -ge 6) {
+        Write-Action "Starting voice TTS sidecar (dpf-tts -- NVIDIA GPU detected)..."
+        $oldEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        docker compose @coreComposeArgs --profile tts up -d dpf-tts 2>&1 | Out-Null
+        $ttsExit = $LASTEXITCODE
+        $ErrorActionPreference = $oldEAP
+        if ($ttsExit -eq 0) {
+            Write-Action "Voice TTS container started -- spoken output works out of the box."
+        } else {
+            Write-Warn "dpf-tts failed to start (NVIDIA container runtime / GPU issue?); voice output will stay silent."
+        }
+    } else {
+        Write-Action "Voice TTS sidecar skipped (no NVIDIA GPU >=6 GB VRAM detected); STT still works. See docs/install/windows.md -> Voice to enable."
+    }
+
     # Sync postgres password -- if the volume was reused from a prior install,
     # the DB user still has the old password. Update it to match the new .env.
     Write-Action "Syncing database credentials..."

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -711,6 +711,33 @@ fi
 docker compose "${DPF_COMPOSE_FILES[@]}" up -d
 ok "docker compose up returned"
 
+# 10b. Voice / TTS sidecar (Linux hosts with an NVIDIA GPU).
+#      Spoken output uses the bundled dpf-tts container, but it's behind the
+#      `tts` compose profile (and carries an NVIDIA deploy reservation), so a
+#      plain `up` never starts it — leaving voice silent out of the box. Start
+#      it here so a fresh customer install speaks, per
+#      bundled-services-active-by-default. We only enable it when an NVIDIA GPU
+#      with >=6 GB VRAM is detected: the deploy reservation would fail on a
+#      GPU-less host, and the CPU tier is ~10-30x slower (no fast CPU path like
+#      the Mac's native MPS sidecar). Guarded + non-fatal so a missing
+#      nvidia-container runtime can't abort the install (set -euo pipefail).
+#      Skipped on macOS, which uses the native-host sidecar above.
+if [ "$DPF_PLATFORM" != "darwin" ]; then
+  _tts_vram="$(printf '%s' "${DPF_HOST_PROFILE:-}" | sed -nE 's/.*"vramGB"[[:space:]]*:[[:space:]]*([0-9]+(\.[0-9]+)?).*/\1/p')"
+  if [ -n "$_tts_vram" ] && awk "BEGIN{exit !(${_tts_vram} >= 6)}" 2>/dev/null; then
+    step "Voice / TTS sidecar (NVIDIA GPU)"
+    if docker compose "${DPF_COMPOSE_FILES[@]}" --profile tts up -d dpf-tts; then
+      ok "Voice TTS container started (dpf-tts) — spoken output works out of the box"
+    else
+      warn "dpf-tts failed to start (NVIDIA container runtime / GPU issue?); voice output will stay silent."
+      info "  Inspect: docker compose ${DPF_COMPOSE_FILES[*]} --profile tts logs dpf-tts"
+    fi
+  else
+    info "Voice TTS sidecar skipped (no NVIDIA GPU >=6 GB VRAM detected); STT still works."
+    info "  Enable later (CPU tier or managed API): see docs/install/linux.md → Voice."
+  fi
+fi
+
 # 11. Wait for /api/health (or DPF_HEALTH_TIMEOUT seconds, default 300).
 step "Health check"
 HEALTH_TIMEOUT="${DPF_HEALTH_TIMEOUT:-300}"


### PR DESCRIPTION
## What

Make a fresh **customer** install on Linux/Windows speak out of the box on NVIDIA-GPU hosts, by auto-starting the bundled `dpf-tts` container. Sibling of [#1612](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1612) (macOS, BI-9C2FCB0F), found while closing it.

## Why

`dpf-stt` is profile-free ("voice ships working on `docker compose up`"), but `dpf-tts` sits behind `profiles: ["tts"]` **and** carries an NVIDIA `deploy` reservation. Neither `install-dpf.sh` nor `install-dpf.ps1` enabled that profile, so a plain customer `up` never started it — coworkers transcribed (STT) but stayed **silent** (TTS). The portal already defaults `TTS_PROVIDER=chatterbox` / `DPF_TTS_URL=http://dpf-tts:8000`, so the only missing piece was starting the container.

## Change

- **Linux** (`install-dpf.sh`) and **Windows** (`install-dpf.ps1`): after the core bring-up, start `dpf-tts` **when an NVIDIA GPU with ≥ 6 GB VRAM is detected** (reusing the existing `nvidia-smi` / `.host-profile.json` signal) — no manual `--profile tts` step.
- **GPU-gated by necessity, not preference:** `dpf-tts`'s deploy reservation can't start on a GPU-less host, and the self-hosted CPU tier is ~10–30× slower (no fast CPU path like the Mac's native MPS sidecar). On GPU-less hosts the installer **skips cleanly** with a one-line note pointing at the managed-API option (`TTS_PROVIDER=cartesia|fish-audio`); STT still works.
- **Guarded + non-fatal:** a separate `--profile tts up -d dpf-tts` wrapped so a missing nvidia-container runtime can't abort the core install (`install-dpf.sh` runs under `set -euo pipefail`; the PS path checks `$LASTEXITCODE`).
- **macOS unaffected** — it uses the native-host sidecar from #1612, not `dpf-tts` (guarded `!= darwin`).
- `docs/install/linux.md` + `docs/install/windows.md` gain a **Voice (STT + TTS)** section.

## Design fork I settled (flagged for review)

On a **GPU-less** Linux/Windows host I chose *clear opt-in* (managed-API guidance) over shipping a CPU-tier default, because the CPU tier needs a GPU-reservation-free compose override that doesn't exist yet and would otherwise ship a ~10–30×-slower experience or a failed reservation. A CPU-tier-active default is noted as a tracked follow-up. Happy to flip to CPU-active if you'd rather.

## Verification

- `bash -n install-dpf.sh` ✓ · PowerShell `Parser::ParseFile` on `install-dpf.ps1` ✓.
- Reuses existing GPU-detection plumbing; non-fatal isolation mirrors the Edge Node bring-up.
- ⚠️ **Functional verification pending on real NVIDIA hardware** — CI only runs the install `--dry-run` path. Spoken-output-on-fresh-GPU-install must be driven on a real NVIDIA box.

Backlog: **BI-3C812E4E** · Epic: **EP-INSTALL-HARDENING-2026-05-23**

🤖 Generated with [Claude Code](https://claude.com/claude-code)