### PR TITLE
fix(self-upgrade): activity precheck before draining — stop periodic portal bad-state (BI-F36E7510)

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -33,6 +33,9 @@ const mocks = vi.hoisted(() => ({
   signalSwapStarting: vi.fn(),
   signalSwapComplete: vi.fn(),
   failQuiescenceSwap: vi.fn(),
+  // Activity precheck snapshot (BI-F36E7510). Default empty so existing tests
+  // proceed to the drain exactly as before; the new skip-path test overrides it.
+  captureActiveSessionBlockers: vi.fn().mockResolvedValue({ surfaces: [] }),
 }));
 
 vi.mock("@/lib/self-upgrade/config", () => ({
@@ -122,6 +125,7 @@ vi.mock("@/lib/self-upgrade/quiescence", () => ({
   signalSwapStarting: mocks.signalSwapStarting,
   signalSwapComplete: mocks.signalSwapComplete,
   failQuiescenceSwap: mocks.failQuiescenceSwap,
+  captureActiveSessionBlockers: mocks.captureActiveSessionBlockers,
 }));
 
 import type { SelfUpgradeRunEventData } from "./self-upgrade";
@@ -370,6 +374,28 @@ describe("success path", () => {
     expect(result).toMatchObject({ skipped: true, reason: "up-to-date" });
     expect(mocks.prepareUpgradeSource).not.toHaveBeenCalled();
     expect(mocks.runPromoter).not.toHaveBeenCalled();
+  });
+
+  it("skips BEFORE draining when activity is in flight — no drain/defer/cooldown cycle (BI-F36E7510)", async () => {
+    // Build Studio work in flight: the activity precheck must skip cleanly
+    // instead of flipping the portal to draining and burning the full budget
+    // waiting for a BuildPhaseRun that outlasts it (the periodic bad-state bug).
+    mocks.captureActiveSessionBlockers.mockResolvedValueOnce({
+      surfaces: [{ surface: "build-studio.phase.plan" }],
+    });
+    const result = await runSelfUpgrade({ triggeredBy: "ops" });
+    expect(result).toMatchObject({ skipped: true, reason: "activity-in-flight" });
+    // The whole point: no drain, no cooldown — the portal never refuses actions.
+    expect(mocks.startQuiescence).not.toHaveBeenCalled();
+    expect(mocks.recordCooldown).not.toHaveBeenCalled();
+  });
+
+  it("force bypasses the activity precheck and proceeds to drain", async () => {
+    mocks.captureActiveSessionBlockers.mockResolvedValueOnce({
+      surfaces: [{ surface: "build-studio.phase.plan" }],
+    });
+    await runSelfUpgrade({ triggeredBy: "ops", force: true });
+    expect(mocks.startQuiescence).toHaveBeenCalled();
   });
 
   it("runs the promoter with the host install path, backup, image, and health paths", async () => {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -153,6 +153,30 @@ export async function runSelfUpgrade(
     }
   }
 
+  // Activity precheck — skip BEFORE any drain (mirrors the promoter precheck
+  // above). This fixes the live periodic bad-state bug (BI-F36E7510): the
+  // coordinator flips the portal to `draining` (refusing every mutation/MCP
+  // action) and THEN waits the full ~5min budget for the in-flight BuildPhaseRun
+  // / coworker loop to quiesce — but Build Studio phases routinely outlast the
+  // budget, so it times out and defers ("quiescence-deferred:
+  // build-studio.phase.plan") having refused work the entire time, then sets a
+  // cooldown and retries, repeating the drain every cycle. Snapshot the active
+  // surfaces FIRST; if anything is in flight, skip cleanly (no drain, no
+  // cooldown) and let the next tick retry once the surfaces are idle. This is the
+  // same snapshot the coordinator drains against, so "empty here" means the drain
+  // would converge immediately. force/dryRun bypass (the operator is asking now).
+  if (!params.dryRun && !params.force) {
+    const { captureActiveSessionBlockers } = await import("@/lib/self-upgrade/quiescence");
+    const snapshot = await captureActiveSessionBlockers();
+    if (snapshot.surfaces.length > 0) {
+      return {
+        skipped: true,
+        reason: "activity-in-flight",
+        surfaces: snapshot.surfaces.map((s) => s.surface),
+      };
+    }
+  }
+
   const gitRun = defaultGitRunner;
   const hostSourcePath =
     config.hostSourceMountPath ??


### PR DESCRIPTION
## Root cause (drain-before-check race)
Operator reported the portal periodically enters a bad state. Traced it: `runSelfUpgrade` prechecks the promoter image before draining but had **no check for active Build Studio work**. So it would:
1. `startQuiescence` → flip portal to **`draining`** (refuses every mutation/MCP action),
2. `awaitReady` → wait the **full 5-min budget** for in-flight `BuildPhaseRun`/coworker loops to quiesce,
3. BS phases **outlast the budget** → times out → **defers** (`quiescence-deferred: build-studio.phase.plan`), having refused work the whole time → cooldown → retry → repeat.

That repeating ~5-min drain window = the periodic bad state. (The authors already knew this shape — there's a cooldown comment about "refuses every MCP/UX action ~5 of every 6 minutes" — but the cooldown only *spaces* cycles; it doesn't prevent each drain.)

## Fix
Add an **activity precheck before `startQuiescence`** (mirroring the existing promoter precheck), reusing the coordinator's own **`captureActiveSessionBlockers`** snapshot — the same surfaces the drain waits on. If anything is in flight → **skip cleanly** (`activity-in-flight`, no drain, no cooldown), retry next tick once idle. Empty snapshot ⇒ the drain would converge immediately, so we only drain when it'll succeed fast. `force`/`dryRun` bypass.

## Tests
- Mocked `captureActiveSessionBlockers` (default empty → existing drain tests unchanged).
- New: skip-before-drain when surfaces active (no `startQuiescence`, no `recordCooldown`); `force` bypasses + drains.

Self-upgrade is currently **disabled** on the install to stop the live churn; re-enable after this deploys. Companion to BI-A5AFB664 (graceful update-imminent advisory). Run full vitest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)