### PR TITLE
fix(dev): isolate package-local node_modules from host worktrees (BI-9C557535)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,30 @@
 name: ${COMPOSE_PROJECT_NAME:-dpf}
 
+# Dev-profile workspace mount (BI-9C557535). The dev services bind-mount the
+# whole repo at /workspace, then overlay every node_modules directory with a
+# named volume. Overlaying ONLY the root node_modules is not enough: pnpm also
+# materialises package-local node_modules (symlink farms) under apps/* and
+# packages/*, which would be written straight onto the host bind mount —
+# polluting host worktrees with container-owned, Linux-style reparse points
+# that Windows/BuildKit cannot open. Named (not anonymous) volumes are required
+# so dev-init's install is visible to dev-portal at runtime.
+x-dev-workspace-volumes: &dev-workspace-volumes
+  - .:/workspace
+  - dev_node_modules:/workspace/node_modules
+  - dev_nm_apps_web:/workspace/apps/web/node_modules
+  - dev_nm_apps_mobile:/workspace/apps/mobile/node_modules
+  - dev_nm_api_client:/workspace/packages/api-client/node_modules
+  - dev_nm_db:/workspace/packages/db/node_modules
+  - dev_nm_dpf_bootstrap:/workspace/packages/dpf-bootstrap/node_modules
+  - dev_nm_finance_templates:/workspace/packages/finance-templates/node_modules
+  - dev_nm_integration_shared:/workspace/packages/integration-shared/node_modules
+  - dev_nm_storefront_templates:/workspace/packages/storefront-templates/node_modules
+  - dev_nm_types:/workspace/packages/types/node_modules
+  - dev_nm_validators:/workspace/packages/validators/node_modules
+  - dev_nm_svc_adp:/workspace/services/adp/node_modules
+  - dev_nm_svc_edge_node:/workspace/services/edge-node/node_modules
+  - dev_nm_svc_integration_test_harness:/workspace/services/integration-test-harness/node_modules
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -495,9 +520,7 @@ services:
       NEO4J_PASSWORD: dpf_dev_password
       PRODUCTION_NEO4J_URI: bolt://neo4j:7687
       DPF_ENVIRONMENT: dev
-    volumes:
-      - .:/workspace
-      - dev_node_modules:/workspace/node_modules
+    volumes: *dev-workspace-volumes
     depends_on:
       dev-postgres:
         condition: service_healthy
@@ -518,9 +541,7 @@ services:
     profiles: ["dev"]
     ports:
       - "3001:3000"
-    volumes:
-      - .:/workspace
-      - dev_node_modules:/workspace/node_modules
+    volumes: *dev-workspace-volumes
     environment:
       DATABASE_URL: postgresql://dpf:dpf_dev@dev-postgres:5432/dpf
       NEO4J_URI: bolt://dev-neo4j:7687
@@ -854,6 +875,21 @@ volumes:
   dev_neo4jdata:
   dev_qdrant_data:
   dev_node_modules:
+  # Package-local node_modules overlays (BI-9C557535) — keep pnpm's per-package
+  # symlink farms off the host bind mount. One per workspace package.
+  dev_nm_apps_web:
+  dev_nm_apps_mobile:
+  dev_nm_api_client:
+  dev_nm_db:
+  dev_nm_dpf_bootstrap:
+  dev_nm_finance_templates:
+  dev_nm_integration_shared:
+  dev_nm_storefront_templates:
+  dev_nm_types:
+  dev_nm_validators:
+  dev_nm_svc_adp:
+  dev_nm_svc_edge_node:
+  dev_nm_svc_integration_test_harness:
   sandbox_pgdata:
   sandbox_workspace:
   dpf_tts_voices:


### PR DESCRIPTION
## Problem (BI-9C557535)
The dev-profile services (`dev-init`, `dev-portal`) bind-mount the whole repo at `/workspace` and overlay **only the root** `node_modules` with the `dev_node_modules` named volume. pnpm still materialises **package-local** `node_modules` (symlink farms) under `apps/*`, `packages/*`, `services/*` — written straight onto the **host bind mount**. On Windows worktrees these become container-owned, Linux-style reparse points that Windows/BuildKit cannot open (observed 2026-06-04), which is the root of the recurring *"dev-portal-start pollutes host node_modules" / EACCES on workspace symlinks* failures.

## Fix
Overlay **every** workspace package's `node_modules` with its own **named** volume, via a shared YAML anchor (`x-dev-workspace-volumes`) referenced by both dev services. Container installs now stay container-owned; the host worktree is never written to. Named (not anonymous) volumes are used so `dev-init`'s `pnpm install --frozen-lockfile` is visible to `dev-portal` at runtime.

Covers all 13 workspace packages (apps/web, apps/mobile, packages/{api-client,db,dpf-bootstrap,finance-templates,integration-shared,storefront-templates,types,validators}, services/{adp,edge-node,integration-test-harness}).

## Verification
- `docker compose --profile dev config` → **PARSE_OK**
- Both dev services resolve all 13 package `node_modules` mounts; 13 named volumes declared.
- Config-only change, scoped to the `dev` profile — does not touch the production `portal`/`portal-init` services or the running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)