### PR TITLE
feat(archetypes): small-town municipality archetype + public-sector category (BI-8D477188 Phase 1)

### DIFF
--- a/apps/web/components/workspace/WorkspaceCalendar.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.tsx
@@ -45,6 +45,7 @@ const ARCHETYPE_DEFAULT_HIDDEN: Record<string, string[]> = {
   "professional-services":   ["providers"],
   "nonprofit-community":     ["bookings", "providers"],
   "trades-maintenance":      ["providers"],
+  "public-sector":           ["bookings", "providers", "crm"],
 };
 
 type Props = {

--- a/apps/web/lib/finance/setup-profile.ts
+++ b/apps/web/lib/finance/setup-profile.ts
@@ -12,6 +12,7 @@ const FINANCE_PROFILE_BY_ARCHETYPE_CATEGORY: Record<string, string> = {
   "fitness-recreation": "fitness_recreation",
   "nonprofit-community": "nonprofit",
   "hoa-property-management": "hoa_property_management",
+  "public-sector": "fund_accounting",
 };
 
 export function financeProfileSlugFromCategory(category: string | null | undefined): string {

--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -56,6 +56,7 @@ describe("resolveBusinessProfile", () => {
       "education-training",
       "retail-goods",
       "nonprofit-community",
+      "public-sector",
     ];
 
     it("populates a non-empty supplyChain on every industry profile", () => {

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -110,6 +110,18 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
     supplyChain:
       "Our physical supply chain is intentionally light — most of what we consume is software, research databases, and professional subscriptions. The discipline is in vendor selection and renewal review: a stale tool can cost more than its licence.",
   },
+  "public-sector": {
+    missionTheme:
+      "serve every resident of our community fairly, openly, and well with the public services they rely on",
+    businessModel:
+      "We are funded by levies, fees, and grants set in public session — not by sales. The measure of the operation is budget-to-actual stewardship and resident trust, not profit.",
+    whoWeServe:
+      "We serve the residents of our jurisdiction — everyone within it, by right, not by contract. Residents are simultaneously the people we serve, the taxpayers who fund us, and the voters we answer to.",
+    howWeDecide:
+      "We decide in public: open meetings, published agendas and minutes, and records anyone can request. Equal treatment and due process are non-negotiable — we cannot pick our customers, so fairness and transparency lead every call.",
+    supplyChain:
+      "Purchasing follows public procurement rules — quotes and sealed bids above statutory thresholds, with an audit trail. We rely on local contractors for streets, parks, and facilities work, and intergovernmental agreements for what we cannot staff ourselves.",
+  },
   "hoa-property-management": {
     missionTheme:
       "care for the properties and communities entrusted to us so owners and residents can thrive",

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -190,6 +190,9 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
 
   // HOA
   "hoa-management": ["Assessments", "Maintenance", "Amenities"],
+
+  // Public sector
+  "small-town-municipality": ["Permits & Licenses", "Public Works", "Parks & Recreation", "Clerk's Office", "Code Enforcement"],
 };
 
 export function getCategorySuggestions(archetypeId: string | null | undefined): string[] {

--- a/apps/web/lib/storefront/industries.test.ts
+++ b/apps/web/lib/storefront/industries.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from "vitest";
 import { INDUSTRY_OPTIONS, INDUSTRY_SLUGS, isIndustrySlug, industryLabel } from "./industries";
 
 describe("industries", () => {
-  it("exposes exactly the 12 canonical industries", () => {
-    expect(INDUSTRY_OPTIONS).toHaveLength(12);
+  it("exposes exactly the 13 canonical industries", () => {
+    expect(INDUSTRY_OPTIONS).toHaveLength(13);
     expect(INDUSTRY_SLUGS).toContain("healthcare-wellness");
     expect(INDUSTRY_SLUGS).toContain("hoa-property-management");
     expect(INDUSTRY_SLUGS).toContain("software-platform");
+    expect(INDUSTRY_SLUGS).toContain("public-sector");
   });
 
   it("slugs are kebab-case, never underscore", () => {

--- a/apps/web/lib/storefront/industries.ts
+++ b/apps/web/lib/storefront/industries.ts
@@ -11,6 +11,7 @@ export const INDUSTRY_OPTIONS = [
   { value: "fitness-recreation", label: "Fitness & Recreation" },
   { value: "nonprofit-community", label: "Nonprofit & Community" },
   { value: "hoa-property-management", label: "HOA & Property Management" },
+  { value: "public-sector", label: "Public Sector & Local Government" },
 ] as const;
 
 export type IndustrySlug = (typeof INDUSTRY_OPTIONS)[number]["value"];

--- a/apps/web/lib/tak/marketing-playbooks.ts
+++ b/apps/web/lib/tak/marketing-playbooks.ts
@@ -40,6 +40,31 @@ const CATEGORY_PLAYBOOKS: Record<string, MarketingPlaybook> = {
     agentSkills: ["Draft community announcement", "Prepare assessment notice", "Summarise maintenance requests", "Board meeting agenda"],
   },
 
+  "public-sector": {
+    primaryGoal: "Resident awareness, participation, and trust through transparent civic communication",
+    stakeholders: "Residents, council members, town staff, local businesses, neighboring jurisdictions",
+    campaignTypes: [
+      "Council and board meeting notices with agenda previews",
+      "Public hearing and comment-period announcements",
+      "Service disruption and road work notices",
+      "Seasonal reminders (leaf pickup, snow routes, hydrant flushing)",
+      "Budget season and levy communications with plain-language summaries",
+      "Permit and licensing deadline reminders",
+      "Community event and parks programming announcements",
+      "Emergency notifications (weather, water, public safety)",
+    ],
+    contentTone: "Official, plain-language, neutral, accessible to every resident",
+    keyMetrics: [
+      "Meeting attendance and public-comment participation",
+      "Service request response time",
+      "Records request on-time completion rate",
+      "Notice reach (open/read rate)",
+      "Resident satisfaction",
+    ],
+    ctaLanguage: ["Report an issue", "View the agenda", "Request records", "Apply for a permit"],
+    agentSkills: ["Draft meeting notice", "Plain-language budget summary", "Service disruption notice", "Public hearing announcement"],
+  },
+
   "professional-services": {
     primaryGoal: "Build authority pipeline through expertise demonstration and client nurture",
     stakeholders: "Clients, prospects, referral partners, industry contacts",

--- a/docs/superpowers/plans/2026-06-09-small-town-municipality-archetype.md
+++ b/docs/superpowers/plans/2026-06-09-small-town-municipality-archetype.md
@@ -1,0 +1,100 @@
+# Implementation Plan — Small-Town Municipality Archetype (Phase 1 of civic archetypes)
+
+- **Backlog item:** `BI-8D477188` (epic `EP-ARCH-8D4F2A`; triaged `build`, size `xlarge`)
+- **Design spec:** [`docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md`](../specs/2026-06-09-civic-and-member-governed-archetypes-design.md) §7, §10, §11
+- **Depends on:** BI-938D1B71 Phase-0 substrate (PR #1692) — governance axis, civic capability registry, fund-accounting COA fragment
+- **Unblocks:** BI-0938EFF5 (municipal utility), BI-C1578821 (law enforcement) — both specialize this base
+- **Date:** 2026-06-09
+
+Grounded by direct exploration (hoa-property-management.ts precedent; `grep hoa-property-management`
+across apps/web; Prisma schema sweep for Meeting/RecordsRequest/Budget/Fund models — none exist;
+StorefrontInquiry at schema.prisma ~7516; licensing substrate at schema.prisma 2935–3359 with
+`LicenseRequirementReference.archetypeCategories` filtering).
+
+Substrate verdicts (verify-substrate-first):
+
+| Surface | Verdict |
+| --- | --- |
+| Council meetings (agenda → meeting → minutes) | NEW thin model `GovernanceMeeting` — CalendarEvent is too generic for the linked workflow; one table (not three): bodyType, scheduledAt, agenda/minutes content + publication timestamps, status, attendees/decisions Json. Shared with the credit-union board workflow (BI-D9ACE184) by design. |
+| Records requests (FOIA) | NEW thin model `RecordsRequest` — statutory deadline lifecycle, exemption/denial fields; nothing comparable exists (compliance models track recurring duties, not inbound requests). |
+| Service requests (311) | REUSE `StorefrontInquiry` — already the intake + inbox pipeline (trades "Job Requests" pattern); department/type via formData; no new schema in this slice. |
+| Budget-to-actual funds | `fund_accounting` finance profile consuming `LEDGER_COA_FRAGMENTS["fund-accounting"]` + minimal `FundBudgetLine` (orgId, fiscalYear, fund, accountCode, budgetedAmount) so the view has a budget side. No GL changes. |
+| Permits & licenses | REUSE licensing substrate — seed `license_requirement_reference` entries with `archetypeCategories: ["public-sector"]`; no schema change. |
+
+## Phase 1 — Archetype definition + category wiring (ships independently)
+
+- `packages/storefront-templates/src/archetypes/public-sector.ts` *(new)* — `small-town-municipality`
+  per the HOA shape: ctaType `inquiry`; itemTemplates = resident-facing services (Building Permit
+  Application, Business License, Park Pavilion Reservation, Public Records Request, Report an Issue
+  / 311, Utility Billing Inquiry); sectionTemplates hero/about/items("Departments & Services")/
+  team("Council & Staff")/contact; formSchema with address + department select + description;
+  activationProfile axes per spec §7 (resident / public-body / statutory-fees-and-levies /
+  fund-accounting via finance wiring), portfolios (manufactureAndDeliver standard with
+  request-to-fulfill), seededServiceCategories (Permits, Public Works, Parks & Recreation, Clerk,
+  Court). Export from `archetypes/index.ts`; extend archetypes.test.ts invariants.
+- Category wiring (all sites named by the hoa grep): `industries.ts` (+test), 
+  `archetype-business-context.ts` INDUSTRY_PROFILES (+test), `marketing-playbooks.ts`,
+  `lib/finance/setup-profile.ts` → `"public-sector": "fund_accounting"`,
+  `WorkspaceCalendar.tsx` source defaults, `archetype-vocabulary.ts` CATEGORY_SUGGESTIONS.
+- `packages/finance-templates/src/profiles.ts` — `fund_accounting` profile (archetypeCategory
+  `public-sector`, `ledgerModel: "fund-accounting"`, COA seed = fund-accounting fragment,
+  USD, dunning gentle, billingPatternProfile from statutory derivation); profile tests + count.
+- `packages/db/src/seed-storefront-archetypes.ts` — verify the new archetype upserts (count
+  assertion +1, silent-skip guard per the known failure class).
+
+**Verification:** package vitest + typecheck green (storefront-templates, finance-templates, db,
+web); seed test asserts the archetype row lands.
+
+## Phase 2 — Civic Prisma models + town compliance pack
+
+- `packages/db/prisma/schema.prisma` — `GovernanceMeeting`, `RecordsRequest`, `FundBudgetLine`
+  (+ relations to Organization; semantic ids; indexes on org + status/dueAt) + migration.
+- Town compliance pack seed on existing Regulation/Obligation models (spec §10): open-meetings
+  notice deadline, records-request response deadline (org-configurable days), records-retention
+  schedule, annual state-audit prep, procurement thresholds — `Regulation.industry:
+  "public-sector"`, with seed-count test.
+- State selection: `BusinessContext.stateCode` (nullable) + setup capture; obligations read the
+  org-configured deadline rather than hardcoding 50 variants.
+
+**Verification:** migration applies on shadow DB; db vitest green incl. new count assertions.
+
+## Phase 3 — Capability surface UI v1 (capability-gated routes)
+
+- First read how the partner-program surfaces gate routes/navigation (EP-PARTNER-CHANNEL Phase 1b
+  implementation) and mirror that mechanism exactly — do not invent a parallel gate.
+- `/meetings` (surface `meetings`): list + create meeting, agenda compose → publish (timestamp),
+  record minutes → approve; driven by `GovernanceMeeting`.
+- `/records-requests` (surface `records-requests`): intake queue with due-date countdown,
+  status transitions (submitted → in-progress → fulfilled/denied/partially-fulfilled), denial
+  reason capture.
+- `/service-requests` (surface `service-requests`): StorefrontInquiry queue view re-labeled by
+  vocabulary (inbox "Service Requests"), department filter from formData, close-with-note.
+- Finance: Funds view section grouping COA by fund + budget-to-actual columns from
+  `FundBudgetLine` (empty-state safe).
+- Public storefront: Records-request + 311 intake land via the existing inquiry pipeline.
+
+**Verification:** web typecheck + targeted vitest; surfaces hidden for non-public-body archetypes
+(test via derived activations).
+
+## Phase 4 — Licensing seed + functional verification (canonical runtime)
+
+- `packages/db/data/license_requirement_reference.json` — town entries (business license,
+  building permit, sign permit, special-event permit) with `archetypeCategories:
+  ["public-sector"]`; seed-count test (BIAN §9.1 pattern).
+- Functional verification per `dpf-verify-on-live-install` (preflight first; BLOCKED stop-rule):
+  fresh-seed sandbox → onboard as Small Town → picker shows Public Sector + archetype; Residents
+  vocabulary; meetings/records/service-request surfaces present and drive end-to-end (create
+  meeting + publish agenda; file records request and watch deadline; file a 311 from the
+  storefront and close it); Funds view renders with seeded COA; commercial archetype regression
+  (salon unchanged). Record evidence on BI-8D477188 (dynamic-analysis prose).
+
+## Risks & rollback
+
+- **Scope blowout (xlarge):** Phases 1–2 are mechanical and shippable alone; Phase 3 is the bulk.
+  Each phase is its own PR; stop-line after any phase leaves main consistent.
+- **Surface→route gating mechanism assumption:** Phase 3 step 1 verifies the real mechanism before
+  building; if partner-portal gating is bespoke, file the gap rather than forking a second gate.
+- **Meeting model shared with member-governance:** `bodyType` enum covers council/board/committee
+  so BI-D9ACE184 reuses the table — review that BI's needs before freezing the migration.
+- **Silent seed skips:** count assertions on archetype, compliance-pack, and license seeds.
+- **Rollback:** additive schema + seeds + routes; revert PR(s). Archetype rows soft-delete.

--- a/packages/db/src/seed-storefront-archetypes.ts
+++ b/packages/db/src/seed-storefront-archetypes.ts
@@ -33,6 +33,14 @@ const MARKETING_SKILL_RULES: Record<string, Record<string, unknown>> = {
       reframe: "Focus on term launches, open day invitations, student success stories, and enrolment drives. Tone is encouraging and achievement-focused.",
     },
   },
+  "public-sector": {
+    "seo-content-optimizer": { visible: false },
+    "competitive-analysis": { visible: false },
+    "email-campaign-builder": {
+      label: "Public Notice Builder",
+      reframe: "Focus on official civic communications: meeting notices, public hearings, service disruptions, budget and levy communications, permit deadlines, and emergency notifications. Tone is official, plain-language, and neutral — public bodies inform every resident equally; they do not market or persuade.",
+    },
+  },
   "nonprofit-community": {
     "seo-content-optimizer": {
       label: "Cause Visibility Advisor",

--- a/packages/finance-templates/src/profiles.test.ts
+++ b/packages/finance-templates/src/profiles.test.ts
@@ -18,12 +18,13 @@ const EXPECTED_SLUGS = [
   "beauty_personal",
   "pet_services",
   "hoa_property_management",
+  "fund_accounting",
 ];
 
 describe("financial profile catalog", () => {
-  it("has all 11 profiles", () => {
+  it("has all 12 profiles", () => {
     const all = getAllProfiles();
-    expect(all).toHaveLength(11);
+    expect(all).toHaveLength(12);
     const slugs = all.map((p) => p.slug);
     for (const expected of EXPECTED_SLUGS) {
       expect(slugs, `missing profile: ${expected}`).toContain(expected);
@@ -143,10 +144,25 @@ describe("financial profile catalog", () => {
     );
   });
 
-  it("every existing profile resolves ledgerModel to commercial", () => {
+  it("every profile resolves a ledgerModel, defaulting to commercial", () => {
     for (const profile of getAllProfiles()) {
-      expect(profile.ledgerModel, `${profile.slug} should default to commercial`).toBe("commercial");
+      if (profile.slug === "fund_accounting") {
+        expect(profile.ledgerModel).toBe("fund-accounting");
+      } else {
+        expect(profile.ledgerModel, `${profile.slug} should default to commercial`).toBe("commercial");
+      }
     }
+  });
+
+  it("the fund_accounting profile composes the fund-accounting COA fragment with statutory billing", () => {
+    const profile = getFinancialProfile("fund_accounting");
+    expect(profile?.archetypeCategory).toBe("public-sector");
+    expect(profile?.chartOfAccountsSeed).toEqual(LEDGER_COA_FRAGMENTS["fund-accounting"]);
+    expect(profile?.billingPatternProfile).toMatchObject({
+      primaryPaymentPattern: "ad-hoc-invoice",
+      invoiceExecutionMode: "prepared-not-prescribed",
+      recurringBillingApplicability: "optional",
+    });
   });
 });
 

--- a/packages/finance-templates/src/profiles.ts
+++ b/packages/finance-templates/src/profiles.ts
@@ -49,6 +49,68 @@ const AD_HOC_INVOICE_PATTERN: BillingPatternProfile = {
   recurringBillingApplicability: "optional",
 };
 
+const STATUTORY_FEES_PATTERN: BillingPatternProfile = {
+  primaryPaymentPattern: "ad-hoc-invoice",
+  supportedPaymentPatterns: ["ad-hoc-invoice", "recurring-agreement"],
+  invoiceExecutionMode: "prepared-not-prescribed",
+  recurringBillingApplicability: "optional",
+};
+
+// ─── Ledger-model chart-of-accounts fragments ─────────────────────────────────
+// Named template fragments consumed by archetype financial profiles that declare
+// a non-commercial ledgerModel (civic archetypes spec §6.2). They are seeds for
+// the management view; the org's core/accounting system stays authoritative.
+// Defined before PROFILES so profile seeds can compose them.
+
+type ChartOfAccountsSeed = FinancialProfile["chartOfAccountsSeed"];
+
+const LEDGER_FRAGMENTS_INTERNAL: Record<Exclude<LedgerModel, "commercial">, ChartOfAccountsSeed> = {
+  "fund-accounting": [
+    { code: "1000", name: "General Fund Cash", type: "asset" },
+    { code: "3000", name: "Fund Balance — Unassigned", type: "equity" },
+    { code: "3010", name: "Fund Balance — Restricted", type: "equity" },
+    { code: "4000", name: "Property Tax & Levy Revenue", type: "revenue" },
+    { code: "4010", name: "Intergovernmental Revenue & Grants", type: "revenue" },
+    { code: "4020", name: "Charges for Services", type: "revenue" },
+    { code: "4030", name: "Fines, Fees & Permits", type: "revenue" },
+    { code: "4100", name: "Special Revenue Fund Revenue", type: "revenue" },
+    { code: "4200", name: "Enterprise Fund Charges", type: "revenue" },
+    { code: "5000", name: "General Government Expenditures", type: "expense" },
+    { code: "5010", name: "Public Safety Expenditures", type: "expense" },
+    { code: "5020", name: "Public Works Expenditures", type: "expense" },
+    { code: "5030", name: "Culture & Recreation Expenditures", type: "expense" },
+    { code: "5100", name: "Capital Outlay", type: "expense" },
+    { code: "5200", name: "Debt Service — Principal & Interest", type: "expense" },
+  ],
+  "financial-institution": [
+    { code: "1000", name: "Loans Receivable", type: "asset" },
+    { code: "1010", name: "Allowance for Credit Losses (contra)", type: "asset" },
+    { code: "1100", name: "Investment Portfolio", type: "asset" },
+    { code: "2000", name: "Deposits / Member Shares", type: "liability" },
+    { code: "3000", name: "Retained / Undivided Earnings", type: "equity" },
+    { code: "3010", name: "Regular Reserves", type: "equity" },
+    { code: "4000", name: "Interest Income — Loans", type: "revenue" },
+    { code: "4010", name: "Interest Income — Investments", type: "revenue" },
+    { code: "4020", name: "Fee & Service Charge Income", type: "revenue" },
+    { code: "5000", name: "Interest / Dividend Expense", type: "expense" },
+    { code: "5010", name: "Provision for Credit Losses", type: "expense" },
+    { code: "5020", name: "Personnel Expense", type: "expense" },
+    { code: "5030", name: "Occupancy & Operations Expense", type: "expense" },
+    { code: "5040", name: "Exam & Compliance Costs", type: "expense" },
+  ],
+  "cooperative-equity": [
+    { code: "2000", name: "Patronage Dividends Payable", type: "liability" },
+    { code: "2010", name: "Equity Retirement Payable", type: "liability" },
+    { code: "3000", name: "Allocated Member Equity", type: "equity" },
+    { code: "3010", name: "Unallocated Retained Earnings", type: "equity" },
+    { code: "3020", name: "Per-Unit Retains", type: "equity" },
+    { code: "4000", name: "Member Sales Revenue", type: "revenue" },
+    { code: "4010", name: "Non-Member Revenue", type: "revenue" },
+    { code: "5000", name: "Cost of Goods & Services", type: "expense" },
+    { code: "5010", name: "Operating Expenses", type: "expense" },
+  ],
+};
+
 const PROFILES: Record<string, FinancialProfileSeed> = {
   healthcare_wellness: {
     archetypeCategory: "healthcare-wellness",
@@ -394,6 +456,32 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
       { code: "5030", name: "Vehicle & Travel", type: "expense" },
     ],
   },
+
+  fund_accounting: {
+    archetypeCategory: "public-sector",
+    displayName: "Public Sector (Fund Accounting)",
+    defaultPaymentTerms: "Due on receipt",
+    defaultCurrency: "USD",
+    vatRegistered: false,
+    defaultTaxRate: 0,
+    dunningEnabled: true,
+    dunningStyle: "gentle",
+    ledgerModel: "fund-accounting",
+    billingPatternProfile: STATUTORY_FEES_PATTERN,
+    invoiceTemplateStyle: "professional",
+    expenseCategories: [
+      "Personnel & Benefits",
+      "Public Works & Streets",
+      "Parks & Recreation",
+      "Utilities (Facilities)",
+      "Professional & Legal Services",
+      "Equipment & Fleet",
+      "Capital Projects",
+      "Debt Service",
+    ],
+    purchaseOrdersEnabled: true,
+    chartOfAccountsSeed: LEDGER_FRAGMENTS_INTERNAL["fund-accounting"],
+  },
 };
 
 // ─── Exported functions ───────────────────────────────────────────────────────
@@ -447,56 +535,4 @@ export function getAllProfiles(): Array<{ slug: string } & FinancialProfile> {
   }));
 }
 
-// ─── Ledger-model chart-of-accounts fragments ─────────────────────────────────
-// Named template fragments consumed by archetype financial profiles that declare
-// a non-commercial ledgerModel (civic archetypes spec §6.2). They are seeds for
-// the management view; the org's core/accounting system stays authoritative.
-
-type ChartOfAccountsSeed = FinancialProfile["chartOfAccountsSeed"];
-
-export const LEDGER_COA_FRAGMENTS: Record<Exclude<LedgerModel, "commercial">, ChartOfAccountsSeed> = {
-  "fund-accounting": [
-    { code: "1000", name: "General Fund Cash", type: "asset" },
-    { code: "3000", name: "Fund Balance — Unassigned", type: "equity" },
-    { code: "3010", name: "Fund Balance — Restricted", type: "equity" },
-    { code: "4000", name: "Property Tax & Levy Revenue", type: "revenue" },
-    { code: "4010", name: "Intergovernmental Revenue & Grants", type: "revenue" },
-    { code: "4020", name: "Charges for Services", type: "revenue" },
-    { code: "4030", name: "Fines, Fees & Permits", type: "revenue" },
-    { code: "4100", name: "Special Revenue Fund Revenue", type: "revenue" },
-    { code: "4200", name: "Enterprise Fund Charges", type: "revenue" },
-    { code: "5000", name: "General Government Expenditures", type: "expense" },
-    { code: "5010", name: "Public Safety Expenditures", type: "expense" },
-    { code: "5020", name: "Public Works Expenditures", type: "expense" },
-    { code: "5030", name: "Culture & Recreation Expenditures", type: "expense" },
-    { code: "5100", name: "Capital Outlay", type: "expense" },
-    { code: "5200", name: "Debt Service — Principal & Interest", type: "expense" },
-  ],
-  "financial-institution": [
-    { code: "1000", name: "Loans Receivable", type: "asset" },
-    { code: "1010", name: "Allowance for Credit Losses (contra)", type: "asset" },
-    { code: "1100", name: "Investment Portfolio", type: "asset" },
-    { code: "2000", name: "Deposits / Member Shares", type: "liability" },
-    { code: "3000", name: "Retained / Undivided Earnings", type: "equity" },
-    { code: "3010", name: "Regular Reserves", type: "equity" },
-    { code: "4000", name: "Interest Income — Loans", type: "revenue" },
-    { code: "4010", name: "Interest Income — Investments", type: "revenue" },
-    { code: "4020", name: "Fee & Service Charge Income", type: "revenue" },
-    { code: "5000", name: "Interest / Dividend Expense", type: "expense" },
-    { code: "5010", name: "Provision for Credit Losses", type: "expense" },
-    { code: "5020", name: "Personnel Expense", type: "expense" },
-    { code: "5030", name: "Occupancy & Operations Expense", type: "expense" },
-    { code: "5040", name: "Exam & Compliance Costs", type: "expense" },
-  ],
-  "cooperative-equity": [
-    { code: "2000", name: "Patronage Dividends Payable", type: "liability" },
-    { code: "2010", name: "Equity Retirement Payable", type: "liability" },
-    { code: "3000", name: "Allocated Member Equity", type: "equity" },
-    { code: "3010", name: "Unallocated Retained Earnings", type: "equity" },
-    { code: "3020", name: "Per-Unit Retains", type: "equity" },
-    { code: "4000", name: "Member Sales Revenue", type: "revenue" },
-    { code: "4010", name: "Non-Member Revenue", type: "revenue" },
-    { code: "5000", name: "Cost of Goods & Services", type: "expense" },
-    { code: "5010", name: "Operating Expenses", type: "expense" },
-  ],
-};
+export const LEDGER_COA_FRAGMENTS = LEDGER_FRAGMENTS_INTERNAL;

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -211,13 +211,15 @@ describe("existing archetype regression (governance axis is inert)", () => {
     "service-request-311",
   ] as const;
 
-  it("every seeded archetype normalizes to investor-owned with all civic capabilities not-applicable", () => {
-    const archetypesWithProfiles = ALL_ARCHETYPES.filter(
-      (archetype) => archetype.activationProfile !== undefined,
+  it("every archetype without a governance declaration normalizes to investor-owned with all civic capabilities not-applicable", () => {
+    const legacyArchetypes = ALL_ARCHETYPES.filter(
+      (archetype) =>
+        archetype.activationProfile !== undefined &&
+        archetype.activationProfile.axes?.governance === undefined,
     );
-    expect(archetypesWithProfiles.length).toBeGreaterThan(0);
+    expect(legacyArchetypes.length).toBeGreaterThan(0);
 
-    for (const archetype of archetypesWithProfiles) {
+    for (const archetype of legacyArchetypes) {
       const profile = readActivationProfile(archetype.activationProfile);
       expect(profile, `profile for ${archetype.archetypeId} should normalize`).not.toBeNull();
       expect(
@@ -232,5 +234,19 @@ describe("existing archetype regression (governance axis is inert)", () => {
         ).toBe("not-applicable");
       }
     }
+  });
+
+  it("the small-town municipality archetype derives the public-body capability set from its declared axes", () => {
+    const town = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "small-town-municipality");
+    expect(town?.activationProfile).toBeDefined();
+
+    const profile = readActivationProfile(town?.activationProfile);
+    expect(profile?.axes.governance).toBe("public-body");
+    expect(profile?.axes.primaryConsumer).toBe("resident");
+    expect(getCapabilityApplicability(profile, "public-body-governance")).toBe("required");
+    expect(getCapabilityApplicability(profile, "records-request")).toBe("required");
+    expect(getCapabilityApplicability(profile, "service-request-311")).toBe("required");
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("not-applicable");
+    expect(profile?.billingProfile.primaryPaymentPattern).toBe("ad-hoc-invoice");
   });
 });

--- a/packages/storefront-templates/src/archetypes/index.ts
+++ b/packages/storefront-templates/src/archetypes/index.ts
@@ -10,6 +10,7 @@ import { retailGoodsArchetypes } from "./retail-goods";
 import { fitnessRecreationArchetypes } from "./fitness-recreation";
 import { nonprofitCommunityArchetypes } from "./nonprofit-community";
 import { hoaPropertyManagementArchetypes } from "./hoa-property-management";
+import { publicSectorArchetypes } from "./public-sector";
 
 export const ALL_ARCHETYPES = [
   ...healthcareWellnessArchetypes,
@@ -24,4 +25,5 @@ export const ALL_ARCHETYPES = [
   ...fitnessRecreationArchetypes,
   ...nonprofitCommunityArchetypes,
   ...hoaPropertyManagementArchetypes,
+  ...publicSectorArchetypes,
 ];

--- a/packages/storefront-templates/src/archetypes/public-sector.ts
+++ b/packages/storefront-templates/src/archetypes/public-sector.ts
@@ -1,0 +1,68 @@
+import type { ArchetypeDefinition } from "../types";
+
+const RESIDENT_CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: false },
+  { name: "address", label: "Street address", type: "text" as const, required: true },
+];
+
+export const publicSectorArchetypes: ArchetypeDefinition[] = [
+  {
+    archetypeId: "small-town-municipality",
+    name: "Small Town / Municipality",
+    category: "public-sector",
+    ctaType: "inquiry",
+    tags: ["town", "city", "municipality", "village", "township", "local-government", "public-sector", "civic"],
+    itemTemplates: [
+      { name: "Report an Issue (311)", description: "Report a pothole, streetlight outage, drainage problem, or other non-emergency issue", priceType: "free", ctaType: "inquiry" },
+      { name: "Building Permit Application", description: "Apply for a residential or commercial building permit", priceType: "fixed", ctaType: "inquiry" },
+      { name: "Business License", description: "Apply for or renew a business license to operate in town", priceType: "fixed", ctaType: "inquiry" },
+      { name: "Public Records Request", description: "Request copies of public records, meeting minutes, or town documents", priceType: "free", ctaType: "inquiry" },
+      { name: "Park Pavilion Reservation", description: "Reserve a pavilion, ball field, or community room for an event", priceType: "fixed", ctaType: "booking" },
+      { name: "Special Event Permit", description: "Apply to hold a parade, street fair, or public gathering", priceType: "fixed", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Our Town", sortOrder: 1 },
+      { type: "items", title: "Departments & Services", sortOrder: 2 },
+      { type: "team", title: "Council & Staff", sortOrder: 3 },
+      { type: "contact", title: "Town Hall", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...RESIDENT_CONTACT_FIELDS,
+      { name: "department", label: "Department", type: "select" as const, required: true, options: ["Clerk's Office", "Public Works", "Parks & Recreation", "Planning & Zoning", "Code Enforcement", "Finance / Utility Billing", "Other"] },
+      { name: "notes", label: "How can we help?", type: "textarea" as const, required: true },
+    ],
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "projects"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "resident",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "statutory-fees-and-levies",
+        provisioning: "account-with-billing",
+        platform: "no",
+        governance: "public-body",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "standard", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "Permits & Licenses",
+        "Public Works",
+        "Parks & Recreation",
+        "Clerk's Office",
+        "Code Enforcement",
+      ],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Phase 1 of **BI-8D477188** (small-town municipality archetype, `EP-ARCH-8D4F2A`) — the first public-sector archetype on the civic substrate merged in #1692.

- `small-town-municipality` archetype (`public-sector` category, CTA inquiry, town-website storefront sections) with a full activation profile: `resident` + `public-body` + `statutory-fees-and-levies` axes. A new test proves the rules engine derives public-body-governance / records-request / service-request-311 as **required** from the axes alone — no archetype-id conditionals.
- `fund_accounting` finance profile (category `public-sector`, `ledgerModel: fund-accounting`) composing the fund-accounting COA fragment with statutory billing.
- Category wiring at all sites named by the `hoa-property-management` sweep: industry picker, onboarding business context, marketing playbook + skill rules (towns inform, they don't market — SEO/competitive analysis hidden), finance setup mapping, calendar defaults, category suggestions.
- Phase-0 regression test rescoped: archetypes **without** a governance declaration still all normalize to investor-owned/inert; the town asserts the public-body set positively.

Plan for the remaining phases (civic Prisma models, capability surface UI, licensing seed, live-install verification): `docs/superpowers/plans/2026-06-09-small-town-municipality-archetype.md`.

## Verification

- `@dpf/storefront-templates` 55 tests + typecheck green; `@dpf/finance-templates` 15 tests + typecheck green; web storefront/onboarding/finance/tak libs 747 tests + typecheck green; `@dpf/db` typecheck green (seed derives from `ARCHETYPE_SEED_DATA`, picks the new archetype up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)