### PR TITLE
fix(routing): reap orphaned in-sandbox CLI processes on dispatch timeout (BI-F36E7510)

### DIFF
--- a/apps/web/lib/routing/cli-adapter.test.ts
+++ b/apps/web/lib/routing/cli-adapter.test.ts
@@ -180,6 +180,53 @@ describe("cliAdapter", () => {
     );
   });
 
+  it("reaps the in-sandbox process tree on dispatch timeout (BI-F36E7510)", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetProviderBearerToken.mockResolvedValue({ token: "sk-ant-oat01-test" });
+
+      // A hung dispatch: the spawned proc never emits "close" until we kill it.
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      mockSpawn.mockReturnValue(proc);
+
+      const p = cliAdapter.execute(makeRequest());
+      p.catch(() => {}); // prevent unhandled-rejection noise before we assert
+
+      // Advance past CLI_TIMEOUT_MS — the dispatch timer fires.
+      await vi.advanceTimersByTimeAsync(600_000);
+
+      // The local docker-exec client is signalled...
+      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+      // ...AND the in-container tree is reaped (the actual fix): a docker exec
+      // that SIGTERMs the recorded pid + the runner sh.
+      const calls = mockExecAsync.mock.calls.map((c) => String(c[0]));
+      const termReap = calls.find(
+        (cmd) => /kill -TERM/.test(cmd) && /(cli-pid-|cli-run-)/.test(cmd),
+      );
+      expect(termReap).toBeDefined();
+
+      // After the grace period it escalates to SIGKILL.
+      await vi.advanceTimersByTimeAsync(3_000);
+      const killReap = mockExecAsync.mock.calls
+        .map((c) => String(c[0]))
+        .some((cmd) => /kill -KILL/.test(cmd) && /(cli-pid-|cli-run-)/.test(cmd));
+      expect(killReap).toBe(true);
+
+      // The wrapper dies → the dispatch rejects as a timeout.
+      proc.emit("close", null);
+      await expect(p).rejects.toThrow(/timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("parses tool calls from CLI JSON output", async () => {
     mockGetProviderBearerToken.mockResolvedValue({
       token: "sk-ant-oat01-test-token",

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -435,6 +435,10 @@ export const cliAdapter: ExecutionAdapterHandler = {
     const tokenFile = `/tmp/cli-token-${slug}.txt`;
     const mcpConfigFile = `/tmp/cli-mcp-${slug}.json`;
     const runnerScript = `/tmp/cli-run-${slug}.sh`;
+    // Records the in-container claude PID so a timeout can reap the actual
+    // process inside the sandbox (BI-F36E7510). proc.kill() below only reaches
+    // the local `docker exec` client, not the containerized process.
+    const pidFile = `/tmp/cli-pid-${slug}.txt`;
 
     const cp = lazyChildProcess();
     const execAsync = lazyUtil().promisify(cp.exec);
@@ -512,12 +516,21 @@ export const cliAdapter: ExecutionAdapterHandler = {
       const mcpFlags = mcpJwt
         ? `--mcp-config ${mcpConfigFile} --strict-mcp-config `
         : "";
+      // NOTE: claude is backgrounded (NOT `exec`ed) so the runner sh stays the
+      // parent and records claude's PID to pidFile. This lets the timeout path
+      // reap the real in-container process tree (BI-F36E7510); `exec` would
+      // replace the sh, leaving the cmdline as bare `claude -p ...` with no
+      // unique handle and no way to signal it from the host. stdout/stderr are
+      // inherited by the background child, so capture is unchanged.
       const script = [
         "#!/bin/sh",
         "cd /workspace",
         authExportLine,
         `SYSPROMPT=$(cat ${systemFile})`,
-        `exec claude ${bareFlag}-p - --dangerously-skip-permissions ${mcpFlags}--disallowedTools "${CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE}" --output-format json --model ${cliModel} --system-prompt "$SYSPROMPT" < ${promptFile}`,
+        `claude ${bareFlag}-p - --dangerously-skip-permissions ${mcpFlags}--disallowedTools "${CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE}" --output-format json --model ${cliModel} --system-prompt "$SYSPROMPT" < ${promptFile} &`,
+        `CLIPID=$!`,
+        `echo "$CLIPID" > ${pidFile}`,
+        `wait "$CLIPID"`,
       ].join("\n");
 
       const scriptB64 = Buffer.from(script).toString("base64");
@@ -544,6 +557,19 @@ export const cliAdapter: ExecutionAdapterHandler = {
         const timer = setTimeout(() => {
           timedOut = true;
           proc.kill("SIGTERM");
+          // proc.kill() only signals the local `docker exec` client; the
+          // process INSIDE the container is not forwarded the signal and would
+          // orphan, pinning the shared sandbox to this build's branch and
+          // leaking pids/threads (BI-F36E7510 — the "portal bad state from too
+          // many CLIs" symptom). Reap the in-container tree explicitly: SIGTERM
+          // the recorded claude PID + the runner sh, then escalate to SIGKILL.
+          const reap = (sig: "TERM" | "KILL") =>
+            execAsync(
+              `docker exec ${SANDBOX_CONTAINER} sh -c "kill -${sig} $(cat ${pidFile} 2>/dev/null) 2>/dev/null; pkill -${sig} -f ${runnerScript} 2>/dev/null; true"`,
+              { timeout: 5_000 },
+            ).catch(() => {});
+          void reap("TERM");
+          setTimeout(() => void reap("KILL"), 3_000);
         }, CLI_TIMEOUT_MS);
 
         proc.stdout.on("data", (data: Buffer) => { stdout += data.toString(); });
@@ -689,7 +715,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
       // so a leaked sandbox shell can't dump the bearer from disk after the
       // call returns.
       execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${systemFile} ${tokenFile} ${mcpConfigFile} ${runnerScript}"`,
+        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${systemFile} ${tokenFile} ${mcpConfigFile} ${runnerScript} ${pidFile}"`,
         { timeout: 5_000 },
       ).catch(() => {});
     }

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -247,6 +247,10 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
     const slug = `codex-conv-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const promptFile = `/tmp/${slug}-prompt.txt`;
     const runnerScript = `/tmp/${slug}-run.sh`;
+    // Records the in-container codex PID so a timeout can reap the actual
+    // process inside the sandbox (BI-F36E7510). proc.kill() below only reaches
+    // the local `docker exec` client, not the containerized process.
+    const pidFile = `/tmp/${slug}-pid.txt`;
 
     const cp = lazyChildProcess();
     const execAsync = lazyUtil().promisify(cp.exec);
@@ -268,11 +272,18 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
         authExportLine = "# OAuth auth via ~/.codex/auth.json";
       }
 
+      // codex is backgrounded (NOT `exec`ed) so the runner sh stays the parent
+      // and records codex's PID to pidFile — letting the timeout path reap the
+      // real in-container process tree (BI-F36E7510). stdout/stderr are
+      // inherited by the background child, so capture is unchanged.
       const script = [
         "#!/bin/sh",
         "cd /workspace",
         authExportLine,
-        `exec codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ${modelFlag} < ${promptFile}`,
+        `codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ${modelFlag} < ${promptFile} &`,
+        `CLIPID=$!`,
+        `echo "$CLIPID" > ${pidFile}`,
+        `wait "$CLIPID"`,
       ].join("\n");
 
       const scriptB64 = Buffer.from(script).toString("base64");
@@ -302,6 +313,17 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
         const timer = setTimeout(() => {
           timedOut = true;
           proc.kill("SIGTERM");
+          // proc.kill() only signals the local `docker exec` client; the
+          // containerized process is not forwarded the signal and would orphan,
+          // pinning the shared sandbox and leaking pids/threads (BI-F36E7510).
+          // Reap the in-container tree explicitly, escalating to SIGKILL.
+          const reap = (sig: "TERM" | "KILL") =>
+            execAsync(
+              `docker exec ${SANDBOX_CONTAINER} sh -c "kill -${sig} $(cat ${pidFile} 2>/dev/null) 2>/dev/null; pkill -${sig} -f ${runnerScript} 2>/dev/null; true"`,
+              { timeout: 5_000 },
+            ).catch(() => {});
+          void reap("TERM");
+          setTimeout(() => void reap("KILL"), 3_000);
         }, CLI_TIMEOUT_MS);
 
         proc.stdout.on("data", (data: Buffer) => { stdout += data.toString(); });
@@ -439,7 +461,7 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
     } finally {
       // Clean up temp files (fire-and-forget)
       execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${runnerScript}"`,
+        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${runnerScript} ${pidFile}"`,
         { timeout: 5_000 },
       ).catch(() => {});
     }


### PR DESCRIPTION
## Problem
The CLI dispatch path (`cli-adapter.ts` + `codex-cli-adapter.ts`) runs the build agent inside the sandbox via `docker exec … runner.sh`, whose script `exec`s `claude`/`codex`. On timeout it called `proc.kill("SIGTERM")` — but that only signals the **local `docker exec` client**, never the process running **inside** the container. The containerized agent orphans and keeps running, pinning the single shared sandbox to that build's branch and leaking pids/threads.

**Live-confirmed this session:** a dispatch for `FB-6681A00B` was found at 0.34% CPU as a sleeping `sh` wrapper, 23 min stale, no commits — holding the shared sandbox and blocking other builds (including hive contributions for the shipped `FB-F4D77326`). This is the "portal gets in a bad state from too many threads/CLIs" symptom. **BI-F36E7510.**

## Fix
- Background the agent (no `exec`) and record its PID to a pidfile, so the runner `sh` stays the parent and the in-container PID is known.
- On dispatch timeout, in addition to killing the local wrapper, reap the in-container tree: `docker exec … kill -TERM <pid>; pkill -TERM -f <runner>`, escalating to `SIGKILL` after a 3s grace.
- `stdout`/`stderr` are inherited by the background child, so output capture is unchanged.
- Applied to **both** `cli-adapter` and `codex-cli-adapter`.
- Added a functional test: a hung dispatch times out → asserts the reap fires (TERM then KILL) → the dispatch rejects as a timeout.

## Verification
- `vitest run lib/routing/cli-adapter.test.ts lib/routing/codex-cli-adapter.test.ts` → 49 existing pass; cli-adapter.test.ts now 25 (incl. the new reap test).
- `pnpm typecheck` (apps/web) clean.

## Follow-ups (filed)
- BI-F36E7510 also proposes a periodic reaper (defense in depth). This fix removes the orphan/contention half of the hive-contribution blocker; the other half (synthetic-root sandbox history → no merge-base with `origin/main`) is **BI-5F288AAA**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
