### PR TITLE
feat(workbooks): reference columns wired to live platform entities (EP-GRID-WORKBOOKS Phase 2)

### DIFF
--- a/apps/web/components/ui/ReferenceTypeahead.tsx
+++ b/apps/web/components/ui/ReferenceTypeahead.tsx
@@ -28,6 +28,7 @@ type ReferenceTypeaheadProps = {
   addNewLabel?: string;
   value: RefItem | null;
   disabled?: boolean;
+  autoFocus?: boolean;
 };
 
 export function ReferenceTypeahead({
@@ -39,6 +40,7 @@ export function ReferenceTypeahead({
   addNewLabel = "item",
   value,
   disabled = false,
+  autoFocus = false,
 }: ReferenceTypeaheadProps) {
   const [query, setQuery] = useState(value?.label ?? "");
   const [results, setResults] = useState<RefItem[]>([]);
@@ -181,6 +183,7 @@ export function ReferenceTypeahead({
         id={inputId}
         type="text"
         role="combobox"
+        autoFocus={autoFocus}
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-autocomplete="list"

--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { addColumnAction } from "@/lib/actions/workbooks";
-import type { FieldType, SelectOption } from "@/lib/workbooks/types";
+import { addColumnAction, listReferenceTargetsAction } from "@/lib/actions/workbooks";
+import type { ReferenceTarget } from "@/lib/workbooks/platform-tables";
+import type { FieldType, SelectOption, FieldConfig } from "@/lib/workbooks/types";
 
-// Field types with a fully-functional in-grid editor in Phase 1.
-// multi_select and reference exist in the data model but are not offered here
-// yet (reference needs platform adapters; tracked under EP-GRID-WORKBOOKS).
+// Field types with a fully-functional in-grid editor.
+// multi_select exists in the data model but is not offered here yet (rendered
+// read-only; tracked under EP-GRID-WORKBOOKS).
 const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "text", label: "Text" },
   { value: "number", label: "Number" },
@@ -15,6 +16,7 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "datetime", label: "Date & time" },
   { value: "checkbox", label: "Checkbox" },
   { value: "select", label: "Single select" },
+  { value: "reference", label: "Reference" },
   { value: "url", label: "URL" },
   { value: "email", label: "Email" },
 ];
@@ -43,18 +45,41 @@ export function AddColumnButton({
   const [name, setName] = useState("");
   const [fieldType, setFieldType] = useState<FieldType>("text");
   const [optionsRaw, setOptionsRaw] = useState("");
+  const [referenceType, setReferenceType] = useState("");
+  const [referenceTargets, setReferenceTargets] = useState<ReferenceTarget[]>([]);
   const [required, setRequired] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+
+  // Load the available reference targets once the picker is opened.
+  useEffect(() => {
+    if (!open || referenceTargets.length > 0) return;
+    let active = true;
+    void listReferenceTargetsAction().then((res) => {
+      if (active && res.ok) setReferenceTargets(res.data);
+    });
+    return () => {
+      active = false;
+    };
+  }, [open, referenceTargets.length]);
 
   function reset() {
     setOpen(false);
     setName("");
     setFieldType("text");
     setOptionsRaw("");
+    setReferenceType("");
     setRequired(false);
     setError(null);
   }
+
+  function buildConfig(): FieldConfig | undefined {
+    if (fieldType === "select") return { options: parseOptions(optionsRaw) };
+    if (fieldType === "reference") return { referenceType };
+    return undefined;
+  }
+
+  const missingReferenceTarget = fieldType === "reference" && !referenceType;
 
   function submit() {
     setError(null);
@@ -63,7 +88,7 @@ export function AddColumnButton({
         name: name.trim(),
         fieldType,
         required,
-        config: fieldType === "select" ? { options: parseOptions(optionsRaw) } : undefined,
+        config: buildConfig(),
       });
       if (!res.ok) {
         setError(res.error);
@@ -114,6 +139,26 @@ export function AddColumnButton({
           className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
         />
       )}
+      {fieldType === "reference" && (
+        <select
+          value={referenceType}
+          onChange={(e) => setReferenceType(e.target.value)}
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+        >
+          <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+            {referenceTargets.length === 0 ? "No reference targets available" : "Select what to reference…"}
+          </option>
+          {referenceTargets.map((t) => (
+            <option
+              key={t.entityType}
+              value={t.entityType}
+              className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+            >
+              {t.label}
+            </option>
+          ))}
+        </select>
+      )}
       <label className="flex items-center gap-1 text-sm text-[var(--dpf-muted)]">
         <input type="checkbox" checked={required} onChange={(e) => setRequired(e.target.checked)} />
         Required
@@ -121,7 +166,7 @@ export function AddColumnButton({
       <button
         type="button"
         onClick={submit}
-        disabled={pending || !name.trim()}
+        disabled={pending || !name.trim() || missingReferenceTarget}
         className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm text-white disabled:opacity-50"
       >
         Add

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -35,6 +35,7 @@ import {
   renderEmailCell,
   renderDateCell,
   renderReferenceCell,
+  makeReferenceEditor,
 } from "./cell-editors";
 import {
   createRowAction,
@@ -116,9 +117,16 @@ function buildColumn(
     case "multi_select":
       // Phase 1: rendered read-only in the grid; edit via API/MCP.
       return { ...base, renderCell: makeMultiSelectRenderer(options) };
-    case "reference":
-      // Phase 1: rendered read-only until platform adapters land.
-      return { ...base, renderCell: renderReferenceCell };
+    case "reference": {
+      // Phase 2: editable in-cell typeahead over a live platform entity.
+      const referenceType = col.config?.referenceType;
+      return {
+        ...base,
+        renderCell: renderReferenceCell,
+        renderEditCell:
+          editable && referenceType ? makeReferenceEditor(referenceType) : undefined,
+      };
+    }
     default:
       return base;
   }

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -7,6 +7,8 @@
 import type { ReactNode } from "react";
 import type { RenderEditCellProps, RenderCellProps } from "react-data-grid";
 import type { CellValue, SelectOption, ReferenceValue } from "@/lib/workbooks/types";
+import { ReferenceTypeahead } from "@/components/ui/ReferenceTypeahead";
+import { searchReferencesAction } from "@/lib/actions/workbooks";
 
 /** Flat row shape react-data-grid consumes: rowId + a value per columnId. */
 export type GridRowData = { rowId: string } & Record<string, CellValue>;
@@ -99,6 +101,49 @@ export function makeSelectEditor(options: SelectOption[]) {
           </option>
         ))}
       </select>
+    );
+  };
+}
+
+/**
+ * Reference editor: an in-cell typeahead over a live platform entity. Searching
+ * proxies through searchReferencesAction (capability-gated server-side); selecting
+ * commits a ReferenceValue and closes the editor. The dropdown renders inside the
+ * editor's DOM subtree, so react-data-grid does not treat a result click as an
+ * outside-click that cancels the edit.
+ */
+export function makeReferenceEditor(referenceType: string) {
+  return function ReferenceEditor({
+    row,
+    column,
+    onRowChange,
+  }: RenderEditCellProps<GridRowData>): ReactNode {
+    const current = row[column.key];
+    const value =
+      current && typeof current === "object" && !Array.isArray(current) && "referenceId" in current
+        ? {
+            id: (current as ReferenceValue).referenceId,
+            label: (current as ReferenceValue).label ?? (current as ReferenceValue).referenceId,
+          }
+        : null;
+    return (
+      <div className="dpf-grid-editor-reference">
+        <ReferenceTypeahead
+          autoFocus
+          placeholder="Search…"
+          value={value}
+          onSearch={async (q) => {
+            const res = await searchReferencesAction(referenceType, q);
+            return res.ok ? res.data : [];
+          }}
+          onSelect={(item) => {
+            onRowChange(
+              { ...row, [column.key]: { referenceId: item.id, referenceType, label: item.label } },
+              true,
+            );
+          }}
+        />
+      </div>
     );
   };
 }

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -62,3 +62,17 @@
   outline-offset: -2px;
   box-sizing: border-box;
 }
+
+/* Reference typeahead editor: fill the cell; let the floating result list overflow. */
+.dpf-grid-editor-reference {
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.dpf-grid-editor-reference input {
+  block-size: 100%;
+  border: none;
+  border-radius: 0;
+  outline: 2px solid var(--dpf-accent);
+  outline-offset: -2px;
+}

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -27,6 +27,13 @@ import {
   deleteRow as svcDeleteRow,
   getTableGridData as svcGetTableGridData,
 } from "@/lib/workbooks/workbook-service";
+import {
+  type PlatformUser,
+  type ReferenceTarget,
+  listReferenceTargets,
+  searchPlatformReferences,
+  resolvePlatformReference,
+} from "@/lib/workbooks/platform-tables";
 import type { CellValue, ColumnDefinition, FieldType, FieldConfig } from "@/lib/workbooks/types";
 
 export type ActionResult<T = void> =
@@ -190,6 +197,54 @@ export async function getTableGridDataAction(tableId: string): Promise<
   try {
     const user = await requireUser("view_workbooks");
     return { ok: true, data: await svcGetTableGridData(user, tableId) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// ── Reference columns (Phase 2) ─────────────────────────────────────────────
+// A reference column points a workbook cell at a live platform entity. These
+// actions back the add-column target picker and the in-cell typeahead. Auth
+// requires view_workbooks; each target re-checks its own view capability.
+
+async function requirePlatformUser(): Promise<PlatformUser> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new WorkbookError("Not authenticated", 401);
+  if (!can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_workbooks")) {
+    throw new WorkbookError("You do not have permission to use Workbooks", 403);
+  }
+  return { id: user.id, platformRole: user.platformRole, isSuperuser: user.isSuperuser };
+}
+
+export async function listReferenceTargetsAction(): Promise<ActionResult<ReferenceTarget[]>> {
+  try {
+    const user = await requirePlatformUser();
+    return { ok: true, data: listReferenceTargets(user) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function searchReferencesAction(
+  referenceType: string,
+  query: string,
+): Promise<ActionResult<{ id: string; label: string }[]>> {
+  try {
+    const user = await requirePlatformUser();
+    return { ok: true, data: await searchPlatformReferences(user, referenceType, query) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function resolveReferenceAction(
+  referenceType: string,
+  referenceId: string,
+): Promise<ActionResult<{ id: string; label: string } | null>> {
+  try {
+    const user = await requirePlatformUser();
+    return { ok: true, data: await resolvePlatformReference(user, referenceType, referenceId) };
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/workbooks/custom-table-adapter.ts
+++ b/apps/web/lib/workbooks/custom-table-adapter.ts
@@ -18,6 +18,7 @@ import {
   type CellValue,
   type FieldType,
   type FieldConfig,
+  type ReferenceValue,
   type DataSourceFilter,
   type SortSpec,
   type Pagination,
@@ -30,7 +31,38 @@ import {
   type CellStorage,
 } from "./cell-validation";
 import { applyFilters, applySort, paginate } from "./grid-query";
+import { resolveReferenceLabels, referenceKey } from "./reference-resolver";
 import { genSemanticId } from "./ids";
+
+function asReference(value: CellValue): ReferenceValue | null {
+  if (value && typeof value === "object" && !Array.isArray(value) && "referenceId" in value) {
+    return value as ReferenceValue;
+  }
+  return null;
+}
+
+/** Hydrate live display labels for every reference cell (labels are not persisted). */
+async function hydrateReferenceLabels(rows: GridRow[]): Promise<void> {
+  const refs: { referenceType: string; referenceId: string }[] = [];
+  for (const row of rows) {
+    for (const value of Object.values(row.cells)) {
+      const ref = asReference(value);
+      if (ref?.referenceId && ref.referenceType) {
+        refs.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
+      }
+    }
+  }
+  if (refs.length === 0) return;
+  const labels = await resolveReferenceLabels(refs);
+  for (const row of rows) {
+    for (const [colId, value] of Object.entries(row.cells)) {
+      const ref = asReference(value);
+      if (!ref?.referenceId || !ref.referenceType) continue;
+      const label = labels.get(referenceKey(ref.referenceType, ref.referenceId));
+      if (label) row.cells[colId] = { ...ref, label };
+    }
+  }
+}
 
 interface ColumnMeta {
   internalId: string;
@@ -116,7 +148,7 @@ class CustomTableAdapter implements DataSourceAdapter {
       orderBy: { position: "asc" },
       include: { cells: true },
     });
-    return rows.map((row) => {
+    const gridRows = rows.map((row) => {
       const cells: Record<string, CellValue> = {};
       // default every column to null so the grid renders empty cells
       for (const m of metas) cells[m.columnId] = m.fieldType === "multi_select" ? [] : null;
@@ -127,6 +159,8 @@ class CustomTableAdapter implements DataSourceAdapter {
       }
       return { rowId: row.rowId, cells };
     });
+    await hydrateReferenceLabels(gridRows);
+    return gridRows;
   }
 
   async queryRows(

--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -3,6 +3,8 @@ import {
   toCell,
   genericRowToGridRow,
   genericColumnDefs,
+  referenceLabelField,
+  buildReferenceSearchArgs,
   type GenericTableConfig,
 } from "./generic-read-adapter";
 
@@ -56,6 +58,45 @@ describe("genericRowToGridRow", () => {
       secretField: "should-not-leak",
     });
     expect(row.cells).not.toHaveProperty("secretField");
+  });
+});
+
+describe("referenceLabelField", () => {
+  it("prefers an explicit labelField", () => {
+    expect(referenceLabelField({ ...config, labelField: "status" })).toBe("status");
+  });
+
+  it("defaults to the first text column after the id field", () => {
+    expect(referenceLabelField(config)).toBe("title");
+  });
+
+  it("falls back to the id field when no other text column exists", () => {
+    const idOnly: GenericTableConfig = {
+      entityType: "thing",
+      prismaModel: "thing",
+      idField: "thingId",
+      columns: [
+        { field: "thingId", name: "ID", fieldType: "text" },
+        { field: "count", name: "Count", fieldType: "number" },
+      ],
+    };
+    expect(referenceLabelField(idOnly)).toBe("thingId");
+  });
+});
+
+describe("buildReferenceSearchArgs", () => {
+  it("filters by a case-insensitive contains on the label field and caps results", () => {
+    const args = buildReferenceSearchArgs(config, "  grid  ");
+    expect(args.where).toEqual({ title: { contains: "grid", mode: "insensitive" } });
+    expect(args.select).toEqual({ epicId: true, title: true });
+    expect(args.orderBy).toEqual({ title: "asc" });
+    expect(args.take).toBe(20);
+  });
+
+  it("returns an unfiltered (capped) query for a blank search", () => {
+    const args = buildReferenceSearchArgs(config, "   ");
+    expect(args.where).toEqual({});
+    expect(args.take).toBe(20);
   });
 });
 

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -13,6 +13,7 @@ import {
   gridRegistry,
   type DataSourceAdapter,
   type AdapterContext,
+  type ReferenceResolution,
 } from "./adapter";
 import {
   type ColumnDefinition,
@@ -48,9 +49,37 @@ export interface GenericTableConfig {
   orderBy?: { field: string; dir: "asc" | "desc" };
   /** Hard cap on rows loaded (push-down pagination is a Phase-4 follow-up). */
   maxRows?: number;
+  /**
+   * Scalar field shown as the human label when this model is the target of a
+   * reference column (Phase 2). Defaults to the first text column after the id
+   * field, falling back to the id field itself.
+   */
+  labelField?: string;
 }
 
 const DEFAULT_CAP = 500;
+const REFERENCE_SEARCH_LIMIT = 20;
+
+/** The field used as the reference display label — explicit, else first non-id text column, else the id. */
+export function referenceLabelField(config: GenericTableConfig): string {
+  if (config.labelField) return config.labelField;
+  const firstText = config.columns.find(
+    (c) => c.fieldType === "text" && c.field !== config.idField,
+  );
+  return firstText?.field ?? config.idField;
+}
+
+/** Pure builder for the reference-typeahead findMany args (testable without Prisma). */
+export function buildReferenceSearchArgs(config: GenericTableConfig, query: string) {
+  const labelField = referenceLabelField(config);
+  const trimmed = query.trim();
+  return {
+    where: trimmed ? { [labelField]: { contains: trimmed, mode: "insensitive" } } : {},
+    select: { [config.idField]: true, [labelField]: true },
+    orderBy: { [labelField]: "asc" as const },
+    take: REFERENCE_SEARCH_LIMIT,
+  };
+}
 
 /** Convert a Prisma scalar into the grid's CellValue based on the declared field type. */
 export function toCell(fieldType: FieldType, v: unknown): CellValue {
@@ -151,6 +180,33 @@ class GenericReadAdapter implements DataSourceAdapter {
       select: this.select(),
     });
     return r ? genericRowToGridRow(this.cfg, r) : null;
+  }
+
+  async searchReferences(
+    _referenceType: string,
+    query: string,
+  ): Promise<{ id: string; label: string }[]> {
+    const labelField = referenceLabelField(this.cfg);
+    const records = await delegate(this.cfg.prismaModel).findMany(
+      buildReferenceSearchArgs(this.cfg, query),
+    );
+    return records.map((r) => ({
+      id: String(r[this.cfg.idField]),
+      label: String(r[labelField] ?? r[this.cfg.idField]),
+    }));
+  }
+
+  async resolveReference(
+    _referenceType: string,
+    referenceId: string,
+  ): Promise<ReferenceResolution | null> {
+    const labelField = referenceLabelField(this.cfg);
+    const r = await delegate(this.cfg.prismaModel).findUnique({
+      where: { [this.cfg.idField]: referenceId },
+      select: { [this.cfg.idField]: true, [labelField]: true },
+    });
+    if (!r) return null;
+    return { label: String(r[labelField] ?? r[this.cfg.idField]) };
   }
 
   getCapabilities(_ctx: AdapterContext): GridCapabilities {

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -62,6 +62,7 @@ const EPIC_TABLE: GenericTableConfig = {
   entityType: "epic",
   prismaModel: "epic",
   idField: "epicId",
+  labelField: "title",
   orderBy: { field: "updatedAt", dir: "desc" },
   columns: [
     { field: "epicId", name: "ID", fieldType: "text", width: 160 },
@@ -88,6 +89,7 @@ const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {
   entityType: "digital_product",
   prismaModel: "digitalProduct",
   idField: "productId",
+  labelField: "name",
   orderBy: { field: "updatedAt", dir: "desc" },
   columns: [
     { field: "productId", name: "ID", fieldType: "text", width: 140 },
@@ -246,4 +248,55 @@ export async function updatePlatformCells(
     userId: user.id,
     canManage: true,
   });
+}
+
+// ── Reference columns (Phase 2) ─────────────────────────────────────────────
+// A reference column on any workbook table points at a platform entity. The set
+// of valid targets is exactly the platform tables whose adapter implements
+// searchReferences, filtered to those the user may view (no leak of targets the
+// viewer cannot see). Search/resolve re-check the target's view capability.
+
+export interface ReferenceTarget {
+  entityType: string;
+  label: string;
+}
+
+/** Platform entities the user may reference from a workbook column. */
+export function listReferenceTargets(user: PlatformUser): ReferenceTarget[] {
+  const seen = new Set<string>();
+  const targets: ReferenceTarget[] = [];
+  for (const t of PLATFORM_TABLES) {
+    if (seen.has(t.entityType)) continue;
+    const adapter = gridRegistry.get(t.entityType);
+    if (!adapter || typeof adapter.searchReferences !== "function") continue;
+    if (!can(userCtx(user), t.viewCapability)) continue;
+    seen.add(t.entityType);
+    targets.push({ entityType: t.entityType, label: t.label });
+  }
+  return targets;
+}
+
+export async function searchPlatformReferences(
+  user: PlatformUser,
+  entityType: string,
+  query: string,
+): Promise<{ id: string; label: string }[]> {
+  requireTable(user, entityType); // 404 unknown / 403 no view capability — no leak
+  const adapter = gridRegistry.require(entityType);
+  if (!adapter.searchReferences) {
+    throw new WorkbookError("This data source cannot be referenced", 400);
+  }
+  return adapter.searchReferences(entityType, query);
+}
+
+export async function resolvePlatformReference(
+  user: PlatformUser,
+  entityType: string,
+  referenceId: string,
+): Promise<{ id: string; label: string } | null> {
+  requireTable(user, entityType);
+  const adapter = gridRegistry.require(entityType);
+  if (!adapter.resolveReference) return null;
+  const res = await adapter.resolveReference(entityType, referenceId);
+  return res ? { id: referenceId, label: res.label } : null;
 }

--- a/apps/web/lib/workbooks/reference-resolver.test.ts
+++ b/apps/web/lib/workbooks/reference-resolver.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { gridRegistry, type DataSourceAdapter } from "./adapter";
+import {
+  referenceKey,
+  collectUniqueReferences,
+  resolveReferenceLabels,
+} from "./reference-resolver";
+
+describe("referenceKey", () => {
+  it("joins type and id", () => {
+    expect(referenceKey("epic", "EP-1")).toBe("epic:EP-1");
+  });
+});
+
+describe("collectUniqueReferences", () => {
+  it("de-dupes by type:id and drops incomplete entries", () => {
+    const unique = collectUniqueReferences([
+      { referenceType: "epic", referenceId: "EP-1" },
+      { referenceType: "epic", referenceId: "EP-1" },
+      { referenceType: "epic", referenceId: "EP-2" },
+      { referenceType: "epic", referenceId: "" },
+      { referenceType: "", referenceId: "EP-3" },
+    ]);
+    expect([...unique.keys()]).toEqual(["epic:EP-1", "epic:EP-2"]);
+  });
+});
+
+describe("resolveReferenceLabels", () => {
+  // Minimal fake adapter so resolution runs against the registry without the
+  // platform-tables dynamic import (which only fires for unregistered types).
+  function registerFake(entityType: string, labels: Record<string, string>) {
+    const adapter = {
+      entityType,
+      getColumns: async () => [],
+      queryRows: async () => ({ data: [], nextCursor: null }),
+      getRow: async () => null,
+      getCapabilities: () => ({
+        canAddRow: false,
+        canAddColumn: false,
+        canEditCell: false,
+        canDeleteRow: false,
+      }),
+      resolveReference: async (_t: string, id: string) =>
+        labels[id] ? { label: labels[id] } : null,
+    } as unknown as DataSourceAdapter;
+    gridRegistry.register(adapter);
+  }
+
+  it("resolves labels per unique reference and omits unresolvable ones", async () => {
+    registerFake("fake_ref_a", { "A-1": "Alpha", "A-2": "Beta" });
+    const labels = await resolveReferenceLabels([
+      { referenceType: "fake_ref_a", referenceId: "A-1" },
+      { referenceType: "fake_ref_a", referenceId: "A-1" },
+      { referenceType: "fake_ref_a", referenceId: "A-2" },
+      { referenceType: "fake_ref_a", referenceId: "A-missing" },
+    ]);
+    expect(labels.get("fake_ref_a:A-1")).toBe("Alpha");
+    expect(labels.get("fake_ref_a:A-2")).toBe("Beta");
+    expect(labels.has("fake_ref_a:A-missing")).toBe(false);
+  });
+
+  it("returns an empty map for no references", async () => {
+    const labels = await resolveReferenceLabels([]);
+    expect(labels.size).toBe(0);
+  });
+});

--- a/apps/web/lib/workbooks/reference-resolver.ts
+++ b/apps/web/lib/workbooks/reference-resolver.ts
@@ -1,0 +1,73 @@
+// Universal Grid & Workbooks — reference label hydration (EP-GRID-WORKBOOKS, Phase 2)
+//
+// A reference cell stores only referenceId + referenceType (the system-of-record
+// identity). The human-readable label is resolved live from the target entity's
+// adapter so it never goes stale (SoR-integral). This module batches + de-dupes
+// that resolution for a set of reference cells.
+//
+// It imports only ./adapter statically; the platform adapters that own the target
+// entities are registered via a runtime dynamic import so there is no load-time
+// import cycle (custom-table-adapter → reference-resolver → platform-tables →
+// workbook-service → custom-table-adapter).
+
+import { gridRegistry } from "./adapter";
+
+let registrationPromise: Promise<unknown> | null = null;
+
+/** Ensure platform adapters (epic, digital_product, …) are registered before resolving. */
+function ensurePlatformAdaptersRegistered(): Promise<unknown> {
+  if (!registrationPromise) registrationPromise = import("./platform-tables");
+  return registrationPromise;
+}
+
+export function referenceKey(referenceType: string, referenceId: string): string {
+  return `${referenceType}:${referenceId}`;
+}
+
+/** De-dupe a list of references by type:id, dropping incomplete entries. Pure. */
+export function collectUniqueReferences(
+  refs: { referenceType: string; referenceId: string }[],
+): Map<string, { type: string; id: string }> {
+  const unique = new Map<string, { type: string; id: string }>();
+  for (const r of refs) {
+    if (!r.referenceId || !r.referenceType) continue;
+    unique.set(referenceKey(r.referenceType, r.referenceId), {
+      type: r.referenceType,
+      id: r.referenceId,
+    });
+  }
+  return unique;
+}
+
+/**
+ * Resolve display labels for a batch of references, de-duped by type:id.
+ * Returns a Map keyed by `referenceKey`. References whose target adapter is
+ * unknown or cannot resolve are simply absent (caller falls back to the id).
+ */
+export async function resolveReferenceLabels(
+  refs: { referenceType: string; referenceId: string }[],
+): Promise<Map<string, string>> {
+  const labels = new Map<string, string>();
+  const unique = collectUniqueReferences(refs);
+  if (unique.size === 0) return labels;
+
+  // Only pay the registration import when a target adapter is not yet loaded.
+  const types = new Set([...unique.values()].map((u) => u.type));
+  if (![...types].every((t) => gridRegistry.has(t))) {
+    await ensurePlatformAdaptersRegistered();
+  }
+
+  await Promise.all(
+    [...unique.entries()].map(async ([key, { type, id }]) => {
+      const adapter = gridRegistry.get(type);
+      if (!adapter?.resolveReference) return;
+      try {
+        const res = await adapter.resolveReference(type, id);
+        if (res) labels.set(key, res.label);
+      } catch {
+        // A dangling reference (target deleted) just renders as its id.
+      }
+    }),
+  );
+  return labels;
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -1,0 +1,115 @@
+# Universal Grid & Workbooks — Phase 2 implementation plan (relational + provenance core)
+
+**Epic**: EP-GRID-WORKBOOKS
+**Spec**: [2026-06-07-workbooks-hybrid-systems-of-record-reporting-lifecycle-design.md](../specs/2026-06-07-workbooks-hybrid-systems-of-record-reporting-lifecycle-design.md) (Phase 2 row of the phased build order)
+**Date**: 2026-06-11
+**Status**: Active — slice 1 in progress
+
+Phase 2 = the relational + provenance core: reference columns over real platform
+entities, rollups/lookups over those references (v1 function set), `provenanceKind`
+first-class with progressive disclosure, generic Prisma adapter (shipped #1722), and
+multi-step undo/redo. This plan decomposes Phase 2 into single-concern PRs grounded
+in the current substrate, ordered by leverage and dependency.
+
+## Backlog items
+
+| BI | Concern | Slice(s) |
+|---|---|---|
+| BI-1F70A9AC | Reference columns + rollups/lookups (relational core) | 1, 2 |
+| BI-B8549363 | `provenanceKind` + progressive disclosure | 3 |
+| BI-BA57AB71 | Grid multi-step undo/redo | 4 |
+| BI-29E1F452 | More read-only generic grids (customers, employees-safe, suppliers) | 5 |
+
+## Substrate already in place (do not rebuild)
+
+- `reference` is already a `FieldType` and `ReferenceValue` is already a `CellValue`
+  member (`lib/workbooks/types.ts`). `FieldConfig.referenceType` already exists.
+- The adapter interface already declares optional `searchReferences(referenceType, query)`
+  and `resolveReference(referenceType, referenceId)` (`lib/workbooks/adapter.ts:64-72`) —
+  **no adapter implements them yet**.
+- `ReferenceTypeahead` is a finished standalone component (`components/ui/ReferenceTypeahead.tsx`,
+  floating-UI, 300ms debounce, keyboard nav, async `onSearch`) — **not yet wired into the grid**.
+- Reference cells already render read-only via `renderReferenceCell` (`components/workbooks/cell-editors.tsx:187`);
+  `Grid.tsx` assigns no `renderEditCell` for `reference` (comment: "Phase 1: read-only until platform adapters land").
+- `cell-validation.ts` already validates `ReferenceValue`.
+- Add-column picker (`components/workbooks/AddColumnButton.tsx`) offers 8 types; explicitly
+  excludes `reference`/`multi_select` ("reference needs platform adapters").
+- `WorkbookColumn` Prisma model (`packages/db/prisma/schema.prisma`) has `fieldType` +
+  `fieldConfig Json?`; **no `provenanceKind`/`lifecycleState` columns yet**.
+- Formula/rollup infra is **greenfield** — no formula library in any `package.json`.
+
+## Slice 1 — Reference columns wired to platform entities (this PR)
+
+Goal: a user can add a `reference` column to a custom workbook table, pick which platform
+entity it points at, and pick/resolve real records in the cell — end to end, read + write,
+through the existing validated write path. This is the relational foundation slice 2 builds on.
+
+1. **Reference-target registry** (`lib/workbooks/platform-tables.ts` or a small
+   `reference-targets.ts`): expose the list of registered adapters that can be referenced
+   (entityType + human label + the entity's display field), derived from the existing
+   `PLATFORM_TABLES`/`gridRegistry` so adding a target stays one row. Read-only generic
+   adapters (epic, digital_product) and the editable ones (backlog_item, invoice,
+   risk_assessment) are all valid targets.
+2. **Adapter `searchReferences` + `resolveReference`**: implement once in
+   `generic-read-adapter.ts` (it already holds the Prisma model + label-field config — search
+   by `contains` on the label field, resolve by id→label). Add thin implementations to
+   `backlog-adapter.ts` and `invoice-adapter.ts`/`risk-adapter.ts` reusing the same helper, OR
+   register them through the generic mechanism so one implementation covers all. Prefer the
+   single shared helper to avoid per-adapter drift.
+3. **Server action proxy** (`lib/actions/workbooks.ts`): `searchReferencesAction(referenceType,
+   query)` and `resolveReferenceAction(referenceType, id)` → `gridRegistry.get(referenceType)?.…`,
+   gated by the same session auth as the grid (and the target's own view capability — a
+   reference search must not leak rows the viewer cannot see; capability check before query).
+4. **Add-column UI** (`AddColumnButton.tsx`): add `reference` to the offered types; when chosen,
+   show a target-entity `<select>` populated from the reference-target registry; persist
+   `fieldConfig.referenceType`.
+5. **Grid edit wiring** (`Grid.tsx` + `cell-editors.tsx`): add `makeReferenceEditor` that mounts
+   `ReferenceTypeahead`, wiring `onSearch` → `searchReferencesAction`; on select, persist a
+   `ReferenceValue { referenceId, referenceType, label }` through the existing `persistCell`
+   path (custom-table-adapter write + optimistic revert on error from #1634).
+6. **Label resolution on read**: when `queryRows` returns reference cells, resolve labels (store
+   label in the cell value on write so reads are cheap; fall back to `resolveReference` if absent).
+
+**Acceptance (functional, per structural≠functional)**: add a reference column on a custom
+table pointing at Epics; the cell typeahead searches live epics; selecting one persists and the
+grid shows the epic's title; reload still shows the label; a viewer lacking the target's view
+capability gets no results (no leak). Validate by driving it on the live install after deploy.
+
+**Tests**: unit-test the reference-target registry derivation, `searchReferences`/`resolveReference`
+on the generic adapter (against a seeded model), and the action's capability gate; component-level
+test that the add-column picker persists `referenceType` and the grid mounts the editor for
+`reference` columns.
+
+## Slice 2 — Rollups / lookups over references (v1 function set) — follow-up PR
+
+Greenfield formula layer. **Library decision required** (research before implementing):
+evaluate HyperFormula (GPL/commercial — license-check against AGENTS.md), formulajs (MIT,
+Excel-function library, no parser), or a scoped custom evaluator. Recommendation to confirm in
+that PR: formulajs (MIT) for the function implementations + a small safe expression parser, OR a
+purpose-built rollup/lookup evaluator for v1 (REF/LOOKUP/XLOOKUP/SUMIFS family) without a full
+Excel grammar. Derived columns compute over reference-joined rows; **write a lineage edge for every
+derived column (fail-closed)** per the spec invariant. Out of scope for slice 1.
+
+## Slice 3 — `provenanceKind` + progressive disclosure — separate PR (BI-B8549363)
+
+Additive migration: `WorkbookColumn.provenanceKind` (`system|source|derived|manual`). Platform-adapter
+columns report `system`; custom columns default `manual`; slice-2 derived columns are `derived`.
+Progressive disclosure: labels hidden until hover/advanced toggle (Dale review). One migration +
+seed-safe default + adapter `getColumns` populates it + a hover label in the grid header.
+
+## Slice 4 — Multi-step undo/redo — separate PR (BI-BA57AB71)
+
+Undo/redo stack in the `<Grid>` contract; each undo replays the inverse edit through the same
+validated dispatch (never raw write); reject + show error + leave cell unchanged when the inverse
+is invalid (parity with #1634 optimistic revert). Cell-value edits in scope; row add/delete deferred.
+
+## Slice 5 — More read-only generic grids — separate PR (BI-29E1F452)
+
+~15-line config rows on the #1722 generic adapter for customers, employees (safe-fields allow-list
+only — no PII/comp), suppliers. Each behind its domain view capability.
+
+## Ordering rationale
+
+References (1) are the relational substrate rollups/lookups (2) require. `provenanceKind` (3) is
+cheap and clarifies tiers but does not block 1–2. Undo/redo (4) is independent. Generic grids (5)
+are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.


### PR DESCRIPTION
## What

Slice 1 of the **Universal Grid & Workbooks Phase-2 relational core** (EP-GRID-WORKBOOKS, BI-1F70A9AC). A workbook column can now reference a **live platform entity** (Epics, Digital products) and pick/resolve real records in-cell — the cross-tier link Airtable lacks (it links user-table↔user-table only). This is the foundation that rollups/lookups (slice 2) build on.

Follows the merged hybrid-SoR design spec (`docs/superpowers/specs/2026-06-07-workbooks-hybrid-systems-of-record-reporting-lifecycle-design.md`, Phase 2 row). A new plan doc decomposes Phase 2 into single-concern slices.

## How

- **generic-read-adapter** — `searchReferences`/`resolveReference` for any registered generic table via a configurable `labelField` (defaults to the first text column after the id). Pure helpers `referenceLabelField` + `buildReferenceSearchArgs` are unit-tested.
- **platform-tables** — `listReferenceTargets` (only targets the viewer may see) + capability-gated `searchPlatformReferences`/`resolvePlatformReference` (each re-checks the target's view capability — **no leak** of rows the viewer can't see). `epic`/`digital_product` gain `labelField` (title / name).
- **reference-resolver** (new) — hydrates live display labels for a batch of reference cells, de-duped by `type:id`. Labels resolve to the **system of record** (not persisted) so they never go stale. Avoids a load-time import cycle via a runtime dynamic import, skipped when targets are already registered (also makes it unit-testable).
- **custom-table-adapter** — `materializeRows` hydrates reference labels on read.
- **Grid / cell-editors** — in-cell `ReferenceTypeahead` editor for reference columns; selecting commits a `ReferenceValue` through the existing validated write path (optimistic revert on error, per #1634).
- **AddColumnButton** — offers "Reference" with a target-entity picker from `listReferenceTargets`; persists `fieldConfig.referenceType`.
- **ReferenceTypeahead** — optional `autoFocus` (backwards-compatible).

No migration — storage already had `referenceId`/`referenceType` + `cell-validation` for references.

## Test / build gate

- `apps/web` workbooks vitest: **65 passing** (added `referenceLabelField`, `buildReferenceSearchArgs`, reference-resolver dedup + resolution).
- `pnpm --filter web typecheck`: green.
- `pnpm --filter web build`: green.

## Verification status

Live functional verification is **pending the next self-upgrade deploy** — the served image (`8b7d5868`, 2026-06-10) predates even #1722, so the Epics/Digital-products grids this references aren't live yet. Will drive the add-reference-column → typeahead → resolve happy path on the live install once deployed (structural ≠ functional).

## Scope

One concern (reference columns). Rollups/lookups (formula engine), `provenanceKind`, undo/redo, and more generic grids are separate slices in the plan (BI-1F70A9AC slice 2, BI-B8549363, BI-BA57AB71, BI-29E1F452).

🤖 Generated with [Claude Code](https://claude.com/claude-code)