### PR TITLE
feat(build-engine): ProvisionEngineButton + provision server action (Phase 2 UI)

### DIFF
--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -7,6 +7,7 @@ import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-con
 import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 import { engineReadinessBadgeContent, ENGINE_READINESS_TONE_COLOR } from "./engine-readiness-badge";
+import { ProvisionEngineButton } from "./ProvisionEngineButton";
 import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
 
 type ProviderOption = {
@@ -179,6 +180,7 @@ export function BuildStudioConfigForm({
             desc="Anthropic models"
             unconfiguredMsg={!hasClaudeCreds ? "No Anthropic credentials found." : undefined}
             readiness={engineReadiness?.claude}
+            canProvision={canWrite}
           />
           <ProviderRadio
             name="provider"
@@ -190,6 +192,7 @@ export function BuildStudioConfigForm({
             desc="OpenAI models"
             unconfiguredMsg={!hasCodexCreds ? "No OpenAI credentials found." : undefined}
             readiness={engineReadiness?.codex}
+            canProvision={canWrite}
           />
           <ProviderRadio
             name="provider"
@@ -201,6 +204,7 @@ export function BuildStudioConfigForm({
             desc="xAI models · headless grok -p"
             unconfiguredMsg={!hasGrokCreds ? "No xAI credentials found." : undefined}
             readiness={engineReadiness?.grok}
+            canProvision={canWrite}
           />
           <ProviderRadio
             name="provider"
@@ -421,7 +425,7 @@ function EngineReadinessBadgeView({ readiness }: { readiness: EngineReadinessBad
   );
 }
 
-function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg, readiness }: {
+function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, unconfiguredMsg, readiness, canProvision }: {
   name: string;
   value: string;
   checked: boolean;
@@ -431,6 +435,7 @@ function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, 
   desc: string;
   unconfiguredMsg?: string;
   readiness?: EngineReadinessBadge;
+  canProvision?: boolean;
 }) {
   return (
     <label style={{
@@ -449,6 +454,9 @@ function ProviderRadio({ name, value, checked, onChange, disabled, label, desc, 
         <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>{label}</div>
         <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>{desc}</div>
         {readiness && <EngineReadinessBadgeView readiness={readiness} />}
+        {canProvision && readiness?.present === false && (
+          <ProvisionEngineButton engineId={value} label={value.charAt(0).toUpperCase() + value.slice(1)} />
+        )}
         {unconfiguredMsg && (
           <div style={{ fontSize: 10, color: "var(--dpf-warning)", marginTop: 2 }}>
             {unconfiguredMsg}{" "}

--- a/apps/web/components/platform/ProvisionEngineButton.tsx
+++ b/apps/web/components/platform/ProvisionEngineButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { provisionBuildEngineAction } from "@/lib/actions/build-engine-actions";
+
+type Props = {
+  /** Engine id: "claude" | "codex" | "grok". */
+  engineId: string;
+  /** Short display label, e.g. "Grok". */
+  label: string;
+};
+
+/**
+ * Inline "Provision" action for a build engine that is selectable but not
+ * installed in the sandbox (its readiness badge shows "Not installed"). Runs the
+ * engine's registry recipe via the governed provisionBuildEngineAction, then
+ * refreshes so the readiness badge re-renders — closing the
+ * "select → provision → green" loop without hand-editing Dockerfile.sandbox.
+ */
+export function ProvisionEngineButton({ engineId, label }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function handleProvision() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const outcome = await provisionBuildEngineAction(engineId);
+        if (outcome.kind === "no-recipe") {
+          setError(outcome.reason);
+        } else if (outcome.kind === "verify-failed") {
+          setError(`Still not installed after the ${outcome.recipe} recipe.`);
+        } else if (outcome.kind === "error") {
+          setError(outcome.error);
+        }
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not provision this engine.");
+      }
+    });
+  }
+
+  return (
+    <div style={{ display: "inline-flex", flexDirection: "column", gap: 2, marginTop: 4 }}>
+      <button
+        type="button"
+        onClick={handleProvision}
+        disabled={isPending}
+        style={{
+          alignSelf: "flex-start",
+          borderRadius: 4,
+          padding: "2px 8px",
+          fontSize: 10,
+          fontWeight: 600,
+          background: "var(--dpf-accent)",
+          color: "white",
+          border: "none",
+          cursor: isPending ? "wait" : "pointer",
+          opacity: isPending ? 0.6 : 1,
+        }}
+      >
+        {isPending ? `Provisioning ${label}…` : `Provision ${label} in sandbox`}
+      </button>
+      {error ? (
+        <span role="alert" style={{ fontSize: 10, color: "var(--dpf-warning)", maxWidth: "16rem" }}>
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/build-engine-actions.ts
+++ b/apps/web/lib/actions/build-engine-actions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { revalidatePath } from "next/cache";
+
+import {
+  provisionBuildEngine,
+  type ProvisionOutcome,
+} from "@/lib/integrate/build-engine-provision";
+
+/**
+ * Provision a build-dispatch engine into the running sandbox from its registry
+ * recipe (Build-Engine Provisioning, EP-2D477458, Phase 2). Operator-gated by
+ * `manage_provider_connections` — the same authority that manages provider
+ * credentials and toggles runners. Returns the structured outcome so the button
+ * can show a precise result, and revalidates the config page so the readiness
+ * badge re-renders.
+ */
+export async function provisionBuildEngineAction(
+  engineId: string,
+  offline = false,
+): Promise<ProvisionOutcome> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    throw new Error(
+      "Unauthorized: managing provider connections is required to provision build engines.",
+    );
+  }
+
+  const outcome = await provisionBuildEngine(engineId, { offline, actorUserId: user.id });
+  revalidatePath("/platform/ai/build-studio");
+  return outcome;
+}


### PR DESCRIPTION
## What
Completes Phase 2's **operator surface** for EP-2D477458 — the "select → provision → green" loop, no `Dockerfile.sandbox` edit.

- **`provisionBuildEngineAction`** server action: operator-gated by `manage_provider_connections`, calls `provisionBuildEngine`, `revalidatePath` so the readiness badge re-renders. Returns the structured outcome.
- **`ProvisionEngineButton`**: mirrors `EnableRunnerButton`; runs the action, shows a precise error on `no-recipe` / `verify-failed` / `error`, refreshes on success.
- Wired into the Build Studio config page: each engine whose badge shows **"Not installed in sandbox"** now gets a **"Provision \<Engine\> in sandbox"** button (only for users who can manage providers). Grok — selectable but absent — installs in one click instead of failing at dispatch.

Pairs with the readiness badge (#1662) and the `provision_build_engine` MCP tool / provision core (#1663). Built in an isolated worktree; CI runs typecheck + tests.

## Follow-up
Readiness-gated Enable; phase 3 (auto-replay reconciler on sandbox rebuild + `/opt/dpf-engines` air-gap staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)