### PR TITLE
feat(quality): crash boundary hands operators an AI-client diagnostic prompt (BI-B4F401B3)

### DIFF
--- a/apps/web/app/(shell)/error.test.tsx
+++ b/apps/web/app/(shell)/error.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 import "@/components/build-studio/test-setup";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ShellError from "./error";
+
+function crashError(digest?: string): Error & { digest?: string } {
+  const e = new Error("Cannot read properties of undefined (reading 'split')") as Error & { digest?: string };
+  if (digest) e.digest = digest;
+  return e;
+}
 
 describe("ShellError", () => {
   beforeEach(() => {
@@ -33,5 +39,37 @@ describe("ShellError", () => {
     const feedback = screen.getByLabelText("What were you doing when this happened?");
     expect(feedback).toHaveValue("");
     expect(feedback).toHaveAttribute("rows", "4");
+  });
+
+  // BI-B4F401B3: the AI-client diagnostic prompt is the headline behavior.
+  it("renders a copy-paste AI diagnostic prompt with route, digest, and investigation steps", () => {
+    render(<ShellError error={crashError("digest-xyz-123")} reset={() => undefined} />);
+
+    const prompt = screen.getByText(/You are debugging a production crash/);
+    expect(prompt.textContent).toContain("Route: /portal/build");
+    expect(prompt.textContent).toContain("Error digest: digest-xyz-123");
+    // The checklist must steer the AI client to the real log/migration evidence,
+    // not a guessed cause.
+    expect(prompt.textContent).toContain("prisma migrate status");
+    expect(prompt.textContent).toContain("server logs");
+  });
+
+  it("copies the prompt to the clipboard and confirms, with an accessible label", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    render(<ShellError error={crashError("digest-xyz-123")} reset={() => undefined} />);
+
+    // Button carries the descriptive aria-label and enables once the auto-report resolves.
+    const btn = await screen.findByRole("button", { name: "Copy AI diagnostic prompt to clipboard" });
+    await waitFor(() => expect(btn).not.toBeDisabled());
+
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0]?.[0]).toContain("Error digest: digest-xyz-123");
+    expect(await screen.findByText("Copied!")).toBeInTheDocument();
+    // Screen-reader confirmation is announced.
+    expect(screen.getByText("Diagnostic prompt copied to clipboard")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/(shell)/error.tsx
+++ b/apps/web/app/(shell)/error.tsx
@@ -12,12 +12,27 @@ export default function ShellError({
   const [submitted, setSubmitted] = useState(false);
   const [reportId, setReportId] = useState<string | null>(null);
 
+  // BI-B4F401B3: crash-boundary diagnostic prompt. The production error message
+  // is sanitized by Next.js — only the digest survives to the client. Rather
+  // than let downstream triage guess a (usually wrong) root cause, we hand the
+  // operator a copy-paste prompt for their AI client, which can read the server
+  // logs and resolve the real error. See apps/web/lib/operate/issue-report-triage.ts.
+  const [deployedSha, setDeployedSha] = useState<string | null>(null);
+  const [autoReportId, setAutoReportId] = useState<string | null>(null);
+  const [prepared, setPrepared] = useState(false);
+  const [promptCopied, setPromptCopied] = useState(false);
+  // Stamp the crash time once, on mount, so the prompt is stable across renders.
+  const [crashTime] = useState(() => new Date().toISOString());
+
   const route = typeof window !== "undefined" ? window.location.pathname : "";
   const cleanError =
     error.message?.replace(/\s+/g, " ").trim().slice(0, 240) || "Unknown error";
   const [description, setDescription] = useState("");
 
-  // Auto-report on mount (fire-and-forget)
+  // Auto-report on mount. Resolve the deployed SHA first, then file the report
+  // (with digest + SHA) and capture its reportId so the diagnostic prompt can
+  // reference it. Fire-and-forget for the page, but we await internally so the
+  // prompt is populated.
   useEffect(() => {
     const body = {
       type: "runtime_error",
@@ -26,26 +41,86 @@ export default function ShellError({
       description: error.message,
       routeContext: typeof window !== "undefined" ? window.location.pathname : null,
       errorStack: error.stack?.slice(0, 20000),
+      errorDigest: error.digest ?? null,
       userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
       source: "crash_boundary",
     };
-    fetch("/api/quality/report", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).catch(() => {
-      // Queue to localStorage if fetch fails
+
+    let cancelled = false;
+
+    (async () => {
+      // Resolve the running image SHA (best-effort).
+      let sha: string | null = null;
       try {
-        const key = "dpf-quality-queue";
-        const raw = localStorage.getItem(key);
-        const queue = raw ? JSON.parse(raw) : [];
-        if (Array.isArray(queue)) {
-          queue.push({ ...body, queuedAt: new Date().toISOString() });
-          localStorage.setItem(key, JSON.stringify(queue));
+        const vres = await fetch("/api/platform/version");
+        if (vres.ok) {
+          const v = (await vres.json()) as { gitSha?: unknown };
+          sha = typeof v.gitSha === "string" ? v.gitSha : null;
         }
-      } catch { /* silent */ }
-    });
+      } catch {
+        /* version unavailable — prompt shows a retrieval hint instead */
+      }
+      if (!cancelled && sha) setDeployedSha(sha);
+
+      try {
+        const res = await fetch("/api/quality/report", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...body, deployedSha: sha }),
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { reportId?: string };
+          if (!cancelled && typeof data.reportId === "string") setAutoReportId(data.reportId);
+        }
+      } catch {
+        // Queue to localStorage if fetch fails
+        try {
+          const key = "dpf-quality-queue";
+          const raw = localStorage.getItem(key);
+          const queue = raw ? JSON.parse(raw) : [];
+          if (Array.isArray(queue)) {
+            queue.push({ ...body, deployedSha: sha, queuedAt: new Date().toISOString() });
+            localStorage.setItem(key, JSON.stringify(queue));
+          }
+        } catch { /* silent */ }
+      } finally {
+        if (!cancelled) setPrepared(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [error]);
+
+  // The copy-paste prompt the operator drops into Claude / Codex / Grok. It
+  // bundles everything the AI client needs to find the REAL error in the server
+  // logs and resolve it — exactly the path a human operator would take.
+  const diagnosticPrompt = [
+    "You are debugging a production crash in the DPF portal. Investigate it on the live install and resolve it.",
+    "",
+    `Route: ${route || "(unknown)"}`,
+    `Error digest: ${error.digest || "(none captured)"}`,
+    `Crash time: ${crashTime}`,
+    `Deployed SHA: ${deployedSha || "(unknown — retrieve with: git -C /app rev-parse HEAD in the portal container, or GET /api/platform/version)"}`,
+    `Report: ${autoReportId || "(auto-report not filed — the crash is still in the server logs)"}`,
+    "",
+    "The production error message is sanitized — the REAL error is only in the server logs. Do NOT guess the cause from this screen. Steps:",
+    "1. Find the real error: search the portal server logs for the digest above (e.g. docker logs dpf-portal-1 2>&1 | grep -i <digest>), or read the logs around the crash time on this route.",
+    "2. Check for unapplied DB migrations: docker exec dpf-portal-1 sh -c \"cd /app && pnpm --filter @dpf/db exec prisma migrate status\" — a Prisma P2022 ColumnNotFound almost always means a migration did not run.",
+    "3. Identify the actual root cause from the real error text, not from this sanitized message.",
+    "4. Propose and apply a fix, or file a specific, actionable bug containing the REAL error text and root cause.",
+  ].join("\n");
+
+  async function copyPrompt() {
+    try {
+      await navigator.clipboard.writeText(diagnosticPrompt);
+      setPromptCopied(true);
+      setTimeout(() => setPromptCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable — the visible block below is the fallback */
+    }
+  }
 
   async function handleSubmit() {
     const reportDescription = [
@@ -66,6 +141,8 @@ export default function ShellError({
           description: reportDescription,
           routeContext: typeof window !== "undefined" ? window.location.pathname : null,
           errorStack: error.stack?.slice(0, 20000),
+          errorDigest: error.digest ?? null,
+          deployedSha,
           source: "crash_boundary",
         }),
       });
@@ -103,6 +180,43 @@ export default function ShellError({
             <dd className="break-words font-mono text-[var(--dpf-text)]">{cleanError}</dd>
           </div>
         </dl>
+
+        {/* BI-B4F401B3: hand the operator a copy-paste prompt for their AI client
+            instead of relying on an LLM to guess the cause from a sanitized message. */}
+        <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-left">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-[var(--dpf-text)]">
+              Resolve faster with your AI assistant
+            </span>
+            <button
+              type="button"
+              onClick={copyPrompt}
+              disabled={!prepared}
+              aria-disabled={!prepared}
+              aria-label={
+                prepared
+                  ? "Copy AI diagnostic prompt to clipboard"
+                  : "Preparing diagnostic prompt, please wait"
+              }
+              className="shrink-0 rounded-md border border-[var(--dpf-accent)] px-3 py-1 text-xs font-medium text-[var(--dpf-accent)] disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--dpf-accent)]"
+            >
+              {!prepared ? "Preparing…" : promptCopied ? "Copied!" : "Copy diagnostic prompt"}
+            </button>
+          </div>
+          <p className="mb-2 text-xs leading-5 text-[var(--dpf-muted)]">
+            Paste this into Claude, Codex, or Grok — it can read the server logs and fix the real error.
+          </p>
+          <pre
+            tabIndex={0}
+            className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 font-mono text-[11px] leading-5 text-[var(--dpf-text)]"
+          >
+            {diagnosticPrompt}
+          </pre>
+          {/* Screen-reader confirmation without a visual-only color flash. */}
+          <span role="status" aria-live="polite" className="sr-only">
+            {promptCopied ? "Diagnostic prompt copied to clipboard" : ""}
+          </span>
+        </div>
 
         {!submitted ? (
           <div className="space-y-3 text-left">

--- a/apps/web/app/api/quality/report/route.test.ts
+++ b/apps/web/app/api/quality/report/route.test.ts
@@ -53,6 +53,29 @@ describe("POST /api/quality/report", () => {
     );
   });
 
+  it("forwards crash-boundary diagnostics (errorDigest, deployedSha) — BI-B4F401B3", async () => {
+    await POST(makeReq({
+      type: "runtime_error",
+      title: "Boom",
+      source: "crash_boundary",
+      errorDigest: "abc123digest",
+      deployedSha: "f002cd496f1e2e696deefedb8319a1e57e12df11",
+    }));
+    expect(writerMock.createPlatformIssueReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorDigest: "abc123digest",
+        deployedSha: "f002cd496f1e2e696deefedb8319a1e57e12df11",
+      }),
+    );
+  });
+
+  it("coerces non-string diagnostics to null", async () => {
+    await POST(makeReq({ type: "runtime_error", title: "Boom", errorDigest: 42, deployedSha: false }));
+    const args = writerMock.createPlatformIssueReport.mock.calls[0]?.[0];
+    expect(args?.errorDigest).toBeNull();
+    expect(args?.deployedSha).toBeNull();
+  });
+
   it("defaults source to manual when not provided", async () => {
     await POST(makeReq({ type: "user_report", title: "Hi" }));
     const args = writerMock.createPlatformIssueReport.mock.calls[0]?.[0];

--- a/apps/web/app/api/quality/report/route.ts
+++ b/apps/web/app/api/quality/report/route.ts
@@ -19,6 +19,9 @@ export async function POST(request: Request): Promise<Response> {
       description: typeof body.description === "string" ? body.description : null,
       routeContext: typeof body.routeContext === "string" ? body.routeContext : null,
       errorStack: typeof body.errorStack === "string" ? body.errorStack : null,
+      // BI-B4F401B3: crash-boundary diagnostics forwarded from error.tsx.
+      errorDigest: typeof body.errorDigest === "string" ? body.errorDigest : null,
+      deployedSha: typeof body.deployedSha === "string" ? body.deployedSha : null,
       userAgent: typeof body.userAgent === "string" ? body.userAgent : null,
       triggerKind: typeof body.triggerKind === "string" ? body.triggerKind : null,
       supportSessionId,

--- a/apps/web/lib/operate/issue-report-triage-runner.ts
+++ b/apps/web/lib/operate/issue-report-triage-runner.ts
@@ -58,6 +58,7 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
           routeContext: true,
           errorStack: true,
           source: true,
+          errorDigest: true,
         },
       }),
 
@@ -91,6 +92,17 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
         where: { id },
         data: { status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL },
       });
+    },
+
+    // BI-B4F401B3: find an existing crash BI that already captured this digest.
+    // buildCrashBoundaryItem writes `Error digest: <digest>` into the body, so a
+    // body match folds repeat crashes (same real error, any route) into one item.
+    findCrashItemTitleByDigest: async (digest) => {
+      const existing = await prisma.backlogItem.findFirst({
+        where: { workType: "bug", body: { contains: `Error digest: ${digest}` } },
+        select: { title: true },
+      });
+      return existing?.title ?? null;
     },
 
     resolveTaxonomyNodeByPath: async (path) => {

--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { buildIssueBacklogItem, triageIssueReports, llmTriageReport, checkForSpike, _resetCache } from "./issue-report-triage";
 
+// General-path fixture. NOTE: source is "manual" (not "crash_boundary") because
+// crash_boundary reports take the dedicated honest-triage gate (BI-B4F401B3)
+// that skips the LLM — see the "crash_boundary gate" suite below for that path.
 const report = {
   id: "r1",
   reportId: "PIR-ABC12",
@@ -10,7 +13,7 @@ const report = {
   description: "Server component render error",
   routeContext: "/platform/ai/providers/ollama",
   errorStack: "Error: Something went wrong\n  at render (file.tsx:42)",
-  source: "crash_boundary",
+  source: "manual",
 };
 
 beforeEach(() => _resetCache());
@@ -179,6 +182,81 @@ describe("triageIssueReports", () => {
     const item = created[0] as { title: string; priority: number };
     expect(item.title).toBe("Page crash on /platform/ai/providers/ollama");
     expect(item.priority).toBe(1); // original critical → 1
+  });
+});
+
+describe("triageIssueReports — crash_boundary gate (BI-B4F401B3)", () => {
+  const crashReport = {
+    id: "rc1",
+    reportId: "PIR-CR001",
+    type: "runtime_error",
+    severity: "critical",
+    title: "Page crash",
+    description: "An error occurred in the Server Components render.",
+    routeContext: "/ops/self-upgrade",
+    errorStack: null,
+    source: "crash_boundary",
+    errorDigest: "1234567890",
+  };
+
+  it("skips the LLM and files an honest deterministic item (no guessed root cause)", async () => {
+    const created: unknown[] = [];
+    const mockLlm = vi.fn();
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [crashReport],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      callLlm: mockLlm,
+    }));
+
+    expect(mockLlm).not.toHaveBeenCalled(); // never feeds the sanitized message to the LLM
+    expect(result.llmEnhanced).toBe(0);
+    expect(result.created).toBe(1);
+    const item = created[0] as { title: string; body: string; workType: string };
+    expect(item.title).toBe("Crash: /ops/self-upgrade (PIR-CR001) — investigate via diagnostic prompt");
+    expect(item.body).toContain("Error digest: 1234567890");
+    expect(item.body).toContain("NOT a diagnosed root cause");
+    expect(item.workType).toBe("bug");
+  });
+
+  it("folds repeat crashes with the same digest into one item (cross-route incident dedup)", async () => {
+    const created: unknown[] = [];
+    const incremented: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [crashReport],
+      findCrashItemTitleByDigest: async (digest: string) =>
+        digest === "1234567890" ? "Crash: /build (PIR-CR000) — investigate via diagnostic prompt" : null,
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      incrementOccurrence: async (t: string) => { incremented.push(t); },
+    }));
+
+    expect(result.created).toBe(0);
+    expect(created).toHaveLength(0);
+    expect(incremented).toEqual(["Crash: /build (PIR-CR000) — investigate via diagnostic prompt"]);
+  });
+
+  it("creates a fresh item when no prior crash shares the digest", async () => {
+    const created: unknown[] = [];
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [crashReport],
+      findCrashItemTitleByDigest: async () => null,
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+    }));
+    expect(result.created).toBe(1);
+    expect(created).toHaveLength(1);
+  });
+
+  it("never title-dedups crash reports — only the digest folds them", async () => {
+    // Distinct real errors can share a sanitized title; title-matching must not
+    // fold them. A digest-less crash always files its own item.
+    const created: unknown[] = [];
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [{ ...crashReport, errorDigest: null }],
+      getExistingTitles: async () => ["Page crash"], // would match by title under the old path
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+    }));
+    expect(result.created).toBe(1);
   });
 });
 

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -25,6 +25,39 @@ interface IssueReport {
   routeContext: string | null;
   errorStack: string | null;
   source: string;
+  // BI-B4F401B3: Next.js server digest token for crash_boundary reports. Used
+  // to dedup a whole crash incident (same real error across routes) and to
+  // anchor the operator's diagnostic prompt.
+  errorDigest?: string | null;
+}
+
+// BI-B4F401B3: reports filed by the production crash boundary carry only a
+// sanitized message + an opaque digest — the real error lives in the server
+// logs. Feeding that to the triage LLM only manufactures a plausible-but-wrong
+// root cause (a single 2026-06-07 migration-drift incident spawned 12+ phantom
+// "/build undefined.toLowerCase()" BIs). For these we skip the LLM entirely and
+// file an honest, deterministic item that points the operator at the real
+// diagnostic path instead of a guess.
+const CRASH_BOUNDARY_SOURCE = "crash_boundary";
+
+function buildCrashBoundaryItem(report: IssueReport, base: BacklogItemData): BacklogItemData {
+  const route = report.routeContext || "unknown route";
+  const note =
+    "NOTE: auto-captured production crash. This title is NOT a diagnosed root cause — " +
+    "Next.js sanitizes the real error message in production. Use the diagnostic prompt " +
+    "shown on the crash screen (or grep the portal server logs by the digest above) to " +
+    "find the real error before acting on this item.";
+  return {
+    ...base,
+    title: `Crash: ${route} (${report.reportId}) — investigate via diagnostic prompt`.slice(0, 200),
+    body: [
+      report.errorDigest ? `Error digest: ${report.errorDigest}` : null,
+      note,
+      base.body,
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+  };
 }
 
 // ─── Pure Functions ─────────────────────────────────────────────────────────
@@ -150,6 +183,10 @@ export async function triageIssueReports(deps: {
   createBacklogItem: (data: BacklogItemData) => Promise<void>;
   incrementOccurrence: (title: string) => Promise<void>;
   acknowledgeReport: (id: string) => Promise<void>;
+  /** BI-B4F401B3: returns the title of an existing crash BI that already
+   *  captured this error digest, or null. Powers cross-route incident dedup so
+   *  one underlying error reported from N routes folds into one BI. */
+  findCrashItemTitleByDigest?: (digest: string) => Promise<string | null>;
   resolveProductId?: () => Promise<string | null>;
   resolveTaxonomyNodeId?: () => Promise<string | null>;
   resolveTaxonomyNodeByPath?: (path: string) => Promise<string | null>;
@@ -172,18 +209,35 @@ export async function triageIssueReports(deps: {
   let llmEnhanced = 0;
 
   for (const report of reports) {
+    const isCrashBoundary = report.source === CRASH_BOUNDARY_SOURCE;
+
     // ── Step 1: Try LLM-enhanced triage ──────────────────────────────────
+    // BI-B4F401B3: NEVER run the LLM on crash-boundary reports — their only
+    // input is a sanitized message, so the model invents a phantom root cause.
     let llmResult: LlmTriageResult | null = null;
-    if (deps.callLlm) {
+    if (deps.callLlm && !isCrashBoundary) {
       llmResult = await llmTriageReport(report, existingTitles, deps.callLlm);
     }
 
-    // ── Step 2: Dedup — semantic (LLM) then deterministic fallback ───────
+    // ── Step 2: Dedup ────────────────────────────────────────────────────
+    // Crash boundary: fold the whole incident by error digest (same real error
+    // surfaces from several routes with different sanitized titles, so the
+    // title-based path below cannot catch it).
+    if (isCrashBoundary && report.errorDigest && deps.findCrashItemTitleByDigest) {
+      const existingTitle = await deps.findCrashItemTitleByDigest(report.errorDigest);
+      if (existingTitle) {
+        await deps.incrementOccurrence(existingTitle);
+        await deps.acknowledgeReport(report.id);
+        continue;
+      }
+    }
+
+    // Non-crash: semantic (LLM) then deterministic title dedup.
     const isDupe = llmResult?.duplicateOf
       ? existingTitles.some((t) => t.toLowerCase() === llmResult!.duplicateOf!.toLowerCase())
       : isDuplicate(report.title, existingTitles);
 
-    if (isDupe) {
+    if (!isCrashBoundary && isDupe) {
       await deps.incrementOccurrence(llmResult?.duplicateOf ?? report.title);
       await deps.acknowledgeReport(report.id);
       continue;
@@ -196,11 +250,13 @@ export async function triageIssueReports(deps: {
       if (resolved) taxonomyNodeId = resolved;
     }
 
-    // ── Step 4: Build backlog item — enhanced or basic ───────────────────
-    const data = buildIssueBacklogItem(report, dpfProductId, taxonomyNodeId);
+    // ── Step 4: Build backlog item — crash-honest, LLM-enhanced, or basic ─
+    let data = buildIssueBacklogItem(report, dpfProductId, taxonomyNodeId);
 
-    // Apply LLM enhancements
-    if (llmResult) {
+    if (isCrashBoundary) {
+      // Deterministic, honest item — no guessed root cause.
+      data = buildCrashBoundaryItem(report, data);
+    } else if (llmResult) {
       data.title = llmResult.suggestedTitle;
       data.priority = severityToPriority(llmResult.severity);
       if (llmResult.rootCause) {

--- a/apps/web/lib/quality/platform-issue-reports.test.ts
+++ b/apps/web/lib/quality/platform-issue-reports.test.ts
@@ -102,6 +102,39 @@ describe("createPlatformIssueReport", () => {
     expect(createArgs?.data.errorStack.length).toBe(20000);
   });
 
+  it("persists crash-boundary diagnostics (errorDigest, deployedSha) — BI-B4F401B3", async () => {
+    await createPlatformIssueReport({
+      type: "runtime_error",
+      title: "Test",
+      source: "crash_boundary",
+      errorDigest: "abc123digest",
+      deployedSha: "f002cd496f1e2e696deefedb8319a1e57e12df11",
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.errorDigest).toBe("abc123digest");
+    expect(args?.data.deployedSha).toBe("f002cd496f1e2e696deefedb8319a1e57e12df11");
+  });
+
+  it("defaults errorDigest / deployedSha to null when absent", async () => {
+    await createPlatformIssueReport({ type: "user_report", title: "Test", source: "manual" });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.errorDigest).toBeNull();
+    expect(args?.data.deployedSha).toBeNull();
+  });
+
+  it("truncates errorDigest (191) and deployedSha (64)", async () => {
+    await createPlatformIssueReport({
+      type: "runtime_error",
+      title: "Test",
+      source: "crash_boundary",
+      errorDigest: "x".repeat(300),
+      deployedSha: "y".repeat(100),
+    });
+    const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+    expect(args?.data.errorDigest.length).toBe(191);
+    expect(args?.data.deployedSha.length).toBe(64);
+  });
+
   it("truncates routeContext, userAgent, type, source, severity", async () => {
     await createPlatformIssueReport({
       type: "x".repeat(60),

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -11,6 +11,8 @@ const LIMITS = {
   description: 10_000,
   routeContext: 500,
   errorStack: 20_000,
+  errorDigest: 191,
+  deployedSha: 64,
   userAgent: 500,
   triggerKind: 100,
   supportSessionId: 191,
@@ -59,6 +61,10 @@ export interface CreatePlatformIssueReportInput {
   description?: string | null;
   routeContext?: string | null;
   errorStack?: string | null;
+  // BI-B4F401B3: crash-boundary diagnostics. errorDigest = Next.js server
+  // digest token; deployedSha = running image SHA at crash time.
+  errorDigest?: string | null;
+  deployedSha?: string | null;
   userAgent?: string | null;
   triggerKind?: string | null;
   supportSessionId?: string | null;
@@ -134,6 +140,8 @@ export async function createPlatformIssueReport(
       description: trimTo(input.description ?? null, LIMITS.description),
       routeContext: trimTo(input.routeContext ?? null, LIMITS.routeContext),
       errorStack: trimTo(input.errorStack ?? null, LIMITS.errorStack),
+      errorDigest: trimTo(input.errorDigest ?? null, LIMITS.errorDigest),
+      deployedSha: trimTo(input.deployedSha ?? null, LIMITS.deployedSha),
       userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
       triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
       supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),

--- a/packages/db/prisma/migrations/20260607140000_add_pir_crash_diagnostics/migration.sql
+++ b/packages/db/prisma/migrations/20260607140000_add_pir_crash_diagnostics/migration.sql
@@ -1,0 +1,12 @@
+-- BI-B4F401B3: crash-boundary diagnostics on PlatformIssueReport.
+-- Additive, nullable columns — existing rows are unaffected.
+-- errorDigest: Next.js server digest token (stable per real error on a build);
+--   lets operators/AI clients grep server logs for the sanitized-away message
+--   and lets triage dedup a whole crash incident across routes.
+-- deployedSha: git SHA of the running image at crash time; anchors the
+--   diagnostic prompt to the exact build that crashed.
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "errorDigest" TEXT;
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "deployedSha" TEXT;
+
+-- Powers cross-route incident dedup at triage time.
+CREATE INDEX "PlatformIssueReport_errorDigest_idx" ON "PlatformIssueReport"("errorDigest");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4426,6 +4426,13 @@ model PlatformIssueReport {
   description         String?
   routeContext        String?
   errorStack          String?
+  // BI-B4F401B3: crash-boundary diagnostics. errorDigest is the Next.js server
+  // digest token (stable per real error on a build) — it lets operators and AI
+  // clients grep server logs for the message Next.js sanitizes away, and lets
+  // triage dedup a whole crash incident across routes. deployedSha anchors the
+  // diagnostic prompt to the exact image SHA that crashed.
+  errorDigest         String?
+  deployedSha         String?
   userAgent           String?
   reportedById        String?
   digitalProductId    String?
@@ -4450,6 +4457,8 @@ model PlatformIssueReport {
   @@index([featureBuildId])
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId])
+  // BI-B4F401B3: digest lookup powers cross-route incident dedup at triage time.
+  @@index([errorDigest])
   @@unique([reportedById, supportSessionId])
   @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }


### PR DESCRIPTION
## What & why

When a production Server Component crashes, Next.js delivers only a sanitized message and an opaque `digest` to the client error boundary — the real error stays in the server logs. Today the crash-boundary report is fed to an LLM that **invents** a plausible-but-wrong root cause, creating phantom backlog bugs. A single 2026-06-07 migration-drift incident (Prisma `P2022 ColumnNotFound`) spawned **12+ bogus `/build` "undefined.toLowerCase()" BIs** that sent Build Studio chasing errors that did not exist.

This replaces the guess with **evidence + a self-service handoff**: the crash screen gives the operator a one-click copy-paste prompt for their AI client (Claude / Codex / Grok), which *can* read the server logs and resolve the real error.

Implements **BI-B4F401B3** (operator request, origin reports PIR-T8499 + PIR-IJ2N1), following the Build-Studio-reviewed design doc for `FB-8010B564`.

## Changes
- **`error.tsx`** — a "Copy diagnostic prompt" button + always-visible block bundling the route, error digest, crash time, deployed SHA, and PIR id with a numbered log/migration investigation checklist. Clipboard write + `aria-live` confirmation, keyboard accessible. Captures the deployed SHA from `/api/platform/version` and the auto-report's `reportId`.
- **`PlatformIssueReport`** — additive `errorDigest` + `deployedSha` columns (nullable migration, indexed digest), persisted via the writer and forwarded by `POST /api/quality/report`.
- **Triage gate** — `crash_boundary` reports **skip the LLM** and file an honest, deterministic `Crash: <route> (PIR-XXXXX) — investigate via diagnostic prompt` item; cross-route incidents **fold by error digest** instead of guessed titles.

## Tests
- Triage `crash_boundary` gate: skips LLM, deterministic honest title, digest dedup, no title-folding.
- Writer + API: `errorDigest`/`deployedSha` passthrough, truncation, null-coercion.
- `error.tsx` (jsdom): renders the prompt with route/digest/checklist; copy writes to clipboard, shows "Copied!", announces to screen readers.
- Full `web` suite green (10,163 passed); `web` typecheck clean.

## Provenance note
Built in-session because the Build Studio **Plan phase stalled** on a plan-generation JSON-parse error (~15 min, no retry) on `FB-8010B564`; the operator authorized the in-session path. The BS Ideate design review **passed** and explicitly credited the design for *"gating the LLM to prevent phantom bugs"*. Separately filed **BI-D9BAB4FA** for the root-cause infra bug behind the original incident (self-upgrade swap skips DB migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)