### PR TITLE
ci: cache Next.js build to speed the Production Build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,20 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @dpf/db exec prisma generate
 
+      # Restore Next.js's build cache (SWC/webpack compilation artifacts). On a
+      # cache hit, unchanged modules are not recompiled, which is the bulk of a
+      # cold `next build`. Key on the lockfile + all source so any source change
+      # rolls the key; restore-keys fall back to the most recent build for the
+      # same deps so a typical PR still warm-starts. See
+      # https://nextjs.org/docs/app/building-your-application/deploying/ci-build-caching
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/apps/web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.{ts,tsx,js,jsx}') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Build web (Next.js production)
         run: pnpm --filter web build
 


### PR DESCRIPTION
## Why

Follow-up to #1632. With unit tests now sharded to ~2 min, the new CI critical path is **Production Build (~3m26s)** — the single slowest job and a *required* merge gate (`Typecheck` / `Production Build` / `DCO`). It ran a cold `next build` on every PR, recompiling every module from scratch.

## What

Restore Next.js's `.next/cache` (SWC/webpack compilation cache) via `actions/cache@v4`, keyed on `pnpm-lock.yaml` + source hash, with a deps-only `restore-keys` fallback so a typical PR warm-starts from the most recent build.

- Coverage-neutral and output-neutral — only recompilation of *unchanged* modules is skipped; the produced build is identical.
- Per [Next.js CI caching guidance](https://nextjs.org/docs/app/building-your-application/deploying/ci-build-caching).
- The win lands on the **second run onward** — the first run seeds the cache (expect no change, possibly +a few seconds for the cache save).

## Verification

CI on this PR seeds the cache; a re-run (or the next PR) should show Production Build drop. I'll report the before/after once a warm run lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)