### PR TITLE
fix(test): green up origin/main web unit suite — stale scheduler @dpf/db mock + self-upgrade test leak (BI-D092F9AF, BI-5EAD8B9C)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -45,7 +45,14 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
-vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@dpf/db", () => ({
+  prisma: mocks.prisma,
+  // executeScheduledAgentTask short-circuits to the deterministic data-model
+  // mirror when task.taskId === DATA_MODEL_MIRROR_TASK_ID (EP-DATA-ARCH, #1618).
+  // The const must be exported from the mock or vitest throws on access; none of
+  // these tests use the mirror task id, so any non-matching value is fine.
+  DATA_MODEL_MIRROR_TASK_ID: "data-model-mirror-nightly",
+}));
 vi.mock("@/lib/tak/agent-routing-server", () => ({
   resolveAgentForRouteWithPrompts: mocks.resolveAgentForRouteWithPrompts,
   resolveAgentByIdWithPrompts: mocks.resolveAgentByIdWithPrompts,

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -290,6 +290,13 @@ const ENABLED_CONFIG = {
 describe("success path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Activity precheck default: no in-flight surfaces. mockReset (not just
+    // clearAllMocks, which leaves implementations and one-shot queues intact)
+    // clears any leftover mockResolvedValueOnce — the "force bypasses" test
+    // below queues a once-value that force never consumes, so without this it
+    // leaks into the next test and spuriously skips it with activity-in-flight.
+    mocks.captureActiveSessionBlockers.mockReset();
+    mocks.captureActiveSessionBlockers.mockResolvedValue({ surfaces: [] });
     mocks.getSelfUpgradeConfig.mockResolvedValue(ENABLED_CONFIG);
     mocks.isUpgradeWindowOpen.mockReturnValue(true);
     mocks.getDeployedSha.mockResolvedValue("oldsha1");


### PR DESCRIPTION
## Summary

`origin/main` was **red on every PR** with 9 failing `apps/web` unit tests, unrelated to whatever change was under test. This PR fixes both clusters. Both are **stale/buggy tests, not source regressions** — the source behavior added by the responsible PRs is correct.

| Cluster | File | Failing | Cause |
|---|---|---|---|
| 1 | `apps/web/lib/actions/agent-task-scheduler.test.ts` | 8 (`executeScheduledAgentTask TaskRun lifecycle`) | Stale `@dpf/db` mock missing an export added by #1618 |
| 2 | `apps/web/lib/queue/functions/self-upgrade.test.ts` | 1 (`success path > runs the promoter …`) | Test-isolation leak introduced by #1621 |

## Cluster 1 — `DATA_MODEL_MIRROR_TASK_ID` missing from the `@dpf/db` mock

[#1618](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1618) (EP-DATA-ARCH Phases 5+6) added `import { prisma, DATA_MODEL_MIRROR_TASK_ID } from "@dpf/db"` to `agent-task-scheduler.ts` and an early short-circuit branch:

```ts
if (task.taskId === DATA_MODEL_MIRROR_TASK_ID) { /* run deterministic mirror */ }
```

The test still mocked `vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }))` with **no** `DATA_MODEL_MIRROR_TASK_ID` export, so vitest threw *"No DATA_MODEL_MIRROR_TASK_ID export is defined on the @dpf/db mock"* the moment the branch was evaluated — erroring all 8 lifecycle tests before any behavior ran.

**Fix:** add `DATA_MODEL_MIRROR_TASK_ID: "data-model-mirror-nightly"` to the mock (canonical value from `packages/db/src/data-model-mirror-config.ts`; no test uses the mirror task id, so it never takes the branch).

## Cluster 2 — leaked `mockResolvedValueOnce` between tests

[#1621](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1621) (activity precheck before draining, BI-F36E7510) added a *"force bypasses the activity precheck and proceeds to drain"* test that queues:

```ts
mocks.captureActiveSessionBlockers.mockResolvedValueOnce({ surfaces: [{ surface: "build-studio.phase.plan" }] });
```

But `force` makes `runSelfUpgrade` bypass the precheck **before** `captureActiveSessionBlockers` is ever called, so the one-shot value is never consumed. `vi.clearAllMocks()` (used in the describe's `beforeEach`) clears call history but **does not** drain `mockResolvedValueOnce` queues — so the dangling value leaked into the very next test, *"runs the promoter …"*, whose non-force path called `captureActiveSessionBlockers`, received the leaked active surface, and skipped with `reason: "activity-in-flight"` → `runPromoter` never called → assertion failed. (Confirmed: the test passes in isolation, fails after *"force bypasses"*.)

**Fix:** reset the mock to the empty-surfaces default in the `success path` `beforeEach`:

```ts
mocks.captureActiveSessionBlockers.mockReset();
mocks.captureActiveSessionBlockers.mockResolvedValue({ surfaces: [] });
```

`mockReset()` (unlike `clearAllMocks`) drains the once-queue, so each test starts isolated.

## Verification

- Both files together: **73 passed**.
- Full `apps/web` vitest suite: **10068 passed / 18 skipped / 0 failed** (1187 files).
- `tsc --noEmit`: **clean**.
- Pre-commit gitleaks + scoped typecheck: passed.
- A full `next build` was not run: `*.test.ts` files are excluded from the production bundle, so the build is unaffected by test-only edits.

Backlog: BI-D092F9AF (cluster 1), BI-5EAD8B9C (cluster 2) — both `workType=bug`, `source=automated-detection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
