### PR TITLE
feat(build-engine): auto-replay reconciler for sandbox rebuilds (Phase 3)

### DIFF
--- a/apps/web/lib/integrate/build-engine-reconcile.test.ts
+++ b/apps/web/lib/integrate/build-engine-reconcile.test.ts
@@ -1,0 +1,23 @@
+// apps/web/lib/integrate/build-engine-reconcile.test.ts
+import { describe, expect, it } from "vitest";
+import { shouldReprovision } from "./build-engine-reconcile";
+
+describe("shouldReprovision", () => {
+  it("restores an engine we provisioned on demand before (desired + lastProvisionedAt)", () => {
+    expect(shouldReprovision({ desired: "present", lastProvisionedAt: new Date() })).toBe(true);
+    expect(shouldReprovision({ desired: "present", lastProvisionedAt: "2026-06-09T00:00:00Z" })).toBe(true);
+  });
+
+  it("does NOT restore a baked-but-never-provisioned engine (no lastProvisionedAt)", () => {
+    expect(shouldReprovision({ desired: "present", lastProvisionedAt: null })).toBe(false);
+  });
+
+  it("does NOT restore an engine that is not desired", () => {
+    expect(shouldReprovision({ desired: "absent", lastProvisionedAt: new Date() })).toBe(false);
+  });
+
+  it("does NOT restore when there is no state row", () => {
+    expect(shouldReprovision(null)).toBe(false);
+    expect(shouldReprovision(undefined)).toBe(false);
+  });
+});

--- a/apps/web/lib/integrate/build-engine-reconcile.ts
+++ b/apps/web/lib/integrate/build-engine-reconcile.ts
@@ -1,0 +1,99 @@
+// apps/web/lib/integrate/build-engine-reconcile.ts
+//
+// Build-Engine Provisioning (EP-2D477458) — Phase 3, the auto-replay reconciler.
+//
+// Sandboxes are recreated (recovery restart/reset, slot reuse), which wipes any
+// engine that was provisioned ON DEMAND (i.e. not baked into the image). This
+// reconciler re-installs exactly those: engines we previously provisioned
+// successfully (desired=present AND lastProvisionedAt set) that a fresh probe
+// now reports absent.
+//
+// Deliberately NARROW so it is cheap and safe to fire on every sandbox-ready:
+//   - It never re-installs a baked engine that is merely missing (that is an
+//     image problem, not a re-provision case) — those have no lastProvisionedAt.
+//   - It never installs a never-provisioned engine.
+//   - For a fresh sandbox with no prior on-demand provisioning it is a no-op
+//     (a few cheap `--version` probes, no installs, no 137MB downloads).
+//
+// Spec: docs/superpowers/specs/2026-06-06-build-engine-provisioning-design.md (Phase 3, §4.4)
+
+import { prisma } from "@dpf/db";
+
+import {
+  probeEngineReadiness,
+  type EngineProbeConfig,
+} from "@/lib/routing/capability-probes/probe-engine-readiness";
+import { persistEngineReadiness } from "@/lib/routing/persist-engine-readiness";
+import { provisionBuildEngine, type ProvisionOutcome } from "./build-engine-provision";
+
+/** The persisted-state fields the reconcile decision depends on. */
+export type ReconcileEngineState = {
+  desired: string | null;
+  lastProvisionedAt: Date | string | null;
+};
+
+/**
+ * True when an engine should be auto-restored after a sandbox rebuild: it is
+ * desired present AND we successfully provisioned it on demand before (so its
+ * absence now means the rebuild wiped it). Pure — unit-tested.
+ */
+export function shouldReprovision(state: ReconcileEngineState | null | undefined): boolean {
+  return state?.desired === "present" && state?.lastProvisionedAt != null;
+}
+
+export type ReconcileSummary = {
+  checked: number;
+  restored: Array<{ engineId: string; outcome: ProvisionOutcome["kind"] }>;
+  skipped: number;
+};
+
+/**
+ * Re-provision desired, previously-provisioned, now-absent engines into the
+ * running sandbox. Best-effort and idempotent; safe to fire-and-forget on
+ * sandbox-ready.
+ */
+export async function reconcileBuildEngines(opts: {
+  actorUserId: string;
+  offline?: boolean;
+}): Promise<ReconcileSummary> {
+  const engines = await prisma.buildEngine.findMany({
+    select: {
+      engineId: true,
+      binary: true,
+      verifyCommand: true,
+      versionRegex: true,
+      state: { select: { desired: true, lastProvisionedAt: true } },
+    },
+  });
+
+  const restored: ReconcileSummary["restored"] = [];
+  let skipped = 0;
+
+  for (const engine of engines) {
+    if (!shouldReprovision(engine.state)) {
+      skipped++;
+      continue;
+    }
+
+    const probeConfig: EngineProbeConfig = {
+      engineId: engine.engineId,
+      binary: engine.binary,
+      verifyCommand: engine.verifyCommand,
+      versionRegex: engine.versionRegex,
+    };
+    const probe = await probeEngineReadiness(probeConfig);
+    await persistEngineReadiness(probe).catch(() => undefined);
+    if (probe.present) {
+      skipped++;
+      continue; // still there — nothing to restore
+    }
+
+    const outcome = await provisionBuildEngine(engine.engineId, {
+      offline: opts.offline,
+      actorUserId: opts.actorUserId,
+    });
+    restored.push({ engineId: engine.engineId, outcome: outcome.kind });
+  }
+
+  return { checked: engines.length, restored, skipped };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2321,6 +2321,23 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: "reconcile_build_engines",
+    description: "Re-provision build engines that were provisioned on demand and are now missing from the sandbox (e.g. after a sandbox rebuild). Idempotent and narrow: only restores engines with desired=present AND a prior successful provision that a fresh probe reports absent — a no-op for fresh or baked-only sandboxes. Side-effecting (may run installs). Also fires automatically when start_sandbox brings a recreated sandbox to ready. Returns { checked, restored[], skipped }.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        offline: {
+          type: "boolean",
+          description: "When true, only use no-egress (prestaged-binary) recipes. Default false.",
+        },
+      },
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    buildPhases: ["ideate", "plan", "build", "review"],
+  },
+  {
     name: "provision_build_engine",
     description: "Install a build-dispatch engine (claude, codex, grok) into the running sandbox from its registry recipe, then verify by re-probing. Idempotent — a no-op if the engine is already present. Side-effecting: runs the install command (e.g. `npm install -g`, or the grok curl-installer) inside the sandbox, so it requires sandbox_execute. Pass offline:true to use only no-egress (prestaged-binary) recipes for air-gapped installs. Returns { kind, version, recipe }.",
     inputSchema: {
@@ -8993,6 +9010,22 @@ export async function executeTool(
       });
     }
 
+    case "reconcile_build_engines": {
+      const offline = params["offline"] === true;
+      const { reconcileBuildEngines } = await import("@/lib/integrate/build-engine-reconcile");
+      const summary = await reconcileBuildEngines({ offline, actorUserId: userId });
+      return {
+        success: true,
+        message:
+          summary.restored.length === 0
+            ? `No engines needed restoring (checked ${summary.checked}, skipped ${summary.skipped}).`
+            : `Restored ${summary.restored.length} engine(s): ${summary.restored
+                .map((r) => `${r.engineId} (${r.outcome})`)
+                .join(", ")}.`,
+        data: summary,
+      };
+    }
+
     case "provision_build_engine": {
       const engineId = optionalString(params["engineId"]);
       if (!engineId) {
@@ -9201,6 +9234,13 @@ export async function executeTool(
           try {
             const { stdout } = await execAsync(`docker inspect -f "{{.State.Status}}" ${sandboxId}`, { timeout: 3_000 });
             if (stdout.trim() === "running") {
+              // Auto-replay (EP-2D477458 Phase 3): a freshly (re)started sandbox
+              // may have lost any on-demand-provisioned engine. Restore desired,
+              // previously-provisioned, now-absent engines in the background —
+              // a no-op for fresh or baked-only sandboxes.
+              void import("@/lib/integrate/build-engine-reconcile")
+                .then((m) => m.reconcileBuildEngines({ actorUserId: userId }))
+                .catch(() => undefined);
               return { success: true, message: `Sandbox (${sandboxId}) started successfully and is ready.`, data: { status: "running" } };
             }
           } catch { /* keep waiting */ }

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -43,6 +43,12 @@ describe("TOOL_TO_GRANTS — Build / Sandbox entries", () => {
     expect(isToolAllowedByGrants("provision_build_engine", [])).toBe(false);
   });
 
+  it("reconcile_build_engines (may run installs in the sandbox) requires sandbox_execute", () => {
+    expect(isToolAllowedByGrants("reconcile_build_engines", ["sandbox_execute"])).toBe(true);
+    expect(isToolAllowedByGrants("reconcile_build_engines", ["work_capsule_read"])).toBe(false);
+    expect(isToolAllowedByGrants("reconcile_build_engines", [])).toBe(false);
+  });
+
   it("start_build requires sandbox_execute", () => {
     expect(isToolAllowedByGrants("start_build", ["sandbox_execute"])).toBe(true);
     expect(isToolAllowedByGrants("start_build", ["file_read"])).toBe(false);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -434,6 +434,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   // Build lifecycle (sandbox-adjacent)
   // Provisioning a build engine runs an install command inside the sandbox.
   provision_build_engine:     ["sandbox_execute"],
+  reconcile_build_engines:    ["sandbox_execute"],
   check_sandbox:              ["sandbox_execute"],
   start_sandbox:              ["sandbox_execute"],
   start_build:                ["sandbox_execute"],


### PR DESCRIPTION
## What
Phase 3 of EP-2D477458 (BI-6A41CBA1) — make **on-demand-provisioned engines survive sandbox recreation** (recovery restart/reset, slot reuse wipe non-baked engines).

- **`reconcileBuildEngines({actorUserId, offline})`** — re-provisions engines that are `desired=present` AND were **successfully provisioned before** (`lastProvisionedAt` set) but a fresh probe now reports **absent**. Deliberately **narrow** so it's cheap+safe to fire on every sandbox-ready:
  - never re-installs a baked-but-missing engine (image problem — no `lastProvisionedAt`),
  - never installs a never-provisioned engine,
  - a pure **no-op** (a few `--version` probes, no installs, no 137MB re-download) for fresh / baked-only sandboxes.
  `shouldReprovision()` is pure + **unit-tested**.
- **Auto-replay hook**: `start_sandbox` fires `reconcileBuildEngines` in the background (fire-and-forget, guarded) when a (re)started sandbox reaches ready — restoring a wiped on-demand engine with no operator action.
- **`reconcile_build_engines` MCP tool** (`sideEffect:true`, granted `sandbox_execute`) for explicit/Coworker-triggered reconciliation; default-deny otherwise.

Built in an isolated worktree; CI runs typecheck + tests.

## Remaining Phase 3
`/opt/dpf-engines` air-gap staging + musl-compat validation (BI-178A9177 / BI-A2F0A608); readiness-gated Enable precondition (BI-3B40F71F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)