### PR TITLE
fix(build-studio): surface ideate/plan/review build strands on boot, not silent orphans (BI-17377D05)

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -310,13 +310,13 @@ describe("recoverContradictoryBuildExecStatesOnBoot (FIX 1)", () => {
 describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
   it("re-dispatches a stranded, internally-consistent mid-step build", async () => {
     featureBuildFindManyMock.mockResolvedValueOnce([
-      { buildId: "BLD-STRANDED", buildExecState: { step: "deps_installed" }, verificationOut: null },
+      { buildId: "BLD-STRANDED", phase: "build", buildExecState: { step: "deps_installed" }, verificationOut: null },
     ]);
     const dispatch = vi.fn();
 
     const result = await resumeStrandedBuildsOnBoot({ dispatch }, { log: vi.fn(), error: vi.fn() });
 
-    expect(result).toEqual({ resumed: 1 });
+    expect(result).toEqual({ resumed: 1, flagged: 0 });
     expect(dispatch).toHaveBeenCalledWith("BLD-STRANDED");
     expect(buildActivityCreateMock).toHaveBeenCalledTimes(1);
   });
@@ -324,31 +324,48 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
   it("skips contradictory shapes (owned by FIX 1) and terminal/null steps", async () => {
     featureBuildFindManyMock.mockResolvedValueOnce([
       // contradictory: error-without-fail
-      { buildId: "BLD-CONTRA", buildExecState: { step: "complete", error: "x" }, verificationOut: null },
+      { buildId: "BLD-CONTRA", phase: "build", buildExecState: { step: "complete", error: "x" }, verificationOut: null },
       // terminal
-      { buildId: "BLD-COMPLETE", buildExecState: { step: "complete" }, verificationOut: { typecheckPassed: true } },
-      { buildId: "BLD-FAILED", buildExecState: { step: "failed", failedAt: "db_ready", error: "x" }, verificationOut: null },
+      { buildId: "BLD-COMPLETE", phase: "build", buildExecState: { step: "complete" }, verificationOut: { typecheckPassed: true } },
+      { buildId: "BLD-FAILED", phase: "build", buildExecState: { step: "failed", failedAt: "db_ready", error: "x" }, verificationOut: null },
       // missing step (contradictory)
-      { buildId: "BLD-NOSTEP", buildExecState: { sourceCurrency: { a: 1 } }, verificationOut: null },
+      { buildId: "BLD-NOSTEP", phase: "build", buildExecState: { sourceCurrency: { a: 1 } }, verificationOut: null },
     ]);
     const dispatch = vi.fn();
 
     const result = await resumeStrandedBuildsOnBoot({ dispatch }, { log: vi.fn(), error: vi.fn() });
 
-    expect(result).toEqual({ resumed: 0 });
+    expect(result).toEqual({ resumed: 0, flagged: 0 });
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it("passes a staleAfter cutoff to the query so live builds are excluded", async () => {
+  // BI-17377D05: pre-build phases have no resumable step-machine; surface them
+  // as recoverable instead of auto-re-dispatching the fragile pre-build flow.
+  it("flags ideate/plan/review strands for recovery without auto-dispatch", async () => {
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-IDEATE", phase: "ideate", buildExecState: null, verificationOut: null },
+      { buildId: "BLD-PLAN", phase: "plan", buildExecState: { step: "deps_installed" }, verificationOut: null },
+      { buildId: "BLD-REVIEW", phase: "review", buildExecState: null, verificationOut: null },
+    ]);
+    const dispatch = vi.fn();
+
+    const result = await resumeStrandedBuildsOnBoot({ dispatch }, { log: vi.fn(), error: vi.fn() });
+
+    expect(result).toEqual({ resumed: 0, flagged: 3 });
+    expect(dispatch).not.toHaveBeenCalled(); // never auto-dispatches pre-build phases
+    expect(buildActivityCreateMock).toHaveBeenCalledTimes(3); // one recovery signal each
+  });
+
+  it("queries all non-terminal pre-ship phases with a staleAfter cutoff", async () => {
     featureBuildFindManyMock.mockResolvedValueOnce([]);
     const dispatch = vi.fn();
 
     await resumeStrandedBuildsOnBoot({ staleAfterMs: 60_000, dispatch }, { log: vi.fn(), error: vi.fn() });
 
     const where = (featureBuildFindManyMock.mock.calls[0]![0] as {
-      where: { phase: string; updatedAt: { lt: Date } };
+      where: { phase: { in: string[] }; updatedAt: { lt: Date } };
     }).where;
-    expect(where.phase).toBe("build");
+    expect(where.phase).toEqual({ in: ["ideate", "plan", "build", "review"] });
     expect(where.updatedAt.lt).toBeInstanceOf(Date);
   });
 

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -305,7 +305,7 @@ export async function recoverContradictoryBuildExecStatesOnBoot(
 export async function resumeStrandedBuildsOnBoot(
   opts: { staleAfterMs?: number; dispatch?: (buildId: string) => void } = {},
   logger: Pick<Console, "log" | "error"> = console,
-): Promise<{ resumed: number } | null> {
+): Promise<{ resumed: number; flagged: number } | null> {
   const staleAfterMs = opts.staleAfterMs ?? 5 * 60 * 1000;
   try {
     const { prisma } = await import("@dpf/db");
@@ -314,9 +314,18 @@ export async function resumeStrandedBuildsOnBoot(
     );
     type ExecStateLike = import("@/lib/integrate/build-exec-types").ExecStateLike;
     const cutoff = new Date(Date.now() - staleAfterMs);
+    // BI-17377D05: cover ALL non-terminal pre-ship phases, not just `build`.
+    // Only the `build` phase has a resumable step-machine (buildExecState) that
+    // autoExecuteBuild can re-dispatch; ideate/plan/review are dispatch-driven
+    // with no resume, so a swap (or a dead dispatch) used to strand them
+    // SILENTLY. We still auto-resume `build`; for the pre-build phases we surface
+    // the strand as recoverable so it stops being a silent orphan.
     const candidates = await prisma.featureBuild.findMany({
-      where: { phase: "build", updatedAt: { lt: cutoff } },
-      select: { buildId: true, buildExecState: true, verificationOut: true },
+      where: {
+        phase: { in: ["ideate", "plan", "build", "review"] },
+        updatedAt: { lt: cutoff },
+      },
+      select: { buildId: true, phase: true, buildExecState: true, verificationOut: true },
     });
 
     // Default dispatcher lazy-imports the system executor to avoid pulling the
@@ -338,7 +347,30 @@ export async function resumeStrandedBuildsOnBoot(
       });
 
     let resumed = 0;
+    let flagged = 0;
     for (const build of candidates) {
+      // ── Pre-build phases (ideate/plan/review): no resumable step-machine.
+      // Surface as recoverable instead of auto-re-dispatching the fragile,
+      // unverified pre-build flow. Full auto-resume of these phases is the
+      // remaining BI-17377D05 / EP-BUILD-4DB1C0 work.
+      if (build.phase !== "build") {
+        logger.log(
+          `[build-resume] ${build.buildId} stranded in ${build.phase} phase after restart — flagged for recovery (pre-build phases have no auto-resume)`,
+        );
+        await prisma.buildActivity
+          .create({
+            data: {
+              buildId: build.buildId,
+              tool: "resumeStrandedBuildsOnBoot",
+              summary: `Stranded in ${build.phase} phase after a restart/swap — flagged for operator recovery; pre-build phases have no auto-resume yet (BI-17377D05).`,
+            },
+          })
+          .catch(() => {});
+        flagged++;
+        continue;
+      }
+
+      // ── Build phase: proven step-machine resume (unchanged behavior). ──
       const state = build.buildExecState as ExecStateLike | null;
       // Skip contradictory shapes — the contradictory-recovery reconciler owns
       // those. Skip null/terminal steps — nothing to resume.
@@ -364,7 +396,10 @@ export async function resumeStrandedBuildsOnBoot(
     if (resumed > 0) {
       logger.log(`[build-resume] re-dispatched ${resumed} stranded build(s)`);
     }
-    return { resumed };
+    if (flagged > 0) {
+      logger.log(`[build-resume] flagged ${flagged} pre-build-phase strand(s) for recovery`);
+    }
+    return { resumed, flagged };
   } catch (err) {
     logger.error("[build-resume] failed (non-fatal):", err);
     return null;


### PR DESCRIPTION
## What & why

`resumeStrandedBuildsOnBoot` only re-dispatched builds stranded in the **`build`** phase — the one phase with a resumable step-machine (`buildExecState`, replayed by `autoExecuteBuild`/`runBuildPipeline`). Builds stranded in **ideate / plan / review** — a self-upgrade swap mid-phase, or a dead phase dispatch — were picked up by **no boot reconciler**, so they wedged **silently** until a long watchdog heartbeat timeout. Both happened live this session (`FB-49DCB2DE` in ideate, `FB-8010B564` in plan).

## Change
Broaden the boot reconciler to all non-terminal pre-ship phases:
- **`build`** keeps its proven, unchanged auto-resume.
- **ideate / plan / review** strands are now **detected on boot and flagged for recovery** (a `BuildActivity` recovery signal + log) so they're immediately visible/operator-actionable instead of silent orphans. They are deliberately **not** auto-re-dispatched: the pre-build phases have no resumable step-machine, and re-triggering the fragile pre-build dispatch **unverified** (Build Studio's own ideate/plan handoff is currently flaky) would be a quick-fix to a load-bearing path.

## Scope boundary (honest)
Full **auto-resume** of the pre-build phases (idempotently re-driving ideate/plan/review dispatch) remains **BI-17377D05 / EP-BUILD-4DB1C0** — it needs the orchestrator phase-dispatch-resume design *and a working Build Studio to verify against* (structural-verification-is-not-functional). This PR removes the **silent-orphan** half now; the auto-resume half is intentionally out of scope rather than hacked in blind.

## Tests
- Pre-build strands are flagged (not dispatched), one recovery signal each; `build` resume unchanged; the query covers ideate/plan/build/review with the stale cutoff (live builds excluded).
- `web` typecheck clean; instrumentation + integrate suites (883) green; full `web` suite **10,301 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)