### PR TITLE
fix(routing): fail fast on hung local model so fallback/error surfaces

### DIFF
--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -27,6 +27,19 @@ import { isAnthropic } from "./provider-utils";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls";
 
+// ─── Inference HTTP timeouts ──────────────────────────────────────────────────
+// A hung local Docker Model Runner endpoint must fail fast so callWithFallbackChain
+// can advance to a cloud endpoint (or surface a clear error) instead of leaving the
+// coworker on a "still working" spinner for three minutes — the failure observed in
+// the fresh-install audit (R1-*-O-001). Cloud providers keep the longer ceiling.
+// Both are env-overridable for operators on slow local hardware / cold model loads.
+const DEFAULT_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_INFERENCE_TIMEOUT_MS) || 180_000;
+const LOCAL_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS) || 60_000;
+
+function resolveInferenceTimeoutMs(providerId: string): number {
+  return providerId === "local" ? LOCAL_INFERENCE_TIMEOUT_MS : DEFAULT_INFERENCE_TIMEOUT_MS;
+}
+
 // ─── Gemini part types ───────────────────────────────────────────────────────
 
 interface GeminiPart {
@@ -318,7 +331,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
         method: "POST",
         headers,
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(180_000),
+        signal: AbortSignal.timeout(resolveInferenceTimeoutMs(providerId)),
       });
     } catch (e) {
       throw new InferenceError(


### PR DESCRIPTION
## Finding
R1-*-O-001 (Important, 3 of 4 archetypes). The Storefront Operations Manager coworker (`local:docker.io/ai/gemma4:latest`) timed out at ~128-178s with an infinite "still working" spinner and no cloud fallback within the test window.

## Root cause
`chat-adapter.ts` used a fixed `AbortSignal.timeout(180_000)` for **every** provider. A hung local Docker Model Runner endpoint therefore pinned the request for three minutes before `callWithFallbackChain` could advance to a cloud endpoint or surface an error.

## Change
- Provider-aware inference timeout: local endpoints abort after **60s** (`DPF_LOCAL_INFERENCE_TIMEOUT_MS`); cloud keeps 180s (`DPF_INFERENCE_TIMEOUT_MS`). Both env-overridable for slow local hardware / cold model loads.
- The existing fallback loop already continues to the next chain endpoint on a `network` error, so a configured cloud fallback is now reached in ~60s instead of 180s, and a no-fallback install surfaces an error fast instead of spinning indefinitely.

This is the smallest correct change: the fallback chain machinery already exists; the excessive shared timeout was what made it unreachable in time.

Closes #1757.

## Verification
Functional verification handled by the operator audit session (drive the coworker with the local model hung/slow and confirm it falls back or errors within ~60s).

Generated with Claude Code
