### PR TITLE
feat(admission): build-pipeline concurrency lane → self-upgrade priority lane (BI-602BC14C)

### DIFF
--- a/apps/web/lib/queue/admission.test.ts
+++ b/apps/web/lib/queue/admission.test.ts
@@ -1,0 +1,41 @@
+// apps/web/lib/queue/admission.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  parseBuildPipelineLimit,
+  buildPipelineLane,
+  BUILD_PIPELINE_LANE_KEY,
+} from "./admission";
+
+describe("parseBuildPipelineLimit", () => {
+  it("returns null when unset/empty (lane disabled by default)", () => {
+    expect(parseBuildPipelineLimit(undefined)).toBeNull();
+    expect(parseBuildPipelineLimit(null)).toBeNull();
+    expect(parseBuildPipelineLimit("")).toBeNull();
+  });
+
+  it("returns null for non-positive or non-integer values", () => {
+    expect(parseBuildPipelineLimit("0")).toBeNull();
+    expect(parseBuildPipelineLimit("-2")).toBeNull();
+    expect(parseBuildPipelineLimit("3.5")).toBeNull();
+    expect(parseBuildPipelineLimit("abc")).toBeNull();
+  });
+
+  it("parses a positive integer cap", () => {
+    expect(parseBuildPipelineLimit("4")).toBe(4);
+  });
+});
+
+describe("buildPipelineLane", () => {
+  it("is empty when the lane is disabled — zero behavior change", () => {
+    expect(buildPipelineLane(null)).toEqual([]);
+  });
+
+  it("emits one shared account-scoped constraint with the constant key when set", () => {
+    const lane = buildPipelineLane(4);
+    expect(lane).toHaveLength(1);
+    expect(lane[0].scope).toBe("account");
+    expect(lane[0].limit).toBe(4);
+    // Constant CEL string literal so all enrolled functions share one queue.
+    expect(lane[0].key).toBe(`'${BUILD_PIPELINE_LANE_KEY}'`);
+  });
+});

--- a/apps/web/lib/queue/admission.test.ts
+++ b/apps/web/lib/queue/admission.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseBuildPipelineLimit,
-  buildPipelineLane,
+  buildPipelineConcurrency,
   BUILD_PIPELINE_LANE_KEY,
 } from "./admission";
 
@@ -25,17 +25,20 @@ describe("parseBuildPipelineLimit", () => {
   });
 });
 
-describe("buildPipelineLane", () => {
-  it("is empty when the lane is disabled — zero behavior change", () => {
-    expect(buildPipelineLane(null)).toEqual([]);
+describe("buildPipelineConcurrency", () => {
+  const base = { limit: 2 } as const;
+
+  it("returns just the base when the lane is disabled — zero behavior change", () => {
+    expect(buildPipelineConcurrency(base, null)).toEqual([base]);
   });
 
-  it("emits one shared account-scoped constraint with the constant key when set", () => {
-    const lane = buildPipelineLane(4);
-    expect(lane).toHaveLength(1);
-    expect(lane[0].scope).toBe("account");
-    expect(lane[0].limit).toBe(4);
+  it("appends one shared account-scoped constraint with the constant key when set", () => {
+    const conc = buildPipelineConcurrency(base, 4);
+    expect(conc).toHaveLength(2);
+    expect(conc[0]).toEqual(base);
+    expect(conc[1]?.scope).toBe("account");
+    expect(conc[1]?.limit).toBe(4);
     // Constant CEL string literal so all enrolled functions share one queue.
-    expect(lane[0].key).toBe(`'${BUILD_PIPELINE_LANE_KEY}'`);
+    expect(conc[1]?.key).toBe(`'${BUILD_PIPELINE_LANE_KEY}'`);
   });
 });

--- a/apps/web/lib/queue/admission.ts
+++ b/apps/web/lib/queue/admission.ts
@@ -12,8 +12,8 @@
 // always use. A queued "Upgrade now" then never sits behind the build flood.
 //
 // Config-gated and OFF by default: with DPF_BUILD_PIPELINE_CONCURRENCY unset,
-// buildPipelineLane() returns [] and every enrolled function keeps EXACTLY its
-// current concurrency — zero behavior change. An operator sizes the cap to
+// buildPipelineConcurrency(base) returns just [base] and every enrolled function
+// keeps EXACTLY its current concurrency — zero behavior change. An operator sizes the cap to
 // their instance (below the account limit, reserving headroom) and load-tests
 // it deliberately under real concurrent load (spec §6), never blind-shipped.
 

--- a/apps/web/lib/queue/admission.ts
+++ b/apps/web/lib/queue/admission.ts
@@ -1,0 +1,66 @@
+// apps/web/lib/queue/admission.ts
+//
+// Instance admission control — shared concurrency lane for the build pipeline
+// (instance admission-control spec §4.1–4.3, building on the merged dead-phase
+// reaper §4.4).
+//
+// Inngest has no "reserve capacity for function X" primitive. So the self-
+// upgrade PRIORITY LANE is implemented the only way the substrate allows: CAP
+// the build/agent flood in a shared account-scoped lane, leaving headroom below
+// the Inngest account concurrency ceiling that the self-upgrade + sandbox-
+// recovery functions — which are deliberately NOT enrolled in this lane — can
+// always use. A queued "Upgrade now" then never sits behind the build flood.
+//
+// Config-gated and OFF by default: with DPF_BUILD_PIPELINE_CONCURRENCY unset,
+// buildPipelineLane() returns [] and every enrolled function keeps EXACTLY its
+// current concurrency — zero behavior change. An operator sizes the cap to
+// their instance (below the account limit, reserving headroom) and load-tests
+// it deliberately under real concurrent load (spec §6), never blind-shipped.
+
+/**
+ * Shared account-scoped concurrency key. Every build-pipeline function enrolled
+ * in this lane shares ONE aggregate limit (a single Inngest virtual queue);
+ * self-upgrade / recovery functions are excluded so they run in the reserved
+ * headroom.
+ */
+export const BUILD_PIPELINE_LANE_KEY = "dpf-build-pipeline";
+
+export const BUILD_PIPELINE_LIMIT_ENV = "DPF_BUILD_PIPELINE_CONCURRENCY";
+
+/** Minimal structural shape of an Inngest concurrency constraint. */
+export type ConcurrencyConstraint = {
+  scope?: "fn" | "account" | "env";
+  key?: string;
+  limit: number;
+};
+
+/**
+ * Parse the configured aggregate cap. Returns a positive integer, or null when
+ * unset/invalid (→ lane disabled). Pure.
+ */
+export function parseBuildPipelineLimit(raw: string | undefined | null): number | null {
+  if (raw == null || raw === "") return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export function readBuildPipelineLimit(): number | null {
+  return parseBuildPipelineLimit(process.env[BUILD_PIPELINE_LIMIT_ENV]);
+}
+
+/**
+ * The shared-lane constraint to spread into an enrolled function's
+ * `concurrency` array, e.g. `concurrency: [{ limit: 2 }, ...buildPipelineLane()]`.
+ *
+ * Returns [] when the lane is unset (the function then keeps exactly its prior
+ * concurrency — zero behavior change). When set, every enrolled function shares
+ * one aggregate `limit` across the account via the constant CEL key.
+ */
+export function buildPipelineLane(
+  limit: number | null = readBuildPipelineLimit(),
+): ConcurrencyConstraint[] {
+  if (limit == null) return [];
+  // Constant CEL string literal → all enrolled functions map to one virtual
+  // queue, so `limit` bounds their AGGREGATE in-flight count, not per-function.
+  return [{ scope: "account", key: `'${BUILD_PIPELINE_LANE_KEY}'`, limit }];
+}

--- a/apps/web/lib/queue/admission.ts
+++ b/apps/web/lib/queue/admission.ts
@@ -49,18 +49,23 @@ export function readBuildPipelineLimit(): number | null {
 }
 
 /**
- * The shared-lane constraint to spread into an enrolled function's
- * `concurrency` array, e.g. `concurrency: [{ limit: 2 }, ...buildPipelineLane()]`.
+ * Build the full `concurrency` value for an enrolled function:
+ *   - lane unset → `[base]` (the function keeps exactly its prior concurrency —
+ *     zero behavior change), or
+ *   - lane set   → `[base, sharedLane]` so every enrolled function shares one
+ *     aggregate `limit` across the account via the constant CEL key.
  *
- * Returns [] when the lane is unset (the function then keeps exactly its prior
- * concurrency — zero behavior change). When set, every enrolled function shares
- * one aggregate `limit` across the account via the constant CEL key.
+ * Returns a FIXED-length tuple (not an open array) so it matches Inngest's
+ * `concurrency` type: `[ConcurrencyOption] | [ConcurrencyOption, ConcurrencyOption]`.
+ *
+ * Usage: `concurrency: buildPipelineConcurrency({ limit: 2 })`.
  */
-export function buildPipelineLane(
+export function buildPipelineConcurrency(
+  base: ConcurrencyConstraint,
   limit: number | null = readBuildPipelineLimit(),
-): ConcurrencyConstraint[] {
-  if (limit == null) return [];
+): [ConcurrencyConstraint] | [ConcurrencyConstraint, ConcurrencyConstraint] {
+  if (limit == null) return [base];
   // Constant CEL string literal → all enrolled functions map to one virtual
   // queue, so `limit` bounds their AGGREGATE in-flight count, not per-function.
-  return [{ scope: "account", key: `'${BUILD_PIPELINE_LANE_KEY}'`, limit }];
+  return [base, { scope: "account", key: `'${BUILD_PIPELINE_LANE_KEY}'`, limit }];
 }

--- a/apps/web/lib/queue/functions/agent-task-dispatch.ts
+++ b/apps/web/lib/queue/functions/agent-task-dispatch.ts
@@ -1,6 +1,7 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
+import { buildPipelineLane } from "../admission";
 
 /**
  * Polls ScheduledAgentTask every 5 minutes and dispatches due tasks.
@@ -10,7 +11,7 @@ export const agentTaskDispatch = inngest.createFunction(
   {
     id: "agent/task-dispatch",
     retries: 1,
-    concurrency: { limit: 1, scope: "fn" },
+    concurrency: [{ limit: 1, scope: "fn" }, ...buildPipelineLane()],
     triggers: [cron("*/5 * * * *")],
   },
   async ({ step }) => {

--- a/apps/web/lib/queue/functions/agent-task-dispatch.ts
+++ b/apps/web/lib/queue/functions/agent-task-dispatch.ts
@@ -1,7 +1,7 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
-import { buildPipelineLane } from "../admission";
+import { buildPipelineConcurrency } from "../admission";
 
 /**
  * Polls ScheduledAgentTask every 5 minutes and dispatches due tasks.
@@ -11,7 +11,7 @@ export const agentTaskDispatch = inngest.createFunction(
   {
     id: "agent/task-dispatch",
     retries: 1,
-    concurrency: [{ limit: 1, scope: "fn" }, ...buildPipelineLane()],
+    concurrency: buildPipelineConcurrency({ limit: 1, scope: "fn" }),
     triggers: [cron("*/5 * * * *")],
   },
   async ({ step }) => {

--- a/apps/web/lib/queue/functions/assurance-bom.ts
+++ b/apps/web/lib/queue/functions/assurance-bom.ts
@@ -1,11 +1,11 @@
 import { inngest } from "../inngest-client";
-import { buildPipelineLane } from "../admission";
+import { buildPipelineConcurrency } from "../admission";
 
 export const assuranceBomGenerate = inngest.createFunction(
   {
     id: "assurance/bom-generate",
     retries: 1,
-    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
+    concurrency: buildPipelineConcurrency({ limit: 2 }),
     triggers: [{ event: "assurance/bom.generate" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/assurance-bom.ts
+++ b/apps/web/lib/queue/functions/assurance-bom.ts
@@ -1,10 +1,11 @@
 import { inngest } from "../inngest-client";
+import { buildPipelineLane } from "../admission";
 
 export const assuranceBomGenerate = inngest.createFunction(
   {
     id: "assurance/bom-generate",
     retries: 1,
-    concurrency: [{ limit: 2 }],
+    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
     triggers: [{ event: "assurance/bom.generate" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/assurance-scan.ts
+++ b/apps/web/lib/queue/functions/assurance-scan.ts
@@ -1,10 +1,11 @@
 import { inngest } from "../inngest-client";
+import { buildPipelineLane } from "../admission";
 
 export const assuranceScanRun = inngest.createFunction(
   {
     id: "assurance/scan-run",
     retries: 1,
-    concurrency: [{ limit: 2 }],
+    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
     triggers: [{ event: "assurance/scan.run" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/assurance-scan.ts
+++ b/apps/web/lib/queue/functions/assurance-scan.ts
@@ -1,11 +1,11 @@
 import { inngest } from "../inngest-client";
-import { buildPipelineLane } from "../admission";
+import { buildPipelineConcurrency } from "../admission";
 
 export const assuranceScanRun = inngest.createFunction(
   {
     id: "assurance/scan-run",
     retries: 1,
-    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
+    concurrency: buildPipelineConcurrency({ limit: 2 }),
     triggers: [{ event: "assurance/scan.run" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -20,12 +20,13 @@
  */
 
 import { inngest } from "../inngest-client";
+import { buildPipelineLane } from "../admission";
 
 export const buildReviewVerification = inngest.createFunction(
   {
     id: "build/review-verification",
     retries: 1,
-    concurrency: [{ limit: 2 }],
+    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
     triggers: [{ event: "build/review.verify" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -20,13 +20,13 @@
  */
 
 import { inngest } from "../inngest-client";
-import { buildPipelineLane } from "../admission";
+import { buildPipelineConcurrency } from "../admission";
 
 export const buildReviewVerification = inngest.createFunction(
   {
     id: "build/review-verification",
     retries: 1,
-    concurrency: [{ limit: 2 }, ...buildPipelineLane()],
+    concurrency: buildPipelineConcurrency({ limit: 2 }),
     triggers: [{ event: "build/review.verify" }],
   },
   async ({ event, step }) => {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -493,6 +493,10 @@ export async function runSelfUpgrade(
   };
 }
 
+// Self-upgrade is the PRIORITY LANE (admission-control spec §4.3): deliberately
+// NOT enrolled in the dpf-build-pipeline lane (apps/web/lib/queue/admission.ts),
+// so when an operator caps that lane it always has account-concurrency headroom
+// below the build/agent flood — a queued "Upgrade now" never sits behind builds.
 export const selfUpgradeScheduled = inngest.createFunction(
   {
     id: SELF_UPGRADE_FUNCTION_ID_SCHEDULED,


### PR DESCRIPTION
## What
Implements **§4.1–4.3** of the instance admission-control spec (building on the merged dead-phase reaper, §4.4). Closes **BI-602BC14C**.

**Root cause (confirmed in code):** every heavy Inngest function has only a *per-fn* concurrency limit and competes in the shared **account pool** — there is **no account-level lane**. So N concurrent builds + their reviewers/assurance/agent-task fan-out saturate the account ceiling, and a queued self-upgrade sits behind the flood; the deploy that would relieve load is itself starved (BI-70D19D15).

Inngest has no "reserve capacity for function X" primitive, so the self-upgrade **priority lane** is implemented the only way the substrate allows: **cap the build/agent flood in a shared account-scoped lane**, leaving headroom the self-upgrade + recovery functions (not enrolled) can always use.

- **`admission.ts`**: `buildPipelineLane()` → a shared account-scoped constraint (constant CEL key `'dpf-build-pipeline'`) so every enrolled function shares **one aggregate limit**. Config-gated via `DPF_BUILD_PIPELINE_CONCURRENCY`; pure helpers **unit-tested**.
- Enrolled the heavy functions: `agent/task-dispatch`, `build/review-verification`, `assurance/bom-generate`, `assurance/scan-run`.
- `self-upgrade.ts`: documented the two self-upgrade functions as the deliberately-excluded **reserved lane**.

## OFF by default
With `DPF_BUILD_PIPELINE_CONCURRENCY` unset, `buildPipelineLane()` returns `[]` and every enrolled function keeps **exactly** its current concurrency — **zero behavior change**. An operator sizes the cap below the account limit and **load-tests it deliberately** (spec §6), never blind-shipped.

## Notes
Done directly — Build Studio is mid-refactor. CI runs typecheck + tests. **Follow-on:** extend enrollment to the remaining build-orchestration functions once the full Inngest inventory is mapped; observability surface (§4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)