### PR TITLE
fix(discovery-scheduler): stop P2025 log-spam from unregistered backlog-triage-drain job

### DIFF
--- a/apps/web/lib/operate/discovery-scheduler.test.ts
+++ b/apps/web/lib/operate/discovery-scheduler.test.ts
@@ -19,20 +19,59 @@ vi.mock("../integrate/code-graph-refresh", () => ({
 }));
 
 // Must import after mock setup
-import { runPrometheusTargetCheck, runFullDiscoverySweep, registerScheduledJobs } from "./discovery-scheduler";
+import { runPrometheusTargetCheck, runFullDiscoverySweep, registerScheduledJobs, recordJobRun } from "./discovery-scheduler";
 import { registerModelDiscoveryJob } from "../inference/model-discovery-scheduler";
 import { registerCodeGraphScheduledJob } from "../integrate/code-graph-refresh";
 
 describe("registerScheduledJobs", () => {
-  it("upserts both ScheduledJob rows", async () => {
+  it("upserts every managed ScheduledJob row", async () => {
     const { prisma } = await import("@dpf/db");
     const upsert = prisma.scheduledJob.upsert as ReturnType<typeof vi.fn>;
     upsert.mockClear();
 
     await registerScheduledJobs();
-    expect(upsert).toHaveBeenCalledTimes(3);
+    expect(upsert).toHaveBeenCalledTimes(4);
     expect(registerModelDiscoveryJob).toHaveBeenCalledTimes(1);
     expect(registerCodeGraphScheduledJob).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: backlog-triage-drain called recordJobRun() for a jobId that was
+  // never registered, so the row was missing and recordJobRun's update() threw
+  // P2025 ~once an hour. Registration must cover every recordJobRun() caller.
+  it("registers the backlog-triage-drain job that recordJobRun() writes back to", async () => {
+    const { prisma } = await import("@dpf/db");
+    const upsert = prisma.scheduledJob.upsert as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+
+    await registerScheduledJobs();
+    const registeredJobIds = upsert.mock.calls.map((c) => c[0].where.jobId);
+    expect(registeredJobIds).toContain("backlog-triage-drain");
+  });
+});
+
+describe("recordJobRun", () => {
+  it("upserts (self-heals) so a missing ScheduledJob row never throws P2025", async () => {
+    const { prisma } = await import("@dpf/db");
+    const upsert = prisma.scheduledJob.upsert as ReturnType<typeof vi.fn>;
+    const update = prisma.scheduledJob.update as ReturnType<typeof vi.fn>;
+    upsert.mockClear();
+    update.mockClear();
+
+    await recordJobRun("backlog-triage-drain", "ok");
+
+    // Must upsert, never bare update() — update() is what threw P2025.
+    expect(update).not.toHaveBeenCalled();
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const call = upsert.mock.calls[0][0];
+    expect(call.where).toEqual({ jobId: "backlog-triage-drain" });
+    // create branch carries name + schedule so the row can materialize.
+    expect(call.create).toMatchObject({
+      jobId: "backlog-triage-drain",
+      name: expect.any(String),
+      schedule: expect.any(String),
+      lastStatus: "ok",
+    });
+    expect(call.update).toMatchObject({ lastStatus: "ok" });
   });
 });
 

--- a/apps/web/lib/operate/discovery-scheduler.ts
+++ b/apps/web/lib/operate/discovery-scheduler.ts
@@ -7,12 +7,39 @@ import { decryptSecret } from "../govern/credential-crypto";
 
 const PROMETHEUS_POLL_INTERVAL_MS = 60 * 60_000;
 const FULL_SWEEP_INTERVAL_MS = 60 * 60_000;
+const ISSUE_TRIAGE_INTERVAL_MS = 15 * 60_000;
+const BACKLOG_TRIAGE_DRAIN_INTERVAL_MS = 60 * 60_000;
 const PROMETHEUS_URL = process.env.PROMETHEUS_URL ?? "http://prometheus:9090";
 
-const JOB_PROMETHEUS_POLL = "discovery-prometheus-poll";
-const JOB_FULL_SWEEP      = "discovery-full-sweep";
-const JOB_ISSUE_TRIAGE    = "issue-report-triage";
-const ISSUE_TRIAGE_INTERVAL_MS = 15 * 60_000;
+const JOB_PROMETHEUS_POLL       = "discovery-prometheus-poll";
+const JOB_FULL_SWEEP            = "discovery-full-sweep";
+const JOB_ISSUE_TRIAGE          = "issue-report-triage";
+const JOB_BACKLOG_TRIAGE_DRAIN  = "backlog-triage-drain";
+
+/**
+ * Single source of truth for the ScheduledJob rows this module owns.
+ *
+ * Both registerScheduledJobs() (startup) and recordJobRun() (after each run)
+ * read from this registry, so a job can never be wired into one path but not
+ * the other. That drift was the cause of the recurring P2025 log-spam: the
+ * backlog-triage-drain cron called recordJobRun() for a jobId that
+ * registerScheduledJobs() never upserted, so the update() hit a missing row.
+ *
+ * model-discovery + code-graph self-register elsewhere (own schedules), so they
+ * are intentionally not listed here.
+ */
+type ManagedJob = { jobId: string; name: string; schedule: string; intervalMs: number };
+
+const MANAGED_JOBS: ManagedJob[] = [
+  { jobId: JOB_PROMETHEUS_POLL,      name: "Discovery: Prometheus target poll",      schedule: "hourly",     intervalMs: PROMETHEUS_POLL_INTERVAL_MS },
+  { jobId: JOB_FULL_SWEEP,           name: "Discovery: full infrastructure sweep",   schedule: "hourly",     intervalMs: FULL_SWEEP_INTERVAL_MS },
+  { jobId: JOB_ISSUE_TRIAGE,         name: "Quality: issue report triage",           schedule: "every-15m",  intervalMs: ISSUE_TRIAGE_INTERVAL_MS },
+  { jobId: JOB_BACKLOG_TRIAGE_DRAIN, name: "Operate: backlog triage drain",          schedule: "hourly",     intervalMs: BACKLOG_TRIAGE_DRAIN_INTERVAL_MS },
+];
+
+const MANAGED_JOBS_BY_ID: Record<string, ManagedJob> = Object.fromEntries(
+  MANAGED_JOBS.map((job) => [job.jobId, job]),
+);
 
 /** Upsert ScheduledJob rows so calendar-data.ts can project discovery events. */
 export async function registerScheduledJobs(): Promise<void> {
@@ -20,68 +47,53 @@ export async function registerScheduledJobs(): Promise<void> {
   const { registerModelDiscoveryJob } = await import("../inference/model-discovery-scheduler");
   const { registerCodeGraphScheduledJob } = await import("../integrate/code-graph-refresh");
   await Promise.all([
-    prisma.scheduledJob.upsert({
-      where:  { jobId: JOB_PROMETHEUS_POLL },
-      create: {
-        jobId: JOB_PROMETHEUS_POLL,
-        name:  "Discovery: Prometheus target poll",
-        schedule: "hourly",
-        nextRunAt: new Date(now.getTime() + PROMETHEUS_POLL_INTERVAL_MS),
-      },
-      update: {
-        schedule: "hourly",
-        nextRunAt: new Date(now.getTime() + PROMETHEUS_POLL_INTERVAL_MS),
-      },
-    }),
-    prisma.scheduledJob.upsert({
-      where:  { jobId: JOB_FULL_SWEEP },
-      create: {
-        jobId: JOB_FULL_SWEEP,
-        name:  "Discovery: full infrastructure sweep",
-        schedule: "hourly",
-        nextRunAt: new Date(now.getTime() + FULL_SWEEP_INTERVAL_MS),
-      },
-      update: {
-        schedule: "hourly",
-        nextRunAt: new Date(now.getTime() + FULL_SWEEP_INTERVAL_MS),
-      },
-    }),
-    prisma.scheduledJob.upsert({
-      where:  { jobId: JOB_ISSUE_TRIAGE },
-      create: {
-        jobId: JOB_ISSUE_TRIAGE,
-        name:  "Quality: issue report triage",
-        schedule: "every-15m",
-        nextRunAt: new Date(now.getTime() + ISSUE_TRIAGE_INTERVAL_MS),
-      },
-      update: {
-        schedule: "every-15m",
-        nextRunAt: new Date(now.getTime() + ISSUE_TRIAGE_INTERVAL_MS),
-      },
-    }),
+    ...MANAGED_JOBS.map((job) =>
+      prisma.scheduledJob.upsert({
+        where:  { jobId: job.jobId },
+        create: {
+          jobId: job.jobId,
+          name:  job.name,
+          schedule: job.schedule,
+          nextRunAt: new Date(now.getTime() + job.intervalMs),
+        },
+        update: {
+          schedule: job.schedule,
+          nextRunAt: new Date(now.getTime() + job.intervalMs),
+        },
+      }),
+    ),
     registerModelDiscoveryJob(),
     registerCodeGraphScheduledJob(),
   ]);
 }
 
-const JOB_INTERVALS: Record<string, number> = {
-  [JOB_PROMETHEUS_POLL]: PROMETHEUS_POLL_INTERVAL_MS,
-  [JOB_FULL_SWEEP]:      FULL_SWEEP_INTERVAL_MS,
-  [JOB_ISSUE_TRIAGE]:    ISSUE_TRIAGE_INTERVAL_MS,
-};
-
-/** Update a ScheduledJob after a run completes. */
+/**
+ * Record a ScheduledJob run.
+ *
+ * Uses upsert (not update) so a missing registration self-heals — materializing
+ * the row from the managed registry — instead of throwing P2025 and spamming
+ * the logs on every run. Unknown jobIds fall back to a generic name/schedule so
+ * the row still appears on the calendar rather than vanishing silently.
+ */
 export async function recordJobRun(jobId: string, status: string, error?: string): Promise<void> {
-  const intervalMs = JOB_INTERVALS[jobId] ?? FULL_SWEEP_INTERVAL_MS;
+  const job = MANAGED_JOBS_BY_ID[jobId];
+  const intervalMs = job?.intervalMs ?? FULL_SWEEP_INTERVAL_MS;
   const now = new Date();
-  await prisma.scheduledJob.update({
+  const runData = {
+    lastRunAt:  now,
+    lastStatus: status,
+    lastError:  error ?? null,
+    nextRunAt:  new Date(now.getTime() + intervalMs),
+  };
+  await prisma.scheduledJob.upsert({
     where: { jobId },
-    data: {
-      lastRunAt:  now,
-      lastStatus: status,
-      lastError:  error ?? null,
-      nextRunAt:  new Date(now.getTime() + intervalMs),
+    create: {
+      jobId,
+      name: job?.name ?? jobId,
+      schedule: job?.schedule ?? "hourly",
+      ...runData,
     },
+    update: runData,
   }).catch((err) => console.error(`[discovery-scheduler] Failed to update job ${jobId}:`, err));
 }
 


### PR DESCRIPTION
## Problem

`dpf-portal-1` logs show a recurring P2025 error (~30× / 30 min):

```
[discovery-scheduler] Failed to update job backlog-triage-drain: PrismaClientKnownRequestError
Invalid `prisma.scheduledJob.update()` invocation:
An operation failed because it depends on one or more records that were required but not found.
  code: 'P2025', meta: { modelName: 'ScheduledJob', operation: 'an update' }
```

The `backlog-triage-drain` cron runs fine (`considered=25 autoBuilt=0 leftForOperator=25`); only the status write-back to its `ScheduledJob` row fails — and it has failed on every run since the job was added.

## Root cause

The job was added in #1526. Its cron calls `recordJobRun("backlog-triage-drain")` after every run, but:

- `registerScheduledJobs()` never upserted a `ScheduledJob` row for that `jobId`, and
- the `jobId` was absent from `JOB_INTERVALS`.

`recordJobRun()` used `prisma.scheduledJob.update()`, which throws **P2025** when the row is missing. (`issue-report-triage` works precisely because it *is* in both lists.) The underlying fragility was **drift between two hand-maintained lists** — the upsert list in `registerScheduledJobs` and `JOB_INTERVALS`.

## Fix

- **Single source of truth.** Collapse the two lists into one `MANAGED_JOBS` registry (`jobId`, `name`, `schedule`, `intervalMs`). Both `registerScheduledJobs()` and `recordJobRun()` read from it, so a job can never be wired into one path but not the other. Added the missing `backlog-triage-drain` entry.
- **Self-healing write-back.** `recordJobRun()` now `upsert`s instead of `update`s — a missing or late registration materializes the row from the registry instead of spamming P2025. The row also appears on the calendar (`calendar-data.ts` projects `ScheduledJob` rows) as it should.

No SQL seed change: these rows are registered at runtime by `registerScheduledJobs()` (called from `instrumentation.ts` at startup), not seeded. The registry is the seed-equivalent and now covers the job.

## Tests

Added two regression tests to `discovery-scheduler.test.ts`:
1. Registration covers every `recordJobRun()` caller — asserts `backlog-triage-drain` is among the registered job IDs.
2. `recordJobRun()` upserts (never bare `update()`), with `name`/`schedule` on the create branch so the row can materialize.

All 6 tests in the file pass (ran via the root toolchain; this is a source-only worktree). Local typecheck skipped (`next`/`node_modules` absent in source-only worktree) — CI gates the real typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
