### PR TITLE
fix(workbooks): make the Backlog grid editable for all items via true partial update (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -170,13 +170,19 @@ export function WorkbookGrid({
   }, [rowData, sortColumns]);
 
   const persistCell = useCallback(
-    async (rowId: string, columnId: string, value: CellValue) => {
+    async (rowId: string, columnId: string, value: CellValue, prevValue: CellValue) => {
       setError(null);
       const res =
         source === "platform"
           ? await updatePlatformCellsAction(tableId, rowId, { [columnId]: value })
           : await updateCellsAction(tableId, rowId, { [columnId]: value });
-      if (!res.ok) setError(res.error);
+      if (!res.ok) {
+        setError(res.error);
+        // Revert the optimistic edit so the grid doesn't show an unsaved value.
+        setRowData((prev) =>
+          prev.map((r) => (r.rowId === rowId ? { ...r, [columnId]: prevValue } : r)),
+        );
+      }
     },
     [tableId, source],
   );
@@ -185,14 +191,17 @@ export function WorkbookGrid({
     (newRows: GridRowData[], data: RowsChangeData<GridRowData>) => {
       // newRows are in sorted order; map back into the canonical rowData by rowId.
       const byId = new Map(newRows.map((r) => [r.rowId, r]));
-      setRowData((prev) => prev.map((r) => byId.get(r.rowId) ?? r));
       const columnId = data.column.key;
       for (const idx of data.indexes) {
         const changed = newRows[idx];
-        if (changed) void persistCell(changed.rowId, columnId, changed[columnId] ?? null);
+        if (!changed) continue;
+        const prevRow = rowData.find((r) => r.rowId === changed.rowId);
+        const prevValue: CellValue = prevRow ? prevRow[columnId] ?? null : null;
+        void persistCell(changed.rowId, columnId, changed[columnId] ?? null, prevValue);
       }
+      setRowData((prev) => prev.map((r) => byId.get(r.rowId) ?? r));
     },
-    [persistCell],
+    [persistCell, rowData],
   );
 
   const onAddRow = useCallback(async () => {

--- a/apps/web/lib/actions/backlog.ts
+++ b/apps/web/lib/actions/backlog.ts
@@ -7,7 +7,13 @@ import { can } from "@/lib/permissions";
 import {
   validateBacklogInput,
   validateEpicInput,
+  BACKLOG_STATUS_VALUES,
+  BACKLOG_WORK_TYPE_VALUES,
+  BACKLOG_SOURCE_VALUES,
   type BacklogItemInput,
+  type BacklogStatus,
+  type BacklogWorkType,
+  type BacklogSource,
   type EpicInput,
 } from "@/lib/backlog";
 
@@ -93,6 +99,88 @@ export async function updateBacklogItem(id: string, input: BacklogItemInput): Pr
           data: { status: "done", completedAt: new Date() },
         });
       }
+    }
+  }
+}
+
+/**
+ * Partial field update for a backlog item — only the supplied fields are written
+ * and only those fields are validated. Unlike updateBacklogItem (which requires a
+ * complete, fully-valid BacklogItemInput), this does NOT re-require untouched
+ * fields, so a single-field edit (e.g. priority/status from the grid) succeeds
+ * even on items whose other fields are incomplete (null workType, legacy items).
+ * Mirrors the conditional-spread pattern of updateRiskAssessment. Preserves the
+ * status side-effects (completedAt) and epic auto-completion of the full update.
+ */
+export type BacklogFieldPatch = {
+  title?: string;
+  status?: BacklogStatus;
+  priority?: number | null;
+  type?: "product" | "portfolio";
+  workType?: BacklogWorkType;
+  source?: BacklogSource;
+  body?: string | null;
+};
+
+export async function updateBacklogItemFields(id: string, patch: BacklogFieldPatch): Promise<void> {
+  await requireManageBacklog();
+
+  const existing = await prisma.backlogItem.findUnique({
+    where: { id },
+    select: { status: true, type: true, digitalProductId: true, epicId: true },
+  });
+  if (!existing) throw new Error("Backlog item not found");
+
+  // Validate ONLY the fields actually being changed.
+  if (patch.title !== undefined && !patch.title.trim()) throw new Error("Title is required");
+  if (patch.status !== undefined && !BACKLOG_STATUS_VALUES.includes(patch.status)) {
+    throw new Error(`Invalid status: ${patch.status}`);
+  }
+  if (patch.workType !== undefined && !BACKLOG_WORK_TYPE_VALUES.includes(patch.workType)) {
+    throw new Error(`Invalid work type: ${patch.workType}`);
+  }
+  if (patch.source !== undefined && !BACKLOG_SOURCE_VALUES.includes(patch.source)) {
+    throw new Error(`Invalid source: ${patch.source}`);
+  }
+  if (patch.type !== undefined && patch.type !== "product" && patch.type !== "portfolio") {
+    throw new Error(`Invalid type: ${patch.type}`);
+  }
+  // Only enforce the product->digitalProduct rule when the caller is switching to
+  // product without one — never block edits to items that are already product.
+  if (patch.type === "product" && !existing.digitalProductId) {
+    throw new Error("A digital product is required for product-type items");
+  }
+
+  const nextStatus = patch.status ?? existing.status;
+  const isNowDone = nextStatus === "done" || nextStatus === "deferred";
+  const wasDone = existing.status === "done" || existing.status === "deferred";
+
+  const data: Record<string, unknown> = {};
+  if (patch.title !== undefined) data.title = patch.title.trim();
+  if (patch.status !== undefined) data.status = patch.status;
+  if (patch.priority !== undefined) data.priority = patch.priority;
+  if (patch.type !== undefined) data.type = patch.type;
+  if (patch.workType !== undefined) data.workType = patch.workType;
+  if (patch.source !== undefined) data.source = patch.source;
+  if (patch.body !== undefined) data.body = patch.body && patch.body.trim() ? patch.body.trim() : null;
+  if (patch.status !== undefined) {
+    if (isNowDone && !wasDone) data.completedAt = new Date();
+    if (!isNowDone && wasDone) data.completedAt = null;
+  }
+
+  if (Object.keys(data).length === 0) return;
+  await prisma.backlogItem.update({ where: { id }, data });
+
+  // Auto-complete the epic when this status change makes all its items done/deferred.
+  if (patch.status !== undefined && isNowDone && !wasDone && existing.epicId) {
+    const remaining = await prisma.backlogItem.count({
+      where: { epicId: existing.epicId, status: { notIn: ["done", "deferred"] } },
+    });
+    if (remaining === 0) {
+      await prisma.epic.update({
+        where: { id: existing.epicId },
+        data: { status: "done", completedAt: new Date() },
+      });
     }
   }
 }

--- a/apps/web/lib/workbooks/backlog-adapter-mapping.test.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-mapping.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   BACKLOG_COLUMNS,
   backlogItemToGridRow,
-  buildBacklogInput,
-  type BacklogEditableExisting,
+  buildBacklogPatch,
 } from "./backlog-adapter-mapping";
 
 describe("BACKLOG_COLUMNS", () => {
@@ -54,47 +53,43 @@ describe("backlogItemToGridRow", () => {
   });
 });
 
-describe("buildBacklogInput", () => {
-  const existing: BacklogEditableExisting = {
-    title: "Old title",
-    type: "product",
-    status: "open",
-    workType: "bug",
-    source: "user-request",
-    priority: 2,
-    body: "old body",
-    epicId: "EP-1",
-    digitalProductId: "dp-1",
-    taxonomyNodeId: null,
-  };
-
-  it("overlays a single changed field and preserves the rest", () => {
-    const input = buildBacklogInput(existing, { status: "done" });
-    expect(input.status).toBe("done");
-    expect(input.title).toBe("Old title");
-    expect(input.workType).toBe("bug");
-    expect(input.type).toBe("product");
-    expect(input.digitalProductId).toBe("dp-1");
-    expect(input.epicId).toBe("EP-1");
+describe("buildBacklogPatch", () => {
+  it("includes ONLY the changed field (the core of the partial-edit fix)", () => {
+    const patch = buildBacklogPatch({ priority: 5 });
+    expect(patch).toEqual({ priority: 5 });
   });
 
-  it("coerces a numeric-string priority to a number", () => {
-    const input = buildBacklogInput(existing, { priority: "5" });
-    expect(input.priority).toBe(5);
+  it("does NOT require workType when editing an unrelated field", () => {
+    // This is the regression the fix addresses: a priority edit on an item with
+    // a null workType must NOT mention or require workType.
+    const patch = buildBacklogPatch({ priority: 3 });
+    expect(patch).not.toHaveProperty("workType");
+    expect(patch).not.toHaveProperty("title");
   });
 
-  it("throws when required workType is missing and not supplied", () => {
-    const noWorkType = { ...existing, workType: null };
-    expect(() => buildBacklogInput(noWorkType, { status: "done" })).toThrow(/work type/i);
+  it("coerces a numeric-string priority to a number and empty to null", () => {
+    expect(buildBacklogPatch({ priority: "7" }).priority).toBe(7);
+    expect(buildBacklogPatch({ priority: "" }).priority).toBeNull();
+    expect(buildBacklogPatch({ priority: null }).priority).toBeNull();
   });
 
-  it("accepts a supplied workType for an item that was missing one", () => {
-    const noWorkType = { ...existing, workType: null };
-    const input = buildBacklogInput(noWorkType, { workType: "chore" });
-    expect(input.workType).toBe("chore");
+  it("carries status/type/workType/source when explicitly changed", () => {
+    const patch = buildBacklogPatch({ status: "done", type: "portfolio", workType: "chore", source: "user-request" });
+    expect(patch).toEqual({ status: "done", type: "portfolio", workType: "chore", source: "user-request" });
   });
 
-  it("throws when title is cleared", () => {
-    expect(() => buildBacklogInput(existing, { title: "  " })).toThrow(/title/i);
+  it("treats an emptied required select as a no-op (no invalid write)", () => {
+    expect(buildBacklogPatch({ status: "" })).toEqual({});
+    expect(buildBacklogPatch({ workType: "" })).toEqual({});
+  });
+
+  it("normalizes body: trims, empty -> null", () => {
+    expect(buildBacklogPatch({ body: "  notes " }).body).toBe("notes");
+    expect(buildBacklogPatch({ body: "   " }).body).toBeNull();
+  });
+
+  it("throws only when title is explicitly cleared", () => {
+    expect(() => buildBacklogPatch({ title: "  " })).toThrow(/title/i);
+    expect(buildBacklogPatch({ title: "New" }).title).toBe("New");
   });
 });

--- a/apps/web/lib/workbooks/backlog-adapter-mapping.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-mapping.ts
@@ -9,7 +9,6 @@ import {
   BACKLOG_STATUS_VALUES,
   BACKLOG_WORK_TYPE_VALUES,
   BACKLOG_SOURCE_VALUES,
-  type BacklogItemInput,
   type BacklogStatus,
   type BacklogWorkType,
   type BacklogSource,
@@ -83,20 +82,6 @@ export const BACKLOG_COLUMNS: ColumnDefinition[] = [
   { columnId: "updatedAt", name: "Updated", fieldType: "datetime", position: 9, required: false, editable: false, width: 170 },
 ];
 
-/** The subset of BacklogItem fields needed to build a complete update payload. */
-export interface BacklogEditableExisting {
-  title: string;
-  type: string;
-  status: string;
-  workType: string | null;
-  source: string | null;
-  priority: number | null;
-  body: string | null;
-  epicId: string | null;
-  digitalProductId: string | null;
-  taxonomyNodeId: string | null;
-}
-
 /** Map a backlog record (list/detail shape) into a grid row keyed by field name. */
 export function backlogItemToGridRow(item: {
   itemId: string;
@@ -127,54 +112,66 @@ export function backlogItemToGridRow(item: {
   };
 }
 
-function asNumberOrUndef(v: CellValue | undefined): number | undefined {
-  if (typeof v === "number") return v;
-  if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) return Number(v);
-  return undefined;
+/** Patch of only the backlog fields a grid edit changed. Structurally matches
+ *  BacklogFieldPatch in lib/actions/backlog.ts (kept separate so this stays pure). */
+export interface BacklogPatch {
+  title?: string;
+  status?: BacklogStatus;
+  priority?: number | null;
+  type?: "product" | "portfolio";
+  workType?: BacklogWorkType;
+  source?: BacklogSource;
+  body?: string | null;
 }
 
-function asStringOrUndef(v: CellValue | undefined): string | undefined {
-  return typeof v === "string" && v !== "" ? v : undefined;
+function asNumber(v: CellValue): number | null {
+  if (typeof v === "number") return v;
+  if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) return Number(v);
+  return null;
+}
+
+function asStr(v: CellValue): string {
+  if (typeof v === "string") return v;
+  return v == null ? "" : String(v);
 }
 
 /**
- * Build a complete BacklogItemInput by overlaying grid changes (keyed by field
- * name) onto the existing record. Throws if a required field would be empty —
- * we never silently invent a workType/type/title.
+ * Build a partial patch from the grid's changed cells (keyed by field name).
+ * Only includes fields actually present in `changes`, and only the changed
+ * fields are touched — untouched required fields (e.g. a null workType on a
+ * legacy item) are left alone, so editing one cell no longer requires the whole
+ * record to be valid. Empty values for the required selects (status/type/
+ * workType/source) are treated as no-ops rather than invalid writes.
  */
-export function buildBacklogInput(
-  existing: BacklogEditableExisting,
-  changes: Record<string, CellValue>,
-): BacklogItemInput {
-  const pick = <T>(field: string, fallback: T): CellValue | T =>
-    field in changes ? changes[field] : fallback;
-
-  const title = String(pick("title", existing.title) ?? "").trim();
-  if (!title) throw new Error("Title cannot be empty");
-
-  const type = String(pick("type", existing.type)) as "product" | "portfolio";
-
-  const workTypeRaw = pick("workType", existing.workType);
-  const workType = (typeof workTypeRaw === "string" ? workTypeRaw : "") as BacklogWorkType;
-  if (!workType) {
-    throw new Error("This item is missing a work type — set it in the backlog form first");
+export function buildBacklogPatch(changes: Record<string, CellValue>): BacklogPatch {
+  const patch: BacklogPatch = {};
+  if ("title" in changes) {
+    const t = asStr(changes.title).trim();
+    if (!t) throw new Error("Title cannot be empty");
+    patch.title = t;
   }
-
-  const status = String(pick("status", existing.status)) as BacklogStatus;
-
-  const sourceRaw = pick("source", existing.source ?? undefined);
-  const source = (asStringOrUndef(sourceRaw) as BacklogSource | undefined) ?? undefined;
-
-  return {
-    title,
-    type,
-    workType,
-    status,
-    source,
-    priority: asNumberOrUndef(pick("priority", existing.priority ?? undefined)),
-    body: asStringOrUndef(pick("body", existing.body ?? undefined)),
-    epicId: existing.epicId ?? undefined,
-    digitalProductId: existing.digitalProductId ?? undefined,
-    taxonomyNodeId: existing.taxonomyNodeId ?? undefined,
-  };
+  if ("status" in changes) {
+    const s = asStr(changes.status);
+    if (s) patch.status = s as BacklogStatus;
+  }
+  if ("type" in changes) {
+    const t = asStr(changes.type);
+    if (t) patch.type = t as "product" | "portfolio";
+  }
+  if ("workType" in changes) {
+    const w = asStr(changes.workType);
+    if (w) patch.workType = w as BacklogWorkType;
+  }
+  if ("source" in changes) {
+    const s = asStr(changes.source);
+    if (s) patch.source = s as BacklogSource;
+  }
+  if ("priority" in changes) {
+    patch.priority = asNumber(changes.priority);
+  }
+  if ("body" in changes) {
+    const b = asStr(changes.body).trim();
+    patch.body = b || null;
+  }
+  return patch;
 }

--- a/apps/web/lib/workbooks/backlog-adapter.ts
+++ b/apps/web/lib/workbooks/backlog-adapter.ts
@@ -2,12 +2,13 @@
 //
 // Renders real BacklogItem records as an editable grid. This is the first
 // platform-data adapter: the grid is a live view over the same records the
-// backlog forms edit, NOT a copy. Writes route through the canonical
-// updateBacklogItem server action (which itself enforces manage_backlog and all
-// status/validation rules) — never a raw prisma write.
+// backlog forms edit, NOT a copy. Single-cell edits route through the
+// updateBacklogItemFields partial update (enforces manage_backlog; validates only
+// the changed fields) so editing one cell never requires the rest of the record
+// to be complete — never a raw prisma write.
 
 import { prisma } from "@dpf/db";
-import { updateBacklogItem } from "@/lib/actions/backlog";
+import { updateBacklogItemFields } from "@/lib/actions/backlog";
 import { getBacklogItems } from "@/lib/explore/backlog-data";
 import {
   gridRegistry,
@@ -18,8 +19,7 @@ import {
   BACKLOG_ENTITY_TYPE,
   BACKLOG_COLUMNS,
   backlogItemToGridRow,
-  buildBacklogInput,
-  type BacklogEditableExisting,
+  buildBacklogPatch,
 } from "./backlog-adapter-mapping";
 import {
   type ColumnDefinition,
@@ -82,38 +82,13 @@ class BacklogItemAdapter implements DataSourceAdapter {
   ): Promise<GridRow> {
     const existing = await prisma.backlogItem.findUnique({
       where: { itemId: rowId },
-      select: {
-        id: true,
-        title: true,
-        type: true,
-        status: true,
-        workType: true,
-        source: true,
-        priority: true,
-        body: true,
-        epicId: true,
-        digitalProductId: true,
-        taxonomyNodeId: true,
-      },
+      select: { id: true },
     });
     if (!existing) throw new Error("Backlog item not found");
 
-    const editable: BacklogEditableExisting = {
-      title: existing.title,
-      type: existing.type,
-      status: existing.status,
-      workType: existing.workType,
-      source: existing.source,
-      priority: existing.priority,
-      body: existing.body,
-      epicId: existing.epicId,
-      digitalProductId: existing.digitalProductId,
-      taxonomyNodeId: existing.taxonomyNodeId,
-    };
-
-    const input = buildBacklogInput(editable, changes);
-    // Canonical, fully-validated + authorized update path (enforces manage_backlog).
-    await updateBacklogItem(existing.id, input);
+    // Partial update: only the changed fields are written + validated. Enforces
+    // manage_backlog and preserves status side-effects / epic auto-completion.
+    await updateBacklogItemFields(existing.id, buildBacklogPatch(changes));
 
     const updated = await readGridRow(rowId);
     if (!updated) throw new Error("Item updated but could not be read back");


### PR DESCRIPTION
## What & why

Live functional verification (post-deploy) found the platform-**Backlog grid was effectively read-only for the common case**: editing one cell re-ran `updateBacklogItem`'s *full* validation (requires `workType` always, and `digitalProductId` for `product`-type), and `BacklogItemAdapter` also guarded a null `workType`. But most real backlog items have a null `workType` or are `product` without a linked digital product — so virtually every grid edit was rejected (confirmed: every visible row had a null workType; a product-item priority edit returned "A digital product is required…"). Read/board/render were perfect; only *edit* was blocked.

## Fix — true partial update (mirrors the working `RiskAssessmentAdapter` pattern)

- **`updateBacklogItemFields(id, patch)`** (new, `lib/actions/backlog.ts`): writes + validates **only the changed fields**, enforces `manage_backlog`, and preserves the full updater's status side-effects (`completedAt`) + epic auto-completion. The product→digitalProduct rule now fires **only when switching to product without one** — it never blocks edits to items already `product`. `updateBacklogItem` (full) is untouched.
- **`buildBacklogPatch`** replaces `buildBacklogInput`: changed-fields-only; empty required-selects are no-ops; no untouched-field requirements.
- **`BacklogItemAdapter.updateCells`** resolves `itemId`→`id` and calls `updateBacklogItemFields(buildBacklogPatch(changes))`.
- **`Grid.tsx`**: reverts the optimistic cell on server error (parity with `KanbanBoard`) — a rejected edit no longer leaves an unsaved value on screen.

## Verification (worktree)

- New `buildBacklogPatch` unit tests: a priority edit yields `{priority}` only and **never** requires `workType`; empty required-select = no-op; body normalize; title-clear throws. `vitest lib/workbooks` → **18/18**.
- `typecheck` clean; production `build` green; system route intact.
- Live re-verification (drag/edit on real items) will run after this deploys.

Closes the platform-edit limitation found during live verification of Phase 1b (the read/board paths were already verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)