### PR TITLE
fix(test): mock storefrontConfig in setup integration walk for the storefront guard

### DIFF
--- a/apps/web/lib/actions/setup-integration.test.ts
+++ b/apps/web/lib/actions/setup-integration.test.ts
@@ -9,6 +9,12 @@ vi.mock("@dpf/db", () => {
         count: vi.fn(() => 0),
         findFirst: vi.fn(() => null),
       },
+      // The storefront step guard (advanceStep) checks that a StorefrontConfig
+      // exists before advancing. This integration walk simulates a completed
+      // storefront setup, so the config is present and the sequence proceeds.
+      storefrontConfig: {
+        findFirst: vi.fn(() => ({ id: "sf-1" })),
+      },
       platformSetupProgress: {
         findFirst: vi.fn(() => null),
         findUniqueOrThrow: vi.fn((args: any) => {


### PR DESCRIPTION
## Problem
`lib/actions/setup-integration.test.ts` is failing on `main` (web shard 4/4).

`advanceStep` now guards the storefront onboarding step (introduced in #1764): it calls `prisma.storefrontConfig.findFirst(...)` before advancing past `"storefront"`. The integration test mocks `@dpf/db` **without** a `storefrontConfig` model, so the guard hit `undefined.findFirst` and threw at `setup-progress.ts:114`, breaking the full-sequence walk.

## Fix
Add a `storefrontConfig.findFirst` mock returning `{ id: "sf-1" }`, so the walk simulates a completed storefront setup and the sequence advances as the test intends (mirroring real usage, where the storefront exists by the time you advance past that step).

One-line test-only change; restores `main` to green. Surfaced while fixing CI on #1760, whose branch carries the merged guard.

Generated with Claude Code
