### PR TITLE
feat(archetypes): law-enforcement agency archetype — no-CJI Phase 1 (BI-C1578821)

### DIFF
--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -212,6 +212,7 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
   // Cooperative (nonprofit-community)
   "cooperative": ["Membership", "Member Services", "Patronage & Equity", "Governance"],
   "municipal-utility": ["Residential", "Commercial", "Irrigation", "Connection Fees", "Service Orders"],
+  "law-enforcement-agency": ["Records", "Permits", "Community Programs", "Professional Standards"],
 };
 
 export function getCategorySuggestions(archetypeId: string | null | undefined): string[] {

--- a/docs/superpowers/plans/2026-06-10-law-enforcement-archetype.md
+++ b/docs/superpowers/plans/2026-06-10-law-enforcement-archetype.md
@@ -1,0 +1,72 @@
+# Implementation Plan — Law-Enforcement Agency Archetype (no-CJI Phase 1)
+
+- **Backlog item:** `BI-C1578821` (epic `EP-ARCH-8D4F2A`; triaged `build`, size `large`)
+- **Design spec:** [`docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md`](../specs/2026-06-09-civic-and-member-governed-archetypes-design.md) §7 (law-enforcement note), §10, §12 Phase 2 item 10
+- **Depends on:** small-town public-sector base (merged — records-request, service-request-311, public-body-governance, fund-accounting all landed this session)
+- **Date:** 2026-06-10
+
+**HARD CONSTRAINT (spec §4.6, §13.6): Phase 1 stores NO criminal justice information.**
+No case/incident records, no RMS, no evidence/BWC media, no NCIC/CAD. The activation
+summary must state the CJIS Phase-2 gate explicitly. Anything touching case data is a
+separate future spec + security review.
+
+Substrate verdict (verify-substrate-first): **zero new Prisma models.** The police
+archetype reuses the public-sector base surfaces (records-request, service-request,
+public-body governance), the existing `Policy` / `PolicyAcknowledgment` models for policy
+attestation, the existing `TrainingRequirement` model for POST hours, and seeds a
+compliance pack on the existing Regulation/Obligation/Control substrate. The only genuinely
+new thing is the archetype definition + the pack + a Community vocabulary skin. This is the
+cheapest archetype of the initiative by design — the no-CJI scoping is what makes it small.
+
+## Slice — archetype + compliance pack (one PR)
+
+- `packages/storefront-templates/src/archetypes/public-sector.ts` — add
+  `law-enforcement-agency`: axes `resident` / `public-body` / `statutory-fees-and-levies`
+  / fund-accounting (via finance wiring, same as town); item templates are **non-CJI
+  citizen intake only** — Request a Records Copy (with the LE exemption note),
+  File a Compliment or Complaint, Alarm Permit Application, Public-Records Request,
+  Community Concern; sections Hero / About the Department / Services & Programs /
+  Command & Staff / Contact; vocabulary skin Community / Community Portal / Requests &
+  Reports / Community Liaison. seededServiceCategories: Records, Permits, Community
+  Programs, Professional Standards. **No capabilityOverride** — the public-body rules
+  derive the right set; member-equity stays not-applicable.
+- `apps/web/lib/storefront/archetype-vocabulary.ts` — `law-enforcement-agency` category
+  suggestions; the Community vocabulary ships via the archetype `vocabulary` field
+  (customVocabulary mechanism), same as utility/co-op.
+- `packages/db/src/seed-law-enforcement-compliance.ts` — pack on the existing substrate,
+  `industry: "public-safety"`:
+  - `REG-US-STATE-POST` (Peace Officer Standards & Training): annual in-service training
+    hours per officer, officer certification currency, decertification reporting,
+    firearms/use-of-force qualification cadence.
+  - `REG-US-LE-POLICY-ATTESTATION`: use-of-force policy issued + attested, body-worn-camera
+    policy + retention schedule (state-configurable), pursuit policy, complaint-intake &
+    internal-affairs process.
+  - `REG-US-CJIS-READINESS` (**Phase-2 GATE, not a compliance claim**): a single readiness
+    checklist obligation flagged as a future gate — MFA/advanced authentication, audit
+    logging, encryption at rest/in transit, personnel screening — with applicability text
+    stating "Required BEFORE any criminal-justice-information feature; Phase 1 stores no
+    CJI." Category `operational`, frequency `event-driven`.
+  Controls: POST Training Tracker (TrainingRequirement-backed), Policy Issuance &
+  Attestation (Policy/PolicyAcknowledgment-backed), CJIS Readiness Checklist. Wired into
+  seed.ts after the cooperative pack; pure-data integrity test.
+
+## Verification
+
+Package vitest + typecheck (storefront-templates, db) + full web vitest before push; then
+fresh-runtime verification on the shared lease: onboard a police department, confirm
+Community vocabulary, public-body governance surface (no member-equity, no records-request
+*duty* removed — police DO answer records requests, so records-request stays active with
+LE exemption handling), the non-CJI citizen items on the public site, a citizen
+records-copy request landing in the queue, and the three compliance packs in the library
+**including the CJIS readiness gate rendering as a Phase-2 item, not a satisfied control.**
+Confirm no table persists CJI. Record evidence; close BI.
+
+## Risks & rollback
+
+- **CJIS over-claim** is the headline risk — mitigated by making the CJIS entry a single
+  explicit readiness-gate obligation with applicability text that says "Phase 1 stores no
+  CJI," verified live to render as a gate not a green control.
+- Records-request applies to police (they have FOIA duties), unlike the co-op — so unlike
+  the cooperative the police archetype keeps the Records Requests link. Confirmed by the
+  derived capability set (public-body → records-request required).
+- All additive (archetype + seed); revert the PR. No migration.

--- a/packages/db/src/seed-law-enforcement-compliance.ts
+++ b/packages/db/src/seed-law-enforcement-compliance.ts
@@ -1,0 +1,314 @@
+import type { PrismaClient } from "../generated/client/client";
+import * as crypto from "crypto";
+
+// BI-C1578821 — law-enforcement compliance pack (civic spec §10).
+// industry "public-safety". Phase 1 is NO-CJI by design: this pack covers POST
+// training, policy attestation, and a CJIS READINESS GATE that is an explicit
+// Phase-2 prerequisite, NOT a satisfied control.
+
+function makeId(prefix: string): string {
+  const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
+  return `${prefix}-${hex}`;
+}
+
+type ObligationSeed = {
+  title: string;
+  reference: string;
+  description: string;
+  category: string;
+  frequency: string;
+  applicability: string;
+  penaltySummary: string | null;
+};
+
+type RegulationSeed = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string;
+  sourceType: "external";
+  notes: string;
+  obligations: ObligationSeed[];
+};
+
+export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
+  {
+    regulationId: "REG-US-STATE-POST",
+    name: "Peace Officer Standards & Training (state POST)",
+    shortName: "POST",
+    jurisdiction: "US-state",
+    industry: "public-safety",
+    sourceType: "external",
+    notes:
+      "State Peace Officer Standards and Training (POST) commissions set officer " +
+      "certification, mandated annual in-service training hours, firearms and use-of-force " +
+      "qualification, and decertification reporting. Hour requirements and cadence vary by " +
+      "state; configure from the agency's state.",
+    obligations: [
+      {
+        title: "Annual in-service training hours per officer",
+        reference: "post/in-service-hours",
+        description:
+          "Each sworn officer completes the state-mandated annual in-service training hours " +
+          "(commonly 20–40), with documented topics. Track completion per officer against the " +
+          "state requirement and flag shortfalls before the reporting deadline.",
+        category: "operational",
+        frequency: "annual",
+        applicability: "All sworn officers",
+        penaltySummary: "Officers below required hours may lose certification eligibility.",
+      },
+      {
+        title: "Officer certification currency",
+        reference: "post/certification-currency",
+        description:
+          "Maintain current POST certification for every sworn officer (initial academy, " +
+          "field training completion, and continuing requirements). Track certification status " +
+          "and expirations.",
+        category: "operational",
+        frequency: "continuous",
+        applicability: "All sworn officers",
+        penaltySummary: "Employing an uncertified officer exposes the agency to liability.",
+      },
+      {
+        title: "Firearms & use-of-force qualification cadence",
+        reference: "post/use-of-force-qualification",
+        description:
+          "Conduct and document firearms qualification and use-of-force/defensive-tactics " +
+          "training on the state-required cadence (commonly annual or semi-annual).",
+        category: "operational",
+        frequency: "annual",
+        applicability: "All sworn officers carrying firearms",
+        penaltySummary: null,
+      },
+      {
+        title: "Decertification & separation reporting",
+        reference: "post/decertification-reporting",
+        description:
+          "Report officer separations for misconduct and decertification events to the state " +
+          "POST commission (and the national decertification index where applicable) within the " +
+          "statutory window.",
+        category: "operational",
+        frequency: "event-driven",
+        applicability: "Agency professional-standards function",
+        penaltySummary: null,
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-LE-POLICY-ATTESTATION",
+    name: "Law Enforcement Policy Issuance & Attestation",
+    shortName: "LE Policy",
+    jurisdiction: "US-state",
+    industry: "public-safety",
+    sourceType: "external",
+    notes:
+      "Agencies must issue, update, and obtain officer attestation to core policies, and " +
+      "retain body-worn-camera footage per state schedules. Specifics vary by state and " +
+      "agency accreditation (e.g. CALEA).",
+    obligations: [
+      {
+        title: "Use-of-force policy issued and attested",
+        reference: "le-policy/use-of-force",
+        description:
+          "Maintain a current use-of-force policy (including de-escalation and duty-to-intervene " +
+          "where required) and obtain documented officer attestation on issuance and material update.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "All sworn officers",
+        penaltySummary: "Outdated or un-attested policy is a frequent civil-liability finding.",
+      },
+      {
+        title: "Body-worn camera policy and retention schedule",
+        reference: "le-policy/bwc-retention",
+        description:
+          "Maintain a body-worn-camera policy and retain footage per the state schedule " +
+          "(non-evidentiary commonly 60–90 days; use-of-force/complaint footage longer). " +
+          "Configure the retention window from the agency's state. NOTE: Phase 1 tracks the " +
+          "POLICY and schedule only — it stores no footage (CJI/evidence is Phase 2).",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "Agencies deploying body-worn cameras",
+        penaltySummary: null,
+      },
+      {
+        title: "Complaint intake & internal-affairs process",
+        reference: "le-policy/complaint-intake",
+        description:
+          "Maintain an accessible citizen complaint-intake process and a documented internal-" +
+          "affairs/professional-standards review workflow with defined timelines and disposition records.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "All agencies",
+        penaltySummary: null,
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-CJIS-READINESS",
+    name: "FBI CJIS Security Policy — Readiness Gate (Phase 2 prerequisite)",
+    shortName: "CJIS Gate",
+    jurisdiction: "US-federal",
+    industry: "public-safety",
+    sourceType: "external",
+    notes:
+      "The FBI CJIS Security Policy governs any system that stores, processes, or transmits " +
+      "criminal justice information (CJI). DPF Phase 1 for law enforcement stores NO CJI. This " +
+      "single readiness obligation is a GATE that must be satisfied BEFORE any case/incident/" +
+      "evidence feature is enabled — it is not a Phase-1 compliance claim.",
+    obligations: [
+      {
+        title: "CJIS Security Policy readiness — REQUIRED before any CJI feature (Phase 2 gate)",
+        reference: "cjis/readiness-gate",
+        description:
+          "Before DPF may store, process, or transmit any criminal justice information, the agency " +
+          "and the deployment must satisfy the CJIS Security Policy: advanced authentication (MFA), " +
+          "encryption of CJI in transit and at rest, comprehensive audit logging, personnel security " +
+          "screening, and physical/media protection. This is a Phase-2 gate; Phase 1 stores no CJI and " +
+          "makes no CJIS compliance claim. Do NOT mark satisfied until a security review confirms it.",
+        category: "operational",
+        frequency: "event-driven",
+        applicability: "Required before enabling any criminal-justice-information feature (Phase 2)",
+        penaltySummary: "CJI handling without CJIS compliance can terminate the agency's CJIS access.",
+      },
+    ],
+  },
+];
+
+type ControlSeed = {
+  title: string;
+  description: string;
+  controlType: "preventive" | "detective" | "corrective";
+  obligationRefs: string[];
+};
+
+export const LAW_ENFORCEMENT_CONTROLS: ControlSeed[] = [
+  {
+    title: "POST Training & Certification Tracker",
+    description:
+      "Per-officer record of in-service hours, certification status/expiry, and firearms/use-of-force " +
+      "qualification against the state POST requirement, backed by the training-requirement substrate.",
+    controlType: "detective",
+    obligationRefs: [
+      "post/in-service-hours",
+      "post/certification-currency",
+      "post/use-of-force-qualification",
+    ],
+  },
+  {
+    title: "Policy Issuance & Attestation Register",
+    description:
+      "Register of core policies (use-of-force, BWC, complaint intake) with officer attestation on " +
+      "issuance and update, backed by the policy/acknowledgment substrate.",
+    controlType: "preventive",
+    obligationRefs: [
+      "le-policy/use-of-force",
+      "le-policy/bwc-retention",
+      "le-policy/complaint-intake",
+    ],
+  },
+  {
+    title: "CJIS Readiness Checklist (Phase-2 gate)",
+    description:
+      "Checklist tracking CJIS Security Policy prerequisites — MFA, encryption, audit logging, personnel " +
+      "screening — that MUST be satisfied before any CJI feature. Tracked as a future gate, not a " +
+      "Phase-1 control.",
+    controlType: "preventive",
+    obligationRefs: ["cjis/readiness-gate"],
+  },
+];
+
+export async function seedLawEnforcementCompliance(prisma: PrismaClient): Promise<void> {
+  let regUpserts = 0;
+  let oblCreated = 0;
+  let ctlCreated = 0;
+  let linksCreated = 0;
+
+  const oblIdByRef = new Map<string, string>();
+
+  for (const reg of LAW_ENFORCEMENT_REGULATIONS) {
+    const { obligations, ...regData } = reg;
+    const regulation = await prisma.regulation.upsert({
+      where: { regulationId: regData.regulationId },
+      update: {
+        name: regData.name,
+        shortName: regData.shortName,
+        jurisdiction: regData.jurisdiction,
+        industry: regData.industry,
+        notes: regData.notes,
+      },
+      create: regData,
+    });
+    regUpserts++;
+
+    for (const obl of obligations) {
+      const existing = await prisma.obligation.findFirst({
+        where: { regulationId: regulation.id, reference: obl.reference, status: "active" },
+        select: { id: true },
+      });
+      if (existing) {
+        oblIdByRef.set(obl.reference, existing.id);
+        continue;
+      }
+      const created = await prisma.obligation.create({
+        data: {
+          obligationId: makeId("OBL"),
+          regulationId: regulation.id,
+          title: obl.title,
+          description: obl.description,
+          reference: obl.reference,
+          category: obl.category,
+          frequency: obl.frequency,
+          applicability: obl.applicability,
+          penaltySummary: obl.penaltySummary,
+        },
+      });
+      oblIdByRef.set(obl.reference, created.id);
+      oblCreated++;
+    }
+  }
+
+  for (const ctl of LAW_ENFORCEMENT_CONTROLS) {
+    const existing = await prisma.control.findFirst({
+      where: { title: ctl.title, status: "active" },
+      select: { id: true },
+    });
+    const controlId =
+      existing?.id ??
+      (
+        await prisma.control.create({
+          data: {
+            controlId: makeId("CTL"),
+            title: ctl.title,
+            description: ctl.description,
+            controlType: ctl.controlType,
+            implementationStatus: "planned",
+          },
+        })
+      ).id;
+    if (!existing) ctlCreated++;
+
+    for (const ref of ctl.obligationRefs) {
+      const oblId = oblIdByRef.get(ref);
+      if (!oblId) {
+        throw new Error(
+          `[seed-law-enforcement-compliance] control "${ctl.title}" references unknown obligation "${ref}"`,
+        );
+      }
+      const link = await prisma.controlObligationLink.findUnique({
+        where: { controlId_obligationId: { controlId, obligationId: oblId } },
+      });
+      if (!link) {
+        await prisma.controlObligationLink.create({ data: { controlId, obligationId: oblId } });
+        linksCreated++;
+      }
+    }
+  }
+
+  const expectedObligations = LAW_ENFORCEMENT_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+  console.log(
+    `[seed] law-enforcement compliance pack: ${regUpserts}/${LAW_ENFORCEMENT_REGULATIONS.length} regulations upserted, ` +
+      `${oblCreated} obligations created (${expectedObligations} expected total), ` +
+      `${ctlCreated} controls created, ${linksCreated} links created`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -16,6 +16,7 @@ import { seedWorkforceReferenceData } from "./workforce-seed.js";
 import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
 import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
 import { seedCooperativeCompliance } from "./seed-cooperative-compliance.js";
+import { seedLawEnforcementCompliance } from "./seed-law-enforcement-compliance.js";
 import { seedBusinessCapabilityPerspective } from "./business-capability-perspectives.js";
 import { seedGeographicData } from "./seed-geographic-data.js";
 import { seedTaxJurisdictions } from "./seed-tax-jurisdictions.js";
@@ -2536,6 +2537,7 @@ async function main(): Promise<void> {
   await step("storefrontArchetypes", () => seedStorefrontArchetypes(prisma));
   await step("publicSectorCompliance", () => seedPublicSectorCompliance(prisma));
   await step("cooperativeCompliance", () => seedCooperativeCompliance(prisma));
+  await step("lawEnforcementCompliance", () => seedLawEnforcementCompliance(prisma));
   await step("businessCapabilityPerspective", async () => {
     const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(

--- a/packages/db/test/seed-law-enforcement-compliance.test.ts
+++ b/packages/db/test/seed-law-enforcement-compliance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  LAW_ENFORCEMENT_CONTROLS,
+  LAW_ENFORCEMENT_REGULATIONS,
+} from "../src/seed-law-enforcement-compliance";
+
+// Pure-data integrity tests — no database. Mirrors the public-sector pack tests.
+
+describe("law-enforcement compliance pack data", () => {
+  it("ships POST, policy attestation, and the CJIS readiness gate with expected counts", () => {
+    expect(LAW_ENFORCEMENT_REGULATIONS.map((r) => r.regulationId).sort()).toEqual([
+      "REG-US-CJIS-READINESS",
+      "REG-US-LE-POLICY-ATTESTATION",
+      "REG-US-STATE-POST",
+    ]);
+    const total = LAW_ENFORCEMENT_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+    expect(total).toBe(8);
+    for (const reg of LAW_ENFORCEMENT_REGULATIONS) {
+      expect(reg.industry).toBe("public-safety");
+      expect(reg.obligations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("frames the CJIS entry as a Phase-2 gate, not a Phase-1 compliance claim", () => {
+    const cjis = LAW_ENFORCEMENT_REGULATIONS.find((r) => r.regulationId === "REG-US-CJIS-READINESS");
+    expect(cjis).toBeDefined();
+    expect(cjis!.obligations).toHaveLength(1);
+    const gate = cjis!.obligations[0]!;
+    // The applicability and description must make the no-CJI Phase-1 boundary explicit.
+    expect(gate.applicability.toLowerCase()).toContain("phase 2");
+    expect(gate.description.toLowerCase()).toContain("phase 1 stores no cji");
+  });
+
+  it("obligation references are globally unique", () => {
+    const refs = LAW_ENFORCEMENT_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference));
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it("every control references only known obligations", () => {
+    const known = new Set(
+      LAW_ENFORCEMENT_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference)),
+    );
+    for (const control of LAW_ENFORCEMENT_CONTROLS) {
+      expect(control.obligationRefs.length).toBeGreaterThan(0);
+      for (const ref of control.obligationRefs) {
+        expect(known.has(ref), `${control.title} references unknown obligation ${ref}`).toBe(true);
+      }
+    }
+  });
+
+  it("every obligation carries the fields the compliance surfaces render", () => {
+    for (const reg of LAW_ENFORCEMENT_REGULATIONS) {
+      for (const obl of reg.obligations) {
+        expect(obl.title.length).toBeGreaterThan(10);
+        expect(obl.description.length).toBeGreaterThan(40);
+        expect(["governance", "operational"]).toContain(obl.category);
+        expect(["event-driven", "continuous", "annual", "monthly"]).toContain(obl.frequency);
+      }
+    }
+  });
+});

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -251,6 +251,22 @@ describe("existing archetype regression (governance axis is inert)", () => {
     expect(getCapabilityApplicability(profile, "records-request")).toBe("not-applicable");
   });
 
+  it("the law-enforcement archetype derives public-body governance (with records requests) and no member machinery", () => {
+    const police = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "law-enforcement-agency");
+    expect(police?.activationProfile).toBeDefined();
+
+    const profile = readActivationProfile(police?.activationProfile);
+    expect(profile?.axes.governance).toBe("public-body");
+    expect(profile?.axes.primaryConsumer).toBe("resident");
+    expect(getCapabilityApplicability(profile, "public-body-governance")).toBe("required");
+    // Police DO answer public records requests (unlike a co-op).
+    expect(getCapabilityApplicability(profile, "records-request")).toBe("required");
+    expect(getCapabilityApplicability(profile, "service-request-311")).toBe("required");
+    // No member-owned machinery.
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("not-applicable");
+    expect(getCapabilityApplicability(profile, "member-equity")).toBe("not-applicable");
+  });
+
   it("the small-town municipality archetype derives the public-body capability set from its declared axes", () => {
     const town = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "small-town-municipality");
     expect(town?.activationProfile).toBeDefined();

--- a/packages/storefront-templates/src/archetypes/public-sector.ts
+++ b/packages/storefront-templates/src/archetypes/public-sector.ts
@@ -131,4 +131,71 @@ export const publicSectorArchetypes: ArchetypeDefinition[] = [
       ],
     },
   },
+  {
+    // Phase 1 is NO-CJI by design (civic spec §4.6/§13.6): agency operations
+    // around the incumbent RMS — POST training, policy attestation, equipment,
+    // and non-CJI citizen intake. Anything touching case/incident data is a
+    // separate future spec gated on CJIS Security Policy posture.
+    archetypeId: "law-enforcement-agency",
+    name: "Law Enforcement Agency (Police / Sheriff)",
+    category: "public-sector",
+    ctaType: "inquiry",
+    tags: ["police", "sheriff", "law-enforcement", "public-safety", "community", "no-cji", "public-sector"],
+    itemTemplates: [
+      { name: "Request a Records Copy", description: "Request a copy of a crash report, incident report, or other releasable public record (subject to law-enforcement exemptions)", priceType: "free", ctaType: "inquiry" },
+      { name: "File a Compliment or Complaint", description: "Submit a compliment or a complaint about an officer or service interaction", priceType: "free", ctaType: "inquiry" },
+      { name: "Alarm Permit Application", description: "Apply for or renew a residential or commercial alarm permit", priceType: "fixed", ctaType: "inquiry" },
+      { name: "Public Records Request", description: "Request agency records under the state public records law", priceType: "free", ctaType: "inquiry" },
+      { name: "Community Concern", description: "Report a non-emergency community concern or request extra patrol", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About the Department", sortOrder: 1 },
+      { type: "items", title: "Services & Programs", sortOrder: 2 },
+      { type: "team", title: "Command & Staff", sortOrder: 3 },
+      { type: "contact", title: "Contact Us", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...RESIDENT_CONTACT_FIELDS,
+      { name: "requestType", label: "Request type", type: "select" as const, required: true, options: ["Records copy", "Compliment", "Complaint", "Alarm permit", "Community concern", "Other"] },
+      { name: "notes", label: "Details", type: "textarea" as const, required: true },
+    ],
+    // Community skin over the public-sector category vocabulary (civic spec §8).
+    vocabulary: {
+      itemsLabel: "Services & Programs",
+      portalLabel: "Community Portal",
+      stakeholderLabel: "Community",
+      inboxLabel: "Requests & Reports",
+      agentName: "Community Liaison",
+    },
+    activationProfile: {
+      profileType: "standard",
+      modules: ["service-operations", "projects"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "resident",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "statutory-fees-and-levies",
+        provisioning: "none",
+        platform: "no",
+        governance: "public-body",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "standard", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "Records",
+        "Permits",
+        "Community Programs",
+        "Professional Standards",
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

**BI-C1578821** (`EP-ARCH-8D4F2A`) — the third public-sector specialization, completing the town/utility/law-enforcement trio.

- `law-enforcement-agency` archetype (public-sector): `resident` / `public-body` / `statutory-fees-and-levies` axes; **Community / Community Portal / Requests & Reports** vocabulary skin; non-CJI citizen-intake items only. Derives the public-body capability set — `records-request` stays **required** (police answer FOIA, unlike a co-op), no member machinery.
- **HARD no-CJI Phase 1** (spec §4.6/§13.6): zero new schema, zero case/incident/evidence/CAD. POST training reuses `TrainingRequirement`; policy attestation reuses `Policy`/`PolicyAcknowledgment` — the no-CJI scoping is what makes this the cheapest archetype of the initiative.
- Compliance pack (`industry: public-safety`): `REG-US-STATE-POST` (4 obligations), `REG-US-LE-POLICY-ATTESTATION` (3), and `REG-US-CJIS-READINESS` — a **single explicit Phase-2 gate, not a Phase-1 claim**: its applicability and description both state "Phase 1 stores no CJI," and a test asserts that framing so it can never silently render as a satisfied control. 3 linked controls.

## Verification

Full web vitest **10,334 passed**; storefront-templates 59 (incl. the police no-CJI public-body fixture); db pack tests including the CJIS-gate-framing assertion; typechecks green. Fresh-runtime functional verification follows merge (confirm Community vocabulary, records-request active with LE exemption, the CJIS gate rendering as a future item, and no table persisting CJI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)