### PR TITLE
feat(intake): fold origin queue pages into backlog evidence views (EP-INTAKE-UNIFY Phase 6)

### DIFF
--- a/apps/web/app/(shell)/admin/issue-reports/page.tsx
+++ b/apps/web/app/(shell)/admin/issue-reports/page.tsx
@@ -1,13 +1,16 @@
 import Link from "next/link";
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { IssueReportPanel } from "@/components/admin/IssueReportPanel";
-import { getIssueReports, getIssueReportStats } from "@/lib/actions/quality";
+import { getIssueReports, getIssueReportStats, getBacklogLinksForReports } from "@/lib/actions/quality";
 
 export default async function AdminIssueReportsPage() {
   const [data, stats] = await Promise.all([
     getIssueReports(),
     getIssueReportStats(),
   ]);
+  const backlogLinks = await getBacklogLinksForReports(
+    data.items.map((r: { reportId: string }) => r.reportId),
+  );
 
   return (
     <div>
@@ -29,6 +32,7 @@ export default async function AdminIssueReportsPage() {
         items={JSON.parse(JSON.stringify(data.items))}
         total={data.total}
         stats={JSON.parse(JSON.stringify(stats))}
+        backlogLinks={backlogLinks}
       />
     </div>
   );

--- a/apps/web/app/(shell)/ops/improvements/page.tsx
+++ b/apps/web/app/(shell)/ops/improvements/page.tsx
@@ -20,6 +20,10 @@ export default async function ImprovementsPage() {
           {total} improvement{total !== 1 ? "s" : ""}
           {actionable > 0 ? ` · ${actionable} need${actionable !== 1 ? "" : "s"} attention` : ""}
         </p>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Evidence view — each proposal is auto-filed to the backlog for triage and
+          prioritized there. The backlog is the one place work is tracked.
+        </p>
       </div>
 
       <OpsTabNav />

--- a/apps/web/app/(shell)/platform/ai/capability-needs/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/capability-needs/page.tsx
@@ -34,8 +34,9 @@ export default async function CoworkerCapabilityNeedsPage({ searchParams }: Page
           </p>
           <h1 className="mt-1 text-xl font-bold text-[var(--dpf-text)]">Capability Needs</h1>
           <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
-            Review queue for AI coworker self-assessments, capability gaps, and submitted
-            investment needs.
+            Evidence view for AI coworker self-assessments and capability gaps. Each
+            submitted need is auto-filed to the backlog and prioritized there — the
+            backlog is the one place work is tracked.
           </p>
         </div>
         <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs text-[var(--dpf-muted)]">
@@ -180,10 +181,13 @@ function NeedRow({ need }: { need: CoworkerCapabilityNeedReviewItem }) {
         {need.routeContext ? <span>Route {need.routeContext}</span> : null}
         {need.duplicateCount > 0 ? <span>{need.duplicateCount} duplicate signals</span> : null}
         {need.linkedBacklogItemId ? (
-          <span>
-            Backlog {need.linkedBacklogItemId}
-            {need.linkedBacklogItemTitle ? ` - ${need.linkedBacklogItemTitle}` : ""}
-          </span>
+          <Link
+            href={`/ops?itemId=${need.linkedBacklogItemId}`}
+            className="text-[var(--dpf-accent)] hover:underline"
+          >
+            View backlog {need.linkedBacklogItemId}
+            {need.linkedBacklogItemTitle ? ` - ${need.linkedBacklogItemTitle}` : ""} →
+          </Link>
         ) : null}
       </div>
 

--- a/apps/web/components/admin/IssueReportPanel.tsx
+++ b/apps/web/components/admin/IssueReportPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useMemo, useState, useTransition } from "react";
 import { Archive, Bot, CheckCircle2, Filter, ShieldAlert, Wrench } from "lucide-react";
 import { updateIssueReportStatus, sendIssueReportToBuildStudioAsFix } from "@/lib/actions/quality";
@@ -53,10 +54,13 @@ export function IssueReportPanel({
   items: initialItems,
   total,
   stats,
+  backlogLinks,
 }: {
   items: ReportRow[];
   total: number;
   stats: Stats;
+  /** reportId → projected BacklogItem itemId (resolved from the BI body marker). */
+  backlogLinks?: Record<string, string>;
 }) {
   const [items, setItems] = useState(initialItems);
   const [expandedId, setExpandedId] = useState<string | null>(items[0]?.id ?? null);
@@ -224,6 +228,7 @@ export function IssueReportPanel({
               <IssueReportRow
                 key={item.id}
                 report={item}
+                backlogItemId={backlogLinks?.[item.reportId]}
                 expanded={expandedId === item.id}
                 onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
                 onAskAdmin={() => handleAskAdmin(item)}
@@ -246,6 +251,7 @@ export function IssueReportPanel({
 
 function IssueReportRow({
   report,
+  backlogItemId,
   expanded,
   onToggle,
   onAskAdmin,
@@ -254,6 +260,7 @@ function IssueReportRow({
   isPending,
 }: {
   report: ReportRow;
+  backlogItemId?: string;
   expanded: boolean;
   onToggle: () => void;
   onAskAdmin: () => void;
@@ -295,6 +302,15 @@ function IssueReportRow({
         </button>
 
         <div className="flex flex-wrap gap-2 lg:justify-end">
+          {backlogItemId && (
+            <Link
+              href={`/ops?itemId=${backlogItemId}`}
+              title="This report is tracked as a backlog item; open it in the backlog"
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-accent)] hover:border-[var(--dpf-accent)]"
+            >
+              View backlog item
+            </Link>
+          )}
           <button
             type="button"
             onClick={onAskAdmin}

--- a/apps/web/components/ops/ImprovementsClient.tsx
+++ b/apps/web/components/ops/ImprovementsClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { ImprovementRow } from "@/lib/improvement-data";
 import {
@@ -149,10 +150,15 @@ export function ImprovementsClient({ proposals }: Props) {
               </div>
             )}
 
-            {/* Backlog link */}
+            {/* Backlog link — the proposal is evidence; the work lives in the backlog. */}
             {p.backlogItemId && (
-              <div className="text-[11px] text-[var(--dpf-accent)] mb-2">
-                Linked to backlog item {p.backlogItemId}
+              <div className="text-[11px] mb-2">
+                <Link
+                  href={`/ops?itemId=${p.backlogItemId}`}
+                  className="text-[var(--dpf-accent)] hover:underline"
+                >
+                  View backlog item {p.backlogItemId} →
+                </Link>
               </div>
             )}
 

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -81,6 +81,40 @@ export async function getIssueReports(filters?: {
   return { items, total, page, pageSize };
 }
 
+/**
+ * Resolve each report to its projected BacklogItem (EP-INTAKE-UNIFY Phase 6).
+ * PlatformIssueReport has no FK to the BI; the projection embeds the public
+ * reportId in the BI body ("Source report: PIR-XXXXX"). One query over the
+ * bug-class items that mention any of the given reportIds, mapped back by
+ * substring. Returns reportId → BacklogItem.itemId.
+ */
+export async function getBacklogLinksForReports(
+  reportIds: string[],
+): Promise<Record<string, string>> {
+  const ids = Array.from(new Set(reportIds.filter((id) => typeof id === "string" && id.length > 0)));
+  if (ids.length === 0) return {};
+
+  const candidates = await prisma.backlogItem.findMany({
+    where: {
+      workType: "bug",
+      OR: ids.map((id) => ({ body: { contains: id } })),
+    },
+    select: { itemId: true, body: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const links: Record<string, string> = {};
+  for (const item of candidates) {
+    const body = item.body ?? "";
+    for (const id of ids) {
+      // First (oldest) BI that references the report wins — that's the canonical
+      // projection; later same-title reports dedupe into it.
+      if (!links[id] && body.includes(id)) links[id] = item.itemId;
+    }
+  }
+  return links;
+}
+
 export async function updateIssueReportStatus(
   reportId: string,
   status: IssueReportStatus | LegacyIssueReportStatus,


### PR DESCRIPTION
## Why

Phase 6 of the consolidation ([EP-INTAKE-UNIFY](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1584)). The origin queues now project into the backlog (Phases 1–4), but their **pages still read like parallel to-do lists** — the thing your original ask called out ("isolated spots all over the place"). This makes them evidence views that point at the one canonical work record.

## What

- **/ops/improvements** — the "Linked to backlog item" text is now a deep link to `/ops?itemId=…`; header reframed to an evidence view.
- **/platform/ai/capability-needs** — the linked-backlog metadata is now a deep link; header reframed.
- **/admin/issue-reports** — resolve each report to its projected `BacklogItem` via the body marker (`Source report: PIR-…`) with a new `getBacklogLinksForReports` helper (one query, oldest match wins) and render a **"View backlog item"** link per report row.

Reuses the existing `/ops?itemId` deep-link convention (auto-scroll + highlight) and report-kit / theme tokens — **no new dashboard, no new status/lifecycle surface**, per the spec's EA guardrails.

## Deferred (called out, not silently dropped)

- A `workType` **filter facet** on the `/ops` list. The per-row workType **badge already ships** (from the 2026-05-30 spec); the filter needs `OpsClient`/`EpicCard` surgery and is a small low-risk follow-up — kept out to keep this PR reviewable.
- Routing the PIR projection through the shared `ingestBacklogItem` front door (the PIR path keeps its specialized title-dedup/LLM triage).

## Verification

- `pnpm --filter web typecheck` ✅, `pnpm --filter web build` ✅.
- Targeted ops / admin / quality suites — **222 passing** (incl. `OpsClient`, `ImprovementsClient`, issue-report panel).
- Full web vitest — **10059 passed**; the **9 failing tests in `agent-task-scheduler` + `self-upgrade` are pre-existing on `origin/main`** (confirmed by re-running them with this branch stashed) and unrelated to this change.

## Epic status after this

Every queue that was invisible to the backlog now projects into it on detection, and the former queue pages are evidence views linking to the one backlog. Remaining: Phase 5 (route the audit ledgers — AssuranceFinding et al. — through the front door) and the deferred `/ops` workType filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)