### PR TITLE
feat(rental): reservation→return lifecycle + Rental Desk + equitable-rationing scheduler (BI-EEA24A34, BI-D7FCD029 Phase 4)

### DIFF
--- a/apps/web/app/(shell)/rental/page.tsx
+++ b/apps/web/app/(shell)/rental/page.tsx
@@ -1,0 +1,64 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { getActiveOrgCapabilities } from "@/lib/storefront/civic-surfaces.server";
+import {
+  RentalDeskPanel,
+  type RentalAgreementRow,
+} from "@/components/rental/RentalDeskPanel";
+import { occupancyPercent } from "@/lib/storefront/rental";
+
+// Rental Desk daily board (BI-EEA24A34 Phase 4) — operator surface for the
+// reserve → checkout → return & inspect → re-pool lifecycle. Capability-gated
+// (rental-fleet OR rental-agreements) so it renders only for rental archetypes,
+// per the same capability-driven-surface discipline as the civic pages.
+export default async function RentalDeskPage() {
+  const active = await getActiveOrgCapabilities();
+  if (!active.has("rental-fleet") && !active.has("rental-agreements")) notFound();
+
+  const [agreements, units] = await Promise.all([
+    prisma.rentalAgreement.findMany({
+      orderBy: { periodStart: "asc" },
+      take: 200,
+      include: {
+        item: { select: { name: true } },
+        rentableUnit: { select: { label: true } },
+      },
+    }),
+    prisma.rentableUnit.findMany({ select: { status: true } }),
+  ]);
+
+  const live = agreements.filter((a) => !["closed", "cancelled"].includes(a.status));
+
+  const rows: RentalAgreementRow[] = live.map((a) => ({
+    id: a.id,
+    ref: a.agreementRef,
+    itemName: a.item?.name ?? "Rental",
+    unitLabel: a.rentableUnit?.label ?? null,
+    customerName: a.customerName,
+    periodStart: a.periodStart.toISOString(),
+    periodEnd: a.periodEnd.toISOString(),
+    status: a.status,
+    verificationStatus: a.verificationStatus,
+    depositAmount: a.depositAmount != null ? Number(a.depositAmount) : null,
+    currency: a.currency,
+  }));
+
+  const totalUnits = units.length;
+  const occupiedUnits = units.filter((u) => ["reserved", "out"].includes(u.status)).length;
+  const occupancy = occupancyPercent(totalUnits, occupiedUnits);
+  const out = live.filter((a) => a.status === "active").length;
+  const dueOut = live.filter((a) => a.status === "reserved" || a.status === "verified").length;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Rental Desk</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          {dueOut} awaiting checkout · {out} out now
+          {totalUnits > 0 && ` · ${occupancy}% of ${totalUnits} units occupied`}
+        </p>
+      </div>
+      <RentalDeskPanel agreements={rows} />
+    </div>
+  );
+}

--- a/apps/web/components/rental/RentalDeskPanel.tsx
+++ b/apps/web/components/rental/RentalDeskPanel.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  verifyAgreement,
+  checkoutAgreement,
+  returnAgreement,
+  cancelAgreement,
+} from "@/lib/actions/rental";
+
+const STATUS_CHIPS: Record<string, string> = {
+  reserved: "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)]",
+  verified: "bg-[var(--dpf-accent)]/15 text-[var(--dpf-accent)]",
+  active: "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)]",
+  closed: "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+  cancelled: "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+};
+
+export type RentalAgreementRow = {
+  id: string;
+  ref: string;
+  itemName: string;
+  unitLabel: string | null;
+  customerName: string;
+  periodStart: string;
+  periodEnd: string;
+  status: string;
+  verificationStatus: string;
+  depositAmount: number | null;
+  currency: string;
+};
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString();
+}
+
+export function RentalDeskPanel({ agreements }: { agreements: RentalAgreementRow[] }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(id: string, fn: () => Promise<{ ok: boolean; message: string }>) {
+    setBusy(id);
+    setError(null);
+    const result = await fn();
+    setBusy(null);
+    if (!result.ok) setError(result.message);
+    else router.refresh();
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+
+      <ul className="space-y-2">
+        {agreements.map((a) => {
+          const isBusy = busy === a.id;
+          return (
+            <li key={a.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={`rounded px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIPS[a.status] ?? STATUS_CHIPS.reserved}`}>
+                  {a.status}
+                </span>
+                <span className="text-xs font-mono text-[var(--dpf-muted)]">{a.ref}</span>
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{a.itemName}</span>
+                {a.unitLabel && (
+                  <span className="rounded bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[11px] text-[var(--dpf-muted)]">
+                    {a.unitLabel}
+                  </span>
+                )}
+                {a.verificationStatus === "pending" && (
+                  <span className="rounded bg-[var(--dpf-error)]/15 px-2 py-0.5 text-[11px] text-[var(--dpf-error)]">
+                    verify required
+                  </span>
+                )}
+                <span className="ml-auto text-xs text-[var(--dpf-muted)]">
+                  {fmtDate(a.periodStart)} → {fmtDate(a.periodEnd)}
+                </span>
+              </div>
+              <div className="mt-1 flex items-center gap-3 text-xs text-[var(--dpf-muted)]">
+                <span>{a.customerName}</span>
+                {a.depositAmount != null && a.depositAmount > 0 && (
+                  <span>deposit {a.currency} {a.depositAmount.toFixed(2)}</span>
+                )}
+              </div>
+
+              <div className="mt-2 flex flex-wrap gap-2">
+                {a.status === "reserved" && a.verificationStatus === "pending" && (
+                  <button
+                    onClick={() => run(a.id, () => verifyAgreement(a.id))}
+                    disabled={isBusy}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-accent)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                  >
+                    Verify renter
+                  </button>
+                )}
+                {(a.status === "reserved" || a.status === "verified") && a.verificationStatus !== "pending" && (
+                  <button
+                    onClick={() => run(a.id, () => checkoutAgreement(a.id, {}))}
+                    disabled={isBusy}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-warning)] hover:border-[var(--dpf-warning)] disabled:opacity-50"
+                  >
+                    Check out
+                  </button>
+                )}
+                {a.status === "active" && (
+                  <>
+                    <button
+                      onClick={() => run(a.id, () => returnAgreement(a.id, {}))}
+                      disabled={isBusy}
+                      className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-success)] hover:border-[var(--dpf-success)] disabled:opacity-50"
+                    >
+                      Return &amp; re-pool
+                    </button>
+                    <button
+                      onClick={() => run(a.id, () => returnAgreement(a.id, { needsMaintenance: true }))}
+                      disabled={isBusy}
+                      className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                    >
+                      Return → maintenance
+                    </button>
+                  </>
+                )}
+                {(a.status === "reserved" || a.status === "verified") && (
+                  <button
+                    onClick={() => run(a.id, () => cancelAgreement(a.id))}
+                    disabled={isBusy}
+                    className="px-2 py-1 text-[11px] rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:border-[var(--dpf-error)] disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+        {agreements.length === 0 && (
+          <li className="rounded-lg border border-dashed border-[var(--dpf-border)] p-6 text-center text-sm text-[var(--dpf-muted)]">
+            No reservations yet. Bookings from your public rental portal land here for
+            checkout and return.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/rental.ts
+++ b/apps/web/lib/actions/rental.ts
@@ -1,0 +1,300 @@
+"use server";
+
+import * as crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  RENTAL_CONDITION_PHASES,
+  hasUnitConflict,
+  type AgreementPeriod,
+} from "@/lib/storefront/rental";
+
+// EP-ARCH-8D4F2A · BI-EEA24A34/BI-D7FCD029 Phase 4 — rental reservation→return
+// lifecycle. Conventions mirror lib/actions/civic-governance.ts: auth via the
+// storefront capability, single-org resolution, { ok, message } result shape,
+// revalidatePath refresh. The durable conflict guard reuses the Phase 3 pure
+// capacity helpers (BookingHold covers the optimistic-concurrency window; this
+// is the confirm-time check).
+
+export type RentalActionResult = { ok: boolean; message: string; id?: string };
+
+async function requireManageRental() {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_storefront",
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+  return session.user;
+}
+
+function makeRef(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+}
+
+async function getStorefront(): Promise<{ id: string }> {
+  const sf = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+  if (!sf) throw new Error("No storefront configured");
+  return sf;
+}
+
+// ─── Fleet setup ──────────────────────────────────────────────────────────────
+
+export async function addRentableUnit(input: {
+  storefrontItemId: string;
+  label: string;
+  unitRef?: string;
+  meterReading?: number;
+}): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    if (!input.label.trim()) return { ok: false, message: "A unit label is required" };
+    const sf = await getStorefront();
+    const item = await prisma.storefrontItem.findFirst({
+      where: { id: input.storefrontItemId, storefrontId: sf.id },
+      select: { id: true },
+    });
+    if (!item) return { ok: false, message: "Rental class not found" };
+    const unit = await prisma.rentableUnit.create({
+      data: {
+        unitId: makeRef("RU"),
+        storefrontId: sf.id,
+        storefrontItemId: item.id,
+        label: input.label.trim(),
+        unitRef: input.unitRef?.trim() || null,
+        meterReading: input.meterReading ?? null,
+        status: "available",
+      },
+    });
+    revalidatePath("/rental");
+    return { ok: true, message: `Unit ${unit.unitId} added`, id: unit.id };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to add unit" };
+  }
+}
+
+// ─── Reservation ────────────────────────────────────────────────────────────
+
+export async function createReservation(input: {
+  storefrontItemId: string;
+  rentableUnitId?: string;
+  customerEmail: string;
+  customerName: string;
+  customerPhone?: string;
+  periodStart: string;
+  periodEnd: string;
+  pricingModel?: string;
+  rateAmount?: number;
+  depositAmount?: number;
+}): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    const periodStart = new Date(input.periodStart);
+    const periodEnd = new Date(input.periodEnd);
+    if (Number.isNaN(periodStart.getTime()) || Number.isNaN(periodEnd.getTime())) {
+      return { ok: false, message: "Valid start and end dates are required" };
+    }
+    if (periodEnd <= periodStart) {
+      return { ok: false, message: "Return date must be after pickup date" };
+    }
+    if (!input.customerName.trim() || !input.customerEmail.trim()) {
+      return { ok: false, message: "Renter name and email are required" };
+    }
+    const sf = await getStorefront();
+
+    // Durable double-booking guard for serialized units.
+    if (input.rentableUnitId) {
+      const existing = await prisma.rentalAgreement.findMany({
+        where: { storefrontId: sf.id, rentableUnitId: input.rentableUnitId },
+        select: { status: true, periodStart: true, periodEnd: true, rentableUnitId: true },
+      });
+      const conflict = hasUnitConflict({
+        rentableUnitId: input.rentableUnitId,
+        agreements: existing as AgreementPeriod[],
+        windowStart: periodStart,
+        windowEnd: periodEnd,
+      });
+      if (conflict) {
+        return { ok: false, message: "That unit is already booked for the selected dates" };
+      }
+    }
+
+    const agreement = await prisma.rentalAgreement.create({
+      data: {
+        agreementRef: makeRef("RA"),
+        storefrontId: sf.id,
+        storefrontItemId: input.storefrontItemId,
+        rentableUnitId: input.rentableUnitId || null,
+        customerEmail: input.customerEmail.trim(),
+        customerName: input.customerName.trim(),
+        customerPhone: input.customerPhone?.trim() || null,
+        periodStart,
+        periodEnd,
+        pricingModel: input.pricingModel || "per-day",
+        rateAmount: input.rateAmount ?? null,
+        depositAmount: input.depositAmount ?? null,
+        status: "reserved",
+        verificationStatus: input.depositAmount && input.depositAmount > 0 ? "pending" : "not-required",
+      },
+    });
+    if (input.rentableUnitId) {
+      await prisma.rentableUnit.update({
+        where: { id: input.rentableUnitId },
+        data: { status: "reserved" },
+      });
+    }
+    revalidatePath("/rental");
+    return { ok: true, message: `Reservation ${agreement.agreementRef} created`, id: agreement.id };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to create reservation" };
+  }
+}
+
+export async function verifyAgreement(id: string): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    await prisma.rentalAgreement.update({
+      where: { id },
+      data: { status: "verified", verificationStatus: "verified" },
+    });
+    revalidatePath("/rental");
+    return { ok: true, message: "Renter verified" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to verify" };
+  }
+}
+
+// ─── Checkout (hand the asset over) ───────────────────────────────────────────
+
+export async function checkoutAgreement(
+  id: string,
+  condition: { meterReading?: number; notes?: string },
+): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    const agreement = await prisma.rentalAgreement.findUnique({
+      where: { id },
+      select: { id: true, rentableUnitId: true, verificationStatus: true },
+    });
+    if (!agreement) return { ok: false, message: "Agreement not found" };
+    if (agreement.verificationStatus === "pending") {
+      return { ok: false, message: "Verify the renter before checkout (deposit pending)" };
+    }
+    await prisma.$transaction(async (tx) => {
+      const record = await tx.rentalConditionRecord.create({
+        data: {
+          agreementId: id,
+          phase: "checkout" satisfies (typeof RENTAL_CONDITION_PHASES)[number],
+          meterReading: condition.meterReading ?? null,
+          notes: condition.notes?.trim() || null,
+        },
+      });
+      await tx.rentalAgreement.update({
+        where: { id },
+        data: { status: "active", checkoutConditionId: record.id },
+      });
+      if (agreement.rentableUnitId) {
+        await tx.rentableUnit.update({
+          where: { id: agreement.rentableUnitId },
+          data: {
+            status: "out",
+            meterReading: condition.meterReading ?? undefined,
+          },
+        });
+      }
+    });
+    revalidatePath("/rental");
+    return { ok: true, message: "Checked out — asset is now out" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to check out" };
+  }
+}
+
+// ─── Return & inspect → re-pool ───────────────────────────────────────────────
+
+export async function returnAgreement(
+  id: string,
+  condition: { meterReading?: number; notes?: string; needsMaintenance?: boolean },
+): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    const agreement = await prisma.rentalAgreement.findUnique({
+      where: { id },
+      select: { id: true, rentableUnitId: true, depositAmount: true },
+    });
+    if (!agreement) return { ok: false, message: "Agreement not found" };
+    await prisma.$transaction(async (tx) => {
+      const record = await tx.rentalConditionRecord.create({
+        data: {
+          agreementId: id,
+          phase: "return" satisfies (typeof RENTAL_CONDITION_PHASES)[number],
+          meterReading: condition.meterReading ?? null,
+          notes: condition.notes?.trim() || null,
+        },
+      });
+      await tx.rentalAgreement.update({
+        where: { id },
+        data: { status: "closed", returnConditionId: record.id },
+      });
+      if (agreement.rentableUnitId) {
+        // Re-pool: damaged units divert to maintenance, otherwise back to available.
+        await tx.rentableUnit.update({
+          where: { id: agreement.rentableUnitId },
+          data: {
+            status: condition.needsMaintenance ? "maintenance" : "available",
+            meterReading: condition.meterReading ?? undefined,
+          },
+        });
+      }
+    });
+    revalidatePath("/rental");
+    const depositNote =
+      agreement.depositAmount && Number(agreement.depositAmount) > 0
+        ? condition.needsMaintenance
+          ? " Deposit held pending damage assessment."
+          : " Deposit cleared for release."
+        : "";
+    return { ok: true, message: `Returned and re-pooled.${depositNote}` };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to record return" };
+  }
+}
+
+export async function cancelAgreement(
+  id: string,
+  reason?: string,
+): Promise<RentalActionResult> {
+  await requireManageRental();
+  try {
+    const agreement = await prisma.rentalAgreement.findUnique({
+      where: { id },
+      select: { rentableUnitId: true, status: true },
+    });
+    if (!agreement) return { ok: false, message: "Agreement not found" };
+    if (agreement.status === "active") {
+      return { ok: false, message: "Cannot cancel an active rental — record a return instead" };
+    }
+    await prisma.$transaction(async (tx) => {
+      await tx.rentalAgreement.update({
+        where: { id },
+        data: { status: "cancelled", cancellationReason: reason?.trim() || null, cancelledAt: new Date() },
+      });
+      if (agreement.rentableUnitId) {
+        await tx.rentableUnit.update({
+          where: { id: agreement.rentableUnitId },
+          data: { status: "available" },
+        });
+      }
+    });
+    revalidatePath("/rental");
+    return { ok: true, message: "Reservation cancelled" };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : "Failed to cancel" };
+  }
+}

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -337,6 +337,26 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     },
   },
   {
+    // Rental / shared-asset value stream (BI-EEA24A34 Phase 4): the operator
+    // daily board for the reserve → checkout → return & inspect → re-pool
+    // lifecycle. Renders only for rental archetypes (equipment rental,
+    // self-storage, agricultural shared-machinery co-op) whose archetype
+    // derives the rental capabilities — any-of fleet/agreements.
+    key: "rental",
+    label: "Rental Desk",
+    path: "/rental",
+    parentPath: "/rental",
+    domain: "business",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_storefront",
+    orgCapabilityKey: ["rental-fleet", "rental-agreements"],
+    shellNav: {
+      sectionKey: "business",
+      description: "Reservations, checkouts, and returns for your asset pool.",
+    },
+  },
+  {
     key: "portfolio",
     label: "Portfolio",
     path: "/portfolio",

--- a/apps/web/lib/storefront/rental-rationing.test.ts
+++ b/apps/web/lib/storefront/rental-rationing.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  rationReservations,
+  wouldGrant,
+  type RationRequest,
+} from "./rental-rationing";
+
+const d = (iso: string) => new Date(iso);
+
+const req = (
+  requestRef: string,
+  memberId: string,
+  requestedAt: string,
+  start = "2026-07-01",
+  end = "2026-07-03",
+): RationRequest => ({
+  requestRef,
+  memberId,
+  requestedAt: d(requestedAt),
+  periodStart: d(start),
+  periodEnd: d(end),
+});
+
+describe("rationReservations — equitable allocation", () => {
+  it("prioritises the least-served member over first-come ordering", () => {
+    // m-heavy requested FIRST but has high recent usage; m-light should win the
+    // single available slot despite requesting later. This is the whole point:
+    // a member pool is not first-come-first-served.
+    const requests = [
+      req("r1", "m-heavy", "2026-06-01T08:00:00Z"),
+      req("r2", "m-light", "2026-06-01T09:00:00Z"),
+    ];
+    const out = rationReservations(requests, {
+      capacity: 1,
+      maxConcurrentPerMember: 5,
+      recentUsage: { "m-heavy": 40, "m-light": 2 },
+    });
+    expect(out.granted.map((g) => g.requestRef)).toEqual(["r2"]);
+    const wl = out.waitlisted[0];
+    expect(wl.requestRef).toBe("r1");
+    expect(wl.status === "waitlisted" && wl.reason).toBe("capacity-exhausted");
+  });
+
+  it("falls back to earlier request time when usage is equal", () => {
+    const requests = [
+      req("late", "m2", "2026-06-01T10:00:00Z"),
+      req("early", "m1", "2026-06-01T08:00:00Z"),
+    ];
+    const out = rationReservations(requests, {
+      capacity: 1,
+      maxConcurrentPerMember: 5,
+      recentUsage: { m1: 5, m2: 5 },
+    });
+    expect(out.granted.map((g) => g.requestRef)).toEqual(["early"]);
+  });
+
+  it("enforces a per-member concurrency cap", () => {
+    // One member floods the pool; the cap reserves capacity for others.
+    const requests = [
+      req("a1", "m1", "2026-06-01T08:00:00Z", "2026-07-01", "2026-07-03"),
+      req("a2", "m1", "2026-06-01T08:05:00Z", "2026-07-04", "2026-07-06"),
+      req("b1", "m2", "2026-06-01T09:00:00Z", "2026-07-01", "2026-07-03"),
+    ];
+    const out = rationReservations(requests, {
+      capacity: 5,
+      maxConcurrentPerMember: 1,
+      recentUsage: { m1: 0, m2: 0 },
+    });
+    const granted = out.granted.map((g) => g.requestRef).sort();
+    expect(granted).toEqual(["a1", "b1"]); // m1's second request capped
+    const capped = out.waitlisted.find((w) => w.requestRef === "a2");
+    expect(capped && capped.status === "waitlisted" && capped.reason).toBe(
+      "member-cap-reached",
+    );
+  });
+
+  it("grants non-overlapping windows beyond nominal capacity", () => {
+    // Capacity 1, but the two requests don't overlap in time, so both fit.
+    const requests = [
+      req("w1", "m1", "2026-06-01T08:00:00Z", "2026-07-01", "2026-07-03"),
+      req("w2", "m2", "2026-06-01T09:00:00Z", "2026-07-10", "2026-07-12"),
+    ];
+    const out = rationReservations(requests, {
+      capacity: 1,
+      maxConcurrentPerMember: 5,
+    });
+    expect(out.granted).toHaveLength(2);
+  });
+
+  it("counts pre-existing occupying agreements against capacity", () => {
+    const requests = [req("r1", "m1", "2026-06-01T08:00:00Z")];
+    const out = rationReservations(requests, {
+      capacity: 1,
+      maxConcurrentPerMember: 5,
+      existing: [
+        { status: "active", periodStart: d("2026-06-30"), periodEnd: d("2026-07-02") },
+      ],
+    });
+    expect(out.granted).toHaveLength(0);
+    expect(out.waitlisted[0].status === "waitlisted" && out.waitlisted[0].reason).toBe(
+      "capacity-exhausted",
+    );
+  });
+
+  it("is deterministic — identical inputs yield identical ordering", () => {
+    const build = () => [
+      req("r1", "m1", "2026-06-01T08:00:00Z"),
+      req("r2", "m2", "2026-06-01T08:00:00Z"),
+      req("r3", "m3", "2026-06-01T08:00:00Z"),
+    ];
+    const cfg = { capacity: 2, maxConcurrentPerMember: 5 };
+    const a = rationReservations(build(), cfg);
+    const b = rationReservations(build(), cfg);
+    expect(a.decisions).toEqual(b.decisions);
+  });
+});
+
+describe("wouldGrant", () => {
+  it("is true when capacity remains for the window", () => {
+    expect(
+      wouldGrant(req("r1", "m1", "2026-06-01T08:00:00Z"), { capacity: 1, maxConcurrentPerMember: 5 }),
+    ).toBe(true);
+  });
+  it("is false when an overlapping agreement saturates capacity", () => {
+    expect(
+      wouldGrant(req("r1", "m1", "2026-06-01T08:00:00Z"), {
+        capacity: 1,
+        maxConcurrentPerMember: 5,
+        existing: [{ status: "reserved", periodStart: d("2026-06-30"), periodEnd: d("2026-07-02") }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/storefront/rental-rationing.ts
+++ b/apps/web/lib/storefront/rental-rationing.ts
@@ -1,0 +1,163 @@
+// Equitable-rationing scheduler for member-owned shared-asset pools.
+// EP-ARCH-8D4F2A · BI-D7FCD029 (agricultural shared-machinery co-op).
+//
+// A commercial rental desk allocates contended capacity first-come-first-served
+// — whoever books first wins. A member-OWNED pool cannot: the asset belongs to
+// the members collectively, so when demand for a window exceeds capacity the
+// allocation must be *equitable*, not merely fast. This is the co-op analog of
+// the member-equity/patronage principle applied to the booking calendar.
+//
+// Pure + deterministic so it unit-tests without a DB and the same ranking can
+// be shown to members as the published allocation rationale. Fairness =
+// lower recent usage first (patronage-balanced / "everyone gets a turn"), then
+// a per-member concurrency cap during the window, then earlier request time as
+// the final tiebreak. No randomness — ties resolve on stable, explainable keys.
+
+import {
+  type AgreementPeriod,
+  countOverlappingAgreements,
+  periodsOverlap,
+} from "./rental";
+
+export interface RationRequest {
+  /** Stable request identity (agreementRef or a transient key). */
+  requestRef: string;
+  /** Member-owner placing the request. */
+  memberId: string;
+  /** When the request was submitted (tiebreak only — never the primary key). */
+  requestedAt: Date;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+export interface RationConfig {
+  /** Total pool capacity for the class over the contended window. */
+  capacity: number;
+  /** Max concurrent active+granted reservations a single member may hold in the window. */
+  maxConcurrentPerMember: number;
+  /**
+   * Recent usage per member (e.g. unit-days consumed this season) — the
+   * patronage-balancing signal. Absent members are treated as zero usage and
+   * therefore rank ahead of heavy users. Lower usage = higher priority.
+   */
+  recentUsage?: Record<string, number>;
+  /** Reservations already occupying the pool in this window (count against capacity). */
+  existing?: readonly AgreementPeriod[];
+}
+
+export type RationDecision =
+  | { requestRef: string; memberId: string; status: "granted" }
+  | {
+      requestRef: string;
+      memberId: string;
+      status: "waitlisted";
+      reason: "capacity-exhausted" | "member-cap-reached";
+    };
+
+export interface RationOutcome {
+  decisions: RationDecision[];
+  granted: RationDecision[];
+  waitlisted: RationDecision[];
+}
+
+/** Lower score = allocate earlier. Stable, fully explainable ordering. */
+function fairnessKey(
+  req: RationRequest,
+  recentUsage: Record<string, number>,
+): [number, number, string] {
+  return [
+    recentUsage[req.memberId] ?? 0, // 1. least-served member first
+    req.requestedAt.getTime(), // 2. earlier request wins the tie
+    req.requestRef, // 3. fully deterministic final tiebreak
+  ];
+}
+
+function compareKeys(
+  a: [number, number, string],
+  b: [number, number, string],
+): number {
+  if (a[0] !== b[0]) return a[0] - b[0];
+  if (a[1] !== b[1]) return a[1] - b[1];
+  return a[2] < b[2] ? -1 : a[2] > b[2] ? 1 : 0;
+}
+
+/**
+ * Allocate contended reservation requests equitably across member-owners.
+ * Greedy over the fairness ranking: grant while window capacity remains and the
+ * member is under their concurrency cap; otherwise waitlist with a reason.
+ * Capacity is checked per-request against the union of pre-existing occupying
+ * agreements and grants made earlier in this pass that overlap the request.
+ */
+export function rationReservations(
+  requests: readonly RationRequest[],
+  config: RationConfig,
+): RationOutcome {
+  const recentUsage = config.recentUsage ?? {};
+  const existing = config.existing ?? [];
+  const capacity = Math.max(0, config.capacity);
+  const perMemberCap = Math.max(0, config.maxConcurrentPerMember);
+
+  const ordered = [...requests].sort((a, b) =>
+    compareKeys(fairnessKey(a, recentUsage), fairnessKey(b, recentUsage)),
+  );
+
+  const grants: AgreementPeriod[] = existing.map((e) => ({ ...e }));
+  const memberGrantCount: Record<string, number> = {};
+  const decisions: RationDecision[] = [];
+
+  for (const req of ordered) {
+    const held = memberGrantCount[req.memberId] ?? 0;
+    if (held >= perMemberCap) {
+      decisions.push({
+        requestRef: req.requestRef,
+        memberId: req.memberId,
+        status: "waitlisted",
+        reason: "member-cap-reached",
+      });
+      continue;
+    }
+    const overlapping = countOverlappingAgreements(
+      grants,
+      req.periodStart,
+      req.periodEnd,
+    );
+    if (overlapping >= capacity) {
+      decisions.push({
+        requestRef: req.requestRef,
+        memberId: req.memberId,
+        status: "waitlisted",
+        reason: "capacity-exhausted",
+      });
+      continue;
+    }
+    grants.push({
+      status: "reserved",
+      periodStart: req.periodStart,
+      periodEnd: req.periodEnd,
+    });
+    memberGrantCount[req.memberId] = held + 1;
+    decisions.push({
+      requestRef: req.requestRef,
+      memberId: req.memberId,
+      status: "granted",
+    });
+  }
+
+  return {
+    decisions,
+    granted: decisions.filter((d) => d.status === "granted"),
+    waitlisted: decisions.filter((d) => d.status === "waitlisted"),
+  };
+}
+
+/** Convenience: would this single request be granted against the current pool? */
+export function wouldGrant(
+  req: RationRequest,
+  config: RationConfig,
+): boolean {
+  const existing = config.existing ?? [];
+  const overlapping = existing.filter((e) =>
+    periodsOverlap(e.periodStart, e.periodEnd, req.periodStart, req.periodEnd),
+  ).length;
+  return overlapping < Math.max(0, config.capacity);
+}

--- a/docs/superpowers/plans/2026-06-11-rental-shared-asset-value-stream.md
+++ b/docs/superpowers/plans/2026-06-11-rental-shared-asset-value-stream.md
@@ -1,0 +1,82 @@
+---
+title: Rental / shared-asset utilization value stream
+epic: EP-ARCH-8D4F2A
+backlog: [BI-EEA24A34, BI-2754B64E, BI-4C3CFC35, BI-D7FCD029]
+status: implemented
+date: 2026-06-11
+supersedes_research: docs/superpowers/specs/2026-05-29-vehicle-equipment-rental-archetype-design.md
+value_stream_ref: docs/architecture/archetype-business-value-streams.md §10.1
+---
+
+# Rental / shared-asset utilization value stream
+
+## Why
+
+None of the existing 53 archetypes / 8 commercial models could express the
+**rental / shared-asset utilization** value stream: the time-bounded loan of a
+stocked, returnable asset. Its defining shape — `reserve → checkout → return &
+inspect → re-pool` — adds an `S4b Return & Inspect → re-pool` stage and a
+*reusable pooled asset* capacity unit that "services sold" (booking) and "goods
+sold" (one-way purchase) archetypes do not have. Verified against the seed
+before building (no `reservation-and-return` provisioning value, no rental
+ctaType, no pooled-asset capacity); the gap is real but **not greenfield** —
+spec #1265 already designed the `RentableUnit`/`RentalAgreement` model (Option
+B) and the value-stream doc §10.1 corroborates the candidate split exactly.
+
+## Decisions
+
+- **Archetype vs sub-type.** Rental is a *cross-cutting value stream*, not one
+  archetype. The clean signal is a new **provisioning axis value**
+  `reservation-and-return` (axis-derived capability, not per-archetype-id) — it
+  distinguishes a returnable pool from a usage-metered utility (`usage-based` +
+  `account-with-billing`). Three candidate archetypes instantiate it.
+- **Category placement.** New `asset-rental` `ArchetypeCategory` ("Rental &
+  Shared Assets") for the commercial leaves (equipment rental, self-storage);
+  the **agricultural shared-machinery co-op** stays under `nonprofit-community`
+  because it derives **both** the member-owned governance set and the rental
+  set — the intersection is the point.
+- **Substrate reuse (Option B, spec #1265).** `StorefrontItem` stays the
+  rate-card *class*; `BookingHold` carries reservation concurrency;
+  `RentalAgreement` is the rental analog of `StorefrontBooking`. No parallel
+  "renter" identity — renter resolves to a `CustomerContact` (principal
+  convergence). `InventoryEntity` reuse explicitly rejected (CMDB semantics).
+- **Equitable rationing (co-op).** A member-OWNED pool cannot allocate contended
+  capacity first-come-first-served; allocation is patronage-balanced
+  (least-served first, per-member concurrency cap, deterministic tiebreaks).
+
+## Delivery (shipped)
+
+| Phase | Content | PR |
+|---|---|---|
+| 1 — substrate | `reservation-and-return` provisioning, `rental` ctaType, `asset-rental` category, `rental-fleet`/`rental-agreements` modules, 3 capabilities + applicability rule | #1725 |
+| 2 — leaves | equipment-rental, self-storage, agricultural-cooperative | #1725 |
+| 3 — domain model | `RentableUnit`/`RentalAgreement`/`RentalConditionRecord` + migration + pure capacity engine (`rental.ts`) | #1725 |
+| 4 — runtime | reservation→return lifecycle server actions, capability-gated Rental Desk daily board, equitable-rationing scheduler (`rental-rationing.ts`) | this PR |
+
+## Capacity engine (pure, unit-tested)
+
+`apps/web/lib/storefront/rental.ts` — `availableCapacity` (pool = stock −
+overlapping occupying agreements; serialized = available-unit count),
+`countOverlappingAgreements` (half-open overlap, occupying statuses only),
+`utilizationRate` (point-in-time pool fraction), `occupancyPercent`
+(self-storage standing-inventory KPI), `hasUnitConflict` (serialized
+double-booking guard), `rentalDays`.
+
+`apps/web/lib/storefront/rental-rationing.ts` — `rationReservations` (greedy
+over a stable fairness ranking) + `wouldGrant`.
+
+## Lifecycle
+
+`reserve` (BookingHold + agreement `reserved`) → `verify` (deposit gate) →
+`checkout` (checkout `RentalConditionRecord`, unit `out`, agreement `active`) →
+`return` (return condition record, meter delta, unit `available`|`maintenance`,
+deposit release/hold note, agreement `closed`). Cancellation re-pools the unit;
+an active rental cannot be cancelled (must be returned).
+
+## Follow-ups (not in scope)
+
+- Real Stripe deposit auth/capture (extends `billing-readiness`).
+- Public storefront rental booking form with date pickers (Phase 2 CTAs route
+  to `/inquire`, which carries the date fields, until then).
+- Batch rationing operator tool surfacing the published allocation rationale to
+  members.


### PR DESCRIPTION
## What

Completes the **rental / shared-asset value stream** (EP-ARCH-8D4F2A) — the runtime that operates the `reserve → checkout → return & inspect → re-pool` lifecycle on top of the foundation merged in #1725. Builds on `origin/main` (includes #1725).

## Server actions — `apps/web/lib/actions/rental.ts`
Full lifecycle, gated on `view_storefront`, transactional unit/agreement state:
- `addRentableUnit` — operator fleet setup
- `createReservation` — durable serialized double-booking guard (reuses Phase 3 `hasUnitConflict`); a deposit puts the agreement in `verification: pending`
- `verifyAgreement` → `checkoutAgreement` (checkout `RentalConditionRecord`, unit → `out`, agreement → `active`) → `returnAgreement` (return condition record, meter delta, unit → `available`|`maintenance`, deposit release/hold note, agreement → `closed`)
- `cancelAgreement` — re-pools the unit; refuses an active rental (must be returned)

## Rental Desk daily board
- `app/(shell)/rental` + `components/rental/RentalDeskPanel` — **capability-gated** (`rental-fleet` OR `rental-agreements`, the same capability-driven-surface discipline as the civic pages), per-agreement lifecycle controls, and a header summary (awaiting checkout / out now / self-storage **occupancy %**).
- Nav entry **"Rental Desk"** gated on the rental capabilities (any-of).

## Equitable-rationing scheduler — `apps/web/lib/storefront/rental-rationing.ts`
`rationReservations`: a member-**owned** pool can't allocate contended capacity first-come-first-served, so allocation is patronage-balanced — **least-served member first**, a **per-member concurrency cap**, deterministic tiebreaks, and a waitlist reason. The booking-calendar analog of the co-op member-equity principle (BI-D7FCD029).

## Verification
- `rental-rationing` vitest: **8 passed**; full `web` suite: **10399 passed** / 20 skipped
- `web` typecheck: clean

Implementation plan + decisions: `docs/superpowers/plans/2026-06-11-rental-shared-asset-value-stream.md`.

### Follow-ups (out of scope, noted in the plan)
Real Stripe deposit auth/capture; the public storefront rental booking form with date pickers (today the `rental` CTA routes to `/inquire`, which carries the date fields); a batch-rationing operator tool that surfaces the published allocation to members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)