### PR TITLE
fix(storefront): operating-hours success toast + personal-trainer OH consistency

### DIFF
--- a/apps/web/components/admin/OperatingHoursEditor.test.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+import { OperatingHoursEditor } from "./OperatingHoursEditor";
+
+afterEach(() => cleanup());
+
+const DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] as const;
+const schedule = Object.fromEntries(
+  DAYS.map((d) => [d, { enabled: d === "monday", open: "09:00", close: "17:00" }]),
+) as unknown as WeeklySchedule;
+
+describe("OperatingHoursEditor save feedback", () => {
+  it("shows a success toast after a successful save", async () => {
+    const onSave = vi.fn(async () => {});
+    render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/Chicago" onSave={onSave} />);
+
+    expect(screen.queryByText(/operating hours saved/i)).toBeNull();
+    fireEvent.click(screen.getByText("Save Operating Hours"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText(/operating hours saved/i)).toBeTruthy());
+  });
+});

--- a/apps/web/components/admin/OperatingHoursEditor.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import type { WeeklySchedule, DaySchedule } from "@/lib/operating-hours-types";
 
 const DAY_ORDER = [
@@ -26,6 +26,13 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
   const [saved, setSaved] = useState(false);
 
   const busy = externalSaving || isPending;
+
+  // Auto-dismiss the success toast a few seconds after a save.
+  useEffect(() => {
+    if (!saved) return;
+    const t = setTimeout(() => setSaved(false), 3000);
+    return () => clearTimeout(t);
+  }, [saved]);
 
   function updateDay(day: string, patch: Partial<DaySchedule>) {
     setSchedule((prev) => ({
@@ -145,16 +152,35 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
         >
           {busy ? "Saving..." : "Save Operating Hours"}
         </button>
-        {saved && !busy && (
-          <span
-            className="text-xs font-medium"
-            style={{ color: "var(--dpf-success, #22c55e)" }}
-            role="status"
-          >
-            ✓ Saved
-          </span>
-        )}
       </div>
+
+      {/* Success toast — auto-dismissing confirmation that the save persisted. */}
+      {saved && !busy && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "fixed",
+            right: 24,
+            bottom: 24,
+            zIndex: 60,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "10px 16px",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-border)",
+            background: "var(--dpf-surface-2)",
+            color: "var(--dpf-text)",
+            fontSize: 13,
+            fontWeight: 600,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+          }}
+        >
+          <span style={{ color: "var(--dpf-success, #22c55e)" }}>✓</span>
+          Operating hours saved
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -26,6 +26,22 @@ describe("archetype catalog", () => {
     expect(unique.size).toBe(ids.length);
   });
 
+  it("personal-trainer shares the scheduling/operating-hours setup of the other beauty booking archetypes", () => {
+    // AUDIT-R2-PT-P-001 alleged the personal-trainer wizard skips the Operating
+    // Hours step. That step is driven by the shared scheduling/activation config,
+    // not archetype-specific code; this guards against personal-trainer silently
+    // diverging from its siblings.
+    const beautyBooking = ALL_ARCHETYPES.filter(
+      (a) => a.category === "beauty-personal-care" && a.ctaType === "booking",
+    );
+    expect(beautyBooking.length).toBeGreaterThan(1);
+    const pt = beautyBooking.find((a) => a.archetypeId === "personal-trainer");
+    expect(pt, "personal-trainer should be a beauty-personal-care booking archetype").toBeTruthy();
+    const reference = beautyBooking.find((a) => a.archetypeId !== "personal-trainer")!;
+    expect(pt!.schedulingDefaults).toEqual(reference.schedulingDefaults);
+    expect(pt!.activationProfile).toEqual(reference.activationProfile);
+  });
+
   it("hero section always comes first", () => {
     for (const a of ALL_ARCHETYPES) {
       const sorted = [...a.sectionTemplates].sort((x, y) => x.sortOrder - y.sortOrder);


### PR DESCRIPTION
## Findings
AUDIT-R2-HS-P-001 (OH save feedback) + AUDIT-R2-PT-P-001 (PT OH step).

## Change
- **OH toast:** the inline "✓ Saved" (#1762) is replaced with a proper auto-dismissing success toast ("Operating hours saved", `role="status"`).
- **PT consistency:** there is **no archetype-specific OH skip** in code — the operating-hours step is a shared `SETUP_STEPS` entry and personal-trainer uses the same `BEAUTY_SCHEDULING` / `BEAUTY_ACTIVATION_PROFILE` as every other beauty booking archetype. Added a catalog regression test asserting personal-trainer parity so it cannot silently diverge.
- Tests: toast appears after save; personal-trainer scheduling/activation parity.

Closes AUDIT-R2-HS-P-001; addresses AUDIT-R2-PT-P-001.
