### PR TITLE
fix(seed): fault-isolate reconcile so updates land reliably without wiping operator data

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,12 +25,12 @@ echo "  OK Migrations complete"
 
 echo "[2/5] Syncing provider registry..."
 cd /app
-pnpm --filter @dpf/db exec tsx scripts/sync-provider-registry.ts || echo "  WARN Provider sync had warnings (non-fatal)"
+pnpm --filter @dpf/db exec tsx scripts/sync-provider-registry.ts || echo "  ⚠️  PROVIDER SYNC FAILED — provider catalog (new providers, auth methods, cliEngine) was NOT reconciled into the DB on this start. The portal will run, but provider/Build-Studio catalog updates from this release may be missing. See the error above."
 echo "  OK Provider registry synced"
 
 echo "[3/5] Seeding reference data..."
 cd /app
-pnpm --filter @dpf/db exec tsx src/seed.ts || echo "  WARN Seed had warnings (non-fatal)"
+pnpm --filter @dpf/db exec tsx src/seed.ts || echo "  ⚠️  SEED INCOMPLETE — one or more reconcile steps failed (see the 'SEED INCOMPLETE' summary above). The portal will start; catalog/reference updates from this release may be partial."
 echo "  OK Seed complete"
 
 echo "[3b/5] Reconciling model capability catalog..."

--- a/packages/db/src/seed-reconcile-no-wipe.test.ts
+++ b/packages/db/src/seed-reconcile-no-wipe.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// No-wipe invariant for the catalog/provider reconcile paths.
+//
+// On a portal update the seed + sync-provider-registry reconcile catalog metadata
+// (provider names, cliEngine, supportedAuthMethods, pricing, …) into existing rows.
+// That reconcile MUST be upsert/merge only — it must never delete operator-owned
+// rows, or an update would wipe an operator's configured credentials / provider
+// selections / platform config. This guards against a future change silently
+// reintroducing a table reset (a real early-days incident).
+//
+// Targeted, not blanket: `modelProfile` rows ARE deletable (runtime-discovered
+// calibration data), so only the operator-owned tables are protected here.
+
+const RECONCILE_SOURCES = [
+  join(__dirname, "seed.ts"),
+  join(__dirname, "..", "scripts", "sync-provider-registry.ts"),
+];
+
+const PROTECTED_MODELS = ["modelProvider", "credentialEntry", "platformConfig"] as const;
+
+describe("seed/sync reconcile no-wipe invariant", () => {
+  for (const sourcePath of RECONCILE_SOURCES) {
+    const source = readFileSync(sourcePath, "utf8");
+    const label = sourcePath.split(/[\\/]/).slice(-1)[0];
+
+    for (const model of PROTECTED_MODELS) {
+      it(`${label} never calls delete/deleteMany on ${model}`, () => {
+        // Matches prisma.<model>.delete( / .deleteMany( with any whitespace.
+        const re = new RegExp(`\\.${model}\\s*\\.\\s*(delete|deleteMany)\\b`);
+        const match = source.match(re);
+        expect(
+          match === null,
+          match
+            ? `${label} contains "${match[0]}" — the reconcile must be upsert/merge only; ` +
+                `operator-owned ${model} rows must never be wiped on update.`
+            : "",
+        ).toBe(true);
+      });
+    }
+
+    it(`${label} contains no raw TRUNCATE/DELETE on protected tables`, () => {
+      const re = /(TRUNCATE|DELETE\s+FROM)\s+"?(ModelProvider|CredentialEntry|PlatformConfig)"?/i;
+      expect(source.match(re)).toBeNull();
+    });
+  }
+});

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -2450,96 +2450,134 @@ async function seedWorkQueues(): Promise<void> {
 
 async function main(): Promise<void> {
   console.log("Starting seed...");
+
+  // Fault-isolation: every step runs independently. A failure is recorded and
+  // logged loudly but does NOT abort the remaining steps — so an unrelated
+  // failure (e.g. a ScheduledJob schema drift) can no longer silently skip the
+  // idempotent catalog/provider reconciles that follow on a portal update.
+  // Reconciles are upsert/merge only and never delete operator-owned rows
+  // (enforced by seed-reconcile-no-wipe.test.ts).
+  const failures: Array<{ step: string; error: string }> = [];
+  const step = async (name: string, fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await fn();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      failures.push({ step: name, error: message });
+      console.error(`  ✗ [seed] step "${name}" FAILED (continuing): ${message}`);
+    }
+  };
+
+  // Bootstrap org is a hard prerequisite for everything below; if it cannot be
+  // created the seed genuinely cannot proceed, so it is intentionally not isolated.
   const bootstrapOrganizationId = await ensureBootstrapOrganization();
-  await seedIntegrationCoverage(prisma, bootstrapOrganizationId);
-  await seedStallThresholds(prisma);
-  await seedGeographicData(prisma);
-  await seedTaxJurisdictions(prisma);
-  await seedLicenseRequirements(prisma);
-  await seedRoles();
-  await seedGovernanceReferenceData(prisma);
-  await seedWorkforceReferenceData(prisma);
-  await seedPortfolios();
-  await seedBusinessModels();
-  await seedAgents();
-  await seedCoworkerAgents();
+
+  await step("integrationCoverage", () => seedIntegrationCoverage(prisma, bootstrapOrganizationId));
+  await step("stallThresholds", () => seedStallThresholds(prisma));
+  await step("geographicData", () => seedGeographicData(prisma));
+  await step("taxJurisdictions", () => seedTaxJurisdictions(prisma));
+  await step("licenseRequirements", () => seedLicenseRequirements(prisma));
+  await step("roles", () => seedRoles());
+  await step("governanceReferenceData", () => seedGovernanceReferenceData(prisma));
+  await step("workforceReferenceData", () => seedWorkforceReferenceData(prisma));
+  await step("portfolios", () => seedPortfolios());
+  await step("businessModels", () => seedBusinessModels());
+  await step("agents", () => seedAgents());
+  await step("coworkerAgents", () => seedCoworkerAgents());
   // EP-AI-WORKFORCE-001: Seed unified agent lifecycle data
-  await seedCoworkerSkills();
-  await seedAgentPromptContexts();
-  await seedFeatureDegradationMappings();
-  await seedTaxonomyNodes();
-  await seedDiscoveryFingerprints();
-  await seedAgentControlPlaneMaturity(prisma);
-  await seedEaReferenceModels().catch((err: unknown) => {
-    console.warn("[seed] EA reference models skipped:", err instanceof Error ? err.message : err);
-  });
-  await seedDigitalProducts();
-  await seedEaArchimate4();
-  await seedEaBpmn20();
-  await seedEaCrossNotation();
-  await seedEaStructureRules();
-  await seedEaViewpoints();
-  await seedEaViews();
-  await seedDpfSelfRegistration();
-  await seedDefaultAdminUser();
-  await ensureDiscoveryTriageScheduledTask(prisma);
-  await ensureDataModelMirrorScheduledTask(prisma);
-  await ensureHiveScoutScheduledTask(prisma);
-  await ensureAllBackupScheduledJobs(prisma);
-  await ensureContributorInventoryScheduledJob(prisma);
-  await seedMcpServers();
-  await seedSandboxPool();
-  await seedRuntimeTargets();
-  await seedProviderRegistry();
-  await seedCodexModels();
-  await seedChatGPTModels();
-  await seedLocalModels();
-  await seedModelProfiles();
-  await seedSpeachesTranscriptionModel();
-  await seedAnthropicSubScope();
-  await ensureBuildStudioModelConfig();
-  await seedModelPricing();
-  await seedAgentModelDefaults();
-  await seedPlatformConfig();
-  await seedClientIdentity();
-  await seedHiveContributionCredential();
-  await seedStorefrontArchetypes(prisma);
-  const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
-  console.log(
-    `  business-capability-perspective: sources=${capabilityPerspectiveSeed.sourcePerspectiveIds.join(",")} ` +
-      `active=${capabilityPerspectiveSeed.appliedCount} deactivated=${capabilityPerspectiveSeed.deactivatedCount}`,
-  );
-  await seedWorkQueues();
-  await seedPromptTemplates(prisma);
-  await seedSkills(prisma);
-  const wikiSeed = await seedWikiKernel(prisma);
-  if (wikiSeed.emptyKernel) {
-    console.log("  founder-kernel: empty (no docs/founder-kernel/wiki/ or raw-sources/ content yet)");
-  } else {
-    const qdrantSummary = wikiSeed.embeddingsSidecarPresent
-      ? `qdrant=${wikiSeed.qdrantPointsSeeded}`
-      : "qdrant=no-sidecar";
+  await step("coworkerSkills", () => seedCoworkerSkills());
+  await step("agentPromptContexts", () => seedAgentPromptContexts());
+  await step("featureDegradationMappings", () => seedFeatureDegradationMappings());
+  await step("taxonomyNodes", () => seedTaxonomyNodes());
+  await step("discoveryFingerprints", () => seedDiscoveryFingerprints());
+  await step("agentControlPlaneMaturity", () => seedAgentControlPlaneMaturity(prisma));
+  await step("eaReferenceModels", () => seedEaReferenceModels());
+  await step("digitalProducts", () => seedDigitalProducts());
+  await step("eaArchimate4", () => seedEaArchimate4());
+  await step("eaBpmn20", () => seedEaBpmn20());
+  await step("eaCrossNotation", () => seedEaCrossNotation());
+  await step("eaStructureRules", () => seedEaStructureRules());
+  await step("eaViewpoints", () => seedEaViewpoints());
+  await step("eaViews", () => seedEaViews());
+  await step("dpfSelfRegistration", () => seedDpfSelfRegistration());
+  await step("defaultAdminUser", () => seedDefaultAdminUser());
+  await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
+  await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));
+  await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));
+  await step("allBackupScheduledJobs", () => ensureAllBackupScheduledJobs(prisma));
+  await step("contributorInventoryScheduledJob", () => ensureContributorInventoryScheduledJob(prisma));
+  await step("mcpServers", () => seedMcpServers());
+  await step("sandboxPool", () => seedSandboxPool());
+  await step("runtimeTargets", () => seedRuntimeTargets());
+  await step("providerRegistry", () => seedProviderRegistry());
+  await step("codexModels", () => seedCodexModels());
+  await step("chatGPTModels", () => seedChatGPTModels());
+  await step("localModels", () => seedLocalModels());
+  await step("modelProfiles", () => seedModelProfiles());
+  await step("speachesTranscriptionModel", () => seedSpeachesTranscriptionModel());
+  await step("anthropicSubScope", () => seedAnthropicSubScope());
+  await step("buildStudioModelConfig", () => ensureBuildStudioModelConfig());
+  await step("modelPricing", () => seedModelPricing());
+  await step("agentModelDefaults", () => seedAgentModelDefaults());
+  await step("platformConfig", () => seedPlatformConfig());
+  await step("clientIdentity", () => seedClientIdentity());
+  await step("hiveContributionCredential", () => seedHiveContributionCredential());
+  await step("storefrontArchetypes", () => seedStorefrontArchetypes(prisma));
+  await step("businessCapabilityPerspective", async () => {
+    const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(
-      `  founder-kernel: kernelVersion=${wikiSeed.kernelVersion} ` +
-        `pages=${wikiSeed.pageCount} sources=${wikiSeed.sourceCount} ` +
-        `orphan-links=${wikiSeed.orphanLinks.length} ${qdrantSummary}`,
+      `  business-capability-perspective: sources=${capabilityPerspectiveSeed.sourcePerspectiveIds.join(",")} ` +
+        `active=${capabilityPerspectiveSeed.appliedCount} deactivated=${capabilityPerspectiveSeed.deactivatedCount}`,
     );
-  }
-  await seedDeliberationPatterns(prisma);
-  const decisionPerspectiveSeed = await seedDecisionPerspective(prisma);
-  console.log(
-    `  decision-perspective: profile=${decisionPerspectiveSeed.profileId} ` +
-      `version=${decisionPerspectiveSeed.versionId} materials=${decisionPerspectiveSeed.materialCount}`,
-  );
+  });
+  await step("workQueues", () => seedWorkQueues());
+  await step("promptTemplates", () => seedPromptTemplates(prisma));
+  await step("skills", () => seedSkills(prisma));
+  await step("wikiKernel", async () => {
+    const wikiSeed = await seedWikiKernel(prisma);
+    if (wikiSeed.emptyKernel) {
+      console.log("  founder-kernel: empty (no docs/founder-kernel/wiki/ or raw-sources/ content yet)");
+    } else {
+      const qdrantSummary = wikiSeed.embeddingsSidecarPresent
+        ? `qdrant=${wikiSeed.qdrantPointsSeeded}`
+        : "qdrant=no-sidecar";
+      console.log(
+        `  founder-kernel: kernelVersion=${wikiSeed.kernelVersion} ` +
+          `pages=${wikiSeed.pageCount} sources=${wikiSeed.sourceCount} ` +
+          `orphan-links=${wikiSeed.orphanLinks.length} ${qdrantSummary}`,
+      );
+    }
+  });
+  await step("deliberationPatterns", () => seedDeliberationPatterns(prisma));
+  await step("decisionPerspective", async () => {
+    const decisionPerspectiveSeed = await seedDecisionPerspective(prisma);
+    console.log(
+      `  decision-perspective: profile=${decisionPerspectiveSeed.profileId} ` +
+        `version=${decisionPerspectiveSeed.versionId} materials=${decisionPerspectiveSeed.materialCount}`,
+    );
+  });
   // BI-2535D6F4: ship the founder's recorded seed voice on the platform profile.
-  const platformVoice = await seedPlatformVoice(prisma);
-  console.log(`  platform-voice: ${platformVoice.status} (clip-copied=${platformVoice.copiedClip})`);
-  await syncCapabilities(prisma);
-  await assertActiveProvidersHaveClearance();
-  await assertAnthropicSubToolCapability();
-  await assertCoworkerAgentsHaveGrants();
-  await assertSharedOAuthClientsHaveSharedRedirectUri();
-  console.log("Seed complete.");
+  await step("platformVoice", async () => {
+    const platformVoice = await seedPlatformVoice(prisma);
+    console.log(`  platform-voice: ${platformVoice.status} (clip-copied=${platformVoice.copiedClip})`);
+  });
+  await step("syncCapabilities", () => syncCapabilities(prisma));
+  // Invariant asserts — isolated so a violation is surfaced in the summary
+  // rather than aborting the whole seed (they run after all seeding).
+  await step("assert:activeProvidersHaveClearance", () => assertActiveProvidersHaveClearance());
+  await step("assert:anthropicSubToolCapability", () => assertAnthropicSubToolCapability());
+  await step("assert:coworkerAgentsHaveGrants", () => assertCoworkerAgentsHaveGrants());
+  await step("assert:sharedOAuthClientsHaveSharedRedirectUri", () => assertSharedOAuthClientsHaveSharedRedirectUri());
+
+  if (failures.length > 0) {
+    console.error(`\n================ SEED INCOMPLETE: ${failures.length} step(s) failed ================`);
+    for (const f of failures) console.error(`  - ${f.step}: ${f.error}`);
+    console.error("  Surfaced (not swallowed) so a partially-failed update is visible. Other steps still ran.");
+    console.error("============================================================================");
+    process.exitCode = 1;
+  } else {
+    console.log("Seed complete.");
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem
Existing installs get catalog/provider updates via the reconcile that runs on every portal start (`docker-entrypoint.sh` → `sync-provider-registry.ts` + the full seed). That reconcile is **already merge-aware and upsert-only** — it preserves operator status/credentials/selections and **never deletes** operator rows. But it was fragile:

- The full seed ran as **one monolithic sequence**; any step throwing (e.g. the live `ScheduledJob.category` schema drift) aborted everything after it — including `seedProviderRegistry` near the end — so new providers / auth methods / `cliEngine` silently never landed.
- Failures were **swallowed**: `tsx src/seed.ts || echo WARN` hid a full abort as a benign warning.

Net effect: a portal update could appear to do nothing — literally *"I updated, no OAuth option."*

## Changes (reliability only — same data seeded, no reordering, **no new deletes**)
- **`seed.ts` `main()`**: each step wrapped in a fault-isolated `step()` helper. One failure is recorded + logged loudly but does **not** abort the rest, so the idempotent catalog/provider reconciles always run. A `SEED INCOMPLETE` summary lists failures and sets a non-zero exit (surfaced to the entrypoint, still non-fatal to startup).
- **`docker-entrypoint.sh`**: replace the `WARN … non-fatal` swallow on **both** the provider sync and the seed with prominent, actionable messages (still non-fatal — the portal must start).
- **`seed-reconcile-no-wipe.test.ts`**: invariant test asserting neither `seed.ts` **nor** `sync-provider-registry.ts` ever calls `delete`/`deleteMany` (or raw `TRUNCATE`/`DELETE`) on `ModelProvider` / `CredentialEntry` / `PlatformConfig` — guards against re-introducing the early-days table-reset that wiped operator config.

## Answer to "how do existing installs get seed updates without overwriting local changes?"
The merge-aware, upsert-only reconcile already does exactly that — it just needs to **run reliably and fail loudly**. This makes it so.

## Verification
- ✅ `@dpf/db` typecheck clean; no-wipe test **8/8**.
- The 19 failing tests in the suite are pre-existing DB-integration round-trips needing a migrated local DB — unrelated; they don't touch the seed orchestration.

## Follow-ups (separate)
- The live `ScheduledJob.category` schema/migration drift (P2022 — also breaking discovery-job registration).
- Confirm the self-upgrade path re-runs this reconcile after a bundle swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)