### PR TITLE
feat(grok): persist CLI-refreshed OAuth token after dispatch — refresh durability (EP-GROK-001)

### DIFF
--- a/apps/web/lib/integrate/grok-dispatch.ts
+++ b/apps/web/lib/integrate/grok-dispatch.ts
@@ -84,6 +84,40 @@ async function ensureGrokAuth(providerId: string, containerId: string, taskSlug:
 }
 
 /**
+ * Refresh durability. After an OAuth-mode run, the Grok CLI may have refreshed its access
+ * token (and, if xAI rotates them, its refresh token) and rewritten ~/.grok/auth.json
+ * inside the build sandbox. That sandbox is ephemeral, so read the (possibly-updated)
+ * credential back out and persist it to the stored xAI credential — otherwise the next
+ * build keeps injecting the original token, which eventually goes stale.
+ *
+ * Last-write-wins under concurrent builds (acceptable for non-rotating refresh tokens;
+ * rotating-token concurrency is a known edge — see the device-code OAuth design doc).
+ * Best-effort: never fails the build.
+ */
+async function persistRefreshedGrokOAuth(providerId: string, containerId: string): Promise<void> {
+  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
+  const read = await execAsync(
+    `docker exec --user node ${containerId} sh -c "cat ~/.grok/auth.json 2>/dev/null || true"`,
+    { timeout: 5_000 },
+  ).catch(() => ({ stdout: "" }));
+  const blob = String((read as { stdout?: string }).stdout ?? "").trim();
+  if (!blob.startsWith("{")) return;
+
+  const current = await getDecryptedCredential(providerId);
+  if (current?.cachedToken && current.cachedToken.trim() === blob) return; // unchanged — no write
+
+  const [{ prisma }, { encryptSecret }] = await Promise.all([
+    import("@dpf/db"),
+    import("@/lib/credential-crypto"),
+  ]);
+  await prisma.credentialEntry.update({
+    where: { providerId },
+    data: { cachedToken: encryptSecret(blob), status: "ok" },
+  });
+  console.log(`[grok-dispatch] persisted refreshed Grok OAuth token for "${providerId}".`);
+}
+
+/**
  * Ensure the sandbox /workspace is writable by the node user (uid 1000) and
  * that git is configured for it. Matches the prep done for Claude Code runs
  * (prevents root-owned file issues when the CLI or subsequent steps write).
@@ -361,6 +395,14 @@ export async function dispatchGrokTask(params: {
         reject(err);
       });
     });
+
+    // Refresh durability: persist any token the CLI refreshed during this run so the
+    // stored credential stays current across ephemeral build sandboxes (best-effort).
+    if (grokAuth.mode === "oauth") {
+      await persistRefreshedGrokOAuth(providerId, containerId).catch((e) => {
+        console.warn(`[grok-dispatch] could not persist refreshed Grok OAuth token: ${(e as Error).message}`);
+      });
+    }
 
     // Best-effort JSON extraction (Grok CLI may add --json later; today mostly text)
     let content: string;

--- a/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md
@@ -55,16 +55,17 @@ Verified empirically (grok 0.2.32 in a node:24-alpine + gcompat container):
 - `grok-dispatch.ts`: `ensureGrokAuth` returns a mode; injects `~/.grok/auth.json` for OAuth, `XAI_API_KEY` otherwise; runner script branches.
 - `lib/actions/grok-device-login.ts`: `startGrokDeviceLogin` + `completeGrokDeviceLogin`.
 
-## Remaining phases
-- **Slice 2 — operator UX**: a "Sign in to Grok" affordance on the Build Studio / External
-  Services provider card that calls start → shows the URL+code → polls complete. (Mirror
-  the existing OAuth connect button.)
-- **Slice 3 — AI-Coworker control**: MCP tools wrapping start/complete so the Coworker can
-  drive setup (per the "AI Coworker as conduit" principle). Slots into the Build-Engine
-  Provisioning capability (separate design).
-- **Slice 4 — refresh durability**: the CLI self-refreshes inside ephemeral build
-  sandboxes, but that refreshed token doesn't persist back to the stored credential.
-  Re-capture or persist-on-refresh so the stored refresh token can't go stale long-term.
+## Slices (status)
+- **Slice 2 — operator UX** ✅ (#1622): "Sign in to Grok" card on the xAI provider page —
+  start → shows URL+code → polls complete.
+- **Slice 3 — AI-Coworker control** ✅ (#1624): `grok_signin_start` / `grok_signin_status`
+  MCP tools over the shared auth-free core, so the Coworker can drive setup.
+- **Slice 4 — refresh durability** ✅ (this PR): after an OAuth-mode dispatch run,
+  `grok-dispatch` reads the (possibly CLI-refreshed) `~/.grok/auth.json` back out of the
+  ephemeral build sandbox and persists it to the stored xAI credential, so the next build
+  injects the latest token instead of the original (which would eventually go stale).
+  Last-write-wins under concurrent builds; rotating-refresh-token concurrency is the one
+  remaining edge (acceptable today — non-rotating tokens just refresh again next run).
 
 ## Open items / constraints
 - Requires the grok-equipped sandbox image (#1613).


### PR DESCRIPTION
## Why
Slice 4 (final) of Grok device-code OAuth. The Grok CLI self-refreshes its access token inside the build sandbox and rewrites `~/.grok/auth.json` — but that sandbox is **ephemeral**, so the refreshed token was thrown away and every build re-injected the *original* stored token. Over a long horizon that goes stale (expired access token every run; and if xAI rotates refresh tokens, the original eventually stops working).

## What
After an OAuth-mode dispatch run, `grok-dispatch` reads `~/.grok/auth.json` back out of the sandbox and, **if it changed**, persists it to the stored xAI credential (`cachedToken`). So the next build injects the latest token.

- Best-effort — wrapped so it never fails the build.
- No-op when unchanged (compares against the stored blob before writing).
- Last-write-wins under concurrent builds: fine for non-rotating refresh tokens; rotating-refresh-token concurrency is the one documented edge (acceptable — a non-rotating token simply refreshes again next run).

## Verification
- ✅ `pnpm --filter web typecheck` clean.
- Functional behavior (an actual token refresh persisting) needs a live OAuth-connected Grok build — the standing gate.

Completes the OAuth design doc (slices 2–4 now ✅). Builds on #1616 (backend); independent of #1622 (UI) / #1624 (MCP) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)