### PR TITLE
fix(finance): US installs default to USD, per-job invoicing, and 0% bill tax

### DIFF
--- a/apps/web/app/(shell)/finance/bills/new/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/new/page.tsx
@@ -1,10 +1,24 @@
 // apps/web/app/(shell)/finance/bills/new/page.tsx
+import { prisma } from "@dpf/db";
+import { getFinancialProfile } from "@dpf/finance-templates";
 import { listSuppliers, listPurchaseOrders } from "@/lib/actions/ap";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { CreateBillForm } from "@/components/finance/CreateBillForm";
 import Link from "next/link";
 
 type Props = { searchParams: Promise<{ supplierId?: string }> };
+
+// Default line-item tax rate: 0 unless the org configured a VAT/GST tax model at
+// setup. Avoids the legacy hardcoded 20% UK VAT default on US (and other
+// non-VAT) installs.
+async function getDefaultBillTaxRate(appliedProfileSlug: string | null): Promise<number> {
+  const taxProfile = await prisma.organizationTaxProfile.findFirst({
+    select: { taxModel: true },
+  });
+  if (taxProfile?.taxModel !== "vat") return 0;
+  const profile = appliedProfileSlug ? getFinancialProfile(appliedProfileSlug) : null;
+  return profile?.defaultTaxRate ?? 0;
+}
 
 export default async function NewBillPage({ searchParams }: Props) {
   const { supplierId } = await searchParams;
@@ -14,6 +28,7 @@ export default async function NewBillPage({ searchParams }: Props) {
     listPurchaseOrders(),
     getOrgSettings(),
   ]);
+  const defaultTaxRate = await getDefaultBillTaxRate(orgSettings.appliedProfileSlug ?? null);
 
   return (
     <div>
@@ -53,6 +68,7 @@ export default async function NewBillPage({ searchParams }: Props) {
           }))}
           {...(supplierId ? { defaultSupplierId: supplierId } : {})}
           defaultCurrency={orgSettings.baseCurrency}
+          defaultTaxRate={defaultTaxRate}
         />
       </div>
     </div>

--- a/apps/web/components/finance/CreateBillForm.tsx
+++ b/apps/web/components/finance/CreateBillForm.tsx
@@ -39,6 +39,8 @@ interface Props {
   purchaseOrders: PurchaseOrder[];
   defaultSupplierId?: string;
   defaultCurrency?: string;
+  /** Org default line-item tax rate (%). 0 unless the org is VAT/GST registered. */
+  defaultTaxRate?: number;
 }
 
 function round2(n: number): number {
@@ -55,7 +57,7 @@ function getDefaultDueDate(): string {
   return d.toISOString().split("T")[0]!;
 }
 
-export function CreateBillForm({ suppliers, purchaseOrders, defaultSupplierId, defaultCurrency }: Props) {
+export function CreateBillForm({ suppliers, purchaseOrders, defaultSupplierId, defaultCurrency, defaultTaxRate = 0 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -64,11 +66,11 @@ export function CreateBillForm({ suppliers, purchaseOrders, defaultSupplierId, d
   const [invoiceRef, setInvoiceRef] = useState("");
   const [issueDate, setIssueDate] = useState(getToday());
   const [dueDate, setDueDate] = useState(getDefaultDueDate());
-  const [currency, setCurrency] = useState(defaultCurrency ?? "GBP");
+  const [currency, setCurrency] = useState(defaultCurrency ?? "USD");
   const [selectedPoId, setSelectedPoId] = useState("");
   const [notes, setNotes] = useState("");
   const [lineItems, setLineItems] = useState<LineItem[]>([
-    { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+    { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
   ]);
 
   // When supplier changes, update currency default
@@ -107,7 +109,7 @@ export function CreateBillForm({ suppliers, purchaseOrders, defaultSupplierId, d
   const addLineItem = () => {
     setLineItems((prev) => [
       ...prev,
-      { description: "", quantity: 1, unitPrice: 0, taxRate: 20 },
+      { description: "", quantity: 1, unitPrice: 0, taxRate: defaultTaxRate },
     ]);
   };
 

--- a/apps/web/components/storefront-admin/FinancialSetupStep.tsx
+++ b/apps/web/components/storefront-admin/FinancialSetupStep.tsx
@@ -28,15 +28,26 @@ function getLocaleFallbackCurrency(): string {
   return "USD";
 }
 
+// VAT/GST is a UK/EU concept. On a USD (or other non-VAT) install we should not
+// pre-select "VAT registered" even when the business-type profile commonly is in
+// the UK — that is what drove the 20% UK VAT default on US installs.
+const VAT_REGION_CURRENCIES = new Set(["GBP", "EUR"]);
+
 // ─── FinancialSetupStep ────────────────────────────────────────────────────────
 
 export function FinancialSetupStep({ archetypeSlug, archetypeName, suggestedCurrency, onComplete }: Props) {
   // Load profile defaults (client-safe: pure function, no DB call)
   const profile = getFinancialProfile(archetypeSlug);
 
-  const [vatRegistered, setVatRegistered] = useState<boolean>(profile?.vatRegistered ?? false);
-  const [baseCurrency, setBaseCurrency] = useState<string>(
-    suggestedCurrency ?? profile?.defaultCurrency ?? getLocaleFallbackCurrency(),
+  // Currency: prefer a location-detected suggestion, then the operator's browser
+  // locale, before any UK-biased profile default. Without this, every fresh
+  // install pre-filled GBP regardless of where the operator actually is.
+  const initialCurrency = suggestedCurrency ?? getLocaleFallbackCurrency();
+  const [baseCurrency, setBaseCurrency] = useState<string>(initialCurrency);
+  // Only pre-select "VAT registered" when both the business-type profile expects
+  // it AND the resolved currency is in a VAT region.
+  const [vatRegistered, setVatRegistered] = useState<boolean>(
+    (profile?.vatRegistered ?? false) && VAT_REGION_CURRENCIES.has(initialCurrency),
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/packages/finance-templates/src/profiles.test.ts
+++ b/packages/finance-templates/src/profiles.test.ts
@@ -141,6 +141,12 @@ describe("financial profile catalog", () => {
     expect(profile!.dunningStyle).toBe("aggressive");
   });
 
+  it("trades_construction defaults to ad-hoc per-job invoicing, not a recurring agreement", () => {
+    const profile = getFinancialProfile("trades_construction");
+    expect(profile?.billingPatternProfile.primaryPaymentPattern).toBe("ad-hoc-invoice");
+    expect(profile?.billingPatternProfile.recurringBillingApplicability).toBe("optional");
+  });
+
   it("professional services supports recurring agreements without prescribing invoice execution", () => {
     const profile = getFinancialProfile("professional_services");
     expect(profile?.billingPatternProfile).toMatchObject({

--- a/packages/finance-templates/src/profiles.ts
+++ b/packages/finance-templates/src/profiles.ts
@@ -555,9 +555,12 @@ const PROFILES: Record<string, FinancialProfileSeed> = {
 function defaultBillingPatternForSlug(slug: string): BillingPatternProfile {
   switch (slug) {
     case "professional_services":
-    case "trades_construction":
     case "hoa_property_management":
       return RECURRING_AGREEMENT_PATTERN;
+    // Trades & construction work is predominantly ad-hoc / per-job invoicing
+    // (electrician, landscaping, cleaning). Recurring agreements are still a
+    // supported pattern, but per-job invoicing is the correct zero-touch
+    // default — falls through to AD_HOC_INVOICE_PATTERN below.
     case "retail":
     case "food_hospitality":
       return POINT_OF_SALE_PATTERN;


### PR DESCRIPTION
@
## Findings
Fresh-install Run 1 (all 4 trades-maintenance archetypes):
- **R1-*-A-001** (Important) — currency pre-filled GBP regardless of locale.
- **R1-*-A-002** (Important) — payment model defaulted to "Recurring Agreement / Required" for ad-hoc trades.
- **R1-*-G-002** (Important) — new bill line items pre-populated Tax % = 20 (UK VAT) on USD installs.

## Change
- `FinancialSetupStep.tsx`: currency resolves from location/browser-locale before any profile default (GBP no longer wins); "VAT registered" only pre-selected when the resolved currency is a VAT-region currency (GBP/EUR) — USD installs start at "No" → `taxModel=none`.
- `finance-templates/profiles.ts`: `trades_construction` defaults to ad-hoc per-job invoicing (`AD_HOC_INVOICE_PATTERN`) instead of `RECURRING_AGREEMENT_PATTERN`; recurring remains supported. Unit test added.
- `CreateBillForm.tsx`: line-item tax rate from a `defaultTaxRate` prop (default 0) instead of hardcoded 20; currency fallback USD.
- `bills/new/page.tsx`: derives `defaultTaxRate` from the org tax profile (0 unless a VAT tax model is configured).

All four trades-maintenance archetypes resolve to the `trades_construction` finance profile (`financeProfileSlugFromCategory`), so this fixes them uniformly.

Closes #1753.

## Verification
Functional verification handled by the operator audit session on a fresh install. Added a finance-templates unit test for the new trades billing default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@