### PR TITLE
fix(self-upgrade): emit Connection: close during drain/swap to prevent browser keep-alive socket wedge (BI-79676285)

### DIFF
--- a/apps/web/lib/proxy/quiescence-gate.test.ts
+++ b/apps/web/lib/proxy/quiescence-gate.test.ts
@@ -137,6 +137,8 @@ describe("evaluateGate — pure decision", () => {
       expect(d.response.headers.get("x-bundle-hash")).toBe("abc123");
       expect(d.response.headers.get("x-quiescence-level")).toBe("draining");
       expect(d.response.headers.get("x-quiescence-run-id")).toBe("QR-2026-05-24-abc12345");
+      // 503 drain response must close the socket (BI-79676285)
+      expect(d.response.headers.get("connection")).toBe("close");
     }
   });
 
@@ -194,6 +196,24 @@ describe("attachVersionHeaders", () => {
     expect(result.headers.get("x-quiescence-level")).toBeNull();
     // But version + bundle headers ARE still set even on unknown
     expect(result.headers.get("x-platform-version")).toBe("1.0.0");
+  });
+
+  it("sets Connection: close during draining (BI-79676285)", () => {
+    const res = NextResponse.next();
+    const result = attachVersionHeaders(res, drainingState);
+    expect(result.headers.get("connection")).toBe("close");
+  });
+
+  it("sets Connection: close during swapping (BI-79676285)", () => {
+    const res = NextResponse.next();
+    const result = attachVersionHeaders(res, swappingState);
+    expect(result.headers.get("connection")).toBe("close");
+  });
+
+  it("does NOT set Connection: close during normal (keep-alive preserved)", () => {
+    const res = NextResponse.next();
+    const result = attachVersionHeaders(res, normalState);
+    expect(result.headers.get("connection")).toBeNull();
   });
 });
 

--- a/apps/web/lib/proxy/quiescence-gate.ts
+++ b/apps/web/lib/proxy/quiescence-gate.ts
@@ -257,6 +257,7 @@ function build503(state: ProxyQuiescenceState, swapping: boolean): NextResponse 
     "X-Quiescence-Level": state.level,
   });
   if (state.runId) headers.set("X-Quiescence-Run-Id", state.runId);
+  headers.set("Connection", "close");
   const body = JSON.stringify({
     error: "portal_quiescing",
     message: swapping
@@ -287,6 +288,15 @@ export function attachVersionHeaders(
   // mid-drain. Cheap, no PII.
   if (state.level !== "unknown") {
     response.headers.set("X-Quiescence-Level", state.level);
+  }
+  // During drain/swap the container is about to be recycled. Signal browsers
+  // to close their keep-alive sockets now so the connection pool is empty by
+  // the time the container stops. Without this, wslrelay (Windows/WSL2) and
+  // equivalent relay layers absorb the TCP RST from the dying container and
+  // never propagate it to the browser — leaving Chrome's 6-socket pool wedged
+  // on dead connections indefinitely (BI-79676285).
+  if (state.level === "draining" || state.level === "swapping") {
+    response.headers.set("Connection", "close");
   }
   return response;
 }


### PR DESCRIPTION
## Summary

- **Root cause diagnosed:** Every self-upgrade container recycle orphaned Chrome's 6-socket keep-alive pool on the `::1`/wslrelay path (Windows/WSL2). The relay layer absorbs the TCP RST from the dying container without propagating it to the browser, leaving Chrome's per-host connection pool permanently wedged on dead connections. Portal appears completely unresponsive after every upgrade swap with no error shown.
- **Fix:** `attachVersionHeaders()` and `build503()` in `quiescence-gate.ts` now emit `Connection: close` on all responses when quiescence level is `draining` or `swapping`. Browsers naturally retire pooled sockets on close — pool is empty before the container stops.
- **Tests:** 4 new unit tests added to `quiescence-gate.test.ts` covering drain, swap, normal (no close), and 503 response paths. All 31 tests pass.

## Test plan

- [ ] All existing unit tests pass: `31 tests | 31 passed` confirmed in portal container
- [ ] After next self-upgrade, navigate to `http://localhost:3000/ops/self-upgrade` in a previously-connected Chrome window — should load without manual restart or switching to `127.0.0.1`
- [ ] Normal portal operation: verify no `Connection: close` header emitted when `x-quiescence-level` is `normal`

## Evidence

Diagnosed 2026-06-10. Three self-upgrades in 24 hours each silently wedged all open Chrome windows. `netstat` confirmed exactly 6 dead Established connections to `::1:3000` (Chrome's per-host pool limit). `curl` over IPv6 returned 200 in 12ms — server healthy, only pooled sockets affected.

Backlog item: `BI-79676285` | Epic: `EP-UPGRADE-LIFECYCLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)