### PR TITLE
docs(wsid): WSID per-coworker professional corpus — design spec + phased plan (BI-48B3CEC4)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
+++ b/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
@@ -1,0 +1,164 @@
+# Plan: WSID — Per-Coworker Professional Corpus (BI-48B3CEC4)
+
+- **Date:** 2026-06-09
+- **Backlog:** BI-48B3CEC4 — epic EP-WSID (xlarge umbrella; phases below are the decomposition)
+- **Spec:** `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md`
+- **Definition of done:** the BI's acceptance criteria (§8 of the spec)
+
+## Substrate grounding (verified 2026-06-09)
+
+| Claim | Evidence |
+|---|---|
+| Profile kinds are a TS registry over an open DB string | `apps/web/lib/decision-perspective/types.ts:1` (`DECISION_PROFILE_KINDS`), `schema.prisma` `DecisionPerspectiveProfile.kind String` |
+| Fallback chains exist | `DecisionPerspectiveProfile.fallbackProfileId` self-relation (schema.prisma ~9383) |
+| Profile selection point | `apps/web/lib/decision-perspective/build-studio-gate.ts:155-170` via `resolveProfileMaterial` |
+| Org-scoped resolution precedent | `resolveProfileMaterialForOrg` in `apps/web/lib/decision-perspective/material.ts` (+ BI-230C9EF7 entry-point work in EP-WWMD-MCP) |
+| Profile seeding home | `packages/db/src/seed-decision-perspective.ts` |
+| Enrichment facade to generalize | `apps/web/lib/wiki/enrich-org-corpus.ts` (`EnrichOrgCorpusInput`, `TRUST_TO_MATERIAL`, draft-by-default per BI-1378) |
+| Retrieval scoping axes exist | `packages/db/src/wiki-taxonomy.ts` (`specialist` archetype, `finance`/`marketing`/`data-model` context slugs, `ring-1-coworker`) |
+| Coworker role slugs | `packages/db/data/agent_registry.json` + `prompts/specialist/*.prompt.md` (e.g. `data-architect`) |
+
+No structural migration anywhere in this plan — by design (spec §6).
+
+## Phase 0 — Taxonomy & type registry (ships independently)
+
+**Deliverable:** the platform recognizes the third scope, with zero behavior change.
+
+- `apps/web/lib/decision-perspective/types.ts`: add `"profession"` to
+  `DECISION_PROFILE_KINDS`; add `"professional-practice"` to `DECISION_DOMAIN_CLASSES`;
+  extend `DecisionPerspectiveScope` with optional `professionKey` + `roles`.
+- `apps/web/lib/mcp-tools.ts`: wherever profile kind / domain class enums are validated
+  for the wwmd tools, accept the new values (grep `DECISION_DOMAIN_CLASSES` /
+  `DECISION_PROFILE_KINDS` imports at implementation time).
+- Tests: extend `evaluator.test.ts` kind-acceptance case (the `persona-real` test at
+  `evaluator.test.ts:266` is the template) for `"profession"`; domain-class round-trip.
+
+**Verification:** `pnpm --filter web exec vitest run lib/decision-perspective` green;
+`pnpm --filter web typecheck` green. No UX change to verify (registry-only).
+
+## Phase 1 — Profession profiles + role resolver
+
+**Deliverable:** three seeded profession profiles and a resolver from coworker role →
+profile; unbound roles resolve to null (existing behavior preserved).
+
+- `packages/db/src/seed-decision-perspective.ts`: seed `WSID-DATA-ARCHITECT`,
+  `WSID-FINANCE`, `WSID-MARKETING` (kind `profession`, scope per spec §4.2,
+  `fallbackProfileId` → the org/platform profile, initial version row). Idempotent
+  upsert; loud skip-logging (silent-seed-skips audit).
+- New `apps/web/lib/decision-perspective/resolve-profession-profile.ts`:
+  `resolveProfessionProfile({ agentId | roleSlug })` mapping agent registry role slug →
+  profile via `scope.roles`. Mirror the `resolveProfileMaterialForOrg` client-injection
+  pattern so tests use a structural fake.
+- Tests: resolver hit, miss (null), and fallback-chain shape.
+
+**Verification:** unit tests; then seed against a disposable shadow Postgres
+(`source-only worktree verification` pattern) and assert 3 profile rows + version rows +
+chain wiring via a seed invariant check. Runtime-bound seed verification routes through
+the local-CI convergence sandbox lease, not the worktree.
+
+## Phase 2 — Data-architect starter corpus (first user-visible value)
+
+**Deliverable:** the first real corpus — DMBOK/ANSI-SQL/OWASP distillations — installed,
+embedded, and retrievable.
+
+- Corpus content: DPF-authored distillation pages (markdown, founder-kernel wiki layout)
+  under a new `docs/professions/data-architect/wiki/` tree — `principle`, `heuristic`,
+  `entity`, `summary` kinds; frontmatter carries `principleConsumerArchetype: specialist`,
+  `principleConsumerContexts: [data-model]` (+ `data-security` slug if authoring needs
+  it — slugs are open kebab-case, no schema change), `principleRingScope: ring-1-coworker`.
+  Commandment-in-context for the safety rules (parameterized SQL, least-privilege DB
+  access). **Copyright-clean: citations via RawSource, no reproduced licensed text.**
+- New `packages/db/src/seed-profession-corpus.ts`: seed RawSources (DMBOK2, ISO/IEC 9075,
+  OWASP ASVS/Top 10 citations), WikiPages + WikiPageSource links + WikiPageLink
+  neighborhood, PerspectiveMaterials on `WSID-DATA-ARCHITECT` (grade B / derived /
+  promoted — PR-reviewed like kernel pages), embeddings via the existing `storeWikiPage`
+  path.
+- `pnpm wiki:lint` (or the existing lint entry) passes on the new pages.
+
+**Verification:** fresh-seed run shows pages + materials + zero silent skips;
+`resolveProfileMaterial` for `WSID-DATA-ARCHITECT` returns promoted materials; a Qdrant
+recall for "SQL injection" surfaces the OWASP-derived page. Functional, not structural:
+run one `wwmd_evaluate` against the profile with a craft question and confirm a
+`recommend` citing the seeded material (sandbox lease).
+
+## Phase 3 — Role-aware gate resolution
+
+**Deliverable:** a coworker hitting a craft question is governed by its profession
+profile, with the chain recorded in the ledger.
+
+- Profile-selection wiring at the coworker gate entry (the in-portal handler that calls
+  `evaluateDecisionPerspective` for coworker threads — locate via the gate panel's server
+  action at implementation time; `build-studio-gate.ts` is the template): when the caller
+  is an agent with a bound role and the question's domain is `professional-practice` (or
+  the profile scopes the domain), select the profession profile; else current behavior.
+  Compose with BI-230C9EF7 (org profile resolution) — same entry-point, two resolvers.
+- Authority boundary (spec §4.5): craft-vs-business conflict arbitrates org-over-
+  profession; profession commandments escalate instead of yielding. This is evaluator
+  *input* shaping (which profile is primary, which is fallback), not evaluator changes.
+- `DecisionInteraction` rows already record profile + version + fallback level — assert,
+  don't rebuild.
+
+**Verification:** unit tests for selection logic; **live-install functional gate** (the
+`dpf-verify-on-live-install` flow, preflight first): drive a data-architect coworker
+craft question on the canonical install, observe `recommend` + cited WSID materials in
+the Decision Canvas, and the ledger row naming `WSID-DATA-ARCHITECT`. A role with no
+profile behaves exactly as before (regression check on an unbound coworker).
+
+## Phase 4 — Role-scoped enrichment + gap loop
+
+**Deliverable:** profession corpora grow at runtime under review, and `defer`s feed them.
+
+- `apps/web/lib/wiki/enrich-org-corpus.ts`: generalize input with the
+  `EnrichCorpusTarget` discriminator (spec §4.7); `profession` targets write
+  platform-scoped pages/materials onto the profession profile; source-key
+  `profession/${professionKey}/${origin}/${fingerprint}`. **Org path behavior is frozen
+  by existing tests (`enrich-org-corpus.test.ts`) — they must stay green untouched.**
+- Review-inbox lane: profession-profile gaps group under owner/operator wording
+  (explainability spec's generic projection — verify, extend only if the projection
+  hardcodes org/founder).
+- Gap capture: a `defer` against a profession profile writes the profile-gap record
+  (existing mechanics) — assert it lands in the inbox lane.
+
+**Verification:** new enrichment tests for the profession target (disposition, draft-by-
+default, idempotent source-key); org-path regression suite green; functional: enrich one
+researched note into the data-architect corpus on the sandbox, see it as draft in the
+review inbox.
+
+## Phase 5 — Finance + marketing corpora, MCP exposure, docs
+
+**Deliverable:** the remaining starter corpora and the external surface.
+
+- `docs/professions/finance/wiki/` (GAAP/ASC distillations, double-entry invariants,
+  SoD/SOX concepts) and `docs/professions/marketing/wiki/` (AMA ethics, STP/4Ps,
+  consent-compliance commandments) + seed wiring in `seed-profession-corpus.ts`.
+- MCP: profession profile ids accepted by `wwmd_evaluate`/`wwmd_decide`/
+  `wwmd_record_outcome` `profileId` param under existing scopes; agent→profile resolution
+  exposed through the BI-230C9EF7 entry-point rather than a new tool.
+- Operator docs (doc-at-ship): extend
+  `docs/user-guide/ai-workforce/decision-perspective.md` profile-kind table with
+  `profession` and the WSID naming; AGENTS.md §16 WWMD-vs-WWWD note gains the WSID line.
+
+**Verification:** the BI's acceptance criteria run end-to-end on the canonical install:
+craft question per role → cited recommend; unbound role → unchanged; fresh install seeds
+all three corpora; org overlay wins for that org. Full build gate (§5 AGENTS.md) before
+each PR.
+
+## Risks & rollback
+
+| Risk | Mitigation / rollback |
+|---|---|
+| Gate selection regression for existing flows | Selection is additive (null resolver → exact current path); unbound-role regression test in Phase 3; rollback = unbind roles (profiles stay, nothing selects them). |
+| Enrichment generalization breaks org corpus | Org tests frozen-green requirement in Phase 4; discriminated union keeps the org branch byte-compatible; rollback = revert the facade commit, profession seeds unaffected. |
+| Seed bloat / silent skips on fresh install | Idempotent upserts + loud skip logging + seed invariant check (Phase 1/2); the silent-seed-skips audit pattern applies. |
+| Copyright exposure from BoK content | Distillation-only policy + RawSource citations + quotation-length lint (spec §7); content reviewed at PR time. |
+| Profession doctrine overriding org business judgment | Authority boundary is explicit evaluator-input shaping (Phase 3) with arbitrate/escalate rules from spec §4.5; the non-inherit boundary is untouched. |
+
+## Sequencing notes
+
+- Phase 0 ships independently and unblocks everything; Phases 1→2→3 are strictly ordered;
+  Phase 4 depends on 1 (profiles) but not 3; Phase 5 depends on 2's content pattern.
+- Each phase is a Build Studio-sized slice: file child BIs under EP-WSID at promotion
+  time (umbrella BI-48B3CEC4 stays the parent, EP-WWMD-MCP umbrella pattern).
+- Composition risk with EP-WWMD-MCP: BI-230C9EF7 (org profile resolution) touches the
+  same entry-point as Phase 3 — overlap-sweep before that slice starts; if it has landed,
+  compose; if not, Phase 3 builds the entry-point and BI-230C9EF7 shrinks.

--- a/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
+++ b/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
@@ -39,41 +39,61 @@ No structural migration anywhere in this plan — by design (spec §6).
 **Verification:** `pnpm --filter web exec vitest run lib/decision-perspective` green;
 `pnpm --filter web typecheck` green. No UX change to verify (registry-only).
 
-## Phase 1 — Profession profiles + role resolver
+## Phase 1 — Profession Source Registry + all family profiles + role resolver
 
-**Deliverable:** three seeded profession profiles and a resolver from coworker role →
-profile; unbound roles resolve to null (existing behavior preserved).
+**Deliverable:** the full-roster coverage contract (spec §4.11) made concrete — the
+governed registry, a profession profile for **every family** (~18 families covering all
+63 registry agents + ~24 route personas), and the resolver; unbound identifiers resolve
+to null (existing behavior preserved).
 
-- `packages/db/src/seed-decision-perspective.ts`: seed `WSID-DATA-ARCHITECT`,
-  `WSID-FINANCE`, `WSID-MARKETING` (kind `profession`, scope per spec §4.2,
-  `fallbackProfileId` → the org/platform profile, initial version row). Role bindings
-  use registry `agent_name` keys + prompt-slug aliases (spec §4.3):
-  `build-data-architect`+`data-architect`, `finance-agent`, `marketing-specialist`.
-  Idempotent upsert; loud skip-logging (silent-seed-skips audit).
+- New `docs/professions/registry.json` (spec §4.12 #1): every `professionKey` → bound
+  roles (registry `agent_name` keys + persona/prompt-slug aliases per spec §4.3),
+  context slugs, candidate source list with **license class**
+  (`open`/`licensed`/`org-supplied`), and an SFIA/O*NET-derived coverage checklist per
+  family. Coverage lint: every active registry agent and route persona appears in
+  exactly one family — an unmapped role fails CI (spec §4.11 rule 1).
+- `packages/db/src/seed-decision-perspective.ts`: seed one profile per registry family
+  (kind `profession`, scope per spec §4.2, `fallbackProfileId` → the org/platform
+  profile, initial version row). Families without a built corpus still get profiles —
+  their `defer`s are the demand signal that prioritizes corpus rollout (spec §4.11
+  rule 2). Idempotent upsert; loud skip-logging (silent-seed-skips audit).
 - New `apps/web/lib/decision-perspective/resolve-profession-profile.ts`:
   `resolveProfessionProfile({ agentId | roleSlug })` resolving agentId → registry entry
   → `agent_name` (or alias) → profile via `scope.roles`. Mirror the landed
   `resolveProfileMaterialForOrg` client-injection pattern so tests use a structural
   fake.
-- Tests: resolver hit, miss (null), and fallback-chain shape.
+- Tests: resolver hit, alias hit, miss (null), fallback-chain shape, and the
+  registry-coverage lint (a synthetic unmapped agent fails).
 
 **Verification:** unit tests; then seed against a disposable shadow Postgres
-(`source-only worktree verification` pattern) and assert 3 profile rows + version rows +
-chain wiring via a seed invariant check. Runtime-bound seed verification routes through
-the local-CI convergence sandbox lease, not the worktree.
+(`source-only worktree verification` pattern) and assert one profile row per registry
+family + version rows + chain wiring via a seed invariant check. Runtime-bound seed
+verification routes through the local-CI convergence sandbox lease, not the worktree.
 
-## Phase 2 — Data-architect starter corpus (first user-visible value)
+## Phase 2 — Research-ingest pipeline + data-architect corpus through it
 
-**Deliverable:** the first real corpus — DMBOK/ANSI-SQL/OWASP distillations — installed,
-embedded, and retrievable.
+**Deliverable:** the §4.12 research pipeline working end-to-end, proven by producing the
+first real corpus — DMBOK/ANSI-SQL/OWASP — **from fetched sources, not model memory**.
 
-- Corpus content: DPF-authored distillation pages (markdown, founder-kernel wiki layout)
-  under a new `docs/professions/data-architect/wiki/` tree — `principle`, `heuristic`,
-  `entity`, `summary` kinds; frontmatter carries `principleConsumerArchetype: specialist`,
-  `principleConsumerContexts: [data-model]` (+ `data-security` slug if authoring needs
-  it — slugs are open kebab-case, no schema change), `principleRingScope: ring-1-coworker`.
-  Commandment-in-context for the safety rules (parameterized SQL, least-privilege DB
-  access). **Copyright-clean: citations via RawSource, no reproduced licensed text.**
+- Research run first (spec §4.12 #2–3): execute the data-architect research pass with
+  the existing research-execution harness (`apps/web/lib/wiki/research-execution.ts`,
+  `market-research.ts` precedent) against the registry's `open`-class sources (OWASP
+  Top 10/ASVS/Query Parameterization Cheat Sheet, NIST/ISO public abstracts, DAMA
+  public knowledge-area structure). Every fetch lands as a `RawSource` with locator,
+  `retrievedAt`, content fingerprint, license class. `licensed`-class sources (DMBOK2
+  text, ISO/IEC 9075 text) stay checklist-only or await `org-supplied` upload — the
+  conduit rule (spec §7.7).
+- Corpus content: distillation pages proposed **from the fetched source text** via
+  `proposeWikiDiff` (markdown, founder-kernel wiki layout) under
+  `docs/professions/data-architect/wiki/` — `principle`, `heuristic`, `entity`,
+  `summary` kinds; frontmatter carries `principleConsumerArchetype: specialist`,
+  `principleConsumerContexts: [data-model]` (+ `data-security` slug — open kebab-case,
+  no schema change), `principleRingScope: ring-1-coworker`. Commandment-in-context for
+  the safety rules (parameterized SQL, least-privilege DB access). **Copyright-clean:
+  citations via RawSource, no reproduced licensed text.**
+- Provenance invariant lint (spec §4.12 #4): every corpus page must carry ≥1 source
+  reference resolving to a fetched RawSource; every material's `sourceRef` must trace.
+  Wire into `wiki_lint`/CI so unsourced content cannot publish or promote.
 - New `packages/db/src/seed-profession-corpus.ts`: **generalize the `seed-wiki-kernel.ts`
   machinery** (frontmatter parse, `deriveSlug`, RawSource ingest, embeddings sidecar)
   over a `docs/professions/<role>/` tree — parameterize the kernel loader, don't fork a
@@ -137,13 +157,17 @@ default, idempotent source-key); org-path regression suite green; functional: en
 researched note into the data-architect corpus on the sandbox, see it as draft in the
 review inbox.
 
-## Phase 5 — Finance + marketing corpora, MCP exposure, docs
+## Phase 5 — Finance + marketing corpora (via the pipeline), MCP exposure, docs
 
-**Deliverable:** the remaining starter corpora and the external surface.
+**Deliverable:** the remaining pilot corpora — each through its own dedicated research
+run — and the external surface.
 
-- `docs/professions/finance/wiki/` (GAAP/ASC distillations, double-entry invariants,
-  SoD/SOX concepts) and `docs/professions/marketing/wiki/` (AMA ethics, STP/4Ps,
-  consent-compliance commandments) + seed wiring in `seed-profession-corpus.ts`.
+- Dedicated research passes per profession (spec §4.12 — own effort, own sources):
+  finance against FASB ASC public guidance, SOX/PCAOB public materials, double-entry
+  invariants; marketing against AMA public definitions/ethics, deliverability/consent
+  regulations (CAN-SPAM, GDPR). Then `docs/professions/finance/wiki/` and
+  `docs/professions/marketing/wiki/` produced from the fetched text + seed wiring in
+  `seed-profession-corpus.ts`. The provenance lint from Phase 2 gates both.
 - MCP (conditional on EP-WWMD-MCP): the `wwmd_evaluate`/`wwmd_decide`/
   `wwmd_record_outcome` tools are not yet registered in `mcp-tools.ts` — if they have
   landed by this phase, verify profession profile ids are accepted as `profileId` under
@@ -155,9 +179,30 @@ review inbox.
   `profession` and the WSID naming; AGENTS.md §16 WWMD-vs-WWWD note gains the WSID line.
 
 **Verification:** the BI's acceptance criteria run end-to-end on the canonical install:
-craft question per role → cited recommend; unbound role → unchanged; fresh install seeds
-all three corpora; org overlay wins for that org. Full build gate (§5 AGENTS.md) before
-each PR.
+craft question per pilot role → cited recommend; unbound identifier → unchanged; fresh
+install seeds all family profiles + three pilot corpora; org overlay wins for that org.
+Full build gate (§5 AGENTS.md) before each PR.
+
+## Phase 6 — Roster-wide corpus rollout (demand-prioritized waves)
+
+**Deliverable:** the remaining ~15 profession families get corpora, in waves, ordered by
+observed demand — not by guess.
+
+- Prioritization signal: per-family `defer` counts from the gate ledger (spec §4.11
+  rule 2 / §8.6) — the families whose coworkers most often hit craft questions their
+  profile can't answer go first. Query surfaces from the existing `DecisionInteraction`
+  ledger; no new telemetry.
+- Per wave (batch of 2–4 families): dedicated research run against the family's
+  registry source list → pipeline-produced corpus tree under
+  `docs/professions/<family>/wiki/` → seed wiring → provenance lint → review → promote.
+  Each wave is a Build-Studio-sized child BI under EP-WSID.
+- Registry hygiene per wave: research passes confirm or supersede the candidate anchor
+  standards recorded in Phase 1's registry; update `registry.json` in the same PR.
+
+**Verification:** per wave — same functional gate as Phase 2 (craft question →
+recommend with cited fetched sources, on the canonical install or sandbox lease).
+Roster-coverage acceptance (spec §8.2) re-asserted after each wave: every active role
+resolves; defer-queue trend for covered families decreases.
 
 ## Risks & rollback
 
@@ -168,11 +213,15 @@ each PR.
 | Seed bloat / silent skips on fresh install | Idempotent upserts + loud skip logging + seed invariant check (Phase 1/2); the silent-seed-skips audit pattern applies. |
 | Copyright exposure from BoK content | Distillation-only policy + RawSource citations + quotation-length lint (spec §7); content reviewed at PR time. |
 | Profession doctrine overriding org business judgment | Authority boundary is explicit evaluator-input shaping (Phase 3) with arbitrate/escalate rules from spec §4.5; the non-inherit boundary is untouched. |
+| Training-data authoring sneaks in (research pass skipped under time pressure) | The provenance invariant is mechanical (Phase 2 lint/CI): unsourced pages can't publish, unsourced materials can't promote — the shortcut fails the gate, not a review judgment call. |
+| Key sources unavailable or licensed (DMBOK text, ISO standards) | License-class field in the registry decides the path up front: `open` fetched, `licensed` checklist-only, `org-supplied` via document upload (conduit rule, spec §7.7); a thin-but-honest corpus beats a rich fabricated one. |
+| Roster drift (new coworkers added without a family mapping) | Coverage lint (Phase 1) fails CI on any active agent/persona missing from `registry.json` — drift is caught at the PR that introduces the role. |
 
 ## Sequencing notes
 
 - Phase 0 ships independently and unblocks everything; Phases 1→2→3 are strictly ordered;
-  Phase 4 depends on 1 (profiles) but not 3; Phase 5 depends on 2's content pattern.
+  Phase 4 depends on 1 (profiles) but not 3; Phase 5 depends on 2's pipeline; Phase 6
+  repeats Phase 5's shape per wave and runs as long as the defer queue says it should.
 - Each phase is a Build Studio-sized slice: file child BIs under EP-WSID at promotion
   time (umbrella BI-48B3CEC4 stays the parent, EP-WWMD-MCP umbrella pattern).
 - BI-230C9EF7 (org profile resolution) **has landed** (verified 2026-06-09 —

--- a/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
+++ b/docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md
@@ -12,8 +12,11 @@
 | Profile kinds are a TS registry over an open DB string | `apps/web/lib/decision-perspective/types.ts:1` (`DECISION_PROFILE_KINDS`), `schema.prisma` `DecisionPerspectiveProfile.kind String` |
 | Fallback chains exist | `DecisionPerspectiveProfile.fallbackProfileId` self-relation (schema.prisma ~9383) |
 | Profile selection point | `apps/web/lib/decision-perspective/build-studio-gate.ts:155-170` via `resolveProfileMaterial` |
-| Org-scoped resolution precedent | `resolveProfileMaterialForOrg` in `apps/web/lib/decision-perspective/material.ts` (+ BI-230C9EF7 entry-point work in EP-WWMD-MCP) |
+| Org-scoped resolution **landed** (BI-230C9EF7) | `resolveProfileMaterialForOrg` at `apps/web/lib/decision-perspective/material.ts:363`; tests at `material.test.ts:155` — compose, don't rebuild |
 | Profile seeding home | `packages/db/src/seed-decision-perspective.ts` |
+| Kernel wiki seed machinery to generalize | `packages/db/src/seed-wiki-kernel.ts` — frontmatter parse, `deriveSlug`, RawSource ingest, precomputed `embeddings.jsonl` sidecar |
+| wwmd MCP tools **not yet shipped** | specced in `2026-05-19-wwmd-mcp-exposure-design.md`; no registration in `apps/web/lib/mcp-tools.ts` — Phase 5's MCP item is conditional on EP-WWMD-MCP |
+| Role identifiers in agent registry | `agent_registry.json` has no `role` field; canonical key is `agent_name` (`build-data-architect` / `finance-agent` / `marketing-specialist`); `prompts/specialist/*` slugs are a separate namespace (spec §4.3) |
 | Enrichment facade to generalize | `apps/web/lib/wiki/enrich-org-corpus.ts` (`EnrichOrgCorpusInput`, `TRUST_TO_MATERIAL`, draft-by-default per BI-1378) |
 | Retrieval scoping axes exist | `packages/db/src/wiki-taxonomy.ts` (`specialist` archetype, `finance`/`marketing`/`data-model` context slugs, `ring-1-coworker`) |
 | Coworker role slugs | `packages/db/data/agent_registry.json` + `prompts/specialist/*.prompt.md` (e.g. `data-architect`) |
@@ -43,12 +46,15 @@ profile; unbound roles resolve to null (existing behavior preserved).
 
 - `packages/db/src/seed-decision-perspective.ts`: seed `WSID-DATA-ARCHITECT`,
   `WSID-FINANCE`, `WSID-MARKETING` (kind `profession`, scope per spec §4.2,
-  `fallbackProfileId` → the org/platform profile, initial version row). Idempotent
-  upsert; loud skip-logging (silent-seed-skips audit).
+  `fallbackProfileId` → the org/platform profile, initial version row). Role bindings
+  use registry `agent_name` keys + prompt-slug aliases (spec §4.3):
+  `build-data-architect`+`data-architect`, `finance-agent`, `marketing-specialist`.
+  Idempotent upsert; loud skip-logging (silent-seed-skips audit).
 - New `apps/web/lib/decision-perspective/resolve-profession-profile.ts`:
-  `resolveProfessionProfile({ agentId | roleSlug })` mapping agent registry role slug →
-  profile via `scope.roles`. Mirror the `resolveProfileMaterialForOrg` client-injection
-  pattern so tests use a structural fake.
+  `resolveProfessionProfile({ agentId | roleSlug })` resolving agentId → registry entry
+  → `agent_name` (or alias) → profile via `scope.roles`. Mirror the landed
+  `resolveProfileMaterialForOrg` client-injection pattern so tests use a structural
+  fake.
 - Tests: resolver hit, miss (null), and fallback-chain shape.
 
 **Verification:** unit tests; then seed against a disposable shadow Postgres
@@ -68,18 +74,24 @@ embedded, and retrievable.
   it — slugs are open kebab-case, no schema change), `principleRingScope: ring-1-coworker`.
   Commandment-in-context for the safety rules (parameterized SQL, least-privilege DB
   access). **Copyright-clean: citations via RawSource, no reproduced licensed text.**
-- New `packages/db/src/seed-profession-corpus.ts`: seed RawSources (DMBOK2, ISO/IEC 9075,
-  OWASP ASVS/Top 10 citations), WikiPages + WikiPageSource links + WikiPageLink
-  neighborhood, PerspectiveMaterials on `WSID-DATA-ARCHITECT` (grade B / derived /
-  promoted — PR-reviewed like kernel pages), embeddings via the existing `storeWikiPage`
-  path.
+- New `packages/db/src/seed-profession-corpus.ts`: **generalize the `seed-wiki-kernel.ts`
+  machinery** (frontmatter parse, `deriveSlug`, RawSource ingest, embeddings sidecar)
+  over a `docs/professions/<role>/` tree — parameterize the kernel loader, don't fork a
+  parallel parser. Seeds RawSources (DMBOK2, ISO/IEC 9075, OWASP ASVS/Top 10 citations),
+  WikiPages + WikiPageSource links + WikiPageLink neighborhood, PerspectiveMaterials on
+  `WSID-DATA-ARCHITECT` (grade B / derived / promoted — PR-reviewed like kernel pages).
+  Seed-time embeddings via a precomputed `embeddings.jsonl` sidecar (kernel precedent —
+  a fresh install has no embedding provider configured at seed time); runtime
+  enrichment embeds via `storeWikiPage`.
 - `pnpm wiki:lint` (or the existing lint entry) passes on the new pages.
 
 **Verification:** fresh-seed run shows pages + materials + zero silent skips;
 `resolveProfileMaterial` for `WSID-DATA-ARCHITECT` returns promoted materials; a Qdrant
 recall for "SQL injection" surfaces the OWASP-derived page. Functional, not structural:
-run one `wwmd_evaluate` against the profile with a craft question and confirm a
-`recommend` citing the seeded material (sandbox lease).
+run one evaluation against the profile with a craft question through the in-portal gate
+path (`evaluateDecisionPerspective` via the decision-perspective server action — the
+`wwmd_evaluate` MCP tool is not yet shipped) and confirm a `recommend` citing the
+seeded material (sandbox lease).
 
 ## Phase 3 — Role-aware gate resolution
 
@@ -91,7 +103,7 @@ profile, with the chain recorded in the ledger.
   action at implementation time; `build-studio-gate.ts` is the template): when the caller
   is an agent with a bound role and the question's domain is `professional-practice` (or
   the profile scopes the domain), select the profession profile; else current behavior.
-  Compose with BI-230C9EF7 (org profile resolution) — same entry-point, two resolvers.
+  Compose with the landed BI-230C9EF7 org resolution — same entry-point, two resolvers.
 - Authority boundary (spec §4.5): craft-vs-business conflict arbitrates org-over-
   profession; profession commandments escalate instead of yielding. This is evaluator
   *input* shaping (which profile is primary, which is fallback), not evaluator changes.
@@ -111,7 +123,8 @@ profile behaves exactly as before (regression check on an unbound coworker).
 - `apps/web/lib/wiki/enrich-org-corpus.ts`: generalize input with the
   `EnrichCorpusTarget` discriminator (spec §4.7); `profession` targets write
   platform-scoped pages/materials onto the profession profile; source-key
-  `profession/${professionKey}/${origin}/${fingerprint}`. **Org path behavior is frozen
+  `enrich:profession:${professionKey}:${sourceType}:${fingerprint}` (extends the
+  shipped `deriveSourceKey` colon scheme). **Org path behavior is frozen
   by existing tests (`enrich-org-corpus.test.ts`) — they must stay green untouched.**
 - Review-inbox lane: profession-profile gaps group under owner/operator wording
   (explainability spec's generic projection — verify, extend only if the projection
@@ -131,9 +144,12 @@ review inbox.
 - `docs/professions/finance/wiki/` (GAAP/ASC distillations, double-entry invariants,
   SoD/SOX concepts) and `docs/professions/marketing/wiki/` (AMA ethics, STP/4Ps,
   consent-compliance commandments) + seed wiring in `seed-profession-corpus.ts`.
-- MCP: profession profile ids accepted by `wwmd_evaluate`/`wwmd_decide`/
-  `wwmd_record_outcome` `profileId` param under existing scopes; agent→profile resolution
-  exposed through the BI-230C9EF7 entry-point rather than a new tool.
+- MCP (conditional on EP-WWMD-MCP): the `wwmd_evaluate`/`wwmd_decide`/
+  `wwmd_record_outcome` tools are not yet registered in `mcp-tools.ts` — if they have
+  landed by this phase, verify profession profile ids are accepted as `profileId` under
+  existing scopes (should be free if the tools are kind-generic); if not, record the
+  requirement on EP-WWMD-MCP and ship this phase without the MCP claim. Agent→profile
+  resolution composes with the landed BI-230C9EF7 entry-point rather than a new tool.
 - Operator docs (doc-at-ship): extend
   `docs/user-guide/ai-workforce/decision-perspective.md` profile-kind table with
   `profession` and the WSID naming; AGENTS.md §16 WWMD-vs-WWWD note gains the WSID line.
@@ -159,6 +175,8 @@ each PR.
   Phase 4 depends on 1 (profiles) but not 3; Phase 5 depends on 2's content pattern.
 - Each phase is a Build Studio-sized slice: file child BIs under EP-WSID at promotion
   time (umbrella BI-48B3CEC4 stays the parent, EP-WWMD-MCP umbrella pattern).
-- Composition risk with EP-WWMD-MCP: BI-230C9EF7 (org profile resolution) touches the
-  same entry-point as Phase 3 — overlap-sweep before that slice starts; if it has landed,
-  compose; if not, Phase 3 builds the entry-point and BI-230C9EF7 shrinks.
+- BI-230C9EF7 (org profile resolution) **has landed** (verified 2026-06-09 —
+  `resolveProfileMaterialForOrg` in `material.ts` with tests): Phase 3 composes with it —
+  same entry-point, two resolvers. Still overlap-sweep before each slice; EP-WWMD-MCP
+  remains active on adjacent surfaces (the wwmd MCP tools themselves are unshipped, see
+  Phase 5).

--- a/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
@@ -44,16 +44,26 @@ point, inside the governed gate — not as prompt folklore.
 
 1. A third `DecisionPerspectiveProfile` scope — the **profession profile** — one per
    coworker role family (`WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING`, …).
-2. A per-role **professional corpus** on the existing substrate: `WikiPage` pages with
+2. **Full-roster coverage contract**: WSID scopes **every AI Coworker on the platform**,
+   not a handpicked few — all 63 registry agents (48 specialists, 9 orchestrators,
+   6 cross-cutting; counted 2026-06-09) plus the ~24 route personas, collapsed into
+   profession *families* (§4.11). Data architect / finance / marketing are the **pilot
+   three**, chosen to prove the pipeline — they are not the scope.
+3. A per-role **professional corpus** on the existing substrate: `WikiPage` pages with
    `RawSource` provenance for the body of knowledge, `PerspectiveMaterial` rows for
    decision-bearing doctrine, Qdrant embeddings for recall.
-3. **Role-aware gate resolution**: when a coworker hits a craft question, the Decision
+4. **Research-sourced content — never training-data authoring**: every corpus page is
+   produced by the research-ingest pipeline from *fetched, verifiable sources* (§4.12).
+   The LLM distills retrieved source text; it never writes doctrine from its own
+   training-data memory. Each profession gets **its own research effort and its own
+   source list**, governed by the Profession Source Registry.
+5. **Role-aware gate resolution**: when a coworker hits a craft question, the Decision
    Perspective Gate evaluates against its profession profile, falling back through the
    existing chain (role → org WWWD → DPF doctrine advisory → defer-with-gap-capture).
-4. **Seed = bootstrap, enrichment = runtime**: starter corpora for the first three roles
-   install on a fresh portal; ongoing growth flows through the (role-scoped) enrichment
-   pipeline with draft-by-default review.
-5. **Org overridability**: an organization can extend or override a profession profile
+6. **Seed = bootstrap, enrichment = runtime**: pilot corpora install on a fresh portal
+   (themselves pipeline-produced with recorded provenance, §5); ongoing growth flows
+   through the (role-scoped) enrichment pipeline with draft-by-default review.
+7. **Org overridability**: an organization can extend or override a profession profile
    without mutating the platform-seeded baseline (existing kernel-page overlay pattern).
 
 **Non-goals (V1)**
@@ -83,8 +93,11 @@ point, inside the governed gate — not as prompt folklore.
 
 ### Professional bodies of knowledge (the corpus contents)
 
-The standards each starter role's corpus distills, per the platform's
-`research-and-use-standards` principle (cite sources; deviate only with reason):
+Candidate anchor standards for the **pilot three**, per the platform's
+`research-and-use-standards` principle (cite sources; deviate only with reason). These
+lists are *starting hypotheses* — each profession's dedicated research pass (§4.12)
+confirms, extends, and supersedes them with fetched sources; the full-roster family map
+is in §4.11:
 
 - **Data architect:** DAMA-DMBOK2 (11 knowledge areas — governance, modeling, storage,
   security, MDM, metadata, quality…), ISO/IEC 9075 (ANSI SQL), OWASP Top 10 + ASVS +
@@ -144,9 +157,9 @@ WSID   profile kind "profession"    — role professional doctrine       (this s
 
 ```jsonc
 {
-  "domains": ["data-model", "data-security"],     // existing scope axis
+  "domains": ["data-model", "data-security"],      // existing scope axis
   "professionKey": "data-architect",               // NEW, kebab-case role-family slug
-  "roles": ["data-architect"]                      // coworker role slugs this profile serves
+  "roles": ["build-data-architect", "data-architect"] // registry agent_name + prompt-slug alias (§4.3)
 }
 ```
 
@@ -161,10 +174,18 @@ A small resolver, mirroring the org-profile resolution entry-point (BI-230C9EF7)
 resolveProfessionProfile({ agentId | roleSlug }) → DecisionPerspectiveProfile | null
 ```
 
-- Source of the role slug: the coworker's registry entry (`agent_registry.json` /
-  `Agent` model) already names specialist roles (`data-architect`, etc. — the
-  `prompts/specialist/*.prompt.md` slugs). The resolver maps agent → role slug →
-  profession profile whose `scope.roles` contains it.
+- **Role-slug source of truth** (verified 2026-06-09): `agent_registry.json` has no
+  `role` field — its identifiers are `agent_id` / `agent_name`
+  (`AGT-BUILD-DA` / `build-data-architect`, `AGT-900` / `finance-agent`,
+  `AGT-WS-MARKETING` / `marketing-specialist`). The `prompts/specialist/*.prompt.md`
+  slugs (`data-architect`, …) are a *separate namespace* that only sometimes coincides.
+  `scope.roles` therefore binds to the registry **`agent_name`** as the canonical key,
+  with the specialist-prompt slug listed as an alias when it differs, so the resolver
+  accepts whichever identifier the gate call site carries:
+  agentId → registry entry → `agent_name` (or prompt-slug alias) → profile.
+- Seed bindings: `WSID-DATA-ARCHITECT` ← `build-data-architect` (alias
+  `data-architect`); `WSID-FINANCE` ← `finance-agent`; `WSID-MARKETING` ←
+  `marketing-specialist`.
 - Null result = no WSID profile for this role → gate proceeds with the org/platform chain
   exactly as today (additive, zero behavior change for unbound roles).
 
@@ -215,7 +236,9 @@ Per-role corpus on the existing wiki substrate:
 - **Principle taxonomy scoping** (existing axes, no additions):
   `principleConsumerArchetype: "specialist"`,
   `principleConsumerContexts: ["data-model"] | ["finance"] | ["marketing"]` (slugs already
-  in `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES`), `principleRingScope: "ring-1-coworker"`.
+  in `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES`; `data-security` is a new governed slug —
+  contexts are open kebab-case, but append it to the examples registry so docs and lint
+  stay honest), `principleRingScope: "ring-1-coworker"`.
   `recallPrincipleContext`'s strict context filter then keeps finance doctrine out of
   marketing prompts for free.
 - **Knowledge graph**: `WikiPageLink` neighborhoods (existing), projected through the
@@ -234,8 +257,11 @@ type EnrichCorpusTarget =
   | { kind: "profession"; professionKey: string };            // NEW
 ```
 
-- Source-key contract extends the existing scheme:
-  `profession/${professionKey}/${origin}/${stableSourceFingerprint}`.
+- Source-key contract extends the shipped `deriveSourceKey` scheme
+  (`enrich:${organizationId}:${sourceType}:${fingerprint}` — colon-delimited, not
+  path-style): `enrich:profession:${professionKey}:${sourceType}:${fingerprint}`.
+  Keeping the `enrich:` prefix preserves existing prefix-scoped queries and the
+  idempotent-upsert semantics keyed on `RawSource.sourceKey`.
 - Same dispositions, same **draft-by-default** review routing (BI-1378 precedent), same
   `WikiIngestEvent` audit. Review-inbox grouping gains the profession as an owner lane
   (the explainability spec's review inbox is already gap-reason generic).
@@ -255,13 +281,18 @@ type EnrichCorpusTarget =
 
 ### 4.9 MCP exposure
 
-No new tool family. `wwmd_evaluate` / `wwmd_decide` / `wwmd_record_outcome` already accept
-`profileId`; WSID adds:
+No new tool family. The `wwmd_evaluate` / `wwmd_decide` / `wwmd_record_outcome` surface
+is specced (`2026-05-19-wwmd-mcp-exposure-design.md`, EP-WWMD-MCP) but **not yet
+registered** in `apps/web/lib/mcp-tools.ts` (verified 2026-06-09) — until it lands, the
+in-portal gate is WSID's only decision surface. WSID's MCP requirement is purely
+additive to that epic:
 
-- profession profile ids as valid targets under the same scopes/grants;
-- a `resolveProfileForAgent` convenience (so an external client can ask "which profile
-  governs the finance coworker?") — read-only, exposed via the existing profile-resolution
-  entry-point work (BI-230C9EF7) rather than a parallel tool.
+- when the wwmd tools land, profession profile ids are valid `profileId` targets under
+  the same scopes/grants — no WSID-specific tool work;
+- agent→profile resolution (so an external client can ask "which profile governs the
+  finance coworker?") rides the **landed** BI-230C9EF7 entry-point
+  (`resolveProfileMaterialForOrg`, `apps/web/lib/decision-perspective/material.ts`)
+  extended with the §4.3 resolver — read-only, no parallel tool.
 
 ### 4.10 Explainability
 
@@ -278,7 +309,11 @@ Per `seed-is-bootstrap-calibration-is-runtime` and `fix-the-seed-not-the-runtime
 - **Seed** installs: 3 profession profiles, their starter WikiPages + RawSources +
   PerspectiveMaterials (platform-authored distillations, published status, promoted
   materials — they are reviewed at PR time like kernel pages), and the role bindings.
-  Idempotent, FK-safe, loud on skip (silent-seed-skips audit applies).
+  Idempotent, FK-safe, loud on skip (silent-seed-skips audit applies). Seed-time
+  embeddings follow the founder-kernel precedent (`seed-wiki-kernel.ts`): a precomputed
+  `embeddings.jsonl` sidecar per corpus tree, because a fresh install has no embedding
+  provider configured at seed time (`zero-click-provider-setup`); runtime enrichment
+  embeds through the live `storeWikiPage` path.
 - **Runtime** owns growth: enrichment pipeline (§4.7), gap capture from `defer`s,
   org overlays. Seed content is never the long-term source of truth for routing
   decisions — the corpus lives in the DB and evolves there.
@@ -291,7 +326,8 @@ Per `seed-is-bootstrap-calibration-is-runtime` and `fix-the-seed-not-the-runtime
 | `"professional-practice"` in `DECISION_DOMAIN_CLASSES` | TS registry | No |
 | `scope.professionKey` / `scope.roles` | Json contract + type | No |
 | `EnrichCorpusTarget` discriminator | `enrich-org-corpus.ts` generalization | No |
-| Profession seed module | `packages/db/src/seed-*` | Seed only |
+| `"data-security"` in `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` | `packages/db/src/wiki-taxonomy.ts` examples registry | No (contexts are open kebab-case) |
+| Profession seed module | `packages/db/src/seed-*` (generalizes `seed-wiki-kernel.ts` machinery) | Seed only |
 
 Zero structural migrations is a deliberate outcome of the schema-audit-before-features
 pass (§4.1): the 2026-05 decision-perspective models were built profile-kind-generic.

--- a/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
@@ -1,0 +1,339 @@
+# WSID (What Should I Do) — Per-Coworker Professional Corpus & Knowledge Graph
+
+- **Date:** 2026-06-09
+- **Backlog:** BI-48B3CEC4 (epic EP-WSID)
+- **Status:** Draft for review
+- **Family:** WWMD (founder/platform) → WWWD (organization) → **WSID (profession/role)**
+- **Related specs:**
+  - `2026-05-17-wwmd-decision-perspective-kernel-design.md` — the kernel
+  - `2026-05-19-wwmd-mcp-exposure-design.md` — MCP tool surface
+  - `2026-05-19-persona-voice-layer-wwtd-design.md` — profile kinds & WWTD generalization
+  - `2026-05-31-continuous-corpus-enrichment-design.md` — `enrichOrgCorpus` pipeline
+  - `2026-05-31-wwmd-explainability-layer-design.md` — Decision Canvas / backlinks / review inbox
+  - `2026-05-12-principles-as-wiki-kind-design.md` — principle taxonomy (consumer archetypes, contexts)
+
+---
+
+## 1. Problem
+
+WWMD answers *"what would the founder/platform do?"* and WWWD answers *"what would this
+organization do?"* — but a coworker doing a specialist's job has no governed source for
+**what a competent professional in this role should do**.
+
+Concretely:
+
+- The **data-architect coworker** has no DAMA-DMBOK grounding, no ANSI SQL standards
+  doctrine, no OWASP guidance on preventing SQL injection or insecure data handling.
+- The **finance coworker** has no GAAP / general-accounting-practice doctrine.
+- The **marketing specialist** has no marketing body of knowledge.
+
+Today that professional judgment is whatever the underlying LLM happens to produce —
+ungoverned, unauditable, and inconsistent across model routings. The platform already
+solved this exact problem twice (founder doctrine, org doctrine); the third scope reuses
+the same architecture: **a versioned profile + a source-traced corpus + weighted retrieval
++ an audited gate**, scoped to the profession instead of the founder or the org.
+
+WSID is also the human-equivalence story: the corpus a data-architect coworker consults is
+the same body of knowledge a human data architect is expected to know. The platform should
+be aware of each role's professional canon and incorporate it *in situ* — at the decision
+point, inside the governed gate — not as prompt folklore.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+1. A third `DecisionPerspectiveProfile` scope — the **profession profile** — one per
+   coworker role family (`WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING`, …).
+2. A per-role **professional corpus** on the existing substrate: `WikiPage` pages with
+   `RawSource` provenance for the body of knowledge, `PerspectiveMaterial` rows for
+   decision-bearing doctrine, Qdrant embeddings for recall.
+3. **Role-aware gate resolution**: when a coworker hits a craft question, the Decision
+   Perspective Gate evaluates against its profession profile, falling back through the
+   existing chain (role → org WWWD → DPF doctrine advisory → defer-with-gap-capture).
+4. **Seed = bootstrap, enrichment = runtime**: starter corpora for the first three roles
+   install on a fresh portal; ongoing growth flows through the (role-scoped) enrichment
+   pipeline with draft-by-default review.
+5. **Org overridability**: an organization can extend or override a profession profile
+   without mutating the platform-seeded baseline (existing kernel-page overlay pattern).
+
+**Non-goals (V1)**
+
+- Voice layer for profession profiles (the surface exists; no profession voice work).
+- Per-individual coworker *instance* profiles (WSID is per role family, not per agent id).
+- Verbatim ingestion of licensed/copyrighted texts (see §7 corpus content policy).
+- A new vector DB, graph DB, or parallel table family — reuse is the design.
+
+## 3. Research & Benchmarking
+
+### Open-source systems
+
+| System | Pattern studied | Verdict |
+|---|---|---|
+| **Onyx (formerly Danswer)** | "Personas"/assistants bound to **document sets** — each assistant retrieves only from its curated connector subset. Data model: assistant → document-set join, shared index underneath. | **Adopt the shape**: shared corpus store + per-profile scoping, not per-agent silo stores. Their single-index/many-scopes model matches our WikiPage + profile-scoped recall. |
+| **CrewAI (Knowledge)** | Per-agent `knowledge_sources` lists (files/strings/URLs) embedded per crew run. Simple, but knowledge is config-time, unversioned, and has no review lifecycle. | **Reject the lifecycle**: config-time knowledge with no provenance/versioning is exactly the ungoverned state WSID exists to replace. Adopt only the ergonomics — binding knowledge at the role level, not the prompt level. |
+| **Microsoft GraphRAG** | Corpus → entity/relationship graph → community summaries for retrieval. | **Defer**: our knowledge graph V1 stays WikiPageLink-based (local neighborhoods, per the explainability spec's "bound the graph" principle). GraphRAG-style community summarization is a possible enrichment for large corpora, not a V1 dependency. |
+
+### Commercial systems
+
+| System | Pattern studied | Verdict |
+|---|---|---|
+| **OpenAI Assistants API** | Per-assistant vector stores (`file_search` binds a vector store per assistant). Clean scoping, but stores are opaque — no review states, no evidence grades, no audit of *why* a chunk applied. | **Adopt scoping, reject opacity** — every WSID retrieval must remain explainable through Decision Canvas with cited, graded materials. |
+| **Microsoft Copilot Studio** | Per-agent "knowledge sources" with admin governance and tenant boundaries. | Confirms the per-role knowledge binding as the industry norm for enterprise agents; their tenant boundary maps to our platform-seed vs org-overlay split. |
+| **Glean** | Single governed enterprise index with permission-trimmed, persona-aware retrieval. | Reinforces shared-index + scoped-retrieval over per-agent stores at enterprise scale. |
+
+### Professional bodies of knowledge (the corpus contents)
+
+The standards each starter role's corpus distills, per the platform's
+`research-and-use-standards` principle (cite sources; deviate only with reason):
+
+- **Data architect:** DAMA-DMBOK2 (11 knowledge areas — governance, modeling, storage,
+  security, MDM, metadata, quality…), ISO/IEC 9075 (ANSI SQL), OWASP Top 10 + ASVS +
+  Query Parameterization Cheat Sheet (SQL injection prevention), ISO 11179 (metadata
+  registries), Data Mesh / data-product thinking as contextual material.
+- **Finance:** US GAAP (FASB ASC) presentation and recognition principles, double-entry
+  bookkeeping invariants, month-end close discipline, segregation-of-duties / SOX 404
+  control concepts, IFRS divergences as contextual material.
+- **Marketing:** AMA definitions and ethics statement, classic frameworks (4Ps/7Ps, STP,
+  funnel/AARRR), brand-consistency doctrine, CAN-SPAM/GDPR consent constraints as
+  commandment-tier contextual rules.
+- **Role→competency mapping:** SFIA 9 and O*NET/ESCO inform which knowledge areas a role
+  profile must cover — used as the checklist for corpus completeness, not ingested text.
+
+### Anti-patterns identified
+
+1. **Prompt-stuffed expertise** ("You are an expert in DMBOK…") — unversioned, unauditable,
+   silently lost on model swap. WSID replaces this; it must not reintroduce it via giant
+   role prompts.
+2. **Per-agent silo vector stores** — N copies of overlapping knowledge, no shared review
+   lifecycle, divergence between roles that share material (e.g. OWASP applies to data
+   architect *and* software engineer). Shared WikiPage corpus + many profiles solves this.
+3. **Licensed-text ingestion** — DMBOK/PMBOK are licensed works. Corpus stores DPF-authored
+   distillations *citing* the standard (RawSource locator = citation), never reproduced text.
+
+### Gap this design fills
+
+No surveyed system combines per-role knowledge scoping with a **governed decision gate**
+(weighted principle aggregation, confidence earned-in-drops, escalate/defer outcomes,
+audit ledger). That combination is the platform's existing WWMD kernel; WSID extends it to
+professions rather than building a parallel RAG feature.
+
+## 4. Architecture
+
+### 4.1 One substrate, third scope
+
+No new tables. WSID is a configuration of the existing decision-perspective substrate
+(verified against `packages/db/prisma/schema.prisma` — `DecisionPerspectiveProfile.kind`
+is an open string column; `fallbackProfileId` already implements chains;
+`PerspectiveMaterial` already carries `domains`, `evidenceGrade`, `freshness`,
+`reviewStatus`, `promotionState`).
+
+```
+WWMD   profile kind "platform"      — founder/platform doctrine        (shipped)
+WWWD   profile kind "organization"  — org operating principles         (shipped surface)
+WSID   profile kind "profession"    — role professional doctrine       (this spec)
+```
+
+### 4.2 Profile kind & identity
+
+- Add `"profession"` to `DECISION_PROFILE_KINDS`
+  (`apps/web/lib/decision-perspective/types.ts`). DB needs no migration for the kind
+  (string column); the TS registry, lint, and MCP input validation are the gate.
+- One profile per role family, platform-seeded with deterministic ids:
+  `WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING`.
+- `scope` (existing Json) carries the role binding:
+
+```jsonc
+{
+  "domains": ["data-model", "data-security"],     // existing scope axis
+  "professionKey": "data-architect",               // NEW, kebab-case role-family slug
+  "roles": ["data-architect"]                      // coworker role slugs this profile serves
+}
+```
+
+- `fallbackProfileId` → the org's WWWD profile (which itself falls back to platform
+  doctrine), so the chain in §4.5 is pure existing mechanics.
+
+### 4.3 Role → profile resolution
+
+A small resolver, mirroring the org-profile resolution entry-point (BI-230C9EF7):
+
+```
+resolveProfessionProfile({ agentId | roleSlug }) → DecisionPerspectiveProfile | null
+```
+
+- Source of the role slug: the coworker's registry entry (`agent_registry.json` /
+  `Agent` model) already names specialist roles (`data-architect`, etc. — the
+  `prompts/specialist/*.prompt.md` slugs). The resolver maps agent → role slug →
+  profession profile whose `scope.roles` contains it.
+- Null result = no WSID profile for this role → gate proceeds with the org/platform chain
+  exactly as today (additive, zero behavior change for unbound roles).
+
+### 4.4 Decision domain
+
+`DECISION_DOMAIN_CLASSES` is a closed registry (`plan-readiness`, `architecture-tradeoff`,
+`risk-assessment`). Add **`professional-practice`** — the domain class for craft questions
+("how should this be normalized", "which account does this accrual hit", "is this subject
+line compliant"). Existing domain classes remain valid against profession profiles (a
+data-architect plan-readiness question can still score WSID material tagged for it).
+
+### 4.5 Inheritance chain & authority boundary
+
+```
+1. Profession profile (WSID)        — authoritative for CRAFT questions
+2. Org WWWD profile                 — authoritative for BUSINESS questions
+3. DPF product doctrine             — advisory only (non-inherit boundary, unchanged)
+4. defer                            — captured as a profile gap (review inbox)
+```
+
+Conflict rule: **org-over-profession for business context, profession-over-silence for
+craft**. If the org's WWWD materially contradicts a professional standard (e.g. org policy
+mandates a denormalized reporting table where DMBOK doctrine pulls normalize), the gate
+returns `arbitrate` with the dissent preserved — same mechanics as today's two-credible-
+directions outcome — and org doctrine wins the business framing. A profession commandment
+that encodes *public safety or legal exposure* (e.g. "never interpolate untrusted input
+into SQL" — OWASP; "revenue is recognized when earned" — GAAP) does not yield: that
+conflict `escalate`s rather than arbitrates. Every interaction row records which chain
+level produced the answer (existing ledger fields).
+
+### 4.6 Corpus structure
+
+Per-role corpus on the existing wiki substrate:
+
+- **`WikiPage`** — body-of-knowledge pages, `organizationId = null` for platform-seeded
+  baseline (the kernel-overlay pattern gives orgs `kernelPageId`-linked override pages).
+  Page kinds used as-is: `principle` (decision-bearing rules — e.g. *parameterize all
+  SQL*), `heuristic` (e.g. *prefer 3NF until a measured read-path needs denormalization*),
+  `entity` (e.g. *DMBOK knowledge area: Data Quality*), `stance`, `summary`.
+- **`RawSource`** — one row per standard cited (DMBOK2, ISO/IEC 9075, OWASP ASVS, FASB
+  ASC…), `sourceType: "framework" | "spec"`, locator = formal citation. Pages link via
+  `WikiPageSource`. This is the provenance that makes a WSID recommendation auditable
+  back to the professional standard.
+- **`PerspectiveMaterial`** — the decision-bearing subset, attached to the profession
+  profile, graded per the existing trust ladder (platform-distilled standards enter as
+  `evidenceGrade: "B"`, `derived` trust — they are DPF's *reading* of the standard, not
+  first-party org fact).
+- **Principle taxonomy scoping** (existing axes, no additions):
+  `principleConsumerArchetype: "specialist"`,
+  `principleConsumerContexts: ["data-model"] | ["finance"] | ["marketing"]` (slugs already
+  in `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES`), `principleRingScope: "ring-1-coworker"`.
+  `recallPrincipleContext`'s strict context filter then keeps finance doctrine out of
+  marketing prompts for free.
+- **Knowledge graph**: `WikiPageLink` neighborhoods (existing), projected through the
+  shipped Material Backlinks surface. Cross-role links are first-class (OWASP pages link
+  from both data-architect and software-engineer corpora — one page, two profiles citing
+  it through their own materials).
+
+### 4.7 Enrichment (role-scoped)
+
+Generalize the shipped `enrichOrgCorpus` facade (`apps/web/lib/wiki/enrich-org-corpus.ts`)
+with a target discriminator rather than forking it:
+
+```ts
+type EnrichCorpusTarget =
+  | { kind: "organization"; organizationId: string }          // existing behavior
+  | { kind: "profession"; professionKey: string };            // NEW
+```
+
+- Source-key contract extends the existing scheme:
+  `profession/${professionKey}/${origin}/${stableSourceFingerprint}`.
+- Same dispositions, same **draft-by-default** review routing (BI-1378 precedent), same
+  `WikiIngestEvent` audit. Review-inbox grouping gains the profession as an owner lane
+  (the explainability spec's review inbox is already gap-reason generic).
+- Gap capture closes the loop: a `defer` on a craft question writes a profession-profile
+  gap, which is the enrichment backlog for that corpus — identical to WWMD founder-review
+  mechanics, pointed at a different owner.
+
+### 4.8 Gate & retrieval integration
+
+- The gate's profile-selection step becomes role-aware: coworker decision points pass the
+  agent identity; selection resolves profession profile for `professional-practice` (and
+  other domains when the profile scopes them), else the active org/platform profile.
+  `evaluateDecisionPerspective` itself is untouched — it already takes profile +
+  fallbacks + materials.
+- Qdrant recall reuses the existing wiki/material embedding path (`storeWikiPage`);
+  payload filtering by the profession's context slugs.
+
+### 4.9 MCP exposure
+
+No new tool family. `wwmd_evaluate` / `wwmd_decide` / `wwmd_record_outcome` already accept
+`profileId`; WSID adds:
+
+- profession profile ids as valid targets under the same scopes/grants;
+- a `resolveProfileForAgent` convenience (so an external client can ask "which profile
+  governs the finance coworker?") — read-only, exposed via the existing profile-resolution
+  entry-point work (BI-230C9EF7) rather than a parallel tool.
+
+### 4.10 Explainability
+
+Nothing new to build: Decision Canvas, Material Backlinks, and the review inbox project
+profile-generic records. A WSID decision renders as "the data-architect doctrine
+recommended X, citing *Parameterize all SQL* (OWASP ASVS v5, grade B, current)". The
+review queue wording for profession profiles uses owner/operator language (per the
+explainability spec's WWMD-vs-WWWD wording rule).
+
+## 5. Seeding (bootstrap) vs runtime (calibration)
+
+Per `seed-is-bootstrap-calibration-is-runtime` and `fix-the-seed-not-the-runtime`:
+
+- **Seed** installs: 3 profession profiles, their starter WikiPages + RawSources +
+  PerspectiveMaterials (platform-authored distillations, published status, promoted
+  materials — they are reviewed at PR time like kernel pages), and the role bindings.
+  Idempotent, FK-safe, loud on skip (silent-seed-skips audit applies).
+- **Runtime** owns growth: enrichment pipeline (§4.7), gap capture from `defer`s,
+  org overlays. Seed content is never the long-term source of truth for routing
+  decisions — the corpus lives in the DB and evolves there.
+
+## 6. Data model changes (summary)
+
+| Change | Layer | Migration? |
+|---|---|---|
+| `"profession"` in `DECISION_PROFILE_KINDS` | TS registry + lint + MCP validation | No (DB column is string) |
+| `"professional-practice"` in `DECISION_DOMAIN_CLASSES` | TS registry | No |
+| `scope.professionKey` / `scope.roles` | Json contract + type | No |
+| `EnrichCorpusTarget` discriminator | `enrich-org-corpus.ts` generalization | No |
+| Profession seed module | `packages/db/src/seed-*` | Seed only |
+
+Zero structural migrations is a deliberate outcome of the schema-audit-before-features
+pass (§4.1): the 2026-05 decision-perspective models were built profile-kind-generic.
+
+## 7. Governance & corpus content policy
+
+1. **Copyright-clean**: corpus pages are DPF-authored distillations citing standards;
+   never reproduced licensed text. RawSource rows carry the citation; lint can flag pages
+   exceeding a quotation-length budget per source.
+2. **Draft-by-default enrichment** (unchanged from org corpus): trust sets grade/weight,
+   not review state.
+3. **Evidence grades**: platform distillations B; org first-party overrides A; researched
+   additions C — the existing ladder.
+4. **Security doctrine is commandment-in-context**: injection prevention, secrets
+   handling, consent/compliance rules seed at `principleTier: commandment` scoped to
+   their contexts, so they win conflict resolution inside the role without leaking
+   platform-wide.
+5. **Non-inherit boundary preserved**: profession doctrine is craft authority, not
+   business authority; the customer's WWWD remains the business voice (§4.5).
+
+## 8. Acceptance (V1)
+
+1. Data-architect coworker, craft question ("is this query injection-safe / how should
+   this table be normalized") → `recommend` citing WSID materials with standard-traced
+   provenance; `DecisionInteraction` records the profession profile + version.
+2. Role without a WSID profile → unchanged behavior, ledger shows org/platform chain level.
+3. Fresh install seeds all three corpora; `pnpm verify` seed invariants pass; no silent
+   skips.
+4. Org overlay: an org-scoped override page/material wins over the platform baseline for
+   that org without mutating it.
+5. `defer` on a craft question lands in the review inbox under the profession lane.
+
+## 9. Open questions (tracked, non-blocking)
+
+- Whether `team` profile kind (already in the registry, unshipped) should share the role
+  resolver — deferred until a team profile exists.
+- GraphRAG-style community summaries for large corpora (§3) — revisit when a corpus
+  exceeds local-neighborhood explainability.
+- Per-instance coworker profiles (a specific agent's learned preferences) — explicitly
+  out of scope; the agent-memory Qdrant collection continues to serve that need.
+
+## 10. Phasing
+
+See the implementation plan:
+`docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md`.

--- a/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
@@ -302,14 +302,90 @@ recommended X, citing *Parameterize all SQL* (OWASP ASVS v5, grade B, current)".
 review queue wording for profession profiles uses owner/operator language (per the
 explainability spec's WWMD-vs-WWWD wording rule).
 
+### 4.11 Coverage contract — every coworker, mapped to a profession family
+
+WSID covers the **whole roster**: all 63 `agent_registry.json` agents and all ~24
+`prompts/route-persona/*` personas. Many coworkers share a craft, so coverage is by
+**profession family** — one profile, one corpus, N bound roles. The working family map
+(maintained as the Profession Source Registry, §4.12; candidate anchor standards subject
+to each family's research pass):
+
+| Profession family (`professionKey`) | Bound roles (registry `agent_name` / persona) | Candidate anchor standards |
+|---|---|---|
+| `data-management` | build-data-architect/data-architect, data-governance-agent | DAMA-DMBOK2, ISO/IEC 9075, ISO 11179, OWASP |
+| `finance-accounting` | finance-agent, investment-analysis-agent | US GAAP (FASB ASC), SOX 404, FP&A practice |
+| `marketing` | marketing-specialist | AMA BoK, STP/4Ps, CAN-SPAM/GDPR consent |
+| `software-engineering` | software-engineer, frontend-engineer, platform-engineer, iac-execution-agent | SWEBOK v4, OWASP, 12-factor, IaC practice |
+| `software-quality` | qa-engineer, release-acceptance-agent | ISTQB CTFL, ISO/IEC 25010 |
+| `security-compliance` | security-auditor-agent, policy-enforcement-agent, policy-specialist | ISO/IEC 27001, NIST CSF 2.0, CIS Controls |
+| `enterprise-architecture` | ea-architect, architecture-agent, architecture-definition-agent, architecture-guardrail-agent, governance-orchestrator | TOGAF 10, IT4IT 3.0, ArchiMate 3.2 |
+| `portfolio-management` | portfolio-advisor, portfolio-backlog-agent/-specialist, portfolio-rationalization-agent, gap-analysis-agent, strategy-alignment-agent | PMI Std for Portfolio Mgmt, IT4IT S2P |
+| `product-management` | product-backlog-specialist, product-backlog-prioritization-agent, roadmap-assembly-agent, scope-agreement-agent | PDMA BoK, discovery/prioritization practice |
+| `service-management-sre` | operate-orchestrator, ops-coordinator, monitoring-agent, incident-detection-agent, incident-resolution-agent, service-support-agent | ITIL 4, Google SRE, ISO/IEC 20000 |
+| `release-engineering` | integrate/deploy/release-orchestrators, release-planning-agent, deployment-planning-agent, sbom-management-agent, resource-reservation-agent | DORA, SLSA, NTIA SBOM / CycloneDX |
+| `customer-service` | consume-orchestrator, customer-advisor, consumer-onboarding-agent, order-fulfillment-agent, subscription-management-agent | service blueprinting, CX practice (CXPA) |
+| `service-catalog-licensing` | catalog-publication-agent, service-offer-definition-agent, licensing-specialist | ITIL service catalog, ISO/IEC 19770 (ITAM/SAM) |
+| `asset-estate-management` | inventory-specialist, estate-specialist | ISO 55000, IAITAM ITAM |
+| `human-resources` | hr-specialist | SHRM BASK, employment-compliance basics |
+| `technical-communication` | documentation-specialist | tech-writing practice, structured authoring |
+| `ux-accessibility` | ux-accessibility | WCAG 2.2, ISO 9241, heuristic evaluation |
+| `general-management` | coo, onboarding-coo, admin-assistant, evaluate/explore-orchestrators, remaining cross-cutting reviewers | management practice; mostly WWWD-governed |
+
+Rules:
+
+1. **Every active coworker role resolves** — to its family profile, or explicitly to
+   `general-management` as the typed generalist bucket. An unmapped role is a lint
+   failure in the registry, not a silent fallthrough.
+2. **Profiles ship for all families from V1; corpora roll out in waves.** A profile
+   whose corpus isn't built yet still participates in the gate — its `defer` outcomes
+   are the gap signal, and per-family defer counts are the **prioritization queue** for
+   which corpus gets researched next (demand-driven, not guessed).
+3. Platform-internal pipeline agents (hive-scout reviewers, discovery-triage) are
+   governed by the engineering-flow/WWMD platform doctrine they already have; they map
+   to families only where a real external profession exists.
+
+### 4.12 Research-sourced corpus pipeline — no training-data authoring
+
+The corpus is only as trustworthy as its sources. **A model writing "DMBOK says X" from
+its own training-data memory is the exact ungoverned state WSID exists to replace** —
+so the pipeline makes that impossible to pass review:
+
+1. **Profession Source Registry** (governed artifact, `docs/professions/registry.json`,
+   PR-reviewed): per `professionKey` — bound roles, context slugs, the source list
+   (locator, publisher, edition/version, **license class**: `open` / `licensed` /
+   `org-supplied`), and a coverage checklist of knowledge areas (SFIA 9 / O*NET-derived)
+   the corpus must span. This registry is the per-profession research mandate Mark's
+   directive requires: each family gets its own research effort and its own sources.
+2. **Fetch & capture**: a per-profession research run (the existing research-execution
+   harness — `apps/web/lib/wiki/research-execution.ts`, `market-research.ts` precedent —
+   plus deep-research style multi-source sweeps) retrieves each open source. Every fetch
+   is stored as a `RawSource` with verifiable provenance: locator (URL/citation),
+   `retrievedAt`, content fingerprint, license class. Licensed works enter only via the
+   `document` origin (org-supplied upload under the customer's own license — DPF is a
+   conduit, never the licensee) or stay checklist-only (knowledge-area names and
+   structure are facts; licensed prose is not ingested).
+3. **Distill from retrieved text only**: page proposals run through the existing
+   `proposeWikiDiff` adapters **with the fetched source text as input**. The model's job
+   is distillation and structure-mapping of text in front of it, never recall.
+4. **Provenance invariant (lint + CI gate)**: every WSID corpus `WikiPage` has ≥1
+   `WikiPageSource` link to a `RawSource` carrying retrieval metadata; every
+   `PerspectiveMaterial.sourceRef` traces to those RawSources. A page with no fetched
+   source cannot reach `published`; a material with no traceable source cannot reach
+   `promoted`. This is mechanical, not honor-system.
+5. **Freshness loop**: `scheduled-refresh` origin re-validates sources (standards get
+   new editions; OWASP Top 10 rotates), updating `lastValidatedAt` and flagging
+   `stale`/`superseded` materials through the existing freshness states.
+
 ## 5. Seeding (bootstrap) vs runtime (calibration)
 
 Per `seed-is-bootstrap-calibration-is-runtime` and `fix-the-seed-not-the-runtime`:
 
-- **Seed** installs: 3 profession profiles, their starter WikiPages + RawSources +
-  PerspectiveMaterials (platform-authored distillations, published status, promoted
-  materials — they are reviewed at PR time like kernel pages), and the role bindings.
-  Idempotent, FK-safe, loud on skip (silent-seed-skips audit applies). Seed-time
+- **Seed** installs: profession profiles **for every family in the registry** (§4.11)
+  with full role bindings, plus the pilot corpora — WikiPages + RawSources +
+  PerspectiveMaterials that were **produced by the §4.12 research pipeline** (run at
+  authoring time, provenance recorded in the committed content, PR-reviewed like kernel
+  pages — never hand-authored from model memory). Idempotent, FK-safe, loud on skip
+  (silent-seed-skips audit applies). Seed-time
   embeddings follow the founder-kernel precedent (`seed-wiki-kernel.ts`): a precomputed
   `embeddings.jsonl` sidecar per corpus tree, because a fresh install has no embedding
   provider configured at seed time (`zero-click-provider-setup`); runtime enrichment
@@ -327,6 +403,7 @@ Per `seed-is-bootstrap-calibration-is-runtime` and `fix-the-seed-not-the-runtime
 | `scope.professionKey` / `scope.roles` | Json contract + type | No |
 | `EnrichCorpusTarget` discriminator | `enrich-org-corpus.ts` generalization | No |
 | `"data-security"` in `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` | `packages/db/src/wiki-taxonomy.ts` examples registry | No (contexts are open kebab-case) |
+| Profession Source Registry | `docs/professions/registry.json` (governed artifact + lint) | No (file + seed) |
 | Profession seed module | `packages/db/src/seed-*` (generalizes `seed-wiki-kernel.ts` machinery) | Seed only |
 
 Zero structural migrations is a deliberate outcome of the schema-audit-before-features
@@ -337,28 +414,42 @@ pass (§4.1): the 2026-05 decision-perspective models were built profile-kind-ge
 1. **Copyright-clean**: corpus pages are DPF-authored distillations citing standards;
    never reproduced licensed text. RawSource rows carry the citation; lint can flag pages
    exceeding a quotation-length budget per source.
-2. **Draft-by-default enrichment** (unchanged from org corpus): trust sets grade/weight,
+2. **No training-data authoring**: corpus content is distilled from *fetched* source
+   text with recorded retrieval provenance (§4.12). The provenance invariant is a CI/lint
+   gate — unsourced pages cannot publish, unsourced materials cannot promote.
+3. **Draft-by-default enrichment** (unchanged from org corpus): trust sets grade/weight,
    not review state.
-3. **Evidence grades**: platform distillations B; org first-party overrides A; researched
+4. **Evidence grades**: platform distillations B; org first-party overrides A; researched
    additions C — the existing ladder.
-4. **Security doctrine is commandment-in-context**: injection prevention, secrets
+5. **Security doctrine is commandment-in-context**: injection prevention, secrets
    handling, consent/compliance rules seed at `principleTier: commandment` scoped to
    their contexts, so they win conflict resolution inside the role without leaking
    platform-wide.
-5. **Non-inherit boundary preserved**: profession doctrine is craft authority, not
+6. **Non-inherit boundary preserved**: profession doctrine is craft authority, not
    business authority; the customer's WWWD remains the business voice (§4.5).
+7. **Licensed bodies of knowledge follow the conduit rule**: DPF never enrolls as a
+   licensee of DMBOK/ISO/SFIA content. Where a standard is licensed, the customer brings
+   their own copy (`org-supplied` document origin) or the corpus covers the open
+   knowledge-area structure only.
 
 ## 8. Acceptance (V1)
 
 1. Data-architect coworker, craft question ("is this query injection-safe / how should
    this table be normalized") → `recommend` citing WSID materials with standard-traced
    provenance; `DecisionInteraction` records the profession profile + version.
-2. Role without a WSID profile → unchanged behavior, ledger shows org/platform chain level.
-3. Fresh install seeds all three corpora; `pnpm verify` seed invariants pass; no silent
-   skips.
-4. Org overlay: an org-scoped override page/material wins over the platform baseline for
+2. **Every active coworker role resolves to a profession profile** via the registry
+   family map (§4.11) — an unmapped role is a lint failure. Families without a built
+   corpus participate via `defer` + gap capture (the demand queue for the next corpus).
+3. **Provenance invariant holds mechanically**: 100% of published corpus pages link to a
+   fetched `RawSource` with retrieval metadata; 100% of promoted materials trace to
+   those sources. The lint/CI gate rejects violations — no training-data-only content
+   can ship.
+4. Fresh install seeds all family profiles + the three pilot corpora; `pnpm verify` seed
+   invariants pass; no silent skips.
+5. Org overlay: an org-scoped override page/material wins over the platform baseline for
    that org without mutating it.
-5. `defer` on a craft question lands in the review inbox under the profession lane.
+6. `defer` on a craft question lands in the review inbox under the profession lane, and
+   per-family defer counts are queryable as the corpus-rollout prioritization signal.
 
 ## 9. Open questions (tracked, non-blocking)
 


### PR DESCRIPTION
## Summary

Design spec + phased implementation plan for **WSID (What Should I Do)** — the third member of the decision-perspective family:

- **WWMD** (founder/platform) → **WWWD** (organization) → **WSID** (profession/role)
- Each AI Coworker role gets a governed professional corpus matching its human equivalent: data architect → DAMA-DMBOK / ANSI SQL / OWASP injection prevention; finance → GAAP; marketing → marketing bodies of knowledge.

## What's in

- `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md` — architecture: `profession` profile kind, role→profile resolver, corpus on the existing WikiPage + RawSource + PerspectiveMaterial substrate, `professional-practice` decision domain, inheritance chain (role → org WWWD → DPF advisory → defer), craft-vs-business authority boundary, role-scoped enrichment via `EnrichCorpusTarget` generalization of `enrichOrgCorpus`, copyright-clean distillation policy. Research & Benchmarking per AGENTS.md §10 (Onyx/Danswer, CrewAI, GraphRAG; OpenAI Assistants, Copilot Studio, Glean; DMBOK2/GAAP/AMA/SFIA).
- `docs/superpowers/plans/2026-06-09-wsid-coworker-professional-corpus.md` — 6 phases (0–5), each with grounded touch points, verification, risks + rollback. **Zero structural migrations** — the 2026-05 decision-perspective models are profile-kind-generic by design.

## Governance

- Backlog: BI-48B3CEC4 (triaged build/xlarge), new epic EP-WSID (overlap-verified: EP-WWMD-MCP is MCP-exposure-scoped; no WSID specs/commits/PRs existed)
- Composition risk with BI-230C9EF7 (org profile resolution entry-point) is named in the plan's sequencing notes
- Implementation slices go through Build Studio per standing rule; this PR is docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)