### PR TITLE
feat(build-studio): durable build execution on Inngest, flag-gated (BI-89030C9B Phase 1)

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -733,6 +733,32 @@ export async function advanceBuildPhase(
  * invokes it for rows it has already confirmed are resumable in-flight builds).
  */
 export async function autoExecuteBuild(buildId: string): Promise<void> {
+  // BI-89030C9B Phase 1 — durable path. When the flag is on, hand the run to
+  // the Inngest function (build/execute.run) instead of executing in-process:
+  // the engine's journal then owns crash recovery, so a portal recycle no
+  // longer strands the build. The send carries a deterministic idempotency id
+  // so the four call sites (and their retries) collapse duplicate dispatches
+  // of the same logical attempt into one durable run.
+  const { isBuildDurableExecutionEnabled, buildExecuteSendId } = await import(
+    "@/lib/integrate/build-execute-helpers"
+  );
+  if (isBuildDurableExecutionEnabled()) {
+    const current = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { buildExecState: true },
+    });
+    const { inngest } = await import("@/lib/queue/inngest-client");
+    await inngest.send({
+      name: "build/execute.run",
+      data: { buildId },
+      id: buildExecuteSendId(
+        buildId,
+        current?.buildExecState as import("@/lib/build-exec-types").BuildExecutionState | null,
+      ),
+    });
+    return;
+  }
+
   const { agentEventBus } = await import("@/lib/agent-event-bus");
   const { runBuildPipeline } = await import("@/lib/build-pipeline");
 

--- a/apps/web/lib/integrate/build-execute-helpers.test.ts
+++ b/apps/web/lib/integrate/build-execute-helpers.test.ts
@@ -1,0 +1,92 @@
+// BI-89030C9B Phase 1 — unit tests for the pure decision logic behind the
+// durable build-execution path. Side-effect helpers (ensureBuildTaskRun,
+// runPipelineStepDurable, finalizeDurableBuild) are exercised by the
+// functional kill-test on the live install (plan Phase-1 verification);
+// these tests pin the pure contracts the Inngest function relies on.
+
+import { describe, expect, it } from "vitest";
+import type { BuildExecutionState } from "@/lib/build-exec-types";
+import {
+  BUILD_DURABLE_EXECUTION_FLAG,
+  buildExecuteSendId,
+  isBuildDurableExecutionEnabled,
+  shouldRunPipelineStep,
+} from "./build-execute-helpers";
+
+function state(partial: Partial<BuildExecutionState>): BuildExecutionState {
+  return {
+    step: "pending",
+    retryCount: 0,
+    startedAt: "2026-06-10T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+describe("isBuildDurableExecutionEnabled", () => {
+  it("is off by default (legacy path untouched without the flag)", () => {
+    expect(isBuildDurableExecutionEnabled({})).toBe(false);
+    expect(isBuildDurableExecutionEnabled({ [BUILD_DURABLE_EXECUTION_FLAG]: "" })).toBe(false);
+    expect(isBuildDurableExecutionEnabled({ [BUILD_DURABLE_EXECUTION_FLAG]: "0" })).toBe(false);
+    expect(isBuildDurableExecutionEnabled({ [BUILD_DURABLE_EXECUTION_FLAG]: "off" })).toBe(false);
+  });
+
+  it("accepts the standard truthy spellings", () => {
+    for (const v of ["1", "true", "yes", "on", " TRUE "]) {
+      expect(isBuildDurableExecutionEnabled({ [BUILD_DURABLE_EXECUTION_FLAG]: v })).toBe(true);
+    }
+  });
+});
+
+describe("buildExecuteSendId", () => {
+  it("is stable for the same logical attempt (dedup across the four call sites)", () => {
+    const s = state({ step: "deps_installed" });
+    expect(buildExecuteSendId("b1", s)).toBe(buildExecuteSendId("b1", s));
+  });
+
+  it("differs across builds, checkpoints, and retry counts (new attempts get new runs)", () => {
+    const atDeps = state({ step: "deps_installed" });
+    expect(buildExecuteSendId("b1", atDeps)).not.toBe(buildExecuteSendId("b2", atDeps));
+    expect(buildExecuteSendId("b1", atDeps)).not.toBe(
+      buildExecuteSendId("b1", state({ step: "code_generated" })),
+    );
+    expect(buildExecuteSendId("b1", atDeps)).not.toBe(
+      buildExecuteSendId("b1", state({ step: "deps_installed", retryCount: 1 })),
+    );
+  });
+
+  it("treats a fresh build (no checkpoint) distinctly", () => {
+    expect(buildExecuteSendId("b1", null)).toBe("build-execute:b1:fresh:r0");
+  });
+});
+
+describe("shouldRunPipelineStep", () => {
+  it("runs every step on a fresh build", () => {
+    expect(shouldRunPipelineStep(null, "pending")).toBe("run");
+    expect(shouldRunPipelineStep(null, "deps_installed")).toBe("run");
+  });
+
+  it("runs the step the checkpoint is at (state.step names the reached milestone)", () => {
+    expect(shouldRunPipelineStep(state({ step: "pending" }), "pending")).toBe("run");
+    expect(shouldRunPipelineStep(state({ step: "deps_installed" }), "deps_installed")).toBe("run");
+  });
+
+  it("skips steps the checkpoint is already past (resume semantics)", () => {
+    const atCodeGen = state({ step: "code_generated" });
+    expect(shouldRunPipelineStep(atCodeGen, "pending")).toBe("skip-completed");
+    expect(shouldRunPipelineStep(atCodeGen, "deps_installed")).toBe("skip-completed");
+    expect(shouldRunPipelineStep(atCodeGen, "code_generated")).toBe("run");
+  });
+
+  it("halts on a failed checkpoint — failure is a journaled outcome, not a re-run", () => {
+    const failed = state({ step: "failed", failedAt: "deps_installed", error: "boom" });
+    expect(shouldRunPipelineStep(failed, "pending")).toBe("halt-failed");
+    expect(shouldRunPipelineStep(failed, "deps_installed")).toBe("halt-failed");
+    expect(shouldRunPipelineStep(failed, "tests_run")).toBe("halt-failed");
+  });
+
+  it("skips everything once complete", () => {
+    const complete = state({ step: "complete", completedAt: "2026-06-10T01:00:00.000Z" });
+    expect(shouldRunPipelineStep(complete, "pending")).toBe("skip-completed");
+    expect(shouldRunPipelineStep(complete, "tests_run")).toBe("skip-completed");
+  });
+});

--- a/apps/web/lib/integrate/build-execute-helpers.ts
+++ b/apps/web/lib/integrate/build-execute-helpers.ts
@@ -89,6 +89,9 @@ export async function ensureBuildTaskRun(buildId: string): Promise<string> {
   if (!build) throw new Error(`ensureBuildTaskRun: unknown build ${JSON.stringify(buildId)}`);
 
   const taskRunId = `build-${buildId}-${Date.now().toString(36)}`;
+  // Created in the schema-default "submitted" state, then transitioned via
+  // the canonical markTaskRunWorking helper so status + lastHeartbeatAt move
+  // atomically (BI-4ab6be39 stall-detection write guard).
   await prisma.taskRun.create({
     data: {
       taskRunId,
@@ -99,10 +102,10 @@ export async function ensureBuildTaskRun(buildId: string): Promise<string> {
       title: `Build: ${build.title}`,
       objective: `Durable build execution for ${buildId} (BI-89030C9B Phase 1)`,
       source: "build",
-      status: "working",
-      lastHeartbeatAt: new Date(),
     },
   });
+  const { markTaskRunWorking } = await import("@/lib/observability/heartbeat");
+  await markTaskRunWorking(taskRunId);
   return taskRunId;
 }
 

--- a/apps/web/lib/integrate/build-execute-helpers.ts
+++ b/apps/web/lib/integrate/build-execute-helpers.ts
@@ -1,0 +1,294 @@
+// BI-89030C9B Phase 1 — helpers for the durable build-execution Inngest function.
+//
+// The durable path (apps/web/lib/queue/functions/build-execute.ts) runs each
+// existing pipeline step as its own journaled `step.run`. These helpers hold
+// everything the function body delegates to, split so the decision logic is
+// pure and unit-testable while the side effects stay in lazily-imported
+// functions (keeping prisma out of the Inngest function's module graph at
+// definition time, matching the established queue-function idiom).
+//
+// Plan: docs/superpowers/plans/2026-06-09-build-studio-durable-execution-migration.md
+// Spec: docs/architecture/2026-06-09-long-running-agentic-process-architecture.md §7.1
+
+import type { BuildExecStep, BuildExecutionState } from "@/lib/build-exec-types";
+import { STEP_ORDER, MAX_RETRIES, RETRY_DELAYS_MS } from "@/lib/build-exec-types";
+import { buildFailedState } from "@/lib/integrate/build-pipeline";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+
+// ─── Pure decision logic (unit-tested) ───────────────────────────────────────
+
+export const BUILD_DURABLE_EXECUTION_FLAG = "DPF_BUILD_DURABLE_EXECUTION_ENABLED";
+
+export function isBuildDurableExecutionEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, BUILD_DURABLE_EXECUTION_FLAG);
+}
+
+/**
+ * Deterministic idempotency id for the `build/execute.run` send.
+ *
+ * autoExecuteBuild has four call sites and is itself retry-prone; without
+ * dedup, two sends would queue two durable runs of the same build. The id is
+ * keyed on the build's current checkpoint so duplicate sends from the same
+ * logical attempt collapse, while a later legitimate re-dispatch (after the
+ * checkpoint moved or was reset) gets a fresh id. The per-build concurrency
+ * key on the function is the belt to this braces.
+ */
+export function buildExecuteSendId(
+  buildId: string,
+  state: BuildExecutionState | null | undefined,
+): string {
+  const checkpoint = state?.step ?? "fresh";
+  const retry = state?.retryCount ?? 0;
+  return `build-execute:${buildId}:${checkpoint}:r${retry}`;
+}
+
+export type PipelineStepDecision = "run" | "skip-completed" | "halt-failed";
+
+/**
+ * Whether the durable loop should execute, skip, or halt at `step` given the
+ * persisted checkpoint. Mirrors getResumeStep()/STEP_ORDER semantics from the
+ * legacy runBuildPipeline: `state.step` names the last reached milestone, and
+ * executeStep(X) runs when the pipeline is AT milestone X.
+ */
+export function shouldRunPipelineStep(
+  state: BuildExecutionState | null | undefined,
+  step: BuildExecStep,
+): PipelineStepDecision {
+  if (!state) return "run"; // fresh run executes sequentially from pending
+  if (state.step === "failed") return "halt-failed";
+  const stateIdx = STEP_ORDER.indexOf(state.step);
+  const stepIdx = STEP_ORDER.indexOf(step);
+  if (stateIdx === -1 || stepIdx === -1) return "run";
+  return stateIdx > stepIdx ? "skip-completed" : "run";
+}
+
+// ─── Side-effect helpers (called inside step.run bodies) ─────────────────────
+
+/**
+ * Stand up (or find) the per-build TaskRun — the durable identity the spec
+ * §7.4 caveat says builds lack today. Idempotent: a re-invoked step returns
+ * the existing row. Heartbeats flow via withHeartbeatTicker during steps so
+ * the taskrun-watchdog covers durable builds.
+ */
+export async function ensureBuildTaskRun(buildId: string): Promise<string> {
+  const { prisma } = await import("@dpf/db");
+
+  const existing = await prisma.taskRun.findFirst({
+    where: { buildId, source: "build", status: { notIn: ["archived", "canceled"] } },
+    select: { taskRunId: true },
+    orderBy: { createdAt: "desc" },
+  });
+  if (existing) return existing.taskRunId;
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { title: true, createdById: true, threadId: true },
+  });
+  if (!build) throw new Error(`ensureBuildTaskRun: unknown build ${JSON.stringify(buildId)}`);
+
+  const taskRunId = `build-${buildId}-${Date.now().toString(36)}`;
+  await prisma.taskRun.create({
+    data: {
+      taskRunId,
+      userId: build.createdById,
+      threadId: build.threadId ?? null,
+      buildId,
+      routeContext: "build-pipeline",
+      title: `Build: ${build.title}`,
+      objective: `Durable build execution for ${buildId} (BI-89030C9B Phase 1)`,
+      source: "build",
+      status: "working",
+      lastHeartbeatAt: new Date(),
+    },
+  });
+  return taskRunId;
+}
+
+export async function loadBuildExecState(
+  buildId: string,
+): Promise<BuildExecutionState | null> {
+  const { prisma } = await import("@dpf/db");
+  const row = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { buildExecState: true },
+  });
+  return (row?.buildExecState as BuildExecutionState | null) ?? null;
+}
+
+/**
+ * Dual-write of buildExecState — a faithful port of autoExecuteBuild's
+ * updateState closure (sourceCurrency preservation + sandbox pointer
+ * mirroring). Duplicated rather than imported from the server-action module;
+ * Phase 3 consolidates when the legacy path is deleted.
+ */
+export async function persistBuildExecState(
+  buildId: string,
+  state: BuildExecutionState,
+): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  const persisted = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { buildExecState: true },
+  });
+  const persistedState = persisted?.buildExecState as
+    | { sourceCurrency?: unknown }
+    | null;
+  const persistedSourceCurrency =
+    persistedState && typeof persistedState === "object" && !Array.isArray(persistedState)
+      ? persistedState.sourceCurrency ?? null
+      : null;
+  const nextState =
+    state.sourceCurrency || !persistedSourceCurrency
+      ? state
+      : { ...state, sourceCurrency: persistedSourceCurrency as BuildExecutionState["sourceCurrency"] };
+
+  await prisma.featureBuild.update({
+    where: { buildId },
+    data: {
+      buildExecState: nextState as unknown as import("@dpf/db").Prisma.InputJsonValue,
+      ...(nextState.containerId ? { sandboxId: nextState.containerId } : {}),
+      ...(nextState.hostPort ? { sandboxPort: nextState.hostPort } : {}),
+    },
+  });
+}
+
+async function emitForBuild(
+  buildId: string,
+  event: import("@/lib/agent-event-bus").AgentEvent,
+): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  const { agentEventBus } = await import("@/lib/agent-event-bus");
+  const row = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { threadId: true },
+  });
+  if (row?.threadId) agentEventBus.emit(row.threadId, event);
+}
+
+/**
+ * Execute one pipeline step with the legacy in-step retry budget.
+ *
+ * Layering (deliberate — see plan Phase 1): app-level transient retries
+ * (MAX_RETRIES + RETRY_DELAYS_MS backoff) stay INSIDE the step body so they
+ * are fast and don't burn engine retries; the engine's function-level retries
+ * are reserved for process death (the F2 recovery path). A step that
+ * exhausts its app-level budget returns a `failed` state rather than
+ * throwing, so a genuine build failure is a journaled outcome, not an engine
+ * retry storm.
+ *
+ * Returns small checkpoint state only (artifacts stay in their existing DB
+ * homes — the by-reference rule that keeps run-state under the 32MB cap).
+ */
+export async function runPipelineStepDurable(params: {
+  buildId: string;
+  taskRunId: string;
+  step: BuildExecStep;
+  state: BuildExecutionState | null;
+}): Promise<BuildExecutionState> {
+  const { buildId, taskRunId, step } = params;
+  let state: BuildExecutionState =
+    params.state ?? { step: "pending", retryCount: 0, startedAt: new Date().toISOString() };
+
+  const decision = shouldRunPipelineStep(state, step);
+  if (decision !== "run") return state;
+
+  const { executeStep, nextStep } = await import("@/lib/integrate/build-pipeline");
+  const { withHeartbeatTicker, heartbeat } = await import("@/lib/observability/heartbeat");
+
+  await emitForBuild(buildId, { type: "phase:change", buildId, phase: step });
+
+  let attempt = 0;
+  const maxAttempts = (MAX_RETRIES[step] ?? 0) + 1;
+  const emit = (event: import("@/lib/agent-event-bus").AgentEvent) => {
+    void emitForBuild(buildId, event);
+  };
+
+  while (attempt < maxAttempts) {
+    try {
+      state = await withHeartbeatTicker(taskRunId, () =>
+        executeStep(step, buildId, state, emit),
+      );
+      const advanced = nextStep(step);
+      state = { ...state, step: advanced ?? step, retryCount: 0 };
+      await persistBuildExecState(buildId, state);
+      await heartbeat(taskRunId);
+      return state;
+    } catch (err) {
+      attempt++;
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      if (attempt < maxAttempts) {
+        const delay =
+          RETRY_DELAYS_MS[attempt - 1] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!;
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      } else {
+        const failed = buildFailedState(state, step, errorMsg);
+        await persistBuildExecState(buildId, failed);
+        return failed;
+      }
+    }
+  }
+  return state;
+}
+
+/**
+ * Terminal bookkeeping: completion checkpoint (stripping stale failure
+ * breadcrumbs, mirroring the legacy pipeline), sandbox slot release (the
+ * legacy `finally`), TaskRun terminal status, and the buildActivity audit
+ * line. Also emits the A4 guardrail audit signal so an engine-resumed build
+ * is automatic but never silent.
+ */
+export async function finalizeDurableBuild(params: {
+  buildId: string;
+  taskRunId: string;
+  state: BuildExecutionState | null;
+}): Promise<{ terminal: BuildExecStep }> {
+  const { buildId, taskRunId } = params;
+  const { prisma } = await import("@dpf/db");
+  let state = params.state;
+
+  if (state && state.step !== "failed") {
+    const { error: _e, failedAt: _f, ...rest } = state;
+    void _e;
+    void _f;
+    state = {
+      ...rest,
+      step: "complete",
+      completedAt: state.completedAt ?? new Date().toISOString(),
+    };
+    await persistBuildExecState(buildId, state);
+    await emitForBuild(buildId, { type: "phase:change", buildId, phase: "complete" });
+  }
+
+  const { releaseSandbox } = await import("@/lib/integrate/sandbox/sandbox-pool");
+  await releaseSandbox(buildId).catch((err) =>
+    console.error("[build-execute] failed to release sandbox slot:", { buildId }, err),
+  );
+
+  const terminal: BuildExecStep = state?.step === "failed" ? "failed" : "complete";
+  await prisma.taskRun
+    .update({
+      where: { taskRunId },
+      data: {
+        status: terminal === "complete" ? "completed" : "failed",
+        completedAt: new Date(),
+      },
+    })
+    .catch(() => {});
+
+  await prisma.buildActivity
+    .create({
+      data: {
+        buildId,
+        tool: "build/execute (durable)",
+        summary:
+          terminal === "complete"
+            ? "Durable build pipeline completed successfully"
+            : `Durable build pipeline failed at step: ${state?.failedAt ?? state?.step ?? "unknown"}`,
+      },
+    })
+    .catch(() => {});
+
+  return { terminal };
+}

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -226,8 +226,12 @@ export async function runBuildPipeline(params: {
  *
  * workspace_initialized comes BEFORE db_ready because prisma migrate deploy
  * needs the prisma/ directory to exist inside the container.
+ *
+ * Exported for the durable execution path (BI-89030C9B Phase 1) — the
+ * Inngest function runs each step as its own journaled step.run via
+ * build-execute-helpers.runPipelineStepDurable.
  */
-async function executeStep(
+export async function executeStep(
   step: BuildExecStep,
   buildId: string,
   state: BuildExecutionState,

--- a/apps/web/lib/integrate/claude-dispatch.ts
+++ b/apps/web/lib/integrate/claude-dispatch.ts
@@ -28,6 +28,13 @@ export type ClaudeResult = {
   executedTools: Array<{ name: string; args: unknown; result: { success: boolean } }>;
   durationMs: number;
   sessionId?: string;    // Claude Code session ID (for session continuity across tasks)
+  // BI-89030C9B Phase 1 ($/build): the --output-format json envelope already
+  // carries cost + token usage; capture instead of discarding. Especially
+  // material since headless Claude Code bills per-token against a metered
+  // credit pool (spec §9.3) — a build is real spend now.
+  costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
 };
 
 /**
@@ -312,18 +319,30 @@ export async function dispatchClaudeTask(params: {
       });
     });
 
-    // Parse JSON output — Claude Code --output-format json returns { result, session_id, ... }
+    // Parse JSON output — Claude Code --output-format json returns
+    // { result, session_id, total_cost_usd, usage, ... }
     let content: string;
     let returnedSessionId: string | undefined;
+    let costUsd: number | undefined;
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
     try {
       const parsed = JSON.parse(stdout.trim());
       content = typeof parsed.result === "string" ? parsed.result : JSON.stringify(parsed.result);
       returnedSessionId = parsed.session_id ?? undefined;
+      // BI-89030C9B Phase 1 ($/build): keep the cost/usage fields the envelope
+      // already returns instead of discarding them.
+      costUsd = typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : undefined;
+      const usage = parsed.usage as
+        | { input_tokens?: number; output_tokens?: number }
+        | undefined;
+      inputTokens = typeof usage?.input_tokens === "number" ? usage.input_tokens : undefined;
+      outputTokens = typeof usage?.output_tokens === "number" ? usage.output_tokens : undefined;
     } catch {
       content = stdout.trim();
     }
 
-    console.log(`[claude-dispatch] Task "${task.title}" completed in ${(elapsed / 1000).toFixed(1)}s (${content.length} chars)${returnedSessionId ? ` [session: ${returnedSessionId}]` : ""}`);
+    console.log(`[claude-dispatch] Task "${task.title}" completed in ${(elapsed / 1000).toFixed(1)}s (${content.length} chars)${returnedSessionId ? ` [session: ${returnedSessionId}]` : ""}${costUsd != null ? ` [cost: $${costUsd.toFixed(4)}, tokens ${inputTokens ?? "?"}in/${outputTokens ?? "?"}out]` : ""}`);
 
     return {
       content: content || "Task completed with no output.",
@@ -331,6 +350,9 @@ export async function dispatchClaudeTask(params: {
       executedTools: [],
       durationMs: elapsed,
       sessionId: returnedSessionId,
+      costUsd,
+      inputTokens,
+      outputTokens,
     };
   } catch (err) {
     const durationMs = Date.now() - startMs;

--- a/apps/web/lib/queue/functions/build-execute.ts
+++ b/apps/web/lib/queue/functions/build-execute.ts
@@ -57,7 +57,13 @@ export const buildExecute = inngest.createFunction(
       const { prisma } = await import("@dpf/db");
       await prisma.taskRun
         .updateMany({
-          where: { buildId, source: "build", status: "working" },
+          // Any non-terminal run for this build fails — covers both the
+          // working state and a run that died before its first transition.
+          where: {
+            buildId,
+            source: "build",
+            status: { notIn: ["completed", "failed", "canceled", "rejected", "archived"] },
+          },
           data: { status: "failed", completedAt: new Date() },
         })
         .catch(() => {});

--- a/apps/web/lib/queue/functions/build-execute.ts
+++ b/apps/web/lib/queue/functions/build-execute.ts
@@ -1,0 +1,99 @@
+/**
+ * BI-89030C9B Phase 1 — durable build execution.
+ *
+ * Runs the existing checkpoint pipeline (lib/integrate/build-pipeline.ts) as
+ * an Inngest function with one journaled `step.run` per STEP_ORDER entry, so
+ * a portal recycle mid-build resumes from the engine's journal instead of
+ * relying on boot-time reconciliation hooks. Flag-gated by
+ * DPF_BUILD_DURABLE_EXECUTION_ENABLED — when off, autoExecuteBuild runs the
+ * legacy in-process path byte-for-byte unchanged.
+ *
+ * Design notes (deviations from the plan doc, deliberate):
+ *  - Function-level `retries: 3`, not 0: engine retries ARE the
+ *    crash-recovery mechanism (Phase-0 finding F2 — ~37s kill→re-invocation).
+ *    App-level transient retries (MAX_RETRIES per step) run inside each step
+ *    body; a step that exhausts them returns a journaled `failed` state
+ *    rather than throwing, so build failures never burn engine retries.
+ *  - Quiescence uses gateBetweenSteps (defer-not-skip): a build paused by an
+ *    upgrade drain suspends on platform.quiescence-cleared rather than being
+ *    silently dropped (plan Phase-1; guardrail A3).
+ *  - Concurrency: one run per build via the event-keyed concurrency below.
+ *    The global admission cap stays with assertWipCapacity() at the
+ *    promote/advance call sites — one source of truth, per the plan's
+ *    correction (a flat limit here would have serialized builds).
+ *
+ * Step outputs are small checkpoint states only; artifacts live in their
+ * existing DB homes (by-reference rule, 32MB run-state cap).
+ *
+ * Plan: docs/superpowers/plans/2026-06-09-build-studio-durable-execution-migration.md
+ */
+
+import { inngest } from "../inngest-client";
+import { gateBetweenSteps, type GateBetweenStepsRunner } from "../quiescence-gates";
+import { STEP_ORDER } from "@/lib/build-exec-types";
+import type { BuildExecutionState } from "@/lib/build-exec-types";
+
+export const buildExecute = inngest.createFunction(
+  {
+    id: "build/execute",
+    retries: 3,
+    concurrency: [{ key: "event.data.buildId", limit: 1 }],
+    triggers: [{ event: "build/execute.run" }],
+    // Terminal engine failure (all retries exhausted — e.g. the portal stayed
+    // down past the retry window): release the sandbox slot and fail the
+    // TaskRun so nothing leaks and the watchdog/UI see a terminal state, not
+    // a silent hang. The happy and build-failed paths release via the
+    // finalize step instead (releaseSandbox is idempotent/no-op when the
+    // slot is already released).
+    onFailure: async ({ event, error }) => {
+      const original = (event.data as { event?: { data?: { buildId?: string } } }).event;
+      const buildId = original?.data?.buildId;
+      if (!buildId) return;
+      console.error(
+        `[build-execute] terminal engine failure for build ${JSON.stringify(buildId)}: ${error instanceof Error ? JSON.stringify(error.message) : "unknown"}`,
+      );
+      const { releaseSandbox } = await import("@/lib/integrate/sandbox/sandbox-pool");
+      await releaseSandbox(buildId).catch(() => {});
+      const { prisma } = await import("@dpf/db");
+      await prisma.taskRun
+        .updateMany({
+          where: { buildId, source: "build", status: "working" },
+          data: { status: "failed", completedAt: new Date() },
+        })
+        .catch(() => {});
+    },
+  },
+  async ({ event, step }) => {
+    const buildId = event.data.buildId as string;
+
+    // Defer-not-skip: if an upgrade drain is in progress, suspend until
+    // platform.quiescence-cleared instead of dropping the build.
+    await gateBetweenSteps(step as unknown as GateBetweenStepsRunner, "build-execute-entry");
+
+    const taskRunId = (await step.run("ensure-task-run", async () => {
+      const { ensureBuildTaskRun } = await import("@/lib/integrate/build-execute-helpers");
+      return ensureBuildTaskRun(buildId);
+    })) as string;
+
+    let state = (await step.run("load-exec-state", async () => {
+      const { loadBuildExecState } = await import("@/lib/integrate/build-execute-helpers");
+      return loadBuildExecState(buildId);
+    })) as BuildExecutionState | null;
+
+    for (const pipelineStep of STEP_ORDER) {
+      if (pipelineStep === "complete" || pipelineStep === "failed") break;
+      state = (await step.run(`pipeline:${pipelineStep}`, async () => {
+        const { runPipelineStepDurable } = await import("@/lib/integrate/build-execute-helpers");
+        return runPipelineStepDurable({ buildId, taskRunId, step: pipelineStep, state });
+      })) as BuildExecutionState;
+      if (state.step === "failed") break;
+    }
+
+    const summary = (await step.run("finalize", async () => {
+      const { finalizeDurableBuild } = await import("@/lib/integrate/build-execute-helpers");
+      return finalizeDurableBuild({ buildId, taskRunId, state });
+    })) as { terminal: string };
+
+    return { buildId, taskRunId, terminal: summary.terminal };
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -17,6 +17,7 @@ import { materialFreshnessDecay } from "./material-freshness-decay";
 import { researchExecute } from "./research-execute";
 import { researchScheduleScan } from "./research-schedule";
 import { buildReviewVerification } from "./build-review-verification";
+import { buildExecute } from "./build-execute";
 import { assuranceBomGenerate } from "./assurance-bom";
 import { assuranceScanRun } from "./assurance-scan";
 import { deliberationRun } from "./deliberation-run";
@@ -85,6 +86,7 @@ export const eventFunctions = [
   brandExtract,
   researchExecute,
   buildReviewVerification,
+  buildExecute,
   assuranceBomGenerate,
   assuranceScanRun,
   deliberationRun,

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -125,6 +125,18 @@ export interface BuildGitUpdateReceivedEvent {
   };
 }
 
+/** BI-89030C9B Phase 1 — durable build execution. Sent by autoExecuteBuild
+ *  when DPF_BUILD_DURABLE_EXECUTION_ENABLED is on; handled by
+ *  queue/functions/build-execute.ts. Sends carry a deterministic idempotency
+ *  id (buildExecuteSendId) so duplicate dispatches of the same logical
+ *  attempt collapse to one run. */
+export interface BuildExecuteRunEvent {
+  name: "build/execute.run";
+  data: {
+    buildId: string;
+  };
+}
+
 export interface AssuranceBomGenerateEvent {
   name: "assurance/bom.generate";
   data: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,11 @@ services:
       # for installed runtimes. Without this, first-run installs have no
       # code-graph job row and status surfaces report missing background work.
       DPF_OPTIONAL_STARTUP_TASKS_ENABLED: ${DPF_OPTIONAL_STARTUP_TASKS_ENABLED:-1}
+      # BI-89030C9B Phase 1 — durable build execution. When on, autoExecuteBuild
+      # hands the run to the build/execute Inngest function (journaled per-step,
+      # resumes across portal recycles) instead of the legacy in-process loop.
+      # Default OFF during the burn-in window; flip per-install via host .env.
+      DPF_BUILD_DURABLE_EXECUTION_ENABLED: ${DPF_BUILD_DURABLE_EXECUTION_ENABLED:-0}
       # Tell Inngest's serve() the externally-reachable URL for this app so
       # sync registrations announce the Docker-DNS hostname (not the Host
       # header of the /api/inngest PUT, which would be "localhost:3000"


### PR DESCRIPTION
## Summary

**Phase 1 of the BI-89030C9B durable-execution migration** ([plan](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-06-09-build-studio-durable-execution-migration.md), [spec §7.1](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/2026-06-09-long-running-agentic-process-architecture.md)): the build pipeline runs as an Inngest function with one journaled `step.run` per `STEP_ORDER` entry, so a portal recycle mid-build resumes from the engine journal instead of boot-time reconciliation hooks.

**Flag-gated:** `DPF_BUILD_DURABLE_EXECUTION_ENABLED` (default **OFF**, plumbed through docker-compose). Flag off → legacy in-process path byte-for-byte unchanged. Rollback = flag off.

## What's in

- `build/execute.run` event + `queue/functions/build-execute.ts`: per-build concurrency key (global admission stays with `assertWipCapacity()` at call sites — one source of truth, per the plan's operator correction); `onFailure` releases the sandbox slot + fails the TaskRun so terminal engine failure can't leak or hang silently.
- **Per-build `TaskRun`** (`source: "build"`, 1:1 via existing `TaskRun.buildId`, heartbeats via `withHeartbeatTicker`) — closes the spec §7.4 identity caveat; the taskrun-watchdog now covers durable builds.
- `autoExecuteBuild` branches on the flag and sends with a **deterministic idempotency id** (`buildExecuteSendId`) so duplicate dispatches from the four call sites collapse into one run.
- **Artifacts by reference**: steps return small checkpoint states; outputs stay in their existing DB homes (32MB run-state cap respected).
- **$/build capture at the source**: `claude-dispatch` stops discarding `total_cost_usd` + `usage` from the CLI JSON envelope (returned + logged; persistence rollup lands Phase 3 per plan).

## Deliberate deviations from the plan doc (documented in the function header)

1. **Fn-level `retries: 3`, not 0** — engine retries ARE the crash-recovery mechanism (Phase-0 finding F2: ~37s kill→re-invocation). App-level transient retries (`MAX_RETRIES`/`RETRY_DELAYS_MS`) run inside each step body; a step that exhausts them returns a journaled `failed` state rather than throwing, so build failures never burn engine retries.
2. **Quiescence defer-not-skip uses the existing `gateBetweenSteps`** (BI-QUIESCE-004b suspend-on-`platform.quiescence-cleared`) rather than a hand-rolled sleep loop — the substrate already had the right primitive.

## Verification

- Typecheck clean; **full apps/web vitest suite green (1213 files / 10,307 tests)**; 10 new unit tests pin the pure contracts (flag parsing, send-id dedup semantics, step run/skip/halt decisions).
- **Functional kill-test (the Phase-1 acceptance gate) is NOT claimed here** — it runs on the live install post-deploy with the flag on: contained build, `docker restart` portal mid-step, observe resume from the journal with the boot hooks as no-ops, plus step memoization in the run trace (Phase-0 F3). Evidence will be recorded in the plan as a dated addendum before Phase 2 starts.

Backlog: `BI-89030C9B` (EP-BUILD-STUDIO). Known Phase-1 limitation per plan: the monolithic `code_generated` step is subject to the 2h/step ceiling until Phase 2 splits per task — flag stays gated to contained builds during burn-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)