### PR TITLE
fix(build-studio): recover plan generation from truncated/wrapped JSON instead of silently stalling

### DIFF
--- a/apps/web/lib/integrate/plan-on-approval.test.ts
+++ b/apps/web/lib/integrate/plan-on-approval.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePlanJson } from "./plan-on-approval";
+
+const validPlan = {
+  fileStructure: [{ path: "apps/web/lib/x.ts", action: "modify" }],
+  tasks: [{ title: "Do the thing", files: ["apps/web/lib/x.ts"] }],
+};
+
+describe("parsePlanJson", () => {
+  it("parses a bare JSON object", () => {
+    const r = parsePlanJson(JSON.stringify(validPlan));
+    expect(r).toEqual(validPlan);
+  });
+
+  it("parses JSON wrapped in a ```json markdown fence", () => {
+    const r = parsePlanJson("```json\n" + JSON.stringify(validPlan) + "\n```");
+    expect(r).toEqual(validPlan);
+  });
+
+  it("parses JSON wrapped in surrounding prose (first-brace…last-brace slice)", () => {
+    const r = parsePlanJson(
+      "Here is the plan you requested:\n" + JSON.stringify(validPlan) + "\nLet me know if you need changes.",
+    );
+    expect(r).toEqual(validPlan);
+  });
+
+  it("returns null for JSON truncated mid-array (so the caller retries)", () => {
+    // Exactly the failure that silently stalled the build: unclosed tasks array.
+    const truncated = '{"fileStructure":[{"path":"a.ts"}],"tasks":[{"title":"one"},{"title":"two"';
+    expect(parsePlanJson(truncated)).toBeNull();
+  });
+
+  it("returns null for empty or non-JSON output", () => {
+    expect(parsePlanJson("")).toBeNull();
+    expect(parsePlanJson("I could not produce a plan.")).toBeNull();
+  });
+
+  it("does not treat a bare JSON array or scalar as a plan object", () => {
+    // first-brace…last-brace slice must not misfire on these.
+    expect(parsePlanJson("[1,2,3]")).toBeNull();
+    expect(parsePlanJson("42")).toBeNull();
+  });
+});

--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -113,6 +113,48 @@ Respond with ONLY the JSON object, no markdown fences, no explanation.`;
 }
 
 /**
+ * Robustly parse the plan JSON from portal-inference output.
+ *
+ * The model occasionally wraps the JSON in prose/markdown fences, or — on a
+ * large plan — truncates mid-array when it hits its output ceiling. A bare
+ * JSON.parse then fails and (before this) silently stalled the build in `plan`.
+ * Strategy: markdown code-block → first-brace…last-brace slice → raw. Returns
+ * null when no strategy yields a parseable object; the caller then RETRIES the
+ * generation (which recovers truncation — a fresh, complete response).
+ */
+export function parsePlanJson(
+  output: string,
+): { fileStructure?: unknown[]; tasks?: unknown[] } | null {
+  const tryParse = (text: string): { fileStructure?: unknown[]; tasks?: unknown[] } | null => {
+    const t = text.trim();
+    if (!t) return null;
+    try {
+      const parsed = JSON.parse(t);
+      // A plan is a JSON object, never an array or scalar.
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  };
+
+  // 1. Markdown code block (```json … ``` or ``` … ```).
+  const fence = output.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) {
+    const r = tryParse(fence[1]!);
+    if (r) return r;
+  }
+  // 2. Bare object: first "{" to last "}" (strips surrounding prose).
+  const first = output.indexOf("{");
+  const last = output.lastIndexOf("}");
+  if (first >= 0 && last > first) {
+    const r = tryParse(output.slice(first, last + 1));
+    if (r) return r;
+  }
+  // 3. Raw.
+  return tryParse(output);
+}
+
+/**
  * Auto-dispatch Plan-phase implementation-plan generation for a build that just
  * advanced from ideate → plan. Designed to be called fire-and-forget from the
  * reviewDesignDoc success path; never throws.
@@ -219,23 +261,35 @@ export async function dispatchPlanForApprovedBuild(params: {
       verifiedPaths,
     });
 
-    const response = await routeAndCall(
-      [{ role: "user" as const, content: prompt }],
-      "You are a senior software engineer creating a precise, actionable implementation plan. Respond with ONLY valid JSON.",
-      "internal",
-      { budgetClass: "quality_first" },
-    );
+    // 4. Generate + parse with a bounded retry. A single bare JSON.parse used to
+    //    silently stall the build in `plan` whenever the model wrapped the JSON
+    //    in prose or truncated a large plan mid-array. parsePlanJson handles the
+    //    wrapping; the retry recovers truncation with a fresh, complete response
+    //    (and an explicit corrective instruction on the second attempt).
+    const PLAN_GEN_MAX_ATTEMPTS = 2;
+    let planObj: { fileStructure?: unknown[]; tasks?: unknown[] } | null = null;
+    for (let attempt = 1; attempt <= PLAN_GEN_MAX_ATTEMPTS && !planObj; attempt++) {
+      const systemPrompt =
+        attempt === 1
+          ? "You are a senior software engineer creating a precise, actionable implementation plan. Respond with ONLY valid JSON."
+          : "Your previous response was not valid JSON — it was likely truncated mid-array or wrapped in prose. Respond with ONLY the COMPLETE, valid JSON object (both the fileStructure and tasks arrays fully closed). No prose, no markdown fences.";
+      const response = await routeAndCall(
+        [{ role: "user" as const, content: prompt }],
+        systemPrompt,
+        "internal",
+        { budgetClass: "quality_first" },
+      );
+      planObj = parsePlanJson(response.content);
+      if (!planObj) {
+        await log(
+          `Plan generation attempt ${attempt}/${PLAN_GEN_MAX_ATTEMPTS} returned unparseable JSON` +
+            (attempt < PLAN_GEN_MAX_ATTEMPTS ? " — retrying" : ""),
+        );
+      }
+    }
 
-    // 4. Parse JSON.
-    const rawContent = response.content.trim();
-    // Strip optional markdown fences.
-    const jsonStr = rawContent.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "").trim();
-
-    let planObj: { fileStructure?: unknown[]; tasks?: unknown[] };
-    try {
-      planObj = JSON.parse(jsonStr);
-    } catch (parseErr) {
-      const msg = `Plan generation returned unparseable JSON: ${String(parseErr).slice(0, 200)}`;
+    if (!planObj) {
+      const msg = `Plan generation returned unparseable JSON after ${PLAN_GEN_MAX_ATTEMPTS} attempts`;
       await log(msg);
       return { kind: "dispatched-failure", error: msg, durationMs: Date.now() - t0 };
     }


### PR DESCRIPTION
## Problem
Build Studio plan generation did a bare `JSON.parse` on the portal-inference output ([`plan-on-approval.ts`](apps/web/lib/integrate/plan-on-approval.ts)). When the model wrapped the JSON in prose/markdown, or — on a large/`decompose-recommended` design — **truncated the plan mid-array** at its output-token ceiling, the parse threw and the build was left **parked in `plan` forever with no recovery**.

Observed live on `FB-8010B564`: `Plan generation returned unparseable JSON: SyntaxError: Expected ',' or ']' after array element at position 6747` → silent stall, no plan review / build / ship. This is the Build Studio plan-gen stoppage.

## Fix
- **`parsePlanJson()`** — robust extraction: markdown code-block → first-brace…last-brace slice → raw; rejects arrays/scalars; returns `null` when nothing parses (mirrors the proven `parseDesignDoc` strategy already used in `ideate-dispatch.ts`).
- **Bounded retry (2 attempts)** — a parse miss re-generates with an explicit corrective instruction ("your previous response was truncated/wrapped; return ONLY the complete valid JSON object"), which recovers truncation via a fresh, complete response. Only after both attempts fail does it return `dispatched-failure` (preserving the prior terminal behavior as a last resort).

No signature changes; blast radius is this one module.

## Tests
`plan-on-approval.test.ts`: bare/markdown/prose-wrapped parse, truncation→`null` (the case that triggers the recovery retry), and array/scalar rejection. 6/6 pass; surrounding `lib/integrate` suite green (786 tests).

## Notes
- Maintenance/reliability fix opened directly (Build Studio pipeline can't build its own unblocker while stalled).
- Local typecheck/full-suite run via CI: the local worktree has the known `@dpf/*` workspace-link breakage; the affected + integrate vitest pass locally, CI runs the full typecheck + suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)