### PR TITLE
fix(setup): block onboarding from skipping the storefront step with no portal

### DIFF
--- a/apps/web/components/setup/SetupOverlay.tsx
+++ b/apps/web/components/setup/SetupOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { SetupProgressBar } from "./SetupProgressBar";
 import {
@@ -78,6 +78,7 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
   const router = useRouter();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
+  const [blockedMsg, setBlockedMsg] = useState<string | null>(null);
 
   // Auto-open the coworker panel and trigger a live COO response for this step.
   // Uses autoMessage so the LLM generates personalised guidance from the setup
@@ -123,6 +124,17 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
   const handleContinue = () => {
     startTransition(async () => {
       const updated = await advanceStep(progressId);
+      if ("blocked" in updated && updated.blocked === "storefront-required") {
+        // The storefront hasn't been created yet — keep the operator on the
+        // storefront setup so they finish the wizard before moving on.
+        setBlockedMsg(
+          "Finish creating your storefront below before continuing — it hasn't been set up yet.",
+        );
+        const route = STEP_ROUTES["storefront"] ?? "/storefront";
+        if (!pathname.startsWith(route)) router.push(route);
+        return;
+      }
+      setBlockedMsg(null);
       navigateToStep(updated.currentStep, !!updated.completedAt);
     });
   };
@@ -186,6 +198,28 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
         steps={steps}
         onStepClick={handleStepClick}
       />
+      {blockedMsg && (
+        <div
+          role="alert"
+          style={{
+            position: "fixed",
+            top: 56,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 60,
+            maxWidth: 520,
+            padding: "10px 16px",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-border)",
+            background: "var(--dpf-surface-2)",
+            color: "var(--dpf-text)",
+            fontSize: 13,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+          }}
+        >
+          {blockedMsg}
+        </div>
+      )}
     </>
   );
 }

--- a/apps/web/lib/actions/setup-progress.test.ts
+++ b/apps/web/lib/actions/setup-progress.test.ts
@@ -12,6 +12,9 @@ vi.mock("@dpf/db", () => ({
       count: vi.fn(),
       findFirst: vi.fn(),
     },
+    storefrontConfig: {
+      findFirst: vi.fn(),
+    },
   },
 }));
 
@@ -104,6 +107,44 @@ describe("setup-progress", () => {
         data: expect.objectContaining({
           currentStep: "ai-providers",
         }),
+      });
+    });
+
+    it("blocks advancing past the storefront step until a StorefrontConfig exists", async () => {
+      const mockProgress = {
+        id: "test-id",
+        currentStep: "storefront",
+        steps: Object.fromEntries(SETUP_STEPS.map((s) => [s, "pending"])),
+        context: {},
+      };
+      (prisma.platformSetupProgress.findUniqueOrThrow as any).mockResolvedValue(mockProgress);
+      (prisma.storefrontConfig.findFirst as any).mockResolvedValue(null);
+
+      const result = await advanceStep("test-id");
+
+      expect((result as { blocked?: string }).blocked).toBe("storefront-required");
+      expect(prisma.platformSetupProgress.update).not.toHaveBeenCalled();
+    });
+
+    it("advances past the storefront step once a StorefrontConfig exists", async () => {
+      const mockProgress = {
+        id: "test-id",
+        currentStep: "storefront",
+        steps: Object.fromEntries(SETUP_STEPS.map((s) => [s, "pending"])),
+        context: {},
+      };
+      (prisma.platformSetupProgress.findUniqueOrThrow as any).mockResolvedValue(mockProgress);
+      (prisma.storefrontConfig.findFirst as any).mockResolvedValue({ id: "sf-1" });
+      (prisma.platformSetupProgress.update as any).mockResolvedValue({
+        ...mockProgress,
+        currentStep: "platform-development",
+      });
+
+      await advanceStep("test-id");
+
+      expect(prisma.platformSetupProgress.update).toHaveBeenCalledWith({
+        where: { id: "test-id" },
+        data: expect.objectContaining({ currentStep: "platform-development" }),
       });
     });
   });

--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -104,6 +104,19 @@ export async function advanceStep(
   const context = { ...(progress.context as SetupContext), ...contextUpdate };
   const currentIdx = SETUP_STEPS.indexOf(progress.currentStep as SetupStep);
 
+  // The storefront step is only "complete" once the storefront actually exists.
+  // The setup overlay's Continue must not advance past it (to operating-hours /
+  // platform-development / ...) while StorefrontConfig is still null — otherwise
+  // the operator finishes onboarding with no portal (R1-CS-A-003). Completing the
+  // embedded SetupWizard creates the config; until then, Continue is a no-op that
+  // keeps the user on the storefront setup.
+  if (progress.currentStep === "storefront") {
+    const storefront = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+    if (!storefront) {
+      return { ...progress, blocked: "storefront-required" as const };
+    }
+  }
+
   steps[progress.currentStep] = "completed";
 
   const nextIdx = currentIdx + 1;


### PR DESCRIPTION
## Finding
R1-CS-A-003 (Important). Selecting an archetype in the storefront setup and clicking Continue advanced the onboarding wizard (to Operating Hours, then Platform Dev) but never created `StorefrontConfig` — the operator could complete onboarding with no portal.

## Root cause
The storefront onboarding step is the `SetupOverlay` rendered over the real `/storefront` page (which redirects to the embedded `SetupWizard`). The overlay's **Continue** called `advanceStep`, which blindly marked the step complete and advanced the step counter — it never checked that the `SetupWizard` had actually created the storefront. So Continue skipped straight past with no config.

## Change
- `advanceStep` guards the `"storefront"` step: if no `StorefrontConfig` exists it returns `{ blocked: "storefront-required" }` and does **not** advance.
- `SetupOverlay.handleContinue` surfaces a clear inline message ("Finish creating your storefront below before continuing") and keeps the operator on the storefront setup.
- Unit tests for both the blocked and unblocked storefront-step paths.
- Removed a pre-existing unused `useRef` import on the line I edited.

The embedded `SetupWizard.handleComplete` already POSTs `/api/storefront/admin/setup` correctly; the gap was the overlay letting the operator bypass it.

Closes #1758.

## Verification
Functional verification handled by the operator audit session: run the storefront step, click Continue before completing the wizard (blocked), complete the wizard, then Continue advances.

Generated with Claude Code
