### PR TITLE
feat(workbooks): computed columns — lookups + Excel-style formulas (EP-GRID-WORKBOOKS Phase 2)

### DIFF
--- a/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
@@ -100,7 +100,11 @@ export default async function WorkbookDetailPage({ params, searchParams }: Props
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-3">
           {canManage && activeTableId && (
-            <AddColumnButton workbookId={workbookId} tableId={activeTableId} />
+            <AddColumnButton
+              workbookId={workbookId}
+              tableId={activeTableId}
+              columns={grid.schema.columns}
+            />
           )}
           <div className="min-h-0 flex-1">
             <WorkbookGrid

--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -2,9 +2,13 @@
 
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { addColumnAction, listReferenceTargetsAction } from "@/lib/actions/workbooks";
-import type { ReferenceTarget } from "@/lib/workbooks/platform-tables";
-import type { FieldType, SelectOption, FieldConfig } from "@/lib/workbooks/types";
+import {
+  addColumnAction,
+  listReferenceTargetsAction,
+  getReferenceTargetFieldsAction,
+} from "@/lib/actions/workbooks";
+import type { ReferenceTarget, ReferenceFieldOption } from "@/lib/workbooks/platform-tables";
+import type { FieldType, SelectOption, FieldConfig, ColumnDefinition } from "@/lib/workbooks/types";
 
 // Field types with a fully-functional in-grid editor.
 // multi_select exists in the data model but is not offered here yet (rendered
@@ -17,9 +21,23 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "checkbox", label: "Checkbox" },
   { value: "select", label: "Single select" },
   { value: "reference", label: "Reference" },
+  { value: "lookup", label: "Lookup (from a reference)" },
+  { value: "formula", label: "Formula" },
   { value: "url", label: "URL" },
   { value: "email", label: "Email" },
 ];
+
+const RESULT_TYPES: { value: FieldType; label: string }[] = [
+  { value: "text", label: "Text" },
+  { value: "number", label: "Number" },
+  { value: "checkbox", label: "Checkbox" },
+];
+
+const inputClass =
+  "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)]";
+const selectClass =
+  "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]";
+const optionClass = "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]";
 
 function slugify(label: string): string {
   return label.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
@@ -36,9 +54,11 @@ function parseOptions(raw: string): SelectOption[] {
 export function AddColumnButton({
   workbookId,
   tableId,
+  columns = [],
 }: {
   workbookId: string;
   tableId: string;
+  columns?: ColumnDefinition[];
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -47,9 +67,18 @@ export function AddColumnButton({
   const [optionsRaw, setOptionsRaw] = useState("");
   const [referenceType, setReferenceType] = useState("");
   const [referenceTargets, setReferenceTargets] = useState<ReferenceTarget[]>([]);
+  const [formula, setFormula] = useState("");
+  const [resultType, setResultType] = useState<FieldType>("text");
+  const [lookupRefColumnId, setLookupRefColumnId] = useState("");
+  const [lookupTargetField, setLookupTargetField] = useState("");
+  const [targetFields, setTargetFields] = useState<ReferenceFieldOption[]>([]);
   const [required, setRequired] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+
+  // Reference columns on this table are the only valid lookup sources.
+  const referenceColumns = columns.filter((c) => c.fieldType === "reference");
+  const selectedRefColumn = referenceColumns.find((c) => c.columnId === lookupRefColumnId);
 
   // Load the available reference targets once the picker is opened.
   useEffect(() => {
@@ -63,12 +92,33 @@ export function AddColumnButton({
     };
   }, [open, referenceTargets.length]);
 
+  // When a lookup's source reference column changes, load that entity's fields.
+  useEffect(() => {
+    const refType = selectedRefColumn?.config?.referenceType;
+    if (fieldType !== "lookup" || !refType) {
+      setTargetFields([]);
+      return;
+    }
+    let active = true;
+    void getReferenceTargetFieldsAction(refType).then((res) => {
+      if (active && res.ok) setTargetFields(res.data);
+    });
+    return () => {
+      active = false;
+    };
+  }, [fieldType, selectedRefColumn?.config?.referenceType]);
+
   function reset() {
     setOpen(false);
     setName("");
     setFieldType("text");
     setOptionsRaw("");
     setReferenceType("");
+    setFormula("");
+    setResultType("text");
+    setLookupRefColumnId("");
+    setLookupTargetField("");
+    setTargetFields([]);
     setRequired(false);
     setError(null);
   }
@@ -76,10 +126,17 @@ export function AddColumnButton({
   function buildConfig(): FieldConfig | undefined {
     if (fieldType === "select") return { options: parseOptions(optionsRaw) };
     if (fieldType === "reference") return { referenceType };
+    if (fieldType === "formula") return { formula, resultType };
+    if (fieldType === "lookup") {
+      return { lookup: { referenceColumnId: lookupRefColumnId, targetField: lookupTargetField } };
+    }
     return undefined;
   }
 
   const missingReferenceTarget = fieldType === "reference" && !referenceType;
+  const missingFormula = fieldType === "formula" && !formula.trim();
+  const missingLookup = fieldType === "lookup" && (!lookupRefColumnId || !lookupTargetField);
+  const invalidConfig = missingReferenceTarget || missingFormula || missingLookup;
 
   function submit() {
     setError(null);
@@ -143,21 +200,81 @@ export function AddColumnButton({
         <select
           value={referenceType}
           onChange={(e) => setReferenceType(e.target.value)}
-          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+          className={selectClass}
         >
-          <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+          <option value="" className={optionClass}>
             {referenceTargets.length === 0 ? "No reference targets available" : "Select what to reference…"}
           </option>
           {referenceTargets.map((t) => (
-            <option
-              key={t.entityType}
-              value={t.entityType}
-              className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
-            >
+            <option key={t.entityType} value={t.entityType} className={optionClass}>
               {t.label}
             </option>
           ))}
         </select>
+      )}
+      {fieldType === "formula" && (
+        <>
+          <input
+            value={formula}
+            onChange={(e) => setFormula(e.target.value)}
+            placeholder='Formula, e.g. =IF(Priority>3,"high","low")'
+            className={`${inputClass} min-w-[20rem]`}
+          />
+          <select
+            value={resultType}
+            onChange={(e) => setResultType(e.target.value as FieldType)}
+            className={selectClass}
+            aria-label="Result type"
+          >
+            {RESULT_TYPES.map((t) => (
+              <option key={t.value} value={t.value} className={optionClass}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+      {fieldType === "lookup" && (
+        <>
+          <select
+            value={lookupRefColumnId}
+            onChange={(e) => {
+              setLookupRefColumnId(e.target.value);
+              setLookupTargetField("");
+            }}
+            className={selectClass}
+            aria-label="Reference column"
+          >
+            <option value="" className={optionClass}>
+              {referenceColumns.length === 0 ? "Add a reference column first" : "From reference column…"}
+            </option>
+            {referenceColumns.map((c) => (
+              <option key={c.columnId} value={c.columnId} className={optionClass}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={lookupTargetField}
+            onChange={(e) => setLookupTargetField(e.target.value)}
+            className={selectClass}
+            aria-label="Target field"
+            disabled={!lookupRefColumnId}
+          >
+            <option value="" className={optionClass}>
+              {!lookupRefColumnId
+                ? "Pick a reference column first"
+                : targetFields.length === 0
+                  ? "No fields available"
+                  : "Field to pull…"}
+            </option>
+            {targetFields.map((f) => (
+              <option key={f.field} value={f.field} className={optionClass}>
+                {f.name}
+              </option>
+            ))}
+          </select>
+        </>
       )}
       <label className="flex items-center gap-1 text-sm text-[var(--dpf-muted)]">
         <input type="checkbox" checked={required} onChange={(e) => setRequired(e.target.checked)} />
@@ -166,7 +283,7 @@ export function AddColumnButton({
       <button
         type="button"
         onClick={submit}
-        disabled={pending || !name.trim() || missingReferenceTarget}
+        disabled={pending || !name.trim() || invalidConfig}
         className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm text-white disabled:opacity-50"
       >
         Add

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -35,6 +35,7 @@ import {
   renderEmailCell,
   renderDateCell,
   renderReferenceCell,
+  renderComputedCell,
   makeReferenceEditor,
 } from "./cell-editors";
 import {
@@ -127,6 +128,10 @@ function buildColumn(
           editable && referenceType ? makeReferenceEditor(referenceType) : undefined,
       };
     }
+    case "formula":
+    case "lookup":
+      // Phase 2: computed read-only columns (derived server-side).
+      return { ...base, renderCell: renderComputedCell };
     default:
       return base;
   }

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -237,3 +237,18 @@ export function renderReferenceCell({ row, column }: RenderCellProps<GridRowData
   }
   return null;
 }
+
+/** Read-only renderer for computed (formula/lookup) cells. */
+export function renderComputedCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {
+  const v = row[column.key];
+  if (v === null || v === undefined) return null;
+  if (Array.isArray(v)) return <span>{v.join(", ")}</span>;
+  if (typeof v === "object" && "referenceId" in v) {
+    const ref = v as ReferenceValue;
+    return <span className="dpf-grid-chip">{ref.label ?? ref.referenceId}</span>;
+  }
+  if (typeof v === "boolean") return <span>{v ? "TRUE" : "FALSE"}</span>;
+  const text = String(v);
+  const isError = text.startsWith("#ERROR");
+  return <span className={isError ? "dpf-grid-formula-error" : undefined}>{text}</span>;
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -53,6 +53,11 @@
   text-decoration: underline;
 }
 
+.dpf-grid-formula-error {
+  color: var(--dpf-error);
+  font-size: 0.8125rem;
+}
+
 .dpf-grid-editor {
   inline-size: 100%;
   block-size: 100%;

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -30,9 +30,11 @@ import {
 import {
   type PlatformUser,
   type ReferenceTarget,
+  type ReferenceFieldOption,
   listReferenceTargets,
   searchPlatformReferences,
   resolvePlatformReference,
+  getReferenceTargetFields,
 } from "@/lib/workbooks/platform-tables";
 import type { CellValue, ColumnDefinition, FieldType, FieldConfig } from "@/lib/workbooks/types";
 
@@ -245,6 +247,17 @@ export async function resolveReferenceAction(
   try {
     const user = await requirePlatformUser();
     return { ok: true, data: await resolvePlatformReference(user, referenceType, referenceId) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function getReferenceTargetFieldsAction(
+  referenceType: string,
+): Promise<ActionResult<ReferenceFieldOption[]>> {
+  try {
+    const user = await requirePlatformUser();
+    return { ok: true, data: await getReferenceTargetFields(user, referenceType) };
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/workbooks/cell-validation.ts
+++ b/apps/web/lib/workbooks/cell-validation.ts
@@ -200,6 +200,12 @@ export function validateCell(
       return { ok: true, storage };
     }
 
+    case "formula":
+    case "lookup": {
+      // Computed columns are derived on read and never user-written.
+      return { ok: false, error: `${column.name} is a computed column and cannot be set` };
+    }
+
     default: {
       // Exhaustiveness guard — a new FieldType must extend this switch.
       const _never: never = column.fieldType;
@@ -237,6 +243,10 @@ export function storageToCellValue(
             referenceType: cell.referenceType ?? "",
           }
         : null;
+    case "formula":
+    case "lookup":
+      // Computed on read — no stored value.
+      return null;
     default:
       return null;
   }

--- a/apps/web/lib/workbooks/custom-table-adapter.ts
+++ b/apps/web/lib/workbooks/custom-table-adapter.ts
@@ -24,6 +24,7 @@ import {
   type Pagination,
   type PagedRows,
   type GridCapabilities,
+  isComputedFieldType,
 } from "./types";
 import {
   validateCell,
@@ -32,6 +33,7 @@ import {
 } from "./cell-validation";
 import { applyFilters, applySort, paginate } from "./grid-query";
 import { resolveReferenceLabels, referenceKey } from "./reference-resolver";
+import { computeDerivedCells } from "./formula/compute";
 import { genSemanticId } from "./ids";
 
 function asReference(value: CellValue): ReferenceValue | null {
@@ -97,7 +99,7 @@ function toColumnDefinition(meta: ColumnMeta, position: number, width: number | 
     required: meta.required,
     width: width ?? undefined,
     config: meta.config,
-    editable: true,
+    editable: !isComputedFieldType(meta.fieldType),
     groupable: meta.fieldType === "select",
   };
 }
@@ -160,6 +162,7 @@ class CustomTableAdapter implements DataSourceAdapter {
       return { rowId: row.rowId, cells };
     });
     await hydrateReferenceLabels(gridRows);
+    await computeDerivedCells(metas, gridRows);
     return gridRows;
   }
 
@@ -186,8 +189,10 @@ class CustomTableAdapter implements DataSourceAdapter {
     const metas = await loadColumnMeta(internalTableId);
 
     // Validate every column (required checks included, even if absent from input).
+    // Computed columns (formula/lookup) are derived on read — never stored.
     const writes: { internalColumnId: string; storage: CellStorage }[] = [];
     for (const meta of metas) {
+      if (isComputedFieldType(meta.fieldType)) continue;
       const value = meta.columnId in input ? input[meta.columnId] : null;
       const result = validateCell(meta, value);
       if (!result.ok) throw new Error(result.error);
@@ -236,6 +241,9 @@ class CustomTableAdapter implements DataSourceAdapter {
       for (const [semanticColId, value] of Object.entries(changes)) {
         const meta = bySemantic.get(semanticColId);
         if (!meta) throw new Error(`Unknown column: ${semanticColId}`);
+        if (isComputedFieldType(meta.fieldType)) {
+          throw new Error(`${meta.name} is a computed column and cannot be edited`);
+        }
         const result = validateCell(meta, value);
         if (!result.ok) throw new Error(result.error);
         await tx.workbookCell.upsert({

--- a/apps/web/lib/workbooks/formula/compute.test.ts
+++ b/apps/web/lib/workbooks/formula/compute.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { gridRegistry, type DataSourceAdapter } from "../adapter";
+import { computeDerivedCells, type DerivableColumn } from "./compute";
+import type { GridRow } from "../types";
+
+describe("computeDerivedCells — formulas", () => {
+  it("computes a formula over base columns and coerces the result type", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_price", name: "Price", fieldType: "number" },
+      { columnId: "c_qty", name: "Qty", fieldType: "number" },
+      {
+        columnId: "c_total",
+        name: "Total",
+        fieldType: "formula",
+        config: { formula: "=Price * Qty", resultType: "number" },
+      },
+    ];
+    const rows: GridRow[] = [{ rowId: "r1", cells: { c_price: 4, c_qty: 3, c_total: null } }];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_total).toBe(12);
+  });
+
+  it("lets a later formula reference an earlier formula (position order)", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_a", name: "A", fieldType: "number" },
+      { columnId: "c_d", name: "Double", fieldType: "formula", config: { formula: "=A*2", resultType: "number" } },
+      { columnId: "c_q", name: "Quad", fieldType: "formula", config: { formula: "=Double*2", resultType: "number" } },
+    ];
+    const rows: GridRow[] = [{ rowId: "r1", cells: { c_a: 5, c_d: null, c_q: null } }];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_d).toBe(10);
+    expect(rows[0].cells.c_q).toBe(20);
+  });
+
+  it("writes a #ERROR sentinel for a broken formula instead of throwing", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_a", name: "A", fieldType: "number" },
+      { columnId: "c_x", name: "X", fieldType: "formula", config: { formula: "=A/0" } },
+    ];
+    const rows: GridRow[] = [{ rowId: "r1", cells: { c_a: 1, c_x: null } }];
+    await computeDerivedCells(columns, rows);
+    expect(String(rows[0].cells.c_x)).toMatch(/^#ERROR/);
+  });
+
+  it("is a no-op when there are no computed columns", async () => {
+    const columns: DerivableColumn[] = [{ columnId: "c_a", name: "A", fieldType: "number" }];
+    const rows: GridRow[] = [{ rowId: "r1", cells: { c_a: 1 } }];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_a).toBe(1);
+  });
+});
+
+describe("computeDerivedCells — lookups", () => {
+  it("pulls a field from the referenced record via the registry", async () => {
+    const adapter = {
+      entityType: "fake_lookup_epic",
+      getColumns: async () => [],
+      queryRows: async () => ({ data: [], nextCursor: null }),
+      getRow: async (_t: string, id: string) =>
+        id === "EP-1" ? { rowId: "EP-1", cells: { status: "open", title: "Alpha" } } : null,
+      getCapabilities: () => ({ canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false }),
+    } as unknown as DataSourceAdapter;
+    gridRegistry.register(adapter);
+
+    const columns: DerivableColumn[] = [
+      { columnId: "c_epic", name: "Epic", fieldType: "reference", config: { referenceType: "fake_lookup_epic" } },
+      {
+        columnId: "c_epicstatus",
+        name: "Epic Status",
+        fieldType: "lookup",
+        config: { lookup: { referenceColumnId: "c_epic", targetField: "status" } },
+      },
+    ];
+    const rows: GridRow[] = [
+      {
+        rowId: "r1",
+        cells: {
+          c_epic: { referenceId: "EP-1", referenceType: "fake_lookup_epic", label: "Alpha" },
+          c_epicstatus: null,
+        },
+      },
+      { rowId: "r2", cells: { c_epic: null, c_epicstatus: null } },
+    ];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_epicstatus).toBe("open");
+    expect(rows[1].cells.c_epicstatus).toBeNull();
+  });
+
+  it("makes a lookup value available to a downstream formula", async () => {
+    const adapter = {
+      entityType: "fake_lookup_prod",
+      getColumns: async () => [],
+      queryRows: async () => ({ data: [], nextCursor: null }),
+      getRow: async (_t: string, id: string) =>
+        id === "P-1" ? { rowId: "P-1", cells: { name: "Widget" } } : null,
+      getCapabilities: () => ({ canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false }),
+    } as unknown as DataSourceAdapter;
+    gridRegistry.register(adapter);
+
+    const columns: DerivableColumn[] = [
+      { columnId: "c_p", name: "Product", fieldType: "reference", config: { referenceType: "fake_lookup_prod" } },
+      {
+        columnId: "c_pn",
+        name: "ProdName",
+        fieldType: "lookup",
+        config: { lookup: { referenceColumnId: "c_p", targetField: "name" } },
+      },
+      { columnId: "c_label", name: "Label", fieldType: "formula", config: { formula: '=UPPER(ProdName)' } },
+    ];
+    const rows: GridRow[] = [
+      {
+        rowId: "r1",
+        cells: {
+          c_p: { referenceId: "P-1", referenceType: "fake_lookup_prod", label: "Widget" },
+          c_pn: null,
+          c_label: null,
+        },
+      },
+    ];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_pn).toBe("Widget");
+    expect(rows[0].cells.c_label).toBe("WIDGET");
+  });
+});

--- a/apps/web/lib/workbooks/formula/compute.ts
+++ b/apps/web/lib/workbooks/formula/compute.ts
@@ -1,0 +1,108 @@
+// Universal Grid & Workbooks — derived-column computation (EP-GRID-WORKBOOKS, Phase 2)
+//
+// Computes `lookup` and `formula` cells for a set of grid rows, server-side, on
+// read. Lookups pull an allow-listed field from a referenced platform record;
+// formulas evaluate an Excel-style expression over the row's other columns (and
+// earlier computed columns, in position order). Computed cells are never stored.
+
+import {
+  type CellValue,
+  type FieldType,
+  type FieldConfig,
+  type GridRow,
+  type ReferenceValue,
+} from "../types";
+import { fetchReferenceRecords, referenceKey } from "../reference-resolver";
+import { evaluateFormula, normalizeName, type FormulaValue } from "./evaluate";
+
+/** The minimal column shape compute needs (ColumnMeta and ColumnDefinition both satisfy it). */
+export interface DerivableColumn {
+  columnId: string;
+  name: string;
+  fieldType: FieldType;
+  config?: FieldConfig | undefined;
+}
+
+function asReference(value: CellValue): ReferenceValue | null {
+  if (value && typeof value === "object" && !Array.isArray(value) && "referenceId" in value) {
+    return value as ReferenceValue;
+  }
+  return null;
+}
+
+/** Flatten a stored cell into a scalar a formula can operate on. */
+function toFormulaValue(value: CellValue): FormulaValue {
+  if (value === null || value === undefined) return null;
+  if (Array.isArray(value)) return value.join(", ");
+  const ref = asReference(value);
+  if (ref) return ref.label ?? ref.referenceId;
+  return value as FormulaValue;
+}
+
+/** Coerce a formula result to the column's declared result type for storage/display. */
+function coerceResult(value: FormulaValue, resultType: FieldType | undefined): CellValue {
+  if (value === null) return null;
+  switch (resultType) {
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "checkbox":
+      return typeof value === "boolean" ? value : Boolean(value);
+    default:
+      return typeof value === "boolean" ? (value ? "TRUE" : "FALSE") : value;
+  }
+}
+
+/**
+ * Fill in `lookup` and `formula` cells on the given rows in place. `columns` must
+ * be in position order. No-op when there are no computed columns.
+ */
+export async function computeDerivedCells(
+  columns: DerivableColumn[],
+  rows: GridRow[],
+): Promise<void> {
+  const lookupCols = columns.filter((c) => c.fieldType === "lookup" && c.config?.lookup);
+  const formulaCols = columns.filter((c) => c.fieldType === "formula");
+  if (lookupCols.length === 0 && formulaCols.length === 0) return;
+
+  // 1) Batch-fetch every referenced record needed by lookup columns.
+  const refsNeeded: { referenceType: string; referenceId: string }[] = [];
+  for (const row of rows) {
+    for (const lc of lookupCols) {
+      const ref = asReference(row.cells[lc.config!.lookup!.referenceColumnId]);
+      if (ref?.referenceId && ref.referenceType) {
+        refsNeeded.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
+      }
+    }
+  }
+  const records = refsNeeded.length > 0 ? await fetchReferenceRecords(refsNeeded) : new Map();
+
+  for (const row of rows) {
+    // 2) Lookups: pull the target field from the referenced record.
+    for (const lc of lookupCols) {
+      const { referenceColumnId, targetField } = lc.config!.lookup!;
+      const ref = asReference(row.cells[referenceColumnId]);
+      let value: CellValue = null;
+      if (ref?.referenceId && ref.referenceType) {
+        const rec = records.get(referenceKey(ref.referenceType, ref.referenceId));
+        if (rec) value = rec.cells[targetField] ?? null;
+      }
+      row.cells[lc.columnId] = value;
+    }
+
+    // 3) Formulas: evaluate in position order, each seeing earlier columns.
+    if (formulaCols.length > 0) {
+      const scope = new Map<string, FormulaValue>();
+      for (const c of columns) {
+        if (c.fieldType === "formula") continue;
+        scope.set(normalizeName(c.name), toFormulaValue(row.cells[c.columnId] ?? null));
+      }
+      for (const fc of formulaCols) {
+        const res = evaluateFormula(fc.config?.formula ?? "", scope);
+        row.cells[fc.columnId] = res.ok
+          ? coerceResult(res.value, fc.config?.resultType)
+          : `#ERROR: ${res.error ?? "formula"}`;
+        scope.set(normalizeName(fc.name), res.ok ? res.value : null);
+      }
+    }
+  }
+}

--- a/apps/web/lib/workbooks/formula/evaluate.test.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { evaluateFormula, normalizeName, normalizeFormulaSource, type FormulaValue } from "./evaluate";
+
+function scope(obj: Record<string, FormulaValue>): Map<string, FormulaValue> {
+  const m = new Map<string, FormulaValue>();
+  for (const [k, v] of Object.entries(obj)) m.set(normalizeName(k), v);
+  return m;
+}
+
+describe("normalizeFormulaSource", () => {
+  it("strips a leading =, maps <> to != and single = to ==, and resolves [Name]", () => {
+    // Bare identifiers keep their case (lookup is case-insensitive); only
+    // bracketed [Names] are normalized to a comparison key.
+    expect(normalizeFormulaSource("=A = B")).toBe("A == B");
+    expect(normalizeFormulaSource("A <> B")).toBe("A != B");
+    expect(normalizeFormulaSource("[Total Amount] >= 10")).toBe("totalamount >= 10");
+    expect(normalizeFormulaSource("a <= b")).toBe("a <= b");
+  });
+});
+
+describe("evaluateFormula — arithmetic & operators", () => {
+  it("evaluates arithmetic over column refs", () => {
+    expect(evaluateFormula("=price * qty", scope({ price: 4, qty: 3 }))).toEqual({ ok: true, value: 12 });
+  });
+  it("supports Excel string concat with &", () => {
+    expect(evaluateFormula('=first & " " & last', scope({ first: "Ada", last: "Lovelace" }))).toEqual({
+      ok: true,
+      value: "Ada Lovelace",
+    });
+  });
+  it("supports Excel equality (=) and inequality (<>)", () => {
+    expect(evaluateFormula("=status = \"open\"", scope({ status: "open" }))).toEqual({ ok: true, value: true });
+    expect(evaluateFormula("=status <> \"open\"", scope({ status: "done" }))).toEqual({ ok: true, value: true });
+  });
+});
+
+describe("evaluateFormula — functions", () => {
+  it("IF / IFS branch on conditions", () => {
+    expect(evaluateFormula('=IF(p>3,"high","low")', scope({ p: 5 }))).toEqual({ ok: true, value: "high" });
+    expect(evaluateFormula('=IFS(p>9,"a",p>3,"b")', scope({ p: 5 }))).toEqual({ ok: true, value: "b" });
+  });
+  it("text functions", () => {
+    expect(evaluateFormula("=UPPER(LEFT(name,3))", scope({ name: "lovelace" }))).toEqual({ ok: true, value: "LOV" });
+    expect(evaluateFormula("=LEN(TRIM(s))", scope({ s: "  hi  " }))).toEqual({ ok: true, value: 2 });
+  });
+  it("math functions", () => {
+    expect(evaluateFormula("=ROUND(a/b,2)", scope({ a: 10, b: 3 }))).toEqual({ ok: true, value: 3.33 });
+    expect(evaluateFormula("=MAX(a,b,c)", scope({ a: 1, b: 9, c: 4 }))).toEqual({ ok: true, value: 9 });
+  });
+  it("DATEDIF in days", () => {
+    expect(
+      evaluateFormula('=DATEDIF(start,end,"D")', scope({ start: "2026-01-01", end: "2026-01-11" })),
+    ).toEqual({ ok: true, value: 10 });
+  });
+});
+
+describe("evaluateFormula — error handling (never throws)", () => {
+  it("reports division by zero", () => {
+    const r = evaluateFormula("=a/b", scope({ a: 1, b: 0 }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/zero/i);
+  });
+  it("reports an unknown field", () => {
+    const r = evaluateFormula("=missing+1", scope({ a: 1 }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/unknown field/i);
+  });
+  it("reports an unknown function", () => {
+    const r = evaluateFormula("=BOGUS(1)", scope({}));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/unknown function/i);
+  });
+  it("rejects property access (no arbitrary code)", () => {
+    const r = evaluateFormula("=a.b", scope({ a: 1 }));
+    expect(r.ok).toBe(false);
+  });
+  it("treats an empty formula as null", () => {
+    expect(evaluateFormula("=", scope({}))).toEqual({ ok: true, value: null });
+  });
+});

--- a/apps/web/lib/workbooks/formula/evaluate.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.ts
@@ -1,0 +1,187 @@
+// Universal Grid & Workbooks — formula evaluator (EP-GRID-WORKBOOKS, Phase 2)
+//
+// Parses an Excel-style expression with jsep (a tiny, dependency-free parser) and
+// walks the resulting AST against a row scope. Only literals, operators, and names
+// in FORMULA_FUNCTIONS are honored — there is no `eval`/`new Function`, no member
+// access, and no way to reach arbitrary globals, so a user formula can never run
+// code. Column references resolve by normalized name (case/space/punctuation
+// insensitive); `[Column Name]` bracket syntax is also accepted.
+
+import jsep from "jsep";
+import {
+  FORMULA_FUNCTIONS,
+  FormulaError,
+  toNumber,
+  toStr,
+  toBool,
+  type FormulaValue,
+} from "./functions";
+
+export { FormulaError } from "./functions";
+export type { FormulaValue } from "./functions";
+
+/** Normalize a column name / identifier to a comparison key. */
+export function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+const CONSTANTS: Record<string, FormulaValue> = {
+  true: true,
+  false: false,
+  null: null,
+  // Excel-style booleans
+  yes: true,
+  no: false,
+};
+
+/** Excel → jsep-friendly normalization: drop leading `=`, `<>`→`!=`, `=`→`==`, `[Name]`→name. */
+export function normalizeFormulaSource(src: string): string {
+  let s = src.trim();
+  if (s.startsWith("=")) s = s.slice(1);
+  s = s.replace(/\[([^\]]+)\]/g, (_m, inner: string) => normalizeName(inner));
+  s = s.replace(/<>/g, "!=");
+  // single `=` (not part of <=, >=, ==, !=) → `==`
+  s = s.replace(/(?<![<>=!])=(?!=)/g, "==");
+  return s;
+}
+
+type Node = {
+  type: string;
+  value?: unknown;
+  name?: string;
+  operator?: string;
+  left?: Node;
+  right?: Node;
+  argument?: Node;
+  prefix?: boolean;
+  test?: Node;
+  consequent?: Node;
+  alternate?: Node;
+  callee?: Node;
+  arguments?: Node[];
+  elements?: Node[];
+};
+
+function applyBinary(op: string, l: FormulaValue, r: FormulaValue): FormulaValue {
+  switch (op) {
+    case "+":
+      return toNumber(l) + toNumber(r);
+    case "-":
+      return toNumber(l) - toNumber(r);
+    case "*":
+      return toNumber(l) * toNumber(r);
+    case "/": {
+      const d = toNumber(r);
+      if (d === 0) throw new FormulaError("Division by zero");
+      return toNumber(l) / d;
+    }
+    case "%":
+      return toNumber(l) % toNumber(r);
+    case "&": // Excel string concatenation
+      return toStr(l) + toStr(r);
+    case "==":
+      return toStr(l) === toStr(r);
+    case "!=":
+      return toStr(l) !== toStr(r);
+    case "<":
+      return toNumber(l) < toNumber(r);
+    case ">":
+      return toNumber(l) > toNumber(r);
+    case "<=":
+      return toNumber(l) <= toNumber(r);
+    case ">=":
+      return toNumber(l) >= toNumber(r);
+    default:
+      throw new FormulaError(`Unsupported operator: ${op}`);
+  }
+}
+
+function evalNode(node: Node, scope: Map<string, FormulaValue>): FormulaValue {
+  switch (node.type) {
+    case "Literal":
+      return (node.value ?? null) as FormulaValue;
+
+    case "Identifier": {
+      const key = normalizeName(node.name ?? "");
+      if (scope.has(key)) return scope.get(key) ?? null;
+      if (key in CONSTANTS) return CONSTANTS[key];
+      throw new FormulaError(`Unknown field or name: ${node.name}`);
+    }
+
+    case "UnaryExpression": {
+      const v = evalNode(node.argument as Node, scope);
+      if (node.operator === "-") return -toNumber(v);
+      if (node.operator === "+") return toNumber(v);
+      if (node.operator === "!") return !toBool(v);
+      throw new FormulaError(`Unsupported unary operator: ${node.operator}`);
+    }
+
+    case "BinaryExpression":
+      return applyBinary(
+        node.operator as string,
+        evalNode(node.left as Node, scope),
+        evalNode(node.right as Node, scope),
+      );
+
+    case "LogicalExpression": {
+      const left = evalNode(node.left as Node, scope);
+      if (node.operator === "&&") return toBool(left) ? evalNode(node.right as Node, scope) : false;
+      if (node.operator === "||") return toBool(left) ? true : evalNode(node.right as Node, scope);
+      throw new FormulaError(`Unsupported logical operator: ${node.operator}`);
+    }
+
+    case "ConditionalExpression":
+      return toBool(evalNode(node.test as Node, scope))
+        ? evalNode(node.consequent as Node, scope)
+        : evalNode(node.alternate as Node, scope);
+
+    case "CallExpression": {
+      const callee = node.callee as Node;
+      if (callee.type !== "Identifier" || !callee.name) {
+        throw new FormulaError("Only named function calls are allowed");
+      }
+      const fn = FORMULA_FUNCTIONS[callee.name.toUpperCase()];
+      if (!fn) throw new FormulaError(`Unknown function: ${callee.name}`);
+      const args = (node.arguments ?? []).map((a) => evalNode(a, scope));
+      return fn(args);
+    }
+
+    case "ArrayExpression":
+      // Arrays are only meaningful as call args; flatten to first element otherwise.
+      throw new FormulaError("Array literals are not supported");
+
+    case "MemberExpression":
+      throw new FormulaError("Property access is not supported");
+
+    case "Compound":
+      throw new FormulaError("A formula must be a single expression");
+
+    default:
+      throw new FormulaError(`Unsupported expression: ${node.type}`);
+  }
+}
+
+export interface FormulaResult {
+  ok: boolean;
+  value: FormulaValue;
+  error?: string;
+}
+
+/**
+ * Evaluate a formula against a scope of column values (keyed by normalized name).
+ * Returns a structured result — a bad formula yields { ok:false } with the message,
+ * never throws, so one broken cell can't crash a grid load.
+ */
+export function evaluateFormula(
+  formula: string,
+  scope: Map<string, FormulaValue>,
+): FormulaResult {
+  try {
+    const normalized = normalizeFormulaSource(formula);
+    if (!normalized) return { ok: true, value: null };
+    const ast = jsep(normalized) as unknown as Node;
+    return { ok: true, value: evalNode(ast, scope) };
+  } catch (e) {
+    return { ok: false, value: null, error: e instanceof Error ? e.message : "Formula error" };
+  }
+}

--- a/apps/web/lib/workbooks/formula/functions.ts
+++ b/apps/web/lib/workbooks/formula/functions.ts
@@ -1,0 +1,134 @@
+// Universal Grid & Workbooks — formula function registry (EP-GRID-WORKBOOKS, Phase 2)
+//
+// The v1 function set from the hybrid-SoR design spec, implemented as plain,
+// synchronous, row-local functions (no range/aggregation-over-rows — those need
+// the full dataset + push-down and are a reporting-phase concern). Every function
+// is pure and side-effect-free; the evaluator only ever calls names that appear
+// in this registry, so a formula can never invoke arbitrary code.
+
+export type FormulaValue = string | number | boolean | null;
+
+export class FormulaError extends Error {}
+
+// ── coercion helpers ────────────────────────────────────────────────────────
+
+export function toNumber(v: FormulaValue): number {
+  if (v === null || v === "") return 0;
+  if (typeof v === "boolean") return v ? 1 : 0;
+  const n = typeof v === "number" ? v : Number(v);
+  if (Number.isNaN(n)) throw new FormulaError(`Expected a number, got "${String(v)}"`);
+  return n;
+}
+
+export function toStr(v: FormulaValue): string {
+  if (v === null) return "";
+  if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+  return String(v);
+}
+
+export function toBool(v: FormulaValue): boolean {
+  if (typeof v === "boolean") return v;
+  if (v === null || v === "" || v === 0) return false;
+  if (typeof v === "string") return v.toLowerCase() !== "false" && v !== "";
+  return Boolean(v);
+}
+
+function toDate(v: FormulaValue): Date {
+  const d = new Date(typeof v === "number" ? v : String(v ?? ""));
+  if (Number.isNaN(d.getTime())) throw new FormulaError(`Expected a date, got "${String(v)}"`);
+  return d;
+}
+
+const DAY_MS = 86_400_000;
+
+export type FormulaFn = (args: FormulaValue[]) => FormulaValue;
+
+// ── the registry ────────────────────────────────────────────────────────────
+
+export const FORMULA_FUNCTIONS: Record<string, FormulaFn> = {
+  // Logical
+  IF: (a) => (toBool(a[0]) ? a[1] ?? null : a[2] ?? null),
+  IFS: (a) => {
+    for (let i = 0; i + 1 < a.length; i += 2) {
+      if (toBool(a[i])) return a[i + 1] ?? null;
+    }
+    return null;
+  },
+  AND: (a) => a.every((v) => toBool(v)),
+  OR: (a) => a.some((v) => toBool(v)),
+  NOT: (a) => !toBool(a[0]),
+  SWITCH: (a) => {
+    const subject = a[0] ?? null;
+    for (let i = 1; i + 1 < a.length; i += 2) {
+      if (toStr(a[i]) === toStr(subject)) return a[i + 1] ?? null;
+    }
+    // trailing odd arg = default
+    return a.length % 2 === 0 ? a[a.length - 1] ?? null : null;
+  },
+
+  // Math / stats (over the literal args, not column ranges)
+  SUM: (a) => a.reduce<number>((s, v) => s + toNumber(v), 0),
+  AVERAGE: (a) => (a.length ? a.reduce<number>((s, v) => s + toNumber(v), 0) / a.length : 0),
+  MIN: (a) => Math.min(...a.map(toNumber)),
+  MAX: (a) => Math.max(...a.map(toNumber)),
+  COUNT: (a) => a.filter((v) => v !== null && v !== "" && !Number.isNaN(Number(v))).length,
+  ROUND: (a) => {
+    const f = 10 ** (a[1] === undefined ? 0 : toNumber(a[1]));
+    return Math.round(toNumber(a[0]) * f) / f;
+  },
+  FLOOR: (a) => {
+    const s = a[1] === undefined ? 1 : toNumber(a[1]);
+    return Math.floor(toNumber(a[0]) / s) * s;
+  },
+  CEILING: (a) => {
+    const s = a[1] === undefined ? 1 : toNumber(a[1]);
+    return Math.ceil(toNumber(a[0]) / s) * s;
+  },
+  ABS: (a) => Math.abs(toNumber(a[0])),
+
+  // Text
+  CONCAT: (a) => a.map(toStr).join(""),
+  CONCATENATE: (a) => a.map(toStr).join(""),
+  TEXT: (a) => toStr(a[0]),
+  LEFT: (a) => toStr(a[0]).slice(0, a[1] === undefined ? 1 : toNumber(a[1])),
+  RIGHT: (a) => {
+    const n = a[1] === undefined ? 1 : toNumber(a[1]);
+    return n <= 0 ? "" : toStr(a[0]).slice(-n);
+  },
+  MID: (a) => {
+    const start = Math.max(0, toNumber(a[1]) - 1);
+    return toStr(a[0]).slice(start, start + toNumber(a[2]));
+  },
+  LEN: (a) => toStr(a[0]).length,
+  TRIM: (a) => toStr(a[0]).trim(),
+  SUBSTITUTE: (a) => toStr(a[0]).split(toStr(a[1])).join(toStr(a[2])),
+  LOWER: (a) => toStr(a[0]).toLowerCase(),
+  UPPER: (a) => toStr(a[0]).toUpperCase(),
+
+  // Date / time
+  TODAY: () => new Date().toISOString().slice(0, 10),
+  NOW: () => new Date().toISOString(),
+  YEAR: (a) => toDate(a[0]).getUTCFullYear(),
+  MONTH: (a) => toDate(a[0]).getUTCMonth() + 1,
+  DAY: (a) => toDate(a[0]).getUTCDate(),
+  DATEDIF: (a) => {
+    const start = toDate(a[0]).getTime();
+    const end = toDate(a[1]).getTime();
+    const unit = toStr(a[2]).toUpperCase();
+    const days = Math.floor((end - start) / DAY_MS);
+    if (unit === "D") return days;
+    if (unit === "M") return Math.floor(days / 30);
+    if (unit === "Y") return Math.floor(days / 365);
+    throw new FormulaError(`DATEDIF unit must be D, M, or Y (got "${unit}")`);
+  },
+  EOMONTH: (a) => {
+    const d = toDate(a[0]);
+    const months = a[1] === undefined ? 0 : toNumber(a[1]);
+    const eom = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + months + 1, 0));
+    return eom.toISOString().slice(0, 10);
+  },
+};
+
+export function isFormulaFunction(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(FORMULA_FUNCTIONS, name.toUpperCase());
+}

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -300,3 +300,19 @@ export async function resolvePlatformReference(
   const res = await adapter.resolveReference(entityType, referenceId);
   return res ? { id: referenceId, label: res.label } : null;
 }
+
+export interface ReferenceFieldOption {
+  field: string;
+  name: string;
+}
+
+/** The allow-listed fields of a reference target, available for a lookup column. */
+export async function getReferenceTargetFields(
+  user: PlatformUser,
+  entityType: string,
+): Promise<ReferenceFieldOption[]> {
+  requireTable(user, entityType); // 403/404 — gated by the target's view capability
+  const adapter = gridRegistry.require(entityType);
+  const columns = await adapter.getColumns(entityType);
+  return columns.map((c) => ({ field: c.columnId, name: c.name }));
+}

--- a/apps/web/lib/workbooks/reference-resolver.ts
+++ b/apps/web/lib/workbooks/reference-resolver.ts
@@ -11,6 +11,7 @@
 // workbook-service → custom-table-adapter).
 
 import { gridRegistry } from "./adapter";
+import type { GridRow } from "./types";
 
 let registrationPromise: Promise<unknown> | null = null;
 
@@ -70,4 +71,36 @@ export async function resolveReferenceLabels(
     }),
   );
   return labels;
+}
+
+/**
+ * Fetch the full target record for a batch of references (de-duped), used by
+ * `lookup` columns to pull an arbitrary allow-listed field. Returns a Map keyed
+ * by `referenceKey`; missing/dangling references are absent.
+ */
+export async function fetchReferenceRecords(
+  refs: { referenceType: string; referenceId: string }[],
+): Promise<Map<string, GridRow>> {
+  const records = new Map<string, GridRow>();
+  const unique = collectUniqueReferences(refs);
+  if (unique.size === 0) return records;
+
+  const types = new Set([...unique.values()].map((u) => u.type));
+  if (![...types].every((t) => gridRegistry.has(t))) {
+    await ensurePlatformAdaptersRegistered();
+  }
+
+  await Promise.all(
+    [...unique.entries()].map(async ([key, { type, id }]) => {
+      const adapter = gridRegistry.get(type);
+      if (!adapter) return;
+      try {
+        const row = await adapter.getRow(type, id);
+        if (row) records.set(key, row);
+      } catch {
+        // Dangling reference — lookup renders empty.
+      }
+    }),
+  );
+  return records;
 }

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -7,7 +7,11 @@
 // implementation detail hidden behind the Grid component — nothing here
 // references it, so it stays swappable.
 
-/** Phase-1 field types. Phase-2 (formula, rollup, lookup, attachment, currency) are out of scope. */
+/**
+ * Field types. `formula` and `lookup` (Phase 2) are *computed* — read-only,
+ * never user-written, derived on read. `rollup`, attachment, currency remain out
+ * of scope.
+ */
 export const FIELD_TYPES = [
   "text",
   "number",
@@ -19,9 +23,18 @@ export const FIELD_TYPES = [
   "reference",
   "url",
   "email",
+  "formula",
+  "lookup",
 ] as const;
 
 export type FieldType = (typeof FIELD_TYPES)[number];
+
+/** Field types whose value is computed on read, not stored or user-edited. */
+export const COMPUTED_FIELD_TYPES: readonly FieldType[] = ["formula", "lookup"];
+
+export function isComputedFieldType(fieldType: FieldType): boolean {
+  return COMPUTED_FIELD_TYPES.includes(fieldType);
+}
 
 /** Option for select / multi_select columns, stored in WorkbookColumn.fieldConfig.options. */
 export interface SelectOption {
@@ -29,6 +42,16 @@ export interface SelectOption {
   label: string;
   /** optional semantic intent so the grid can color the chip via report-kit statusColors */
   intent?: string;
+}
+
+/** Configuration for a `lookup` column: pull a field from a referenced record. */
+export interface LookupConfig {
+  /** columnId of a `reference` column on the same table */
+  referenceColumnId: string;
+  /** the field key on the referenced entity to surface */
+  targetField: string;
+  /** how to render the looked-up value (defaults to text) */
+  targetFieldType?: FieldType;
 }
 
 /** Column-level configuration, persisted as WorkbookColumn.fieldConfig (JSON). */
@@ -41,6 +64,12 @@ export interface FieldConfig {
   multiline?: boolean;
   /** number fields: decimal places hint for display */
   precision?: number;
+  /** formula columns: an Excel-style expression over other columns in the row */
+  formula?: string;
+  /** formula columns: how to render/coerce the computed result (defaults to text) */
+  resultType?: FieldType;
+  /** lookup columns: where to pull the value from */
+  lookup?: LookupConfig;
 }
 
 /** A column as the grid consumes it — derived from a WorkbookColumn or an adapter's getColumns(). */

--- a/apps/web/lib/workbooks/workbook-service.ts
+++ b/apps/web/lib/workbooks/workbook-service.ts
@@ -74,21 +74,43 @@ const selectOptionSchema = z.object({
   intent: z.string().optional(),
 });
 
+const lookupConfigSchema = z.object({
+  referenceColumnId: z.string().min(1),
+  targetField: z.string().min(1),
+  targetFieldType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]).optional(),
+});
+
 const fieldConfigSchema = z
   .object({
     options: z.array(selectOptionSchema).optional(),
     referenceType: z.string().optional(),
     multiline: z.boolean().optional(),
     precision: z.number().optional(),
+    formula: z.string().max(2000).optional(),
+    resultType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]).optional(),
+    lookup: lookupConfigSchema.optional(),
   })
   .optional();
 
-export const addColumnSchema = z.object({
-  name: z.string().min(1).max(200),
-  fieldType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]),
-  config: fieldConfigSchema,
-  required: z.boolean().optional(),
-});
+export const addColumnSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    fieldType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]),
+    config: fieldConfigSchema,
+    required: z.boolean().optional(),
+  })
+  .superRefine((val, ctx) => {
+    // Computed columns must carry their definition (fail-closed, not silent).
+    if (val.fieldType === "formula" && !val.config?.formula?.trim()) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A formula is required for a formula column", path: ["config", "formula"] });
+    }
+    if (val.fieldType === "lookup" && !val.config?.lookup) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A lookup column needs a reference column and target field", path: ["config", "lookup"] });
+    }
+    if (val.fieldType === "reference" && !val.config?.referenceType) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A reference column needs a target entity", path: ["config", "referenceType"] });
+    }
+  });
 
 // ---------------------------------------------------------------------------
 // Access resolution

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "gray-matter": "^4.0.3",
     "inngest": "^4.5.0",
     "jose": "^6.2.3",
+    "jsep": "^1.4.0",
     "libphonenumber-js": "^1.13.6",
     "lucide-react": "^1.17.0",
     "mammoth": "^1.12.0",

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -80,15 +80,31 @@ on the generic adapter (against a seeded model), and the action's capability gat
 test that the add-column picker persists `referenceType` and the grid mounts the editor for
 `reference` columns.
 
-## Slice 2 — Rollups / lookups over references (v1 function set) — follow-up PR
+## Slice 2 — Lookups + formulas (computed columns) — SHIPPED
 
-Greenfield formula layer. **Library decision required** (research before implementing):
-evaluate HyperFormula (GPL/commercial — license-check against AGENTS.md), formulajs (MIT,
-Excel-function library, no parser), or a scoped custom evaluator. Recommendation to confirm in
-that PR: formulajs (MIT) for the function implementations + a small safe expression parser, OR a
-purpose-built rollup/lookup evaluator for v1 (REF/LOOKUP/XLOOKUP/SUMIFS family) without a full
-Excel grammar. Derived columns compute over reference-joined rows; **write a lineage edge for every
-derived column (fail-closed)** per the spec invariant. Out of scope for slice 1.
+**Library decision (resolved):** `jsep` (MIT, ~5KB, already in the lockfile) to parse + a
+purpose-built AST evaluator with a closed function allow-list (`formula/functions.ts`). Rejected
+HyperFormula (GPL/heavy) and formulajs (still needs a parser; less control). No `eval`/`new
+Function`, no member access — a user formula can never run arbitrary code.
+
+Delivered:
+- **`lookup` columns** — pull an allow-listed field from a referenced platform record
+  (`formula/compute.ts` via `reference-resolver.fetchReferenceRecords`). Builds directly on slice-1
+  references; can only read fields the target adapter already exposes (security preserved).
+- **`formula` columns** — Excel-style row-local expressions over other columns (`formula/evaluate.ts`),
+  v1 function set: IF/IFS/AND/OR/NOT/SWITCH, SUM/AVERAGE/MIN/MAX/COUNT/ROUND/FLOOR/CEILING/ABS,
+  CONCAT/TEXT/LEFT/RIGHT/MID/LEN/TRIM/SUBSTITUTE/LOWER/UPPER, TODAY/NOW/YEAR/MONTH/DAY/DATEDIF/EOMONTH.
+  Excel `=`/`<>`/`&` normalized; `[Column Name]` refs; formulas can reference earlier computed columns.
+- Computed columns are read-only (`isComputedFieldType`), never stored, derived on read for grid+MCP+API;
+  broken formulas render a `#ERROR:` sentinel, never crash a load. AddColumnButton gains Formula +
+  Lookup pickers (lookup target fields via `getReferenceTargetFieldsAction`).
+
+**Deferred (named so scope is clear):** cross-row aggregations (SUMIFS/COUNTIFS over a *column*),
+rollups over one-to-many collections, and REF/LOOKUP *inside* formulas — all need the full dataset /
+reverse-references / push-down, so they belong with the reporting phase. **Lineage edges for derived
+columns (fail-closed)** are NOT yet written — tracked for the governance/lifecycle phase (slice 5+);
+v1 computed columns are local-derivation only, no SoR mutation, so the fail-closed lineage invariant
+(which guards *promotion*) is not yet engaged.
 
 ## Slice 3 — `provenanceKind` + progressive disclosure — separate PR (BI-B8549363)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      jsep:
+        specifier: ^1.4.0
+        version: 1.4.0
       libphonenumber-js:
         specifier: ^1.13.6
         version: 1.13.6


### PR DESCRIPTION
## What

Slice 2 of the **Universal Grid & Workbooks Phase-2 relational core** (EP-GRID-WORKBOOKS, BI-1F70A9AC), building on the merged reference columns ([#1727](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1727)). Adds two **computed** column types — derived server-side on read (grid + MCP + API), read-only, never stored:

- **lookup** — pull an allow-listed field from a referenced platform record (a custom row references an Epic → a `lookup` column surfaces that Epic's status). Can only read fields the target adapter already exposes, so the generic-read allow-list keeps governing visibility.
- **formula** — Excel-style, row-local expressions over the row's other columns (and earlier computed columns, in position order). v1 function set: `IF/IFS/AND/OR/NOT/SWITCH`, `SUM/AVERAGE/MIN/MAX/COUNT/ROUND/FLOOR/CEILING/ABS`, `CONCAT/TEXT/LEFT/RIGHT/MID/LEN/TRIM/SUBSTITUTE/LOWER/UPPER`, `TODAY/NOW/YEAR/MONTH/DAY/DATEDIF/EOMONTH`.

## Engine choice

`jsep` (MIT, ~5KB, already in the lockfile) parses; a **purpose-built AST evaluator** (`lib/workbooks/formula/`) walks it against a **closed function allow-list**. No `eval`/`new Function`, no member access — a user formula can never run arbitrary code. Excel niceties normalized (`=`→equality, `<>`→`!=`, `&`→concat, `[Column Name]` refs). A broken formula renders a `#ERROR:` sentinel; it never throws or crashes a grid load. (Rejected HyperFormula — GPL/heavy; formulajs — still needs a parser, less control.)

## How

- **types** — `formula`/`lookup` field types + `COMPUTED_FIELD_TYPES`/`isComputedFieldType`; `FieldConfig` gains `formula`/`resultType`/`lookup`.
- **cell-validation** — computed columns reject writes (exhaustive switch) — fail-closed.
- **custom-table-adapter** — `computeDerivedCells` runs after reference-label hydration; computed columns are `editable:false` and skipped by create/update.
- **reference-resolver** — `fetchReferenceRecords` (batched, de-duped) backs lookups.
- **workbook-service** — `addColumnSchema.superRefine` requires a formula for formula columns, a lookup config for lookup columns, a target for references.
- **Grid/cell-editors** — `renderComputedCell` (read-only, `#ERROR` styling).
- **AddColumnButton** — Formula + Lookup pickers; lookup target fields via capability-gated `getReferenceTargetFieldsAction`.

## Deferred (named in the plan)

Cross-row aggregations (`SUMIFS`/`COUNTIFS` over a *column*), rollups over one-to-many collections, and `REF`/`LOOKUP` *inside* formulas — these need the full dataset / reverse-references / push-down, so they belong with the reporting phase. Derived-column **lineage edges (fail-closed)** are deferred to the governance/lifecycle phase: v1 computed columns are local derivation with no SoR mutation, so the promotion-time lineage invariant isn't engaged yet.

## Test / build gate

- workbooks vitest: **84 passing** (added `formula/evaluate` + `formula/compute` suites covering arithmetic/operators, the function set, Excel normalization, error handling, formula→formula chaining, and lookup-via-registry).
- `pnpm --filter web typecheck`: green.
- `pnpm --filter web build`: green (EXIT 0). Warnings are the pre-existing Turbopack edge-runtime/NFT cascade (`crypto`/`child_process` in instrumentation paths) — no slice-2 file is a root cause.

## Verification status

Live functional verification pending the next self-upgrade deploy (served image `8b7d5868` predates even #1722). Will drive add-formula-column / add-lookup-column on the live install once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)