### PR TITLE
feat(archetypes): capability-gated civic surfaces — governance, records, 311, funds (BI-8D477188 Phase 3)

### DIFF
--- a/apps/web/app/(shell)/finance/funds/page.tsx
+++ b/apps/web/app/(shell)/finance/funds/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { getFinancialProfile, LEDGER_COA_FRAGMENTS } from "@dpf/finance-templates";
+import { getOrgSettings } from "@/lib/actions/currency";
+import { FundBudgetPanel, type FundBudgetRow } from "@/components/civic/FundBudgetPanel";
+
+// Budget-to-actual fund view (BI-8D477188 Phase 3) — first consumer of
+// FinancialProfile.ledgerModel. Renders only for fund-accounting profiles;
+// commercial archetypes never see a Funds surface (civic spec §13.5).
+export default async function FundsPage() {
+  const orgSettings = await getOrgSettings();
+  const profile = orgSettings.appliedProfileSlug
+    ? getFinancialProfile(orgSettings.appliedProfileSlug)
+    : null;
+
+  if (profile?.ledgerModel !== "fund-accounting") notFound();
+
+  const fiscalYear = new Date().getFullYear();
+  const lines = await prisma.fundBudgetLine.findMany({
+    where: { fiscalYear },
+    orderBy: [{ fund: "asc" }, { accountCode: "asc" }],
+  });
+
+  // Resolve display names from the fund-accounting COA fragment.
+  const accountNames = new Map(
+    LEDGER_COA_FRAGMENTS["fund-accounting"].map((account) => [account.code, account.name]),
+  );
+
+  const rows: FundBudgetRow[] = lines.map((line) => ({
+    id: line.id,
+    fiscalYear: line.fiscalYear,
+    fund: line.fund,
+    accountCode: line.accountCode,
+    accountName: accountNames.get(line.accountCode) ?? null,
+    budgetedAmount: Number(line.budgetedAmount),
+  }));
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Funds</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Budget-to-actual by fund · FY{fiscalYear} · appropriations are the legal spending
+          constraint
+        </p>
+      </div>
+      <FundBudgetPanel
+        lines={rows}
+        fiscalYear={fiscalYear}
+        currency={orgSettings.baseCurrency ?? "USD"}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/governance/page.tsx
+++ b/apps/web/app/(shell)/governance/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
+import { CivicMeetingsPanel, type MeetingRow } from "@/components/civic/CivicMeetingsPanel";
+
+// Public-body governance workbench (BI-8D477188 Phase 3). Capability-gated:
+// reachable only when the org's archetype derives public-body-governance active
+// (civic spec §12 — surfaces fall out of capabilities, not archetype ids).
+export default async function GovernancePage() {
+  if (!(await hasActiveOrgCapability("public-body-governance"))) notFound();
+
+  const meetings = await prisma.governanceMeeting.findMany({
+    orderBy: { scheduledAt: "desc" },
+    take: 50,
+  });
+
+  const rows: MeetingRow[] = meetings.map((m) => ({
+    id: m.id,
+    meetingId: m.meetingId,
+    bodyType: m.bodyType,
+    title: m.title,
+    scheduledAt: m.scheduledAt.toISOString(),
+    location: m.location,
+    status: m.status,
+    agendaPublishedAt: m.agendaPublishedAt?.toISOString() ?? null,
+    minutesRecordedAt: m.minutesRecordedAt?.toISOString() ?? null,
+  }));
+
+  const openRequests = await prisma.recordsRequest.count({
+    where: { status: { in: ["submitted", "in-progress"] } },
+  });
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">Governance</h1>
+          <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+            Meetings, agendas, and minutes · {rows.length} meetings
+          </p>
+        </div>
+        <Link
+          href="/governance/records-requests"
+          className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          Records Requests {openRequests > 0 ? `(${openRequests} open)` : ""}
+        </Link>
+      </div>
+      <CivicMeetingsPanel meetings={rows} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/governance/records-requests/page.tsx
+++ b/apps/web/app/(shell)/governance/records-requests/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
+import {
+  RecordsRequestsPanel,
+  type RecordsRequestRow,
+} from "@/components/civic/RecordsRequestsPanel";
+
+// Statutory records-request queue (BI-8D477188 Phase 3). Capability-gated on
+// records-request (public-body archetypes).
+export default async function RecordsRequestsPage() {
+  if (!(await hasActiveOrgCapability("records-request"))) notFound();
+
+  const requests = await prisma.recordsRequest.findMany({
+    orderBy: [{ status: "asc" }, { responseDueAt: "asc" }],
+    take: 100,
+  });
+
+  const rows: RecordsRequestRow[] = requests.map((r) => ({
+    id: r.id,
+    requestId: r.requestId,
+    requesterName: r.requesterName,
+    requesterEmail: r.requesterEmail,
+    description: r.description,
+    receivedAt: r.receivedAt.toISOString(),
+    responseDueAt: r.responseDueAt.toISOString(),
+    status: r.status,
+    denialReason: r.denialReason,
+  }));
+
+  const open = rows.filter((r) => r.status === "submitted" || r.status === "in-progress").length;
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">Records Requests</h1>
+          <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+            {open} open · {rows.length} total · statutory deadlines tracked per request
+          </p>
+        </div>
+        <Link
+          href="/governance"
+          className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+        >
+          Meetings
+        </Link>
+      </div>
+      <RecordsRequestsPanel requests={rows} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -16,6 +16,7 @@ import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
 import { SetupOverlay } from "@/components/setup/SetupOverlay";
 import { getShellNavSections } from "@/lib/permissions";
+import { getActiveOrgCapabilities } from "@/lib/storefront/civic-surfaces.server";
 import { AppRail } from "@/components/shell/AppRail";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveHomePhoneCountry } from "@/lib/phone-country.server";
@@ -39,25 +40,37 @@ export default async function ShellLayout({ children }: { children: React.ReactN
 
   const user = session.user;
 
-  const [latestDiscoveryRun, activeBranding, organization, useUnifiedCoworker, phoneCountry] =
-    await Promise.all([
-      prisma.discoveryRun.findFirst({
-        orderBy: { startedAt: "desc" },
-        select: { id: true },
-      }),
-      prisma.brandingConfig.findUnique({
-        where: { scope: "organization" },
-        select: {
-          logoUrlLight: true,
-          tokens: true,
-        },
-      }),
-      prisma.organization.findFirst({
-        select: { name: true, logoUrl: true },
-      }),
-      isUnifiedCoworkerEnabled(),
-      resolveHomePhoneCountry(),
-    ]);
+  const [
+    latestDiscoveryRun,
+    activeBranding,
+    organization,
+    useUnifiedCoworker,
+    phoneCountry,
+    activeOrgCapabilities,
+  ] = await Promise.all([
+    prisma.discoveryRun.findFirst({
+      orderBy: { startedAt: "desc" },
+      select: { id: true },
+    }),
+    prisma.brandingConfig.findUnique({
+      where: { scope: "organization" },
+      select: {
+        logoUrlLight: true,
+        tokens: true,
+      },
+    }),
+    prisma.organization.findFirst({
+      select: { name: true, logoUrl: true },
+    }),
+    isUnifiedCoworkerEnabled(),
+    resolveHomePhoneCountry(),
+    getActiveOrgCapabilities().catch((error: unknown) => {
+      // Nav must render even if capability resolution fails — archetype-gated
+      // entries just stay hidden.
+      console.error("[shell-nav] active-capability resolution failed", error);
+      return new Set<string>() as ReadonlySet<string>;
+    }),
+  ]);
 
   if (!latestDiscoveryRun) {
     await executeBootstrapDiscovery(prisma as never, {
@@ -123,11 +136,14 @@ export default async function ShellLayout({ children }: { children: React.ReactN
   const brandingCss = buildBrandingStyleTag(activeBranding?.tokens ?? null);
   const shellNavSections = activeSetup
     ? []
-    : getShellNavSections({
-        userId: user.id,
-        platformRole: user.platformRole,
-        isSuperuser: user.isSuperuser,
-      });
+    : getShellNavSections(
+        {
+          userId: user.id,
+          platformRole: user.platformRole,
+          isSuperuser: user.isSuperuser,
+        },
+        { activeOrgCapabilities },
+      );
 
   return (
     <PhoneCountryProvider country={phoneCountry}>

--- a/apps/web/app/(shell)/service-requests/page.tsx
+++ b/apps/web/app/(shell)/service-requests/page.tsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
+import {
+  ServiceRequestsPanel,
+  type ServiceRequestRow,
+} from "@/components/civic/ServiceRequestsPanel";
+
+// 311 service-request queue (BI-8D477188 Phase 3) — a civic re-skin over the
+// existing StorefrontInquiry intake pipeline (substrate verdict: reuse, no new
+// model). Department comes from the public form's formData.
+export default async function ServiceRequestsPage() {
+  if (!(await hasActiveOrgCapability("service-request-311"))) notFound();
+
+  const inquiries = await prisma.storefrontInquiry.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 100,
+  });
+
+  const rows: ServiceRequestRow[] = inquiries.map((i) => {
+    const formData = (i.formData ?? {}) as Record<string, unknown>;
+    const department = typeof formData.department === "string" ? formData.department : null;
+    return {
+      id: i.id,
+      ref: i.inquiryRef,
+      requesterName: i.customerName,
+      requesterEmail: i.customerEmail,
+      message: i.message,
+      department,
+      status: i.status,
+      createdAt: i.createdAt.toISOString(),
+    };
+  });
+
+  const open = rows.filter((r) => r.status !== "closed").length;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Service Requests</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          {open} open · {rows.length} total · resident submissions routed by department
+        </p>
+      </div>
+      <ServiceRequestsPanel requests={rows} />
+    </div>
+  );
+}

--- a/apps/web/components/civic/CivicMeetingsPanel.tsx
+++ b/apps/web/components/civic/CivicMeetingsPanel.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  approveMeetingMinutes,
+  cancelGovernanceMeeting,
+  createGovernanceMeeting,
+  markMeetingHeld,
+  publishMeetingAgenda,
+  recordMeetingMinutes,
+} from "@/lib/actions/civic-governance";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+const chipClasses: Record<string, string> = {
+  scheduled: "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+  "agenda-published": "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)]",
+  held: "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)]",
+  "minutes-recorded": "bg-[var(--dpf-accent)]/15 text-[var(--dpf-accent)]",
+  "minutes-approved": "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)]",
+  cancelled: "bg-[var(--dpf-error)]/15 text-[var(--dpf-error)]",
+};
+
+export type MeetingRow = {
+  id: string;
+  meetingId: string;
+  bodyType: string;
+  title: string;
+  scheduledAt: string;
+  location: string | null;
+  status: string;
+  agendaPublishedAt: string | null;
+  minutesRecordedAt: string | null;
+};
+
+const BODY_TYPES = ["council", "board", "committee", "annual-meeting"] as const;
+
+export function CivicMeetingsPanel({ meetings }: { meetings: MeetingRow[] }) {
+  const router = useRouter();
+  const [showCreate, setShowCreate] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [composeFor, setComposeFor] = useState<{ id: string; kind: "agenda" | "minutes" } | null>(null);
+  const [composeText, setComposeText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(id: string, fn: () => Promise<{ ok: boolean; message: string }>) {
+    setBusy(id);
+    setError(null);
+    const result = await fn();
+    setBusy(null);
+    if (!result.ok) setError(result.message);
+    else {
+      setComposeFor(null);
+      setComposeText("");
+      router.refresh();
+    }
+  }
+
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    await run("create", () =>
+      createGovernanceMeeting({
+        bodyType: form.get("bodyType") as string,
+        title: form.get("title") as string,
+        scheduledAt: form.get("scheduledAt") as string,
+        location: (form.get("location") as string) || undefined,
+      }),
+    );
+    setShowCreate(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowCreate((v) => !v)}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          {showCreate ? "Close" : "Schedule Meeting"}
+        </button>
+      </div>
+
+      {showCreate && (
+        <form
+          onSubmit={handleCreate}
+          className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:grid-cols-2"
+        >
+          <div className="sm:col-span-2">
+            <label className={labelClasses}>Title *</label>
+            <input name="title" required className={inputClasses} placeholder="Regular Council Meeting" />
+          </div>
+          <div>
+            <label className={labelClasses}>Body *</label>
+            <select name="bodyType" required className={inputClasses}>
+              {BODY_TYPES.map((b) => (
+                <option key={b} value={b}>{b.replace(/-/g, " ")}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClasses}>Date & time *</label>
+            <input name="scheduledAt" type="datetime-local" required className={inputClasses} />
+          </div>
+          <div className="sm:col-span-2">
+            <label className={labelClasses}>Location</label>
+            <input name="location" className={inputClasses} placeholder="Town Hall, Council Chambers" />
+          </div>
+          <div className="sm:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={busy === "create"}
+              className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy === "create" ? "Scheduling..." : "Schedule"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+
+      <ul className="space-y-2">
+        {meetings.map((m) => (
+          <li key={m.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`rounded px-2 py-0.5 text-[11px] font-medium ${chipClasses[m.status] ?? chipClasses.scheduled}`}>
+                {m.status.replace(/-/g, " ")}
+              </span>
+              <span className="text-[11px] uppercase tracking-wide text-[var(--dpf-muted)]">{m.bodyType.replace(/-/g, " ")}</span>
+              <span className="text-sm font-medium text-[var(--dpf-text)]">{m.title}</span>
+              <span className="ml-auto text-xs text-[var(--dpf-muted)]">
+                {new Date(m.scheduledAt).toLocaleString()} {m.location ? `· ${m.location}` : ""}
+              </span>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {m.status === "scheduled" && (
+                <button
+                  onClick={() => setComposeFor({ id: m.id, kind: "agenda" })}
+                  className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+                >
+                  Publish agenda
+                </button>
+              )}
+              {m.status === "agenda-published" && (
+                <button
+                  onClick={() => run(m.id, () => markMeetingHeld(m.id))}
+                  disabled={busy === m.id}
+                  className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                >
+                  Mark held
+                </button>
+              )}
+              {m.status === "held" && (
+                <button
+                  onClick={() => setComposeFor({ id: m.id, kind: "minutes" })}
+                  className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+                >
+                  Record minutes
+                </button>
+              )}
+              {m.status === "minutes-recorded" && (
+                <button
+                  onClick={() => run(m.id, () => approveMeetingMinutes(m.id))}
+                  disabled={busy === m.id}
+                  className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                >
+                  Approve minutes
+                </button>
+              )}
+              {!["cancelled", "minutes-approved"].includes(m.status) && (
+                <button
+                  onClick={() => run(m.id, () => cancelGovernanceMeeting(m.id))}
+                  disabled={busy === m.id}
+                  className="px-2 py-1 text-[11px] rounded text-[var(--dpf-error)] hover:underline disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+            {composeFor?.id === m.id && (
+              <div className="mt-3 space-y-2">
+                <textarea
+                  value={composeText}
+                  onChange={(e) => setComposeText(e.target.value)}
+                  rows={5}
+                  className={inputClasses}
+                  placeholder={composeFor.kind === "agenda" ? "1. Call to order\n2. Public comment\n3. ..." : "Attendees, motions, votes, decisions..."}
+                />
+                <div className="flex justify-end gap-2">
+                  <button
+                    onClick={() => setComposeFor(null)}
+                    className="px-2 py-1 text-[11px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  >
+                    Discard
+                  </button>
+                  <button
+                    onClick={() =>
+                      run(m.id, () =>
+                        composeFor.kind === "agenda"
+                          ? publishMeetingAgenda(m.id, composeText)
+                          : recordMeetingMinutes(m.id, composeText),
+                      )
+                    }
+                    disabled={busy === m.id}
+                    className="px-2 py-1 text-[11px] font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+                  >
+                    {composeFor.kind === "agenda" ? "Publish" : "Record"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+        {meetings.length === 0 && (
+          <li className="rounded-lg border border-dashed border-[var(--dpf-border)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+            No meetings yet. Schedule the first council or board meeting.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/civic/FundBudgetPanel.tsx
+++ b/apps/web/components/civic/FundBudgetPanel.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { upsertFundBudgetLine } from "@/lib/actions/civic-governance";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+const FUND_LABELS: Record<string, string> = {
+  general: "General Fund",
+  "special-revenue": "Special Revenue",
+  enterprise: "Enterprise Fund",
+  "capital-projects": "Capital Projects",
+  "debt-service": "Debt Service",
+};
+
+export type FundBudgetRow = {
+  id: string;
+  fiscalYear: number;
+  fund: string;
+  accountCode: string;
+  accountName: string | null;
+  budgetedAmount: number;
+};
+
+export function FundBudgetPanel({
+  lines,
+  fiscalYear,
+  currency,
+}: {
+  lines: FundBudgetRow[];
+  fiscalYear: number;
+  currency: string;
+}) {
+  const router = useRouter();
+  const [showAdd, setShowAdd] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fmt = new Intl.NumberFormat(undefined, { style: "currency", currency, maximumFractionDigits: 0 });
+
+  const byFund = new Map<string, FundBudgetRow[]>();
+  for (const line of lines) {
+    const list = byFund.get(line.fund) ?? [];
+    list.push(line);
+    byFund.set(line.fund, list);
+  }
+
+  async function handleAdd(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    setBusy(true);
+    setError(null);
+    const result = await upsertFundBudgetLine({
+      fiscalYear: Number(form.get("fiscalYear")),
+      fund: form.get("fund") as string,
+      accountCode: form.get("accountCode") as string,
+      budgetedAmount: Number(form.get("budgetedAmount")),
+      notes: (form.get("notes") as string) || undefined,
+    });
+    setBusy(false);
+    if (!result.ok) setError(result.message);
+    else {
+      setShowAdd(false);
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowAdd((v) => !v)}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          {showAdd ? "Close" : "Add Budget Line"}
+        </button>
+      </div>
+
+      {showAdd && (
+        <form
+          onSubmit={handleAdd}
+          className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:grid-cols-2"
+        >
+          <div>
+            <label className={labelClasses}>Fiscal year *</label>
+            <input name="fiscalYear" type="number" defaultValue={fiscalYear} required className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>Fund *</label>
+            <select name="fund" required className={inputClasses}>
+              {Object.entries(FUND_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>{label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClasses}>Account code *</label>
+            <input name="accountCode" required className={inputClasses} placeholder="5020" />
+          </div>
+          <div>
+            <label className={labelClasses}>Budgeted amount *</label>
+            <input name="budgetedAmount" type="number" min="0" step="0.01" required className={inputClasses} />
+          </div>
+          <div className="sm:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={busy}
+              className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+
+      {Array.from(byFund.entries()).map(([fund, fundLines]) => {
+        const total = fundLines.reduce((sum, l) => sum + l.budgetedAmount, 0);
+        return (
+          <section key={fund} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+            <header className="flex items-center justify-between border-b border-[var(--dpf-border)] px-4 py-2">
+              <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{FUND_LABELS[fund] ?? fund}</h2>
+              <span className="text-xs text-[var(--dpf-muted)]">Budgeted {fmt.format(total)}</span>
+            </header>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-[11px] uppercase tracking-wide text-[var(--dpf-muted)]">
+                  <th className="px-4 py-2 font-medium">Account</th>
+                  <th className="px-4 py-2 font-medium text-right">Budget (FY{fiscalYear})</th>
+                  <th className="px-4 py-2 font-medium text-right">Actual</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fundLines.map((line) => (
+                  <tr key={line.id} className="border-t border-[var(--dpf-border)]/50">
+                    <td className="px-4 py-2 text-[var(--dpf-text)]">
+                      <span className="font-mono text-xs text-[var(--dpf-muted)]">{line.accountCode}</span>{" "}
+                      {line.accountName ?? ""}
+                    </td>
+                    <td className="px-4 py-2 text-right text-[var(--dpf-text)]">{fmt.format(line.budgetedAmount)}</td>
+                    <td className="px-4 py-2 text-right text-[var(--dpf-muted)]">—</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        );
+      })}
+
+      {lines.length === 0 && (
+        <div className="rounded-lg border border-dashed border-[var(--dpf-border)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+          No budget lines for FY{fiscalYear}. Add appropriations per fund to start the
+          budget-to-actual view; actuals populate as fund-tagged transactions land.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/civic/RecordsRequestsPanel.tsx
+++ b/apps/web/components/civic/RecordsRequestsPanel.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  createRecordsRequest,
+  updateRecordsRequestStatus,
+} from "@/lib/actions/civic-governance";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+const STATUS_CHIPS: Record<string, string> = {
+  submitted: "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)]",
+  "in-progress": "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)]",
+  fulfilled: "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)]",
+  "partially-fulfilled": "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)]",
+  denied: "bg-[var(--dpf-error)]/15 text-[var(--dpf-error)]",
+  withdrawn: "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+};
+
+export type RecordsRequestRow = {
+  id: string;
+  requestId: string;
+  requesterName: string;
+  requesterEmail: string | null;
+  description: string;
+  receivedAt: string;
+  responseDueAt: string;
+  status: string;
+  denialReason: string | null;
+};
+
+function daysLeft(dueIso: string): number {
+  return Math.ceil((new Date(dueIso).getTime() - Date.now()) / 86_400_000);
+}
+
+export function RecordsRequestsPanel({ requests }: { requests: RecordsRequestRow[] }) {
+  const router = useRouter();
+  const [showCreate, setShowCreate] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [denyFor, setDenyFor] = useState<string | null>(null);
+  const [denialReason, setDenialReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(id: string, fn: () => Promise<{ ok: boolean; message: string }>) {
+    setBusy(id);
+    setError(null);
+    const result = await fn();
+    setBusy(null);
+    if (!result.ok) setError(result.message);
+    else {
+      setDenyFor(null);
+      setDenialReason("");
+      router.refresh();
+    }
+  }
+
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    await run("create", () =>
+      createRecordsRequest({
+        requesterName: form.get("requesterName") as string,
+        requesterEmail: (form.get("requesterEmail") as string) || undefined,
+        description: form.get("description") as string,
+      }),
+    );
+    setShowCreate(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowCreate((v) => !v)}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          {showCreate ? "Close" : "Log Request"}
+        </button>
+      </div>
+
+      {showCreate && (
+        <form
+          onSubmit={handleCreate}
+          className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:grid-cols-2"
+        >
+          <div>
+            <label className={labelClasses}>Requester name *</label>
+            <input name="requesterName" required className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>Requester email</label>
+            <input name="requesterEmail" type="email" className={inputClasses} />
+          </div>
+          <div className="sm:col-span-2">
+            <label className={labelClasses}>Records requested *</label>
+            <textarea
+              name="description"
+              required
+              rows={3}
+              className={inputClasses}
+              placeholder="Copies of council meeting minutes, January–March"
+            />
+          </div>
+          <div className="sm:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={busy === "create"}
+              className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy === "create" ? "Logging..." : "Log"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+
+      <ul className="space-y-2">
+        {requests.map((r) => {
+          const open = r.status === "submitted" || r.status === "in-progress";
+          const remaining = daysLeft(r.responseDueAt);
+          return (
+            <li key={r.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={`rounded px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIPS[r.status] ?? STATUS_CHIPS.submitted}`}>
+                  {r.status.replace(/-/g, " ")}
+                </span>
+                <span className="text-xs font-mono text-[var(--dpf-muted)]">{r.requestId}</span>
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{r.requesterName}</span>
+                {open && (
+                  <span
+                    className={`ml-auto rounded px-2 py-0.5 text-[11px] font-medium ${
+                      remaining < 0
+                        ? "bg-[var(--dpf-error)]/15 text-[var(--dpf-error)]"
+                        : remaining <= 3
+                          ? "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)]"
+                          : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]"
+                    }`}
+                  >
+                    {remaining < 0 ? `${-remaining}d overdue` : `due in ${remaining}d`}
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 text-sm text-[var(--dpf-muted)]">{r.description}</p>
+              {r.denialReason && (
+                <p className="mt-1 text-xs text-[var(--dpf-error)]">Denied: {r.denialReason}</p>
+              )}
+              {open && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {r.status === "submitted" && (
+                    <button
+                      onClick={() => run(r.id, () => updateRecordsRequestStatus(r.id, "in-progress"))}
+                      disabled={busy === r.id}
+                      className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                    >
+                      Start
+                    </button>
+                  )}
+                  <button
+                    onClick={() => run(r.id, () => updateRecordsRequestStatus(r.id, "fulfilled"))}
+                    disabled={busy === r.id}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-success)] hover:border-[var(--dpf-success)] disabled:opacity-50"
+                  >
+                    Fulfill
+                  </button>
+                  <button
+                    onClick={() => setDenyFor(denyFor === r.id ? null : r.id)}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-error)] hover:border-[var(--dpf-error)]"
+                  >
+                    Deny
+                  </button>
+                </div>
+              )}
+              {denyFor === r.id && (
+                <div className="mt-2 space-y-2">
+                  <input
+                    value={denialReason}
+                    onChange={(e) => setDenialReason(e.target.value)}
+                    className={inputClasses}
+                    placeholder="Statutory exemption cited (required)"
+                  />
+                  <div className="flex justify-end">
+                    <button
+                      onClick={() =>
+                        run(r.id, () => updateRecordsRequestStatus(r.id, "denied", { denialReason }))
+                      }
+                      disabled={busy === r.id}
+                      className="px-2 py-1 text-[11px] font-medium rounded bg-[var(--dpf-error)] text-white hover:opacity-90 disabled:opacity-50"
+                    >
+                      Confirm denial
+                    </button>
+                  </div>
+                </div>
+              )}
+            </li>
+          );
+        })}
+        {requests.length === 0 && (
+          <li className="rounded-lg border border-dashed border-[var(--dpf-border)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+            No records requests logged.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/civic/ServiceRequestsPanel.tsx
+++ b/apps/web/components/civic/ServiceRequestsPanel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateServiceRequestStatus } from "@/lib/actions/civic-governance";
+
+const STATUS_CHIPS: Record<string, string> = {
+  new: "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)]",
+  "in-progress": "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)]",
+  closed: "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+};
+
+export type ServiceRequestRow = {
+  id: string;
+  ref: string;
+  requesterName: string;
+  requesterEmail: string;
+  message: string | null;
+  department: string | null;
+  status: string;
+  createdAt: string;
+};
+
+export function ServiceRequestsPanel({ requests }: { requests: ServiceRequestRow[] }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [departmentFilter, setDepartmentFilter] = useState("");
+
+  const departments = Array.from(
+    new Set(requests.map((r) => r.department).filter((d): d is string => !!d)),
+  ).sort();
+
+  const visible = departmentFilter
+    ? requests.filter((r) => r.department === departmentFilter)
+    : requests;
+
+  async function transition(id: string, status: "in-progress" | "closed") {
+    setBusy(id);
+    setError(null);
+    const result = await updateServiceRequestStatus(id, status);
+    setBusy(null);
+    if (!result.ok) setError(result.message);
+    else router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      {departments.length > 0 && (
+        <select
+          value={departmentFilter}
+          onChange={(e) => setDepartmentFilter(e.target.value)}
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1.5 text-xs text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
+        >
+          <option value="">All departments</option>
+          {departments.map((d) => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
+      )}
+
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+
+      <ul className="space-y-2">
+        {visible.map((r) => (
+          <li key={r.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`rounded px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIPS[r.status] ?? STATUS_CHIPS.new}`}>
+                {r.status.replace(/-/g, " ")}
+              </span>
+              <span className="text-xs font-mono text-[var(--dpf-muted)]">{r.ref}</span>
+              {r.department && (
+                <span className="rounded bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[11px] text-[var(--dpf-muted)]">
+                  {r.department}
+                </span>
+              )}
+              <span className="text-sm font-medium text-[var(--dpf-text)]">{r.requesterName}</span>
+              <span className="ml-auto text-xs text-[var(--dpf-muted)]">
+                {new Date(r.createdAt).toLocaleDateString()}
+              </span>
+            </div>
+            {r.message && <p className="mt-1 text-sm text-[var(--dpf-muted)]">{r.message}</p>}
+            {r.status !== "closed" && (
+              <div className="mt-2 flex gap-2">
+                {r.status === "new" && (
+                  <button
+                    onClick={() => transition(r.id, "in-progress")}
+                    disabled={busy === r.id}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                  >
+                    Start
+                  </button>
+                )}
+                <button
+                  onClick={() => transition(r.id, "closed")}
+                  disabled={busy === r.id}
+                  className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-success)] hover:border-[var(--dpf-success)] disabled:opacity-50"
+                >
+                  Close
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+        {visible.length === 0 && (
+          <li className="rounded-lg border border-dashed border-[var(--dpf-border)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+            No service requests{departmentFilter ? ` for ${departmentFilter}` : ""}. Resident
+            submissions from the public site land here.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/shell/AppRail.test.tsx
+++ b/apps/web/components/shell/AppRail.test.tsx
@@ -39,6 +39,7 @@ const sections: ShellNavSection[] = [
         description: "See what needs attention next.",
         sectionKey: "workspace",
         capabilityKey: null,
+        orgCapabilityKey: null,
       },
     ],
   },
@@ -54,6 +55,7 @@ const sections: ShellNavSection[] = [
         description: "Cashflow, receivables, payables, and close.",
         sectionKey: "business",
         capabilityKey: "view_finance",
+        orgCapabilityKey: null,
       },
       {
         key: "compliance",
@@ -62,6 +64,7 @@ const sections: ShellNavSection[] = [
         description: "Controls, risk, obligations, and posture.",
         sectionKey: "business",
         capabilityKey: "view_compliance",
+        orgCapabilityKey: null,
       },
     ],
   },

--- a/apps/web/lib/actions/civic-governance.ts
+++ b/apps/web/lib/actions/civic-governance.ts
@@ -1,0 +1,301 @@
+"use server";
+
+import * as crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireManageCompliance } from "./compliance-helpers";
+
+// BI-8D477188 Phase 3 — public-body governance + records-request + 311 actions.
+// "Civic" prefix distinguishes this from lib/actions/governance.ts (agent/TAK
+// delegation governance). Conventions mirror lib/actions/compliance.ts: auth via
+// requireManageCompliance, single-org resolution, { ok, message } result shape,
+// revalidatePath refresh.
+
+export type CivicActionResult = { ok: boolean; message: string; id?: string };
+
+const RECORDS_REQUEST_STATUSES = [
+  "submitted",
+  "in-progress",
+  "fulfilled",
+  "partially-fulfilled",
+  "denied",
+  "withdrawn",
+] as const;
+
+export type RecordsRequestStatus = (typeof RECORDS_REQUEST_STATUSES)[number];
+
+/** Default statutory response window (calendar days) when the org has not configured one. */
+const DEFAULT_RECORDS_RESPONSE_DAYS = 10;
+
+function makeId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+}
+
+async function getCurrentOrgId(): Promise<string> {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) throw new Error("No organization found");
+  return org.id;
+}
+
+// ─── Governance meetings ──────────────────────────────────────────────────────
+
+export async function createGovernanceMeeting(input: {
+  bodyType: string;
+  title: string;
+  scheduledAt: string;
+  location?: string;
+}): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!input.title.trim()) return { ok: false, message: "Title is required" };
+    const scheduledAt = new Date(input.scheduledAt);
+    if (Number.isNaN(scheduledAt.getTime())) {
+      return { ok: false, message: "A valid meeting date/time is required" };
+    }
+    const organizationId = await getCurrentOrgId();
+    const meeting = await prisma.governanceMeeting.create({
+      data: {
+        meetingId: makeId("GM"),
+        organizationId,
+        bodyType: input.bodyType || "council",
+        title: input.title.trim(),
+        scheduledAt,
+        location: input.location?.trim() || null,
+      },
+    });
+    revalidatePath("/governance");
+    return { ok: true, message: `Meeting ${meeting.meetingId} scheduled`, id: meeting.id };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to create meeting" };
+  }
+}
+
+export async function publishMeetingAgenda(
+  id: string,
+  agendaContent: string,
+): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!agendaContent.trim()) return { ok: false, message: "Agenda content is required" };
+    await prisma.governanceMeeting.update({
+      where: { id },
+      data: {
+        agendaContent: agendaContent.trim(),
+        agendaPublishedAt: new Date(),
+        status: "agenda-published",
+      },
+    });
+    revalidatePath("/governance");
+    return { ok: true, message: "Agenda published" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to publish agenda" };
+  }
+}
+
+export async function recordMeetingMinutes(
+  id: string,
+  minutesContent: string,
+): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!minutesContent.trim()) return { ok: false, message: "Minutes content is required" };
+    await prisma.governanceMeeting.update({
+      where: { id },
+      data: {
+        minutesContent: minutesContent.trim(),
+        minutesRecordedAt: new Date(),
+        status: "minutes-recorded",
+      },
+    });
+    revalidatePath("/governance");
+    return { ok: true, message: "Minutes recorded" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to record minutes" };
+  }
+}
+
+export async function approveMeetingMinutes(id: string): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    const meeting = await prisma.governanceMeeting.findUnique({
+      where: { id },
+      select: { minutesRecordedAt: true },
+    });
+    if (!meeting?.minutesRecordedAt) {
+      return { ok: false, message: "Minutes must be recorded before approval" };
+    }
+    await prisma.governanceMeeting.update({
+      where: { id },
+      data: { minutesApprovedAt: new Date(), status: "minutes-approved" },
+    });
+    revalidatePath("/governance");
+    return { ok: true, message: "Minutes approved" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to approve minutes" };
+  }
+}
+
+export async function markMeetingHeld(id: string): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    await prisma.governanceMeeting.update({ where: { id }, data: { status: "held" } });
+    revalidatePath("/governance");
+    return { ok: true, message: "Meeting marked held" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to update meeting" };
+  }
+}
+
+export async function cancelGovernanceMeeting(id: string): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    await prisma.governanceMeeting.update({ where: { id }, data: { status: "cancelled" } });
+    revalidatePath("/governance");
+    return { ok: true, message: "Meeting cancelled" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to cancel meeting" };
+  }
+}
+
+// ─── Records requests ─────────────────────────────────────────────────────────
+
+export async function createRecordsRequest(input: {
+  requesterName: string;
+  requesterEmail?: string;
+  requesterPhone?: string;
+  description: string;
+}): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!input.requesterName.trim()) return { ok: false, message: "Requester name is required" };
+    if (!input.description.trim()) return { ok: false, message: "Request description is required" };
+    const organizationId = await getCurrentOrgId();
+    const receivedAt = new Date();
+    const responseDueAt = new Date(receivedAt);
+    responseDueAt.setDate(responseDueAt.getDate() + DEFAULT_RECORDS_RESPONSE_DAYS);
+
+    const request = await prisma.recordsRequest.create({
+      data: {
+        requestId: makeId("RR"),
+        organizationId,
+        requesterName: input.requesterName.trim(),
+        requesterEmail: input.requesterEmail?.trim() || null,
+        requesterPhone: input.requesterPhone?.trim() || null,
+        description: input.description.trim(),
+        receivedAt,
+        responseDueAt,
+      },
+    });
+    revalidatePath("/governance/records-requests");
+    return { ok: true, message: `Records request ${request.requestId} logged`, id: request.id };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to log request" };
+  }
+}
+
+export async function updateRecordsRequestStatus(
+  id: string,
+  status: string,
+  detail?: { responseSummary?: string; denialReason?: string },
+): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!RECORDS_REQUEST_STATUSES.includes(status as RecordsRequestStatus)) {
+      return { ok: false, message: `Invalid status: ${status}` };
+    }
+    if (status === "denied" && !detail?.denialReason?.trim()) {
+      return { ok: false, message: "A denial must cite the statutory exemption" };
+    }
+    const isTerminal = ["fulfilled", "partially-fulfilled", "denied", "withdrawn"].includes(status);
+    await prisma.recordsRequest.update({
+      where: { id },
+      data: {
+        status,
+        responseSummary: detail?.responseSummary?.trim() || undefined,
+        denialReason: detail?.denialReason?.trim() || undefined,
+        ...(isTerminal ? { respondedAt: new Date() } : {}),
+      },
+    });
+    revalidatePath("/governance/records-requests");
+    return { ok: true, message: `Request marked ${status}` };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to update request" };
+  }
+}
+
+// ─── Fund budget lines (budget side of the budget-to-actual fund view) ────────
+
+const FUNDS = [
+  "general",
+  "special-revenue",
+  "enterprise",
+  "capital-projects",
+  "debt-service",
+] as const;
+
+export type FundKey = (typeof FUNDS)[number];
+
+export async function upsertFundBudgetLine(input: {
+  fiscalYear: number;
+  fund: string;
+  accountCode: string;
+  budgetedAmount: number;
+  notes?: string;
+}): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!FUNDS.includes(input.fund as FundKey)) {
+      return { ok: false, message: `Invalid fund: ${input.fund}` };
+    }
+    if (!input.accountCode.trim()) return { ok: false, message: "Account code is required" };
+    if (!Number.isFinite(input.budgetedAmount) || input.budgetedAmount < 0) {
+      return { ok: false, message: "Budgeted amount must be a non-negative number" };
+    }
+    if (!Number.isInteger(input.fiscalYear) || input.fiscalYear < 2000 || input.fiscalYear > 2100) {
+      return { ok: false, message: "A valid fiscal year is required" };
+    }
+    const organizationId = await getCurrentOrgId();
+    await prisma.fundBudgetLine.upsert({
+      where: {
+        organizationId_fiscalYear_fund_accountCode: {
+          organizationId,
+          fiscalYear: input.fiscalYear,
+          fund: input.fund,
+          accountCode: input.accountCode.trim(),
+        },
+      },
+      create: {
+        organizationId,
+        fiscalYear: input.fiscalYear,
+        fund: input.fund,
+        accountCode: input.accountCode.trim(),
+        budgetedAmount: input.budgetedAmount,
+        notes: input.notes?.trim() || null,
+      },
+      update: {
+        budgetedAmount: input.budgetedAmount,
+        notes: input.notes?.trim() || null,
+      },
+    });
+    revalidatePath("/finance/funds");
+    return { ok: true, message: "Budget line saved" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to save budget line" };
+  }
+}
+
+// ─── Service requests (311 over StorefrontInquiry) ────────────────────────────
+
+export async function updateServiceRequestStatus(
+  id: string,
+  status: "new" | "in-progress" | "closed",
+): Promise<CivicActionResult> {
+  await requireManageCompliance();
+  try {
+    await prisma.storefrontInquiry.update({ where: { id }, data: { status } });
+    revalidatePath("/service-requests");
+    return { ok: true, message: `Service request marked ${status}` };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to update service request" };
+  }
+}

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -105,6 +105,28 @@ describe("getShellNavSections()", () => {
     ]);
     expect(sections.find((section) => section.key === "platform")).toBeUndefined();
   });
+
+  it("hides archetype-gated entries unless the org capability is active", () => {
+    const businessItems = (sections: ReturnType<typeof getShellNavSections>) =>
+      sections.find((section) => section.key === "business")?.items.map((item) => item.key) ?? [];
+
+    // No org context → civic entries hidden (safe default), permission entries unaffected.
+    const withoutOrg = getShellNavSections(hr000);
+    expect(businessItems(withoutOrg)).not.toContain("governance");
+    expect(businessItems(withoutOrg)).not.toContain("service-requests");
+    expect(businessItems(withoutOrg)).toContain("compliance");
+
+    // Public-body org → civic entries render for a permitted user.
+    const withCivicOrg = getShellNavSections(hr000, {
+      activeOrgCapabilities: new Set(["public-body-governance", "service-request-311"]),
+    });
+    expect(businessItems(withCivicOrg)).toContain("governance");
+    expect(businessItems(withCivicOrg)).toContain("service-requests");
+
+    // Commercial org (empty set) → still hidden.
+    const withCommercialOrg = getShellNavSections(hr000, { activeOrgCapabilities: new Set() });
+    expect(businessItems(withCommercialOrg)).not.toContain("governance");
+  });
 });
 
 describe("getAccessibleSectionNavEntries()", () => {

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -133,6 +133,8 @@ export type ShellNavItem = {
   description: string;
   sectionKey: PortalShellSectionKey;
   capabilityKey: CapabilityKey | null;
+  /** Archetype-capability gate — see PortalNavRecord.orgCapabilityKey. */
+  orgCapabilityKey: string | null;
 };
 
 export type SectionNavItem = {
@@ -207,6 +209,7 @@ const SHELL_ITEMS: ShellNavItem[] = getShellNavEntries().map((entry) => ({
   description: entry.description,
   sectionKey: entry.sectionKey,
   capabilityKey: entry.capabilityKey,
+  orgCapabilityKey: entry.orgCapabilityKey,
 }));
 
 const WORKSPACE_SECTION_BLUEPRINTS: Array<{
@@ -259,10 +262,28 @@ export function getWorkspaceTiles(user: UserContext): WorkspaceTile[] {
   return ALL_TILES.filter((t) => can(user, t.capabilityKey));
 }
 
-export function getShellNavSections(user: UserContext): ShellNavSection[] {
+export function getShellNavSections(
+  user: UserContext,
+  options?: {
+    /**
+     * Effectively-active archetype capability keys for the org (from
+     * getActiveOrgCapabilities). Nav items carrying an orgCapabilityKey render
+     * only when that key is in the set; when the set is not provided they stay
+     * hidden — the safe default for callers without org context.
+     */
+    activeOrgCapabilities?: ReadonlySet<string>;
+  },
+): ShellNavSection[] {
+  const activeOrgCapabilities = options?.activeOrgCapabilities;
   return SHELL_SECTIONS.map((section) => ({
     ...section,
-    items: SHELL_ITEMS.filter((item) => item.sectionKey === section.key && isAllowed(user, item.capabilityKey)),
+    items: SHELL_ITEMS.filter(
+      (item) =>
+        item.sectionKey === section.key &&
+        isAllowed(user, item.capabilityKey) &&
+        (item.orgCapabilityKey === null ||
+          (activeOrgCapabilities?.has(item.orgCapabilityKey) ?? false)),
+    ),
   })).filter((section) => section.items.length > 0);
 }
 

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -36,6 +36,14 @@ export type PortalNavRecord = {
   audienceModes: readonly PortalAudienceMode[];
   destinationKind: PortalDestinationKind;
   capabilityKey?: CapabilityKey | null;
+  /**
+   * Archetype-capability gate (capability registry key from
+   * @dpf/storefront-templates, e.g. "public-body-governance"). Entries carrying
+   * this key render only when the org's effective capability activation has it
+   * active — capability-driven surfaces per the civic archetypes spec §12, on
+   * top of (not instead of) the user-permission capabilityKey.
+   */
+  orgCapabilityKey?: string | null;
   primaryOrder?: number;
   sectionNavLabel?: string;
   shellNav?: {
@@ -51,6 +59,7 @@ export type PortalNavEntry = Pick<
   "key" | "label" | "path" | "parentPath" | "domain" | "destinationKind"
 > & {
   capabilityKey: CapabilityKey | null;
+  orgCapabilityKey: string | null;
   audienceModes: readonly PortalAudienceMode[];
 };
 
@@ -242,6 +251,52 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     shellNav: {
       sectionKey: "business",
       description: "Controls, risk, obligations, and posture.",
+    },
+  },
+  {
+    // Civic archetypes (BI-8D477188 Phase 3): public-body governance workflow.
+    // Renders only when the org's archetype derives public-body-governance
+    // active (towns, utilities, law enforcement — and member-owned boards
+    // reuse the same surface via member-governance in a later slice).
+    key: "governance",
+    label: "Governance",
+    path: "/governance",
+    parentPath: "/governance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_compliance",
+    orgCapabilityKey: "public-body-governance",
+    shellNav: {
+      sectionKey: "business",
+      description: "Meetings, agendas, minutes, and records requests.",
+    },
+    sectionSiblings: ["/governance", "/governance/records-requests"],
+  },
+  {
+    key: "governance-records-requests",
+    label: "Records Requests",
+    path: "/governance/records-requests",
+    parentPath: "/governance",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_compliance",
+    orgCapabilityKey: "records-request",
+  },
+  {
+    key: "service-requests",
+    label: "Service Requests",
+    path: "/service-requests",
+    parentPath: "/service-requests",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_storefront",
+    orgCapabilityKey: "service-request-311",
+    shellNav: {
+      sectionKey: "business",
+      description: "Resident service requests routed to departments.",
     },
   },
   {
@@ -803,6 +858,7 @@ function toEntry(route: PortalNavRecord): PortalNavEntry {
     audienceModes: route.audienceModes,
     destinationKind: route.destinationKind,
     capabilityKey: route.capabilityKey ?? null,
+    orgCapabilityKey: route.orgCapabilityKey ?? null,
   };
 }
 

--- a/apps/web/lib/storefront/civic-surfaces.server.ts
+++ b/apps/web/lib/storefront/civic-surfaces.server.ts
@@ -1,0 +1,45 @@
+import { prisma } from "@dpf/db";
+import { readActivationProfile } from "@dpf/storefront-templates";
+import { getEffectiveCapabilityActivations } from "@/lib/storefront/capability-activation";
+
+/**
+ * Resolve the set of capability keys that are effectively ACTIVE for the
+ * install's organization — archetype-derived applicability folded with the
+ * org's persisted opt-in choices (the same `resolveOrgCapabilityActivations`
+ * read path the setup wizard and admin toggle use, so gating cannot drift).
+ *
+ * Consumed by the shell nav filter (archetype-gated entries) and by the civic
+ * surface pages' server-side guards (civic spec §12: capability-driven
+ * surfaces, no archetype-id conditionals).
+ *
+ * Returns an empty set when no storefront config / archetype profile exists
+ * (pre-setup installs) — archetype-gated surfaces stay hidden.
+ */
+export async function getActiveOrgCapabilities(): Promise<ReadonlySet<string>> {
+  const [org, config] = await Promise.all([
+    prisma.organization.findFirst({ select: { id: true } }),
+    prisma.storefrontConfig.findFirst({
+      include: {
+        archetype: { select: { archetypeId: true, activationProfile: true } },
+      },
+    }),
+  ]);
+
+  if (!org || !config?.archetype?.activationProfile) return new Set();
+
+  const profile = readActivationProfile(config.archetype.activationProfile);
+  if (!profile) return new Set();
+
+  const effective = await getEffectiveCapabilityActivations(
+    org.id,
+    profile.capabilityActivations,
+  );
+
+  return new Set(effective.filter((a) => a.active).map((a) => a.capabilityKey));
+}
+
+/** True when the given archetype-capability is effectively active for this org. */
+export async function hasActiveOrgCapability(capabilityKey: string): Promise<boolean> {
+  const active = await getActiveOrgCapabilities();
+  return active.has(capabilityKey);
+}


### PR DESCRIPTION
## Summary

Phase 3 of **BI-8D477188** (small-town municipality, `EP-ARCH-8D4F2A`) — the operator-facing surfaces on the Phase-2 models, all capability-gated per the civic spec §12 (surfaces fall out of capabilities; zero archetype-id conditionals).

**Archetype-gated navigation (new mechanism, additive):** `orgCapabilityKey` on `PortalNavRecord`/`ShellNavItem`, filtered in `getShellNavSections` against the org''s effective capability activations (`getActiveOrgCapabilities` — resolved through the same `resolveOrgCapabilityActivations` read path as the setup wizard and admin toggle, so nav, pages, and setup cannot drift). Safe default: callers without org context hide archetype-gated entries. Existing nav behavior is unchanged.

**Surfaces:**
- `/governance` — council/board meeting workflow: schedule → publish agenda → mark held → record minutes → approve.
- `/governance/records-requests` — statutory-deadline queue: due-date countdown chips, overdue highlighting, denial requires the cited exemption.
- `/service-requests` — 311 queue over the existing `StorefrontInquiry` pipeline with department filter (substrate reuse).
- `/finance/funds` — budget-to-actual fund view; **first consumer of `FinancialProfile.ledgerModel`** — renders only for fund-accounting profiles; account names resolve from the COA fragment; actuals column is em-dash until fund-tagged transactions exist.

Server actions in `lib/actions/civic-governance.ts` (named to avoid the existing agent-governance `governance.ts`), mirroring `compliance.ts` conventions. Every page guards server-side via `hasActiveOrgCapability` + `notFound()` — a salon install 404s.

## Verification

- Web typecheck green; **full web vitest: 10,323 passed / 1,216 files**.
- New nav-gating test covers: no org context (hidden), civic org (visible), commercial org (hidden).
- Pre-commit gitleaks + scoped typecheck green.

Remaining for BI-8D477188: licensing seed (town permits) + functional verification on the canonical runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)