### PR TITLE
fix(storefront): render archetype-specific inquiry form fields

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
@@ -1,13 +1,6 @@
 import { notFound } from "next/navigation";
-import { getPublicStorefront, getPublicItem } from "@/lib/storefront-data";
+import { getPublicStorefront, getPublicItem, resolveInquiryFormSchema } from "@/lib/storefront-data";
 import { InquiryForm } from "@/components/storefront/InquiryForm";
-
-const DEFAULT_INQUIRY_SCHEMA = [
-  { name: "name", label: "Your name", type: "text", required: true },
-  { name: "email", label: "Email address", type: "email", required: true },
-  { name: "phone", label: "Phone number (optional)", type: "tel", required: false },
-  { name: "message", label: "Message or question", type: "textarea", required: false },
-];
 
 export default async function ItemInquirePage({
   params,
@@ -21,11 +14,13 @@ export default async function ItemInquirePage({
   ]);
   if (!storefront || !item) notFound();
 
+  const formSchema = await resolveInquiryFormSchema(storefront.archetypeId);
+
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
       <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Enquire about {item.name}</h1>
       <p style={{ color: "var(--dpf-muted)", marginBottom: 24, fontSize: 14 }}>{item.description}</p>
-      <InquiryForm orgSlug={slug} itemId={itemId} formSchema={DEFAULT_INQUIRY_SCHEMA} />
+      <InquiryForm orgSlug={slug} itemId={itemId} formSchema={formSchema} />
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
@@ -1,13 +1,6 @@
 import { notFound } from "next/navigation";
-import { getPublicStorefront } from "@/lib/storefront-data";
+import { getPublicStorefront, resolveInquiryFormSchema } from "@/lib/storefront-data";
 import { InquiryForm } from "@/components/storefront/InquiryForm";
-
-const DEFAULT_INQUIRY_SCHEMA = [
-  { name: "name", label: "Your name", type: "text", required: true },
-  { name: "email", label: "Email address", type: "email", required: true },
-  { name: "phone", label: "Phone number (optional)", type: "tel", required: false },
-  { name: "message", label: "Message", type: "textarea", required: false },
-];
 
 export default async function InquirePage({
   params,
@@ -18,6 +11,7 @@ export default async function InquirePage({
   const storefront = await getPublicStorefront(slug);
   if (!storefront) notFound();
 
+  const formSchema = await resolveInquiryFormSchema(storefront.archetypeId);
   const isSoftwarePlatform = storefront.archetypeId === "software-platform";
 
   return (
@@ -30,7 +24,7 @@ export default async function InquirePage({
           ? "Tell us about your current product operation, delivery workflow, or customer-zero goals and we will route the conversation through the platform."
           : "Share what you need and we will route your inquiry to the right team."}
       </p>
-      <InquiryForm orgSlug={slug} formSchema={DEFAULT_INQUIRY_SCHEMA} />
+      <InquiryForm orgSlug={slug} formSchema={formSchema} />
     </div>
   );
 }

--- a/apps/web/components/storefront/InquiryForm.tsx
+++ b/apps/web/components/storefront/InquiryForm.tsx
@@ -35,7 +35,10 @@ export function InquiryForm({
     const email = fd.get("email") as string;
     const name = fd.get("name") as string;
     const phone = (fd.get("phone") as string | null) ?? undefined;
-    const message = (fd.get("message") as string | null) ?? undefined;
+    // Archetype schemas use a "notes" textarea for free-text; the generic schema
+    // uses "message". Treat either as the inquiry message.
+    const message =
+      ((fd.get("message") ?? fd.get("notes")) as string | null) ?? undefined;
 
     const formData: Record<string, unknown> = {};
     for (const field of formSchema) {

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -1,10 +1,54 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
+import type { FormField } from "@dpf/storefront-templates";
 import type {
   PublicStorefrontConfig,
   PublicItem,
   PublicSection,
 } from "./storefront-types";
+
+// Generic fallback used when an archetype defines no form schema (or for custom
+// archetypes that were created without one).
+export const DEFAULT_INQUIRY_SCHEMA: FormField[] = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "phone", label: "Phone number", type: "tel", required: false },
+  { name: "message", label: "Message", type: "textarea", required: false },
+];
+
+function isFormField(value: unknown): value is FormField {
+  if (typeof value !== "object" || value === null) return false;
+  const f = value as Record<string, unknown>;
+  return (
+    typeof f.name === "string" &&
+    typeof f.label === "string" &&
+    typeof f.type === "string" &&
+    typeof f.required === "boolean"
+  );
+}
+
+/**
+ * Resolve the inquiry form schema for a storefront's archetype. The schema is
+ * seeded onto StorefrontArchetype.formSchema from the storefront-templates
+ * definitions; without this, every archetype rendered the same generic
+ * name/email/phone/message form. Falls back to DEFAULT_INQUIRY_SCHEMA when the
+ * archetype is missing or has no (valid) schema.
+ */
+export async function resolveInquiryFormSchema(
+  archetypeId: string,
+): Promise<FormField[]> {
+  if (!archetypeId) return DEFAULT_INQUIRY_SCHEMA;
+  const archetype = await prisma.storefrontArchetype.findUnique({
+    where: { archetypeId },
+    select: { formSchema: true },
+  });
+  const schema = archetype?.formSchema;
+  if (Array.isArray(schema)) {
+    const fields = schema.filter(isFormField);
+    if (fields.length > 0) return fields;
+  }
+  return DEFAULT_INQUIRY_SCHEMA;
+}
 
 export const getPublicStorefront = cache(async function getPublicStorefront(
   slug: string,

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -44,7 +44,10 @@ export async function resolveInquiryFormSchema(
   });
   const schema = archetype?.formSchema;
   if (Array.isArray(schema)) {
-    const fields = schema.filter(isFormField);
+    // Cast through unknown[] so the isFormField type guard narrows to
+    // FormField[]; Prisma's JsonValue does not satisfy the filter overload's
+    // `S extends T` constraint directly.
+    const fields = (schema as unknown[]).filter(isFormField);
     if (fields.length > 0) return fields;
   }
   return DEFAULT_INQUIRY_SCHEMA;

--- a/packages/storefront-templates/src/archetypes/trades-maintenance.ts
+++ b/packages/storefront-templates/src/archetypes/trades-maintenance.ts
@@ -14,6 +14,18 @@ const TRADES_FORM_FIELDS = [
   { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
 ];
 
+// Facilities maintenance is B2B-primary: who is asking and how many sites are in
+// scope drive the quote, so the form captures company name and site count.
+const FACILITIES_FORM_FIELDS = [
+  ...INQUIRY_BASE_FIELDS,
+  { name: "companyName", label: "Company name", type: "text" as const, required: true },
+  { name: "siteCount", label: "Number of sites", type: "select" as const, required: true, options: ["1", "2–5", "6–20", "21–50", "50+"] },
+  { name: "jobType", label: "Service required", type: "text" as const, required: true },
+  { name: "urgency", label: "Urgency", type: "select" as const, required: true, options: ["Emergency", "Routine", "Planned"] },
+  { name: "propertyType", label: "Property type", type: "select" as const, required: true, options: ["Residential", "Commercial", "Industrial"] },
+  { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
+];
+
 export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
   {
     archetypeId: "facilities-maintenance",
@@ -36,7 +48,7 @@ export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
       { type: "testimonials", title: "Client Feedback", sortOrder: 3 },
       { type: "contact", title: "Request a Quote", sortOrder: 4 },
     ],
-    formSchema: TRADES_FORM_FIELDS,
+    formSchema: FACILITIES_FORM_FIELDS,
   },
   {
     archetypeId: "plumber",
@@ -108,6 +120,7 @@ export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
       ...INQUIRY_BASE_FIELDS,
       { name: "jobType", label: "Type of clean", type: "select" as const, required: true, options: ["Regular domestic", "One-off deep clean", "End of tenancy", "Office", "Carpet cleaning", "Window cleaning"] },
       { name: "propertyType", label: "Property type", type: "select" as const, required: true, options: ["Residential", "Commercial", "Industrial"] },
+      { name: "propertySize", label: "Property size", type: "select" as const, required: true, options: ["Studio / 1 bed", "2 bed", "3 bed", "4+ bed", "Commercial premises"] },
       { name: "frequency", label: "Frequency", type: "select" as const, required: false, options: ["One-off", "Weekly", "Fortnightly", "Monthly"] },
       { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
     ],
@@ -138,7 +151,8 @@ export const tradesMaintenanceArchetypes: ArchetypeDefinition[] = [
       { name: "jobType", label: "Type of work", type: "text" as const, required: true },
       { name: "urgency", label: "Urgency", type: "select" as const, required: true, options: ["Emergency", "Routine", "Planned"] },
       { name: "propertyType", label: "Property type", type: "select" as const, required: true, options: ["Residential", "Commercial", "Industrial"] },
-      { name: "gardenSize", label: "Garden size", type: "select" as const, required: false, options: ["Small (under 50m²)", "Medium (50–200m²)", "Large (200m²+)"] },
+      { name: "gardenSize", label: "Property / garden size", type: "select" as const, required: true, options: ["Small (under 50m²)", "Medium (50–200m²)", "Large (200m²+)"] },
+      { name: "frequency", label: "Frequency", type: "select" as const, required: false, options: ["One-off", "Weekly", "Fortnightly", "Monthly", "Seasonal"] },
       { name: "notes", label: "Additional details", type: "textarea" as const, required: false },
     ],
   },


### PR DESCRIPTION
## Finding
R1-*-B-002 (Important, all 4 trades-maintenance archetypes). The public storefront inquiry form rendered the same generic 4 fields for every archetype, even though archetype-specific `formSchema` is already seeded to `StorefrontArchetype.formSchema`.

## Change
- `resolveInquiryFormSchema(archetypeId)` (new): loads + validates the seeded archetype schema, falling back to a shared `DEFAULT_INQUIRY_SCHEMA` for missing/custom archetypes.
- Both `/s/[slug]/inquire` and `.../[itemId]` pages render the resolved schema instead of the hardcoded default.
- `InquiryForm` maps the archetype `notes` textarea to the inquiry message so free-text isn't dropped (archetype schemas use `notes`; generic used `message`).
- Extended trades-maintenance archetype schemas to the audit expectations: facilities-maintenance gets company name + site count (its own schema); landscaping gets frequency; cleaning-service gets property size; electrician already carried property type.

Archetype schema lives in `StorefrontArchetype.formSchema`, seeded from `storefront-templates` — the fix is at the seed source.

Closes #1754.

## Verification
Functional verification handled by the operator audit session on a fresh install (new fields ship via the archetype seed).

Generated with Claude Code
