### PR TITLE
feat(workforce): unified human + AI-agent Workforce roster (BI-554E1A14) — EP-BOM-WIRING Phase 2

### DIFF
--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -8,6 +8,8 @@ import { LifecycleEventPanel } from "@/components/employee/LifecycleEventPanel";
 import { NewEmployeeButton } from "@/components/employee/NewEmployeeButton";
 import { OrgAssignmentPanel } from "@/components/employee/OrgAssignmentPanel";
 import { OrgChartView } from "@/components/employee/OrgChartView";
+import { WorkforceRosterPanel } from "@/components/employee/WorkforceRosterPanel";
+import { loadWorkforceRoster } from "@/lib/workforce/workforce-roster";
 import { TimesheetGrid } from "@/components/employee/TimesheetGrid";
 import { TimesheetApprovalPanel } from "@/components/employee/TimesheetApprovalPanel";
 import { MyPoliciesView } from "@/components/employee/MyPoliciesView";
@@ -90,6 +92,7 @@ export default async function EmployeePage({ searchParams }: Props) {
   const pendingTimesheets = view === "timesheets" && currentUserProfile
     ? await getPendingTimesheetsForManager(currentUserProfile.id)
     : [];
+  const workforceRoster = view === "workforce" ? await loadWorkforceRoster() : null;
 
   return (
     <div>
@@ -170,7 +173,9 @@ export default async function EmployeePage({ searchParams }: Props) {
       <div className="mt-8">
         <EmployeeTabNav />
 
-        {view === "timesheets" ? (
+        {view === "workforce" && workforceRoster ? (
+          <WorkforceRosterPanel roster={workforceRoster} />
+        ) : view === "timesheets" ? (
           <div className="space-y-4">
             {pendingTimesheets.length > 0 && (
               <TimesheetApprovalPanel pendingTimesheets={pendingTimesheets} />

--- a/apps/web/components/employee/EmployeeTabNav.tsx
+++ b/apps/web/components/employee/EmployeeTabNav.tsx
@@ -4,6 +4,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 
 const TABS = [
   { label: "Directory", value: "directory" },
+  { label: "Workforce", value: "workforce" },
   { label: "Org Chart", value: "orgchart" },
   { label: "Timesheets", value: "timesheets" },
   { label: "My Policies", value: "mypolicies" },

--- a/apps/web/components/employee/WorkforceRosterPanel.test.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { WorkforceRosterPanel } from "./WorkforceRosterPanel";
+import type { WorkforceRoster } from "@/lib/workforce/workforce-roster";
+
+const roster: WorkforceRoster = {
+  members: [
+    {
+      kind: "human",
+      id: "EMP-1",
+      displayName: "Ada Lovelace",
+      status: "active",
+      role: "Engineer",
+      group: "Product",
+      agentNeeds: null,
+    },
+    {
+      kind: "agent",
+      id: "AGT-COO",
+      displayName: "Chief of Staff",
+      status: "active",
+      role: "evaluate",
+      group: "for_employees",
+      agentNeeds: {
+        valueStream: "evaluate",
+        supervisorId: "HR-000",
+        hitlTier: 2,
+        lifecycleStage: "production",
+        model: "claude-sonnet-4-6",
+        dailyTokenLimit: 200000,
+        perTaskTokenLimit: 20000,
+        toolGrantCount: 5,
+        skillCount: 3,
+        unmetNeedCount: 2,
+      },
+    },
+  ],
+  summary: { total: 2, humans: 1, agents: 1, agentsWithUnmetNeeds: 1 },
+};
+
+describe("WorkforceRosterPanel", () => {
+  it("renders both humans and AI agents with the agent-needs lens", () => {
+    const html = renderToStaticMarkup(<WorkforceRosterPanel roster={roster} />);
+
+    // both populations present
+    expect(html).toContain("Ada Lovelace");
+    expect(html).toContain("human");
+    expect(html).toContain("Chief of Staff");
+    expect(html).toContain("AI agent");
+
+    // agent-needs lens surfaced
+    expect(html).toContain("HR-000"); // supervisor
+    expect(html).toContain("T2"); // HITL tier
+    expect(html).toContain("claude-sonnet-4-6"); // model
+    expect(html).toContain("200k/day"); // token budget
+    expect(html).toContain("unmet needs");
+
+    // summary
+    expect(html).toContain("Workforce");
+  });
+
+  it("renders an empty state with no members", () => {
+    const empty: WorkforceRoster = {
+      members: [],
+      summary: { total: 0, humans: 0, agents: 0, agentsWithUnmetNeeds: 0 },
+    };
+    const html = renderToStaticMarkup(<WorkforceRosterPanel roster={empty} />);
+    expect(html).toContain("No workforce members yet");
+  });
+});

--- a/apps/web/components/employee/WorkforceRosterPanel.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.tsx
@@ -1,0 +1,98 @@
+// Unified Workforce roster panel (BI-554E1A14, EP-BOM-WIRING Phase 2).
+//
+// Renders the org's workforce as ONE roster spanning human employees and AI
+// agents. For agents it shows the "needs lens" — what the non-human identity
+// needs to contribute: value-stream role, supervising human, HITL tier, model +
+// token budget, tool/skill counts, and unmet capability needs (the gap signal).
+//
+// Presentational and theme-aware (DPF CSS custom properties, dense layout, no
+// hardcoded colors, no nested cards). Server component — no client state.
+
+import type { WorkforceMember, WorkforceRoster } from "@/lib/workforce/workforce-roster";
+
+function StatPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span className="text-[9px] text-[var(--dpf-muted)]">
+      {label} <span className="text-[var(--dpf-text)]">{value}</span>
+    </span>
+  );
+}
+
+function AgentNeeds({ member }: { member: WorkforceMember }) {
+  const needs = member.agentNeeds;
+  if (!needs) return null;
+
+  const tokenBudget =
+    needs.dailyTokenLimit != null ? `${(needs.dailyTokenLimit / 1000).toFixed(0)}k/day` : "—";
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+      <StatPill label="stream" value={needs.valueStream ?? "—"} />
+      <StatPill label="supervisor" value={needs.supervisorId ?? "unassigned"} />
+      <StatPill label="HITL" value={`T${needs.hitlTier}`} />
+      <StatPill label="model" value={needs.model ?? "unset"} />
+      <StatPill label="budget" value={tokenBudget} />
+      <StatPill label="tools" value={needs.toolGrantCount} />
+      <StatPill label="skills" value={needs.skillCount} />
+      <span
+        className={[
+          "text-[9px]",
+          needs.unmetNeedCount > 0 ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-muted)]",
+        ].join(" ")}
+      >
+        unmet needs <span className="text-[var(--dpf-text)]">{needs.unmetNeedCount}</span>
+      </span>
+    </div>
+  );
+}
+
+function MemberRow({ member }: { member: WorkforceMember }) {
+  const isAgent = member.kind === "agent";
+  return (
+    <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)]">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight truncate">
+            {member.displayName}
+          </p>
+          <p className="text-[10px] text-[var(--dpf-muted)] truncate">
+            {member.role ?? "—"}
+            {member.group ? ` · ${member.group}` : ""}
+          </p>
+        </div>
+        <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-muted)] shrink-0">
+          {isAgent ? "AI agent" : "human"}
+        </span>
+      </div>
+      {isAgent && <AgentNeeds member={member} />}
+    </div>
+  );
+}
+
+export function WorkforceRosterPanel({ roster }: { roster: WorkforceRoster }) {
+  const { members, summary } = roster;
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Workforce</h2>
+        <StatPill label="total" value={summary.total} />
+        <StatPill label="people" value={summary.humans} />
+        <StatPill label="AI agents" value={summary.agents} />
+        <StatPill label="agents w/ unmet needs" value={summary.agentsWithUnmetNeeds} />
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-sm text-[var(--dpf-muted)] py-8 text-center">
+          No workforce members yet. Humans and AI agents will appear here as they are onboarded.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {members.map((m) => (
+            <MemberRow key={`${m.kind}:${m.id}`} member={m} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/workforce/workforce-roster.test.ts
+++ b/apps/web/lib/workforce/workforce-roster.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadWorkforceRoster } from "./workforce-roster";
+
+function makeDb(opts: { employees?: unknown[]; agents?: unknown[] }) {
+  return {
+    employeeProfile: { findMany: vi.fn().mockResolvedValue(opts.employees ?? []) },
+    agent: { findMany: vi.fn().mockResolvedValue(opts.agents ?? []) },
+  };
+}
+
+const HUMAN = {
+  id: "EMP-1",
+  displayName: "Ada Lovelace",
+  status: "active",
+  position: { title: "Engineer" },
+  department: { name: "Product" },
+};
+
+const AGENT = {
+  agentId: "AGT-COO",
+  name: "Chief of Staff",
+  status: "active",
+  valueStream: "evaluate",
+  humanSupervisorId: "HR-000",
+  hitlTierDefault: 2,
+  lifecycleStage: "production",
+  portfolioId: "for_employees",
+  executionConfig: {
+    defaultModelId: "claude-sonnet-4-6",
+    dailyTokenLimit: 200000,
+    perTaskTokenLimit: 20000,
+  },
+  _count: { toolGrants: 5, skills: 3 },
+  coworkerNeeds: [{ status: "submitted" }, { status: "resolved" }, { status: "in-progress" }],
+};
+
+describe("loadWorkforceRoster (BI-554E1A14)", () => {
+  it("unifies humans and agents into one roster", async () => {
+    const db = makeDb({ employees: [HUMAN], agents: [AGENT] });
+
+    const { members, summary } = await loadWorkforceRoster({ db: db as never });
+
+    expect(summary).toEqual({
+      total: 2,
+      humans: 1,
+      agents: 1,
+      agentsWithUnmetNeeds: 1,
+    });
+    // humans first, then agents
+    expect(members.map((m) => m.kind)).toEqual(["human", "agent"]);
+  });
+
+  it("maps a human with no agent-needs lens", async () => {
+    const db = makeDb({ employees: [HUMAN], agents: [] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0]).toEqual({
+      kind: "human",
+      id: "EMP-1",
+      displayName: "Ada Lovelace",
+      status: "active",
+      role: "Engineer",
+      group: "Product",
+      agentNeeds: null,
+    });
+  });
+
+  it("surfaces the agent-needs lens (tools/tokens/skills/supervision)", async () => {
+    const db = makeDb({ employees: [], agents: [AGENT] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+    const agent = members[0];
+
+    expect(agent.kind).toBe("agent");
+    expect(agent.id).toBe("AGT-COO");
+    expect(agent.role).toBe("evaluate");
+    expect(agent.agentNeeds).toEqual({
+      valueStream: "evaluate",
+      supervisorId: "HR-000",
+      hitlTier: 2,
+      lifecycleStage: "production",
+      model: "claude-sonnet-4-6",
+      dailyTokenLimit: 200000,
+      perTaskTokenLimit: 20000,
+      toolGrantCount: 5,
+      skillCount: 3,
+      // 2 of 3 needs are not resolved (submitted + in-progress)
+      unmetNeedCount: 2,
+    });
+  });
+
+  it("counts only non-resolved needs as unmet", async () => {
+    const allResolved = {
+      ...AGENT,
+      coworkerNeeds: [{ status: "resolved" }, { status: "closed" }, { status: "duplicate" }],
+    };
+    const db = makeDb({ employees: [], agents: [allResolved] });
+
+    const { members, summary } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.unmetNeedCount).toBe(0);
+    expect(summary.agentsWithUnmetNeeds).toBe(0);
+  });
+
+  it("tolerates an agent with no execution config", async () => {
+    const noConfig = { ...AGENT, executionConfig: null };
+    const db = makeDb({ employees: [], agents: [noConfig] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].agentNeeds?.model).toBeNull();
+    expect(members[0].agentNeeds?.dailyTokenLimit).toBeNull();
+    expect(members[0].agentNeeds?.perTaskTokenLimit).toBeNull();
+  });
+
+  it("returns an empty roster when there is no workforce", async () => {
+    const db = makeDb({ employees: [], agents: [] });
+
+    const { members, summary } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members).toEqual([]);
+    expect(summary).toEqual({ total: 0, humans: 0, agents: 0, agentsWithUnmetNeeds: 0 });
+  });
+});

--- a/apps/web/lib/workforce/workforce-roster.ts
+++ b/apps/web/lib/workforce/workforce-roster.ts
@@ -1,0 +1,206 @@
+// Unified Workforce roster (BI-554E1A14, EP-BOM-WIRING Phase 2).
+//
+// The "For Employees" portfolio is too narrow when it means only humans: the AI
+// agent workforce (non-human identities) is workforce too. This projection
+// returns ONE roster spanning both populations — human EmployeeProfiles and AI
+// Agents — so the Workforce portfolio can manage them together.
+//
+// For AI agents it surfaces the "needs lens": what a non-human identity needs to
+// be successful and contribute — its value-stream role, supervising human, HITL
+// tier, assigned model + token budget (the agent's cost-to-employ), tool and
+// skill counts (its equipment), and unmet capability needs (the gap signal). The
+// underlying Agent substrate already carries all of this; this module surfaces it
+// under the workforce lens rather than the platform-internals lens.
+//
+// Pure projection: no schema change, no mutation. The persisted portfolio link
+// and the operator UI are separate follow-on slices.
+
+import { prisma } from "@dpf/db";
+
+export type WorkforceMemberKind = "human" | "agent";
+
+/** What an AI agent needs to be successful and contribute. Null for humans. */
+export type AgentNeeds = {
+  valueStream: string | null;
+  /** Supervising human (HR role id), e.g. "HR-000". */
+  supervisorId: string | null;
+  /** 0=human-only, 1=approve, 2=review, 3=autonomous. */
+  hitlTier: number;
+  lifecycleStage: string;
+  /** Assigned model id, or null when no execution config is set. */
+  model: string | null;
+  dailyTokenLimit: number | null;
+  perTaskTokenLimit: number | null;
+  /** Tools the agent is granted (its equipment list). */
+  toolGrantCount: number;
+  /** Skills assigned to the agent. */
+  skillCount: number;
+  /** Capability needs the agent has flagged that are not yet resolved. */
+  unmetNeedCount: number;
+};
+
+export type WorkforceMember = {
+  kind: WorkforceMemberKind;
+  /** EmployeeProfile.id for humans; Agent.agentId for agents. */
+  id: string;
+  displayName: string;
+  status: string;
+  /** Human: position title. Agent: value-stream role. */
+  role: string | null;
+  /** Human: department name. Agent: portfolio id the agent's work serves. */
+  group: string | null;
+  /** Present only for AI agents. */
+  agentNeeds: AgentNeeds | null;
+};
+
+export type WorkforceRosterSummary = {
+  total: number;
+  humans: number;
+  agents: number;
+  /** Agents with at least one unmet capability need — the workforce gap signal. */
+  agentsWithUnmetNeeds: number;
+};
+
+export type WorkforceRoster = {
+  members: WorkforceMember[];
+  summary: WorkforceRosterSummary;
+};
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type WorkforceRosterClient = {
+  employeeProfile: { findMany: (args: unknown) => Promise<unknown> };
+  agent: { findMany: (args: unknown) => Promise<unknown> };
+};
+
+/**
+ * Capability-need statuses that count as resolved — an unmet need is any flagged
+ * need NOT in this set. Conservative: anything we don't recognize as closed is
+ * treated as still-open (so a real gap is never hidden).
+ */
+const RESOLVED_NEED_STATUSES = new Set(["resolved", "closed", "duplicate", "withdrawn", "rejected"]);
+
+type EmployeeRow = {
+  id: string;
+  displayName: string;
+  status: string;
+  position: { title: string } | null;
+  department: { name: string } | null;
+};
+
+type AgentRow = {
+  agentId: string;
+  name: string;
+  status: string;
+  valueStream: string | null;
+  humanSupervisorId: string | null;
+  hitlTierDefault: number;
+  lifecycleStage: string;
+  portfolioId: string | null;
+  executionConfig: {
+    defaultModelId: string | null;
+    dailyTokenLimit: number | null;
+    perTaskTokenLimit: number | null;
+  } | null;
+  _count: { toolGrants: number; skills: number };
+  coworkerNeeds: Array<{ status: string }>;
+};
+
+function humanToMember(row: EmployeeRow): WorkforceMember {
+  return {
+    kind: "human",
+    id: row.id,
+    displayName: row.displayName,
+    status: row.status,
+    role: row.position?.title ?? null,
+    group: row.department?.name ?? null,
+    agentNeeds: null,
+  };
+}
+
+function agentToMember(row: AgentRow): WorkforceMember {
+  const unmetNeedCount = row.coworkerNeeds.filter(
+    (n) => !RESOLVED_NEED_STATUSES.has(n.status),
+  ).length;
+
+  return {
+    kind: "agent",
+    id: row.agentId,
+    displayName: row.name,
+    status: row.status,
+    role: row.valueStream,
+    group: row.portfolioId,
+    agentNeeds: {
+      valueStream: row.valueStream,
+      supervisorId: row.humanSupervisorId,
+      hitlTier: row.hitlTierDefault,
+      lifecycleStage: row.lifecycleStage,
+      model: row.executionConfig?.defaultModelId ?? null,
+      dailyTokenLimit: row.executionConfig?.dailyTokenLimit ?? null,
+      perTaskTokenLimit: row.executionConfig?.perTaskTokenLimit ?? null,
+      toolGrantCount: row._count.toolGrants,
+      skillCount: row._count.skills,
+      unmetNeedCount,
+    },
+  };
+}
+
+/**
+ * Load the unified Workforce roster: human employees + AI agents, with the
+ * agent-needs lens. Deterministic ordering (humans then agents, each by name).
+ */
+export async function loadWorkforceRoster(input?: {
+  db?: WorkforceRosterClient;
+}): Promise<WorkforceRoster> {
+  const db = input?.db ?? (prisma as unknown as WorkforceRosterClient);
+
+  const [employees, agents] = await Promise.all([
+    db.employeeProfile.findMany({
+      orderBy: { displayName: "asc" },
+      select: {
+        id: true,
+        displayName: true,
+        status: true,
+        position: { select: { title: true } },
+        department: { select: { name: true } },
+      },
+    }) as Promise<EmployeeRow[]>,
+    db.agent.findMany({
+      orderBy: { name: "asc" },
+      select: {
+        agentId: true,
+        name: true,
+        status: true,
+        valueStream: true,
+        humanSupervisorId: true,
+        hitlTierDefault: true,
+        lifecycleStage: true,
+        portfolioId: true,
+        executionConfig: {
+          select: {
+            defaultModelId: true,
+            dailyTokenLimit: true,
+            perTaskTokenLimit: true,
+          },
+        },
+        _count: { select: { toolGrants: true, skills: true } },
+        coworkerNeeds: { select: { status: true } },
+      },
+    }) as Promise<AgentRow[]>,
+  ]);
+
+  const humanMembers = employees.map(humanToMember);
+  const agentMembers = agents.map(agentToMember);
+  const members = [...humanMembers, ...agentMembers];
+
+  return {
+    members,
+    summary: {
+      total: members.length,
+      humans: humanMembers.length,
+      agents: agentMembers.length,
+      agentsWithUnmetNeeds: agentMembers.filter(
+        (m) => (m.agentNeeds?.unmetNeedCount ?? 0) > 0,
+      ).length,
+    },
+  };
+}


### PR DESCRIPTION
## What
**EP-BOM-WIRING Phase 2.** Reframes the "For Employees" portfolio from humans-only to a true **Workforce** spanning humans **and** the AI agent workforce (non-human identities).

- **`loadWorkforceRoster()`** (`apps/web/lib/workforce/workforce-roster.ts`) — one roster across human `EmployeeProfile`s and AI `Agent`s, with a summary (people / AI agents / agents-with-unmet-needs).
- **Agent "needs lens"** — what a non-human identity needs to contribute, surfaced per agent: value-stream role, supervising human, HITL tier, assigned model + token budget (its cost-to-employ), tool/skill counts (its equipment), and **unmet capability needs** (the workforce gap signal). All of this already lives on the `Agent` substrate (`executionConfig`, `toolGrants`, `skills`, `coworkerNeeds`, `humanSupervisorId`, `valueStream`); this surfaces it under the workforce lens.
- **UI** — a `Workforce` tab on `/employee` rendering `WorkforceRosterPanel` (theme-aware, dense, no hardcoded colors).

## Why
Per the founder goal: "Employees portfolio is too narrow — it excludes the AI agent workforce. What do these non-human identities need to be successful and contribute? Tools, tokens, etc." This makes humans and agents one managed workforce.

## Scope
Pure projection + presentational panel — **no schema change, no mutation**. Independent of PR #1643 / #1646 and EP-LIFECYCLE. The persisted `EmployeeProfile`/`Agent` → portfolio FK link and the agent-needs drill-down are follow-on slices.

## Test plan
- [x] `vitest run lib/workforce/workforce-roster.test.ts` — 6 passed (unify, human-mapping, agent-needs lens, unmet-need filtering, no-config tolerance, empty)
- [x] `vitest run components/employee/WorkforceRosterPanel.test.tsx` — 2 passed (renders both populations + needs lens; empty state) via `renderToStaticMarkup`
- [x] `vitest run lib/workforce/ components/employee/` — 14 passed
- [x] `pnpm run typecheck` (apps/web) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)