### PR TITLE
fix(storefront): booking calendar timezone matches the Operating Hours page

### DIFF
--- a/apps/web/lib/actions/operating-hours.ts
+++ b/apps/web/lib/actions/operating-hours.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
-import { GENERIC_DEFAULTS } from "@/lib/operating-hours-types";
+import { GENERIC_DEFAULTS, resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
 import type { DaySchedule, WeeklySchedule } from "@/lib/operating-hours-types";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
@@ -175,10 +175,12 @@ export async function getOperatingHours(opts?: {
     select: { businessHours: true, timezone: true, hoursConfirmedAt: true },
   });
 
-  // Resolve timezone: confirmed profile > suggested from URL import > UTC fallback
-  const resolvedTimezone = profile?.timezone && profile.timezone !== "UTC"
-    ? profile.timezone
-    : opts?.suggestedTimezone ?? profile?.timezone ?? "UTC";
+  // Resolve timezone: confirmed profile > suggested from URL import > UTC fallback.
+  // Shared with the public booking calendar so the two never diverge.
+  const resolvedTimezone = resolveOperatingHoursTimezone(
+    profile?.timezone,
+    opts?.suggestedTimezone,
+  );
 
   // Priority 1: Existing confirmed hours
   if (profile?.hoursConfirmedAt) {

--- a/apps/web/lib/operating-hours-timezone.test.ts
+++ b/apps/web/lib/operating-hours-timezone.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { resolveOperatingHoursTimezone } from "./operating-hours-types";
+
+describe("resolveOperatingHoursTimezone", () => {
+  it("returns a confirmed profile timezone verbatim", () => {
+    expect(resolveOperatingHoursTimezone("America/New_York")).toBe("America/New_York");
+  });
+
+  it("falls back to UTC when no profile timezone is set", () => {
+    // Mirrors what the Operating Hours settings page shows on a fresh install —
+    // the booking calendar must agree, never the stale Europe/London default.
+    expect(resolveOperatingHoursTimezone(null)).toBe("UTC");
+    expect(resolveOperatingHoursTimezone(undefined)).toBe("UTC");
+    expect(resolveOperatingHoursTimezone("   ")).toBe("UTC");
+  });
+
+  it("keeps the UTC placeholder when no suggestion is offered", () => {
+    expect(resolveOperatingHoursTimezone("UTC")).toBe("UTC");
+  });
+
+  it("prefers an import-suggested timezone only while the profile is the UTC placeholder", () => {
+    expect(resolveOperatingHoursTimezone("UTC", "Europe/Paris")).toBe("Europe/Paris");
+    // A real confirmed timezone always wins over the suggestion.
+    expect(resolveOperatingHoursTimezone("Asia/Tokyo", "Europe/Paris")).toBe("Asia/Tokyo");
+  });
+
+  it("trims surrounding whitespace on a real timezone", () => {
+    expect(resolveOperatingHoursTimezone("  America/Chicago  ")).toBe("America/Chicago");
+  });
+});

--- a/apps/web/lib/operating-hours-types.ts
+++ b/apps/web/lib/operating-hours-types.ts
@@ -26,3 +26,28 @@ export const GENERIC_DEFAULTS: WeeklySchedule = {
   saturday:  { enabled: false, open: "09:00", close: "17:00" },
   sunday:    { enabled: false, open: "09:00", close: "17:00" },
 };
+
+// Fallback used everywhere the org has not pinned an Operating Hours timezone.
+export const DEFAULT_OPERATING_HOURS_TIMEZONE = "UTC";
+
+/**
+ * Single source of truth for the org's display timezone, derived from the
+ * Operating Hours setting (BusinessProfile.timezone). Both the Operating Hours
+ * settings page and the public booking calendar resolve through this so the two
+ * can never diverge (AUDIT-R2-NS-B-005). The stale StorefrontConfig.timezone
+ * 'Europe/London' schema default is never consulted — an unset profile timezone
+ * resolves to UTC, exactly what the settings page shows on a fresh install.
+ *
+ * `suggestedTimezone` (e.g. inferred during URL import setup) is honoured only
+ * while the profile still holds the UTC placeholder, mirroring getOperatingHours.
+ */
+export function resolveOperatingHoursTimezone(
+  profileTimezone: string | null | undefined,
+  suggestedTimezone?: string | null,
+): string {
+  const profileTz = profileTimezone?.trim();
+  if (profileTz && profileTz !== DEFAULT_OPERATING_HOURS_TIMEZONE) return profileTz;
+  return (
+    suggestedTimezone?.trim() || profileTz || DEFAULT_OPERATING_HOURS_TIMEZONE
+  );
+}

--- a/apps/web/lib/release/storefront-data.test.ts
+++ b/apps/web/lib/release/storefront-data.test.ts
@@ -130,7 +130,7 @@ describe("getPublicStorefront", () => {
     expect(result?.timezone).toBe("America/New_York");
   });
 
-  it("never falls back to Europe/London when no Operating Hours timezone is set", async () => {
+  it("falls back to UTC (matching the OH settings page) when no Operating Hours timezone is set, never Europe/London", async () => {
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
       ...mockStorefront,
       timezone: "Europe/London",
@@ -138,6 +138,6 @@ describe("getPublicStorefront", () => {
     vi.mocked(prisma.businessProfile.findFirst).mockResolvedValue(null as never);
 
     const result = await getPublicStorefront("acme-vet");
-    expect(result?.timezone).toBe("America/Chicago");
+    expect(result?.timezone).toBe("UTC");
   });
 });

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { FormField } from "@dpf/storefront-templates";
+import { resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
 import type {
   PublicStorefrontConfig,
   PublicItem,
@@ -124,14 +125,14 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
   // setting (BusinessProfile.timezone). StorefrontConfig.timezone carries a stale
   // Europe/London default that is never re-synced when the operator sets hours,
   // which is why US salons saw "Times shown in Europe/London" (AUDIT-R2-NS-B-005).
+  // Resolve through the same helper the Operating Hours settings page uses so the
+  // calendar label always matches what the operator sees there (UTC on a fresh
+  // install), never the stale config default.
   const businessProfile = await prisma.businessProfile.findFirst({
     where: { isActive: true },
     select: { timezone: true },
   });
-  const resolvedTimezone =
-    businessProfile?.timezone?.trim() ||
-    (config.timezone && config.timezone !== "Europe/London" ? config.timezone : null) ||
-    "America/Chicago";
+  const resolvedTimezone = resolveOperatingHoursTimezone(businessProfile?.timezone);
 
   // Confirmed regulatory display obligations for the "disclosures" section
   // (BI-5D9DCDE6 spec §9.3). D5 honesty rule: only obligations whose parent


### PR DESCRIPTION
@
## Summary

The public booking calendar (`/s/<slug>/book/<item>`) and the Operating Hours settings page (`/storefront/settings/operations`) resolved the org display timezone two different ways. When no Operating Hours timezone is set (fresh install), the OH page falls back to **UTC** but the calendar fell back to **America/Chicago** — so the two surfaces disagreed for the same org. (Re-validation in #1778 observed the calendar showing `America/Chicago` while the OH page shows `UTC`.)

This routes both surfaces through a single `resolveOperatingHoursTimezone()` helper that derives the timezone from `BusinessProfile.timezone` and falls back to **UTC**, never to the stale `StorefrontConfig.timezone` `Europe/London` schema default. The calendar label now always matches what the operator sees on the Operating Hours page.

## Changes

- `lib/operating-hours-types.ts` — new pure `resolveOperatingHoursTimezone()` (single source of truth) + `DEFAULT_OPERATING_HOURS_TIMEZONE`.
- `lib/release/storefront-data.ts` — calendar timezone resolves through the helper; drops the divergent `America/Chicago` / `config.timezone` fallback.
- `lib/actions/operating-hours.ts` — OH settings page uses the same helper (honours import-suggested tz only while the profile holds the UTC placeholder).
- Tests: pure-resolver unit tests + updated storefront-data expectation (UTC, not America/Chicago).

## Test plan

- [x] `pnpm --filter web test` — full suite green (10433 passed)
- [x] `tsc --noEmit` clean
- [x] New resolver unit tests cover unset/UTC/suggested/confirmed cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@