### PR TITLE
fix(ci): reclaim runner disk before E2E install verification

### DIFF
--- a/.github/workflows/install-verification.yml
+++ b/.github/workflows/install-verification.yml
@@ -60,6 +60,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The full stack no longer fits in the ~14 GB a stock
+      # ubuntu-latest runner leaves free: the v6.0.0 and v6.1.0 release
+      # verify jobs both died mid-install with the runner worker itself
+      # crashing on "No space left on device". Reclaim the ~25 GB of
+      # preinstalled toolchains this job never touches. Inline rm rather
+      # than a third-party action to keep the supply-chain surface at
+      # zero. Mirrors the verify job in publish-image.yml.
+      - name: Free runner disk space
+        run: |
+          echo "Disk before reclaim:"
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/lib/node_modules
+          sudo docker image prune --all --force
+          echo "Disk after reclaim:"
+          df -h /
+
       - name: Show docker context (preinstalled on ubuntu-latest)
         run: |
           docker --version

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -305,6 +305,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The full release stack no longer fits in the ~14 GB a stock
+      # ubuntu-latest runner leaves free: v6.0.0 and v6.1.0 both died
+      # mid-install with the runner worker itself crashing on "No space
+      # left on device" (v5.6.0 was the last release that still fit).
+      # Reclaim the ~25 GB of preinstalled toolchains this job never
+      # touches. Inline rm rather than a third-party action to keep the
+      # supply-chain surface at zero.
+      - name: Free runner disk space
+        run: |
+          echo "Disk before reclaim:"
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/lib/node_modules
+          sudo docker image prune --all --force
+          echo "Disk after reclaim:"
+          df -h /
+
       - name: Show docker context
         run: |
           docker --version


### PR DESCRIPTION
## Problem

The **v6.1.0** production stamp ([run 27247294148](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/27247294148)) failed at the final **E2E install verification (release mode)** job. All 12 image builds and 6 manifest merges succeeded — the images are published — but the verify job's runner died mid `install-dpf.sh` with the GitHub Actions worker process itself crashing:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.334.0/_diag/Worker_….log'
```

This is systemic, not a flake: **v6.0.0** ([run 27159873944](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/27159873944)) failed identically on 2026-06-08, while v5.6.0 (2026-05-27) still passed. The full release stack has outgrown the ~14 GB a stock `ubuntu-latest` runner leaves free.

## Fix

Add a **Free runner disk space** step before the install in both:

- `publish-image.yml` → `verify` job (release-tag path that blocked the stamp)
- `install-verification.yml` (manual-dispatch twin, kept in lockstep per its header comment)

It removes ~25 GB of preinstalled toolchains the job never uses (Android SDK, .NET, CodeQL, Haskell, Swift, PowerShell) and prunes prefetched docker images. Inline `rm` rather than a third-party action to keep the supply-chain surface at zero. `df -h` before/after is logged so future image-footprint growth is visible in the job log.

## Verification

Workflow-only change; YAML validated locally. After merge, dispatching `install-verification.yml` in **release** mode runs the identical job body from `main` with the fix and exercises the already-published v6.1.0 release images end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)