### PR TITLE
feat(archetypes): cooperative archetype — member-owned governance, member equity & patronage (BI-AFC178F3)

### DIFF
--- a/apps/web/app/(shell)/governance/page.tsx
+++ b/apps/web/app/(shell)/governance/page.tsx
@@ -1,14 +1,19 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
-import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
+import { getActiveOrgCapabilities } from "@/lib/storefront/civic-surfaces.server";
 import { CivicMeetingsPanel, type MeetingRow } from "@/components/civic/CivicMeetingsPanel";
 
-// Public-body governance workbench (BI-8D477188 Phase 3). Capability-gated:
-// reachable only when the org's archetype derives public-body-governance active
-// (civic spec §12 — surfaces fall out of capabilities, not archetype ids).
+// Governance workbench (BI-8D477188 Phase 3; member-owned flavor BI-AFC178F3).
+// Capability-gated: public bodies (council/committee, open-meetings law) and
+// member-owned organizations (board/annual meeting) share this surface — the
+// GovernanceMeeting bodyType carries the distinction (civic spec §12).
 export default async function GovernancePage() {
-  if (!(await hasActiveOrgCapability("public-body-governance"))) notFound();
+  const activeCapabilities = await getActiveOrgCapabilities();
+  const isPublicBody = activeCapabilities.has("public-body-governance");
+  const isMemberGoverned = activeCapabilities.has("member-governance");
+  if (!isPublicBody && !isMemberGoverned) notFound();
+  const showRecordsRequests = activeCapabilities.has("records-request");
 
   const meetings = await prisma.governanceMeeting.findMany({
     orderBy: { scheduledAt: "desc" },
@@ -27,9 +32,11 @@ export default async function GovernancePage() {
     minutesRecordedAt: m.minutesRecordedAt?.toISOString() ?? null,
   }));
 
-  const openRequests = await prisma.recordsRequest.count({
-    where: { status: { in: ["submitted", "in-progress"] } },
-  });
+  const openRequests = showRecordsRequests
+    ? await prisma.recordsRequest.count({
+        where: { status: { in: ["submitted", "in-progress"] } },
+      })
+    : 0;
 
   return (
     <div>
@@ -40,12 +47,14 @@ export default async function GovernancePage() {
             Meetings, agendas, and minutes · {rows.length} meetings
           </p>
         </div>
-        <Link
-          href="/governance/records-requests"
-          className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
-        >
-          Records Requests {openRequests > 0 ? `(${openRequests} open)` : ""}
-        </Link>
+        {showRecordsRequests && (
+          <Link
+            href="/governance/records-requests"
+            className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+          >
+            Records Requests {openRequests > 0 ? `(${openRequests} open)` : ""}
+          </Link>
+        )}
       </div>
       <CivicMeetingsPanel meetings={rows} />
     </div>

--- a/apps/web/app/(shell)/member-equity/page.tsx
+++ b/apps/web/app/(shell)/member-equity/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { hasActiveOrgCapability } from "@/lib/storefront/civic-surfaces.server";
+import {
+  MemberEquityPanel,
+  type MemberEquityMemberRow,
+} from "@/components/civic/MemberEquityPanel";
+
+// Member equity & patronage ledger (BI-AFC178F3). Capability-gated on
+// member-equity — required for cooperatives via archetype override, available
+// later for member-owned utilities (capital credits).
+export default async function MemberEquityPage() {
+  if (!(await hasActiveOrgCapability("member-equity"))) notFound();
+
+  const [accounts, entries] = await Promise.all([
+    prisma.customerAccount.findMany({
+      orderBy: { name: "asc" },
+      take: 200,
+      select: { id: true, accountId: true, name: true, status: true },
+    }),
+    prisma.memberEquityEntry.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 500,
+      select: {
+        memberAccountId: true,
+        fiscalYear: true,
+        kind: true,
+        amount: true,
+        qualified: true,
+      },
+    }),
+  ]);
+
+  const balances = new Map<string, number>();
+  const entryCounts = new Map<string, number>();
+  for (const entry of entries) {
+    balances.set(entry.memberAccountId, (balances.get(entry.memberAccountId) ?? 0) + Number(entry.amount));
+    entryCounts.set(entry.memberAccountId, (entryCounts.get(entry.memberAccountId) ?? 0) + 1);
+  }
+
+  const rows: MemberEquityMemberRow[] = accounts.map((account) => ({
+    id: account.id,
+    accountId: account.accountId,
+    name: account.name,
+    status: account.status,
+    balance: Math.round((balances.get(account.id) ?? 0) * 100) / 100,
+    entryCount: entryCounts.get(account.id) ?? 0,
+  }));
+
+  const fiscalYear = new Date().getFullYear();
+  const totalEquity = rows.reduce((sum, row) => sum + row.balance, 0);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Member Equity</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          {rows.length} member accounts · allocated equity {totalEquity.toFixed(2)} · patronage
+          allocations, retains, and retirements
+        </p>
+      </div>
+      <MemberEquityPanel members={rows} fiscalYear={fiscalYear} />
+    </div>
+  );
+}

--- a/apps/web/components/civic/MemberEquityPanel.tsx
+++ b/apps/web/components/civic/MemberEquityPanel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { retireEquity, runPatronageAllocation } from "@/lib/actions/member-equity";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+export type MemberEquityMemberRow = {
+  id: string;
+  accountId: string;
+  name: string;
+  status: string;
+  balance: number;
+  entryCount: number;
+};
+
+export function MemberEquityPanel({
+  members,
+  fiscalYear,
+}: {
+  members: MemberEquityMemberRow[];
+  fiscalYear: number;
+}) {
+  const router = useRouter();
+  const [showAllocate, setShowAllocate] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [retireFor, setRetireFor] = useState<string | null>(null);
+  const [retireAmount, setRetireAmount] = useState("");
+
+  async function handleAllocate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    const result = await runPatronageAllocation({
+      fiscalYear: Number(form.get("fiscalYear")),
+      totalPool: Number(form.get("totalPool")),
+      cashPct: Number(form.get("cashPct")),
+      qualified: form.get("qualified") === "on",
+    });
+    setBusy(false);
+    if (!result.ok) setError(result.message);
+    else {
+      setNotice(result.message);
+      setShowAllocate(false);
+      router.refresh();
+    }
+  }
+
+  async function handleRetire(memberAccountId: string) {
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    const result = await retireEquity({
+      memberAccountId,
+      fiscalYear,
+      amount: Number(retireAmount),
+    });
+    setBusy(false);
+    if (!result.ok) setError(result.message);
+    else {
+      setNotice(result.message);
+      setRetireFor(null);
+      setRetireAmount("");
+      router.refresh();
+    }
+  }
+
+  const activeMembers = members.filter((m) => m.status === "active").length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-[var(--dpf-muted)]">
+          {activeMembers} active members participate in allocations
+        </p>
+        <button
+          onClick={() => setShowAllocate((v) => !v)}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          {showAllocate ? "Close" : "Run Year-End Allocation"}
+        </button>
+      </div>
+
+      {showAllocate && (
+        <form
+          onSubmit={handleAllocate}
+          className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:grid-cols-3"
+        >
+          <div>
+            <label className={labelClasses}>Fiscal year *</label>
+            <input name="fiscalYear" type="number" defaultValue={fiscalYear} required className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>Total patronage pool *</label>
+            <input name="totalPool" type="number" min="0.01" step="0.01" required className={inputClasses} placeholder="50000" />
+          </div>
+          <div>
+            <label className={labelClasses}>Cash portion % *</label>
+            <input name="cashPct" type="number" min="0" max="100" defaultValue="20" required className={inputClasses} />
+          </div>
+          <label className="flex items-center gap-2 text-xs text-[var(--dpf-text)] sm:col-span-2">
+            <input name="qualified" type="checkbox" defaultChecked />
+            Qualified allocation (written notice; ≥20% cash required)
+          </label>
+          <div className="flex justify-end sm:col-span-1">
+            <button
+              type="submit"
+              disabled={busy}
+              className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? "Allocating..." : "Allocate"}
+            </button>
+          </div>
+          <p className="sm:col-span-3 text-[11px] text-[var(--dpf-muted)]">
+            v1 allocates the pool equally across active members; patronage-basis weighting
+            arrives with purchase-volume data.
+          </p>
+        </form>
+      )}
+
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+      {notice && <p className="text-xs text-[var(--dpf-success)]">{notice}</p>}
+
+      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-[11px] uppercase tracking-wide text-[var(--dpf-muted)]">
+              <th className="px-4 py-2 font-medium">Member</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium text-right">Entries</th>
+              <th className="px-4 py-2 font-medium text-right">Equity balance</th>
+              <th className="px-4 py-2 font-medium text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((member) => (
+              <tr key={member.id} className="border-t border-[var(--dpf-border)]/50 align-top">
+                <td className="px-4 py-2 text-[var(--dpf-text)]">
+                  {member.name}{" "}
+                  <span className="font-mono text-xs text-[var(--dpf-muted)]">{member.accountId}</span>
+                </td>
+                <td className="px-4 py-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-[11px] font-medium ${
+                      member.status === "active"
+                        ? "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)]"
+                        : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]"
+                    }`}
+                  >
+                    {member.status}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-right text-[var(--dpf-muted)]">{member.entryCount}</td>
+                <td className="px-4 py-2 text-right text-[var(--dpf-text)]">{member.balance.toFixed(2)}</td>
+                <td className="px-4 py-2 text-right">
+                  {member.balance > 0 && (
+                    <button
+                      onClick={() => setRetireFor(retireFor === member.id ? null : member.id)}
+                      className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+                    >
+                      Retire
+                    </button>
+                  )}
+                  {retireFor === member.id && (
+                    <div className="mt-2 flex justify-end gap-2">
+                      <input
+                        value={retireAmount}
+                        onChange={(e) => setRetireAmount(e.target.value)}
+                        type="number"
+                        min="0.01"
+                        step="0.01"
+                        className="w-28 rounded border border-[var(--dpf-border)] bg-transparent px-2 py-1 text-xs text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
+                        placeholder="Amount"
+                      />
+                      <button
+                        onClick={() => handleRetire(member.id)}
+                        disabled={busy || !retireAmount}
+                        className="px-2 py-1 text-[11px] font-medium rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+                      >
+                        Confirm
+                      </button>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {members.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-[var(--dpf-muted)]">
+                  No member accounts yet. Members appear here once accounts exist; allocations
+                  target active members.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/member-equity.ts
+++ b/apps/web/lib/actions/member-equity.ts
@@ -1,0 +1,190 @@
+"use server";
+
+import * as crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireManageCompliance } from "./compliance-helpers";
+
+// BI-AFC178F3 — member equity & patronage actions for member-owned archetypes.
+// Conventions mirror lib/actions/civic-governance.ts.
+
+export type MemberEquityActionResult = { ok: boolean; message: string };
+
+const ENTRY_KINDS = [
+  "patronage-allocation",
+  "equity-retirement",
+  "per-unit-retain",
+  "adjustment",
+] as const;
+
+export type MemberEquityEntryKind = (typeof ENTRY_KINDS)[number];
+
+/** Subchapter T floor: qualified allocations must pay at least 20% in cash. */
+const QUALIFIED_CASH_FLOOR = 0.2;
+
+function makeId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+}
+
+async function getCurrentOrgId(): Promise<string> {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) throw new Error("No organization found");
+  return org.id;
+}
+
+export async function recordEquityEntry(input: {
+  memberAccountId: string;
+  fiscalYear: number;
+  kind: string;
+  amount: number;
+  qualified?: boolean;
+  cashPortion?: number;
+  notes?: string;
+}): Promise<MemberEquityActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!ENTRY_KINDS.includes(input.kind as MemberEquityEntryKind)) {
+      return { ok: false, message: `Invalid entry kind: ${input.kind}` };
+    }
+    if (!Number.isFinite(input.amount) || input.amount === 0) {
+      return { ok: false, message: "Amount must be a non-zero number" };
+    }
+    if (!Number.isInteger(input.fiscalYear) || input.fiscalYear < 2000 || input.fiscalYear > 2100) {
+      return { ok: false, message: "A valid fiscal year is required" };
+    }
+    const organizationId = await getCurrentOrgId();
+    await prisma.memberEquityEntry.create({
+      data: {
+        entryId: makeId("MEQ"),
+        organizationId,
+        memberAccountId: input.memberAccountId,
+        fiscalYear: input.fiscalYear,
+        kind: input.kind,
+        amount: input.amount,
+        qualified: input.qualified ?? false,
+        cashPortion: input.cashPortion ?? null,
+        notes: input.notes?.trim() || null,
+      },
+    });
+    revalidatePath("/member-equity");
+    return { ok: true, message: "Equity entry recorded" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to record entry" };
+  }
+}
+
+export async function retireEquity(input: {
+  memberAccountId: string;
+  fiscalYear: number;
+  amount: number;
+  notes?: string;
+}): Promise<MemberEquityActionResult> {
+  await requireManageCompliance();
+  try {
+    if (!Number.isFinite(input.amount) || input.amount <= 0) {
+      return { ok: false, message: "Retirement amount must be a positive number" };
+    }
+    const organizationId = await getCurrentOrgId();
+    const balance = await prisma.memberEquityEntry.aggregate({
+      where: { organizationId, memberAccountId: input.memberAccountId },
+      _sum: { amount: true },
+    });
+    const current = Number(balance._sum.amount ?? 0);
+    if (input.amount > current) {
+      return {
+        ok: false,
+        message: `Retirement exceeds the member's equity balance (${current.toFixed(2)})`,
+      };
+    }
+    await prisma.memberEquityEntry.create({
+      data: {
+        entryId: makeId("MEQ"),
+        organizationId,
+        memberAccountId: input.memberAccountId,
+        fiscalYear: input.fiscalYear,
+        kind: "equity-retirement",
+        amount: -input.amount,
+        notes: input.notes?.trim() || null,
+      },
+    });
+    revalidatePath("/member-equity");
+    return { ok: true, message: "Equity retired" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to retire equity" };
+  }
+}
+
+/**
+ * Year-end patronage allocation v1: allocates the pool EQUALLY across all
+ * active member accounts (proportional-to-patronage weighting is a documented
+ * follow-up — no purchase-volume basis exists on the platform yet). Enforces
+ * the Subchapter T >=20% cash floor for qualified allocations.
+ */
+export async function runPatronageAllocation(input: {
+  fiscalYear: number;
+  totalPool: number;
+  cashPct: number;
+  qualified: boolean;
+}): Promise<MemberEquityActionResult & { members?: number; perMember?: number }> {
+  await requireManageCompliance();
+  try {
+    if (!Number.isFinite(input.totalPool) || input.totalPool <= 0) {
+      return { ok: false, message: "Total patronage pool must be a positive number" };
+    }
+    if (!Number.isInteger(input.fiscalYear) || input.fiscalYear < 2000 || input.fiscalYear > 2100) {
+      return { ok: false, message: "A valid fiscal year is required" };
+    }
+    if (input.qualified && input.cashPct < QUALIFIED_CASH_FLOOR * 100) {
+      return {
+        ok: false,
+        message: "Qualified allocations must pay at least 20% in cash (Subchapter T)",
+      };
+    }
+    const organizationId = await getCurrentOrgId();
+
+    const existing = await prisma.memberEquityEntry.findFirst({
+      where: { organizationId, fiscalYear: input.fiscalYear, kind: "patronage-allocation" },
+      select: { id: true },
+    });
+    if (existing) {
+      return {
+        ok: false,
+        message: `A patronage allocation already exists for FY${input.fiscalYear} — record adjustments instead of re-running`,
+      };
+    }
+
+    const members = await prisma.customerAccount.findMany({
+      where: { status: "active" },
+      select: { id: true },
+    });
+    if (members.length === 0) {
+      return { ok: false, message: "No active member accounts to allocate to" };
+    }
+
+    const perMember = Math.floor((input.totalPool / members.length) * 100) / 100;
+    const cashPerMember = Math.floor(perMember * input.cashPct) / 100;
+
+    await prisma.memberEquityEntry.createMany({
+      data: members.map((member) => ({
+        entryId: makeId("MEQ"),
+        organizationId,
+        memberAccountId: member.id,
+        fiscalYear: input.fiscalYear,
+        kind: "patronage-allocation",
+        amount: perMember,
+        qualified: input.qualified,
+        cashPortion: cashPerMember,
+        notes: `FY${input.fiscalYear} year-end allocation — equal split of ${input.totalPool.toFixed(2)} across ${members.length} members (patronage-basis weighting pending)`,
+      })),
+    });
+    revalidatePath("/member-equity");
+    return {
+      ok: true,
+      message: `Allocated to ${members.length} members (${perMember.toFixed(2)} each)`,
+      members: members.length,
+      perMember,
+    };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Allocation failed" };
+  }
+}

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -127,6 +127,28 @@ describe("getShellNavSections()", () => {
     const withCommercialOrg = getShellNavSections(hr000, { activeOrgCapabilities: new Set() });
     expect(businessItems(withCommercialOrg)).not.toContain("governance");
   });
+
+  it("renders the shared /governance entry for either governance flavor via the any-of gate", () => {
+    const governanceItems = (capabilities: Set<string>) =>
+      getShellNavSections(hr000, { activeOrgCapabilities: capabilities })
+        .find((section) => section.key === "business")
+        ?.items.filter((item) => item.href === "/governance") ?? [];
+
+    // Member-owned org: governance via the any-of gate, plus member equity.
+    const memberOwned = getShellNavSections(hr000, {
+      activeOrgCapabilities: new Set(["member-governance", "member-equity"]),
+    });
+    expect(governanceItems(new Set(["member-governance", "member-equity"]))).toHaveLength(1);
+    expect(
+      memberOwned.find((section) => section.key === "business")?.items.map((item) => item.key),
+    ).toContain("member-equity");
+
+    // Public body: same single entry.
+    expect(governanceItems(new Set(["public-body-governance"]))).toHaveLength(1);
+
+    // Commercial: none.
+    expect(governanceItems(new Set())).toHaveLength(0);
+  });
 });
 
 describe("getAccessibleSectionNavEntries()", () => {

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -133,8 +133,8 @@ export type ShellNavItem = {
   description: string;
   sectionKey: PortalShellSectionKey;
   capabilityKey: CapabilityKey | null;
-  /** Archetype-capability gate — see PortalNavRecord.orgCapabilityKey. */
-  orgCapabilityKey: string | null;
+  /** Archetype-capability gate (any-of when array) — see PortalNavRecord.orgCapabilityKey. */
+  orgCapabilityKey: string | readonly string[] | null;
 };
 
 export type SectionNavItem = {
@@ -275,14 +275,19 @@ export function getShellNavSections(
   },
 ): ShellNavSection[] {
   const activeOrgCapabilities = options?.activeOrgCapabilities;
+  const orgGateOpen = (gate: string | readonly string[] | null): boolean => {
+    if (gate === null) return true;
+    if (!activeOrgCapabilities) return false;
+    const keys = typeof gate === "string" ? [gate] : gate;
+    return keys.some((key) => activeOrgCapabilities.has(key));
+  };
   return SHELL_SECTIONS.map((section) => ({
     ...section,
     items: SHELL_ITEMS.filter(
       (item) =>
         item.sectionKey === section.key &&
         isAllowed(user, item.capabilityKey) &&
-        (item.orgCapabilityKey === null ||
-          (activeOrgCapabilities?.has(item.orgCapabilityKey) ?? false)),
+        orgGateOpen(item.orgCapabilityKey),
     ),
   })).filter((section) => section.items.length > 0);
 }

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -37,13 +37,15 @@ export type PortalNavRecord = {
   destinationKind: PortalDestinationKind;
   capabilityKey?: CapabilityKey | null;
   /**
-   * Archetype-capability gate (capability registry key from
+   * Archetype-capability gate (capability registry key(s) from
    * @dpf/storefront-templates, e.g. "public-body-governance"). Entries carrying
-   * this key render only when the org's effective capability activation has it
-   * active — capability-driven surfaces per the civic archetypes spec §12, on
-   * top of (not instead of) the user-permission capabilityKey.
+   * this render only when the org's effective capability activation has AT
+   * LEAST ONE of the keys active (any-of) — capability-driven surfaces per the
+   * civic archetypes spec §12, on top of (not instead of) the user-permission
+   * capabilityKey. An array expresses shared surfaces like /governance, which
+   * serves both public-body and member-owned governance.
    */
-  orgCapabilityKey?: string | null;
+  orgCapabilityKey?: string | readonly string[] | null;
   primaryOrder?: number;
   sectionNavLabel?: string;
   shellNav?: {
@@ -59,7 +61,7 @@ export type PortalNavEntry = Pick<
   "key" | "label" | "path" | "parentPath" | "domain" | "destinationKind"
 > & {
   capabilityKey: CapabilityKey | null;
-  orgCapabilityKey: string | null;
+  orgCapabilityKey: string | readonly string[] | null;
   audienceModes: readonly PortalAudienceMode[];
 };
 
@@ -266,12 +268,32 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     audienceModes: ["worker", "operator"],
     destinationKind: "domain-home",
     capabilityKey: "view_compliance",
-    orgCapabilityKey: "public-body-governance",
+    // Any-of: the surface serves council/open-meetings governance (public
+    // bodies) AND board/annual-meeting governance (member-owned orgs,
+    // BI-AFC178F3); the page adapts via the same capability activations.
+    orgCapabilityKey: ["public-body-governance", "member-governance"],
     shellNav: {
       sectionKey: "business",
-      description: "Meetings, agendas, minutes, and records requests.",
+      description: "Meetings, agendas, minutes — council or board.",
     },
     sectionSiblings: ["/governance", "/governance/records-requests"],
+  },
+  {
+    // Member equity & patronage ledger (BI-AFC178F3) — co-ops and, later,
+    // member-owned utilities (capital credits).
+    key: "member-equity",
+    label: "Member Equity",
+    path: "/member-equity",
+    parentPath: "/member-equity",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_finance",
+    orgCapabilityKey: "member-equity",
+    shellNav: {
+      sectionKey: "business",
+      description: "Per-member equity, patronage allocations, and retirements.",
+    },
   },
   {
     key: "governance-records-requests",

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -208,6 +208,9 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
 
   // Public sector
   "small-town-municipality": ["Permits & Licenses", "Public Works", "Parks & Recreation", "Clerk's Office", "Code Enforcement"],
+
+  // Cooperative (nonprofit-community)
+  "cooperative": ["Membership", "Member Services", "Patronage & Equity", "Governance"],
   "municipal-utility": ["Residential", "Commercial", "Irrigation", "Connection Fees", "Service Orders"],
 };
 

--- a/docs/superpowers/plans/2026-06-10-cooperative-archetype.md
+++ b/docs/superpowers/plans/2026-06-10-cooperative-archetype.md
@@ -1,0 +1,82 @@
+# Implementation Plan — Cooperative Archetype (first member-owned activation)
+
+- **Backlog item:** `BI-AFC178F3` (epic `EP-ARCH-8D4F2A`; triaged `build`, size `large`)
+- **Design spec:** [`docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md`](../specs/2026-06-09-civic-and-member-governed-archetypes-design.md) §6.4, §7, §10
+- **Depends on:** Phase-0 substrate (merged #1692 — `member-governance`/`membership-eligibility`/`member-equity` capabilities + member-owned rules), GovernanceMeeting model (merged #1696 — `bodyType` was designed for board/annual-meeting reuse), vocabulary mechanism (merged #1699)
+- **Sequencing note:** the spec assigned member-governance v1 to the credit-union BI, but that BI is blocked on the BIAN leaf implementation — the cooperative ships it instead; the credit-union delta then reuses everything here.
+- **Date:** 2026-06-10
+
+Grounded against the worktree at merged main (governance surfaces, nav model, civic actions, compliance seed pattern all landed this session — file claims below are to code written or verified hours ago).
+
+## Slice 1 — Archetype + member-governance surface gate (one PR with slice 2)
+
+- `packages/storefront-templates/src/archetypes/nonprofit-community.ts` — add `cooperative`
+  archetype (spec §6.4 puts it in this category; cooperative-ness lives in the axis):
+  axes `member` / `member-owned` / `transactional` / `account-with-billing`;
+  `capabilityOverrides: [{ capabilityKey: "member-equity", applicability: "required",
+  reason: "Cooperatives allocate patronage by statute (Subchapter T)" }]` — first real
+  use of the override path; vocabulary skin (Member-Owners / Member Portal / Member
+  Requests / Member Services); item templates: Membership Share (fixed, purchase),
+  Membership Application (free, inquiry), Member Account Question, Patronage & Equity
+  Inquiry; sections About Our Co-op / Products & Services / Board & Committees / Contact.
+  Sub-type tuning (ag/electric/food/housing/worker wizard question) is **deferred** like
+  the utility's ownership question — same residual class, noted on close-out.
+- `/governance` gate extension: `apps/web/app/(shell)/governance/page.tsx` currently
+  requires `public-body-governance`; change to required-any of
+  `["public-body-governance", "member-governance"]` via `getActiveOrgCapabilities()`;
+  hide the Records Requests header link when `records-request` is inactive (co-ops have
+  no FOIA duty). Records-requests page keeps its own gate unchanged.
+- Nav: second `PORTAL_NAV_ROUTES` record `governance-member` (same `/governance` path,
+  `orgCapabilityKey: "member-governance"`, business section, description "Board,
+  committees, annual meeting, and minutes."). Governance values are mutually exclusive
+  per archetype so both records never render together; add a permissions test asserting
+  exactly one Governance item for a member-owned set and none for commercial.
+- Tests: archetypes.test invariants pick the new definition up; activation-profile test
+  asserting the cooperative derives member-governance/membership-eligibility required +
+  member-equity **required via override** (override path proof).
+
+## Slice 2 — Member equity module + Subchapter T pack
+
+- `packages/db/prisma/schema.prisma` — `MemberEquityEntry`: org-scoped, additive
+  (`entryId` unique, `memberAccountId → CustomerAccount`, `fiscalYear Int`,
+  `kind: "patronage-allocation" | "equity-retirement" | "per-unit-retain" | "adjustment"`,
+  `amount Decimal(14,2)` (negative = retirement), `qualified Boolean`, `cashPortion
+  Decimal(14,2)?`, `notes`, indexes on (org, memberAccountId) and (org, fiscalYear)) +
+  hand-authored migration verified against `prisma migrate diff` (the #1696 procedure).
+- `apps/web/lib/actions/member-equity.ts` — conventions of `civic-governance.ts`:
+  `recordEquityEntry`, `retireEquity` (negative amount, balance check),
+  `runPatronageAllocation(fiscalYear, totalPool, cashPct)` — v1 allocates the pool
+  **equally across active CustomerAccounts** with `qualified=true` rows and warns when
+  `cashPct < 20` (Subchapter T floor); proportional-to-patronage basis is a documented
+  follow-up (no purchase-volume data exists yet to weight by).
+- `apps/web/app/(shell)/member-equity/page.tsx` + `components/civic/MemberEquityPanel.tsx`
+  — gated on `member-equity`; per-member balance table (sum of entries), entry history,
+  allocation-runner form, retire action. Nav record `member-equity` (path
+  `/member-equity`, `capabilityKey: "view_finance"`, `orgCapabilityKey: "member-equity"`,
+  business section).
+- `packages/db/src/seed-cooperative-compliance.ts` — pack on the DORA/civic pattern,
+  `industry: "cooperative"`: `REG-US-IRS-SUBCHAPTER-T` (qualified written notices of
+  allocation within 8.5 months, ≥20% cash on qualified allocations, member consent
+  records, Form 1099-PATR) + `REG-US-COOP-GOVERNANCE` (annual member meeting, director
+  elections, bylaws/membership-record maintenance, patronage-basis records). Wired into
+  `seed.ts` after the public-sector pack; pure-data integrity test mirroring
+  `seed-public-sector-compliance.test.ts`.
+
+## Verification
+
+Package vitest + typecheck (storefront-templates, db, web) + full web vitest before push;
+fresh-runtime verification on the shared lease (claim → throwaway pg → migrate/seed →
+dev-portal): onboard as a worker co-op, confirm Member-Owners vocabulary + Governance
+(member flavor, no Records Requests link) + Membership Share on the public site +
+member-equity page with a runnable allocation across seeded member accounts + Subchapter
+T pack in the compliance library. Teardown includes the node_modules sweep + reinstall
+(dev-portal pollution) and lease release.
+
+## Risks & rollback
+
+- Equal-split allocation may read as wrong for real co-ops — labelled in-UI as
+  "equal allocation (patronage-basis weighting coming)" so the v1 semantics are explicit.
+- Two nav records sharing one path is novel — covered by the exactly-one-item test;
+  worst case both render as duplicate links (cosmetic), only if an archetype ever
+  declares both governance values, which the axis type prevents.
+- All changes additive; revert the PR. Migration is a single new table.

--- a/packages/db/prisma/migrations/20260610150000_add_member_equity_entry/migration.sql
+++ b/packages/db/prisma/migrations/20260610150000_add_member_equity_entry/migration.sql
@@ -1,0 +1,26 @@
+-- BI-AFC178F3: member equity & patronage ledger for member-owned archetypes.
+-- Additive table only.
+
+CREATE TABLE "MemberEquityEntry" (
+    "id" TEXT NOT NULL,
+    "entryId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "memberAccountId" TEXT NOT NULL,
+    "fiscalYear" INTEGER NOT NULL,
+    "kind" TEXT NOT NULL,
+    "amount" DECIMAL(14,2) NOT NULL,
+    "qualified" BOOLEAN NOT NULL DEFAULT false,
+    "cashPortion" DECIMAL(14,2),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MemberEquityEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MemberEquityEntry_entryId_key" ON "MemberEquityEntry"("entryId");
+CREATE INDEX "MemberEquityEntry_organizationId_memberAccountId_idx" ON "MemberEquityEntry"("organizationId", "memberAccountId");
+CREATE INDEX "MemberEquityEntry_organizationId_fiscalYear_idx" ON "MemberEquityEntry"("organizationId", "fiscalYear");
+
+ALTER TABLE "MemberEquityEntry" ADD CONSTRAINT "MemberEquityEntry_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "MemberEquityEntry" ADD CONSTRAINT "MemberEquityEntry_memberAccountId_fkey" FOREIGN KEY ("memberAccountId") REFERENCES "CustomerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2312,6 +2312,7 @@ model CustomerAccount {
 
   @@index([status])
   @@index([parentAccountId])
+  memberEquityEntries MemberEquityEntry[]
 }
 
 model CustomerSite {
@@ -2839,6 +2840,7 @@ model Organization {
   governanceMeetings            GovernanceMeeting[]
   recordsRequests               RecordsRequest[]
   fundBudgetLines               FundBudgetLine[]
+  memberEquityEntries           MemberEquityEntry[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -10452,5 +10454,34 @@ model FundBudgetLine {
   updatedAt DateTime @updatedAt
 
   @@unique([organizationId, fiscalYear, fund, accountCode])
+  @@index([organizationId, fiscalYear])
+}
+
+// Member equity & patronage ledger (BI-AFC178F3 — civic spec §7 cooperative).
+// One row per allocation/retirement/retain event; a member's equity balance is
+// the sum of amounts (retirements are negative). Serves co-ops first and
+// member-owned utilities (capital credits) later.
+model MemberEquityEntry {
+  id              String          @id @default(cuid())
+  entryId         String          @unique
+  organizationId  String
+  organization    Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  memberAccountId String
+  memberAccount   CustomerAccount @relation(fields: [memberAccountId], references: [id], onDelete: Cascade)
+
+  fiscalYear  Int
+  // patronage-allocation | equity-retirement | per-unit-retain | adjustment
+  kind        String
+  // Negative for retirements.
+  amount      Decimal  @db.Decimal(14, 2)
+  // Qualified written notice of allocation (Subchapter T) — drives the >=20% cash rule.
+  qualified   Boolean  @default(false)
+  cashPortion Decimal? @db.Decimal(14, 2)
+  notes       String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([organizationId, memberAccountId])
   @@index([organizationId, fiscalYear])
 }

--- a/packages/db/src/seed-cooperative-compliance.ts
+++ b/packages/db/src/seed-cooperative-compliance.ts
@@ -1,0 +1,290 @@
+import type { PrismaClient } from "../generated/client/client";
+import * as crypto from "crypto";
+
+// BI-AFC178F3 — cooperative compliance pack (civic spec §10).
+// Same global-Regulation pattern as the public-sector pack, industry
+// "cooperative": Subchapter T patronage mechanics + member-governance duties.
+
+function makeId(prefix: string): string {
+  const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
+  return `${prefix}-${hex}`;
+}
+
+type ObligationSeed = {
+  title: string;
+  reference: string;
+  description: string;
+  category: string;
+  frequency: string;
+  applicability: string;
+  penaltySummary: string | null;
+};
+
+type RegulationSeed = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string;
+  sourceType: "external";
+  notes: string;
+  obligations: ObligationSeed[];
+};
+
+export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
+  {
+    regulationId: "REG-US-IRS-SUBCHAPTER-T",
+    name: "IRC Subchapter T — Cooperative Patronage Taxation",
+    shortName: "Subchapter T",
+    jurisdiction: "US-federal",
+    industry: "cooperative",
+    sourceType: "external",
+    notes:
+      "Internal Revenue Code §§1381–1388 govern how cooperatives deduct patronage dividends: " +
+      "allocations must be made on the basis of business done with members, qualified written " +
+      "notices of allocation require at least 20% paid in cash and member consent, and notices " +
+      "must issue within 8.5 months of fiscal year end.",
+    obligations: [
+      {
+        title: "Patronage allocated on the basis of business done with members",
+        reference: "subchapter-t/patronage-basis",
+        description:
+          "Allocate patronage dividends to members in proportion to the business each member did " +
+          "with the cooperative during the fiscal year, under a pre-existing obligation (bylaws or " +
+          "member agreement). Maintain the per-member patronage-basis records that support the allocation.",
+        category: "finance",
+        frequency: "annual",
+        applicability: "All cooperatives operating on a cooperative basis under Subchapter T",
+        penaltySummary: "Allocations without basis records or a pre-existing obligation lose the patronage deduction.",
+      },
+      {
+        title: "Qualified allocations: at least 20% cash and valid member consent",
+        reference: "subchapter-t/qualified-cash-floor",
+        description:
+          "For a written notice of allocation to be qualified (deductible in the year of allocation), " +
+          "pay at least 20% of the patronage dividend in cash or check and hold valid member consent " +
+          "(bylaw consent, written consent, or qualified-check consent).",
+        category: "finance",
+        frequency: "annual",
+        applicability: "Cooperatives issuing qualified written notices of allocation",
+        penaltySummary: "Below the 20% floor the notice is nonqualified — deduction deferred until redemption.",
+      },
+      {
+        title: "Written notices of allocation issued within the payment period",
+        reference: "subchapter-t/notice-timing",
+        description:
+          "Issue written notices of allocation (and any cash portion) within the payment period — " +
+          "8.5 months after the close of the fiscal year — for the allocation to count toward that year.",
+        category: "finance",
+        frequency: "annual",
+        applicability: "All cooperatives allocating patronage",
+        penaltySummary: null,
+      },
+      {
+        title: "Form 1099-PATR filed for patronage distributions",
+        reference: "subchapter-t/1099-patr",
+        description:
+          "File Form 1099-PATR for each member paid $10 or more in patronage dividends (or subject to " +
+          "backup withholding) and furnish member copies by the statutory deadline.",
+        category: "finance",
+        frequency: "annual",
+        applicability: "All cooperatives distributing patronage",
+        penaltySummary: "Standard information-return penalties per missed or late form.",
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-COOP-GOVERNANCE",
+    name: "Cooperative Governance Requirements (state co-op statutes & bylaws)",
+    shortName: "Co-op Governance",
+    jurisdiction: "US-state",
+    industry: "cooperative",
+    sourceType: "external",
+    notes:
+      "State cooperative statutes and the co-op's own bylaws require democratic member control: " +
+      "an annual member meeting, director elections, one-member-one-vote (with limited exceptions), " +
+      "and maintained membership and equity records. Specifics vary by state and co-op type.",
+    obligations: [
+      {
+        title: "Annual member meeting held with required notice",
+        reference: "coop-governance/annual-meeting",
+        description:
+          "Hold the annual meeting of members with the notice period required by statute and bylaws; " +
+          "present financial reports and conduct the business reserved to members (director elections, " +
+          "bylaw amendments). Record minutes.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "All cooperatives",
+        penaltySummary: "Failure can void elections and expose directors to member action.",
+      },
+      {
+        title: "Director elections by the membership",
+        reference: "coop-governance/director-elections",
+        description:
+          "Elect directors by member vote per bylaws (terms, districts/seats, nomination process). " +
+          "Document election results in the meeting minutes and maintain the board roster.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "All cooperatives",
+        penaltySummary: null,
+      },
+      {
+        title: "Membership and equity records maintained",
+        reference: "coop-governance/member-records",
+        description:
+          "Maintain the membership register (admissions, terminations) and each member's equity " +
+          "ledger (allocations, retains, retirements) — the records that support both governance " +
+          "rights and Subchapter T allocations.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "All cooperatives",
+        penaltySummary: null,
+      },
+      {
+        title: "Bylaws current and available to members",
+        reference: "coop-governance/bylaws",
+        description:
+          "Keep bylaws current with statute and practice (patronage obligation, consent provisions, " +
+          "board structure) and available to members; amendments follow the member-vote process.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "All cooperatives",
+        penaltySummary: null,
+      },
+    ],
+  },
+];
+
+type ControlSeed = {
+  title: string;
+  description: string;
+  controlType: "preventive" | "detective" | "corrective";
+  obligationRefs: string[];
+};
+
+export const COOPERATIVE_CONTROLS: ControlSeed[] = [
+  {
+    title: "Year-End Patronage Allocation Procedure",
+    description:
+      "Documented year-end run: determine the patronage pool, allocate on member patronage basis, " +
+      "enforce the 20% cash floor for qualified notices, and issue notices within 8.5 months. " +
+      "Backed by the Member Equity allocation runner.",
+    controlType: "preventive",
+    obligationRefs: [
+      "subchapter-t/patronage-basis",
+      "subchapter-t/qualified-cash-floor",
+      "subchapter-t/notice-timing",
+    ],
+  },
+  {
+    title: "Member Equity Ledger",
+    description:
+      "Per-member equity ledger recording allocations, per-unit retains, and retirements — the " +
+      "system of record behind notices, 1099-PATR amounts, and member equity statements.",
+    controlType: "detective",
+    obligationRefs: ["coop-governance/member-records", "subchapter-t/1099-patr"],
+  },
+  {
+    title: "Annual Meeting & Election Workflow",
+    description:
+      "Meeting notice → agenda → annual meeting → minutes → recorded election results, on the " +
+      "governance meeting workflow (bodyType annual-meeting / board).",
+    controlType: "preventive",
+    obligationRefs: ["coop-governance/annual-meeting", "coop-governance/director-elections"],
+  },
+];
+
+export async function seedCooperativeCompliance(prisma: PrismaClient): Promise<void> {
+  let regUpserts = 0;
+  let oblCreated = 0;
+  let ctlCreated = 0;
+  let linksCreated = 0;
+
+  const oblIdByRef = new Map<string, string>();
+
+  for (const reg of COOPERATIVE_REGULATIONS) {
+    const { obligations, ...regData } = reg;
+    const regulation = await prisma.regulation.upsert({
+      where: { regulationId: regData.regulationId },
+      update: {
+        name: regData.name,
+        shortName: regData.shortName,
+        jurisdiction: regData.jurisdiction,
+        industry: regData.industry,
+        notes: regData.notes,
+      },
+      create: regData,
+    });
+    regUpserts++;
+
+    for (const obl of obligations) {
+      const existing = await prisma.obligation.findFirst({
+        where: { regulationId: regulation.id, reference: obl.reference, status: "active" },
+        select: { id: true },
+      });
+      if (existing) {
+        oblIdByRef.set(obl.reference, existing.id);
+        continue;
+      }
+      const created = await prisma.obligation.create({
+        data: {
+          obligationId: makeId("OBL"),
+          regulationId: regulation.id,
+          title: obl.title,
+          description: obl.description,
+          reference: obl.reference,
+          category: obl.category,
+          frequency: obl.frequency,
+          applicability: obl.applicability,
+          penaltySummary: obl.penaltySummary,
+        },
+      });
+      oblIdByRef.set(obl.reference, created.id);
+      oblCreated++;
+    }
+  }
+
+  for (const ctl of COOPERATIVE_CONTROLS) {
+    const existing = await prisma.control.findFirst({
+      where: { title: ctl.title, status: "active" },
+      select: { id: true },
+    });
+    const controlId =
+      existing?.id ??
+      (
+        await prisma.control.create({
+          data: {
+            controlId: makeId("CTL"),
+            title: ctl.title,
+            description: ctl.description,
+            controlType: ctl.controlType,
+            implementationStatus: "planned",
+          },
+        })
+      ).id;
+    if (!existing) ctlCreated++;
+
+    for (const ref of ctl.obligationRefs) {
+      const oblId = oblIdByRef.get(ref);
+      if (!oblId) {
+        throw new Error(
+          `[seed-cooperative-compliance] control "${ctl.title}" references unknown obligation "${ref}"`,
+        );
+      }
+      const link = await prisma.controlObligationLink.findUnique({
+        where: { controlId_obligationId: { controlId, obligationId: oblId } },
+      });
+      if (!link) {
+        await prisma.controlObligationLink.create({ data: { controlId, obligationId: oblId } });
+        linksCreated++;
+      }
+    }
+  }
+
+  const expectedObligations = COOPERATIVE_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+  console.log(
+    `[seed] cooperative compliance pack: ${regUpserts}/${COOPERATIVE_REGULATIONS.length} regulations upserted, ` +
+      `${oblCreated} obligations created (${expectedObligations} expected total), ` +
+      `${ctlCreated} controls created, ${linksCreated} links created`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -15,6 +15,7 @@ import { seedGovernanceReferenceData } from "./governance-seed.js";
 import { seedWorkforceReferenceData } from "./workforce-seed.js";
 import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
 import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
+import { seedCooperativeCompliance } from "./seed-cooperative-compliance.js";
 import { seedBusinessCapabilityPerspective } from "./business-capability-perspectives.js";
 import { seedGeographicData } from "./seed-geographic-data.js";
 import { seedTaxJurisdictions } from "./seed-tax-jurisdictions.js";
@@ -2534,6 +2535,7 @@ async function main(): Promise<void> {
   await step("hiveContributionCredential", () => seedHiveContributionCredential());
   await step("storefrontArchetypes", () => seedStorefrontArchetypes(prisma));
   await step("publicSectorCompliance", () => seedPublicSectorCompliance(prisma));
+  await step("cooperativeCompliance", () => seedCooperativeCompliance(prisma));
   await step("businessCapabilityPerspective", async () => {
     const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(

--- a/packages/db/test/seed-cooperative-compliance.test.ts
+++ b/packages/db/test/seed-cooperative-compliance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  COOPERATIVE_CONTROLS,
+  COOPERATIVE_REGULATIONS,
+} from "../src/seed-cooperative-compliance";
+
+// Pure-data integrity tests — no database. Mirrors the public-sector pack tests.
+
+describe("cooperative compliance pack data", () => {
+  it("ships Subchapter T and co-op governance with the expected obligation counts", () => {
+    expect(COOPERATIVE_REGULATIONS.map((r) => r.regulationId).sort()).toEqual([
+      "REG-US-COOP-GOVERNANCE",
+      "REG-US-IRS-SUBCHAPTER-T",
+    ]);
+    const total = COOPERATIVE_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+    expect(total).toBe(8);
+    for (const reg of COOPERATIVE_REGULATIONS) {
+      expect(reg.industry).toBe("cooperative");
+      expect(reg.obligations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("obligation references are globally unique", () => {
+    const refs = COOPERATIVE_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference));
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it("every control references only known obligations", () => {
+    const known = new Set(
+      COOPERATIVE_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference)),
+    );
+    for (const control of COOPERATIVE_CONTROLS) {
+      expect(control.obligationRefs.length).toBeGreaterThan(0);
+      for (const ref of control.obligationRefs) {
+        expect(known.has(ref), `${control.title} references unknown obligation ${ref}`).toBe(true);
+      }
+    }
+  });
+
+  it("every obligation carries the fields the compliance surfaces render", () => {
+    for (const reg of COOPERATIVE_REGULATIONS) {
+      for (const obl of reg.obligations) {
+        expect(obl.title.length).toBeGreaterThan(10);
+        expect(obl.description.length).toBeGreaterThan(40);
+        expect(["governance", "finance"]).toContain(obl.category);
+        expect(["event-driven", "continuous", "annual", "monthly"]).toContain(obl.frequency);
+      }
+    }
+  });
+});

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -236,6 +236,21 @@ describe("existing archetype regression (governance axis is inert)", () => {
     }
   });
 
+  it("the cooperative archetype derives the member-owned set, with member-equity required via override", () => {
+    const coop = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "cooperative");
+    expect(coop?.activationProfile).toBeDefined();
+
+    const profile = readActivationProfile(coop?.activationProfile);
+    expect(profile?.axes.governance).toBe("member-owned");
+    expect(profile?.axes.primaryConsumer).toBe("member");
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("required");
+    expect(getCapabilityApplicability(profile, "membership-eligibility")).toBe("required");
+    // The rules derive member-equity as recommended; the archetype override promotes it.
+    expect(getCapabilityApplicability(profile, "member-equity")).toBe("required");
+    expect(getCapabilityApplicability(profile, "public-body-governance")).toBe("not-applicable");
+    expect(getCapabilityApplicability(profile, "records-request")).toBe("not-applicable");
+  });
+
   it("the small-town municipality archetype derives the public-body capability set from its declared axes", () => {
     const town = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "small-town-municipality");
     expect(town?.activationProfile).toBeDefined();

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -131,4 +131,76 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { name: "position", label: "Playing position / role (if applicable)", type: "text" as const, required: false },
     ],
   },
+  {
+    // First member-owned activation (civic spec §6.4/§7): cooperative-ness lives in
+    // the governance axis, so one general-purpose archetype covers ag / electric /
+    // consumer-food / housing / worker co-ops; sub-type template tuning is a
+    // documented follow-up, like the utility's ownership question.
+    archetypeId: "cooperative",
+    name: "Cooperative (Member-Owned)",
+    category: "nonprofit-community",
+    ctaType: "inquiry",
+    tags: ["cooperative", "co-op", "member-owned", "patronage", "worker-coop", "food-coop", "housing-coop", "agricultural"],
+    itemTemplates: [
+      { name: "Membership Share", description: "Purchase a membership share to become a member-owner of the cooperative", priceType: "fixed", ctaType: "purchase" },
+      { name: "Membership Application", description: "Apply to join the cooperative as a member-owner", priceType: "free", ctaType: "inquiry" },
+      { name: "Member Account Question", description: "Ask about your member account, statements, or services", priceType: "free", ctaType: "inquiry" },
+      { name: "Patronage & Equity Inquiry", description: "Ask about your patronage allocation, capital credits, or equity retirement", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Our Co-op", sortOrder: 1 },
+      { type: "items", title: "Products & Services", sortOrder: 2 },
+      { type: "team", title: "Board & Committees", sortOrder: 3 },
+      { type: "contact", title: "Contact Us", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "requestType", label: "Request type", type: "select" as const, required: true, options: ["Membership", "Member account", "Patronage / equity", "Board & governance", "Other"] },
+    ],
+    // Member-owner skin over the nonprofit-community category vocabulary (civic spec §8).
+    vocabulary: {
+      itemsLabel: "Products & Services",
+      portalLabel: "Member Portal",
+      stakeholderLabel: "Member-Owners",
+      inboxLabel: "Member Requests",
+      agentName: "Member Services",
+    },
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "projects"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "member",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+        governance: "member-owned",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "standard", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      capabilityOverrides: [
+        {
+          capabilityKey: "member-equity",
+          applicability: "required",
+          reason: "Cooperatives allocate patronage and retire member equity by statute (Subchapter T) — not optional for this archetype.",
+        },
+      ],
+      seededServiceCategories: [
+        "Membership",
+        "Member Services",
+        "Patronage & Equity",
+        "Governance",
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

**BI-AFC178F3** (`EP-ARCH-8D4F2A`) — the first **member-owned** activation of the governance axis, covering the strongest whitespace in the civic research (~30,000 US co-ops with no horizontal product for the member-owner lifecycle).

- `cooperative` archetype (nonprofit-community; cooperative-ness lives in the axis per spec §6.4): `member`/`member-owned` axes, Member-Owners vocabulary skin, Membership Share + Application items, and the **first real `capabilityOverride`** — member-equity promoted recommended→required with the Subchapter T rationale visible in review.
- **/governance serves both flavors**: public-body (council/open-meetings) and member-owned (board/annual meeting) on the same `GovernanceMeeting.bodyType`, Records Requests link hidden when the FOIA capability is inactive. Nav `orgCapabilityKey` gains **any-of array semantics** on the single `/governance` record — the path-uniqueness invariant test correctly rejected a twin-record approach.
- **Member equity module**: `MemberEquityEntry` (diff-verified additive migration) + `/member-equity` surface — per-member balances, year-end patronage allocation runner (≥20% qualified-cash floor enforced, duplicate-FY guard, equal-split v1 semantics labelled in-UI), balance-checked retirement.
- **Compliance pack**: `REG-US-IRS-SUBCHAPTER-T` + `REG-US-COOP-GOVERNANCE` (8 obligations, 3 linked controls) on the existing substrate, integrity-tested, seeded after the public-sector pack.

Deferred (same residual class as the utility, tracked): sub-type wizard question (ag/electric/food/housing/worker template tuning), patronage-basis-weighted allocation (needs purchase-volume data).

## Verification

Full web vitest **10,326 passed**; storefront-templates 58 (incl. cooperative override-path fixture); db pack integrity tests; typechecks green. Migration SQL identical to `prisma migrate diff` output. Fresh-runtime functional verification follows merge (lease + throwaway DB, same harness as the town/utility runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)