### PR TITLE
feat(mdm): Master Data Management foundation — trust dimensions + domain registry (EP-MDM)

### DIFF
--- a/apps/web/lib/mdm/domain-registry.test.ts
+++ b/apps/web/lib/mdm/domain-registry.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MASTER_DATA_DOMAINS,
+  MASTER_DATA_DOMAIN_KEYS,
+  getMasterDataDomain,
+  isIdentityBearingDomain,
+  masterDataSourceRefDomains,
+} from "@/lib/mdm/domain-registry";
+
+const KEBAB_SLUG = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+// Resolve real Prisma model names from the schema (hermetic — no DB, no client
+// runtime). schema.prisma is the canonical source the EA extractor also reads.
+const SCHEMA_PATH = fileURLToPath(
+  new URL("../../../../packages/db/prisma/schema.prisma", import.meta.url),
+);
+const PRISMA_MODEL_NAMES = new Set<string>(
+  Array.from(
+    readFileSync(SCHEMA_PATH, "utf8").matchAll(/^model\s+(\w+)\s*\{/gm),
+    (m) => m[1],
+  ),
+);
+
+describe("master-data domain registry", () => {
+  it("every domain's canonicalModel resolves to a real Prisma model", () => {
+    for (const key of MASTER_DATA_DOMAIN_KEYS) {
+      const config = MASTER_DATA_DOMAINS[key];
+      expect(
+        PRISMA_MODEL_NAMES.has(config.canonicalModel),
+        `domain "${key}" canonicalModel "${config.canonicalModel}" is not a Prisma model`,
+      ).toBe(true);
+    }
+  });
+
+  it("identityBearing is consistent with the crosswalk mechanism", () => {
+    for (const key of MASTER_DATA_DOMAIN_KEYS) {
+      const config = MASTER_DATA_DOMAINS[key];
+      if (config.identityBearing) {
+        expect(config.crosswalkVia, key).toBe("principal-alias");
+      } else {
+        expect(config.crosswalkVia, key).toBe("master-data-source-ref");
+      }
+    }
+  });
+
+  it("identity-bearing domains are excluded from the MasterDataSourceRef crosswalk", () => {
+    const refDomains = masterDataSourceRefDomains();
+    // Per spec §6.2 / AGENTS.md §11, organization and customer-contact resolve
+    // identity via PrincipalAlias and must NOT appear in the crosswalk set.
+    expect(refDomains).not.toContain("organization");
+    expect(refDomains).not.toContain("customer-contact");
+    expect(isIdentityBearingDomain("organization")).toBe(true);
+    expect(isIdentityBearingDomain("customer-contact")).toBe(true);
+    expect(isIdentityBearingDomain("customer-account")).toBe(false);
+    for (const domain of refDomains) {
+      expect(isIdentityBearingDomain(domain)).toBe(false);
+    }
+  });
+
+  it("the crosswalk set matches the non-identity domains named in spec §6.2", () => {
+    expect(new Set(masterDataSourceRefDomains())).toEqual(
+      new Set([
+        "customer-account",
+        "customer-site",
+        "digital-product",
+        "supplier",
+        "inventory-entity",
+        "taxonomy-node",
+        "reference-data",
+      ]),
+    );
+  });
+
+  it("every domain is fully specified with a well-formed steward capability", () => {
+    for (const key of MASTER_DATA_DOMAIN_KEYS) {
+      const config = MASTER_DATA_DOMAINS[key];
+      expect(config.domain, key).toBe(key);
+      expect(config.canonicalIdField.length, key).toBeGreaterThan(0);
+      expect(config.identityAttributes.length, key).toBeGreaterThan(0);
+      expect(config.qualityDimensions.length, key).toBeGreaterThan(0);
+      expect(config.publishingReadModel.length, key).toBeGreaterThan(0);
+      expect(KEBAB_SLUG.test(config.stewardCapabilityId), key).toBe(true);
+    }
+  });
+
+  it("merge policy is tombstone for every domain (resolved §6.6 decision: no hard-delete)", () => {
+    for (const key of MASTER_DATA_DOMAIN_KEYS) {
+      expect(MASTER_DATA_DOMAINS[key].mergePolicy, key).toBe("tombstone");
+    }
+  });
+
+  it("getMasterDataDomain resolves known keys and rejects unknown ones", () => {
+    expect(getMasterDataDomain("supplier")?.canonicalModel).toBe("Supplier");
+    expect(getMasterDataDomain("not-a-domain")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/mdm/domain-registry.ts
+++ b/apps/web/lib/mdm/domain-registry.ts
@@ -1,0 +1,239 @@
+/**
+ * Master Data Management — domain registry (MDM spec §6.1).
+ *
+ * A code-level registry of the business entities DPF governs as master data.
+ * This is NOT a new table: the canonical record for each domain stays in its
+ * existing Prisma model (spec §5.1). The registry declares HOW each domain is
+ * mastered so crosswalk, match/dedupe, survivorship, stewardship, and
+ * publishing all read one source of truth.
+ *
+ * Two crosswalk mechanisms, never duplicated (spec §6.2):
+ *  - identity-bearing domains resolve cross-source identity through
+ *    `PrincipalAlias` (AGENTS.md §11) and are OUT of scope for
+ *    `MasterDataSourceRef`;
+ *  - non-identity domains use the `MasterDataSourceRef` crosswalk.
+ *
+ * Domain "reference-data" is a domain-family (Country/Region/City). `Region`
+ * is its representative canonical model for the merge surface (MDM-5).
+ *
+ * Relationship to EP-DATA-ARCH: the data-architecture steward derives a domain
+ * map from the schema; this registry is the governed overlay declaring which
+ * of those domains are managed master data — it is not an independent taxonomy.
+ */
+import type { TrustDimensionKey } from "@/lib/trust-vector";
+
+export type MasterDataDomain =
+  | "organization"
+  | "customer-account"
+  | "customer-contact"
+  | "customer-site"
+  | "digital-product"
+  | "supplier"
+  | "inventory-entity"
+  | "taxonomy-node"
+  | "reference-data";
+
+/** How a domain resolves the same real-world entity across source systems. */
+export type CrosswalkMechanism = "principal-alias" | "master-data-source-ref";
+
+/**
+ * Merge policy. Only "tombstone" exists: the merge-severity decision (spec §6.6,
+ * kernel 2026-06-06) resolved that a merge never hard-deletes — the losing
+ * canonical row is superseded and retained with a pre-merge snapshot.
+ */
+export type MergePolicy = "tombstone";
+
+export type MasterDataDomainConfig = {
+  readonly domain: MasterDataDomain;
+  /** Prisma model name that owns the canonical record. Validated at test time. */
+  readonly canonicalModel: string;
+  /** Canonical primary-key field on that model. */
+  readonly canonicalIdField: string;
+  /** Attributes used to identify/match records within the domain. */
+  readonly identityAttributes: readonly string[];
+  /**
+   * Quality dimensions this domain must score. Typed against the single trust
+   * registry (MDM-0) — tsc rejects any non-registry key here.
+   */
+  readonly qualityDimensions: readonly TrustDimensionKey[];
+  /** Source systems whose records may map onto this domain. */
+  readonly allowedSourceSystems: readonly string[];
+  /** Identity crosswalk mechanism. principal-alias ⇔ identityBearing. */
+  readonly crosswalkVia: CrosswalkMechanism;
+  /** True iff this is an identity-bearing entity (PrincipalAlias territory). */
+  readonly identityBearing: boolean;
+  readonly mergePolicy: MergePolicy;
+  /**
+   * PlatformCapability id checked at the steward action boundary (spec §6.1).
+   * Kebab-case slug; the capability is seeded + bound in MDM-3 (steward queue).
+   */
+  readonly stewardCapabilityId: string;
+  /** Stable read-model name downstream surfaces consume (spec §7 step 7). */
+  readonly publishingReadModel: string;
+};
+
+const STEWARD_CAPABILITY = "mdm-steward" as const;
+
+const SHARED_QUALITY_DIMENSIONS: readonly TrustDimensionKey[] = [
+  "coverageCompleteness",
+  "freshness",
+  "sourceAuthority",
+  "dataLineage",
+  "humanValidation",
+  "conflictContradiction",
+  "validityConformity",
+  "uniqueness",
+  "relationshipIntegrity",
+];
+
+export const MASTER_DATA_DOMAINS: Readonly<
+  Record<MasterDataDomain, MasterDataDomainConfig>
+> = {
+  organization: {
+    domain: "organization",
+    canonicalModel: "Organization",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "legalName", "domain"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: [],
+    crosswalkVia: "principal-alias",
+    identityBearing: true,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.organization",
+  },
+  "customer-account": {
+    domain: "customer-account",
+    canonicalModel: "CustomerAccount",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "website", "domain"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["pipedrive", "quickbooks", "csv-import", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.customer-account",
+  },
+  "customer-contact": {
+    domain: "customer-contact",
+    canonicalModel: "CustomerContact",
+    canonicalIdField: "id",
+    identityAttributes: ["email", "fullName", "phone"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: [],
+    crosswalkVia: "principal-alias",
+    identityBearing: true,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.customer-contact",
+  },
+  "customer-site": {
+    domain: "customer-site",
+    canonicalModel: "CustomerSite",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "addressId"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["csv-import", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.customer-site",
+  },
+  "digital-product": {
+    domain: "digital-product",
+    canonicalModel: "DigitalProduct",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "slug"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["build-studio", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.digital-product",
+  },
+  supplier: {
+    domain: "supplier",
+    canonicalModel: "Supplier",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "website", "taxId"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["quickbooks", "csv-import", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.supplier",
+  },
+  "inventory-entity": {
+    domain: "inventory-entity",
+    canonicalModel: "InventoryEntity",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "externalRef"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["discovery", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.inventory-entity",
+  },
+  "taxonomy-node": {
+    domain: "taxonomy-node",
+    canonicalModel: "TaxonomyNode",
+    canonicalIdField: "id",
+    identityAttributes: ["slug", "label"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.taxonomy-node",
+  },
+  "reference-data": {
+    // Domain-family (Country/Region/City). Region is the representative
+    // canonical model for the merge surface (MDM-5).
+    domain: "reference-data",
+    canonicalModel: "Region",
+    canonicalIdField: "id",
+    identityAttributes: ["name", "code", "countryId"],
+    qualityDimensions: SHARED_QUALITY_DIMENSIONS,
+    allowedSourceSystems: ["iso-3166", "manual"],
+    crosswalkVia: "master-data-source-ref",
+    identityBearing: false,
+    mergePolicy: "tombstone",
+    stewardCapabilityId: STEWARD_CAPABILITY,
+    publishingReadModel: "mdm.reference-data",
+  },
+};
+
+/** All registered master-data domains. */
+export const MASTER_DATA_DOMAIN_KEYS = Object.keys(
+  MASTER_DATA_DOMAINS,
+) as MasterDataDomain[];
+
+/** Look up a domain config, or undefined if the key is not a master-data domain. */
+export function getMasterDataDomain(
+  domain: string,
+): MasterDataDomainConfig | undefined {
+  return (MASTER_DATA_DOMAINS as Record<string, MasterDataDomainConfig>)[domain];
+}
+
+/** True iff the domain resolves identity via PrincipalAlias (not MasterDataSourceRef). */
+export function isIdentityBearingDomain(domain: MasterDataDomain): boolean {
+  return MASTER_DATA_DOMAINS[domain].identityBearing;
+}
+
+/**
+ * Domains eligible for the `MasterDataSourceRef` crosswalk (spec §6.2): every
+ * non-identity domain. Identity-bearing domains are excluded — a second identity
+ * crosswalk would violate single-source-of-truth.
+ */
+export function masterDataSourceRefDomains(): MasterDataDomain[] {
+  return MASTER_DATA_DOMAIN_KEYS.filter(
+    (domain) => MASTER_DATA_DOMAINS[domain].crosswalkVia === "master-data-source-ref",
+  );
+}

--- a/apps/web/lib/trust-vector/score.test.ts
+++ b/apps/web/lib/trust-vector/score.test.ts
@@ -115,4 +115,45 @@ describe("scoreTrustVector", () => {
     expect(assessment.tier).toBe("high");
     expect(assessment.overallScore).toBe(1);
   });
+
+  it("scores master-data dimensions (validity/uniqueness/relationship integrity) through the shared registry", () => {
+    const assessment = scoreTrustVector({
+      subject: {
+        type: "customer-account",
+        id: "cust-1",
+        label: "Acme Corp",
+      },
+      asOf: "2026-06-06T12:00:00.000Z",
+      dimensions: [
+        dimension("validityConformity", 0.9, "Email and domain pass format validation."),
+        dimension("uniqueness", 0.85, "No duplicate candidate above threshold."),
+        dimension("relationshipIntegrity", 0.95, "All crosswalk rows resolve to live canonical ids."),
+      ],
+    });
+
+    const keys = assessment.dimensions.map((d) => d.key);
+    expect(keys).toEqual(["validityConformity", "uniqueness", "relationshipIntegrity"]);
+    expect(assessment.tier).toBe("high");
+    expect(assessment.overallScore).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("qualifies a master-data record with low uniqueness (duplicate risk)", () => {
+    const assessment = scoreTrustVector({
+      subject: {
+        type: "customer-account",
+        id: "cust-2",
+        label: "Acme Corporation",
+      },
+      asOf: "2026-06-06T12:00:00.000Z",
+      dimensions: [
+        dimension("validityConformity", 0.9, "Fields well-formed."),
+        dimension("uniqueness", 0.2, "A high-confidence duplicate candidate exists."),
+        dimension("relationshipIntegrity", 0.9, "Crosswalk rows resolve."),
+      ],
+    });
+
+    expect(assessment.tier).toBe("low");
+    expect(assessment.action).not.toBe("present");
+    expect(assessment.primaryRationale).toContain("duplicate");
+  });
 });

--- a/apps/web/lib/trust-vector/score.ts
+++ b/apps/web/lib/trust-vector/score.ts
@@ -13,6 +13,11 @@ const LOW_DIMENSION_THRESHOLD = 0.4;
 const CAP_ORDER: TrustDimensionKey[] = [
   "conflictContradiction",
   "runtimeAvailability",
+  // Master-data integrity dimensions (MDM §6.5): a broken crosswalk reference or
+  // a high-confidence duplicate must degrade trust the same way a source conflict
+  // does — a duplicated/orphaned record cannot be presented as a clean fact.
+  "relationshipIntegrity",
+  "uniqueness",
   "freshness",
   "evidenceGrade",
   "coverageCompleteness",
@@ -132,7 +137,12 @@ function determineStatementKind(input: {
   freshnessLow: boolean;
   graphTraversalLow: boolean;
 }): TrustStatementKind {
-  if (input.capKey === "conflictContradiction" || input.capKey === "runtimeAvailability") {
+  if (
+    input.capKey === "conflictContradiction" ||
+    input.capKey === "runtimeAvailability" ||
+    input.capKey === "relationshipIntegrity" ||
+    input.capKey === "uniqueness"
+  ) {
     return "low-confidence-result";
   }
 
@@ -158,6 +168,8 @@ function determineAction(input: {
   highRisk: boolean;
 }): TrustAction {
   if (input.capKey === "conflictContradiction") return "escalate";
+  if (input.capKey === "relationshipIntegrity") return "escalate";
+  if (input.capKey === "uniqueness") return "qualify";
   if (input.capKey === "runtimeAvailability") return "defer";
   if (input.capKey === "evidenceGrade") return "defer";
   if (input.capKey === "freshness") {

--- a/apps/web/lib/trust-vector/types.ts
+++ b/apps/web/lib/trust-vector/types.ts
@@ -29,7 +29,13 @@ export type TrustDimensionKey =
   | "conflictContradiction"
   | "runtimeAvailability"
   | "sampleSize"
-  | "riskImpact";
+  | "riskImpact"
+  // Master Data Management dimensions (MDM spec sec 6.5; shared with EP-DATA-ARCH
+  // steward drift detection). Added 2026-06-06 — this union is the single trust
+  // vocabulary registry; MDM does not introduce a parallel dimension list.
+  | "validityConformity"
+  | "uniqueness"
+  | "relationshipIntegrity";
 
 export type TrustEvidenceRef = {
   kind:

--- a/docs/superpowers/plans/2026-06-06-master-data-management-foundation.md
+++ b/docs/superpowers/plans/2026-06-06-master-data-management-foundation.md
@@ -1,0 +1,253 @@
+---
+title: Master Data Management Foundation — Implementation Plan
+authoredAt: 2026-06-06
+authoredBy: claude
+planFor: BI-C5F3CB36
+epic: EP-MDM
+spec: docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md
+status: draft
+---
+
+# Master Data Management Foundation — Implementation Plan
+
+Implements **BI-C5F3CB36** under **EP-MDM**, against the approved
+[Master Data Management Alignment Design](../specs/2026-05-31-master-data-management-alignment-design.md).
+
+## Definition of done
+
+The plan is complete when BI-C5F3CB36's acceptance criteria (spec §9) hold on a
+live install: imported customer records link to an existing `CustomerAccount`
+without creating duplicates; possible duplicates surface as steward-visible
+candidates with reasons; conflicting source values show survivorship rationale;
+reference-data changes show usage impact before deactivate/merge; canonical reads
+carry a `TrustAssessment` envelope; a steward merge produces an auditable
+`ToolExecution` with a pre-merge snapshot and repointed (never orphaned)
+crosswalk rows; survivorship rules are governed, versioned config.
+
+## Resolved decisions (binding on this plan)
+
+- **Crosswalk integrity = typed-FK hybrid.** Typed nullable FK columns
+  (`customerAccountId`, `supplierId`) on `MasterDataSourceRef` for the two
+  high-volume domains (DB cascade); polymorphic `(domain, canonicalId)` pointer
+  for low-volume domains. (spec §6.2, kernel 2026-06-06)
+- **Merge severity = permanent tombstone.** No hard-delete path, ever. A merge is
+  link + supersede with a pre-merge snapshot. (spec §6.6, kernel 2026-06-06)
+
+## Substrate grounding (verified 2026-06-06)
+
+| Concern | Real substrate (file:line) | Plan posture |
+|---|---|---|
+| Canonical customer | `CustomerAccount` — `packages/db/prisma/schema.prisma:2250` | Typed FK target; never duplicated |
+| Canonical supplier | `Supplier` — `schema.prisma:7682` | Typed FK target |
+| Import intake / candidates | `IntegrationImportStagedRecord` — `schema.prisma:1429` | Reuse as import-candidate queue; crosswalk is the resolved mapping |
+| Survivorship config precedent | `EaDqRule` (5609), `PolicyRule` (6825), `ApprovalRule` (7939) | Store survivorship as governed rule-as-JSON, same shape family |
+| Trust vocabulary | `TrustDimensionKey` — `apps/web/lib/trust-vector/types.ts:19-32` | Add 3 net-new keys; reuse 6 existing |
+| Trust envelope | `apps/web/lib/trust-vector/{types,score}.ts`, `surface-data-provenance.ts` | Publishing contracts emit `TrustAssessment` |
+| Reference-data admin | `apps/web/app/(shell)/admin/reference-data/page.tsx`; actions `apps/web/lib/actions/reference-data-admin.ts` (+ `.test.ts`) | Extend with merge; reuse soft-delete + CI uniqueness indexes |
+| Identity crosswalk (out of scope) | `PrincipalAlias` (AGENTS.md §11) | organization / customer-contact resolve here, NOT via `MasterDataSourceRef` |
+| Enum registration | `apps/web/lib/backlog.ts`, `apps/web/lib/mcp-tools.ts` | Register `domain`/`status`/`trustTier` values (hyphens) |
+
+## Relationship to EP-DATA-ARCH (parallel data-architecture capability)
+
+EP-DATA-ARCH (Self-Maintaining Data Architecture,
+`docs/superpowers/specs/2026-06-06-data-architecture-self-maintenance-design.md`)
+runs in parallel. It governs the data **model** (mirror `schema.prisma` into the
+EA tool as a live ERD, stewarded by AGT-BUILD-DA). MDM governs the data
+**records** (canonical instances, crosswalk, dedup, survivorship). They are
+distinct layers and stay as **two epics** — but share substrate at three seams:
+
+1. **Trust dimensions are shared (Phase 0).** EP-DATA-ARCH §6.4 files drift
+   findings for uniqueness, relationship integrity, and FK-index/validity issues —
+   the same three net-new `TrustDimensionKey`s MDM Phase 0 adds. **Phase 0 is a
+   single coordinated BI both epics consume**, owned in the neutral
+   graph-trust-vector spec. File once; both epics depend on it.
+2. **One "domain" notion.** EP-DATA-ARCH's steward proposes
+   `proposedProperties.domain` clustering on EA elements; MDM Phase 1's
+   `MasterDataDomain` registry must be a **governed overlay** on that map
+   (declaring which domains are managed master data), not an independent taxonomy.
+   Phase 1 coordinates with EP-DATA-ARCH BI-6E5BF91F (steward domain clustering).
+3. **Findings reuse `EaConformanceIssue`.** MDM record-level integrity findings
+   (polymorphic-domain crosswalk orphans, uniqueness violations) extend the
+   existing `EaConformanceIssue` + drift machinery rather than a parallel MDM issue
+   queue. The Data Architect steward may surface MDM crosswalk orphans.
+
+Non-seams (kept separate): MDM's record crosswalk/dedup/survivorship has no
+EP-DATA-ARCH analog; EP-DATA-ARCH's Prisma extractor/ERD mirror has no MDM analog.
+
+## Child BI ledger (filed 2026-06-06 under EP-MDM)
+
+| Phase | Label | BI id | Size | Blocked by |
+| --- | --- | --- | --- | --- |
+| 0 | trust-dimension registry (shared w/ EP-DATA-ARCH) | BI-7535C218 | small | — |
+| 1 | domain registry | BI-AC85936F | small | — |
+| 2 | customer-account crosswalk + candidates | BI-247A03E1 | large | 0, 1 |
+| 3 | steward queue | BI-A03F059A | large | 2 |
+| 4 | survivorship v1 | BI-4E6C0819 | large | 2 |
+| 5 | reference-data/locations merge | BI-969ACC4A | medium | — |
+| 6 | supplier pilot | BI-3227FA4C | medium | 2, 3 |
+| 7 | publishing contracts | BI-C5E81603 | medium | 0, 2, 4 |
+
+## Phasing — each phase becomes a child BI under EP-MDM
+
+Phases are dependency-ordered. **Phase 0 is the only hard blocker on the rest.**
+Phases 1 and 5 can ship independently of 2–4/6–7.
+
+### Phase 0 — Trust-dimension registry extension (cross-spec prerequisite) — BLOCKS all consumers
+- **Deliverable:** Add `validityConformity`, `uniqueness`, `relationshipIntegrity`
+  to the `TrustDimensionKey` union and any label/weight maps; update the
+  2026-05-26 graph-data-trust-vector spec's registry section to match.
+- **Files:** `apps/web/lib/trust-vector/types.ts`, `apps/web/lib/trust-vector/wording.ts`,
+  `apps/web/lib/trust-vector/score.ts`; spec `docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md`.
+- **Verification:** Unit test asserts the three keys are accepted by `TrustDimension`
+  construction and render labels; existing trust-vector tests still pass.
+- **Risk/rollback:** Additive union members — low blast radius. Rollback = revert the
+  three additions; no consumers exist yet until later phases.
+- **Child BI:** `MDM-0 trust-dimension registry extension` (size: small). **Shared
+  coordinated dependency for both EP-MDM and EP-DATA-ARCH** (see "Relationship to
+  EP-DATA-ARCH" above) — file once, both epics consume; flag overlap with open
+  graph-trust-vector / data-architecture work before push.
+
+### Phase 1 — Code-level domain registry (no schema) — independent
+- **Deliverable:** `MasterDataDomain` type + per-domain config (canonical model,
+  canonical id field, identity attributes, required quality dimensions, allowed
+  source systems, merge policy, steward `capabilityId`, publishing read model).
+- **Files:** new `apps/web/lib/mdm/domain-registry.ts` (+ test). No Prisma change.
+- **Verification:** Unit test: every registry entry resolves a real Prisma model name
+  and a real `PlatformCapability` id; identity-bearing domains (organization,
+  customer-contact) are marked crosswalk-via-PrincipalAlias and rejected from the
+  `MasterDataSourceRef` path.
+- **Risk/rollback:** Pure code, no runtime wiring yet. Rollback = delete the module.
+- **Child BI:** `MDM-1 domain registry` (size: small). Not blocked by Phase 0.
+
+### Phase 2 — Customer-account pilot: crosswalk + duplicate-candidate detection — needs Phase 0,1
+- **Deliverable:** `MasterDataSourceRef` model (typed-FK hybrid per §6.2) +
+  migration + enum registration; in-place duplicate-candidate detection for two
+  existing `CustomerAccount`s (net-new substrate only for the case
+  `IntegrationImportStagedRecord` does not cover); standardization helpers (name,
+  domain, email/phone) before match scoring.
+- **Files:** `packages/db/prisma/schema.prisma` (+ migration under
+  `packages/db/prisma/migrations/`), `apps/web/lib/backlog.ts`,
+  `apps/web/lib/mcp-tools.ts`, new `apps/web/lib/mdm/crosswalk.ts`,
+  `apps/web/lib/mdm/match-candidate.ts` (+ tests).
+- **Verification (functional):** On a live install, import/create two
+  near-duplicate customer rows → a candidate appears with match score + reasons;
+  a confirmed link writes one `MasterDataSourceRef` with `customerAccountId`
+  populated and equal to `canonicalId`; the CHECK constraint rejects a mismatched
+  pair. No duplicate `CustomerAccount` is created.
+- **Risk/rollback:** New table + FK to a high-volume domain. Blast radius contained
+  to additive table; rollback = down-migration drops `MasterDataSourceRef`. Verify
+  no enum drift between `backlog.ts`/`mcp-tools.ts` (AGENTS.md §3).
+- **Child BI:** `MDM-2 customer-account crosswalk + candidates` (size: large).
+
+### Phase 3 — Steward queue admin surface (link / reject / create-new) — needs Phase 2
+- **Deliverable:** Admin/steward page listing duplicate candidates + source
+  conflicts with reasons; actions link / reject / create-new. **No destructive
+  merge yet** — merge ships in a follow-on once snapshot/reversal is wired.
+  Steward decisions gated by `PlatformCapability`, each recorded as a
+  `ToolExecution` (+ receipt) — no bespoke steward-action log.
+- **Files:** new route under `apps/web/app/(shell)/admin/` (mirror the
+  reference-data page pattern), client panel components, server actions in
+  `apps/web/lib/actions/`.
+- **Verification (functional):** Drive the page on a live install — a steward links
+  a candidate (crosswalk row written), rejects another (candidate closed with
+  rationale), and creates-new; each action produces a `ToolExecution` carrying the
+  steward `capabilityId`; a non-steward is denied at the action boundary.
+- **Risk/rollback:** UI + governed actions, additive. Rollback = remove route +
+  actions; crosswalk data persists harmlessly.
+- **Child BI:** `MDM-3 steward queue (non-destructive)` (size: large).
+
+### Phase 4 — Survivorship v1 (rules-as-JSON) — needs Phase 2
+- **Deliverable:** Field-level survivorship rules for customer name, website,
+  source-status mapping, primary contact, primary site/address, stored as governed
+  rule-as-JSON (precedent: `EaDqRule.rule` / `PolicyRule` / `ApprovalRule`), scoped
+  by `domain` + attribute class, versioned + deactivatable, with usage-impact
+  preview before change. Survivorship rule set is itself a mastered reference-data
+  domain (§5.5).
+- **Files:** survivorship rule model/rows (reuse existing rule substrate where it
+  fits before adding net-new), `apps/web/lib/mdm/survivorship.ts` (+ test),
+  steward UI surfacing the chosen winner + rationale.
+- **Verification (functional):** Conflicting source values on a linked customer
+  resolve per rule; the steward view shows the winning value and the rule that
+  decided it; changing a rule shows usage impact before it takes effect; a rule
+  change is versioned (not a silent code redeploy).
+- **Risk/rollback:** Config-driven; rollback = deactivate the rule set (reverts to
+  human-override-only). Guard against a hardcoded constant re-deciding on deploy.
+- **Child BI:** `MDM-4 survivorship v1` (size: large).
+
+### Phase 5 — Reference-data / locations merge (finish the deferred merge) — independent
+- **Deliverable:** Extend `/admin/reference-data` with duplicate **merge/replace**
+  for regions and cities + usage-impact preview before merge — implementing the
+  merge the 2026-03-17 admin reference-data spec explicitly deferred (only
+  deactivate/reactivate shipped). Reuse existing soft-delete (`status`) and the
+  case-insensitive uniqueness indexes (`Region_countryId_name_ci`,
+  `City_regionId_name_ci`). Merge repoints address references from the losing row
+  to the survivor (tombstone the loser; never delete).
+- **Files:** `apps/web/app/(shell)/admin/reference-data/page.tsx`,
+  `apps/web/components/admin/{RegionPanel,CityPanel}.tsx`,
+  `apps/web/lib/actions/reference-data-admin.ts` (+ `.test.ts`).
+- **Verification (functional):** On a live install, merge "Calfornia" → "California":
+  usage-impact preview lists affected addresses; on confirm, addresses repoint to
+  the survivor, the loser is tombstoned (status inactive/superseded, excluded from
+  typeahead), and the action is audited. Existing reference-data tests still pass.
+- **Risk/rollback:** Touches a live admin surface and real address FKs. Mitigate
+  with usage-impact preview + tombstone (reversible). Rollback = reactivate the
+  tombstoned row and reverse repointing from the audit snapshot.
+- **Child BI:** `MDM-5 reference-data/locations merge` (size: medium). Not blocked by
+  Phase 0 (no trust-dimension dependency); good early independent win.
+
+### Phase 6 — Supplier pilot (reuse crosswalk + steward queue) — needs Phase 2,3
+- **Deliverable:** Reuse `MasterDataSourceRef` (`supplierId` typed FK) + steward
+  queue for `Supplier`, including AI provider finance profiles and imported
+  vendor/bill records.
+- **Files:** extend `apps/web/lib/mdm/*`, register `supplier` domain config, steward
+  UI handles the supplier domain.
+- **Verification (functional):** Two near-duplicate suppliers produce a candidate;
+  link writes a crosswalk row with `supplierId` populated = `canonicalId`; steward
+  flow works identically to customer-account.
+- **Risk/rollback:** Mostly config + reuse; low net-new code. Rollback = unregister
+  supplier domain.
+- **Child BI:** `MDM-6 supplier pilot` (size: medium).
+
+### Phase 7 — Publishing contracts (stable read models + TrustAssessment) — needs Phase 0,2,4
+- **Deliverable:** Expose canonical mastered records via stable read models for
+  coworkers/dashboards/integrations, each carrying a `TrustAssessment`
+  (`kind: "data-trust-vector"`) on `DataSourceProvenance.trust` when the record is
+  incomplete/stale/inferred/source-conflicted. No bespoke MDM payload shape.
+- **Files:** `apps/web/lib/mdm/read-model.ts` (+ test),
+  `apps/web/lib/surface-data-provenance.ts`, consumer wiring for at least one
+  coworker/dashboard surface.
+- **Verification (functional):** A coworker/dashboard reading a customer with a
+  source conflict receives the canonical value plus a `TrustAssessment` naming the
+  `conflictContradiction` dimension; a complete confirmed record carries a
+  high-tier assessment.
+- **Risk/rollback:** Additive read layer. Rollback = stop emitting the envelope;
+  callers fall back to raw reads.
+- **Child BI:** `MDM-7 publishing contracts` (size: medium).
+
+## Cross-cutting risks
+
+- **Enum drift** between `backlog.ts` and `mcp-tools.ts` for `domain`/`status`/
+  `trustTier` — register in the same commit, hyphens not underscores (AGENTS.md §3).
+- **Polymorphic orphans** on the low-volume domains — the orphan-reconciliation
+  sweep (§6.2) must exist before those domains carry production data.
+- **Identity boundary** — never let `organization`/`customer-contact` reach
+  `MasterDataSourceRef`; that's a `PrincipalAlias` job. Registry (Phase 1) enforces.
+- **Live-surface phases (3, 5)** touch real admin pages — drive them functionally on
+  a live install per `structural-verification-is-not-functional`; tests passing is
+  not sign-off.
+
+## Sequencing summary
+
+```
+Phase 0 ──┬─> Phase 2 ──┬─> Phase 3 ──┐
+          │             ├─> Phase 4 ──┼─> Phase 7
+          │             └─> Phase 6 (also needs 3)
+Phase 1 ──┘  (registry feeds 2,3,6)
+Phase 5  (independent — earliest shippable win)
+```
+
+## Next step after this plan
+
+File the 8 child BIs (MDM-0 … MDM-7) under EP-MDM with the sizes above and
+`Blocked by:` references per the sequencing graph, then promote the first
+unblocked slices (MDM-0, MDM-1, MDM-5) to Build Studio.

--- a/docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md
+++ b/docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md
@@ -223,7 +223,13 @@ export type TrustDimensionKey =
   | "conflictContradiction"
   | "runtimeAvailability"
   | "sampleSize"
-  | "riskImpact";
+  | "riskImpact"
+  // Master Data Management dimensions (added 2026-06-06, MDM spec §6.5).
+  // This registry is the single source of trust vocabulary; MDM and
+  // EP-DATA-ARCH steward drift both consume these by canonical key.
+  | "validityConformity"
+  | "uniqueness"
+  | "relationshipIntegrity";
 
 export type TrustDimension = {
   key: TrustDimensionKey;
@@ -296,6 +302,9 @@ export type TrustAssessment = {
 | `runtimeAvailability` | Whether dependencies needed to answer were available. | Neo4j unavailable, so graph view is Postgres-only. |
 | `sampleSize` | Whether the denominator is meaningful. | Portfolio health from 1 product vs 200 products. |
 | `riskImpact` | How much trust is required before presenting the result as current. | Compliance/security claims need higher thresholds than decorative summary counts. |
+| `validityConformity` | Whether the value conforms to its expected format/domain. | Email/domain/phone pass validation; status is an allowed enum value; postal code matches country format. (MDM §6.5) |
+| `uniqueness` | Whether the record is free of duplicate-candidate risk. | No high-confidence duplicate candidate above the match threshold for this canonical record. (MDM §6.5) |
+| `relationshipIntegrity` | Whether the record's relationships/crosswalk references resolve. | All `MasterDataSourceRef` rows resolve to a live canonical id; FK targets exist; no orphaned polymorphic pointer. (MDM §6.5) |
 
 Not every surface needs every dimension. The scorer excludes `null` dimensions from the denominator but includes "unknown" dimensions when the missing dimension itself should reduce trust.
 

--- a/docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md
+++ b/docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md
@@ -2,7 +2,7 @@
 title: Master Data Management Alignment Design
 authoredAt: 2026-05-31
 authoredBy: codex
-status: draft
+status: approved
 specKind: design
 relatedSpecs:
   - docs/superpowers/specs/2026-03-17-admin-reference-data-design.md
@@ -224,6 +224,12 @@ model MasterDataSourceRef {
   id              String   @id @default(cuid())
   domain          String
   canonicalId     String
+  // Typed FK columns for high-volume domains (resolved typed-FK hybrid).
+  // Exactly one is populated when domain is customer-account / supplier;
+  // null for polymorphic-only domains. A CHECK constraint requires the
+  // populated column to equal canonicalId for its domain.
+  customerAccountId String?
+  supplierId        String?
   sourceSystem    String
   sourceEntityType String?
   sourceEntityId  String
@@ -235,9 +241,14 @@ model MasterDataSourceRef {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  customerAccount CustomerAccount? @relation(fields: [customerAccountId], references: [id], onDelete: Cascade)
+  supplier        Supplier?        @relation(fields: [supplierId], references: [id], onDelete: Cascade)
+
   @@unique([domain, sourceSystem, sourceEntityId])
   @@index([domain, canonicalId])
   @@index([sourceSystem, sourceEntityId])
+  @@index([customerAccountId])
+  @@index([supplierId])
 }
 ```
 
@@ -269,17 +280,30 @@ string-enum columns: register their values in `apps/web/lib/backlog.ts` and
 AGENTS.md §3, and constrain `trustTier` to the `TrustTier` set
 (`high | medium | low | unknown`) rather than a free string.
 
-**Referential integrity (polymorphic by design).** `(domain, canonicalId)` is a
-polymorphic pointer with no foreign key, because one table spans many canonical
-models. The cost is that the database cannot enforce the link: deleting a
-`CustomerAccount` does not cascade, and a merge must repoint crosswalk rows from
-the losing canonical id to the surviving one. The spec therefore requires
-application-level integrity: (a) the merge flow (§6.6) repoints all
-`MasterDataSourceRef` rows for the losing id, and (b) an orphan sweep reconciles
-crosswalk rows whose `canonicalId` no longer resolves. Whether the highest-volume
-domains (`customer-account`, `supplier`) instead warrant a typed nullable FK
-column for DB-enforced integrity is an open decision (§10) for
-`dpf-decision-via-kernel`, not settled here.
+**Referential integrity (resolved 2026-06-06: typed-FK hybrid).** The crosswalk
+integrity shape was an open decision (§10) resolved via `dpf-decision-via-kernel`
+(`callingSurface: mdm-spec-open-decision`, high confidence, no commandment
+conflict). The kernel recommended the **typed-FK hybrid** over a pure polymorphic
+pointer — *Single Source of Truth*, *Architecture Over Shortcuts*, and *Research
+and Use Standards* weight a database-guaranteed link over application-code
+integrity that can drift into orphans. The resolved shape:
+
+- **High-volume domains (`customer-account`, `supplier`)** carry a **typed
+  nullable FK column** on the crosswalk row, so the database enforces cascade and
+  referential integrity directly. These two domains dominate import volume and
+  duplicate risk; DB-enforced integrity is worth the per-domain column.
+- **Low-volume domains (`digital-product`, `inventory-entity`, `reference-data`)**
+  retain the **polymorphic `(domain, canonicalId)` pointer** on the same
+  `MasterDataSourceRef` table — one reusable table, no per-domain column churn.
+
+The model below therefore keeps `(domain, canonicalId)` as the universal pointer
+**and** adds nullable typed FK columns (`customerAccountId`, `supplierId`) used by
+the high-volume domains. Where a typed FK is present the DB enforces the link;
+where only the polymorphic pointer is present the application enforces integrity
+via (a) the merge flow (§6.6) repointing all `MasterDataSourceRef` rows for the
+losing id, and (b) an orphan sweep reconciling crosswalk rows whose `canonicalId`
+no longer resolves. A `CHECK` constraint requires that, for the FK-backed
+domains, the typed column is populated and matches `canonicalId`.
 
 ### 6.3 Match candidate queue
 
@@ -368,9 +392,16 @@ Reversibility requires a **pre-merge snapshot**: the losing record's attributes,
 its `MasterDataSourceRef` rows, and its relationships, captured as receipt
 evidence on that `ToolExecution` before mutation. Reversal repoints crosswalk
 rows back and restores the snapshot; it is itself a governed, audited steward
-action. Destructive hard-delete of the losing canonical row is deferred (§7
-step 3) until this snapshot/reversal path exists — until then a "merge" is a
-link + supersede, never a delete.
+action.
+
+**Merge severity resolved (§10, 2026-06-06): tombstone, never hard-delete.** The
+kernel resolved this decisively in favour of permanent tombstoning over
+hard-delete. A "merge" is always a link + supersede: the losing canonical row is
+retained as a superseded tombstone (status flag, excluded from default reads)
+carrying its pre-merge snapshot. There is no destructive hard-delete path in v1
+or later — this honours *Never wipe the DB to fix code* and *Destructive actions
+require explicit go*. Right-to-erasure, if needed, is a separate governed flow,
+not a side effect of a merge.
 
 ## 7. Implementation Sequence
 
@@ -426,27 +457,34 @@ link + supersede, never a delete.
 - Survivorship rules are stored as governed, versioned config — not a code
   constant — and a change shows usage impact before it takes effect.
 
-## 10. Open Decisions and Backlog Linkage
+## 10. Resolved Decisions and Backlog Linkage
 
-**Open decisions (for `dpf-decision-via-kernel`, not settled here):**
+**Resolved decisions (via `dpf-decision-via-kernel`, 2026-06-06, profile
+`mark-dpf-platform`, `callingSurface: mdm-spec-open-decision` — both high
+confidence, strong structured coverage, no commandment conflict):**
 
-- **Crosswalk integrity shape.** Polymorphic `(domain, canonicalId)` with
-  application-enforced integrity (this spec's default) vs. typed nullable FK
-  columns per high-volume domain for DB-enforced cascade. Trade-off: one
-  reusable table vs. referential safety on `customer-account`/`supplier`.
-- **Merge severity.** Whether v1 ever hard-deletes a losing canonical row once
-  the snapshot/reversal path exists, or permanently keeps it as a superseded
-  tombstone.
+- **Crosswalk integrity shape → typed-FK hybrid.** Recommendation `typed-fk`
+  (composite 7.77 vs polymorphic 5.82, margin 1.95). This **flipped the spec's
+  original polymorphic default**: top contributors *Single Source of Truth*,
+  *Research and Use Standards*, *Architecture Over Shortcuts*, and *Never
+  Assume—Verify* weight a DB-guaranteed link over application-enforced integrity.
+  Resolution: typed nullable FK columns for `customer-account` and `supplier`;
+  polymorphic `(domain, canonicalId)` retained for low-volume domains. See §6.2.
+- **Merge severity → tombstone.** Recommendation `tombstone` (composite 10.71 vs
+  hard-delete 3.53, margin 7.19 — decisive). Top contributors *Never wipe the DB
+  to fix code* and *Destructive actions require explicit go*. Resolution: a merge
+  never hard-deletes; the losing canonical row is kept permanently as a
+  superseded tombstone with its pre-merge snapshot, fully reversible. See §6.6.
 
-**Backlog linkage.** Per DPF doctrine a spec is built against a backlog item,
-not floating intent. This design still needs an epic + sized BIs filed and
-promoted to Build Studio, sequenced per §7. One BI is **cross-spec**: adding
-`validityConformity`, `uniqueness`, and `relationshipIntegrity` to the
-`TrustDimensionKey` registry in
-`docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md` must land
-before MDM consumes them, so it is a coordinated dependency, not an MDM-internal
-task. Status stays `draft` until the epic is filed and the two open decisions
-are resolved.
+**Backlog linkage.** Per DPF doctrine a spec is built against a backlog item, not
+floating intent. Epic **EP-MDM** and the foundational item **BI-C5F3CB36** were
+filed 2026-06-06; §7 is sliced into child BIs in the implementation plan
+(`docs/superpowers/plans/2026-06-06-master-data-management-foundation.md`). One BI
+is **cross-spec** and **must land first**: adding `validityConformity`,
+`uniqueness`, and `relationshipIntegrity` to the `TrustDimensionKey` registry in
+`docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md`, since MDM
+consumes them (§6.5). With the epic filed and both decisions resolved, the spec
+moves from `draft` to `approved`.
 
 ## 11. Architecture Review Notes
 
@@ -458,3 +496,10 @@ audit/reversibility on the existing `ToolExecution` envelope (§6.6),
 survivorship config storage (§6.4), and the steward gate bound to
 `PlatformCapability` (§6.1). No new audit, config, or steward-action tables were
 introduced — each concern was placed on substrate that already exists.
+
+The two open decisions that kept the spec at `draft` were resolved 2026-06-06 via
+`dpf-decision-via-kernel` (§10): crosswalk integrity → typed-FK hybrid (a flip of
+the original polymorphic default), and merge severity → permanent tombstone. With
+epic `EP-MDM` and `BI-C5F3CB36` filed, the spec advanced to `approved` and is
+sliced for delivery in
+`docs/superpowers/plans/2026-06-06-master-data-management-foundation.md`.


### PR DESCRIPTION
## Summary

First slices of the Master Data Management effort (**EP-MDM**), implementing the now-**approved** [MDM Alignment Design](docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md). MDM governs DPF's existing domain **records** as managed master data (canonical identity, source crosswalk, dedup, survivorship, stewardship) by **extending existing substrate** — not building a parallel MDM suite.

This PR delivers the governance scaffolding plus the two unblocked foundational slices:

- **Docs**: spec moved `draft → approved` with the two open §10 decisions resolved via `dpf-decision-via-kernel` — crosswalk integrity = **typed-FK hybrid** (flipped the original polymorphic default), merge severity = **permanent tombstone** (no hard-delete). Adds the phased implementation plan slicing §7 into child BIs MDM-0…MDM-7, including the EP-DATA-ARCH shared-substrate seams.
- **MDM-0** (`BI-7535C218`): adds `validityConformity`, `uniqueness`, `relationshipIntegrity` to the single `TrustDimensionKey` registry — consumed by both MDM (§6.5) and EP-DATA-ARCH steward drift. `uniqueness`/`relationshipIntegrity` are cap-worthy: a duplicate or orphaned crosswalk degrades trust like a source conflict.
- **MDM-1** (`BI-AC85936F`): code-level `MasterDataDomain` registry (canonical model/id, identity attributes, quality dimensions, crosswalk mechanism, steward capability, publishing read model). Enforces the identity boundary — `organization`/`customer-contact` resolve via `PrincipalAlias`, excluded from the `MasterDataSourceRef` crosswalk.

## Relationship to EP-DATA-ARCH
Two epics, three shared seams (baked into the plan): the trust dimensions above (file once, both consume), one "domain" notion (MDM registry = governed overlay on the data-arch domain map), and `EaConformanceIssue` for findings. No epic merge — model-layer vs record-layer concerns.

## Verification
- `vitest` trust-vector + mdm + surface-data-provenance: **29 passing** (incl. new cap behavior and canonical-model-name validation against `schema.prisma`).
- Scoped typecheck green on both commits (pre-commit hook).
- Additive only: new enum members + new `lib/mdm/` module; no existing consumer changed.

## Follow-ups (not in this PR)
MDM-2 customer-account crosswalk + candidates (now unblocked), MDM-3 steward queue, MDM-4 survivorship, MDM-5 reference-data/locations merge (independent), MDM-6 supplier, MDM-7 publishing contracts.

Refs: EP-MDM, BI-C5F3CB36, BI-7535C218, BI-AC85936F

🤖 Generated with [Claude Code](https://claude.com/claude-code)