### PR TITLE
fix(storefront): booking calendar follows the operating-hours timezone

### DIFF
--- a/apps/web/lib/release/storefront-data.test.ts
+++ b/apps/web/lib/release/storefront-data.test.ts
@@ -19,6 +19,9 @@ vi.mock("@dpf/db", () => ({
     organization: {
       findFirst: vi.fn(),
     },
+    businessProfile: {
+      findFirst: vi.fn(),
+    },
   },
 }));
 
@@ -112,5 +115,29 @@ describe("getPublicStorefront", () => {
     expect(result?.archetypeId).toBe("software-platform");
     expect(result?.items[0]?.ctaType).toBe("inquiry");
     expect(result?.items[0]?.name).toBe("Open Digital Product Factory");
+  });
+
+  it("resolves the display timezone from the operator's Operating Hours setting", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
+      ...mockStorefront,
+      timezone: "Europe/London", // stale config default — must be ignored
+    } as never);
+    vi.mocked(prisma.businessProfile.findFirst).mockResolvedValue({
+      timezone: "America/New_York",
+    } as never);
+
+    const result = await getPublicStorefront("acme-vet");
+    expect(result?.timezone).toBe("America/New_York");
+  });
+
+  it("never falls back to Europe/London when no Operating Hours timezone is set", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
+      ...mockStorefront,
+      timezone: "Europe/London",
+    } as never);
+    vi.mocked(prisma.businessProfile.findFirst).mockResolvedValue(null as never);
+
+    const result = await getPublicStorefront("acme-vet");
+    expect(result?.timezone).toBe("America/Chicago");
   });
 });

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -120,6 +120,19 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
 
   const org = config.organization;
 
+  // Booking calendar display timezone must follow the operator's Operating Hours
+  // setting (BusinessProfile.timezone). StorefrontConfig.timezone carries a stale
+  // Europe/London default that is never re-synced when the operator sets hours,
+  // which is why US salons saw "Times shown in Europe/London" (AUDIT-R2-NS-B-005).
+  const businessProfile = await prisma.businessProfile.findFirst({
+    where: { isActive: true },
+    select: { timezone: true },
+  });
+  const resolvedTimezone =
+    businessProfile?.timezone?.trim() ||
+    (config.timezone && config.timezone !== "Europe/London" ? config.timezone : null) ||
+    "America/Chicago";
+
   // Confirmed regulatory display obligations for the "disclosures" section
   // (BI-5D9DCDE6 spec §9.3). D5 honesty rule: only obligations whose parent
   // credential record is ACTIVE are exposed — uncaptured posture must render
@@ -169,7 +182,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
   return {
     tagline: config.tagline,
     description: config.description,
-    timezone: config.timezone ?? "America/Chicago",
+    timezone: resolvedTimezone,
     heroImageUrl: config.heroImageUrl,
     contactEmail: config.contactEmail,
     contactPhone: config.contactPhone,


### PR DESCRIPTION
## Finding
AUDIT-R2-NS-B-005 (Important, systemic across booking archetypes). The booking calendar showed "Times shown in Europe/London" on US installs. It rendered `StorefrontConfig.timezone` (UK-biased `Europe/London` column default, never re-synced); the operators real timezone lives on `BusinessProfile.timezone` (the Operating Hours setting).

## Change
`getPublicStorefront` now resolves the calendar display timezone from `BusinessProfile.timezone` first, then a non-default `StorefrontConfig.timezone`, then `America/Chicago` — never the stale `Europe/London`.
- Tests: timezone follows BusinessProfile; never falls back to Europe/London.

Note: I also tried lowering the `StorefrontConfig.timezone` column default, but the schema-regression guard treats a default change as a field removal (needs schema-steward sign-off), so this PR fixes the read path only — which fully resolves the user-visible bug.

Closes AUDIT-R2-NS-B-005 (and SPA/OPT/PT/BS variants).
