### PR TITLE
feat(archetypes): banking compliance packs + credit-union member-equity refinement (BI-D9ACE184, BI-E677F250)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-banking-deltas-credit-union-community-bank.md
+++ b/docs/superpowers/plans/2026-06-11-banking-deltas-credit-union-community-bank.md
@@ -1,0 +1,63 @@
+# Implementation Plan — Banking Deltas (credit union + community bank)
+
+- **Backlog items:** `BI-D9ACE184` (credit-union deltas) + `BI-E677F250` (community-bank deltas), both `EP-ARCH-8D4F2A`
+- **Design spec:** [`docs/superpowers/specs/2026-06-09-civic-and-member-governed-archetypes-design.md`](../specs/2026-06-09-civic-and-member-governed-archetypes-design.md) §7, §10
+- **Date:** 2026-06-11
+
+## What the BIAN work already delivered (verified by direct read)
+
+The landed BIAN banking PR (#1694, BI-5D9DCDE6) consumed the Phase-0 civic substrate, so
+most of what the spec assigned to these two BIs is **already live**:
+
+- `credit-union` leaf already sets `primaryConsumer: "member"` + `governance: "member-owned"`
+  (`banking-financial-services.ts:178-179`) → already derives member-governance,
+  membership-eligibility, member-equity; the field-of-membership eligibility form field
+  exists; Members / Member Advisors vocabulary is set.
+- `financial-institution` ledgerModel is already wired on the `banking-financial-services`
+  finance profile (`profiles.ts:471`), composing the COA fragment.
+- Licensing/jurisdiction capture (charter, FDIC cert, NCUA charter, NMLS) already lands on
+  the licensing substrate per the BIAN §9 work.
+
+## What remains (this PR — closes both BIs)
+
+The §10 delineation: the licensing substrate already holds posture/credentials; the
+**recurring-obligation compliance packs** are not seeded yet. That is the remaining delta.
+
+1. `packages/db/src/seed-banking-compliance.ts` — one pack on the existing
+   Regulation/Obligation/Control substrate, factored so the shared regime is not
+   double-seeded:
+   - `REG-US-BSA-AML` (**shared** by bank + CU, `industry: "financial"`): CIP/KYC program,
+     SAR filing cadence, CTR filing, OFAC/sanctions screening, BSA officer & independent
+     testing.
+   - `REG-US-NCUA` (**credit union**, `industry: "financial"`): NCUA 5300 quarterly call
+     report, field-of-membership compliance, supervisory-committee annual audit, DOR
+     (document of resolution) tracking.
+   - `REG-US-FDIC-CRA` (**community bank**, `industry: "financial"`): quarterly FFIEC call
+     report, CRA performance, fair lending (ECOA/HMDA), Reg O insider lending, exam-finding
+     remediation.
+   Controls: BSA/AML Program, NCUA Call-Report & Supervisory Audit, FFIEC Call-Report &
+   Exam Remediation. Wired into seed.ts after the law-enforcement pack; pure-data integrity
+   test mirroring the others.
+2. `packages/storefront-templates/src/archetypes/banking-financial-services.ts` —
+   credit-union `capabilityOverrides`: `member-equity → not-applicable` (reason: credit
+   unions distribute dividends and hold member shares through the core banking system, not
+   patronage-equity allocation/retirement — the /member-equity surface is a co-op concept
+   and would mislead). The community bank is `investor-owned` so it never derives
+   member-equity — no override needed there.
+3. Tests: activation-profile fixtures asserting (a) credit-union derives member-governance +
+   membership-eligibility required with member-equity **not-applicable via override**, and
+   (b) community-bank derives none of the member/public-body machinery (investor-owned).
+
+## Verification
+
+Package vitest + typecheck + full web vitest before push; fresh-runtime verification on the
+shared lease: onboard a credit union → Members vocabulary, member-governance surface,
+NCUA + BSA packs in the compliance library, **no /member-equity surface**; onboard a
+community bank → BSA + FDIC/CRA packs, no member machinery, financial-institution finance
+profile. Record evidence; close both BIs.
+
+## Risks & rollback
+
+- Double-seeding BSA/AML across bank and CU — mitigated by a single shared `REG-US-BSA-AML`
+  regulation both archetypes are accountable to (industry filter `financial`), not two copies.
+- All additive seed + one override; revert the PR. No schema, no migration.

--- a/packages/db/src/seed-banking-compliance.ts
+++ b/packages/db/src/seed-banking-compliance.ts
@@ -1,0 +1,382 @@
+import type { PrismaClient } from "../generated/client/client";
+import * as crypto from "crypto";
+
+// BI-D9ACE184 + BI-E677F250 — banking deltas compliance pack (civic spec §10).
+// industry "financial". The recurring-obligation regimes the BIAN leaf work
+// (BI-5D9DCDE6) deliberately left out — licensing/credentials live on the
+// licensing substrate; recurring obligations live here. BSA/AML is a SINGLE
+// shared regulation both bank and credit union answer to (not double-seeded);
+// NCUA is credit-union-specific; FDIC/CRA is community-bank-specific.
+
+function makeId(prefix: string): string {
+  const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
+  return `${prefix}-${hex}`;
+}
+
+type ObligationSeed = {
+  title: string;
+  reference: string;
+  description: string;
+  category: string;
+  frequency: string;
+  applicability: string;
+  penaltySummary: string | null;
+};
+
+type RegulationSeed = {
+  regulationId: string;
+  name: string;
+  shortName: string;
+  jurisdiction: string;
+  industry: string;
+  sourceType: "external";
+  notes: string;
+  obligations: ObligationSeed[];
+};
+
+export const BANKING_REGULATIONS: RegulationSeed[] = [
+  {
+    regulationId: "REG-US-BSA-AML",
+    name: "Bank Secrecy Act / Anti-Money Laundering",
+    shortName: "BSA/AML",
+    jurisdiction: "US-federal",
+    industry: "financial",
+    sourceType: "external",
+    notes:
+      "The Bank Secrecy Act and its AML program requirements apply to all insured " +
+      "depositories — community banks AND credit unions alike. A single shared regime: " +
+      "customer identification, suspicious-activity and currency-transaction reporting, " +
+      "sanctions screening, and an independently-tested program under a designated BSA officer.",
+    obligations: [
+      {
+        title: "Customer Identification Program (CIP) / KYC",
+        reference: "bsa/cip-kyc",
+        description:
+          "Maintain a written Customer Identification Program: verify identity at account " +
+          "opening, perform customer due diligence and beneficial-ownership identification for " +
+          "legal-entity members/customers, and apply risk-based enhanced due diligence.",
+        category: "operational",
+        frequency: "continuous",
+        applicability: "All insured depositories (banks and credit unions)",
+        penaltySummary: "Civil money penalties and consent orders for program deficiencies.",
+      },
+      {
+        title: "Suspicious Activity Report (SAR) filing",
+        reference: "bsa/sar",
+        description:
+          "File a SAR with FinCEN within 30 days of detecting suspicious activity meeting the " +
+          "reporting threshold (60 days where no suspect is identified). Maintain SAR confidentiality.",
+        category: "operational",
+        frequency: "event-driven",
+        applicability: "All insured depositories",
+        penaltySummary: "Failure to file is a frequent BSA enforcement basis; criminal exposure for willful violations.",
+      },
+      {
+        title: "Currency Transaction Report (CTR) filing",
+        reference: "bsa/ctr",
+        description:
+          "File a CTR for cash transactions exceeding $10,000 (single or aggregated) within 15 days, " +
+          "and maintain the exemption list for eligible customers.",
+        category: "operational",
+        frequency: "event-driven",
+        applicability: "All insured depositories",
+        penaltySummary: null,
+      },
+      {
+        title: "OFAC / sanctions screening",
+        reference: "bsa/ofac",
+        description:
+          "Screen customers and transactions against OFAC sanctions lists, block or reject " +
+          "prohibited transactions, and report blocked property within the required window.",
+        category: "operational",
+        frequency: "continuous",
+        applicability: "All insured depositories",
+        penaltySummary: "Strict-liability OFAC penalties per violation.",
+      },
+      {
+        title: "BSA officer designation & independent testing",
+        reference: "bsa/officer-testing",
+        description:
+          "Designate a qualified BSA/AML compliance officer and conduct independent testing of the " +
+          "program on a risk-based cadence (commonly annual), with board reporting of findings.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "All insured depositories",
+        penaltySummary: null,
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-NCUA",
+    name: "NCUA Regulatory Requirements (federally insured credit unions)",
+    shortName: "NCUA",
+    jurisdiction: "US-federal",
+    industry: "financial",
+    sourceType: "external",
+    notes:
+      "The National Credit Union Administration regulates and insures federal and most " +
+      "state-chartered credit unions: quarterly Call Report (Form 5300), field-of-membership " +
+      "compliance, supervisory-committee audit, and remediation of examiner findings (DORs).",
+    obligations: [
+      {
+        title: "NCUA 5300 Call Report — quarterly",
+        reference: "ncua/5300-call-report",
+        description:
+          "File the NCUA Form 5300 Call Report each quarter by the filing deadline with accurate " +
+          "financial and statistical data. Late or inaccurate filings draw examiner scrutiny.",
+        category: "finance",
+        frequency: "monthly",
+        applicability: "All federally insured credit unions",
+        penaltySummary: "Civil money penalties for late Call Report filing.",
+      },
+      {
+        title: "Field-of-membership compliance",
+        reference: "ncua/field-of-membership",
+        description:
+          "Admit members only within the approved field of membership (common bond, community, or " +
+          "associational), and maintain records evidencing each member's eligibility.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "All credit unions",
+        penaltySummary: "Out-of-FOM membership can trigger charter action.",
+      },
+      {
+        title: "Supervisory-committee annual audit",
+        reference: "ncua/supervisory-audit",
+        description:
+          "The supervisory committee ensures an annual audit (or NCUA-acceptable alternative) and a " +
+          "periodic verification of member accounts, reporting results to the board.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "All credit unions",
+        penaltySummary: null,
+      },
+      {
+        title: "Document of Resolution (DOR) tracking & remediation",
+        reference: "ncua/dor-tracking",
+        description:
+          "Track examiner-issued Documents of Resolution and other findings to remediation with owners " +
+          "and due dates; report status to the board until each is resolved.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "Credit unions with open examination findings",
+        penaltySummary: null,
+      },
+    ],
+  },
+  {
+    regulationId: "REG-US-FDIC-CRA",
+    name: "FDIC/OCC Bank Supervision — Call Report, CRA & Fair Lending",
+    shortName: "Bank Supervision",
+    jurisdiction: "US-federal",
+    industry: "financial",
+    sourceType: "external",
+    notes:
+      "Community banks file the quarterly FFIEC Call Report and are examined for Community " +
+      "Reinvestment Act performance, fair-lending compliance (ECOA/HMDA), insider-lending limits " +
+      "(Reg O), with examiner findings tracked to remediation.",
+    obligations: [
+      {
+        title: "FFIEC Call Report — quarterly",
+        reference: "bank/ffiec-call-report",
+        description:
+          "File the quarterly FFIEC Consolidated Reports of Condition and Income (Call Report) by the " +
+          "filing deadline with accurate data subject to validation edits.",
+        category: "finance",
+        frequency: "monthly",
+        applicability: "All insured banks",
+        penaltySummary: "Civil money penalties for late or materially inaccurate Call Reports.",
+      },
+      {
+        title: "Community Reinvestment Act (CRA) performance",
+        reference: "bank/cra",
+        description:
+          "Help meet the credit needs of the entire community including low- and moderate-income " +
+          "neighborhoods; maintain the CRA public file and prepare for periodic CRA examination.",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "Insured banks subject to CRA",
+        penaltySummary: "A poor CRA rating can block mergers, branches, and acquisitions.",
+      },
+      {
+        title: "Fair lending — ECOA & HMDA",
+        reference: "bank/fair-lending",
+        description:
+          "Comply with the Equal Credit Opportunity Act (non-discrimination) and, where applicable, " +
+          "collect and report HMDA loan data accurately; monitor for disparate treatment and impact.",
+        category: "governance",
+        frequency: "annual",
+        applicability: "Insured banks engaged in lending",
+        penaltySummary: "Fair-lending violations carry referrals to DOJ and significant penalties.",
+      },
+      {
+        title: "Regulation O — insider lending limits",
+        reference: "bank/reg-o",
+        description:
+          "Comply with Regulation O limits and approval/reporting requirements for extensions of " +
+          "credit to insiders (directors, executive officers, principal shareholders, and their interests).",
+        category: "governance",
+        frequency: "continuous",
+        applicability: "All insured banks",
+        penaltySummary: null,
+      },
+      {
+        title: "Examination-finding remediation (MRAs / MRIAs)",
+        reference: "bank/exam-remediation",
+        description:
+          "Track Matters Requiring Attention and Matters Requiring Immediate Attention from examinations " +
+          "to remediation with owners and due dates; report status to the board until resolved.",
+        category: "governance",
+        frequency: "event-driven",
+        applicability: "Banks with open examination findings",
+        penaltySummary: null,
+      },
+    ],
+  },
+];
+
+type ControlSeed = {
+  title: string;
+  description: string;
+  controlType: "preventive" | "detective" | "corrective";
+  obligationRefs: string[];
+};
+
+export const BANKING_CONTROLS: ControlSeed[] = [
+  {
+    title: "BSA/AML Program",
+    description:
+      "Documented BSA/AML program: CIP/KYC, SAR/CTR filing procedures, OFAC screening, designated " +
+      "BSA officer, and independent testing — shared by banks and credit unions.",
+    controlType: "preventive",
+    obligationRefs: [
+      "bsa/cip-kyc",
+      "bsa/sar",
+      "bsa/ctr",
+      "bsa/ofac",
+      "bsa/officer-testing",
+    ],
+  },
+  {
+    title: "NCUA Call-Report & Supervisory Audit",
+    description:
+      "Quarterly 5300 Call Report filing, field-of-membership eligibility records, supervisory-" +
+      "committee annual audit, and DOR remediation tracking.",
+    controlType: "detective",
+    obligationRefs: [
+      "ncua/5300-call-report",
+      "ncua/field-of-membership",
+      "ncua/supervisory-audit",
+      "ncua/dor-tracking",
+    ],
+  },
+  {
+    title: "FFIEC Call-Report & Exam Remediation",
+    description:
+      "Quarterly FFIEC Call Report, CRA public file and performance, fair-lending (ECOA/HMDA) " +
+      "monitoring, Reg O insider-lending controls, and MRA/MRIA remediation tracking.",
+    controlType: "detective",
+    obligationRefs: [
+      "bank/ffiec-call-report",
+      "bank/cra",
+      "bank/fair-lending",
+      "bank/reg-o",
+      "bank/exam-remediation",
+    ],
+  },
+];
+
+export async function seedBankingCompliance(prisma: PrismaClient): Promise<void> {
+  let regUpserts = 0;
+  let oblCreated = 0;
+  let ctlCreated = 0;
+  let linksCreated = 0;
+
+  const oblIdByRef = new Map<string, string>();
+
+  for (const reg of BANKING_REGULATIONS) {
+    const { obligations, ...regData } = reg;
+    const regulation = await prisma.regulation.upsert({
+      where: { regulationId: regData.regulationId },
+      update: {
+        name: regData.name,
+        shortName: regData.shortName,
+        jurisdiction: regData.jurisdiction,
+        industry: regData.industry,
+        notes: regData.notes,
+      },
+      create: regData,
+    });
+    regUpserts++;
+
+    for (const obl of obligations) {
+      const existing = await prisma.obligation.findFirst({
+        where: { regulationId: regulation.id, reference: obl.reference, status: "active" },
+        select: { id: true },
+      });
+      if (existing) {
+        oblIdByRef.set(obl.reference, existing.id);
+        continue;
+      }
+      const created = await prisma.obligation.create({
+        data: {
+          obligationId: makeId("OBL"),
+          regulationId: regulation.id,
+          title: obl.title,
+          description: obl.description,
+          reference: obl.reference,
+          category: obl.category,
+          frequency: obl.frequency,
+          applicability: obl.applicability,
+          penaltySummary: obl.penaltySummary,
+        },
+      });
+      oblIdByRef.set(obl.reference, created.id);
+      oblCreated++;
+    }
+  }
+
+  for (const ctl of BANKING_CONTROLS) {
+    const existing = await prisma.control.findFirst({
+      where: { title: ctl.title, status: "active" },
+      select: { id: true },
+    });
+    const controlId =
+      existing?.id ??
+      (
+        await prisma.control.create({
+          data: {
+            controlId: makeId("CTL"),
+            title: ctl.title,
+            description: ctl.description,
+            controlType: ctl.controlType,
+            implementationStatus: "planned",
+          },
+        })
+      ).id;
+    if (!existing) ctlCreated++;
+
+    for (const ref of ctl.obligationRefs) {
+      const oblId = oblIdByRef.get(ref);
+      if (!oblId) {
+        throw new Error(
+          `[seed-banking-compliance] control "${ctl.title}" references unknown obligation "${ref}"`,
+        );
+      }
+      const link = await prisma.controlObligationLink.findUnique({
+        where: { controlId_obligationId: { controlId, obligationId: oblId } },
+      });
+      if (!link) {
+        await prisma.controlObligationLink.create({ data: { controlId, obligationId: oblId } });
+        linksCreated++;
+      }
+    }
+  }
+
+  const expectedObligations = BANKING_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+  console.log(
+    `[seed] banking compliance pack: ${regUpserts}/${BANKING_REGULATIONS.length} regulations upserted, ` +
+      `${oblCreated} obligations created (${expectedObligations} expected total), ` +
+      `${ctlCreated} controls created, ${linksCreated} links created`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -17,6 +17,7 @@ import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
 import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
 import { seedCooperativeCompliance } from "./seed-cooperative-compliance.js";
 import { seedLawEnforcementCompliance } from "./seed-law-enforcement-compliance.js";
+import { seedBankingCompliance } from "./seed-banking-compliance.js";
 import { seedBusinessCapabilityPerspective } from "./business-capability-perspectives.js";
 import { seedGeographicData } from "./seed-geographic-data.js";
 import { seedTaxJurisdictions } from "./seed-tax-jurisdictions.js";
@@ -2539,6 +2540,7 @@ async function main(): Promise<void> {
   await step("publicSectorCompliance", () => seedPublicSectorCompliance(prisma));
   await step("cooperativeCompliance", () => seedCooperativeCompliance(prisma));
   await step("lawEnforcementCompliance", () => seedLawEnforcementCompliance(prisma));
+  await step("bankingCompliance", () => seedBankingCompliance(prisma));
   await step("businessCapabilityPerspective", async () => {
     const capabilityPerspectiveSeed = await seedBusinessCapabilityPerspective(prisma);
     console.log(

--- a/packages/db/test/seed-banking-compliance.test.ts
+++ b/packages/db/test/seed-banking-compliance.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  BANKING_CONTROLS,
+  BANKING_REGULATIONS,
+} from "../src/seed-banking-compliance";
+
+// Pure-data integrity tests — no database. Mirrors the other compliance packs.
+
+describe("banking compliance pack data", () => {
+  it("ships BSA/AML (shared), NCUA (credit union), and FDIC/CRA (bank) with expected counts", () => {
+    expect(BANKING_REGULATIONS.map((r) => r.regulationId).sort()).toEqual([
+      "REG-US-BSA-AML",
+      "REG-US-FDIC-CRA",
+      "REG-US-NCUA",
+    ]);
+    const total = BANKING_REGULATIONS.reduce((n, r) => n + r.obligations.length, 0);
+    expect(total).toBe(14);
+    for (const reg of BANKING_REGULATIONS) {
+      expect(reg.industry).toBe("financial");
+      expect(reg.obligations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("models BSA/AML as a single shared regulation, not double-seeded per archetype", () => {
+    const bsa = BANKING_REGULATIONS.filter((r) => r.regulationId === "REG-US-BSA-AML");
+    expect(bsa).toHaveLength(1);
+    expect(bsa[0]!.notes.toLowerCase()).toContain("credit unions");
+    expect(bsa[0]!.notes.toLowerCase()).toContain("community banks");
+  });
+
+  it("obligation references are globally unique", () => {
+    const refs = BANKING_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference));
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it("every control references only known obligations", () => {
+    const known = new Set(
+      BANKING_REGULATIONS.flatMap((r) => r.obligations.map((o) => o.reference)),
+    );
+    for (const control of BANKING_CONTROLS) {
+      expect(control.obligationRefs.length).toBeGreaterThan(0);
+      for (const ref of control.obligationRefs) {
+        expect(known.has(ref), `${control.title} references unknown obligation ${ref}`).toBe(true);
+      }
+    }
+  });
+
+  it("every obligation carries the fields the compliance surfaces render", () => {
+    for (const reg of BANKING_REGULATIONS) {
+      for (const obl of reg.obligations) {
+        expect(obl.title.length).toBeGreaterThan(10);
+        expect(obl.description.length).toBeGreaterThan(40);
+        expect(["governance", "finance", "operational"]).toContain(obl.category);
+        expect(["event-driven", "continuous", "annual", "monthly"]).toContain(obl.frequency);
+      }
+    }
+  });
+});

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -251,6 +251,38 @@ describe("existing archetype regression (governance axis is inert)", () => {
     expect(getCapabilityApplicability(profile, "records-request")).toBe("not-applicable");
   });
 
+  it("the credit-union leaf derives member governance + eligibility, with member-equity suppressed via override (BI-D9ACE184)", () => {
+    const cu = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "credit-union");
+    expect(cu?.activationProfile).toBeDefined();
+
+    const profile = readActivationProfile(cu?.activationProfile);
+    expect(profile?.axes.governance).toBe("member-owned");
+    expect(profile?.axes.primaryConsumer).toBe("member");
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("required");
+    expect(getCapabilityApplicability(profile, "membership-eligibility")).toBe("required");
+    // Credit unions don't run patronage equity — the override suppresses the surface.
+    expect(getCapabilityApplicability(profile, "member-equity")).toBe("not-applicable");
+    expect(getCapabilityApplicability(profile, "public-body-governance")).toBe("not-applicable");
+  });
+
+  it("the community-bank leaf is investor-owned and derives no member or public-body machinery (BI-E677F250)", () => {
+    const bank = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "community-bank");
+    expect(bank?.activationProfile).toBeDefined();
+
+    const profile = readActivationProfile(bank?.activationProfile);
+    expect(profile?.axes.governance).toBe("investor-owned");
+    for (const key of [
+      "member-governance",
+      "membership-eligibility",
+      "member-equity",
+      "public-body-governance",
+      "records-request",
+      "service-request-311",
+    ] as const) {
+      expect(getCapabilityApplicability(profile, key)).toBe("not-applicable");
+    }
+  });
+
   it("the law-enforcement archetype derives public-body governance (with records requests) and no member machinery", () => {
     const police = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "law-enforcement-agency");
     expect(police?.activationProfile).toBeDefined();

--- a/packages/storefront-templates/src/archetypes/banking-financial-services.ts
+++ b/packages/storefront-templates/src/archetypes/banking-financial-services.ts
@@ -178,6 +178,18 @@ export const bankingFinancialServicesArchetypes: ArchetypeDefinition[] = [
         primaryConsumer: "member" as const,
         governance: "member-owned" as const,
       },
+      // member-owned derives member-equity as recommended, but a credit union
+      // distributes dividends and holds member shares through the core banking
+      // system — it does NOT run patronage-equity allocation/retirement (a co-op
+      // concept). Suppress the /member-equity surface so it doesn't mislead
+      // (BI-D9ACE184; civic spec §9 row "Member equity / patronage" = n/a for CUs).
+      capabilityOverrides: [
+        {
+          capabilityKey: "member-equity",
+          applicability: "not-applicable" as const,
+          reason: "Credit unions distribute dividends and hold member shares via the core banking system, not patronage-equity allocation/retirement.",
+        },
+      ],
       seededServiceCategories: [
         "loans-and-deposits",
         "cards",


### PR DESCRIPTION
## Summary

Closes the two banking deltas — completing all six new verticals from the civic & member-governed archetypes initiative.

The BIAN leaf work (#1694) already consumed the Phase-0 civic substrate, so the credit-union''s `member` / `member-owned` axes, the `financial-institution` ledgerModel, and member vocabulary were **already live**. The remaining delta (the §10 delineation — licensing substrate holds credentials, compliance models hold recurring obligations) is the compliance packs plus one refinement:

- **`seed-banking-compliance.ts`** (`industry: financial`): `REG-US-BSA-AML` — a **single shared regulation** both banks and credit unions answer to (CIP/KYC, SAR, CTR, OFAC, BSA officer + independent testing), not double-seeded; `REG-US-NCUA` (5300 call report, field-of-membership, supervisory-committee audit, DOR tracking); `REG-US-FDIC-CRA` (FFIEC call report, CRA, fair lending ECOA/HMDA, Reg O, exam-finding remediation). 14 obligations, 3 controls.
- **Credit-union `capabilityOverride`**: `member-equity → not-applicable` — credit unions distribute dividends/shares through the core banking system, not patronage-equity allocation; the `/member-equity` surface is a co-op concept that would mislead. Community bank is `investor-owned` and derives no member machinery.
- Tests assert the credit-union derives member-governance + eligibility with member-equity suppressed, and the community bank derives none of the member/public-body machinery.

## Verification

Full web vitest **10,367 passed**; storefront-templates 61 (incl. both banking delta fixtures); db banking pack integrity tests including the shared-BSA-not-double-seeded assertion; typechecks green. Fresh-runtime functional verification of both archetypes follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)