### PR TITLE
fix(self-upgrade): portal self-migrates on boot — a swap can never drift the DB (BI-5322D025)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,11 @@ COPY --from=init /app/deliberation ./deliberation
 COPY --from=init /app/docs/Reference ./docs/Reference
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+# BI-5322D025: the portal self-migrates on boot (see script header). Absolute
+# path so it is invoked directly, not shadowed by the Node base image's
+# /usr/local/bin/docker-entrypoint.sh passthrough.
+COPY scripts/portal-migrate-boot.sh /usr/local/bin/portal-migrate-boot.sh
+RUN chmod +x /usr/local/bin/portal-migrate-boot.sh
 
 # Source for Build Studio — copied to -src paths to avoid collision with standalone output
 # Note: /app/apps/web/ and /app/packages/ are occupied by the standalone NFT output.
@@ -205,4 +210,9 @@ EXPOSE 3000
 # content hash); seed DEPLOYED_SHA from that baked file whenever the env is unset
 # so the runtime always reports the identity of its own bytes regardless of how
 # it was started. An explicit DEPLOYED_SHA from the deploy pipeline still wins.
-CMD ["sh", "-c", "if [ -z \"$DEPLOYED_SHA\" ] && [ -s /app/.dpf-image-version ]; then DEPLOYED_SHA=\"$(tr -d '[:space:]' < /app/.dpf-image-version)\"; export DEPLOYED_SHA; fi; exec node apps/web/server.js"]
+# BI-5322D025: portal-migrate-boot.sh applies pending migrations from THIS
+# image's bytes before exec'ing the server, so a self-upgrade swap (or any
+# restart) can never leave the DB drifted. It is fail-closed: if migrations
+# can't apply, the portal does not start. portal-init is unaffected — it
+# overrides CMD with /docker-entrypoint.sh.
+CMD ["/usr/local/bin/portal-migrate-boot.sh", "sh", "-c", "if [ -z \"$DEPLOYED_SHA\" ] && [ -s /app/.dpf-image-version ]; then DEPLOYED_SHA=\"$(tr -d '[:space:]' < /app/.dpf-image-version)\"; export DEPLOYED_SHA; fi; exec node apps/web/server.js"]

--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Functional proof of scripts/portal-migrate-boot.sh (BI-5322D025): the portal's
+// boot wrapper applies migrations from its own bytes, then execs the server —
+// fail-closed if migrations can't apply. We run the REAL script with a fake
+// `pnpm` (success/fail) + instant `sleep` on PATH and a scratch DPF_APP_DIR.
+
+const SCRIPT = resolve(__dirname, "../../../../scripts/portal-migrate-boot.sh");
+const BASH_OK = spawnSync("bash", ["--version"], { encoding: "utf8" }).status === 0;
+const TIMEOUT_MS = 30_000;
+
+function toBashPath(value: string): string {
+  if (process.platform !== "win32") return value;
+  const normalized = value.replace(/\\/g, "/");
+  const m = /^([A-Za-z]):\/(.*)$/.exec(normalized);
+  if (!m) return normalized;
+  const cwdDrive = /^([A-Za-z]):/.exec(process.cwd())?.[1]?.toLowerCase();
+  const pwd = spawnSync("bash", ["-lc", "pwd"], { encoding: "utf8" }).stdout.trim();
+  const prefix = cwdDrive && pwd.startsWith(`/mnt/${cwdDrive}/`) ? "/mnt" : "";
+  return `${prefix}/${m[1].toLowerCase()}/${m[2]}`;
+}
+
+function q(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Fake `pnpm` (exit code configurable via PNPM_EXIT) and an instant `sleep`. */
+function makeFakeBin(root: string): string {
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, "pnpm"),
+    '#!/bin/sh\necho "[fake pnpm] $*"\nexit ${PNPM_EXIT:-0}\n',
+  );
+  writeFileSync(join(bin, "sleep"), "#!/bin/sh\nexit 0\n"); // instant — no real waits
+  chmodSync(join(bin, "pnpm"), 0o755);
+  chmodSync(join(bin, "sleep"), 0o755);
+  return bin;
+}
+
+function run(opts: { appDir: string; fakeBin: string; pnpmExit: number }) {
+  const exports = [
+    `export PATH=${q(toBashPath(opts.fakeBin))}:"$PATH"`,
+    `export DPF_APP_DIR=${q(toBashPath(opts.appDir))}`,
+    `export PNPM_EXIT=${opts.pnpmExit}`,
+  ].join("\n");
+  // The server command is a marker echo — it only runs if migrate succeeds.
+  const r = spawnSync(
+    "bash",
+    ["-lc", `${exports}\nbash ${q(toBashPath(SCRIPT))} sh -c 'echo BOOT_MARKER'`],
+    { encoding: "utf8" },
+  );
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
+  it("applies migrations then execs the server command", () => {
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const appDir = join(root, "app");
+      mkdirSync(appDir, { recursive: true });
+      const r = run({ appDir, fakeBin: makeFakeBin(root), pnpmExit: 0 });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("prisma migrate deploy"); // the fake pnpm echoed its args
+      expect(r.stdout).toContain("migrations applied");
+      expect(r.stdout).toContain("BOOT_MARKER"); // server command was exec'd
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+
+  it("FAILS CLOSED — does not start the server when migrations cannot apply", () => {
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const appDir = join(root, "app");
+      mkdirSync(appDir, { recursive: true });
+      const r = run({ appDir, fakeBin: makeFakeBin(root), pnpmExit: 1 });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain("failed after 5 attempts");
+      expect(r.stdout).not.toContain("BOOT_MARKER"); // server never started
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+
+  it("FAILS LOUD when the app dir is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const r = run({ appDir: join(root, "does-not-exist"), fakeBin: makeFakeBin(root), pnpmExit: 0 });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain("app dir");
+      expect(r.stdout).not.toContain("BOOT_MARKER");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+});

--- a/scripts/portal-migrate-boot.sh
+++ b/scripts/portal-migrate-boot.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# BI-5322D025 — the portal self-migrates on every boot.
+#
+# A self-upgrade swap recreates ONLY the `portal` container (promote.sh step 4,
+# --no-deps), so it never runs the one-shot `portal-init` service that a normal
+# `docker compose up` runs to migrate the DB. A plain `docker restart portal`
+# skips it too. Without this the live DB drifts whenever an upgrade ships a
+# migration, and every query for a new column throws Prisma P2022 ColumnNotFound
+# (the 2026-06-07 incident: /ops/self-upgrade, /build, /platform, /workbooks all
+# crashed after a swap). Making the portal apply migrations from its OWN bytes on
+# boot removes the dependency on portal-init AND on the freshness of the separate
+# dpf-promoter image (BI-D9BAB4FA / BI-5322D025).
+#
+# `prisma migrate deploy` is forward-only, idempotent, and advisory-locked, so
+# running it on every boot is safe and ~free when nothing is pending. Retried for
+# the first-boot DB-readiness race (mirrors docker-entrypoint.sh). FAIL-CLOSED: if
+# migrations cannot apply, the portal does NOT start (exec is never reached) — far
+# better than serving a drifted schema. Then exec the passed server command.
+#
+# DPF_APP_DIR overrides the app root (defaults to /app); used only by the unit
+# test so it can run this script against a scratch dir + a fake `pnpm`.
+cd "${DPF_APP_DIR:-/app}" || {
+  echo "[portal-boot] FATAL: app dir '${DPF_APP_DIR:-/app}' is missing" >&2
+  exit 1
+}
+
+attempts=0
+until pnpm --filter @dpf/db exec prisma migrate deploy; do
+  attempts=$((attempts + 1))
+  if [ "$attempts" -ge 5 ]; then
+    echo "[portal-boot] FATAL: prisma migrate deploy failed after 5 attempts" >&2
+    exit 1
+  fi
+  echo "[portal-boot] migrate retry $attempts/5 in 3s..." >&2
+  sleep 3
+done
+
+echo "[portal-boot] migrations applied; starting server"
+exec "$@"


### PR DESCRIPTION
## What & why

The portal **never ran migrations on its own boot**. Its container inherits the Node base image's bare `docker-entrypoint.sh` (PATH-shadowed to a passthrough), and migrations live in the separate **`portal-init`** one-shot that a self-upgrade swap (`promote.sh` recreates only `portal --no-deps`) — and a plain `docker restart` — **skip**.

Result: every upgrade shipping a migration left the live DB drifted → `P2022 ColumnNotFound` across `/ops/self-upgrade`, `/build`, `/platform`, `/workbooks`. This **kept recurring even after the promoter-side fix (#1647)**, because `promote.sh` runs from the baked `dpf-promoter` image, which the upgrade never rebuilds (BI-5322D025).

## Change — the robust fix
Make the portal apply migrations from its **own bytes on boot**, removing the dependency on both `portal-init` running *and* the `dpf-promoter` image being fresh:

- **`scripts/portal-migrate-boot.sh`** — `prisma migrate deploy` (forward-only, idempotent, advisory-locked) with first-boot retry, then `exec "$@"`. **Fail-closed**: if migrations can't apply, the portal does not start (never serves a drifted schema). `DPF_APP_DIR` override makes it unit-testable.
- **`Dockerfile` (runner)** — copy the script to an **absolute path** (no PATH shadow) and make it the portal CMD's wrapper before `node server.js`. **`portal-init` is unaffected** — it overrides CMD with `/docker-entrypoint.sh`.

Migrate-deploy on every boot is ~free when nothing is pending (just a `_prisma_migrations` check), so normal restarts are unaffected in practice.

## Tests
- `portal-migrate-boot.sh` contract (real `bash` + faked `pnpm`/`sleep`): applies-then-execs the server; **fail-closed** (no server start when migrate fails); fail-loud on a missing app dir.
- `bash -n` clean; `web` typecheck clean; self-upgrade suite **286 green**.
- Full image-build verification happens on the next upgrade (the deploy path). The migrate command itself is the exact one proven during the 2026-06-07 recoveries.

## Context
Closes the drift class that ran through this whole thread (BI-D9BAB4FA / #1647 was the promoter-side half; this is the durable portal-side fix). Self-upgrade is currently **paused** on the live install pending this + #1679; safe to re-enable once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)