### PR TITLE
feat(observability): EP-FULL-OBS Tier 2 app-code — log-signature scanner, PIR dedupe, Log Issues panel

### DIFF
--- a/apps/web/components/monitoring/LogIssuesPanel.tsx
+++ b/apps/web/components/monitoring/LogIssuesPanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+// EP-FULL-OBS Tier 2 (BI-5FE8656F) — System Health "Log Issues" panel.
+//
+// Surfaces the log-signature reports the scanner filed from Loki, so an
+// operator sees hidden log problems in-portal without opening Docker Desktop.
+// Each row deep-links to Grafana → Explore → Loki, filtered to that service.
+
+import { useCallback, useEffect, useState } from "react";
+import { TONE_COLOR, type Tone } from "./health-summary";
+import { getLogSignatureIssues } from "@/lib/actions/quality";
+
+interface LogIssue {
+  reportId: string;
+  title: string;
+  severity: string;
+  status: string;
+  description: string | null;
+  dedupeKey: string | null;
+  createdAt: string;
+}
+
+const GRAFANA_BASE = "http://localhost:3002";
+
+function severityTone(severity: string): Tone {
+  if (severity === "critical" || severity === "error") return "critical";
+  if (severity === "high" || severity === "medium" || severity === "warn") return "warning";
+  return "success";
+}
+
+// dedupeKey is `log-sig:<service>:<sigId>` — pull the service for the drill-down.
+function serviceOf(issue: LogIssue): string | null {
+  const parts = issue.dedupeKey?.split(":");
+  return parts && parts.length >= 3 ? parts[1] : null;
+}
+
+// Best-effort Grafana Explore deep link (lands on Explore even if the pane
+// param is ignored by a Grafana version mismatch).
+function lokiExploreUrl(service: string | null): string {
+  const selector = service ? `{compose_project="dpf", service="${service}"}` : `{compose_project="dpf"}`;
+  const panes = {
+    dpf: {
+      datasource: "loki",
+      queries: [
+        { refId: "A", datasource: { type: "loki" }, expr: `${selector} |~ "(?i)(error|fatal|panic|exception|traceback)"` },
+      ],
+      range: { from: "now-3h", to: "now" },
+    },
+  };
+  return `${GRAFANA_BASE}/explore?schemaVersion=1&orgId=1&panes=${encodeURIComponent(JSON.stringify(panes))}`;
+}
+
+export function LogIssuesPanel() {
+  const [issues, setIssues] = useState<LogIssue[]>([]);
+  const [state, setState] = useState<"loading" | "ready" | "unauthorized" | "error">("loading");
+
+  const load = useCallback(async () => {
+    try {
+      const res = await getLogSignatureIssues();
+      if (!res.authorized) {
+        setState("unauthorized");
+        return;
+      }
+      setIssues(res.items);
+      setState("ready");
+    } catch {
+      setState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 60_000);
+    return () => clearInterval(id);
+  }, [load]);
+
+  if (state === "unauthorized") return null;
+
+  return (
+    <section>
+      <h3 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-wider mb-2">
+        Log Issues
+      </h3>
+
+      {state === "loading" && (
+        <p className="text-xs text-[var(--dpf-muted)]">Scanning…</p>
+      )}
+
+      {state === "error" && (
+        <p className="text-xs text-[var(--dpf-muted)]">Log issue data unavailable</p>
+      )}
+
+      {state === "ready" && issues.length === 0 && (
+        <p className="text-xs text-[var(--dpf-success)]">No open log issues</p>
+      )}
+
+      {state === "ready" && issues.length > 0 && (
+        <div className="rounded-lg border border-[var(--dpf-border)] overflow-hidden">
+          <table className="w-full text-xs">
+            <tbody>
+              {issues.map((issue) => {
+                const tone = severityTone(issue.severity);
+                const service = serviceOf(issue);
+                const time = new Date(issue.createdAt).toLocaleString([], {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+                return (
+                  <tr key={issue.reportId} className="border-t border-[var(--dpf-border)] first:border-t-0 align-top">
+                    <td className="px-3 py-1.5 text-[var(--dpf-muted)] w-28 whitespace-nowrap">{time}</td>
+                    <td className="px-2 py-1.5 w-16">
+                      <span className="text-[10px] font-bold uppercase" style={{ color: TONE_COLOR[tone] }}>
+                        {issue.severity.toUpperCase()}
+                      </span>
+                    </td>
+                    <td className="px-2 py-1.5 text-[var(--dpf-text)]">{issue.title}</td>
+                    <td className="px-3 py-1.5 text-right whitespace-nowrap">
+                      <a
+                        href={lokiExploreUrl(service)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--dpf-accent)] hover:underline"
+                      >
+                        Logs ↗
+                      </a>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/monitoring/SystemHealthDashboard.tsx
+++ b/apps/web/components/monitoring/SystemHealthDashboard.tsx
@@ -9,6 +9,7 @@ import { MetricStat } from "./MetricStat";
 import { MetricTable } from "./MetricTable";
 import { ContainerResourceTable } from "./ContainerResourceTable";
 import { AiCoworkerHealthPanel } from "./AiCoworkerHealthPanel";
+import { LogIssuesPanel } from "./LogIssuesPanel";
 import { RecentAlertsPanel } from "./RecentAlertsPanel";
 import { HOST_RESOURCE_QUERIES, isHostTelemetryConfigured } from "./health-summary";
 import { useMetricQuery } from "./useMetricQuery";
@@ -157,6 +158,10 @@ function SystemHealthContent() {
           />
         </div>
       </section>
+
+      {/* Log issues — signatures the log scanner filed from container logs
+          (EP-FULL-OBS Tier 2). Surfaces hidden log problems without Docker Desktop. */}
+      <LogIssuesPanel />
 
       {/* Recent alerts history */}
       <RecentAlertsPanel />

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -81,6 +81,55 @@ export async function getIssueReports(filters?: {
   return { items, total, page, pageSize };
 }
 
+// BI-5FE8656F (EP-FULL-OBS Tier 2): the data source for the System Health
+// "Log Issues" panel. Returns unresolved log_signature reports the scanner
+// filed. Auth-gated (defense in depth — the System Health tab is already
+// admin-scoped) so a client component can call it directly.
+export async function getLogSignatureIssues(): Promise<{
+  authorized: boolean;
+  items: {
+    reportId: string;
+    title: string;
+    severity: string;
+    status: string;
+    description: string | null;
+    dedupeKey: string | null;
+    createdAt: string;
+  }[];
+}> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")
+  ) {
+    return { authorized: false, items: [] };
+  }
+
+  const rows = await prisma.platformIssueReport.findMany({
+    where: {
+      type: "log_signature",
+      status: { notIn: ["resolved_locally", "resolved_upstream", "suppressed"] },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      reportId: true,
+      title: true,
+      severity: true,
+      status: true,
+      description: true,
+      dedupeKey: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    authorized: true,
+    items: rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })),
+  };
+}
+
 /**
  * Resolve each report to its projected BacklogItem (EP-INTAKE-UNIFY Phase 6).
  * PlatformIssueReport has no FK to the BI; the projection embeds the public

--- a/apps/web/lib/observability/log-signature.test.ts
+++ b/apps/web/lib/observability/log-signature.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  isErrorLine,
+  toTemplate,
+  signatureId,
+  dedupeKeyFor,
+  severityForCount,
+  clusterBySignature,
+  type RawLogLine,
+} from "./log-signature";
+
+describe("isErrorLine", () => {
+  it("matches genuine error lines", () => {
+    expect(isErrorLine("[discovery-scheduler] Failed: Error [PrismaClientKnownRequestError]")).toBe(true);
+    expect(isErrorLine("panic: runtime error: nil pointer")).toBe(true);
+    expect(isErrorLine("Traceback (most recent call last):")).toBe(true);
+  });
+
+  it("rejects the ErrorCode substring false-positive caught live", () => {
+    // grafana info line — 'error' only appears inside the field name ErrorCode.
+    expect(
+      isErrorLine(
+        'logger=plugins t=2026-06-09T22:59:44Z level=info msg="flag evaluation succeeded" flag="{ErrorCode: ErrorMessage:}"',
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects structured info/debug logs even if they contain the word error", () => {
+    expect(isErrorLine('level=info msg="no error occurred"')).toBe(false);
+    expect(isErrorLine('{"level":"debug","msg":"error budget ok"}')).toBe(false);
+  });
+
+  it("rejects Loki/Alloy self-noise", () => {
+    expect(isErrorLine("entry has timestamp too old: 2026-05-26")).toBe(false);
+    expect(isErrorLine("final error sending batch, no retries left")).toBe(false);
+  });
+
+  it("rejects empty/clean lines", () => {
+    expect(isErrorLine("")).toBe(false);
+    expect(isErrorLine("request completed in 12ms")).toBe(false);
+  });
+});
+
+describe("toTemplate", () => {
+  it("masks timestamps, numbers, hex and paths so variants collapse", () => {
+    const a = toTemplate("2026-06-09T23:28:04.039Z worker 4821 failed at /app/src/x.js:61:8024");
+    const b = toTemplate("2026-06-09T11:02:55.001Z worker 9 failed at /app/src/x.js:12:3");
+    expect(a).toBe(b);
+    expect(a).toContain("<ts>");
+    expect(a).toContain("<n>");
+    expect(a).toContain("<path>");
+  });
+
+  it("masks uuids", () => {
+    expect(toTemplate("session 4f9c1a2b-1111-2222-3333-444455556666 dropped")).toContain("<uuid>");
+  });
+});
+
+describe("signatureId / dedupeKeyFor", () => {
+  it("is stable for the same (service, template) and differs across services", () => {
+    const t = toTemplate("Error connecting to db at 12:00");
+    expect(signatureId("portal", t)).toBe(signatureId("portal", t));
+    expect(signatureId("portal", t)).not.toBe(signatureId("inngest", t));
+    expect(signatureId("portal", t)).toMatch(/^[0-9a-f]{10}$/);
+  });
+
+  it("formats a namespaced dedupe key", () => {
+    expect(dedupeKeyFor("portal", "abc1234567")).toBe("log-sig:portal:abc1234567");
+  });
+});
+
+describe("severityForCount", () => {
+  it("scales severity with occurrence count (loud == higher)", () => {
+    expect(severityForCount(1)).toBe("low");
+    expect(severityForCount(10)).toBe("medium");
+    expect(severityForCount(60)).toBe("high");
+    expect(severityForCount(500)).toBe("critical");
+  });
+});
+
+describe("clusterBySignature", () => {
+  it("collapses hundreds of near-identical error lines into one signature", () => {
+    const lines: RawLogLine[] = [];
+    for (let i = 0; i < 250; i++) {
+      lines.push({
+        service: "portal",
+        line: `2026-06-09T23:0${i % 9}:00Z [scheduler] Failed to update job drain ${i}: Error [PrismaClientKnownRequestError]`,
+        tsMs: 1_000 + i,
+      });
+    }
+    const buckets = clusterBySignature(lines);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].count).toBe(250);
+    expect(buckets[0].service).toBe("portal");
+    expect(buckets[0].firstTs).toBe(1_000);
+    expect(buckets[0].lastTs).toBe(1_249);
+  });
+
+  it("separates distinct problems and distinct services, sorts by count desc", () => {
+    const lines: RawLogLine[] = [
+      { service: "portal", line: "Error: db timeout 5ms", tsMs: 1 },
+      { service: "portal", line: "Error: db timeout 9ms", tsMs: 2 },
+      { service: "portal", line: "Error: db timeout 3ms", tsMs: 3 },
+      { service: "inngest", line: "panic: worker crashed code 7", tsMs: 4 },
+      { service: "grafana", line: 'level=info msg="started ok"', tsMs: 5 }, // filtered out
+    ];
+    const buckets = clusterBySignature(lines);
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].count).toBe(3); // portal db timeout, sorted first
+    expect(buckets[0].service).toBe("portal");
+    expect(buckets[1].service).toBe("inngest");
+    expect(buckets.some((b) => b.service === "grafana")).toBe(false);
+  });
+});

--- a/apps/web/lib/observability/log-signature.ts
+++ b/apps/web/lib/observability/log-signature.ts
@@ -1,0 +1,113 @@
+// EP-FULL-OBS Tier 2 (BI-5FE8656F) — pure log-line signature clustering.
+//
+// Turns raw container log lines into stable "signatures" by template
+// extraction (strip timestamps, ids, paths, numbers) so that hundreds of
+// near-identical error lines collapse to ONE actionable signature. Pure and
+// dependency-free so it is exhaustively unit-testable without Loki, Prisma, or
+// Inngest. The Inngest scanner (log-signature-scanner.ts) is the only caller.
+
+import { createHash } from "node:crypto";
+
+export interface RawLogLine {
+  service: string;
+  line: string;
+  /** epoch milliseconds */
+  tsMs: number;
+}
+
+export interface SignatureBucket {
+  service: string;
+  signatureId: string;
+  template: string;
+  count: number;
+  sample: string;
+  /** epoch milliseconds */
+  firstTs: number;
+  lastTs: number;
+}
+
+export type LogIssueSeverity = "critical" | "high" | "medium" | "low";
+
+// Lines that are Alloy/Loki self-noise about their own backfill — never an
+// application problem, must never become a signature.
+const SELF_NOISE = /has timestamp too old|final error sending batch|loki\.write/i;
+// Structured INFO/DEBUG logs: the "error" match is almost always a field name
+// (e.g. grafana `ErrorCode:`), not an actual error. Caught live during the
+// interim bring-up — filtering these is what keeps the detector trustworthy.
+const INFO_DEBUG = /level=(info|debug)\b|"level":\s*"(info|debug)"/i;
+// A whole-word error token, NOT a substring of ErrorCode / ErrorMessage.
+const ERROR_TOKEN = /\b(error|fatal|panic|exception|traceback)\b/i;
+
+/** True when a line is a genuine error worth clustering (not info/debug/self-noise). */
+export function isErrorLine(line: string): boolean {
+  if (!line) return false;
+  if (SELF_NOISE.test(line)) return false;
+  if (INFO_DEBUG.test(line)) return false;
+  return ERROR_TOKEN.test(line);
+}
+
+/** Collapse a log line to a stable template by masking variable tokens. */
+export function toTemplate(line: string): string {
+  return line
+    .replace(/\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?/g, "<ts>") // ISO timestamps
+    .replace(/\b[0-9a-fA-F]{8}-[0-9a-fA-F-]{20,}\b/g, "<uuid>") // uuids
+    .replace(/\b0x[0-9a-fA-F]+\b/g, "<hex>") // hex addresses
+    .replace(/\b[0-9a-fA-F]{12,}\b/g, "<hex>") // long hex ids / shas
+    .replace(/([/\\])[^\s:]+(\.[a-zA-Z0-9]+)?(:\d+:\d+)?/g, "<path>") // paths / file:line:col
+    .replace(/\b\d+(\.\d+)?(ms|s|MB|GB|KB|GiB|MiB)?\b/g, "<n>") // numbers / durations / sizes
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+/** Deterministic 10-char id for a (service, template) pair. */
+export function signatureId(service: string, template: string): string {
+  return createHash("sha1").update(`${service}|${template}`).digest("hex").slice(0, 10);
+}
+
+/** Stable dedupe key used as PlatformIssueReport.dedupeKey for idempotent filing. */
+export function dedupeKeyFor(service: string, sigId: string): string {
+  return `log-sig:${service}:${sigId}`;
+}
+
+/**
+ * Fold rate-awareness into the single PIR path: a louder signature (more
+ * occurrences in the window) files at a higher severity. This is why the scan
+ * covers both the "loud" Mac-incident case and the "quiet" first-occurrence
+ * case without a separate alert pipeline.
+ */
+export function severityForCount(count: number): LogIssueSeverity {
+  if (count >= 300) return "critical";
+  if (count >= 60) return "high";
+  if (count >= 10) return "medium";
+  return "low";
+}
+
+/** Cluster raw lines into signatures, sorted by descending occurrence count. */
+export function clusterBySignature(lines: RawLogLine[]): SignatureBucket[] {
+  const buckets = new Map<string, SignatureBucket>();
+  for (const { service, line, tsMs } of lines) {
+    if (!isErrorLine(line)) continue;
+    const template = toTemplate(line);
+    if (template.length < 12) continue; // too short to be a meaningful signature
+    const sigId = signatureId(service, template);
+    const key = `${service}|${sigId}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count++;
+      existing.firstTs = Math.min(existing.firstTs, tsMs);
+      existing.lastTs = Math.max(existing.lastTs, tsMs);
+    } else {
+      buckets.set(key, {
+        service,
+        signatureId: sigId,
+        template,
+        count: 1,
+        sample: line.trim().slice(0, 300),
+        firstTs: tsMs,
+        lastTs: tsMs,
+      });
+    }
+  }
+  return [...buckets.values()].sort((a, b) => b.count - a.count);
+}

--- a/apps/web/lib/observability/loki-query.ts
+++ b/apps/web/lib/observability/loki-query.ts
@@ -1,0 +1,59 @@
+// EP-FULL-OBS Tier 2 (BI-5FE8656F) — server-side Loki query helper.
+//
+// Thin wrapper over Loki's query_range HTTP API. The portal reaches Loki by
+// its Docker-network DNS name (loki:3100) — same as it reaches Prometheus. No
+// browser access (CORS / network isolation); this runs server-side only.
+
+import type { RawLogLine } from "@/lib/observability/log-signature";
+
+const DEFAULT_LOKI_URL = process.env.LOKI_URL || "http://loki:3100";
+// Whole-word-ish error filter pushed down to Loki to bound the result set.
+// Fine-grained filtering (info/debug exclusion, substring guards) happens in
+// log-signature.isErrorLine — this is just a cheap server-side prefilter.
+const ERROR_FILTER = "(?i)(error|fatal|panic|exception|traceback)";
+
+export interface LokiQueryOptions {
+  lookbackMinutes: number;
+  lokiUrl?: string;
+  limit?: number;
+  /** Injectable clock for deterministic tests. */
+  nowMs?: number;
+  timeoutMs?: number;
+}
+
+interface LokiStream {
+  stream?: Record<string, string>;
+  values?: [string, string][];
+}
+
+/** Query Loki for error/warn lines across all dpf containers in the window. */
+export async function queryLokiErrorLines(opts: LokiQueryOptions): Promise<RawLogLine[]> {
+  const lokiUrl = opts.lokiUrl ?? DEFAULT_LOKI_URL;
+  const now = opts.nowMs ?? Date.now();
+  const startNs = String((now - opts.lookbackMinutes * 60_000) * 1_000_000);
+  const endNs = String(now * 1_000_000);
+
+  const url = new URL("/loki/api/v1/query_range", lokiUrl);
+  url.searchParams.set("query", `{compose_project="dpf"} |~ "${ERROR_FILTER}"`);
+  url.searchParams.set("start", startNs);
+  url.searchParams.set("end", endNs);
+  url.searchParams.set("limit", String(opts.limit ?? 5000));
+  url.searchParams.set("direction", "forward");
+
+  const res = await fetch(url.toString(), {
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 10_000),
+  });
+  if (!res.ok) {
+    throw new Error(`Loki query failed: ${res.status} ${await res.text().catch(() => "")}`);
+  }
+
+  const data = (await res.json()) as { data?: { result?: LokiStream[] } };
+  const out: RawLogLine[] = [];
+  for (const stream of data?.data?.result ?? []) {
+    const service = stream.stream?.service || stream.stream?.container || "unknown";
+    for (const [tsNs, line] of stream.values ?? []) {
+      out.push({ service, line, tsMs: Math.floor(Number(tsNs) / 1e6) });
+    }
+  }
+  return out;
+}

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -16,6 +16,7 @@ const LIMITS = {
   userAgent: 500,
   triggerKind: 100,
   supportSessionId: 191,
+  dedupeKey: 191,
 } as const;
 
 // Same route → portfolio slug map used today by reportQualityIssue().
@@ -68,6 +69,8 @@ export interface CreatePlatformIssueReportInput {
   userAgent?: string | null;
   triggerKind?: string | null;
   supportSessionId?: string | null;
+  // BI-5FE8656F: stable idempotency key for automated producers (log scanner).
+  dedupeKey?: string | null;
 
   // Identity / linkage
   reportedById?: string | null;
@@ -145,6 +148,7 @@ export async function createPlatformIssueReport(
       userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
       triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
       supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
+      dedupeKey: trimTo(input.dedupeKey ?? null, LIMITS.dedupeKey),
       reportedById: input.reportedById ?? null,
       threadId: input.threadId ?? null,
       agentId: input.agentId ?? null,

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -44,6 +44,7 @@ import {
   qdrantBackupRequested,
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
+import { logSignatureScanner } from "./log-signature-scanner";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -69,6 +70,7 @@ export const scheduledFunctions = [
   postgresDailyBackupScheduled,
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
+  logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
 ];
 
 export const eventFunctions = [

--- a/apps/web/lib/queue/functions/log-signature-scanner.test.ts
+++ b/apps/web/lib/queue/functions/log-signature-scanner.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RawLogLine } from "@/lib/observability/log-signature";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  createPIR: vi.fn(),
+  queryLoki: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformIssueReport: { findFirst: mocks.findFirst },
+  },
+}));
+
+vi.mock("@/lib/quality/platform-issue-reports", () => ({
+  createPlatformIssueReport: mocks.createPIR,
+}));
+
+vi.mock("@/lib/observability/loki-query", () => ({
+  queryLokiErrorLines: mocks.queryLoki,
+}));
+
+import { runLogSignatureScan } from "./log-signature-scanner";
+
+function errLines(service: string, msg: string, n: number): RawLogLine[] {
+  return Array.from({ length: n }, (_, i) => ({ service, line: `Error: ${msg} ${i}`, tsMs: 1000 + i }));
+}
+
+describe("runLogSignatureScan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findFirst.mockResolvedValue(null); // nothing filed yet by default
+    mocks.createPIR.mockResolvedValue({ reportId: "PIR-TEST" });
+  });
+
+  it("files one PIR per novel signature, with a stable dedupeKey", async () => {
+    mocks.queryLoki.mockResolvedValue([
+      ...errLines("portal", "db timeout", 3),
+      ...errLines("inngest", "worker crashed", 5),
+    ]);
+
+    const res = await runLogSignatureScan({ lookbackMinutes: 20 });
+
+    expect(res.reportsCreated).toBe(2);
+    expect(res.skippedExisting).toBe(0);
+    expect(mocks.createPIR).toHaveBeenCalledTimes(2);
+    for (const call of mocks.createPIR.mock.calls) {
+      const arg = call[0];
+      expect(arg.type).toBe("log_signature");
+      expect(arg.source).toBe("log-signature-scanner");
+      expect(arg.dedupeKey).toMatch(/^log-sig:(portal|inngest):[0-9a-f]{10}$/);
+    }
+  });
+
+  it("does NOT re-file a signature that already has an unresolved report", async () => {
+    mocks.queryLoki.mockResolvedValue(errLines("portal", "db timeout", 3));
+    mocks.findFirst.mockResolvedValue({ id: "existing" }); // already filed + open
+
+    const res = await runLogSignatureScan();
+
+    expect(res.reportsCreated).toBe(0);
+    expect(res.skippedExisting).toBe(1);
+    expect(mocks.createPIR).not.toHaveBeenCalled();
+  });
+
+  it("treats a P2002 race as skipped, not a crash", async () => {
+    mocks.queryLoki.mockResolvedValue(errLines("portal", "db timeout", 3));
+    mocks.findFirst.mockResolvedValue(null);
+    mocks.createPIR.mockRejectedValue(Object.assign(new Error("unique"), { code: "P2002" }));
+
+    const res = await runLogSignatureScan();
+
+    expect(res.reportsCreated).toBe(0);
+    expect(res.skippedExisting).toBe(1);
+  });
+
+  it("returns lokiUnreachable without filing when Loki is down", async () => {
+    mocks.queryLoki.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await runLogSignatureScan();
+
+    expect(res.lokiUnreachable).toBe(true);
+    expect(res.reportsCreated).toBe(0);
+    expect(mocks.createPIR).not.toHaveBeenCalled();
+  });
+
+  it("queries the unresolved-status filter for idempotency", async () => {
+    mocks.queryLoki.mockResolvedValue(errLines("portal", "db timeout", 1));
+    await runLogSignatureScan();
+    const where = mocks.findFirst.mock.calls[0][0].where;
+    expect(where.dedupeKey).toMatch(/^log-sig:portal:/);
+    expect(where.status.notIn).toContain("resolved_locally");
+  });
+});

--- a/apps/web/lib/queue/functions/log-signature-scanner.ts
+++ b/apps/web/lib/queue/functions/log-signature-scanner.ts
@@ -1,0 +1,127 @@
+// apps/web/lib/queue/functions/log-signature-scanner.ts
+// EP-FULL-OBS Tier 2 (BI-5FE8656F) — novel-signature log scanner.
+//
+// Every 15 minutes: query Loki for error lines across all containers, cluster
+// them into signatures, and file ONE PlatformIssueReport per NEW signature via
+// the single PIR writer. Filing emits quality/issue-report.created, which
+// projects the report into the backlog and (via auto-triage) into a tracked
+// item — closing the "managed going forward" loop. The platform surfaces
+// hidden log problems with no operator watching Docker Desktop.
+//
+// Mirrors token-expiry-monitor.ts exactly: a pure exported scan function (so
+// tests drive it without the Inngest harness) + a thin wrapper with the
+// quiescence gate. Idempotency is DB-backed via PlatformIssueReport.dedupeKey:
+// an open report for a signature is never re-filed; a resolved one may re-file
+// (the problem recurred — worth knowing).
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  clusterBySignature,
+  dedupeKeyFor,
+  severityForCount,
+} from "@/lib/observability/log-signature";
+import { queryLokiErrorLines } from "@/lib/observability/loki-query";
+
+const LOOKBACK_MIN = Number(process.env.DPF_LOG_SCAN_LOOKBACK_MIN ?? 20);
+// Only file for signatures seen at least this many times in the window. 1 =
+// surface even a single novel occurrence (the silent-Qdrant case). Operators
+// can raise it to reduce noise. No hard pin.
+const MIN_COUNT = Number(process.env.DPF_LOG_SCAN_MIN_COUNT ?? 1);
+
+// Statuses that mean "already resolved" — a signature in one of these is NOT
+// considered an open duplicate, so a recurrence after resolution re-files.
+const RESOLVED_STATUSES = ["resolved_locally", "resolved_upstream", "suppressed"];
+
+export interface LogScanResult {
+  scanned: number;
+  signatures: number;
+  reportsCreated: number;
+  skippedExisting: number;
+  lokiUnreachable?: boolean;
+}
+
+/**
+ * The actual scan, exported separately so unit tests can drive it without the
+ * Inngest harness (mirrors runTokenExpiryScan()).
+ */
+export async function runLogSignatureScan(opts?: {
+  lookbackMinutes?: number;
+}): Promise<LogScanResult> {
+  const { prisma } = await import("@dpf/db");
+  const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+  const lookbackMinutes = opts?.lookbackMinutes ?? LOOKBACK_MIN;
+
+  let lines;
+  try {
+    lines = await queryLokiErrorLines({ lookbackMinutes });
+  } catch (err) {
+    // Loki not running (e.g. monitoring stack down) — do not fail the job, do
+    // not create false reports. The next cycle retries.
+    console.error("[log-signature-scanner] Loki unreachable; skipping scan", err);
+    return { scanned: 0, signatures: 0, reportsCreated: 0, skippedExisting: 0, lokiUnreachable: true };
+  }
+
+  const buckets = clusterBySignature(lines).filter((b) => b.count >= MIN_COUNT);
+  let reportsCreated = 0;
+  let skippedExisting = 0;
+
+  for (const b of buckets) {
+    const dedupeKey = dedupeKeyFor(b.service, b.signatureId);
+
+    // Skip if an unresolved report for this signature already exists.
+    const existing = await prisma.platformIssueReport.findFirst({
+      where: { dedupeKey, status: { notIn: RESOLVED_STATUSES } },
+      select: { id: true },
+    });
+    if (existing) {
+      skippedExisting++;
+      continue;
+    }
+
+    try {
+      await createPlatformIssueReport({
+        type: "log_signature",
+        source: "log-signature-scanner",
+        severity: severityForCount(b.count),
+        dedupeKey,
+        title: `New error signature in ${b.service}: ${b.sample.slice(0, 120)}`,
+        description: [
+          `Service: ${b.service}`,
+          `Signature: ${b.signatureId}`,
+          `Occurrences (last ${lookbackMinutes}m): ${b.count}`,
+          `First seen: ${new Date(b.firstTs).toISOString()}`,
+          `Last seen: ${new Date(b.lastTs).toISOString()}`,
+          ``,
+          `Template: ${b.template}`,
+          ``,
+          `Sample line:`,
+          b.sample,
+        ].join("\n"),
+        routeContext: "/platform",
+      });
+      reportsCreated++;
+    } catch (err) {
+      // Partial-unique index on dedupeKey is the race backstop: a concurrent
+      // run may have filed the same signature between our findFirst and create.
+      if (err && typeof err === "object" && "code" in err && (err as { code?: string }).code === "P2002") {
+        skippedExisting++;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  return { scanned: lines.length, signatures: buckets.length, reportsCreated, skippedExisting };
+}
+
+export const logSignatureScanner = inngest.createFunction(
+  { id: "ops/log-signature-scanner", retries: 2, triggers: [cron("*/15 * * * *")] },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return await step.run("scan-log-signatures", async () => runLogSignatureScan());
+  },
+);

--- a/monitoring/loki/rules/dpf-log-alerts.yml
+++ b/monitoring/loki/rules/dpf-log-alerts.yml
@@ -40,15 +40,12 @@ groups:
           summary: "{{ $labels.service }} log error storm (>60/min)"
           description: "{{ $labels.service }} is flooding stderr with errors. Likely a tight failure loop (e.g. a dependency timing out on every request)."
 
-      - alert: LogIngestionThrottled
-        # loki_discarded_samples_total rises when per_stream_rate_limit drops
-        # lines — i.e. a container is flooding logs faster than the cap. A
-        # throttle is itself a strong "something is very wrong" signal.
-        expr: sum(rate(loki_discarded_samples_total[5m])) > 0
-        for: 5m
-        labels:
-          severity: warning
-          source: log-ingest
-        annotations:
-          summary: "Loki is dropping logs — a container is flooding stdout"
-          description: "Ingestion throttling active. A service is logging past the per-stream cap; inspect the loudest stream in Loki."
+# NOTE: ingestion-throttle detection ("Loki is dropping logs because a
+# container is flooding stdout") is NOT a LogQL rule — it keys on Loki's own
+# Prometheus metric `loki_discarded_samples_total`, which Prometheus scrapes
+# from loki:3100/metrics. It therefore lives in
+# monitoring/prometheus/alerts.yml (a LogIngestionThrottled rule in the
+# dpf_application group), NOT in this Loki ruler file. A PromQL expression here
+# is a parse error that fails the WHOLE rule group — verified live: the first
+# ruler load rejected the mis-placed rule and silenced the spike/storm rules
+# with it (structural-verification-is-not-functional).

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -144,3 +144,17 @@ groups:
           severity: critical
         annotations:
           summary: "Semantic memory store/recall failing -- AI Coworker context degraded"
+
+      # ─── Log Aggregation (EP-FULL-OBS Tier 2) ──────────────────
+      # Loki drops lines when a container floods stdout past the per-stream
+      # rate cap (disk-safety). A throttle is itself a strong "something is
+      # very wrong" signal. Keys on Loki's own Prometheus metric (scraped via
+      # the loki job), so it lives here -- NOT in the LogQL ruler, where a
+      # PromQL expression is a parse error that fails the whole rule group.
+      - alert: LogIngestionThrottled
+        expr: sum(rate(loki_discarded_samples_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Loki is dropping logs -- a container is flooding stdout past the rate cap"

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -86,6 +86,21 @@ scrape_configs:
         labels:
           instance: "windows-host"
 
+  # ─── Log Aggregation (EP-FULL-OBS Tier 2) ───────────────────
+  # Loki + Alloy expose their own /metrics. Scraping Loki lets the
+  # LogIngestionThrottled alert (alerts.yml) fire when a flooding container
+  # makes Loki drop lines (loki_discarded_samples_total) — the disk-safety
+  # signal that does NOT belong in the LogQL ruler.
+  - job_name: "loki"
+    static_configs:
+      - targets: ["loki:3100"]
+    metrics_path: /metrics
+
+  - job_name: "alloy"
+    static_configs:
+      - targets: ["alloy:12345"]
+    metrics_path: /metrics
+
   # ─── Self-monitoring ────────────────────────────────────────
   - job_name: "prometheus"
     scrape_interval: 30s

--- a/packages/db/prisma/migrations/20260609180000_add_pir_dedupe_key/migration.sql
+++ b/packages/db/prisma/migrations/20260609180000_add_pir_dedupe_key/migration.sql
@@ -1,0 +1,19 @@
+-- BI-5FE8656F (EP-FULL-OBS Tier 2): dedupeKey on PlatformIssueReport.
+-- Additive, nullable column — existing rows are unaffected. Automated
+-- producers (the log-signature scanner) write `log-sig:<service>:<sigId>` so
+-- the same recurring signature is filed once, not every 15-minute cycle.
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "dedupeKey" TEXT;
+
+-- Lookup index for the scanner's idempotency check.
+CREATE INDEX "PlatformIssueReport_dedupeKey_idx" ON "PlatformIssueReport"("dedupeKey");
+
+-- Partial UNIQUE index: enforce ONE non-resolved report per dedupeKey while
+-- leaving resolved/suppressed rows free, so a recurrence after resolution can
+-- re-file. Prisma cannot express partial-unique predicates, so this lives here
+-- as raw SQL. The predicate uses only immutable constants (a literal status
+-- list), which Postgres requires for index predicates. NULL dedupeKey rows
+-- (every non-scanner producer) are excluded and so are never constrained.
+CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+  ON "PlatformIssueReport"("dedupeKey")
+  WHERE "dedupeKey" IS NOT NULL
+    AND "status" NOT IN ('resolved_locally', 'resolved_upstream', 'suppressed');

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4453,6 +4453,12 @@ model PlatformIssueReport {
   triggerKind         String?
   supportSessionId    String?
   source              String        @default("manual")
+  // BI-5FE8656F (EP-FULL-OBS Tier 2): stable idempotency key for automated
+  // producers (the log-signature scanner files `log-sig:<service>:<sigId>`).
+  // A partial UNIQUE index — open rows only — lives in the migration (Prisma
+  // can't express partial-unique predicates); it lets a resolved signature
+  // re-file when the problem recurs while preventing duplicate open reports.
+  dedupeKey           String?
   // Governed Hermes learning Slice 1: link runtime issues to the thread/run
   // that produced them so reflection can avoid route/time-window heuristics.
   threadId            String?
@@ -4470,6 +4476,8 @@ model PlatformIssueReport {
   @@index([taskRunId])
   // BI-B4F401B3: digest lookup powers cross-route incident dedup at triage time.
   @@index([errorDigest])
+  // BI-5FE8656F: dedupeKey lookup powers the scanner's idempotency check.
+  @@index([dedupeKey])
   @@unique([reportedById, supportSessionId])
   @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }


### PR DESCRIPTION
## What & why

Implements the **EP-FULL-OBS Tier 2 application layer** (BI-5FE8656F) that closes the **"managed going forward"** loop the goal asked for. The capture layer (Loki + Alloy) shipped in #1658; this turns captured logs into tracked, deduped backlog issues with an in-portal surface — so hidden log problems (the macOS "hundreds of error lines across 3 subsystems" incident) are detected and managed without anyone watching Docker Desktop.

Built **directly in-repo** because Build Studio is under re-architecture (explicit operator instruction).

## The loop

```
container logs → Loki → signature scanner (cluster + dedup) → PlatformIssueReport → backlog → System Health "Log Issues" panel
```

## Changes

**Detection (app-code)**
- `lib/observability/log-signature.ts` — pure signature clustering (template extraction; filters info/debug + the `ErrorCode`-substring false positive caught live). **10 unit tests.**
- `lib/observability/loki-query.ts` — server-side Loki `query_range` helper.
- `lib/queue/functions/log-signature-scanner.ts` — Inngest cron (every 15m): query Loki → cluster → file one PIR per **new** signature via the single writer. Mirrors `token-expiry-monitor` (pure scan fn + `gateAtEntry`). DB-backed idempotency; severity scales with occurrence count so **loud and quiet** problems share one path. **7 unit tests.** Registered in the scheduled catalog.

**Surface**
- `components/monitoring/LogIssuesPanel.tsx` — System Health panel (open `log_signature` reports + Grafana/Loki drill-down), mounted in `SystemHealthDashboard`.
- `lib/actions/quality.ts` — `getLogSignatureIssues()` (auth-gated) feeds the panel.

**Schema**
- `PlatformIssueReport.dedupeKey` (nullable) + migration with a **partial unique index** (open rows only): a resolved signature can re-file on recurrence, duplicate open reports can't. Wired through `createPlatformIssueReport()`; NULL keys (every non-scanner producer) are unconstrained.

**Monitoring fix (regression merged in #1658)**
- The LogQL ruler carried a PromQL `LogIngestionThrottled` rule whose parse error silenced the **entire** `dpf_log_rate` group (verified live). Moved to `prometheus/alerts.yml`; added `loki` + `alloy` scrape jobs so the metric exists.

## Verification
- **17/17 unit tests pass** via the root toolchain (logic + scanner behavior incl. dedup, P2002 race, Loki-down).
- `prisma validate` + `generate` confirm the schema/migration; pure modules typecheck clean.
- Full typecheck/build/migrate run in **CI** (worktree has no `node_modules`).
- Post-merge functional acceptance (induce repeating errors on a live macOS install → deduped backlog items in ≤15m) per BI-5FE8656F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
