### PR TITLE
feat(build-engine): per-engine readiness badge on Build Studio config (Phase 1b)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { headers } from "next/headers";
 import { getProviders } from "@/lib/inference/ai-provider-data";
+import { prisma } from "@dpf/db";
 import { getBuildStudioConfig } from "@/lib/integrate/build-studio-config";
 import { getContributorMcpReadiness, type ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import {
@@ -40,13 +41,32 @@ export default async function BuildStudioPage() {
   const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
   const baseUrl = `${proto}://${host}`;
 
-  const [allProviders, config, contributorMcpReadiness] = await Promise.all([
+  const [allProviders, config, contributorMcpReadiness, engineStates] = await Promise.all([
     getProviders(),
     getBuildStudioConfig(),
     user
       ? getContributorMcpReadiness(user.id, { probe: false })
       : Promise.resolve(unauthenticatedReadiness()),
+    prisma.buildEngine.findMany({
+      select: { engineId: true, state: { select: { present: true, version: true, lastProbedAt: true } } },
+    }),
   ]);
+
+  // Per-engine readiness from the last probe (BuildEngineState) — drives the
+  // present/absent badge so an engine that is selectable but not actually
+  // installed in the sandbox shows "not installed" instead of silently failing
+  // at dispatch. Build-Engine Provisioning (EP-2D477458) Phase 1b.
+  const engineReadiness: Record<
+    string,
+    { present: boolean | null; version: string | null; lastProbedAt: string | null }
+  > = {};
+  for (const e of engineStates) {
+    engineReadiness[e.engineId] = {
+      present: e.state?.present ?? null,
+      version: e.state?.version ?? null,
+      lastProbedAt: e.state?.lastProbedAt ? e.state.lastProbedAt.toISOString() : null,
+    };
+  }
 
   // Dynamic: group providers by cliEngine field instead of hardcoded IDs
   const claudeProviders = allProviders.filter(p =>
@@ -102,6 +122,7 @@ export default async function BuildStudioPage() {
           costNotes: p.provider.costPerformanceNotes,
         }))}
         contributorMcpReadiness={contributorMcpReadiness}
+        engineReadiness={engineReadiness}
         baseUrl={baseUrl}
         canWrite={canWrite}
       />

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -6,6 +6,7 @@ import { saveBuildStudioConfig } from "@/lib/actions/build-studio";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
 import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
+import { engineReadinessBadgeContent, ENGINE_READINESS_TONE_COLOR } from "./engine-readiness-badge";
 import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
 
 type ProviderOption = {
@@ -16,12 +17,20 @@ type ProviderOption = {
   costNotes: string | null;
 };
 
+type EngineReadinessBadge = {
+  present: boolean | null;
+  version: string | null;
+  lastProbedAt: string | null;
+};
+
 type Props = {
   config: BuildStudioDispatchConfig;
   claudeProviders: ProviderOption[];
   codexProviders: ProviderOption[];
   grokProviders: ProviderOption[];
   contributorMcpReadiness: ContributorMcpReadiness;
+  /** Per-engine sandbox readiness (engineId → last probe), keyed "claude"|"codex"|"grok". */
+  engineReadiness?: Record<string, EngineReadinessBadge>;
   baseUrl: string;
   canWrite: boolean;
 };
@@ -66,6 +75,7 @@ export function BuildStudioConfigForm({
   codexProviders,
   grokProviders,
   contributorMcpReadiness,
+  engineReadiness,
   baseUrl,
   canWrite,
 }: Props) {
@@ -168,6 +178,7 @@ export function BuildStudioConfigForm({
             label="Claude Code CLI"
             desc="Anthropic models"
             unconfiguredMsg={!hasClaudeCreds ? "No Anthropic credentials found." : undefined}
+            readiness={engineReadiness?.claude}
           />
           <ProviderRadio
             name="provider"
@@ -178,6 +189,7 @@ export function BuildStudioConfigForm({
             label="Codex CLI"
             desc="OpenAI models"
             unconfiguredMsg={!hasCodexCreds ? "No OpenAI credentials found." : undefined}
+            readiness={engineReadiness?.codex}
           />
           <ProviderRadio
             name="provider"
@@ -188,6 +200,7 @@ export function BuildStudioConfigForm({
             label="Grok CLI (Preview)"
             desc="xAI models · headless grok -p"
             unconfiguredMsg={!hasGrokCreds ? "No xAI credentials found." : undefined}
+            readiness={engineReadiness?.grok}
           />
           <ProviderRadio
             name="provider"
@@ -387,7 +400,28 @@ export function BuildStudioConfigForm({
 
 // ─── Sub-components ──────────────────────────────────────────────────────────
 
-function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg }: {
+function EngineReadinessBadgeView({ readiness }: { readiness: EngineReadinessBadge }) {
+  const { icon, text, tone } = engineReadinessBadgeContent(readiness.present, readiness.version);
+  return (
+    <div
+      role="status"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        marginTop: 3,
+        fontSize: 10,
+        fontWeight: 600,
+        color: ENGINE_READINESS_TONE_COLOR[tone],
+      }}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg, readiness }: {
   name: string;
   value: string;
   checked: boolean;
@@ -396,6 +430,7 @@ function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, 
   label: string;
   desc: string;
   unconfiguredMsg?: string;
+  readiness?: EngineReadinessBadge;
 }) {
   return (
     <label style={{
@@ -413,6 +448,7 @@ function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, 
       <div>
         <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>{label}</div>
         <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{desc}</div>
+        {readiness && <EngineReadinessBadgeView readiness={readiness} />}
         {unconfiguredMsg && (
           <div style={{ fontSize: 10, color: "var(--dpf-warning)", marginTop: 2 }}>
             {unconfiguredMsg}{" "}

--- a/apps/web/components/platform/engine-readiness-badge.test.ts
+++ b/apps/web/components/platform/engine-readiness-badge.test.ts
@@ -1,0 +1,31 @@
+// apps/web/components/platform/engine-readiness-badge.test.ts
+import { describe, expect, it } from "vitest";
+import { engineReadinessBadgeContent } from "./engine-readiness-badge";
+
+describe("engineReadinessBadgeContent", () => {
+  it("present with a version → installed (success) and includes the version", () => {
+    const r = engineReadinessBadgeContent(true, "1.2.3");
+    expect(r.tone).toBe("success");
+    expect(r.icon).toBe("✓");
+    expect(r.text).toContain("1.2.3");
+  });
+
+  it("present without a version → 'Installed in sandbox'", () => {
+    const r = engineReadinessBadgeContent(true, null);
+    expect(r.tone).toBe("success");
+    expect(r.text).toBe("Installed in sandbox");
+  });
+
+  it("absent → not installed (warning)", () => {
+    const r = engineReadinessBadgeContent(false, null);
+    expect(r.tone).toBe("warning");
+    expect(r.icon).toBe("✗");
+    expect(r.text).toMatch(/not installed/i);
+  });
+
+  it("never probed (null) → muted, not probed", () => {
+    const r = engineReadinessBadgeContent(null, null);
+    expect(r.tone).toBe("muted");
+    expect(r.text).toMatch(/not yet probed/i);
+  });
+});

--- a/apps/web/components/platform/engine-readiness-badge.ts
+++ b/apps/web/components/platform/engine-readiness-badge.ts
@@ -1,0 +1,36 @@
+// apps/web/components/platform/engine-readiness-badge.ts
+//
+// Pure state→badge-content mapping for the Build Studio engine readiness badge
+// (Build-Engine Provisioning, EP-2D477458, Phase 1b). Kept out of the
+// "use client" form component so it is unit-testable without a React renderer.
+
+export type EngineReadinessTone = "success" | "warning" | "muted";
+
+/**
+ * Map a probed engine's `present` state (+ optional version) to the badge's
+ * icon, text, and tone. `present === null` means "never probed".
+ *
+ * State is conveyed by text + icon, never by color alone (accessibility).
+ */
+export function engineReadinessBadgeContent(
+  present: boolean | null,
+  version: string | null,
+): { icon: string; text: string; tone: EngineReadinessTone } {
+  if (present === true) {
+    return {
+      icon: "✓",
+      text: version ? `Installed in sandbox · v${version}` : "Installed in sandbox",
+      tone: "success",
+    };
+  }
+  if (present === false) {
+    return { icon: "✗", text: "Not installed in sandbox", tone: "warning" };
+  }
+  return { icon: "•", text: "Sandbox readiness not yet probed", tone: "muted" };
+}
+
+export const ENGINE_READINESS_TONE_COLOR: Record<EngineReadinessTone, string> = {
+  success: "var(--dpf-success)",
+  warning: "var(--dpf-warning)",
+  muted: "var(--dpf-muted)",
+};


### PR DESCRIPTION
## What
The **human-facing half of Phase 1b** readiness surfacing (EP-2D477458), pairing with the `get_build_engine_readiness` MCP tool (#1661). The Build Studio config page now shows a per-engine badge from the last probe (`BuildEngineState`):

- present → **Installed in sandbox · vX.Y.Z** (success)
- absent → **Not installed in sandbox** (warning)
- never probed → **Sandbox readiness not yet probed** (muted)

So Grok — selectable but possibly not installed — now reads "Not installed in sandbox" instead of black-boxing the sandbox and failing at dispatch with `grok: not found`.

## Changes
- `page.tsx`: additive `prisma.buildEngine` query (+ `state`), passed as `engineReadiness` to the form.
- `BuildStudioConfigForm`: optional `engineReadiness` prop + badge on the claude/codex/grok rows. **State conveyed by text + icon, never color alone** (accessibility).
- Pure `engine-readiness-badge.ts` (no `"use client"`) for the state→content mapping, **unit-tested** without a React renderer.

Built in an **isolated worktree** (a concurrent session was sharing the prior one — the contention the recent admission-control BI tracks). CI runs typecheck + tests.

Follow-up: a "Re-check" button calling `get_build_engine_readiness({refresh:true})`, then phase 2 (governed provision action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)