### PR TITLE
fix(grants): map TOOL_TO_GRANTS for the Grok sign-in MCP tools (INV-1 hotfix)

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -354,6 +354,11 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   add_provider: ["agent_control_read"],
   update_provider_category: ["agent_control_read"],
   run_endpoint_tests: ["agent_control_read"],
+  // Grok device-code sign-in (EP-GROK-001, #1624). The grant_catalog already
+  // lists these under agent_control_read; #1624 added the catalog entries but
+  // not the TOOL_TO_GRANTS mapping, so INV-1 flagged them as default-deny.
+  grok_signin_start: ["agent_control_read"],
+  grok_signin_status: ["agent_control_read"],
 
   // Employee / HR
   list_departments: ["registry_read"],


### PR DESCRIPTION
## Why

The **Routing Invariants Audit (INV-1)** is failing on every PR's merge result with:

> [INV-1] 2 PLATFORM_TOOLS entries have no TOOL_TO_GRANTS mapping

[#1624](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1624) (EP-GROK-001) added the `grok_signin_start` / `grok_signin_status` MCP tools and listed them in `grant_catalog.json` (under `agent_control_read`), but did not add the `TOOL_TO_GRANTS` entry in `apps/web/lib/tak/agent-grants.ts`. By the default-deny policy that makes the tools unreachable from any coworker, and the violation isn't in the audit baseline — so it blocks the whole PR queue (surfaced on #1626 and now on main).

## What

Map both tools to `agent_control_read` — matching the catalog entry #1624 already added and the sibling provider-management tools (`add_provider`, `update_provider_category`, `run_endpoint_tests`).

## Verification

- INV-1 audit: 2 missing → **0**.
- Coworker Tool-Grant Audit (GRANT-002/003): **no new violations** (the catalog already honors these tools).
- `apps/web/lib/tak/agent-grants.test.ts` — 106 passing. Typecheck green (pre-commit).

(Same omission pattern as the Workbooks tools fixed in #1588. Worth a lint/CI guard so new MCP tools can't merge without a grant mapping — noting for follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)