### PR TITLE
feat(wsid): Phase 1 — Profession Source Registry + 23 family profiles + role resolver

### DIFF
--- a/apps/web/lib/decision-perspective/resolve-profession-profile.test.ts
+++ b/apps/web/lib/decision-perspective/resolve-profession-profile.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  findProfessionFamily,
+  professionKeyFromRole,
+  professionProfileId,
+  PROFESSION_REGISTRY,
+  resolveProfessionProfile,
+  type ProfessionProfileClient,
+} from "./resolve-profession-profile";
+// Platform profile ID — must match seed-decision-perspective.ts MARK_DPF_PLATFORM_PROFILE_ID
+const PLATFORM_PROFILE_ID = "mark-dpf-platform";
+
+// ─── Fake DB client ──────────────────────────────────────────────────────────
+
+function fakeDb(profileId: string): ProfessionProfileClient {
+  return {
+    decisionPerspectiveProfile: {
+      findUnique: async (args) => {
+        if (args.where.profileId !== profileId) return null;
+        return {
+          profileId,
+          name: "Test Profession Profile",
+          kind: "profession",
+          scope: { domains: ["professional-practice"], professionKey: "data-architect", roles: ["build-data-architect", "data-architect"] },
+          fallbackProfileId: PLATFORM_PROFILE_ID,
+          defaultResolver: { type: "build-studio-owner" },
+          autonomyPolicy: {
+            allowRecommendation: true,
+            allowArbitration: false,
+            maxRiskForArbitration: "low",
+            minimumConfidenceForRecommendation: 0.55,
+            minimumConfidenceForArbitration: 0.9,
+          },
+          currentVersion: {
+            versionId: `${profileId}-v1`,
+            versionNumber: 1,
+            materialFingerprint: "empty",
+            changeSummary: "Initial empty profession profile.",
+            createdAt: new Date("2026-06-11T00:00:00.000Z"),
+          },
+        };
+      },
+    },
+  };
+}
+
+function emptyDb(): ProfessionProfileClient {
+  return {
+    decisionPerspectiveProfile: {
+      findUnique: async () => null,
+    },
+  };
+}
+
+// ─── Pure registry helpers ───────────────────────────────────────────────────
+
+describe("findProfessionFamily", () => {
+  it("finds a family by canonical agent_name", () => {
+    const family = findProfessionFamily("build-data-architect");
+    expect(family).not.toBeNull();
+    expect(family?.professionKey).toBe("data-architect");
+  });
+
+  it("finds a family by prompt-slug alias", () => {
+    const family = findProfessionFamily("data-architect");
+    expect(family).not.toBeNull();
+    expect(family?.professionKey).toBe("data-architect");
+  });
+
+  it("returns null for an unregistered identifier", () => {
+    expect(findProfessionFamily("totally-unknown-agent")).toBeNull();
+  });
+});
+
+describe("professionKeyFromRole", () => {
+  it("returns the professionKey for a registered agent", () => {
+    expect(professionKeyFromRole("build-software-engineer")).toBe("software-engineer");
+  });
+
+  it("returns null for an unregistered agent", () => {
+    expect(professionKeyFromRole("not-an-agent")).toBeNull();
+  });
+});
+
+describe("professionProfileId", () => {
+  it("produces the deterministic profile id convention", () => {
+    expect(professionProfileId("data-architect")).toBe("wsid-data-architect");
+    expect(professionProfileId("finance")).toBe("wsid-finance");
+  });
+});
+
+// ─── DB-driven resolver ──────────────────────────────────────────────────────
+
+describe("resolveProfessionProfile", () => {
+  it("resolves a profile by agent_name", async () => {
+    const db = fakeDb("wsid-data-architect");
+    const result = await resolveProfessionProfile({ db, agentId: "build-data-architect" });
+    expect(result).not.toBeNull();
+    expect(result?.profileId).toBe("wsid-data-architect");
+    expect(result?.kind).toBe("profession");
+  });
+
+  it("resolves a profile by prompt-slug alias", async () => {
+    const db = fakeDb("wsid-data-architect");
+    const result = await resolveProfessionProfile({ db, roleSlug: "data-architect" });
+    expect(result).not.toBeNull();
+    expect(result?.profileId).toBe("wsid-data-architect");
+  });
+
+  it("returns null for an unbound identifier", async () => {
+    const db = emptyDb();
+    const result = await resolveProfessionProfile({ db, agentId: "totally-unknown-agent" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when called with no identifier", async () => {
+    const db = emptyDb();
+    const result = await resolveProfessionProfile({ db });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the DB has no matching profile (corpus not yet seeded)", async () => {
+    const db = emptyDb();
+    const result = await resolveProfessionProfile({ db, agentId: "marketing-specialist" });
+    expect(result).toBeNull();
+  });
+
+  it("resolved profile has a fallback chain pointing to the platform profile", async () => {
+    const db = fakeDb("wsid-data-architect");
+    const result = await resolveProfessionProfile({ db, agentId: "build-data-architect" });
+    expect(result?.fallbackProfileId).toBe(PLATFORM_PROFILE_ID);
+  });
+});
+
+// ─── Coverage lint ───────────────────────────────────────────────────────────
+
+describe("profession registry coverage lint", () => {
+  const registryPath = join(__dirname, "../../../../packages/db/data/agent_registry.json");
+  const agentRegistryData = JSON.parse(readFileSync(registryPath, "utf-8")) as {
+    agents: Array<{ agent_name: string; status?: string }>;
+  };
+
+  const activeAgents = agentRegistryData.agents.filter(
+    (a) => !a.status || a.status === "active",
+  );
+
+  const allRegisteredRoles = new Set(
+    PROFESSION_REGISTRY.families.flatMap((f) => f.roles),
+  );
+
+  it("every active registry agent maps to exactly one profession family", () => {
+    const unmapped = activeAgents.filter((a) => !allRegisteredRoles.has(a.agent_name));
+    expect(unmapped, `Unmapped agents: ${unmapped.map((a) => a.agent_name).join(", ")}`).toHaveLength(0);
+  });
+
+  it("no agent_name appears in more than one family", () => {
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+    for (const family of PROFESSION_REGISTRY.families) {
+      for (const role of family.roles) {
+        if (seen.has(role)) {
+          duplicates.push(`${role} in both ${seen.get(role)} and ${family.professionKey}`);
+        } else {
+          seen.set(role, family.professionKey);
+        }
+      }
+    }
+    expect(duplicates, `Duplicate role bindings: ${duplicates.join("; ")}`).toHaveLength(0);
+  });
+
+  it("every family has at least one role bound", () => {
+    const empty = PROFESSION_REGISTRY.families.filter((f) => f.roles.length === 0);
+    expect(empty.map((f) => f.professionKey)).toHaveLength(0);
+  });
+
+  it("every family has at least one source entry", () => {
+    const noSources = PROFESSION_REGISTRY.families.filter((f) => f.sources.length === 0);
+    expect(noSources.map((f) => f.professionKey)).toHaveLength(0);
+  });
+
+  it("all source licenseClass values are valid", () => {
+    const valid = new Set(["open", "licensed", "org-supplied"]);
+    const invalid: string[] = [];
+    for (const family of PROFESSION_REGISTRY.families) {
+      for (const source of family.sources) {
+        if (!valid.has(source.licenseClass)) {
+          invalid.push(`${family.professionKey}/${source.name}: ${source.licenseClass}`);
+        }
+      }
+    }
+    expect(invalid).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/decision-perspective/resolve-profession-profile.ts
+++ b/apps/web/lib/decision-perspective/resolve-profession-profile.ts
@@ -1,0 +1,152 @@
+import type { DecisionPerspectiveProfile } from "./types";
+import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
+import professionRegistryData from "../../../../docs/professions/registry.json";
+
+// ─── Registry types ─────────────────────────────────────────────────────────
+
+export type ProfessionSource = {
+  name: string;
+  url: string;
+  licenseClass: "open" | "licensed" | "org-supplied";
+};
+
+export type ProfessionFamily = {
+  professionKey: string;
+  label: string;
+  roles: string[];
+  contextSlugs: string[];
+  sources: ProfessionSource[];
+  coverageChecklist: string[];
+};
+
+export type ProfessionRegistry = {
+  version: string;
+  description: string;
+  families: ProfessionFamily[];
+};
+
+export const PROFESSION_REGISTRY = professionRegistryData as ProfessionRegistry;
+
+// ─── DB client surface ───────────────────────────────────────────────────────
+
+type DbProfessionProfile = {
+  profileId: string;
+  name: string | null;
+  kind: string | null;
+  scope: Record<string, unknown> | null;
+  fallbackProfileId: string | null;
+  defaultResolver: Record<string, unknown> | null;
+  autonomyPolicy: Record<string, unknown> | null;
+  currentVersion: { versionId: string; versionNumber: number; materialFingerprint: string; changeSummary: string; createdAt: Date } | null;
+};
+
+export type ProfessionProfileClient = {
+  decisionPerspectiveProfile: {
+    findUnique(args: {
+      where: { profileId: string };
+      select: {
+        profileId: boolean;
+        name: boolean;
+        kind: boolean;
+        scope: boolean;
+        fallbackProfileId: boolean;
+        defaultResolver: boolean;
+        autonomyPolicy: boolean;
+        currentVersion: { select: { versionId: boolean; versionNumber: boolean; materialFingerprint: boolean; changeSummary: boolean; createdAt: boolean } };
+      };
+    }): Promise<DbProfessionProfile | null>;
+  };
+};
+
+// ─── Pure registry helpers ───────────────────────────────────────────────────
+
+/**
+ * Find the profession family that claims this agent or role slug. Returns
+ * `null` when the identifier is not bound to any registered family.
+ */
+export function findProfessionFamily(agentIdOrSlug: string): ProfessionFamily | null {
+  return PROFESSION_REGISTRY.families.find((f) => f.roles.includes(agentIdOrSlug)) ?? null;
+}
+
+/**
+ * Return the professionKey for a given agent identifier, or `null` when the
+ * agent is not registered in any family. Pure function — no DB access needed.
+ */
+export function professionKeyFromRole(agentIdOrSlug: string): string | null {
+  return findProfessionFamily(agentIdOrSlug)?.professionKey ?? null;
+}
+
+/**
+ * Compute the deterministic profileId for a profession family. Seeded profiles
+ * follow this convention: `wsid-${professionKey}`.
+ */
+export function professionProfileId(professionKey: string): string {
+  return `wsid-${professionKey}`;
+}
+
+// ─── DB-driven resolver ──────────────────────────────────────────────────────
+
+/**
+ * Resolve a profession profile for a given agent identifier or role slug
+ * (WSID Phase 1, BI-3AC81394).
+ *
+ * Resolution path:
+ *   agentId / roleSlug → registry family → professionKey → profileId →
+ *   DB lookup → DecisionPerspectiveProfile
+ *
+ * Returns `null` when:
+ *   - the identifier maps to no registered family (unbound role)
+ *   - the family's profile does not yet exist in the DB (corpus not yet seeded)
+ *
+ * Mirror of `resolveProfileMaterialForOrg` (BI-230C9EF7): takes an injected
+ * `db` client so callers in tests can pass a structural fake without touching
+ * a real database.
+ */
+export async function resolveProfessionProfile(input: {
+  db: ProfessionProfileClient;
+  agentId?: string;
+  roleSlug?: string;
+}): Promise<DecisionPerspectiveProfile | null> {
+  const key = input.agentId ?? input.roleSlug;
+  if (!key) return null;
+
+  const family = findProfessionFamily(key);
+  if (!family) return null;
+
+  const profileId = professionProfileId(family.professionKey);
+
+  const row = await input.db.decisionPerspectiveProfile.findUnique({
+    where: { profileId },
+    select: {
+      profileId: true,
+      name: true,
+      kind: true,
+      scope: true,
+      fallbackProfileId: true,
+      defaultResolver: true,
+      autonomyPolicy: true,
+      currentVersion: {
+        select: {
+          versionId: true,
+          versionNumber: true,
+          materialFingerprint: true,
+          changeSummary: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!row || !row.currentVersion) return null;
+
+  return {
+    profileId: row.profileId,
+    name: row.name ?? family.label,
+    kind: (row.kind ?? "profession") as DecisionPerspectiveProfile["kind"],
+    scope: (row.scope as DecisionPerspectiveProfile["scope"]) ?? { domains: ["professional-practice"], professionKey: family.professionKey, roles: family.roles },
+    fallbackProfileId: row.fallbackProfileId,
+    defaultResolver: (row.defaultResolver as DecisionPerspectiveProfile["defaultResolver"]) ?? MARK_DPF_PLATFORM_PROFILE.defaultResolver,
+    autonomyPolicy: (row.autonomyPolicy as DecisionPerspectiveProfile["autonomyPolicy"]) ?? MARK_DPF_PLATFORM_PROFILE.autonomyPolicy,
+    currentVersion: row.currentVersion,
+  };
+}

--- a/docs/professions/registry.json
+++ b/docs/professions/registry.json
@@ -1,0 +1,725 @@
+{
+  "version": "1.0.0",
+  "description": "Profession Source Registry — maps every active AI Coworker and route persona to exactly one profession family. Each family lists bound roles (agent_name keys + prompt-slug aliases), context slugs for principle retrieval, candidate knowledge sources with license class, and a SFIA/O*NET-derived coverage checklist. Provenance rule: open-class sources are fetched; licensed-class sources are checklist-only or org-supplied uploads (conduit rule, WSID spec §7.7).",
+  "families": [
+    {
+      "professionKey": "data-architect",
+      "label": "Data Architect",
+      "roles": ["build-data-architect", "data-architect"],
+      "contextSlugs": ["data-model", "data-security"],
+      "sources": [
+        {
+          "name": "DAMA DMBOK2 — knowledge area overview (public)",
+          "url": "https://www.dama.org/cpages/body-of-knowledge",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "OWASP SQL Injection Prevention Cheat Sheet",
+          "url": "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OWASP Top 10",
+          "url": "https://owasp.org/www-project-top-ten/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OWASP Query Parameterization Cheat Sheet",
+          "url": "https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html",
+          "licenseClass": "open"
+        },
+        {
+          "name": "ISO/IEC 9075 SQL Standard — public abstracts",
+          "url": "https://www.iso.org/standard/76583.html",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "NIST SP 800-53 Data Security Controls",
+          "url": "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "data-modelling-concepts",
+        "normalisation-and-denormalisation",
+        "sql-standards",
+        "data-security-sql-injection",
+        "data-governance-principles",
+        "schema-migration-practices"
+      ]
+    },
+    {
+      "professionKey": "software-engineer",
+      "label": "Software Engineer",
+      "roles": ["build-software-engineer", "software-engineer"],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "OWASP Application Security Verification Standard (ASVS)",
+          "url": "https://owasp.org/www-project-application-security-verification-standard/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OWASP Top 10",
+          "url": "https://owasp.org/www-project-top-ten/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "Semantic Versioning Specification",
+          "url": "https://semver.org/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "Conventional Commits Specification",
+          "url": "https://www.conventionalcommits.org/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "REST API Design Best Practices (IETF RFC 9110)",
+          "url": "https://www.rfc-editor.org/rfc/rfc9110",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "secure-coding-practices",
+        "api-design-principles",
+        "testing-and-verification",
+        "dependency-management",
+        "code-review-standards",
+        "error-handling-and-logging"
+      ]
+    },
+    {
+      "professionKey": "frontend-engineer",
+      "label": "Frontend Engineer",
+      "roles": ["build-frontend-engineer", "frontend-engineer"],
+      "contextSlugs": ["ui"],
+      "sources": [
+        {
+          "name": "WCAG 2.2 — Web Content Accessibility Guidelines",
+          "url": "https://www.w3.org/TR/WCAG22/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "WAI-ARIA Authoring Practices",
+          "url": "https://www.w3.org/WAI/ARIA/apg/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "MDN Web Docs — CSS, HTML, JS references",
+          "url": "https://developer.mozilla.org/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "wcag-2-2-aa-compliance",
+        "semantic-html",
+        "responsive-design",
+        "design-token-adherence",
+        "keyboard-navigation",
+        "performance-budgets"
+      ]
+    },
+    {
+      "professionKey": "qa-engineer",
+      "label": "QA Engineer",
+      "roles": ["build-qa-engineer", "qa-engineer"],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "ISTQB Glossary (public)",
+          "url": "https://glossary.istqb.org/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OWASP Testing Guide",
+          "url": "https://owasp.org/www-project-web-security-testing-guide/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "test-planning",
+        "unit-and-integration-testing",
+        "regression-testing",
+        "security-testing-basics",
+        "defect-lifecycle",
+        "test-reporting"
+      ]
+    },
+    {
+      "professionKey": "product-manager",
+      "label": "Product Manager",
+      "roles": [
+        "inventory-specialist",
+        "product-backlog-prioritization-agent",
+        "product-backlog-specialist",
+        "roadmap-assembly-agent",
+        "explore-orchestrator",
+        "discovery-triage-reviewer"
+      ],
+      "contextSlugs": ["discovery"],
+      "sources": [
+        {
+          "name": "Agile Alliance — Agile Manifesto and principles",
+          "url": "https://agilemanifesto.org/principles.html",
+          "licenseClass": "open"
+        },
+        {
+          "name": "BABOK Guide overview (public excerpt)",
+          "url": "https://www.iiba.org/career-resources/a-business-analysis-body-of-knowledge/babok/",
+          "licenseClass": "licensed"
+        }
+      ],
+      "coverageChecklist": [
+        "product-vision-and-roadmap",
+        "backlog-prioritisation-wsjf",
+        "user-story-authoring",
+        "stakeholder-management",
+        "product-metrics",
+        "discovery-and-research"
+      ]
+    },
+    {
+      "professionKey": "scrum-master",
+      "label": "Scrum Master / Delivery Lead",
+      "roles": ["ops-coordinator", "release-planning-agent"],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "Scrum Guide 2020",
+          "url": "https://scrumguides.org/scrum-guide.html",
+          "licenseClass": "open"
+        },
+        {
+          "name": "Scaled Agile Framework (SAFe) public principles",
+          "url": "https://scaledagileframework.com/safe-principles/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "sprint-ceremonies",
+        "wip-limits-and-flow",
+        "impediment-removal",
+        "velocity-and-forecasting",
+        "team-health-and-retrospectives"
+      ]
+    },
+    {
+      "professionKey": "finance",
+      "label": "Finance",
+      "roles": ["finance-agent", "investment-analysis-agent", "portfolio-rationalization-agent"],
+      "contextSlugs": ["finance"],
+      "sources": [
+        {
+          "name": "FASB Accounting Standards Codification — public summaries",
+          "url": "https://asc.fasb.org/",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "IFRS Standards — public summaries",
+          "url": "https://www.ifrs.org/issued-standards/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "SOX Section 302/404 — public SEC guidance",
+          "url": "https://www.sec.gov/spotlight/sarbanes-oxley.htm",
+          "licenseClass": "open"
+        },
+        {
+          "name": "PCAOB Auditing Standards (public)",
+          "url": "https://pcaobus.org/Standards/Auditing",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "gaap-and-ifrs-fundamentals",
+        "budget-cap-enforcement",
+        "chargeback-and-cost-attribution",
+        "financial-reporting",
+        "sox-compliance-basics",
+        "investment-scoring"
+      ]
+    },
+    {
+      "professionKey": "portfolio-management",
+      "label": "Portfolio Manager",
+      "roles": [
+        "portfolio-backlog-agent",
+        "portfolio-backlog-specialist",
+        "portfolio-advisor",
+        "evaluate-orchestrator",
+        "gap-analysis-agent",
+        "scope-agreement-agent"
+      ],
+      "contextSlugs": ["portfolio"],
+      "sources": [
+        {
+          "name": "PMI Portfolio Management Standard (public overview)",
+          "url": "https://www.pmi.org/pmbok-guide-standards/foundational/standard-for-portfolio-management",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "WSJF prioritisation — SAFe public",
+          "url": "https://scaledagileframework.com/wsjf/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "portfolio-lifecycle-management",
+        "investment-prioritisation-wsjf",
+        "gap-and-rationalization-analysis",
+        "scope-agreement-authoring",
+        "portfolio-health-metrics"
+      ]
+    },
+    {
+      "professionKey": "marketing",
+      "label": "Marketing Strategist",
+      "roles": ["marketing-specialist"],
+      "contextSlugs": ["marketing"],
+      "sources": [
+        {
+          "name": "AMA — American Marketing Association definitions",
+          "url": "https://www.ama.org/the-definition-of-marketing-what-is-marketing/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "AMA Code of Ethics",
+          "url": "https://www.ama.org/ama-statement-of-ethics/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "CAN-SPAM Act guidance (FTC public)",
+          "url": "https://www.ftc.gov/tips-advice/business-center/guidance/can-spam-act-compliance-guide-business",
+          "licenseClass": "open"
+        },
+        {
+          "name": "GDPR email consent guidance (EU public)",
+          "url": "https://edpb.europa.eu/our-work-tools/our-documents/guidelines/guidelines-052021-interplay-between-article-6_en",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "acquisition-strategy",
+        "campaign-planning",
+        "funnel-analysis",
+        "email-deliverability-and-consent",
+        "marketing-ethics",
+        "brand-strategy"
+      ]
+    },
+    {
+      "professionKey": "hr-people-ops",
+      "label": "HR / People Operations",
+      "roles": ["hr-specialist"],
+      "contextSlugs": ["compliance"],
+      "sources": [
+        {
+          "name": "SHRM Body of Competency and Knowledge (public outline)",
+          "url": "https://www.shrm.org/credentials/certification/pages/shrm-bock.aspx",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "EEOC Guidance (US public)",
+          "url": "https://www.eeoc.gov/laws/guidance",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "capability-mapping",
+        "delegation-and-accountability",
+        "compliance-and-eeoc",
+        "succession-planning",
+        "workforce-development"
+      ]
+    },
+    {
+      "professionKey": "legal-compliance",
+      "label": "Legal & Compliance",
+      "roles": ["licensing-specialist", "policy-specialist", "policy-enforcement-agent"],
+      "contextSlugs": ["compliance"],
+      "sources": [
+        {
+          "name": "SPDX License List (open)",
+          "url": "https://spdx.org/licenses/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "EU AI Act — public text",
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024R1689",
+          "licenseClass": "open"
+        },
+        {
+          "name": "GDPR — official public text",
+          "url": "https://gdpr-info.eu/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "ISO 42001 AI Management System — public abstract",
+          "url": "https://www.iso.org/standard/81230.html",
+          "licenseClass": "licensed"
+        }
+      ],
+      "coverageChecklist": [
+        "software-licensing-spdx",
+        "ai-regulatory-compliance",
+        "data-privacy-gdpr",
+        "policy-lifecycle-management",
+        "jurisdiction-layered-analysis"
+      ]
+    },
+    {
+      "professionKey": "security",
+      "label": "Security Engineer / Data Governance",
+      "roles": ["security-auditor-agent", "data-governance-agent"],
+      "contextSlugs": ["data-security", "compliance"],
+      "sources": [
+        {
+          "name": "CoSAI 12-category AI threat model (public)",
+          "url": "https://www.coalitionforsecureai.org/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OWASP Top 10",
+          "url": "https://owasp.org/www-project-top-ten/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "NIST Cybersecurity Framework (public)",
+          "url": "https://www.nist.gov/cyberframework",
+          "licenseClass": "open"
+        },
+        {
+          "name": "CVE / NVD — NIST National Vulnerability Database",
+          "url": "https://nvd.nist.gov/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "threat-modelling-cosai",
+        "cve-and-sbom-auditing",
+        "supply-chain-security",
+        "data-residency-and-retention",
+        "credential-detection",
+        "attack-surface-analysis"
+      ]
+    },
+    {
+      "professionKey": "devops-platform",
+      "label": "DevOps / Platform Engineer",
+      "roles": [
+        "iac-execution-agent",
+        "deployment-planning-agent",
+        "resource-reservation-agent",
+        "deploy-orchestrator",
+        "platform-engineer"
+      ],
+      "contextSlugs": ["engineering-flow", "release"],
+      "sources": [
+        {
+          "name": "DORA DevOps Research — public reports",
+          "url": "https://dora.dev/research/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "CycloneDX SBOM Specification",
+          "url": "https://cyclonedx.org/specification/overview/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "iac-and-gitops",
+        "deployment-pipeline-design",
+        "dora-metrics",
+        "resource-capacity-planning",
+        "rollback-and-recovery",
+        "observability-and-alerting"
+      ]
+    },
+    {
+      "professionKey": "operations",
+      "label": "IT Operations",
+      "roles": [
+        "operate-orchestrator",
+        "monitoring-agent",
+        "incident-detection-agent",
+        "incident-resolution-agent",
+        "service-support-agent"
+      ],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "ITIL 4 Foundation — public overview",
+          "url": "https://www.axelos.com/certifications/itil-service-management/itil-4-foundation",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "NIST SP 800-61 Computer Security Incident Handling Guide",
+          "url": "https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "incident-severity-classification",
+        "sla-compliance",
+        "runbook-driven-resolution",
+        "post-incident-review",
+        "monitoring-and-alerting-design"
+      ]
+    },
+    {
+      "professionKey": "enterprise-architecture",
+      "label": "Enterprise Architect",
+      "roles": [
+        "architecture-agent",
+        "architecture-definition-agent",
+        "architecture-guardrail-agent",
+        "ea-architect",
+        "governance-orchestrator",
+        "constraint-validation-agent",
+        "evidence-chain-agent"
+      ],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "ArchiMate 4 Specification (public)",
+          "url": "https://pubs.opengroup.org/architecture/archimate3-doc/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "TOGAF Standard overview (public)",
+          "url": "https://www.opengroup.org/togaf",
+          "licenseClass": "licensed"
+        },
+        {
+          "name": "IT4IT Reference Architecture overview",
+          "url": "https://www.opengroup.org/it4it",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "archimate-notation",
+        "togaf-adm-phases",
+        "it4it-value-streams",
+        "conways-law-alignment",
+        "architecture-decision-records",
+        "guardrail-and-constraint-enforcement"
+      ]
+    },
+    {
+      "professionKey": "customer-success",
+      "label": "Customer Success",
+      "roles": [
+        "customer-advisor",
+        "consumer-onboarding-agent",
+        "order-fulfillment-agent",
+        "estate-specialist"
+      ],
+      "contextSlugs": ["storefront"],
+      "sources": [
+        {
+          "name": "Customer Success Association — body of knowledge overview",
+          "url": "https://www.customersuccessassociation.com/library/the-customer-success-manifesto/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "customer-journey-mapping",
+        "onboarding-and-activation",
+        "adoption-and-friction-analysis",
+        "service-level-monitoring",
+        "escalation-and-handoff"
+      ]
+    },
+    {
+      "professionKey": "strategy-executive",
+      "label": "Strategy & Executive",
+      "roles": ["coo-orchestrator", "strategy-alignment-agent", "coo"],
+      "contextSlugs": ["portfolio"],
+      "sources": [
+        {
+          "name": "Balanced Scorecard Institute — public overview",
+          "url": "https://balancedscorecard.org/bsc-basics/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "OKR framework — public methodology",
+          "url": "https://www.whatmatters.com/faqs/okr-meaning-definition-example",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "strategic-theme-management",
+        "okr-and-kpi-alignment",
+        "cross-orchestrator-coordination",
+        "constitutional-governance",
+        "budget-authority-delegation"
+      ]
+    },
+    {
+      "professionKey": "release-service-management",
+      "label": "Release & Service Management",
+      "roles": [
+        "sbom-management-agent",
+        "release-acceptance-agent",
+        "release-orchestrator",
+        "catalog-publication-agent",
+        "service-offer-definition-agent",
+        "subscription-management-agent",
+        "integrate-orchestrator",
+        "consume-orchestrator"
+      ],
+      "contextSlugs": ["release"],
+      "sources": [
+        {
+          "name": "CycloneDX SBOM Specification",
+          "url": "https://cyclonedx.org/specification/overview/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "SPDX License Specification",
+          "url": "https://spdx.github.io/spdx-spec/v2.3/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "ITIL 4 Release Management — public overview",
+          "url": "https://www.axelos.com/certifications/itil-service-management/itil-4-foundation",
+          "licenseClass": "licensed"
+        }
+      ],
+      "coverageChecklist": [
+        "sbom-composition-cyclonedx",
+        "release-gate-package",
+        "service-catalog-management",
+        "subscription-lifecycle",
+        "release-acceptance-criteria"
+      ]
+    },
+    {
+      "professionKey": "ux-design",
+      "label": "UX / Accessibility Designer",
+      "roles": ["ux-accessibility-agent", "ux-accessibility"],
+      "contextSlugs": ["ui"],
+      "sources": [
+        {
+          "name": "WCAG 2.2 — Web Content Accessibility Guidelines",
+          "url": "https://www.w3.org/TR/WCAG22/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "WAI-ARIA Authoring Practices",
+          "url": "https://www.w3.org/WAI/ARIA/apg/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "Nielsen Norman Group UX research (public articles)",
+          "url": "https://www.nngroup.com/articles/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "wcag-2-2-aa-audit",
+        "colour-contrast-and-dark-theme",
+        "keyboard-and-focus-management",
+        "semantic-html-and-aria",
+        "usability-heuristics",
+        "design-system-adherence"
+      ]
+    },
+    {
+      "professionKey": "documentation-content",
+      "label": "Documentation & Content",
+      "roles": ["documentation-specialist"],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "Diátaxis documentation framework",
+          "url": "https://diataxis.fr/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "Mermaid diagramming documentation",
+          "url": "https://mermaid.js.org/intro/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "diataxis-documentation-types",
+        "mermaid-diagram-authoring",
+        "cross-reference-integrity",
+        "it4it-alignment-in-docs"
+      ]
+    },
+    {
+      "professionKey": "build-studio",
+      "label": "Build Studio Specialist",
+      "roles": ["build-specialist", "hive-scout-ambiguity-reviewer"],
+      "contextSlugs": ["build-studio"],
+      "sources": [
+        {
+          "name": "DPF AGENTS.md — public platform rules",
+          "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "build-phase-lifecycle",
+        "design-review-gates",
+        "ideate-plan-build-review-ship",
+        "scope-containment"
+      ]
+    },
+    {
+      "professionKey": "admin-operations",
+      "label": "Platform Administration",
+      "roles": ["admin-assistant", "onboarding-coo"],
+      "contextSlugs": ["engineering-flow"],
+      "sources": [
+        {
+          "name": "DPF platform documentation (public)",
+          "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "platform-configuration",
+        "access-control",
+        "seed-and-migration-management",
+        "first-run-onboarding"
+      ]
+    },
+    {
+      "professionKey": "external-intelligence",
+      "label": "External Intelligence & Scouting",
+      "roles": ["external-catalog-scout"],
+      "contextSlugs": ["discovery"],
+      "sources": [
+        {
+          "name": "Smithery MCP Registry (public)",
+          "url": "https://smithery.ai/",
+          "licenseClass": "open"
+        },
+        {
+          "name": "npm registry public API",
+          "url": "https://registry.npmjs.org/",
+          "licenseClass": "open"
+        }
+      ],
+      "coverageChecklist": [
+        "external-agent-catalog-reconnaissance",
+        "gap-detection",
+        "governed-backlog-suggestion"
+      ]
+    }
+  ]
+}

--- a/packages/db/src/seed-decision-perspective.ts
+++ b/packages/db/src/seed-decision-perspective.ts
@@ -1,4 +1,6 @@
 import { createHash } from "crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Prisma, PrismaClient } from "../generated/client/client";
 
 export const MARK_DPF_PLATFORM_PROFILE_ID = "mark-dpf-platform";
@@ -153,6 +155,112 @@ export function buildDecisionPerspectiveSeed(): DecisionPerspectiveSeed {
     },
     materials,
   };
+}
+
+// ─── Profession profile seeding (WSID Phase 1 — BI-3AC81394) ────────────────
+
+type ProfessionFamilyEntry = {
+  professionKey: string;
+  label: string;
+  roles: string[];
+  contextSlugs: string[];
+};
+
+function loadProfessionFamilies(): ProfessionFamilyEntry[] {
+  const registryPath = join(__dirname, "../../../docs/professions/registry.json");
+  const raw = readFileSync(registryPath, "utf-8");
+  const data = JSON.parse(raw) as { families: ProfessionFamilyEntry[] };
+  return data.families;
+}
+
+/**
+ * Seed one empty DecisionPerspectiveProfile per registered profession family
+ * (kind="profession"). Profiles without corpus still get a row so their
+ * `defer` counts function as the demand signal for Phase 6 rollout order.
+ * Idempotent upsert; loud skip-logging per the silent-seed-skips audit pattern.
+ */
+export async function seedProfessionProfiles(
+  db: DecisionPerspectiveSeedClient,
+): Promise<{ seeded: number; skipped: number }> {
+  const families = loadProfessionFamilies();
+  let seeded = 0;
+  let skipped = 0;
+
+  for (const family of families) {
+    const profileId = `wsid-${family.professionKey}`;
+    const versionId = `wsid-${family.professionKey}-v1`;
+
+    try {
+      await db.decisionPerspectiveProfile.upsert({
+        where: { profileId },
+        update: {
+          name: family.label,
+          kind: "profession",
+          scope: {
+            domains: ["professional-practice"],
+            professionKey: family.professionKey,
+            roles: family.roles,
+          },
+          fallbackProfileId: MARK_DPF_PLATFORM_PROFILE_ID,
+          status: "active",
+        },
+        create: {
+          profileId,
+          name: family.label,
+          kind: "profession",
+          scope: {
+            domains: ["professional-practice"],
+            professionKey: family.professionKey,
+            roles: family.roles,
+          },
+          fallbackProfileId: MARK_DPF_PLATFORM_PROFILE_ID,
+          defaultResolver: { type: "build-studio-owner" },
+          autonomyPolicy: {
+            allowRecommendation: true,
+            allowArbitration: false,
+            maxRiskForArbitration: "low",
+            minimumConfidenceForRecommendation: 0.55,
+            minimumConfidenceForArbitration: 0.9,
+          },
+          status: "active",
+        },
+      });
+
+      await db.decisionPerspectiveProfileVersion.upsert({
+        where: { versionId },
+        update: { changeSummary: `Empty profession profile for ${family.label}.` },
+        create: {
+          versionId,
+          profileId,
+          versionNumber: 1,
+          materialFingerprint: createHash("sha256")
+            .update(`${profileId}-v1-empty`)
+            .digest("hex"),
+          changeSummary: `Empty profession profile for ${family.label}.`,
+        },
+      });
+
+      await db.decisionPerspectiveProfile.update({
+        where: { profileId },
+        data: { currentVersionId: versionId },
+      });
+
+      seeded++;
+    } catch (err) {
+      console.warn(
+        `[seed-profession-profiles] SKIP ${profileId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      skipped++;
+    }
+  }
+
+  if (skipped > 0) {
+    console.warn(
+      `[seed-profession-profiles] ${skipped} profile(s) skipped — check warnings above.`,
+    );
+  }
+
+  return { seeded, skipped };
 }
 
 export async function seedDecisionPerspective(db: DecisionPerspectiveSeedClient): Promise<{


### PR DESCRIPTION
## Summary

WSID Phase 1 (BI-3AC81394, parent BI-48B3CEC4, epic EP-WSID). Full-roster coverage contract made concrete.

- **`docs/professions/registry.json`** — 23 profession families covering all 63 `agent_registry.json` agents + route personas. Each family: `professionKey`, bound `roles` (canonical `agent_name` keys + prompt-slug aliases), `contextSlugs`, candidate `sources` with `licenseClass` (`open`/`licensed`/`org-supplied`), SFIA/O*NET-derived `coverageChecklist`. Coverage lint in CI: every active agent maps to exactly one family; no duplicates.

- **`resolve-profession-profile.ts`** — new resolver. `resolveProfessionProfile({ agentId | roleSlug })` mirrors the `resolveProfileMaterialForOrg` client-injection pattern (BI-230C9EF7). Pure helpers (`findProfessionFamily`, `professionKeyFromRole`, `professionProfileId`) exposed for callers that need registry-only lookups. Deterministic profileId: `wsid-${professionKey}`.

- **`resolve-profession-profile.test.ts`** — resolver hit (agent_name), alias hit (prompt-slug), miss (null), fallback-chain shape, and 5 coverage-lint assertions: all 63 active agents mapped, no duplicates, all families have roles, all families have sources, all licenseClass values valid.

- **`seed-decision-perspective.ts`** — `seedProfessionProfiles()` reads `registry.json` at seed time and upserts one `DecisionPerspectiveProfile` + version row per family (`kind="profession"`, `fallbackProfileId → platform`). Loud skip-logging. No materials seeded (Phase 2 adds data-architect corpus via the research-ingest pipeline).

Zero DB migration. Profiles without corpus still land so their `defer` counts function as the Phase 6 demand signal.

## Test plan

- [ ] `pnpm --filter web exec vitest run lib/decision-perspective/resolve-profession-profile` — all resolver + coverage-lint cases green
- [ ] `pnpm --filter web typecheck` — clean
- [ ] `seedProfessionProfiles` upserts 23 rows + 23 versions on a fresh DB, idempotent on re-run
- [ ] Coverage lint: all 63 active agents mapped; injecting a synthetic unmapped agent → test fails

Unblocks: Phase 2 (research-ingest pipeline + data-architect corpus from fetched sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)