### PR TITLE
feat(portfolio): persist per-org PortfolioDecomposition (BI-2D452667) — EP-BOM-WIRING Phase 0

### DIFF
--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -3,13 +3,15 @@
 import { prisma } from "@dpf/db";
 import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from "./setup-constants";
 import { seedOrgWwwdCorpus } from "@/lib/onboarding/seed-org-wwwd-corpus";
+import { seedPortfolioDecomposition } from "@/lib/onboarding/seed-portfolio-decomposition";
 import { applyMissionPrompt } from "@/lib/onboarding/apply-mission-prompt";
 
 /**
  * Runs once when initial setup completes: persist the captured mission into
- * the company-mission prompt (visible to every coworker) and seed the per-org
- * WWWD corpus. Fail-open and idempotent — onboarding completion must never
- * block on embedding/seeding errors, and the seed is safe to re-run.
+ * the company-mission prompt (visible to every coworker), seed the per-org
+ * WWWD corpus, and persist the per-org portfolio decomposition (BI-2D452667).
+ * Fail-open and idempotent — onboarding completion must never block on
+ * embedding/seeding errors, and the seeds are safe to re-run.
  */
 async function finalizeSetupCompletion(organizationId: string | null): Promise<void> {
   try {
@@ -26,6 +28,7 @@ async function finalizeSetupCompletion(organizationId: string | null): Promise<v
 
     await applyMissionPrompt({ mission: bc?.mission ?? null });
     await seedOrgWwwdCorpus({ organizationId: orgId });
+    await seedPortfolioDecomposition({ organizationId: orgId });
   } catch (err) {
     console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", err);
   }

--- a/apps/web/lib/onboarding/seed-portfolio-decomposition.test.ts
+++ b/apps/web/lib/onboarding/seed-portfolio-decomposition.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import { readActivationProfile } from "@/lib/storefront/archetype-activation";
+import {
+  seedPortfolioDecomposition,
+  resolvePortfolioDecomposition,
+} from "./seed-portfolio-decomposition";
+
+const ORG = "org-test-1";
+
+// A real archetype whose activationProfile yields a portfolio decomposition,
+// so the derive step exercises the actual readActivationProfile path.
+const archetypeWithPortfolios = ALL_ARCHETYPES.find(
+  (a) => readActivationProfile(a.activationProfile)?.portfolios,
+);
+const ACTIVATION_PROFILE = archetypeWithPortfolios!.activationProfile;
+const EXPECTED = readActivationProfile(ACTIVATION_PROFILE)!.portfolios;
+
+function makeDb(opts: {
+  businessContext: { id: string; portfolioDecomposition: unknown } | null;
+  activationProfile?: unknown;
+}) {
+  const update = vi.fn().mockResolvedValue({});
+  const db = {
+    businessContext: {
+      findUnique: vi.fn().mockResolvedValue(opts.businessContext),
+      update,
+    },
+    storefrontConfig: {
+      findFirst: vi.fn().mockResolvedValue(
+        opts.activationProfile === undefined
+          ? null
+          : { archetype: { activationProfile: opts.activationProfile } },
+      ),
+    },
+  };
+  return { db, update };
+}
+
+describe("seedPortfolioDecomposition (BI-2D452667)", () => {
+  it("seeds from the archetype when BusinessContext has no decomposition", async () => {
+    const { db, update } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: null },
+      activationProfile: ACTIVATION_PROFILE,
+    });
+
+    const result = await seedPortfolioDecomposition({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(true);
+    expect(result.alreadyPresent).toBe(false);
+    expect(result.decomposition).toEqual(EXPECTED);
+    expect(update).toHaveBeenCalledWith({
+      where: { organizationId: ORG },
+      data: { portfolioDecomposition: EXPECTED },
+    });
+  });
+
+  it("does NOT overwrite an existing decomposition (seed-is-bootstrap)", async () => {
+    const refined = { foundational: { scope: "primary" } };
+    const { db, update } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: refined },
+      activationProfile: ACTIVATION_PROFILE,
+    });
+
+    const result = await seedPortfolioDecomposition({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(false);
+    expect(result.alreadyPresent).toBe(true);
+    expect(result.decomposition).toEqual(refined);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there is no BusinessContext row", async () => {
+    const { db, update } = makeDb({ businessContext: null, activationProfile: ACTIVATION_PROFILE });
+
+    const result = await seedPortfolioDecomposition({ organizationId: ORG, db: db as never });
+
+    expect(result).toEqual({ seeded: false, alreadyPresent: false, decomposition: null });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the archetype yields no decomposition", async () => {
+    const { db, update } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: null },
+      activationProfile: "not-a-profile",
+    });
+
+    const result = await seedPortfolioDecomposition({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(false);
+    expect(result.decomposition).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: a second run after seeding does not overwrite", async () => {
+    // Simulate the post-seed state: BusinessContext now carries EXPECTED.
+    const { db, update } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: EXPECTED },
+      activationProfile: ACTIVATION_PROFILE,
+    });
+
+    const result = await seedPortfolioDecomposition({ organizationId: ORG, db: db as never });
+
+    expect(result.alreadyPresent).toBe(true);
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolvePortfolioDecomposition (BI-2D452667)", () => {
+  it("prefers the persisted BusinessContext value", async () => {
+    const persisted = { productsAndServicesSold: { scope: "primary" } };
+    const { db } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: persisted },
+      activationProfile: ACTIVATION_PROFILE,
+    });
+
+    await expect(
+      resolvePortfolioDecomposition({ organizationId: ORG, db: db as never }),
+    ).resolves.toEqual(persisted);
+    // archetype fallback must not be consulted when a persisted value exists
+    expect(db.storefrontConfig.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the archetype-derived value when not yet persisted", async () => {
+    const { db } = makeDb({
+      businessContext: { id: "bc1", portfolioDecomposition: null },
+      activationProfile: ACTIVATION_PROFILE,
+    });
+
+    await expect(
+      resolvePortfolioDecomposition({ organizationId: ORG, db: db as never }),
+    ).resolves.toEqual(EXPECTED);
+    expect(db.storefrontConfig.findFirst).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/onboarding/seed-portfolio-decomposition.ts
+++ b/apps/web/lib/onboarding/seed-portfolio-decomposition.ts
@@ -1,0 +1,138 @@
+// Onboarding Portfolio-decomposition seeding (BI-2D452667).
+//
+// Persists each org's Digital Product Portfolio decomposition — the per-role
+// scope (foundational | manufactureAndDeliver | forEmployees |
+// productsAndServicesSold) — onto BusinessContext.portfolioDecomposition.
+//
+// Until now the decomposition was computed from the shared archetype template's
+// activationProfile at runtime (readActivationProfile) and discarded, so a
+// company could not refine its own portfolio shape independent of the template
+// (spec §3). This seeds it ONCE at setup completion from the archetype
+// (seed-is-bootstrap), after which the persisted value is the source of truth
+// and the operator can refine it. The read helper prefers the persisted value
+// and falls back to the archetype-derived computation when absent.
+//
+// Idempotent and non-destructive: if BusinessContext already carries a
+// decomposition (operator refinement, or a prior seed run), it is NOT
+// overwritten. Safe to re-run on re-completion or replay.
+
+import { prisma } from "@dpf/db";
+import type { PortfolioDecomposition } from "@dpf/storefront-templates";
+import { readActivationProfile } from "@/lib/storefront/archetype-activation";
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type SeedPortfolioDecompositionClient = {
+  businessContext: {
+    findUnique: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+  storefrontConfig: {
+    findFirst: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type SeedPortfolioDecompositionInput = {
+  organizationId: string;
+  /** Defaults to the shared prisma client. */
+  db?: SeedPortfolioDecompositionClient;
+};
+
+export type SeedPortfolioDecompositionResult = {
+  /** True only if a decomposition was written to BusinessContext this run. */
+  seeded: boolean;
+  /** True if BusinessContext already had a decomposition (left untouched). */
+  alreadyPresent: boolean;
+  /** The resulting decomposition (persisted or just-seeded), or null if none. */
+  decomposition: PortfolioDecomposition | null;
+};
+
+type BusinessContextRow = {
+  id: string;
+  portfolioDecomposition: unknown;
+} | null;
+
+type StorefrontConfigRow = {
+  archetype: { activationProfile: unknown } | null;
+} | null;
+
+/** Minimal structural guard — a decomposition is a non-empty object map. */
+function asDecomposition(value: unknown): PortfolioDecomposition | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  if (Object.keys(value as Record<string, unknown>).length === 0) return null;
+  return value as PortfolioDecomposition;
+}
+
+/** Derive the decomposition from the org's archetype activationProfile. */
+async function deriveFromArchetype(
+  db: SeedPortfolioDecompositionClient,
+  organizationId: string,
+): Promise<PortfolioDecomposition | null> {
+  const sf = (await db.storefrontConfig.findFirst({
+    where: { organizationId },
+    select: { archetype: { select: { activationProfile: true } } },
+  })) as StorefrontConfigRow;
+
+  return readActivationProfile(sf?.archetype?.activationProfile ?? null)?.portfolios ?? null;
+}
+
+/**
+ * Seed BusinessContext.portfolioDecomposition once from the archetype at setup
+ * completion. Non-destructive: never overwrites an existing decomposition.
+ */
+export async function seedPortfolioDecomposition(
+  input: SeedPortfolioDecompositionInput,
+): Promise<SeedPortfolioDecompositionResult> {
+  const db = input.db ?? (prisma as unknown as SeedPortfolioDecompositionClient);
+  const organizationId = input.organizationId;
+
+  const bc = (await db.businessContext.findUnique({
+    where: { organizationId },
+    select: { id: true, portfolioDecomposition: true },
+  })) as BusinessContextRow;
+
+  // No business-context row yet → nothing to attach the decomposition to.
+  if (!bc) {
+    return { seeded: false, alreadyPresent: false, decomposition: null };
+  }
+
+  // Already set (operator refinement or prior seed) → preserve it.
+  const existing = asDecomposition(bc.portfolioDecomposition);
+  if (existing) {
+    return { seeded: false, alreadyPresent: true, decomposition: existing };
+  }
+
+  const derived = await deriveFromArchetype(db, organizationId);
+  if (!derived) {
+    return { seeded: false, alreadyPresent: false, decomposition: null };
+  }
+
+  await db.businessContext.update({
+    where: { organizationId },
+    data: { portfolioDecomposition: derived },
+  });
+
+  return { seeded: true, alreadyPresent: false, decomposition: derived };
+}
+
+/**
+ * Resolve the org's portfolio decomposition for downstream wiring (Facet A/B
+ * seeding, capability-map dispatch). Prefers the persisted, refinable
+ * BusinessContext value; falls back to the archetype-derived computation when
+ * it has not been seeded yet.
+ */
+export async function resolvePortfolioDecomposition(input: {
+  organizationId: string;
+  db?: SeedPortfolioDecompositionClient;
+}): Promise<PortfolioDecomposition | null> {
+  const db = input.db ?? (prisma as unknown as SeedPortfolioDecompositionClient);
+
+  const bc = (await db.businessContext.findUnique({
+    where: { organizationId: input.organizationId },
+    select: { id: true, portfolioDecomposition: true },
+  })) as BusinessContextRow;
+
+  const persisted = bc ? asDecomposition(bc.portfolioDecomposition) : null;
+  if (persisted) return persisted;
+
+  return deriveFromArchetype(db, input.organizationId);
+}

--- a/packages/db/prisma/migrations/20260607020000_add_business_context_portfolio_decomposition/migration.sql
+++ b/packages/db/prisma/migrations/20260607020000_add_business_context_portfolio_decomposition/migration.sql
@@ -1,0 +1,10 @@
+-- Per-org Digital Product Portfolio decomposition (BI-2D452667, spec
+-- docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md §3 / §8 Phase 0).
+-- Additive, nullable: holds the PortfolioDecomposition (Record<PortfolioRole,
+-- PortfolioProfile>) derived once from the archetype activationProfile at setup
+-- completion, then refinable by the operator. Closes the "computed at runtime,
+-- never persisted" gap so a company's portfolio shape can be driven from and
+-- refined independent of the shared archetype template.
+
+-- AlterTable
+ALTER TABLE "BusinessContext" ADD COLUMN "portfolioDecomposition" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2892,6 +2892,17 @@ model BusinessContext {
   /// @deprecated Read StorefrontConfig.archetypeId. Column kept until next migration cycle.
   archetypeId String?
 
+  // Per-org Digital Product Portfolio decomposition (BI-2D452667, spec
+  // docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md §3/§8 Phase 0).
+  // Shape: PortfolioDecomposition (Record<PortfolioRole, PortfolioProfile>) from
+  // @dpf/storefront-templates — roles foundational | manufactureAndDeliver |
+  // forEmployees | productsAndServicesSold, each with a scope. Seeded ONCE from
+  // the archetype's activationProfile at setup completion (seed-is-bootstrap),
+  // then refinable by the operator. Read via resolvePortfolioDecomposition(),
+  // which prefers this persisted value and falls back to the archetype-derived
+  // computation when null.
+  portfolioDecomposition Json?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## What
**EP-BOM-WIRING Phase 0.** Persist each org's Digital Product Portfolio decomposition so a company's portfolio shape is refinable, instead of being recomputed-and-discarded from the shared archetype template on every read.

### The gap
`readActivationProfile()` normalizes a `PortfolioDecomposition` (per-role scope: `foundational | manufactureAndDeliver | forEmployees | productsAndServicesSold`) from the archetype's `activationProfile` JSON at **runtime**, and every consumer recomputes it. It is **never persisted per-org**, so an operator can't refine their own portfolio shape and downstream wiring has nothing stable to read.

### The change
- **Schema + migration:** `BusinessContext.portfolioDecomposition` (nullable `JSONB`). `BusinessContext` is the per-org business data already "derived from archetype (auto-populated)".
- **`seedPortfolioDecomposition`** (`apps/web/lib/onboarding/seed-portfolio-decomposition.ts`): derives the decomposition from the archetype **once** at setup completion and persists it. **Non-destructive** — never overwrites an existing value (seed-is-bootstrap); idempotent; safe to re-run.
- **`resolvePortfolioDecomposition`**: read helper that **prefers the persisted value** and falls back to the archetype-derived computation when not yet seeded — the stable read for Facet-A/B seeding and the capability-map dispatcher.
- **Wired** into `finalizeSetupCompletion` alongside the WWWD seed (fail-open, idempotent).

## Scope / de-confliction
Net-new; no touch to `lib/lifecycle.ts` or decision-perspective (independent of PR #1643 and EP-LIFECYCLE). Unblocks BI-4503E6B9 (market offer) and BI-554E1A14 (Workforce).

## Test plan
- [x] `vitest run lib/onboarding/seed-portfolio-decomposition.test.ts` — 7 passed (seed-from-archetype, no-overwrite, no-row, no-profile, idempotency, resolve-prefers-persisted, resolve-fallback)
- [x] `vitest run lib/onboarding/` — 45 passed
- [x] `pnpm run typecheck` (apps/web) — clean; schema regression guard — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)