### PR TITLE
feat(build-engine): governed provision action + provision_build_engine MCP tool (Phase 2)

### DIFF
--- a/apps/web/lib/integrate/build-engine-provision.test.ts
+++ b/apps/web/lib/integrate/build-engine-provision.test.ts
@@ -1,0 +1,59 @@
+// apps/web/lib/integrate/build-engine-provision.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  selectRecipe,
+  buildInstallCommand,
+  type EngineRecipe,
+} from "./build-engine-provision";
+
+describe("selectRecipe", () => {
+  const npm: EngineRecipe = { method: "npm-global", package: "p", muslSafe: true, requiresEgress: true, priority: 10 };
+  const prestaged: EngineRecipe = { method: "prestaged-binary", stagedPath: "/opt/x", muslSafe: true, requiresEgress: false, priority: 20 };
+  const native: EngineRecipe = { method: "curl-installer", command: "c", muslSafe: false, requiresEgress: true, priority: 5 };
+
+  it("picks the lowest-priority musl-safe recipe online", () => {
+    expect(selectRecipe([prestaged, npm], { offline: false })?.method).toBe("npm-global");
+  });
+
+  it("never picks a non-musl-safe recipe even if it has the lowest priority", () => {
+    expect(selectRecipe([native, npm], { offline: false })?.method).toBe("npm-global");
+  });
+
+  it("offline drops egress recipes and falls back to the prestaged one", () => {
+    expect(selectRecipe([npm, prestaged], { offline: true })?.method).toBe("prestaged-binary");
+  });
+
+  it("returns null when nothing is eligible", () => {
+    expect(selectRecipe([npm], { offline: true })).toBeNull(); // npm needs egress
+    expect(selectRecipe([native], { offline: false })).toBeNull(); // native not musl-safe
+    expect(selectRecipe([], { offline: false })).toBeNull();
+  });
+});
+
+describe("buildInstallCommand", () => {
+  it("npm-global builds the global install command", () => {
+    expect(buildInstallCommand({ method: "npm-global", package: "@openai/codex" }, "codex")).toBe(
+      "npm install -g @openai/codex",
+    );
+  });
+
+  it("prestaged-binary copies the staged binary into PATH", () => {
+    expect(buildInstallCommand({ method: "prestaged-binary", stagedPath: "/opt/dpf-engines/grok" }, "grok")).toBe(
+      "install -m 0755 /opt/dpf-engines/grok /usr/local/bin/grok",
+    );
+  });
+
+  it("curl-installer requires an explicit command (never blind curl|sh)", () => {
+    expect(buildInstallCommand({ method: "curl-installer" }, "grok")).toBeNull();
+    expect(buildInstallCommand({ method: "curl-installer", command: "curl x | bash" }, "grok")).toBe("curl x | bash");
+  });
+
+  it("returns null when a method is missing its required field", () => {
+    expect(buildInstallCommand({ method: "npm-global" }, "x")).toBeNull();
+    expect(buildInstallCommand({ method: "prestaged-binary" }, "x")).toBeNull();
+  });
+
+  it("an explicit command overrides the npm-global default", () => {
+    expect(buildInstallCommand({ method: "npm-global", package: "p", command: "custom" }, "x")).toBe("custom");
+  });
+});

--- a/apps/web/lib/integrate/build-engine-provision.ts
+++ b/apps/web/lib/integrate/build-engine-provision.ts
@@ -1,0 +1,188 @@
+// apps/web/lib/integrate/build-engine-provision.ts
+//
+// Build-Engine Provisioning (EP-2D477458) — Phase 2, the governed provision
+// action. Installs a build-dispatch engine into the RUNNING sandbox from its
+// registry recipe, idempotently, and verifies by re-probing.
+//
+// Governance:
+//   - Side-effecting: runs an install command inside the sandbox. Callers MUST
+//     authorize first — the MCP tool via the sandbox_execute grant, a future
+//     server action via requireManageProviders(). This module trusts the
+//     `actorUserId` it is given (records it as provisionedBy) and does not do
+//     its own session auth, so it works from both call paths.
+//   - Runs via execInSandbox (NOT the agent-facing run_sandbox_command, whose
+//     blocklist intentionally rejects `curl | sh`). Recipe commands come from
+//     the operator-curated registry (build-engines.json), never user input.
+//   - structural-verification-is-not-functional: "ran the installer" != "binary
+//     present". Success requires a fresh probe to confirm the binary responds.
+//
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 2)
+
+import { prisma } from "@dpf/db";
+
+import { execInSandbox } from "@/lib/integrate/sandbox/sandbox";
+import {
+  probeEngineReadiness,
+  type EngineProbeConfig,
+} from "@/lib/routing/capability-probes/probe-engine-readiness";
+import { persistEngineReadiness } from "@/lib/routing/persist-engine-readiness";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+
+export type EngineRecipe = {
+  method: "npm-global" | "prestaged-binary" | "curl-installer";
+  /** npm-global: the package to install globally. */
+  package?: string;
+  /** prestaged-binary: path of a binary baked into the image to copy into PATH. */
+  stagedPath?: string;
+  /** Explicit shell command (required for curl-installer; optional override otherwise). */
+  command?: string;
+  /** false ⇒ never run on the musl/alpine sandbox base. */
+  muslSafe?: boolean;
+  /** true ⇒ needs network egress (skipped in offline/air-gapped mode). */
+  requiresEgress?: boolean;
+  /** Lower runs first. */
+  priority?: number;
+};
+
+export type ProvisionOutcome =
+  | { kind: "already-present"; engineId: string; version: string | null }
+  | { kind: "provisioned"; engineId: string; version: string | null; recipe: string }
+  | { kind: "no-recipe"; engineId: string; reason: string }
+  | { kind: "verify-failed"; engineId: string; recipe: string; error: string }
+  | { kind: "error"; engineId: string; error: string };
+
+/**
+ * Pick the first recipe that can run here: musl-safe, and (when offline) not
+ * egress-dependent, ordered by priority. Pure — unit-tested.
+ */
+export function selectRecipe(
+  recipes: EngineRecipe[],
+  opts: { offline: boolean },
+): EngineRecipe | null {
+  return (
+    [...recipes]
+      .filter((r) => r.muslSafe !== false)
+      .filter((r) => !opts.offline || r.requiresEgress !== true)
+      .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))[0] ?? null
+  );
+}
+
+/**
+ * Build the sandbox shell command for a recipe, or null when it is missing the
+ * fields its method requires. Pure — unit-tested. curl-installer never falls
+ * back to a blind `curl | sh`: it requires an explicit, registry-curated
+ * `command` (installers vary and often need post-install fixups).
+ */
+export function buildInstallCommand(recipe: EngineRecipe, binary: string): string | null {
+  switch (recipe.method) {
+    case "npm-global":
+      return recipe.command ?? (recipe.package ? `npm install -g ${recipe.package}` : null);
+    case "prestaged-binary":
+      return (
+        recipe.command ??
+        (recipe.stagedPath
+          ? `install -m 0755 ${recipe.stagedPath} /usr/local/bin/${binary}`
+          : null)
+      );
+    case "curl-installer":
+      return recipe.command ?? null;
+    default:
+      return null;
+  }
+}
+
+function asRecipes(value: unknown): EngineRecipe[] {
+  return Array.isArray(value) ? (value as EngineRecipe[]) : [];
+}
+
+/**
+ * Provision `engineId` into the running sandbox. Idempotent (no-op when already
+ * present), governed by the caller, verified by re-probe.
+ */
+export async function provisionBuildEngine(
+  engineId: string,
+  opts: { offline?: boolean; actorUserId: string },
+): Promise<ProvisionOutcome> {
+  const engine = await prisma.buildEngine.findUnique({
+    where: { engineId },
+    select: { engineId: true, binary: true, verifyCommand: true, versionRegex: true, recipes: true },
+  });
+  if (!engine) {
+    return {
+      kind: "error",
+      engineId,
+      error: `Unknown engine '${engineId}'. Run sync-engine-registry to populate the BuildEngine catalog.`,
+    };
+  }
+
+  const probeConfig: EngineProbeConfig = {
+    engineId: engine.engineId,
+    binary: engine.binary,
+    verifyCommand: engine.verifyCommand,
+    versionRegex: engine.versionRegex,
+  };
+
+  // Idempotency — already installed?
+  const before = await probeEngineReadiness(probeConfig);
+  await persistEngineReadiness(before).catch(() => undefined);
+  if (before.present) {
+    return { kind: "already-present", engineId, version: before.version };
+  }
+
+  const recipe = selectRecipe(asRecipes(engine.recipes), { offline: opts.offline ?? false });
+  if (!recipe) {
+    return {
+      kind: "no-recipe",
+      engineId,
+      reason: opts.offline
+        ? "no offline (no-egress) recipe available for this engine"
+        : "no musl-safe recipe available for this engine",
+    };
+  }
+
+  const command = buildInstallCommand(recipe, engine.binary);
+  if (!command) {
+    return {
+      kind: "no-recipe",
+      engineId,
+      reason: `recipe method '${recipe.method}' is missing the fields it needs to run`,
+    };
+  }
+
+  try {
+    await execInSandbox(SANDBOX_CONTAINER, command);
+  } catch (err) {
+    return {
+      kind: "error",
+      engineId,
+      error: `provision command failed in sandbox: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Verify by re-probing — "ran the installer" is not "binary present".
+  const after = await probeEngineReadiness(probeConfig);
+  await persistEngineReadiness(after).catch(() => undefined);
+  await prisma.buildEngineState
+    .update({
+      where: { engineId },
+      data: {
+        lastProvisionedAt: new Date(),
+        recipeApplied: recipe.method,
+        provisionedBy: opts.actorUserId,
+        desired: "present",
+      },
+    })
+    .catch(() => undefined);
+
+  if (!after.present) {
+    return {
+      kind: "verify-failed",
+      engineId,
+      recipe: recipe.method,
+      error: after.error ?? "binary still not present after running the install recipe",
+    };
+  }
+
+  return { kind: "provisioned", engineId, version: after.version, recipe: recipe.method };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2321,6 +2321,25 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: "provision_build_engine",
+    description: "Install a build-dispatch engine (claude, codex, grok) into the running sandbox from its registry recipe, then verify by re-probing. Idempotent — a no-op if the engine is already present. Side-effecting: runs the install command (e.g. `npm install -g`, or the grok curl-installer) inside the sandbox, so it requires sandbox_execute. Pass offline:true to use only no-egress (prestaged-binary) recipes for air-gapped installs. Returns { kind, version, recipe }.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        engineId: { type: "string", description: "Engine to provision: 'claude' | 'codex' | 'grok'." },
+        offline: {
+          type: "boolean",
+          description: "When true, only run no-egress (prestaged-binary) recipes (air-gapped install). Default false.",
+        },
+      },
+      required: ["engineId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    buildPhases: ["ideate", "plan", "build", "review"],
+  },
+  {
     name: "get_build_engine_readiness",
     description: "Report whether each build-dispatch engine (claude, codex, grok) is present and healthy in the build sandbox. Returns per-engine { present, version, lastProbedAt, bakeInDefault } from the last probe (BuildEngineState). Pass refresh:true to live re-probe each engine (docker exec <verifyCommand>) and persist the fresh result. Use this to see engine readiness before selecting a build dispatch engine — e.g. an engine that is selectable but shows present:false would fail at runtime with 'not found'.",
     inputSchema: {
@@ -8972,6 +8991,32 @@ export async function executeTool(
         available?: unknown;
         summary?: unknown;
       });
+    }
+
+    case "provision_build_engine": {
+      const engineId = optionalString(params["engineId"]);
+      if (!engineId) {
+        return {
+          success: false,
+          error: "engineId is required.",
+          message: "Provide engineId — one of 'claude', 'codex', 'grok'.",
+        };
+      }
+      const offline = params["offline"] === true;
+      const { provisionBuildEngine } = await import("@/lib/integrate/build-engine-provision");
+      const outcome = await provisionBuildEngine(engineId, { offline, actorUserId: userId });
+      const ok = outcome.kind === "provisioned" || outcome.kind === "already-present";
+      const message =
+        outcome.kind === "provisioned"
+          ? `Provisioned ${engineId}${outcome.version ? ` v${outcome.version}` : ""} via ${outcome.recipe}; verified present in the sandbox.`
+          : outcome.kind === "already-present"
+            ? `${engineId} is already installed in the sandbox${outcome.version ? ` (v${outcome.version})` : ""}.`
+            : outcome.kind === "no-recipe"
+              ? `Cannot provision ${engineId}: ${outcome.reason}.`
+              : outcome.kind === "verify-failed"
+                ? `Ran the ${outcome.recipe} recipe for ${engineId} but it is still not present: ${outcome.error}`
+                : `Failed to provision ${engineId}: ${outcome.error}`;
+      return { success: ok, message, data: outcome };
     }
 
     case "get_build_engine_readiness": {

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -37,6 +37,12 @@ describe("TOOL_TO_GRANTS — Build / Sandbox entries", () => {
     expect(isToolAllowedByGrants("start_sandbox", [])).toBe(false);
   });
 
+  it("provision_build_engine (runs an install in the sandbox) requires sandbox_execute", () => {
+    expect(isToolAllowedByGrants("provision_build_engine", ["sandbox_execute"])).toBe(true);
+    expect(isToolAllowedByGrants("provision_build_engine", ["work_capsule_read"])).toBe(false);
+    expect(isToolAllowedByGrants("provision_build_engine", [])).toBe(false);
+  });
+
   it("start_build requires sandbox_execute", () => {
     expect(isToolAllowedByGrants("start_build", ["sandbox_execute"])).toBe(true);
     expect(isToolAllowedByGrants("start_build", ["file_read"])).toBe(false);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -432,6 +432,8 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   admin_run_command:       ["admin_write"],
 
   // Build lifecycle (sandbox-adjacent)
+  // Provisioning a build engine runs an install command inside the sandbox.
+  provision_build_engine:     ["sandbox_execute"],
   check_sandbox:              ["sandbox_execute"],
   start_sandbox:              ["sandbox_execute"],
   start_build:                ["sandbox_execute"],

--- a/packages/db/data/build-engines.json
+++ b/packages/db/data/build-engines.json
@@ -8,10 +8,11 @@
     "bakeInDefault": true,
     "recipes": [
       {
-        "method": "agentic",
+        "method": "npm-global",
+        "package": "@anthropic-ai/claude-code",
         "muslSafe": true,
         "requiresEgress": true,
-        "priority": 1
+        "priority": 10
       }
     ]
   },
@@ -21,13 +22,14 @@
       "command": "codex --version",
       "versionRegex": "([0-9.]+)"
     },
-    "bakeInDefault": false,
+    "bakeInDefault": true,
     "recipes": [
       {
-        "method": "agentic",
+        "method": "npm-global",
+        "package": "@openai/codex",
         "muslSafe": true,
         "requiresEgress": true,
-        "priority": 2
+        "priority": 10
       }
     ]
   },
@@ -40,10 +42,18 @@
     "bakeInDefault": false,
     "recipes": [
       {
-        "method": "agentic",
-        "muslSafe": false,
+        "method": "curl-installer",
+        "command": "curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash && install -m 0755 \"$(readlink -f /usr/local/bin/grok)\" /usr/local/bin/grok.bin && ln -sf /usr/local/bin/grok.bin /usr/local/bin/grok && rm -rf /root/.grok",
+        "muslSafe": true,
         "requiresEgress": true,
-        "priority": 3
+        "priority": 10
+      },
+      {
+        "method": "prestaged-binary",
+        "stagedPath": "/opt/dpf-engines/grok",
+        "muslSafe": true,
+        "requiresEgress": false,
+        "priority": 20
       }
     ]
   }


### PR DESCRIPTION
## What
Phase 2 of **EP-2D477458** — the **net-new write path**: install a dispatch engine into the *running* sandbox from its registry recipe, idempotently, verified by re-probe. Makes "select Grok → it installs → green" true without hand-editing `Dockerfile.sandbox`.

- **`provisionBuildEngine(engineId, {offline, actorUserId})`** — probe-first (no-op if present) → select recipe (musl-safe + offline/egress filters) → run via **`execInSandbox`** (not the agent-facing `run_sandbox_command`, whose blocklist rejects `curl|sh`) → **re-probe to verify** (ran-installer ≠ binary-present) → persist `BuildEngineState` + provisioning metadata. Trusts the caller's `actorUserId` (MCP grant gate / future server action authorizes).
- **`provision_build_engine` MCP tool** (`sideEffect:true`) → granted **`sandbox_execute`** (default-deny otherwise).
- **Real recipes** in `build-engines.json` — replacing the placeholder `"agentic"` method with the authoritative installs from `Dockerfile.sandbox`:
  - claude → `npm-global @anthropic-ai/claude-code`
  - codex → `npm-global @openai/codex`
  - grok → `curl-installer` (`x.ai/cli/install.sh` + the **exact permission relocation** the Dockerfile performs — the old `@xai/grok-cli` npm package never existed) + a `prestaged-binary` air-gap fallback.
- Pure helpers `selectRecipe` + `buildInstallCommand` are **unit-tested** (musl/offline selection; per-method command building; curl-installer never blind `curl|sh`).

## Safety
The action is **gated** (`sandbox_execute`), **operator/Coworker-triggered** (dormant until invoked), and **re-probe-verified** (fails gracefully as `verify-failed`). Recipe commands come from the operator-curated registry, never user input. Built in an isolated worktree; CI runs typecheck + tests.

## Follow-up
`ProvisionEngineButton` (mirroring `EnableRunnerButton`) + readiness-gated Enable; phase 3 (auto-replay reconciler + `/opt/dpf-engines` staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)