### PR TITLE
feat(observability): release verification health surfacing — alert when a stamp's verify gate fails (BI-3630773C)

### DIFF
--- a/apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx
@@ -8,7 +8,12 @@ import { prisma } from "@dpf/db";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ServiceHealthDashboard } from "@/components/monitoring/ServiceHealthDashboard";
-import { TONE_COLOR, type Tone } from "@/components/monitoring/health-summary";
+import {
+  TONE_COLOR,
+  type ReleaseHealthCardData,
+  type Tone,
+} from "@/components/monitoring/health-summary";
+import { loadReleaseHealthState } from "@/lib/release-health/state";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -46,10 +51,19 @@ export default async function ProductHealthPage({ params }: Props) {
   const hasOfferings = product.serviceOfferings.length > 0;
   const hasObservation = product.observationConfig != null;
 
+  // BI-3630773C — last-known release stamp state for the portal's Latest
+  // Release card. Read from PlatformConfig (written by the release-health
+  // cron); null when never polled or never stamped.
+  const releaseHealth = isPortal ? await loadReleaseHealthCard() : null;
+
   return (
     <div>
       {isPortal ? (
-        <PortalHealth openBugs={product._count.backlogItems} productId={id} />
+        <PortalHealth
+          openBugs={product._count.backlogItems}
+          productId={id}
+          releaseHealth={releaseHealth}
+        />
       ) : (
         <ProductHealth
           hasObservation={hasObservation}
@@ -63,11 +77,37 @@ export default async function ProductHealthPage({ params }: Props) {
   );
 }
 
-function PortalHealth({ openBugs, productId }: { openBugs: number; productId: string }) {
+async function loadReleaseHealthCard(): Promise<ReleaseHealthCardData | null> {
+  try {
+    const state = await loadReleaseHealthState();
+    if (!state?.snapshot) return null;
+    return {
+      tag: state.snapshot.tag,
+      status: state.snapshot.status,
+      runUrl: state.snapshot.runUrl,
+      checkedAt: state.checkedAt,
+    };
+  } catch {
+    // State read failure must not break the health page — the card falls
+    // back to its "no stamps observed" neutral state.
+    return null;
+  }
+}
+
+function PortalHealth({
+  openBugs,
+  productId,
+  releaseHealth,
+}: {
+  openBugs: number;
+  productId: string;
+  releaseHealth: ReleaseHealthCardData | null;
+}) {
   return (
     <ServiceHealthDashboard
       openBacklogItems={openBugs}
       backlogHref={`/portfolio/product/${productId}/backlog`}
+      releaseHealth={releaseHealth}
     />
   );
 }

--- a/apps/web/components/monitoring/PortalHealthSummary.tsx
+++ b/apps/web/components/monitoring/PortalHealthSummary.tsx
@@ -6,7 +6,9 @@ import {
   TONE_COLOR,
   deriveMonitoringSummary,
   derivePlatformSummary,
+  deriveReleaseSummary,
   type HealthSummary,
+  type ReleaseHealthCardData,
   type Tone,
 } from "./health-summary";
 import { useAlertQuery } from "./useAlertQuery";
@@ -16,9 +18,13 @@ import { useMonitoringStatus } from "./MonitoringContext";
 type Props = {
   openBacklogItems: number;
   backlogHref: string;
+  // BI-3630773C — latest release stamp state; null when never stamped or
+  // never polled. The card always renders so a silent red release can't
+  // hide by omission.
+  releaseHealth?: ReleaseHealthCardData | null;
 };
 
-export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
+export function PortalHealthSummary({ openBacklogItems, backlogHref, releaseHealth }: Props) {
   const { checked, online } = useMonitoringStatus();
   const { data: upTargets, loading: upTargetsLoading } = useMetricQuery("up");
   const { alerts } = useAlertQuery();
@@ -42,8 +48,10 @@ export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
   const hasBacklog = openBacklogItems > 0;
   const backlogTone: Tone = hasBacklog ? "warning" : "success";
 
+  const release = deriveReleaseSummary(releaseHealth ?? null);
+
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       <HealthCard label="Platform Status" summary={platform} />
       <HealthCard
         label="Open Backlog Items"
@@ -58,6 +66,11 @@ export function PortalHealthSummary({ openBacklogItems, backlogHref }: Props) {
         href={hasBacklog ? backlogHref : undefined}
       />
       <HealthCard label="Health Monitoring" summary={monitoring} />
+      <HealthCard
+        label="Latest Release"
+        summary={release}
+        href={releaseHealth?.runUrl}
+      />
     </div>
   );
 }
@@ -85,6 +98,15 @@ function HealthCard({
   );
 
   if (href) {
+    // External targets (e.g. the GitHub Actions run behind the Latest
+    // Release card) open in a new tab; internal routes stay client-side.
+    if (href.startsWith("http")) {
+      return (
+        <a href={href} target="_blank" rel="noreferrer" className="block">
+          {body}
+        </a>
+      );
+    }
     return (
       <Link href={href} className="block">
         {body}

--- a/apps/web/components/monitoring/ServiceHealthDashboard.tsx
+++ b/apps/web/components/monitoring/ServiceHealthDashboard.tsx
@@ -23,9 +23,12 @@ import {
 import { useAlertQuery } from "./useAlertQuery";
 import { useMetricQuery } from "./useMetricQuery";
 
+import type { ReleaseHealthCardData } from "./health-summary";
+
 type ServiceHealthDashboardProps = {
   openBacklogItems?: number;
   backlogHref?: string;
+  releaseHealth?: ReleaseHealthCardData | null;
 };
 
 export function ServiceHealthDashboard(props: ServiceHealthDashboardProps = {}) {
@@ -39,6 +42,7 @@ export function ServiceHealthDashboard(props: ServiceHealthDashboardProps = {}) 
 function ServiceHealthContent({
   openBacklogItems,
   backlogHref,
+  releaseHealth,
 }: ServiceHealthDashboardProps) {
   const { online, checked } = useMonitoringStatus();
   const { data: upTargets, loading: upTargetsLoading } = useMetricQuery("up");
@@ -82,7 +86,11 @@ function ServiceHealthContent({
   return (
     <div className="space-y-6">
       {openBacklogItems !== undefined && backlogHref && (
-        <PortalHealthSummary openBacklogItems={openBacklogItems} backlogHref={backlogHref} />
+        <PortalHealthSummary
+          openBacklogItems={openBacklogItems}
+          backlogHref={backlogHref}
+          releaseHealth={releaseHealth}
+        />
       )}
 
       {/* Active alerts (deduped against the Platform Status StatCard above) */}

--- a/apps/web/components/monitoring/health-summary.ts
+++ b/apps/web/components/monitoring/health-summary.ts
@@ -29,6 +29,53 @@ export type HealthSummary = {
   detail: string;
 };
 
+// BI-3630773C — serializable shape the health page server component derives
+// from lib/release-health state and hands to the client summary cards.
+export type ReleaseHealthCardData = {
+  tag: string;
+  status: "in-progress" | "verified" | "verify-failed" | "publish-failed";
+  runUrl: string;
+  checkedAt: string;
+};
+
+export function deriveReleaseSummary(
+  data: ReleaseHealthCardData | null,
+): HealthSummary {
+  if (!data) {
+    return {
+      value: "—",
+      tone: "neutral",
+      detail: "No release stamps observed yet",
+    };
+  }
+  switch (data.status) {
+    case "verified":
+      return {
+        value: data.tag,
+        tone: "success",
+        detail: "Stamp verified end-to-end",
+      };
+    case "in-progress":
+      return {
+        value: data.tag,
+        tone: "neutral",
+        detail: "Stamp in progress",
+      };
+    case "verify-failed":
+      return {
+        value: data.tag,
+        tone: "critical",
+        detail: "Published but install verification FAILED — view run",
+      };
+    case "publish-failed":
+      return {
+        value: data.tag,
+        tone: "warning",
+        detail: "Stamp failed before publish completed — view run",
+      };
+  }
+}
+
 export type ServiceDefinition = {
   name: string;
   job?: string;

--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
@@ -45,7 +45,7 @@ export type GithubReaderDeps = {
 };
 
 /** Resolved repo coordinates `{owner}/{repo}`. */
-type RepoIdentity = { owner: string; name: string };
+export type RepoIdentity = { owner: string; name: string };
 
 /**
  * Production GitHub PR reader. Returns the rows for the open-PR list,
@@ -113,12 +113,15 @@ export async function readGithubPullRequests(
 
 import type { prisma } from "@dpf/db";
 
-type PrismaLike = Pick<
+export type PrismaLike = Pick<
   typeof prisma,
   "credentialEntry" | "platformDevConfig" | "scheduledJob"
 >;
 
-async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
+// Exported for reuse by release-health (BI-3630773C) — same optional
+// "github-pr-sync" credential; callers that can read public repos treat a
+// null return as "proceed unauthenticated", not an error.
+export async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
   const cred = await prisma.credentialEntry.findUnique({
     where: { providerId: GITHUB_PR_CREDENTIAL_PROVIDER_ID },
     select: { secretRef: true, status: true },
@@ -137,7 +140,8 @@ async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
   }
 }
 
-async function resolveRepoIdentity(prisma: PrismaLike): Promise<RepoIdentity> {
+// Exported for reuse by release-health (BI-3630773C).
+export async function resolveRepoIdentity(prisma: PrismaLike): Promise<RepoIdentity> {
   const cfg = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
     select: { upstreamRemoteUrl: true },

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -45,6 +45,7 @@ import {
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
 import { logSignatureScanner } from "./log-signature-scanner";
+import { releaseHealthCheck } from "./release-health-check";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -71,6 +72,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
+  releaseHealthCheck,    // BI-3630773C: EP-FULL-OBS release stamp verify-gate watch, every 15m
 ];
 
 export const eventFunctions = [

--- a/apps/web/lib/queue/functions/release-health-check.ts
+++ b/apps/web/lib/queue/functions/release-health-check.ts
@@ -1,0 +1,27 @@
+// apps/web/lib/queue/functions/release-health-check.ts
+// BI-3630773C (EP-FULL-OBS) — poll the latest release stamp's verify-gate
+// outcome and keep the operator notification + health-card state in sync.
+//
+// Two GitHub API reads per tick (runs list + jobs on a red run) — fits the
+// anonymous 60/hr budget at the 15-minute cadence even with no token bound.
+
+import { cron } from "inngest";
+
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import { runReleaseHealthCheck } from "@/lib/release-health/runner";
+
+export const releaseHealthCheck = inngest.createFunction(
+  {
+    id: "ops/release-health-check",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("*/15 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return await step.run("check-release-health", () => runReleaseHealthCheck());
+  },
+);

--- a/apps/web/lib/release-health/release-runs-reader.test.ts
+++ b/apps/web/lib/release-health/release-runs-reader.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  platformDevConfig: { findUnique: vi.fn() },
+  credentialEntry: { findUnique: vi.fn() },
+  scheduledJob: { findUnique: vi.fn(), update: vi.fn() },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: db }));
+
+import { classifyRedRun, readLatestReleaseStamp } from "./release-runs-reader";
+
+// The v6.1.0 incident shape: every build/merge job green, verify gate red.
+const PUBLISHED_UNVERIFIED_JOBS = [
+  { name: "Typecheck gate", conclusion: "success" },
+  { name: "Build dpf-portal (amd64)", conclusion: "success" },
+  { name: "Merge dpf-portal manifest", conclusion: "success" },
+  { name: "E2E install verification (release mode)", conclusion: "failure" },
+];
+
+describe("classifyRedRun", () => {
+  it("classifies verify-gate-only failure as verify-failed (published unverified)", () => {
+    expect(classifyRedRun(PUBLISHED_UNVERIFIED_JOBS)).toBe("verify-failed");
+  });
+
+  it("classifies a red build job as publish-failed even when verify also failed", () => {
+    expect(
+      classifyRedRun([
+        { name: "Build dpf-portal (amd64)", conclusion: "failure" },
+        { name: "E2E install verification (release mode)", conclusion: "failure" },
+      ]),
+    ).toBe("publish-failed");
+  });
+
+  it("classifies an all-green-but-cancelled-verify run as verify-failed", () => {
+    expect(
+      classifyRedRun([
+        { name: "Build dpf-portal (amd64)", conclusion: "success" },
+        { name: "E2E install verification (release mode)", conclusion: "cancelled" },
+      ]),
+    ).toBe("verify-failed");
+  });
+
+  it("treats skipped non-verify jobs as passing", () => {
+    expect(
+      classifyRedRun([
+        { name: "Build dpf-portal (amd64)", conclusion: "success" },
+        { name: "signoff", conclusion: "skipped" },
+        { name: "E2E install verification (release mode)", conclusion: "failure" },
+      ]),
+    ).toBe("verify-failed");
+  });
+
+  it("falls back to publish-failed when no job explains the red run", () => {
+    expect(
+      classifyRedRun([{ name: "Build dpf-portal (amd64)", conclusion: "success" }]),
+    ).toBe("publish-failed");
+  });
+});
+
+describe("readLatestReleaseStamp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.platformDevConfig.findUnique.mockResolvedValue(null);
+    db.credentialEntry.findUnique.mockResolvedValue(null);
+  });
+
+  function runsResponse(runs: unknown[]) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ workflow_runs: runs }),
+    } as unknown as Response;
+  }
+
+  function jobsResponse(jobs: unknown[]) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ jobs }),
+    } as unknown as Response;
+  }
+
+  const greenRun = {
+    id: 100,
+    head_branch: "v6.1.0",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    html_url: "https://github.com/o/r/actions/runs/100",
+    created_at: "2026-06-10T01:38:00Z",
+    updated_at: "2026-06-10T02:00:00Z",
+  };
+
+  it("returns the latest v-tag run as verified on success, without a jobs fetch", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(runsResponse([greenRun]));
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result).toEqual({
+      ok: true,
+      latest: {
+        tag: "v6.1.0",
+        runId: 100,
+        runUrl: "https://github.com/o/r/actions/runs/100",
+        status: "verified",
+        runConclusion: "success",
+        runUpdatedAt: "2026-06-10T02:00:00Z",
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // No credential bound — request must go out unauthenticated.
+    const headers = fetchImpl.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("skips non-release runs (branch pushes, workflow_dispatch) when finding the stamp", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      runsResponse([
+        { ...greenRun, id: 102, head_branch: "main", event: "push" },
+        { ...greenRun, id: 101, head_branch: "v6.0.0", event: "workflow_dispatch" },
+        { ...greenRun, id: 100 },
+      ]),
+    );
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.runId).toBe(100);
+  });
+
+  it("returns latest: null when no release stamp exists", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(runsResponse([]));
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result).toEqual({ ok: true, latest: null });
+  });
+
+  it("reports in-progress runs without fetching jobs", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      runsResponse([{ ...greenRun, status: "in_progress", conclusion: null }]),
+    );
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("in-progress");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies a red run via its jobs (verify-failed shape)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        runsResponse([{ ...greenRun, conclusion: "failure" }]),
+      )
+      .mockResolvedValueOnce(jobsResponse(PUBLISHED_UNVERIFIED_JOBS))
+      // Superseding-dispatch check: no green dispatch runs exist.
+      .mockResolvedValueOnce(runsResponse([]));
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("verify-failed");
+    expect(String(fetchImpl.mock.calls[1]![0])).toContain("/actions/runs/100/jobs");
+    expect(String(fetchImpl.mock.calls[2]![0])).toContain(
+      "/actions/workflows/install-verification.yml/runs",
+    );
+  });
+
+  it("upgrades verify-failed to verified when a newer green release-mode dispatch run exists", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        runsResponse([{ ...greenRun, conclusion: "failure" }]),
+      )
+      .mockResolvedValueOnce(jobsResponse(PUBLISHED_UNVERIFIED_JOBS))
+      .mockResolvedValueOnce(
+        runsResponse([
+          { id: 555, created_at: "2026-06-10T02:30:00Z", status: "completed", conclusion: "success" },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jobsResponse([
+          { name: "Linux E2E Install (ubuntu-latest, release)", conclusion: "success" },
+        ]),
+      );
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("verified");
+  });
+
+  it("does not let a dev-mode dispatch run supersede a red verify gate", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        runsResponse([{ ...greenRun, conclusion: "failure" }]),
+      )
+      .mockResolvedValueOnce(jobsResponse(PUBLISHED_UNVERIFIED_JOBS))
+      .mockResolvedValueOnce(
+        runsResponse([
+          { id: 555, created_at: "2026-06-10T02:30:00Z", status: "completed", conclusion: "success" },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jobsResponse([
+          { name: "Linux E2E Install (ubuntu-latest, dev)", conclusion: "success" },
+        ]),
+      );
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("verify-failed");
+  });
+
+  it("ignores dispatch runs that predate the red stamp", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        runsResponse([{ ...greenRun, conclusion: "failure" }]),
+      )
+      .mockResolvedValueOnce(jobsResponse(PUBLISHED_UNVERIFIED_JOBS))
+      .mockResolvedValueOnce(
+        runsResponse([
+          { id: 444, created_at: "2026-06-09T00:00:00Z", status: "completed", conclusion: "success" },
+        ]),
+      );
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("verify-failed");
+    // No jobs fetch for a too-old candidate.
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps verify-failed when the superseding check itself errors (best-effort)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        runsResponse([{ ...greenRun, conclusion: "failure" }]),
+      )
+      .mockResolvedValueOnce(jobsResponse(PUBLISHED_UNVERIFIED_JOBS))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "boom",
+      } as unknown as Response);
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok && result.latest?.status).toBe("verify-failed");
+  });
+
+  it("propagates API errors instead of guessing a status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () => "rate limited",
+    } as unknown as Response);
+    const result = await readLatestReleaseStamp({ fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("HTTP 403");
+  });
+
+  it("sends the bound github-pr-sync token when one is active", async () => {
+    db.credentialEntry.findUnique.mockResolvedValue({
+      secretRef: "plain-token",
+      status: "active",
+    });
+    const fetchImpl = vi.fn().mockResolvedValueOnce(runsResponse([greenRun]));
+    await readLatestReleaseStamp({ fetchImpl });
+    const headers = fetchImpl.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer plain-token");
+  });
+});

--- a/apps/web/lib/release-health/release-runs-reader.ts
+++ b/apps/web/lib/release-health/release-runs-reader.ts
@@ -1,0 +1,264 @@
+// apps/web/lib/release-health/release-runs-reader.ts
+// BI-3630773C (EP-FULL-OBS) — release verification health surfacing.
+//
+// Reads the latest release stamp's outcome from the GitHub Actions API.
+// A "stamp" is a vX.Y.Z tag push, which triggers the Publish Docker Images
+// workflow (.github/workflows/publish-image.yml). That workflow publishes
+// images FIRST and runs the E2E install verification gate AFTER — so a red
+// run can mean a published-but-unverified release. Distinguishing the two
+// failure shapes requires looking at the run's jobs, not just its
+// conclusion.
+//
+// Auth is optional: the upstream repo is public, so unauthenticated reads
+// work within GitHub's anonymous rate budget (60/hr — two requests per
+// 15-minute poll fits comfortably). When the operator has bound the
+// "github-pr-sync" credential (Contributor MCP card), its token is reused
+// for the higher budget.
+
+import {
+  resolveGithubToken,
+  resolveRepoIdentity,
+} from "@/lib/contributor-change-lanes/github-rest-reader";
+
+// Workflow file paths are the stable identifiers — run names and display
+// titles change; the paths do not.
+const PUBLISH_WORKFLOW_PATH = "publish-image.yml";
+// Manual-dispatch twin of the publish workflow's verify job. A green
+// release-mode run of this workflow that is NEWER than a red stamp is
+// superseding evidence: the published release images install green even
+// though the stamp run itself stays red forever (re-runs of a tag run
+// execute the tag's stale workflow definition, so operators re-verify via
+// dispatch instead — exactly the v6.1.0 recovery path).
+const DISPATCH_VERIFY_WORKFLOW_PATH = "install-verification.yml";
+const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+/;
+// The verify job inside the publish workflow; matched by prefix so a
+// rename like "(release mode)" → "(release)" doesn't silently reclassify.
+const VERIFY_JOB_PREFIX = "E2E install verification";
+
+export type ReleaseStampStatus =
+  | "in-progress"
+  | "verified"
+  | "verify-failed"
+  | "publish-failed";
+
+export type ReleaseStampSnapshot = {
+  tag: string;
+  runId: number;
+  runUrl: string;
+  status: ReleaseStampStatus;
+  /** Raw workflow-run conclusion ("success" | "failure" | ...), null while running. */
+  runConclusion: string | null;
+  /** ISO timestamp of the run's last update on GitHub's side. */
+  runUpdatedAt: string | null;
+};
+
+export type ReleaseRunsResult =
+  | { ok: true; latest: ReleaseStampSnapshot | null }
+  | { ok: false; error: string };
+
+export type ReleaseRunsDeps = {
+  /** Injection point so tests don't fetch real URLs. */
+  fetchImpl?: typeof fetch;
+};
+
+type RawWorkflowRun = {
+  id?: number;
+  head_branch?: string | null;
+  event?: string;
+  status?: string | null;
+  conclusion?: string | null;
+  html_url?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type RawJob = {
+  name?: string;
+  conclusion?: string | null;
+};
+
+/**
+ * Latest release stamp and its publish/verify outcome, or `latest: null`
+ * when no vX.Y.Z run exists yet (fresh fork, never stamped).
+ */
+export async function readLatestReleaseStamp(
+  deps: ReleaseRunsDeps = {},
+): Promise<ReleaseRunsResult> {
+  const { prisma } = await import("@dpf/db");
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  const repo = await resolveRepoIdentity(prisma);
+  const token = await resolveGithubToken(prisma);
+
+  const runsRes = await githubGet(
+    fetchImpl,
+    token,
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows/${PUBLISH_WORKFLOW_PATH}/runs?per_page=10`,
+  );
+  if (!runsRes.ok) return runsRes;
+
+  const runs = (runsRes.json as { workflow_runs?: RawWorkflowRun[] })
+    .workflow_runs;
+  const latest = (runs ?? []).find(
+    (r) =>
+      r.event === "push" &&
+      typeof r.head_branch === "string" &&
+      RELEASE_TAG_PATTERN.test(r.head_branch) &&
+      typeof r.id === "number",
+  );
+  if (!latest) return { ok: true, latest: null };
+
+  const base: Omit<ReleaseStampSnapshot, "status"> = {
+    tag: latest.head_branch as string,
+    runId: latest.id as number,
+    runUrl:
+      latest.html_url ??
+      `https://github.com/${repo.owner}/${repo.name}/actions/runs/${latest.id}`,
+    runConclusion: latest.conclusion ?? null,
+    runUpdatedAt: latest.updated_at ?? null,
+  };
+
+  if (latest.status !== "completed") {
+    return { ok: true, latest: { ...base, status: "in-progress" } };
+  }
+  if (latest.conclusion === "success") {
+    return { ok: true, latest: { ...base, status: "verified" } };
+  }
+
+  // Red run — fetch jobs to tell "publish failed" from "published but the
+  // verify gate failed". On jobs-fetch failure return the error rather than
+  // guessing: the runner keeps the previous state and retries next tick.
+  const jobsRes = await githubGet(
+    fetchImpl,
+    token,
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${latest.id}/jobs?per_page=100`,
+  );
+  if (!jobsRes.ok) return jobsRes;
+
+  const jobs = ((jobsRes.json as { jobs?: RawJob[] }).jobs ?? []).map((j) => ({
+    name: j.name ?? "",
+    conclusion: j.conclusion ?? null,
+  }));
+  let status: ReleaseStampStatus = classifyRedRun(jobs);
+
+  // A red verify gate can be superseded by a later green release-mode run
+  // of the manual-dispatch verification workflow. Best-effort: any failure
+  // in this check leaves the stamp verify-failed (alerting too much beats
+  // silently clearing a real failure).
+  if (
+    status === "verify-failed" &&
+    (await hasSupersedingDispatchVerification(
+      fetchImpl,
+      token,
+      repo,
+      latest.created_at ?? null,
+    ))
+  ) {
+    status = "verified";
+  }
+
+  return { ok: true, latest: { ...base, status } };
+}
+
+/**
+ * True when a release-mode run of install-verification.yml completed green
+ * AFTER the (red) stamp run started. Release mode is detected from the job
+ * name — the workflow's single job renders as
+ * "Linux E2E Install (ubuntu-latest, release)" — because workflow_dispatch
+ * inputs are not exposed on the runs API.
+ */
+async function hasSupersedingDispatchVerification(
+  fetchImpl: typeof fetch,
+  token: string | null,
+  repo: { owner: string; name: string },
+  stampCreatedAt: string | null,
+): Promise<boolean> {
+  if (!stampCreatedAt) return false;
+  const stampMs = Date.parse(stampCreatedAt);
+  if (Number.isNaN(stampMs)) return false;
+
+  const runsRes = await githubGet(
+    fetchImpl,
+    token,
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/workflows/${DISPATCH_VERIFY_WORKFLOW_PATH}/runs?status=success&per_page=10`,
+  );
+  if (!runsRes.ok) return false;
+
+  const candidates = (
+    (runsRes.json as { workflow_runs?: RawWorkflowRun[] }).workflow_runs ?? []
+  ).filter(
+    (r) =>
+      typeof r.id === "number" &&
+      typeof r.created_at === "string" &&
+      Date.parse(r.created_at) > stampMs,
+  );
+
+  // Newest-first from the API; one jobs fetch on the most recent candidate
+  // keeps the rate budget flat. A dev-mode run there simply returns false.
+  const newest = candidates[0];
+  if (!newest) return false;
+
+  const jobsRes = await githubGet(
+    fetchImpl,
+    token,
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/actions/runs/${newest.id}/jobs?per_page=100`,
+  );
+  if (!jobsRes.ok) return false;
+
+  const jobs = (jobsRes.json as { jobs?: RawJob[] }).jobs ?? [];
+  return jobs.some(
+    (j) =>
+      (j.name ?? "").includes("release") && j.conclusion === "success",
+  );
+}
+
+/**
+ * Pure classifier for a completed-red run's jobs. "verify-failed" only when
+ * every job EXCEPT the verify gate succeeded (or was skipped) — i.e. the
+ * images are published and the install verification alone is red. Anything
+ * else red means the publish itself did not complete.
+ */
+export function classifyRedRun(
+  jobs: Array<{ name: string; conclusion: string | null }>,
+): Extract<ReleaseStampStatus, "verify-failed" | "publish-failed"> {
+  let verifyFailed = false;
+  for (const job of jobs) {
+    const passed = job.conclusion === "success" || job.conclusion === "skipped";
+    if (job.name.startsWith(VERIFY_JOB_PREFIX)) {
+      if (!passed) verifyFailed = true;
+      continue;
+    }
+    if (!passed) return "publish-failed";
+  }
+  return verifyFailed ? "verify-failed" : "publish-failed";
+}
+
+async function githubGet(
+  fetchImpl: typeof fetch,
+  token: string | null,
+  url: string,
+): Promise<{ ok: true; json: unknown } | { ok: false; error: string }> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "dpf-release-health",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const res = await fetchImpl(url, { method: "GET", headers });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        ok: false,
+        error: `GitHub release-run read failed: HTTP ${res.status} ${body.slice(0, 200)}`,
+      };
+    }
+    return { ok: true, json: await res.json() };
+  } catch (err) {
+    return {
+      ok: false,
+      error: (err as Error).message ?? "fetch failed",
+    };
+  }
+}

--- a/apps/web/lib/release-health/runner.test.ts
+++ b/apps/web/lib/release-health/runner.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  platformConfig: { findUnique: vi.fn(), upsert: vi.fn() },
+  platformNotification: { create: vi.fn(), updateMany: vi.fn() },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: db }));
+
+const reader = vi.hoisted(() => ({
+  readLatestReleaseStamp: vi.fn(),
+}));
+
+vi.mock("./release-runs-reader", () => reader);
+
+import { runReleaseHealthCheck } from "./runner";
+import type { ReleaseStampSnapshot } from "./release-runs-reader";
+
+const NOW = new Date("2026-06-10T03:00:00Z");
+
+function snapshot(over: Partial<ReleaseStampSnapshot> = {}): ReleaseStampSnapshot {
+  return {
+    tag: "v6.1.0",
+    runId: 100,
+    runUrl: "https://github.com/o/r/actions/runs/100",
+    status: "verified",
+    runConclusion: "success",
+    runUpdatedAt: "2026-06-10T02:00:00Z",
+    ...over,
+  };
+}
+
+function priorState(over: Record<string, unknown> = {}) {
+  return {
+    value: {
+      snapshot: snapshot(),
+      checkedAt: "2026-06-10T02:45:00Z",
+      notifiedRunId: null,
+      ...over,
+    },
+  };
+}
+
+describe("runReleaseHealthCheck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.platformConfig.findUnique.mockResolvedValue(null);
+    db.platformConfig.upsert.mockResolvedValue({});
+    db.platformNotification.create.mockResolvedValue({});
+    db.platformNotification.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("notifies critical on a verify-failed stamp and records the run id", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "verify-failed" }),
+    });
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok && result.notificationCreated).toBe(true);
+    expect(db.platformNotification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        severity: "critical",
+        category: "release-verification",
+        subjectId: "v6.1.0",
+        message: expect.stringContaining("published but its install verification FAILED"),
+      }),
+    });
+    expect(db.platformConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          value: expect.objectContaining({ notifiedRunId: 100 }),
+        },
+      }),
+    );
+  });
+
+  it("notifies warning on a publish-failed stamp", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "publish-failed" }),
+    });
+
+    await runReleaseHealthCheck({ now: NOW });
+
+    expect(db.platformNotification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ severity: "warning" }),
+    });
+  });
+
+  it("does not re-notify the same red run on subsequent polls", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "verify-failed" }),
+    });
+    db.platformConfig.findUnique.mockResolvedValue(
+      priorState({
+        snapshot: snapshot({ status: "verify-failed" }),
+        notifiedRunId: 100,
+      }),
+    );
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok && result.notificationCreated).toBe(false);
+    expect(db.platformNotification.create).not.toHaveBeenCalled();
+  });
+
+  it("notifies again when a NEW red run appears after an already-notified one", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "verify-failed", runId: 200, tag: "v6.2.0" }),
+    });
+    db.platformConfig.findUnique.mockResolvedValue(
+      priorState({ notifiedRunId: 100 }),
+    );
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok && result.notificationCreated).toBe(true);
+    expect(db.platformNotification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ subjectId: "v6.2.0" }),
+    });
+  });
+
+  it("resolves open notifications when the latest stamp is verified", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "verified", runId: 300 }),
+    });
+    db.platformNotification.updateMany.mockResolvedValue({ count: 2 });
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok && result.notificationsResolved).toBe(2);
+    expect(db.platformNotification.updateMany).toHaveBeenCalledWith({
+      where: { category: "release-verification", resolvedAt: null },
+      data: { resolvedAt: NOW },
+    });
+  });
+
+  it("does NOT resolve open notifications while a re-stamp is merely in progress", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: true,
+      latest: snapshot({ status: "in-progress", runId: 300 }),
+    });
+    db.platformConfig.findUnique.mockResolvedValue(
+      priorState({ notifiedRunId: 100 }),
+    );
+
+    await runReleaseHealthCheck({ now: NOW });
+
+    expect(db.platformNotification.updateMany).not.toHaveBeenCalled();
+    // The dedupe marker survives so the old failure can't re-alert either.
+    expect(db.platformConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { value: expect.objectContaining({ notifiedRunId: 100 }) },
+      }),
+    );
+  });
+
+  it("keeps prior state untouched on a read error", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({
+      ok: false,
+      error: "HTTP 403 rate limited",
+    });
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok).toBe(false);
+    expect(db.platformConfig.upsert).not.toHaveBeenCalled();
+    expect(db.platformNotification.create).not.toHaveBeenCalled();
+  });
+
+  it("persists a null snapshot for never-stamped installs without alerting", async () => {
+    reader.readLatestReleaseStamp.mockResolvedValue({ ok: true, latest: null });
+
+    const result = await runReleaseHealthCheck({ now: NOW });
+
+    expect(result.ok && result.snapshot).toBeNull();
+    expect(db.platformNotification.create).not.toHaveBeenCalled();
+    expect(db.platformConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          value: expect.objectContaining({ snapshot: null, notifiedRunId: null }),
+        },
+      }),
+    );
+  });
+});

--- a/apps/web/lib/release-health/runner.ts
+++ b/apps/web/lib/release-health/runner.ts
@@ -1,0 +1,107 @@
+// apps/web/lib/release-health/runner.ts
+// BI-3630773C — release verification health check runner.
+//
+// One poll: read the latest stamp from GitHub, persist it, and keep the
+// operator notification in sync. The founding incident: the v6.0.0 stamp's
+// verify gate failed on 2026-06-08 and sat unnoticed in the GitHub CI
+// dashboard for two days — masking an installer-breaking bug — until the
+// v6.1.0 stamp hit the same wall. A red verify gate means a
+// published-but-unverified release; that must reach the operator without
+// them watching CI.
+//
+// Notification lifecycle (mirrors contributor-inventory-sync):
+//   - red stamp (verify-failed / publish-failed) → one PlatformNotification
+//     per run id (notifiedRunId in state dedupes across polls).
+//   - a later stamp verifying green → resolve all open release-verification
+//     notifications. An in-progress re-stamp does NOT resolve — the failed
+//     release stays alerted until a green verify actually lands.
+
+import {
+  readLatestReleaseStamp,
+  type ReleaseRunsDeps,
+  type ReleaseStampSnapshot,
+} from "./release-runs-reader";
+import { loadReleaseHealthState, saveReleaseHealthState } from "./state";
+
+export const RELEASE_VERIFICATION_NOTIFICATION_CATEGORY = "release-verification";
+
+export type ReleaseHealthCheckResult =
+  | {
+      ok: true;
+      snapshot: ReleaseStampSnapshot | null;
+      notificationCreated: boolean;
+      notificationsResolved: number;
+    }
+  | { ok: false; error: string };
+
+export async function runReleaseHealthCheck(
+  deps: ReleaseRunsDeps & { now?: Date } = {},
+): Promise<ReleaseHealthCheckResult> {
+  const now = deps.now ?? new Date();
+
+  const read = await readLatestReleaseStamp(deps);
+  if (!read.ok) {
+    // Offline / rate-limited / API error: keep the previous state untouched
+    // (the card keeps showing the last known truth) and retry next tick.
+    return { ok: false, error: read.error };
+  }
+
+  const prior = await loadReleaseHealthState();
+  const snapshot = read.latest;
+
+  let notificationCreated = false;
+  let notificationsResolved = 0;
+
+  const isRed =
+    snapshot !== null &&
+    (snapshot.status === "verify-failed" || snapshot.status === "publish-failed");
+
+  if (isRed && prior?.notifiedRunId !== snapshot.runId) {
+    await createRedStampNotification(snapshot);
+    notificationCreated = true;
+  } else if (snapshot?.status === "verified") {
+    notificationsResolved = await resolveOpenNotifications(now);
+  }
+
+  await saveReleaseHealthState({
+    snapshot,
+    checkedAt: now.toISOString(),
+    notifiedRunId: isRed ? snapshot.runId : (prior?.notifiedRunId ?? null),
+  });
+
+  return { ok: true, snapshot, notificationCreated, notificationsResolved };
+}
+
+async function createRedStampNotification(
+  snapshot: ReleaseStampSnapshot,
+): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  // verify-failed is the silent-bad-release case (images are live but
+  // unverified) — critical. publish-failed means the stamp itself broke and
+  // nothing new shipped — warning.
+  const severity = snapshot.status === "verify-failed" ? "critical" : "warning";
+  const message =
+    snapshot.status === "verify-failed"
+      ? `Release ${snapshot.tag} published but its install verification FAILED — the release is live and unverified. Run: ${snapshot.runUrl}`
+      : `Release stamp ${snapshot.tag} failed before publishing completed. Run: ${snapshot.runUrl}`;
+  await prisma.platformNotification.create({
+    data: {
+      severity,
+      category: RELEASE_VERIFICATION_NOTIFICATION_CATEGORY,
+      subjectId: snapshot.tag,
+      message,
+    },
+  });
+}
+
+async function resolveOpenNotifications(now: Date): Promise<number> {
+  const { prisma } = await import("@dpf/db");
+  const result = await prisma.platformNotification.updateMany({
+    where: {
+      category: RELEASE_VERIFICATION_NOTIFICATION_CATEGORY,
+      resolvedAt: null,
+    },
+    data: { resolvedAt: now },
+  });
+  return result.count;
+}

--- a/apps/web/lib/release-health/state.ts
+++ b/apps/web/lib/release-health/state.ts
@@ -1,0 +1,44 @@
+// apps/web/lib/release-health/state.ts
+// BI-3630773C — last-known release verification state.
+//
+// PlatformConfig key-value row (same pattern as self_upgrade.lastCheckedAt
+// in lib/self-upgrade/last-check.ts): the state is one small JSON blob, the
+// health card reads it server-side, and it survives portal restarts without
+// a dedicated model or migration.
+
+import type { ReleaseStampSnapshot } from "./release-runs-reader";
+
+const RELEASE_HEALTH_CONFIG_KEY = "release_health.latest";
+
+export type ReleaseHealthState = {
+  /** Latest observed stamp, or null when the repo has never been stamped. */
+  snapshot: ReleaseStampSnapshot | null;
+  /** ISO timestamp of the last successful poll. */
+  checkedAt: string;
+  /** Run id an open red-stamp notification was written for (alert dedupe). */
+  notifiedRunId: number | null;
+};
+
+export async function loadReleaseHealthState(): Promise<ReleaseHealthState | null> {
+  const { prisma } = await import("@dpf/db");
+  const row = await prisma.platformConfig.findUnique({
+    where: { key: RELEASE_HEALTH_CONFIG_KEY },
+  });
+  const value = row?.value as ReleaseHealthState | null | undefined;
+  if (!value || typeof value.checkedAt !== "string") return null;
+  return {
+    snapshot: value.snapshot ?? null,
+    checkedAt: value.checkedAt,
+    notifiedRunId: typeof value.notifiedRunId === "number" ? value.notifiedRunId : null,
+  };
+}
+
+export async function saveReleaseHealthState(state: ReleaseHealthState): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  const value = state as unknown as object;
+  await prisma.platformConfig.upsert({
+    where: { key: RELEASE_HEALTH_CONFIG_KEY },
+    update: { value },
+    create: { key: RELEASE_HEALTH_CONFIG_KEY, value },
+  });
+}

--- a/docs/superpowers/specs/2026-06-09-release-verification-health-surfacing-design.md
+++ b/docs/superpowers/specs/2026-06-09-release-verification-health-surfacing-design.md
@@ -1,0 +1,90 @@
+# Release Verification Health Surfacing — Design
+
+- **BI:** BI-3630773C
+- **Epic:** EP-FULL-OBS (Full Observability)
+- **Status:** shipped with this spec's PR
+- **Date:** 2026-06-09
+
+## Problem
+
+A release stamp (`vX.Y.Z` tag push) runs the Publish Docker Images workflow,
+which publishes images **first** and runs the E2E install verification gate
+**after**. A red verify gate therefore means a *published but unverified*
+release — and that signal previously lived only in the GitHub Actions
+dashboard.
+
+Founding incident: the v6.0.0 stamp's verify gate failed on 2026-06-08 and
+sat unnoticed for two days, masking an installer-breaking bug (impossible
+distroless Loki healthcheck, fixed in PR #1677), until the v6.1.0 stamp hit
+the same wall. Watching CI dashboards is not the operator's job.
+
+## Design
+
+Three small pieces on existing rails — no new Prisma models, no migration:
+
+1. **Reader** — `apps/web/lib/release-health/release-runs-reader.ts`
+   - Reads the publish workflow's runs via the GitHub Actions REST API,
+     filtered to `event=push` + `head_branch` matching `vX.Y.Z` (GitHub
+     puts the tag name in `head_branch` for tag pushes).
+   - Auth is optional: the upstream repo is public, and two requests per
+     15-minute tick fit the anonymous 60/hr budget. When the
+     `github-pr-sync` credential (Contributor MCP card) is bound, its token
+     is reused (resolvers exported from
+     `lib/contributor-change-lanes/github-rest-reader.ts`).
+   - Classification: run green → `verified`; running → `in-progress`; red →
+     fetch the run's jobs and distinguish `verify-failed` (every job except
+     the E2E verify gate passed — images are live, verification is not)
+     from `publish-failed` (the publish itself broke).
+   - **Superseding dispatch verification:** a red stamp run stays red on
+     GitHub forever — re-runs execute the tag's stale workflow definition,
+     so operators re-verify via the manual `install-verification.yml`
+     dispatch in release mode instead (the v6.1.0 recovery path). A green
+     release-mode dispatch run *newer than the stamp* upgrades
+     `verify-failed` → `verified`. Release mode is detected from the job
+     name (`… (ubuntu-latest, release)`) because dispatch inputs are not
+     exposed on the runs API. Best-effort: any failure in this check leaves
+     the stamp `verify-failed` — alerting too much beats silently clearing
+     a real failure.
+
+2. **State + notifications** — `state.ts`, `runner.ts`
+   - Last-known state persists as one JSON blob in `PlatformConfig`
+     (`release_health.latest`), the same pattern as
+     `self_upgrade.lastCheckedAt`. Survives portal restarts.
+   - Red stamp → one `PlatformNotification` (category
+     `release-verification`, subjectId = tag) per run id; `notifiedRunId`
+     in state dedupes across polls. `verify-failed` is **critical**
+     (silent bad release), `publish-failed` is **warning** (loud failure,
+     nothing shipped).
+   - A later stamp verifying green resolves all open release-verification
+     notifications. An in-progress re-stamp does NOT resolve — the failed
+     release stays alerted until a green verify actually lands.
+   - Poll errors (offline, rate-limited) leave prior state untouched.
+
+3. **Surfaces**
+   - Inngest cron `ops/release-health-check` every 15 minutes
+     (`lib/queue/functions/release-health-check.ts`), gated by
+     `gateAtEntry` like every scheduled function.
+   - A fourth "Latest Release" card on the portal Health tab summary grid
+     (`PortalHealthSummary`), fed server-side from `PlatformConfig` by the
+     health page. Tones: verified → success, in-progress → neutral,
+     verify-failed → critical, publish-failed → warning, never-stamped →
+     neutral "—". The card links to the GitHub Actions run (external link,
+     new tab).
+
+## Out of scope
+
+- Re-running or gating the stamp itself (stays operator-initiated).
+- Auto-filing PIR/backlog items from the failure log (the Tier 2 log
+  scanner owns log-derived intake).
+- Non-release workflow monitoring (PR CI health).
+
+## Verification evidence (at ship)
+
+- 24 unit tests across reader classification, superseding logic, and the
+  runner's notification lifecycle.
+- Live-contract check against the real GitHub API (2026-06-10): the
+  v6.1.0 incident classifies as `verify-failed` from its real jobs payload,
+  and the real green dispatch run 27248800875 (created 02:21Z, job
+  "Linux E2E Install (ubuntu-latest, release)") supersedes it to
+  `verified` — so the first cron tick after merge shows v6.1.0 verified
+  rather than raising a stale false alarm.


### PR DESCRIPTION
## Problem (BI-3630773C, EP-FULL-OBS)

A release stamp publishes images **first** and runs the E2E install verification gate **after** — so a red verify gate means a *published-but-unverified* release, and that signal lived only in the GitHub Actions dashboard. The v6.0.0 stamp's red verify gate sat unnoticed for two days, masking the installer-breaking Loki healthcheck bug ([#1677](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1677)), until the v6.1.0 stamp hit the same wall. Watching CI dashboards is not the operator's job.

## What this adds

**`apps/web/lib/release-health/`** — all on existing rails, no new models, no migration:

- **Reader**: GitHub Actions REST read of the publish workflow's `vX.Y.Z` tag runs. Token optional (public repo; 2 requests / 15-min tick fits the anonymous budget; reuses the `github-pr-sync` credential when bound). Red runs classify by jobs: **verify-failed** (every job green except the verify gate — images live, unverified) vs **publish-failed**.
- **Superseding dispatch verification**: a red stamp run stays red on GitHub forever (tag re-runs execute the tag's stale workflow definition), and the canonical recovery is a green release-mode `install-verification.yml` dispatch — exactly how v6.1.0 was recovered. A newer green release-mode dispatch run upgrades verify-failed → verified. Without this, the first cron tick would raise a stale false **critical** for the already-verified v6.1.0.
- **State**: one `PlatformConfig` JSON blob (`release_health.latest`), mirroring `self_upgrade.lastCheckedAt`; survives restarts.
- **Notifications**: `PlatformNotification` category `release-verification` — critical on verify-failed, warning on publish-failed, one per run id (deduped), auto-resolved when a later stamp verifies green; an in-progress re-stamp does **not** resolve.
- **Cron**: `ops/release-health-check` every 15 minutes (quiescence-gated like all scheduled functions).
- **UI**: fourth **Latest Release** card on the portal Health tab summary grid, linking to the run.

## Verification

- 24 unit tests: classification (including the exact v6.1.0 job shape), superseding logic (release vs dev mode, ordering, best-effort error handling), notification lifecycle (create/dedupe/re-fire/resolve).
- Typecheck + full `apps/web` vitest suite green (10,290 passed).
- **Live-contract check** against the real GitHub API: the v6.1.0 run's real jobs payload classifies `verify-failed`, and real dispatch run [27248800875](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/27248800875) (job "Linux E2E Install (ubuntu-latest, release)", created after the stamp) supersedes it to `verified`.

Spec: `docs/superpowers/specs/2026-06-09-release-verification-health-surfacing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)