### PR TITLE
fix(storefront): make inbox banner archetype-neutral for booking operators

### DIFF
--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -116,10 +116,10 @@ export function StorefrontInbox({
           }}
         >
           <div style={{ fontSize: 12, fontWeight: 700, color: "var(--dpf-text)" }}>
-            Inquiries from your storefront
+            Requests from your storefront
           </div>
           <div style={{ marginTop: 4, fontSize: 12, color: "var(--dpf-muted)" }}>
-            Use <strong>Send to backlog</strong> to turn an inquiry into tracked work you can follow up on.
+            Use <strong>Send to backlog</strong> to track a customer request as work you can follow up on.
           </div>
         </div>
       ) : (
@@ -134,7 +134,7 @@ export function StorefrontInbox({
             fontSize: 12,
           }}
         >
-          No digital product is configured yet, so storefront inquiries cannot be routed into the product backlog.
+          Sending storefront requests to your backlog isn&apos;t available yet.
         </div>
       )}
 


### PR DESCRIPTION
## Finding
AUDIT-R2-HS-I-001 (Critical). On booking archetypes the inbox banner used inquiry-specific wording. The DPF "Customer-zero" meta-language was already removed in #1752 (the Run 2 audit ran a stale install); this neutralises the remaining inquiry-only copy so it reads correctly for booking operators.

## Change
- Banner -> "Requests from your storefront" with request-neutral helper text.
- Empty-state copy reworded off "product backlog".
- Booking entries already carry a "Booking" type badge; inquiry entries keep "New lead".

Closes AUDIT-R2-HS-I-001.

Verification handled by the operator audit on a fresh (rebuilt) install. Copy-only change.
