### PR TITLE
fix(storefront): replace DPF meta-language in inbox with business copy

### DIFF
--- a/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
+++ b/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
@@ -66,7 +66,7 @@ beforeEach(() => {
   mockBacklogItem.create.mockResolvedValue({
     id: "backlog_1",
     itemId: "BI-SFI-INQ0001",
-    title: "Customer-zero product inquiry INQ-0001",
+    title: "Inquiry from Jane Prospect (INQ-0001)",
     status: "triaging",
   });
 });
@@ -114,7 +114,7 @@ describe("POST /api/storefront/admin/inquiries/[id]/product-backlog", () => {
     mockBacklogItem.findUnique.mockResolvedValue({
       id: "backlog_1",
       itemId: "BI-SFI-INQ0001",
-      title: "Customer-zero product inquiry INQ-0001",
+      title: "Inquiry from Jane Prospect (INQ-0001)",
       status: "triaging",
     });
 

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -116,11 +116,10 @@ export function StorefrontInbox({
           }}
         >
           <div style={{ fontSize: 12, fontWeight: 700, color: "var(--dpf-text)" }}>
-            Customer-zero inquiry intake is wired to product backlog triage
+            Inquiries from your storefront
           </div>
           <div style={{ marginTop: 4, fontSize: 12, color: "var(--dpf-muted)" }}>
-            Use <strong>Send to product backlog</strong> to capture DPF sales or product signals as triaging work for{" "}
-            {defaultDigitalProduct.name}.
+            Use <strong>Send to backlog</strong> to turn an inquiry into tracked work you can follow up on.
           </div>
         </div>
       ) : (
@@ -197,7 +196,7 @@ export function StorefrontInbox({
                     color: "var(--dpf-accent)",
                   }}
                 >
-                  Customer-zero signal
+                  New lead
                 </span>
               )}
               <span style={{ fontSize: 12, fontFamily: "monospace" }}>{e.ref}</span>
@@ -229,7 +228,7 @@ export function StorefrontInbox({
                     opacity: !defaultDigitalProduct || pendingInquiryId === e.id ? 0.6 : 1,
                   }}
                 >
-                  {pendingInquiryId === e.id ? "Sending..." : "Send to product backlog"}
+                  {pendingInquiryId === e.id ? "Sending..." : "Send to backlog"}
                 </button>
                 {e.backlogItemId && (
                   <span style={{ fontSize: 12, color: "var(--dpf-success, #22c55e)" }}>

--- a/apps/web/lib/governed-backlog-workflow.test.ts
+++ b/apps/web/lib/governed-backlog-workflow.test.ts
@@ -85,7 +85,7 @@ describe("deriveLifecycleLabel", () => {
     ).toBe("In Progress");
   });
 
-  it("maps a storefront inquiry into customer-zero governed backlog intake metadata", () => {
+  it("maps a storefront inquiry into governed backlog intake metadata with business-facing copy", () => {
     expect(
       createStorefrontInquiryBacklogDraft({
         inquiryId: "inquiry_1",
@@ -94,11 +94,11 @@ describe("deriveLifecycleLabel", () => {
         customerEmail: "jane@example.com",
         message: "We want to run our own digital product operation on DPF.",
         storefrontLabel: "Open Digital Product Factory",
-        itemLabel: "Open Digital Product Factory",
+        itemLabel: "Emergency Call-Out",
       }),
     ).toMatchObject({
       itemId: "BI-SFI-INQ1001",
-      title: "Customer-zero product inquiry INQ-1001",
+      title: "Emergency Call-Out inquiry from Jane Prospect (INQ-1001)",
       type: "product",
       status: "triaging",
       source: "user-request",

--- a/apps/web/lib/governed-backlog-workflow.ts
+++ b/apps/web/lib/governed-backlog-workflow.ts
@@ -97,10 +97,13 @@ export function createStorefrontInquiryBacklogDraft(
   const messageLine = inquiry.message?.trim()
     ? `Inquiry detail:\n${inquiry.message.trim()}`
     : "Inquiry detail:\nNo additional message provided.";
+  const customerLabel = inquiry.customerName?.trim() || "a customer";
+  const itemSubject = inquiry.itemLabel?.trim();
+  const titleSubject = itemSubject ? `${itemSubject} inquiry` : "Inquiry";
 
   return {
     itemId: `BI-SFI-${normalizedRef}`,
-    title: `Customer-zero product inquiry ${inquiry.inquiryRef}`,
+    title: `${titleSubject} from ${customerLabel} (${inquiry.inquiryRef})`,
     type: "product",
     status: "triaging",
     source: "user-request",
@@ -111,14 +114,14 @@ export function createStorefrontInquiryBacklogDraft(
     recommendedTriageOutcome: "build",
     signalLabel: "customer-zero",
     body: [
-      "Customer-zero intake captured from the storefront inquiry flow.",
+      "Inquiry captured from your storefront.",
       `Inquiry ref: ${inquiry.inquiryRef}`,
       `Inquiry row: ${inquiry.inquiryId}`,
-      `Prospect: ${inquiry.customerName?.trim() || "Unknown contact"} <${inquiry.customerEmail}>`,
+      `Customer: ${inquiry.customerName?.trim() || "Unknown contact"} <${inquiry.customerEmail}>`,
       storefrontLine,
       itemLine,
       messageLine,
-      "Recommended next step: triage as product work and decide whether it should become a governed Build Studio effort.",
+      "Recommended next step: triage this inquiry and decide how to follow up.",
     ]
       .filter(Boolean)
       .join("\n\n"),


### PR DESCRIPTION
@
## Finding
AUDIT-R1-E-F-001 / FM-F-001 / L-F-001 / CS-F-001 — **Critical** (all 4 trades-maintenance archetypes), fresh-install Run 1.

The `/storefront/inbox` surfaced DPF internal build terminology to operators:
- Header: "Customer-zero inquiry intake is wired to product backlog triage"
- Badge: "Customer-zero signal"
- Backlog item title on send-to-backlog: "Customer-zero product inquiry INQ-XXXX"

Operators see their own business language, not DPF customer-zero/dogfooding terms.

## Change
- `StorefrontInbox.tsx`: header → "Inquiries from your storefront"; badge → "New lead"; button/help → "Send to backlog".
- `governed-backlog-workflow.ts`: backlog title → `"<Item> inquiry from <Customer> (INQ-XXXX)"`; body copy → business-facing follow-up language. Internal `signalLabel`/`itemId` (`BI-SFI-…`) preserved so lookups are unaffected.
- Updated unit + route tests for the new title format.

Closes #1749.

## Verification
Per audit instructions, functional verification is handled by the operator audit session on a fresh install. Source-only change (string/copy + test updates); no schema or runtime contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@