### PR TITLE
feat(grok): MCP tools for AI-Coworker-driven Grok sign-in (EP-GROK-001)

### DIFF
--- a/apps/web/lib/actions/grok-device-login.ts
+++ b/apps/web/lib/actions/grok-device-login.ts
@@ -1,33 +1,27 @@
 "use server";
 
-// Grok (xAI) device-code OAuth — the "sign in with Google" alternative to pasting
-// an xAI API key. Mirrors how Codex obtains a ChatGPT OAuth token, but uses the
-// Grok CLI's own device-code flow instead of an in-portal authorization-code redirect:
+// Grok (xAI) device-code OAuth — the "sign in with Google" alternative to pasting an xAI
+// API key. These server actions are the operator (UI) entry points: they add the
+// manage_provider_connections session check, then delegate to the shared, auth-free core
+// in lib/integrate/grok-device-login-core.ts. The same core is reused by the MCP tools
+// (grok_signin_start / grok_signin_status), which gate on the same capability via the
+// bearer token before dispatch.
 //
-//   1. startGrokDeviceLogin() runs `grok login --device-auth` (detached) inside the
-//      sandbox — the only place the `grok` binary lives — and returns the
-//      accounts.x.ai/oauth2/device verification URL + user code for the operator.
-//   2. The operator opens the URL and signs in with the account-level method they
-//      enabled at xAI (Google / X / Apple). The CLI then writes ~/.grok/auth.json.
-//   3. completeGrokDeviceLogin() reads that auth.json out of the sandbox and stores
-//      it (encrypted) as the xAI credential. The build dispatch injects it back into
-//      each build sandbox's ~/.grok/auth.json (see grok-dispatch ensureGrokAuth), and
-//      the CLI self-refreshes from the embedded refresh token.
+// Flow:
+//   1. startGrokDeviceLogin() runs `grok login --device-auth` in the sandbox and returns
+//      the accounts.x.ai/oauth2/device URL + user code.
+//   2. The operator signs in with the account method enabled at xAI (Google / X / Apple).
+//   3. completeGrokDeviceLogin() captures ~/.grok/auth.json and stores it as the xAI
+//      credential; the build dispatch injects it (see grok-dispatch ensureGrokAuth).
 //
-// Requires the grok-equipped sandbox image (Dockerfile.sandbox installs `grok`).
-// Both actions are gated on manage_provider_connections and are safe to call from a
-// human-facing button or, later, an MCP tool for AI-Coworker-driven setup.
+// See docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md.
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { prisma } from "@dpf/db";
-import { encryptSecret } from "@/lib/credential-crypto";
-import { activateProvider } from "@/lib/govern/activate-provider";
-import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
-
-const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-const XAI_PROVIDER_ID = "xai";
-const LOGIN_OUT = "/tmp/grok-device-login.out";
+import {
+  grokDeviceLoginStart,
+  grokDeviceLoginComplete,
+} from "@/lib/integrate/grok-device-login-core";
 
 async function requireManageProviders(): Promise<void> {
   const session = await auth();
@@ -35,13 +29,6 @@ async function requireManageProviders(): Promise<void> {
   if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections")) {
     throw new Error("Unauthorized");
   }
-}
-
-function dockerExecAsync(): (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }> {
-  const { exec } = lazyChildProcess();
-  const { promisify } = lazyUtil();
-  const execAsync = promisify(exec) as (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
-  return (cmd, opts) => execAsync(cmd, opts).catch(() => ({ stdout: "", stderr: "" }));
 }
 
 export async function startGrokDeviceLogin(): Promise<
@@ -52,41 +39,7 @@ export async function startGrokDeviceLogin(): Promise<
   } catch {
     return { error: "Your admin session expired — sign in again and retry." };
   }
-
-  const execAsync = dockerExecAsync();
-
-  // Fresh start: clear any prior credential file + output, then launch the device-auth
-  // flow detached as the `node` user (same user the build dispatch runs grok as).
-  await execAsync(
-    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "mkdir -p ~/.grok; rm -f ~/.grok/auth.json ${LOGIN_OUT}"`,
-    { timeout: 10_000 },
-  );
-  await execAsync(
-    `docker exec -d --user node ${SANDBOX_CONTAINER} sh -c "grok login --device-auth > ${LOGIN_OUT} 2>&1"`,
-    { timeout: 10_000 },
-  );
-
-  // grok prints the verification URL + user code immediately, then blocks on
-  // "Waiting for authorization...". Poll the captured output for the URL.
-  for (let attempt = 0; attempt < 15; attempt++) {
-    await new Promise((r) => setTimeout(r, 700));
-    const { stdout } = await execAsync(
-      `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
-      { timeout: 5_000 },
-    );
-    const urlMatch = stdout.match(/https:\/\/\S*oauth2\/device\S*/);
-    if (urlMatch) {
-      const codeMatch =
-        stdout.match(/user_code=([A-Za-z0-9-]+)/) ?? stdout.match(/\b([A-Z0-9]{4}-[A-Z0-9]{4})\b/);
-      return { verificationUrl: urlMatch[0], userCode: codeMatch?.[1] ?? "" };
-    }
-    if (/not found|no such file|executable file not found/i.test(stdout)) break;
-  }
-
-  return {
-    error:
-      "Grok did not return a device-code URL. Ensure the `grok` CLI is installed in the build sandbox (Dockerfile.sandbox) and the sandbox is running, then retry.",
-  };
+  return grokDeviceLoginStart();
 }
 
 export async function completeGrokDeviceLogin(): Promise<
@@ -97,41 +50,5 @@ export async function completeGrokDeviceLogin(): Promise<
   } catch {
     return { status: "failed", detail: "Your admin session expired — sign in again and retry." };
   }
-
-  const execAsync = dockerExecAsync();
-
-  // The login process writes ~/.grok/auth.json on success.
-  const { stdout: authJson } = await execAsync(
-    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "cat ~/.grok/auth.json 2>/dev/null || true"`,
-    { timeout: 5_000 },
-  );
-  const blob = authJson.trim();
-
-  if (blob.startsWith("{")) {
-    // Persist the auth.json blob as the xAI credential. The build dispatch injects it
-    // verbatim into each sandbox's ~/.grok/auth.json; the CLI self-refreshes from the
-    // embedded refresh token. We store it in `cachedToken` and deliberately preserve any
-    // existing `secretRef` (API key): the CLI-dispatch path detects OAuth by the auth.json
-    // blob shape (grok-dispatch ensureGrokAuth), while xAI *inference* (chat) keeps using
-    // the API key via the unchanged `api_key` authMethod — the two paths don't collide.
-    await prisma.credentialEntry.upsert({
-      where: { providerId: XAI_PROVIDER_ID },
-      create: { providerId: XAI_PROVIDER_ID, cachedToken: encryptSecret(blob), status: "ok" },
-      update: { cachedToken: encryptSecret(blob), status: "ok" },
-    });
-    // Activate the provider properly (status/clearance/linked services) without overriding
-    // authMethod — leaving it as `api_key` so inference auth resolution is unaffected.
-    await activateProvider(XAI_PROVIDER_ID, { trigger: "oauth_exchange", activateLinked: true });
-    return { status: "ok" };
-  }
-
-  // Not authorized yet — distinguish "still waiting" from a failed/expired attempt.
-  const { stdout: out } = await execAsync(
-    `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
-    { timeout: 5_000 },
-  );
-  if (/error|failed|timed out|expired/i.test(out) && !/Waiting for authorization/i.test(out)) {
-    return { status: "failed", detail: out.slice(-300) };
-  }
-  return { status: "pending" };
+  return grokDeviceLoginComplete();
 }

--- a/apps/web/lib/integrate/grok-device-login-core.ts
+++ b/apps/web/lib/integrate/grok-device-login-core.ts
@@ -1,0 +1,104 @@
+// Core logic for Grok (xAI) device-code OAuth — shared by the operator server actions
+// (lib/actions/grok-device-login.ts, which add the manage_provider_connections session
+// check) and the MCP tools (mcp-tools.ts, which gate on the same capability via the
+// bearer token before dispatch). Kept auth-free so both callers can reuse it without the
+// server-action `auth()` session, which is absent in the MCP/bearer context.
+//
+// See docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md.
+
+import { prisma } from "@dpf/db";
+import { encryptSecret } from "@/lib/credential-crypto";
+import { activateProvider } from "@/lib/govern/activate-provider";
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const XAI_PROVIDER_ID = "xai";
+const LOGIN_OUT = "/tmp/grok-device-login.out";
+
+function dockerExecAsync(): (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }> {
+  const { exec } = lazyChildProcess();
+  const { promisify } = lazyUtil();
+  const execAsync = promisify(exec) as (cmd: string, opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
+  return (cmd, opts) => execAsync(cmd, opts).catch(() => ({ stdout: "", stderr: "" }));
+}
+
+/**
+ * Launch the Grok CLI device-code flow inside the sandbox and return the verification
+ * URL + user code for a human to authorize in a browser.
+ */
+export async function grokDeviceLoginStart(): Promise<
+  { verificationUrl: string; userCode: string } | { error: string }
+> {
+  const execAsync = dockerExecAsync();
+
+  // Fresh start: clear any prior credential file + output, then launch device-auth
+  // detached as the `node` user (same user the build dispatch runs grok as).
+  await execAsync(
+    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "mkdir -p ~/.grok; rm -f ~/.grok/auth.json ${LOGIN_OUT}"`,
+    { timeout: 10_000 },
+  );
+  await execAsync(
+    `docker exec -d --user node ${SANDBOX_CONTAINER} sh -c "grok login --device-auth > ${LOGIN_OUT} 2>&1"`,
+    { timeout: 10_000 },
+  );
+
+  // grok prints the verification URL + user code immediately, then blocks on
+  // "Waiting for authorization...". Poll the captured output for the URL.
+  for (let attempt = 0; attempt < 15; attempt++) {
+    await new Promise((r) => setTimeout(r, 700));
+    const { stdout } = await execAsync(
+      `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
+      { timeout: 5_000 },
+    );
+    const urlMatch = stdout.match(/https:\/\/\S*oauth2\/device\S*/);
+    if (urlMatch) {
+      const codeMatch =
+        stdout.match(/user_code=([A-Za-z0-9-]+)/) ?? stdout.match(/\b([A-Z0-9]{4}-[A-Z0-9]{4})\b/);
+      return { verificationUrl: urlMatch[0], userCode: codeMatch?.[1] ?? "" };
+    }
+    if (/not found|no such file|executable file not found/i.test(stdout)) break;
+  }
+
+  return {
+    error:
+      "Grok did not return a device-code URL. Ensure the `grok` CLI is installed in the build sandbox (Dockerfile.sandbox) and the sandbox is running, then retry.",
+  };
+}
+
+/**
+ * Check whether the device-code sign-in has been authorized; on success, store the
+ * captured ~/.grok/auth.json as the xAI credential and activate the provider.
+ */
+export async function grokDeviceLoginComplete(): Promise<
+  { status: "ok" } | { status: "pending" } | { status: "failed"; detail: string }
+> {
+  const execAsync = dockerExecAsync();
+
+  const { stdout: authJson } = await execAsync(
+    `docker exec --user node ${SANDBOX_CONTAINER} sh -c "cat ~/.grok/auth.json 2>/dev/null || true"`,
+    { timeout: 5_000 },
+  );
+  const blob = authJson.trim();
+
+  if (blob.startsWith("{")) {
+    // Store the auth.json blob (encrypted) in cachedToken; preserve any existing
+    // secretRef (API key). Dispatch detects OAuth by blob shape; inference keeps using
+    // the api_key authMethod — the two paths don't collide.
+    await prisma.credentialEntry.upsert({
+      where: { providerId: XAI_PROVIDER_ID },
+      create: { providerId: XAI_PROVIDER_ID, cachedToken: encryptSecret(blob), status: "ok" },
+      update: { cachedToken: encryptSecret(blob), status: "ok" },
+    });
+    await activateProvider(XAI_PROVIDER_ID, { trigger: "oauth_exchange", activateLinked: true });
+    return { status: "ok" };
+  }
+
+  const { stdout: out } = await execAsync(
+    `docker exec ${SANDBOX_CONTAINER} sh -c "cat ${LOGIN_OUT} 2>/dev/null || true"`,
+    { timeout: 5_000 },
+  );
+  if (/error|failed|timed out|expired/i.test(out) && !/Waiting for authorization/i.test(out)) {
+    return { status: "failed", detail: out.slice(-300) };
+  }
+  return { status: "pending" };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -3113,6 +3113,20 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "grok_signin_start",
+    description: "Begin Grok (xAI) device-code OAuth sign-in for the build sandbox — the 'sign in with Google' alternative to an xAI API key. Runs `grok login --device-auth` in the sandbox and returns a verification URL + user code. Relay these to a human to authorize in their browser (Google / X / Apple), then call grok_signin_status to detect completion.",
+    inputSchema: { type: "object", properties: {} },
+    requiredCapability: "manage_provider_connections",
+    sideEffect: true,
+  },
+  {
+    name: "grok_signin_status",
+    description: "Check whether the Grok device-code sign-in started by grok_signin_start has been authorized. Returns status 'ok' (credential captured + xAI provider activated), 'pending' (still waiting for the human to authorize), or 'failed'.",
+    inputSchema: { type: "object", properties: {} },
+    requiredCapability: "manage_provider_connections",
+    sideEffect: true,
+  },
+  {
     name: "analyze_brand_document",
     description: "Analyze an uploaded brand guidelines document (PDF or image) and extract brand assets: logo, colors, and fonts",
     inputSchema: {
@@ -11946,6 +11960,40 @@ export async function executeTool(
         entityId: providerId,
         message: `Provider "${provider.name}" category updated to "${category}".`,
       };
+    }
+
+    case "grok_signin_start": {
+      const { grokDeviceLoginStart } = await import("@/lib/integrate/grok-device-login-core");
+      const result = await grokDeviceLoginStart();
+      if ("error" in result) {
+        return { success: false, error: "device_login_failed", message: result.error };
+      }
+      return {
+        success: true,
+        message: `Grok sign-in started. Ask the operator to open ${result.verificationUrl}${result.userCode ? ` and confirm the code ${result.userCode}` : ""}, then call grok_signin_status to detect completion.`,
+        data: { verificationUrl: result.verificationUrl, userCode: result.userCode },
+      };
+    }
+
+    case "grok_signin_status": {
+      const { grokDeviceLoginComplete } = await import("@/lib/integrate/grok-device-login-core");
+      const result = await grokDeviceLoginComplete();
+      if (result.status === "ok") {
+        return {
+          success: true,
+          entityId: "xai",
+          message: "Grok is connected — the xAI credential was captured and the provider activated. Build Studio can now dispatch to the grok engine via OAuth.",
+          data: { status: "ok" },
+        };
+      }
+      if (result.status === "pending") {
+        return {
+          success: true,
+          message: "Still waiting for the operator to authorize the Grok sign-in. Poll grok_signin_status again shortly.",
+          data: { status: "pending" },
+        };
+      }
+      return { success: false, error: "device_login_failed", message: `Grok sign-in failed: ${result.detail}`, data: { status: "failed" } };
     }
 
     case "analyze_brand_document": {

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -83,6 +83,8 @@
       "honored_by_tools": [
         "add_provider",
         "configure_gateway_scan",
+        "grok_signin_start",
+        "grok_signin_status",
         "run_endpoint_tests",
         "update_provider_category"
       ],


### PR DESCRIPTION
## Why
Slice 3 of Grok device-code OAuth (slice 1 backend #1616 merged; slice 2 UI #1622). This is the **AI-Coworker** half of your "AI Coworker *and* humans" requirement — the Coworker can now drive Grok sign-in.

## What
Two MCP tools so the Coworker can set up Grok the same way a human clicks the button:
- **`grok_signin_start`** — runs `grok login --device-auth` in the sandbox, returns the `accounts.x.ai/oauth2/device` URL + user code to relay to a human.
- **`grok_signin_status`** — polls for completion; on `ok` the xAI credential is captured + the provider activated.

Both gated on `manage_provider_connections` (same as `add_provider`).

## How (the careful part)
MCP handlers run under a **bearer-token capability check, not a NextAuth session**, so calling the `"use server"` actions directly would hit a redundant `auth()` and fail. I extracted the logic into **`lib/integrate/grok-device-login-core.ts`** (auth-free), shared by:
- the UI server actions (now thin `manage_provider_connections` wrappers — signatures unchanged, so the slice-2 `ConnectGrokCard` is unaffected), and
- the MCP handlers.

The tools are added to the **`agent_control_read` grant alongside `add_provider`** — identical wiring to existing provider tools, so the tool↔grant consistency guard passes (no silent-denial risk).

## Verification
- ✅ `pnpm --filter web typecheck` clean.
- ✅ Grant-consistency tests (`agent-grants`, `coworker-self-assessment`): 123 pass.
- ✅ `mcp-tools` suite: 214 pass.
- Functional proof of an end-to-end sign-in needs the grok-equipped sandbox (#1613) + a real operator authorization — the standing gate.

Design: `docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)