### PR TITLE
fix(quiescence): flag-gated dead-phase reaping so self-upgrade drains past corpses (BI-17377D05)

### DIFF
--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -34,6 +34,7 @@ vi.mock("@dpf/db", () => ({
 
 import {
   captureActiveSessionBlockers,
+  isBuildPhaseReapable,
   getQuiescenceConfig,
   invalidateQuiescenceCache,
   isTerminalQuiescenceStatus,
@@ -54,6 +55,30 @@ beforeEach(() => {
   prismaMock.buildPhaseRunFindMany.mockResolvedValue([]);
   prismaMock.buildPhaseRunUpdateMany.mockResolvedValue({ count: 0 });
   prismaMock.toolExecutionFindMany.mockResolvedValue([]);
+});
+
+describe("isBuildPhaseReapable", () => {
+  const now = new Date("2026-06-09T12:00:00Z");
+  const old = new Date(now.getTime() - 20 * 60 * 1000); // 20 min ago
+  const recent = new Date(now.getTime() - 2 * 60 * 1000); // 2 min ago
+  const thresholdMs = 15 * 60 * 1000;
+
+  it("reaps a phase with no heartbeat and an old start (a corpse)", () => {
+    expect(isBuildPhaseReapable({ phaseStartedAt: old, buildLastHeartbeatAt: null, now, thresholdMs })).toBe(true);
+  });
+
+  it("does NOT reap when the build has a recent heartbeat (live work)", () => {
+    expect(isBuildPhaseReapable({ phaseStartedAt: old, buildLastHeartbeatAt: recent, now, thresholdMs })).toBe(false);
+  });
+
+  it("does NOT reap a freshly-started phase even without a heartbeat", () => {
+    expect(isBuildPhaseReapable({ phaseStartedAt: recent, buildLastHeartbeatAt: null, now, thresholdMs })).toBe(false);
+  });
+
+  it("reaps when both the start and the last heartbeat are older than the threshold", () => {
+    const olderHeartbeat = new Date(now.getTime() - 30 * 60 * 1000);
+    expect(isBuildPhaseReapable({ phaseStartedAt: old, buildLastHeartbeatAt: olderHeartbeat, now, thresholdMs })).toBe(true);
+  });
 });
 
 describe("parseQuiescenceConfig", () => {

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -547,6 +547,45 @@ const EDGE_AGENT_PREFIX = "edge-node:";
 const TERMINAL_BUILD_PHASES = ["complete", "failed", "abandoned"] as const;
 
 /**
+ * Liveness threshold for dead-phase reaping (admission-control spec §4.4 /
+ * BI-17377D05): a non-terminal BuildPhaseRun with completedAt=null whose build
+ * shows no active-TaskRun heartbeat AND whose own start is older than this is a
+ * corpse — it must not hold the self-upgrade drain open. 15 min with no
+ * observable signal.
+ */
+const DEAD_PHASE_LIVENESS_MS = 15 * 60 * 1000;
+
+/**
+ * Flag-gate (default OFF). This changes the self-upgrade DRAIN decision (what
+ * counts as "in flight"), so per the spec §6 it is enabled + load-tested
+ * deliberately, never blind-shipped to the deploy path. Operator sets
+ * QUIESCENCE_REAP_DEAD_PHASES=1 to exercise it under real concurrent load.
+ */
+function reapDeadPhasesEnabled(): boolean {
+  return process.env.QUIESCENCE_REAP_DEAD_PHASES === "1";
+}
+
+/**
+ * True when an in-flight build phase is a corpse: the most recent observable
+ * signal — the build's latest active-TaskRun heartbeat, or the phase's own
+ * start if newer — is older than `thresholdMs`. Pure; unit-tested. A live
+ * build (recent heartbeat) or a freshly-started phase is never reapable.
+ */
+export function isBuildPhaseReapable(args: {
+  phaseStartedAt: Date;
+  buildLastHeartbeatAt: Date | null;
+  now: Date;
+  thresholdMs: number;
+}): boolean {
+  const { phaseStartedAt, buildLastHeartbeatAt, now, thresholdMs } = args;
+  const lastSignal =
+    buildLastHeartbeatAt && buildLastHeartbeatAt.getTime() > phaseStartedAt.getTime()
+      ? buildLastHeartbeatAt
+      : phaseStartedAt;
+  return now.getTime() - lastSignal.getTime() > thresholdMs;
+}
+
+/**
  * Repair stale phase-run rows from terminal builds before blocker capture.
  * Abandon/fail paths that predate BI-2CC024DB can leave completedAt null, which
  * otherwise makes quiescence defer forever on work that is no longer active.
@@ -629,7 +668,35 @@ export async function captureActiveSessionBlockers(opts?: {
     select: { buildId: true, phase: true, startedAt: true },
     take: 25,
   });
+  // Dead-phase reaping (flag-gated, default OFF): build a buildId → latest
+  // active-TaskRun heartbeat map from the TaskRuns already fetched above (no
+  // extra query), so a corpse phase (no heartbeat + old start) can be dropped
+  // from the blockers instead of holding the drain open for the full budget.
+  const reapDeadPhases = reapDeadPhasesEnabled();
+  const buildLastHeartbeat = new Map<string, Date>();
+  if (reapDeadPhases) {
+    for (const tr of activeTaskRuns) {
+      if (!tr.buildId || !tr.lastHeartbeatAt) continue;
+      const prev = buildLastHeartbeat.get(tr.buildId);
+      if (!prev || tr.lastHeartbeatAt.getTime() > prev.getTime()) {
+        buildLastHeartbeat.set(tr.buildId, tr.lastHeartbeatAt);
+      }
+    }
+  }
+  let reapedPhaseCount = 0;
   for (const row of inFlightPhases) {
+    if (
+      reapDeadPhases &&
+      isBuildPhaseReapable({
+        phaseStartedAt: row.startedAt,
+        buildLastHeartbeatAt: buildLastHeartbeat.get(row.buildId) ?? null,
+        now,
+        thresholdMs: DEAD_PHASE_LIVENESS_MS,
+      })
+    ) {
+      reapedPhaseCount++;
+      continue; // corpse — does not block the drain
+    }
     const isShipPhase = row.phase === "ship";
     surfaces.push({
       surface: `build-studio.phase.${row.phase}`,
@@ -650,6 +717,11 @@ export async function captureActiveSessionBlockers(opts?: {
         shipPhaseShipForceRequired: isShipPhase,
       },
     });
+  }
+  if (reapedPhaseCount > 0) {
+    console.warn(
+      `[quiescence] reaped ${reapedPhaseCount} dead build phase(s) from the drain (no active heartbeat, started > ${DEAD_PHASE_LIVENESS_MS / 60000} min ago).`,
+    );
   }
 
   // B-class: ToolExecution recency — the existing stopgap signal.


### PR DESCRIPTION
## What
First implementation slice of the **instance admission-control spec** (`docs/superpowers/specs/2026-06-09-instance-admission-control-design.md` §4.4, Phase 1) — **building on that concurrent-session design, not duplicating it.**

**Problem:** `captureActiveSessionBlockers` counts *every* non-terminal `BuildPhaseRun` with `completedAt=null` as a **hard blocker, regardless of liveness**. A build phase silent for hours (orchestration died mid-plan) still holds the self-upgrade drain open for its full phase budget — so **"Upgrade now" waits on corpses and merged fixes never deploy under load** (BI-17377D05 / BI-70D19D15).

**Fix (behind a default-OFF flag `QUIESCENCE_REAP_DEAD_PHASES=1`):** an in-flight phase whose build shows **no active-TaskRun heartbeat** AND whose own start is **older than the liveness threshold (15 min)** is a corpse and is dropped from the blockers — it no longer holds the drain. Live builds (recent heartbeat) and freshly-started phases are **never** reaped. Liveness comes from the active TaskRuns already fetched (no extra query); `isBuildPhaseReapable` is pure + **unit-tested**. A `console.warn` surfaces the reap count.

## Why flag-gated + OFF
This changes the self-upgrade **drain decision** (the deploy path). The spec §6 requires it be **enabled + load-tested under real concurrent load, never blind-shipped**. **Zero behavior change until an operator sets the flag.** It's the one-time cycle-breaker that lets merged work deploy under load — after which build-pipeline fixes can route back **through Build Studio** (this thread's actual goal: exercise + harden BS, not bypass it).

## Follow-on (same spec)
Self-upgrade priority lane (§4.3), global admission budget + backpressure (§4.1/4.2), observability surface (§4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)