### PR TITLE
feat(grok): device-code OAuth — sign in with Google instead of an API key (EP-GROK-001)

### DIFF
--- a/apps/web/lib/actions/grok-device-login.ts
+++ b/apps/web/lib/actions/grok-device-login.ts
@@ -1,0 +1,137 @@
+"use server";
+
+// Grok (xAI) device-code OAuth — the "sign in with Google" alternative to pasting
+// an xAI API key. Mirrors how Codex obtains a ChatGPT OAuth token, but uses the
+// Grok CLI's own device-code flow instead of an in-portal authorization-code redirect:
+//
+//   1. startGrokDeviceLogin() runs `grok login --device-auth` (detached) inside the
+//      sandbox — the only place the `grok` binary lives — and returns the
+//      accounts.x.ai/oauth2/device verification URL + user code for the operator.
+//   2. The operator opens the URL and signs in with the account-level method they
+//      enabled at xAI (Google / X / Apple). The CLI then writes ~/.grok/auth.json.
+//   3. completeGrokDeviceLogin() reads that auth.json out of the sandbox and stores
+//      it (encrypted) as the xAI credential. The build dispatch injects it back into
+//      each build sandbox's ~/.grok/auth.json (see grok-dispatch ensureGrokAuth), and
+//      the CLI self-refreshes from the embedded refresh token.
+//
+// Requires the grok-equipped sandbox image (Dockerfile.sandbox installs `grok`).
+// Both actions are gated on manage_provider_connections and are safe to call from a
+// human-facing button or, later, an MCP tool for AI-Coworker-driven setup.
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+import { encryptSecret } from "@/lib/credential-crypto";
+import { activateProvider } from "@/lib/govern/activate-provider";
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const XAI_PROVIDER_ID = "xai";
+const LOGIN_OUT = "/tmp/grok-device-login.out";
+
+async function requireManageProviders(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections")) {
+    throw new Error("Unauthorized");
+  }
+}
+
+function dockerExecAsync(): (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }> {
+  const { exec } = lazyChildProcess();
+  const { promisify } = lazyUtil();
+  const execAsync = promisify(exec) as (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
+  return (cmd, opts) => execAsync(cmd, opts).catch(() => ({ stdout: "", stderr: "" }));
+}
+
+export async function startGrokDeviceLogin(): Promise<
+  { verificationUrl: string; userCode: string } | { error: string }
+> {
+  try {
+    await requireManageProviders();
+  } catch {
+    return { error: "Your admin session expired — sign in again and retry." };
+  }
+
+  const execAsync = dockerExecAsync();
+
+  // Fresh start: clear any prior credential file + output, then launch the device-auth
+  // flow detached as the `node` user (same user the build dispatch runs grok as).
+  await execAsync(
+    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "mkdir -p ~/.grok; rm -f ~/.grok/auth.json ${LOGIN_OUT}"`,
+    { timeout: 10_000 },
+  );
+  await execAsync(
+    `docker exec -d --user node ${SANDBOX_CONTAINER} sh -c "grok login --device-auth > ${LOGIN_OUT} 2>&1"`,
+    { timeout: 10_000 },
+  );
+
+  // grok prints the verification URL + user code immediately, then blocks on
+  // "Waiting for authorization...". Poll the captured output for the URL.
+  for (let attempt = 0; attempt < 15; attempt++) {
+    await new Promise((r) => setTimeout(r, 700));
+    const { stdout } = await execAsync(
+      `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
+      { timeout: 5_000 },
+    );
+    const urlMatch = stdout.match(/https:\/\/\S*oauth2\/device\S*/);
+    if (urlMatch) {
+      const codeMatch =
+        stdout.match(/user_code=([A-Za-z0-9-]+)/) ?? stdout.match(/\b([A-Z0-9]{4}-[A-Z0-9]{4})\b/);
+      return { verificationUrl: urlMatch[0], userCode: codeMatch?.[1] ?? "" };
+    }
+    if (/not found|no such file|executable file not found/i.test(stdout)) break;
+  }
+
+  return {
+    error:
+      "Grok did not return a device-code URL. Ensure the `grok` CLI is installed in the build sandbox (Dockerfile.sandbox) and the sandbox is running, then retry.",
+  };
+}
+
+export async function completeGrokDeviceLogin(): Promise<
+  { status: "ok" } | { status: "pending" } | { status: "failed"; detail: string }
+> {
+  try {
+    await requireManageProviders();
+  } catch {
+    return { status: "failed", detail: "Your admin session expired — sign in again and retry." };
+  }
+
+  const execAsync = dockerExecAsync();
+
+  // The login process writes ~/.grok/auth.json on success.
+  const { stdout: authJson } = await execAsync(
+    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "cat ~/.grok/auth.json 2>/dev/null || true"`,
+    { timeout: 5_000 },
+  );
+  const blob = authJson.trim();
+
+  if (blob.startsWith("{")) {
+    // Persist the auth.json blob as the xAI credential. The build dispatch injects it
+    // verbatim into each sandbox's ~/.grok/auth.json; the CLI self-refreshes from the
+    // embedded refresh token. We store it in `cachedToken` and deliberately preserve any
+    // existing `secretRef` (API key): the CLI-dispatch path detects OAuth by the auth.json
+    // blob shape (grok-dispatch ensureGrokAuth), while xAI *inference* (chat) keeps using
+    // the API key via the unchanged `api_key` authMethod — the two paths don't collide.
+    await prisma.credentialEntry.upsert({
+      where: { providerId: XAI_PROVIDER_ID },
+      create: { providerId: XAI_PROVIDER_ID, cachedToken: encryptSecret(blob), status: "ok" },
+      update: { cachedToken: encryptSecret(blob), status: "ok" },
+    });
+    // Activate the provider properly (status/clearance/linked services) without overriding
+    // authMethod — leaving it as `api_key` so inference auth resolution is unaffected.
+    await activateProvider(XAI_PROVIDER_ID, { trigger: "oauth_exchange", activateLinked: true });
+    return { status: "ok" };
+  }
+
+  // Not authorized yet — distinguish "still waiting" from a failed/expired attempt.
+  const { stdout: out } = await execAsync(
+    `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
+    { timeout: 5_000 },
+  );
+  if (/error|failed|timed out|expired/i.test(out) && !/Waiting for authorization/i.test(out)) {
+    return { status: "failed", detail: out.slice(-300) };
+  }
+  return { status: "pending" };
+}

--- a/apps/web/lib/integrate/grok-dispatch.ts
+++ b/apps/web/lib/integrate/grok-dispatch.ts
@@ -32,29 +32,55 @@ export type GrokResult = {
   durationMs: number;
 };
 
-/**
- * Inject Grok API key into the sandbox as XAI_API_KEY (per-task file for safety).
- * Simpler than Codex auth.json or Claude's dual OAuth/apikey modes.
- */
-async function ensureGrokAuth(providerId: string, containerId: string, taskSlug: string): Promise<string> {
-  const credential = await getDecryptedCredential(providerId);
-  const apiKey = credential?.secretRef ?? credential?.cachedToken;
+type GrokAuthInjection =
+  | { mode: "oauth" }                    // ~/.grok/auth.json written for the node user; grok reads it
+  | { mode: "apikey"; keyFile: string }; // XAI_API_KEY sourced from this file
 
-  if (!apiKey) {
-    throw new Error(`No xAI API key for provider "${providerId}". Configure via Admin > AI Workforce > External Services.`);
-  }
+/**
+ * Provision Grok auth into the sandbox. Two modes, OAuth preferred:
+ *  - OAuth (subscription "sign in with Google"): the stored credential is the
+ *    `~/.grok/auth.json` blob captured by the device-code login flow
+ *    (lib/actions/grok-device-login.ts). It is written into the node user's
+ *    ~/.grok so the CLI uses it directly and self-refreshes from its embedded
+ *    refresh token — mirrors codex-dispatch's injectCodexAuth (~/.codex/auth.json).
+ *  - API key: the stored credential is a bare xAI key, exported as XAI_API_KEY.
+ */
+async function ensureGrokAuth(providerId: string, containerId: string, taskSlug: string): Promise<GrokAuthInjection> {
+  const credential = await getDecryptedCredential(providerId);
 
   const { exec: execCb } = lazyChildProcess();
   const { promisify } = lazyUtil();
   const execAsync = promisify(execCb);
 
+  // OAuth credential = the whole ~/.grok/auth.json JSON blob, stored in cachedToken.
+  const oauthBlob =
+    credential?.cachedToken && credential.cachedToken.trimStart().startsWith("{")
+      ? credential.cachedToken
+      : null;
+
+  if (oauthBlob) {
+    const authB64 = Buffer.from(oauthBlob).toString("base64");
+    // Write as the `node` user (the same user the dispatch runs grok as) so the
+    // CLI finds it at ~/.grok/auth.json.
+    await execAsync(
+      `docker exec --user node ${containerId} sh -c "mkdir -p ~/.grok && echo '${authB64}' | base64 -d > ~/.grok/auth.json && chmod 600 ~/.grok/auth.json"`,
+      { timeout: 5_000 },
+    );
+    return { mode: "oauth" };
+  }
+
+  // API-key fallback.
+  const apiKey = credential?.secretRef ?? credential?.cachedToken;
+  if (!apiKey) {
+    throw new Error(`No xAI credential for provider "${providerId}". Sign in to Grok (OAuth) or add an API key via Admin > AI Workforce > External Services.`);
+  }
   const keyFile = `/tmp/grok-key-${taskSlug}.txt`;
   const keyB64 = Buffer.from(apiKey).toString("base64");
   await execAsync(
     `docker exec ${containerId} sh -c "echo '${keyB64}' | base64 -d > ${keyFile} && chmod 600 ${keyFile}"`,
     { timeout: 5_000 },
   );
-  return keyFile;
+  return { mode: "apikey", keyFile };
 }
 
 /**
@@ -195,9 +221,9 @@ export async function dispatchGrokTask(params: {
     // Non-fatal; proceed (some sandboxes may already be correct)
   }
 
-  let authKeyFile: string;
+  let grokAuth: GrokAuthInjection;
   try {
-    authKeyFile = await ensureGrokAuth(providerId, containerId, safeRunId);
+    grokAuth = await ensureGrokAuth(providerId, containerId, safeRunId);
   } catch (err) {
     return {
       content: `Auth error: ${(err as Error).message}`,
@@ -250,7 +276,11 @@ export async function dispatchGrokTask(params: {
       `cleanup() { rm -f ${promptFile} ${keyFile} ${runnerScript} 2>/dev/null || true; }`,
       "trap cleanup EXIT INT TERM",
       "cd /workspace",
-      `export XAI_API_KEY=$(cat ${authKeyFile} 2>/dev/null || echo '')`,
+      // OAuth mode: grok reads the ~/.grok/auth.json injected by ensureGrokAuth (no env needed).
+      // API-key mode: export XAI_API_KEY from the per-task key file.
+      grokAuth.mode === "apikey"
+        ? `export XAI_API_KEY=$(cat ${grokAuth.keyFile} 2>/dev/null || echo '')`
+        : `: # OAuth credential injected at ~/.grok/auth.json`,
       // Headless single-turn run, verified against grok 0.2.32:
       //  --prompt-file  : read the prompt from a file. `-p/--single` takes a literal prompt
       //                   ARGUMENT (not stdin), so the old `-p - < file` passed "-" as the

--- a/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md
@@ -1,0 +1,79 @@
+# Grok (xAI) Device-Code OAuth for Build Studio Dispatch
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft — slice 1 implemented (backend) |
+| Date | 2026-06-07 |
+| Epic | EP-GROK-001 (first-class Grok support) |
+| Motivation | Operators (incl. non-technical founders) cannot easily find/obtain an xAI API key. Grok's CLI ships a clean OAuth path; prefer it. |
+| Related | `codex-dispatch.ts` (injectCodexAuth — the mirror), `github-oauth.ts`/`github-device-flow.ts` (existing RFC 8628 device-code precedent), #1606 (EP-GROK-001), #1613 (sandbox install fix) |
+
+## Problem
+
+Build Studio's `grok` dispatch engine authenticates with `XAI_API_KEY`. Getting that
+key means hunting through `console.x.ai` — a poor experience, especially for the
+non-technical operator. xAI's Grok Build CLI instead supports a standard **OAuth 2.0
+device-code** flow (`grok login --device-auth` → `accounts.x.ai/oauth2/device`) that lets
+you sign in with the account method you already use (Google / X / Apple) and is explicitly
+built "for headless/remote environments." This is cleaner and is the preferred path.
+
+## Approach (B): drive Grok's own device-code flow, store + inject the token
+
+Rather than reimplement xAI's OAuth in-portal (which would need Grok's private OAuth
+`client_id`), we **drive the Grok CLI's own `grok login --device-auth`** and capture the
+resulting credential — reusing Grok's OAuth client and self-refresh. The token lands in
+`~/.grok/auth.json`, structurally analogous to Codex's `~/.codex/auth.json`, so the
+sandbox-injection side mirrors `injectCodexAuth` exactly.
+
+Verified empirically (grok 0.2.32 in a node:24-alpine + gcompat container):
+- `grok login --device-auth` emits `https://accounts.x.ai/oauth2/device?user_code=XXXX-XXXX`, then blocks "Waiting for authorization…".
+- On success it writes `~/.grok/auth.json`.
+- Headless dispatch with that credential reaches `https://api.x.ai/v1/responses`.
+
+### Flow
+1. **startGrokDeviceLogin()** — runs `grok login --device-auth` detached in the sandbox
+   (the only place the `grok` binary lives), as the `node` user, and returns the
+   verification URL + user code.
+2. Operator opens the URL, signs in (Google/X/Apple), confirms the code.
+3. **completeGrokDeviceLogin()** — reads `~/.grok/auth.json` out of the sandbox, stores it
+   encrypted as the `xai` credential (`CredentialEntry.cachedToken`), and calls
+   `activateProvider("xai", { authMethod: "oauth2_device" })`.
+4. **Dispatch (ensureGrokAuth)** — when the stored credential is an `auth.json` blob,
+   inject it into each build sandbox's `~/.grok/auth.json` (node user) and let the CLI
+   self-refresh; otherwise fall back to `XAI_API_KEY`.
+
+### Substrate reused vs. added
+| Reused | Added |
+| --- | --- |
+| `CredentialEntry` (cachedToken/status), `encryptSecret`, `getDecryptedCredential` | `oauth2_device` in xai `supportedAuthMethods` |
+| `activateProvider(...)` activation path | `lib/actions/grok-device-login.ts` (start/complete) |
+| `injectCodexAuth` injection pattern | `ensureGrokAuth` OAuth/api-key branch (grok-dispatch.ts) |
+| RFC 8628 precedent (github device flow) | — |
+
+## Slice 1 (this PR) — backend
+- `providers-registry.json`: xai `supportedAuthMethods += oauth2_device`.
+- `grok-dispatch.ts`: `ensureGrokAuth` returns a mode; injects `~/.grok/auth.json` for OAuth, `XAI_API_KEY` otherwise; runner script branches.
+- `lib/actions/grok-device-login.ts`: `startGrokDeviceLogin` + `completeGrokDeviceLogin`.
+
+## Remaining phases
+- **Slice 2 — operator UX**: a "Sign in to Grok" affordance on the Build Studio / External
+  Services provider card that calls start → shows the URL+code → polls complete. (Mirror
+  the existing OAuth connect button.)
+- **Slice 3 — AI-Coworker control**: MCP tools wrapping start/complete so the Coworker can
+  drive setup (per the "AI Coworker as conduit" principle). Slots into the Build-Engine
+  Provisioning capability (separate design).
+- **Slice 4 — refresh durability**: the CLI self-refreshes inside ephemeral build
+  sandboxes, but that refreshed token doesn't persist back to the stored credential.
+  Re-capture or persist-on-refresh so the stored refresh token can't go stale long-term.
+
+## Open items / constraints
+- Requires the grok-equipped sandbox image (#1613).
+- Device-code OAuth uses a **SuperGrok / X Premium+ subscription** (subscription billing),
+  vs. the API key's usage billing. Both remain supported; OAuth is opt-in.
+- **Functional verification is gated on a real Grok sign-in** (operator completes the
+  browser step). Slice 1 is verified structurally (typecheck) and the flow was confirmed
+  in-container up to the authorization wait + the dispatch API call.
+
+## Principles
+`zero-click-provider-setup`, `bundled-services-active-by-default`,
+`verify-substrate-before-proposing-new`, "AI Coworker as the conduit".

--- a/packages/db/data/providers-registry.json
+++ b/packages/db/data/providers-registry.json
@@ -295,7 +295,8 @@
     "baseUrl": "https://api.x.ai/v1",
     "authMethod": "api_key",
     "supportedAuthMethods": [
-      "api_key"
+      "api_key",
+      "oauth2_device"
     ],
     "authHeader": "Authorization",
     "costModel": "token",


### PR DESCRIPTION
## Why
Getting an xAI API key means hunting through console.x.ai — rough for non-technical operators. Grok's CLI ships a clean **OAuth 2.0 device-code** flow (`grok login --device-auth` → `accounts.x.ai/oauth2/device`) where you just sign in with the account method you already use (Google / X / Apple). This makes that the **preferred** auth path for the `grok` build engine, with API key kept as a fallback.

## Approach
Drive the Grok CLI's **own** device-code flow rather than reimplement xAI OAuth (which would need Grok's private `client_id`). The token lands in `~/.grok/auth.json` — structurally the same as Codex's `~/.codex/auth.json` — so the sandbox-injection side **mirrors `injectCodexAuth`**, and the CLI self-refreshes from the embedded refresh token.

Verified in-container (grok 0.2.32): `grok login --device-auth` emits the verification URL + code, blocks for authorization, then writes `~/.grok/auth.json`; dispatch with that credential reaches `https://api.x.ai/v1/responses`.

## Slice 1 (this PR — backend)
- `providers-registry.json`: xai `supportedAuthMethods += "oauth2_device"`.
- `grok-dispatch.ts`: `ensureGrokAuth` returns a mode — injects `~/.grok/auth.json` for OAuth (node user), API key otherwise; runner script branches.
- `lib/actions/grok-device-login.ts`: `startGrokDeviceLogin` (returns the device URL + code) and `completeGrokDeviceLogin` (captures `~/.grok/auth.json`, stores it encrypted as the xAI credential, activates the provider). Permission-gated; ready to wrap in a UI button or MCP tool.

## Non-breaking by design
OAuth serves **CLI dispatch only**: the credential is stored in `cachedToken` and detected by blob shape; `secretRef` (API key) and the `api_key` `authMethod` are preserved, so xAI **inference (chat)** auth is unaffected.

## Verification
- ✅ `pnpm --filter web typecheck` clean.
- Device-code flow confirmed in-container up to the authorization wait + the API call.
- **Functional proof (an operator completing the browser sign-in) is gated on a real SuperGrok/X Premium+ account** — same gate as every other Grok runtime step. Slice 1 is structurally verified.

## Remaining (per design doc)
- Slice 2: operator "Sign in to Grok" UI affordance (mirror the OAuth connect button).
- Slice 3: MCP tools so the AI Coworker can drive setup.
- Slice 4: refresh durability across ephemeral build sandboxes.

Design: `docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md`. Depends on the grok-equipped sandbox image (#1613).

🤖 Generated with [Claude Code](https://claude.com/claude-code)