### PR TITLE
fix(discovery): arp_scan freezes the portal event loop (BI-4CA890B7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,10 @@ LABEL org.opencontainers.image.description="Self-developing digital product mana
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"
 WORKDIR /app
-RUN apk add --no-cache docker-cli docker-cli-compose postgresql16-client git curl
+# nmap powers the fast path of the arp_scan discovery collector. Without it the
+# collector falls back to a 254-host ping sweep; with it a /24 scans in seconds.
+# (See packages/db/src/discovery-collectors/arp-scan.ts — BI-4CA890B7.)
+RUN apk add --no-cache docker-cli docker-cli-compose postgresql16-client git curl nmap
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000

--- a/packages/db/src/discovery-collectors/arp-scan.test.ts
+++ b/packages/db/src/discovery-collectors/arp-scan.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+
+import { collectArpScanDiscovery, type ArpScanDeps } from "./arp-scan";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type Call = { cmd: string; args: string[]; timeoutMs?: number };
+
+/**
+ * Build an async execCommand stub that records every call and returns canned
+ * output per command. Mirrors the real contract: async, resolves to "" when no
+ * handler matches (tool unavailable / no output).
+ */
+function makeExec(
+  handlers: Partial<Record<string, (args: string[]) => string>>,
+): { exec: ArpScanDeps["execCommand"]; calls: Call[] } {
+  const calls: Call[] = [];
+  const exec: ArpScanDeps["execCommand"] = async (cmd, args, timeoutMs) => {
+    calls.push({ cmd, args, timeoutMs });
+    const handler = handlers[cmd];
+    return handler ? handler(args) : "";
+  };
+  return { exec, calls };
+}
+
+const NMAP_TWO_HOSTS = [
+  "# Nmap scan",
+  "Host: 192.168.0.1 () Status: Up",
+  "Host: 192.168.0.42 () Status: Up",
+  "# Nmap done",
+].join("\n");
+
+const IP_NEIGH_TWO = [
+  "192.168.0.1 dev eth0 lladdr aa:bb:cc:dd:ee:01 REACHABLE",
+  "192.168.0.42 dev eth0 lladdr aa:bb:cc:dd:ee:42 STALE",
+].join("\n");
+
+// ─── nmap fast path ──────────────────────────────────────────────────────────
+
+describe("collectArpScanDiscovery — nmap path", () => {
+  it("uses nmap with -n (no DNS) and does NOT fall back to ping when nmap returns hosts", async () => {
+    const { exec, calls } = makeExec({ nmap: () => NMAP_TWO_HOSTS });
+
+    const out = await collectArpScanDiscovery(
+      { sourceKind: "arp_scan" },
+      [{ subnet: "192.168.0.0/24" }],
+      { execCommand: exec },
+    );
+
+    // nmap invoked exactly once, with -n to skip reverse-DNS (the BI-4CA890B7 fix)
+    const nmapCalls = calls.filter((c) => c.cmd === "nmap");
+    expect(nmapCalls).toHaveLength(1);
+    expect(nmapCalls[0]!.args).toContain("-n");
+
+    // No ping fallback when nmap succeeded
+    expect(calls.some((c) => c.cmd === "ping")).toBe(false);
+
+    const hosts = out.items.filter((i) => i.itemType === "host");
+    expect(hosts.map((h) => h.attributes!.address).sort()).toEqual([
+      "192.168.0.1",
+      "192.168.0.42",
+    ]);
+    // One subnet entity + MEMBER_OF rels
+    expect(out.items.some((i) => i.itemType === "subnet")).toBe(true);
+    expect(out.relationships).toHaveLength(2);
+  });
+});
+
+// ─── ping fallback path ──────────────────────────────────────────────────────
+
+describe("collectArpScanDiscovery — ping/arp fallback", () => {
+  it("falls back to a BOUNDED-PARALLEL ping sweep then reads the ARP table", async () => {
+    // nmap absent (returns "") → fallback engages.
+    const { exec, calls } = makeExec({
+      ip: (args) => (args[0] === "neigh" ? IP_NEIGH_TWO : ""),
+    });
+
+    const out = await collectArpScanDiscovery(
+      { sourceKind: "arp_scan" },
+      [{ subnet: "192.168.0.0/24" }],
+      { execCommand: exec },
+    );
+
+    // Pinged the host range (254 usable addresses in a /24).
+    const pings = calls.filter((c) => c.cmd === "ping");
+    expect(pings).toHaveLength(254);
+    // Each ping is time-bounded (never an unbounded blocking call).
+    expect(pings.every((p) => typeof p.timeoutMs === "number" && p.timeoutMs! > 0)).toBe(true);
+    // ARP table read after the sweep.
+    expect(calls.some((c) => c.cmd === "ip" && c.args[0] === "neigh")).toBe(true);
+
+    const hosts = out.items.filter((i) => i.itemType === "host");
+    expect(hosts).toHaveLength(2);
+    expect(hosts.find((h) => h.attributes!.address === "192.168.0.1")!.attributes!.mac).toBe(
+      "aa:bb:cc:dd:ee:01",
+    );
+  });
+
+  it("runs pings with real concurrency (more than one in flight at once)", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const exec: ArpScanDeps["execCommand"] = async (cmd, args) => {
+      if (cmd === "ping") {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 0));
+        inFlight--;
+        return "";
+      }
+      if (cmd === "ip" && args[0] === "neigh") return IP_NEIGH_TWO;
+      return "";
+    };
+
+    await collectArpScanDiscovery(
+      { sourceKind: "arp_scan" },
+      [{ subnet: "192.168.0.0/24" }],
+      { execCommand: exec },
+    );
+
+    // The old implementation was strictly sequential (max 1). The fix runs a
+    // bounded pool, so several pings overlap.
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+});
+
+// ─── guards ──────────────────────────────────────────────────────────────────
+
+describe("collectArpScanDiscovery — guards", () => {
+  it("warns and does nothing when no targets are supplied", async () => {
+    const out = await collectArpScanDiscovery({ sourceKind: "arp_scan" }, []);
+    expect(out.items).toHaveLength(0);
+    expect(out.warnings).toContain("arp_scan_no_targets");
+  });
+
+  it("emits arp_scan_empty when neither nmap nor the ping sweep find hosts", async () => {
+    const { exec } = makeExec({}); // everything returns ""
+    const out = await collectArpScanDiscovery(
+      { sourceKind: "arp_scan" },
+      [{ subnet: "192.168.0.0/24" }],
+      { execCommand: exec },
+    );
+    expect(out.items).toHaveLength(0);
+    expect(out.warnings).toContain("arp_scan_empty:192.168.0.0/24");
+  });
+});

--- a/packages/db/src/discovery-collectors/arp-scan.ts
+++ b/packages/db/src/discovery-collectors/arp-scan.ts
@@ -1,11 +1,21 @@
 // ARP Scan Discovery Collector
-// Discovers all live hosts on a subnet by sending TCP SYN probes.
+// Discovers all live hosts on a subnet by populating the ARP table (via nmap
+// ping-scan, or a ping sweep fallback) and reading neighbours back.
 // Works without managed switches or SNMP — just needs IP connectivity.
-// Runs inside the portal container; reaches the host network via
-// host.docker.internal or the Docker gateway.
+//
+// Runs inside the portal container, ON THE SAME Node event loop that serves
+// HTTP. Therefore every external command MUST be async and time-bounded, and
+// the ping sweep MUST be bounded-parallel. A previous implementation used
+// `spawnSync` to ping all 254 hosts of a /24 sequentially; each dead host
+// waited its full timeout, freezing the entire portal for ~250s per scan
+// (no page, not even /favicon.ico, would respond — CPU sat near 0 because the
+// thread was blocked waiting, not computing). See BI-4CA890B7.
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { CollectorContext, CollectorOutput } from "../discovery-types";
+
+const execFileAsync = promisify(execFile);
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -14,17 +24,69 @@ export type ArpScanTarget = {
 };
 
 export type ArpScanDeps = {
-  execCommand: (cmd: string, args: string[]) => string;
+  /**
+   * Run an external command and resolve its stdout. MUST be async (never
+   * block the event loop) and MUST resolve to "" on any failure/timeout
+   * rather than rejecting — callers treat empty output as "tool unavailable".
+   */
+  execCommand: (cmd: string, args: string[], timeoutMs?: number) => Promise<string>;
 };
 
-function defaultExecCommand(cmd: string, args: string[]): string {
-  const result = spawnSync(cmd, args, { encoding: "utf8", timeout: 30_000 });
-  return result.status === 0 ? result.stdout : "";
+async function defaultExecCommand(
+  cmd: string,
+  args: string[],
+  timeoutMs = 10_000,
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    // Non-zero exit, timeout (SIGTERM), or missing binary → treat as no output.
+    return "";
+  }
 }
 
 const defaultDeps: ArpScanDeps = {
   execCommand: defaultExecCommand,
 };
+
+// Max simultaneous pings during the fallback sweep. High enough that a /24
+// completes in ~(254/limit) seconds of wall time, low enough not to exhaust
+// file descriptors / subprocess slots. The work is I/O-bound (waiting on ICMP
+// replies), so concurrency is cheap.
+const PING_CONCURRENCY = 32;
+
+/**
+ * Run `worker` over every item with at most `limit` in flight at once.
+ * Cooperative and fully async — yields the event loop between each await so
+ * HTTP serving is never starved. Never rejects: a worker that throws is
+ * swallowed (best-effort discovery).
+ */
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const lanes = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (cursor < items.length) {
+        const item = items[cursor++]!;
+        try {
+          await worker(item);
+        } catch {
+          /* best-effort: a single failed ping must not abort the sweep */
+        }
+      }
+    },
+  );
+  await Promise.all(lanes);
+}
 
 // ─── Collector ──────────────────────────────────────────────────────────────
 
@@ -116,26 +178,37 @@ async function scanSubnet(
   subnet: string,
   deps: ArpScanDeps,
 ): Promise<DiscoveredHost[]> {
-  // Try nmap first (most thorough)
-  const nmapHosts = tryNmapScan(subnet, deps);
+  // Try nmap first (fast + thorough when bundled in the image).
+  const nmapHosts = await tryNmapScan(subnet, deps);
   if (nmapHosts.length > 0) return nmapHosts;
 
-  // Fall back to ping sweep + ARP table read
+  // Fall back to bounded-parallel ping sweep + ARP table read.
   return pingAndArp(subnet, deps);
 }
 
-function tryNmapScan(subnet: string, deps: ArpScanDeps): DiscoveredHost[] {
-  // nmap -sn (ping scan, no port scan) with ARP detection
-  const output = deps.execCommand("nmap", ["-sn", "-oG", "-", subnet]);
+async function tryNmapScan(
+  subnet: string,
+  deps: ArpScanDeps,
+): Promise<DiscoveredHost[]> {
+  // -sn  ping scan, no port scan
+  // -n   DO NOT resolve DNS. Critical: reverse-DNS on a /24 can take ~45s and
+  //      blow the command timeout, forcing the slow ping fallback. We don't
+  //      need names here. (BI-4CA890B7)
+  // -T4  aggressive timing — a /24 completes in a few seconds.
+  const output = await deps.execCommand(
+    "nmap",
+    ["-sn", "-n", "-T4", "-oG", "-", subnet],
+    60_000,
+  );
   if (!output) return [];
 
   const hosts: DiscoveredHost[] = [];
   for (const line of output.split(/\r?\n/)) {
-    // Grepable output: Host: 192.168.0.1 (gateway.local) Status: Up
+    // Grepable output. With -n the parens are empty: "Host: 192.168.0.1 () Status: Up"
     const match = line.match(/^Host:\s+(\d+\.\d+\.\d+\.\d+)\s+\(([^)]*)\)\s+Status:\s+Up/i);
     if (match) {
       hosts.push({
-        ip: match[1],
+        ip: match[1]!,
         hostname: match[2] || undefined,
       });
     }
@@ -143,18 +216,22 @@ function tryNmapScan(subnet: string, deps: ArpScanDeps): DiscoveredHost[] {
   return hosts;
 }
 
-function pingAndArp(subnet: string, deps: ArpScanDeps): DiscoveredHost[] {
-  // Generate IPs in the subnet and ping them to populate ARP table
+async function pingAndArp(
+  subnet: string,
+  deps: ArpScanDeps,
+): Promise<DiscoveredHost[]> {
+  // Generate IPs in the subnet and ping them to populate the ARP table.
   const ips = generateSubnetIPs(subnet, 254);
 
-  // Quick parallel ping (best effort — some won't respond)
-  for (const ip of ips) {
-    // Non-blocking ping with 1 packet, 500ms timeout
-    deps.execCommand("ping", ["-c", "1", "-W", "1", ip]);
-  }
+  // Bounded-parallel ping (best effort — some won't respond). Each ping is
+  // async and time-bounded, so this never blocks the event loop. One packet,
+  // 1s reply timeout; the 2s command timeout is a hard backstop.
+  await runWithConcurrency(ips, PING_CONCURRENCY, async (ip) => {
+    await deps.execCommand("ping", ["-c", "1", "-W", "1", ip], 2_000);
+  });
 
-  // Now read the ARP table
-  let output = deps.execCommand("ip", ["neigh"]);
+  // Now read the ARP table that the sweep populated.
+  let output = await deps.execCommand("ip", ["neigh"], 5_000);
   if (output) {
     return output
       .split(/\r?\n/)
@@ -167,7 +244,7 @@ function pingAndArp(subnet: string, deps: ArpScanDeps): DiscoveredHost[] {
   }
 
   // Windows/macOS fallback
-  output = deps.execCommand("arp", ["-a"]);
+  output = await deps.execCommand("arp", ["-a"], 5_000);
   if (output) {
     return output
       .split(/\r?\n/)
@@ -188,8 +265,8 @@ function generateSubnetIPs(subnet: string, maxHosts: number): string[] {
   const cidr = Number(cidrStr) || 24;
   if (cidr < 16) return []; // Don't scan anything larger than /16
 
-  const parts = networkStr.split(".").map(Number);
-  const networkNum = ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+  const parts = networkStr!.split(".").map(Number);
+  const networkNum = ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0;
   const hostBits = 32 - cidr;
   const numHosts = Math.min(maxHosts, (1 << hostBits) - 2); // Exclude network and broadcast
 


### PR DESCRIPTION
## Problem (production-down, operator-reported)

The portal kept becoming completely unresponsive — every route (pages, `/api/health`, even `/favicon.ico`) hung for 45s+ while CPU sat near 0 and the container stayed "healthy". Surfaced to the operator as "Chrome/portal keeps wedging — not enterprise-class."

## Root cause (diagnosed on the live install)

The `arp_scan` discovery collector maps a subnet by pinging all hosts. It pinged **all 254 addresses of a /24 sequentially via `spawnSync`** — on the same Node thread that serves HTTP. Most addresses are empty, so each ping waited its full ~1s timeout → **~250s of total event-loop freeze per scan**. CPU stayed near 0 because the thread was *blocked waiting*, not computing. The discovery scheduler re-ran sweeps back-to-back, so the portal was unreachable almost continuously. The "local LLM timing out" symptom was the same freeze — the async fetch couldn't progress while the loop was blocked (the model itself is healthy).

`nmap` (the intended fast path) was **not bundled in the image**, and the code ran `nmap -sn` **without `-n`**, so reverse-DNS made a /24 take ~47s and blow the 30s command timeout → it always fell back to the blocking ping loop.

Trigger: an `arp_scan` connection for the host LAN (`192.168.0.0/24`) created 2026-06-03.

## Fix

- **Replace `spawnSync` with promisified `execFile`** — async + time-bounded; never blocks the event loop.
- **Bounded-parallel ping sweep** (32 concurrent) instead of 254 sequential → a /24 completes in ~8s worst case.
- **`nmap -sn -n -T4`** (skip reverse-DNS) and **bundle `nmap` in the portal image** so the fast path (~2-5s) is available on every install.
- Honest comments (the old ones falsely claimed "parallel"/"non-blocking").
- New `arp-scan.test.ts`: nmap fast path, bounded-parallel fallback, concurrency >1, guards.

## Verification

- ✅ New tests: 5/5 pass. Existing network tests: 19/19 pass.
- ✅ No typecheck errors from changed files (the worktree's pre-existing `generated/client` errors are an environment artifact; CI runs `prisma generate`).
- ✅ Live install already stabilized via interim containment (paused the arp_scan connection + hand-installed nmap). **After merge/deploy: re-enable the `arp_scan` connection and confirm the portal stays responsive during a live scan.**

## Notes
- Product follow-up (not in scope): this feature scans the entire LAN it runs on, including personal devices — worth a default-behavior decision.

BI-4CA890B7

🤖 Generated with [Claude Code](https://claude.com/claude-code)