### PR TITLE
feat(archetypes): rental/shared-asset value stream — substrate + 3 leaves + domain model (BI-EEA24A34, BI-2754B64E, BI-4C3CFC35, BI-D7FCD029)

### DIFF
--- a/apps/web/components/storefront/CtaButton.tsx
+++ b/apps/web/components/storefront/CtaButton.tsx
@@ -5,6 +5,7 @@ const DEFAULT_LABELS: Record<string, string> = {
   purchase: "Buy",
   inquiry: "Enquire",
   donation: "Donate",
+  rental: "Reserve",
 };
 
 export function CtaButton({

--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -57,6 +57,7 @@ describe("resolveBusinessProfile", () => {
       "retail-goods",
       "nonprofit-community",
       "public-sector",
+      "asset-rental",
     ];
 
     it("populates a non-empty supplyChain on every industry profile", () => {

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -110,6 +110,18 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
     supplyChain:
       "Our physical supply chain is intentionally light — most of what we consume is software, research databases, and professional subscriptions. The discipline is in vendor selection and renewal review: a stale tool can cost more than its licence.",
   },
+  "asset-rental": {
+    missionTheme:
+      "keep a well-maintained pool of equipment available and turning so customers get what they need, when they need it",
+    businessModel:
+      "We earn by renting reusable assets for a period — reserved, handed out, used, returned, inspected, and re-pooled. Utilization, fast turnaround, and avoiding double-bookings are how the business makes money.",
+    whoWeServe:
+      "We serve renters who need an asset for a window of time, not to own it — contractors, event organizers, households, or (for a co-op) member-owners sharing a pool. The asset comes back and serves the next customer.",
+    howWeDecide:
+      "We decide for asset availability and condition: keep the pool maintained and ready, prevent reservation conflicts, recover overdue returns promptly, and protect against damage with deposits. A unit sitting idle or stuck out is lost revenue.",
+    supplyChain:
+      "Our 'inventory' is the rentable pool itself plus maintenance parts and consumables; the operational discipline is turnaround time, condition tracking, and keeping high-demand items available through peak season.",
+  },
   "public-sector": {
     missionTheme:
       "serve every resident of our community fairly, openly, and well with the public services they rely on",

--- a/apps/web/lib/storefront/archetype-activation.ts
+++ b/apps/web/lib/storefront/archetype-activation.ts
@@ -34,6 +34,7 @@ export function deriveRevenueModelFromActivationProfile(
     purchase: "Product/service sales",
     inquiry: "Quote-based services",
     donation: "Donor-funded",
+    rental: "Asset rental for a period (reserve → use → return → re-pool)",
   };
 
   return ctaRevenueModels[ctaType] ?? null;

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -101,6 +101,14 @@ const VOCABULARY: Record<string, ArchetypeVocabulary> = {
     portalLabel: "Resident Portal", stakeholderLabel: "Residents",
     teamLabel: "Staff", inboxLabel: "Service Requests", agentName: "Resident Services",
   },
+  // Rental / shared assets. Per-leaf overrides (Tenants / Storage for self-storage)
+  // ship with the archetype via customVocabulary; this is the category default.
+  "asset-rental": {
+    itemsLabel: "Equipment & Rates", singleItemLabel: "Item", addButtonLabel: "Add item",
+    categoryLabel: "Category", priceLabel: "Rate",
+    portalLabel: "Rental Portal", stakeholderLabel: "Renters",
+    teamLabel: "Team", inboxLabel: "Reservations", agentName: "Rental Desk",
+  },
 };
 
 const DEFAULT_VOCABULARY: ArchetypeVocabulary = {
@@ -213,6 +221,11 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
   "cooperative": ["Membership", "Member Services", "Patronage & Equity", "Governance"],
   "municipal-utility": ["Residential", "Commercial", "Irrigation", "Connection Fees", "Service Orders"],
   "law-enforcement-agency": ["Records", "Permits", "Community Programs", "Professional Standards"],
+  "agricultural-cooperative": ["Harvest Equipment", "Planting Equipment", "Application Equipment", "Membership & Patronage"],
+
+  // Rental & shared assets
+  "equipment-rental": ["Earthmoving", "Access & Lifting", "Power & Site", "Cleaning", "Events"],
+  "self-storage": ["Small Units", "Medium Units", "Large Units", "Climate-Controlled"],
 };
 
 export function getCategorySuggestions(archetypeId: string | null | undefined): string[] {

--- a/apps/web/lib/storefront/industries.test.ts
+++ b/apps/web/lib/storefront/industries.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { INDUSTRY_OPTIONS, INDUSTRY_SLUGS, isIndustrySlug, industryLabel } from "./industries";
 
 describe("industries", () => {
-  it("exposes exactly the 14 canonical industries", () => {
-    expect(INDUSTRY_OPTIONS).toHaveLength(14);
+  it("exposes exactly the 15 canonical industries", () => {
+    expect(INDUSTRY_OPTIONS).toHaveLength(15);
     expect(INDUSTRY_SLUGS).toContain("healthcare-wellness");
     expect(INDUSTRY_SLUGS).toContain("hoa-property-management");
     expect(INDUSTRY_SLUGS).toContain("software-platform");
     expect(INDUSTRY_SLUGS).toContain("banking-financial-services");
     expect(INDUSTRY_SLUGS).toContain("public-sector");
+    expect(INDUSTRY_SLUGS).toContain("asset-rental");
   });
 
   it("slugs are kebab-case, never underscore", () => {

--- a/apps/web/lib/storefront/industries.ts
+++ b/apps/web/lib/storefront/industries.ts
@@ -13,6 +13,7 @@ export const INDUSTRY_OPTIONS = [
   { value: "hoa-property-management", label: "HOA & Property Management" },
   { value: "banking-financial-services", label: "Banking & Financial Services" },
   { value: "public-sector", label: "Public Sector & Local Government" },
+  { value: "asset-rental", label: "Rental & Shared Assets" },
 ] as const;
 
 export type IndustrySlug = (typeof INDUSTRY_OPTIONS)[number]["value"];

--- a/apps/web/lib/storefront/rental.test.ts
+++ b/apps/web/lib/storefront/rental.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RENTABLE_UNIT_STATUSES,
+  RENTAL_AGREEMENT_STATUSES,
+  RENTAL_VERIFICATION_STATUSES,
+  RENTAL_CONDITION_PHASES,
+  RENTAL_PRICING_MODELS,
+  OCCUPYING_AGREEMENT_STATUSES,
+  periodsOverlap,
+  countOverlappingAgreements,
+  availableCapacity,
+  isClassAvailable,
+  utilizationRate,
+  occupancyPercent,
+  hasUnitConflict,
+  rentalDays,
+  type AgreementPeriod,
+} from "./rental";
+
+const d = (iso: string) => new Date(iso);
+
+describe("rental enum registry", () => {
+  it("uses hyphenated, never underscored, string values", () => {
+    const all = [
+      ...RENTABLE_UNIT_STATUSES,
+      ...RENTAL_AGREEMENT_STATUSES,
+      ...RENTAL_VERIFICATION_STATUSES,
+      ...RENTAL_CONDITION_PHASES,
+      ...RENTAL_PRICING_MODELS,
+    ];
+    for (const v of all) {
+      expect(v).not.toMatch(/_/);
+      expect(v).toMatch(/^[a-z]+(?:-[a-z]+)*$/);
+    }
+  });
+
+  it("occupying statuses are a subset of agreement statuses", () => {
+    for (const s of OCCUPYING_AGREEMENT_STATUSES) {
+      expect(RENTAL_AGREEMENT_STATUSES).toContain(s);
+    }
+    // Terminal statuses never occupy capacity.
+    expect(OCCUPYING_AGREEMENT_STATUSES).not.toContain("returned");
+    expect(OCCUPYING_AGREEMENT_STATUSES).not.toContain("closed");
+    expect(OCCUPYING_AGREEMENT_STATUSES).not.toContain("cancelled");
+  });
+});
+
+describe("periodsOverlap (half-open)", () => {
+  it("detects genuine overlap", () => {
+    expect(periodsOverlap(d("2026-06-01"), d("2026-06-05"), d("2026-06-04"), d("2026-06-08"))).toBe(true);
+  });
+  it("treats touching ends as non-overlapping (same-day turnaround)", () => {
+    expect(periodsOverlap(d("2026-06-01"), d("2026-06-05"), d("2026-06-05"), d("2026-06-08"))).toBe(false);
+  });
+  it("disjoint periods do not overlap", () => {
+    expect(periodsOverlap(d("2026-06-01"), d("2026-06-03"), d("2026-06-10"), d("2026-06-12"))).toBe(false);
+  });
+});
+
+describe("countOverlappingAgreements", () => {
+  const agreements: AgreementPeriod[] = [
+    { status: "active", periodStart: d("2026-06-01"), periodEnd: d("2026-06-05") },
+    { status: "reserved", periodStart: d("2026-06-04"), periodEnd: d("2026-06-09") },
+    { status: "cancelled", periodStart: d("2026-06-02"), periodEnd: d("2026-06-06") }, // ignored
+    { status: "closed", periodStart: d("2026-06-03"), periodEnd: d("2026-06-07") }, // ignored
+  ];
+  it("counts only occupying statuses that overlap the window", () => {
+    expect(countOverlappingAgreements(agreements, d("2026-06-04"), d("2026-06-05"))).toBe(2);
+  });
+  it("excludes terminal statuses even when they overlap", () => {
+    expect(countOverlappingAgreements(agreements, d("2026-06-06"), d("2026-06-07"))).toBe(1); // only the reserved one
+  });
+});
+
+describe("availableCapacity — quantity pool", () => {
+  const base = {
+    serialized: false,
+    serializedAvailableUnits: 0,
+    windowStart: d("2026-06-04"),
+    windowEnd: d("2026-06-05"),
+  };
+  it("subtracts overlapping occupying agreements from stock", () => {
+    const agreements: AgreementPeriod[] = [
+      { status: "active", periodStart: d("2026-06-01"), periodEnd: d("2026-06-06") },
+      { status: "reserved", periodStart: d("2026-06-03"), periodEnd: d("2026-06-08") },
+    ];
+    expect(availableCapacity({ ...base, stockQuantity: 5, agreements })).toBe(3);
+  });
+  it("never goes negative when overbooked", () => {
+    const agreements: AgreementPeriod[] = Array.from({ length: 4 }, () => ({
+      status: "active" as const,
+      periodStart: d("2026-06-01"),
+      periodEnd: d("2026-06-10"),
+    }));
+    expect(availableCapacity({ ...base, stockQuantity: 2, agreements })).toBe(0);
+    expect(isClassAvailable({ ...base, stockQuantity: 2, agreements })).toBe(false);
+  });
+});
+
+describe("availableCapacity — serialized", () => {
+  it("uses the available-unit count as the source of truth", () => {
+    expect(
+      availableCapacity({
+        serialized: true,
+        serializedAvailableUnits: 3,
+        stockQuantity: 0,
+        agreements: [],
+        windowStart: d("2026-06-04"),
+        windowEnd: d("2026-06-05"),
+      }),
+    ).toBe(3);
+  });
+});
+
+describe("utilizationRate", () => {
+  const agreements: AgreementPeriod[] = [
+    { status: "active", periodStart: d("2026-06-01T00:00:00Z"), periodEnd: d("2026-06-10T00:00:00Z") },
+    { status: "reserved", periodStart: d("2026-06-05T00:00:00Z"), periodEnd: d("2026-06-12T00:00:00Z") },
+  ];
+  it("reports the point-in-time occupied fraction", () => {
+    expect(utilizationRate(agreements, 4, d("2026-06-06T00:00:00Z"))).toBeCloseTo(0.5);
+  });
+  it("is zero when capacity is zero", () => {
+    expect(utilizationRate(agreements, 0, d("2026-06-06T00:00:00Z"))).toBe(0);
+  });
+  it("caps at 1 when overbooked", () => {
+    expect(utilizationRate(agreements, 1, d("2026-06-06T00:00:00Z"))).toBe(1);
+  });
+});
+
+describe("occupancyPercent (self-storage KPI)", () => {
+  it("returns a 0..100 integer", () => {
+    expect(occupancyPercent(200, 174)).toBe(87);
+  });
+  it("is zero with no units", () => {
+    expect(occupancyPercent(0, 0)).toBe(0);
+  });
+  it("caps at 100", () => {
+    expect(occupancyPercent(10, 12)).toBe(100);
+  });
+});
+
+describe("hasUnitConflict (serialized double-booking guard)", () => {
+  const agreements: AgreementPeriod[] = [
+    { status: "active", rentableUnitId: "u1", periodStart: d("2026-06-01"), periodEnd: d("2026-06-05") },
+    { status: "cancelled", rentableUnitId: "u1", periodStart: d("2026-06-04"), periodEnd: d("2026-06-09") },
+  ];
+  it("flags an overlapping occupying agreement on the same unit", () => {
+    expect(
+      hasUnitConflict({ rentableUnitId: "u1", agreements, windowStart: d("2026-06-03"), windowEnd: d("2026-06-06") }),
+    ).toBe(true);
+  });
+  it("ignores cancelled agreements and other units", () => {
+    expect(
+      hasUnitConflict({ rentableUnitId: "u1", agreements, windowStart: d("2026-06-06"), windowEnd: d("2026-06-08") }),
+    ).toBe(false);
+    expect(
+      hasUnitConflict({ rentableUnitId: "u2", agreements, windowStart: d("2026-06-03"), windowEnd: d("2026-06-06") }),
+    ).toBe(false);
+  });
+});
+
+describe("rentalDays", () => {
+  it("ceils partial days", () => {
+    expect(rentalDays(d("2026-06-01T08:00:00Z"), d("2026-06-03T10:00:00Z"))).toBe(3);
+  });
+  it("is zero for a non-positive span", () => {
+    expect(rentalDays(d("2026-06-05"), d("2026-06-05"))).toBe(0);
+  });
+});

--- a/apps/web/lib/storefront/rental.ts
+++ b/apps/web/lib/storefront/rental.ts
@@ -1,0 +1,200 @@
+// Rental / shared-asset value-stream registry + pure capacity helpers.
+// EP-ARCH-8D4F2A · BI-EEA24A34 Phase 3.
+//
+// Canonical home for the rental string-enum unions (mirrored in the Prisma
+// schema as plain string columns, per AGENTS.md §3 — hyphens, never
+// underscores) and the capacity math that powers availability, utilization,
+// and self-storage occupancy. Helpers are PURE: they take plain rows so they
+// can be unit-tested without a database and reused by server actions, the
+// daily board, and the equitable-rationing scheduler.
+
+// ── Enum registry ────────────────────────────────────────────────────────────
+
+export const RENTABLE_UNIT_STATUSES = [
+  "available",
+  "reserved",
+  "out",
+  "returned",
+  "maintenance",
+  "retired",
+] as const;
+export type RentableUnitStatus = (typeof RENTABLE_UNIT_STATUSES)[number];
+
+export const RENTAL_AGREEMENT_STATUSES = [
+  "reserved",
+  "verified",
+  "active",
+  "returned",
+  "closed",
+  "cancelled",
+] as const;
+export type RentalAgreementStatus = (typeof RENTAL_AGREEMENT_STATUSES)[number];
+
+export const RENTAL_VERIFICATION_STATUSES = [
+  "not-required",
+  "pending",
+  "verified",
+  "failed",
+] as const;
+export type RentalVerificationStatus =
+  (typeof RENTAL_VERIFICATION_STATUSES)[number];
+
+export const RENTAL_CONDITION_PHASES = ["checkout", "return"] as const;
+export type RentalConditionPhase = (typeof RENTAL_CONDITION_PHASES)[number];
+
+export const RENTAL_PRICING_MODELS = [
+  "per-day",
+  "per-week",
+  "usage-based",
+  "fixed",
+] as const;
+export type RentalPricingModel = (typeof RENTAL_PRICING_MODELS)[number];
+
+/** Agreement statuses that occupy capacity (hold a unit / pool slot). */
+export const OCCUPYING_AGREEMENT_STATUSES: readonly RentalAgreementStatus[] = [
+  "reserved",
+  "verified",
+  "active",
+];
+
+/** Unit statuses that count as on-shelf and rentable right now. */
+export const RENTABLE_UNIT_AVAILABLE_STATUSES: readonly RentableUnitStatus[] = [
+  "available",
+];
+
+// ── Capacity helpers ─────────────────────────────────────────────────────────
+
+export interface AgreementPeriod {
+  status: RentalAgreementStatus;
+  periodStart: Date;
+  periodEnd: Date;
+  rentableUnitId?: string | null;
+}
+
+/** Half-open overlap: [aStart, aEnd) intersects [bStart, bEnd). */
+export function periodsOverlap(
+  aStart: Date,
+  aEnd: Date,
+  bStart: Date,
+  bEnd: Date,
+): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+/**
+ * Count agreements occupying capacity for a class over a requested window.
+ * Only occupying statuses (reserved/verified/active) and genuine overlaps count.
+ */
+export function countOverlappingAgreements(
+  agreements: readonly AgreementPeriod[],
+  windowStart: Date,
+  windowEnd: Date,
+): number {
+  return agreements.filter(
+    (a) =>
+      OCCUPYING_AGREEMENT_STATUSES.includes(a.status) &&
+      periodsOverlap(a.periodStart, a.periodEnd, windowStart, windowEnd),
+  ).length;
+}
+
+export interface ClassAvailabilityInput {
+  /** Pool capacity for a quantity-pool class (serialized classes pass 0). */
+  stockQuantity: number;
+  /** Count of serialized RentableUnits in an available status (0 for pool). */
+  serializedAvailableUnits: number;
+  /** Whether the class is serialized (has individual units) or a quantity pool. */
+  serialized: boolean;
+  agreements: readonly AgreementPeriod[];
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+/**
+ * Available capacity for a class over a window.
+ * - Serialized class: count of units in an available status (units are the
+ *   source of truth; overlapping agreements already drove the unit out of
+ *   `available`, so they are not double-subtracted).
+ * - Quantity-pool class: stockQuantity − overlapping occupying agreements.
+ * Never returns a negative number.
+ */
+export function availableCapacity(input: ClassAvailabilityInput): number {
+  if (input.serialized) {
+    return Math.max(0, input.serializedAvailableUnits);
+  }
+  const taken = countOverlappingAgreements(
+    input.agreements,
+    input.windowStart,
+    input.windowEnd,
+  );
+  return Math.max(0, input.stockQuantity - taken);
+}
+
+export function isClassAvailable(input: ClassAvailabilityInput): boolean {
+  return availableCapacity(input) > 0;
+}
+
+/**
+ * Utilization fraction (0..1) of a pool at a point in time: occupying
+ * agreements overlapping `at` divided by total capacity. Capacity of 0 → 0.
+ */
+export function utilizationRate(
+  agreements: readonly AgreementPeriod[],
+  totalCapacity: number,
+  at: Date,
+): number {
+  if (totalCapacity <= 0) return 0;
+  // Point sample: a 1ms probe window so an agreement covering `at` registers
+  // (periodsOverlap is half-open, so a zero-width window never intersects).
+  const probeEnd = new Date(at.getTime() + 1);
+  const occupied = countOverlappingAgreements(agreements, at, probeEnd);
+  return Math.min(1, occupied / totalCapacity);
+}
+
+/**
+ * Self-storage occupancy %: occupied units / total units, expressed 0..100.
+ * Unlike utilization (a point-in-time rate over a pool), occupancy is a
+ * standing snapshot of the unit inventory — the storage industry's headline KPI.
+ */
+export function occupancyPercent(
+  totalUnits: number,
+  occupiedUnits: number,
+): number {
+  if (totalUnits <= 0) return 0;
+  return Math.min(100, Math.round((occupiedUnits / totalUnits) * 100));
+}
+
+export interface UnitConflictInput {
+  rentableUnitId: string;
+  agreements: readonly AgreementPeriod[];
+  windowStart: Date;
+  windowEnd: Date;
+  /** Exclude this agreement id (e.g. when re-checking an existing reservation). */
+  ignoreAgreementRef?: string;
+}
+
+/**
+ * True when a serialized unit is double-booked for the window — any occupying
+ * agreement bound to the same unit whose period overlaps. The reservation
+ * guard for serialized fleet (BookingHold covers the optimistic-concurrency
+ * window; this is the durable check at confirm time).
+ */
+export function hasUnitConflict(input: UnitConflictInput): boolean {
+  return input.agreements.some(
+    (a) =>
+      a.rentableUnitId === input.rentableUnitId &&
+      OCCUPYING_AGREEMENT_STATUSES.includes(a.status) &&
+      periodsOverlap(
+        a.periodStart,
+        a.periodEnd,
+        input.windowStart,
+        input.windowEnd,
+      ),
+  );
+}
+
+/** Whole-day span (inclusive of both ends) for per-day pricing. */
+export function rentalDays(periodStart: Date, periodEnd: Date): number {
+  const ms = periodEnd.getTime() - periodStart.getTime();
+  if (ms <= 0) return 0;
+  return Math.ceil(ms / (1000 * 60 * 60 * 24));
+}

--- a/apps/web/lib/tak/marketing-playbooks.ts
+++ b/apps/web/lib/tak/marketing-playbooks.ts
@@ -64,6 +64,30 @@ const CATEGORY_PLAYBOOKS: Record<string, MarketingPlaybook> = {
     agentSkills: ["Draft rate announcement", "Financial education article", "Branch notice", "Fraud awareness alert"],
   },
 
+  "asset-rental": {
+    primaryGoal: "Keep the rentable pool utilized — drive reservations, fill off-peak, and recover repeat renters",
+    stakeholders: "Renters (contractors, event organizers, households), members (co-op), local trade networks",
+    campaignTypes: [
+      "Seasonal availability pushes (event season, harvest, moving season)",
+      "Off-peak / midweek promotions to lift utilization",
+      "New-equipment-in-the-pool announcements",
+      "Reservation reminders and return-due nudges",
+      "Deposit/damage-policy and how-it-works explainers",
+      "Repeat-renter loyalty and membership offers",
+      "Last-minute availability alerts for high-demand items",
+    ],
+    contentTone: "Practical, availability-forward, trustworthy about condition and deposits",
+    keyMetrics: [
+      "Asset-utilization %",
+      "Reservation conversion rate",
+      "Turnaround time between rentals",
+      "Overdue-return rate",
+      "Repeat-renter rate",
+    ],
+    ctaLanguage: ["Reserve now", "Check availability", "Book your dates", "Join the waitlist"],
+    agentSkills: ["Draft availability push", "Off-peak promotion", "Return-due reminder", "New-equipment announcement"],
+  },
+
   "public-sector": {
     primaryGoal: "Resident awareness, participation, and trust through transparent civic communication",
     stakeholders: "Residents, council members, town staff, local businesses, neighboring jurisdictions",

--- a/packages/db/prisma/migrations/20260611000000_add_rental_models/migration.sql
+++ b/packages/db/prisma/migrations/20260611000000_add_rental_models/migration.sql
@@ -1,0 +1,134 @@
+-- BI-EEA24A34 Phase 3: rental / shared-asset value-stream domain model.
+-- Additive tables only — RentableUnit / RentalAgreement / RentalConditionRecord.
+-- Models the reserve → checkout → return & inspect → re-pool lifecycle for
+-- stocked, returnable assets (equipment rental, self-storage, agricultural
+-- shared-machinery co-op). StorefrontItem stays the rate-card *class*;
+-- RentableUnit is an individual stocked asset (optional — a class may be a
+-- quantity-pool with stockQuantity and zero units); RentalAgreement is the
+-- rental analog of StorefrontBooking and hangs off StorefrontConfig.
+-- BookingHold (existing) is reused for reservation concurrency.
+
+-- CreateTable
+CREATE TABLE "RentableUnit" (
+    "id" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "storefrontId" TEXT NOT NULL,
+    "storefrontItemId" TEXT NOT NULL,
+    "unitRef" TEXT,
+    "label" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'available',
+    "meterReading" DECIMAL(65,30),
+    "attributes" JSONB,
+    "acquiredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RentableUnit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RentalAgreement" (
+    "id" TEXT NOT NULL,
+    "agreementRef" TEXT NOT NULL,
+    "storefrontId" TEXT NOT NULL,
+    "storefrontItemId" TEXT NOT NULL,
+    "rentableUnitId" TEXT,
+    "customerContactId" TEXT,
+    "customerEmail" TEXT NOT NULL,
+    "customerName" TEXT NOT NULL,
+    "customerPhone" TEXT,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "pricingModel" TEXT NOT NULL DEFAULT 'per-day',
+    "rateAmount" DECIMAL(65,30),
+    "depositAmount" DECIMAL(65,30),
+    "currency" TEXT NOT NULL DEFAULT 'GBP',
+    "status" TEXT NOT NULL DEFAULT 'reserved',
+    "verificationStatus" TEXT NOT NULL DEFAULT 'not-required',
+    "checkoutConditionId" TEXT,
+    "returnConditionId" TEXT,
+    "cancellationReason" TEXT,
+    "cancelledAt" TIMESTAMP(3),
+    "idempotencyKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RentalAgreement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RentalConditionRecord" (
+    "id" TEXT NOT NULL,
+    "agreementId" TEXT NOT NULL,
+    "phase" TEXT NOT NULL,
+    "meterReading" DECIMAL(65,30),
+    "notes" TEXT,
+    "mediaRefs" JSONB,
+    "recordedById" TEXT,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RentalConditionRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentableUnit_unitId_key" ON "RentableUnit"("unitId");
+
+-- CreateIndex
+CREATE INDEX "RentableUnit_storefrontId_status_idx" ON "RentableUnit"("storefrontId", "status");
+
+-- CreateIndex
+CREATE INDEX "RentableUnit_storefrontItemId_status_idx" ON "RentableUnit"("storefrontItemId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentalAgreement_agreementRef_key" ON "RentalAgreement"("agreementRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentalAgreement_checkoutConditionId_key" ON "RentalAgreement"("checkoutConditionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentalAgreement_returnConditionId_key" ON "RentalAgreement"("returnConditionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RentalAgreement_idempotencyKey_key" ON "RentalAgreement"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "RentalAgreement_storefrontId_status_idx" ON "RentalAgreement"("storefrontId", "status");
+
+-- CreateIndex
+CREATE INDEX "RentalAgreement_rentableUnitId_status_idx" ON "RentalAgreement"("rentableUnitId", "status");
+
+-- CreateIndex
+CREATE INDEX "RentalAgreement_periodStart_periodEnd_idx" ON "RentalAgreement"("periodStart", "periodEnd");
+
+-- CreateIndex
+CREATE INDEX "RentalAgreement_customerEmail_idx" ON "RentalAgreement"("customerEmail");
+
+-- CreateIndex
+CREATE INDEX "RentalConditionRecord_agreementId_phase_idx" ON "RentalConditionRecord"("agreementId", "phase");
+
+-- AddForeignKey
+ALTER TABLE "RentableUnit" ADD CONSTRAINT "RentableUnit_storefrontId_fkey" FOREIGN KEY ("storefrontId") REFERENCES "StorefrontConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentableUnit" ADD CONSTRAINT "RentableUnit_storefrontItemId_fkey" FOREIGN KEY ("storefrontItemId") REFERENCES "StorefrontItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_storefrontId_fkey" FOREIGN KEY ("storefrontId") REFERENCES "StorefrontConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_storefrontItemId_fkey" FOREIGN KEY ("storefrontItemId") REFERENCES "StorefrontItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_rentableUnitId_fkey" FOREIGN KEY ("rentableUnitId") REFERENCES "RentableUnit"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_customerContactId_fkey" FOREIGN KEY ("customerContactId") REFERENCES "CustomerContact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_checkoutConditionId_fkey" FOREIGN KEY ("checkoutConditionId") REFERENCES "RentalConditionRecord"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalAgreement" ADD CONSTRAINT "RentalAgreement_returnConditionId_fkey" FOREIGN KEY ("returnConditionId") REFERENCES "RentalConditionRecord"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RentalConditionRecord" ADD CONSTRAINT "RentalConditionRecord_agreementId_fkey" FOREIGN KEY ("agreementId") REFERENCES "RentalAgreement"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -138,6 +138,7 @@ model CustomerContact {
   engagements      Engagement[]
   opportunities    Opportunity[]
   activities       Activity[]
+  rentalAgreements RentalAgreement[]
 
   @@index([lastName])
   @@index([phone])
@@ -7017,6 +7018,8 @@ model StorefrontConfig {
   providers           ServiceProvider[]
   bookingHolds        BookingHold[]
   marketingStrategies MarketingStrategy[]
+  rentableUnits       RentableUnit[]
+  rentalAgreements    RentalAgreement[]
 }
 
 model MarketingStrategy {
@@ -7391,6 +7394,8 @@ model StorefrontItem {
   storefront       StorefrontConfig  @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
   providerServices ProviderService[]
   bookingHolds     BookingHold[]
+  rentableUnits    RentableUnit[]
+  rentalAgreements RentalAgreement[]
 
   @@index([storefrontId, isActive, sortOrder])
 }
@@ -7520,6 +7525,94 @@ model StorefrontOrder {
 
   @@index([storefrontId, status])
   @@index([customerEmail])
+}
+
+// ── Rental / shared-asset value stream (EP-ARCH-8D4F2A, BI-EEA24A34) ──────────
+// Models the reserve → checkout → return & inspect → re-pool lifecycle for
+// stocked, returnable assets. StorefrontItem remains the rate-card *class*
+// ("Compact SUV", "Scaffold Tower", "10x10 Unit"); RentableUnit is an
+// individual stocked asset (optional — a class can be a quantity-pool with
+// stockQuantity and zero units); RentalAgreement is the rental analog of
+// StorefrontBooking. BookingHold (reused) carries reservation concurrency.
+// String-enum columns are registered in apps/web/lib/storefront/rental.ts.
+
+model RentableUnit {
+  id               String   @id @default(cuid())
+  unitId           String   @unique
+  storefrontId     String
+  storefrontItemId String
+  unitRef          String? // plate / VIN / serial
+  label            String
+  status           String   @default("available") // available|reserved|out|returned|maintenance|retired
+  meterReading     Decimal? // mileage / hours
+  attributes       Json?
+  acquiredAt       DateTime?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  storefront StorefrontConfig  @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  item       StorefrontItem    @relation(fields: [storefrontItemId], references: [id], onDelete: Cascade)
+  agreements RentalAgreement[]
+
+  @@index([storefrontId, status])
+  @@index([storefrontItemId, status])
+}
+
+model RentalAgreement {
+  id                  String    @id @default(cuid())
+  agreementRef        String    @unique
+  storefrontId        String
+  storefrontItemId    String
+  rentableUnitId      String? // null for quantity-pool classes
+  customerContactId   String?
+  customerEmail       String
+  customerName        String
+  customerPhone       String?
+  periodStart         DateTime
+  periodEnd           DateTime
+  pricingModel        String    @default("per-day") // per-day|per-week|usage-based|fixed
+  rateAmount          Decimal?
+  depositAmount       Decimal?
+  currency            String    @default("GBP")
+  status              String    @default("reserved") // reserved|verified|active|returned|closed|cancelled
+  verificationStatus  String    @default("not-required") // not-required|pending|verified|failed
+  checkoutConditionId String?   @unique
+  returnConditionId   String?   @unique
+  cancellationReason  String?
+  cancelledAt         DateTime?
+  idempotencyKey      String?   @unique
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  storefront        StorefrontConfig        @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  item              StorefrontItem          @relation(fields: [storefrontItemId], references: [id], onDelete: Cascade)
+  rentableUnit      RentableUnit?           @relation(fields: [rentableUnitId], references: [id])
+  customerContact   CustomerContact?        @relation(fields: [customerContactId], references: [id])
+  checkoutCondition RentalConditionRecord?  @relation("CheckoutCondition", fields: [checkoutConditionId], references: [id])
+  returnCondition   RentalConditionRecord?  @relation("ReturnCondition", fields: [returnConditionId], references: [id])
+  conditionRecords  RentalConditionRecord[] @relation("AgreementConditions")
+
+  @@index([storefrontId, status])
+  @@index([rentableUnitId, status])
+  @@index([periodStart, periodEnd])
+  @@index([customerEmail])
+}
+
+model RentalConditionRecord {
+  id           String   @id @default(cuid())
+  agreementId  String
+  phase        String // checkout|return
+  meterReading Decimal?
+  notes        String?
+  mediaRefs    Json?
+  recordedById String?
+  recordedAt   DateTime @default(now())
+
+  agreement            RentalAgreement  @relation("AgreementConditions", fields: [agreementId], references: [id], onDelete: Cascade)
+  checkoutForAgreement RentalAgreement? @relation("CheckoutCondition")
+  returnForAgreement   RentalAgreement? @relation("ReturnCondition")
+
+  @@index([agreementId, phase])
 }
 
 model StorefrontInquiry {

--- a/packages/storefront-templates/src/activation-profile.test.ts
+++ b/packages/storefront-templates/src/activation-profile.test.ts
@@ -283,6 +283,36 @@ describe("existing archetype regression (governance axis is inert)", () => {
     }
   });
 
+  it("the equipment-rental and self-storage archetypes derive the rental capability set from reservation-and-return", () => {
+    for (const id of ["equipment-rental", "self-storage"]) {
+      const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === id);
+      expect(archetype?.activationProfile, id).toBeDefined();
+      const profile = readActivationProfile(archetype?.activationProfile);
+      expect(profile?.axes.provisioning, id).toBe("reservation-and-return");
+      expect(getCapabilityApplicability(profile, "rental-fleet"), id).toBe("required");
+      expect(getCapabilityApplicability(profile, "rental-agreements"), id).toBe("required");
+      expect(getCapabilityApplicability(profile, "asset-pool"), id).toBe("required");
+      // Commercial rental — no member machinery.
+      expect(getCapabilityApplicability(profile, "member-governance"), id).toBe("not-applicable");
+    }
+  });
+
+  it("the agricultural cooperative derives BOTH the member-owned set and the rental set (the §10.1 intersection)", () => {
+    const coop = ALL_ARCHETYPES.find((a) => a.archetypeId === "agricultural-cooperative");
+    expect(coop?.activationProfile).toBeDefined();
+    const profile = readActivationProfile(coop?.activationProfile);
+
+    expect(profile?.axes.governance).toBe("member-owned");
+    expect(profile?.axes.provisioning).toBe("reservation-and-return");
+    // member-owned machinery
+    expect(getCapabilityApplicability(profile, "member-governance")).toBe("required");
+    expect(getCapabilityApplicability(profile, "membership-eligibility")).toBe("required");
+    expect(activationHasCapability(profile, "member-equity")).toBe(true);
+    // rental machinery
+    expect(getCapabilityApplicability(profile, "rental-fleet")).toBe("required");
+    expect(getCapabilityApplicability(profile, "asset-pool")).toBe("required");
+  });
+
   it("the law-enforcement archetype derives public-body governance (with records requests) and no member machinery", () => {
     const police = ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === "law-enforcement-agency");
     expect(police?.activationProfile).toBeDefined();

--- a/packages/storefront-templates/src/activation-profile.ts
+++ b/packages/storefront-templates/src/activation-profile.ts
@@ -41,6 +41,8 @@ const MODULES = new Set<ArchetypeModule>([
   "projects",
   "lifecycle-signals",
   "integrations",
+  "rental-fleet",
+  "rental-agreements",
 ]);
 
 const PROFILE_TYPES = new Set(["standard", "managed-service-provider"] as const);
@@ -94,6 +96,7 @@ const PROVISIONING_VALUES = new Set<ProvisioningModel>([
   "account-with-kyc",
   "device-bound",
   "episode-of-care",
+  "reservation-and-return",
 ]);
 const PLATFORM_VALUES = new Set<PlatformEcosystem>(["no", "yes-marketplace", "yes-developer"]);
 const PORTFOLIO_SCOPES = new Set<PortfolioScope>(["absent", "minimal", "standard", "primary"]);

--- a/packages/storefront-templates/src/applicability-rules.test.ts
+++ b/packages/storefront-templates/src/applicability-rules.test.ts
@@ -354,6 +354,35 @@ describe("civic & member-governed capability derivation", () => {
   });
 });
 
+const rentalAxes: OperatingModelAxes = {
+  form: "services",
+  delivery: "physical",
+  primaryConsumer: "business",
+  consumptionChannel: "onsite-plus-portal",
+  commercialModel: "usage-based",
+  provisioning: "reservation-and-return",
+  platform: "no",
+};
+
+describe("rental / shared-asset capability derivation", () => {
+  it("derives the rental-fleet / rental-agreements / asset-pool set from reservation-and-return provisioning", () => {
+    const capabilities = deriveCapabilityApplicability(rentalAxes, salonPortfolios);
+
+    expect(getCapability(capabilities, "rental-fleet").applicability).toBe("required");
+    expect(getCapability(capabilities, "rental-agreements").applicability).toBe("required");
+    expect(getCapability(capabilities, "asset-pool").applicability).toBe("required");
+  });
+
+  it("does not derive rental capabilities for a usage-based archetype that is not reservation-and-return (e.g. a utility)", () => {
+    const utilityLikeAxes: OperatingModelAxes = { ...rentalAxes, provisioning: "account-with-billing", primaryConsumer: "resident", governance: "public-body" };
+    const capabilities = deriveCapabilityApplicability(utilityLikeAxes, salonPortfolios);
+
+    expect(getCapability(capabilities, "rental-fleet").applicability).toBe("not-applicable");
+    expect(getCapability(capabilities, "rental-agreements").applicability).toBe("not-applicable");
+    expect(getCapability(capabilities, "asset-pool").applicability).toBe("not-applicable");
+  });
+});
+
 describe("statutory and usage-based billing derivation", () => {
   it("derives obligation-driven invoicing for statutory fees and levies", () => {
     expect(deriveBillingPatternProfile(townAxes)).toMatchObject({

--- a/packages/storefront-templates/src/applicability-rules.ts
+++ b/packages/storefront-templates/src/applicability-rules.ts
@@ -485,6 +485,40 @@ const RULES: ApplicabilityRule[] = [
     },
   },
   {
+    // Rental / shared-asset operating model (asset-rental archetypes + the
+    // agricultural shared-machinery co-op). The reservation-and-return
+    // provisioning value is the axis signal — distinct from usage-based billing
+    // alone (a municipal utility is usage-based but not a rental pool).
+    name: "reservation-and-return-rental",
+    evaluate: (axes) => {
+      if (axes.provisioning !== "reservation-and-return") return [];
+
+      return [
+        {
+          key: "rental-fleet",
+          applicability: "required",
+          reason: "Rental operators manage a pool of reusable assets with live state and availability.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "rental-agreements",
+          applicability: "required",
+          reason: "Rentals run a reserve → checkout → return & inspect → re-pool lifecycle with deposits.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+        {
+          key: "asset-pool",
+          applicability: "required",
+          reason: "Asset-utilization %, turnaround, reservation conflicts, and overdue returns are the load-bearing KPIs.",
+          ownershipScopes: ["organization"],
+          isolation: "organization-scope",
+        },
+      ];
+    },
+  },
+  {
     name: "partner-channel-from-axes",
     evaluate: (axes, portfolios) => {
       const program = derivePartnerProgramProfile(axes, portfolios);

--- a/packages/storefront-templates/src/archetypes/asset-rental.ts
+++ b/packages/storefront-templates/src/archetypes/asset-rental.ts
@@ -1,0 +1,147 @@
+import type { ArchetypeDefinition } from "../types";
+
+// Rental / shared-asset archetypes (value-stream doc §10.1; design basis
+// docs/superpowers/specs/2026-05-29-vehicle-equipment-rental-archetype-design.md).
+// The defining value stream is reserve → hand out → use → return → inspect →
+// re-pool. Both leaves declare provisioning "reservation-and-return", which
+// derives the rental-fleet / rental-agreements / asset-pool capabilities.
+
+const RENTER_CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: false },
+];
+
+export const assetRentalArchetypes: ArchetypeDefinition[] = [
+  {
+    archetypeId: "equipment-rental",
+    name: "Equipment & Tool Rental",
+    category: "asset-rental",
+    ctaType: "rental",
+    tags: ["rental", "equipment", "tool-hire", "party-rental", "fleet", "asset-pool", "reservation"],
+    itemTemplates: [
+      { name: "Mini Excavator", description: "Compact excavator — daily/weekly hire, deposit required", priceType: "from", ctaType: "rental", ctaLabel: "Reserve" },
+      { name: "Scaffold Tower", description: "Mobile scaffold tower — quantity-pool stock, per-day rate", priceType: "from", ctaType: "rental", ctaLabel: "Reserve" },
+      { name: "Generator (5kW)", description: "Portable generator — per-day, fuel deposit", priceType: "from", ctaType: "rental", ctaLabel: "Reserve" },
+      { name: "Pressure Washer", description: "Industrial pressure washer — per-day hire", priceType: "from", ctaType: "rental", ctaLabel: "Reserve" },
+      { name: "Party Tent (6x12m)", description: "Event tent with sides — weekend-rate, deposit", priceType: "from", ctaType: "rental", ctaLabel: "Reserve" },
+      { name: "Check Availability", description: "Tell us what you need and your dates — we'll confirm availability", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Us", sortOrder: 1 },
+      { type: "items", title: "Equipment & Rates", sortOrder: 2 },
+      { type: "team", title: "Our Team", sortOrder: 3 },
+      { type: "contact", title: "Reserve or Ask", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...RENTER_CONTACT_FIELDS,
+      { name: "item", label: "What do you need?", type: "text" as const, required: true },
+      { name: "pickupDate", label: "Pickup date", type: "text" as const, required: true, placeholder: "e.g. 2026-07-15" },
+      { name: "returnDate", label: "Return date", type: "text" as const, required: true, placeholder: "e.g. 2026-07-17" },
+      { name: "notes", label: "Anything else?", type: "textarea" as const, required: false },
+    ],
+    // Renter skin over the asset-rental category vocabulary.
+    vocabulary: {
+      itemsLabel: "Equipment & Rates",
+      portalLabel: "Rental Portal",
+      stakeholderLabel: "Renters",
+      inboxLabel: "Reservations",
+      agentName: "Rental Desk",
+    },
+    activationProfile: {
+      profileType: "standard",
+      modules: ["rental-fleet", "rental-agreements", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "business",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "usage-based",
+        provisioning: "reservation-and-return",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill", "detect-to-correct"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "Earthmoving",
+        "Access & Lifting",
+        "Power & Site",
+        "Cleaning",
+        "Events",
+      ],
+    },
+  },
+  {
+    archetypeId: "self-storage",
+    name: "Self-Storage Facility",
+    category: "asset-rental",
+    ctaType: "rental",
+    tags: ["self-storage", "storage", "occupancy", "units", "subscription", "asset-pool"],
+    itemTemplates: [
+      { name: "5x5 Unit", description: "Small storage unit (locker) — billed monthly", priceType: "from", ctaType: "rental", ctaLabel: "Reserve unit" },
+      { name: "10x10 Unit", description: "Medium storage unit — billed monthly", priceType: "from", ctaType: "rental", ctaLabel: "Reserve unit" },
+      { name: "10x20 Unit", description: "Large storage unit (one-car garage) — billed monthly", priceType: "from", ctaType: "rental", ctaLabel: "Reserve unit" },
+      { name: "Climate-Controlled 10x10", description: "Temperature & humidity controlled unit — billed monthly", priceType: "from", ctaType: "rental", ctaLabel: "Reserve unit" },
+      { name: "Check Availability & Waitlist", description: "Tell us the size you need — reserve now or join the waitlist if full", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Our Facility", sortOrder: 1 },
+      { type: "items", title: "Unit Sizes & Rates", sortOrder: 2 },
+      { type: "team", title: "Facility Team", sortOrder: 3 },
+      { type: "contact", title: "Reserve a Unit", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...RENTER_CONTACT_FIELDS,
+      { name: "unitSize", label: "Unit size", type: "select" as const, required: true, options: ["5x5", "10x10", "10x20", "Climate-Controlled 10x10", "Not sure"] },
+      { name: "moveInDate", label: "Desired move-in date", type: "text" as const, required: false, placeholder: "e.g. 2026-07-01" },
+      { name: "notes", label: "What are you storing?", type: "textarea" as const, required: false },
+    ],
+    // Tenant/occupancy skin over the asset-rental category vocabulary.
+    vocabulary: {
+      itemsLabel: "Unit Sizes & Rates",
+      portalLabel: "Storage Portal",
+      stakeholderLabel: "Tenants",
+      inboxLabel: "Move-ins",
+      agentName: "Storage Manager",
+    },
+    activationProfile: {
+      profileType: "standard",
+      modules: ["rental-fleet", "rental-agreements", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "individual",
+        consumptionChannel: "onsite-plus-portal",
+        // Occupancy is billed as a recurring subscription against a fixed unit
+        // inventory; KPI = occupancy %, the hard-cap hybrid in §10.1.
+        commercialModel: "subscription",
+        provisioning: "reservation-and-return",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "Small Units",
+        "Medium Units",
+        "Large Units",
+        "Climate-Controlled",
+      ],
+    },
+  },
+];

--- a/packages/storefront-templates/src/archetypes/index.ts
+++ b/packages/storefront-templates/src/archetypes/index.ts
@@ -12,6 +12,7 @@ import { nonprofitCommunityArchetypes } from "./nonprofit-community";
 import { hoaPropertyManagementArchetypes } from "./hoa-property-management";
 import { bankingFinancialServicesArchetypes } from "./banking-financial-services";
 import { publicSectorArchetypes } from "./public-sector";
+import { assetRentalArchetypes } from "./asset-rental";
 
 export const ALL_ARCHETYPES = [
   ...healthcareWellnessArchetypes,
@@ -28,4 +29,5 @@ export const ALL_ARCHETYPES = [
   ...hoaPropertyManagementArchetypes,
   ...bankingFinancialServicesArchetypes,
   ...publicSectorArchetypes,
+  ...assetRentalArchetypes,
 ];

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -203,4 +203,78 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       ],
     },
   },
+  {
+    // Agricultural shared-machinery cooperative — the intersection of member-owned
+    // governance and the reservation-and-return rental value stream (value-stream
+    // doc §10.1). Members jointly own a pooled machinery fleet; demand is the
+    // sharpest synchronized-contention case (everyone needs the combine in the
+    // same harvest fortnight), so it must ration EQUITABLY among member-owners,
+    // not clear by price. Retires one of the cooperative archetype's documented
+    // unbuilt sub-types (the comment on `cooperative` flags ag as a follow-up).
+    archetypeId: "agricultural-cooperative",
+    name: "Agricultural Cooperative (Shared Machinery)",
+    category: "nonprofit-community",
+    ctaType: "rental",
+    tags: ["cooperative", "agricultural", "shared-machinery", "member-owned", "asset-pool", "patronage", "reservation"],
+    itemTemplates: [
+      { name: "Combine Harvester", description: "Reserve the shared combine for your harvest window — allocated equitably among members", priceType: "from", ctaType: "rental", ctaLabel: "Request booking" },
+      { name: "Grain Drill / Planter", description: "Shared planter — reserve for your planting window", priceType: "from", ctaType: "rental", ctaLabel: "Request booking" },
+      { name: "Sprayer", description: "Self-propelled sprayer — member usage rate", priceType: "from", ctaType: "rental", ctaLabel: "Request booking" },
+      { name: "Become a Member", description: "Join the cooperative to access the shared machinery pool", priceType: "free", ctaType: "inquiry", ctaLabel: "Join" },
+      { name: "Patronage & Equity Inquiry", description: "Ask about your usage-based patronage allocation or capital credits", priceType: "free", ctaType: "inquiry" },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "about", title: "About Our Co-op", sortOrder: 1 },
+      { type: "items", title: "Shared Machinery", sortOrder: 2 },
+      { type: "team", title: "Board & Committees", sortOrder: 3 },
+      { type: "contact", title: "Contact Us", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CONTACT_FIELDS,
+      { name: "requestType", label: "Request type", type: "select" as const, required: true, options: ["Machinery booking", "Membership", "Patronage / equity", "Board & governance", "Other"] },
+    ],
+    vocabulary: {
+      itemsLabel: "Shared Machinery",
+      portalLabel: "Member Portal",
+      stakeholderLabel: "Member-Owners",
+      inboxLabel: "Booking Requests",
+      agentName: "Co-op Coordinator",
+    },
+    activationProfile: {
+      profileType: "standard",
+      modules: ["rental-fleet", "rental-agreements", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "none",
+      estateSeparation: "shared",
+      axes: {
+        form: "services",
+        delivery: "physical",
+        primaryConsumer: "member",
+        consumptionChannel: "onsite-plus-portal",
+        commercialModel: "usage-based",
+        // The intersection: a reservation-and-return pool (rental capabilities)
+        // governed member-owned (member-governance/eligibility/equity). The
+        // equitable-rationing layer over conflicting reservations is the
+        // genuinely new build (BI-D7FCD029, Phase 4).
+        provisioning: "reservation-and-return",
+        platform: "no",
+        governance: "member-owned",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: { scope: "primary", it4itStages: ["request-to-fulfill", "detect-to-correct"] },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      // No member-equity override here (unlike the credit union): ag co-ops DO
+      // allocate usage-based patronage, so member-equity stays derived.
+      seededServiceCategories: [
+        "Harvest Equipment",
+        "Planting Equipment",
+        "Application Equipment",
+        "Membership & Patronage",
+      ],
+    },
+  },
 ];

--- a/packages/storefront-templates/src/capability-registry.test.ts
+++ b/packages/storefront-templates/src/capability-registry.test.ts
@@ -32,6 +32,9 @@ describe("capability registry", () => {
       "public-body-governance",
       "records-request",
       "service-request-311",
+      "rental-fleet",
+      "rental-agreements",
+      "asset-pool",
     ]);
   });
 

--- a/packages/storefront-templates/src/capability-registry.ts
+++ b/packages/storefront-templates/src/capability-registry.ts
@@ -204,6 +204,31 @@ export const CAPABILITY_REGISTRY = {
     defaultIsolation: "organization-scope",
     surfaces: ["service-requests"],
   },
+  // Rental / shared-asset capabilities — gated by the reservation-and-return
+  // provisioning model (asset-rental archetypes; value-stream doc §10.1).
+  "rental-fleet": {
+    label: "Rental Fleet & Asset Pool",
+    portfolio: "productsAndServicesSold",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["rental", "fleet"],
+  },
+  "rental-agreements": {
+    label: "Rental Agreements & Returns",
+    portfolio: "manufactureAndDeliver",
+    it4itStage: "request-to-fulfill",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["rental", "agreements"],
+  },
+  "asset-pool": {
+    label: "Asset-Pool Capacity & Utilization",
+    portfolio: "manufactureAndDeliver",
+    it4itStage: "detect-to-correct",
+    defaultOwnershipScope: "organization",
+    defaultIsolation: "organization-scope",
+    surfaces: ["rental", "utilization"],
+  },
 } as const satisfies Record<string, CapabilityRegistryEntry>;
 
 export type CapabilityKey = keyof typeof CAPABILITY_REGISTRY;

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -1,4 +1,4 @@
-export type CtaType = "booking" | "purchase" | "inquiry" | "donation";
+export type CtaType = "booking" | "purchase" | "inquiry" | "donation" | "rental";
 
 export type PriceType =
   | "fixed" | "from" | "per-hour" | "per-session"
@@ -23,7 +23,13 @@ export type ArchetypeCategory =
   | "nonprofit-community"
   | "hoa-property-management"
   | "banking-financial-services"
-  | "public-sector";
+  | "public-sector"
+  /** Rental of a reusable pooled asset — equipment/tool hire and self-storage.
+   *  The defining value stream is reserve → hand out → use → return → inspect →
+   *  re-pool (the S4b Return & Inspect stage); see
+   *  docs/architecture/archetype-business-value-streams.md §10.1 and
+   *  docs/superpowers/specs/2026-05-29-vehicle-equipment-rental-archetype-design.md. */
+  | "asset-rental";
 
 export interface FormField {
   name: string;
@@ -66,7 +72,9 @@ export type ArchetypeModule =
   | "service-operations"
   | "projects"
   | "lifecycle-signals"
-  | "integrations";
+  | "integrations"
+  | "rental-fleet"
+  | "rental-agreements";
 
 export type ArchetypeProfileType = "standard" | "managed-service-provider";
 
@@ -123,7 +131,12 @@ export type ProvisioningModel =
   | "account-and-entitlement"
   | "account-with-kyc"
   | "device-bound"
-  | "episode-of-care";
+  | "episode-of-care"
+  /** The served party gets access by reserving a pooled asset, receiving it,
+   *  and returning it — the rental/shared-asset entitlement model. Distinct from
+   *  account-with-billing: the asset is re-pooled, not consumed. Gates the
+   *  rental-fleet / rental-agreements / asset-pool capabilities. */
+  | "reservation-and-return";
 
 export type PlatformEcosystem = "no" | "yes-marketplace" | "yes-developer";
 


### PR DESCRIPTION
## What

Models the **rental / shared-asset utilization value stream** (`reserve → use → return & inspect → re-pool`) that none of the existing 53 archetypes / 8 commercial models could express. Closes the gap identified against the seed; corroborated by `docs/architecture/archetype-business-value-streams.md` §10.1 and prior spec #1265.

Part of **EP-ARCH-8D4F2A**. This PR is **Phase 1 (substrate) + Phase 2 (leaves)**; Phase 3 (capacity models) and Phase 4 (lifecycle) follow.

## Phase 1 — substrate (BI-EEA24A34)
- New provisioning axis value `reservation-and-return` — the clean, **axis-derived** signal distinguishing a returnable rental pool from a usage-metered utility (capability derivation gates on the axis, not on archetype id).
- `rental` ctaType (label **"Reserve"**); `asset-rental` `ArchetypeCategory`; `rental-fleet` + `rental-agreements` `ArchetypeModule`s.
- Three capabilities — `rental-fleet`, `rental-agreements`, `asset-pool` — plus an applicability rule that derives the set when `provisioning === "reservation-and-return"`.

## Phase 2 — archetype leaves
| Archetype | Axes | BI |
|---|---|---|
| equipment-rental | business / usage-based / reservation-and-return | BI-2754B64E (promotes #1265) |
| self-storage | individual / subscription / reservation-and-return | BI-4C3CFC35 |
| agricultural-cooperative | member / usage-based / reservation-and-return / member-owned | BI-D7FCD029 |

The ag co-op sits under `nonprofit-community` and derives **both** the member-owned and rental capability sets; it uses patronage (no member-equity override).

Web wiring: industries option, `CtaButton` "Reserve" label, vocabulary + category suggestions, business-context + marketing-playbook profiles.

## Verification
- `@dpf/storefront-templates` vitest: **65 passed**
- `web` vitest: **10371 passed** / 20 skipped
- `web` + `@dpf/db` typecheck: clean

Phase 2 rental CTAs route to `/inquire` (the inquiry form carries the date fields); the dedicated reservation lifecycle lands in Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)