### PR TITLE
ci(spike): trial Turbopack FS build cache on Production Build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,24 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @dpf/db exec prisma generate
 
+      # Restore Turbopack's filesystem cache (written under .next/cache when
+      # DPF_TURBOPACK_BUILD_CACHE=1 enables experimental.turbopackFileSystemCacheForBuild).
+      # Key rolls on any web source change; restore-keys warm-start from the
+      # most recent build for the same deps. NOTE: hashFiles does NOT support
+      # brace globs ({ts,tsx}), so each extension is a separate arg.
+      - name: Cache Turbopack build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/apps/web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.ts', 'apps/web/**/*.tsx', 'apps/web/**/*.js', 'apps/web/**/*.jsx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Build web (Next.js production)
+        # Experimental Turbopack build FS cache, scoped to this verification
+        # gate only — the Docker release build does not set this env.
+        env:
+          DPF_TURBOPACK_BUILD_CACHE: "1"
         run: pnpm --filter web build
 
   dockerfile-node-version:

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,6 +10,17 @@ const config = {
   turbopack: {
     root: turbopackRoot,
   },
+  experimental: {
+    // Turbopack filesystem cache for `next build` — persists compilation
+    // artifacts under `.next/cache` so a warm CI cache skips recompiling
+    // unchanged modules. Still EXPERIMENTAL for production builds in Next 16.2,
+    // so it is gated behind an env var and enabled ONLY in the CI verification
+    // build (see .github/workflows/ci.yml). The shipped Docker release build
+    // (publish-image.yml) leaves it OFF and is unaffected. Flip the env to
+    // measure/disable; remove the gate once the feature is stable.
+    turbopackFileSystemCacheForBuild:
+      process.env.DPF_TURBOPACK_BUILD_CACHE === "1" || undefined,
+  },
   outputFileTracingExcludes: {
     "**/*": ["./node_modules/@swc/core*", "./node_modules/esbuild*"],
   },


### PR DESCRIPTION
## Spike goal
Measure whether enabling Turbopack's experimental filesystem build cache meaningfully speeds the **Production Build** gate (now the slowest CI job + a required check after #1632).

## Why #1638 failed
It cached `.next/cache` but never enabled the feature that *populates* it for Turbopack builds — warm run restored only 358 KB, build unchanged.

## What this does (per Next 16.2 docs)
- Enables `experimental.turbopackFileSystemCacheForBuild` — **but gated behind `DPF_TURBOPACK_BUILD_CACHE=1`**, set **only** in the CI verification build. The Docker release build (`publish-image.yml`) does not set it → unaffected.
- Re-adds `.next/cache` caching with a **correct key** (hashFiles doesn't support brace globs; each extension is a separate arg).

## Risk (honest)
`turbopackFileSystemCacheForBuild` is **experimental for production builds** — Next's docs flag CI cache-invalidation as needing validation. Blast radius here is contained to the **non-shipping verification gate**; the source-hash cache key means any source change rolls the key, limiting stale reuse. Fully reversible (delete env + cache step + experimental block).

## Verification plan
1. This (cold) run seeds the cache → expect ~no change, green.
2. Re-run the build job warm → measure the delta.
3. **Decision rule:** keep only if warm build is materially faster AND stays correct across runs; otherwise close/revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)