### PR TITLE
feat(self-upgrade): mid-flight Force Now / Abort for a running drain (BI-4F3B2FA9)

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -308,11 +308,42 @@ describe("SelfUpgradeClient – trigger control", () => {
     expect(html).not.toContain('disabled=""');
   });
 
-  it("button is disabled when latest run is currently running", () => {
+  // BI-4F3B2FA9: a running upgrade no longer leaves a dead-end disabled button.
+  it("shows an in-flight indicator (not a disabled trigger) when a run is running", () => {
     const html = renderToStaticMarkup(
       <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} />,
     );
-    expect(html).toContain('disabled=""');
+    expect(html).toContain("Upgrade in progress…");
+    expect(html).not.toContain('aria-label="Upgrade now"');
+  });
+
+  it("surfaces Force now / Abort controls when the portal is draining (BI-4F3B2FA9)", () => {
+    const quiescence = {
+      level: "draining" as const,
+      runId: "QR-2026-06-10-test",
+      enteredAt: "2026-06-10T02:00:00.000Z",
+      run: {
+        runId: "QR-2026-06-10-test",
+        status: "draining",
+        trigger: "self-upgrade",
+        targetVersion: null,
+        targetBundleHash: null,
+        deferSurface: null,
+        deferReason: null,
+        budgetMs: 300000,
+        drainStartedAt: "2026-06-10T02:00:00.000Z",
+        lastHeartbeatAt: null,
+      },
+      blockersCapturedAt: null,
+      blockers: [],
+    };
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} quiescence={quiescence} />,
+    );
+    expect(html).toContain("Force now");
+    expect(html).toContain("Abort");
+    // Descriptive aria-label names the run; not a dead-end disabled trigger.
+    expect(html).toContain("Force upgrade run QR-2026-06-10-test now");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { rollbackSelfUpgrade, triggerSelfUpgrade } from "@/lib/actions/promotions";
+import {
+  rollbackSelfUpgrade,
+  triggerSelfUpgrade,
+  forceActiveRun,
+  abortActiveRun,
+} from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 
@@ -195,6 +200,10 @@ export default function SelfUpgradeClient({
   const [override, setOverride] = useState(false);
   const [justQueued, setJustQueued] = useState(false);
   const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(null);
+  // BI-4F3B2FA9: mid-flight Force Now / Abort controls for a running drain.
+  const [forceConfirm, setForceConfirm] = useState(false);
+  const [abortConfirm, setAbortConfirm] = useState(false);
+  const [inFlightError, setInFlightError] = useState<string | null>(null);
   const [rollbackConfirmation, setRollbackConfirmation] = useState("");
   const [rollbackResult, setRollbackResult] = useState<{
     status: "idle" | "ok" | "error";
@@ -257,6 +266,34 @@ export default function SelfUpgradeClient({
     });
   }
 
+  // BI-4F3B2FA9: escalate the active drain to forced — coordinator bypasses
+  // all blockers on its next tick (~5s) and swaps, without restarting the run.
+  function handleForceNow() {
+    const runId = quiescence?.run?.runId;
+    if (!runId) return;
+    setInFlightError(null);
+    startTransition(async () => {
+      const r = await forceActiveRun(runId);
+      setForceConfirm(false);
+      if (!r.ok) setInFlightError(r.error ?? "Force failed");
+      router.refresh();
+    });
+  }
+
+  // BI-4F3B2FA9: abort the active drain — level returns to normal so the
+  // operator can immediately start a fresh run.
+  function handleAbortRun() {
+    const runId = quiescence?.run?.runId;
+    if (!runId) return;
+    setInFlightError(null);
+    startTransition(async () => {
+      const r = await abortActiveRun(runId);
+      setAbortConfirm(false);
+      if (!r.ok) setInFlightError(r.error ?? "Abort failed");
+      router.refresh();
+    });
+  }
+
   function handleRollback(runId: string) {
     setRollbackResult({ status: "idle", message: "" });
     startRollbackTransition(async () => {
@@ -296,34 +333,121 @@ export default function SelfUpgradeClient({
 
         {enabled && (
           <div className="flex items-center gap-3">
-            <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={override}
-                onChange={(e) => setOverride(e.target.checked)}
-                aria-label="Emergency override: bypass the safety drain"
-                title="Bypass the quiescence safety drain. Only for emergencies — it can interrupt in-flight work."
-                className="accent-[var(--dpf-warning)]"
-              />
-              Emergency override
-            </label>
-            <button
-              type="button"
-              onClick={handleTrigger}
-              disabled={triggerBusy || latestRun?.status === "running"}
-              aria-busy={triggerBusy}
-              aria-label="Upgrade now"
-              data-override={override ? "true" : "false"}
-              className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
-            >
-              {isPending
-                ? "Upgrading..."
-                : justQueued
-                  ? "Starting…"
-                  : override
-                    ? "Force upgrade now"
-                    : "Upgrade now"}
-            </button>
+            {upgradeInFlight ? (
+              // BI-4F3B2FA9: a run is in flight. Never a dead-end disabled
+              // button — when the portal is draining, surface Force Now / Abort
+              // so the operator's emergency lever actually works mid-flight.
+              draining && quiescence?.run?.runId ? (
+                <div className="flex items-center gap-2" role="group" aria-label="In-flight upgrade controls">
+                  {inFlightError && (
+                    <span className="text-xs text-[var(--dpf-warning)]" role="status" aria-live="polite">
+                      {inFlightError}
+                    </span>
+                  )}
+                  {forceConfirm ? (
+                    <div role="alertdialog" aria-describedby="force-now-warning" className="flex items-center gap-2">
+                      <span id="force-now-warning" className="text-xs text-[var(--dpf-warning)]">
+                        ⚠ Bypass all in-flight work and swap now?
+                      </span>
+                      <button
+                        type="button"
+                        onClick={handleForceNow}
+                        disabled={isPending}
+                        className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
+                      >
+                        Confirm force
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setForceConfirm(false)}
+                        className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : abortConfirm ? (
+                    <div role="alertdialog" aria-describedby="abort-warning" className="flex items-center gap-2">
+                      <span id="abort-warning" className="text-xs text-[var(--dpf-muted)]">
+                        Abort this drain?
+                      </span>
+                      <button
+                        type="button"
+                        onClick={handleAbortRun}
+                        disabled={isPending}
+                        className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
+                      >
+                        Confirm abort
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setAbortConfirm(false)}
+                        className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => { setAbortConfirm(false); setForceConfirm(true); }}
+                        aria-label={`Force upgrade run ${quiescence.run.runId} now`}
+                        className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 hover:bg-[var(--dpf-warning)]/30 transition-colors"
+                      >
+                        ⚡ Force now
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => { setForceConfirm(false); setAbortConfirm(true); }}
+                        aria-label={`Abort upgrade run ${quiescence.run.runId}`}
+                        className="px-3 py-1.5 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
+                      >
+                        Abort
+                      </button>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <span
+                  className="text-xs text-[var(--dpf-muted)]"
+                  aria-live="polite"
+                  data-upgrade-inflight="true"
+                >
+                  Upgrade in progress…
+                </span>
+              )
+            ) : (
+              <>
+                <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={override}
+                    onChange={(e) => setOverride(e.target.checked)}
+                    aria-label="Emergency override: bypass the safety drain"
+                    title="Bypass the quiescence safety drain. Only for emergencies — it can interrupt in-flight work."
+                    className="accent-[var(--dpf-warning)]"
+                  />
+                  Emergency override
+                </label>
+                <button
+                  type="button"
+                  onClick={handleTrigger}
+                  disabled={triggerBusy}
+                  aria-busy={triggerBusy}
+                  aria-label="Upgrade now"
+                  data-override={override ? "true" : "false"}
+                  className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
+                >
+                  {isPending
+                    ? "Upgrading..."
+                    : justQueued
+                      ? "Starting…"
+                      : override
+                        ? "Force upgrade now"
+                        : "Upgrade now"}
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -18,7 +18,11 @@ import {
 } from "@/lib/self-upgrade/window";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
-import { getQuiescenceActivity } from "@/lib/self-upgrade/quiescence";
+import {
+  getQuiescenceActivity,
+  abortQuiescence,
+  escalateQuiescenceToForced,
+} from "@/lib/self-upgrade/quiescence";
 import { getCooldownUntil } from "@/lib/self-upgrade/cooldown";
 import { loadPlatformVersion } from "@/lib/platform/version";
 import { inngest } from "@/lib/queue/inngest-client";
@@ -741,6 +745,38 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
     },
   });
   return { queued: true } as const;
+}
+
+/**
+ * BI-4F3B2FA9 — emergency "Force Now" on an ALREADY-RUNNING drain. Promotes the
+ * active QuiescenceRun to forced mode so the coordinator bypasses all hard
+ * blockers on its next tick (within ~5s) and proceeds to swap — no restart.
+ * The operator and timestamp are audit-recorded on the run's forcedSurfaces.
+ */
+export async function forceActiveRun(
+  runId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const userId = await requireOpsAccess();
+  const result = await escalateQuiescenceToForced(runId, userId);
+  if (!result.ok) return { ok: false, error: result.reason };
+  return { ok: true };
+}
+
+/**
+ * BI-4F3B2FA9 — abort an in-flight drain. Delegates to abortQuiescence, which
+ * sends the swap-complete event with outcome=aborted; the coordinator flips the
+ * level back to normal and the operator can immediately start a fresh run.
+ */
+export async function abortActiveRun(
+  runId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const userId = await requireOpsAccess();
+  try {
+    await abortQuiescence(runId, userId);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "abort failed" };
+  }
+  return { ok: true };
 }
 
 export async function rollbackSelfUpgrade(

--- a/apps/web/lib/queue/functions/quiescence-run.ts
+++ b/apps/web/lib/queue/functions/quiescence-run.ts
@@ -33,6 +33,7 @@ import {
   flipActiveTaskRunsToQuiescing,
   heartbeatQuiescenceRun,
   invalidateQuiescenceCache,
+  isShipForceEscalated,
   pickPrimaryBlocker,
   setQuiescenceLevel,
   transitionState,
@@ -116,10 +117,22 @@ export const quiescenceRun = inngest.createFunction(
     // even with a sane deadline.
     const maxTicks = Math.ceil(budgetMs / WAIT_TICK_MS) + 5;
 
+    // BI-4F3B2FA9: a drain started non-forced can be promoted to forced
+    // MID-FLIGHT when an operator clicks "Force Now" (escalateQuiescenceToForced
+    // writes shipForceEscalatedAt). Re-read that flag each tick — once set, the
+    // effective shipForce sticks and the next blocker check returns 0, so the
+    // drain reaches ready-to-swap within one tick without restarting the run.
+    let effectiveShipForce = shipForce;
+
     for (let tick = 0; tick < maxTicks; tick++) {
+      if (!effectiveShipForce) {
+        effectiveShipForce = (await step.run(`check-escalation-${tick}`, () =>
+          isShipForceEscalated(runId),
+        )) as boolean;
+      }
       // Re-check the hard-blocker count from the prior snapshot before
       // sleeping. Lets the first tick exit fast in the no-blockers case.
-      const hardBlockers = countEffectiveHardBlockers(lastSnapshot, shipForce);
+      const hardBlockers = countEffectiveHardBlockers(lastSnapshot, effectiveShipForce);
       if (hardBlockers === 0) break;
       if (Date.now() >= deadline) break;
 
@@ -132,7 +145,12 @@ export const quiescenceRun = inngest.createFunction(
       await step.run(`heartbeat-${tick}`, () => heartbeatQuiescenceRun(runId));
     }
 
-    const finalHardBlockers = countEffectiveHardBlockers(lastSnapshot, shipForce);
+    if (!effectiveShipForce) {
+      effectiveShipForce = (await step.run("check-escalation-final", () =>
+        isShipForceEscalated(runId),
+      )) as boolean;
+    }
+    const finalHardBlockers = countEffectiveHardBlockers(lastSnapshot, effectiveShipForce);
     const actualWaitMs = Date.now() - drainStart;
 
     // ─── Step 4a: defer path ─────────────────────────────────────────────

--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -15,6 +15,8 @@ const prismaMock = vi.hoisted(() => ({
   buildPhaseRunFindMany: vi.fn(),
   buildPhaseRunUpdateMany: vi.fn(),
   toolExecutionFindMany: vi.fn(),
+  quiescenceRunFindUnique: vi.fn(),
+  quiescenceRunUpdate: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -29,12 +31,18 @@ vi.mock("@dpf/db", () => ({
     toolExecution: {
       findMany: (...args: unknown[]) => prismaMock.toolExecutionFindMany(...args),
     },
+    quiescenceRun: {
+      findUnique: (...args: unknown[]) => prismaMock.quiescenceRunFindUnique(...args),
+      update: (...args: unknown[]) => prismaMock.quiescenceRunUpdate(...args),
+    },
   },
 }));
 
 import {
   captureActiveSessionBlockers,
+  escalateQuiescenceToForced,
   isBuildPhaseReapable,
+  isShipForceEscalated,
   getQuiescenceConfig,
   invalidateQuiescenceCache,
   isTerminalQuiescenceStatus,
@@ -55,6 +63,80 @@ beforeEach(() => {
   prismaMock.buildPhaseRunFindMany.mockResolvedValue([]);
   prismaMock.buildPhaseRunUpdateMany.mockResolvedValue({ count: 0 });
   prismaMock.toolExecutionFindMany.mockResolvedValue([]);
+  prismaMock.quiescenceRunFindUnique.mockResolvedValue(null);
+  prismaMock.quiescenceRunUpdate.mockResolvedValue({});
+});
+
+describe("escalateQuiescenceToForced (BI-4F3B2FA9)", () => {
+  const NOW = new Date("2026-06-10T02:00:00.000Z");
+
+  it("sets shipForceEscalatedAt/By and appends a mid-flight-escalation audit entry", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue({
+      status: "draining",
+      shipForceEscalatedAt: null,
+      forcedSurfaces: [],
+    });
+    const r = await escalateQuiescenceToForced("QR-1", "user-9", NOW);
+    expect(r).toEqual({ ok: true });
+    const update = prismaMock.quiescenceRunUpdate.mock.calls[0]?.[0];
+    expect(update.where).toEqual({ runId: "QR-1" });
+    expect(update.data.shipForceEscalatedAt).toBe(NOW);
+    expect(update.data.shipForceEscalatedBy).toBe("user-9");
+    expect(update.data.forcedSurfaces).toEqual([
+      { surface: "mid-flight-escalation", reason: expect.stringContaining("user-9"), forcedAt: NOW.toISOString() },
+    ]);
+  });
+
+  it("preserves prior forcedSurfaces entries when appending", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue({
+      status: "draining",
+      shipForceEscalatedAt: null,
+      forcedSurfaces: [{ surface: "ship-force-flag", reason: "x", forcedAt: "t" }],
+    });
+    await escalateQuiescenceToForced("QR-1", "user-9", NOW);
+    const update = prismaMock.quiescenceRunUpdate.mock.calls[0]?.[0];
+    expect(update.data.forcedSurfaces).toHaveLength(2);
+    expect(update.data.forcedSurfaces[0].surface).toBe("ship-force-flag");
+  });
+
+  it("is idempotent — a no-op success when already escalated", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue({
+      status: "draining",
+      shipForceEscalatedAt: new Date(),
+      forcedSurfaces: [],
+    });
+    const r = await escalateQuiescenceToForced("QR-1", "user-9", NOW);
+    expect(r).toEqual({ ok: true });
+    expect(prismaMock.quiescenceRunUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuses a terminal run", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue({
+      status: "completed",
+      shipForceEscalatedAt: null,
+      forcedSurfaces: [],
+    });
+    const r = await escalateQuiescenceToForced("QR-1", "user-9", NOW);
+    expect(r).toEqual({ ok: false, reason: "run already completed" });
+    expect(prismaMock.quiescenceRunUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns not-found when the run is missing", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValue(null);
+    const r = await escalateQuiescenceToForced("QR-missing", "user-9", NOW);
+    expect(r).toEqual({ ok: false, reason: "run not found" });
+  });
+});
+
+describe("isShipForceEscalated (BI-4F3B2FA9)", () => {
+  it("is true when shipForceEscalatedAt is set, false otherwise", async () => {
+    prismaMock.quiescenceRunFindUnique.mockResolvedValueOnce({ shipForceEscalatedAt: new Date() });
+    expect(await isShipForceEscalated("QR-1")).toBe(true);
+    prismaMock.quiescenceRunFindUnique.mockResolvedValueOnce({ shipForceEscalatedAt: null });
+    expect(await isShipForceEscalated("QR-1")).toBe(false);
+    prismaMock.quiescenceRunFindUnique.mockResolvedValueOnce(null);
+    expect(await isShipForceEscalated("QR-missing")).toBe(false);
+  });
 });
 
 describe("isBuildPhaseReapable", () => {

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -480,6 +480,63 @@ export async function abortQuiescence(runId: string, operatorUserId: string): Pr
 }
 
 /**
+ * BI-4F3B2FA9 — mid-flight emergency escalation. Promotes an ALREADY-RUNNING
+ * drain to forced mode: records who/when on the QuiescenceRun and appends an
+ * audit entry to forcedSurfaces. The coordinator's wait loop re-reads
+ * shipForceEscalatedAt every tick (see isShipForceEscalated) and treats a
+ * non-null value as shipForce, so a stuck drain proceeds to ready-to-swap
+ * within one polling interval — without restarting the run.
+ *
+ * Idempotent (a second call on an already-escalated run is a no-op success).
+ * Refuses terminal runs — there is nothing to force once a drain has ended.
+ */
+export async function escalateQuiescenceToForced(
+  runId: string,
+  operatorUserId: string,
+  now: Date = new Date(),
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const row = await prisma.quiescenceRun.findUnique({
+    where: { runId },
+    select: { status: true, shipForceEscalatedAt: true, forcedSurfaces: true },
+  });
+  if (!row) return { ok: false, reason: "run not found" };
+  if (isTerminalQuiescenceStatus(row.status)) {
+    return { ok: false, reason: `run already ${row.status}` };
+  }
+  if (row.shipForceEscalatedAt) return { ok: true }; // already escalated — no-op
+
+  const prior = Array.isArray(row.forcedSurfaces) ? (row.forcedSurfaces as unknown[]) : [];
+  await prisma.quiescenceRun.update({
+    where: { runId },
+    data: {
+      shipForceEscalatedAt: now,
+      shipForceEscalatedBy: operatorUserId,
+      forcedSurfaces: [
+        ...prior,
+        {
+          surface: "mid-flight-escalation",
+          reason: `operator ${operatorUserId} forced an in-flight drain`,
+          forcedAt: now.toISOString(),
+        },
+      ] as unknown as object,
+    },
+  });
+  return { ok: true };
+}
+
+/**
+ * BI-4F3B2FA9 — hot read of the mid-flight escalation flag, polled by the
+ * coordinator each wait tick. True once an operator has clicked "Force Now".
+ */
+export async function isShipForceEscalated(runId: string): Promise<boolean> {
+  const row = await prisma.quiescenceRun.findUnique({
+    where: { runId },
+    select: { shipForceEscalatedAt: true },
+  });
+  return !!row?.shipForceEscalatedAt;
+}
+
+/**
  * Called from app boot (BI-QUIESCE-010 integration). Scans for QuiescenceRun
  * rows that were in flight when the previous bundle died. If the running
  * bundle's version matches `targetVersion`, marks as completed via

--- a/packages/db/prisma/migrations/20260610020000_add_quiescence_midflight_escalation/migration.sql
+++ b/packages/db/prisma/migrations/20260610020000_add_quiescence_midflight_escalation/migration.sql
@@ -1,0 +1,7 @@
+-- BI-4F3B2FA9: mid-flight emergency escalation for an already-running drain.
+-- Additive, nullable columns — existing rows remain valid with null values.
+-- shipForceEscalatedAt / shipForceEscalatedBy record when/who promoted a drain
+-- to forced mode via the "Force Now" operator action; the coordinator re-reads
+-- shipForceEscalatedAt each wait tick and treats non-null as shipForce.
+ALTER TABLE "QuiescenceRun" ADD COLUMN "shipForceEscalatedAt" TIMESTAMP(3);
+ALTER TABLE "QuiescenceRun" ADD COLUMN "shipForceEscalatedBy" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5279,6 +5279,15 @@ model QuiescenceRun {
   completionSource String?
   outcomeNotes     String? @db.Text
 
+  // BI-4F3B2FA9: mid-flight emergency escalation. When an operator clicks
+  // "Force Now" on an ALREADY-RUNNING drain, these record when/who promoted it
+  // to forced mode. The coordinator re-reads shipForceEscalatedAt every wait
+  // tick and treats a non-null value as shipForce, so a stuck drain can be
+  // forced through without restarting the run. Null when started forced or
+  // never escalated; an audit entry is also appended to forcedSurfaces.
+  shipForceEscalatedAt DateTime?
+  shipForceEscalatedBy String?
+
   @@index([trigger, startedAt])
   // Stuck-coordinator query: status NOT IN (terminal) AND lastHeartbeatAt < cutoff.
   @@index([status, lastHeartbeatAt])


### PR DESCRIPTION
## What & why

The emergency override only worked on a **fresh** trigger. "Emergency override" is a checkbox, the trigger button was **disabled whenever a run was `running`** (`SelfUpgradeClient.tsx`), and `shipForce` is frozen at quiescence start. So once a non-forced drain was underway, an operator had **no emergency lever** — confirmed live on 2026-06-07 when the override "did nothing" while a slow drain blocked on a stalled Build Studio phase.

(Note the design intent was already correct: `countEffectiveHardBlockers` returns 0 under `shipForce`. The gap was purely reachability mid-flight.)

## Change
- **`quiescence.ts`** — `escalateQuiescenceToForced(runId, operator)` records `shipForceEscalatedAt`/`By` on the QuiescenceRun and appends a `mid-flight-escalation` entry to `forcedSurfaces` (idempotent; refuses terminal runs). `isShipForceEscalated(runId)` is the hot read.
- **`quiescence-run.ts` (coordinator)** — the wait loop **re-reads `shipForceEscalatedAt` each tick**; effective shipForce = `startShipForce || escalated`. Within one tick (~5s) of Force Now, hard blockers → 0 and the drain reaches ready-to-swap **without restarting the inngest function**.
- **`promotions.ts`** — `forceActiveRun` / `abortActiveRun` server actions (ops-gated); abort delegates to the existing `abortQuiescence`.
- **`SelfUpgradeClient.tsx`** — while a run is in flight the trigger is no longer a dead-end: a **draining** run shows **Force now / Abort** with inline confirm + descriptive aria-labels; a running-not-yet-draining run shows "Upgrade in progress…".
- **Schema** — additive nullable `QuiescenceRun.shipForceEscalatedAt` / `shipForceEscalatedBy` + migration.

## Tests
- `escalateQuiescenceToForced`: sets fields + appends audit entry, preserves prior `forcedSurfaces`, idempotent, refuses terminal, not-found. `isShipForceEscalated` true/false/missing.
- `SelfUpgradeClient`: running shows in-flight indicator (not a disabled trigger); draining surfaces Force now / Abort with the run-named aria-label. (Updated the stale "button is disabled when running" test — that asserted the exact dead-end this fixes.)
- Full `web` suite **10,273 passed**, 0 failures; `web` typecheck clean.

## Provenance
Built in-session against the **Build-Studio-reviewed design doc** for `FB-49DCB2DE` — the BS orchestrator stalled at design-review dispatch (2nd handoff stall in 2 builds), operator-authorized fallback. The design doc specified this implementation exactly (mid-flight flag re-read, the two server actions, the UI swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)