### PR TITLE
fix(finance): add reference-note field to the bill payment form

### DIFF
--- a/apps/web/components/finance/RecordBillPaymentButton.test.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.test.tsx
@@ -43,4 +43,40 @@ describe("RecordBillPaymentButton", () => {
     });
     expect(refresh).toHaveBeenCalled();
   });
+
+  it("passes the operator-entered reference note through to the action", async () => {
+    render(<RecordBillPaymentButton billId="bill-2" amountDue={50} currency="USD" />);
+
+    fireEvent.click(screen.getByText("Record Payment"));
+
+    const reference = screen.getByPlaceholderText(
+      "e.g. cheque no. or transfer ID",
+    ) as HTMLInputElement;
+    fireEvent.change(reference, { target: { value: "CHQ-00123" } });
+
+    fireEvent.click(screen.getByText("Confirm payment"));
+
+    await waitFor(() => {
+      expect(recordBillPayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          billId: "bill-2",
+          amount: 50,
+          reference: "CHQ-00123",
+        }),
+      );
+    });
+  });
+
+  it("omits the reference when left blank", async () => {
+    render(<RecordBillPaymentButton billId="bill-3" amountDue={50} currency="USD" />);
+
+    fireEvent.click(screen.getByText("Record Payment"));
+    fireEvent.click(screen.getByText("Confirm payment"));
+
+    await waitFor(() => {
+      expect(recordBillPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ billId: "bill-3", reference: undefined }),
+      );
+    });
+  });
 });

--- a/apps/web/components/finance/RecordBillPaymentButton.tsx
+++ b/apps/web/components/finance/RecordBillPaymentButton.tsx
@@ -35,6 +35,7 @@ export function RecordBillPaymentButton({ billId, amountDue, currency }: Props) 
   const [amount, setAmount] = useState(amountDue > 0 ? String(amountDue) : "");
   const [method, setMethod] = useState<string>("bank_transfer");
   const [receivedAt, setReceivedAt] = useState(getToday());
+  const [reference, setReference] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -53,6 +54,7 @@ export function RecordBillPaymentButton({ billId, amountDue, currency }: Props) 
         method: method as (typeof PAYMENT_METHODS)[number],
         amount: value,
         receivedAt,
+        reference: reference.trim() || undefined,
       });
       setOpen(false);
       router.refresh();
@@ -117,6 +119,16 @@ export function RecordBillPaymentButton({ billId, amountDue, currency }: Props) 
           value={receivedAt}
           onChange={(e) => setReceivedAt(e.target.value)}
           required
+          className={inputClasses + " w-full"}
+        />
+      </div>
+      <div>
+        <label className={labelClasses}>Reference (optional)</label>
+        <input
+          type="text"
+          value={reference}
+          onChange={(e) => setReference(e.target.value)}
+          placeholder="e.g. cheque no. or transfer ID"
           className={inputClasses + " w-full"}
         />
       </div>


### PR DESCRIPTION
@
## Summary

The Record Payment form on an approved / partially-paid bill (`/finance/bills/<id>`) collected amount, method, and payment date but had **no field for a payment reference**, even though `recordBillPayment` already accepts and persists `reference` (`Payment.reference`). Operators had no way to record a cheque number / transfer ID against the payment.

The task spec for this surface lists a reference note as a required input. This adds the missing field.

## Changes

- `components/finance/RecordBillPaymentButton.tsx` — add an optional **Reference** field; pass it through (trimmed; omitted when blank).
- Tests — assert the reference is forwarded when entered and `undefined` when blank.

No server change: `recordBillPayment` → `recordPayment` and the `Payment` model already supported `reference`. The full payment flow (status → `partially_paid`/`paid`, and `paid` bills flowing into the P&L expense aggregation) is unchanged and already covered.

## Context

The bill-payment surface itself works on a fresh install (re-validated 6/6 in #1778); this PR closes the one remaining spec gap — the missing reference input.

## Test plan

- [x] `pnpm --filter web test` — full suite green (10433 passed)
- [x] `tsc --noEmit` clean
- [x] Component tests cover reference present / absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@