### PR TITLE
feat(archetypes): Phase-0 civic substrate — governance axis, member/resident consumers, ledgerModel (BI-938D1B71)

### DIFF
--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -84,6 +84,14 @@ const VOCABULARY: Record<string, ArchetypeVocabulary> = {
     portalLabel: "Community Portal", stakeholderLabel: "Homeowners",
     teamLabel: "Board & Contractors", inboxLabel: "Requests", agentName: "Community Manager",
   },
+  // Towns, municipal utilities, law enforcement. Leaf overrides (Ratepayers /
+  // Community) ship with each archetype via customVocabulary; civic spec §8.
+  "public-sector": {
+    itemsLabel: "Services & Programs", singleItemLabel: "Service", addButtonLabel: "Add service",
+    categoryLabel: "Department", priceLabel: "Fee",
+    portalLabel: "Resident Portal", stakeholderLabel: "Residents",
+    teamLabel: "Staff", inboxLabel: "Service Requests", agentName: "Resident Services",
+  },
 };
 
 const DEFAULT_VOCABULARY: ArchetypeVocabulary = {

--- a/docs/Reference/operating-model-axes-additions.md
+++ b/docs/Reference/operating-model-axes-additions.md
@@ -1,0 +1,39 @@
+# Operating-Model Axes — Accepted Additions (sidecar to the 4-portfolio workbook)
+
+The canonical taxonomy lives in `4_portfolio_Reworked_V3_Definitions_IT4IT.xlsx`
+(Products and Services Sold sheet carries the axis columns). Per the workbook-first
+contract (2026-05-22 archetype capability spec §3.6), axis-vocabulary changes are
+proposed against the workbook and promoted into platform enums once accepted. This
+sidecar records accepted additions until the taxonomy team's next workbook pass folds
+them in; the workbook + this file together are the source of truth in the interim.
+
+## Accepted 2026-06-09 — civic & member-governed archetypes
+
+Operator-approved via `docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md`
+(review pass applied 2026-06-09; delivery under EP-ARCH-8D4F2A, BI-938D1B71).
+
+### New column: *Governance Model* (`governance` axis)
+
+| Value | Meaning |
+| --- | --- |
+| `investor-owned` | Default. Privately/investor-owned business; every pre-existing archetype normalizes here. |
+| `member-owned` | Member-owners govern: one member one vote, elected board, annual meeting (credit unions, cooperatives). |
+| `public-body` | Council/elected board under open-meetings and public-records law; fund accounting (towns, municipal utilities, law enforcement). |
+
+### Column *Primary External Consumer* (`primaryConsumer`) — new values
+
+| Value | Meaning |
+| --- | --- |
+| `member` | Owner-patron with governance rights; eligibility precedes account creation. |
+| `resident` | Served party defined by jurisdiction: statutory rights, universal-service obligation, cannot be refused or churned. |
+
+### Column *Commercial Model* (`commercialModel`) — new value
+
+| Value | Meaning |
+| --- | --- |
+| `statutory-fees-and-levies` | Revenue arrives by levy/assessment/fee schedule set by ordinance or statute, not by sale. Billing derivation: obligation-driven ad-hoc invoice, prepared-not-prescribed. |
+
+### Related (not an axis): `ledgerModel` on the finance profile
+
+`commercial` (default) | `fund-accounting` | `financial-institution` | `cooperative-equity` —
+see spec §6.2; lives in `packages/finance-templates`, not in the workbook axis columns.

--- a/packages/finance-templates/src/profiles.test.ts
+++ b/packages/finance-templates/src/profiles.test.ts
@@ -3,6 +3,7 @@ import {
   deriveRecurringBillingEnabled,
   getFinancialProfile,
   getAllProfiles,
+  LEDGER_COA_FRAGMENTS,
 } from "./profiles";
 
 const EXPECTED_SLUGS = [
@@ -140,5 +141,48 @@ describe("financial profile catalog", () => {
     expect(profile?.billingPatternProfile.supportedPaymentPatterns).toEqual(
       expect.arrayContaining(["appointment-checkout", "point-of-sale", "optional-package"]),
     );
+  });
+
+  it("every existing profile resolves ledgerModel to commercial", () => {
+    for (const profile of getAllProfiles()) {
+      expect(profile.ledgerModel, `${profile.slug} should default to commercial`).toBe("commercial");
+    }
+  });
+});
+
+describe("ledger-model chart-of-accounts fragments", () => {
+  it("ships fund-accounting, financial-institution, and cooperative-equity fragments", () => {
+    expect(Object.keys(LEDGER_COA_FRAGMENTS).sort()).toEqual([
+      "cooperative-equity",
+      "financial-institution",
+      "fund-accounting",
+    ]);
+  });
+
+  it("every fragment has unique codes and valid account types", () => {
+    for (const [model, fragment] of Object.entries(LEDGER_COA_FRAGMENTS)) {
+      expect(fragment.length, `${model} fragment must not be empty`).toBeGreaterThan(0);
+      const codes = fragment.map((account) => account.code);
+      expect(new Set(codes).size, `${model} fragment has duplicate codes`).toBe(codes.length);
+      for (const account of fragment) {
+        expect(account.name, `${model} account ${account.code} missing name`).toBeTruthy();
+        expect(
+          ["revenue", "expense", "asset", "liability", "equity"],
+          `${model} account ${account.code} has invalid type`,
+        ).toContain(account.type);
+      }
+    }
+  });
+
+  it("captures each model's defining accounts", () => {
+    const names = (model: keyof typeof LEDGER_COA_FRAGMENTS) =>
+      LEDGER_COA_FRAGMENTS[model].map((account) => account.name).join("; ");
+
+    expect(names("fund-accounting")).toContain("Fund Balance");
+    expect(names("fund-accounting")).toContain("Debt Service");
+    expect(names("financial-institution")).toContain("Allowance for Credit Losses");
+    expect(names("financial-institution")).toContain("Provision for Credit Losses");
+    expect(names("cooperative-equity")).toContain("Allocated Member Equity");
+    expect(names("cooperative-equity")).toContain("Patronage Dividends Payable");
   });
 });

--- a/packages/finance-templates/src/profiles.ts
+++ b/packages/finance-templates/src/profiles.ts
@@ -1,4 +1,4 @@
-import type { BillingPatternProfile, FinancialProfile } from "./types";
+import type { BillingPatternProfile, FinancialProfile, LedgerModel } from "./types";
 
 // ─── Profile catalog ──────────────────────────────────────────────────────────
 
@@ -431,6 +431,7 @@ function normalizeFinancialProfile(slug: string, profile: FinancialProfileSeed):
     ...profile,
     billingPatternProfile,
     recurringBillingEnabled: deriveRecurringBillingEnabled(billingPatternProfile),
+    ledgerModel: profile.ledgerModel ?? "commercial",
   };
 }
 
@@ -445,3 +446,57 @@ export function getAllProfiles(): Array<{ slug: string } & FinancialProfile> {
     ...normalizeFinancialProfile(slug, profile),
   }));
 }
+
+// ─── Ledger-model chart-of-accounts fragments ─────────────────────────────────
+// Named template fragments consumed by archetype financial profiles that declare
+// a non-commercial ledgerModel (civic archetypes spec §6.2). They are seeds for
+// the management view; the org's core/accounting system stays authoritative.
+
+type ChartOfAccountsSeed = FinancialProfile["chartOfAccountsSeed"];
+
+export const LEDGER_COA_FRAGMENTS: Record<Exclude<LedgerModel, "commercial">, ChartOfAccountsSeed> = {
+  "fund-accounting": [
+    { code: "1000", name: "General Fund Cash", type: "asset" },
+    { code: "3000", name: "Fund Balance — Unassigned", type: "equity" },
+    { code: "3010", name: "Fund Balance — Restricted", type: "equity" },
+    { code: "4000", name: "Property Tax & Levy Revenue", type: "revenue" },
+    { code: "4010", name: "Intergovernmental Revenue & Grants", type: "revenue" },
+    { code: "4020", name: "Charges for Services", type: "revenue" },
+    { code: "4030", name: "Fines, Fees & Permits", type: "revenue" },
+    { code: "4100", name: "Special Revenue Fund Revenue", type: "revenue" },
+    { code: "4200", name: "Enterprise Fund Charges", type: "revenue" },
+    { code: "5000", name: "General Government Expenditures", type: "expense" },
+    { code: "5010", name: "Public Safety Expenditures", type: "expense" },
+    { code: "5020", name: "Public Works Expenditures", type: "expense" },
+    { code: "5030", name: "Culture & Recreation Expenditures", type: "expense" },
+    { code: "5100", name: "Capital Outlay", type: "expense" },
+    { code: "5200", name: "Debt Service — Principal & Interest", type: "expense" },
+  ],
+  "financial-institution": [
+    { code: "1000", name: "Loans Receivable", type: "asset" },
+    { code: "1010", name: "Allowance for Credit Losses (contra)", type: "asset" },
+    { code: "1100", name: "Investment Portfolio", type: "asset" },
+    { code: "2000", name: "Deposits / Member Shares", type: "liability" },
+    { code: "3000", name: "Retained / Undivided Earnings", type: "equity" },
+    { code: "3010", name: "Regular Reserves", type: "equity" },
+    { code: "4000", name: "Interest Income — Loans", type: "revenue" },
+    { code: "4010", name: "Interest Income — Investments", type: "revenue" },
+    { code: "4020", name: "Fee & Service Charge Income", type: "revenue" },
+    { code: "5000", name: "Interest / Dividend Expense", type: "expense" },
+    { code: "5010", name: "Provision for Credit Losses", type: "expense" },
+    { code: "5020", name: "Personnel Expense", type: "expense" },
+    { code: "5030", name: "Occupancy & Operations Expense", type: "expense" },
+    { code: "5040", name: "Exam & Compliance Costs", type: "expense" },
+  ],
+  "cooperative-equity": [
+    { code: "2000", name: "Patronage Dividends Payable", type: "liability" },
+    { code: "2010", name: "Equity Retirement Payable", type: "liability" },
+    { code: "3000", name: "Allocated Member Equity", type: "equity" },
+    { code: "3010", name: "Unallocated Retained Earnings", type: "equity" },
+    { code: "3020", name: "Per-Unit Retains", type: "equity" },
+    { code: "4000", name: "Member Sales Revenue", type: "revenue" },
+    { code: "4010", name: "Non-Member Revenue", type: "revenue" },
+    { code: "5000", name: "Cost of Goods & Services", type: "expense" },
+    { code: "5010", name: "Operating Expenses", type: "expense" },
+  ],
+};

--- a/packages/finance-templates/src/types.ts
+++ b/packages/finance-templates/src/types.ts
@@ -21,9 +21,25 @@ export type BillingPatternProfile = {
   recurringBillingApplicability: RecurringBillingApplicability;
 };
 
+/**
+ * The accounting shape the archetype's finance surfaces render.
+ * - `commercial` — default; every pre-existing profile.
+ * - `fund-accounting` — GASB-style funds with budget-to-actual as the primary statement (public bodies).
+ * - `financial-institution` — interest-margin P&L shape; the core banking system stays authoritative.
+ * - `cooperative-equity` — commercial P&L plus patronage allocation and allocated/unallocated member equity.
+ * See docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md §6.2.
+ */
+export type LedgerModel =
+  | "commercial"
+  | "fund-accounting"
+  | "financial-institution"
+  | "cooperative-equity";
+
 export type FinancialProfile = {
   archetypeCategory: string;
   displayName: string;
+  /** Absent ⇒ "commercial"; normalization always resolves it. */
+  ledgerModel?: LedgerModel;
   defaultPaymentTerms: string;
   defaultCurrency: string;
   vatRegistered: boolean;

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -5,6 +5,7 @@ import {
   getCapabilityApplicability,
   readActivationProfile,
 } from "./activation-profile";
+import { ALL_ARCHETYPES } from "./archetypes";
 
 describe("readActivationProfile", () => {
   it("normalizes legacy MSP modules into operating axes and derived capabilities", () => {
@@ -105,5 +106,131 @@ describe("readActivationProfile", () => {
         ],
       }),
     ).toBeNull();
+  });
+
+  it("defaults governance to investor-owned for legacy and axis-shaped profiles, and rejects invalid values", () => {
+    const legacy = readActivationProfile({
+      profileType: "standard",
+      modules: ["integrations"],
+      billingReadinessMode: "none",
+      customerGraph: "none",
+      estateSeparation: "shared",
+    });
+    expect(legacy?.axes.governance).toBe("investor-owned");
+
+    const axisShapedWithoutGovernance = readActivationProfile({
+      profileType: "standard",
+      modules: ["integrations"],
+      billingReadinessMode: "none",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "individual",
+        consumptionChannel: "physical",
+        commercialModel: "appointment-checkout",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "minimal" },
+        forEmployees: { scope: "minimal" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    });
+    expect(axisShapedWithoutGovernance?.axes.governance).toBe("investor-owned");
+
+    expect(
+      readActivationProfile({
+        profileType: "standard",
+        modules: ["integrations"],
+        billingReadinessMode: "none",
+        customerGraph: "none",
+        estateSeparation: "shared",
+        axes: {
+          form: "services",
+          delivery: "physical",
+          primaryConsumer: "individual",
+          consumptionChannel: "physical",
+          commercialModel: "appointment-checkout",
+          provisioning: "account-with-billing",
+          platform: "no",
+          governance: "shareholder",
+        },
+        portfolios: {
+          foundational: { scope: "minimal" },
+          manufactureAndDeliver: { scope: "minimal" },
+          forEmployees: { scope: "minimal" },
+          productsAndServicesSold: { scope: "primary" },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("normalizes member-owned axis profiles with the civic capability set derived", () => {
+    const profile = readActivationProfile({
+      profileType: "standard",
+      modules: ["integrations"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "hybrid",
+        primaryConsumer: "member",
+        consumptionChannel: "multi-channel",
+        commercialModel: "account-based-fees",
+        provisioning: "account-with-kyc",
+        platform: "no",
+        governance: "member-owned",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "standard" },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+    });
+
+    expect(profile?.axes.governance).toBe("member-owned");
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("required");
+    expect(getCapabilityApplicability(profile, "membership-eligibility")).toBe("required");
+    expect(activationHasCapability(profile, "member-equity")).toBe(true);
+  });
+});
+
+describe("existing archetype regression (governance axis is inert)", () => {
+  const CIVIC_CAPABILITY_KEYS = [
+    "member-governance",
+    "membership-eligibility",
+    "member-equity",
+    "public-body-governance",
+    "records-request",
+    "service-request-311",
+  ] as const;
+
+  it("every seeded archetype normalizes to investor-owned with all civic capabilities not-applicable", () => {
+    const archetypesWithProfiles = ALL_ARCHETYPES.filter(
+      (archetype) => archetype.activationProfile !== undefined,
+    );
+    expect(archetypesWithProfiles.length).toBeGreaterThan(0);
+
+    for (const archetype of archetypesWithProfiles) {
+      const profile = readActivationProfile(archetype.activationProfile);
+      expect(profile, `profile for ${archetype.archetypeId} should normalize`).not.toBeNull();
+      expect(
+        profile?.axes.governance,
+        `${archetype.archetypeId} should default to investor-owned`,
+      ).toBe("investor-owned");
+
+      for (const key of CIVIC_CAPABILITY_KEYS) {
+        expect(
+          getCapabilityApplicability(profile, key),
+          `${archetype.archetypeId} should not activate ${key}`,
+        ).toBe("not-applicable");
+      }
+    }
   });
 });

--- a/packages/storefront-templates/src/activation-profile.ts
+++ b/packages/storefront-templates/src/activation-profile.ts
@@ -18,6 +18,7 @@ import type {
   ConsumptionChannel,
   CustomerGraphMode,
   EstateSeparationMode,
+  GovernanceModel,
   It4ItStage,
   OperatingModelAxes,
   OperatingModelDelivery,
@@ -56,6 +57,8 @@ const PRIMARY_CONSUMER_VALUES = new Set<PrimaryConsumer>([
   "patient-and-payer",
   "channel-partner",
   "internal",
+  "member",
+  "resident",
 ]);
 const CHANNEL_VALUES = new Set<ConsumptionChannel>([
   "physical",
@@ -76,7 +79,13 @@ const COMMERCIAL_MODEL_VALUES = new Set<CommercialModel>([
   "encounter-based",
   "appointment-checkout",
   "point-of-sale",
+  "statutory-fees-and-levies",
   "hybrid",
+]);
+const GOVERNANCE_VALUES = new Set<GovernanceModel>([
+  "investor-owned",
+  "member-owned",
+  "public-body",
 ]);
 const PROVISIONING_VALUES = new Set<ProvisioningModel>([
   "none",
@@ -103,8 +112,17 @@ const APPLICABILITY_VALUES = new Set<CapabilityApplicability>([
   "not-applicable",
 ]);
 
+/**
+ * Axes after normalization: `governance` is always resolved (absent legacy
+ * values default to "investor-owned"), so downstream consumers never branch
+ * on its presence.
+ */
+export type NormalizedOperatingModelAxes = OperatingModelAxes & {
+  governance: GovernanceModel;
+};
+
 export interface NormalizedActivationProfile extends ActivationProfile {
-  axes: OperatingModelAxes;
+  axes: NormalizedOperatingModelAxes;
   portfolios: PortfolioDecomposition;
   capabilityOverrides: CapabilityOverride[];
   billingProfile: BillingPatternProfile;
@@ -120,7 +138,7 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
-function readAxes(raw: unknown): OperatingModelAxes | null {
+function readAxes(raw: unknown): NormalizedOperatingModelAxes | null {
   if (!isRecord(raw)) return null;
 
   const axes = raw as Partial<OperatingModelAxes>;
@@ -136,6 +154,10 @@ function readAxes(raw: unknown): OperatingModelAxes | null {
     return null;
   }
 
+  if (axes.governance !== undefined && !GOVERNANCE_VALUES.has(axes.governance as GovernanceModel)) {
+    return null;
+  }
+
   return {
     form: axes.form as OperatingModelForm,
     delivery: axes.delivery as OperatingModelDelivery,
@@ -144,6 +166,7 @@ function readAxes(raw: unknown): OperatingModelAxes | null {
     commercialModel: axes.commercialModel as CommercialModel,
     provisioning: axes.provisioning as ProvisioningModel,
     platform: axes.platform as PlatformEcosystem,
+    governance: (axes.governance as GovernanceModel | undefined) ?? "investor-owned",
   };
 }
 
@@ -231,7 +254,7 @@ function isManagedServiceProviderLegacyProfile(input: Pick<ActivationProfile, "p
   );
 }
 
-function inferLegacyAxes(input: Pick<ActivationProfile, "profileType" | "modules" | "customerGraph" | "estateSeparation" | "billingReadinessMode">): OperatingModelAxes {
+function inferLegacyAxes(input: Pick<ActivationProfile, "profileType" | "modules" | "customerGraph" | "estateSeparation" | "billingReadinessMode">): NormalizedOperatingModelAxes {
   if (isManagedServiceProviderLegacyProfile(input)) {
     return {
       form: "services",
@@ -244,6 +267,7 @@ function inferLegacyAxes(input: Pick<ActivationProfile, "profileType" | "modules
           : "transactional",
       provisioning: "account-and-entitlement",
       platform: "no",
+      governance: "investor-owned",
     };
   }
 
@@ -255,6 +279,7 @@ function inferLegacyAxes(input: Pick<ActivationProfile, "profileType" | "modules
     commercialModel: "transactional",
     provisioning: "none",
     platform: "no",
+    governance: "investor-owned",
   };
 }
 

--- a/packages/storefront-templates/src/applicability-rules.test.ts
+++ b/packages/storefront-templates/src/applicability-rules.test.ts
@@ -218,6 +218,160 @@ describe("derivePartnerProgramProfile", () => {
   });
 });
 
+const creditUnionAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "hybrid",
+  primaryConsumer: "member",
+  consumptionChannel: "multi-channel",
+  commercialModel: "account-based-fees",
+  provisioning: "account-with-kyc",
+  platform: "no",
+  governance: "member-owned",
+};
+
+const cooperativeAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "physical",
+  primaryConsumer: "member",
+  consumptionChannel: "physical",
+  commercialModel: "transactional",
+  provisioning: "account-with-billing",
+  platform: "no",
+  governance: "member-owned",
+};
+
+const townAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "physical",
+  primaryConsumer: "resident",
+  consumptionChannel: "onsite-plus-portal",
+  commercialModel: "statutory-fees-and-levies",
+  provisioning: "account-with-billing",
+  platform: "no",
+  governance: "public-body",
+};
+
+const utilityAxes: OperatingModelAxes = {
+  ...townAxes,
+  commercialModel: "usage-based",
+};
+
+const policeAxes: OperatingModelAxes = {
+  ...townAxes,
+  provisioning: "none",
+};
+
+const communityBankAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "hybrid",
+  primaryConsumer: "individual",
+  consumptionChannel: "multi-channel",
+  commercialModel: "account-based-fees",
+  provisioning: "account-with-kyc",
+  platform: "no",
+  governance: "investor-owned",
+};
+
+const civicPortfolios: PortfolioDecomposition = {
+  foundational: { scope: "minimal" },
+  manufactureAndDeliver: { scope: "standard", it4itStages: ["request-to-fulfill"] },
+  forEmployees: { scope: "standard" },
+  productsAndServicesSold: { scope: "primary" },
+};
+
+const CIVIC_CAPABILITY_KEYS = [
+  "member-governance",
+  "membership-eligibility",
+  "member-equity",
+  "public-body-governance",
+  "records-request",
+  "service-request-311",
+] as const;
+
+describe("civic & member-governed capability derivation", () => {
+  it("derives member governance, eligibility intake, and equity for member-owned axes (credit union)", () => {
+    const capabilities = deriveCapabilityApplicability(creditUnionAxes, civicPortfolios);
+
+    expect(getCapability(capabilities, "member-governance")).toMatchObject({
+      applicability: "required",
+      ownershipScopes: ["organization"],
+      isolation: "organization-scope",
+    });
+    expect(getCapability(capabilities, "membership-eligibility").applicability).toBe("required");
+    expect(getCapability(capabilities, "member-equity").applicability).toBe("recommended");
+    expect(getCapability(capabilities, "customer-accounts")).toMatchObject({
+      applicability: "required",
+      isolation: "organization-scope",
+    });
+    expect(getCapability(capabilities, "public-body-governance").applicability).toBe("not-applicable");
+    expect(getCapability(capabilities, "service-request-311").applicability).toBe("not-applicable");
+  });
+
+  it("derives the same member machinery for a cooperative from axes alone", () => {
+    const capabilities = deriveCapabilityApplicability(cooperativeAxes, civicPortfolios);
+
+    expect(getCapability(capabilities, "member-governance").applicability).toBe("required");
+    expect(getCapability(capabilities, "membership-eligibility").applicability).toBe("required");
+    expect(getCapability(capabilities, "member-equity").applicability).toBe("recommended");
+  });
+
+  it("derives public-body governance, records requests, and 311 for a town", () => {
+    const capabilities = deriveCapabilityApplicability(townAxes, civicPortfolios);
+
+    expect(getCapability(capabilities, "public-body-governance")).toMatchObject({
+      applicability: "required",
+      ownershipScopes: ["organization"],
+      isolation: "organization-scope",
+    });
+    expect(getCapability(capabilities, "records-request").applicability).toBe("required");
+    expect(getCapability(capabilities, "service-request-311").applicability).toBe("required");
+    expect(getCapability(capabilities, "customer-accounts")).toMatchObject({
+      applicability: "required",
+      isolation: "organization-scope",
+    });
+    expect(getCapability(capabilities, "member-governance").applicability).toBe("not-applicable");
+  });
+
+  it("derives the public-body set for utility and police specializations from the same rules", () => {
+    const utilityCapabilities = deriveCapabilityApplicability(utilityAxes, civicPortfolios);
+    const policeCapabilities = deriveCapabilityApplicability(policeAxes, civicPortfolios);
+
+    for (const capabilities of [utilityCapabilities, policeCapabilities]) {
+      expect(getCapability(capabilities, "public-body-governance").applicability).toBe("required");
+      expect(getCapability(capabilities, "records-request").applicability).toBe("required");
+      expect(getCapability(capabilities, "service-request-311").applicability).toBe("required");
+    }
+  });
+
+  it("activates no civic machinery for investor-owned axes, explicit or absent", () => {
+    const bankCapabilities = deriveCapabilityApplicability(communityBankAxes, civicPortfolios);
+    const salonCapabilities = deriveCapabilityApplicability(salonAxes, salonPortfolios);
+
+    for (const key of CIVIC_CAPABILITY_KEYS) {
+      expect(getCapability(bankCapabilities, key).applicability).toBe("not-applicable");
+      expect(getCapability(salonCapabilities, key).applicability).toBe("not-applicable");
+    }
+  });
+});
+
+describe("statutory and usage-based billing derivation", () => {
+  it("derives obligation-driven invoicing for statutory fees and levies", () => {
+    expect(deriveBillingPatternProfile(townAxes)).toMatchObject({
+      primaryPaymentPattern: "ad-hoc-invoice",
+      supportedPaymentPatterns: ["ad-hoc-invoice", "recurring-agreement"],
+      invoiceExecutionMode: "prepared-not-prescribed",
+      recurringBillingApplicability: "optional",
+    });
+  });
+
+  it("keeps usage-based billing for utility axes", () => {
+    expect(deriveBillingPatternProfile(utilityAxes)).toMatchObject({
+      primaryPaymentPattern: "usage-based",
+      recurringBillingApplicability: "recommended",
+    });
+  });
+});
+
 describe("partner-program capability derivation", () => {
   it("requires the partner program when selling through channel partners", () => {
     const capabilities = deriveCapabilityApplicability(channelPartnerAxes, mspPortfolios);

--- a/packages/storefront-templates/src/applicability-rules.ts
+++ b/packages/storefront-templates/src/applicability-rules.ts
@@ -384,6 +384,107 @@ const RULES: ApplicabilityRule[] = [
     },
   },
   {
+    // governance is optional on raw axes (normalizer defaults it to
+    // "investor-owned"); strict equality means absent === no civic machinery.
+    name: "member-owned-governance",
+    evaluate: (axes) => {
+      if (axes.governance !== "member-owned") return [];
+
+      return [
+        {
+          key: "member-governance",
+          applicability: "required",
+          reason: "Member-owned organizations run an elected board, committees, and an annual meeting.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "membership-eligibility",
+          applicability: "required",
+          reason: "Member-owned organizations admit members through an eligibility step before account creation.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "member-equity",
+          applicability: "recommended",
+          reason: "Member-owned organizations commonly allocate patronage or member equity; cooperatives require it.",
+          ownershipScopes: ["customer-account"],
+          isolation: "organization-scope",
+        },
+      ];
+    },
+  },
+  {
+    name: "public-body-governance",
+    evaluate: (axes) => {
+      if (axes.governance !== "public-body") return [];
+
+      return [
+        {
+          key: "public-body-governance",
+          applicability: "required",
+          reason: "Public bodies operate under open-meetings law: agendas, meetings, minutes, publication.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "records-request",
+          applicability: "required",
+          reason: "Public bodies answer statutory records requests with deadline tracking.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+      ];
+    },
+  },
+  {
+    name: "resident-service-obligation",
+    evaluate: (axes) => {
+      if (axes.primaryConsumer !== "resident") return [];
+
+      return [
+        {
+          key: "service-request-311",
+          applicability: "required",
+          reason: "Residents file service requests the jurisdiction must route and answer for everyone equally.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "customer-accounts",
+          applicability: "required",
+          reason: "Residents and ratepayers need account records; the relationship is jurisdictional, not contractual.",
+          ownershipScopes: ["customer-account"],
+          isolation: "organization-scope",
+        },
+      ];
+    },
+  },
+  {
+    name: "member-eligibility-before-account",
+    evaluate: (axes) => {
+      if (axes.primaryConsumer !== "member") return [];
+
+      return [
+        {
+          key: "customer-accounts",
+          applicability: "required",
+          reason: "Members need account records bound to their membership.",
+          ownershipScopes: ["customer-account"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "membership-eligibility",
+          applicability: "required",
+          reason: "Membership eligibility is checked before a member account is created.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+      ];
+    },
+  },
+  {
     name: "partner-channel-from-axes",
     evaluate: (axes, portfolios) => {
       const program = derivePartnerProgramProfile(axes, portfolios);
@@ -500,6 +601,15 @@ function supportedPatternsForCommercialModel(commercialModel: CommercialModel): 
         primaryPaymentPattern: "ad-hoc-invoice",
         supportedPaymentPatterns: ["ad-hoc-invoice"],
         invoiceExecutionMode: "manual",
+        recurringBillingApplicability: "optional",
+      };
+    case "statutory-fees-and-levies":
+      // A levy/assessment is an obligation-driven invoice on a published fee
+      // schedule — no new PaymentPattern value (civic archetypes spec §7 note 1).
+      return {
+        primaryPaymentPattern: "ad-hoc-invoice",
+        supportedPaymentPatterns: ["ad-hoc-invoice", "recurring-agreement"],
+        invoiceExecutionMode: "prepared-not-prescribed",
         recurringBillingApplicability: "optional",
       };
     case "hybrid":

--- a/packages/storefront-templates/src/capability-registry.test.ts
+++ b/packages/storefront-templates/src/capability-registry.test.ts
@@ -26,6 +26,12 @@ describe("capability registry", () => {
       "lifecycle-review-queues",
       "remote-support",
       "partner-program",
+      "member-governance",
+      "membership-eligibility",
+      "member-equity",
+      "public-body-governance",
+      "records-request",
+      "service-request-311",
     ]);
   });
 

--- a/packages/storefront-templates/src/capability-registry.ts
+++ b/packages/storefront-templates/src/capability-registry.ts
@@ -153,6 +153,57 @@ export const CAPABILITY_REGISTRY = {
         "Turns on a partner portal, deal registration, and partner tiers for resellers, distributors, or referral partners. You can add this later.",
     },
   },
+  // Civic & member-governed capabilities — gated by the governance axis and the
+  // member/resident primaryConsumer values (spec: 2026-06-09 civic archetypes §6.1).
+  "member-governance": {
+    label: "Member Governance",
+    portfolio: "forEmployees",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["governance", "meetings"],
+  },
+  "membership-eligibility": {
+    label: "Membership Eligibility",
+    portfolio: "productsAndServicesSold",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["customers", "membership"],
+  },
+  "member-equity": {
+    label: "Member Equity & Patronage",
+    portfolio: "productsAndServicesSold",
+    defaultOwnershipScope: "customer-account",
+    defaultIsolation: "organization-scope",
+    surfaces: ["finance", "membership"],
+    setupPrompt: {
+      question: "Do members hold equity or receive patronage allocations?",
+      helpText:
+        "Turns on per-member equity records, year-end patronage allocation, and equity retirement schedules. Common for cooperatives; you can add this later.",
+    },
+  },
+  "public-body-governance": {
+    label: "Public-Body Governance",
+    portfolio: "forEmployees",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["governance", "meetings"],
+  },
+  "records-request": {
+    label: "Records Requests",
+    portfolio: "manufactureAndDeliver",
+    it4itStage: "request-to-fulfill",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["records-requests"],
+  },
+  "service-request-311": {
+    label: "Service Requests (311)",
+    portfolio: "manufactureAndDeliver",
+    it4itStage: "request-to-fulfill",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["service-requests"],
+  },
 } as const satisfies Record<string, CapabilityRegistryEntry>;
 
 export type CapabilityKey = keyof typeof CAPABILITY_REGISTRY;

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -21,7 +21,8 @@ export type ArchetypeCategory =
   | "retail-goods"
   | "fitness-recreation"
   | "nonprofit-community"
-  | "hoa-property-management";
+  | "hoa-property-management"
+  | "public-sector";
 
 export interface FormField {
   name: string;
@@ -86,7 +87,11 @@ export type PrimaryConsumer =
   | "business"
   | "patient-and-payer"
   | "channel-partner"
-  | "internal";
+  | "internal"
+  /** Owner-patron with governance rights (credit union, cooperative). */
+  | "member"
+  /** Served party defined by jurisdiction with statutory rights and a universal-service obligation (town, utility, police). */
+  | "resident";
 
 export type ConsumptionChannel =
   | "physical"
@@ -107,6 +112,8 @@ export type CommercialModel =
   | "encounter-based"
   | "appointment-checkout"
   | "point-of-sale"
+  /** Revenue arrives by levy/assessment/fee schedule set by ordinance or statute, not by sale. */
+  | "statutory-fees-and-levies"
   | "hybrid";
 
 export type ProvisioningModel =
@@ -119,6 +126,16 @@ export type ProvisioningModel =
 
 export type PlatformEcosystem = "no" | "yes-marketplace" | "yes-developer";
 
+/**
+ * How the organization is governed — orthogonal to {@link PrimaryConsumer}
+ * (a community bank is investor-owned serving individuals/businesses; an
+ * electric co-op is member-owned serving member ratepayers; a municipal
+ * utility is a public body serving resident ratepayers). Gates the
+ * member-governance and public-body-governance capabilities; see
+ * docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md §6.1.
+ */
+export type GovernanceModel = "investor-owned" | "member-owned" | "public-body";
+
 export interface OperatingModelAxes {
   form: OperatingModelForm;
   delivery: OperatingModelDelivery;
@@ -127,6 +144,12 @@ export interface OperatingModelAxes {
   commercialModel: CommercialModel;
   provisioning: ProvisioningModel;
   platform: PlatformEcosystem;
+  /**
+   * Optional so the 45+ existing archetype literals stay valid; the
+   * normalizer defaults absent values to "investor-owned"
+   * (readActivationProfile survival rule — consumers never branch on absence).
+   */
+  governance?: GovernanceModel;
 }
 
 export type PortfolioRole =


### PR DESCRIPTION
## Summary

Implements **BI-938D1B71** (Phase 0 of the civic & member-governed archetypes initiative, `EP-ARCH-8D4F2A`) per the operator-approved spec and plan merged in #1688.

- **`governance` axis** (`investor-owned` | `member-owned` | `public-body`) — optional on `OperatingModelAxes`; the normalizer defaults absent values to `investor-owned` (same survival rule as axes/portfolios), so all 45 seeded archetypes are untouched.
- **`primaryConsumer`** gains `member` (owner-patron with governance rights) and `resident` (jurisdiction-defined served party); **`commercialModel`** gains `statutory-fees-and-levies` with obligation-driven billing derivation (no new PaymentPattern).
- **Six civic capability registry entries** — `member-governance`, `membership-eligibility`, `member-equity`, `public-body-governance`, `records-request`, `service-request-311` — plus four additive applicability rules gated on the new axis values.
- **`ledgerModel`** on `FinancialProfile` (defaults `commercial`) + chart-of-accounts fragments for `fund-accounting` / `financial-institution` / `cooperative-equity`. The BIAN banking profile (BI-5D9DCDE6 Phase 3, not yet landed) adopts `financial-institution` per spec §6.2 coordination.
- **`public-sector`** ArchetypeCategory + vocabulary (Residents / Resident Portal / Service Requests). No `industries.ts` entry yet — that ships with the first public-sector archetype (BI-8D477188) so the picker has no dead-end option.
- **Sidecar record** of the accepted axis additions next to the 4-portfolio workbook per the §3.6 workbook-first contract.

## Verification

- `@dpf/storefront-templates`: typecheck + 54 tests green, including civic fixtures for all six archetype axis declarations and a **regression test proving every seeded archetype normalizes to `investor-owned` with all civic capabilities `not-applicable`** (zero behavior change).
- `@dpf/finance-templates`: typecheck + 14 tests green (ledgerModel default + fragment integrity).
- `web`: typecheck green; storefront lib tests green (26).
- `@dpf/db` tests not run locally (environment lacks migrated test DB — failures are pre-existing connection/table errors on tests unrelated to this diff; no `packages/db` file is touched). CI gates them.

Unblocks: BI-D9ACE184, BI-8D477188, BI-E677F250, BI-AFC178F3, BI-0938EFF5, BI-C1578821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)