### PR TITLE
doc(testing): archetype audit plan — Phase P prerequisites, expanded B5 CTA flows, Phase G financial tally

### DIFF
--- a/docs/testing/archetype-audit-plan.md
+++ b/docs/testing/archetype-audit-plan.md
@@ -160,45 +160,111 @@ After the final audit run and before returning to normal development:
 
 ---
 
-## 5. Fresh Install Reset Procedure (Per Run)
+## 5. Reset Procedure (Per Run)
 
-Execute between each audit run. Takes approximately 5–10 minutes.
+Two reset tiers based on what is actually changing between runs.
 
-### Step 1 — Snapshot and persist findings
+### What each tier touches
 
-```
-# Via MCP (in Claude Code terminal):
-# Run list_epics + list_backlog_items, save to backlog-snapshots/
-# Commit the previous run's findings file to git (Section 8)
-```
+| Component | Full install (Run 0 only) | DB-only reset (Runs 1–16) |
+|-----------|--------------------------|--------------------------|
+| PostgreSQL data | wiped + re-seeded | wiped + re-seeded |
+| Neo4j, Qdrant, Redis | wiped | **kept** — empty anyway |
+| Docker containers | torn down and recreated | **kept running** |
+| Docker images | used as-is (no rebuild) | **kept** — unchanged |
+| pnpm / node_modules | re-installed | **kept** — unchanged |
+| `.env` / secrets | regenerated if absent | **kept** — unchanged |
+| Edge Node bootstrap | re-issued | **skipped** |
+| Agent toolchain | re-bootstrapped | **skipped** |
 
-Nothing that must survive the wipe may live only in the database or only in the session context.
+Only PostgreSQL holds the organization, archetype selection, and setup wizard state. Everything else is either empty or irrelevant to archetype testing. Between Runs 1–16, tearing down Docker is pure waste (~5–8 min saved per run, ~80–130 min across 16 runs).
 
-### Step 2 — Wipe and reinstall
+---
+
+### Tier 1 — Full install (Run 0 only)
+
+Run once before Run 0. Sets up Docker from scratch, generates secrets, builds images, bootstraps edge node.
 
 ```powershell
-# From repo root (D:\DPF):
+# From D:\DPF (repo root):
 .\scripts\fresh-install.ps1
 ```
 
-The script itself runs `docker compose down -v` (line ~152) — no separate manual teardown needed. This wipes volumes (`pgdata`, `neo4jdata`, `qdrant_data`, `redis_data`) and re-seeds the database.
+Takes ~10–15 minutes. Validates that Docker Desktop is healthy and images are built and cached for all subsequent runs.
 
-### Step 3 — Verify clean state
+---
+
+### Tier 2 — DB-only reset (Runs 1–16, between every run)
+
+Keeps all containers running. Drops and recreates only the PostgreSQL database, re-runs migrations and seed. Takes ~90 seconds.
+
+**Step 1 — Snapshot and persist findings**
+
+Before every reset, git-commit the previous run's findings file (Section 8) so nothing is lost to the wipe.
+
+**Step 2 — Drop and reseed the database**
+
+```powershell
+# Drop the dpf database inside the running postgres container,
+# recreate it, then re-run migrations and seed from the host.
+# Run from D:\DPF (repo root):
+
+docker compose exec postgres psql -U dpf -d postgres -c "DROP DATABASE dpf WITH (FORCE);"
+docker compose exec postgres psql -U dpf -d postgres -c "CREATE DATABASE dpf;"
+pnpm --filter @dpf/db exec prisma migrate deploy
+pnpm --filter @dpf/db seed
+```
+
+**Step 3 — Restart portal to flush in-memory state**
+
+Next.js caches some state in memory between requests. Restart the portal container so it picks up the fresh DB.
+
+```powershell
+docker compose restart portal portal-init
+```
+
+Wait ~30 seconds for `portal-init` to complete its startup seed pass, then poll for health:
+
+```powershell
+# Poll until healthy (max 2 minutes):
+$deadline = (Get-Date).AddSeconds(120)
+while ((Get-Date) -lt $deadline) {
+    try {
+        $r = Invoke-WebRequest -Uri "http://localhost:3000/api/health" -UseBasicParsing -TimeoutSec 3 -ErrorAction SilentlyContinue
+        if ($r.StatusCode -eq 200) { Write-Host "Portal ready"; break }
+    } catch {}
+    Start-Sleep -Seconds 5
+}
+```
+
+**Step 4 — Verify clean state**
 
 1. Navigate to `http://localhost:3000`
-2. Confirm redirect to `/welcome` (not `/workspace` — which would mean old org data survived)
-3. Confirm no organization exists (no banner, no pre-filled archetype)
+2. Confirm redirect to `/welcome` (no organization exists)
+3. Confirm archetype grid renders with all 53 archetypes visible
 
-### Step 4 — Configure AI provider + coworker health gate
+**Step 5 — Verify provider + coworker health gate**
 
-1. Navigate to `/platform/ai/providers`
-2. Verify the Anthropic provider bootstrapped from the environment (Run 0 confirms whether this claim holds); if not, configure it manually and record the steps
-3. Verify provider shows healthy status
-4. **Health gate:** ask the default coworker one trivial question and confirm a coherent response **before** scoring any AI phase. If the coworker is unresponsive or degraded, that is a platform finding (file it) — and all Phase B6/B7/E results for this run are blocked until resolved, not logged as archetype gaps.
+Provider credentials live in the database — they are wiped on every DB reset and must be re-entered. Run 0 establishes the exact re-entry steps and time budget.
 
-### Step 5 — Run setup wizard
+1. Navigate to `/platform/ai/providers` → re-configure the Anthropic provider (or whichever provider Run 0 confirmed as the standard)
+2. Verify healthy status
+3. **Health gate:** ask the default coworker one trivial question and confirm a coherent response before scoring any AI phase in this run. An unresponsive coworker after re-entry is a platform finding, not an archetype gap.
+
+**Step 6 — Run setup wizard**
 
 Follow the archetype-specific setup script in Section 7 for the current run. For non-lead archetypes in the run, swap via the admin archetype-reset API and run Phases B/E/F only (Section 3).
+
+---
+
+### When to fall back to a full install mid-audit
+
+Use Tier 1 (full install) mid-audit only if:
+- The DB-only reset leaves containers in an unhealthy state after two attempts
+- A previous run triggered a self-upgrade that recycled the portal and left the container in a broken state
+- Docker Desktop reports a volume or container error that `docker compose restart` cannot clear
+
+In these cases: `docker compose down -v` + `.\scripts\fresh-install.ps1`, then pick up the run from Step 4. This is a recovery action, not the normal path.
 
 ---
 

--- a/docs/testing/archetype-audit-plan.md
+++ b/docs/testing/archetype-audit-plan.md
@@ -283,17 +283,92 @@ Apply this checklist to every archetype within a run. Log findings in Section 8 
 - [ ] **A6** Complete financial setup — currency pre-fills correctly for locale
 - [ ] **A7** Complete setup wizard — organization created, redirected to `/workspace`
 
+### Phase P — Catalog & Data Prerequisites
+
+> Run after Phase A, before Phase B. These steps seed real staff, items, operating hours, and a test customer so Phase B5 exercises a live business scenario, not an empty shell. For swapped (non-lead) archetypes running only B/E/F, run the applicable P sub-section below before Phase B.
+
+#### P-BOOKING — booking CTA archetypes (hair-salon, barber-shop, nail-salon, beauty-spa, optician, personal-trainer, veterinary-clinic, dental-practice, physiotherapy, counselling, pet-grooming, pet-boarding, dog-walking, restaurant, tutoring, driving-school, music-school, dance-studio)
+
+- [ ] **P1** Navigate to `/storefront/team` → Add the lead staff member from the run script (name, role title, email address). Save. Confirm the provider appears in the team list.
+- [ ] **P2** On the team record just created → open availability settings → set Mon–Fri 09:00–17:00 (adjust to archetype-specific hours if noted in the run script). Confirm the provider now appears as selectable in the booking calendar.
+- [ ] **P3** Navigate to `/storefront/settings/operations` → Set operating hours: at minimum Mon–Fri open 09:00, close 17:00 (adjust per run script). Save. Confirm the page returns a saved/confirmed state.
+- [ ] **P4** Navigate to `/storefront/items` → Confirm at least 3 seeded service items are visible with names and prices. Add one new service item manually using the run script's "audit item" name and price, ctaType booking. Save and confirm the new item appears in the list.
+- [ ] **P5-PET** *(veterinary-clinic, pet-grooming, pet-boarding, dog-walking only)* Navigate to `/customer` → Create a customer account using the run script's test owner name (e.g., "Robert Chen"). Add a contact with email and phone. On the account record, navigate to Configuration Items → add a new CI: ciType "pet", name from the run script (e.g., "Max"), description: species, breed, approximate DOB (e.g., "Species: Dog | Breed: Labrador Retriever | DOB: 2020-03-15"). Save. Confirm the CI appears under the account.
+- [ ] **P5-DENTAL** *(dental-practice, physiotherapy, counselling only)* Navigate to `/customer` → Create an account for the run script's test patient (full name, email, phone). Add a contact record. Log the account name for use in Phase B5 and Phase G.
+- [ ] **P5-RESTAURANT** *(restaurant only)* Confirm seeded table-type items represent service slots (Table for 2, Table for 6+, Private Dining). If seeded prices are £0/$0, confirm this is intentional (pay on day). Set operating hours to cover a dinner window (18:00–22:00) at minimum; if lunch and dinner are two separate windows and the UI only supports one, set dinner and log single-window limitation as a minor gap.
+
+#### P-PURCHASE — purchase CTA archetypes (bakery, retail-goods, artisan-goods, florist, gym, yoga-studio, sports-club)
+
+- [ ] **P1** Navigate to `/storefront/items` → Confirm seeded product items are visible with names and descriptions. Edit at least 3 items to set realistic non-zero prices (see run script for archetype-appropriate amounts). Save.
+- [ ] **P2** Add one new product item manually using the run script's "audit item" name and price (e.g., "Audit Run Loaf — Seeded Rye" £5.50 for bakery; "Audit Run Day Pass" £12 for gym), ctaType purchase. Save and confirm the item appears on the public portal storefront.
+- [ ] **P3** Navigate to `/customer` → Add a test customer account using the run script's buyer name (e.g., "Test Buyer R5") with a contact email. This account will be linked to the Phase B5 order and used in Phase G for the invoice.
+- [ ] **P4** Navigate to `/storefront/settings/operations` → Set archetype-appropriate hours (retail/bakery Mon–Sat 08:00–18:00; gym/yoga/sports Mon–Sun 06:00–21:00). Save.
+
+#### P-INQUIRY — inquiry CTA archetypes (all trades, catering, consulting, legal, marketing, accounting, IT MSP, landscaping, cleaning-service, wholesale-distribution, HOA, property management, public sector, banking/mortgage)
+
+- [ ] **P1** Navigate to `/storefront/items` → Confirm seeded service items are visible with names on the public portal (inquiry items don't require prices, but blank names must be corrected). Edit any blank item names.
+- [ ] **P2** Navigate to `/storefront/settings/operations` → Set archetype-appropriate hours (trades Mon–Fri 07:00–18:00; professional services Mon–Fri 09:00–17:30; public sector Mon–Fri 08:30–16:30). Save.
+
+#### P-DONATION — donation CTA archetypes (charity, pet-rescue, animal-shelter, community-shelter, cooperative)
+
+- [ ] **P1** Navigate to `/storefront/items` → Confirm donation tier items are present. Edit at least one item to have a meaningful amount (e.g., "Sponsor an Animal — £10/month"). If all amounts are £0/$0, log as an important finding.
+- [ ] **P2** Operating hours are optional for nonprofit public portals — skip unless the portal UI requires operating hours before the donation CTA renders.
+
+---
+
 ### Phase B — Storefront (STORE)
 - [ ] **B1** Navigate to `/storefront` → Workspace loads with correct archetype name
 - [ ] **B2** Click "View Live" → Public portal renders with correct hero, service items
 - [ ] **B3** Verify vocabulary — "Book Now" vs "Shop Now" vs "Get a Quote" vs "Donate" matches archetype CTA
-- [ ] **B4** Verify service/product item names match archetype templates
-- [ ] **B5** Trigger the primary CTA flow end-to-end (confirmation behavior calibrated in Run 0 — if the real UX confirms differently than a reference number, update this criterion before Run 1):
-  - **booking**: calendar → select slot → fill form → confirm booking → reference number shown
-  - **purchase**: add to cart / select item → checkout form → confirm → reference shown
-  - **inquiry**: fill inquiry form → submit → reference shown
-  - **donation**: select amount → fill details → confirm → reference shown
-- [ ] **B5x** Negative path: submit the same CTA form with required fields empty → inline validation appears (no 500, no silent success)
+- [ ] **B4** Verify service/product item names match archetype templates (including the P4/P2 audit item added in Phase P)
+- [ ] **B5** Pre-condition: Phase P complete for this CTA type. Drive the primary CTA end-to-end using the actual data entered in Phase P. Specific steps by CTA type:
+
+  **Booking** (hair-salon, barber-shop, nail-salon, beauty-spa, optician, personal-trainer, vet, dental, physio, counselling, pet-grooming, pet-boarding, dog-walking, restaurant, tutoring, driving-school, music-school, dance-studio):
+  1. Public portal → click the primary booking CTA
+  2. From the service list, select the audit item added in P4 — confirm it is visible with name and price
+  3. Select the P1/P2 staff member as provider — confirm their P2 availability slots appear on the calendar
+  4. Select a date that falls within the P3 operating hours window and choose a time slot
+  5. Fill booking form — standard fields (required for all booking archetypes): full name, email address, phone number
+     - **Vet / pet-grooming / pet-boarding / dog-walking**: add pet name (from P5-PET, e.g., "Max"), species (Dog/Cat/Rabbit/Other), breed, approximate age, reason for visit — confirm these fields render in the booking form; if absent, log as an important finding
+     - **Dental / physiotherapy**: "new or returning patient?" field if present; use the patient name from P5-DENTAL
+     - **Restaurant**: party size (2–12 guests), dietary requirements note if field present; meal service selector (lunch/dinner) if present
+     - **Tutoring**: student name, age/year group, subject
+     - **Driving school**: preferred pickup address or meeting point
+  6. Submit → confirm a reference number is displayed on the confirmation page
+  7. Navigate to `/storefront/inbox` → booking record appears with correct service name, date, staff member name, and submitting name
+  8. **Vet / pet-specific verify**: inbox booking record shows the pet name and species entered in step 5 — if the pet details are not visible on the inbox record, log as an important finding
+
+  **Purchase** (bakery, retail-goods, artisan-goods, florist, gym, yoga-studio, sports-club):
+  1. Public portal → browse product catalog — confirm the P2 audit item is visible with its correct name, description, and price
+  2. Click the audit item → product detail page loads; verify name, description, and price are all correct
+  3. Add to cart (quantity: 1) → cart shows item + price
+  4. Proceed to checkout:
+     - Standard fields (required for all purchase archetypes): full name, email address
+     - **Physical goods (bakery, retail-goods, artisan-goods, florist)**: delivery address (street, city, postcode/zip); for florist — preferred delivery date field if present
+     - **Gym / yoga-studio / sports-club (membership)**: member date of birth; emergency contact name and phone if the form requires it
+  5. Confirm purchase → confirmation page with order reference number shown
+  6. Navigate to `/storefront/inbox` → order appears with the P2 product name and buyer email
+  7. Navigate to `/customer` → P3 customer account shows a linked order or activity entry — if the order is not linked, log as an important finding
+
+  **Inquiry** (plumber, electrician, facilities-maintenance, catering, consulting, legal, marketing, accounting, IT MSP, landscaping, cleaning-service, wholesale-distribution, HOA, property management, banking, public sector):
+  1. Public portal → click the inquiry / quote CTA
+  2. Fill standard fields: full name, email address, phone number, brief description of requirement
+     - **Trades (plumber, electrician, HVAC, landscaping, cleaning)**: property type field (residential/commercial/industrial) if present; urgency level dropdown if present — verify both render and submit without error
+     - **Catering**: event type, event date, approximate guest count
+     - **Facilities / IT MSP / consulting**: company name, approximate number of sites or employees
+     - **HOA / property management**: property address or unit number
+  3. Submit → reference number shown on confirmation page
+  4. Navigate to `/storefront/inbox` → inquiry record appears with submitter name and description
+
+  **Donation** (charity, pet-rescue, animal-shelter, community-shelter, cooperative):
+  1. Public portal → click the donation CTA
+  2. Select the P1 preset amount (confirm it renders with the correct value) OR enter a custom amount
+  3. Fill name and email address
+  4. Confirm donation → thank-you/receipt page shown with a reference or confirmation number
+  5. Verify NO invoice or billing account is auto-created — this is a donation receipt, not a purchase transaction; if an invoice is generated, log as an important finding
+  6. Navigate to `/storefront/inbox` → donation record appears
+
+- [ ] **B5x** Negative path: submit the same CTA form with all required fields empty → inline validation errors appear on each required field (no 500 error, no silent success, no page navigation)
 - [ ] **B6** Coworker panel on `/storefront` → Marketing Specialist agent loads (AI-03 analogue)
 - [ ] **B7** Verify archetype-specific vocabulary in coworker (no "FeatureBuild", "capsule", "worktree" language)
 
@@ -321,10 +396,23 @@ Apply this checklist to every archetype within a run. Log findings in Section 8 
 - [ ] **F3** Navigate to `/ops` → Workspace backlog loads (should be empty on fresh install)
 - [ ] **F4** Send an inbox item "to backlog" → item appears under `/ops`
 
-### Phase G — Responsive & resilience smoke (lead archetype only, once per run)
-- [ ] **G1** Public portal at narrow viewport (~390px) → hero, CTA, and form remain usable; no horizontal overflow
-- [ ] **G2** Browser refresh mid-CTA-flow → no corrupted state, flow restartable
-- [ ] **G3** Public portal direct-load of a non-existent item/slug → graceful 404, not a stack trace
+### Phase G — Financial Tally
+
+> Run after Phase F for all revenue-generating archetypes (booking, purchase, donation). For inquiry-only archetypes, run G1–G2 only (record an expected expense, verify the P&L loads and shows it). Uses the accounts and suppliers created in Phase P.
+
+- [ ] **G1** Navigate to `/finance/suppliers` → Add an archetype-relevant supplier (see run script for name; e.g., vet: "Veterinary Supplies Co.", salon: "Professional Hair Products Ltd", bakery: "Flour & Grain Wholesale", gym: "Fitness Equipment Leasing Co.", trades: "Wholesale Tools & Spares", inquiry-only: any supplier appropriate to the profession). Save and confirm the supplier appears in the supplier list.
+- [ ] **G2** Navigate to `/finance/bills/new` → Create a supplier bill. Set Supplier = G1. Add one archetype-relevant line item (see run script for item name and amount; e.g., vet: "Examination gloves — box 200" qty 1 $28.00; salon: "Color developer 1L" qty 3 £12.00 each; bakery: "Strong bread flour 25kg" qty 2 £18.50 each). Set issue date = today. Save. Confirm the bill appears in the bills list with the correct total.
+- [ ] **G3** *(booking and purchase archetypes only)* Navigate to `/finance/invoices/new` → Create a customer invoice for the Phase B5 CTA. Set Customer = the account created in P5-PET/P5-DENTAL (booking) or P3 (purchase). Add one line item matching the service or product used in Phase B5 with the same price (see run script). Set issue date = today. Save. Verify the invoice appears in the invoice list.
+- [ ] **G4** Navigate to `/finance/reports/profit-loss` → P&L report loads without error. Verify: the G2 bill total appears as an expense entry. For booking/purchase archetypes: the G3 invoice total appears as a revenue/income entry. The net figure = revenue minus expenses (positive or negative — the arithmetic correctness is what matters, not the sign).
+- [ ] **G5** If the P&L report loads empty despite G2/G3 entries being saved: log as an important finding (gap: finance entries not reflected in P&L report).
+- [ ] **G6** Navigate to `/finance` → Finance dashboard loads. Confirm at least one summary metric (revenue, expenses, or net balance) reflects the G2 and G3 entries.
+
+---
+
+### Phase H — Responsive & Resilience Smoke (lead archetype only, once per run)
+- [ ] **H1** Public portal at narrow viewport (~390px) → hero, CTA, and form remain usable; no horizontal overflow
+- [ ] **H2** Browser refresh mid-CTA-flow → no corrupted state, flow restartable
+- [ ] **H3** Public portal direct-load of a non-existent item/slug → graceful 404, not a stack trace
 
 ---
 
@@ -347,13 +435,34 @@ Apply this checklist to every archetype within a run. Log findings in Section 8 
 **Vocabulary must NOT appear:** FeatureBuild, worktree, capsule, MCP, epic, backlog  
 **Special:** Urgent urgency field in form (TRADES_FORM_FIELDS) — verify "Urgency" dropdown renders and submits
 
+**Run-1 Phase P setup (lead archetype):**
+- P-INQUIRY P1: `/storefront/items` → Confirm seeded: Leak Repair, Drain Clearing, Boiler Service, Emergency Call-Out, Bathroom Fitting. Edit any with blank names.
+- P-INQUIRY P2: `/storefront/settings/operations` → Mon–Fri 07:00–18:00, Sat 08:00–14:00, emergency call-out note in description if supported. Save.
+
+**Run-1 Phase B5 walkthrough:**
+1. Public portal → inquiry CTA (confirm label is "Get a Quote" or "Request a Call" — NOT "Book" or "Shop")
+2. Select service "Emergency Call-Out"
+3. Fill inquiry form: name Sandra Hooper (test; re-use operator persona for simplicity), email test@riverside-plumbing.co, phone 555-0101
+4. **Urgency field (TRADES_FORM_FIELDS)**: urgency dropdown renders — select "Emergency". If absent, log as an important finding.
+5. Property type: Residential
+6. Brief description: "Water leak under kitchen sink"
+7. Submit → reference number shown
+8. `/storefront/inbox` → inquiry appears with urgency "Emergency" and service "Emergency Call-Out" visible
+
+**Run-1 Phase G (financial tally — inquiry archetype):**
+- G1: Supplier "Wholesale Plumbing Parts" at `/finance/suppliers`
+- G2: Bill: "Copper pipe fittings — job supply box", qty 1, $85.00
+- G3: Skip (inquiry archetype — no portal invoice; run only G1–G2 and verify G4 shows the expense)
+- G4: P&L → expenses $85.00, revenue $0 (correct for inquiry-only; verify the expense appears)
+- G5: Log if P&L is empty despite G2 entry
+
 **Run-1 setup steps:**
 1. Reset → fresh install
 2. Brand URL: `riverside-plumbing.co` → expect archetype suggestion: `plumber` (or `trades-maintenance`)
 3. Select `plumber` from grid
 4. Company name: Riverside Plumbing Solutions | Timezone: America/Chicago | Currency: USD
 5. Complete wizard → `/workspace`
-6. Run Phases A–F
+6. Run Phase P (P-INQUIRY) → then Phases A–F → Phase G → Phase H (responsive, lead only)
 7. Log gaps
 
 ---
@@ -422,6 +531,30 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **Special:** Verify `appointment-checkout` commercial model means NO account setup required; calendar shows stylist availability; no "invoice" or "account balance" in coworker responses  
 **Activation profile check:** `customer-estate` module should NOT be active for this archetype
 
+**Run-2 Phase P setup:**
+- P1/P2: `/storefront/team` → Add **Chloe Martinez**, role "Salon Owner / Senior Stylist", email chloe@studio44hair.com. Availability: Mon–Fri 09:00–18:00, Sat 09:00–17:00. Confirm she appears as a selectable provider on the booking calendar.
+- Add a second stylist: **Kai Sato**, "Stylist", kai@studio44hair.com. Same hours.
+- P3: `/storefront/settings/operations` → Mon–Fri 09:00–18:00, Sat 09:00–17:00. Save.
+- P4: `/storefront/items` → Confirm seeded: Women's Haircut & Style, Color Treatment, Highlights, Keratin Treatment, Bridal Package. Edit each to set prices if any are £0 (e.g., Women's Haircut £55, Color Treatment £85, Highlights £95, Keratin £120, Bridal £200). Add audit item: "Audit — Blow Dry & Style", £35.00, ctaType booking.
+- No P3 customer pre-creation needed (appointment-checkout = no account estate).
+
+**Run-2 Phase B5 walkthrough:**
+1. Public portal → "Book Now" → service list shows all five seeded items plus "Audit — Blow Dry & Style"
+2. Select "Audit — Blow Dry & Style"
+3. Provider list shows Chloe Martinez and Kai Sato → select Chloe Martinez
+4. Calendar shows her Mon–Sat availability → select next available Mon 10:00 slot
+5. Booking form: name "Lisa Jordan", email lisa@test.com, phone 07700 000 100
+6. Confirm no pet/vehicle/dependent fields in the form
+7. Submit → reference number shown; confirmation includes service name, stylist, date/time
+8. `/storefront/inbox` → booking for Lisa Jordan → "Audit — Blow Dry & Style" with Chloe Martinez
+
+**Run-2 Phase G (financial tally):**
+- G1: Supplier "Wella Professional Products" at `/finance/suppliers`
+- G2: Bill from Wella: "Color Developer 1L", qty 3, £12.00 each (total £36.00)
+- G3: Invoice for Lisa Jordan (create account first if appointment-checkout didn't auto-create one): "Audit — Blow Dry & Style" qty 1, £35.00
+- G4: P&L → revenue £35.00, expenses £36.00, net -£1.00
+- **Appointment-checkout verification**: ask coworker "Do clients have an account balance with us?" → should confirm no running account/balance, payment is at time of service only
+
 ---
 
 #### Archetype: `barber-shop`
@@ -485,6 +618,35 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **Vocabulary expected:** patients (pets), owners, appointments, examinations, treatments  
 **Special:** Ask coworker "A dog came in with labored breathing — how do we handle this?" → Response should stay in operational/scheduling territory, not give medical diagnosis
 
+**Run-3 Phase P setup (lead archetype — fresh install):**
+- P1/P2: `/storefront/team` → Add **Dr. Sarah Park**, role "Veterinarian", drpark@companionvet.com. Availability: Mon–Fri 08:00–18:00, Sat 09:00–13:00.
+- P3: `/storefront/settings/operations` → Mon–Fri 08:00–18:00, Sat 09:00–13:00. Save.
+- P4: `/storefront/items` → Confirm seeded: New Pet Consultation, Wellness Exam & Vaccines, Dental Cleaning, Spay/Neuter, Emergency Appointment. Edit prices if £0/$0 (e.g., New Pet Consultation $65, Wellness Exam & Vaccines $95, Dental Cleaning $250, Emergency Appointment $150). Add audit item: "Audit — Annual Booster & Check-Up", $85.00, ctaType booking.
+- P5-PET: `/customer` → Create account: **Robert Chen**. Contact: Robert Chen, rchen@test.com, 555-0100.
+  - Add Configuration Item: ciType "pet", name **Max**
+  - Description: "Species: Dog | Breed: Labrador Retriever | DOB: 2020-03-15 | Vaccination: Due for annual boosters"
+  - Save. Confirm Max appears under Robert Chen's account record.
+
+**Run-3 Phase B5 walkthrough:**
+1. Public portal → "Book Now" → service list shows seeded services plus "Audit — Annual Booster & Check-Up"
+2. Select "Audit — Annual Booster & Check-Up"
+3. Provider: Dr. Sarah Park → Mon–Fri slots visible in calendar
+4. Select next available Tue 10:00 slot
+5. Booking form fills:
+   - Owner name: Robert Chen, email: rchen@test.com, phone: 555-0100
+   - **Pet fields**: Pet name "Max", species Dog, breed Labrador Retriever, age 4 years
+   - Reason for visit: Annual wellness exam + rabies booster
+6. Submit → reference number shown
+7. `/storefront/inbox` → booking appears with "Max" and "Robert Chen" both visible
+8. If pet fields are absent from the booking form → log as a critical finding (the form schema must capture pet info for any vet CTA to be functional)
+
+**Run-3 Phase G (financial tally):**
+- G1: Supplier "Veterinary Supplies Co." at `/finance/suppliers`
+- G2: Bill: "Examination gloves — box 200", qty 1, $28.00
+- G3: Invoice for Robert Chen (account created in P5-PET): "Audit — Annual Booster & Check-Up", qty 1, $85.00
+- G4: P&L → revenue $85.00, expenses $28.00, net +$57.00
+- Verify Robert Chen's account at `/customer` shows the invoice under their record
+
 ---
 
 #### Archetype: `dental-practice`
@@ -527,6 +689,29 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **Key services to verify:** Full Groom (small/medium/large dog tiers), Bath & Brush, Nail Trim, De-shedding Treatment, Puppy's First Groom  
 **Special:** Verify size-based pricing renders (price-type "from")
 
+**Run-4 Phase P setup (lead archetype — fresh install):**
+- P1/P2: `/storefront/team` → Add **Tina Flores**, role "Master Groomer", tina@pamperedpaws.com. Availability: Tue–Sat 09:00–17:00.
+- P3: `/storefront/settings/operations` → Tue–Sat 09:00–17:00, closed Sun–Mon. Save.
+- P4: `/storefront/items` → Confirm seeded: Full Groom Small (from $45), Full Groom Medium (from $60), Full Groom Large (from $80), Bath & Brush, Nail Trim, De-shedding Treatment, Puppy's First Groom. Verify at least one item uses "from" pricing. Add audit item: "Audit — Bath & Brush (Medium Dog)", $45.00, ctaType booking.
+- P5-PET: `/customer` → Create account **Sarah Tanner**, contact sarah-t@test.com, 555-0400. Add Configuration Item: ciType "pet", name **Bella**, description "Species: Dog | Breed: Golden Retriever | DOB: 2021-08-10 | Notes: No previous grooming anxiety". Save.
+
+**Run-4 Phase B5 walkthrough:**
+1. Public portal → "Book Now"
+2. Select "Audit — Bath & Brush (Medium Dog)"
+3. Provider: Tina Flores → Tue–Sat availability shown
+4. Select a slot → booking form:
+   - Owner: Sarah Tanner, email: sarah-t@test.com, phone: 555-0400
+   - **Pet fields**: Pet name "Bella", species Dog, breed Golden Retriever, age ~3 years, any special notes
+5. Submit → reference shown
+6. `/storefront/inbox` → booking shows pet name "Bella" — if absent, log as important finding
+7. **Size-based pricing check**: on the public portal, click "Full Groom" items → verify "from $45" / "from $60" / "from $80" pricing renders (not a single flat price)
+
+**Run-4 Phase G (financial tally):**
+- G1: Supplier "Professional Grooming Supplies" at `/finance/suppliers`
+- G2: Bill: "Grooming shampoo — 5L professional", qty 2, $28.00 each
+- G3: Invoice for Sarah Tanner (account from P5-PET): "Bath & Brush — Bella", qty 1, $45.00
+- G4: P&L → revenue $45.00, expenses $56.00, net -$11.00
+
 ---
 
 #### Archetype: `pet-boarding`
@@ -562,6 +747,30 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **Key services to verify:** Table for 2 (standard reservation), Table for 6+ (large party), Private Dining Room, Set Menu Experience, Chef's Table  
 **Special:** Party size field in booking form — verify it renders; date+time picker with meal-service slots (lunch 12–2pm, dinner 6–10pm)
 
+**Run-5 Phase P setup (lead archetype):**
+- P1/P2: `/storefront/team` → Add **Marco Reyes**, role "Restaurant Owner / Host", marco@copperandsalt.com. Availability: Tue–Sun 11:30–23:00 (restaurant is closed Mondays).
+- P3: `/storefront/settings/operations` → Tue–Sun open 12:00, close 22:30. Save. Note: if only a single open/close window is supported, set the dinner window (18:00–22:30) and log the missing lunch-window support as a minor gap.
+- P4: `/storefront/items` → Confirm seeded table types: "Table for 2", "Table for 6+", "Private Dining Room", "Set Menu Experience", "Chef's Table". Prices for table reservations may be £0/€0 (pay on the day) — that is intentional. Add audit item: "Audit — Table for 2 (Dinner)", £0, ctaType booking, description "Standard dinner reservation — party of 2". Save.
+- No P5 customer pre-creation needed (restaurant reservations do not require prior account).
+
+**Run-5 Phase B5 walkthrough:**
+1. Public portal → "Book a Table" or "Reserve" (confirm correct CTA label)
+2. Select "Audit — Table for 2 (Dinner)"
+3. Calendar shows Tue–Sun slots from 18:00 → select next available slot
+4. Booking form:
+   - Name: Test Diner R5, email: diner-r5@test.com, phone: 555-0500
+   - **Party size field**: enter 2 — confirm this field renders; if absent, log as an important finding
+   - Dietary requirements / special occasion note: if a free-text field is present, enter "No allergies"
+   - Meal service selector (Lunch/Dinner): if present, select "Dinner"
+5. Submit → reference number shown (no charge taken — reservation only)
+6. `/storefront/inbox` → reservation appears: "Table for 2", party size 2, Test Diner R5, date/time
+
+**Run-5 Phase G (financial tally):**
+- G1: Supplier "Wholesale Produce & Provisions" at `/finance/suppliers`
+- G2: Bill: "Weekly produce delivery — vegetables and herbs", qty 1, £180.00
+- G3: Invoice for Test Diner R5 (create account manually since walk-in pay-on-day model): "Dinner for 2 — 3-course set menu", qty 1, £75.00
+- G4: P&L → revenue £75.00, expenses £180.00, net -£105.00
+
 ---
 
 #### Archetype: `catering`
@@ -580,6 +789,30 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **Key services to verify:** Sourdough Loaf, Croissants (pack of 6), Custom Birthday Cake (custom commission), Seasonal Pastry Box, Wholesale Bread Supply  
 **Special:** Verify purchase CTA renders "Add to Cart" or "Order Now" (not "Book" or "Inquire"); custom cake = commission item with inquiry-style form even within purchase archetype
 
+**Run-5 Phase P setup (archetype swap after catering):**
+- P1: `/storefront/items` → Edit seeded products to set prices: Sourdough Loaf £6.50, Croissants pack £8.50, Seasonal Pastry Box £22.00, Wholesale Bread Supply (bulk — edit to £45 per case).
+- P2: Add audit item: **"Audit Run Loaf — Seeded Rye"**, category "Bread", price £5.50, ctaType purchase, description "400g seeded rye, baked daily". Save.
+- P3: `/customer` → Add account: **Test Buyer R5**, contact email buyer-r5@test.com.
+- P4: `/storefront/settings/operations` → Mon–Sat 07:00–16:00. Save.
+
+**Run-5 Phase B5 walkthrough:**
+1. Public portal → "Shop Now" / "Order Now" (confirm NOT "Book" or "Inquire")
+2. Product catalog shows Sourdough Loaf £6.50, Croissants £8.50, Seasonal Pastry Box £22.00, and "Audit Run Loaf — Seeded Rye" £5.50
+3. Click "Audit Run Loaf — Seeded Rye" → product detail page: name, "400g seeded rye, baked daily", £5.50 all visible
+4. Add to cart (qty: 1) → cart shows "Audit Run Loaf — Seeded Rye" £5.50
+5. Proceed to checkout:
+   - Name: Test Buyer R5, email: buyer-r5@test.com
+   - Delivery address: 10 Test Lane, London, SW1A 0AA
+6. Confirm order → order reference number shown
+7. `/storefront/inbox` → order appears with "Audit Run Loaf — Seeded Rye" and buyer-r5@test.com
+8. **Custom commission check (separate test):** click "Custom Birthday Cake" → if an inquiry-style form appears (not a standard cart), confirm it submits and reaches the inbox
+
+**Run-5 Phase G (financial tally):**
+- G1: Supplier "Flour & Grain Wholesale" at `/finance/suppliers`
+- G2: Bill: "Strong bread flour 25kg", qty 2, £18.50 each (total £37.00)
+- G3: Invoice for Test Buyer R5: "Audit Run Loaf — Seeded Rye", qty 1, £5.50
+- G4: P&L → revenue £5.50, expenses £37.00, net -£31.50 (correct — one loaf cannot recoup a bulk flour purchase; arithmetic is what matters)
+
 ---
 
 ### Run 6 — Retail & Goods
@@ -594,6 +827,31 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **CTA:** purchase  
 **Key services to verify:** Featured Products section, Bundle Deals, Gift Vouchers  
 **Special:** Verify product catalog renders with images placeholders; currency shows correctly; "Shop Now" CTA label
+
+**Run-6 Phase P setup (lead archetype — fresh install):**
+- P1: `/storefront/items` → Edit seeded items to set prices if £0: Featured Product $29.99, Bundle Deal $49.99, Gift Voucher $50.00 (gift vouchers are fixed denomination — confirm ctaType is purchase, not inquiry).
+- P2: Add audit item: **"Audit Run Widget — Test SKU R6"**, category "General Merchandise", price $19.99, ctaType purchase, description "Standard audit product for Run 6 validation". Save. Verify it appears on the public portal storefront.
+- P3: `/customer` → Add account: **Test Buyer R6**, contact email buyer-r6@test.com, phone 555-0200.
+- P4: `/storefront/settings/operations` → Mon–Sat 09:00–18:00, Sun 11:00–17:00. Save.
+
+**Run-6 Phase B5 walkthrough:**
+1. Public portal → "Shop Now" (confirm label is "Shop Now", not "Book" or "Inquire")
+2. Product catalog loads with at least 4 items including "Audit Run Widget — Test SKU R6" at $19.99
+3. Verify at least one product has an image placeholder (not a broken image tag)
+4. Click "Audit Run Widget — Test SKU R6" → product detail page: name "Audit Run Widget — Test SKU R6", description, $19.99 all visible
+5. Add to cart (qty: 1) → cart shows item + $19.99
+6. Proceed to checkout:
+   - Name: Test Buyer R6, email: buyer-r6@test.com
+   - Delivery address: 1 Test Street, Chicago, IL 60601
+7. Confirm purchase → order reference number shown
+8. `/storefront/inbox` → order appears with "Audit Run Widget — Test SKU R6" and buyer-r6@test.com
+9. `/customer` → Test Buyer R6 account shows linked order or activity
+
+**Run-6 Phase G (financial tally):**
+- G1: Supplier "General Merchandise Wholesale" at `/finance/suppliers`
+- G2: Bill: "Quarterly stock replenishment — mixed goods", qty 1, $250.00
+- G3: Invoice for Test Buyer R6: "Audit Run Widget — Test SKU R6", qty 1, $19.99
+- G4: P&L → revenue $19.99, expenses $250.00, net -$230.01
 
 ---
 
@@ -636,6 +894,30 @@ After landscaping test: swap to `cleaning-service` via the admin archetype-reset
 **CTA:** purchase  
 **Key services to verify:** Monthly Membership, Annual Membership, Personal Training Session, Day Pass, Gym Induction  
 **Special:** Membership = subscription commercial model — verify recurring billing language in coworker vs one-off purchase items; no "appointment-checkout" pattern
+
+**Run-7 Phase P setup (lead archetype — fresh install):**
+- P1: `/storefront/items` → Edit seeded items to set prices if £0: Monthly Membership $49.00, Annual Membership $420.00, Personal Training Session $75.00, Day Pass $15.00, Gym Induction $25.00.
+- P2: Add audit item: **"Audit — Monthly Membership (Test R7)"**, price $49.00, ctaType purchase, description "Full gym access, 30 days, auto-renewing". Save.
+- P3: `/customer` → Add account: **Test Member R7**, contact email member-r7@test.com.
+- P4: `/storefront/settings/operations` → Mon–Sun 06:00–22:00. Save.
+
+**Run-7 Phase B5 walkthrough:**
+1. Public portal → product catalog shows all membership tiers and the "Audit — Monthly Membership (Test R7)" item
+2. Click "Audit — Monthly Membership (Test R7)" → detail page: $49.00/month, description mentions 30-day/auto-renewing language
+3. Add to cart → "Purchase" or "Join Now" button (confirm NOT "Book")
+4. Checkout:
+   - Name: Test Member R7, email: member-r7@test.com
+   - Date of birth: 1990-05-15 (if form requires it for age verification)
+   - Emergency contact: "Jane Doe, 555-0300" (if form requires it for gym membership)
+5. Confirm purchase → order/membership reference number shown
+6. `/storefront/inbox` → membership purchase appears
+7. **Subscription model check**: ask coworker "Is this a one-time purchase?" → response should clarify recurring/subscription model, not one-off; no "appointment-checkout" or "book a session" framing
+
+**Run-7 Phase G (financial tally):**
+- G1: Supplier "Fitness Equipment Leasing Co." at `/finance/suppliers`
+- G2: Bill: "Treadmill preventive maintenance contract — monthly", qty 1, $150.00
+- G3: Invoice for Test Member R7: "Audit — Monthly Membership (Test R7)", qty 1, $49.00
+- G4: P&L → revenue $49.00, expenses $150.00, net -$101.00
 
 ---
 
@@ -1018,7 +1300,7 @@ For each observation during a run, log using this format:
 RUN: [run number]
 ARCHETYPE: [archetypeId]
 INSTALL MODE: fresh-install | swapped (archetype-reset)
-PHASE: [A-G + test ID e.g. B5]
+PHASE: [P, A–H + test ID e.g. B5, G3, P5-PET]
 OBSERVATION: [what you saw]
 EXPECTED: [what should have happened]
 SEVERITY: critical | important | minor | observation
@@ -1056,6 +1338,9 @@ These tests apply to EVERY archetype run. Track results in the summary table bel
 | AI-2 | Coworker uses archetype context | Responses reference archetype services and vocabulary, not generic defaults |
 | AI-3 | Regulated archetypes disclaim appropriately | Banking, healthcare, legal, law enforcement — no clinical/legal/financial advice given |
 | FIN-1 | Finance defaults correct | Currency matches setup; commercial model reflected in finance framing |
+| FIN-2 | Supplier bill records correctly | Bill created at `/finance/bills/new` → appears in bills list with correct supplier and total |
+| FIN-3 | Invoice records correctly | Invoice created at `/finance/invoices/new` → appears in invoice list linked to customer account |
+| FIN-4 | P&L report reflects entries | `/finance/reports/profit-loss` shows the G2 expense and G3 revenue; net figure is calculated |
 | GRC-1 | Compliance section loads | Dashboard loads; for regulated archetypes, sector-specific placeholders present |
 
 ---


### PR DESCRIPTION
## Summary

- **Phase P (new)** — Catalog & Data Prerequisites section that runs after wizard setup and before any CTA test. Covers staff creation, availability hours, item pricing, and domain-specific pre-conditions: pet/owner records via `CustomerConfigurationItem` for vet and pet-services archetypes; test customer accounts for purchase archetypes.
- **Phase B5 (expanded)** — Full step-by-step CTA walkthrough for all four types (booking/purchase/inquiry/donation). Booking flows now include pet fields (name, species, breed, age, reason for visit) flagged as important findings if absent. Purchase flows include physical delivery address and membership-specific fields. Inquiry flows include trades urgency/property-type fields and catering guest count.
- **Phase G (new)** — Financial Tally after Phase F. Supplier bill at `/finance/bills/new`, customer invoice at `/finance/invoices/new`, P&L verification at `/finance/reports/profit-loss`. Three new cross-cutting matrix rows: FIN-2, FIN-3, FIN-4.
- **Phase H** — Renamed from old Phase G (responsive smoke); now H1–H3.
- **Archetype run scripts** — Eight archetypes now have detailed Phase P + B5 + G run scripts with named test customers, specific prices, and exact product/service names: hair-salon, veterinary-clinic (pet "Max"), bakery, retail-goods, gym, restaurant (party size), pet-grooming (pet "Bella"), plumber.

## Test plan

- [ ] Review [docs/testing/archetype-audit-plan.md](docs/testing/archetype-audit-plan.md) — confirm Phase P, expanded B5, and Phase G sections read as actionable step-by-step instructions
- [ ] Verify cross-cutting matrix includes FIN-2, FIN-3, FIN-4
- [ ] Confirm vet archetype script includes pet CI creation at `/customer`
- [ ] Confirm bakery and retail-goods scripts include product pricing setup and named test buyer
- [ ] No code changes; CI passes on docs-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)