### PR TITLE
fix(finance): record payment on approved bills so they reach paid

### DIFF
--- a/apps/web/app/(shell)/finance/bills/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getCurrencySymbol } from "@/lib/currency-symbol";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { SubmitBillButton } from "@/components/finance/SubmitBillButton";
+import { RecordBillPaymentButton } from "@/components/finance/RecordBillPaymentButton";
 import { LocalTime } from "@/components/ui/LocalTime";
 
 const STATUS_COLOURS: Record<string, string> = {
@@ -66,6 +67,13 @@ export default async function BillDetailPage({ params }: Props) {
           <p className="text-sm text-[var(--dpf-muted)]">{bill.supplier.name}</p>
         </div>
         {bill.status === "draft" && <SubmitBillButton billId={bill.id} />}
+        {(bill.status === "approved" || bill.status === "partially_paid") && (
+          <RecordBillPaymentButton
+            billId={bill.id}
+            amountDue={Number(bill.amountDue)}
+            currency={bill.currency}
+          />
+        )}
       </div>
 
       {/* Metadata row */}

--- a/apps/web/components/finance/RecordBillPaymentButton.test.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.test.tsx
@@ -3,8 +3,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-const recordPayment = vi.fn(async () => ({ id: "pay-1", paymentRef: "PAY-1" }));
-const refresh = vi.fn();
+const { recordPayment, refresh } = vi.hoisted(() => ({
+  recordPayment: vi.fn(async () => ({ id: "pay-1", paymentRef: "PAY-1" })),
+  refresh: vi.fn(),
+}));
 
 vi.mock("@/lib/actions/finance", () => ({ recordPayment }));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
@@ -23,7 +25,9 @@ describe("RecordBillPaymentButton", () => {
 
     fireEvent.click(screen.getByText("Record Payment"));
 
-    const amount = screen.getByLabelText(/amount/i) as HTMLInputElement;
+    // The amount field is the only number input (role spinbutton); the label is
+    // visual-only so query by role rather than label association.
+    const amount = screen.getByRole("spinbutton") as HTMLInputElement;
     expect(amount.value).toBe("85");
 
     fireEvent.click(screen.getByText("Confirm payment"));

--- a/apps/web/components/finance/RecordBillPaymentButton.test.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const recordPayment = vi.fn(async () => ({ id: "pay-1", paymentRef: "PAY-1" }));
+const refresh = vi.fn();
+
+vi.mock("@/lib/actions/finance", () => ({ recordPayment }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+
+import { RecordBillPaymentButton } from "./RecordBillPaymentButton";
+
+afterEach(() => {
+  cleanup();
+  recordPayment.mockClear();
+  refresh.mockClear();
+});
+
+describe("RecordBillPaymentButton", () => {
+  it("opens a payment form prefilled with the amount due and records an outbound bill payment", async () => {
+    render(<RecordBillPaymentButton billId="bill-1" amountDue={85} currency="USD" />);
+
+    fireEvent.click(screen.getByText("Record Payment"));
+
+    const amount = screen.getByLabelText(/amount/i) as HTMLInputElement;
+    expect(amount.value).toBe("85");
+
+    fireEvent.click(screen.getByText("Confirm payment"));
+
+    await waitFor(() => {
+      expect(recordPayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: "outbound",
+          billId: "bill-1",
+          amount: 85,
+          currency: "USD",
+          method: "bank_transfer",
+        }),
+      );
+    });
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/finance/RecordBillPaymentButton.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { recordPayment } from "@/lib/actions/finance";
+
+const PAYMENT_METHODS = [
+  "bank_transfer", "card", "cash", "cheque", "direct_debit", "stripe",
+] as const;
+
+const METHOD_LABELS: Record<string, string> = {
+  bank_transfer: "Bank transfer",
+  card: "Card",
+  cash: "Cash",
+  cheque: "Cheque",
+  direct_debit: "Direct debit",
+  stripe: "Stripe",
+};
+
+interface Props {
+  billId: string;
+  amountDue: number;
+  currency: string;
+}
+
+function getToday(): string {
+  return new Date().toISOString().split("T")[0]!;
+}
+
+export function RecordBillPaymentButton({ billId, amountDue, currency }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [amount, setAmount] = useState(amountDue > 0 ? String(amountDue) : "");
+  const [method, setMethod] = useState<string>("bank_transfer");
+  const [receivedAt, setReceivedAt] = useState(getToday());
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = parseFloat(amount);
+    if (!Number.isFinite(value) || value <= 0) {
+      setError("Enter a payment amount greater than zero.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await recordPayment({
+        direction: "outbound",
+        method: method as (typeof PAYMENT_METHODS)[number],
+        amount: value,
+        currency,
+        billId,
+        receivedAt,
+      });
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to record payment");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 rounded-md text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity"
+      >
+        Record Payment
+      </button>
+    );
+  }
+
+  const inputClasses =
+    "bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-3 py-2 text-sm focus:border-[var(--dpf-accent)] focus:outline-none";
+  const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-[var(--dpf-border)] p-4 w-72 space-y-3 bg-[var(--dpf-surface-2)]"
+    >
+      <div className="text-sm font-semibold text-[var(--dpf-text)]">Record payment</div>
+      <div>
+        <label className={labelClasses}>Amount ({currency})</label>
+        <input
+          type="number"
+          min="0.01"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          required
+          className={inputClasses + " w-full"}
+        />
+      </div>
+      <div>
+        <label className={labelClasses}>Method</label>
+        <select
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+          className={inputClasses + " w-full"}
+        >
+          {PAYMENT_METHODS.map((m) => (
+            <option key={m} value={m} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+              {METHOD_LABELS[m] ?? m}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className={labelClasses}>Payment date</label>
+        <input
+          type="date"
+          value={receivedAt}
+          onChange={(e) => setReceivedAt(e.target.value)}
+          required
+          className={inputClasses + " w-full"}
+        />
+      </div>
+      {error && <p className="text-xs text-[var(--dpf-error)]">{error}</p>}
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="px-3 py-1.5 rounded-md text-sm border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-3 py-1.5 rounded-md text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 disabled:opacity-50"
+        >
+          {loading ? "Recording…" : "Confirm payment"}
+        </button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Finding
AUDIT-R2-HS-G-004 / G-005 (Important). After a bill was approved there was no UI to record payment, so bills never reached "paid" and the P&L (paid-bills-only) stayed at $0 expenses.

## Change
The `recordPayment` server action already supports bills (billId -> Payment + PaymentAllocation, updates amountPaid/amountDue and status). This adds the missing UI:
- `RecordBillPaymentButton`: on approved/partially_paid bills, opens an inline form (amount prefilled to amount due, method, date) and calls `recordPayment` (outbound).
- Bill detail page renders it for "approved" and "partially_paid".
- Test: opens prefilled form and records an outbound bill payment.

Closes AUDIT-R2-HS-G-004.
