### PR TITLE
fix(self-upgrade): run DB migrations on the new image before the portal swap (BI-D9BAB4FA)

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -141,6 +141,7 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       "step=prepare",
       "step=backup",
       "step=docker-build",
+      "step=migrate",
       "step=docker-up",
       "step=health",
       "step=sha-verify",
@@ -169,6 +170,11 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       expect(dryRunResult.stdout).toContain("step=docker-build");
     });
 
+    // BI-D9BAB4FA: migrations must run on the new image before the swap.
+    it("emits migrate step", () => {
+      expect(dryRunResult.stdout).toContain("step=migrate");
+    });
+
     it("emits docker-up step", () => {
       expect(dryRunResult.stdout).toContain("step=docker-up");
     });
@@ -185,7 +191,7 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       expect(dryRunResult.stdout).toContain("step=content-verify");
     });
 
-    it("steps appear in order: prepare → backup → docker-build → docker-up → health → sha-verify → content-verify", () => {
+    it("steps appear in order: prepare → backup → docker-build → migrate → docker-up → health → sha-verify → content-verify", () => {
       const positions = STEPS.map((s) => dryRunResult.stdout.indexOf(s));
       for (let i = 1; i < positions.length; i++) {
         expect(positions[i]).toBeGreaterThan(positions[i - 1]);

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -227,6 +227,8 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
         `compose --env-file ${toBashPath(envFile)} --project-directory ${toBashPath(source)}`,
       );
       expect(log).toContain("build portal");
+      // BI-D9BAB4FA: migrations run from the freshly-built image, before the swap.
+      expect(log).toContain("run --rm -T --no-deps --entrypoint sh portal -c cd /app && pnpm --filter @dpf/db exec prisma migrate deploy");
       expect(log).toContain("up -d --no-deps --force-recreate portal");
       expect(log).toContain("exec -T portal cat /app/.dpf-source-content-hash");
     } finally {

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -159,6 +159,27 @@ if [[ $_dry_run -eq 0 ]]; then
   }
 fi
 
+# --- Step 3b: migrate ---
+# Apply DB migrations using the FRESHLY BUILT portal image BEFORE recreating the
+# long-running portal. The swap in step 4 recreates ONLY `portal` (--no-deps),
+# so it never runs the one-shot `portal-init` service that a normal
+# `docker compose up` runs to migrate the DB. Without this step a self-upgrade
+# that ships a migration leaves the live DB drifted, and every query for a new
+# column throws Prisma P2022 ColumnNotFound — the 2026-06-07 crash incident
+# (BI-D9BAB4FA) where /ops/self-upgrade, /build, /platform and /workbooks all
+# died after a swap. Running `prisma migrate deploy` from the new image's own
+# bytes is forward-only and FAIL-CLOSED: `set -e` aborts the upgrade on a
+# migration error BEFORE the swap, so the OLD portal keeps serving the OLD code
+# against a consistent DB rather than a new image landing on an un-migrated one.
+# DPF migrations are additive (expand), so applying them while the old portal is
+# still running is safe — it simply ignores the new columns until it is replaced.
+emit_step migrate
+if [[ $_dry_run -eq 0 ]]; then
+  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+    "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+    -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate deploy'
+fi
+
 # --- Step 4: docker-up ---
 # Recreate ONLY the portal from the freshly built image. --no-deps leaves
 # postgres/neo4j/etc. running. DEPLOYED_SHA resolves to DPF_VERSION (the


### PR DESCRIPTION
## What & why

`scripts/promote.sh` recreates **only** the `portal` service during a self-upgrade (`up -d --no-deps --force-recreate portal`). It never runs the one-shot **`portal-init`** service that a normal `docker compose up` runs to migrate the DB. So any migration shipped in the new image **never reaches the live DB**, and every query for a new column throws Prisma **`P2022 ColumnNotFound`**.

This is the root cause of the **2026-06-07 incident**: a self-upgrade swap (`SUR-B0553292`) left the DB 5 migrations behind the running image, crashing `/ops/self-upgrade`, `/build`, `/platform`, and `/workbooks` with Server-Component render errors (which the crash boundary then misdiagnosed as ~12 phantom `/build` bugs — addressed separately in #1645).

The spec already named this gap: *"scripts/promote.sh … does not … run migrations … or automatically roll back on failure"* (`2026-05-23-governed-platform-upgrade-lifecycle-design.md` §"current promoter behavior").

## Change

Add a **`migrate`** step between `docker-build` and `docker-up` that runs `prisma migrate deploy` from the **freshly-built portal image's own bytes**:

```
docker compose … run --rm -T --no-deps --entrypoint sh portal \
  -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate deploy'
```

- **Forward-only** — `migrate deploy` applies pending migrations; idempotent.
- **Fail-closed** — under `set -e`, a migration error aborts the upgrade **before** the swap, so the old portal keeps serving the old code against a consistent DB rather than a new image landing on an un-migrated one.
- **Safe ordering** — DPF migrations are additive (expand), so applying them while the old portal is still running is safe; it ignores the new columns until it's replaced.

## Verification
- `promote-script-contract` test: `migrate` added to the step-order assertion + an emit test (real `bash` dry-run).
- `promote-script-functional` test: asserts the migrate command is invoked from the built image (real `promote.sh` driven end-to-end with faked `docker`/`curl`).
- Full self-upgrade suite: **273 passed**. `bash -n scripts/promote.sh` clean.
- The `prisma migrate deploy` step itself is the exact command already proven to recover the live install during the incident.

> Note: end-to-end confirmation (triggering a real self-upgrade and observing migrations apply pre-swap) should be done deliberately on a controlled install, since it recycles the portal.

## Scope
Fixes the self-upgrade swap path (the incident path). The deeper entrypoint robustness (the portal's bare `ENTRYPOINT` PATH-shadows to the Node base passthrough, so the portal never self-migrates on any boot) is noted as a follow-up — out of scope here to keep blast radius minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)