### PR TITLE
fix(finance): guard bill payments server-side and show paid/due (hardens #1772)

### DIFF
--- a/apps/web/app/(shell)/finance/bills/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/bills/[id]/page.tsx
@@ -150,6 +150,22 @@ export default async function BillDetailPage({ params }: Props) {
                   {sym}{formatMoney(bill.totalAmount)}
                 </td>
               </tr>
+              {Number(bill.amountPaid) > 0 && (
+                <>
+                  <tr>
+                    <td colSpan={4} className="px-4 py-2.5 text-right text-[var(--dpf-muted)] text-[10px] uppercase tracking-widest">
+                      Paid
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">{sym}{formatMoney(bill.amountPaid)}</td>
+                  </tr>
+                  <tr>
+                    <td colSpan={4} className="px-4 py-2.5 text-right text-[var(--dpf-muted)] text-[10px] uppercase tracking-widest">
+                      Due
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-[var(--dpf-text)]">{sym}{formatMoney(bill.amountDue)}</td>
+                  </tr>
+                </>
+              )}
             </tfoot>
           </table>
         </div>

--- a/apps/web/components/finance/RecordBillPaymentButton.test.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.test.tsx
@@ -3,19 +3,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-const { recordPayment, refresh } = vi.hoisted(() => ({
-  recordPayment: vi.fn(async () => ({ id: "pay-1", paymentRef: "PAY-1" })),
+const { recordBillPayment, refresh } = vi.hoisted(() => ({
+  recordBillPayment: vi.fn(async () => undefined),
   refresh: vi.fn(),
 }));
 
-vi.mock("@/lib/actions/finance", () => ({ recordPayment }));
+vi.mock("@/lib/actions/ap", () => ({ recordBillPayment }));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
 
 import { RecordBillPaymentButton } from "./RecordBillPaymentButton";
 
 afterEach(() => {
   cleanup();
-  recordPayment.mockClear();
+  recordBillPayment.mockClear();
   refresh.mockClear();
 });
 
@@ -33,12 +33,10 @@ describe("RecordBillPaymentButton", () => {
     fireEvent.click(screen.getByText("Confirm payment"));
 
     await waitFor(() => {
-      expect(recordPayment).toHaveBeenCalledWith(
+      expect(recordBillPayment).toHaveBeenCalledWith(
         expect.objectContaining({
-          direction: "outbound",
           billId: "bill-1",
           amount: 85,
-          currency: "USD",
           method: "bank_transfer",
         }),
       );

--- a/apps/web/components/finance/RecordBillPaymentButton.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { recordPayment } from "@/lib/actions/finance";
+import { recordBillPayment } from "@/lib/actions/ap";
 
 const PAYMENT_METHODS = [
   "bank_transfer", "card", "cash", "cheque", "direct_debit", "stripe",
@@ -46,12 +46,12 @@ export function RecordBillPaymentButton({ billId, amountDue, currency }: Props) 
     setLoading(true);
     setError(null);
     try {
-      await recordPayment({
-        direction: "outbound",
+      // Routes through the server-side guard (status + outstanding-balance checks);
+      // currency is derived from the bill server-side, so it is not sent from here.
+      await recordBillPayment({
+        billId,
         method: method as (typeof PAYMENT_METHODS)[number],
         amount: value,
-        currency,
-        billId,
         receivedAt,
       });
       setOpen(false);

--- a/apps/web/lib/actions/ap.test.ts
+++ b/apps/web/lib/actions/ap.test.ts
@@ -70,6 +70,7 @@ import {
   convertPOToBill,
   createPaymentRun,
   listPaymentRuns,
+  recordBillPayment,
 } from "./ap";
 
 const mockAuth = auth as ReturnType<typeof vi.fn>;
@@ -486,5 +487,112 @@ describe("listPaymentRuns", () => {
     expect(result).toEqual(fakePayments);
     const callArgs = mockPrisma.payment.findMany.mock.calls[0][0];
     expect(callArgs.where.direction).toBe("outbound");
+  });
+});
+
+// ─── recordBillPayment (server-side guard) ────────────────────────────────────
+
+describe("recordBillPayment", () => {
+  it("throws Unauthorized when no session", async () => {
+    mockAuth.mockResolvedValue(null);
+    mockCan.mockReturnValue(false);
+    await expect(
+      recordBillPayment({ billId: "bill-1", amount: 50, method: "bank_transfer" }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws when the bill does not exist", async () => {
+    authorizedUser();
+    mockPrisma.bill.findUnique.mockResolvedValue(null);
+    await expect(
+      recordBillPayment({ billId: "missing", amount: 50, method: "bank_transfer" }),
+    ).rejects.toThrow("Bill not found");
+  });
+
+  it("refuses to pay a bill that is not approved or partially paid", async () => {
+    authorizedUser();
+    mockPrisma.bill.findUnique.mockResolvedValue({
+      id: "bill-1",
+      status: "draft",
+      currency: "USD",
+      amountDue: 100,
+    });
+    await expect(
+      recordBillPayment({ billId: "bill-1", amount: 100, method: "bank_transfer" }),
+    ).rejects.toThrow(/Cannot record a payment on a bill in "draft" status/);
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an amount greater than the outstanding balance", async () => {
+    authorizedUser();
+    mockPrisma.bill.findUnique.mockResolvedValue({
+      id: "bill-1",
+      status: "approved",
+      currency: "USD",
+      amountDue: 85,
+    });
+    await expect(
+      recordBillPayment({ billId: "bill-1", amount: 120, method: "bank_transfer" }),
+    ).rejects.toThrow(/exceeds the outstanding balance/);
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it("records an outbound payment that drives an approved bill to paid", async () => {
+    authorizedUser();
+    // Guard read + recordPayment's totals read share this mock.
+    mockPrisma.bill.findUnique.mockResolvedValue({
+      id: "bill-1",
+      status: "approved",
+      currency: "USD",
+      amountDue: 85,
+      totalAmount: 85,
+      amountPaid: 0,
+    });
+    mockPrisma.payment.count.mockResolvedValue(0);
+    mockPrisma.payment.create.mockResolvedValue({ id: "pay-1", paymentRef: "PAY-2026-0001" });
+    mockPrisma.paymentAllocation.create.mockResolvedValue({ id: "alloc-1" });
+    mockPrisma.bill.update.mockResolvedValue({ id: "bill-1", status: "paid" });
+
+    await recordBillPayment({ billId: "bill-1", amount: 85, method: "bank_transfer", receivedAt: "2026-06-19" });
+
+    expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ paymentId: "pay-1", billId: "bill-1", amount: 85 }),
+      }),
+    );
+    expect(mockPrisma.bill.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "bill-1" },
+        data: expect.objectContaining({ status: "paid", amountPaid: 85, amountDue: 0 }),
+      }),
+    );
+    // Outbound direction + bill currency are derived server-side, not supplied by the caller.
+    const paymentCreateArgs = mockPrisma.payment.create.mock.calls[0][0];
+    expect(paymentCreateArgs.data.direction).toBe("outbound");
+    expect(paymentCreateArgs.data.currency).toBe("USD");
+  });
+
+  it("leaves a bill partially_paid when the payment is less than the balance", async () => {
+    authorizedUser();
+    mockPrisma.bill.findUnique.mockResolvedValue({
+      id: "bill-2",
+      status: "approved",
+      currency: "USD",
+      amountDue: 200,
+      totalAmount: 200,
+      amountPaid: 0,
+    });
+    mockPrisma.payment.count.mockResolvedValue(3);
+    mockPrisma.payment.create.mockResolvedValue({ id: "pay-2", paymentRef: "PAY-2026-0004" });
+    mockPrisma.paymentAllocation.create.mockResolvedValue({ id: "alloc-2" });
+    mockPrisma.bill.update.mockResolvedValue({ id: "bill-2", status: "partially_paid" });
+
+    await recordBillPayment({ billId: "bill-2", amount: 75, method: "card" });
+
+    expect(mockPrisma.bill.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "partially_paid", amountPaid: 75, amountDue: 125 }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/actions/ap.ts
+++ b/apps/web/lib/actions/ap.ts
@@ -8,6 +8,8 @@ import { revalidatePath } from "next/cache";
 import { sendEmail, composeApprovalEmail } from "@/lib/email";
 import { getOrgIdentity } from "@/lib/org-identity";
 import { resolveAppBaseUrl } from "@/lib/app-url";
+import { recordPayment } from "@/lib/actions/finance";
+import { PAYMENT_METHODS } from "@/lib/finance/finance-validation";
 import type { CreateSupplierInput, CreateBillInput, CreatePOInput, CreatePaymentRunInput } from "@/lib/ap-validation";
 
 // ─── Auth guard ───────────────────────────────────────────────────────────────
@@ -194,6 +196,58 @@ export async function getBill(id: string) {
       },
     },
   });
+}
+
+// ─── recordBillPayment ──────────────────────────────────────────────────────────
+// Server-side guard in front of recordPayment for the supplier-bill (AP) path. The
+// bill detail UI routes through here rather than calling recordPayment directly so
+// the status + outstanding-balance invariants are enforced on the server, not just
+// in the client form: a payment may only be recorded against an approved or
+// partially-paid bill, and never for more than the amount still due. Currency is
+// derived from the bill so the client cannot record a payment in the wrong currency.
+
+export type RecordBillPaymentInput = {
+  billId: string;
+  amount: number;
+  method: (typeof PAYMENT_METHODS)[number];
+  reference?: string;
+  receivedAt?: string;
+};
+
+export async function recordBillPayment(input: RecordBillPaymentInput) {
+  await requireManageFinance();
+
+  const bill = await prisma.bill.findUnique({
+    where: { id: input.billId },
+    select: { id: true, status: true, currency: true, amountDue: true },
+  });
+  if (!bill) throw new Error("Bill not found");
+  if (bill.status !== "approved" && bill.status !== "partially_paid") {
+    throw new Error(
+      `Cannot record a payment on a bill in "${bill.status.replace(/_/g, " ")}" status`,
+    );
+  }
+
+  const due = Number(bill.amountDue);
+  if (!(input.amount > 0)) throw new Error("Payment amount must be greater than zero");
+  // Tolerance covers floating-point rounding on the outstanding balance.
+  if (input.amount > due + 0.005) {
+    throw new Error(`Payment amount exceeds the outstanding balance of ${due.toFixed(2)}`);
+  }
+
+  await recordPayment({
+    direction: "outbound",
+    method: input.method,
+    amount: input.amount,
+    currency: bill.currency,
+    reference: input.reference,
+    receivedAt: input.receivedAt,
+    billId: bill.id,
+  });
+
+  revalidatePath(`/finance/bills/${bill.id}`);
+  revalidatePath("/finance/bills");
+  revalidatePath("/finance/reports/profit-loss");
 }
 
 // ─── listBills ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Hardens the supplier-bill payment path **on top of #1772**. #1772 added the Record Payment UI for approved bills, but the client component called `recordPayment()` directly with **no server-side checks** — a crafted call could record a payment against a draft/void/already-paid bill, overpay beyond the outstanding balance, or post in a client-supplied currency.

This was originally opened as a parallel implementation of the same feature; #1772 landed first, so this PR was rebased onto it and now contains only the non-duplicative hardening.

## Changes

- **`recordBillPayment()` server action** (`apps/web/lib/actions/ap.ts`): enforces that the bill is `approved`/`partially_paid`, the amount is `> 0` and `<=` the outstanding balance, and derives currency from the bill (not the client). Delegates the `Payment`/allocation/status work to `recordPayment()`. Revalidates the bill detail, bill list, and P&L paths.
- **`RecordBillPaymentButton`** now routes through `recordBillPayment()` instead of calling `recordPayment()` directly, so the guards protect the real flow. The form (amount / method / payment date) is otherwise unchanged from #1772.
- **Bill totals footer** shows Paid/Due rows once a payment exists.
- **Tests**: 6 `recordBillPayment` guard cases (auth, not-found, wrong-status, over-amount, approved→paid, approved→partially_paid); the component test now asserts it calls the guarded action.

## Verification

- `pnpm --filter web` typecheck: **0 errors**.
- vitest `lib/actions/ap.test.ts` + `finance.test.ts` + `RecordBillPaymentButton.test.tsx`: **49/49 pass**.
- Run via the root-clone toolchain against this source-only worktree (MCP local-CI sandbox lease unavailable this session). Live-portal UX verification deferred to the self-upgrade pipeline / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
