### PR TITLE
feat(archetypes): civic governance models + town compliance pack (BI-8D477188 Phase 2)

### DIFF
--- a/packages/db/prisma/migrations/20260610060000_add_civic_governance_models/migration.sql
+++ b/packages/db/prisma/migrations/20260610060000_add_civic_governance_models/migration.sql
@@ -1,0 +1,82 @@
+-- BI-8D477188 Phase 2: civic & member-governed archetype models.
+-- Additive tables only — no existing-table changes except BusinessContext.stateCode.
+-- GovernanceMeeting serves both public-body (council/committee) and member-owned
+-- (board/annual-meeting) governance via bodyType, so credit-union/cooperative
+-- archetypes reuse the same workflow table.
+
+ALTER TABLE "BusinessContext" ADD COLUMN "stateCode" TEXT;
+
+CREATE TABLE "GovernanceMeeting" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "bodyType" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "location" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "agendaContent" TEXT,
+    "agendaPublishedAt" TIMESTAMP(3),
+    "minutesContent" TEXT,
+    "minutesRecordedAt" TIMESTAMP(3),
+    "minutesApprovedAt" TIMESTAMP(3),
+    "attendees" JSONB,
+    "decisions" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GovernanceMeeting_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "GovernanceMeeting_meetingId_key" ON "GovernanceMeeting"("meetingId");
+CREATE INDEX "GovernanceMeeting_organizationId_scheduledAt_idx" ON "GovernanceMeeting"("organizationId", "scheduledAt");
+CREATE INDEX "GovernanceMeeting_organizationId_status_idx" ON "GovernanceMeeting"("organizationId", "status");
+
+ALTER TABLE "GovernanceMeeting" ADD CONSTRAINT "GovernanceMeeting_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "RecordsRequest" (
+    "id" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "requesterName" TEXT NOT NULL,
+    "requesterEmail" TEXT,
+    "requesterPhone" TEXT,
+    "description" TEXT NOT NULL,
+    "requestedRecords" JSONB,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "responseDueAt" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "responseSummary" TEXT,
+    "denialReason" TEXT,
+    "exemptionsCited" JSONB,
+    "respondedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecordsRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RecordsRequest_requestId_key" ON "RecordsRequest"("requestId");
+CREATE INDEX "RecordsRequest_organizationId_status_idx" ON "RecordsRequest"("organizationId", "status");
+CREATE INDEX "RecordsRequest_organizationId_responseDueAt_idx" ON "RecordsRequest"("organizationId", "responseDueAt");
+
+ALTER TABLE "RecordsRequest" ADD CONSTRAINT "RecordsRequest_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "FundBudgetLine" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "fiscalYear" INTEGER NOT NULL,
+    "fund" TEXT NOT NULL,
+    "accountCode" TEXT NOT NULL,
+    "budgetedAmount" DECIMAL(14,2) NOT NULL,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FundBudgetLine_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FundBudgetLine_organizationId_fiscalYear_fund_accountCode_key" ON "FundBudgetLine"("organizationId", "fiscalYear", "fund", "accountCode");
+CREATE INDEX "FundBudgetLine_organizationId_fiscalYear_idx" ON "FundBudgetLine"("organizationId", "fiscalYear");
+
+ALTER TABLE "FundBudgetLine" ADD CONSTRAINT "FundBudgetLine_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2836,6 +2836,9 @@ model Organization {
   integrationCoverageProviders  IntegrationCoverageProvider[]  @relation("OrgToCoverageProviders")
   integrationRoleCoverages      IntegrationRoleCoverage[]      @relation("OrgToCoverageCells")
   capabilityActivations         OrganizationCapabilityActivation[]
+  governanceMeetings            GovernanceMeeting[]
+  recordsRequests               RecordsRequest[]
+  fundBudgetLines               FundBudgetLine[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -2885,6 +2888,10 @@ model BusinessContext {
   companyStage    String?
   companySize     String?
   geographicScope String?
+  // US state/province code driving statutory defaults (records-request response
+  // deadlines, retention schedules) for public-sector archetypes. Org-level
+  // configuration on seeded obligations — not 50 seed variants (civic spec $10).
+  stateCode       String?
 
   // Derived from archetype (auto-populated)
   industry    String?
@@ -10360,4 +10367,90 @@ model BuildEngineState {
   provisionedBy     String?
 
   @@map("build_engine_state")
+}
+
+// ─── Civic & member-governed archetype models (BI-8D477188 Phase 2) ──────────
+// Spec: docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md §7
+// Plan: docs/superpowers/plans/2026-06-09-small-town-municipality-archetype.md
+// GovernanceMeeting serves BOTH public-body governance (council/committee, gated
+// by governance=public-body) and member governance (board/annual meeting, gated
+// by governance=member-owned) — bodyType carries the distinction so the
+// credit-union and cooperative archetypes reuse the same workflow table.
+
+model GovernanceMeeting {
+  id             String       @id @default(cuid())
+  meetingId      String       @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  bodyType    String // council | board | committee | annual-meeting
+  title       String
+  scheduledAt DateTime
+  location    String?
+  // scheduled → agenda-published → held → minutes-recorded → minutes-approved | cancelled
+  status      String   @default("scheduled")
+
+  agendaContent     String?
+  agendaPublishedAt DateTime?
+  minutesContent    String?
+  minutesRecordedAt DateTime?
+  minutesApprovedAt DateTime?
+  attendees         Json?
+  decisions         Json?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([organizationId, scheduledAt])
+  @@index([organizationId, status])
+}
+
+model RecordsRequest {
+  id             String       @id @default(cuid())
+  requestId      String       @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  requesterName    String
+  requesterEmail   String?
+  requesterPhone   String?
+  description      String
+  requestedRecords Json?
+
+  receivedAt    DateTime @default(now())
+  // Statutory response deadline — computed from the org-configured response-days
+  // (state-dependent; BusinessContext.stateCode sets the default).
+  responseDueAt DateTime
+  // submitted → in-progress → fulfilled | partially-fulfilled | denied | withdrawn
+  status        String   @default("submitted")
+
+  responseSummary String?
+  denialReason    String?
+  exemptionsCited Json?
+  respondedAt     DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([organizationId, status])
+  @@index([organizationId, responseDueAt])
+}
+
+model FundBudgetLine {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  fiscalYear     Int
+  // general | special-revenue | enterprise | capital-projects | debt-service
+  fund           String
+  accountCode    String
+  budgetedAmount Decimal @db.Decimal(14, 2)
+  notes          String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([organizationId, fiscalYear, fund, accountCode])
+  @@index([organizationId, fiscalYear])
 }

--- a/packages/db/src/seed-public-sector-compliance.ts
+++ b/packages/db/src/seed-public-sector-compliance.ts
@@ -1,0 +1,354 @@
+import type { PrismaClient } from "../generated/client/client";
+import * as crypto from "crypto";
+
+// BI-8D477188 Phase 2 — town/public-body compliance pack (civic spec §10).
+// Seeds the universal state-law FAMILIES as global Regulation rows (industry
+// "public-sector", same pattern as the DORA pack's industry "financial"):
+// statutory deadlines and retention periods vary by state, so obligations carry
+// org-configurable cadence notes rather than 50 per-state seed variants —
+// BusinessContext.stateCode selects the defaults at onboarding.
+
+function makeId(prefix: string): string {
+  const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
+  return `${prefix}-${hex}`;
+}
+
+type ObligationSeed = {
+  title: string;
+  reference: string;
+  description: string;
+  category: string;
+  frequency: string;
+  applicability: string;
+  penaltySummary: string | null;
+};
+
+type RegulationSeed = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string;
+  sourceType: "external";
+  notes: string;
+  obligations: ObligationSeed[];
+};
+
+export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
+  {
+    regulationId: "REG-US-STATE-OPEN-MEETINGS",
+    name: "State Open Meetings Law (Sunshine Law)",
+    shortName: "Open Meetings",
+    jurisdiction: "US-state",
+    industry: "public-sector",
+    sourceType: "external",
+    notes:
+      "All 50 US states require open meetings of public bodies: advance public notice, " +
+      "published agendas, public attendance, recorded minutes, and limited executive sessions. " +
+      "Notice periods and posting rules vary by state — configure deadlines from the " +
+      "organization's state (BusinessContext.stateCode).",
+    obligations: [
+      {
+        title: "Public notice of meetings within the statutory notice period",
+        reference: "open-meetings/notice",
+        description:
+          "Post public notice of every regular and special meeting of the governing body within the " +
+          "state-mandated notice period (commonly 24–72 hours; longer for regular sessions in some states). " +
+          "Notice must state time, place, and accessibility information.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "All public bodies (council, boards, commissions, committees with authority)",
+        penaltySummary: "Actions taken at an improperly noticed meeting may be voidable; statutory fines vary by state.",
+      },
+      {
+        title: "Agenda published before the meeting",
+        reference: "open-meetings/agenda",
+        description:
+          "Publish the meeting agenda in advance per state law. Items not on the published agenda are " +
+          "restricted in many states. The agenda packet should be retained with the meeting record.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "All public bodies",
+        penaltySummary: null,
+      },
+      {
+        title: "Minutes recorded, approved, and made public",
+        reference: "open-meetings/minutes",
+        description:
+          "Record minutes of every open meeting (attendees, motions, votes, decisions), approve them at a " +
+          "subsequent meeting, and make them available to the public within the state-mandated window.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "All public bodies",
+        penaltySummary: null,
+      },
+      {
+        title: "Executive (closed) sessions limited to statutory grounds",
+        reference: "open-meetings/executive-session",
+        description:
+          "Enter executive session only for grounds enumerated in state law (personnel, litigation, " +
+          "real-estate negotiation, security), with the ground cited in open session and recorded in minutes. " +
+          "No final action may be taken in closed session in most states.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "All public bodies",
+        penaltySummary: "Improper closed sessions are a common basis for litigation and voided actions.",
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-STATE-PUBLIC-RECORDS",
+    name: "State Public Records Law (FOIA equivalent)",
+    shortName: "Public Records",
+    jurisdiction: "US-state",
+    industry: "public-sector",
+    sourceType: "external",
+    notes:
+      "All 50 states + DC grant public access to government records, with response deadlines " +
+      "(commonly 3–10 business days), enumerated exemptions, and fee rules. Retention schedules " +
+      "are set by the state archives/records authority. Configure the response-deadline default " +
+      "from the organization's state.",
+    obligations: [
+      {
+        title: "Respond to public records requests within the statutory deadline",
+        reference: "public-records/response-deadline",
+        description:
+          "Acknowledge and respond to each records request within the state deadline — produce the records, " +
+          "deny with the specific statutory exemption cited, or provide a lawful extension notice. Track " +
+          "every request from receipt to disposition with its due date.",
+        category: "records",
+        frequency: "event-driven",
+        applicability: "All public bodies",
+        penaltySummary: "Statutory penalties, attorney-fee awards, and court-ordered production for missed deadlines.",
+      },
+      {
+        title: "Exemption review and denial justification",
+        reference: "public-records/exemptions",
+        description:
+          "Review responsive records against the state's enumerated exemptions (personnel privacy, active " +
+          "investigations, juvenile records, security plans) before release. Denials must cite the exemption; " +
+          "redact rather than withhold where severability applies.",
+        category: "records",
+        frequency: "event-driven",
+        applicability: "All public bodies",
+        penaltySummary: null,
+      },
+      {
+        title: "Records retention schedule adherence",
+        reference: "public-records/retention",
+        description:
+          "Retain and dispose of records per the state archives' retention schedule for local governments " +
+          "(minutes and ordinances commonly permanent; correspondence and working files per schedule). " +
+          "Destruction outside the schedule — or during a pending request or litigation hold — is prohibited.",
+        category: "records",
+        frequency: "continuous",
+        applicability: "All public bodies",
+        penaltySummary: "Unlawful destruction can carry criminal liability in many states.",
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-STATE-MUNI-FINANCE",
+    name: "State Municipal Finance, Audit & Procurement Requirements",
+    shortName: "Municipal Finance",
+    jurisdiction: "US-state",
+    industry: "public-sector",
+    sourceType: "external",
+    notes:
+      "State statutes govern municipal budgeting (annual appropriation), audit/filing with the state " +
+      "auditor (annual or biennial by size), and procurement (competitive quotes and sealed-bid " +
+      "thresholds). Thresholds and filing cadence vary by state and population.",
+    obligations: [
+      {
+        title: "Annual budget adopted by appropriation before the fiscal year",
+        reference: "muni-finance/budget-adoption",
+        description:
+          "Adopt the annual budget by ordinance/resolution before the fiscal year begins, after the " +
+          "state-required public hearing. The appropriation is the legal spending constraint; amendments " +
+          "follow the same public process.",
+        category: "finance",
+        frequency: "annual",
+        applicability: "All general-purpose local governments",
+        penaltySummary: "Spending without appropriation is ultra vires; state oversight escalation.",
+      },
+      {
+        title: "Budget-to-actual monitoring against appropriations",
+        reference: "muni-finance/budget-to-actual",
+        description:
+          "Monitor expenditures against appropriations by fund throughout the year (GASB budgetary " +
+          "comparison). Surface overspend risk to the governing body before, not after, the overrun.",
+        category: "finance",
+        frequency: "monthly",
+        applicability: "All general-purpose local governments",
+        penaltySummary: null,
+      },
+      {
+        title: "State audit preparation and filing",
+        reference: "muni-finance/state-audit",
+        description:
+          "Prepare for and file the state-required annual or biennial audit / annual financial report with " +
+          "the state auditor's office by the statutory deadline. Track findings to remediation.",
+        category: "finance",
+        frequency: "annual",
+        applicability: "All local governments (cadence varies by size and state)",
+        penaltySummary: "Late filings are publicly reported; persistent failure triggers state intervention.",
+      },
+      {
+        title: "Procurement thresholds — quotes and sealed bids",
+        reference: "muni-finance/procurement",
+        description:
+          "Follow state competitive-procurement thresholds: informal quotes above the lower threshold, " +
+          "advertised sealed bids above the upper threshold, with documented exceptions (sole source, " +
+          "emergency) and a complete audit trail.",
+        category: "procurement",
+        frequency: "event-driven",
+        applicability: "All local governments",
+        penaltySummary: "Bid-splitting and threshold evasion are common audit findings with personal liability in some states.",
+      },
+    ],
+  },
+];
+
+type ControlSeed = {
+  title: string;
+  description: string;
+  controlType: "preventive" | "detective" | "corrective";
+  obligationRefs: string[];
+};
+
+export const PUBLIC_SECTOR_CONTROLS: ControlSeed[] = [
+  {
+    title: "Meeting Notice & Agenda Publication Procedure",
+    description:
+      "Documented workflow: meeting scheduled → notice posted within the state notice period → agenda " +
+      "published → minutes recorded and approved. Backed by the GovernanceMeeting workflow surfaces.",
+    controlType: "preventive",
+    obligationRefs: ["open-meetings/notice", "open-meetings/agenda", "open-meetings/minutes"],
+  },
+  {
+    title: "Records Request Log with Deadline Tracking",
+    description:
+      "Every records request logged on receipt with computed statutory due date, status transitions, " +
+      "exemption citations on denial, and disposition record. Backed by the RecordsRequest queue.",
+    controlType: "detective",
+    obligationRefs: ["public-records/response-deadline", "public-records/exemptions"],
+  },
+  {
+    title: "Records Retention Schedule Register",
+    description:
+      "Register of record series mapped to the state retention schedule with disposition holds for " +
+      "pending requests and litigation.",
+    controlType: "preventive",
+    obligationRefs: ["public-records/retention"],
+  },
+  {
+    title: "Procurement Threshold Checklist",
+    description:
+      "Pre-purchase checklist enforcing quote/sealed-bid thresholds with documented exception grounds " +
+      "and approval trail.",
+    controlType: "preventive",
+    obligationRefs: ["muni-finance/procurement"],
+  },
+  {
+    title: "Budget-to-Actual Review Cadence",
+    description:
+      "Monthly budget-to-actual review by fund against appropriations, surfaced to the governing body. " +
+      "Backed by the FundBudgetLine fund view.",
+    controlType: "detective",
+    obligationRefs: ["muni-finance/budget-to-actual", "muni-finance/budget-adoption"],
+  },
+];
+
+export async function seedPublicSectorCompliance(prisma: PrismaClient): Promise<void> {
+  let regUpserts = 0;
+  let oblCreated = 0;
+  let ctlCreated = 0;
+  let linksCreated = 0;
+
+  const oblIdByRef = new Map<string, string>();
+
+  for (const reg of PUBLIC_SECTOR_REGULATIONS) {
+    const { obligations, ...regData } = reg;
+    const regulation = await prisma.regulation.upsert({
+      where: { regulationId: regData.regulationId },
+      update: {
+        name: regData.name,
+        shortName: regData.shortName,
+        jurisdiction: regData.jurisdiction,
+        industry: regData.industry,
+        notes: regData.notes,
+      },
+      create: regData,
+    });
+    regUpserts++;
+
+    for (const obl of obligations) {
+      const existing = await prisma.obligation.findFirst({
+        where: { regulationId: regulation.id, reference: obl.reference, status: "active" },
+        select: { id: true },
+      });
+      if (existing) {
+        oblIdByRef.set(obl.reference, existing.id);
+        continue;
+      }
+      const created = await prisma.obligation.create({
+        data: {
+          obligationId: makeId("OBL"),
+          regulationId: regulation.id,
+          title: obl.title,
+          description: obl.description,
+          reference: obl.reference,
+          category: obl.category,
+          frequency: obl.frequency,
+          applicability: obl.applicability,
+          penaltySummary: obl.penaltySummary,
+        },
+      });
+      oblIdByRef.set(obl.reference, created.id);
+      oblCreated++;
+    }
+  }
+
+  for (const ctl of PUBLIC_SECTOR_CONTROLS) {
+    const existing = await prisma.control.findFirst({
+      where: { title: ctl.title, status: "active" },
+      select: { id: true },
+    });
+    const controlId =
+      existing?.id ??
+      (
+        await prisma.control.create({
+          data: {
+            controlId: makeId("CTL"),
+            title: ctl.title,
+            description: ctl.description,
+            controlType: ctl.controlType,
+            implementationStatus: "planned",
+          },
+        })
+      ).id;
+    if (!existing) ctlCreated++;
+
+    for (const ref of ctl.obligationRefs) {
+      const oblId = oblIdByRef.get(ref);
+      if (!oblId) {
+        // Silent-skip guard: a typo'd reference must fail loudly, not seed 0 links.
+        throw new Error(`[seed-public-sector-compliance] control "${ctl.title}" references unknown obligation "${ref}"`);
+      }
+      const link = await prisma.controlObligationLink.findUnique({
+        where: { controlId_obligationId: { controlId, obligationId: oblId } },
+      });
+      if (!link) {
+        await prisma.controlObligationLink.create({ data: { controlId, obligationId: oblId } });
+        linksCreated++;
+      }
+    }
+  }
+
+  const expectedObligations = PUBLIC_SECTOR_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+  console.log(
+    `[seed] public-sector compliance pack: ${regUpserts}/${PUBLIC_SECTOR_REGULATIONS.length} regulations upserted, ` +
+      `${oblCreated} obligations created (${expectedObligations} expected total), ` +
+      `${ctlCreated} controls created, ${linksCreated} links created`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -14,6 +14,7 @@ import { seedEaStructureRules } from "./seed-ea-structure-rules.js";
 import { seedGovernanceReferenceData } from "./governance-seed.js";
 import { seedWorkforceReferenceData } from "./workforce-seed.js";
 import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
+import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
 import { seedBusinessCapabilityPerspective } from "./business-capability-perspectives.js";
 import { seedGeographicData } from "./seed-geographic-data.js";
 import { seedTaxJurisdictions } from "./seed-tax-jurisdictions.js";
@@ -2532,6 +2533,7 @@ async function main(): Promise<void> {
   await step("clientIdentity", () => seedClientIdentity());
   await step("hiveContributionCredential", () => seedHiveContributionCredential());
   await step("storefrontArchetypes", () => seedStorefrontArchetypes(prisma));
+  await step("publicSectorCompliance", () => seedPublicSectorCompliance(prisma));
   await step("businessCapabilityPerspective", async () => {
     const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(

--- a/packages/db/test/seed-public-sector-compliance.test.ts
+++ b/packages/db/test/seed-public-sector-compliance.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_SECTOR_CONTROLS,
+  PUBLIC_SECTOR_REGULATIONS,
+} from "../src/seed-public-sector-compliance";
+
+// Pure-data integrity tests — no database. The seeder itself throws on a
+// control referencing an unknown obligation (silent-skip guard); these tests
+// catch the same class at review time.
+
+describe("public-sector compliance pack data", () => {
+  it("ships the three state-law families with the expected obligation counts", () => {
+    expect(PUBLIC_SECTOR_REGULATIONS.map((r) => r.regulationId).sort()).toEqual([
+      "REG-US-STATE-MUNI-FINANCE",
+      "REG-US-STATE-OPEN-MEETINGS",
+      "REG-US-STATE-PUBLIC-RECORDS",
+    ]);
+    const total = PUBLIC_SECTOR_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+    expect(total).toBe(11);
+    for (const reg of PUBLIC_SECTOR_REGULATIONS) {
+      expect(reg.industry).toBe("public-sector");
+      expect(reg.obligations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("obligation references are globally unique", () => {
+    const refs = PUBLIC_SECTOR_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference));
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it("every control references only known obligations", () => {
+    const known = new Set(
+      PUBLIC_SECTOR_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference)),
+    );
+    for (const control of PUBLIC_SECTOR_CONTROLS) {
+      expect(control.obligationRefs.length).toBeGreaterThan(0);
+      for (const ref of control.obligationRefs) {
+        expect(known.has(ref), `${control.title} references unknown obligation ${ref}`).toBe(true);
+      }
+    }
+  });
+
+  it("every obligation carries the fields the compliance surfaces render", () => {
+    for (const reg of PUBLIC_SECTOR_REGULATIONS) {
+      for (const obl of reg.obligations) {
+        expect(obl.title.length).toBeGreaterThan(10);
+        expect(obl.description.length).toBeGreaterThan(40);
+        expect(["governance", "records", "finance", "procurement"]).toContain(obl.category);
+        expect(["event-driven", "continuous", "annual", "monthly"]).toContain(obl.frequency);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of **BI-8D477188** (small-town municipality, `EP-ARCH-8D4F2A`), per the plan merged in #1695.

**New Prisma models (additive migration, diff-verified):**
- `GovernanceMeeting` — agenda → meeting → minutes workflow with publication timestamps. `bodyType` covers council/committee (public-body) AND board/annual-meeting (member-owned), so the credit-union (BI-D9ACE184) and cooperative (BI-AFC178F3) slices reuse this table.
- `RecordsRequest` — statutory-deadline lifecycle (received → due-date countdown → fulfilled/denied with exemptions cited).
- `FundBudgetLine` — minimal budget side for the GASB budget-to-actual fund view.
- `BusinessContext.stateCode` — drives state-dependent statutory defaults.

**Town compliance pack** (existing Regulation/Obligation/Control substrate, DORA-pack pattern): three state-law families (`REG-US-STATE-OPEN-MEETINGS`, `REG-US-STATE-PUBLIC-RECORDS`, `REG-US-STATE-MUNI-FINANCE`) with 11 obligations and 5 linked controls, `industry: "public-sector"`. Seeder is idempotent, throws on dangling obligation references (the known silent-seed-skip failure class), logs counts, and runs in the main seed after storefront archetypes.

## Verification

- `prisma validate` green; hand-authored migration SQL compared against `prisma migrate diff --from-empty --to-schema` output — identical table/index/FK definitions.
- `@dpf/db` typecheck green; new pack data tests 4/4 green (no DB required).
- DB-bound seed execution is covered by CI (Unit Tests packages job with migrated postgres).

Next: Phase 3 (capability surface UI — meetings, records queue, 311 queue, funds view) then licensing seed + live-install functional verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)