### PR TITLE
fix(finance): hard-default financial setup to USD and bill tax to 0%

### DIFF
--- a/apps/web/app/(shell)/finance/bills/new/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/new/page.tsx
@@ -1,6 +1,4 @@
 // apps/web/app/(shell)/finance/bills/new/page.tsx
-import { prisma } from "@dpf/db";
-import { getFinancialProfile } from "@dpf/finance-templates";
 import { listSuppliers, listPurchaseOrders } from "@/lib/actions/ap";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { CreateBillForm } from "@/components/finance/CreateBillForm";
@@ -8,17 +6,9 @@ import Link from "next/link";
 
 type Props = { searchParams: Promise<{ supplierId?: string }> };
 
-// Default line-item tax rate: 0 unless the org configured a VAT/GST tax model at
-// setup. Avoids the legacy hardcoded 20% UK VAT default on US (and other
-// non-VAT) installs.
-async function getDefaultBillTaxRate(appliedProfileSlug: string | null): Promise<number> {
-  const taxProfile = await prisma.organizationTaxProfile.findFirst({
-    select: { taxModel: true },
-  });
-  if (taxProfile?.taxModel !== "vat") return 0;
-  const profile = appliedProfileSlug ? getFinancialProfile(appliedProfileSlug) : null;
-  return profile?.defaultTaxRate ?? 0;
-}
+// New bill line items default to 0% tax. US installs do not charge UK VAT; an
+// operator who needs tax sets it per line. Fixed default, not derived at runtime.
+const DEFAULT_BILL_TAX_RATE = 0;
 
 export default async function NewBillPage({ searchParams }: Props) {
   const { supplierId } = await searchParams;
@@ -28,7 +18,6 @@ export default async function NewBillPage({ searchParams }: Props) {
     listPurchaseOrders(),
     getOrgSettings(),
   ]);
-  const defaultTaxRate = await getDefaultBillTaxRate(orgSettings.appliedProfileSlug ?? null);
 
   return (
     <div>
@@ -68,7 +57,7 @@ export default async function NewBillPage({ searchParams }: Props) {
           }))}
           {...(supplierId ? { defaultSupplierId: supplierId } : {})}
           defaultCurrency={orgSettings.baseCurrency}
-          defaultTaxRate={defaultTaxRate}
+          defaultTaxRate={DEFAULT_BILL_TAX_RATE}
         />
       </div>
     </div>

--- a/apps/web/components/storefront-admin/FinancialSetupStep.test.tsx
+++ b/apps/web/components/storefront-admin/FinancialSetupStep.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const applyFinancialProfile = vi.fn(async () => ({ applied: true as const, profileName: "Trades" }));
+vi.mock("@/lib/actions/financial-setup", () => ({ applyFinancialProfile }));
+
+import { FinancialSetupStep } from "./FinancialSetupStep";
+
+afterEach(() => {
+  cleanup();
+  applyFinancialProfile.mockClear();
+});
+
+describe("FinancialSetupStep currency + VAT defaults", () => {
+  it("defaults to USD (not the UK-biased profile/locale) with no suggested currency", async () => {
+    render(
+      <FinancialSetupStep
+        archetypeSlug="trades_construction"
+        archetypeName="Trades & Construction"
+        onComplete={() => {}}
+      />,
+    );
+
+    // Currency select pre-fills USD.
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("USD");
+
+    // Even though the trades profile is VAT-registered in the UK, a USD install
+    // must NOT pre-select VAT — that was the cascade behind the 20% bill tax.
+    fireEvent.click(screen.getByText("Set Up Finances"));
+    await waitFor(() => {
+      expect(applyFinancialProfile).toHaveBeenCalledWith("trades_construction", {
+        vatRegistered: false,
+        baseCurrency: "USD",
+      });
+    });
+  });
+
+  it("honours an explicit suggested currency when one is detected", () => {
+    render(
+      <FinancialSetupStep
+        archetypeSlug="trades_construction"
+        archetypeName="Trades & Construction"
+        suggestedCurrency="EUR"
+        onComplete={() => {}}
+      />,
+    );
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("EUR");
+  });
+});

--- a/apps/web/components/storefront-admin/FinancialSetupStep.test.tsx
+++ b/apps/web/components/storefront-admin/FinancialSetupStep.test.tsx
@@ -3,7 +3,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-const applyFinancialProfile = vi.fn(async () => ({ applied: true as const, profileName: "Trades" }));
+const { applyFinancialProfile } = vi.hoisted(() => ({
+  applyFinancialProfile: vi.fn(async () => ({ applied: true as const, profileName: "Trades" })),
+}));
 vi.mock("@/lib/actions/financial-setup", () => ({ applyFinancialProfile }));
 
 import { FinancialSetupStep } from "./FinancialSetupStep";

--- a/apps/web/components/storefront-admin/FinancialSetupStep.tsx
+++ b/apps/web/components/storefront-admin/FinancialSetupStep.tsx
@@ -13,20 +13,11 @@ type Props = {
   onComplete: () => void;
 };
 
-// ─── Locale-aware currency default ───────────────────────────────────────────
-
-function getLocaleFallbackCurrency(): string {
-  if (typeof navigator === "undefined") return "USD";
-  const lang = (navigator.language ?? "").toLowerCase();
-  if (lang.startsWith("en-gb") || lang.startsWith("en-ie")) return "GBP";
-  if (lang.startsWith("en-au") || lang.startsWith("en-nz")) return "AUD";
-  if (lang.startsWith("en-ca")) return "CAD";
-  if (
-    lang.startsWith("de") || lang.startsWith("fr") || lang.startsWith("it") ||
-    lang.startsWith("nl") || lang.startsWith("es-es") || lang.startsWith("pt-pt")
-  ) return "EUR";
-  return "USD";
-}
+// ─── Currency default ─────────────────────────────────────────────────────────
+// Fixed USD default (not derived from the browser locale at runtime): a US
+// install must pre-fill USD, and an en-GB test browser must not flip it to GBP.
+// A real location signal (suggestedCurrency, from website import) still wins.
+const DEFAULT_BASE_CURRENCY = "USD";
 
 // VAT/GST is a UK/EU concept. On a USD (or other non-VAT) install we should not
 // pre-select "VAT registered" even when the business-type profile commonly is in
@@ -39,10 +30,9 @@ export function FinancialSetupStep({ archetypeSlug, archetypeName, suggestedCurr
   // Load profile defaults (client-safe: pure function, no DB call)
   const profile = getFinancialProfile(archetypeSlug);
 
-  // Currency: prefer a location-detected suggestion, then the operator's browser
-  // locale, before any UK-biased profile default. Without this, every fresh
-  // install pre-filled GBP regardless of where the operator actually is.
-  const initialCurrency = suggestedCurrency ?? getLocaleFallbackCurrency();
+  // Currency: a real location-detected suggestion wins; otherwise default to USD
+  // (never the UK-biased profile default or a browser-locale guess).
+  const initialCurrency = suggestedCurrency ?? DEFAULT_BASE_CURRENCY;
   const [baseCurrency, setBaseCurrency] = useState<string>(initialCurrency);
   // Only pre-select "VAT registered" when both the business-type profile expects
   // it AND the resolved currency is in a VAT region.


### PR DESCRIPTION
## Findings
AUDIT-R2-HS-A-001 (currency) + AUDIT-R2-HS-G-002 (bill tax). The setup wizard derived currency from the browser locale (so an en-GB audit browser still pre-filled GBP), and the new-bill tax was derived from the org tax profile (20% under the GBP cascade).

## Change (fixed defaults, not runtime-derived, per the audit)
- FinancialSetupStep: currency defaults to **USD** (a real detected `suggestedCurrency` still wins); VAT only pre-selected for VAT-region currencies, so USD installs start non-VAT.
- bills/new: line-item tax defaults to a fixed **0%** (removed the VAT-profile derivation).
- Tests: USD + non-VAT default for a VAT-registered profile under USD; honour an explicit suggested currency.

Closes AUDIT-R2-HS-A-001, AUDIT-R2-HS-G-002.
