### PR TITLE
doc(site): public overview + AI-workforce docs — Grok, WSID, full coworker roster, OS-dependent TTS

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -568,7 +568,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       <tbody>
         <tr><td>Portfolio Management</td><td>Organize digital products into portfolios with health metrics, investment tracking, and lifecycle management.</td></tr>
         <tr><td>HR &amp; Workforce</td><td>Manage employees, roles, reviews, timesheets, and organizational structure. The same role hierarchy (HR-000 through HR-500) drives platform access.</td></tr>
-        <tr><td>Customer Relationships</td><td>Track customer accounts, sales pipeline from lead to order, and engagement history.</td></tr>
+        <tr><td>Customer Relationships &amp; CRM</td><td>Track customer accounts and engagement history through a low-friction, Pipedrive-inspired visual pipeline with visible next actions &mdash; a customer-acquisition loop from lead to qualify to opportunity to quote/order/campaign.</td></tr>
         <tr><td>Compliance &amp; Regulatory</td><td>Onboard regulations and standards, map controls to obligations, collect evidence, track posture, and manage licensing readiness.</td></tr>
         <tr><td>Financial Management</td><td>Invoices, suppliers and bills, purchase orders, banking and reconciliation, AI-spend visibility.</td></tr>
         <tr><td>Enterprise Architecture</td><td>Model the application, technology, and business layers with ArchiMate notation; graph-backed via Neo4j.</td></tr>
@@ -578,6 +578,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
         <tr><td>Marketing execution loop</td><td>Draft &rarr; approve &rarr; publish &rarr; respond &rarr; measure for outbound marketing across LinkedIn posts, LinkedIn Ads, and email &mdash; with hard spend ceilings, per-send human approval, and a bounded autopilot scheduler. Every external publish is gated and audited.</td></tr>
         <tr><td>Coworker screen actions</td><td>Coworkers can read what a screen offers (via a screen manifest) and propose on-screen actions on your behalf. Destructive actions flow through a propose &rarr; approve &rarr; dispatch envelope so the coworker drives the real UI under the same human-in-the-loop gates as a button click.</td></tr>
         <tr><td>Organization knowledge corpus (WWWD)</td><td>A governed, org-scoped knowledge base built from onboarding context, uploaded business documents, Q&amp;A, and approved AI research. Everything enters draft-by-default with provenance and trust grading; reviewed material feeds the WWMD decision gate and coworker recall.</td></tr>
+        <tr><td>Profession corpus (WSID)</td><td>The third decision scope: a per-role professional body of knowledge (DAMA-DMBOK, GAAP, the marketing canon&hellip;) so each coworker&rsquo;s craft judgment is source-traced and audited rather than improvised by the underlying model.</td></tr>
         <tr><td>Build Studio</td><td>A guided five-phase pipeline (ideate, plan, build, review, ship) with AI coworkers, sandbox execution, code intelligence, impact reports, and promotion or PR handoff where configured. Active hardening is underway for oversized-build decomposition and safer portal upgrades.</td></tr>
         <tr><td>Operations &amp; Backlog</td><td>Manage delivery work with epics, items, priorities, and status tracking. Coworkers create, triage, size, and link items through governed MCP tools.</td></tr>
         <tr><td>AI Workforce</td><td>Provider configuration, dynamic model discovery, capability-tier routing, operations map, capacity continuity, capability-needs review, agent registry, and per-agent grants.</td></tr>
@@ -625,7 +626,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="archetypes">
     <h2>Twelve market categories, 46 leaf archetypes</h2>
     <p class="sub">
-      Archetypes are the bootstrap mechanism that turns a fresh install into a working business setup. Each one carries storefront design, vocabulary, role emphasis, process defaults, finance assumptions, and marketing posture. The same archetype now also drives <strong>internal workspace homes</strong> &mdash; dispatch boards for trades, appointment-readiness boards for clinics, merchandising boards for retail, and equivalent daily boards for other categories. The workspace-home substrate (registry, resolver, projection service) has landed; the HVAC dispatcher board is the first vertical being implemented against it.
+      Archetypes are the bootstrap mechanism that turns a fresh install into a working business setup. Each one carries storefront design, vocabulary, role emphasis, process defaults, finance assumptions, and marketing posture. The same archetype now also drives <strong>internal workspace homes</strong> &mdash; dispatch boards for trades, appointment-readiness boards for clinics, merchandising boards for retail, and equivalent daily boards for other categories. The workspace-home substrate (registry, resolver, projection service) has landed; the HVAC dispatcher board is the first vertical being implemented against it. <strong>Detailed guide:</strong> <a href="/user-guide/market-archetypes">market-archetypes</a>.
     </p>
     <div class="grid">
       <div class="card"><h3>Healthcare &amp; Wellness</h3><p>Clinics, practitioners, wellness providers; appointment-centric flows.</p></div>
@@ -646,7 +647,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="coworkers">
     <h2>Meet the coworker workforce</h2>
     <p class="sub">
-      Coworkers are role-bound AI personas, each scoped to a value stream, each with its own grant set and skill library. They are the platform&rsquo;s primary surface for getting work done &mdash; you talk to the coworker who owns the area you&rsquo;re working in, and the platform routes you correctly based on the page, active archetype, and permissions in play.
+      Coworkers are role-bound AI personas, each scoped to a value stream, each with its own grant set and skill library. They are the platform&rsquo;s primary surface for getting work done &mdash; you talk to the coworker who owns the area you&rsquo;re working in, and the platform routes you correctly based on the page, active archetype, and permissions in play. The full registry holds <strong>63 agents</strong> (48 value-stream specialists, 9 orchestrators, 6 cross-cutting); the personas below are the ones an operator talks to directly. <strong>Detailed guide:</strong> <a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a> and <a href="/user-guide/market-archetypes">market-archetypes</a>.
     </p>
     <div class="grid">
       <div class="card"><h3>onboarding-coo</h3><p>Hosts first-run setup. Introduces the platform, explains AI providers, walks through identity, branding, and finance configuration.</p></div>
@@ -654,23 +655,34 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       <div class="card"><h3>portfolio-advisor</h3><p>Digital products and portfolios &mdash; health, investment, lifecycle.</p></div>
       <div class="card"><h3>ea-architect</h3><p>Enterprise architecture &mdash; ArchiMate views, capability maps, dependencies.</p></div>
       <div class="card"><h3>build-specialist</h3><p>Drives Build Studio: design docs, sandbox builds, code intelligence, test-first decomposition, code review.</p></div>
-      <div class="card"><h3>compliance-officer</h3><p>Standards onboarding, licensing readiness, control mapping, evidence collection, posture tracking.</p></div>
+      <div class="card"><h3>licensing-specialist</h3><p>Archetype-aware licensing and permit readiness, control mapping, evidence collection, posture tracking. (aka compliance-licensing-specialist.)</p></div>
       <div class="card"><h3>hr-specialist</h3><p>Workforce, roles, reviews, timesheets, organizational structure.</p></div>
       <div class="card"><h3>customer-advisor</h3><p>Customer accounts, sales pipeline, engagement history.</p></div>
-      <div class="card"><h3>storefront-advisor</h3><p>Storefront content, archetype-driven sections, vocabulary, design system.</p></div>
-      <div class="card"><h3>inventory-specialist</h3><p>Items, stock, fulfillment, orders.</p></div>
-      <div class="card"><h3>marketing-specialist</h3><p>Brand voice, content, campaigns &mdash; reads from the same archetype that seeded the storefront.</p></div>
-      <div class="card"><h3>ops-coordinator</h3><p>Operations and backlog: epics, items, priorities, status, scheduling.</p></div>
+      <div class="card"><h3>finance-agent</h3><p>Budget, chargeback, P&amp;L attribution, AI-spend visibility, and financial reporting.</p></div>
+      <div class="card"><h3>inventory-specialist</h3><p>Items, stock, fulfillment, orders, product lifecycle and market fit. (aka estate-specialist.)</p></div>
+      <div class="card"><h3>marketing-specialist</h3><p>Brand voice, content, campaigns, storefront sections &mdash; reads from the same archetype that seeded the storefront.</p></div>
+      <div class="card"><h3>ops-coordinator</h3><p>Operations and backlog: epics, items, priorities, status, scheduling (Scrum Master for delivery flow and WIP limits).</p></div>
       <div class="card"><h3>platform-engineer</h3><p>Platform health: providers, model routing, agent registry, infrastructure observability.</p></div>
-      <div class="card"><h3>docs-specialist</h3><p>Documentation upkeep &mdash; architecture, user guide, in-product help.</p></div>
+      <div class="card"><h3>documentation-specialist</h3><p>Documentation upkeep and validated diagrams &mdash; architecture, user guide, in-product help.</p></div>
+      <div class="card"><h3>external-catalog-scout</h3><p>Scouts external coworker and archetype patterns from the hive mind. (aka hive-scout.)</p></div>
       <div class="card"><h3>admin-assistant</h3><p>Cross-cutting administrative work: scheduling, reminders, filing, follow-ups.</p></div>
+    </div>
+
+    <h3 style="margin-top:24px; font-size:16px;">Behind the personas: value-stream orchestrators and build sub-agents</h3>
+    <p class="sub" style="margin-top:0;">
+      The personas above front a deeper bench. Nine <strong>value-stream orchestrators</strong> (one per IT4IT value stream plus a coordinating COO orchestrator) sequence specialist work, and Build Studio fans a feature out to four <strong>build sub-agents</strong> who each own a slice of the implementation.
+    </p>
+    <div class="grid">
+      <div class="card"><h3>Value-stream orchestrators</h3><p>coo-orchestrator (Jiminy), then evaluate-, explore-, integrate-, deploy-, release-, consume-, operate-, and governance-orchestrator &mdash; each owns flow, prioritization, and gate enforcement within its value stream.</p></div>
+      <div class="card"><h3>Build sub-agents</h3><p>build-data-architect (schema, migrations), build-software-engineer (APIs, server actions), build-frontend-engineer (pages, components, WCAG), and build-qa-engineer (tests, typecheck) &mdash; the team a single build is decomposed across.</p></div>
+      <div class="card"><h3>WSID professional grounding</h3><p>Each coworker role now resolves against a profession corpus (WSID, in the Autonomy section below) so its craft judgment &mdash; data-architecture, finance, marketing &mdash; is sourced and audited, not LLM folklore.</p></div>
     </div>
   </section>
 
   <section id="build-studio">
     <h2>Build Studio: the five-phase pipeline</h2>
     <p class="sub">
-      Build Studio is how the platform extends itself. A user (or a coworker on a user&rsquo;s behalf) proposes a feature, and the request flows through five governed phases. Each phase has its own gate &mdash; nothing advances until the previous gate&rsquo;s artifacts are present and acceptable. Phase-to-phase dispatch is now automatic: once a build is approved to start, Ideate &rarr; Plan &rarr; Build &rarr; Review run without an operator clicking between them, and the deliberate human gate is the final diff review before anything ships. The lifecycle is also right-sized by work type and size, so a bug fix or doc change carries lighter ceremony than a net-new feature. End-to-end reliability hardening continues, so treat Build Studio as the governed evidence and development surface rather than a guarantee that every complex source change lands untouched.
+      Build Studio is how the platform extends itself. A user (or a coworker on a user&rsquo;s behalf) proposes a feature, and the request flows through five governed phases. Each phase has its own gate &mdash; nothing advances until the previous gate&rsquo;s artifacts are present and acceptable. Phase-to-phase dispatch is now automatic: once a build is approved to start, Ideate &rarr; Plan &rarr; Build &rarr; Review run without an operator clicking between them, and the deliberate human gate is the final diff review before anything ships. The lifecycle is also right-sized by work type and size, so a bug fix or doc change carries lighter ceremony than a net-new feature. End-to-end reliability hardening continues, so treat Build Studio as the governed evidence and development surface rather than a guarantee that every complex source change lands untouched. <strong>Detailed guide:</strong> <a href="/user-guide/build-studio/">user-guide/build-studio</a> (with <a href="/user-guide/build-studio/sandbox">sandbox</a> and <a href="/user-guide/build-studio/deployment">deployment</a> notes).
     </p>
     <table class="guide">
       <thead>
@@ -754,7 +766,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="ai-workforce">
     <h2>AI workforce: local-first, with optional cloud</h2>
     <p class="sub">
-      The AI workforce ships ready-to-run on your own hardware and grows as you connect external providers. Routing decisions are dynamic and capability-tier driven &mdash; never hard-pinned to a specific model in seed data &mdash; so the platform can pick the right LLM for each task type and sensitivity level without manual configuration.
+      The AI workforce ships ready-to-run on your own hardware and grows as you connect external providers. Routing decisions are dynamic and capability-tier driven &mdash; never hard-pinned to a specific model in seed data &mdash; so the platform can pick the right LLM for each task type and sensitivity level without manual configuration. <strong>Detailed guides:</strong> <a href="/user-guide/ai-workforce/">ai-workforce</a>, <a href="/user-guide/ai-workforce/connecting-providers">connecting-providers</a>, <a href="/user-guide/ai-workforce/model-routing-lifecycle">model-routing-lifecycle</a>, <a href="/user-guide/ai-workforce/ai-cost-governance">ai-cost-governance</a>, and <a href="/user-guide/ai-workforce/decision-perspective">decision-perspective</a> (WWMD / WSID + voice).
     </p>
     <div class="pillars">
       <div class="pillar">
@@ -764,8 +776,13 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       </div>
       <div class="pillar">
         <div class="tag">Optional cloud</div>
-        <strong>Connect Anthropic, OpenAI, and others.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">External providers are an upgrade, not a prerequisite. Sensitivity clearance per provider decides which traffic each one is allowed to see; local stays the default for restricted data.</p>
+        <strong>Connect Anthropic, OpenAI, Grok, and others.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">External providers are an upgrade, not a prerequisite. Connect with an API key, a subscription OAuth sign-in (Claude Max, ChatGPT Codex), or a device-code sign-in (xAI / Grok). Sensitivity clearance per provider decides which traffic each one is allowed to see; local stays the default for restricted data.</p>
+      </div>
+      <div class="pillar">
+        <div class="tag">xAI / Grok</div>
+        <strong>First-class Grok support, signed in without an API key.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Grok is a direct provider alongside Anthropic and OpenAI, seeded with Grok&nbsp;4.3 (reasoning) and Grok&nbsp;Build&nbsp;0.1 (agentic coding). Because hunting for an xAI key is poor UX for a non-technical founder, the platform drives the Grok CLI&rsquo;s own <code>device-auth</code> OAuth: a coworker or the provider page starts the flow (<code>grok_signin_start</code>), you confirm a code in your browser (Google / X / Apple), and the captured credential is injected into each build sandbox and self-refreshed. See <a href="/user-guide/ai-workforce/provider-xai">provider-xai</a> and <a href="/user-guide/ai-workforce/connecting-providers">connecting-providers</a>.</p>
       </div>
       <div class="pillar">
         <div class="tag">Dynamic discovery</div>
@@ -795,7 +812,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
       <div class="pillar">
         <div class="tag">Persona Voice Layer</div>
         <strong>Coworkers can speak, without gaining authority.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled speaches (faster-whisper) STT service handles voice input, and a founder seed voice now ships in the install seed (with a consent record) so spoken output works out of the box. TTS providers include Apple-Silicon-native sidecars (Chatterbox, MLX) with sentence-level streaming for low time-to-first-audio and per-profile speed/enthusiasm tuning. Voice never changes approval, confidence, or audit rules, and real-person voice requires consent.</p>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled speaches (faster-whisper) STT service handles voice input, and a founder seed voice now ships in the install seed (with a consent record) so spoken output works out of the box. TTS defaults to <strong>self-hosted</strong> so audio stays on your hardware, and the backend is operating-system-dependent: a Chatterbox <code>dpf-tts</code> container on Linux/Windows with an NVIDIA GPU, or a native-host MLX sidecar on Apple Silicon (Docker Desktop on macOS has no GPU passthrough). Cloud TTS (Cartesia, Fish Audio, ElevenLabs) is an optional opt-in. Voice never changes approval, confidence, or audit rules, and real-person voice requires consent. See <a href="/user-guide/ai-workforce/decision-perspective">decision-perspective</a>.</p>
       </div>
       <div class="pillar">
         <div class="tag">Routing resilience</div>
@@ -907,12 +924,17 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
     <p class="sub" style="margin-top:0;">
       WWMD draws on the shared founder-kernel principles. WWWD &mdash; the organization knowledge corpus &mdash; is the org-specific complement: a governed, single-org knowledge base built from onboarding context, uploaded business documents, market Q&amp;A, and approved AI research. Every source &mdash; data entry, document upload, scheduled research, integrations, coverage-gap detection &mdash; flows through one enrichment contract that handles idempotency, provenance, and trust grading (first-party, derived, researched). Material lands <em>draft-by-default</em> regardless of source; human review promotes it to authoritative before it influences anything. Reviewed material projects into the decision profile that feeds the WWMD gate and coworker recall, and a freshness-governance layer supersedes stale material and re-enqueues research when coverage gaps appear.
     </p>
+
+    <h3 style="margin-top:24px; font-size:16px;">The profession corpus (WSID): what a competent professional in this role should do</h3>
+    <p class="sub" style="margin-top:0;">
+      WWMD answers <em>&ldquo;what would the founder/platform do?&rdquo;</em> and WWWD answers <em>&ldquo;what would this organization do?&rdquo;</em> &mdash; but a coworker doing a specialist&rsquo;s job also needs a governed source for <em>what a competent professional in that role should do</em>. WSID (&ldquo;What Should I Do?&rdquo;) is the third scope in the same family, reusing the same architecture &mdash; a versioned profile, a source-traced corpus, weighted retrieval, and an audited gate &mdash; but scoped to the <strong>profession</strong> rather than the founder or the org. Each coworker role family gets its own profile (<code>WSID-DATA-ARCHITECT</code>, <code>WSID-FINANCE</code>, <code>WSID-MARKETING</code>, &hellip;) backed by a corpus distilled from <em>fetched, verifiable sources</em> &mdash; DAMA-DMBOK and ANSI SQL and OWASP for a data architect, GAAP and SOX control concepts for finance, the AMA body of knowledge and CAN-SPAM / GDPR consent rules for marketing &mdash; never authored from model memory. When a coworker hits a craft question, the gate resolves against its profession profile first, then falls back through role &rarr; org WWWD &rarr; DPF doctrine &rarr; defer-with-gap-capture. The contract is full-roster: WSID is designed to scope <em>every</em> coworker on the platform, with data-architect, finance, and marketing as the pilot three that prove the pipeline.
+    </p>
   </section>
 
   <section id="data-layer">
     <h2>The data layer and sandbox containers</h2>
     <p class="sub">
-      The platform is a containerized stack with a small, deliberate set of stateful services. Knowing what lives where helps you reason about backups, sovereignty, and the boundary between safe iteration and production state.
+      The platform is a containerized stack with a small, deliberate set of stateful services. Knowing what lives where helps you reason about backups, sovereignty, and the boundary between safe iteration and production state. <strong>Detailed reference:</strong> <a href="/architecture/platform-overview">architecture/platform-overview</a>.
     </p>
     <table class="guide">
       <thead>
@@ -958,7 +980,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="identity">
     <h2>Identity, federation, and agent interoperability</h2>
     <p class="sub">
-      The platform treats human and agent identity as one design surface. Humans sign in through your existing directory; agents carry their own durable identifiers and traceable claims; coworker-to-coworker work travels as a governed task, not as an implicit chat side-effect.
+      The platform treats human and agent identity as one design surface. Humans sign in through your existing directory; agents carry their own durable identifiers and traceable claims; coworker-to-coworker work travels as a governed task, not as an implicit chat side-effect. <strong>Detailed guides:</strong> <a href="/user-guide/platform/identity-and-access">platform/identity-and-access</a>; architecture: <a href="/architecture/GAID">GAID</a> and <a href="/architecture/trusted-ai-kernel">trusted-ai-kernel</a>.
     </p>
     <table class="guide">
       <thead>
@@ -992,7 +1014,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="observability">
     <h2>Observability and evidence</h2>
     <p class="sub">
-      Governance is only worth the policy if you can see what happened. The platform ships with discovery, metrics, and an append-only audit ledger so every meaningful action by a human or an agent is reviewable end-to-end.
+      Governance is only worth the policy if you can see what happened. The platform ships with discovery, metrics, and an append-only audit ledger so every meaningful action by a human or an agent is reviewable end-to-end. <strong>Detailed guides:</strong> <a href="/user-guide/platform/authority-and-audit">platform/authority-and-audit</a> and <a href="/user-guide/operations/infrastructure-discovery">operations/infrastructure-discovery</a>.
     </p>
     <div class="pillars">
       <div class="pillar">
@@ -1026,7 +1048,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="compliance">
     <h2>Compliance, evidence, and audit</h2>
     <p class="sub">
-      Compliance is treated as a first-class concern in the data model rather than a reporting layer bolted on top. Standards and regulations are first-class objects, controls map to obligations, evidence is collected against controls, and the audit ledger ties every governed action back to a principal, an authority, and an outcome.
+      Compliance is treated as a first-class concern in the data model rather than a reporting layer bolted on top. Standards and regulations are first-class objects, controls map to obligations, evidence is collected against controls, and the audit ledger ties every governed action back to a principal, an authority, and an outcome. <strong>Detailed guides:</strong> <a href="/user-guide/compliance/">compliance</a> &mdash; <a href="/user-guide/compliance/controls-and-evidence">controls &amp; evidence</a>, <a href="/user-guide/compliance/posture-and-gaps">posture &amp; gaps</a>, <a href="/user-guide/compliance/licensing-readiness">licensing readiness</a>.
     </p>
     <table class="guide">
       <thead>
@@ -1135,7 +1157,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="mcp">
     <h2>The platform as a programmable surface (MCP)</h2>
     <p class="sub">
-      The Model Context Protocol (MCP) lets external clients drive the platform with the same tools, the same grants, and the same approval gates that the in-product coworkers face. That means you can connect the platform to your existing AI tooling without giving anything a back-door &mdash; every external call is authorized, audited, and traceable, just like a button click.
+      The Model Context Protocol (MCP) lets external clients drive the platform with the same tools, the same grants, and the same approval gates that the in-product coworkers face. That means you can connect the platform to your existing AI tooling without giving anything a back-door &mdash; every external call is authorized, audited, and traceable, just like a button click. <strong>Detailed guide:</strong> <a href="/user-guide/platform/tools-and-integrations">platform/tools-and-integrations</a>.
     </p>
     <div class="pillars">
       <div class="pillar">
@@ -1164,7 +1186,7 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
   <section id="roles">
     <h2>Roles and access</h2>
     <p class="sub">
-      The platform uses a two-tier role model so platform-wide governance is separated from product-specific operating structures. Tier 1 is six immutable roles aligned to IT4IT v3.0.1 value-stream authority. Tier 2 is per-product roles defined by the business model the product runs on (SaaS, Marketplace, IoT, etc.) &mdash; a user can hold different business-model roles on different products.
+      The platform uses a two-tier role model so platform-wide governance is separated from product-specific operating structures. Tier 1 is six immutable roles aligned to IT4IT v3.0.1 value-stream authority. Tier 2 is per-product roles defined by the business model the product runs on (SaaS, Marketplace, IoT, etc.) &mdash; a user can hold different business-model roles on different products. <strong>Detailed guides:</strong> <a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a> and <a href="/user-guide/products/business-model-roles">products/business-model-roles</a>.
     </p>
     <table class="guide">
       <thead>
@@ -1481,9 +1503,19 @@ powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
           <td>Anthropic cache telemetry, accurate per-model pricing, <code>BuildPhaseRun</code> + <code>ToolExecution</code> metering, <code>AgentBudgetEvent</code>, rolling thread compaction, phase-boundary summarization, and CLI-pool pre-dispatch rate-limit checks are live. Per-phase cost breakdown surfaces in Build Studio. Budget enforcement (hard stops vs. soft alerts) is the closing piece.</td>
         </tr>
         <tr>
-          <td>Decision Perspective Gate (WWMD) + Persona Voice Layer</td>
+          <td>Decision Perspective Gate (WWMD / WWWD / WSID) + Persona Voice Layer</td>
           <td><strong>Early access</strong></td>
           <td>WWMD is the canonical handler for open-question and ambiguity surfaces, returning <em>recommend</em> / <em>arbitrate</em> / <em>escalate</em> / <em>defer</em> with confidence and audit trail; also exposed as an MCP tool, and now backed by the org WWWD corpus for org-specific judgment. The Persona Voice Layer ships speaches-based STT, a seeded founder voice, Apple-Silicon-native TTS sidecars (Chatterbox, MLX) with sentence-level streaming, and per-profile voice tuning.</td>
+        </tr>
+        <tr>
+          <td>WSID profession corpus (third decision scope)</td>
+          <td><strong>Early access</strong></td>
+          <td>The third decision-perspective scope after WWMD (founder/platform) and WWWD (org): a per-role professional corpus so coworker craft judgment is source-traced and audited. Phase&nbsp;0 (profession profile kind + professional-practice domain class), Phase&nbsp;1 (Profession Source Registry + 23 family profiles + role resolver), and the data-architect corpus with provenance lint and seed wiring are merged; finance and marketing corpora and deeper gate-resolution wiring are the pilot-three completion work. Reuses the existing profile + corpus + retrieval + gate substrate &mdash; no new tables.</td>
+        </tr>
+        <tr>
+          <td>xAI / Grok provider support (EP-GROK-001)</td>
+          <td><strong>Early access</strong></td>
+          <td>Grok is a direct provider with seeded Grok&nbsp;4.3 and Grok&nbsp;Build&nbsp;0.1 models. API-key auth plus a device-code OAuth path (drives the Grok CLI&rsquo;s own <code>device-auth</code>, stores and self-refreshes the credential, injects it into build sandboxes) are merged across slices 1&ndash;4, with operator-page and coworker-driven (<code>grok_signin_start</code> / <code>grok_signin_status</code>) setup. End-to-end functional verification on a real sandbox with operator authorization is the closing step.</td>
         </tr>
         <tr>
           <td>Cloud Single-VM (AWS / GCP / Azure)</td>

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -2,8 +2,8 @@
 title: "Connecting AI Providers"
 area: "ai-workforce"
 order: 2
-lastUpdated: "2026-04-24"
-updatedBy: "Codex"
+lastUpdated: "2026-06-11"
+updatedBy: "Claude"
 ---
 
 ## Overview
@@ -16,13 +16,19 @@ The platform connects to external AI providers to run inference for your AI work
 
 The standard method for providers with pay-per-token billing. Obtain a key from the provider's developer console and paste it into the provider detail page. The platform uses the key for every inference request.
 
-Supported providers: Anthropic (API), OpenAI, Gemini, Mistral, and most other hosted providers.
+Supported providers: Anthropic (API), OpenAI, Gemini, xAI / Grok, Mistral, and most other hosted providers.
 
 ### OAuth Sign-in
 
 Browser-based authentication using your existing subscription. No API key is required. The platform redirects you to the provider's login page; once you authenticate, a token is stored securely (encrypted in the database) and refreshed automatically.
 
 Supported providers: Claude / Anthropic (Max subscription), OpenAI Codex (ChatGPT Plus/Pro plan).
+
+### Device-Code Sign-in (xAI / Grok)
+
+A headless-friendly OAuth variant for providers whose CLI ships a device-code flow. Rather than a browser redirect back to the platform, the platform runs the provider CLI's `device-auth` flow in the build sandbox, shows you a verification URL and a short user code, and waits while you authorize in your browser. The captured credential is stored encrypted, injected into each build sandbox, and self-refreshed. This is the recommended path for Grok because obtaining an xAI API key from `console.x.ai` is awkward for non-technical operators. See [xAI / Grok](./provider-xai.md) for the full flow.
+
+Supported providers: xAI / Grok.
 
 ### None
 

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -2,8 +2,8 @@
 title: "Decision Perspective & Persona Voice"
 area: ai-workforce
 order: 5
-lastUpdated: 2026-05-31
-updatedBy: Codex
+lastUpdated: 2026-06-11
+updatedBy: Claude
 ---
 
 ## What This Covers
@@ -14,6 +14,8 @@ This page documents two adjacent capabilities that ship together:
 - **Persona Voice Layer** — an optional audio modality. Speech-to-text (STT) is on by default for voice input; text-to-speech (TTS) is opt-in per profile and narrates decision rationales in the persona's voice.
 
 The naming: **WWMD** is "What Would Mark Do" — the first profile, seeded for the DPF platform itself. **WWTD** is "What Would They Do" — the generalized model that lets a customer organization encode an executive, a domain expert, or an organizational archetype as its own profile. **WWWD** is the customer-organization variant of WWMD; in this DPF portal instance, WWMD and WWWD point at the same profile because the business and the product are the same thing.
+
+There is a third scope in the same family. **WSID** is "What Should I Do" — the *profession* profile. Where WWMD encodes founder/platform doctrine and WWWD encodes organization doctrine, WSID encodes what a competent professional in a given role should do. Each coworker role family gets its own profile (`WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING`, …) backed by a source-traced professional corpus, reusing the same profile + corpus + retrieval + gate architecture. See [The Profession Scope (WSID)](#the-profession-scope-wsid) below.
 
 The full design lives in three specs:
 
@@ -46,10 +48,11 @@ Confidence rises slowly through repeated evidence-backed alignment — a recomme
 
 When the active profile can't answer a question, the gate falls back through a fixed chain:
 
-1. Active profile (WWWD or customer-specific)
-2. DPF product doctrine (general platform principles)
-3. DPF organizational principles (TAK / GAID governance layer)
-4. `defer` — insufficient coverage even for a framing recommendation; capture as a profile gap
+1. Profession profile (WSID) — when the question is a craft question for a coworker with a role profile
+2. Active profile (WWWD or customer-specific)
+3. DPF product doctrine (general platform principles)
+4. DPF organizational principles (TAK / GAID governance layer)
+5. `defer` — insufficient coverage even for a framing recommendation; capture as a profile gap
 
 The chain is wired into the data model from day one so the fallback path is auditable: every interaction row records which level in the chain produced the answer.
 
@@ -61,12 +64,35 @@ The `DecisionPerspectiveProfile` model supports several profile kinds today. Eac
 |------|-------------|---------|--------|
 | `platform` | DPF platform doctrine (Mark / DPF Platform). The first profile, seeded with the founder's writings and approved decisions. | Mark / DPF Platform | **Shipped** — the WWMD kernel for this portal instance |
 | `organization` | Customer organization's operating principles (the WWWD profile). | Acme Corp Operating Principles | **Shipped surface, deferred content** — points at the platform profile in this instance because product and business are the same |
+| `profession` | A coworker role family's professional doctrine (the WSID profile), backed by a source-traced corpus distilled from professional bodies of knowledge. | `WSID-DATA-ARCHITECT`, `WSID-FINANCE`, `WSID-MARKETING` | **Early access** — profile kind, source registry, and 23 family profiles seeded; data-architect corpus shipped; finance and marketing are the pilot completion work |
 | `customer` | Future customer-instance profile, isolated from the platform's product-origin guidance. | Customer org doctrine | **Deferred** — not in V1 |
 | `persona-real` | A real person who has given explicit documented consent. The voice layer can use their voice clone. | An executive at a customer org | **Shipped surface, consent-gated** |
 | `persona-fictional` | A persona not derived from any real person — useful as an archetype profile. | "The Pragmatic Founder" | **Shipped** |
 | `persona-synthetic` | An AI-synthesized persona built from curated training data with no real-person basis. | Industry archetype seeded by DPF | **Shipped** |
 
 The non-negotiable boundary: a customer profile **must not** inherit platform-specific business judgment as authority by default. DPF product doctrine can be advisory product guidance for any profile; the customer's own WWWD profile becomes authoritative for its business context once that profile exists.
+
+## The Profession Scope (WSID)
+
+WWMD answers "what would the founder/platform do?" and WWWD answers "what would this organization do?" — but a coworker doing a specialist's job has no governed source for **what a competent professional in that role should do**. The data-architect coworker has no DAMA-DMBOK grounding; the finance coworker has no GAAP doctrine; the marketing specialist has no marketing body of knowledge. Without WSID, that professional judgment is whatever the underlying LLM happens to produce — ungoverned, unauditable, and inconsistent across model routings.
+
+WSID is the third scope, and it deliberately reuses the architecture the platform already proved twice: **a versioned profile + a source-traced corpus + weighted retrieval + an audited gate**, scoped to the profession instead of the founder or the org. No new vector DB, graph DB, or parallel table family — the corpus lives as `WikiPage` pages with `RawSource` provenance, `PerspectiveMaterial` rows for decision-bearing doctrine, and Qdrant embeddings for recall.
+
+Key properties:
+
+- **Full-roster coverage contract.** WSID is designed to scope *every* coworker on the platform — all 63 registry agents plus the route personas, collapsed into profession *families*. Data architect, finance, and marketing are the **pilot three** chosen to prove the pipeline; they are not the scope.
+- **Research-sourced, never training-data authored.** Every corpus page is produced by the research-ingest pipeline from fetched, verifiable sources. The LLM distills retrieved source text; it never writes doctrine from its own training memory. Each profession gets its own research effort and its own source list, governed by the Profession Source Registry.
+- **Role-aware gate resolution.** When a coworker hits a craft question, the gate evaluates against its profession profile first, then falls back through the existing chain (role → org WWWD → DPF doctrine advisory → defer-with-gap-capture).
+- **Seed = bootstrap, enrichment = runtime.** Pilot corpora install on a fresh portal (themselves pipeline-produced with recorded provenance); ongoing growth flows through the role-scoped enrichment pipeline with draft-by-default review.
+- **Org overridability.** An organization can extend or override a profession profile without mutating the platform-seeded baseline, via the existing kernel-page overlay pattern.
+
+Candidate anchor standards for the pilot three (each profession's research pass confirms, extends, and supersedes them with fetched sources):
+
+- **Data architect** — DAMA-DMBOK2, ISO/IEC 9075 (ANSI SQL), OWASP Top 10 + ASVS + Query Parameterization Cheat Sheet, ISO 11179 (metadata registries), Data Mesh as contextual material.
+- **Finance** — US GAAP (FASB ASC) presentation and recognition, double-entry invariants, month-end close discipline, segregation-of-duties / SOX 404 control concepts, IFRS divergences as context.
+- **Marketing** — AMA definitions and ethics statement, classic frameworks (4Ps/7Ps, STP, funnel/AARRR), brand-consistency doctrine, CAN-SPAM / GDPR consent as commandment-tier contextual rules.
+
+SFIA 9 and O*NET/ESCO inform which knowledge areas each role profile must cover — used as a completeness checklist, not ingested as text. WSID does **not** include verbatim ingestion of licensed/copyrighted texts, per the corpus content policy.
 
 ## Calling the Gate
 
@@ -104,15 +130,19 @@ The mic button is wired into the coworker chat surface; transcripts feed the exi
 
 TTS narrates decision rationales returned by the gate. Synthesis runs **asynchronously** after the gate writes the `DecisionInteraction` row — a TTS provider outage cannot block plan advancement, because audio is always enrichment and text is always the primary output.
 
-Provider options:
+The TTS provider is selected with the `TTS_PROVIDER` env var; the default is **self-hosted Chatterbox**, so voice stays on your hardware like the rest of the AI workforce. The right backend is **operating-system-dependent**, because Docker Desktop on macOS has no GPU passthrough — a cloning-grade model can't be GPU-accelerated inside a Mac container, so Apple Silicon runs a native-host sidecar instead (the same pattern local LLM inference already uses via Docker Model Runner).
 
-| Tier | Provider | GPU required | Notes |
-|------|----------|--------------|-------|
-| **Cloud (default)** | Cartesia Sonic 3 | None | Lowest first-audio latency (~90ms), 3-second minimum sample for voice cloning, streaming-native, professional voice clones without contacting sales. |
-| **Quality / self-hosted** | Fish Audio S2 | 1× RTX 4090 (24GB VRAM) | Highest measured naturalness, enterprise RBAC built in, self-hostable via the open-source repo for customers with data-residency requirements. |
-| **Fallback** | ElevenLabs / XTTS v2 (Coqui) | None (ElevenLabs) / 1× RTX 4090 (XTTS) | Stability fallback for non-real-time pre-rendering, or fully self-hosted budget option. |
+| Tier | Provider | Host path | GPU | Notes |
+|------|----------|-----------|-----|-------|
+| **Self-hosted default (Linux / Windows)** | Chatterbox (`dpf-tts` container, `travisvn/chatterbox-tts-api`) | amd64 container | NVIDIA / CUDA | Zero-shot voice cloning. The code default (`defaultProvider()` falls back to `chatterbox`). |
+| **Self-hosted default (Apple Silicon / non-NVIDIA)** | `mlx-audio` (Kokoro fast path + CSM cloning) | native macOS host process, reached via `host.docker.internal` | Apple MLX / Metal | The macOS path, because Docker Desktop has no GPU passthrough. Mirrors host-native Docker Model Runner. `TTS_PROVIDER=mlx`. |
+| **Cloud (optional)** | Cartesia Sonic 3 | API-only | None | Lowest first-audio latency (~90ms), streaming-native, no GPU. For installs that don't want to self-host. |
+| **Cloud / quality** | Fish Audio S2 | API or self-host | None (API) / RTX 4090 (self-host) | High naturalness, enterprise RBAC, self-hostable for data-residency needs. |
+| **Fallback** | ElevenLabs / XTTS v2 (Coqui) | API / self-host | None (ElevenLabs) / RTX 4090 (XTTS) | Stability fallback for pre-rendering, or fully self-hosted budget option. |
 
-The default deployment path adds zero hardware cost beyond the existing platform — cloud TTS is API-only. GPU is only relevant when a customer specifically requires on-premises voice synthesis.
+The default deployment path keeps audio on the host. Cloud TTS is the API-only opt-in for installs that prefer not to self-host or lack a suitable GPU.
+
+> The OS-dependent backend split is detailed in `docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md` (native-host MLX sidecar), which amends `docs/superpowers/specs/2026-05-21-chatterbox-tts-self-hosted.md` (the Linux/NVIDIA default).
 
 ### Voice Profile Admin
 
@@ -161,8 +191,9 @@ Three constraints are non-negotiable:
 
 ## What's In Progress
 
-Tracked under EP-WWMD and EP-VOICE-LAYER:
+Tracked under EP-WWMD, EP-VOICE-LAYER, and EP-WSID:
 
+- **WSID pilot completion** — the profession profile kind, Profession Source Registry, 23 family profiles, role resolver, and the data-architect corpus (with provenance lint) are merged; the finance and marketing corpora and deeper gate-resolution wiring complete the pilot three before the full-roster rollout
 - **Customer WWWD profiles** — the surface exists; the data and onboarding flow that lets a customer organization seed its own profile is the next deliverable
 - **Real-time voice conversation** — live back-and-forth using streaming TTS in a sub-400ms loop fed by the existing STT pipeline. V2 target
 - **Voice in coworker thread messages** — narrating coworker replies beyond gate rationale audio. V2
@@ -185,3 +216,6 @@ Tracked under EP-WWMD and EP-VOICE-LAYER:
 - `docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md` — voice layer + WWTD profile kinds
 - `docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md` — STT design
 - `docs/superpowers/specs/2026-05-17-voice-input-slice-1-5-default-on-cpu.md` — CPU-default STT + the 3-tier hardware ladder
+- `docs/superpowers/specs/2026-05-21-chatterbox-tts-self-hosted.md` — self-hosted Chatterbox TTS (Linux/NVIDIA default)
+- `docs/superpowers/specs/2026-05-28-tts-apple-silicon-local-design.md` — native-host MLX TTS sidecar for Apple Silicon (the OS-dependent path)
+- `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md` — the WSID profession scope (third decision perspective)

--- a/docs/user-guide/ai-workforce/provider-xai.md
+++ b/docs/user-guide/ai-workforce/provider-xai.md
@@ -1,0 +1,68 @@
+---
+title: "xAI / Grok"
+area: ai-workforce
+order: 6
+lastUpdated: "2026-06-11"
+updatedBy: "Claude"
+---
+
+## Overview
+
+xAI's Grok is a first-class direct AI provider, configured the same way as Anthropic and OpenAI on its provider detail page under **External Services**. It is treated as a standard token-billed provider in capability-tier routing — not special-cased — and it carries the same sensitivity-clearance and grant gating as every other external provider.
+
+Two models are seeded for routing:
+
+| Model | Class | Best for | Context |
+|-------|-------|----------|---------|
+| **Grok 4.3** | reasoning | Reasoning, analysis, long-context, tool use | 1M tokens |
+| **Grok Build 0.1** | code | Agentic coding, web dev, Build Studio tasks, tool use | 256K tokens |
+
+Both support tool use, streaming, structured output, images, thinking, and prompt caching. Because Build Studio OAuth connections can't call xAI's `/v1/models` discovery endpoint, these are seeded known models rather than discovered dynamically.
+
+## Authentication
+
+Grok supports two authentication methods. Choose either on the provider detail page; you can switch between them at any time.
+
+### Device-code sign-in (recommended)
+
+Obtaining an xAI API key from `console.x.ai` is poor UX, especially for a non-technical operator. Grok's CLI ships a clean **OAuth 2.0 device-code** flow, and the platform drives it for you rather than reimplementing xAI's OAuth in-portal:
+
+1. On the xAI provider page, click **Sign in to Grok** (or let a coworker start it — see below).
+2. The platform runs `grok login --device-auth` in the build sandbox and shows you a verification URL (`accounts.x.ai/oauth2/device`) plus a user code.
+3. Open the URL in your browser, sign in with the account method you already use (Google / X / Apple), and confirm the code.
+4. The platform reads the resulting `~/.grok/auth.json` out of the sandbox, stores it encrypted as the `xai` credential, and activates the provider.
+
+On each Build Studio dispatch, the stored credential is injected into the build sandbox's `~/.grok/auth.json` and the CLI self-refreshes it; the platform reads the refreshed token back out and persists it so the next build uses the latest token.
+
+### API key
+
+The standard pay-per-token path: obtain a key from `console.x.ai` and paste it into the provider detail page. The platform sends it as the `Authorization` header against `https://api.x.ai/v1`. When the stored credential is an API key rather than an `auth.json` blob, dispatch falls back to `XAI_API_KEY`.
+
+## Coworker-driven setup
+
+Because the device-code flow runs entirely through governed tools, an AI coworker can drive Grok setup on your behalf instead of you navigating the provider page:
+
+- **`grok_signin_start`** — initiates the device-code flow in the sandbox and returns the verification URL and user code for you to authorize in your browser.
+- **`grok_signin_status`** — polls for completion: `ok` (credential captured and the xAI provider activated), `pending` (waiting for you to authorize), or `failed`.
+
+Both tools require the `manage_provider_connections` capability and are recorded in the tool-execution log like any other governed action.
+
+## Sensitivity Clearance
+
+Like all external providers, Grok is assigned a sensitivity-clearance set (`public`, `internal`, `confidential`, `restricted`) on its provider page. Routing's hard filter refuses to send a request to Grok for data whose sensitivity its clearance does not cover. Local models remain the default for restricted data.
+
+## Cost Model
+
+Grok uses a per-token cost model. Configured-provider usage flows into the Finance module through the Finance Bridge, so Grok spend appears alongside other AI providers under `/finance/spend/ai`.
+
+## Troubleshooting
+
+- **"Sign in to Grok" shows no URL** — the `grok` binary must be present in the build sandbox. Ensure the sandbox image is current (the binary install landed with the EP-GROK-001 sandbox Dockerfile work).
+- **Stuck on "Waiting for authorization…"** — the device-code flow blocks until you confirm the code in your browser. Re-run the sign-in if the code expired.
+- **Token eventually goes stale** — OAuth-mode dispatch reads the CLI-refreshed token back out of the sandbox and persists it after each run; if a build hasn't run recently, the next dispatch refreshes it again.
+- **"No eligible endpoints"** — the seeded Grok models should profile automatically; if not, click "Sync Models & Profiles" on the provider page.
+
+## Related Specs
+
+- `docs/superpowers/specs/2026-05-31-grok-first-class-support-design.md` — first-class Grok support (EP-GROK-001)
+- `docs/superpowers/specs/2026-06-07-grok-device-code-oauth-design.md` — device-code OAuth for Build Studio dispatch


### PR DESCRIPTION
## What & why

The public `docs/index.html` overview had drifted from current platform state, and two shipped/early-access capabilities (WSID, Grok) had **zero** user-facing documentation. This updates the overview and shores up the AI-workforce user guide.

## Changes

**Coworkers** — corrected stale names against the actual `prompts/route-persona/` seed:
- `compliance-officer` → `licensing-specialist`; dropped the nonexistent `storefront-advisor`; `docs-specialist` → `documentation-specialist`
- Added `finance-agent` and `external-catalog-scout`
- New subsection surfacing the deeper bench: 9 value-stream orchestrators, 4 build sub-agents, 63-agent registry

**xAI / Grok (EP-GROK-001)** — first-class Grok support was undocumented:
- Overview pillar + capability/maturity rows (Grok 4.3, Grok Build 0.1, device-code OAuth via `grok_signin_start`/`grok_signin_status`)
- New `provider-xai.md` user guide; Grok wired into `connecting-providers.md`

**WSID (third decision-perspective scope)** — documented the WWMD → WWWD → **WSID** profession corpus on the overview and in `decision-perspective.md` (profile kind, inheritance chain, profession scope section, specs).

**TTS correction (OS-dependent)** — both docs were partially stale. Corrected to reflect the live `voice-service.ts` default + adapters:
- Default is **self-hosted** (not cloud): Chatterbox `dpf-tts` container on Linux/Windows+NVIDIA; native-host **MLX** sidecar on Apple Silicon (Docker Desktop has no GPU passthrough); Cartesia/Fish Audio/ElevenLabs cloud optional.

**Inline links** — added "detailed guide" links from each overview topic to its user-guide / architecture page.

## Verification
- HTML structurally valid (sections 29/29, anchors 96/96 balanced; no stray markup)
- Every link path checked against the actual `docs/` tree (no 404s)
- WSID details verified against `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md` (Phases 0–1 + data-architect corpus merged)
- Grok verified against `2026-06-07-grok-device-code-oauth-design.md` (slices 1–4 merged) and `voice-service.ts` for TTS

## Files
- `docs/index.html`
- `docs/user-guide/ai-workforce/decision-perspective.md`
- `docs/user-guide/ai-workforce/provider-xai.md` (new)
- `docs/user-guide/ai-workforce/connecting-providers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)