### PR TITLE
doc(build-studio): operator review revisions — local-LLM dispatch spec+plan (BI-01D6A51B)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
+++ b/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
@@ -13,29 +13,29 @@ Phased so each phase lands as one PR with its own gates. Spec holds the rational
 ## Phase 0 — Tool admission (no code)
 
 1. Run `/project:tool-evaluation` on **OpenCode** (`opencode-ai` npm package): security, license (MIT), architecture fit, integration. Record the pinned version in `packages/db/data/approved_tools_registry.json`.
-2. Verify the chosen pin's `opencode run` non-interactive behavior and env contract (`OPENAI_BASE_URL`-style provider config) against its docs for that tag — release cadence is fast; do not trust latest-docs for a pinned binary.
+2. Verify the chosen pin's `opencode run` non-interactive behavior and env contract (`OPENAI_BASE_URL`-style provider config) against its docs for that tag — release cadence is fast; do not trust latest-docs for a pinned binary. Also confirm the pin runs on Alpine/musl as a non-root user (the grok failure mode).
 
 Exit: tool registry row merged; exact CLI invocation + env contract documented in the registry entry.
 
 ## Phase 1 — Runner + config (the core slice)
 
-1. `agent-runner-types.ts`: add `"local"` to `BuildAgentId`.
-2. New `apps/web/lib/integrate/sandbox/agents/local-agent-runner.ts`:
-   - `prepare()`: no-op (no credential); write OpenCode provider config into the sandbox (`docker exec` a JSON/TOML config naming the local endpoint + model) so the run command is bare.
-   - `run()`: resolve endpoint via `getOllamaBaseUrl()` + sandbox-reachable rewrite (`host.docker.internal` mapping); context-length preflight against `/v1/models` (refuse < 22k with a BLOCKED-classifiable message); exec `cd /workspace && opencode run ... < prompt` with 30-min default timeout and streamed `onProgress` heartbeats; return `AgentRunResult`.
+1. `agent-runner-types.ts`: add `"opencode"` to `BuildAgentId` (id names the agent, not the locality — see spec Decision section).
+2. New `apps/web/lib/integrate/sandbox/agents/opencode-agent-runner.ts`:
+   - `prepare()`: no credential; write OpenCode provider config into the sandbox (`docker exec` a JSON/TOML config naming the local endpoint + model) so the run command is bare; preflight `curl` of the endpoint from inside the container.
+   - `run()`: resolve endpoint via `getOllamaBaseUrl()` + sandbox-reachable rewrite (`host.docker.internal` mapping, `/v1` path); context-length preflight against `/v1/models` (refuse below `OPENCODE_MIN_CONTEXT_TOKENS`, default 22k, with a BLOCKED-classifiable message); exec `cd /workspace && opencode run ... < prompt` with 30-min default timeout and streamed `onProgress` heartbeats; return `AgentRunResult`.
    - `capabilities()`: `tier: "preview"`, `requiresCredential: false`, `requiresPersistentSession: false`, `honorsLlmBaseUrl: true`.
 3. Register in `agents/index.ts`.
-4. `build-studio-config.ts`: `provider` union += `"local"`; `localProviderId`/`localModel` fields + DEFAULTS; auto-detect via `findConfiguredProvider("local")` (lowest preference — after claude/codex/grok); env overrides `LOCAL_AGENT_PROVIDER_ID`, `LOCAL_AGENT_MODEL`, `CLI_DISPATCH_PROVIDER=local`.
-5. `build-orchestrator.ts`: include `"local"` in the CLI-dispatch branch with providerId/model plumbed from config.
-6. Seed: local provider row (`ollama` / Docker Model Runner) gains `cliEngine: "local"` in `packages/db/src/seed.ts` — seed-on-upgrade safe, no migration (column exists).
+4. `build-studio-config.ts`: `provider` union += `"opencode"`; `opencodeProviderId`/`opencodeModel` fields + DEFAULTS; auto-detect via `findConfiguredProvider("opencode")` — order claude → codex → grok → opencode → agentic, so a credential-free install with a healthy local provider lands on the multi-turn local runner before single-turn `dpf-native`; env overrides `OPENCODE_PROVIDER_ID`, `OPENCODE_MODEL`, `CLI_DISPATCH_PROVIDER=opencode`.
+5. `build-orchestrator.ts`: include `"opencode"` in the CLI-dispatch branch with providerId/model plumbed from config.
+6. Seed: local provider row (`ollama` / Docker Model Runner) gains `cliEngine: "opencode"` in `packages/db/src/seed.ts` — seed-on-upgrade safe, no migration (column exists). Same PR refreshes the stale `cliEngine` comment in `schema.prisma` (lists only claude/codex today).
 7. Unit tests: config auto-detect/env-override matrix; runner outcome classification on canned CLI outputs; context-preflight refusal.
 
 Exit: `pnpm --filter web exec vitest run` green on new tests; `pnpm --filter web typecheck` green. (Source-local gates in worktree; runtime gates Phase 3.)
 
 ## Phase 2 — Sandbox image + admin UI
 
-1. `Dockerfile.sandbox`: `npm install -g opencode-ai@<pin>` (from Phase 0 registry row). No auth material added to the image.
-2. Admin Build Studio dispatch config UI: add "Local model (OpenCode)" option with resolved endpoint + model display, preview-tier banner, and a "no credential required" note. Theme tokens per AGENTS.md §12.
+1. `Dockerfile.sandbox`: `npm install -g opencode-ai@<pin>` (from Phase 0 registry row). No auth material added to the image. Apply the grok lesson already in this Dockerfile — the image is Alpine/musl and the npm package fetches a platform binary, so gate the image build loudly with `opencode --version` as root **and** as the `node` user.
+2. Admin Build Studio dispatch config UI: add "Local model (OpenCode)" option with resolved endpoint + model display, an inline endpoint health/context preflight result (config-time, not first at dispatch), preview-tier banner, and a "no credential required" note. Theme tokens per AGENTS.md §12.
 3. Docs: update the Build Studio operator docs' dispatch-provider section (document at ship).
 
 Exit: sandbox image builds; UI renders all four options; typecheck/build green.
@@ -44,7 +44,7 @@ Exit: sandbox image builds; UI renders all four options; typecheck/build green.
 
 Structural verification is not functional. On the canonical install (or local-CI convergence sandbox lease):
 
-1. Configure dispatch `provider=local` with the install's default qwen3-family model; confirm the endpoint preflight passes (or honestly blocks if the pulled model's context is too small — then pull a ≥22k-context model and document the requirement).
+1. Configure dispatch `provider=opencode` with the install's default qwen3-family model; confirm the endpoint preflight passes (or honestly blocks if the pulled model's context is too small — then pull a ≥22k-context model and document the requirement).
 2. Drive one real small Build Studio task end-to-end: promote a contained BI → Ideate → build dispatch → observe the local agent edit `/workspace`, run verification, classify outcome → review gate.
 3. Record evidence via the Build Studio evidence tools (drove X, observed Y), naming the substrate.
 4. Capture observed quality honestly: if the 30B-class model can't clear `single-file-edit`-grade tasks, that is the expected preview-tier result — file the eval summary, leave tier at `preview`.

--- a/docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md
+++ b/docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md
@@ -59,24 +59,26 @@ Patterns adopted: one-shot CLI dispatch shape (Claude/Codex parity), OpenAI-comp
 
 ### Decision: OpenCode runner first, `dpf-native` as the governed end-state
 
+**Naming:** the agent id is **`opencode`**, not `local`. Every existing `BuildAgentId` names the agent (`claude`, `codex`, `grok`, `dpf-native`), and locality is already carried by `honorsLlmBaseUrl` + the resolved provider row. Naming the id by locality would leave no id-space for the contemplated second local engine (Aider, Phase 4 of the plan). "Local model" remains the user-facing label in the admin UI; `opencode` is the substrate id everywhere (`BuildAgentId`, `cliEngine`, dispatch `provider` union, env overrides).
+
 Two complementary paths, not competitors:
 
-1. **`local` agent runner (this spec):** install **OpenCode (pinned)** into `Dockerfile.sandbox` beside the Claude/Codex/Grok CLIs. It is a thin adapter behind the existing `BuildAgentRunner` contract (AGENTS.md §17: thin adapters behind a stable contract). The agent loop runs *inside the sandbox*, like the other vendor CLIs, but inference goes to the install's own endpoint — no credential, no egress.
+1. **`opencode` agent runner (this spec):** install **OpenCode (pinned)** into `Dockerfile.sandbox` beside the Claude/Codex/Grok CLIs. It is a thin adapter behind the existing `BuildAgentRunner` contract (AGENTS.md §17: thin adapters behind a stable contract). The agent loop runs *inside the sandbox*, like the other vendor CLIs, but inference goes to the install's own endpoint — no credential, no egress.
 2. **`dpf-native` runner (already landed, Phase-1):** the portal-side governed loop with `honorsLlmBaseUrl: true` already unlocks local inference with full `ToolExecution` audit. It stays the strategic path for untrusted-substrate and fully-audited builds; this spec does not change it. When `dpf-native` reaches multi-turn parity, the two options coexist in the dispatch config like Claude and Codex do today.
 
 ### Integration points (all substrate exists)
 
 | Surface | File | Change |
 |---|---|---|
-| Agent id | `apps/web/lib/integrate/sandbox/agent-runner-types.ts` | `BuildAgentId` += `"local"` |
-| Runner | `apps/web/lib/integrate/sandbox/agents/local-agent-runner.ts` (new) | `prepare()` no-op (no credential); `run()` execs `opencode run` in `/workspace` with `OPENAI_BASE_URL`/`OPENAI_API_KEY=dpf-local` env pointing at the resolved local endpoint; `capabilities()` → `tier: "preview"`, `requiresCredential: false`, `requiresPersistentSession: false`, `honorsLlmBaseUrl: true` |
+| Agent id | `apps/web/lib/integrate/sandbox/agent-runner-types.ts` | `BuildAgentId` += `"opencode"` |
+| Runner | `apps/web/lib/integrate/sandbox/agents/opencode-agent-runner.ts` (new) | `prepare()` takes no credential; it writes the OpenCode provider config (resolved endpoint + model) into the sandbox and curl-preflights the endpoint *from inside the container*; `run()` execs `opencode run` in `/workspace` with `OPENAI_BASE_URL`/`OPENAI_API_KEY=dpf-local` env; `capabilities()` → `tier: "preview"`, `requiresCredential: false`, `requiresPersistentSession: false`, `honorsLlmBaseUrl: true` |
 | Registry | `apps/web/lib/integrate/sandbox/agents/index.ts` | register runner |
-| Dispatch config | `apps/web/lib/integrate/build-studio-config.ts` | `provider` union += `"local"`; `localProviderId` / `localModel` fields; auto-detect via `findConfiguredProvider("local")`; env overrides `LOCAL_AGENT_PROVIDER_ID` / `LOCAL_AGENT_MODEL`; `CLI_DISPATCH_PROVIDER=local` |
-| Endpoint resolution | reuse `getOllamaBaseUrl()` (`apps/web/lib/inference/ollama-url.ts`) | honors `LLM_BASE_URL` → `OLLAMA_INTERNAL_URL` → provider row → Docker Model Runner default. Sandbox-reachable URL must be rewritten host-relative (e.g. `host.docker.internal`) — the sandbox container is not on the model-runner network by default. |
-| Orchestrator | `apps/web/lib/integrate/build-orchestrator.ts` | include `"local"` in the CLI-dispatch branch |
-| Sandbox image | `Dockerfile.sandbox` | `npm install -g opencode-ai@<pinned>`; no auth file needed |
-| Provider seed | `packages/db/src/seed.ts` | local provider row gains `cliEngine: "local"` (fix the seed, not the runtime) |
-| Admin UI | Build Studio dispatch config surface | add "Local model (OpenCode)" option; show resolved endpoint + model; surface the preview-tier banner |
+| Dispatch config | `apps/web/lib/integrate/build-studio-config.ts` | `provider` union += `"opencode"`; `opencodeProviderId` / `opencodeModel` fields; auto-detect via `findConfiguredProvider("opencode")`; env overrides `OPENCODE_PROVIDER_ID` / `OPENCODE_MODEL`; `CLI_DISPATCH_PROVIDER=opencode`. **Auto-detect order: claude → codex → grok → opencode → agentic** — a credential-free install with a healthy local provider auto-selects the multi-turn local runner over single-turn `dpf-native` (zero-click-provider-setup); frontier CLIs still win when configured. |
+| Endpoint resolution | reuse `getOllamaBaseUrl()` (`apps/web/lib/inference/ollama-url.ts`) | honors `LLM_BASE_URL` → `OLLAMA_INTERNAL_URL` → provider row → Docker Model Runner default. Sandbox-reachable URL must be rewritten host-relative (e.g. `host.docker.internal`) — the sandbox container is not on the model-runner network by default — and must carry the `/v1` path the OpenAI-compatible surface is served under. |
+| Orchestrator | `apps/web/lib/integrate/build-orchestrator.ts` | include `"opencode"` in the CLI-dispatch branch |
+| Sandbox image | `Dockerfile.sandbox` | `npm install -g opencode-ai@<pinned>`; no auth file needed. The image is **Alpine/musl** and the npm package fetches a platform binary — apply the grok lesson already encoded in this Dockerfile: two loud build-time gates, `opencode --version` as root **and** as the `node` user, so a musl-incompatible or root-homed binary fails the image build instead of failing silently at dispatch. |
+| Provider seed | `packages/db/src/seed.ts` | local provider row gains `cliEngine: "opencode"` (fix the seed, not the runtime). Same PR updates the stale `cliEngine` comment in `schema.prisma` (currently lists only `"claude" \| "codex"` — `"grok"` is already missing) so the implied enum registry stays single-source. |
+| Admin UI | Build Studio dispatch config surface | add "Local model (OpenCode)" option; show resolved endpoint + model **with an inline endpoint health/context preflight result** (operator sees "unreachable" or "context < floor" at config time, not first at dispatch); surface the preview-tier banner and a "no credential required" note |
 
 ### Capability tier & promotion (governance)
 
@@ -85,8 +87,9 @@ The runner is admitted at `tier: "preview"` per the existing onboarding doctrine
 ### Outcome classification & guardrails
 
 - `classifyOutcome()` already maps CLI output to `DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT`; weak local models will land in `NEEDS_CONTEXT`/`BLOCKED` more often — that is the desired honest signal, not a failure of the integration.
-- Context-length preflight: before dispatch, the runner queries the provider's `/v1/models` (or provider row metadata) and refuses dispatch with a clear `BLOCKED` message if the serving context is below 22k tokens.
-- Timeout: local inference is slower; default task timeout rises to 30 min for the `local` runner (configurable), with `onProgress` heartbeats from the CLI's streamed output so the orchestrator's stall detection doesn't false-positive.
+- Context-length preflight: before dispatch, the runner queries the provider's `/v1/models` (or provider row metadata) and refuses dispatch with a clear `BLOCKED` message if the serving context is below the floor. The floor is a named, env-overridable constant (`OPENCODE_MIN_CONTEXT_TOKENS`, default `22_000` — source: OpenHands local-model guidance + observed 39k–156k real-run consumption above), not a magic number in the runner.
+- Timeout: local inference is slower; default task timeout rises to 30 min for the `opencode` runner (configurable), with `onProgress` heartbeats from the CLI's streamed output so the orchestrator's stall detection doesn't false-positive.
+- Trust posture (explicit, not accidental): `honorsLlmBaseUrl: true` means `assertAgentProviderCompatibility` admits this runner on `untrusted-ok` execution providers — intentional, because there is no vendor credential to leak and inference goes to the install-controlled endpoint. The caveat is reachability, not secrecy: the host-relative endpoint rewrite assumes host-local substrate, so the in-container preflight curl in `prepare()` is the guard that fails fast on remote/untrusted providers where the endpoint can't resolve.
 - Tool-evaluation pipeline (AGENTS.md §9): OpenCode enters `packages/db/data/approved_tools_registry.json` version-pinned via `/project:tool-evaluation` before the Dockerfile change merges.
 
 ## Out of scope


### PR DESCRIPTION
## Summary

Operator review revisions to the local-LLM Build Studio dispatch spec + plan merged in #1717:

- **Agent id renamed `local` → `opencode`** throughout (BuildAgentId, cliEngine, dispatch provider union, env overrides `OPENCODE_PROVIDER_ID`/`OPENCODE_MODEL`/`CLI_DISPATCH_PROVIDER=opencode`). Ids name the agent like `claude`/`codex`/`grok`; locality is already carried by `honorsLlmBaseUrl` + the provider row, and this keeps id-space for a second local engine (Aider, Phase 4). "Local model (OpenCode)" stays as the UI label.
- **Auto-detect order made explicit:** claude → codex → grok → opencode → agentic, so a credential-free install with a healthy local provider lands on the multi-turn local runner before single-turn `dpf-native`.
- **Alpine/musl hardening (the grok lesson):** Phase 0 verifies the pin runs on musl as non-root; Phase 2 gates the sandbox image build loudly with `opencode --version` as root **and** the `node` user.
- **Config-time preflight in the admin UI** (endpoint health + context check shown at configuration, not first at dispatch); context floor configurable via `OPENCODE_MIN_CONTEXT_TOKENS` (default 22k).
- Seed PR also refreshes the stale `cliEngine` comment in `schema.prisma`.

Docs only — no code, no migrations. Backlog: BI-01D6A51B (EP-BUILD-STUDIO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)