### PR TITLE
docs(archetypes): regulatory governance + EA review pass that missed the #1680 squash (BI-5D9DCDE6)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-bian-banking-archetypes.md
+++ b/docs/superpowers/plans/2026-06-09-bian-banking-archetypes.md
@@ -21,7 +21,9 @@ JSON `counts` field (8 / 43 / 341 / 258).
 ## Phase 1 — Archetype definitions (`packages/storefront-templates`)
 
 **Files:**
-- `src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`.
+- `src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`,
+  `"disclosures"` to `SectionType` (spec §9.3), and optional
+  `vocabulary?: Partial<ArchetypeVocabulary>` on `ArchetypeDefinition` (spec §7.4).
 - `src/archetypes/banking-financial-services.ts` *(new)* — `community-bank`,
   `credit-union`, `mortgage-lending` per spec §7: shared axes (`account-with-kyc`,
   `account-based-fees`, multi-channel), item templates named from BIAN *Loans and
@@ -50,12 +52,41 @@ JSON `counts` field (8 / 43 / 341 / 258).
   key-uniqueness and parentKey-integrity invariants over the new definitions.
 - `src/seed-storefront-archetypes.ts` — `MARKETING_SKILL_RULES["banking-financial-services"]`
   regulated-communication reframes per spec §7.5 (mirror the `healthcare-wellness` entry
-  shape).
+  shape); upsert writes each leaf's `vocabulary` override into
+  `StorefrontArchetype.customVocabulary` (spec §7.4 — credit-union "Members" labels), with
+  a seed test asserting the override lands.
 
 **Verification:** `pnpm --filter @dpf/db exec vitest run` green. Seed-count assertion:
 seeding logs `upserting N storefront archetypes` with N increased by exactly 3 and zero
 silently-skipped rows (guard against the silent-seed-skip failure class — assert in test,
 don't eyeball logs).
+
+## Phase 2b — Regulatory & jurisdictional governance (spec §9)
+
+**Files:**
+- `packages/db/data/license_requirement_reference.json` — banking authority entries per
+  spec §9.1 (`archetypeCategories: ["banking-financial-services"]`; US OCC/FRB/FDIC/NCUA/
+  CFPB/FinCEN/NMLS-org/NMLS-MLO/CSBS-state/Equal-Housing; GB FCA+PRA; EU EBA; CA OSFI;
+  AU APRA — official source URLs only, directory doctrine, `displayRuleSummary` carries
+  the Member-FDIC / NCUA-sign / NMLS-ID / Equal-Housing display obligations).
+- `packages/db/src/seed-license-requirements.ts` test — count assertion that the banking
+  rows upsert (silent-seed-skip guard).
+- Onboarding flow — **required** jurisdiction/charter capture step for this category per
+  spec §9.2: jurisdiction (default from org location), charter type per leaf, derived
+  regulator + insurance-regime suggestion with §9.1 entries attached, credential ids
+  (FDIC cert / NCUA charter / NMLS ID) stored as licensing-substrate credential rows.
+  Wiring point (verified): extend `apps/web/components/compliance/OnboardingWizard.tsx`
+  (`/compliance/onboard`, `OnboardingDraft` persistence) and persist to
+  `OrganizationLicenseProfile` / `OrganizationLicenseRecord` / `PersonLicenseRecord` /
+  `LicenseDisplayObligation` — reuse `EP-LIC-C64FC2` domain model; do not invent a
+  parallel store. Per spec D5 the step never hard-blocks activation.
+- Leaf `sectionTemplates` — add the "Disclosures" section using the new first-class
+  `disclosures` SectionType (spec §9.3); render the case in
+  `apps/web/components/storefront/SectionRenderer.tsx` from `LicenseDisplayObligation`
+  rows, with the D5 neutral-placeholder state when posture is uncaptured.
+
+**Verification:** `pnpm --filter @dpf/db exec vitest run` green including the new
+count assertion; onboarding-context tests cover the banking profile (§9.5).
 
 ## Phase 3 — Finance profile (`packages/finance-templates`)
 
@@ -92,21 +123,28 @@ worktree; targeted vitest for the touched libs.
 Per `structural-verification-is-not-functional` and the `dpf-verify-on-live-install`
 skill (step zero: `pnpm verify:preflight`, honor the BLOCKED stop-rule):
 
-1. Fresh-seed or re-seed the leased sandbox; confirm 3 new archetypes in the picker.
-2. Onboard as **Credit Union** → items surface shows member vocabulary ("Share Savings",
-   inbox "Applications"), capability page shows BIAN-sourced perspective composed with the
-   common baseline.
-3. Drive a storefront inquiry end-to-end on a share-certificate item; confirm intake lands.
-4. Record evidence via the MCP evidence tools against BI-5D9DCDE6 (dynamic-analysis prose
+1. Fresh-seed or re-seed the leased sandbox; confirm 3 new archetypes in the picker and
+   the banking license-requirement rows seeded (count query, not log eyeballing).
+2. Onboard as **Credit Union** → the required jurisdiction/charter step captures
+   "US / federal credit union" and derives NCUA + NCUSIF posture with the right reference
+   entries attached; items surface shows member vocabulary ("Share Savings", inbox
+   "Applications"); capability page shows BIAN-sourced perspective composed with the
+   common baseline, with regulatory posture attached to the Compliance-domain capabilities.
+3. Confirm the storefront Disclosures section renders the NCUA official sign + Equal
+   Housing content from the captured posture.
+4. Drive a storefront inquiry end-to-end on a share-certificate item; confirm intake lands.
+5. Record evidence via the MCP evidence tools against BI-5D9DCDE6 (dynamic-analysis prose
    report, not screenshots).
 
 ## Risks & rollback
 
 - **Vocabulary is category-keyed; credit-union wants "Members" while banks want
-  "Customers".** v1 compromise per spec §7.4 ("Customers & Members") unless leaf-level
-  vocabulary override already exists — check `resolveVocabularyKey` before choosing.
-  Risk: mid-build scope temptation to add leaf-level vocabulary; resist — file a follow-up
-  BI if needed.
+  "Customers".** Decided per spec §7.4 (EA review pass): seed the leaf's
+  `vocabulary` override into `StorefrontArchetype.customVocabulary` — the column and the
+  `getVocabulary()` read path already exist; no blended "Customers & Members" label.
+  Scope is one optional `ArchetypeDefinition` field + seed write + test; anything beyond
+  that (per-leaf static maps, new resolution layers) is out of scope — file a follow-up
+  BI if tempted.
 - **Silent seed skips** (known DPF failure class): a typo'd category or FK mismatch can
   upsert 0 rows without erroring. Mitigation: Phase 2's count assertion in tests.
 - **Enum sweep completeness:** a missed category switch (e.g. a hardcoded
@@ -114,6 +152,16 @@ skill (step zero: `pnpm verify:preflight`, honor the BLOCKED stop-rule):
   failure mode; fix every site the compiler names.
 - **LFS on CI:** if a CI job lacks `git lfs`, the PDF checks out as a pointer file —
   harmless for build jobs (nothing imports it); verify no doc-lint job reads PDF bytes.
+- **Regulatory display correctness:** disclosure content (Member FDIC wording, NCUA sign,
+  NMLS ID placement) must follow the official sources named in the reference entries —
+  never paraphrase a regulated statement. The entries are directories, not legal advice;
+  the operator's compliance officer owns final wording. Mitigation: render
+  operator-confirmed posture only; never auto-assert insurance membership.
+- **Onboarding-step coupling:** the required jurisdiction step depends on the licensing
+  substrate's credential model (`EP-LIC-C64FC2`). If the coworker investigation flow
+  (BI-LIC-3621D8) hasn't landed, implement the capture step against the existing domain
+  tables directly and leave the investigation handoff as the follow-up — do not block the
+  archetype on the licensing epic's full scope.
 - **Rollback:** all changes are additive seed/template/wiring code on one branch — revert
   the PR. Seeded archetype rows are soft-deletable (`isActive: false`); re-seed does not
   resurrect operator-deactivated archetypes (existing invariant).

--- a/docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md
+++ b/docs/superpowers/specs/2026-06-09-bian-banking-archetypes-design.md
@@ -1,9 +1,9 @@
 # BIAN-Grounded Banking Archetypes Design
 
-- **Status:** Draft for review
+- **Status:** Draft for review (enterprise-architecture review pass applied 2026-06-09; substrate claims verified against `origin/main` @ 240b528f3)
 - **Author:** Claude (directed by maintainer: "incorporate BIAN for the banking archetypes")
 - **Date:** 2026-06-09
-- **Related specs:** `2026-05-29-vehicle-equipment-rental-archetype-design.md` (new-archetype precedent), `2026-05-22-customer-surface-archetype-activation-design.md` (capability activation), `2026-04-04-business-model-portal-vocabulary-design.md` (vocabulary contract)
+- **Related specs:** `2026-05-29-vehicle-equipment-rental-archetype-design.md` (new-archetype precedent), `2026-05-22-customer-surface-archetype-activation-design.md` (capability activation), `2026-04-04-business-model-portal-vocabulary-design.md` (vocabulary contract), `2026-05-11-licensing-permit-jurisdiction-readiness-design.md` (jurisdiction/regulatory substrate, EP-LIC-C64FC2)
 - **Reference data:** [`docs/Reference/bian/`](../../Reference/bian/README.md) — BIAN v14.0 Service Landscape (8 Business Areas / 43 Business Domains / 341 Service Domains, with official Semantic-API descriptions) + the joint ServiceNow/BIAN "Bridging BIAN and CSDM" v7.6 discussion paper (May 2026)
 
 ---
@@ -127,7 +127,47 @@ membership) gates onboarding. This is a vocabulary + item-template delta over th
 BIAN domains — BIAN's *Savings Account* / *Current Account* / *Term Deposit* Service
 Domains cover both charters.
 
-### 3.5 Anti-patterns identified
+### 3.5 Regulatory landscape + existing DPF jurisdiction substrate
+
+Banking is a *chartered* industry: the jurisdiction and charter type determine which
+regulator supervises the institution and which obligations attach. The combinations that
+matter for the three leaves (directory-level, grounded in the named official sources):
+
+- **US banks:** national charter → OCC; state member → Federal Reserve + state regulator;
+  state nonmember → FDIC + state regulator; deposit insurance → FDIC (with the Part 328
+  official-sign / advertising-statement display obligations). State regulators are
+  navigable via the CSBS directory.
+- **US credit unions:** federal charter → NCUA; state charter → state regulator; federally
+  insured share accounts → NCUSIF with the NCUA official insurance sign display obligation.
+- **US mortgage lenders/brokers:** state licensing through **NMLS** at both organization
+  and individual loan-originator level (SAFE Act), with the NMLS Unique Identifier display
+  obligation; CFPB supervision; RESPA/TILA disclosure regimes.
+- **Cross-cutting US:** CFPB (consumer protection/UDAAP), FinCEN (BSA/AML program
+  obligations), Equal Housing Lender/Opportunity display, Reg DD (Truth in Savings — APY
+  accuracy in advertising), Reg Z (trigger-term rules for rate advertising).
+- **International (directory-level only):** UK FCA register number display + PRA for
+  banks; EU national competent authorities + ECB SSM, EBA register; Canada OSFI;
+  Australia APRA/ASIC.
+
+DPF already has the substrate for exactly this shape: the **licensing/permit/jurisdiction
+readiness foundation** (`docs/superpowers/specs/2026-05-11-licensing-permit-jurisdiction-readiness-design.md`,
+Accepted; epic `EP-LIC-C64FC2`; migration `20260511204500_add_licensing_readiness_foundation`).
+Its doctrine — *seed official authority directories, not legal conclusions*; separate
+requirement intelligence from the org's credential inventory; organization-level AND
+individual-level scope; display obligations as first-class records — is precisely the
+regulated-banking posture. `packages/db/data/license_requirement_reference.json` entries
+are already keyed by `countryCode`/`stateProvinceCode` + `archetypeCategories` +
+`scopeLevel`, so banking rows are additive data, not new schema.
+
+- **Adopted:** extend the licensing-readiness substrate with banking authority entries;
+  make the jurisdiction/charter investigation a **required onboarding step** for this
+  category (it is optional posture for most archetypes; for a chartered institution it
+  gates correct configuration).
+- **Rejected:** encoding legal conclusions or per-state rule matrices in seed data
+  (violates the licensing spec's bootstrap doctrine); building regulatory filing
+  automation in v1.
+
+### 3.6 Anti-patterns identified
 
 - Hand-inventing a banking capability list when a maintained standard exists (violates
   `research-and-use-standards`).
@@ -152,6 +192,11 @@ Domains cover both charters.
 4. Encode the regulated-industry posture declaratively: `provisioning:
    "account-with-kyc"`, `commercialModel: "account-based-fees"`, marketing-skill reframes
    (no aggressive competitive claims; rate/term accuracy; NCUA/FDIC tone).
+4a. Make **jurisdictional regulatory governance a first-class archetype concern**: banking
+   authority entries in the licensing-readiness reference data, a required
+   jurisdiction/charter capture step in initial onboarding/configuration, and storefront
+   display obligations (Member FDIC / NCUA sign / Equal Housing / NMLS ID) wired to the
+   captured posture (§9).
 5. Keep the full BIAN landscape available as reference data
    (`docs/Reference/bian/bian-v14-service-landscape.json`) so future work (custom
    archetype refinement, integration modeling, hive analytics) can draw on domains the
@@ -164,6 +209,9 @@ Domains cover both charters.
   institution's core.
 - **KYC/AML execution** — v1 records the provisioning *posture* (`account-with-kyc`);
   identity-verification vendor integration is future work.
+- **Legal advice or regulatory conclusions** — reference entries are official authority
+  *directories* per the licensing-readiness doctrine; the institution's compliance officer
+  owns the legal determination. No automated regulatory filings in v1.
 - **BIAN Service Operation / Semantic API modeling** against DPF's integration substrate
   (the CSDM paper's Digital Interface / Digital Integration analog) — future work, §11.
 - **Wealth management / trading / insurance leaves** — the reference data covers their
@@ -194,6 +242,16 @@ processes (§5).
 projects 4 Business Areas → 8 Business Domains → ~24 Service Domains (§8). Curation rule:
 domains a community institution's *staff portal* plans and reports against. The full
 landscape stays in reference data.
+
+**D5 — Required-but-not-blocking jurisdiction capture; disclosure honesty over
+completeness.** The §9.2 step is "required" in the sense that the category's onboarding
+checklist holds it open and the portal carries a visible "regulatory posture incomplete"
+state until completed — it never hard-blocks archetype activation (operators explore
+before they configure; a hard gate trains them to enter junk data). The disclosures
+surface (§9.3) never renders an insurance or registration claim without a confirmed
+credential row behind it: missing posture renders a neutral placeholder, not a default
+"Member FDIC". Displaying a false FDIC/NCUA sign is itself a regulatory violation, so the
+failure mode must always be **omission, never fabrication**.
 
 ## 7. Leaf Archetype Definitions
 
@@ -243,12 +301,24 @@ Officer *(booking)*. Form adds loan purpose / property type / price range select
 
 ### 7.4 Vocabulary (`archetype-vocabulary.ts`)
 
-`banking-financial-services`: itemsLabel "Products & Rates", singleItemLabel "Product",
-categoryLabel "Product Family", priceLabel "Rate / Fee", portalLabel "Banking Portal",
-stakeholderLabel "Customers" *(leaf-level override to "Members" for credit-union follows
-the existing archetype-wins resolution; if vocabulary remains category-keyed in v1, use
-"Customers & Members")*, teamLabel "Bankers", inboxLabel "Applications", agentName
-"Relationship Manager" *(BIAN Business Domain: Relationship Management)*.
+Category defaults in the `VOCABULARY` map (the map is category-keyed): itemsLabel
+"Products & Rates", singleItemLabel "Product", addButtonLabel "Add product", categoryLabel
+"Product Family", priceLabel "Rate / Fee", portalLabel "Banking Portal", stakeholderLabel
+"Customers", teamLabel "Bankers", inboxLabel "Applications", agentName "Relationship
+Manager" *(BIAN Business Domain: Relationship Management)*.
+
+**Leaf vocabulary override (decided — replaces the earlier hedge).** There is no
+"archetype-wins" resolution in the static map today; the only existing override path is
+`StorefrontArchetype.customVocabulary` (a `Json?` column already consumed by
+`getVocabulary()` everywhere vocabulary renders), currently written only by the
+custom-archetype admin flow. v1 adds an optional `vocabulary?: Partial<ArchetypeVocabulary>`
+field to `ArchetypeDefinition`, which the archetype seed writes into the leaf's
+`customVocabulary` on upsert. `credit-union` uses it: stakeholderLabel "Members",
+portalLabel "Member Portal", agentName "Member Advisor". The blended-label fallback
+("Customers & Members") is **rejected**: member vocabulary is the defining
+cultural/regulatory delta of the credit-union charter (§3.4) and must not be diluted.
+Zero schema change — the column and the read path exist; this is one optional type field,
+one seed write, one test.
 
 ### 7.5 Marketing-skill rules (`seed-storefront-archetypes.ts`)
 
@@ -294,26 +364,122 @@ Wiring: the perspective resolves for `category === "banking-financial-services"`
 still gets the universal small-business capabilities (HR, marketing, finance ops) plus the
 BIAN overlay.
 
-## 9. Wiring Contract (files to touch)
+## 9. Regulatory & Jurisdictional Governance
 
-Following the `hoa-property-management` end-to-end precedent:
+Banks and financial institutions are subject to regulation and governance **specific to
+the jurisdiction they operate in**. This is a first-class archetype concern, captured
+during initial onboarding/configuration — not an afterthought bolted on post-setup. The
+design reuses the licensing-readiness substrate end to end (§3.5); everything below is
+additive data + wiring, zero new schema.
 
-1. `packages/storefront-templates/src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`
-2. `packages/storefront-templates/src/archetypes/banking-financial-services.ts` — three leaf definitions (§7)
+### 9.1 Banking authority reference entries (bootstrap directories)
+
+Add entries to `packages/db/data/license_requirement_reference.json` with
+`archetypeCategories: ["banking-financial-services"]`, following the existing entry shape
+(`requirementRefId`, `countryCode`/`stateProvinceCode`, `authorityType`, `scopeLevel`,
+`displayRuleSummary`, official `sourceUrls`, `confidence`, `staleAfterDays`):
+
+| Entry | Scope | Display obligation captured |
+| ----- | ----- | --------------------------- |
+| `LIC-REQ-US-OCC` / `US-FRB` / `US-FDIC` | organization | FDIC Part 328 official sign + advertising statement ("Member FDIC") |
+| `LIC-REQ-US-NCUA` | organization | NCUA official insurance sign |
+| `LIC-REQ-US-CFPB`, `LIC-REQ-US-FINCEN-BSA` | organization | — (supervision / BSA-AML program directories) |
+| `LIC-REQ-US-NMLS-ORG` | organization | NMLS Unique Identifier on consumer-facing pages |
+| `LIC-REQ-US-NMLS-MLO` | individual | individual loan-originator NMLS ID (SAFE Act) |
+| `LIC-REQ-US-CSBS-STATE` | organization | state banking-department directory (per-state research entry) |
+| `LIC-REQ-US-EQUAL-HOUSING` | organization | Equal Housing Lender / Opportunity logo |
+| `LIC-REQ-GB-FCA` (+ PRA), `LIC-REQ-EU-EBA`, `LIC-REQ-CA-OSFI`, `LIC-REQ-AU-APRA` | organization | FCA register number display (GB); others directory-level |
+
+Per the licensing doctrine these are research entrypoints with official URLs — never
+legal conclusions.
+
+### 9.2 Onboarding / initial configuration capture (required for this category)
+
+For `banking-financial-services` the jurisdiction step is **required** during onboarding
+(other archetypes treat licensing investigation as optional posture):
+
+1. **Operating jurisdiction** — country + state/province (reuses the org's existing
+   location data as the default; confirms rather than re-asks).
+2. **Charter / license type per leaf** — community-bank: national / state-member /
+   state-nonmember; credit-union: federal / state charter; mortgage-lending: lender /
+   broker / servicer.
+3. **Derived regulator suggestion** — from jurisdiction × charter, suggest the primary
+   regulator and insurance regime (e.g. "federal credit union → NCUA, NCUSIF-insured")
+   with the matching reference entries from §9.1 attached as the investigation starting
+   set. Operator confirms or corrects; the confirmation is stored as the org's credential
+   inventory rows (licensing substrate), never silently assumed.
+4. **Credential identifiers** — FDIC certificate number / NCUA charter number / NMLS ID
+   as organization credentials; optional individual MLO NMLS IDs for mortgage-lending
+   staff (scopeLevel `individual`).
+5. **Display obligations** — the confirmed posture activates storefront disclosure
+   rendering (§9.3).
+
+Substrate binding (verified on main): the capture step extends the **existing compliance
+onboarding wizard** (`apps/web/app/(shell)/compliance/onboard` →
+`components/compliance/OnboardingWizard.tsx`, which already has `OnboardingDraft`
+persistence) — no second wizard. Archetype activation for this category deep-links the
+operator into that wizard with the §9.1 reference entries pre-filtered. Confirmations
+persist to the landed licensing models: jurisdiction/charter posture on
+`OrganizationLicenseProfile`; organization credentials (FDIC certificate / NCUA charter /
+NMLS org ID) as `OrganizationLicenseRecord` rows; individual MLO NMLS IDs as
+`PersonLicenseRecord` rows; display duties as `LicenseDisplayObligation` rows
+(`displayType`, `displayLocation`, `isSatisfied`). Skipping the step follows D5: checklist
+stays open, posture banner shows, activation proceeds.
+
+### 9.3 Storefront display obligations
+
+Each leaf's `sectionTemplates` includes a **"Disclosures"** section (sortOrder last)
+using a new first-class `disclosures` member on `SectionType`
+(`packages/storefront-templates/src/types.ts`; precedent: the domain-specific
+`animals-available` type). A `custom` section cannot do this job — its content is static
+seeded copy with no data binding. The `disclosures` case in
+`apps/web/components/storefront/SectionRenderer.tsx` reads the org's
+`LicenseDisplayObligation` rows and renders the confirmed set: "Member FDIC" statement,
+NCUA official sign, Equal Housing Lender/Opportunity logo, NMLS ID line, FCA register
+number (GB). With no captured posture it renders a neutral placeholder per D5 — never a
+fabricated claim. Rate-bearing item presentation carries the Reg DD / Reg Z accuracy
+posture in the marketing-skill reframes (§7.5) — APY/APR claims must match current
+published rates; trigger-term awareness in ad copy.
+
+### 9.4 Capability-map tie (BIAN)
+
+Regulatory posture attaches to the BIAN **Compliance** Business Domain capabilities
+(`Regulatory Compliance`, `Guideline Compliance`) in the `bian-banking-v14` perspective —
+the same place the BIAN↔CSDM paper anchors compliance traceability — so the capability
+page shows jurisdiction readiness where a bank examiner-minded operator expects it.
+
+### 9.5 Onboarding business-context profile
+
+`archetype-business-context.ts` gains a `banking-financial-services` profile whose
+`howWeDecide` leads with safety-and-soundness and regulatory obligation ("regulatory
+compliance and member/customer trust outrank growth and speed; we never trade examination
+posture for short-term revenue"), and whose `supplyChain` names the real vendor shape
+(core processor, card network, deposit-insurance regime, credit bureaus).
+
+## 10. Wiring Contract (files to touch)
+
+Following the `hoa-property-management` end-to-end precedent (items 12–14 add the §9
+regulatory wiring):
+
+1. `packages/storefront-templates/src/types.ts` — add `"banking-financial-services"` to `ArchetypeCategory`, `"disclosures"` to `SectionType` (§9.3), and optional `vocabulary?: Partial<ArchetypeVocabulary>` on `ArchetypeDefinition` (§7.4)
+2. `packages/storefront-templates/src/archetypes/banking-financial-services.ts` — three leaf definitions (§7), incl. credit-union `vocabulary` override
 3. `packages/storefront-templates/src/archetypes/index.ts` — register
 4. `packages/storefront-templates/src/archetypes/archetypes.test.ts` — coverage
 5. `packages/finance-templates/src/profiles.ts` — financial profile (interest income / fee income / interest expense categories; account-based revenue recognition)
 6. `packages/db/src/business-capability-perspectives.ts` (+ test) — `bian-banking-v14` perspective (§8)
-7. `packages/db/src/seed-storefront-archetypes.ts` — marketing-skill rules (§7.5)
+7. `packages/db/src/seed-storefront-archetypes.ts` — marketing-skill rules (§7.5) + write leaf `vocabulary` into `StorefrontArchetype.customVocabulary` on upsert (§7.4)
 8. `apps/web/lib/storefront/industries.ts` (+ test) — "Banking & Financial Services" option
 9. `apps/web/lib/storefront/archetype-vocabulary.ts` — vocabulary (§7.4)
 10. `apps/web/lib/onboarding/archetype-business-context.ts` (+ test) — onboarding context
-11. `apps/web/lib/tak/marketing-playbooks.ts` / `apps/web/lib/finance/setup-profile.ts` — category wiring sweep (grep `hoa-property-management` for the full list at build time)
+11. `apps/web/lib/tak/marketing-playbooks.ts` / `apps/web/lib/finance/setup-profile.ts` / `apps/web/lib/public-web-tools.ts` / `apps/web/lib/integrate/contribution-review.ts` — category wiring sweep (grep `hoa-property-management` — list verified 2026-06-09; re-grep at build time)
+12. `packages/db/data/license_requirement_reference.json` + `packages/db/src/seed-license-requirements.ts` test — banking authority entries (§9.1); seed test asserts the banking rows land (guard the silent-seed-skip class)
+13. `apps/web/components/compliance/OnboardingWizard.tsx` (+ archetype-activation deep link) — required jurisdiction/charter capture for this category (§9.2), persisting to `OrganizationLicenseProfile` / `OrganizationLicenseRecord` / `PersonLicenseRecord` / `LicenseDisplayObligation`
+14. `apps/web/components/storefront/SectionRenderer.tsx` — `disclosures` section case rendering captured display obligations, with the D5 placeholder state (§9.3)
 
 Reference data (this PR, already in repo): `docs/Reference/bian/` JSON + README + the
 v7.6 integration PDF (LFS).
 
-## 10. Verification
+## 11. Verification
 
 - Unit: archetype shape tests (every leaf passes the existing `archetypes.test.ts`
   invariants), perspective resolution test (`banking-financial-services` → BIAN + common
@@ -321,11 +487,19 @@ v7.6 integration PDF (LFS).
 - Seed: fresh-install seed run upserts 3 new archetypes; re-seed is idempotent;
   soft-deleted archetypes stay deleted (existing invariant).
 - Functional (per `structural-verification-is-not-functional`): on the canonical install
-  or CI sandbox lease, drive onboarding selecting *Credit Union*, confirm member
-  vocabulary on the items surface, BIAN capability map on the capability page, and an
-  end-to-end storefront inquiry on a share-certificate item.
+  or CI sandbox lease, drive onboarding selecting *Credit Union*, confirm the **required
+  jurisdiction/charter step** captures "federal credit union / US" and derives
+  NCUA + NCUSIF posture, confirm member vocabulary on the items surface, the BIAN
+  capability map on the capability page, the NCUA/Equal-Housing disclosures section on the
+  storefront, and an end-to-end storefront inquiry on a share-certificate item.
+- Seed: license-requirement seed run asserts the §9.1 banking entries upsert (count
+  assertion, not log eyeballing); archetype seed run asserts credit-union
+  `customVocabulary` lands (§7.4).
+- Disclosures honesty (D5): with no captured posture the storefront disclosures section
+  renders the neutral placeholder (assert no "Member FDIC"/NCUA text); after posture
+  capture it renders exactly the confirmed obligation set.
 
-## 11. Future Work (out of scope, enabled by the reference data)
+## 12. Future Work (out of scope, enabled by the reference data)
 
 - BIAN Service Operation → DPF integration-substrate modeling (the paper's Digital
   Interface / Digital Integration layer) for institutions that connect cores/vendors.
@@ -333,3 +507,6 @@ v7.6 integration PDF (LFS).
 - Custom-archetype refinement flow offering the *full* 341-domain landscape as a picker.
 - Hive-mind analytics keyed on canonical BIAN Service Domain names across banking installs.
 - Semantic-API-informed MCP connector scaffolding for banking vendor integrations.
+- Deeper regulatory automation: per-state rule matrices, examination-calendar signals,
+  automated renewal tracking against NMLS/FDIC/NCUA records, regulatory-filing readiness
+  (builds on `EP-LIC-C64FC2`'s coworker investigation flow once that lands).


### PR DESCRIPTION
## Summary

- Restores the **jurisdiction-specific regulatory governance** content that was pushed to the #1680 branch but missed the squash (GitHub merged from a stale PR head): spec §9 (banking authority entries on the EP-LIC-C64FC2 licensing-readiness substrate, **required** jurisdiction/charter onboarding capture with derived regulator + insurance regime, storefront Disclosures display obligations, BIAN Compliance-domain capability tie) and plan Phase 2b + extended verification/risks.
- Includes the maintainer**'**s EA review pass (2026-06-09): substrate claims verified against main @ 240b528f3, first-class `disclosures` SectionType, leaf-level vocabulary override via `StorefrontArchetype.customVocabulary`, verified wiring points (OnboardingWizard, OrganizationLicenseProfile/Record, PersonLicenseRecord, LicenseDisplayObligation, SectionRenderer), and the D5 never-hard-block onboarding decision.
- BI-5D9DCDE6 (EP-ARCH-8D4F2A) body already reflects this scope.

## Test plan

- [x] Docs-only; gitleaks clean; DCO signed
- [x] vitest / typecheck / next build: n/a

**Merge note:** before squashing, confirm the PR shows commit `57b392a4e` — #1680 merged from a stale head and dropped a pushed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)