### PR TITLE
fix(build-studio): persist ideate designDoc to the correct build + verify the write

### DIFF
--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -109,12 +109,15 @@ describe("dispatchIdeateForApprovedBuild", () => {
     // 2026-05-24: originatingBacklogItemId is a FK to BacklogItem.id (cuid),
     // not BacklogItem.itemId (BI-XXXXX semantic id). Use a cuid-shaped value
     // here so the lookup matches what production code does.
-    mockPrisma.featureBuild.findUnique.mockResolvedValue({
-      originatingBacklogItemId: "cmpj4gz5605xx01o6lzxt278g",
-      designDoc: null,
-      title: "Fallback Title",
-      description: "Fallback description.",
-    });
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        originatingBacklogItemId: "cmpj4gz5605xx01o6lzxt278g",
+        designDoc: null,
+        title: "Fallback Title",
+        description: "Fallback description.",
+      })
+      // read-after-write verification sees the persisted doc on this build
+      .mockResolvedValueOnce({ designDoc: { problemStatement: "P" } });
     mockPrisma.backlogItem.findUnique.mockResolvedValue({
       title: "BI Title",
       body: "Problem statement and acceptance criteria.",
@@ -153,9 +156,13 @@ describe("dispatchIdeateForApprovedBuild", () => {
         dispatchEngine: "claude",
       }),
     );
+    // Regression guard for the wrong-build write bug: the explicit buildId MUST
+    // be passed so saveBuildEvidence targets THIS build instead of falling back
+    // to resolveActiveBuildId(userId), which mis-resolves when multiple builds
+    // are in flight (live evidence: FB-D48D6429, 2026-06-07).
     expect(mockExecuteTool).toHaveBeenCalledWith(
       "saveBuildEvidence",
-      { field: "designDoc", value: expect.objectContaining({ problemStatement: "P" }) },
+      { buildId: "FB-X", field: "designDoc", value: expect.objectContaining({ problemStatement: "P" }) },
       "u-1",
       expect.any(Object),
     );
@@ -206,6 +213,34 @@ describe("dispatchIdeateForApprovedBuild", () => {
     expect(outcome.kind).toBe("dispatched-failure");
     if (outcome.kind === "dispatched-failure") {
       expect(outcome.error).toContain("saveBuildEvidence");
+    }
+  });
+
+  it("returns dispatched-failure when saveBuildEvidence reports success but the designDoc did not persist to this build", async () => {
+    // Read-after-write guard: simulates the wrong-build mis-resolution — save
+    // reports success, but re-reading THIS build shows no designDoc.
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        originatingBacklogItemId: "BI-1",
+        designDoc: null,
+        title: "T",
+        description: "D",
+      })
+      .mockResolvedValueOnce({ designDoc: null });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: true,
+      designDoc: { problemStatement: "P", proposedApproach: "z".repeat(60) },
+      rawOutput: "",
+      durationMs: 100,
+    });
+    mockExecuteTool.mockResolvedValue({ success: true });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-failure");
+    if (outcome.kind === "dispatched-failure") {
+      expect(outcome.error).toContain("no designDoc is present");
     }
   });
 

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -193,9 +193,15 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // saveBuildEvidence audit trail is consistent regardless of which
     // dispatch path produced the designDoc.
     const { executeTool } = await import("@/lib/mcp-tools");
+    // Pass the explicit buildId. Without it, saveBuildEvidence falls back to
+    // resolveActiveBuildId(userId), which resolves to the user's *active* build
+    // — and when several builds are in flight that can be a DIFFERENT build.
+    // The designDoc would then persist to the wrong build while this build's
+    // activity log (correct buildId in scope) records "saved", leaving this
+    // build stuck at the post-ideate gate with no design doc.
     const saveResult = await executeTool(
       "saveBuildEvidence",
-      { field: "designDoc", value: ideateResult.designDoc },
+      { buildId, field: "designDoc", value: ideateResult.designDoc },
       userId,
       {},
     );
@@ -207,6 +213,30 @@ export async function dispatchIdeateForApprovedBuild(params: {
         durationMs,
       };
       await logActivity(`Auto-dispatch saved-evidence step failed after ${(durationMs / 1000).toFixed(1)}s: ${outcome.error.slice(0, 200)}`);
+      return outcome;
+    }
+
+    // Read-after-write: saveBuildEvidence reported success, but verify the
+    // designDoc actually landed on THIS build before logging "saved". Guards
+    // against a silent wrong-build / no-op write reporting success — the
+    // `structural-verification-is-not-functional` principle this file's header
+    // cites, applied to the save itself.
+    const persisted = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { designDoc: true },
+    });
+    const persistedDoc = persisted?.designDoc as { problemStatement?: string } | null;
+    if (
+      !persistedDoc ||
+      typeof persistedDoc.problemStatement !== "string" ||
+      persistedDoc.problemStatement.trim().length === 0
+    ) {
+      const outcome: DispatchOutcome = {
+        kind: "dispatched-failure",
+        error: `saveBuildEvidence reported success but no designDoc is present on ${buildId} after the write (possible active-build mis-resolution).`,
+        durationMs,
+      };
+      await logActivity(`Auto-dispatch saved-evidence VERIFICATION FAILED after ${(durationMs / 1000).toFixed(1)}s: designDoc not present on ${buildId} after save.`);
       return outcome;
     }
 


### PR DESCRIPTION
## Problem
Build Studio builds were silently wedging at the post-ideate gate ("A design document is required") **even though the activity log said the design doc was saved.** Live evidence: `FB-D48D6429` (slice B of the build-engine provisioning work), 2026-06-07.

## Root cause
`dispatchIdeateForApprovedBuild` ([ideate-on-approval.ts](apps/web/lib/integrate/ideate-on-approval.ts)) called `saveBuildEvidence` **without an explicit `buildId`**. Inside the tool, the target is then resolved by `resolveActiveBuildId(userId, …)` — the user's *active* build. With several builds in flight that resolves to a **different** build, so the `designDoc` persisted to the wrong build, while this build's activity log (correct `buildId` in scope) recorded `Auto-dispatched and saved designDoc`. Log says saved; field empty.

## Fix
1. **Pass the explicit `buildId`** to `saveBuildEvidence` so it targets *this* build (`extractBuildIdHint` → `resolveActiveBuildId` honors the hint).
2. **Read-after-write**: after the save reports success, re-read `featureBuild.designDoc` for this `buildId` and only log "saved" when it actually landed; otherwise return `dispatched-failure`. This applies the `structural-verification-is-not-functional` principle (already cited in this file's header) to the save itself — the log can no longer report a success that didn't happen.

`plan-on-approval.ts` persists the buildPlan via a direct `prisma.featureBuild.update` with the explicit buildId, so it is **not** affected.

## Tests
- Regression guard asserting the explicit `buildId` is passed to `saveBuildEvidence`.
- New test: a success-but-not-persisted write returns `dispatched-failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)