### PR TITLE
fix(observability): remove impossible healthchecks on distroless loki + scratch redis-exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -628,12 +628,12 @@ services:
       - ./monitoring/loki/rules/dpf-log-alerts.yml:/loki/rules-config/fake/dpf-log-alerts.yml:ro
       - loki_data:/loki
     command: ["-config.file=/etc/loki/local-config.yaml"]
-    healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:3100/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
+    # No container healthcheck: grafana/loki 3.x is distroless — no shell,
+    # busybox, wget, or curl exists in the image, so every CMD/CMD-SHELL
+    # probe fails with "executable file not found" and the container sits
+    # permanently unhealthy, which blocked the whole install (alloy gates
+    # on it). Loki readiness is observed externally instead: Prometheus
+    # scrapes it and the portal's log-issues panel talks to its API.
 
   alloy:
     image: grafana/alloy:latest
@@ -649,7 +649,11 @@ services:
       - "/etc/alloy/config.alloy"
     depends_on:
       loki:
-        condition: service_healthy
+        # service_started, not service_healthy: the loki image is distroless
+        # and cannot host a healthcheck (see loki service above). Alloy
+        # buffers and retries its Loki pushes internally, so it only needs
+        # the container up, not a readiness gate.
+        condition: service_started
 
   # cadvisor + node-exporter bind-mount Linux-only host paths (/proc, /sys,
   # /var/lib/docker, /). They cannot run on macOS or Windows Docker Desktop
@@ -720,12 +724,10 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:9121/metrics"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+    # No container healthcheck: oliver006/redis_exporter is built FROM
+    # scratch — the exporter binary is the only file in the image, so no
+    # probe command can run. Nothing gates on this service; Prometheus
+    # scraping /metrics is the effective health signal.
 
   inngest:
     image: inngest/inngest:latest


### PR DESCRIPTION
## Problem

With the runner disk exhaustion fixed ([#1675](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1675)), the v6.1.0 release-mode E2E verification ([run 27248258645](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/27248258645)) finally ran the full install — and exposed a real installer bug:

```
dependency failed to start: container dpf-loki-1 is unhealthy
```

## Root cause

The `loki` and `redis-exporter` healthchecks (added with the EP-FULL-OBS Tier 2 observability stack) exec `wget` inside the container, but **neither image can run it**:

- `grafana/loki:latest` (3.x) is distroless — no shell, busybox, wget, or curl. Verified by exec: `executable file not found in $PATH`. The image cannot host *any* CMD/CMD-SHELL probe.
- `oliver006/redis_exporter` is built `FROM scratch` — the exporter binary is the only file in the image.

Both containers sit permanently unhealthy on every fresh install. Loki blocks the whole compose chain because `alloy` gates on `service_healthy`, which kills `install-dpf.sh`. These healthchecks have **never passed anywhere**: every CI E2E run since they merged died earlier on the disk issue (v6.0.0, v6.1.0), and existing installs predate the healthcheck (the live local install's loki container has `Health: null` and runs fine).

## Fix

- Drop both healthchecks, with comments explaining why no probe is possible in those images.
- Relax alloy's loki dependency to `service_started` — alloy buffers and retries Loki pushes internally, so it needs the container up, not a readiness gate.
- Health remains observable externally: Prometheus scrapes both, and the portal's Log Issues panel exercises the Loki API.

Same pattern precedent as the inngest healthcheck comment in this file (image ships no curl/wget/nc).

## Verification

- `docker compose config` renders clean.
- `wget`/`sh`/`bash`/`busybox`/`curl` probed absent in `grafana/loki:latest` (digest matches what CI pulled).
- After merge: re-dispatch release-mode install verification to confirm the full install goes green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)