### PR TITLE
feat(build-engine): Phase 3 tail — air-gap staging + musl validation + readiness-gated select

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -33,6 +33,7 @@ RUN npm install -g @anthropic-ai/claude-code
 RUN curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash \
  && install -m 0755 "$(readlink -f /usr/local/bin/grok)" /usr/local/bin/grok.bin \
  && ln -sf /usr/local/bin/grok.bin /usr/local/bin/grok \
+ && mkdir -p /opt/dpf-engines && cp /usr/local/bin/grok.bin /opt/dpf-engines/grok \
  && rm -rf /root/.grok \
  && grok --version \
  && su -s /bin/sh node -c "grok --version"

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -216,6 +216,13 @@ export function BuildStudioConfigForm({
             desc="Built-in tool-calling loop"
           />
         </div>
+        {(provider === "claude" || provider === "codex" || provider === "grok") &&
+          engineReadiness?.[provider]?.present === false && (
+            <div role="status" style={{ marginTop: 10, fontSize: 11, color: "var(--dpf-warning)" }}>
+              ⚠ {provider.charAt(0).toUpperCase() + provider.slice(1)} is selected but not installed in the sandbox —
+              builds dispatched to it will fail until you provision it (use the “Provision … in sandbox” button above).
+            </div>
+          )}
       </section>
 
       {/* Section 2: Provider Assignments */}

--- a/packages/db/scripts/sync-engine-registry.test.ts
+++ b/packages/db/scripts/sync-engine-registry.test.ts
@@ -3,7 +3,25 @@ import { vi, describe, it, expect } from 'vitest';
 import path from 'path';
 import { writeFileSync, mkdtempSync } from 'fs';
 import os from 'os';
-import { syncEngineRegistry } from './sync-engine-registry';
+import { syncEngineRegistry, enginesMissingMuslSafeRecipe } from './sync-engine-registry';
+
+describe("enginesMissingMuslSafeRecipe", () => {
+  it("flags only engines whose recipes are ALL non-musl-safe", () => {
+    const mk = (recipes: Array<{ muslSafe?: boolean }>) => ({
+      binary: "x",
+      verify: { command: "", versionRegex: "" },
+      bakeInDefault: false,
+      recipes,
+    });
+    const engines = {
+      ok: mk([{ muslSafe: true }]),
+      bad: mk([{ muslSafe: false }]),
+      mixed: mk([{ muslSafe: false }, { muslSafe: true }]),
+      none: mk([]),
+    };
+    expect(enginesMissingMuslSafeRecipe(engines as never)).toEqual(["bad"]);
+  });
+});
 
 const dataPath = path.join(__dirname, '../data/build-engines.json');
 

--- a/packages/db/scripts/sync-engine-registry.ts
+++ b/packages/db/scripts/sync-engine-registry.ts
@@ -33,6 +33,22 @@ type SyncEngineClient = {
   };
 };
 
+type RecipeShape = { muslSafe?: boolean };
+
+/**
+ * Engines whose recipes are ALL non-musl-safe — they cannot be provisioned on
+ * the Alpine/musl sandbox base, so provisionBuildEngine would always return
+ * no-recipe. Pure; surfaced as a sync-time warning (BI-A2F0A608).
+ */
+export function enginesMissingMuslSafeRecipe(engines: Record<string, EngineEntry>): string[] {
+  return Object.entries(engines)
+    .filter(([, e]) => {
+      const recipes = Array.isArray(e.recipes) ? (e.recipes as RecipeShape[]) : [];
+      return recipes.length > 0 && recipes.every((r) => r.muslSafe === false);
+    })
+    .map(([engineId]) => engineId);
+}
+
 export async function syncEngineRegistry(prisma: SyncEngineClient, dataPath: string): Promise<void> {
   const raw = readFileSync(dataPath, 'utf-8');
 
@@ -41,6 +57,13 @@ export async function syncEngineRegistry(prisma: SyncEngineClient, dataPath: str
     engines = JSON.parse(raw) as Record<string, EngineEntry>;
   } catch (e) {
     throw new Error(`Failed to parse ${dataPath}: ${(e as Error).message}`);
+  }
+
+  const unprovisionable = enginesMissingMuslSafeRecipe(engines);
+  if (unprovisionable.length > 0) {
+    console.warn(
+      `[sync-engine-registry] WARNING: no musl-safe recipe for ${unprovisionable.join(", ")} — these engines cannot be provisioned on the Alpine/musl sandbox base.`,
+    );
   }
 
   let created = 0;


### PR DESCRIPTION
## What
Completes **EP-2D477458** — the three long-tail Phase-3 items.

- **Air-gap staging** (BI-178A9177): `Dockerfile.sandbox` copies the installed grok binary to `/opt/dpf-engines/grok`, so the `prestaged-binary` recipe + `offline` mode (already in code) can re-provision grok with **no egress** on air-gapped installs.
- **musl-compat validation** (BI-A2F0A608): `enginesMissingMuslSafeRecipe()` flags engines whose recipes are all non-musl-safe (unprovisionable on the Alpine/musl base); `sync-engine-registry` warns at sync time. Pure + **unit-tested**. (The musl-safe *filter* already runs in `selectRecipe`; `bakeInDefault` already gates baking — this adds the loud validation.)
- **Readiness-gated select** (BI-3B40F71F): the config page warns when the **selected** dispatch engine shows `present:false` — "selected but not installed — builds will fail until you provision it" — pointing at the Provision button.

With this, EP-2D477458 is fully delivered across Phases 1–3. Built in an isolated worktree; CI runs typecheck + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)