### PR TITLE
fix(onboarding): COO names its actual local model instead of stale "Ollama" (BI-0CED314D)

### DIFF
--- a/apps/web/lib/consume/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/consume/__snapshots__/index.test.ts.snap
@@ -13,6 +13,7 @@ exports[`consume barrel export > exports all public symbols 1`] = `
   "getNeedsReviewEntities",
   "getOpenPortfolioQualityIssues",
   "getTasksForEmployee",
+  "resolveLocalModelLabel",
   "summarizeDiscoveryHealth",
 ]
 `;

--- a/apps/web/lib/consume/onboarding-prompt.test.ts
+++ b/apps/web/lib/consume/onboarding-prompt.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProvider: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { resolveLocalModelLabel, buildOnboardingPrompt } from "./onboarding-prompt";
+import type { SetupContext, SetupStep, StepStatus } from "../actions/setup-constants";
+
+const mockProvider = prisma.modelProvider as unknown as {
+  findFirst: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  mockProvider.findFirst.mockReset();
+  mockProvider.findMany.mockReset();
+  mockProvider.findMany.mockResolvedValue([]); // no pricing rows by default
+});
+
+describe("resolveLocalModelLabel", () => {
+  it("returns the general conversational family, title-cased, skipping coder/embed", async () => {
+    mockProvider.findFirst.mockResolvedValue({
+      families: ["qwen3", "qwen2.5-coder", "gemma4", "mistral", "nomic-embed"],
+      enabledFamilies: [],
+    });
+    expect(await resolveLocalModelLabel()).toBe("Qwen3");
+  });
+
+  it("prefers enabledFamilies over the full catalog when set", async () => {
+    mockProvider.findFirst.mockResolvedValue({
+      families: ["qwen3", "gemma4"],
+      enabledFamilies: ["gemma4"],
+    });
+    expect(await resolveLocalModelLabel()).toBe("Gemma4");
+  });
+
+  it("falls back past coder/embed-only pools to the first available family", async () => {
+    mockProvider.findFirst.mockResolvedValue({
+      families: ["qwen2.5-coder", "nomic-embed"],
+      enabledFamilies: [],
+    });
+    expect(await resolveLocalModelLabel()).toBe("Qwen2.5-coder");
+  });
+
+  it("returns null when no local provider is configured", async () => {
+    mockProvider.findFirst.mockResolvedValue(null);
+    expect(await resolveLocalModelLabel()).toBeNull();
+  });
+
+  it("returns null when the local provider has no families", async () => {
+    mockProvider.findFirst.mockResolvedValue({ families: [], enabledFamilies: [] });
+    expect(await resolveLocalModelLabel()).toBeNull();
+  });
+});
+
+describe("buildOnboardingPrompt — local model honesty (BI-0CED314D)", () => {
+  const steps = {} as Record<string, StepStatus>;
+  const context = { industry: null, hasCloudProvider: false } as unknown as SetupContext;
+
+  it("names the actual local model and never hardcodes Ollama/Gemma", async () => {
+    mockProvider.findFirst.mockResolvedValue({
+      families: ["qwen3", "qwen2.5-coder"],
+      enabledFamilies: [],
+    });
+    const prompt = await buildOnboardingPrompt("welcome" as SetupStep, steps, context);
+    expect(prompt).toContain("small local AI model (Qwen3)");
+    expect(prompt).not.toMatch(/Ollama/i);
+    expect(prompt).not.toMatch(/\(Gemma\)/i);
+  });
+
+  it("uses a generic phrase when no local model is configured", async () => {
+    mockProvider.findFirst.mockResolvedValue(null);
+    const prompt = await buildOnboardingPrompt("welcome" as SetupStep, steps, context);
+    expect(prompt).toContain("small local AI model on the user's own hardware");
+    expect(prompt).not.toMatch(/Ollama/i);
+  });
+});

--- a/apps/web/lib/consume/onboarding-prompt.ts
+++ b/apps/web/lib/consume/onboarding-prompt.ts
@@ -3,13 +3,43 @@ import { SETUP_STEPS } from "../actions/setup-constants";
 import { prisma } from "@dpf/db";
 import { MODEL_ROUTING_ENDPOINT_TYPES } from "@/lib/routing/provider-eligibility";
 
-const COO_BASE_PROMPT = `You are the platform's Chief Operating Officer — the user's second-in-command.
+/**
+ * Human-facing name of the local AI model the onboarding COO actually runs on.
+ *
+ * BI-0CED314D: this line used to hardcode "Ollama" (and elsewhere "Gemma") —
+ * but Ollama is a model *runtime*, not a model, and a hardcoded family name
+ * goes stale the moment the bundled local model changes (it now ships Qwen3).
+ * Resolve it from the configured local provider so the COO never misstates it.
+ * Returns null when no local model is configured (caller uses a generic phrase).
+ */
+export async function resolveLocalModelLabel(): Promise<string | null> {
+  const local = await prisma.modelProvider.findFirst({
+    where: { providerId: "local" },
+    select: { families: true, enabledFamilies: true },
+  });
+  if (!local) return null;
+  const asStrings = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((f): f is string => typeof f === "string") : [];
+  const enabled = asStrings(local.enabledFamilies);
+  const families = asStrings(local.families);
+  // Prefer a general conversational model — skip code-specialist and embedding
+  // families so the COO names the model it actually converses with.
+  const pool = (enabled.length ? enabled : families).filter(
+    (f) => !/coder|embed/i.test(f),
+  );
+  const raw = pool[0] ?? enabled[0] ?? families[0];
+  if (!raw) return null;
+  return raw.charAt(0).toUpperCase() + raw.slice(1);
+}
+
+function cooBasePrompt(localModelLine: string): string {
+  return `You are the platform's Chief Operating Officer — the user's second-in-command.
 You are guiding a new platform owner through initial setup.
 
 This is a CONVERSATION request. You have no tools. Do not attempt to call functions, execute actions, or generate structured output.
 
 IMPORTANT CONSTRAINTS:
-- You are running on a local AI model (Ollama). Be honest about this.
+${localModelLine}
 - Do not attempt complex reasoning, multi-step analysis, or tool orchestration.
 - Your job is guided conversation: explain, recommend, and acknowledge.
 - If the user asks something beyond your capability, say so clearly and note that a cloud AI provider would handle it better.
@@ -24,6 +54,7 @@ AT EVERY STEP BOUNDARY, offer three options:
 1. Continue to the next step
 2. Skip this step for now
 3. Pause and come back later`;
+}
 
 /**
  * Assemble the full COO system prompt for the onboarding agent,
@@ -36,6 +67,13 @@ export async function buildOnboardingPrompt(
 ): Promise<string> {
   const completedSteps = SETUP_STEPS.filter((s) => steps[s] === "completed");
   const skippedSteps = SETUP_STEPS.filter((s) => steps[s] === "skipped");
+
+  // Name the actual local model so the COO is honest about what it runs on
+  // (BI-0CED314D), rather than a stale hardcoded "Ollama"/"Gemma".
+  const localModel = await resolveLocalModelLabel();
+  const localModelLine = localModel
+    ? `- You are running on a small local AI model (${localModel}) on the user's own hardware. Be honest about this.`
+    : `- You are running on a small local AI model on the user's own hardware. Be honest about this.`;
 
   // Load provider pricing for cost explanations
   let costSummary = "";
@@ -62,7 +100,7 @@ export async function buildOnboardingPrompt(
     }
   }
 
-  return `${COO_BASE_PROMPT}
+  return `${cooBasePrompt(localModelLine)}
 
 CURRENT STATE:
 - Step: ${currentStep}


### PR DESCRIPTION
## Problem
The onboarding **COO** system prompt (`apps/web/lib/consume/onboarding-prompt.ts`) hardcoded *"You are running on a local AI model (Ollama)."* — but **Ollama is a model runtime, not a model**, and a hardcoded family name goes stale: the bundled local model is now **Qwen3** (the `Docker Model Runner (local)` provider ships `qwen3`/`qwen2.5-coder`/`gemma`/`mistral`). So the COO misstates what it actually runs on (BI-0CED314D).

## Fix
Resolve the local model name **dynamically** from the configured local provider so it never goes stale:
- New `resolveLocalModelLabel()` reads the `local` provider's `enabledFamilies`/`families`, skips code-specialist (`*-coder`) and embedding (`*-embed`) families, and title-cases the general conversational model (e.g. `qwen3` → `Qwen3`).
- `buildOnboardingPrompt()` injects `"a small local AI model (Qwen3) on the user's own hardware"`, falling back to a generic phrase when no local model is configured.

Follows the project's "don't hardcode model names — they go stale / dynamic model discovery" principle.

## Tests
- `resolveLocalModelLabel`: general-family selection, `enabledFamilies` preference, coder/embed-only fallback, null cases.
- `buildOnboardingPrompt`: asserts the real model name appears and `Ollama`/`(Gemma)` never do.
- Updated the consume barrel-export snapshot for the new export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)