### PR TITLE
feat(build-engine): readiness probe + grok probe + BuildEngineState (BI-D1400AC2)

### DIFF
--- a/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
@@ -2,53 +2,36 @@
 //
 // Phase A5: Capability probe for the claude-code CLI adapter.
 //
-// Shells out to `docker exec <sandbox> claude --version` to capture the
-// installed version, then returns a populated AdapterCapabilityProfile
-// (minus the DB-managed id/probedAt/probedBy fields). The cache layer
-// in capability-profile-cache.ts wraps this and persists the result.
+// Delegates the docker-exec + version parse to the shared probeEngineReadiness
+// (Build-Engine Provisioning slice B) so all engines share one detection path,
+// then THROWS when the binary is missing — phantom capabilities would corrupt
+// routing decisions, so probe failure must surface to the cache layer rather
+// than return a stub.
 //
 // Capabilities are observed from cli-adapter.ts and the audit at
 // docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.2.
-//
-// If the CLI is missing or docker exec fails, the probe THROWS — it does not
-// return a stub. Probe failure is operationally meaningful and must surface
-// to the cache layer (and any caller) so the routing system doesn't make
-// decisions based on phantom capabilities.
 
-import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { probeEngineReadiness } from "./probe-engine-readiness";
 import type { CapabilityProbeResult } from "../capability-probe-types";
 
-const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-const PROBE_TIMEOUT_MS = 10_000;
-const VERSION_REGEX = /(\d+\.\d+\.\d+)/;
+const CLAUDE_ENGINE = {
+  engineId: "claude",
+  binary: "claude",
+  verifyCommand: "claude --version",
+  versionRegex: /(\d+\.\d+\.\d+)/,
+};
 
 export async function probeClaudeCli(): Promise<CapabilityProbeResult> {
-  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
-
-  let stdout: string;
-  try {
-    const result = (await execAsync(
-      `docker exec ${SANDBOX_CONTAINER} claude --version`,
-      { timeout: PROBE_TIMEOUT_MS },
-    )) as { stdout: string; stderr: string };
-    stdout = result.stdout ?? "";
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  const readiness = await probeEngineReadiness(CLAUDE_ENGINE);
+  if (!readiness.present || !readiness.version) {
     throw new Error(
-      `probeClaudeCli: failed to invoke 'claude --version' in sandbox '${SANDBOX_CONTAINER}': ${message}`,
-    );
-  }
-
-  const match = VERSION_REGEX.exec(stdout);
-  if (!match) {
-    throw new Error(
-      `probeClaudeCli: could not parse claude version from stdout: ${JSON.stringify(stdout)}`,
+      `probeClaudeCli: claude CLI not available in sandbox: ${readiness.error ?? "unknown error"}`,
     );
   }
 
   return {
     adapterKind: "claude-code-cli",
-    adapterVersion: `claude-code/${match[1]}`,
+    adapterVersion: `claude-code/${readiness.version}`,
 
     // Observed capabilities — see cli-adapter.ts and Claude Code feature set.
     supportsStreamingEvents: true,

--- a/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
@@ -2,8 +2,9 @@
 //
 // Phase A5: Capability probe for the codex CLI adapter.
 //
-// Shells out to `docker exec <sandbox> codex --version` to capture the
-// installed version, then returns a populated AdapterCapabilityProfile shape.
+// Delegates the docker-exec + version parse to the shared probeEngineReadiness
+// (Build-Engine Provisioning slice B) so all engines share one detection path,
+// then THROWS when the binary is missing.
 //
 // Capabilities are observed from codex-cli-adapter.ts and the JSONL audit at
 // docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md.
@@ -11,44 +12,28 @@
 // `knownDegradations` carries the two documented silent-failure modes:
 //   - openai/codex#15451: --json events silently dropped when MCP active
 //   - openai/codex#4776: schema rename (item_type→type, assistant_message→agent_message)
-//
-// These let A6's capability-aware fallback reason about Codex limitations
-// honestly instead of trusting an aspirational booleans table.
 
-import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { probeEngineReadiness } from "./probe-engine-readiness";
 import type { CapabilityProbeResult } from "../capability-probe-types";
 
-const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-const PROBE_TIMEOUT_MS = 10_000;
-const VERSION_REGEX = /(\d+\.\d+\.\d+)/;
+const CODEX_ENGINE = {
+  engineId: "codex",
+  binary: "codex",
+  verifyCommand: "codex --version",
+  versionRegex: /(\d+\.\d+\.\d+)/,
+};
 
 export async function probeCodexCli(): Promise<CapabilityProbeResult> {
-  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
-
-  let stdout: string;
-  try {
-    const result = (await execAsync(
-      `docker exec ${SANDBOX_CONTAINER} codex --version`,
-      { timeout: PROBE_TIMEOUT_MS },
-    )) as { stdout: string; stderr: string };
-    stdout = result.stdout ?? "";
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  const readiness = await probeEngineReadiness(CODEX_ENGINE);
+  if (!readiness.present || !readiness.version) {
     throw new Error(
-      `probeCodexCli: failed to invoke 'codex --version' in sandbox '${SANDBOX_CONTAINER}': ${message}`,
-    );
-  }
-
-  const match = VERSION_REGEX.exec(stdout);
-  if (!match) {
-    throw new Error(
-      `probeCodexCli: could not parse codex version from stdout: ${JSON.stringify(stdout)}`,
+      `probeCodexCli: codex CLI not available in sandbox: ${readiness.error ?? "unknown error"}`,
     );
   }
 
   return {
     adapterKind: "codex-cli",
-    adapterVersion: `codex-cli/${match[1]}`,
+    adapterVersion: `codex-cli/${readiness.version}`,
 
     // Per audit Q1 + JSONL probe evidence:
     supportsStreamingEvents: true, // --json

--- a/apps/web/lib/routing/capability-probes/probe-engine-readiness.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-engine-readiness.test.ts
@@ -1,0 +1,103 @@
+// apps/web/lib/routing/capability-probes/probe-engine-readiness.test.ts
+//
+// Test-first spec for the non-throwing engine readiness probe.
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockExec = vi.fn();
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const result = mockExec(cmd);
+      if (result instanceof Promise) {
+        result
+          .then((resolved: { stdout: string; stderr: string }) => cb(null, resolved))
+          .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+      } else {
+        cb(new Error("mockExec must return a Promise"), { stdout: "", stderr: "" });
+      }
+    },
+  }),
+  lazyUtil: () => ({
+    promisify:
+      (fn: Function) =>
+      (...args: unknown[]) =>
+        new Promise((resolve, reject) => {
+          fn(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        }),
+  }),
+}));
+
+import { probeEngineReadiness, type EngineProbeConfig } from "./probe-engine-readiness";
+
+const GROK: EngineProbeConfig = {
+  engineId: "grok",
+  binary: "grok",
+  verifyCommand: "grok --version",
+  versionRegex: /(\d+\.\d+\.\d+)/,
+};
+
+describe("probeEngineReadiness", () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  it("returns present=false WITHOUT throwing when the binary is absent (docker exec rejects)", async () => {
+    mockExec.mockRejectedValueOnce(new Error("OCI runtime exec failed: grok: executable file not found"));
+
+    const result = await probeEngineReadiness(GROK);
+
+    expect(result.present).toBe(false);
+    expect(result.version).toBeNull();
+    expect(result.engineId).toBe("grok");
+    expect(result.error).toBeTruthy();
+    expect(typeof result.probedAt).toBe("string");
+  });
+
+  it("returns present=true with the parsed version when the binary responds", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "grok 1.2.3\n", stderr: "" });
+
+    const result = await probeEngineReadiness(GROK);
+
+    expect(result.present).toBe(true);
+    expect(result.version).toBe("1.2.3");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns present=false with an error when stdout has no parseable version (does NOT throw)", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "no version here\n", stderr: "" });
+
+    const result = await probeEngineReadiness(GROK);
+
+    expect(result.present).toBe(false);
+    expect(result.version).toBeNull();
+    expect(result.error).toMatch(/parse/i);
+  });
+
+  it("runs docker exec against the sandbox with the engine's verify command", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "grok 1.2.3\n", stderr: "" });
+
+    await probeEngineReadiness(GROK);
+
+    const cmd = mockExec.mock.calls[0]?.[0] as string;
+    expect(cmd).toMatch(/docker exec/);
+    expect(cmd).toMatch(/grok --version/);
+  });
+
+  it("accepts a string versionRegex", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "v0.4.1\n", stderr: "" });
+
+    const result = await probeEngineReadiness({ ...GROK, versionRegex: "([0-9.]+)" });
+
+    expect(result.present).toBe(true);
+    expect(result.version).toBe("0.4.1");
+  });
+});

--- a/apps/web/lib/routing/capability-probes/probe-engine-readiness.ts
+++ b/apps/web/lib/routing/capability-probes/probe-engine-readiness.ts
@@ -1,0 +1,98 @@
+// apps/web/lib/routing/capability-probes/probe-engine-readiness.ts
+//
+// Build-Engine Provisioning (EP-2D477458) — slice B, the readiness detection
+// layer.
+//
+// A NON-throwing readiness probe shared by all CLI build engines. Unlike the
+// capability probes (probe-claude-cli / probe-codex-cli), which THROW when a
+// binary is missing because phantom capabilities would corrupt routing, this
+// returns a structured result: { present, version, ... } and NEVER throws. It
+// is the safe way to answer "is engine X installed in the sandbox?" for UX
+// badges, the Coworker MCP surface, and provisioning reconciliation.
+//
+// Design: the engine descriptor is passed as a PARAMETER (DB-free hot path) so
+// probing never depends on DB availability or a per-probe lookup. Persisting
+// the result to BuildEngineState is a separate caller responsibility — see
+// persist-engine-readiness.ts.
+//
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Minimal engine descriptor needed to probe presence. Mirrors the fields the
+ * BuildEngine registry (build-engines.json / BuildEngine model) carries, but is
+ * passed by value so probing stays DB-free.
+ */
+export type EngineProbeConfig = {
+  /** Short engine id, e.g. "claude" | "codex" | "grok". */
+  engineId: string;
+  /** Executable name, used only for messaging. */
+  binary: string;
+  /** Full verify command argument string, e.g. "claude --version". */
+  verifyCommand: string;
+  /** Regex (string or RegExp) used to extract the version from stdout. */
+  versionRegex: string | RegExp;
+};
+
+/** Non-throwing readiness result. `present` is the only field callers must trust. */
+export type EngineReadiness = {
+  engineId: string;
+  present: boolean;
+  version: string | null;
+  /** ISO timestamp of the probe. */
+  probedAt: string;
+  /** Populated only when present=false, for diagnostics. */
+  error?: string;
+};
+
+/**
+ * Probe whether `engine` is installed and responding in the sandbox. Runs
+ * `docker exec <sandbox> <verifyCommand>` and parses the version. Catches every
+ * failure (missing binary, docker error, unparseable output) and returns
+ * present=false — it never throws.
+ */
+export async function probeEngineReadiness(engine: EngineProbeConfig): Promise<EngineReadiness> {
+  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
+  const probedAt = new Date().toISOString();
+  const regex =
+    typeof engine.versionRegex === "string" ? new RegExp(engine.versionRegex) : engine.versionRegex;
+
+  let stdout: string;
+  try {
+    const result = (await execAsync(`docker exec ${SANDBOX_CONTAINER} ${engine.verifyCommand}`, {
+      timeout: PROBE_TIMEOUT_MS,
+    })) as { stdout: string; stderr: string };
+    stdout = result.stdout ?? "";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      engineId: engine.engineId,
+      present: false,
+      version: null,
+      probedAt,
+      error: `'${engine.verifyCommand}' failed in sandbox '${SANDBOX_CONTAINER}': ${message}`,
+    };
+  }
+
+  const match = regex.exec(stdout);
+  if (!match) {
+    return {
+      engineId: engine.engineId,
+      present: false,
+      version: null,
+      probedAt,
+      error: `could not parse ${engine.binary} version from stdout: ${JSON.stringify(stdout)}`,
+    };
+  }
+
+  return {
+    engineId: engine.engineId,
+    present: true,
+    version: match[1] ?? match[0],
+    probedAt,
+  };
+}

--- a/apps/web/lib/routing/capability-probes/probe-grok-cli.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-grok-cli.test.ts
@@ -1,0 +1,78 @@
+// apps/web/lib/routing/capability-probes/probe-grok-cli.test.ts
+//
+// Test-first spec for the grok CLI capability probe.
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockExec = vi.fn();
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const result = mockExec(cmd);
+      if (result instanceof Promise) {
+        result
+          .then((resolved: { stdout: string; stderr: string }) => cb(null, resolved))
+          .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+      } else {
+        cb(new Error("mockExec must return a Promise"), { stdout: "", stderr: "" });
+      }
+    },
+  }),
+  lazyUtil: () => ({
+    promisify:
+      (fn: Function) =>
+      (...args: unknown[]) =>
+        new Promise((resolve, reject) => {
+          fn(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        }),
+  }),
+}));
+
+import { probeGrokCli } from "./probe-grok-cli";
+
+describe("probeGrokCli", () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  it("throws when the grok binary is absent (preserves throw-on-missing routing contract)", async () => {
+    mockExec.mockRejectedValueOnce(new Error("OCI runtime exec failed: grok: not found"));
+
+    await expect(probeGrokCli()).rejects.toThrow(/grok/i);
+  });
+
+  it("throws when stdout has no parseable version", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "no version here\n", stderr: "" });
+
+    await expect(probeGrokCli()).rejects.toThrow();
+  });
+
+  it("parses the version and returns the grok-cli profile when present", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "grok 1.2.3\n", stderr: "" });
+
+    const profile = await probeGrokCli();
+
+    expect(profile.adapterKind).toBe("grok-cli");
+    expect(profile.adapterVersion).toBe("grok-cli/1.2.3");
+    expect(profile.maxInteractiveLatencyMs).toBe(600_000);
+    expect(profile.supportedAuthModes).toEqual(expect.arrayContaining(["api-key"]));
+  });
+
+  it("invokes docker exec against the sandbox container", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "grok 1.2.3\n", stderr: "" });
+
+    await probeGrokCli();
+
+    const cmd = mockExec.mock.calls[0]?.[0] as string;
+    expect(cmd).toMatch(/docker exec/);
+    expect(cmd).toMatch(/grok --version/);
+  });
+});

--- a/apps/web/lib/routing/capability-probes/probe-grok-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-grok-cli.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/routing/capability-probes/probe-grok-cli.ts
+//
+// Capability probe for the grok CLI adapter (xAI), added with Build-Engine
+// Provisioning slice B. Delegates the docker-exec + version parse to the shared
+// probeEngineReadiness, then THROWS when the binary is missing — preserving the
+// same throw-on-missing routing contract as probe-claude-cli / probe-codex-cli.
+//
+// NOTE: the capability flags below are PROVISIONAL conservative defaults. Grok
+// CLI runs headless (`grok -p`) and has no capability audit yet; they are set
+// false-by-default so routing never over-promises a grok capability. Refine
+// once a grok adapter audit exists (follow-up to EP-GROK-001).
+//
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { probeEngineReadiness } from "./probe-engine-readiness";
+import type { CapabilityProbeResult } from "../capability-probe-types";
+
+const GROK_ENGINE = {
+  engineId: "grok",
+  binary: "grok",
+  verifyCommand: "grok --version",
+  versionRegex: /(\d+\.\d+\.\d+)/,
+};
+
+export async function probeGrokCli(): Promise<CapabilityProbeResult> {
+  const readiness = await probeEngineReadiness(GROK_ENGINE);
+  if (!readiness.present || !readiness.version) {
+    throw new Error(
+      `probeGrokCli: grok CLI not available in sandbox: ${readiness.error ?? "unknown error"}`,
+    );
+  }
+
+  return {
+    adapterKind: "grok-cli",
+    adapterVersion: `grok-cli/${readiness.version}`,
+
+    // Provisional — conservative until a grok adapter audit exists.
+    supportsStreamingEvents: false,
+    supportsMcpAttach: false,
+    supportsMcpAttachPerInvoke: false,
+    supportsSubagents: false,
+    supportsHooks: false,
+    supportsPlanState: false,
+    supportsTodoState: false,
+    supportsWebFetch: false,
+    supportsWebSearch: false,
+    supportsSessionResume: false,
+    supportsExtendedThinking: false,
+    supportsOutputSchema: false,
+
+    maxInteractiveLatencyMs: 600_000,
+    supportedAuthModes: ["api-key"],
+    knownDegradations: null,
+  };
+}

--- a/apps/web/lib/routing/persist-engine-readiness.test.ts
+++ b/apps/web/lib/routing/persist-engine-readiness.test.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/routing/persist-engine-readiness.test.ts
+//
+// Test-first spec for persisting engine readiness to BuildEngineState.
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { describe, expect, it, vi } from "vitest";
+
+// Importing the module pulls in @dpf/db for the default client; stub it so the
+// test never touches a real Prisma client (we pass a mock client explicitly).
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { persistEngineReadiness } from "./persist-engine-readiness";
+import type { EngineReadiness } from "./capability-probes/probe-engine-readiness";
+
+const probedAt = "2026-06-08T00:00:00.000Z";
+
+describe("persistEngineReadiness", () => {
+  it("upserts present=true with the version and lastProbedAt", async () => {
+    const upsert = vi.fn().mockResolvedValue(undefined);
+    const readiness: EngineReadiness = {
+      engineId: "grok",
+      present: true,
+      version: "1.2.3",
+      probedAt,
+    };
+
+    await persistEngineReadiness(readiness, { buildEngineState: { upsert } });
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const arg = upsert.mock.calls[0]?.[0];
+    expect(arg.where).toEqual({ engineId: "grok" });
+    expect(arg.create.present).toBe(true);
+    expect(arg.create.version).toBe("1.2.3");
+    expect(arg.create.lastProbedAt).toEqual(new Date(probedAt));
+    expect(arg.update.present).toBe(true);
+  });
+
+  it("upserts present=false with a null version when the engine is absent", async () => {
+    const upsert = vi.fn().mockResolvedValue(undefined);
+    const readiness: EngineReadiness = {
+      engineId: "grok",
+      present: false,
+      version: null,
+      probedAt,
+      error: "not found",
+    };
+
+    await persistEngineReadiness(readiness, { buildEngineState: { upsert } });
+
+    const arg = upsert.mock.calls[0]?.[0];
+    expect(arg.create.present).toBe(false);
+    expect(arg.create.version).toBeNull();
+    expect(arg.update.version).toBeNull();
+  });
+});

--- a/apps/web/lib/routing/persist-engine-readiness.ts
+++ b/apps/web/lib/routing/persist-engine-readiness.ts
@@ -1,0 +1,52 @@
+// apps/web/lib/routing/persist-engine-readiness.ts
+//
+// Build-Engine Provisioning (EP-2D477458) — slice B.
+//
+// Persists an EngineReadiness result to BuildEngineState. Deliberately SEPARATE
+// from probeEngineReadiness so the probe hot path stays DB-free (architecture
+// advisory): callers that want to record an outcome call this explicitly.
+//
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 1a, slice B)
+
+import { prisma } from "@dpf/db";
+import type { EngineReadiness } from "./capability-probes/probe-engine-readiness";
+
+/**
+ * Structural client shape — avoids coupling this module (and its test) to the
+ * generated Prisma client surface, mirroring sync-engine-registry.ts.
+ */
+type PersistEngineStateClient = {
+  buildEngineState: {
+    upsert(args: {
+      where: { engineId: string };
+      create: { engineId: string; present: boolean; version: string | null; lastProbedAt: Date };
+      update: { present: boolean; version: string | null; lastProbedAt: Date };
+    }): Promise<unknown>;
+  };
+};
+
+/**
+ * Upsert the latest readiness for an engine into BuildEngineState. Never sets
+ * the provisioning fields (lastProvisionedAt/recipeApplied/desired/provisionedBy)
+ * — those belong to the provision action, not a readiness probe.
+ */
+export async function persistEngineReadiness(
+  readiness: EngineReadiness,
+  client: PersistEngineStateClient = prisma as unknown as PersistEngineStateClient,
+): Promise<void> {
+  const lastProbedAt = new Date(readiness.probedAt);
+  await client.buildEngineState.upsert({
+    where: { engineId: readiness.engineId },
+    create: {
+      engineId: readiness.engineId,
+      present: readiness.present,
+      version: readiness.version,
+      lastProbedAt,
+    },
+    update: {
+      present: readiness.present,
+      version: readiness.version,
+      lastProbedAt,
+    },
+  });
+}

--- a/packages/db/prisma/migrations/20260608000000_add_build_engine_state/migration.sql
+++ b/packages/db/prisma/migrations/20260608000000_add_build_engine_state/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "build_engine_state" (
+    "engineId" TEXT NOT NULL,
+    "present" BOOLEAN NOT NULL DEFAULT false,
+    "version" TEXT,
+    "lastProbedAt" TIMESTAMP(3),
+    "lastProvisionedAt" TIMESTAMP(3),
+    "recipeApplied" TEXT,
+    "desired" TEXT NOT NULL DEFAULT 'present',
+    "provisionedBy" TEXT,
+
+    CONSTRAINT "build_engine_state_pkey" PRIMARY KEY ("engineId")
+);
+
+-- AddForeignKey
+ALTER TABLE "build_engine_state" ADD CONSTRAINT "build_engine_state_engineId_fkey" FOREIGN KEY ("engineId") REFERENCES "build_engine"("engineId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10326,6 +10326,21 @@ model BuildEngine {
   recipes         Json
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+  state           BuildEngineState?
 
   @@map("build_engine")
+}
+
+model BuildEngineState {
+  engineId          String      @id
+  engine            BuildEngine @relation(fields: [engineId], references: [engineId], onDelete: Cascade)
+  present           Boolean     @default(false)
+  version           String?
+  lastProbedAt      DateTime?
+  lastProvisionedAt DateTime?
+  recipeApplied     String?
+  desired           String      @default("present")
+  provisionedBy     String?
+
+  @@map("build_engine_state")
 }


### PR DESCRIPTION
## What

Phase 1a **slice B** of **EP-2D477458 — Build-Engine Provisioning**: the engine readiness **detection** layer, building on slice A's `BuildEngine` registry (#1630).

- **`probeEngineReadiness(engine)`** — a **non-throwing** readiness probe shared by all engines. Runs `docker exec <sandbox> <verifyCommand>`, parses the version, returns `{ engineId, present, version, probedAt, error? }`, and **never throws**. Engine descriptor passed by value → the probe stays **DB-free** (architecture advisory).
- **`probe-grok-cli`** — new grok probe delegating to the shared core, re-throwing when absent (preserves the throw-on-missing routing contract). `grok-cli` is already a registered `ExecutionAdapterKind` (EP-GROK-001); capability flags are conservative/provisional pending a grok audit.
- **`probe-claude-cli` / `probe-codex-cli`** refactored to delegate to the shared readiness core — behavior, version format, capabilities, and codex `knownDegradations` preserved; **their existing tests are unchanged and still pass**.
- **`BuildEngineState`** model (1:1 with `BuildEngine`, `engineId` PK + FK) + migration: `present`, `version`, `lastProbedAt`, `lastProvisionedAt`, `recipeApplied`, `desired`, `provisionedBy`.
- **`persistEngineReadiness(result)`** — upserts `BuildEngineState`, kept **out** of the probe hot path so probing never depends on DB availability.

## Test-first
New specs for `probeEngineReadiness` (absent→`present:false` no-throw / present→version / unparseable→error / string regex), `probeGrokCli` (throws when absent, parses version), and `persistEngineReadiness` (upsert shape for present/absent). Existing claude/codex probe tests are untouched and assert the refactor preserved behavior.

## Provenance
Built **directly as a PR** rather than through Build Studio: the BS pipeline and portal self-update were saturated/unreliable under concurrent load this session (the same contention that's tracked for capacity/admission-control work). Slice A's code was BS-built; this slice is hand-written to the same spec with CI as the test gate. Follow-up: phase 2 (governed provision action + MCP tools + readiness-gated Enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)