### PR TITLE
feat(workbooks): generic read-only adapter — any Prisma model becomes a grid via config (EP-GRID-WORKBOOKS Phase 2)

### DIFF
--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  toCell,
+  genericRowToGridRow,
+  genericColumnDefs,
+  type GenericTableConfig,
+} from "./generic-read-adapter";
+
+const config: GenericTableConfig = {
+  entityType: "epic",
+  prismaModel: "epic",
+  idField: "epicId",
+  columns: [
+    { field: "epicId", name: "ID", fieldType: "text" },
+    { field: "title", name: "Title", fieldType: "text" },
+    { field: "status", name: "Status", fieldType: "select", groupable: true, options: [{ key: "open", label: "Open" }] },
+    { field: "priority", name: "Priority", fieldType: "number" },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime" },
+  ],
+};
+
+describe("toCell", () => {
+  it("coerces by declared field type", () => {
+    expect(toCell("number", 5)).toBe(5);
+    expect(toCell("number", null)).toBeNull();
+    expect(toCell("datetime", new Date("2026-06-07T00:00:00.000Z"))).toBe("2026-06-07T00:00:00.000Z");
+    expect(toCell("checkbox", 1)).toBe(true);
+    expect(toCell("text", 42)).toBe("42");
+    expect(toCell("multi_select", null)).toEqual([]);
+  });
+});
+
+describe("genericRowToGridRow", () => {
+  it("maps a Prisma record to a grid row keyed by field, rowId from idField", () => {
+    const row = genericRowToGridRow(config, {
+      epicId: "EP-1",
+      title: "Universal Grid",
+      status: "open",
+      priority: 2,
+      updatedAt: new Date("2026-06-07T10:00:00.000Z"),
+    });
+    expect(row.rowId).toBe("EP-1");
+    expect(row.cells.title).toBe("Universal Grid");
+    expect(row.cells.status).toBe("open");
+    expect(row.cells.priority).toBe(2);
+    expect(row.cells.updatedAt).toBe("2026-06-07T10:00:00.000Z");
+  });
+
+  it("does not include unconfigured fields (allow-list only)", () => {
+    const row = genericRowToGridRow(config, {
+      epicId: "EP-2",
+      title: "x",
+      status: "open",
+      priority: 1,
+      updatedAt: new Date(),
+      secretField: "should-not-leak",
+    });
+    expect(row.cells).not.toHaveProperty("secretField");
+  });
+});
+
+describe("genericColumnDefs", () => {
+  it("produces read-only column definitions in config order", () => {
+    const cols = genericColumnDefs(config);
+    expect(cols.map((c) => c.columnId)).toEqual(["epicId", "title", "status", "priority", "updatedAt"]);
+    expect(cols.every((c) => c.editable === false)).toBe(true);
+    const status = cols.find((c) => c.columnId === "status");
+    expect(status?.groupable).toBe(true);
+    expect(status?.config?.options?.[0].key).toBe("open");
+  });
+});

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -1,0 +1,168 @@
+// Universal Grid & Workbooks — generic read-only adapter (EP-GRID-WORKBOOKS, Phase 2)
+//
+// "Every model is a grid": a config-driven DataSourceAdapter that exposes any
+// Prisma model as a read-only grid/board without a bespoke adapter class. v1 is
+// READ-ONLY by design and config-driven (an explicit field allow-list, not schema
+// introspection) so it can never expose sensitive fields (passwordHash, tokens)
+// and never performs a generic write. Models that need editing keep their
+// bespoke, validated adapters (backlog/invoice/risk). Edit-capable generic
+// adapters + DMMF introspection (with a steward denylist) are a later increment.
+
+import { prisma } from "@dpf/db";
+import {
+  gridRegistry,
+  type DataSourceAdapter,
+  type AdapterContext,
+} from "./adapter";
+import {
+  type ColumnDefinition,
+  type GridRow,
+  type CellValue,
+  type FieldType,
+  type SelectOption,
+  type DataSourceFilter,
+  type SortSpec,
+  type Pagination,
+  type PagedRows,
+  type GridCapabilities,
+} from "./types";
+import { applyFilters, applySort, paginate } from "./grid-query";
+
+export interface GenericColumn {
+  /** Prisma scalar field name — also the grid columnId. Must be a real scalar field. */
+  field: string;
+  name: string;
+  fieldType: FieldType;
+  width?: number;
+  options?: SelectOption[];
+  groupable?: boolean;
+}
+
+export interface GenericTableConfig {
+  entityType: string;
+  /** Prisma delegate name, e.g. "epic", "digitalProduct". */
+  prismaModel: string;
+  /** A @unique scalar used as the grid rowId (e.g. "epicId"). */
+  idField: string;
+  columns: GenericColumn[];
+  orderBy?: { field: string; dir: "asc" | "desc" };
+  /** Hard cap on rows loaded (push-down pagination is a Phase-4 follow-up). */
+  maxRows?: number;
+}
+
+const DEFAULT_CAP = 500;
+
+/** Convert a Prisma scalar into the grid's CellValue based on the declared field type. */
+export function toCell(fieldType: FieldType, v: unknown): CellValue {
+  if (v === null || v === undefined) return fieldType === "multi_select" ? [] : null;
+  switch (fieldType) {
+    case "number":
+      return typeof v === "number" ? v : Number((v as { toString(): string }).toString());
+    case "date":
+    case "datetime":
+      return v instanceof Date ? v.toISOString() : String(v);
+    case "checkbox":
+      return Boolean(v);
+    case "multi_select":
+      return Array.isArray(v) ? (v as string[]) : [];
+    default:
+      return typeof v === "string" ? v : String(v);
+  }
+}
+
+export function genericRowToGridRow(
+  config: GenericTableConfig,
+  row: Record<string, unknown>,
+): GridRow {
+  const cells: Record<string, CellValue> = {};
+  for (const c of config.columns) cells[c.field] = toCell(c.fieldType, row[c.field]);
+  return { rowId: String(row[config.idField]), cells };
+}
+
+export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[] {
+  return config.columns.map((c, i) => ({
+    columnId: c.field,
+    name: c.name,
+    fieldType: c.fieldType,
+    position: i,
+    required: false,
+    editable: false, // generic v1 is read-only
+    width: c.width,
+    groupable: c.groupable ?? c.fieldType === "select",
+    config: c.options ? { options: c.options } : undefined,
+  }));
+}
+
+type ReadDelegate = {
+  findMany(args: unknown): Promise<Record<string, unknown>[]>;
+  findUnique(args: unknown): Promise<Record<string, unknown> | null>;
+};
+
+function delegate(model: string): ReadDelegate {
+  const d = (prisma as unknown as Record<string, ReadDelegate>)[model];
+  if (!d || typeof d.findMany !== "function") {
+    throw new Error(`Unknown Prisma model for generic grid: ${model}`);
+  }
+  return d;
+}
+
+class GenericReadAdapter implements DataSourceAdapter {
+  constructor(private readonly cfg: GenericTableConfig) {}
+
+  get entityType(): string {
+    return this.cfg.entityType;
+  }
+
+  private select(): Record<string, true> {
+    const sel: Record<string, true> = { [this.cfg.idField]: true };
+    for (const c of this.cfg.columns) sel[c.field] = true;
+    return sel;
+  }
+
+  async getColumns(): Promise<ColumnDefinition[]> {
+    return genericColumnDefs(this.cfg);
+  }
+
+  async queryRows(
+    _entityType: string,
+    opts: { filters: DataSourceFilter; sort: SortSpec[]; pagination: Pagination },
+  ): Promise<PagedRows> {
+    const cap = this.cfg.maxRows ?? DEFAULT_CAP;
+    const records = await delegate(this.cfg.prismaModel).findMany({
+      select: this.select(),
+      ...(this.cfg.orderBy ? { orderBy: { [this.cfg.orderBy.field]: this.cfg.orderBy.dir } } : {}),
+      take: cap,
+    });
+    if (records.length === cap) {
+      // No silent caps: surface that older rows were omitted until SQL push-down lands.
+      console.warn(
+        `[workbooks] generic grid "${this.cfg.entityType}" hit the ${cap}-row cap; older rows omitted (push-down pagination is a Phase-4 follow-up).`,
+      );
+    }
+    const rows = records.map((r) => genericRowToGridRow(this.cfg, r));
+    const filtered = applyFilters(rows, opts.filters);
+    const sorted = applySort(filtered, opts.sort);
+    return paginate(sorted, opts.pagination.cursor, opts.pagination.limit);
+  }
+
+  async getRow(_entityType: string, rowId: string): Promise<GridRow | null> {
+    const r = await delegate(this.cfg.prismaModel).findUnique({
+      where: { [this.cfg.idField]: rowId },
+      select: this.select(),
+    });
+    return r ? genericRowToGridRow(this.cfg, r) : null;
+  }
+
+  getCapabilities(_ctx: AdapterContext): GridCapabilities {
+    return { canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false };
+  }
+}
+
+export function makeGenericReadAdapter(config: GenericTableConfig): DataSourceAdapter {
+  return new GenericReadAdapter(config);
+}
+
+/** Build + register a generic read-only grid for a Prisma model. */
+export function registerGenericReadTable(config: GenericTableConfig): void {
+  gridRegistry.register(makeGenericReadAdapter(config));
+}

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -12,6 +12,7 @@ import { gridRegistry, type AdapterContext } from "./adapter";
 import "./backlog-adapter"; // self-register the backlog adapter
 import "./invoice-adapter"; // self-register the invoice adapter
 import "./risk-adapter"; // self-register the risk-assessment adapter
+import { registerGenericReadTable, type GenericTableConfig } from "./generic-read-adapter";
 import {
   type ColumnDefinition,
   type GridRow,
@@ -53,6 +54,66 @@ export interface PlatformTableDef {
   homeSurface: PlatformTableHomeSurface;
 }
 
+// ── Generic read-only grids (Phase 2) ──────────────────────────────────────
+// Any Prisma model becomes a sortable/filterable/board grid via config — no
+// bespoke adapter class. Read-only by design; editable models keep their own
+// validated adapters. Field lists are explicit allow-lists (no sensitive fields).
+const EPIC_TABLE: GenericTableConfig = {
+  entityType: "epic",
+  prismaModel: "epic",
+  idField: "epicId",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "epicId", name: "ID", fieldType: "text", width: 160 },
+    { field: "title", name: "Title", fieldType: "text", width: 360 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "open", label: "Open" },
+        { key: "in-progress", label: "In Progress" },
+        { key: "done", label: "Done" },
+      ],
+    },
+    { field: "priority", name: "Priority", fieldType: "number", width: 90 },
+    { field: "description", name: "Description", fieldType: "text", width: 400 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {
+  entityType: "digital_product",
+  prismaModel: "digitalProduct",
+  idField: "productId",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "productId", name: "ID", fieldType: "text", width: 140 },
+    { field: "name", name: "Name", fieldType: "text", width: 280 },
+    {
+      field: "lifecycleStage",
+      name: "Lifecycle",
+      fieldType: "select",
+      width: 140,
+      groupable: true,
+      options: [
+        { key: "plan", label: "Plan" },
+        { key: "build", label: "Build" },
+        { key: "run", label: "Run" },
+        { key: "retire", label: "Retire" },
+      ],
+    },
+    { field: "version", name: "Version", fieldType: "text", width: 100 },
+    { field: "description", name: "Description", fieldType: "text", width: 360 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+registerGenericReadTable(EPIC_TABLE);
+registerGenericReadTable(DIGITAL_PRODUCT_TABLE);
+
 /** The registry of platform datasets available as grids. Add a row per adapter. */
 export const PLATFORM_TABLES: PlatformTableDef[] = [
   {
@@ -78,6 +139,22 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_compliance",
     manageCapability: "manage_compliance",
     homeSurface: { path: "/compliance/risks", label: "Risk assessments", board: true },
+  },
+  {
+    entityType: "epic",
+    label: "Epics",
+    description: "Every epic as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_operations",
+    manageCapability: "view_operations", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/ops", label: "Operations", board: true },
+  },
+  {
+    entityType: "digital_product",
+    label: "Digital products",
+    description: "The product portfolio as a read-only grid — sort, filter, and board by lifecycle.",
+    viewCapability: "view_portfolio",
+    manageCapability: "view_portfolio", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/portfolio", label: "Portfolio", board: true },
   },
 ];
 


### PR DESCRIPTION
## What

First **Phase 2** increment toward *"every model is a grid."* A config-driven `DataSourceAdapter` exposes any Prisma model as a sortable/filterable/board grid **without a bespoke adapter class**.

- **`generic-read-adapter.ts`** — `makeGenericReadAdapter(config)` + `registerGenericReadTable`. **Read-only by design** and **config-driven** (explicit field allow-list, *not* schema introspection) so it can never expose sensitive fields (passwordHash/tokens) and never performs a generic write. Editable models keep their validated adapters (backlog/invoice/risk). Pure helpers (`toCell` / `genericRowToGridRow` / `genericColumnDefs`) unit-tested. **No silent cap** — warns when the row cap is hit (SQL push-down is the Phase-4 follow-up per the hybrid spec).
- Registered **two real datasets** to prove it end to end: **Epics** (`view_operations`, board by status, home `/ops`) and **Digital products** (`view_portfolio`, board by lifecycle, home `/portfolio`). Each is one config block.

Adding the next read-only dataset is now a ~15-line config, not an adapter + mapping + tests. Editable + DMMF-introspective generic adapters (with a steward denylist) are later increments per the hybrid design spec.

## Verification (worktree)

- `vitest lib/workbooks/generic-read-adapter.test.ts` → **4/4**.
- `typecheck` clean; production `build` green; `/workbooks/system/[entityType]` route intact.
- Live verification (Epics/Digital-products grid + board on real records) after the next deploy.

Design: `docs/superpowers/specs/2026-06-07-workbooks-hybrid-systems-of-record-reporting-lifecycle-design.md` (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)