### PR TITLE
fix(mcp): record failed admin_query_db / admin_view_logs as "error" not "success"

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -15090,7 +15090,7 @@ export async function executeTool(
         return { success: true, message: `Last ${lines} lines from ${service}:`, data: { service, output: stdout.slice(0, 30000) } };
       } catch (err) {
         const msg = (err as Error).message?.slice(0, 500) ?? "Failed";
-        await logAdminActivity(userId, "admin_view_logs", { service, lines }, "success", 1, msg);
+        await logAdminActivity(userId, "admin_view_logs", { service, lines }, "error", 1, msg);
         return { success: true, message: `Logs from ${service}:`, data: { service, output: msg } };
       }
     }
@@ -15124,7 +15124,7 @@ export async function executeTool(
         return { success: true, message: `Query returned ${result.length} row(s).`, data: { sql, rows: result, rowCount: result.length } };
       } catch (err) {
         const msg = (err as Error).message?.slice(0, 500) ?? "Query failed";
-        await logAdminActivity(userId, "admin_query_db", { sql }, "success", 1, msg);
+        await logAdminActivity(userId, "admin_query_db", { sql }, "error", 1, msg);
         return { success: false, error: msg, message: `Query failed: ${msg}` };
       }
     }


### PR DESCRIPTION
## What
Both `admin_query_db` and `admin_view_logs` MCP tool handlers logged their **catch-block (failure) path** to `AdminActivity` with `result="success"`. So failed read-only queries and failed log reads were recorded as successes — invisible in the platform's own audit trail.

## Why it matters
Found while diagnosing recurring Postgres parse errors (PIR-OIRW7 / PIR-OWDB6) that the new EP-FULL-OBS log-signature scanner surfaced. An audit log that records failures as successes is the same *"hidden in logs"* gap the observability work targets — the failures only became visible via raw Postgres logs.

## Change
Two-line fix: `"success"` → `"error"` in the two catch blocks. No change to returned payloads or caller behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)