### PR TITLE
fix(storefront): prompt operators to publish their new portal

### DIFF
--- a/apps/web/components/storefront-admin/StorefrontDashboard.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontDashboard.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StorefrontDashboard } from "./StorefrontDashboard";
+
+afterEach(() => cleanup());
+
+const baseConfig = {
+  id: "sf-1",
+  tagline: "Best in town",
+  orgSlug: "glamour-grace",
+  orgName: "Glamour & Grace",
+  archetypeId: "hair-salon",
+  ctaType: "booking",
+  sectionCount: 4,
+  itemCount: 6,
+};
+const counts = { inquiries: 0, bookings: 0, orders: 0, donations: 0 };
+
+describe("StorefrontDashboard publish CTA", () => {
+  it("shows a prominent publish call-to-action when the portal is unpublished", () => {
+    render(<StorefrontDashboard config={{ ...baseConfig, isPublished: false }} counts={counts} />);
+    expect(screen.getByText(/your storefront is ready — publish it now/i)).toBeTruthy();
+    expect(screen.getByText(/publish now/i)).toBeTruthy();
+  });
+
+  it("hides the call-to-action once the portal is published", () => {
+    render(<StorefrontDashboard config={{ ...baseConfig, isPublished: true }} counts={counts} />);
+    expect(screen.queryByText(/your storefront is ready — publish it now/i)).toBeNull();
+  });
+});

--- a/apps/web/components/storefront-admin/StorefrontDashboard.tsx
+++ b/apps/web/components/storefront-admin/StorefrontDashboard.tsx
@@ -42,6 +42,53 @@ export function StorefrontDashboard({ config, counts }: { config: DashboardConfi
 
   return (
     <div>
+      {/* Publish gate is deliberate (unpublished by default), but operators were
+          not prompted to publish after the wizard and assumed the 404 portal was
+          broken. Surface a prominent call-to-action whenever the portal is not
+          yet live. */}
+      {!published && (
+        <div
+          role="status"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+            marginBottom: 24,
+            padding: "14px 16px",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-accent)",
+            background: "color-mix(in srgb, var(--dpf-accent) 12%, transparent)",
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 220 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, color: "var(--dpf-text)" }}>
+              Your storefront is ready — publish it now
+            </div>
+            <div style={{ marginTop: 2, fontSize: 13, color: "var(--dpf-muted)" }}>
+              It is not live yet, so the public link returns a 404. Publish it so customers can find you.
+            </div>
+          </div>
+          <button
+            onClick={togglePublish}
+            disabled={toggling}
+            style={{
+              padding: "8px 18px",
+              borderRadius: 6,
+              border: "none",
+              background: "var(--dpf-accent)",
+              color: "white",
+              cursor: toggling ? "wait" : "pointer",
+              fontSize: 14,
+              fontWeight: 600,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {toggling ? "Publishing..." : "Publish now"}
+          </button>
+        </div>
+      )}
+
       <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 24 }}>
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: 15, fontWeight: 600 }}>{config.orgName}</div>


### PR DESCRIPTION
## Finding
AUDIT-R2-HS-B-001 (Important). Wizard-created portals start Unpublished; operators got no prompt and hit a 404, assuming the portal was broken.

## Change
Unpublished-by-default is **deliberate** (storefront-foundation spec + the public-route 404 guard and transaction write-guards depend on `isPublished`). So rather than auto-publish, the dashboard now shows a prominent **"Your storefront is ready — publish it now"** CTA whenever the portal is unpublished, with a Publish button that disappears once live.
- Tests: CTA present when unpublished, absent when published.

Closes AUDIT-R2-HS-B-001.
