### PR TITLE
feat(portfolio): seed archetype-derived market offer into Products & Services Sold (BI-4503E6B9) — EP-BOM-WIRING Phase 1

### DIFF
--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -4,14 +4,16 @@ import { prisma } from "@dpf/db";
 import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from "./setup-constants";
 import { seedOrgWwwdCorpus } from "@/lib/onboarding/seed-org-wwwd-corpus";
 import { seedPortfolioDecomposition } from "@/lib/onboarding/seed-portfolio-decomposition";
+import { seedMarketOffer } from "@/lib/onboarding/seed-market-offer";
 import { applyMissionPrompt } from "@/lib/onboarding/apply-mission-prompt";
 
 /**
  * Runs once when initial setup completes: persist the captured mission into
  * the company-mission prompt (visible to every coworker), seed the per-org
- * WWWD corpus, and persist the per-org portfolio decomposition (BI-2D452667).
- * Fail-open and idempotent — onboarding completion must never block on
- * embedding/seeding errors, and the seeds are safe to re-run.
+ * WWWD corpus, persist the per-org portfolio decomposition (BI-2D452667), and
+ * seed the archetype-derived market offer into the Products & Services Sold
+ * portfolio (BI-4503E6B9). Fail-open and idempotent — onboarding completion
+ * must never block on embedding/seeding errors, and the seeds are safe to re-run.
  */
 async function finalizeSetupCompletion(organizationId: string | null): Promise<void> {
   try {
@@ -29,6 +31,7 @@ async function finalizeSetupCompletion(organizationId: string | null): Promise<v
     await applyMissionPrompt({ mission: bc?.mission ?? null });
     await seedOrgWwwdCorpus({ organizationId: orgId });
     await seedPortfolioDecomposition({ organizationId: orgId });
+    await seedMarketOffer({ organizationId: orgId });
   } catch (err) {
     console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", err);
   }

--- a/apps/web/lib/onboarding/seed-market-offer.test.ts
+++ b/apps/web/lib/onboarding/seed-market-offer.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import { seedMarketOffer } from "./seed-market-offer";
+
+const ORG = "org-test-1";
+
+// A real archetype carrying a market offer, so the derive step exercises the
+// actual itemTemplates → ServiceOffering mapping.
+const archetype = ALL_ARCHETYPES.find((a) => a.itemTemplates.length > 0)!;
+const ARCHETYPE_ID = archetype.archetypeId;
+const ITEM_COUNT = archetype.itemTemplates.length;
+
+function makeDb(opts: {
+  archetypeId?: string | null;
+  portfolio?: { id: string } | null;
+  existingProduct?: { id: string } | null;
+}) {
+  const create = vi.fn().mockResolvedValue({ id: "dp-cuid" });
+  const upsert = vi.fn().mockResolvedValue({});
+  const db = {
+    storefrontConfig: {
+      findFirst: vi.fn().mockResolvedValue(
+        opts.archetypeId === undefined ? { archetypeId: ARCHETYPE_ID } : { archetypeId: opts.archetypeId },
+      ),
+    },
+    portfolio: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue(opts.portfolio === undefined ? { id: "port-cuid" } : opts.portfolio),
+    },
+    digitalProduct: {
+      findUnique: vi.fn().mockResolvedValue(opts.existingProduct ?? null),
+      create,
+    },
+    serviceOffering: { upsert },
+  };
+  return { db, create, upsert };
+}
+
+describe("seedMarketOffer (BI-4503E6B9)", () => {
+  it("seeds an offer product + one ServiceOffering per archetype item", async () => {
+    const { db, create, upsert } = makeDb({});
+
+    const result = await seedMarketOffer({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(true);
+    expect(result.alreadyPresent).toBe(false);
+    expect(result.productId).toBe(`DP-MARKET-OFFER-${ORG}`);
+    expect(result.offeringCount).toBe(ITEM_COUNT);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          productId: `DP-MARKET-OFFER-${ORG}`,
+          name: archetype.name,
+          portfolioId: "port-cuid",
+          lifecycleStage: "production",
+          lifecycleStatus: "active",
+        }),
+      }),
+    );
+    expect(upsert).toHaveBeenCalledTimes(ITEM_COUNT);
+    // offerings reference the created product and carry external consumers
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          digitalProductId: "dp-cuid",
+          consumers: ["external"],
+          status: "active",
+        }),
+      }),
+    );
+  });
+
+  it("is non-destructive when the offer product already exists", async () => {
+    const { db, create, upsert } = makeDb({ existingProduct: { id: "dp-existing" } });
+
+    const result = await seedMarketOffer({ organizationId: ORG, db: db as never });
+
+    expect(result).toEqual({
+      seeded: false,
+      alreadyPresent: true,
+      productId: `DP-MARKET-OFFER-${ORG}`,
+      offeringCount: 0,
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the install has no archetype", async () => {
+    const { db, create } = makeDb({ archetypeId: null });
+
+    const result = await seedMarketOffer({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(false);
+    expect(result.productId).toBeNull();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("no-ops for an unknown archetype id", async () => {
+    const { db, create } = makeDb({ archetypeId: "no-such-archetype" });
+
+    const result = await seedMarketOffer({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the Products & Services Sold portfolio is missing", async () => {
+    const { db, create } = makeDb({ portfolio: null });
+
+    const result = await seedMarketOffer({ organizationId: ORG, db: db as never });
+
+    expect(result.seeded).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/onboarding/seed-market-offer.ts
+++ b/apps/web/lib/onboarding/seed-market-offer.ts
@@ -1,0 +1,136 @@
+// Onboarding market-offer seeding (BI-4503E6B9, EP-BOM-WIRING Phase 1).
+//
+// Populates the "Products & Services Sold" portfolio (DPPM "Provided
+// Externally") with the company's actual market offer, derived from the chosen
+// archetype. Each archetype already carries its offer as `itemTemplates`
+// (e.g. a dental practice's "New Patient Examination", "Check-up & Clean") — so
+// a fresh install's portfolio reads like it already understands what the
+// business sells, instead of being empty or showing DPF's own products.
+//
+// Shape (IT4IT v3 / DPPM): one DigitalProduct = the org's offer line, with one
+// ServiceOffering per catalog item. Seeded ONCE from the archetype at setup
+// completion (seed-is-bootstrap); the operator then refines the products and
+// offerings. Idempotent and non-destructive — if the offer product already
+// exists it is left untouched (operator edits preserved). The existing
+// /portfolio surface renders the result; no new UI.
+
+import { prisma } from "@dpf/db";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+/** Stable slug of the Products & Services Sold portfolio root (Portfolio.id is a cuid). */
+const PRODUCTS_AND_SERVICES_SOLD_SLUG = "products_and_services_sold";
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type SeedMarketOfferClient = {
+  storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
+  portfolio: { findUnique: (args: unknown) => Promise<unknown> };
+  digitalProduct: {
+    findUnique: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+  serviceOffering: { upsert: (args: unknown) => Promise<unknown> };
+};
+
+export type SeedMarketOfferInput = {
+  organizationId: string;
+  /** Defaults to the shared prisma client. */
+  db?: SeedMarketOfferClient;
+};
+
+export type SeedMarketOfferResult = {
+  /** True only if the offer product + offerings were created this run. */
+  seeded: boolean;
+  /** True if the offer product already existed (left untouched). */
+  alreadyPresent: boolean;
+  /** The market-offer DigitalProduct.productId, or null when nothing was seeded. */
+  productId: string | null;
+  /** Number of ServiceOfferings created from archetype catalog items. */
+  offeringCount: number;
+};
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Seed the org's market offer into the Products & Services Sold portfolio from
+ * its archetype. Non-destructive: never overwrites an existing offer product.
+ */
+export async function seedMarketOffer(
+  input: SeedMarketOfferInput,
+): Promise<SeedMarketOfferResult> {
+  const db = input.db ?? (prisma as unknown as SeedMarketOfferClient);
+  const organizationId = input.organizationId;
+
+  const empty: SeedMarketOfferResult = {
+    seeded: false,
+    alreadyPresent: false,
+    productId: null,
+    offeringCount: 0,
+  };
+
+  const sf = (await db.storefrontConfig.findFirst({
+    where: { organizationId },
+    select: { archetypeId: true },
+  })) as { archetypeId: string | null } | null;
+
+  const archetypeId = sf?.archetypeId ?? null;
+  if (!archetypeId) return empty;
+
+  const def = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!def || def.itemTemplates.length === 0) return empty;
+
+  const portfolio = (await db.portfolio.findUnique({
+    where: { slug: PRODUCTS_AND_SERVICES_SOLD_SLUG },
+    select: { id: true },
+  })) as { id: string } | null;
+  if (!portfolio) return empty;
+
+  const productId = `DP-MARKET-OFFER-${organizationId}`;
+
+  // Non-destructive: if the offer product already exists, leave it (and its
+  // operator-refined offerings) untouched.
+  const existing = (await db.digitalProduct.findUnique({
+    where: { productId },
+    select: { id: true },
+  })) as { id: string } | null;
+  if (existing) {
+    return { seeded: false, alreadyPresent: true, productId, offeringCount: 0 };
+  }
+
+  const product = (await db.digitalProduct.create({
+    data: {
+      productId,
+      name: def.name,
+      description: `${def.name} — market offer (archetype-seeded; refine as the catalog evolves).`,
+      portfolioId: portfolio.id,
+      lifecycleStage: "production",
+      lifecycleStatus: "active",
+    },
+    select: { id: true },
+  })) as { id: string };
+
+  let offeringCount = 0;
+  for (let i = 0; i < def.itemTemplates.length; i++) {
+    const item = def.itemTemplates[i];
+    const offeringId = `SO-${organizationId}-${i}-${slugify(item.name)}`;
+    await db.serviceOffering.upsert({
+      where: { offeringId },
+      update: {},
+      create: {
+        offeringId,
+        digitalProductId: product.id,
+        name: item.name,
+        description: item.description ?? null,
+        consumers: ["external"],
+        status: "active",
+      },
+    });
+    offeringCount++;
+  }
+
+  return { seeded: true, alreadyPresent: false, productId, offeringCount };
+}


### PR DESCRIPTION
## What
**EP-BOM-WIRING Phase 1.** Populates the **Products & Services Sold** portfolio (DPPM "Provided Externally") with the company's actual market offer, derived from its archetype — instead of leaving it empty or showing DPF's own products.

Each archetype already carries its offer as `itemTemplates` (e.g. a dental practice's *New Patient Examination*, *Check-up & Clean*). `seedMarketOffer`:
- creates **one `DigitalProduct`** (the org's offer line) under the `products_and_services_sold` portfolio (looked up **by slug** — `Portfolio.id` is a cuid),
- creates **one `ServiceOffering` per catalog item**,
- runs **once at setup completion**, **idempotent + non-destructive** (an existing offer product is left untouched, preserving operator edits),
- uses the existing `DigitalProduct.lifecycleStage` field — **no new enum** (EP-LIFECYCLE owns the canonical lifecycle vocabulary).

Wired into `finalizeSetupCompletion` alongside the WWWD + portfolio-decomposition seeds (fail-open). The existing `/portfolio` surface renders the result — **no new UI**, and it's functionally visible on a fresh install.

## Why
Founder goal: the Products & Services Sold portfolio is one of the two business-critical portfolios with nothing wired to it. This makes a fresh install's portfolio read like it understands what the business sells on day one.

## Scope
Net-new; reuses the archetype substrate. No schema change. Independent of EP-LIFECYCLE and WSID. Follow-ons: offer/price/commitment detail (TM Forum SID levels per spec §12.1), lifecycle-stage via EP-LIFECYCLE vocabulary, decomposition edges to Foundational/Manufacturing.

## Test plan
- [x] `vitest run lib/onboarding/seed-market-offer.test.ts` — 5 passed (seed product + offerings, non-destructive, no-archetype, unknown-archetype, missing-portfolio)
- [x] `vitest run lib/onboarding/` — 50 passed
- [x] `pnpm run typecheck` (apps/web) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)