### PR TITLE
feat(wsid): Phase 0 — profession profile kind + professional-practice domain class

### DIFF
--- a/apps/web/lib/decision-perspective/evaluator.test.ts
+++ b/apps/web/lib/decision-perspective/evaluator.test.ts
@@ -12,7 +12,7 @@ import type {
   DecisionPerspectiveProfile,
   PerspectiveMaterial,
 } from "./types";
-import { PLAN_READINESS_DOMAIN_CLASS } from "./types";
+import { DECISION_DOMAIN_CLASSES, PLAN_READINESS_DOMAIN_CLASS } from "./types";
 
 const DOMAIN = PLAN_READINESS_DOMAIN_CLASS;
 
@@ -294,5 +294,27 @@ describe("evaluateDecisionPerspective", () => {
       }),
     );
     expect(result.outcomeType).toBeDefined();
+  });
+
+  it("accepts profession kind without throwing", () => {
+    const result = evaluateDecisionPerspective(
+      baseInput({
+        profile: profile({ kind: "profession" }),
+        riskTier: "medium",
+        materials: [material({ confidenceWeight: 1 })],
+      }),
+    );
+    expect(result.outcomeType).toBeDefined();
+  });
+
+  it("professional-practice is a registered domain class", () => {
+    expect(DECISION_DOMAIN_CLASSES).toContain("professional-practice");
+    const result = evaluateDecisionPerspective(
+      baseInput({
+        questionDomain: "professional-practice",
+        materials: [material({ confidenceWeight: 1 })],
+      }),
+    );
+    expect(result.domainClass).toBe("professional-practice");
   });
 });

--- a/apps/web/lib/decision-perspective/types.ts
+++ b/apps/web/lib/decision-perspective/types.ts
@@ -6,6 +6,7 @@ export const DECISION_PROFILE_KINDS = [
   "persona-real",
   "persona-fictional",
   "persona-synthetic",
+  "profession",
 ] as const;
 export type DecisionPerspectiveProfileKind = typeof DECISION_PROFILE_KINDS[number];
 
@@ -15,7 +16,7 @@ export type DecisionRiskTier = typeof DECISION_RISK_TIERS[number];
 export const DECISION_OUTCOME_TYPES = ["recommend", "arbitrate", "escalate", "defer"] as const;
 export type DecisionOutcomeType = typeof DECISION_OUTCOME_TYPES[number];
 
-export const DECISION_DOMAIN_CLASSES = ["plan-readiness", "architecture-tradeoff", "risk-assessment"] as const;
+export const DECISION_DOMAIN_CLASSES = ["plan-readiness", "architecture-tradeoff", "risk-assessment", "professional-practice"] as const;
 export type DecisionDomainClass = typeof DECISION_DOMAIN_CLASSES[number];
 export const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness" satisfies DecisionDomainClass;
 
@@ -36,6 +37,8 @@ export type DecisionPerspectiveScope = {
   routes?: string[];
   products?: string[];
   riskTiers?: DecisionRiskTier[];
+  professionKey?: string;
+  roles?: string[];
 };
 
 export type DecisionResolverRule = {


### PR DESCRIPTION
## Summary

WSID Phase 0 — the third decision-perspective scope lands as a pure registry addition (BI-A8521438, parent BI-48B3CEC4, epic EP-WSID).

- **`types.ts`**: `"profession"` added to `DECISION_PROFILE_KINDS`; `"professional-practice"` added to `DECISION_DOMAIN_CLASSES`; `DecisionPerspectiveScope` extended with optional `professionKey` and `roles` fields.
- **`evaluator.test.ts`**: profession-kind acceptance test (mirrors the `persona-real`/`persona-fictional`/`persona-synthetic` pattern); `professional-practice` domain-class round-trip (array membership + evaluator passthrough).
- Zero DB migration — `DecisionPerspectiveProfile.kind` and `PerspectiveMaterial.domainClass` are open string columns; the TS registry is the only gate.
- Zero behavior change — no resolver or gate logic touched.

## Test plan

- [ ] `pnpm --filter web exec vitest run lib/decision-perspective` — all prior tests green + 2 new cases green
- [ ] `pnpm --filter web typecheck` — clean
- [ ] Existing profile kinds and domain classes unchanged (registry-only addition)

Unblocks Phase 1: Profession Source Registry + all ~18 family profiles + role resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)