### PR TITLE
docs(archetypes): BIAN v14 reference data + banking-archetypes spec & plan (BI-5D9DCDE6)

### DIFF
--- a/docs/Reference/BIAN_CSDM_Integration_v76-US-English - FINAL.pdf
+++ b/docs/Reference/BIAN_CSDM_Integration_v76-US-English - FINAL.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f053f97e841f9cf3e13c10c5a33776132f98530a88cf9d63f685830ce7bb824a
+size 5483251

--- a/docs/Reference/bian/README.md
+++ b/docs/Reference/bian/README.md
@@ -1,0 +1,62 @@
+# BIAN Reference — Service Landscape v14.0 + CSDM Integration
+
+Banking Industry Architecture Network (BIAN) reference material backing DPF's banking
+archetypes and the BIAN-sourced business-capability perspective. BIAN is the
+vendor-neutral standards body for banking business architecture; its core deliverable is
+the **Service Landscape** — a MECE decomposition of everything a bank does into discrete,
+canonical **Service Domains**.
+
+## Contents
+
+| File | What it is |
+| ---- | ---------- |
+| [`bian-v14-service-landscape.json`](bian-v14-service-landscape.json) | The full BIAN v14.0 Service Landscape hierarchy — 8 Business Areas → 43 Business Domains → 341 Service Domains — extracted from the official Value Chain View, with the official one-line Service Domain descriptions merged in from BIAN's published Semantic API specifications (258 of 341 Service Domains have a published Semantic API in release 14.0.0). |
+| [`../BIAN_CSDM_Integration_v76-US-English - FINAL.pdf`](../BIAN_CSDM_Integration_v76-US-English%20-%20FINAL.pdf) | "Bridging BIAN and ServiceNow CSDM" v7.6 (May 2026) — joint ServiceNow/BIAN discussion paper defining the BIAN→CSDM object mapping. Authors include BIAN's Lead Architect and ServiceNow's CSDM/CMDB product management. |
+
+## Provenance
+
+- **Value Chain View (hierarchy):** <https://bian.org/servicelandscape-14-0-0/views/view_54486.html> — the canonical v14 layout. BIAN is deprecating the older Matrix layout, which uses *different* Business Area / Business Domain terminology for the same Service Domains; do not mix the two vocabularies.
+- **Semantic APIs (descriptions):** <https://github.com/bian-official/public> `release14.0.0/semantic-apis` (OAS 3.x, one spec per Service Domain). Detailed per-operation specs live on the BIAN portal: <https://portal.bian.org>.
+- Retrieved 2026-06-09. Re-extract when BIAN publishes a new landscape release; `version` and `retrieved` fields in the JSON record what this snapshot reflects.
+
+## The BIAN model in one page
+
+- **Business Area** — broad grouping of related banking activity (8 in the v14 Value Chain View, e.g. *Customers*, *Products*, *Operations*).
+- **Business Domain** — coherent collection of related functions used for performance analysis and strategic attribution (43, e.g. *Loans and Deposits*, *Relationship Management*).
+- **Service Domain** — the fundamental building block: an *assignable responsibility partition* with a single well-defined purpose (341 in the Value Chain View). Each applies one of 19 **functional patterns** (Operate, Process, Analyse, …) to the asset it manages. Service Domains are **canonical**: *Customer Credit Rating* means the same thing in any bank, which is what makes cross-install analytics and core-vs-commodity classification trustworthy.
+- **Service Operations / Semantic APIs** — the published contracts a Service Domain exposes to collaborating domains, characterized by Action Terms (Initiate, Retrieve, Evaluate, …) and published as REST-ready Semantic API specs.
+
+## BIAN → CSDM mapping (from the integration paper)
+
+The v7.6 paper scopes the integration to four BIAN objects and keeps both frameworks intact:
+
+| BIAN object | CSDM object | Notes |
+| ----------- | ----------- | ----- |
+| Business Area | Business Capability (L0) | Existing capability hierarchy; `Category = 'BIAN Business Area'` |
+| Business Domain | Business Capability (L1) | Child of the Business Area capability |
+| Service Domain | Service Domain (custom CI) | The cornerstone — conceptual anchor linking business architecture to operational reality; contained by the L1 capability, provided by Business Applications |
+| Service Operation | Digital Interface (DIM) | Owned by the provider Service Domain; Semantic APIs are the reference spec; physical APIs link at the deployed-endpoint level |
+
+Four-layer traversal: **Conceptual** (Business Capability + Service Domain) → **Logical**
+(Digital Interface / Integration) → **Physical** (Service Instance, API CIs) →
+**Business Consumption** (Business Service + Offering). Bidirectional: strategy decomposes
+down to deployed endpoints; an outage or CVE traces up to the capability and
+customer-facing service it threatens.
+
+## How DPF uses this
+
+1. **Banking archetypes** (`banking-financial-services` category) seed their service
+   catalogs, vocabulary, and capability maps from BIAN Business Domains and Service
+   Domains rather than hand-invented lists — see
+   `docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md`.
+2. **Business-capability perspective**: BIAN Business Areas/Domains project into DPF's
+   `BusinessCapability` substrate as a sourced perspective
+   (`packages/db/src/business-capability-perspectives.ts`), the same pattern the paper
+   uses for CSDM Business Capabilities — BIAN supplies the banking vocabulary, DPF's
+   capability model supplies the cross-domain bridge.
+3. **Service Domain canonicality** is what makes hive-mind reuse work across banking
+   installs: two community banks describe the same function with the same name.
+
+Related repo research: `docs/Reference/framework-mapping-playlist/069-csdm-v3-framework-mapping-bian-v8.md`
+(the earlier BIAN v8 ↔ CSDM v3 mapping session; the v14/CSDM-5 paper above supersedes its
+version-specific details while confirming its durable mappings).

--- a/docs/Reference/bian/bian-v14-service-landscape.json
+++ b/docs/Reference/bian/bian-v14-service-landscape.json
@@ -1,0 +1,1896 @@
+{
+ "standard": "BIAN Service Landscape",
+ "version": "14.0.0",
+ "view": "Value Chain View (canonical; Matrix layout is deprecated by BIAN)",
+ "retrieved": "2026-06-09",
+ "sources": {
+  "valueChainView": "https://bian.org/servicelandscape-14-0-0/views/view_54486.html",
+  "semanticApis": "https://github.com/bian-official/public/tree/main/release14.0.0/semantic-apis",
+  "portal": "https://portal.bian.org"
+ },
+ "counts": {
+  "businessAreas": 8,
+  "businessDomains": 43,
+  "serviceDomains": 341,
+  "serviceDomainsWithSemanticApi": 258
+ },
+ "businessAreas": [
+  {
+   "name": "Business Management",
+   "businessDomains": [
+    {
+     "name": "Business Direction",
+     "serviceDomains": [
+      {
+       "name": "Organization Direction",
+       "semanticApi": false
+      },
+      {
+       "name": "Products and Services Direction",
+       "semanticApi": false
+      },
+      {
+       "name": "Corporate Strategy",
+       "semanticApi": false
+      },
+      {
+       "name": "Corporate Policies",
+       "semanticApi": false
+      },
+      {
+       "name": "Human Resources Direction",
+       "semanticApi": false
+      },
+      {
+       "name": "IT Systems Direction",
+       "semanticApi": false
+      },
+      {
+       "name": "Asset And Liability Management",
+       "description": "The unit overseeing the  banks asset & liability policies and position",
+       "semanticApi": true
+      },
+      {
+       "name": "Property Portfolio",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Corporate Relations",
+     "serviceDomains": [
+      {
+       "name": "Investor Relations",
+       "semanticApi": false
+      },
+      {
+       "name": "Corporate Relationship",
+       "semanticApi": false
+      },
+      {
+       "name": "Corporate Alliance and Stake Holder",
+       "semanticApi": false
+      },
+      {
+       "name": "Corporate Communications",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Corporate Services",
+     "serviceDomains": [
+      {
+       "name": "Legal Compliance",
+       "description": "'Provide specialist legal advice, assess for legal compliance and resolve legal cases as they occur'",
+       "semanticApi": true
+      },
+      {
+       "name": "Internal Audit",
+       "description": "Maintain and portfolio of internal audit checks. Select and execute a meaningful sample of checks and identify and resolve non-compliance",
+       "semanticApi": true
+      },
+      {
+       "name": "Security Advisory",
+       "semanticApi": false
+      },
+      {
+       "name": "Security Assurance",
+       "semanticApi": false
+      },
+      {
+       "name": "Continuity Planning",
+       "semanticApi": false
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Resource Management",
+   "businessDomains": [
+    {
+     "name": "Unit Management",
+     "serviceDomains": [
+      {
+       "name": "Business Unit Direction",
+       "semanticApi": false
+      },
+      {
+       "name": "Business Unit Financial Operations",
+       "semanticApi": false
+      },
+      {
+       "name": "Business Unit Management",
+       "description": "Track and report on business unit activity and financial performance",
+       "semanticApi": true
+      },
+      {
+       "name": "Business Unit Accounting",
+       "semanticApi": false
+      },
+      {
+       "name": "Business Unit Financial Analysis",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Buildings And Equipment",
+     "serviceDomains": [
+      {
+       "name": "Fixed Asset Register",
+       "semanticApi": false
+      },
+      {
+       "name": "Procurement",
+       "semanticApi": false
+      },
+      {
+       "name": "Equipment Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Equipment Maintenance",
+       "semanticApi": false
+      },
+      {
+       "name": "Utilities Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Site Operations",
+       "semanticApi": false
+      },
+      {
+       "name": "Site Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Building Maintenance",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Human Resources",
+     "serviceDomains": [
+      {
+       "name": "Recruitment",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Assignment",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Evaluation",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Certification",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee and Contractor Contract",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Data Management",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Payroll And Incentives",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Benefits",
+       "semanticApi": false
+      },
+      {
+       "name": "Workforce Training",
+       "semanticApi": false
+      },
+      {
+       "name": "Travel and Expenses",
+       "semanticApi": false
+      },
+      {
+       "name": "Employee Access",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Platform Operations",
+     "serviceDomains": [
+      {
+       "name": "Systems Assurance",
+       "semanticApi": false
+      },
+      {
+       "name": "System Deployment",
+       "semanticApi": false
+      },
+      {
+       "name": "Systems Operations",
+       "semanticApi": false
+      },
+      {
+       "name": "Internal Network Operation",
+       "semanticApi": false
+      },
+      {
+       "name": "Systems Help Desk",
+       "semanticApi": false
+      },
+      {
+       "name": "Platform Operations",
+       "semanticApi": false
+      },
+      {
+       "name": "Operational Gateway",
+       "description": "'This Service Domain operates production information exchanges with external parties for non-financial messages/transactions. It may employ a broad range of channels, media and technologies as needed to support the different requirements of any particular third party interface'",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Finance And Risk Management",
+   "businessDomains": [
+    {
+     "name": "Market Risk",
+     "serviceDomains": [
+      {
+       "name": "Credit and Margin Management",
+       "semanticApi": false
+      },
+      {
+       "name": "Gap Analysis",
+       "semanticApi": false
+      },
+      {
+       "name": "Limit and Exposure Management",
+       "semanticApi": false
+      },
+      {
+       "name": "Position Management",
+       "description": "The Service Domain tracks the bank's consolidated financial positions for major customers and complex market conditions",
+       "semanticApi": true
+      },
+      {
+       "name": "Economic Capital",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Compliance",
+     "serviceDomains": [
+      {
+       "name": "Regulatory And Legal Authority",
+       "description": "'Maintain effective relations with regulators, accounting and government agencies. Oversee interactions and reporting as necessary'",
+       "semanticApi": true
+      },
+      {
+       "name": "Regulatory Compliance",
+       "description": "'This service domain provides a service to interpret regulatory requirements, provide guidance and define and implement a portfolio of regulatory compliance tests across all appropriate bank activities'",
+       "semanticApi": true
+      },
+      {
+       "name": "Regulatory Reporting",
+       "description": "This service domain administers and orchestrates the tasks required to meet the bank's regulatory reporting obligations",
+       "semanticApi": true
+      },
+      {
+       "name": "Guideline Compliance",
+       "description": "'This service domain develops and applies a portfolio of guideline compliance tests to confirm adherence to bank and regulator imposed internal procedures. Tests may be made on complete transaction data or a meaningful samples as appropriate to mitigate exposure to non-compliant behaviors. Compliance checks may be in response to a schedule, a specific request as part of normal processing or may be initiated randomly as an oversight activity'",
+       "semanticApi": true
+      },
+      {
+       "name": "Compliance Reporting",
+       "description": "This service domain administers and orchestrates the tasks required to apply and report on internal audit control and reporting activity",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Financial Control",
+     "serviceDomains": [
+      {
+       "name": "Financial Control",
+       "semanticApi": false
+      },
+      {
+       "name": "Financial Statements",
+       "semanticApi": false
+      },
+      {
+       "name": "Company Billing and Payments",
+       "semanticApi": false
+      },
+      {
+       "name": "Approved Supplier Directory",
+       "semanticApi": false
+      },
+      {
+       "name": "Enterprise Tax Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Financial Compliance",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Credit Risk",
+     "serviceDomains": [
+      {
+       "name": "Credit Management",
+       "description": "This service domain provides a bank-wide/oversight function to qualify credit pricing for offered products and services to reflect the bank's appetite to write the business. This decision can override the standard product pricing procedure",
+       "semanticApi": true
+      },
+      {
+       "name": "Counterparty Risk",
+       "semanticApi": false
+      },
+      {
+       "name": "Fraud Resolution",
+       "description": "This service domain sets up and processes a fraud case resulting from fraud behavior that has been detected during production processing",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Operational Risk",
+     "serviceDomains": [
+      {
+       "name": "Business Risk Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Operational Risk Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Production Risk Models",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Group Treasury",
+     "serviceDomains": [
+      {
+       "name": "Corporate Treasury",
+       "description": "This service domain orchestrates the consolidation and presentation of summary transaction details in order to assemble a timely and accurate view of the overall treasury position of the Bank at any one time. It is also responsible for determining the different interest and exchange rates applied to different products and services within the bank",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Treasury Analysis",
+       "semanticApi": false
+      },
+      {
+       "name": "Bank Portfolio Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Bank Portfolio Analysis",
+       "semanticApi": false
+      },
+      {
+       "name": "Asset Securitization",
+       "description": "Determine and select assets for securitization as needed to maintain and optimize the Bank's portfolio. Administer the securitization process",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Operations",
+   "businessDomains": [
+    {
+     "name": "External Agency",
+     "serviceDomains": [
+      {
+       "name": "Interbank Relationship Management",
+       "description": "'Manage the bank''s relationship with other banks, covering any specific agreements that may be in place and overseeing operational issues.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Correspondent Bank Relationship Management",
+       "description": "'This Service Domain manages correspondent bank relations, ensuring reciprocity and developing business where possible'",
+       "semanticApi": true
+      },
+      {
+       "name": "Syndicate Management",
+       "description": "This Service Domain manages syndicate membership and compliance",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Service Agency",
+       "description": "This Service Domain establishes and maintains contractual arrangements with product and service agencies",
+       "semanticApi": true
+      },
+      {
+       "name": "Partner Agreement",
+       "description": "'This service domain captures and maintains comprehensive terms and conditions govering Partner relationships. '",
+       "semanticApi": true
+      },
+      {
+       "name": "Sub Custodian Agreement",
+       "description": "This Service Domain establishes and maintains the terms governing sub custodian relationship",
+       "semanticApi": true
+      },
+      {
+       "name": "Commission Agreement",
+       "description": "Maintain and administer the terms and transactions for employee and broker commissions",
+       "semanticApi": true
+      },
+      {
+       "name": "Contractor and Supplier Agreement",
+       "description": "This Service Domain maintains appropriate supplier agreements/contracts",
+       "semanticApi": true
+      },
+      {
+       "name": "Service Provider Operations",
+       "description": "This Service Domain handles the range of operational actions used in production interactions with an external service provider.",
+       "semanticApi": true
+      },
+      {
+       "name": "Partner Management",
+       "description": "'This service domain handles strategic management of collaborative partners including partner development, performance and relationship tracking.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Operations Log",
+       "description": "This service domain handle the day-to-day operations of a collaborative partner related services.",
+       "semanticApi": true
+      },
+      {
+       "name": "Partner Administration",
+       "description": "This service domain handle the day-to-day operations of a collaborative partner related services.",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Operational Services",
+     "serviceDomains": [
+      {
+       "name": "Customer Billing",
+       "description": "'This service domains provides a central service to compose, issue and track customer billing and invoices'",
+       "semanticApi": true
+      },
+      {
+       "name": "Disbursement",
+       "description": "This service domain handles the disbursement of funds to newly established loans/facilities as necessary",
+       "semanticApi": true
+      },
+      {
+       "name": "Open Item Management",
+       "description": "This service domain provides a service for handling the resolution of open items against accounts (such as overdue loan payments)",
+       "semanticApi": true
+      },
+      {
+       "name": "Delinquent Account Handling",
+       "description": "This service domain handles delinquent accounts (typically for active credit/charge cards) for follow-up of payments due through periodic review and contacts. This process ends when the account is cancelled and is transferred to Collections",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Collections",
+       "description": "This service domain administers the recovery of outstanding amounts from cancelled card accounts through internal or external collection agencies.  This may involve negotiating payment terms and/or interest write-downs.",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Combination",
+       "description": "Product Combination supports bundled products applying necessary constraints on embedded product fulfillment and ensuring product performance analysis takes correct account of embedded products' contribution",
+       "semanticApi": true
+      },
+      {
+       "name": "Reward Points Awards And Redemption",
+       "description": "Handle the allocation and redemption of rewards points for customer transaction activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Issued Device Administration",
+       "description": "'This service domain administers the issuance of authentication tokens to customers and third party service providers. Tokens here include physical devices such as cards, fobs, readers and intangible ''devices'' such as passwords and secret questions. Administration includes version tracking, replacement and duration/frequency limits. Specific product/service access permissions may be associated with an issued token when appropriate'",
+       "semanticApi": true
+      },
+      {
+       "name": "Issued Device Tracking",
+       "description": "'This service domain handles operational access to issued device tracking services. Services report on the status of devices such as cards, fobs, etc. that have been issued to customers. Service notifications include fraud warnings/alerts and device cancellation.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Transaction Switch",
+       "description": "'This service domain orchestrates the switching and routing of Card Authorization and Financial transactions received through the Card POS Network, Card E-Commerce Gateway, or the ATM Network from the Acquirer to the Issuer through the Card Networks.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Internal Bank Account",
+       "description": "This Service Domain manages the banking-related accounts that are not owned by customers. These are not general ledger accounts. Typical examples are holding accounts and mirror accounts.",
+       "semanticApi": true
+      },
+      {
+       "name": "Term Deposit Framework Agreement",
+       "description": "A Term Deposit Framework Agreement is an agreement between a customer and the bank under which individual term deposits can be opened. It specifies standard conditions that will apply to each underlying term deposit.",
+       "semanticApi": true
+      },
+      {
+       "name": "Incentive Program Directory",
+       "description": "This service domain maintains specifications of the various Incentive Programs that are on offerr to customers.",
+       "semanticApi": true
+      },
+      {
+       "name": "Incentive Account",
+       "description": "'This service domain orchestrates the scheduled maintenance and transactional activities associated with Incentive Program fulfillment, including enrollment, accrual and redemption. '",
+       "semanticApi": true
+      },
+      {
+       "name": "Rewards Menu",
+       "description": "'The service domain presents a set of eligible rewards a customer can select from. '",
+       "semanticApi": true
+      },
+      {
+       "name": "Rewards Inventory",
+       "description": "The service domain handles the allocation of rewards from available inventory.",
+       "semanticApi": true
+      },
+      {
+       "name": "Rewards Delivery",
+       "description": "The service domain orchestrates the entire end-to-end  process for delivering a redeemed reward.",
+       "semanticApi": true
+      },
+      {
+       "name": "Issued Certificate Directory",
+       "description": "This service domain faciliatates the issuance of Rewards Certificates and their redemption.",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Custody, Collateral And Documents",
+     "serviceDomains": [
+      {
+       "name": "Account Recovery",
+       "description": "This service domain handles the restructuring of a distressed account (loan) after standard recovery procedures have been exhausted",
+       "semanticApi": true
+      },
+      {
+       "name": "Archive Services",
+       "description": "'The Archive Services Service Domain enables the bank to retain, maintain and access significant documents that are no longer actively accessed but that might be required in the future'",
+       "semanticApi": true
+      },
+      {
+       "name": "Custody Administration",
+       "description": "A service to provide safe custody services for marketable securities for bank customers",
+       "semanticApi": true
+      },
+      {
+       "name": "Collateral Allocation Management",
+       "description": "The Service Domain manages the allocation of party owned assets to bank issued lending and other asset products.",
+       "semanticApi": true
+      },
+      {
+       "name": "Collections",
+       "description": "Handles the liquidation of assets to offset the losses for problem accounts",
+       "semanticApi": true
+      },
+      {
+       "name": "Document Directory",
+       "description": "This Service Domain provides a directory based categorization and storage mechanism for documents created and referenced by the bank",
+       "semanticApi": true
+      },
+      {
+       "name": "Investment Account",
+       "description": "'This service domain handles the non-cash holdings positions for a customer, covering multiple instruments as necessary'",
+       "semanticApi": true
+      },
+      {
+       "name": "Document Services",
+       "description": "The Document Services Service Domain manages the creation and maintenance of documents throughout the bank.",
+       "semanticApi": true
+      },
+      {
+       "name": "Party Asset Directory",
+       "description": "'This directory maintains reference details of assets held by a party, usually a customer of the bank. In most case, the bank''s interest in the asset is because it may be pledged to the bank as collateral.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Collateral Asset Administration",
+       "description": "'This service domain maintains the status of a customers collateral assets, including scheduled and ad-hoc valuations and confirmation of the correct completion of scheduled maintenance tasks.'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Clearing And Settlement",
+     "serviceDomains": [
+      {
+       "name": "Counterparty Administration",
+       "description": "This Service Domain maintains key counterparty reference information used in the clearing and settlement of wholesale trading",
+       "semanticApi": true
+      },
+      {
+       "name": "Cheque Processing",
+       "description": "'Handle the processing of paper cheques, generating financial transactions for processing'",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Financial Settlement",
+       "description": "This service domain orchestrates the settlement of the transactions between the Issuers and the Acquirers through the Card Networks.",
+       "semanticApi": true
+      },
+      {
+       "name": "Order Allocation",
+       "description": "This Service Domain allocates partially fulfilled market trades",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Clearing",
+       "description": "'This service domain orchestrates the capture and consolidation of card financial transactions originating from various sources, such as POS Network, E-Commerce Gateway, ATM Network, or Card Case Management. It also handles the clearing of the transactions from the Acquirers to the Issuers through the Card Networks'",
+       "semanticApi": true
+      },
+      {
+       "name": "Transaction Engine",
+       "description": "Orchestrate a schedule of payment transaction and reporting activities for the fulfillment of certain long term instruments or structured facilities",
+       "semanticApi": true
+      },
+      {
+       "name": "Correspondent Bank Directory",
+       "description": "This service domain maintains correspondent bank reference details. This includes correspondent bank payment parameters in particular bank limits and capturing transaction activity to track reciprocity",
+       "semanticApi": true
+      },
+      {
+       "name": "Card eCommerce Gateway",
+       "description": "'This service domain orchestrates the processing of e-commerce transactions for authentication, authorization and capture of the financial transactions.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Payment Rail",
+       "description": "'This Service Domain handles the operational interface with payment service providers, formatting outbound transactions and onward routing inbound transactions during scheduled operating sessions. It also links to holding account facilities for net payment handling'",
+       "semanticApi": true
+      },
+      {
+       "name": "Payment Settlement",
+       "semanticApi": false
+      },
+      {
+       "name": "Payment Confirmation",
+       "semanticApi": false
+      },
+      {
+       "name": "Payment Orchestration",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Accounting Services",
+     "serviceDomains": [
+      {
+       "name": "Position Keeping",
+       "description": "This service domain maintains a log of monetary or value transactions and entitlements log posted to product facilities. Reconciled financial transactions are subsequently used for posting to the accounting systems.",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Position",
+       "description": "'This service domain maintains a consolidated financial position for a customer, combining details from all products and services in use. The position can cover available funds, credit, collateral, tax exposure and other financial measures as necessary'",
+       "semanticApi": true
+      },
+      {
+       "name": "Accounts Receivable",
+       "description": "This service domain handles accounts receivable for invoices issue by the bank to customers and partners. It includes follow-up and resolution activity for delayed/missed payments",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Accounting",
+       "description": "'The Financial Accounting Service Domain takes in financial facts and based on these, creates accounting instructions that will update the general ledger and sub ledger accounts'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Tax Handling",
+       "description": "This service domain handles consumer tax reporting obligations including the consolidation and reporting of customer tax related financial activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Commissions",
+       "description": "The service domain processes commissions for transactions for eligible employees",
+       "semanticApi": true
+      },
+      {
+       "name": "Fraud Evaluation",
+       "description": "The service domain executes fraud behavioral pattern tests to detect possible fraudulent transactions/activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Account Reconciliation",
+       "description": "This Service Domain handles account reconciliation tasks",
+       "semanticApi": true
+      },
+      {
+       "name": "Securities Position Keeping",
+       "description": "This service domain maintains a securities transaction log to support securities investment activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Fraud Diagnosis",
+       "description": "This service domain handles the evaluation of detected possible fraud to support an appropriate response to contain the exposure",
+       "semanticApi": true
+      },
+      {
+       "name": "Reward Points Account",
+       "description": "Administer the booking and remittance of rewards points",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Statement Assessment",
+       "description": "'This Service Domain supports a range of financial analyses that can be used to extract specific insights (e.g. valuations, liquidity, risk, market sensitivities) from an entity''s financial statements'",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Products",
+   "businessDomains": [
+    {
+     "name": "Market Operations",
+     "serviceDomains": [
+      {
+       "name": "Trading Book Oversight",
+       "description": "This Service Domain oversees the bank's trading book (a type of account ledger that records details of frequently traded securities held by the bank) to manage the banks market risk",
+       "semanticApi": true
+      },
+      {
+       "name": "Trade Confirmation Matching",
+       "description": "This Service Domain supports the bank's interface to a central market matching and confirmation service whether the bank acts as broker dealer or institutional investor",
+       "semanticApi": true
+      },
+      {
+       "name": "Trade and Price Reporting",
+       "description": "This Service Domain operates an automated facility that reports executed market trades to the market place as required by the rules of market participation",
+       "semanticApi": true
+      },
+      {
+       "name": "Credit Risk Operations",
+       "description": "This Service Domain monitors counterparty credit limits in the trading unit",
+       "semanticApi": true
+      },
+      {
+       "name": "Securities Fails Processing",
+       "description": "This Service Domain handles the resolution of clerical and processing errors that lead to failures in the securities trade clearing and settlement processes",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Instrument Valuation",
+       "description": "'This Service Domain provides a range of financial asset valuation services  '",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Action",
+       "description": "This Service Domain supports the various custodial tasks associated with processing associated corporate actions for customer's with securities held at the bank",
+       "semanticApi": true
+      },
+      {
+       "name": "Trade Clearing",
+       "description": "This Service Domain handles the back office processes that confirm and notify interested parties that securities and funds are available as traded in anticipation of settlement processing",
+       "semanticApi": true
+      },
+      {
+       "name": "Trade Settlement",
+       "description": "'This Service Domain handles the final movement of cash and securities between depositories as previously confirmed in the clearing process, in order to settle a market trade'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Consumer Banking",
+     "serviceDomains": [
+      {
+       "name": "Current Account",
+       "description": "'This service domain orchestrates a consumer checking/demand deposit account. The typical range of services and fees covers payments and deposits, standing orders, sweeps, liens, check and debit card access.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Brokered Product Proxy",
+       "description": "This Service Domain oversees all activities associated with the coordinated delivery of 3rd party products and services",
+       "semanticApi": true
+      },
+      {
+       "name": "Sales Product",
+       "description": "'A representation of a product as sold to a customer, covering the operational fulfillment requirements'",
+       "semanticApi": true
+      },
+      {
+       "name": "Trust Services",
+       "description": "This Service Domain support a range of trust management services offered to high value customers",
+       "semanticApi": true
+      },
+      {
+       "name": "Payment Order Initiation",
+       "description": "This service domain provides a customer payment service. It captures the payer and payee details and other key properties of the payment and initiates the orchestration of the transaction. It provides support for repeating/scheduled payments.",
+       "semanticApi": true
+      },
+      {
+       "name": "Currency Exchange",
+       "description": "Service Domain supports over the counter currency exchange",
+       "semanticApi": true
+      },
+      {
+       "name": "Funeral Policy",
+       "description": "'The Funeral Policy Service Domain handles the general product maintenance, premium payments and initiates claims processing.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Claim Assessment",
+       "description": "The Claim Assessment Service Domain runs through the required tests to confirm the veracity of a claim made under an insurance policy.",
+       "semanticApi": true
+      },
+      {
+       "name": "Claim Administration",
+       "description": "The claim administration Service Domain implements the payment and support obligations of the policy in respect to a verified claim",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Advisory Services",
+     "serviceDomains": [
+      {
+       "name": "Mergers and Acquisitions Advisory",
+       "description": "'This Service Domain handles mergers and acquisition, IPO, MBO and LBO projects with the bank acting in the lead and/or subordinate role'",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Finance",
+       "description": "This Service Domain handles the provision of a broad range of financial advisory services to corporate clients",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Tax Advisory",
+       "description": "'A fee or commission based product providing tax specific assessments, advice and guidance for corporate customers'",
+       "semanticApi": true
+      },
+      {
+       "name": "Consumer Advisory Services",
+       "description": "'Offer financial advisory services to consumer customers, possibly for a fee'",
+       "semanticApi": true
+      },
+      {
+       "name": "Legal Advisory",
+       "description": "'The role of the Service Domain is to provide customers and bank employees with advice on legal aspects of product sales and servicing as well as on planned and executed transactions. '",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Market Trading",
+     "serviceDomains": [
+      {
+       "name": "Trader Position Operations",
+       "description": "This Service Domain supports the activities of individual traders working within a trading book group",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Order",
+       "description": "Market Order records an instruction from a customer or his or her representative to buy or sell securities. It follows the order during its lifetime and reports back to the requestor on the execution.",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Order Execution",
+       "description": "'The Market Order Execution Service Domain is responsible for the booking of securities transactions (e.g. resulting from market orders or some types of corporate actions) on investment accounts, so in terms of security name plus quantity.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Dealer Desk",
+       "description": "The Dealer Workbench represents the bank's dealing desk facility supporting one or more trading lines of activity for both agency and principal trading in all chosen market instruments. It also supports sales and market risk trading desk functions",
+       "semanticApi": true
+      },
+      {
+       "name": "Suitability Checking",
+       "description": "Confirm that all involved counterparties are suitable for a proposed market trade.",
+       "semanticApi": true
+      },
+      {
+       "name": "Quote Management",
+       "description": "'This service domain handles the procedure used by traders to obtain and selecting quotes from market makers '",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Making",
+       "description": "This Service Domain enables the bank to fulfill its market making function typically in collaboration with a trading exchange. The bank maintains a buy/sell quote for the securities it supports as a market maker and accepts buy/sell orders on request",
+       "semanticApi": true
+      },
+      {
+       "name": "Program Trading",
+       "description": "This Service Domain supports a program trading capability where the trading decisions are made based on predefined/programmed rules and policies. Manual oversight and monitoring capabilities are supported as appropriate",
+       "semanticApi": true
+      },
+      {
+       "name": "Stock Lending and Repos",
+       "description": "This Service Domain supports the bank offering tri-party repo transactions made between its customers to support their short term capital management requirements",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Corporate Banking",
+     "serviceDomains": [
+      {
+       "name": "Corporate Current Account",
+       "description": "'This service domain orchestrates a corporate checking/demand deposit account. The typical range of services and fees covers payments and deposits, standing orders, sweeps, liens, check and debit card access.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Direct Debit Mandate",
+       "description": "This service domains manages the customer mandates associated with direct debit processing for a corporate client",
+       "semanticApi": true
+      },
+      {
+       "name": "Cash Management And Account Services",
+       "description": "This service domain orchestrates a cash management and accounting services facility typically used by corporations to support additional cash management features over and above the standard facilities of current and savings accounts",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Trust Services",
+       "description": "This Service Domain provides corporate trust services centered on the handling of debt instruments and escrow account support",
+       "semanticApi": true
+      },
+      {
+       "name": "Credit Facility",
+       "description": "The Credit Facility Service Domain manages the Credit Facilities that a Corporate Customer has with the bank. A Credit Facility is an agreement between the bank and a (corporate) customer to allow the customer to acquire asset products from the bank up to the limit of the credit facility without the need for a full due diligence and underwriting for each of these products.",
+       "semanticApi": true
+      },
+      {
+       "name": "Direct Debit",
+       "description": "Fulfils a direct debit agreement.  Handles the creditor side of direct debits.",
+       "semanticApi": true
+      },
+      {
+       "name": "Cheque Lock Box",
+       "description": "This Service Domain support paper cheque processing services offered to corporate customers",
+       "semanticApi": true
+      },
+      {
+       "name": "Factoring",
+       "description": "This Service Domain supports a factoring service for corporate customers enabling them to convert accounts receivable into immediate funds at a discount",
+       "semanticApi": true
+      },
+      {
+       "name": "Cash Concentration",
+       "description": "'Cash Concentration is a cash management service aimed at moving a balance, or part of a balance of an account to a different account to meet various requirements.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Payroll Services",
+       "description": "The Corporate Payroll Services Service Domain handles payroll payment processing for the employees of a corporate customer.",
+       "semanticApi": true
+      },
+      {
+       "name": "Project Finance",
+       "description": "This Service Domain fulfills project financing by which major (government) projects can attract privet sector financing",
+       "semanticApi": true
+      },
+      {
+       "name": "Notional Pooling",
+       "description": "'Notional pooling allows corporate customer with multiple active accounts to pool credit and debit balances to provide a single centralized liquidity position and to minimize interest expense, simplify cash management and retain a degree of local autonomy to the accounts'",
+       "semanticApi": true
+      },
+      {
+       "name": "Virtual Account",
+       "description": "'A Virtual Account is a bank account that is defined on an underlying real account. It can receive and send payments for the underlying account while behaving towards the outside as a separate account. '",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Cards",
+     "serviceDomains": [
+      {
+       "name": "Credit Card",
+       "description": "This service domain orchestrates the scheduled maintenance and transactional activities associated with credit card product fulfillment",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Authorization",
+       "description": "This service domain is responsible for the real time card authorization decisions for credit/charge cards.",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Transaction Capture",
+       "description": "A distributed facility to capture card transactions at the point of sale",
+       "semanticApi": true
+      },
+      {
+       "name": "Merchant Relations",
+       "description": "This service domain maintains the terms and conditions agreed with merchants for cards related activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Network Participant Facility",
+       "description": "'This service domain orchestrates the activities related to the inclusion of new Acquirers and Issuers in the Card Network, their terms and conditions and their status.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Merchant Acquiring Facility",
+       "description": "'This service domain orchestrates the activities related to Merchant fulfillment, Merchant Account maintenance, Merchant transactional activities and settlement, including the billing of merchant fees and charges.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Transaction Tracking",
+       "description": "'Maintain a log of credit card bookings and authorizations for operational and management information, tracking and reconciliation purposes.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Card Service",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Trade Banking",
+     "serviceDomains": [
+      {
+       "name": "Letter of Credit",
+       "description": "This Service Domain handles the pricing and issuance of letters of credit to its corporate customers in support of their international trading requirements",
+       "semanticApi": true
+      },
+      {
+       "name": "Bank Guarantee",
+       "description": "This Service Domain handles the pricing and issuance of a broad range of bank guarantee instruments",
+       "semanticApi": true
+      },
+      {
+       "name": "Bank Drafts",
+       "description": "This Service Domain support bank guaranteed payment transactions such as bank drafts",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Corporate Finance",
+     "serviceDomains": [
+      {
+       "name": "ECM And DCM",
+       "description": "'Supports the specification, pricing and issuance of equity and debt (bond) primary capital market products for corporate financing services'",
+       "semanticApi": true
+      },
+      {
+       "name": "Private Placement",
+       "description": "This Service Domain provides the complete range of functions involved in providing private placement services to corporate customers.",
+       "semanticApi": true
+      },
+      {
+       "name": "Public Offering",
+       "description": "'This Service Domain supports a broad range of complex financial, accounting and regulatory actions involved in providing advice and practical support to companies going public and/or raising additional capital through the issuance of publicly traded securities'",
+       "semanticApi": true
+      },
+      {
+       "name": "Unit Trust Administration",
+       "description": "This Service Domain handles the implementation and fulfillment of unit investment trusts",
+       "semanticApi": true
+      },
+      {
+       "name": "Hedge Fund Administration",
+       "description": "The Hedge Fund Administration Service Domain handles all aspects of the set-up and operation of a hedge fund that is offered to accredited investors within the bank's customer base",
+       "semanticApi": true
+      },
+      {
+       "name": "Mutual Fund Administration",
+       "description": "The Mutual Fund Administration Service Domain handles all aspects of the set-up and operation of mutual funds that can be offered to the bank's general (non-accredited) customers",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Loans and Deposits",
+     "serviceDomains": [
+      {
+       "name": "Loan",
+       "description": "This service domain handles the fulfillment of a general loan product. This includes the initial set-up of the loan facility and the completion of scheduled and ad-hoc product processing tasks",
+       "semanticApi": true
+      },
+      {
+       "name": "Consumer Loan",
+       "description": "This service domain handles the fulfillment of a consumer loan product. This includes the initial set-up of the loan facility and the completion of scheduled and ad-hoc product processing tasks",
+       "semanticApi": true
+      },
+      {
+       "name": "Mortgage Loan",
+       "description": "Fulfillment of a loan product for  the purpose of property purchase. Note different servicing patterns can be applied to interest calculations and principle and interest repayments",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Loan",
+       "description": "This service domain handles the fulfillment of a corporate loan product. This includes the initial set-up of the loan facility and the completion of scheduled and ad-hoc product processing tasks",
+       "semanticApi": true
+      },
+      {
+       "name": "Corporate Lease",
+       "description": "The Corporate Lease product provides corporate customers with loans to support leasing activity for property and equipment under an umbrella leasing arrangement",
+       "semanticApi": true
+      },
+      {
+       "name": "Merchandising Loan",
+       "description": "Fulfillment of loan product used in the purchase of a larger merchandise item such as a car or boat. The purchased item is typically treated as collateral for the loan",
+       "semanticApi": true
+      },
+      {
+       "name": "Leasing Item Administration",
+       "description": "Track the status of the assets underlying leasing agreements as they represent collateral items that could be accessed in the event of account recovery",
+       "semanticApi": true
+      },
+      {
+       "name": "Syndicated Loan",
+       "description": "Handle the processing of syndicated loans with the bank playing the lead coordination role with other syndicate bank members. Note some initial preparation may have been made through prior customer offer processing.",
+       "semanticApi": true
+      },
+      {
+       "name": "Fiduciary Agreement",
+       "description": "An agreement where the bank agrees to act on behalf of the customer in a financial matter and in accordance with the agreement terms",
+       "semanticApi": true
+      },
+      {
+       "name": "Underwriting",
+       "description": "This service domain manages the underwriting decision process for products as appropriate (including many loan types and some insurance products)",
+       "semanticApi": true
+      },
+      {
+       "name": "Leasing",
+       "description": "The leasing products enables customers to finance equipment purchases using the leased item as collateral when necessary",
+       "semanticApi": true
+      },
+      {
+       "name": "Savings Account",
+       "description": "'This service domain orchestrates a consumer savings account. The typical range of services and fees covers payments from and scheduled and ad-hoc deposits to the account, standing orders, sweeps, and liens.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Term Deposit",
+       "description": "'A Term Deposit is an interest bearing account into which a customer can place a fixed amount of funds for a fixed amount of time. The Service Domain handles the opening, servicing and maturity processing of a Term Deposit.     '",
+       "semanticApi": true
+      },
+      {
+       "name": "Standing Order",
+       "description": "'Customers can issue standing orders to the bank. In most cases this is for the execution of a periodical payment, but there are other standing instructions like, sweeping balances at end of month, topping off excess funds for a current account, etc. '",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Customers",
+   "businessDomains": [
+    {
+     "name": "Sales",
+     "serviceDomains": [
+      {
+       "name": "Customer Campaign Execution",
+       "description": "Execute a customer campaign (version) and track and respond to impact",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Expert Sales Support",
+       "description": "Administer the availability and allocation of product specialists to support sales activity",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Matching",
+       "description": "'Capability used to match eligible product and product combinations to a customer based on prevailing conditions such as customer type, product interest, solicitation/retention, campaign alignment'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Offer",
+       "description": "'This service domain orchestrates the processing of a product offer for a new or established  customer. The offer process is defined specifically for the product or service being considered and can include actions such as document checks, collateral allocation, credit assessments, underwriting decisions, regulatory and procedural checks, eligibility checks, the use of internal and external specialist services (such as evaluations and legal advice).'",
+       "semanticApi": true
+      },
+      {
+       "name": "Special Pricing Conditions",
+       "description": "Maintain a pricing list or conditions (with ranges and optional terms) categorized by various dimensions to impose exceptional product pricing conditions that override standard pricing terms (for special events/situations)",
+       "semanticApi": true
+      },
+      {
+       "name": "Party Lifecycle Management",
+       "description": "This service domain tracks the state of a party relationship with the bank from the initial checks made during the establishment of a new party connection and subsequently maintained as necessary over the duration of the relationship. The checks and the maintenance requirements will vary by party type and jurisdiction. The checks cover bank specific and legal and regulatory considerations and may be updated based on a standard schedule or by request in specific circumstances.",
+       "semanticApi": true
+      },
+      {
+       "name": "Prospect Campaign Execution",
+       "description": "Execute a prospect campaign (version) and track and respond to impact",
+       "semanticApi": true
+      },
+      {
+       "name": "Lead and Opportunity Management",
+       "description": "'This service domain captures, classifies and track sales lead/opportunities with established clients for additional products or services. It handles the processing of the opportunity through to the point of formal offer processing.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Sales Support",
+       "description": "This Service Domain administers customer access to product specialists",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Relationship Management",
+     "serviceDomains": [
+      {
+       "name": "Customer Relationship Management",
+       "description": "'This service domain develops and executes a customer plan to maintain and build a customer relationship. Activities include ongoing customer contact, tracking internal and external events and activity of interest and relevance, product and service matching and sales, processing ad-hoc queries, trouble shooting and issue resolution including the initial phases of troubled account recovery'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Behavior Insights",
+       "description": "This service domain applies behavioral analysis to customer event history to maintain a range of customer ratings/scores (such as 'propensity to buy') and to detect life events or trends",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Credit Rating",
+       "description": "This service domain maintains and administers the bank's credit assessment for customers based on consolidated internal data and optionally by referencing external credit agency reports",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Agreement",
+       "description": "This service domain maintains the master customer agreement/legal contract. Note that a customer can be a complex corporate entity with many subsidiaries operating in different geopolitical areas. The customer agreement is linked to as many Sales Product Agreements as needed for all in-force products",
+       "semanticApi": true
+      },
+      {
+       "name": "Sales Product Agreement",
+       "description": "This service domain maintains a structured legal agreement defining the contractual terms and conditions for an in-force product for a customer. It is subordinate to the customer's master agreement that is maintained by the Customer Agreement service domain",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Product And Service Eligibility",
+       "description": "This Service Domain maintains a list of products and services for which a customer is eligible.",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Proposition",
+       "description": "This Service Domain maintains bank and customer defined requirements spanning all products and services",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Event History",
+       "description": "'This service domain captures, classifies and stores relationship, servicing and product fulfillment related customer events. In addition to servicing and product transaction details, the log can capture life/relationship events that are revealed during customer exchanges'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Product and Service Directory",
+       "description": "This Service Domain maintains the most important details of all the products and services that a customer has acquired from the bank.",
+       "semanticApi": true
+      },
+      {
+       "name": "Loan Syndication",
+       "description": "\"Loan Syndication is a Service Domain that supports orgination, set-up and servicing of syndicated loans. It provides services that are used in lead banks, agents and banks providing administrative support.\\nIt handles the orchestration of origination and servicing processes for syndicated loans.\"",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Financial Insights",
+       "description": "This service domain applies behavioral analysis to the customer financial history to develop financial insights that can highlight business development opportunities or detect possible concerns with a customer's financial wellfare",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Consent",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Customer Care",
+     "serviceDomains": [
+      {
+       "name": "Servicing Mandate",
+       "description": "This service domain maintains the allowed customer servicing arrangements for a service provider covering general access to the bank's products and services and optionally customer specific arrangements",
+       "semanticApi": true
+      },
+      {
+       "name": "Servicing Order",
+       "description": "This service domain handles the processing of a customer servicing request as a predefined procedure. A range of standard servicing requests can be supported. The process can include a check of permissions when the request is made by a third party/service provider",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Case Management",
+       "description": "Track and assess case load and resolution activity - allocate resources as necessary to optimize case resolution performance",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Case",
+       "description": "'This service domain handles the processing of a customer card case, typically a disputed charge'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Case",
+       "description": "'This service domain handles the initiation, tracking, resolution and reporting on customer cases (issues that typically require corrective response to some financial transaction)'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Party Reference",
+     "serviceDomains": [
+      {
+       "name": "Legal Entity Directory",
+       "description": "This service domain maintains details of the legal entity structure of the party including dependents and associations for individuals and ownership/subsidiary structures for corporations. Some financial indicators and product coverage/activity details can be included where this defines the nature of the legal entity relationship in particular for corporate entities",
+       "semanticApi": true
+      },
+      {
+       "name": "Location Data Management",
+       "description": "This service domain maintain details of the use and state of locations of interest to the bank. This can include both physical and virtual addresses. It is used to check for valid use and for sales/marketing activities",
+       "semanticApi": true
+      },
+      {
+       "name": "Party Reference Data Directory",
+       "description": "'This service domain maintains a range of party reference information covering aspects including general reference details, contacts and associations and demographic information'",
+       "semanticApi": true
+      },
+      {
+       "name": "Payee Management",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Investment Services",
+     "serviceDomains": [
+      {
+       "name": "Consumer Investments",
+       "description": "Handle the consumer front-end trading requests. These will typically be blocked/netted for market execution",
+       "semanticApi": true
+      },
+      {
+       "name": "Investment Portfolio Management",
+       "description": "'Manage an investment portfolio, initiating trading to leverage market opportunities, remaining within portfolio trading policies'",
+       "semanticApi": true
+      },
+      {
+       "name": "Investment Portfolio Analysis",
+       "description": "'Assess and report on investment portfolio make-up, valuation and performance'",
+       "semanticApi": true
+      },
+      {
+       "name": "Investment Portfolio Planning",
+       "description": "Agree the policies and required make-up of an investment portfolio and ensure all required bank and regulatory terms and conditions are addressed",
+       "semanticApi": true
+      },
+      {
+       "name": "eTrading Workbench",
+       "description": "This Service Domain supports consumer securities trading of their investment portfolio through the bank",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Channels",
+   "businessDomains": [
+    {
+     "name": "Information Providers",
+     "serviceDomains": [
+      {
+       "name": "Public Reference Data Management",
+       "description": "'Provide structured access to standard ''global'' reference data and definitions associated with market activity such as currency, country and segment identifiers.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Instrument Reference Data Management",
+       "description": "This Service Domain maintains a directory of financial instrument reference data",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Market Research",
+       "description": "The service domain consolidates external financial market research",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Market Analysis",
+       "description": "Provide different types of financial market analysis using available financial market information and research",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Information Management",
+       "description": "Market information management consolidates and improves market information from multiple sources in order to build up a bank knowledge base in targeted areas",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Data Switch Operation",
+       "description": "This service domain operates the internal information distribution facility/switch in compliance with administered external subscription information feed service access rights. Note the content is retrieved by the Market Feed Operation service domain from the various external feed services. Internal information can also be published over the switch from various bank sources (such as bank rates provided by treasury).",
+       "semanticApi": true
+      },
+      {
+       "name": "Information Provider Operation",
+       "description": "''",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Cross Channel",
+     "serviceDomains": [
+      {
+       "name": "Customer Workbench",
+       "description": "This service domain represents customer side devices. Most commonly providing a customer access portal to the banks products and services through any suitable channel and device",
+       "semanticApi": true
+      },
+      {
+       "name": "Contact Handler",
+       "description": "This service domain handles a customer's interactive contact with the bank. This will typically involve launching of one or more channel/device specific dialogue sessions as necessary within the customer contact",
+       "semanticApi": true
+      },
+      {
+       "name": "Contact Routing",
+       "description": "'The Contact Routing service domain tracks servicing resource availability and uses any known details about the customer contact (e.g. identity, indicated purpose of call, status of the relationship) to make an optimal routing decision. The routing selection may include matching the required product knowledge/skills to the available servicing resources.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Session Dialogue",
+       "description": "'This service domain handles/structures the customer narrative during an interactive session. It consolidates and presents pertinent customer information and provides servicing guidelines with standard dialogue/scripting as appropriate. It can include the capability to provoke questions to capture key relationship and sales triggers. It also ensures the correct sequencing, dialogue content and actions are performed/initiated during the customer interaction. It may further leverage the session by passing on customer notifications, status updates and triggering sales/marketing efforts.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Party Routing Profile",
+       "description": "'This service domain maintains a small profile of key indicators for a customer that is referenced during customer interactions to facilitate routing, servicing and product/service fulfillment decisions. This can include status (such as account in arrears), ratings (such as high value customer) and alerts (such possible fraud activity detected)'",
+       "semanticApi": true
+      },
+      {
+       "name": "Transaction Authorization",
+       "description": "'This service domain handles risk based authorization for interactive customer transactions. This combines the context (channel) transaction, customer details and recent activity analysis as appropriate. The authorization may require a specific level of party/customer authentication to get approval.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Access Entitlement",
+       "description": "This service domain maintains the details of the allowed channel/device based access to products and services that the customer has in place.  This profile is referenced in servicing and fulfillment activity and may include customer preferences and access limits/constraints that span multiple products.",
+       "semanticApi": true
+      },
+      {
+       "name": "Channel Activity History",
+       "description": "This service domains consolidates and captures customer channel usage activity to support channel activity analysis and also can be referenced for customer access authorization and routing decisions",
+       "semanticApi": true
+      },
+      {
+       "name": "Processing Order",
+       "description": "'The Processing Order Service Domain handles the processing of a service request that comes in via a secure channel from a known requestor, which is typically an automated process itself and not a customer.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Party Authentication",
+       "description": "This service domain provides a customer identify authentication service covering all channels and devices to support access to the banks products and services",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Channel Specific",
+     "serviceDomains": [
+      {
+       "name": "ATM Network Operations",
+       "description": "'Handling the automated operation of the ATM network and linked devices, including tracing physical cash and document movements'",
+       "semanticApi": true
+      },
+      {
+       "name": "Branch Location Operations",
+       "description": "'The day to day administration of branch activity, including teller assignment and cash handling oversight'",
+       "semanticApi": true
+      },
+      {
+       "name": "Advanced Voice Services Operations",
+       "description": "'This service domain operates the telephone channel infrastructure, including the IVR and any other automated devices as appropriate. This includes handling default routing rules and intra-day/session adjustments to deal with peak load or other operational variations'",
+       "semanticApi": true
+      },
+      {
+       "name": "eBranch Operations",
+       "description": "This service domain operates the bank's on-line web based electronic branch capabilities - controlling access and load balancing across available communications and processing resources to optimize performance/availability",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Gateway",
+       "description": "'This service domain operates automated message interfaces to secure networks such as SWIFT, TELEX, ACH and Financial Market/Exchange reporting services'",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Terminal Administration",
+       "description": "'This service domain administers the POS Network including the inventory, terminal characteristics, deployment and status of the POS devices.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Card Terminal Operation",
+       "description": "'This service domain handle POS operations including processing, capture and tracking of the transactions originating at the Point of Sale devices.'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Distribution",
+     "serviceDomains": [
+      {
+       "name": "Product Inventory Distribution",
+       "description": "Administer the provisioning and distribution of product inventory across the branch network and/or distribute direct to customers (e.g. mail) where appropriate",
+       "semanticApi": true
+      },
+      {
+       "name": "Branch Currency Distribution",
+       "description": "Schedule and coordinate the secure distribution of cash inventory across the branch and ATM networks.",
+       "semanticApi": true
+      },
+      {
+       "name": "Correspondence",
+       "description": "This service domain orchestrates the production of pre-formatted correspondence and batches of correspondence (e.g. mail shots).",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Servicing",
+     "serviceDomains": [
+      {
+       "name": "Contact Center Operations",
+       "description": "Administer the day to day activity in the contact center - allocate positions and track staff availability and performance",
+       "semanticApi": true
+      },
+      {
+       "name": "Point of Service",
+       "description": "'This service domain operates servicing positions within the bank. It administers all media connections, inventory holdings (e.g. cash), provides access to support utilities and tracks servicing activity -e.g. time spent, activity logs, capturing servicing events including commission and training related actions. In cases servicing positions can be automated'",
+       "semanticApi": true
+      },
+      {
+       "name": "Interactive Help",
+       "description": "Operate the automated facility that provides interactive context sensitive servicing guidance to employees and self-serve customers",
+       "semanticApi": true
+      },
+      {
+       "name": "Servicing Issue",
+       "description": "This Service Domain handles production customer servicing issues detected in the customer servicing environment",
+       "semanticApi": true
+      },
+      {
+       "name": "Servicing Event History",
+       "description": "'This service domain captures, classifies and stores servicing activity and events to support root cause analysis'",
+       "semanticApi": true
+      },
+      {
+       "name": "Service Directory",
+       "description": "'This Service Domain presents a structured set of services that the customer can select from '",
+       "semanticApi": true
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "Business Development",
+   "businessDomains": [
+    {
+     "name": "Marketing And Development",
+     "serviceDomains": [
+      {
+       "name": "Business Development",
+       "description": "'Define, implement, track and assess the new business development plans'",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Research",
+       "description": "'This service domain handles the capture of market research from multiple external sources. This can include live feeds, analysis and reports in any form. The information is classified/catalogued and stored for retrieval.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Market Analysis",
+       "description": "This service domain analyzes internal and external market information sources as necessary to develop specific market insights. It may maintain a collection of predefined market analyses and may also offer specific ad-hoc analysis on request",
+       "semanticApi": true
+      },
+      {
+       "name": "Competitor Analysis",
+       "description": "'Solicit, consolidate and analyze competitor specific public domain data to develop competitor insights and comparisons'",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Campaign Management",
+       "description": "Assess the coverage and impact of internal/customer campaigns and redirect campaign development and execution activity accordingly",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Campaign Design",
+       "description": "Design and refine customer campaign specifications based on their impact",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Portfolio",
+       "description": "Maintain a portfolio of analytical views of the customer base to support customer segment profitability and performance analysis",
+       "semanticApi": true
+      },
+      {
+       "name": "Advertising",
+       "description": "'Develop the plan for and oversee advertising campaign activity, including budget and resource management'",
+       "semanticApi": true
+      },
+      {
+       "name": "Promotional Events",
+       "description": "'Develop the plan for and oversee promotional event activity, including budget and resource management'",
+       "semanticApi": true
+      },
+      {
+       "name": "Sales Planning",
+       "semanticApi": false
+      },
+      {
+       "name": "Contribution Analysis",
+       "semanticApi": false
+      },
+      {
+       "name": "Brand Management",
+       "description": "Respond to events that potentially damage the brand or provide an opportunity to strengthen/leverage brand awareness",
+       "semanticApi": true
+      },
+      {
+       "name": "Segment Direction",
+       "description": "Define market segments and develop and assess performance against the segment plan's performance goals",
+       "semanticApi": true
+      },
+      {
+       "name": "Prospect Campaign Design",
+       "description": "Design and refine prospect campaign specifications based on their impact",
+       "semanticApi": true
+      },
+      {
+       "name": "Customer Surveys",
+       "description": "Define and execute and analyze customer surveys",
+       "semanticApi": true
+      },
+      {
+       "name": "Prospect Campaign Management",
+       "description": "Assess the coverage and impact of external/prospect campaigns and redirect campaign development and execution activity accordingly",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Product Management",
+     "serviceDomains": [
+      {
+       "name": "Product Portfolio",
+       "description": "Maintain a portfolio of analytical views of the product portfolio to support product profitability and performance analysis",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Design",
+       "description": "Develop/refine product designs and supporting specification details",
+       "semanticApi": true
+      },
+      {
+       "name": "Production Release",
+       "description": "Maintain and apply production release tests for new and updated systems",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Deployment",
+       "description": "Plan and administer the production deployment new and updated products and services",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Quality Assurance",
+       "description": "Maintain and execute a portfolio of product quality assurance tests and certifications that can be applied to evaluate any aspect of production activity for quality assurance",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Training",
+       "description": "'Develop and provide product specific training across the workforce. This includes all media and training mechanisms (on-line, self taught, classroom etc.)'",
+       "semanticApi": true
+      },
+      {
+       "name": "Case Root Cause Analysis",
+       "description": "Root cause analysis business function reviews case reports to identify possible improvements to eliminate/mitigate servicing issues",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Directory",
+       "description": "'This service domain maintains a comprehensive directory of the bank''s products and services. It can be referenced to obtain product details used to support activities including product selection, sales and marketing, on-boarding, servicing and product fulfillment.'",
+       "semanticApi": true
+      },
+      {
+       "name": "Discount Pricing",
+       "semanticApi": false
+      }
+     ]
+    },
+    {
+     "name": "Solution Development",
+     "serviceDomains": [
+      {
+       "name": "IT Standards And Guidelines",
+       "description": "'Define and apply comprehensive IT architectures, policies and standards as appropriate. Also define the IT usage guidelines and procedures governing systems use across the enterprise'",
+       "semanticApi": true
+      },
+      {
+       "name": "Systems Administration",
+       "description": "'Administer the configuration, maintenance, assignment and track usage and status of all IT assets deployed in development and production across the enterprise'",
+       "semanticApi": true
+      },
+      {
+       "name": "Development Environment",
+       "semanticApi": false
+      },
+      {
+       "name": "System Development",
+       "description": "'Develop new, enhance existing applications and integrate package based systems solutions'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Channel Management",
+     "serviceDomains": [
+      {
+       "name": "Channel Portfolio",
+       "semanticApi": false
+      },
+      {
+       "name": "Branch Portfolio",
+       "semanticApi": false
+      },
+      {
+       "name": "Contact Center Management",
+       "description": "Oversee the assignment and operation of the customer contact center",
+       "semanticApi": true
+      },
+      {
+       "name": "Servicing Activity Analysis",
+       "description": "This service domain analyzes servicing activity to support continual service improvement",
+       "semanticApi": true
+      },
+      {
+       "name": "Financial Message Analysis",
+       "semanticApi": false
+      },
+      {
+       "name": "Channel Activity Analysis",
+       "description": "'This service domain tracks and analyzes channel activity to support relationship development, to detect unwanted behavior, possible fraud, and to constrain channel use as necessary (for example tracking usage frequency and cumulative transaction amounts within a period)'",
+       "semanticApi": true
+      },
+      {
+       "name": "Information Provider Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Market Data Switch Administration",
+       "semanticApi": false
+      },
+      {
+       "name": "Branch Location Management",
+       "description": "'Manage and oversee branch activity, assign resources to optimize branch performance'",
+       "semanticApi": true
+      },
+      {
+       "name": "ATM Network Management",
+       "semanticApi": false
+      },
+      {
+       "name": "Branch Network Management",
+       "semanticApi": false
+      },
+      {
+       "name": "Advanced Voice Services Management",
+       "description": "Oversee the configuration and operation of the voice channel facilities",
+       "semanticApi": true
+      },
+      {
+       "name": "eBranch Management",
+       "description": "Oversee the configuration and operation of the e-branch channel facilities",
+       "semanticApi": true
+      },
+      {
+       "name": "Product Inventory Item Management",
+       "description": "Maintain and distribute product inventory",
+       "semanticApi": true
+      },
+      {
+       "name": "Central Cash Handling",
+       "description": "'Track cash inventory, project demand and allocate inventory across the branch/ATM network'",
+       "semanticApi": true
+      },
+      {
+       "name": "Branch Currency Management",
+       "description": "'Track cash inventory, project demand and ensure all cash is accounted for within the branch'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Intelectual Property And Knowledge",
+     "serviceDomains": [
+      {
+       "name": "Intellectual Property Portfolio",
+       "description": "Administer the bank's intellectual property assets",
+       "semanticApi": true
+      },
+      {
+       "name": "Management Manual",
+       "description": "'Develop, maintain and promulgate the management manual of required procedures and guidelines. Provide support in its reference and interpretation as appropriate'",
+       "semanticApi": true
+      },
+      {
+       "name": "Enterprise Architecture",
+       "description": "Define and maintain comprehensive business architectural definitions/blueprints to help organize/direct the business",
+       "semanticApi": true
+      },
+      {
+       "name": "Knowledge Exchange",
+       "description": "'Consolidate, classify and provide structured access to consolidated market intelligence, product and procedural knowledge gained from the workforce in the execution of business to inform business activity and support continual improvement'",
+       "semanticApi": true
+      }
+     ]
+    },
+    {
+     "name": "Models And Analytics",
+     "serviceDomains": [
+      {
+       "name": "Contribution Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Customer Behavior Models",
+       "description": "'This service domain handles the design and maintenance of a portfolio of customer behavior models that might be used in all aspects of customer relationship development, sales, servicing and product fulfillment'",
+       "semanticApi": true
+      },
+      {
+       "name": "Credit Risk Models",
+       "description": "This service domain handles the design and maintenance of a portfolio of credit models that are used in all aspects of customer credit assessments",
+       "semanticApi": true
+      },
+      {
+       "name": "Fraud Model",
+       "description": "'This service domain handles the design and maintenance of a portfolio of fraud models used across all production activity to detect potential fraud on the part of customers, merchants and other involved parties'",
+       "semanticApi": true
+      },
+      {
+       "name": "Quant Model",
+       "semanticApi": false
+      },
+      {
+       "name": "Trading Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Financial Instrument Valuation Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Liquidity Risk Models",
+       "semanticApi": false
+      },
+      {
+       "name": "Market Risk Models",
+       "semanticApi": false
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/docs/superpowers/plans/2026-06-09-bian-banking-archetypes.md
+++ b/docs/superpowers/plans/2026-06-09-bian-banking-archetypes.md
@@ -1,0 +1,126 @@
+# Implementation Plan — BIAN-Grounded Banking Archetypes
+
+- **Backlog item:** `BI-5D9DCDE6` (epic `EP-ARCH-8D4F2A` — Archetype Model V2: Unified Business Archetypes; triaged `build`, size `large`)
+- **Design spec (source of truth for shape):** [`docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md`](../specs/2026-06-09-bian-banking-archetypes-design.md)
+- **Reference data:** [`docs/Reference/bian/bian-v14-service-landscape.json`](../../Reference/bian/bian-v14-service-landscape.json) — the canonical BIAN v14 hierarchy + descriptions; all Service Domain → Business Domain placements MUST be read from this file, not from prose.
+- **Date:** 2026-06-09
+
+Every "touch file X" claim below was grounded by direct read/grep in the authoring session
+(sweep key: `grep -r "hoa-property-management"` — the newest end-to-end category precedent).
+
+## Phase 0 — Reference data + spec + plan (ships independently; THIS PR)
+
+**Deliverable:** `docs/Reference/bian/` (landscape JSON + README), the v7.6 BIAN/CSDM
+integration PDF (Git LFS — `.gitattributes` already routes `*.pdf` to LFS), the design
+spec, this plan, and BI-5D9DCDE6 filed + triaged.
+
+**Verification:** docs-only PR passes CI; LFS object uploads (confirm `git lfs ls-files`
+shows the PDF post-commit); JSON validates (`python -m json.tool`); counts in README match
+JSON `counts` field (8 / 43 / 341 / 258).
+
+## Phase 1 — Archetype definitions (`packages/storefront-templates`)
+
+**Files:**
+- `src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`.
+- `src/archetypes/banking-financial-services.ts` *(new)* — `community-bank`,
+  `credit-union`, `mortgage-lending` per spec §7: shared axes (`account-with-kyc`,
+  `account-based-fees`, multi-channel), item templates named from BIAN *Loans and
+  Deposits* / *Cards* Service Domains, booking items for banker/advisor/loan-officer
+  appointments (30 min), inquiry forms with product-interest / field-of-membership /
+  loan-purpose selects, `seededServiceCategories` as kebab-case BIAN domain names.
+- `src/archetypes/index.ts` — import + spread into `ALL_ARCHETYPES`.
+- `src/archetypes/archetypes.test.ts` — extend coverage (unique ids, category validity,
+  section sortOrder monotonicity, booking items carry durations — match existing
+  invariants in that file).
+
+**Verification:** `pnpm --filter @dpf/storefront-templates exec vitest run` green;
+`pnpm --filter @dpf/storefront-templates typecheck` green (source-local gates, worktree OK).
+
+## Phase 2 — BIAN capability perspective + seed rules (`packages/db`)
+
+**Files:**
+- `src/business-capability-perspectives.ts` — new `BIAN_BANKING_V14` perspective
+  (`perspectiveId: "bian-banking-v14"`, source string citing the reference JSON);
+  L1 Business Areas / L2 Business Domains / L3 Service Domains per spec §8 with
+  descriptions copied from the reference JSON; resolution: `category ===
+  "banking-financial-services"` composes `[COMMON_SMALL_BUSINESS, BIAN_BANKING_V14]`
+  (same composition pattern as the MSP overlay — read `resolveBusinessCapabilityPerspective`
+  before wiring).
+- `test/business-capability-perspectives.test.ts` — resolution test for the new category;
+  key-uniqueness and parentKey-integrity invariants over the new definitions.
+- `src/seed-storefront-archetypes.ts` — `MARKETING_SKILL_RULES["banking-financial-services"]`
+  regulated-communication reframes per spec §7.5 (mirror the `healthcare-wellness` entry
+  shape).
+
+**Verification:** `pnpm --filter @dpf/db exec vitest run` green. Seed-count assertion:
+seeding logs `upserting N storefront archetypes` with N increased by exactly 3 and zero
+silently-skipped rows (guard against the silent-seed-skip failure class — assert in test,
+don't eyeball logs).
+
+## Phase 3 — Finance profile (`packages/finance-templates`)
+
+**Files:** `src/profiles.ts` — `banking-financial-services` profile (interest income,
+fee income, interest expense, provision expense categories; account-based revenue
+recognition; matching the shape of existing entries keyed by `archetypeCategory`);
+`src/profiles.test.ts` — coverage.
+
+**Verification:** package vitest + typecheck green; `getFinancialProfile("community-bank")`
+resolves (confirm the lookup key is archetype slug vs category by reading
+`normalizeFinancialProfile` first — the existing file keys `PROFILES` by archetype slug
+in some entries; match reality, not this plan).
+
+## Phase 4 — Portal wiring (`apps/web`)
+
+**Files (sweep `grep -r "hoa-property-management" apps/web` at build time for the full
+list; known from the authoring-session sweep):**
+- `lib/storefront/industries.ts` + `industries.test.ts` — "Banking & Financial Services".
+- `lib/storefront/archetype-vocabulary.ts` — vocabulary per spec §7.4.
+- `lib/onboarding/archetype-business-context.ts` + test — onboarding context for the category.
+- `lib/tak/marketing-playbooks.ts` — category playbook entry.
+- `lib/finance/setup-profile.ts` — category → finance-profile wiring.
+- `lib/public-web-tools.ts`, `components/workspace/WorkspaceCalendar.tsx`,
+  `app/(shell)/admin/business-models/page.tsx` — verify whether each branches on category;
+  extend only where a category switch exists (do not invent surface area).
+
+**Verification:** `pnpm --filter web typecheck` (worktree) green; `pnpm --filter web build`
+via the shared local-CI convergence sandbox lease
+(`claim_nonprod_environment_lease(environmentKey="local-integration-ci")`) — NOT in the
+worktree; targeted vitest for the touched libs.
+
+## Phase 5 — Functional verification (canonical runtime)
+
+Per `structural-verification-is-not-functional` and the `dpf-verify-on-live-install`
+skill (step zero: `pnpm verify:preflight`, honor the BLOCKED stop-rule):
+
+1. Fresh-seed or re-seed the leased sandbox; confirm 3 new archetypes in the picker.
+2. Onboard as **Credit Union** → items surface shows member vocabulary ("Share Savings",
+   inbox "Applications"), capability page shows BIAN-sourced perspective composed with the
+   common baseline.
+3. Drive a storefront inquiry end-to-end on a share-certificate item; confirm intake lands.
+4. Record evidence via the MCP evidence tools against BI-5D9DCDE6 (dynamic-analysis prose
+   report, not screenshots).
+
+## Risks & rollback
+
+- **Vocabulary is category-keyed; credit-union wants "Members" while banks want
+  "Customers".** v1 compromise per spec §7.4 ("Customers & Members") unless leaf-level
+  vocabulary override already exists — check `resolveVocabularyKey` before choosing.
+  Risk: mid-build scope temptation to add leaf-level vocabulary; resist — file a follow-up
+  BI if needed.
+- **Silent seed skips** (known DPF failure class): a typo'd category or FK mismatch can
+  upsert 0 rows without erroring. Mitigation: Phase 2's count assertion in tests.
+- **Enum sweep completeness:** a missed category switch (e.g. a hardcoded
+  `ArchetypeCategory` exhaustiveness check) breaks typecheck — that is the desired
+  failure mode; fix every site the compiler names.
+- **LFS on CI:** if a CI job lacks `git lfs`, the PDF checks out as a pointer file —
+  harmless for build jobs (nothing imports it); verify no doc-lint job reads PDF bytes.
+- **Rollback:** all changes are additive seed/template/wiring code on one branch — revert
+  the PR. Seeded archetype rows are soft-deletable (`isActive: false`); re-seed does not
+  resurrect operator-deactivated archetypes (existing invariant).
+
+## Definition of done
+
+BI-5D9DCDE6 acceptance criteria, verbatim: 3 archetypes seeded + idempotent re-seed;
+BIAN perspective composed on the capability page; credit-union vocabulary + end-to-end
+storefront inquiry functionally verified on canonical runtime; all wiring-contract
+touchpoints tested.

--- a/docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md
+++ b/docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md
@@ -1,0 +1,335 @@
+# BIAN-Grounded Banking Archetypes Design
+
+- **Status:** Draft for review
+- **Author:** Claude (directed by maintainer: "incorporate BIAN for the banking archetypes")
+- **Date:** 2026-06-09
+- **Related specs:** `2026-05-29-vehicle-equipment-rental-archetype-design.md` (new-archetype precedent), `2026-05-22-customer-surface-archetype-activation-design.md` (capability activation), `2026-04-04-business-model-portal-vocabulary-design.md` (vocabulary contract)
+- **Reference data:** [`docs/Reference/bian/`](../../Reference/bian/README.md) — BIAN v14.0 Service Landscape (8 Business Areas / 43 Business Domains / 341 Service Domains, with official Semantic-API descriptions) + the joint ServiceNow/BIAN "Bridging BIAN and CSDM" v7.6 discussion paper (May 2026)
+
+---
+
+## 1. Problem Statement
+
+DPF's archetype catalog covers 12 categories and ~45 leaf templates, but has **no banking
+or financial-institution archetype**. The nearest neighbor (`professional-services →
+accounting`) models an accounting *practice*, not a deposit-taking, lending institution.
+A community bank, credit union, or mortgage lender that installs DPF today has no
+archetype that matches its products, vocabulary ("members," "branches," "rates"), KYC-gated
+account provisioning, or regulated-industry communication posture.
+
+Banking is also the one vertical where DPF does **not** need to invent the capability
+taxonomy: BIAN publishes a canonical, vendor-neutral decomposition of everything a bank
+does (the Service Landscape), and the 2026 ServiceNow/BIAN integration paper (v7.6,
+co-authored and endorsed by BIAN's Lead Architect and ServiceNow CSDM product management)
+demonstrates exactly how that taxonomy projects onto a CSDM-style capability/service data
+model — the same conceptual family DPF's own capability and EA substrate descends from.
+
+This spec defines a new `banking-financial-services` archetype **category** whose leaf
+archetypes, item templates, vocabulary, and business-capability perspective are **derived
+from BIAN v14** rather than hand-invented — making DPF's banking archetypes
+standards-grounded, hive-comparable across installs, and traceable to a maintained
+industry reference.
+
+## 2. Live Backlog Context
+
+Queried via the `dpf` MCP backlog tools on 2026-06-09 (`list_epics`, limit 100):
+
+- **No existing banking / BIAN / financial-institution epic or backlog item.** A sweep of
+  `origin/main` history for `bank`/`BIAN` finds only the org-side finance module (the
+  install's *own* bank accounts/reconciliation — EP-FINANCE, done) and the BIAN v8↔CSDM v3
+  research note (`docs/Reference/framework-mapping-playlist/069-…`), neither of which
+  overlaps an archetype category.
+- **Epic home:** `EP-ARCH-8D4F2A` "Archetype Model V2: Unified Business Archetypes"
+  (in-progress) is the natural parent — this work extends the archetype model with a new
+  category; it does not need a new epic.
+
+## 3. Research & Benchmarking
+
+Per the Design Research rule (AGENTS.md §10): standards first, then data models of leaders.
+
+### 3.1 BIAN Service Landscape v14.0 — the standard (primary anchor)
+
+Source: `docs/Reference/bian/bian-v14-service-landscape.json` (extracted 2026-06-09 from
+bian.org's canonical Value Chain View + the official `bian-official/public` GitHub
+Semantic API specs).
+
+The landscape decomposes banking into 8 Business Areas → 43 Business Domains → 341
+**Service Domains** — MECE building blocks, each canonical ("Customer Credit Rating" means
+the same thing in any bank), each carrying one of 19 functional patterns and publishing
+Service Operations as Semantic APIs (258 of 341 have published OAS 3.x specs in release
+14.0.0).
+
+- **Adopted:** Business Domains and Service Domains as the **source taxonomy** for the
+  banking capability perspective, service categories, and item templates. Canonicality is
+  the property that makes hive-mind comparison across banking installs trustworthy — two
+  community banks describe the same function with the same name.
+- **Adopted:** the SMB-relevant subset. A community bank or credit union storefront needs
+  the *Customers*, *Products*, and *Channels*-facing domains (Loans and Deposits, Consumer
+  Banking, Cards, Relationship Management, Customer Care, Sales, Servicing) plus
+  *Compliance* and *Credit Risk* awareness. The full 341-domain landscape (Market Trading,
+  Syndicated Loans, Custody, Group Treasury…) stays in the reference JSON, not in the seed.
+- **Rejected:** importing all 341 Service Domains as seeded capabilities. DPF's target
+  operator is SMB through mid-market; a community bank does not run a trading desk.
+  Over-seeding would bury the useful 30 domains under 300 irrelevant rows.
+
+### 3.2 BIAN ↔ CSDM integration paper v7.6 (May 2026) — the projection pattern
+
+Source: `docs/Reference/BIAN_CSDM_Integration_v76-US-English - FINAL.pdf` (+ distilled
+summary in `docs/Reference/bian/README.md`).
+
+The paper's core moves: Business Area → Business Capability L0, Business Domain →
+Business Capability L1, Service Domain → a first-class conceptual anchor *contained by*
+the capability hierarchy and *provided by* applications; Service Operations → Digital
+Interfaces with Semantic APIs as reference specs. Four-layer traversal (Conceptual →
+Logical → Physical → Consumption) gives bidirectional strategy↔operations traceability.
+
+- **Adopted:** the **projection pattern**: BIAN supplies the banking vocabulary; the
+  platform's existing capability substrate supplies the cross-domain bridge. DPF mirrors
+  this by projecting BIAN levels into the existing `BusinessCapability` model via the
+  existing sourced-perspective mechanism (`business-capability-perspectives.ts`) — L1 =
+  Business Area, L2 = Business Domain, L3 = selected Service Domain. **No new tables.**
+- **Adopted:** "core vs commodity" classification as the strategic payoff to preserve in
+  capability descriptions (it drives outsource/retain decisions in the paper's worked
+  examples); DPF's maturity fields (`currentMaturity`/`targetMaturity`) already carry this
+  kind of strategic attribution.
+- **Rejected (for v1):** a DPF analog of the custom Service Domain CI + Digital
+  Interface/Digital Integration objects. That is the ServiceNow *operational estate*
+  integration; DPF's banking archetype v1 is a storefront/portal + capability-map concern.
+  Modeling BIAN Service Operations against DPF's integration/EA substrate is real future
+  work (§11), not part of an archetype seed.
+
+### 3.3 Digital banking platform vendors (commercial comparators)
+
+Read for portal shape, not feature lists: **Banno (Jack Henry)** and **Alkami** — the two
+dominant community-bank/credit-union digital banking platforms — and **Backbase**
+(international engagement-banking platform).
+
+- Common shape: a *marketing/storefront site* (products, rates, branch/ATM info, financial
+  education) feeding an *account-opening funnel* with KYC identity verification, plus an
+  authenticated servicing portal. The storefront/funnel/servicing split matches DPF's
+  storefront → inquiry/booking → portal progression exactly.
+- **Adopted:** product-card storefront with rate-forward presentation (`from`/`fixed`
+  price types read as APY/APR "as low as" rates); appointment booking with a banker as a
+  first-class CTA (Banno and Alkami both ship branch-appointment scheduling); KYC-gated
+  account opening as *provisioning posture*, not as a built flow.
+- **Rejected:** building account-opening/KYC execution, online banking, payments, or core
+  integration in v1. DPF is the **engagement layer**; the core ledger stays with the
+  institution's core (Jack Henry, Fiserv, FIS…). This is also the explicit BIAN-paper
+  posture: the taxonomy classifies what the institution does; it does not replace the
+  systems that do it.
+
+### 3.4 Credit-union specifics
+
+Credit unions are member-owned cooperatives; the vocabulary is regulator-enforced in
+practice (NCUA): **members** not customers, **share accounts** (share savings, share
+draft checking, share certificates) not deposit products. Membership eligibility (field of
+membership) gates onboarding. This is a vocabulary + item-template delta over the same
+BIAN domains — BIAN's *Savings Account* / *Current Account* / *Term Deposit* Service
+Domains cover both charters.
+
+### 3.5 Anti-patterns identified
+
+- Hand-inventing a banking capability list when a maintained standard exists (violates
+  `research-and-use-standards`).
+- Mixing BIAN's deprecated Matrix-layout vocabulary with the canonical Value Chain View
+  vocabulary (the two use different Business Area/Domain names for the same Service
+  Domains — the reference JSON pins the Value Chain View).
+- Treating the archetype as a core-banking system (scope explosion; regulated processing
+  DPF must not own).
+
+## 4. Design Goals
+
+1. Add `banking-financial-services` as a first-class archetype **category** with three
+   leaf archetypes — `community-bank`, `credit-union`, `mortgage-lending` — following the
+   same wiring contract as every existing category.
+2. Ground every taxonomy-bearing surface in BIAN v14: item templates name the products of
+   BIAN's *Loans and Deposits* / *Consumer Banking* / *Cards* Service Domains; seeded
+   service categories are kebab-case Business/Service Domain names; the
+   business-capability perspective is a `bian-banking-v14`-sourced projection.
+3. Reuse existing substrate exclusively: `ArchetypeDefinition` + `ActivationProfile`,
+   `BusinessCapabilityPerspective`, `FinancialProfile`, vocabulary map, industries list.
+   **Zero new tables, zero new modules.**
+4. Encode the regulated-industry posture declaratively: `provisioning:
+   "account-with-kyc"`, `commercialModel: "account-based-fees"`, marketing-skill reframes
+   (no aggressive competitive claims; rate/term accuracy; NCUA/FDIC tone).
+5. Keep the full BIAN landscape available as reference data
+   (`docs/Reference/bian/bian-v14-service-landscape.json`) so future work (custom
+   archetype refinement, integration modeling, hive analytics) can draw on domains the
+   seed deliberately omits.
+
+## 5. Non-Goals
+
+- **Core banking execution** — no ledger, no transaction processing, no online/mobile
+  banking, no payment rails. DPF is the engagement/storefront/operations layer beside the
+  institution's core.
+- **KYC/AML execution** — v1 records the provisioning *posture* (`account-with-kyc`);
+  identity-verification vendor integration is future work.
+- **BIAN Service Operation / Semantic API modeling** against DPF's integration substrate
+  (the CSDM paper's Digital Interface / Digital Integration analog) — future work, §11.
+- **Wealth management / trading / insurance leaves** — the reference data covers their
+  domains; leaves can be added later without rework.
+- Live rate feeds; rates are operator-entered item attributes in v1.
+
+## 6. Core Design Decisions
+
+**D1 — BIAN projects into existing substrate; no parallel banking taxonomy.**
+Options: (a) new `ServiceDomain` table mirroring the CSDM paper's custom CI; (b) projection
+into the existing `BusinessCapability` perspective mechanism; (c) tags only.
+**Decision: (b).** The paper itself maps BIAN's upper levels onto the *existing* capability
+hierarchy and only adds a custom CI for operational-estate traversal DPF v1 doesn't need.
+(a) duplicates `BusinessCapability` (violates `verify-substrate-before-proposing-new`,
+`single-source-of-truth`); (c) loses the hierarchy that makes the capability map useful.
+
+**D2 — Three leaves, one category.** `community-bank` (retail bank), `credit-union`
+(member cooperative), `mortgage-lending` (lender/broker). These cover the dominant SMB
+financial-institution charters with materially different vocabulary/products. Wealth
+advisory, insurance, and fintech leaves are deferred — same category, later additions.
+
+**D3 — Engagement-layer scope.** The archetype seeds storefront (products & rates,
+branches, education, appointment booking), inquiry/application intake, and the
+BIAN-grounded capability map. It deliberately does not execute regulated banking
+processes (§5).
+
+**D4 — Curated SMB subset for the perspective.** The seeded `bian-banking-v14` perspective
+projects 4 Business Areas → 8 Business Domains → ~24 Service Domains (§8). Curation rule:
+domains a community institution's *staff portal* plans and reports against. The full
+landscape stays in reference data.
+
+## 7. Leaf Archetype Definitions
+
+Shared activation posture (all three leaves):
+
+| Axis | Value | Rationale |
+| ---- | ----- | --------- |
+| `form` / `delivery` | `services` / `hybrid` | Branch + digital |
+| `primaryConsumer` | `individual` (household for credit-union) | Retail focus |
+| `consumptionChannel` | `multi-channel` | Branch, web, phone |
+| `commercialModel` | `account-based-fees` | Existing enum value, built for this |
+| `provisioning` | `account-with-kyc` | Existing enum value, built for this |
+| `platform` | `no` | Not a marketplace |
+| `billingProfile` | primary `recurring-agreement`; `invoiceExecutionMode: "prepared-not-prescribed"` | Fees accrue to accounts; DPF prepares, never moves money |
+| modules | `customer-estate`, `service-agreements`, `billing-readiness`, `lifecycle-signals`, `integrations` | Reuse; no new modules |
+| `ctaType` | `inquiry` (booking on banker-appointment items) | Application intake + branch appointments |
+
+### 7.1 `community-bank` — items grounded in BIAN Service Domains
+
+| Item template | BIAN Service Domain (Business Domain) |
+| ------------- | ------------------------------------- |
+| Checking Account | Current Account (Loans and Deposits) |
+| Savings Account | Savings Account (Loans and Deposits) |
+| Certificate of Deposit | Term Deposit (Loans and Deposits) |
+| Personal Loan | Consumer Loan (Loans and Deposits) |
+| Mortgage | Mortgage Loan (Loans and Deposits) |
+| Business Loan | Corporate Loan (Loans and Deposits) |
+| Debit & Credit Cards | Card products (Cards) |
+| Meet with a Banker *(booking, 30 min)* | Bank Customer Contact Handling / Servicing |
+
+Sections: hero, items ("Products & Rates"), about ("About the Bank"), team ("Our
+Bankers"), contact ("Visit a Branch"). Form: inquiry base + product interest select +
+"existing customer?" select.
+
+### 7.2 `credit-union` — member vocabulary over the same domains
+
+Share Savings, Share Draft Checking, Share Certificate, Auto Loan, Personal Loan,
+Mortgage & HELOC, Become a Member *(inquiry; Party Lifecycle Management SD)*, Meet with a
+Member Advisor *(booking)*. Sections rename accordingly ("Membership", "Rates").
+Form adds field-of-membership eligibility select.
+
+### 7.3 `mortgage-lending` — lender/broker funnel
+
+Pre-Approval *(inquiry; Underwriting + Customer Credit Rating SDs)*, Purchase Mortgage,
+Refinance, HELOC *(Consumer Loan)*, Rate Quote *(quote price type)*, Meet with a Loan
+Officer *(booking)*. Form adds loan purpose / property type / price range selects.
+
+### 7.4 Vocabulary (`archetype-vocabulary.ts`)
+
+`banking-financial-services`: itemsLabel "Products & Rates", singleItemLabel "Product",
+categoryLabel "Product Family", priceLabel "Rate / Fee", portalLabel "Banking Portal",
+stakeholderLabel "Customers" *(leaf-level override to "Members" for credit-union follows
+the existing archetype-wins resolution; if vocabulary remains category-keyed in v1, use
+"Customers & Members")*, teamLabel "Bankers", inboxLabel "Applications", agentName
+"Relationship Manager" *(BIAN Business Domain: Relationship Management)*.
+
+### 7.5 Marketing-skill rules (`seed-storefront-archetypes.ts`)
+
+Regulated-communication reframes mirroring the healthcare pattern: competitive-analysis →
+"Local Institution Positioning" (trust- and community-anchored, no aggressive claims;
+rate claims must match current published rates); email-campaign-builder → "Customer &
+Member Communication Builder" (rate changes, financial education, branch notices;
+compliance-reviewable tone).
+
+## 8. BIAN-Sourced Business-Capability Perspective
+
+New perspective in `packages/db/src/business-capability-perspectives.ts`:
+
+```
+perspectiveId: "bian-banking-v14"
+label: "Banking (BIAN v14)"
+source: "BIAN Service Landscape v14.0 Value Chain View — docs/Reference/bian/bian-v14-service-landscape.json"
+```
+
+Curated projection (L1 = BIAN Business Area, L2 = Business Domain, L3 = Service Domain;
+keys `bian-<kebab-name>`; descriptions from the official Semantic-API descriptions in the
+reference JSON):
+
+- **Customers** → Relationship Management (Customer Relationship Management, Customer
+  Behavior Insights), Customer Care (Customer Case Management, Bank Customer Contact
+  Handling), Sales (Customer Offer, Lead/Opportunity Management), Party Reference (Party
+  Reference Data Directory, Party Lifecycle Management)
+- **Products** → Loans and Deposits (Current Account, Savings Account, Term Deposit,
+  Consumer Loan, Mortgage Loan, Corporate Loan, Underwriting), Cards (Card Issuance &
+  servicing), Consumer Banking (Customer Credit Rating† if retained in this BD in v14 —
+  resolve against the reference JSON at implementation time)
+- **Operations** → Accounting Services (Position Keeping / Account Reconciliation),
+  Clearing and Settlement (Payment Order)
+- **Finance & Risk Management** → Compliance (Regulatory Compliance, Guideline
+  Compliance), Credit Risk (Credit Management)
+
+† Implementation note: exact Service Domain → Business Domain placement MUST be read from
+`bian-v14-service-landscape.json`, not from this prose — the JSON is the source of truth
+extracted from the canonical view.
+
+Wiring: the perspective resolves for `category === "banking-financial-services"` alongside
+`COMMON_SMALL_BUSINESS` (same composition pattern as the MSP overlay), so a bank install
+still gets the universal small-business capabilities (HR, marketing, finance ops) plus the
+BIAN overlay.
+
+## 9. Wiring Contract (files to touch)
+
+Following the `hoa-property-management` end-to-end precedent:
+
+1. `packages/storefront-templates/src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`
+2. `packages/storefront-templates/src/archetypes/banking-financial-services.ts` — three leaf definitions (§7)
+3. `packages/storefront-templates/src/archetypes/index.ts` — register
+4. `packages/storefront-templates/src/archetypes/archetypes.test.ts` — coverage
+5. `packages/finance-templates/src/profiles.ts` — financial profile (interest income / fee income / interest expense categories; account-based revenue recognition)
+6. `packages/db/src/business-capability-perspectives.ts` (+ test) — `bian-banking-v14` perspective (§8)
+7. `packages/db/src/seed-storefront-archetypes.ts` — marketing-skill rules (§7.5)
+8. `apps/web/lib/storefront/industries.ts` (+ test) — "Banking & Financial Services" option
+9. `apps/web/lib/storefront/archetype-vocabulary.ts` — vocabulary (§7.4)
+10. `apps/web/lib/onboarding/archetype-business-context.ts` (+ test) — onboarding context
+11. `apps/web/lib/tak/marketing-playbooks.ts` / `apps/web/lib/finance/setup-profile.ts` — category wiring sweep (grep `hoa-property-management` for the full list at build time)
+
+Reference data (this PR, already in repo): `docs/Reference/bian/` JSON + README + the
+v7.6 integration PDF (LFS).
+
+## 10. Verification
+
+- Unit: archetype shape tests (every leaf passes the existing `archetypes.test.ts`
+  invariants), perspective resolution test (`banking-financial-services` → BIAN + common
+  perspectives), finance profile + industries tests.
+- Seed: fresh-install seed run upserts 3 new archetypes; re-seed is idempotent;
+  soft-deleted archetypes stay deleted (existing invariant).
+- Functional (per `structural-verification-is-not-functional`): on the canonical install
+  or CI sandbox lease, drive onboarding selecting *Credit Union*, confirm member
+  vocabulary on the items surface, BIAN capability map on the capability page, and an
+  end-to-end storefront inquiry on a share-certificate item.
+
+## 11. Future Work (out of scope, enabled by the reference data)
+
+- BIAN Service Operation → DPF integration-substrate modeling (the paper's Digital
+  Interface / Digital Integration layer) for institutions that connect cores/vendors.
+- Wealth-advisory / insurance / fintech leaves on the same category.
+- Custom-archetype refinement flow offering the *full* 341-domain landscape as a picker.
+- Hive-mind analytics keyed on canonical BIAN Service Domain names across banking installs.
+- Semantic-API-informed MCP connector scaffolding for banking vendor integrations.


### PR DESCRIPTION
## Summary

- Adds the canonical **BIAN Service Landscape v14.0** as repo reference data (`docs/Reference/bian/`): 8 Business Areas / 43 Business Domains / 341 Service Domains extracted from the official Value Chain View, enriched with the 258 published Semantic-API descriptions from `bian-official/public`, plus a README distilling the BIAN→CSDM object mapping from the joint ServiceNow/BIAN "Bridging BIAN and CSDM" v7.6 paper (May 2026, committed via LFS).
- Adds the **design spec** for a new `banking-financial-services` archetype category (`community-bank`, `credit-union`, `mortgage-lending`) whose item templates, vocabulary, service categories, and `bian-banking-v14` BusinessCapability perspective are derived from BIAN v14 — zero new tables; projection into existing substrate per the CSDM paper's pattern.
- Adds the **implementation plan** (6 phases) anchored to **BI-5D9DCDE6** (epic EP-ARCH-8D4F2A, triaged build/large), ready for Build Studio promotion.

## Test plan

- [x] JSON artifact validates; counts cross-checked against README (8/43/341/258)
- [x] `git lfs ls-files` confirms the PDF is an LFS object
- [x] Gitleaks pre-commit scan clean; DCO sign-off on the commit
- [x] vitest / typecheck / next build: n/a (docs-only change, no code touched)

Overlap sweep: no open PR or main commit touches banking/BIAN/archetype-category surface (only #1509, unrelated A2A spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)