### PR TITLE
fix(grok): "Test connection" recognizes OAuth instead of "No API key configured"

### DIFF
--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -313,6 +313,33 @@ describe("testProviderAuth", () => {
     });
     expect(mockActivateProvider).not.toHaveBeenCalled();
   });
+
+  it("reports the OAuth connection for a Grok provider connected via device-code (no API key needed)", async () => {
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({
+      providerId: "xai",
+      name: "xAI (Grok)",
+      baseUrl: "https://api.x.ai/v1",
+      endpoint: null,
+      authMethod: "api_key",
+      authHeader: "Authorization",
+      category: "direct",
+      cliEngine: "grok",
+      families: [],
+      enabledFamilies: [],
+      supportedAuthMethods: ["api_key", "oauth2_device"],
+    });
+    // OAuth dispatch credential = the ~/.grok/auth.json blob stored in cachedToken; no API key.
+    mockGetDecryptedCredential.mockResolvedValue({
+      cachedToken: '{"access_token":"xai-oauth","refresh_token":"r"}',
+      secretRef: null,
+    });
+
+    const result = await testProviderAuth("xai");
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/OAuth/i);
+    expect(result.message).not.toMatch(/No API key/i);
+  });
 });
 
 describe("discoverModels", () => {

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -443,6 +443,22 @@ export async function testProviderAuth(providerId: string): Promise<{ ok: boolea
   const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
   if (!provider) return { ok: false, message: "Provider not found" };
 
+  // Grok can be connected two ways: an API key (for inference/chat) OR device-code
+  // OAuth (the Build Studio "grok" engine, whose ~/.grok/auth.json blob is stored in
+  // cachedToken). When only the OAuth dispatch credential is present, testing the
+  // inference API would misleadingly report "No API key configured" — so report the
+  // OAuth connection the provider actually has.
+  if (provider.cliEngine === "grok" && (provider.supportedAuthMethods as string[]).includes("oauth2_device")) {
+    const oauthCred = await getDecryptedCredential(providerId);
+    const hasOAuth = !!oauthCred?.cachedToken && oauthCred.cachedToken.trimStart().startsWith("{");
+    if (hasOAuth && !oauthCred?.secretRef) {
+      return {
+        ok: true,
+        message: "Connected via your xAI account (OAuth). The Grok build engine is ready — an API key is optional and only needed for chat/inference.",
+      };
+    }
+  }
+
   const providerRow = {
     ...provider,
     families: provider.families as string[],


### PR DESCRIPTION
## Problem
After signing in to Grok via device-code OAuth, the xAI provider page showed the green "Grok is connected via your xAI account" card **and** a red "✗ No API key configured" from **Test connection** — confusing and looks broken.

Root cause: `testProviderAuth` only checks the **inference api_key** path (`secretRef`). Grok's OAuth credential lives in `cachedToken` (the `~/.grok/auth.json` blob used for **Build Studio dispatch**), so the test reported "no API key" even though the OAuth connection is real and working.

## Fix
`testProviderAuth` now short-circuits for a Grok provider (`cliEngine="grok"` + `supportedAuthMethods` includes `oauth2_device`) that has the OAuth dispatch credential but no API key — returning `ok:true` with:
> "Connected via your xAI account (OAuth). The Grok build engine is ready — an API key is optional and only needed for chat/inference."

The UI already renders `ok:true` as a green ✓ and advances the setup wizard, so this flips the false red error to an accurate green success.

## Verification
- The connection is genuinely real: on the live install the stored OAuth token authenticates and `grok` responds in the sandbox (`PONG`) — only the *test reporting* was wrong.
- `pnpm --filter web typecheck` clean; `ai-providers` tests **10/10** (incl. a new OAuth-grok case).

Completes the Grok OAuth UX: sign in → "Test connection" now correctly shows connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)