### PR TITLE
fix(health): drop misleading "->" arrow on Open Backlog Items card at zero (BI-FDE4A056)

### DIFF
--- a/apps/web/components/monitoring/PortalHealthSummary.test.tsx
+++ b/apps/web/components/monitoring/PortalHealthSummary.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("./MonitoringContext", () => ({
+  useMonitoringStatus: () => ({ checked: true, online: true }),
+}));
+
+vi.mock("./useMetricQuery", () => ({
+  useMetricQuery: () => ({ data: [], loading: false }),
+}));
+
+vi.mock("./useAlertQuery", () => ({
+  useAlertQuery: () => ({ alerts: [] }),
+}));
+
+import { PortalHealthSummary } from "./PortalHealthSummary";
+
+describe("PortalHealthSummary — Open Backlog Items card (BI-FDE4A056)", () => {
+  it("shows no '->' arrow and no link when there are zero open backlog items", () => {
+    const html = renderToStaticMarkup(
+      <PortalHealthSummary openBacklogItems={0} backlogHref="/portfolio/backlog" />,
+    );
+    expect(html).toContain("No open backlog items");
+    // The misleading affordance must be gone: no arrow, no link to the backlog.
+    // renderToStaticMarkup HTML-escapes ">" so the arrow is "-&gt;".
+    expect(html).not.toContain("-&gt;");
+    expect(html).not.toContain('href="/portfolio/backlog"');
+  });
+
+  it("links to the backlog and shows the '->' affordance when items exist", () => {
+    const html = renderToStaticMarkup(
+      <PortalHealthSummary openBacklogItems={5} backlogHref="/portfolio/backlog" />,
+    );
+    expect(html).toContain("View list");
+    expect(html).toContain("-&gt;");
+    expect(html).toContain('href="/portfolio/backlog"');
+  });
+});

--- a/apps/web/components/monitoring/PortalHealthSummary.tsx
+++ b/apps/web/components/monitoring/PortalHealthSummary.tsx
@@ -39,7 +39,8 @@ export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
     alerts,
   });
 
-  const backlogTone: Tone = openBacklogItems > 0 ? "warning" : "success";
+  const hasBacklog = openBacklogItems > 0;
+  const backlogTone: Tone = hasBacklog ? "warning" : "success";
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -49,9 +50,12 @@ export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
         summary={{
           value: String(openBacklogItems),
           tone: backlogTone,
-          detail: openBacklogItems > 0 ? "View list" : "No open backlog items",
+          detail: hasBacklog ? "View list" : "No open backlog items",
         }}
-        href={backlogHref}
+        // Only link (and render the "->" affordance) when there's actually a
+        // backlog to view — at zero, the arrow misleadingly implies a
+        // navigable list (BI-FDE4A056).
+        href={hasBacklog ? backlogHref : undefined}
       />
       <HealthCard label="Health Monitoring" summary={monitoring} />
     </div>


### PR DESCRIPTION
## Problem (BI-FDE4A056)
The Health tab **"Open Backlog Items"** StatCard always passed an `href`, so the generic `HealthCard` always rendered the `->` affordance. At **zero** open items the card read *"No open backlog items ->"* — the arrow (and the link) misleadingly implied a navigable list when there was nothing to view.

## Fix
Only link and render the `->` affordance when `openBacklogItems > 0`. At zero: no link, no arrow, just *"No open backlog items"*.

## Tests
New `PortalHealthSummary.test.tsx` (lightweight `renderToStaticMarkup` + mocked hooks):
- zero items → no arrow, no `href` to the backlog
- items exist → `View list`, arrow, and the backlog `href`

🤖 Generated with [Claude Code](https://claude.com/claude-code)