### PR TITLE
fix(grok): sandbox grok binary must be runnable by the node user (EP-GROK-001)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -20,11 +20,22 @@ RUN npm install -g @anthropic-ai/claude-code
 # engine (grok-dispatch.ts). xAI ships it as a glibc-linked native binary via a curl
 # installer — there is NO npm package (the previous `@xai/grok-cli` line was a silent
 # no-op: that package does not exist, so provider=grok never actually worked). The binary
-# runs on this Alpine/musl base through the gcompat shim added above. The build-time
-# `grok --version` gate fails the image build loudly if the binary is missing or won't load.
-# Verified end-to-end: grok 0.2.32 installs under gcompat and reaches api.x.ai with XAI_API_KEY.
+# runs on this Alpine/musl base through the gcompat shim added above.
+#
+# The installer downloads the 137MB binary under /root/.grok (root's HOME, mode 0700) and
+# only symlinks /usr/local/bin/grok at it. Build Studio dispatch and the device-login flow
+# run grok as the `node` user (uid 1000), which cannot traverse /root → "grok: Permission
+# denied" at dispatch time even though `grok --version` works as root. So we relocate the
+# real binary into /usr/local/bin (world-traversable) and drop the /root copy.
+#
+# Two build-time gates fail the image loudly: `grok --version` as root AND as the node user
+# — the latter is the one that actually matters, and its absence let the perms bug ship.
 RUN curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash \
- && grok --version
+ && install -m 0755 "$(readlink -f /usr/local/bin/grok)" /usr/local/bin/grok.bin \
+ && ln -sf /usr/local/bin/grok.bin /usr/local/bin/grok \
+ && rm -rf /root/.grok \
+ && grok --version \
+ && su -s /bin/sh node -c "grok --version"
 RUN git config --global user.email "sandbox@dpf.local" \
  && git config --global user.name "DPF Sandbox"
 # Codex CLI defaults: bypass internal sandbox (Docker IS the sandbox),


### PR DESCRIPTION
## The bug (caught by live functional testing)
Build Studio dispatch and the new device-login flow run `grok` as the **node** user (uid 1000). But #1613's installer drops the 137MB binary under `/root/.grok` (root HOME, `0700`) and only symlinks `/usr/local/bin/grok` at it. node can't traverse `/root`, so dispatch fails with **`grok: Permission denied`** — on every freshly-built sandbox.

It shipped because the existing build gate (`grok --version`) runs as **root**, where it works. This is a textbook structural-vs-functional gap: the image built green but the actual dispatch path (`--user node`) was broken.

## Fix
- Relocate the real binary into `/usr/local/bin` (world-traversable); drop the `/root` copy (also saves ~137MB).
- Add a second build-time gate: **`su -s /bin/sh node -c "grok --version"`** — the check that actually matters.

## Verification
- ✅ Full `docker build -f Dockerfile.sandbox` green; **both** the root gate and the **node-user** gate print `grok 0.2.32`.
- ✅ The currently-running `dpf-sandbox-1` was hot-patched the same way (binary relocated), and `docker exec --user node ... grok --version` now succeeds — so OAuth sign-in works on the live install before the image rebuilds.

Found while functionally verifying EP-GROK-001 end-to-end after the OAuth slices merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)