### PR TITLE
fix(build-engines): wire sync-engine-registry into startup so the engine catalog reconciles

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,10 @@ cd /app
 pnpm --filter @dpf/db exec tsx scripts/sync-provider-registry.ts || echo "  ⚠️  PROVIDER SYNC FAILED — provider catalog (new providers, auth methods, cliEngine) was NOT reconciled into the DB on this start. The portal will run, but provider/Build-Studio catalog updates from this release may be missing. See the error above."
 echo "  OK Provider registry synced"
 
+echo "[2b/5] Syncing build-engine registry..."
+pnpm --filter @dpf/db exec tsx scripts/sync-engine-registry.ts || echo "  ⚠️  ENGINE SYNC FAILED — the build-engine catalog (claude/codex/grok) was NOT reconciled into the DB on this start. Build Studio dispatch still works, but engine readiness/provisioning may not reflect this release. See the error above."
+echo "  OK Build-engine registry synced"
+
 echo "[3/5] Seeding reference data..."
 cd /app
 pnpm --filter @dpf/db exec tsx src/seed.ts || echo "  ⚠️  SEED INCOMPLETE — one or more reconcile steps failed (see the 'SEED INCOMPLETE' summary above). The portal will start; catalog/reference updates from this release may be partial."


### PR DESCRIPTION
## Problem
The Build-Engine Provisioning capability ships `sync-engine-registry.ts` — a dedicated, **upsert-based** reconcile of the `BuildEngine` catalog (claude/codex/grok) from `build-engines.json`, mirroring `sync-provider-registry.ts`. But it was **never wired into `docker-entrypoint.sh`**, so it never ran on startup/update. On existing installs the `BuildEngine` catalog stayed **empty**, and `get_build_engine_readiness` returned `engines: []` even though Grok was installed and functionally working.

## Fix
Add the engine sync next to the provider sync (step 2b), with the same loud-on-failure, **non-fatal** pattern.

## Why it's safe (the "without overwriting the DB" guarantee)
`sync-engine-registry.ts` is `buildEngine.upsert` only — merge, never delete/wipe — and it writes **solely to the `BuildEngine` catalog table**. It never reads or writes `CredentialEntry` (OAuth/API keys), `ModelProvider` config, or `PlatformConfig`. So it reconciles new engines on every update without touching operator config or credentials.

## Verification (live)
Running `sync-engine-registry` against the install populated the catalog (`3 created, 0 updated`), after which `get_build_engine_readiness` reports:
```
grok  → present: true, version: 0.2.32
codex → present: true, version: 0.136.0
```

Completes the Grok build-engine path: the platform now self-reports Grok as a ready, readiness-tracked engine, and future updates reconcile the catalog automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)