### PR TITLE
fix(assurance): require authenticated session for SBOM export route

### DIFF
--- a/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.test.ts
+++ b/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockGetLatest } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockGetLatest: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/assurance/bom-export", () => ({
+  getLatestCycloneDxForProduct: mockGetLatest,
+}));
+
+// Import under test AFTER mocks are registered
+import { GET } from "./route";
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockGetLatest.mockReset();
+});
+
+async function call(id: string) {
+  const params = Promise.resolve({ id });
+  return GET(new Request("http://localhost/ignored"), { params });
+}
+
+describe("GET /api/portfolio/product/:id/supply-chain/bom", () => {
+  it("returns 401 when there's no session", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await call("prod-1");
+    expect(res.status).toBe(401);
+    // The SBOM must not be loaded or leaked to an unauthenticated caller.
+    expect(mockGetLatest).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when authenticated but no BOM exists", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockGetLatest.mockResolvedValue(null);
+    const res = await call("prod-1");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the shareable CycloneDX document for an authenticated caller", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockGetLatest.mockResolvedValue({
+      documentId: "BOM-123",
+      raw: { bomFormat: "CycloneDX", specVersion: "1.7", components: [] },
+    });
+    const res = await call("prod-1");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/vnd.cyclonedx+json; charset=utf-8",
+    );
+    expect(res.headers.get("content-disposition")).toBe(
+      'attachment; filename="BOM-123.shareable.cdx.json"',
+    );
+    const body = JSON.parse(await res.text());
+    expect(body).toMatchObject({ bomFormat: "CycloneDX", specVersion: "1.7" });
+  });
+});

--- a/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.ts
+++ b/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.ts
@@ -1,12 +1,27 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
 import { getLatestCycloneDxForProduct } from "@/lib/assurance/bom-export";
 
 type Context = {
   params: Promise<{ id: string }>;
 };
 
+// "Shareable" here is the redaction *profile* (createShareableCycloneDxBom strips
+// internal paths, user ids, secrets, and route context) so the downloaded artifact
+// is safe for an authenticated operator to forward to customers/auditors. It is NOT
+// an anonymous public share link: the only UI that links here lives under the
+// (shell) layout, which already requires an authenticated, non-customer session.
+// API route handlers do not inherit that layout's auth, so the guard is enforced
+// explicitly below. If a genuinely public/customer-facing SBOM share is ever wanted,
+// it should be a separate route keyed by an unguessable share token, not the
+// guessable product id.
 export async function GET(_request: Request, { params }: Context) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { id } = await params;
   const bom = await getLatestCycloneDxForProduct(prisma, id);
 


### PR DESCRIPTION
## Security fix: SBOM export route served unauthenticated

`GET /api/portfolio/product/[id]/supply-chain/bom` returned a product's full CycloneDX SBOM (`bom.raw`) with **no auth check** — no `auth()`, no `authenticateRequest()`, querying Prisma directly. There is no global `apps/web/middleware.ts`, so nothing enforced auth ahead of it. On an internet-facing install, anonymous callers could download the component/version inventory by iterating product ids.

### Intent: is this a deliberate public share endpoint?

The `.shareable.` filename raised the question. Resolved against the [Phase-1A assurance plan](docs/superpowers/plans/2026-05-22-assurance-ledger-phase-1a-bom-persistence.md) — it is **not** meant to be anonymous:

- **"Shareable" is the redaction _profile_, not the URL.** `createShareableCycloneDxBom` strips internal paths, user ids, secrets, and route context so the *downloaded file* is safe for an operator to forward to customers/auditors. The plan frames internal vs shareable as two views of the same artifact, never as an anonymous link.
- **The only UI link is already auth-gated.** The "Export shareable SBOM" `<Link>` in `ProductSupplyChainPanel` lives under `app/(shell)/layout.tsx`, which enforces `auth()` and redirects `customer`-type users to `/portal`. API route handlers don't inherit that layout — that's the gap.
- **Sibling surfaces are gated.** The generation action `requestBuildBomGeneration` requires `auth()` + `view_platform`; the analogous `build/[buildId]/evidence/[fileName]` download route is auth-gated (401 + ownership). This route was the outlier.
- **No share-token mechanism exists** — a genuine public share would key on an unguessable token, not a guessable product id.

### Changes

- **`route.ts`** — add the canonical guard (`const session = await auth(); if (!session?.user) return 401`), matching the rest of `app/api/**`. Added a comment documenting the access model and noting that any future public/customer-facing share should be a separate token-keyed route.
- **`route.test.ts`** (new) — behavioral tests: **401 when unauthenticated** (and the SBOM loader is never called), 404 when authenticated with no BOM, 200 with correct CycloneDX headers when authenticated.

### No regression

The legitimate operator download is unaffected — the UI uses a same-origin anchor navigation that carries the session cookie.

### Verification

Tests follow the proven `build/[buildId]/evidence/[fileName]/route.test.ts` mock pattern. They were **not run locally** (this source-only worktree has no `node_modules`); CI executes them on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
