### PR TITLE
doc(build-studio): local-LLM dispatch option — research, design, plan (BI-01D6A51B)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
+++ b/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
@@ -1,0 +1,65 @@
+---
+status: ready
+backlogItem: BI-01D6A51B
+epic: EP-BUILD-STUDIO
+spec: docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md
+date: 2026-06-10
+---
+
+# Local-LLM Build Studio Dispatch — Implementation Plan
+
+Phased so each phase lands as one PR with its own gates. Spec holds the rationale; this file holds the order of operations.
+
+## Phase 0 — Tool admission (no code)
+
+1. Run `/project:tool-evaluation` on **OpenCode** (`opencode-ai` npm package): security, license (MIT), architecture fit, integration. Record the pinned version in `packages/db/data/approved_tools_registry.json`.
+2. Verify the chosen pin's `opencode run` non-interactive behavior and env contract (`OPENAI_BASE_URL`-style provider config) against its docs for that tag — release cadence is fast; do not trust latest-docs for a pinned binary.
+
+Exit: tool registry row merged; exact CLI invocation + env contract documented in the registry entry.
+
+## Phase 1 — Runner + config (the core slice)
+
+1. `agent-runner-types.ts`: add `"local"` to `BuildAgentId`.
+2. New `apps/web/lib/integrate/sandbox/agents/local-agent-runner.ts`:
+   - `prepare()`: no-op (no credential); write OpenCode provider config into the sandbox (`docker exec` a JSON/TOML config naming the local endpoint + model) so the run command is bare.
+   - `run()`: resolve endpoint via `getOllamaBaseUrl()` + sandbox-reachable rewrite (`host.docker.internal` mapping); context-length preflight against `/v1/models` (refuse < 22k with a BLOCKED-classifiable message); exec `cd /workspace && opencode run ... < prompt` with 30-min default timeout and streamed `onProgress` heartbeats; return `AgentRunResult`.
+   - `capabilities()`: `tier: "preview"`, `requiresCredential: false`, `requiresPersistentSession: false`, `honorsLlmBaseUrl: true`.
+3. Register in `agents/index.ts`.
+4. `build-studio-config.ts`: `provider` union += `"local"`; `localProviderId`/`localModel` fields + DEFAULTS; auto-detect via `findConfiguredProvider("local")` (lowest preference — after claude/codex/grok); env overrides `LOCAL_AGENT_PROVIDER_ID`, `LOCAL_AGENT_MODEL`, `CLI_DISPATCH_PROVIDER=local`.
+5. `build-orchestrator.ts`: include `"local"` in the CLI-dispatch branch with providerId/model plumbed from config.
+6. Seed: local provider row (`ollama` / Docker Model Runner) gains `cliEngine: "local"` in `packages/db/src/seed.ts` — seed-on-upgrade safe, no migration (column exists).
+7. Unit tests: config auto-detect/env-override matrix; runner outcome classification on canned CLI outputs; context-preflight refusal.
+
+Exit: `pnpm --filter web exec vitest run` green on new tests; `pnpm --filter web typecheck` green. (Source-local gates in worktree; runtime gates Phase 3.)
+
+## Phase 2 — Sandbox image + admin UI
+
+1. `Dockerfile.sandbox`: `npm install -g opencode-ai@<pin>` (from Phase 0 registry row). No auth material added to the image.
+2. Admin Build Studio dispatch config UI: add "Local model (OpenCode)" option with resolved endpoint + model display, preview-tier banner, and a "no credential required" note. Theme tokens per AGENTS.md §12.
+3. Docs: update the Build Studio operator docs' dispatch-provider section (document at ship).
+
+Exit: sandbox image builds; UI renders all four options; typecheck/build green.
+
+## Phase 3 — Functional verification (the gate that counts)
+
+Structural verification is not functional. On the canonical install (or local-CI convergence sandbox lease):
+
+1. Configure dispatch `provider=local` with the install's default qwen3-family model; confirm the endpoint preflight passes (or honestly blocks if the pulled model's context is too small — then pull a ≥22k-context model and document the requirement).
+2. Drive one real small Build Studio task end-to-end: promote a contained BI → Ideate → build dispatch → observe the local agent edit `/workspace`, run verification, classify outcome → review gate.
+3. Record evidence via the Build Studio evidence tools (drove X, observed Y), naming the substrate.
+4. Capture observed quality honestly: if the 30B-class model can't clear `single-file-edit`-grade tasks, that is the expected preview-tier result — file the eval summary, leave tier at `preview`.
+
+Exit: one end-to-end local-model dispatch with recorded evidence; BI-01D6A51B status updated.
+
+## Phase 4 (follow-on, separate BIs)
+
+- **Aider as a second local engine** if OpenCode's free-form agency proves too weak on small models (aider's structured edits degrade more gracefully).
+- **Frontier-escalation routing** (local first, escalate on BLOCKED/NEEDS_CONTEXT) — file under EP-COST-001.
+- **Eval-driven tier promotion** runs: mini-SWE-agent harness against the install's model to justify `single-file-edit`.
+- **ACP adapter abstraction** when a second ACP-speaking agent is adopted.
+
+## Risks
+
+- **Endpoint reachability from the sandbox container** is the most likely first failure (model-runner network vs sandbox network). Mitigation: explicit sandbox-reachable URL rewrite + a preflight `curl` from inside the container during `prepare()`.
+- **Small-model quality**: managed by preview tier + honest outcome classification; never inflate.
+- **OpenCode churn**: version pin + tool-registry re-evaluation cadence.

--- a/docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md
+++ b/docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md
@@ -1,0 +1,97 @@
+---
+status: approved-pending-operator-review
+backlogItem: BI-01D6A51B
+epic: EP-BUILD-STUDIO
+date: 2026-06-10
+---
+
+# Local-LLM Build Studio Dispatch — Design
+
+## Problem
+
+Build Studio dispatches coding tasks to vendor CLI agents (Claude Code, Codex, Grok) running inside the sandbox container. Every dispatch path requires a frontier API/OAuth credential. An early attempt at local-LLM building predates the current agent-runner substrate and failed on plumbing that now exists (OpenAI-compatible inference layer, `LLM_BASE_URL` override, agent-runner capability tiers, eval-gated promotion).
+
+Goal: a fourth dispatch option powered entirely by a local model (Docker Model Runner / Ollama / vLLM — anything OpenAI-compatible), so an install can run builds:
+
+- **air-gapped / credential-free** — no vendor account at all,
+- **at zero marginal token cost**,
+- **with data sovereignty** — code never leaves the host.
+
+This is the Build Studio analog of the platform's existing local-AI inference story (EP-LOCAL-AI), not a replacement for frontier dispatch. Frontier CLIs remain the quality ceiling; local dispatch is the floor that makes the platform self-sufficient.
+
+## Research & Benchmarking (2026-06-10)
+
+### Why editors don't fit
+
+The operator's candidate list included editor-shaped tools. Build Studio's dispatch contract is headless: prompt in via `docker exec`, commits/diffs out of `/workspace`, no human at a screen. That rules out:
+
+- **Void** — AI-first VS Code fork; GUI-only, and the repo was archived 2026-06-02. Skip.
+- **Zed** — GUI editor. Its **Agent Client Protocol (ACP)** (Apache-2.0, JSON-RPC over stdio, backed by Zed + JetBrains, registry live) is however exactly the shape of our dispatch pipe and is the standard to track for a future adapter abstraction. Cline and others already speak it.
+- **Cursor** — closed-source, GUI; it is a comparison benchmark, not a candidate.
+
+The correct comparison axis is **Claude Code CLI / Codex CLI vs open-source headless agents**.
+
+### Headless open-source agents compared
+
+| Agent | License | Headless mechanism | Local-model support | Fit for our sandbox |
+|---|---|---|---|---|
+| **OpenCode** (sst) | MIT | `opencode run "<prompt>"`; also headless HTTP server mode | Any OpenAI-compatible endpoint; 75+ providers | **Best** — npm-installable into `Dockerfile.sandbox` (node:24-alpine), same one-shot shape as `claude -p` / `codex exec`. ~170k stars; pin the version (fast release cadence). |
+| **Aider** | Apache-2.0 | `aider --message "..."`; Python API; git auto-commit; `--test-cmd` self-fix loop | Any model via LiteLLM; first-class Ollama | **Strong second** — most deterministic diff/commit contract; structured-edit approach degrades most gracefully on small local models. Needs Python in the sandbox image. |
+| **OpenHands** (ex-OpenDevin) | MIT | `openhands --headless -t` + `--json` event stream | LiteLLM; publishes local-model guidance (context ≥ 22k) | **Not a fit inside our sandbox** — it brings its own Docker runtime sandbox, which conflicts with our `BuildExecutionProvider` model. Would be a separate *execution provider*, not an agent runner. Strongest harness if we ever want that. |
+| **Cline CLI 2.0** | Apache-2.0 | `cline -y "task"` (Feb 2026; purpose-built for CI) | BYOK incl. Ollama / OpenAI-compatible | Viable alternate; speaks ACP. |
+| **Continue (`cn`)** | Apache-2.0 | `cn -p "prompt"` | First-class Ollama | Viable; output is final-response-oriented, less structured. |
+| **Goose** (Block / Linux Foundation) | Apache-2.0 | `goose run -t` + YAML recipes | 15+ providers incl. Ollama | Viable; Rust single binary; strong MCP story. |
+| **Qwen Code CLI** | Apache-2.0 | `qwen -p` | Any OpenAI-compatible baseUrl | Viable; tuned for Qwen3-Coder — pairs with our default local model family. |
+| **Crush** (charmbracelet) | FSL-1.1-MIT | `crush run` | OpenAI-compatible | **Rejected** — FSL is not OSI open source. |
+| **Gemini CLI** | Apache-2.0 | `gemini -p` | Limited | **Rejected** — Google stops serving it 2026-06-18. |
+| **mini-SWE-agent** | MIT | batch runner, ~100 lines | LiteLLM / vLLM | Not a dispatch agent, but the right **eval harness** for benchmarking local models before tier promotion. |
+
+### How local stacks stack up vs Claude / Codex / Cursor
+
+- **SWE-bench Verified, June 2026:** best open-weight giants (DeepSeek-V4-Pro, MiniMax M3, Qwen3.7-Max) ≈ 80%; Claude Opus 4.8 ≈ 88.6%, current frontier ≈ 95%. The **consumer-hardware local tier (30B-class)** is ~35–55% — usable for contained tasks, not hard multi-file refactors.
+- **Recommended local model floor:** Qwen3-Coder-30B-A3B-class MoE (3.3B active params, ~17–22 GB at Q4 — one RTX 4090/5090 or 32 GB Mac). Devstral Small 2 and Qwen3.6-35B-A3B are peers. Installer already defaults to the qwen3 family (PR #1047).
+- **Context is the hidden constraint:** real agent runs consume 39k–156k tokens; anything under ~22k context fails outright. The runner must assert/configure context length, not assume it.
+- **Industry pattern (2026):** route the easy 60–80% of agent traffic to local/open models, escalate the hard remainder to frontier APIs. Maps directly onto our capability-tier doctrine: local runner enters at `preview`, earns `single-file-edit` → `multi-file-refactor` via eval evidence — never by assertion.
+
+Patterns adopted: one-shot CLI dispatch shape (Claude/Codex parity), OpenAI-compatible endpoint as the only model contract, version-pinned binary in the sandbox image, eval-gated tier promotion. Patterns rejected: embedding an editor, agent-owned sandboxes (OpenHands), license-encumbered tools (Crush), static model catalogs (discovery comes from the provider's `/v1/models`).
+
+## Design
+
+### Decision: OpenCode runner first, `dpf-native` as the governed end-state
+
+Two complementary paths, not competitors:
+
+1. **`local` agent runner (this spec):** install **OpenCode (pinned)** into `Dockerfile.sandbox` beside the Claude/Codex/Grok CLIs. It is a thin adapter behind the existing `BuildAgentRunner` contract (AGENTS.md §17: thin adapters behind a stable contract). The agent loop runs *inside the sandbox*, like the other vendor CLIs, but inference goes to the install's own endpoint — no credential, no egress.
+2. **`dpf-native` runner (already landed, Phase-1):** the portal-side governed loop with `honorsLlmBaseUrl: true` already unlocks local inference with full `ToolExecution` audit. It stays the strategic path for untrusted-substrate and fully-audited builds; this spec does not change it. When `dpf-native` reaches multi-turn parity, the two options coexist in the dispatch config like Claude and Codex do today.
+
+### Integration points (all substrate exists)
+
+| Surface | File | Change |
+|---|---|---|
+| Agent id | `apps/web/lib/integrate/sandbox/agent-runner-types.ts` | `BuildAgentId` += `"local"` |
+| Runner | `apps/web/lib/integrate/sandbox/agents/local-agent-runner.ts` (new) | `prepare()` no-op (no credential); `run()` execs `opencode run` in `/workspace` with `OPENAI_BASE_URL`/`OPENAI_API_KEY=dpf-local` env pointing at the resolved local endpoint; `capabilities()` → `tier: "preview"`, `requiresCredential: false`, `requiresPersistentSession: false`, `honorsLlmBaseUrl: true` |
+| Registry | `apps/web/lib/integrate/sandbox/agents/index.ts` | register runner |
+| Dispatch config | `apps/web/lib/integrate/build-studio-config.ts` | `provider` union += `"local"`; `localProviderId` / `localModel` fields; auto-detect via `findConfiguredProvider("local")`; env overrides `LOCAL_AGENT_PROVIDER_ID` / `LOCAL_AGENT_MODEL`; `CLI_DISPATCH_PROVIDER=local` |
+| Endpoint resolution | reuse `getOllamaBaseUrl()` (`apps/web/lib/inference/ollama-url.ts`) | honors `LLM_BASE_URL` → `OLLAMA_INTERNAL_URL` → provider row → Docker Model Runner default. Sandbox-reachable URL must be rewritten host-relative (e.g. `host.docker.internal`) — the sandbox container is not on the model-runner network by default. |
+| Orchestrator | `apps/web/lib/integrate/build-orchestrator.ts` | include `"local"` in the CLI-dispatch branch |
+| Sandbox image | `Dockerfile.sandbox` | `npm install -g opencode-ai@<pinned>`; no auth file needed |
+| Provider seed | `packages/db/src/seed.ts` | local provider row gains `cliEngine: "local"` (fix the seed, not the runtime) |
+| Admin UI | Build Studio dispatch config surface | add "Local model (OpenCode)" option; show resolved endpoint + model; surface the preview-tier banner |
+
+### Capability tier & promotion (governance)
+
+The runner is admitted at `tier: "preview"` per the existing onboarding doctrine in `agent-runner-types.ts`. Promotion to `single-file-edit` and beyond requires eval evidence on the install's actual local model — produced by running the same task-level verification (typecheck + tests + outcome classification) that gates every dispatch, optionally benchmarked offline with mini-SWE-agent. Governance approves evidence, not provenance: a local-model build that passes the gates ships like any other.
+
+### Outcome classification & guardrails
+
+- `classifyOutcome()` already maps CLI output to `DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT`; weak local models will land in `NEEDS_CONTEXT`/`BLOCKED` more often — that is the desired honest signal, not a failure of the integration.
+- Context-length preflight: before dispatch, the runner queries the provider's `/v1/models` (or provider row metadata) and refuses dispatch with a clear `BLOCKED` message if the serving context is below 22k tokens.
+- Timeout: local inference is slower; default task timeout rises to 30 min for the `local` runner (configurable), with `onProgress` heartbeats from the CLI's streamed output so the orchestrator's stall detection doesn't false-positive.
+- Tool-evaluation pipeline (AGENTS.md §9): OpenCode enters `packages/db/data/approved_tools_registry.json` version-pinned via `/project:tool-evaluation` before the Dockerfile change merges.
+
+## Out of scope
+
+- Replacing or modifying the `dpf-native` runner (parallel effort, EP-ROUTING-11 / Build-Engine work).
+- OpenHands as an alternative *execution provider* (would be a new `BuildExecutionProviderId`, file under EP-2D477458 if ever wanted).
+- Automatic frontier-escalation routing (local first, escalate on failure) — natural Phase 3 once the local runner has eval history; noted for EP-COST-001.
+- ACP adapter abstraction — track the standard; adopt when a second ACP-speaking agent is wanted.


### PR DESCRIPTION
## Summary

Research + design + phased plan for a fourth Build Studio dispatch option backed entirely by a **local LLM** — no frontier credential, air-gapped capable, zero marginal token cost. Backlog: **BI-01D6A51B** (triaged `build`, medium, EP-BUILD-STUDIO).

- **Spec** (`docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md`): Research & Benchmarking of open-source headless coding agents (OpenCode, Aider, OpenHands, Cline CLI 2.0, Continue, Goose, Qwen Code; Crush/Gemini CLI/Void rejected, Zed's ACP noted as the protocol to track) against the existing Claude Code / Codex CLI dispatch shape; local-model landscape (Qwen3-Coder-30B-class floor, ≥22k context requirement, honest frontier-gap numbers); design decision: thin `local` BuildAgentRunner wrapping a **pinned OpenCode CLI** in the sandbox, pointed at the install's OpenAI-compatible local endpoint via existing `getOllamaBaseUrl()`/`LLM_BASE_URL` plumbing; preview-tier admission with eval-gated promotion; `dpf-native` remains the governed strategic path.
- **Plan** (`docs/superpowers/plans/2026-06-10-local-llm-build-agent.md`): Phase 0 tool-evaluation admission → Phase 1 runner + dispatch config → Phase 2 sandbox image + admin UI → Phase 3 functional verification on the canonical install → Phase 4 follow-ons (Aider second engine, frontier-escalation routing, mini-SWE-agent eval harness).

Docs only — no code, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)