### PR TITLE
feat(discovery): add Re-run scan action to Discovery Connections

### DIFF
--- a/apps/web/app/api/v1/discovery/connections/[id]/run/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/discovery/connections/[id]/run/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRerunDiscoveryConnection } = vi.hoisted(() => ({
+  mockRerunDiscoveryConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/discovery", () => ({
+  rerunDiscoveryConnection: mockRerunDiscoveryConnection,
+}));
+
+import { POST } from "../route";
+
+const PERSISTENCE_SUMMARY = {
+  ok: true as const,
+  runId: "run-abc",
+  itemCount: 5,
+  relationshipCount: 2,
+  status: "active",
+};
+
+function makeRequest(): Request {
+  return new Request("http://test/api/v1/discovery/connections/conn-1/run", {
+    method: "POST",
+  });
+}
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/v1/discovery/connections/[id]/run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when requireManageDiscovery denies access", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({ ok: false, error: "Unauthorized" });
+
+    const res = await POST(makeRequest(), makeContext("conn-1"));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 400 when connection is not found", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({ ok: false, error: "Connection not found" });
+
+    const res = await POST(makeRequest(), makeContext("conn-does-not-exist"));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Connection not found" });
+  });
+
+  it("returns 400 when connection status is unconfigured", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({
+      ok: false,
+      error: 'Cannot rerun discovery for connection with status "unconfigured"',
+    });
+
+    const res = await POST(makeRequest(), makeContext("conn-1"));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("unconfigured");
+  });
+
+  it("returns 400 when connection status is auth_failed", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({
+      ok: false,
+      error: 'Cannot rerun discovery for connection with status "auth_failed"',
+    });
+
+    const res = await POST(makeRequest(), makeContext("conn-1"));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("auth_failed");
+  });
+
+  it("returns 200 with discovery summary on success", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue(PERSISTENCE_SUMMARY);
+
+    const res = await POST(makeRequest(), makeContext("conn-1"));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(PERSISTENCE_SUMMARY);
+    expect(mockRerunDiscoveryConnection).toHaveBeenCalledWith("conn-1");
+  });
+
+  it("returns 200 with runId, itemCount, relationshipCount on success", async () => {
+    const result = { ok: true as const, runId: "run-1", itemCount: 3, relationshipCount: 1, status: "active" };
+    mockRerunDiscoveryConnection.mockResolvedValue(result);
+
+    const res = await POST(makeRequest(), makeContext("conn-1"));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(result);
+  });
+});

--- a/apps/web/app/api/v1/discovery/connections/[id]/run/route.ts
+++ b/apps/web/app/api/v1/discovery/connections/[id]/run/route.ts
@@ -1,0 +1,18 @@
+import { rerunDiscoveryConnection } from "@/lib/actions/discovery";
+import { NextResponse } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function POST(_req: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const result = await rerunDiscoveryConnection(id);
+
+  if (!result.ok) {
+    const status = result.error === "Unauthorized" ? 401 : 400;
+    return NextResponse.json({ error: result.error }, { status });
+  }
+
+  return NextResponse.json(result);
+}

--- a/apps/web/components/inventory/SavedConnectionRow.tsx
+++ b/apps/web/components/inventory/SavedConnectionRow.tsx
@@ -19,6 +19,7 @@
 import { useState, useTransition } from "react";
 import {
   deleteDiscoveryConnection,
+  rerunDiscoveryConnection,
   testDiscoveryConnection,
   type DiscoveryConnectionSummary,
 } from "@/lib/actions/discovery";
@@ -61,9 +62,25 @@ export function SavedConnectionRow({ connection }: Props) {
   const [mode, setMode] = useState<"view" | "editing" | "confirming-delete">("view");
   const [lastAction, setLastAction] = useState<{ kind: "ok" | "err"; message: string } | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [isRunning, startRerun] = useTransition();
 
   const statusInfo = STATUS_LABELS[connection.status] ?? { label: connection.status, tone: "muted" as const };
   const tone = TONE_STYLES[statusInfo.tone];
+
+  const handleRerun = () => {
+    setLastAction(null);
+    startRerun(async () => {
+      const result = await rerunDiscoveryConnection(connection.id);
+      if (!result.ok) {
+        setLastAction({ kind: "err", message: result.error });
+        return;
+      }
+      setLastAction({
+        kind: "ok",
+        message: `Re-run complete — ${result.itemCount} item(s), ${result.relationshipCount} relationship(s)`,
+      });
+    });
+  };
 
   const handleRetest = () => {
     setLastAction(null);
@@ -152,8 +169,16 @@ export function SavedConnectionRow({ connection }: Props) {
         <div className="flex shrink-0 items-center gap-1.5">
           <button
             type="button"
+            onClick={handleRerun}
+            disabled={isPending || isRunning}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+          >
+            {isRunning ? "Running…" : "Re-run"}
+          </button>
+          <button
+            type="button"
             onClick={handleRetest}
-            disabled={isPending}
+            disabled={isPending || isRunning}
             className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
           >
             {isPending && mode === "view" ? "Testing…" : "Re-test"}

--- a/apps/web/components/inventory/__tests__/SavedConnectionRow.test.tsx
+++ b/apps/web/components/inventory/__tests__/SavedConnectionRow.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const { mockRerunDiscoveryConnection } = vi.hoisted(() => ({
+  mockRerunDiscoveryConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/discovery", () => ({
+  deleteDiscoveryConnection: vi.fn(),
+  rerunDiscoveryConnection: mockRerunDiscoveryConnection,
+  testDiscoveryConnection: vi.fn(),
+}));
+
+vi.mock("@/components/inventory/ConfigureConnectionInline", () => ({
+  ConfigureConnectionInline: () => null,
+}));
+
+import { SavedConnectionRow } from "../SavedConnectionRow";
+import type { DiscoveryConnectionSummary } from "@/lib/actions/discovery";
+
+const BASE_CONNECTION: DiscoveryConnectionSummary = {
+  id: "conn-1",
+  connectionKey: "unifi:192.168.0.1",
+  name: "HQ Gateway",
+  collectorType: "unifi",
+  status: "active",
+  endpointUrl: "https://192.168.0.1",
+  hasApiKey: true,
+  configuration: { site: "default" },
+  lastTestedAt: null,
+  lastTestStatus: null,
+  lastTestMessage: null,
+  gatewayEntityId: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+describe("SavedConnectionRow Re-run button", () => {
+  it("renders the Re-run button", () => {
+    render(<SavedConnectionRow connection={BASE_CONNECTION} />);
+    expect(screen.getByRole("button", { name: /re-run/i })).toBeInTheDocument();
+  });
+
+  it("calls rerunDiscoveryConnection with the connection id when clicked", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({ ok: false, error: "fail" });
+
+    render(<SavedConnectionRow connection={BASE_CONNECTION} />);
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await waitFor(() => {
+      expect(mockRerunDiscoveryConnection).toHaveBeenCalledWith("conn-1");
+    });
+  });
+
+  it("shows inline success feedback after a successful re-run", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({
+      ok: true,
+      runId: "run-1",
+      itemCount: 5,
+      relationshipCount: 2,
+      status: "active",
+    });
+
+    render(<SavedConnectionRow connection={BASE_CONNECTION} />);
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/re-run complete/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/5 item/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 relationship/i)).toBeInTheDocument();
+  });
+
+  it("shows inline error feedback on failure", async () => {
+    mockRerunDiscoveryConnection.mockResolvedValue({
+      ok: false,
+      error: "auth_failed",
+    });
+
+    render(<SavedConnectionRow connection={BASE_CONNECTION} />);
+    fireEvent.click(screen.getByRole("button", { name: /re-run/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/auth_failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it("disables the Re-run button while a re-run is in progress", async () => {
+    let resolveRerun: (v: unknown) => void;
+    mockRerunDiscoveryConnection.mockReturnValue(
+      new Promise((resolve) => { resolveRerun = resolve; }),
+    );
+
+    render(<SavedConnectionRow connection={BASE_CONNECTION} />);
+    const btn = screen.getByRole("button", { name: /re-run/i });
+
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(mockRerunDiscoveryConnection).toHaveBeenCalled();
+    });
+
+    resolveRerun!({ ok: false, error: "done" });
+  });
+});

--- a/apps/web/e2e/discovery-rerun.spec.ts
+++ b/apps/web/e2e/discovery-rerun.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const E2E_EMAIL = process.env.E2E_USER_EMAIL ?? "admin@dpf.local";
+const E2E_PASSWORD = process.env.E2E_USER_PASSWORD ?? "password";
+
+async function login(page: Page) {
+  await page.goto("/login");
+  await page.fill('input[name="email"]', E2E_EMAIL);
+  await page.fill('input[name="password"]', E2E_PASSWORD);
+  await page.click('button[type="submit"]');
+  // Wait for redirect away from login page
+  await page.waitForURL((url) => !url.pathname.includes("/login"), { timeout: 10_000 });
+}
+
+test.describe("discovery re-run flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("re-runs a discovery connection and reflects updated data on inventory page", async ({
+    page,
+  }) => {
+    // ── 1. Navigate to the discovery page ───────────────────────────────
+    await page.goto("/platform/tools/discovery");
+    await page.waitForLoadState("networkidle");
+
+    // ── 2. Find the first connection card with a Re-run button ──────────
+    const rerunButton = page.locator('button', { hasText: "Re-run" }).first();
+
+    // If no connections exist, the test cannot proceed — skip gracefully.
+    const connectionExists = await rerunButton.count() > 0;
+    if (!connectionExists) {
+      test.skip();
+      return;
+    }
+
+    // Capture the connection row containing the button
+    const connectionRow = rerunButton.locator("xpath=ancestor::div[contains(@class,'rounded-lg')]").first();
+
+    // Record the "Last tested" text before the re-run
+    const lastTestedLocator = connectionRow.locator("p").filter({ hasText: "Last tested" });
+    const lastTestedBefore = await lastTestedLocator.textContent();
+
+    // ── 3. Click Re-run and assert the button enters Running… state ─────
+    await rerunButton.click();
+
+    // The button should immediately read "Running…" (U+2026 ellipsis)
+    await expect(rerunButton).toHaveText("Running…", { timeout: 5_000 });
+
+    // ── 4. Wait for completion — button reverts to "Re-run" ─────────────
+    await expect(rerunButton).toHaveText("Re-run", { timeout: 60_000 });
+
+    // ── 5. Assert success message with entity / relationship counts ──────
+    const successMessage = connectionRow.locator("p").filter({ hasText: "Re-run complete" });
+    await expect(successMessage).toBeVisible({ timeout: 5_000 });
+
+    const messageText = await successMessage.textContent();
+    expect(messageText).toMatch(/Re-run complete\s*—\s*\d+ item\(s\),\s*\d+ relationship\(s\)/);
+
+    // ── 6. Assert connection's lastTestedAt timestamp has updated ────────
+    // After the server action, Next.js revalidates the route and re-renders
+    // the server components, so the "Last tested" line should now read
+    // "Last tested just now" (or at minimum be different from before).
+    const lastTestedAfter = await lastTestedLocator.textContent();
+    expect(lastTestedAfter).toContain("just now");
+    expect(lastTestedAfter).not.toBe(lastTestedBefore);
+
+    // ── 7. Navigate to /inventory — page loads with fresh data ──────────
+    // Verify the inventory route is reachable without a manual browser
+    // refresh, confirming that revalidatePath covered the /inventory path.
+    await page.goto("/inventory");
+    await page.waitForLoadState("networkidle");
+
+    // The /inventory alias renders DiscoveryOperationsPage with the legacy
+    // alias banner, confirming the page rendered successfully.
+    await expect(page.locator("text=Inventory Has Moved")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/apps/web/lib/actions/__tests__/discovery-rerun.test.ts
+++ b/apps/web/lib/actions/__tests__/discovery-rerun.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockCan, mockPrisma, mockDecryptSecret, mockCollectUnifi, mockBuildDeps, mockNormalize, mockPersistRun } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockPrisma: {
+    discoveryConnection: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  mockDecryptSecret: vi.fn(),
+  mockCollectUnifi: vi.fn(),
+  mockBuildDeps: vi.fn(),
+  mockNormalize: vi.fn(),
+  mockPersistRun: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+  normalizeDiscoveredFacts: mockNormalize,
+  persistBootstrapDiscoveryRun: mockPersistRun,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: mockCan,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  encryptSecret: vi.fn(),
+  decryptSecret: mockDecryptSecret,
+}));
+
+vi.mock("@dpf/db/discovery-collectors-unifi", () => ({
+  collectUnifiDiscovery: mockCollectUnifi,
+  buildDepsFromConnection: mockBuildDeps,
+}));
+
+import { rerunDiscoveryConnection } from "../discovery";
+
+const authorizedSession = {
+  user: { id: "user-1", platformRole: "IT-000", isSuperuser: true },
+};
+
+const baseConnection = {
+  id: "conn-1",
+  connectionKey: "unifi:192.168.0.1",
+  collectorType: "unifi",
+  endpointUrl: "https://192.168.0.1",
+  encryptedApiKey: "enc-key",
+  configuration: { site: "default" },
+  status: "active",
+};
+
+describe("rerunDiscoveryConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error when unauthorized", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const result = await rerunDiscoveryConnection("conn-1");
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+  });
+
+  it("returns error when requireManageDiscovery fails", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(false);
+
+    const result = await rerunDiscoveryConnection("conn-1");
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+  });
+
+  it("returns error when connection not found", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(true);
+    mockPrisma.discoveryConnection.findUnique.mockResolvedValue(null);
+
+    const result = await rerunDiscoveryConnection("conn-does-not-exist");
+
+    expect(result).toEqual({ ok: false, error: "Connection not found" });
+  });
+
+  it("returns error when status is unconfigured", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(true);
+    mockPrisma.discoveryConnection.findUnique.mockResolvedValue({
+      ...baseConnection,
+      status: "unconfigured",
+      encryptedApiKey: null,
+    });
+
+    const result = await rerunDiscoveryConnection("conn-1");
+
+    expect(result).toMatchObject({ ok: false });
+    expect((result as { ok: false; error: string }).error).toContain("unconfigured");
+  });
+
+  it("returns error when status is auth_failed", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(true);
+    mockPrisma.discoveryConnection.findUnique.mockResolvedValue({
+      ...baseConnection,
+      status: "auth_failed",
+    });
+
+    const result = await rerunDiscoveryConnection("conn-1");
+
+    expect(result).toMatchObject({ ok: false });
+    expect((result as { ok: false; error: string }).error).toContain("auth_failed");
+  });
+
+  it("returns success with discovery summary", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(true);
+    mockPrisma.discoveryConnection.findUnique.mockResolvedValue(baseConnection);
+    mockDecryptSecret.mockReturnValue("plain-api-key");
+    mockBuildDeps.mockReturnValue({ fetchFn: vi.fn() });
+    mockCollectUnifi.mockResolvedValue({ items: [], relationships: [], warnings: [] });
+    mockNormalize.mockReturnValue({ entities: [], relationships: [] });
+    mockPersistRun.mockResolvedValue({
+      runId: "run-abc",
+      createdEntities: 4,
+      updatedEntities: 1,
+      staleEntities: 0,
+      createdRelationships: 2,
+      updatedRelationships: 0,
+      staleRelationships: 0,
+      createdIssues: 0,
+    });
+    mockPrisma.discoveryConnection.update.mockResolvedValue({ ...baseConnection });
+
+    const result = await rerunDiscoveryConnection("conn-1");
+
+    expect(result).toEqual({
+      ok: true,
+      runId: "run-abc",
+      itemCount: 5,
+      relationshipCount: 2,
+      status: "active",
+    });
+    expect(mockPersistRun).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ trigger: "manual_connection" }),
+    );
+  });
+});

--- a/apps/web/lib/actions/discovery.ts
+++ b/apps/web/lib/actions/discovery.ts
@@ -2,6 +2,7 @@
 
 import {
   executeBootstrapDiscovery,
+  normalizeDiscoveredFacts,
   persistBootstrapDiscoveryRun,
   prisma,
   type Prisma,
@@ -410,6 +411,74 @@ export async function testDiscoveryConnection(connectionId: string): Promise<
     return { ok: true, status: "ok", deviceCount };
   }
   return { ok: true, status: "ok", deviceCount, message: testMessage };
+}
+
+export type RerunDiscoveryResult =
+  | { ok: true; runId: string; itemCount: number; relationshipCount: number; status: string }
+  | { ok: false; error: string };
+
+/** Re-run discovery for an existing connection. */
+export async function rerunDiscoveryConnection(connectionId: string): Promise<RerunDiscoveryResult> {
+  const authResult = await requireManageDiscovery();
+  if (!authResult.ok) return authResult;
+
+  const conn = await prisma.discoveryConnection.findUnique({
+    where: { id: connectionId },
+  });
+  if (!conn) return { ok: false, error: "Connection not found" };
+
+  if (conn.status === "unconfigured" || conn.status === "auth_failed") {
+    return { ok: false, error: `Cannot rerun discovery for connection with status "${conn.status}"` };
+  }
+
+  if (!conn.encryptedApiKey) return { ok: false, error: "No API key configured" };
+  const apiKey = decryptSecret(conn.encryptedApiKey);
+  if (!apiKey) return { ok: false, error: "Cannot decrypt API key" };
+
+  const { collectUnifiDiscovery, buildDepsFromConnection } = await import("@dpf/db/discovery-collectors-unifi");
+  const config = (conn.configuration ?? {}) as Record<string, unknown>;
+  const deps = buildDepsFromConnection({
+    endpointUrl: conn.endpointUrl,
+    apiKey,
+    configuration: {
+      site: (config.site as string) ?? "default",
+      discoverClients: (config.discoverClients as boolean) ?? false,
+    },
+  });
+
+  const collectorOutput = await collectUnifiDiscovery({ sourceKind: conn.collectorType as never }, deps);
+  const normalized = normalizeDiscoveredFacts(collectorOutput);
+
+  const summary = await persistBootstrapDiscoveryRun(
+    prisma as never,
+    normalized,
+    {
+      runKey: conn.connectionKey,
+      sourceSlug: conn.connectionKey,
+      trigger: "manual_connection",
+    },
+  );
+
+  const status = "active";
+  await prisma.discoveryConnection.update({
+    where: { id: connectionId },
+    data: {
+      lastTestedAt: new Date(),
+      lastTestStatus: "ok",
+      lastTestMessage: `Discovered ${summary.createdEntities + summary.updatedEntities} items`,
+      status,
+    },
+  });
+
+  revalidateDiscoverySurfaces();
+
+  return {
+    ok: true,
+    runId: summary.runId ?? "",
+    itemCount: summary.createdEntities + summary.updatedEntities,
+    relationshipCount: summary.createdRelationships + summary.updatedRelationships,
+    status,
+  };
 }
 
 /** Delete a discovery connection. */


### PR DESCRIPTION
## Hive contribution: Re-run scan for Discovery Connections

Adds a one-click **Re-run** for an existing discovery connection, so operators can refresh discovered inventory without re-entering credentials or recreating the connection.

### What's included
- **`rerunDiscoveryConnection`** server action — permission-checked (`requireManageDiscovery`), decrypts the stored API key, re-collects via the existing UniFi collector, normalizes + persists the run, and updates the connection's status/last-tested fields. Cleanly handles `unconfigured`, `auth_failed`, and not-found states.
- **`POST /api/v1/discovery/connections/[id]/run`** endpoint.
- **Re-run button** on `SavedConnectionRow` (disabled while a run/test is in flight; shows "Running…").
- Tests for the action, the endpoint, and the component — all error paths covered.

### Provenance & verification
Built and shipped through **Build Studio** on a DPF install (FB-F4D77326 / BI-24CEA79E), then re-integrated against current `main` (the build's sandbox baseline had drifted). Reuses the same collector/normalizer/persist path that `testDiscoveryConnection` already uses.

- `pnpm typecheck` (apps/web) — clean
- 17 feature tests pass (`discovery-rerun.test.ts`, `run/route.test.ts`, `SavedConnectionRow.test.tsx`)
- DCO signed; authored under the contributing install's coworker pseudonym.

> Note: an e2e spec (`e2e/discovery-rerun.spec.ts`) is included but requires a running portal — it runs in the maintainer's CI/e2e environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
