### PR TITLE
fix(build-studio): default sandbox baseline upstream to origin/main — unblocks hive contributions (BI-5F288AAA)

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: { platformDevConfig: { findUnique: vi.fn() } },
+}));
 
 import {
   buildSandboxGitAddCommand,
@@ -6,6 +10,7 @@ import {
   buildSandboxGitCleanCommand,
   buildSandboxGitCommitPrunedArtifactsCommand,
   buildSandboxGitPruneTrackedArtifactsCommand,
+  getClientIdentity,
   wrapSandboxGitCommand,
 } from "./build-branch";
 
@@ -96,5 +101,30 @@ describe("buildSandboxGitAddCommand generated-client exclusion", () => {
     // never appear in the diff baseline because a stale sandbox image will
     // produce the wrong types and bloat the patch with conflicts.
     expect(command).toContain("**/generated/client/**");
+  });
+});
+
+// ─── Client identity upstream default (BI-5F288AAA) ──────────────────────────
+
+describe("getClientIdentity upstream default", () => {
+  it("defaults upstreamRemoteUrl to the canonical Hive repo when PlatformDevConfig.upstreamRemoteUrl is null", async () => {
+    const { prisma } = (await import("@dpf/db")) as unknown as {
+      prisma: { platformDevConfig: { findUnique: ReturnType<typeof vi.fn> } };
+    };
+    prisma.platformDevConfig.findUnique.mockResolvedValue({
+      clientId: "client-test",
+      gitAgentEmail: "agent-abc12345@dpf.local",
+      upstreamRemoteUrl: null,
+    });
+
+    const identity = await getClientIdentity();
+
+    // Without this default the sandbox bootstrap skips the origin/main baseline
+    // reset (build-branch.ts ensureGitBaseline) and creates a synthetic-root
+    // repo with no merge-base against origin/main — which blocks every hive
+    // contribution at the source_currency readiness gate (BI-5F288AAA).
+    expect(identity.upstreamRemoteUrl).toBe(
+      "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+    );
   });
 });

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -257,6 +257,15 @@ type ClientIdentity = {
   upstreamRemoteUrl: string | null; // Canonical repo URL for fetching origin/main
 };
 
+// Canonical Hive upstream — used when PlatformDevConfig.upstreamRemoteUrl is
+// unset so the sandbox baseline is ALWAYS reset to origin/main (shared history),
+// never a synthetic-root `git init`. Without this, build branches have no
+// merge-base with main and contributions can never form a valid PR (BI-5F288AAA).
+// Mirrors the same default in contribute_to_hive (mcp-tools.ts) and
+// platform-dev-config's UPSTREAM_OWNER_REPO_FALLBACK.
+const DEFAULT_UPSTREAM_REMOTE_URL =
+  "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git";
+
 let _cachedIdentity: ClientIdentity | null = null;
 
 /**
@@ -288,7 +297,11 @@ export async function getClientIdentity(): Promise<ClientIdentity> {
     gitAgentEmail: config.gitAgentEmail,
     gitAuthorName: `dpf-agent-${shortId}`,
     clientBranch: `client/${config.clientId}`,
-    upstreamRemoteUrl: config.upstreamRemoteUrl ?? null,
+    // Default to the canonical Hive upstream when unset so the sandbox baseline
+    // always shares history with origin/main (the keystone for contributions —
+    // BI-5F288AAA). The fetch/reset is wrapped in try/catch downstream, so an
+    // offline/token failure falls back safely to the portal-copy baseline.
+    upstreamRemoteUrl: config.upstreamRemoteUrl ?? DEFAULT_UPSTREAM_REMOTE_URL,
   };
 
   return _cachedIdentity;


### PR DESCRIPTION
## The keystone blocker for hive contributions
Diagnosed this session by driving the real shipped build (FB-F4D77326) through every `contribute_to_hive` readiness gate. The final, decisive failure was `source_currency`: the sandbox git repo has a **synthetic root** (`bootstrap from dpf-image`) with **no merge-base against `origin/main`** — so no contribution can ever form a valid PR.

**Root cause:** `ensureGitBaseline` (`build-branch.ts`) only fetches `origin/main` and resets the baseline to it **when `PlatformDevConfig.upstreamRemoteUrl` is set**. When it's null (the default on this install), it falls through to a bare `git init` → synthetic-root repo, orphaned from `main`. So every build branch lacks shared history with the repo it's meant to PR into.

## Fix
Default `getClientIdentity().upstreamRemoteUrl` to the canonical Hive repo when unset — mirroring the default already used by `contribute_to_hive` (`mcp-tools.ts`) and `platform-dev-config`'s `UPSTREAM_OWNER_REPO_FALLBACK`. Now the baseline is always reset to `origin/main`, so build branches share history → `source_currency` resolves → contributions can form valid PRs.

- The fetch/reset is already wrapped in try/catch, so offline/token failures fall back safely to the portal-copy baseline (unchanged behavior on failure).
- **Note:** sandboxes bootstrapped before this lands keep their synthetic root until re-bootstrapped; this fixes all *future* baselines.

## Verification
- `vitest run lib/integrate/sandbox/build-branch.test.ts` → 11 pass, incl. a new test asserting the null-config default resolves to the canonical Hive URL.
- `pnpm typecheck` (apps/web) clean; pre-commit secret-scan + typecheck passed. DCO signed.

## Context
This is the second of the two halves of the hive-contribution blocker. The first (orphaned dispatches pinning the shared sandbox) is **#1635**. With both deployed, a fresh build forks from real `origin/main` and can flow straight through to a hive PR. **BI-5F288AAA.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
