### PR TITLE
fix(finance): surface draft/pending bills on the P&L report

### DIFF
--- a/apps/web/app/(shell)/finance/reports/profit-loss/page.tsx
+++ b/apps/web/app/(shell)/finance/reports/profit-loss/page.tsx
@@ -181,6 +181,33 @@ export default async function ProfitAndLossPage({
         {data.expenseCount !== 1 ? "s" : ""}.
       </p>
 
+      {/* Draft / pending bills — visible but not yet counted in net profit */}
+      {data.pendingBillCount > 0 && (
+        <div className="mb-4 p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <p className="text-sm text-[var(--dpf-text)]">
+              <span
+                className="inline-block text-[10px] uppercase tracking-widest mr-2 px-1.5 py-0.5 rounded align-middle"
+                style={{ background: "color-mix(in srgb, var(--dpf-warning, #f59e0b) 18%, transparent)", color: "var(--dpf-warning, #f59e0b)" }}
+              >
+                Draft
+              </span>
+              {formatMoney(data.pendingBillTotal)} across {data.pendingBillCount} bill
+              {data.pendingBillCount !== 1 ? "s" : ""} not yet paid
+            </p>
+            <p className="text-xs text-[var(--dpf-muted)] mt-1">
+              These expenses are not in the net profit above until each bill is approved and paid.
+            </p>
+          </div>
+          <Link
+            href="/finance/bills?status=draft"
+            className="text-xs px-3 py-1.5 rounded bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity whitespace-nowrap"
+          >
+            Review &amp; approve bills
+          </Link>
+        </div>
+      )}
+
       {/* Export */}
       <Link
         href={`/api/v1/finance/reports/profit-loss?start=${startStr}&end=${endStr}&format=csv`}

--- a/apps/web/lib/actions/reports.test.ts
+++ b/apps/web/lib/actions/reports.test.ts
@@ -58,6 +58,22 @@ describe("getProfitAndLoss", () => {
     expect(result.grossProfit).toBe(0);
     expect(result.netProfit).toBe(0);
   });
+
+  it("surfaces draft/pending bills separately without affecting net profit", async () => {
+    mockPrisma.invoice.aggregate.mockResolvedValue({ _sum: { totalAmount: "1000.00" }, _count: 5 });
+    // First bill.aggregate = paid bills; second = draft/pending bills.
+    mockPrisma.bill.aggregate
+      .mockResolvedValueOnce({ _sum: { totalAmount: "0.00" }, _count: 0 })
+      .mockResolvedValueOnce({ _sum: { totalAmount: "130.00" }, _count: 1 });
+    mockPrisma.expenseClaim.aggregate.mockResolvedValue({ _sum: { totalAmount: null }, _count: 0 });
+
+    const result = await getProfitAndLoss(startDate, endDate);
+
+    // Net profit reflects only realised (paid) figures — draft bill excluded.
+    expect(result.netProfit).toBe(1000);
+    expect(result.pendingBillTotal).toBe(130);
+    expect(result.pendingBillCount).toBe(1);
+  });
 });
 
 describe("getCashFlowReport", () => {

--- a/apps/web/lib/actions/reports.ts
+++ b/apps/web/lib/actions/reports.ts
@@ -1,7 +1,13 @@
 import { prisma } from "@dpf/db";
 
+// Bill statuses that represent a committed cost not yet paid. Surfaced on the
+// P&L as a clearly-labelled "draft / pending" figure so a draft bill is never
+// silently invisible (it stays out of the realised net-profit number, which
+// remains paid-only and accounting-correct).
+const PENDING_BILL_STATUSES = ["draft", "awaiting_approval", "approved", "partially_paid"];
+
 export async function getProfitAndLoss(startDate: Date, endDate: Date) {
-  const [revenueResult, costResult, expenseResult] = await Promise.all([
+  const [revenueResult, costResult, expenseResult, pendingBillResult] = await Promise.all([
     // Revenue: sum of totalAmount from paid invoices in period
     prisma.invoice.aggregate({
       where: { status: "paid", paidAt: { gte: startDate, lte: endDate } },
@@ -17,6 +23,13 @@ export async function getProfitAndLoss(startDate: Date, endDate: Date) {
     // Expenses: sum of totalAmount from paid expense claims in period
     prisma.expenseClaim.aggregate({
       where: { status: "paid", paidAt: { gte: startDate, lte: endDate } },
+      _sum: { totalAmount: true },
+      _count: true,
+    }),
+    // Draft / pending bills in period (by issue date): visible but NOT included
+    // in realised net profit.
+    prisma.bill.aggregate({
+      where: { status: { in: PENDING_BILL_STATUSES }, issueDate: { gte: startDate, lte: endDate } },
       _sum: { totalAmount: true },
       _count: true,
     }),
@@ -37,6 +50,8 @@ export async function getProfitAndLoss(startDate: Date, endDate: Date) {
     invoiceCount: revenueResult._count,
     billCount: costResult._count,
     expenseCount: expenseResult._count,
+    pendingBillTotal: Number(pendingBillResult._sum.totalAmount ?? 0),
+    pendingBillCount: pendingBillResult._count,
   };
 }
 


### PR DESCRIPTION
## Finding
R1-*-G-004 (Important, all 4 archetypes). `/finance/reports/profit-loss` showed `$0.00` expenses / "0 paid bills" even when draft bills existed. The draft bill was invisible and the draft -> approved -> paid path was undiscoverable.

## Change
- `getProfitAndLoss` now aggregates draft/awaiting_approval/approved/partially_paid bills (by issue date) and returns `pendingBillTotal` + `pendingBillCount`. The realised **net profit** number stays paid-only and accounting-correct.
- The P&L page renders a labelled **Draft** callout with the pending total/count and a **Review & approve bills** link to `/finance/bills?status=draft` (the bills list already supports that filter), giving a visible draft -> approved -> paid path.
- Unit test added: pending bills are surfaced without affecting net profit.

Closes #1755.

## Verification
Functional verification handled by the operator audit session. Unit test covers the new aggregation.

Generated with Claude Code
