### PR TITLE
feat(mdm): MasterDataSourceRef crosswalk + duplicate-candidate scoring (MDM-2)

### DIFF
--- a/apps/web/lib/mdm/match-candidate.test.ts
+++ b/apps/web/lib/mdm/match-candidate.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findMatchCandidates,
+  scoreMatchCandidate,
+  type MatchSubject,
+} from "@/lib/mdm/match-candidate";
+import {
+  diceCoefficient,
+  standardizeDomain,
+  standardizeName,
+  standardizePhone,
+} from "@/lib/mdm/standardize";
+
+describe("standardize", () => {
+  it("normalizes company names (case, diacritics, legal suffix, punctuation)", () => {
+    expect(standardizeName("Acme, Inc.")).toBe("acme");
+    expect(standardizeName("ACME Corporation")).toBe("acme");
+    expect(standardizeName("Café Ltd")).toBe("cafe");
+    expect(standardizeName("Foo & Bar LLC")).toBe("foo and bar");
+  });
+
+  it("reduces URLs to a bare host", () => {
+    expect(standardizeDomain("https://www.Acme.com/contact?x=1")).toBe("acme.com");
+    expect(standardizeDomain("acme.com")).toBe("acme.com");
+  });
+
+  it("normalizes phone numbers to digits with + (00 → +)", () => {
+    expect(standardizePhone("+1 (415) 555-0100")).toBe("+14155550100");
+    expect(standardizePhone("0044 20 7946 0000")).toBe("+442079460000");
+  });
+
+  it("dice coefficient is 1 for equal and lower for typos", () => {
+    expect(diceCoefficient("acme", "acme")).toBe(1);
+    expect(diceCoefficient("california", "calfornia")).toBeGreaterThan(0.8);
+    expect(diceCoefficient("acme", "globex")).toBeLessThan(0.3);
+  });
+});
+
+describe("scoreMatchCandidate", () => {
+  it("flags a likely duplicate when the web domain matches exactly", () => {
+    const a: MatchSubject = { id: "1", name: "Acme Inc", website: "https://acme.com" };
+    const b: MatchSubject = { id: "2", name: "ACME Corporation", domain: "www.acme.com" };
+    const result = scoreMatchCandidate(a, b);
+    expect(result.score).toBeGreaterThanOrEqual(0.8);
+    expect(result.recommendation).toBe("likely-duplicate");
+    expect(result.reasons.map((r) => r.attribute)).toContain("domain");
+  });
+
+  it("treats unrelated records as distinct", () => {
+    const a: MatchSubject = { id: "1", name: "Acme Inc", website: "acme.com" };
+    const b: MatchSubject = { id: "2", name: "Globex LLC", website: "globex.io" };
+    const result = scoreMatchCandidate(a, b);
+    expect(result.recommendation).toBe("distinct");
+    expect(result.score).toBeLessThan(0.5);
+  });
+
+  it("surfaces a possible duplicate when normalized names match exactly (legal suffix dropped)", () => {
+    const a: MatchSubject = { id: "1", name: "Northwind Trading Company" };
+    const b: MatchSubject = { id: "2", name: "Northwind Trading Co." };
+    const result = scoreMatchCandidate(a, b);
+    // "company" and "co" are legal suffixes → both normalize to "northwind trading"
+    expect(result.score).toBeGreaterThanOrEqual(0.45);
+    expect(result.recommendation).toBe("possible-duplicate");
+  });
+
+  it("surfaces a possible duplicate on a shared email alone", () => {
+    const a: MatchSubject = { id: "1", name: "Jane at Acme", email: "Jane@Acme.com" };
+    const b: MatchSubject = { id: "2", name: "J. Doe", email: "jane@acme.com" };
+    const result = scoreMatchCandidate(a, b);
+    expect(result.reasons.map((r) => r.attribute)).toContain("email");
+    expect(result.recommendation).not.toBe("distinct");
+  });
+
+  it("never returns a score above 1 even when every signal matches", () => {
+    const subject: MatchSubject = {
+      id: "1",
+      name: "Acme",
+      website: "acme.com",
+      email: "ar@acme.com",
+      phone: "+1 415 555 0100",
+    };
+    const result = scoreMatchCandidate(subject, { ...subject, id: "2" });
+    expect(result.score).toBe(1);
+    expect(result.recommendation).toBe("likely-duplicate");
+  });
+});
+
+describe("findMatchCandidates", () => {
+  it("excludes self, drops distinct records, and ranks by score", () => {
+    const subject: MatchSubject = { id: "1", name: "Acme Inc", website: "acme.com" };
+    const pool: MatchSubject[] = [
+      subject,
+      { id: "2", name: "ACME Corp", domain: "acme.com" }, // likely (domain + name)
+      { id: "3", name: "Acme", email: "x@acme.io" }, // weaker (name only)
+      { id: "4", name: "Globex", website: "globex.io" }, // distinct
+    ];
+    const candidates = findMatchCandidates(subject, pool);
+    const ids = candidates.map((c) => c.candidate.id);
+    expect(ids).not.toContain("1");
+    expect(ids).not.toContain("4");
+    expect(ids[0]).toBe("2"); // highest score first
+    expect(candidates[0].result.score).toBeGreaterThanOrEqual(candidates[candidates.length - 1].result.score);
+  });
+});

--- a/apps/web/lib/mdm/match-candidate.ts
+++ b/apps/web/lib/mdm/match-candidate.ts
@@ -1,0 +1,129 @@
+/**
+ * Duplicate-candidate scoring for master data (MDM spec §6.3).
+ *
+ * Scores how likely two canonical records are the same real-world entity, with
+ * human-readable reasons. This NEVER merges: per doctrine (spec §5.4 / Non-Goals)
+ * uncertain matches route to stewardship — the score is advisory input to the
+ * steward queue (MDM-3), not an auto-merge trigger.
+ */
+import {
+  diceCoefficient,
+  standardizeDomain,
+  standardizeEmail,
+  standardizeName,
+  standardizePhone,
+} from "./standardize";
+
+export type MatchSubject = {
+  id: string;
+  name?: string | null;
+  website?: string | null;
+  domain?: string | null;
+  email?: string | null;
+  phone?: string | null;
+};
+
+export type MatchReason = {
+  attribute: "domain" | "name" | "email" | "phone";
+  kind: "exact" | "strong" | "weak";
+  detail: string;
+};
+
+/** Advisory recommendation — a steward still decides the action (link/reject/create-new). */
+export type MatchRecommendation =
+  | "likely-duplicate"
+  | "possible-duplicate"
+  | "distinct";
+
+export type MatchCandidateResult = {
+  /** 0..1 confidence that the two records are the same entity. */
+  score: number;
+  reasons: MatchReason[];
+  recommendation: MatchRecommendation;
+};
+
+const LIKELY_THRESHOLD = 0.8;
+// A single strong identity signal (shared domain, exact normalized name, or
+// shared email) is enough to put a pair in front of a steward — doctrine
+// prefers surfacing a possible duplicate over silently missing it (spec §6.3).
+const POSSIBLE_THRESHOLD = 0.45;
+const NAME_STRONG_SIMILARITY = 0.85;
+const NAME_WEAK_SIMILARITY = 0.6;
+
+/**
+ * Score a candidate match between two records. Weights reflect signal strength:
+ * a shared web domain is the single strongest identity signal; exact name,
+ * email, and phone add corroboration; a fuzzy name match adds partial weight.
+ */
+export function scoreMatchCandidate(
+  a: MatchSubject,
+  b: MatchSubject,
+): MatchCandidateResult {
+  const reasons: MatchReason[] = [];
+  let score = 0;
+
+  const domainA = standardizeDomain(a.domain ?? a.website);
+  const domainB = standardizeDomain(b.domain ?? b.website);
+  if (domainA && domainB && domainA === domainB) {
+    score += 0.6;
+    reasons.push({ attribute: "domain", kind: "exact", detail: domainA });
+  }
+
+  const nameA = standardizeName(a.name);
+  const nameB = standardizeName(b.name);
+  if (nameA && nameB) {
+    if (nameA === nameB) {
+      score += 0.45;
+      reasons.push({ attribute: "name", kind: "exact", detail: nameA });
+    } else {
+      const similarity = diceCoefficient(nameA, nameB);
+      if (similarity >= NAME_STRONG_SIMILARITY) {
+        score += 0.3;
+        reasons.push({ attribute: "name", kind: "strong", detail: `~${similarity.toFixed(2)}` });
+      } else if (similarity >= NAME_WEAK_SIMILARITY) {
+        score += 0.15;
+        reasons.push({ attribute: "name", kind: "weak", detail: `~${similarity.toFixed(2)}` });
+      }
+    }
+  }
+
+  const emailA = standardizeEmail(a.email);
+  const emailB = standardizeEmail(b.email);
+  if (emailA && emailB && emailA === emailB) {
+    score += 0.5;
+    reasons.push({ attribute: "email", kind: "exact", detail: emailA });
+  }
+
+  const phoneA = standardizePhone(a.phone);
+  const phoneB = standardizePhone(b.phone);
+  if (phoneA && phoneB && phoneA === phoneB) {
+    score += 0.4;
+    reasons.push({ attribute: "phone", kind: "exact", detail: phoneA });
+  }
+
+  score = Math.min(1, Number(score.toFixed(2)));
+  const recommendation: MatchRecommendation =
+    score >= LIKELY_THRESHOLD
+      ? "likely-duplicate"
+      : score >= POSSIBLE_THRESHOLD
+        ? "possible-duplicate"
+        : "distinct";
+
+  return { score, reasons, recommendation };
+}
+
+/**
+ * Find candidate duplicates of `subject` among `pool` (excluding itself),
+ * ranked by score, keeping only possible/likely duplicates. Output feeds the
+ * steward queue — it does not act.
+ */
+export function findMatchCandidates(
+  subject: MatchSubject,
+  pool: readonly MatchSubject[],
+): Array<{ candidate: MatchSubject; result: MatchCandidateResult }> {
+  return pool
+    .filter((candidate) => candidate.id !== subject.id)
+    .map((candidate) => ({ candidate, result: scoreMatchCandidate(subject, candidate) }))
+    .filter((entry) => entry.result.recommendation !== "distinct")
+    .sort((x, y) => y.result.score - x.result.score);
+}

--- a/apps/web/lib/mdm/standardize.ts
+++ b/apps/web/lib/mdm/standardize.ts
@@ -1,0 +1,75 @@
+/**
+ * Standardization helpers for master-data match decisions (MDM spec §3).
+ *
+ * Normalize names, domains, emails, and phone numbers to a comparable form
+ * BEFORE scoring duplicate candidates. Pure functions — no DB, no I/O.
+ */
+
+const LEGAL_SUFFIXES =
+  /\b(inc|incorporated|llc|l\.l\.c|ltd|limited|corp|corporation|co|company|plc|gmbh|s\.?a|s\.?a\.?s|b\.?v|pty|group|holdings)\b/g;
+
+/** Combining diacritical marks (U+0300–U+036F), stripped after NFKD normalization. */
+const DIACRITICS = /[̀-ͯ]/g;
+
+/** Lowercase, strip diacritics, drop legal suffixes/punctuation, collapse whitespace. */
+export function standardizeName(value: string | null | undefined): string {
+  if (!value) return "";
+  return value
+    .normalize("NFKD")
+    .replace(DIACRITICS, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[.,'"`()\-_/]/g, " ")
+    .replace(LEGAL_SUFFIXES, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Reduce a URL or domain to a bare host: drop scheme, www, path, query. */
+export function standardizeDomain(value: string | null | undefined): string {
+  if (!value) return "";
+  let v = value.trim().toLowerCase();
+  v = v.replace(/^[a-z]+:\/\//, "").replace(/^www\./, "");
+  v = (v.split("/")[0] ?? "").split("?")[0] ?? "";
+  return v.trim();
+}
+
+/** Trim + lowercase an email for comparison. */
+export function standardizeEmail(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.trim().toLowerCase();
+}
+
+/** Reduce a phone number to digits with an optional leading +, normalizing 00 → +. */
+export function standardizePhone(value: string | null | undefined): string {
+  if (!value) return "";
+  const digits = value.replace(/[^\d+]/g, "");
+  return digits.replace(/^00/, "+");
+}
+
+/**
+ * Dice coefficient on character bigrams — a fast 0..1 string similarity that is
+ * forgiving of typos/word-order without an external dependency.
+ */
+export function diceCoefficient(a: string, b: string): number {
+  if (a === b) return a.length === 0 ? 0 : 1;
+  if (a.length < 2 || b.length < 2) return 0;
+
+  const bigrams = (s: string): Map<string, number> => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < s.length - 1; i++) {
+      const bg = s.slice(i, i + 2);
+      map.set(bg, (map.get(bg) ?? 0) + 1);
+    }
+    return map;
+  };
+
+  const aMap = bigrams(a);
+  const bMap = bigrams(b);
+  let intersection = 0;
+  for (const [bg, count] of aMap) {
+    const other = bMap.get(bg) ?? 0;
+    intersection += Math.min(count, other);
+  }
+  return (2 * intersection) / (a.length - 1 + (b.length - 1));
+}

--- a/packages/db/prisma/migrations/20260607000000_add_master_data_source_ref/migration.sql
+++ b/packages/db/prisma/migrations/20260607000000_add_master_data_source_ref/migration.sql
@@ -1,0 +1,54 @@
+-- Master Data Management source crosswalk (MDM spec §6.2, typed-FK hybrid).
+-- Additive: new table + FKs to high-volume canonical domains. No existing data touched.
+
+-- CreateTable
+CREATE TABLE "MasterDataSourceRef" (
+    "id" TEXT NOT NULL,
+    "domain" TEXT NOT NULL,
+    "canonicalId" TEXT NOT NULL,
+    "customerAccountId" TEXT,
+    "supplierId" TEXT,
+    "sourceSystem" TEXT NOT NULL,
+    "sourceEntityType" TEXT,
+    "sourceEntityId" TEXT NOT NULL,
+    "sourcePayloadHash" TEXT,
+    "observedAt" TIMESTAMP(3) NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "trustTier" TEXT NOT NULL DEFAULT 'unknown',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MasterDataSourceRef_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MasterDataSourceRef_domain_sourceSystem_sourceEntityId_key" ON "MasterDataSourceRef"("domain", "sourceSystem", "sourceEntityId");
+
+-- CreateIndex
+CREATE INDEX "MasterDataSourceRef_domain_canonicalId_idx" ON "MasterDataSourceRef"("domain", "canonicalId");
+
+-- CreateIndex
+CREATE INDEX "MasterDataSourceRef_sourceSystem_sourceEntityId_idx" ON "MasterDataSourceRef"("sourceSystem", "sourceEntityId");
+
+-- CreateIndex
+CREATE INDEX "MasterDataSourceRef_customerAccountId_idx" ON "MasterDataSourceRef"("customerAccountId");
+
+-- CreateIndex
+CREATE INDEX "MasterDataSourceRef_supplierId_idx" ON "MasterDataSourceRef"("supplierId");
+
+-- AddForeignKey
+ALTER TABLE "MasterDataSourceRef" ADD CONSTRAINT "MasterDataSourceRef_customerAccountId_fkey" FOREIGN KEY ("customerAccountId") REFERENCES "CustomerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MasterDataSourceRef" ADD CONSTRAINT "MasterDataSourceRef_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Typed-FK hybrid invariant (spec §6.2): for FK-backed domains the typed column
+-- must be populated and equal canonicalId; for all other (polymorphic) domains
+-- both typed columns must be null. Enforced in the DB, not just application code.
+ALTER TABLE "MasterDataSourceRef" ADD CONSTRAINT "MasterDataSourceRef_typed_fk_check"
+    CHECK (
+      ("domain" = 'customer-account' AND "customerAccountId" = "canonicalId" AND "supplierId" IS NULL)
+      OR ("domain" = 'supplier' AND "supplierId" = "canonicalId" AND "customerAccountId" IS NULL)
+      OR ("domain" NOT IN ('customer-account', 'supplier') AND "customerAccountId" IS NULL AND "supplierId" IS NULL)
+    );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2300,6 +2300,7 @@ model CustomerAccount {
   recurringSchedules     RecurringSchedule[]
   inventoryEntities      InventoryEntity[]           @relation("InventoryEntityCustomerAccount")
   inventoryRelationships InventoryRelationship[]     @relation("InventoryRelationshipCustomerAccount")
+  masterDataSourceRefs   MasterDataSourceRef[]       @relation("CustomerAccountMdmSourceRef")
 
   @@index([status])
   @@index([parentAccountId])
@@ -7734,8 +7735,44 @@ model Supplier {
   aiProviderProfiles AiProviderFinanceProfile[]
   supplierContracts  SupplierContract[]
   financeWorkItems   FinanceWorkItem[]
+  masterDataSourceRefs MasterDataSourceRef[] @relation("SupplierMdmSourceRef")
 
   @@index([status])
+}
+
+/// Master Data Management source crosswalk (MDM spec §6.2, typed-FK hybrid,
+/// resolved 2026-06-06). The durable, resolved mapping from a source-system
+/// record to a canonical DPF record — written once a staged import record is
+/// accepted/linked, not a second intake table. Identity-bearing domains
+/// (organization, customer-contact) crosswalk via PrincipalAlias instead and
+/// are out of scope here. High-volume domains (customer-account, supplier)
+/// carry a typed FK for DB-enforced cascade; low-volume domains rely on the
+/// polymorphic (domain, canonicalId) pointer with application-enforced integrity.
+model MasterDataSourceRef {
+  id                String   @id @default(cuid())
+  domain            String
+  canonicalId       String
+  customerAccountId String?
+  supplierId        String?
+  sourceSystem      String
+  sourceEntityType  String?
+  sourceEntityId    String
+  sourcePayloadHash String?
+  observedAt        DateTime
+  lastSeenAt        DateTime
+  trustTier         String   @default("unknown")
+  status            String   @default("active")
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  customerAccount CustomerAccount? @relation("CustomerAccountMdmSourceRef", fields: [customerAccountId], references: [id], onDelete: Cascade)
+  supplier        Supplier?        @relation("SupplierMdmSourceRef", fields: [supplierId], references: [id], onDelete: Cascade)
+
+  @@unique([domain, sourceSystem, sourceEntityId])
+  @@index([domain, canonicalId])
+  @@index([sourceSystem, sourceEntityId])
+  @@index([customerAccountId])
+  @@index([supplierId])
 }
 
 model AiProviderFinanceProfile {


### PR DESCRIPTION
## Summary

**MDM-2** (`BI-247A03E1`) under **EP-MDM** — the record-level architectural core of Master Data Management, building on the merged foundation (MDM-0 trust dimensions + MDM-1 domain registry, PR #1623). Follows the approved [MDM Alignment Design](docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md) and [plan](docs/superpowers/plans/2026-06-06-master-data-management-foundation.md).

### Schema — `MasterDataSourceRef` crosswalk (typed-FK hybrid, spec §6.2)
- Polymorphic `(domain, canonicalId)` pointer for low-volume domains **plus** typed nullable `customerAccountId` / `supplierId` FKs (DB-enforced cascade) for the two high-volume domains — the kernel-resolved hybrid.
- A **CHECK constraint** enforces the invariant in the database: for an FK-backed domain the typed column is populated and equals `canonicalId`; for polymorphic-only domains both typed columns are null.
- Additive migration; back-relations added to `CustomerAccount` and `Supplier`. Identity-bearing domains stay on `PrincipalAlias` (not this table).

### Logic — standardization + duplicate-candidate scoring
- Pure `standardize.ts`: name (diacritics/legal-suffix/punctuation), domain (scheme/www/path strip), email, phone normalization, + Dice bigram similarity.
- `match-candidate.ts`: advisory scoring with human-readable reasons. **Never merges** — per doctrine (§5.4) it feeds the steward queue (MDM-3). Weights tuned so a single strong identity signal (shared domain, exact normalized name, or shared email) surfaces a pair as a *possible duplicate* rather than silently missing it.

### Design note
MDM-internal enums (`domain`/`status`/`trustTier`) live in the `lib/mdm` module, **not** `backlog.ts`/`mcp-tools.ts` — AGENTS.md §3's enum registry is scoped to BacklogItem/Epic enums, so registering arbitrary schema columns there (as spec §6.2 loosely suggested) would misapply that convention.

## Verification
- `vitest` mdm + trust-vector: **35 passing** (standardization, scoring tuning, self-exclusion/ranking).
- `prisma validate` ✅, schema-regression-guard ✅, scoped typecheck ✅ (pre-commit).
- Migration apply + live functional verification run on CI / the convergence sandbox (runtime-bound gate per AGENTS.md §4).

## Follow-ups
MDM-3 steward queue (consumes this scoring), MDM-4 survivorship, MDM-5 reference-data/locations merge, MDM-6 supplier, MDM-7 publishing.

Refs: EP-MDM, BI-247A03E1, BI-C5F3CB36

🤖 Generated with [Claude Code](https://claude.com/claude-code)