### PR TITLE
feat(workbooks): Phase 2-4 — relational core, reporting, editable grids & views (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { WorkbookGrid } from "@/components/workbooks/Grid";
 import { CreateTableButton } from "@/components/workbooks/CreateTableButton";
 import { AddColumnButton } from "@/components/workbooks/AddColumnButton";
+import { ImportSheetButton } from "@/components/workbooks/ImportSheetButton";
 
 export const dynamic = "force-dynamic";
 
@@ -89,6 +90,7 @@ export default async function WorkbookDetailPage({ params, searchParams }: Props
           );
         })}
         {canManage && <CreateTableButton workbookId={workbookId} />}
+        {canManage && <ImportSheetButton workbookId={workbookId} />}
       </div>
 
       {!grid ? (

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -55,6 +55,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
+import { quickFilterRows } from "./grid-filter";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -188,6 +189,7 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
@@ -198,8 +200,9 @@ export function WorkbookGrid({
   }, [columns, capabilities, showProvenance]);
 
   const sortedRows = useMemo<GridRowData[]>(() => {
-    if (sortColumns.length === 0) return rowData;
-    const sorted = [...rowData];
+    const filtered = quickFilterRows(rowData, columns, filterQuery);
+    if (sortColumns.length === 0) return filtered;
+    const sorted = [...filtered];
     sorted.sort((ra, rb) => {
       for (const sc of sortColumns) {
         const cmp = compareValues(ra[sc.columnKey], rb[sc.columnKey]);
@@ -208,7 +211,7 @@ export function WorkbookGrid({
       return 0;
     });
     return sorted;
-  }, [rowData, sortColumns]);
+  }, [rowData, columns, filterQuery, sortColumns]);
 
   const persistCell = useCallback(
     async (
@@ -338,6 +341,19 @@ export function WorkbookGrid({
   return (
     <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
+        <input
+          type="search"
+          value={filterQuery}
+          onChange={(e) => setFilterQuery(e.target.value)}
+          placeholder="Filter…"
+          aria-label="Filter rows"
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+        />
+        {filterQuery.trim() && (
+          <span className="text-xs text-[var(--dpf-muted)]">
+            {sortedRows.length} of {rowData.length}
+          </span>
+        )}
         {capabilities.canAddRow && (
           <button
             type="button"

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,14 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -68,6 +75,12 @@ import {
   operatorNeedsValue,
 } from "./grid-conditional-format";
 import { summarize, numericColumns, summaryChartBars } from "./grid-summary";
+import {
+  viewStorageKey,
+  serializeViewState,
+  parseViewState,
+  type SortState,
+} from "./grid-view-state";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -215,6 +228,42 @@ export function WorkbookGrid({
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
+
+  // Persist the per-grid view (filters/sort/formatting/provenance) per tableId so
+  // it survives reloads. Client-only (localStorage); hydrate once, then save on change.
+  const viewHydratedRef = useRef(false);
+  useEffect(() => {
+    viewHydratedRef.current = false;
+    try {
+      const parsed = parseViewState(localStorage.getItem(viewStorageKey(tableId)));
+      if (parsed) {
+        if (parsed.filterQuery !== undefined) setFilterQuery(parsed.filterQuery);
+        if (parsed.columnFilters) setColumnFilters(parsed.columnFilters);
+        if (parsed.sort) setSortColumns(parsed.sort);
+        if (parsed.cfRules) setCfRules(parsed.cfRules);
+        if (parsed.showProvenance !== undefined) setShowProvenance(parsed.showProvenance);
+      }
+    } catch {
+      // ignore unreadable storage
+    }
+    viewHydratedRef.current = true;
+  }, [tableId]);
+
+  useEffect(() => {
+    if (!viewHydratedRef.current) return;
+    try {
+      const sort: SortState[] = sortColumns.map((s) => ({
+        columnKey: s.columnKey,
+        direction: s.direction,
+      }));
+      localStorage.setItem(
+        viewStorageKey(tableId),
+        serializeViewState({ filterQuery, columnFilters, sort, cfRules, showProvenance }),
+      );
+    } catch {
+      // ignore quota / unavailable storage
+    }
+  }, [tableId, filterQuery, columnFilters, sortColumns, cfRules, showProvenance]);
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
     const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -55,7 +55,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
-import { quickFilterRows } from "./grid-filter";
+import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -190,6 +190,9 @@ export function WorkbookGrid({
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [showFilters, setShowFilters] = useState(false);
+  const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
+  const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
@@ -200,7 +203,10 @@ export function WorkbookGrid({
   }, [columns, capabilities, showProvenance]);
 
   const sortedRows = useMemo<GridRowData[]>(() => {
-    const filtered = quickFilterRows(rowData, columns, filterQuery);
+    const filtered = applyColumnFilters(
+      quickFilterRows(rowData, columns, filterQuery),
+      columnFilters,
+    );
     if (sortColumns.length === 0) return filtered;
     const sorted = [...filtered];
     sorted.sort((ra, rb) => {
@@ -211,7 +217,7 @@ export function WorkbookGrid({
       return 0;
     });
     return sorted;
-  }, [rowData, columns, filterQuery, sortColumns]);
+  }, [rowData, columns, filterQuery, columnFilters, sortColumns]);
 
   const persistCell = useCallback(
     async (
@@ -398,15 +404,89 @@ export function WorkbookGrid({
         )}
         <button
           type="button"
+          onClick={() => setShowFilters((v) => !v)}
+          aria-pressed={showFilters}
+          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Filter by column"
+        >
+          {showFilters ? "Hide filters" : "Filters"}
+          {activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
-          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           title="Show where each column's values come from"
         >
           {showProvenance ? "Hide data sources" : "Show data sources"}
         </button>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
+
+      {showFilters && columns.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+          {columns.map((col) => {
+            const value = columnFilters[col.columnId] ?? "";
+            const set = (v: string) =>
+              setColumnFilters((f) => ({ ...f, [col.columnId]: v }));
+            const ctrlClass =
+              "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+            if (col.fieldType === "select") {
+              return (
+                <select
+                  key={col.columnId}
+                  value={value}
+                  onChange={(e) => set(e.target.value)}
+                  aria-label={`Filter ${col.name}`}
+                  className={ctrlClass}
+                >
+                  <option value="">{col.name}: any</option>
+                  {(col.config?.options ?? []).map((o) => (
+                    <option key={o.key} value={o.key}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              );
+            }
+            if (col.fieldType === "checkbox") {
+              return (
+                <select
+                  key={col.columnId}
+                  value={value}
+                  onChange={(e) => set(e.target.value)}
+                  aria-label={`Filter ${col.name}`}
+                  className={ctrlClass}
+                >
+                  <option value="">{col.name}: any</option>
+                  <option value="true">Checked</option>
+                  <option value="false">Unchecked</option>
+                </select>
+              );
+            }
+            return (
+              <input
+                key={col.columnId}
+                value={value}
+                onChange={(e) => set(e.target.value)}
+                placeholder={col.name}
+                aria-label={`Filter ${col.name}`}
+                className={ctrlClass}
+              />
+            );
+          })}
+          {activeFilterCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setColumnFilters({})}
+              className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
 
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -56,6 +56,7 @@ import {
   commitRedo,
 } from "./grid-history";
 import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
+import { rowsToCsv } from "./grid-csv";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -344,6 +345,20 @@ export function WorkbookGrid({
     setBusy(false);
   }, [tableId, selectedRows]);
 
+  const onExportCsv = useCallback(() => {
+    if (typeof document === "undefined") return;
+    const csv = rowsToCsv(columns, sortedRows);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${tableId}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [columns, sortedRows, tableId]);
+
   return (
     <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
@@ -404,9 +419,18 @@ export function WorkbookGrid({
         )}
         <button
           type="button"
+          onClick={onExportCsv}
+          disabled={columns.length === 0}
+          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
+          title="Export the current view to CSV"
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
           onClick={() => setShowFilters((v) => !v)}
           aria-pressed={showFilters}
-          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           title="Filter by column"
         >
           {showFilters ? "Hide filters" : "Filters"}

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -62,7 +62,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
-import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
+import { quickFilterRows, applyColumnFilters, cellSearchText, type ColumnFilters } from "./grid-filter";
 import { rowsToCsv } from "./grid-csv";
 import {
   type ConditionalRule,
@@ -214,6 +214,7 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  const [gallery, setGallery] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
   const [showFormat, setShowFormat] = useState(false);
@@ -531,6 +532,30 @@ export function WorkbookGrid({
         >
           {showProvenance ? "Hide data sources" : "Show data sources"}
         </button>
+        <div className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+          <button
+            type="button"
+            onClick={() => setGallery(false)}
+            className={
+              gallery
+                ? "px-2 py-1 text-[var(--dpf-muted)]"
+                : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+            }
+          >
+            Grid
+          </button>
+          <button
+            type="button"
+            onClick={() => setGallery(true)}
+            className={
+              gallery
+                ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                : "px-2 py-1 text-[var(--dpf-muted)]"
+            }
+          >
+            Gallery
+          </button>
+        </div>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
 
@@ -798,6 +823,36 @@ export function WorkbookGrid({
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
+        </div>
+      ) : gallery ? (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3 p-1">
+            {sortedRows.map((row) => {
+              const color = rowColor(row, cfRules);
+              return (
+                <div
+                  key={row.rowId}
+                  className={`dpf-gallery-card rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 ${
+                    color ? rowColorClass(color) : ""
+                  }`}
+                >
+                  <dl className="flex flex-col gap-1">
+                    {columns.map((col) => (
+                      <div key={col.columnId} className="flex justify-between gap-2 text-sm">
+                        <dt className="shrink-0 text-[var(--dpf-muted)]">{col.name}</dt>
+                        <dd className="truncate text-right text-[var(--dpf-text)]" title={cellSearchText(row[col.columnId] ?? null)}>
+                          {cellSearchText(row[col.columnId] ?? null)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              );
+            })}
+            {sortedRows.length === 0 && (
+              <div className="text-sm text-[var(--dpf-muted)]">No rows.</div>
+            )}
+          </div>
         </div>
       ) : (
         <div className="min-h-0 flex-1">

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,7 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -57,6 +57,16 @@ import {
 } from "./grid-history";
 import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
 import { rowsToCsv } from "./grid-csv";
+import {
+  type ConditionalRule,
+  CF_OPERATORS,
+  CF_OPERATOR_LABELS,
+  CF_COLORS,
+  rowColor,
+  rowColorClass,
+  blankRule,
+  operatorNeedsValue,
+} from "./grid-conditional-format";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -192,6 +202,9 @@ export function WorkbookGrid({
   const [showProvenance, setShowProvenance] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
+  const [showFormat, setShowFormat] = useState(false);
+  const [cfRules, setCfRules] = useState<ConditionalRule[]>([]);
+  const cfIdRef = useRef(0);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -438,6 +451,16 @@ export function WorkbookGrid({
         </button>
         <button
           type="button"
+          onClick={() => setShowFormat((v) => !v)}
+          aria-pressed={showFormat}
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Highlight rows by a condition"
+        >
+          {showFormat ? "Hide formatting" : "Format"}
+          {cfRules.length > 0 ? ` (${cfRules.length})` : ""}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -512,6 +535,85 @@ export function WorkbookGrid({
         </div>
       )}
 
+      {showFormat && columns.length > 0 && (
+        <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+          {cfRules.map((rule) => {
+            const update = (patch: Partial<ConditionalRule>) =>
+              setCfRules((rs) => rs.map((r) => (r.id === rule.id ? { ...r, ...patch } : r)));
+            const ctrlClass =
+              "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+            return (
+              <div key={rule.id} className="flex flex-wrap items-center gap-2">
+                <span className="text-sm text-[var(--dpf-muted)]">Highlight when</span>
+                <select
+                  value={rule.columnId}
+                  onChange={(e) => update({ columnId: e.target.value })}
+                  aria-label="Column"
+                  className={ctrlClass}
+                >
+                  {columns.map((c) => (
+                    <option key={c.columnId} value={c.columnId}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={rule.operator}
+                  onChange={(e) => update({ operator: e.target.value as ConditionalRule["operator"] })}
+                  aria-label="Operator"
+                  className={ctrlClass}
+                >
+                  {CF_OPERATORS.map((op) => (
+                    <option key={op} value={op}>
+                      {CF_OPERATOR_LABELS[op]}
+                    </option>
+                  ))}
+                </select>
+                {operatorNeedsValue(rule.operator) && (
+                  <input
+                    value={rule.value}
+                    onChange={(e) => update({ value: e.target.value })}
+                    placeholder="value"
+                    aria-label="Value"
+                    className={ctrlClass}
+                  />
+                )}
+                <select
+                  value={rule.color}
+                  onChange={(e) => update({ color: e.target.value as ConditionalRule["color"] })}
+                  aria-label="Color"
+                  className={ctrlClass}
+                >
+                  {CF_COLORS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                <span className={`dpf-cf-swatch ${rowColorClass(rule.color)}`} aria-hidden="true" />
+                <button
+                  type="button"
+                  onClick={() => setCfRules((rs) => rs.filter((r) => r.id !== rule.id))}
+                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  aria-label="Remove rule"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() =>
+              setCfRules((rs) => [...rs, blankRule(`cf-${(cfIdRef.current += 1)}`, columns)])
+            }
+            className="w-fit rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)]"
+          >
+            + Add formatting rule
+          </button>
+        </div>
+      )}
+
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
@@ -528,6 +630,10 @@ export function WorkbookGrid({
             onSortColumnsChange={setSortColumns}
             selectedRows={selectedRows}
             onSelectedRowsChange={setSelectedRows}
+            rowClass={(row) => {
+              const color = rowColor(row, cfRules);
+              return color ? rowColorClass(color) : undefined;
+            }}
             defaultColumnOptions={{ resizable: true, sortable: true }}
           />
         </div>

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -22,6 +22,8 @@ import {
   type GridRow,
   type CellValue,
   type GridCapabilities,
+  type ProvenanceKind,
+  PROVENANCE_LABELS,
 } from "@/lib/workbooks/types";
 import {
   type GridRowData,
@@ -66,15 +68,28 @@ function toRowData(rows: GridRow[]): GridRowData[] {
 function buildColumn(
   col: ColumnDefinition,
   canEdit: boolean,
+  showProvenance: boolean,
 ): Column<GridRowData> {
   const options = col.config?.options ?? [];
+  const label = col.required ? `${col.name} *` : col.name;
+  const kind: ProvenanceKind = col.provenanceKind ?? "manual";
   const base: Column<GridRowData> = {
     key: col.columnId,
-    name: col.required ? `${col.name} *` : col.name,
+    name: label,
     resizable: true,
     sortable: true,
     width: col.width,
     minWidth: 80,
+    // Progressive disclosure (Dale review): provenance is hidden until the user
+    // turns on "Show data sources" — the grid reads as an ordinary spreadsheet.
+    renderHeaderCell: showProvenance
+      ? () => (
+          <div className="dpf-grid-header">
+            <span className="dpf-grid-header-name">{label}</span>
+            <span className={`dpf-prov dpf-prov-${kind}`}>{PROVENANCE_LABELS[kind]}</span>
+          </div>
+        )
+      : undefined,
   };
   const editable = canEdit && col.editable;
 
@@ -163,11 +178,12 @@ export function WorkbookGrid({
   const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [showProvenance, setShowProvenance] = useState(false);
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
-    const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell));
+    const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));
     return capabilities.canDeleteRow ? [SelectColumn, ...cols] : cols;
-  }, [columns, capabilities]);
+  }, [columns, capabilities, showProvenance]);
 
   const sortedRows = useMemo<GridRowData[]>(() => {
     if (sortColumns.length === 0) return rowData;
@@ -272,6 +288,15 @@ export function WorkbookGrid({
             Delete {selectedRows.size} selected
           </button>
         )}
+        <button
+          type="button"
+          onClick={() => setShowProvenance((v) => !v)}
+          aria-pressed={showProvenance}
+          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Show where each column's values come from"
+        >
+          {showProvenance ? "Hide data sources" : "Show data sources"}
+        </button>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
 

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,7 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -46,6 +46,15 @@ import {
   deleteRowAction,
 } from "@/lib/actions/workbooks";
 import { updatePlatformCellsAction } from "@/lib/actions/platform-grid";
+import {
+  type GridHistory,
+  EMPTY_HISTORY,
+  recordEdit,
+  peekUndo,
+  peekRedo,
+  commitUndo,
+  commitRedo,
+} from "./grid-history";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -179,6 +188,9 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  // Multi-step undo/redo of cell edits (distinct from the audit history). Each
+  // entry's inverse replays through the same validated dispatch as a normal edit.
+  const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
     const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));
@@ -199,7 +211,12 @@ export function WorkbookGrid({
   }, [rowData, sortColumns]);
 
   const persistCell = useCallback(
-    async (rowId: string, columnId: string, value: CellValue, prevValue: CellValue) => {
+    async (
+      rowId: string,
+      columnId: string,
+      value: CellValue,
+      prevValue: CellValue,
+    ): Promise<boolean> => {
       setError(null);
       const res =
         source === "platform"
@@ -211,7 +228,9 @@ export function WorkbookGrid({
         setRowData((prev) =>
           prev.map((r) => (r.rowId === rowId ? { ...r, [columnId]: prevValue } : r)),
         );
+        return false;
       }
+      return true;
     },
     [tableId, source],
   );
@@ -226,11 +245,62 @@ export function WorkbookGrid({
         if (!changed) continue;
         const prevRow = rowData.find((r) => r.rowId === changed.rowId);
         const prevValue: CellValue = prevRow ? prevRow[columnId] ?? null : null;
-        void persistCell(changed.rowId, columnId, changed[columnId] ?? null, prevValue);
+        const nextValue: CellValue = changed[columnId] ?? null;
+        void persistCell(changed.rowId, columnId, nextValue, prevValue).then((ok) => {
+          // Only a committed edit is undoable; a rejected one is already reverted.
+          if (ok) {
+            setHistory((h) => recordEdit(h, { rowId: changed.rowId, columnId, prevValue, nextValue }));
+          }
+        });
       }
       setRowData((prev) => prev.map((r) => byId.get(r.rowId) ?? r));
     },
     [persistCell, rowData],
+  );
+
+  // Replay a cell to a target value through the validated dispatch; on success
+  // commit the stack transition. A failed persist leaves history unchanged
+  // (persistCell already reverted the optimistic cell).
+  const undo = useCallback(() => {
+    const entry = peekUndo(history);
+    if (!entry) return;
+    setRowData((prev) =>
+      prev.map((r) => (r.rowId === entry.rowId ? { ...r, [entry.columnId]: entry.prevValue } : r)),
+    );
+    void persistCell(entry.rowId, entry.columnId, entry.prevValue, entry.nextValue).then((ok) => {
+      if (ok) setHistory((h) => commitUndo(h));
+    });
+  }, [history, persistCell]);
+
+  const redo = useCallback(() => {
+    const entry = peekRedo(history);
+    if (!entry) return;
+    setRowData((prev) =>
+      prev.map((r) => (r.rowId === entry.rowId ? { ...r, [entry.columnId]: entry.nextValue } : r)),
+    );
+    void persistCell(entry.rowId, entry.columnId, entry.nextValue, entry.prevValue).then((ok) => {
+      if (ok) setHistory((h) => commitRedo(h));
+    });
+  }, [history, persistCell]);
+
+  const onKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!capabilities.canEditCell) return;
+      // Don't hijack a cell editor's own text undo while editing.
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+      const key = e.key.toLowerCase();
+      if (key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      } else if (key === "y" || (key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        redo();
+      }
+    },
+    [capabilities.canEditCell, undo, redo],
   );
 
   const onAddRow = useCallback(async () => {
@@ -266,7 +336,7 @@ export function WorkbookGrid({
   }, [tableId, selectedRows]);
 
   return (
-    <div className="flex h-full flex-col gap-2">
+    <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
         {capabilities.canAddRow && (
           <button
@@ -287,6 +357,28 @@ export function WorkbookGrid({
           >
             Delete {selectedRows.size} selected
           </button>
+        )}
+        {capabilities.canEditCell && (
+          <>
+            <button
+              type="button"
+              onClick={undo}
+              disabled={history.undo.length === 0}
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-40"
+              title="Undo (Ctrl+Z)"
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={redo}
+              disabled={history.redo.length === 0}
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-40"
+              title="Redo (Ctrl+Y)"
+            >
+              Redo
+            </button>
+          </>
         )}
         <button
           type="button"

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,6 +67,7 @@ import {
   blankRule,
   operatorNeedsValue,
 } from "./grid-conditional-format";
+import { summarize, numericColumns } from "./grid-summary";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -205,6 +206,9 @@ export function WorkbookGrid({
   const [showFormat, setShowFormat] = useState(false);
   const [cfRules, setCfRules] = useState<ConditionalRule[]>([]);
   const cfIdRef = useRef(0);
+  const [showSummary, setShowSummary] = useState(false);
+  const [summaryGroupBy, setSummaryGroupBy] = useState("");
+  const [summaryValue, setSummaryValue] = useState("");
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -461,6 +465,15 @@ export function WorkbookGrid({
         </button>
         <button
           type="button"
+          onClick={() => setShowSummary((v) => !v)}
+          aria-pressed={showSummary}
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Group rows and summarize"
+        >
+          {showSummary ? "Hide summary" : "Summary"}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -613,6 +626,82 @@ export function WorkbookGrid({
           </button>
         </div>
       )}
+
+      {showSummary && columns.length > 0 && (() => {
+        const groupBy = summaryGroupBy || columns[0]!.columnId;
+        const valueCol = summaryValue || undefined;
+        const numCols = numericColumns(columns);
+        const summary = summarize(sortedRows, groupBy, valueCol);
+        const ctrlClass =
+          "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+        return (
+          <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
+              <select
+                value={groupBy}
+                onChange={(e) => setSummaryGroupBy(e.target.value)}
+                aria-label="Group by column"
+                className={ctrlClass}
+              >
+                {columns.map((c) => (
+                  <option key={c.columnId} value={c.columnId}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-[var(--dpf-muted)]">summarize</span>
+              <select
+                value={summaryValue}
+                onChange={(e) => setSummaryValue(e.target.value)}
+                aria-label="Value column"
+                className={ctrlClass}
+              >
+                <option value="">count only</option>
+                {numCols.map((c) => (
+                  <option key={c.columnId} value={c.columnId}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-[var(--dpf-muted)]">
+                    <th className="px-2 py-1">Group</th>
+                    <th className="px-2 py-1">Count</th>
+                    {valueCol && (
+                      <>
+                        <th className="px-2 py-1">Sum</th>
+                        <th className="px-2 py-1">Avg</th>
+                        <th className="px-2 py-1">Min</th>
+                        <th className="px-2 py-1">Max</th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.map((s) => (
+                    <tr key={s.group} className="border-t border-[var(--dpf-border)]">
+                      <td className="px-2 py-1">{s.group}</td>
+                      <td className="px-2 py-1">{s.count}</td>
+                      {valueCol && (
+                        <>
+                          <td className="px-2 py-1">{s.sum}</td>
+                          <td className="px-2 py-1">{s.avg}</td>
+                          <td className="px-2 py-1">{s.min}</td>
+                          <td className="px-2 py-1">{s.max}</td>
+                        </>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })()}
 
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,7 +67,7 @@ import {
   blankRule,
   operatorNeedsValue,
 } from "./grid-conditional-format";
-import { summarize, numericColumns } from "./grid-summary";
+import { summarize, numericColumns, summaryChartBars } from "./grid-summary";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -209,6 +209,7 @@ export function WorkbookGrid({
   const [showSummary, setShowSummary] = useState(false);
   const [summaryGroupBy, setSummaryGroupBy] = useState("");
   const [summaryValue, setSummaryValue] = useState("");
+  const [summaryChart, setSummaryChart] = useState(false);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -664,7 +665,48 @@ export function WorkbookGrid({
                   </option>
                 ))}
               </select>
+              <div className="ml-auto inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(false)}
+                  className={
+                    summaryChart
+                      ? "px-2 py-1 text-[var(--dpf-muted)]"
+                      : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                  }
+                >
+                  Table
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(true)}
+                  className={
+                    summaryChart
+                      ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                      : "px-2 py-1 text-[var(--dpf-muted)]"
+                  }
+                >
+                  Chart
+                </button>
+              </div>
             </div>
+            {summaryChart ? (
+              <div className="flex flex-col gap-1">
+                {summaryChartBars(summary, Boolean(valueCol)).map((bar) => (
+                  <div key={bar.group} className="flex items-center gap-2 text-sm">
+                    <span className="w-32 shrink-0 truncate text-[var(--dpf-muted)]" title={bar.group}>
+                      {bar.group}
+                    </span>
+                    <span className="dpf-summary-bar-track">
+                      <span className="dpf-summary-bar-fill" style={{ width: `${bar.pct}%` }} />
+                    </span>
+                    <span className="w-16 shrink-0 text-right tabular-nums text-[var(--dpf-text)]">
+                      {bar.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
             <div className="overflow-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -699,6 +741,7 @@ export function WorkbookGrid({
                 </tbody>
               </table>
             </div>
+            )}
           </div>
         );
       })()}

--- a/apps/web/components/workbooks/ImportSheetButton.tsx
+++ b/apps/web/components/workbooks/ImportSheetButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { importSheetAction } from "@/lib/actions/workbooks";
+
+/** Upload an .xlsx and create a new workbook table from it (columns + rows inferred). */
+export function ImportSheetButton({ workbookId }: { workbookId: string }) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [isError, setIsError] = useState(false);
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setMessage(null);
+    setIsError(false);
+    const fd = new FormData();
+    fd.append("file", file);
+    startTransition(async () => {
+      const res = await importSheetAction(workbookId, fd);
+      if (inputRef.current) inputRef.current.value = "";
+      if (!res.ok) {
+        setIsError(true);
+        setMessage(res.error);
+        return;
+      }
+      setMessage(
+        `Imported ${res.data.rowCount} rows, ${res.data.columnCount} columns` +
+          (res.data.truncated ? " (truncated to the import limit)" : ""),
+      );
+      router.refresh();
+    });
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => inputRef.current?.click()}
+        className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
+      >
+        {pending ? "Importing…" : "Import .xlsx"}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        className="hidden"
+        onChange={onFile}
+      />
+      {message && (
+        <span className={`text-sm ${isError ? "text-[var(--dpf-error)]" : "text-[var(--dpf-muted)]"}`}>
+          {message}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -110,3 +110,24 @@
   outline: 2px solid var(--dpf-accent);
   outline-offset: -2px;
 }
+
+/* Conditional formatting — row tints (subtle, theme-token based). */
+.dpf-cf-red .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-error) 16%, transparent);
+}
+.dpf-cf-amber .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-warning, #b8860b) 18%, transparent);
+}
+.dpf-cf-green .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-success, #2e7d32) 16%, transparent);
+}
+.dpf-cf-blue .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-accent) 16%, transparent);
+}
+.dpf-cf-swatch {
+  display: inline-block;
+  inline-size: 1rem;
+  block-size: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--dpf-border);
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -58,6 +58,35 @@
   font-size: 0.8125rem;
 }
 
+/* Provenance progressive disclosure — column header with a small source label. */
+.dpf-grid-header {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+.dpf-grid-header-name {
+  font-weight: 600;
+}
+.dpf-prov {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 600;
+  opacity: 0.85;
+}
+.dpf-prov-system {
+  color: var(--dpf-accent);
+}
+.dpf-prov-source {
+  color: var(--dpf-warning, var(--dpf-accent));
+}
+.dpf-prov-derived {
+  color: var(--dpf-success, var(--dpf-accent));
+}
+.dpf-prov-manual {
+  color: var(--dpf-muted);
+}
+
 .dpf-grid-editor {
   inline-size: 100%;
   block-size: 100%;

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -147,3 +147,17 @@
   min-inline-size: 2px;
   background-color: var(--dpf-accent);
 }
+
+/* Gallery card conditional-format accent (scoped so it never restyles grid rows). */
+.dpf-gallery-card.dpf-cf-red {
+  border-inline-start: 3px solid var(--dpf-error);
+}
+.dpf-gallery-card.dpf-cf-amber {
+  border-inline-start: 3px solid var(--dpf-warning, #b8860b);
+}
+.dpf-gallery-card.dpf-cf-green {
+  border-inline-start: 3px solid var(--dpf-success, #2e7d32);
+}
+.dpf-gallery-card.dpf-cf-blue {
+  border-inline-start: 3px solid var(--dpf-accent);
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -131,3 +131,19 @@
   border-radius: 0.25rem;
   border: 1px solid var(--dpf-border);
 }
+
+/* Group-by summary chart — simple CSS bars. */
+.dpf-summary-bar-track {
+  flex: 1 1 auto;
+  block-size: 0.75rem;
+  border-radius: 9999px;
+  background-color: var(--dpf-surface-1);
+  border: 1px solid var(--dpf-border);
+  overflow: hidden;
+}
+.dpf-summary-bar-fill {
+  display: block;
+  block-size: 100%;
+  min-inline-size: 2px;
+  background-color: var(--dpf-accent);
+}

--- a/apps/web/components/workbooks/grid-conditional-format.test.ts
+++ b/apps/web/components/workbooks/grid-conditional-format.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  ruleMatches,
+  rowColor,
+  rowColorClass,
+  operatorNeedsValue,
+  type ConditionalRule,
+} from "./grid-conditional-format";
+import type { GridRowData } from "./cell-editors";
+
+const rule = (over: Partial<ConditionalRule>): ConditionalRule => ({
+  id: "r",
+  columnId: "status",
+  operator: "eq",
+  value: "",
+  color: "amber",
+  ...over,
+});
+
+const row: GridRowData = { rowId: "r1", status: "overdue", amount: 120, note: "" };
+
+describe("ruleMatches", () => {
+  it("eq / neq are case-insensitive on display text", () => {
+    expect(ruleMatches(rule({ operator: "eq", value: "OVERDUE" }), row)).toBe(true);
+    expect(ruleMatches(rule({ operator: "neq", value: "open" }), row)).toBe(true);
+  });
+  it("contains needs a non-empty needle", () => {
+    expect(ruleMatches(rule({ operator: "contains", value: "due" }), row)).toBe(true);
+    expect(ruleMatches(rule({ operator: "contains", value: "" }), row)).toBe(false);
+  });
+  it("empty / notEmpty test the raw value", () => {
+    expect(ruleMatches(rule({ columnId: "note", operator: "empty" }), row)).toBe(true);
+    expect(ruleMatches(rule({ columnId: "status", operator: "notEmpty" }), row)).toBe(true);
+  });
+  it("gt / lt coerce numerically and fail closed on non-numbers", () => {
+    expect(ruleMatches(rule({ columnId: "amount", operator: "gt", value: "100" }), row)).toBe(true);
+    expect(ruleMatches(rule({ columnId: "amount", operator: "lt", value: "100" }), row)).toBe(false);
+    expect(ruleMatches(rule({ columnId: "status", operator: "gt", value: "1" }), row)).toBe(false);
+  });
+});
+
+describe("rowColor", () => {
+  it("returns the first matching rule's color", () => {
+    const rules = [
+      rule({ id: "a", columnId: "amount", operator: "lt", value: "100", color: "green" }),
+      rule({ id: "b", columnId: "status", operator: "eq", value: "overdue", color: "red" }),
+    ];
+    expect(rowColor(row, rules)).toBe("red");
+  });
+  it("returns undefined when nothing matches", () => {
+    expect(rowColor(row, [rule({ value: "paid" })])).toBeUndefined();
+  });
+});
+
+describe("helpers", () => {
+  it("rowColorClass maps to a css class", () => {
+    expect(rowColorClass("blue")).toBe("dpf-cf-blue");
+  });
+  it("operatorNeedsValue is false only for empty/notEmpty", () => {
+    expect(operatorNeedsValue("eq")).toBe(true);
+    expect(operatorNeedsValue("empty")).toBe(false);
+    expect(operatorNeedsValue("notEmpty")).toBe(false);
+  });
+});

--- a/apps/web/components/workbooks/grid-conditional-format.ts
+++ b/apps/web/components/workbooks/grid-conditional-format.ts
@@ -1,0 +1,91 @@
+// Universal Grid & Workbooks — conditional formatting (EP-GRID-WORKBOOKS Phase 3)
+//
+// Pure rule evaluation for highlighting rows that match a condition (the Smartsheet
+// "color rows where status = overdue" affordance). The first matching rule wins.
+// Kept pure + unit-testable; the Grid owns the (session) rule list and applies the
+// resulting class via react-data-grid's rowClass.
+
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+export const CF_OPERATORS = ["eq", "neq", "contains", "gt", "lt", "empty", "notEmpty"] as const;
+export type CfOperator = (typeof CF_OPERATORS)[number];
+
+export const CF_OPERATOR_LABELS: Record<CfOperator, string> = {
+  eq: "equals",
+  neq: "not equals",
+  contains: "contains",
+  gt: "greater than",
+  lt: "less than",
+  empty: "is empty",
+  notEmpty: "is not empty",
+};
+
+export const CF_COLORS = ["red", "amber", "green", "blue"] as const;
+export type CfColor = (typeof CF_COLORS)[number];
+
+export interface ConditionalRule {
+  id: string;
+  columnId: string;
+  operator: CfOperator;
+  value: string;
+  color: CfColor;
+}
+
+/** Does a single rule match a row? Numeric ops coerce; text ops are case-insensitive. */
+export function ruleMatches(rule: ConditionalRule, row: GridRowData): boolean {
+  const raw = cellSearchText(row[rule.columnId] ?? null);
+  const text = raw.toLowerCase();
+  const target = rule.value.trim().toLowerCase();
+  switch (rule.operator) {
+    case "eq":
+      return text === target;
+    case "neq":
+      return text !== target;
+    case "contains":
+      return target.length > 0 && text.includes(target);
+    case "empty":
+      return raw === "";
+    case "notEmpty":
+      return raw !== "";
+    case "gt":
+    case "lt": {
+      const n = Number(raw);
+      const t = Number(rule.value);
+      if (Number.isNaN(n) || Number.isNaN(t)) return false;
+      return rule.operator === "gt" ? n > t : n < t;
+    }
+    default:
+      return false;
+  }
+}
+
+/** The color of the first matching rule for a row, or undefined. */
+export function rowColor(row: GridRowData, rules: ConditionalRule[]): CfColor | undefined {
+  for (const rule of rules) {
+    if (ruleMatches(rule, row)) return rule.color;
+  }
+  return undefined;
+}
+
+/** The CSS class that paints a row a given conditional-format color. */
+export function rowColorClass(color: CfColor): string {
+  return `dpf-cf-${color}`;
+}
+
+/** Operators that don't need a value input. */
+export function operatorNeedsValue(op: CfOperator): boolean {
+  return op !== "empty" && op !== "notEmpty";
+}
+
+/** A blank rule seeded to the first column (for the rule builder). */
+export function blankRule(id: string, columns: ColumnDefinition[]): ConditionalRule {
+  return {
+    id,
+    columnId: columns[0]?.columnId ?? "",
+    operator: "eq",
+    value: "",
+    color: "amber",
+  };
+}

--- a/apps/web/components/workbooks/grid-csv.test.ts
+++ b/apps/web/components/workbooks/grid-csv.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { escapeCsvField, rowsToCsv } from "./grid-csv";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const col = (columnId: string, name: string): ColumnDefinition => ({
+  columnId,
+  name,
+  fieldType: "text",
+  position: 0,
+  required: false,
+  editable: true,
+});
+
+describe("escapeCsvField", () => {
+  it("leaves plain values untouched", () => {
+    expect(escapeCsvField("hello")).toBe("hello");
+  });
+  it("quotes and doubles interior quotes when needed", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+});
+
+describe("rowsToCsv", () => {
+  const columns = [col("name", "Name"), col("status", "Status"), col("epic", "Epic")];
+
+  it("emits a header row then one row per record", () => {
+    const rows: GridRowData[] = [
+      { rowId: "r1", name: "Alpha", status: "open", epic: { referenceId: "EP-1", referenceType: "epic", label: "Launch" } },
+    ];
+    expect(rowsToCsv(columns, rows)).toBe("Name,Status,Epic\r\nAlpha,open,Launch");
+  });
+
+  it("escapes commas and quotes in values, renders empty cells blank", () => {
+    const rows: GridRowData[] = [{ rowId: "r1", name: 'Acme, Inc "HQ"', status: null, epic: null }];
+    expect(rowsToCsv(columns, rows)).toBe('Name,Status,Epic\r\n"Acme, Inc ""HQ""",,');
+  });
+
+  it("emits just the header for no rows", () => {
+    expect(rowsToCsv(columns, [])).toBe("Name,Status,Epic");
+  });
+});

--- a/apps/web/components/workbooks/grid-csv.ts
+++ b/apps/web/components/workbooks/grid-csv.ts
@@ -1,0 +1,24 @@
+// Universal Grid & Workbooks — CSV export (EP-GRID-WORKBOOKS, Phase 3)
+//
+// Serialize the rows currently shown in the grid (already filtered + sorted) to
+// RFC-4180-ish CSV. Pure + unit-testable; the browser download is a thin wrapper
+// in the Grid component. Reuses cellSearchText so exported values match what the
+// user sees (reference labels, joined multi-selects, etc.).
+
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+/** Quote a field if it contains a comma, quote, or newline; double interior quotes. */
+export function escapeCsvField(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Build a CSV document (header row + one row per record) for the given columns. */
+export function rowsToCsv(columns: ColumnDefinition[], rows: GridRowData[]): string {
+  const header = columns.map((c) => escapeCsvField(c.name)).join(",");
+  const body = rows.map((row) =>
+    columns.map((c) => escapeCsvField(cellSearchText(row[c.columnId] ?? null))).join(","),
+  );
+  return [header, ...body].join("\r\n");
+}

--- a/apps/web/components/workbooks/grid-filter.test.ts
+++ b/apps/web/components/workbooks/grid-filter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { cellSearchText, quickFilterRows } from "./grid-filter";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const col = (columnId: string): ColumnDefinition => ({
+  columnId,
+  name: columnId,
+  fieldType: "text",
+  position: 0,
+  required: false,
+  editable: true,
+});
+
+describe("cellSearchText", () => {
+  it("stringifies each cell shape for matching", () => {
+    expect(cellSearchText(null)).toBe("");
+    expect(cellSearchText(42)).toBe("42");
+    expect(cellSearchText(true)).toBe("true");
+    expect(cellSearchText(["a", "b"])).toBe("a b");
+    expect(cellSearchText({ referenceId: "EP-1", referenceType: "epic", label: "Grid epic" })).toBe(
+      "Grid epic",
+    );
+    expect(cellSearchText({ referenceId: "EP-2", referenceType: "epic" })).toBe("EP-2");
+  });
+});
+
+describe("quickFilterRows", () => {
+  const columns = [col("name"), col("status"), col("epic")];
+  const rows: GridRowData[] = [
+    { rowId: "r1", name: "Alpha", status: "open", epic: { referenceId: "EP-1", referenceType: "epic", label: "Launch" } },
+    { rowId: "r2", name: "Beta", status: "done", epic: null },
+    { rowId: "r3", name: "Gamma", status: "open", epic: { referenceId: "EP-2", referenceType: "epic", label: "Migrate" } },
+  ];
+
+  it("returns all rows for an empty query", () => {
+    expect(quickFilterRows(rows, columns, "  ")).toHaveLength(3);
+  });
+
+  it("matches case-insensitively across any column", () => {
+    expect(quickFilterRows(rows, columns, "ALPHA").map((r) => r.rowId)).toEqual(["r1"]);
+    expect(quickFilterRows(rows, columns, "open").map((r) => r.rowId)).toEqual(["r1", "r3"]);
+  });
+
+  it("matches against a reference label, not just scalar columns", () => {
+    expect(quickFilterRows(rows, columns, "migrate").map((r) => r.rowId)).toEqual(["r3"]);
+  });
+
+  it("returns no rows when nothing matches", () => {
+    expect(quickFilterRows(rows, columns, "zzz")).toHaveLength(0);
+  });
+});

--- a/apps/web/components/workbooks/grid-filter.test.ts
+++ b/apps/web/components/workbooks/grid-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { cellSearchText, quickFilterRows } from "./grid-filter";
+import {
+  cellSearchText,
+  quickFilterRows,
+  applyColumnFilters,
+  activeColumnFilters,
+} from "./grid-filter";
 import type { ColumnDefinition } from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
@@ -48,5 +53,34 @@ describe("quickFilterRows", () => {
 
   it("returns no rows when nothing matches", () => {
     expect(quickFilterRows(rows, columns, "zzz")).toHaveLength(0);
+  });
+});
+
+describe("activeColumnFilters", () => {
+  it("keeps only non-empty filters, lowercased", () => {
+    expect(activeColumnFilters({ a: "  Open ", b: "", c: "X" })).toEqual([
+      ["a", "open"],
+      ["c", "x"],
+    ]);
+  });
+});
+
+describe("applyColumnFilters", () => {
+  const rows: GridRowData[] = [
+    { rowId: "r1", name: "Alpha", status: "open" },
+    { rowId: "r2", name: "Beta", status: "done" },
+    { rowId: "r3", name: "Alpine", status: "open" },
+  ];
+
+  it("returns all rows when no filters are active", () => {
+    expect(applyColumnFilters(rows, { name: "", status: "" })).toHaveLength(3);
+  });
+
+  it("AND-combines per-column substring filters", () => {
+    expect(applyColumnFilters(rows, { name: "alp", status: "open" }).map((r) => r.rowId)).toEqual([
+      "r1",
+      "r3",
+    ]);
+    expect(applyColumnFilters(rows, { name: "alp", status: "done" })).toHaveLength(0);
   });
 });

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -45,3 +45,27 @@ export function quickFilterRows(
   if (!lowered) return rows;
   return rows.filter((r) => rowMatchesQuery(r, columns, lowered));
 }
+
+/** Per-column filters: columnId → substring the column's value must contain. */
+export type ColumnFilters = Record<string, string>;
+
+/** Keep only the non-empty filters (lowercased), as [columnId, needle] pairs. */
+export function activeColumnFilters(filters: ColumnFilters): [string, string][] {
+  return Object.entries(filters)
+    .map(([k, v]) => [k, v.trim().toLowerCase()] as [string, string])
+    .filter(([, v]) => v.length > 0);
+}
+
+/** AND-combine per-column substring filters. No active filters → all rows. */
+export function applyColumnFilters(
+  rows: GridRowData[],
+  filters: ColumnFilters,
+): GridRowData[] {
+  const active = activeColumnFilters(filters);
+  if (active.length === 0) return rows;
+  return rows.filter((row) =>
+    active.every(([columnId, needle]) =>
+      cellSearchText(row[columnId] ?? null).toLowerCase().includes(needle),
+    ),
+  );
+}

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -1,0 +1,47 @@
+// Universal Grid & Workbooks — client-side quick filter (EP-GRID-WORKBOOKS, Phase 2)
+//
+// A pure, case-insensitive substring filter across a row's visible cell values —
+// the "type to narrow" affordance every spreadsheet has. Operates over the rows
+// already loaded in the grid (server-side / push-down filtering for large datasets
+// is a reporting-phase concern). Kept pure so it is unit-testable.
+
+import type { CellValue, ColumnDefinition, ReferenceValue } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+/** Render a cell value to the text a user would see, for substring matching. */
+export function cellSearchText(value: CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) return value.join(" ");
+  if (typeof value === "object" && "referenceId" in value) {
+    const ref = value as ReferenceValue;
+    return ref.label ?? ref.referenceId;
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+/** True if any of the row's column values contains the (lowercased) query. */
+export function rowMatchesQuery(
+  row: GridRowData,
+  columns: ColumnDefinition[],
+  loweredQuery: string,
+): boolean {
+  if (!loweredQuery) return true;
+  for (const col of columns) {
+    if (cellSearchText(row[col.columnId] ?? null).toLowerCase().includes(loweredQuery)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Filter rows by a free-text query across all columns. Empty query → all rows. */
+export function quickFilterRows(
+  rows: GridRowData[],
+  columns: ColumnDefinition[],
+  query: string,
+): GridRowData[] {
+  const lowered = query.trim().toLowerCase();
+  if (!lowered) return rows;
+  return rows.filter((r) => rowMatchesQuery(r, columns, lowered));
+}

--- a/apps/web/components/workbooks/grid-history.test.ts
+++ b/apps/web/components/workbooks/grid-history.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_HISTORY,
+  recordEdit,
+  peekUndo,
+  peekRedo,
+  commitUndo,
+  commitRedo,
+  type CellEdit,
+} from "./grid-history";
+
+const edit = (rowId: string, prev: string, next: string): CellEdit => ({
+  rowId,
+  columnId: "c1",
+  prevValue: prev,
+  nextValue: next,
+});
+
+describe("grid-history", () => {
+  it("records an edit onto undo and clears the redo branch", () => {
+    let h = recordEdit(EMPTY_HISTORY, edit("r1", "a", "b"));
+    h = commitUndo(h); // r1 now on redo
+    expect(h.redo).toHaveLength(1);
+    // a new edit must clear the redo branch (no longer reachable)
+    h = recordEdit(h, edit("r2", "x", "y"));
+    expect(h.redo).toHaveLength(0);
+    expect(h.undo).toHaveLength(1);
+  });
+
+  it("peeks the most recent undo/redo entry", () => {
+    const h = recordEdit(recordEdit(EMPTY_HISTORY, edit("r1", "a", "b")), edit("r2", "c", "d"));
+    expect(peekUndo(h)?.rowId).toBe("r2");
+    expect(peekRedo(h)).toBeUndefined();
+  });
+
+  it("moves entries undo → redo on commitUndo and back on commitRedo", () => {
+    let h = recordEdit(EMPTY_HISTORY, edit("r1", "a", "b"));
+    h = commitUndo(h);
+    expect(h.undo).toHaveLength(0);
+    expect(peekRedo(h)?.rowId).toBe("r1");
+    h = commitRedo(h);
+    expect(peekUndo(h)?.rowId).toBe("r1");
+    expect(h.redo).toHaveLength(0);
+  });
+
+  it("round-trips a multi-edit stack in LIFO order", () => {
+    let h = EMPTY_HISTORY;
+    h = recordEdit(h, edit("r1", "1", "2"));
+    h = recordEdit(h, edit("r2", "3", "4"));
+    expect(peekUndo(h)?.rowId).toBe("r2");
+    h = commitUndo(h); // undo r2
+    expect(peekUndo(h)?.rowId).toBe("r1");
+    expect(peekRedo(h)?.rowId).toBe("r2");
+    h = commitUndo(h); // undo r1
+    expect(h.undo).toHaveLength(0);
+    expect(h.redo.map((e) => e.rowId)).toEqual(["r2", "r1"]);
+  });
+
+  it("is a no-op when committing past the end of a stack", () => {
+    expect(commitUndo(EMPTY_HISTORY)).toBe(EMPTY_HISTORY);
+    expect(commitRedo(EMPTY_HISTORY)).toBe(EMPTY_HISTORY);
+  });
+});

--- a/apps/web/components/workbooks/grid-history.ts
+++ b/apps/web/components/workbooks/grid-history.ts
@@ -1,0 +1,50 @@
+// Universal Grid & Workbooks — undo/redo stack transitions (EP-GRID-WORKBOOKS, Phase 2)
+//
+// Pure list transitions for multi-step cell-edit undo/redo, kept out of the
+// component so the invariants are unit-testable. The component owns the async
+// replay (persisting the inverse edit through the validated dispatch) and only
+// commits a transition here once the persist succeeds.
+
+import type { CellValue } from "@/lib/workbooks/types";
+
+/** One undoable cell edit. */
+export interface CellEdit {
+  rowId: string;
+  columnId: string;
+  prevValue: CellValue;
+  nextValue: CellValue;
+}
+
+export interface GridHistory {
+  undo: CellEdit[];
+  redo: CellEdit[];
+}
+
+export const EMPTY_HISTORY: GridHistory = { undo: [], redo: [] };
+
+/** Record a fresh edit: push onto undo and clear the redo branch. */
+export function recordEdit(h: GridHistory, edit: CellEdit): GridHistory {
+  return { undo: [...h.undo, edit], redo: [] };
+}
+
+export function peekUndo(h: GridHistory): CellEdit | undefined {
+  return h.undo[h.undo.length - 1];
+}
+
+export function peekRedo(h: GridHistory): CellEdit | undefined {
+  return h.redo[h.redo.length - 1];
+}
+
+/** After a successful undo of the top entry: move it from undo → redo. */
+export function commitUndo(h: GridHistory): GridHistory {
+  const entry = peekUndo(h);
+  if (!entry) return h;
+  return { undo: h.undo.slice(0, -1), redo: [...h.redo, entry] };
+}
+
+/** After a successful redo of the top entry: move it from redo → undo. */
+export function commitRedo(h: GridHistory): GridHistory {
+  const entry = peekRedo(h);
+  if (!entry) return h;
+  return { undo: [...h.undo, entry], redo: h.redo.slice(0, -1) };
+}

--- a/apps/web/components/workbooks/grid-summary.test.ts
+++ b/apps/web/components/workbooks/grid-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { summarize, toSummaryNumber, numericColumns } from "./grid-summary";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const rows: GridRowData[] = [
+  { rowId: "1", status: "open", amount: 100 },
+  { rowId: "2", status: "open", amount: 50 },
+  { rowId: "3", status: "done", amount: 200 },
+  { rowId: "4", status: "", amount: null },
+];
+
+describe("toSummaryNumber", () => {
+  it("coerces numerics and rejects non-numbers", () => {
+    expect(toSummaryNumber(5)).toBe(5);
+    expect(toSummaryNumber("12")).toBe(12);
+    expect(toSummaryNumber(true)).toBe(1);
+    expect(toSummaryNumber("abc")).toBeNull();
+    expect(toSummaryNumber(null)).toBeNull();
+    expect(toSummaryNumber("")).toBeNull();
+  });
+});
+
+describe("numericColumns", () => {
+  it("keeps only number columns", () => {
+    const cols: ColumnDefinition[] = [
+      { columnId: "a", name: "A", fieldType: "number", position: 0, required: false, editable: true },
+      { columnId: "b", name: "B", fieldType: "text", position: 1, required: false, editable: true },
+    ];
+    expect(numericColumns(cols).map((c) => c.columnId)).toEqual(["a"]);
+  });
+});
+
+describe("summarize", () => {
+  it("counts rows per group (empty group labelled), sorted by count desc", () => {
+    const s = summarize(rows, "status");
+    expect(s.map((g) => [g.group, g.count])).toEqual([
+      ["open", 2],
+      ["(empty)", 1],
+      ["done", 1],
+    ]);
+  });
+
+  it("aggregates a numeric value column per group", () => {
+    const s = summarize(rows, "status", "amount");
+    const open = s.find((g) => g.group === "open")!;
+    expect(open).toMatchObject({ count: 2, sum: 150, avg: 75, min: 50, max: 100 });
+    const empty = s.find((g) => g.group === "(empty)")!;
+    // row 4 has a null amount → counted as a row, but no numeric contribution
+    expect(empty).toMatchObject({ count: 1, sum: 0, avg: 0, min: 0, max: 0 });
+  });
+});

--- a/apps/web/components/workbooks/grid-summary.test.ts
+++ b/apps/web/components/workbooks/grid-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { summarize, toSummaryNumber, numericColumns } from "./grid-summary";
+import { summarize, toSummaryNumber, numericColumns, summaryChartBars } from "./grid-summary";
 import type { ColumnDefinition } from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
@@ -48,5 +48,24 @@ describe("summarize", () => {
     const empty = s.find((g) => g.group === "(empty)")!;
     // row 4 has a null amount → counted as a row, but no numeric contribution
     expect(empty).toMatchObject({ count: 1, sum: 0, avg: 0, min: 0, max: 0 });
+  });
+});
+
+describe("summaryChartBars", () => {
+  it("uses count when no value column, scaled to the max bar", () => {
+    const bars = summaryChartBars(summarize(rows, "status"), false);
+    const open = bars.find((b) => b.group === "open")!;
+    expect(open).toMatchObject({ value: 2, pct: 100 });
+    const done = bars.find((b) => b.group === "done")!;
+    expect(done).toMatchObject({ value: 1, pct: 50 });
+  });
+
+  it("uses sum when a value column is set", () => {
+    const bars = summaryChartBars(summarize(rows, "status", "amount"), true);
+    const done = bars.find((b) => b.group === "done")!; // sum 200 is the max
+    expect(done).toMatchObject({ value: 200, pct: 100 });
+    const open = bars.find((b) => b.group === "open")!; // sum 150
+    expect(open.value).toBe(150);
+    expect(open.pct).toBe(75);
   });
 });

--- a/apps/web/components/workbooks/grid-summary.ts
+++ b/apps/web/components/workbooks/grid-summary.ts
@@ -78,3 +78,24 @@ export function summarize(
   out.sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
   return out;
 }
+
+export interface SummaryBar {
+  group: string;
+  value: number;
+  /** 0–100, relative to the largest bar (for a CSS bar width). */
+  pct: number;
+}
+
+/**
+ * Turn a summary into chart bars: the bar value is the chosen metric's `sum` when
+ * a value column is set, else the group `count`. `pct` is relative to the max bar.
+ */
+export function summaryChartBars(summary: GroupSummary[], hasValueColumn: boolean): SummaryBar[] {
+  const value = (s: GroupSummary) => (hasValueColumn ? s.sum : s.count);
+  const max = summary.reduce((m, s) => Math.max(m, value(s)), 0);
+  return summary.map((s) => ({
+    group: s.group,
+    value: value(s),
+    pct: max > 0 ? Math.round((value(s) / max) * 100) : 0,
+  }));
+}

--- a/apps/web/components/workbooks/grid-summary.ts
+++ b/apps/web/components/workbooks/grid-summary.ts
@@ -1,0 +1,80 @@
+// Universal Grid & Workbooks — group-by summary (EP-GRID-WORKBOOKS Phase 4)
+//
+// The "pivot-lite" affordance: group the rows by one column and show count plus
+// numeric aggregates (sum/avg/min/max) of another column per group. Pure +
+// unit-testable; operates over the rows already loaded in the grid (full pivots
+// and SQL push-down are later Phase-4 work).
+
+import type { CellValue, ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+export interface GroupSummary {
+  group: string;
+  count: number;
+  sum: number;
+  avg: number;
+  min: number;
+  max: number;
+}
+
+const EMPTY_GROUP = "(empty)";
+
+/** Coerce a cell to a finite number, or null if it isn't numeric. */
+export function toSummaryNumber(value: CellValue): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  const n = typeof value === "number" ? value : Number(cellSearchText(value));
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Columns whose values are meaningfully summable (numeric). */
+export function numericColumns(columns: ColumnDefinition[]): ColumnDefinition[] {
+  return columns.filter((c) => c.fieldType === "number");
+}
+
+/** Round to 2dp without floating-point noise. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Group rows by `groupByColumnId` and aggregate `valueColumnId` (optional) per
+ * group. Groups are returned sorted by descending count, then group label.
+ */
+export function summarize(
+  rows: GridRowData[],
+  groupByColumnId: string,
+  valueColumnId?: string,
+): GroupSummary[] {
+  const counts = new Map<string, number>();
+  const values = new Map<string, number[]>();
+  for (const row of rows) {
+    const key = cellSearchText(row[groupByColumnId] ?? null) || EMPTY_GROUP;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (valueColumnId) {
+      const n = toSummaryNumber(row[valueColumnId] ?? null);
+      if (n !== null) {
+        const bucket = values.get(key) ?? [];
+        bucket.push(n);
+        values.set(key, bucket);
+      }
+    }
+  }
+
+  const out: GroupSummary[] = [];
+  for (const [group, count] of counts) {
+    const nums = values.get(group) ?? [];
+    const sum = nums.reduce((s, v) => s + v, 0);
+    out.push({
+      group,
+      count,
+      sum: round2(sum),
+      avg: nums.length ? round2(sum / nums.length) : 0,
+      min: nums.length ? round2(Math.min(...nums)) : 0,
+      max: nums.length ? round2(Math.max(...nums)) : 0,
+    });
+  }
+  out.sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
+  return out;
+}

--- a/apps/web/components/workbooks/grid-view-state.test.ts
+++ b/apps/web/components/workbooks/grid-view-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  viewStorageKey,
+  serializeViewState,
+  parseViewState,
+  type GridViewState,
+} from "./grid-view-state";
+
+const sample: GridViewState = {
+  filterQuery: "open",
+  columnFilters: { status: "active" },
+  sort: [{ columnKey: "name", direction: "ASC" }],
+  cfRules: [{ id: "r1", columnId: "status", operator: "eq", value: "overdue", color: "red" }],
+  showProvenance: true,
+};
+
+describe("viewStorageKey", () => {
+  it("namespaces by tableId", () => {
+    expect(viewStorageKey("TBL-1")).toBe("dpf-workbook-view:TBL-1");
+  });
+});
+
+describe("serialize/parse round-trip", () => {
+  it("preserves a valid view state", () => {
+    expect(parseViewState(serializeViewState(sample))).toEqual(sample);
+  });
+});
+
+describe("parseViewState — defensive", () => {
+  it("returns null for empty or malformed JSON", () => {
+    expect(parseViewState(null)).toBeNull();
+    expect(parseViewState("")).toBeNull();
+    expect(parseViewState("{not json")).toBeNull();
+    expect(parseViewState("[]")).toBeNull(); // not an object
+  });
+
+  it("drops fields with the wrong type instead of throwing", () => {
+    const parsed = parseViewState(
+      JSON.stringify({ filterQuery: 5, columnFilters: { a: 1, b: "x" }, sort: "nope", showProvenance: "yes" }),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.filterQuery).toBeUndefined(); // 5 is not a string
+    expect(parsed!.columnFilters).toEqual({ b: "x" }); // a:1 dropped
+    expect(parsed!.sort).toBeUndefined(); // "nope" is not an array
+    expect(parsed!.showProvenance).toBeUndefined(); // "yes" is not boolean
+  });
+
+  it("filters invalid conditional-format rules", () => {
+    const parsed = parseViewState(
+      JSON.stringify({
+        cfRules: [
+          { id: "ok", columnId: "c", operator: "eq", value: "v", color: "red" },
+          { id: "bad-op", columnId: "c", operator: "bogus", value: "v", color: "red" },
+          { id: "bad-color", columnId: "c", operator: "eq", value: "v", color: "purple" },
+        ],
+      }),
+    );
+    expect(parsed!.cfRules).toHaveLength(1);
+    expect(parsed!.cfRules![0].id).toBe("ok");
+  });
+
+  it("keeps only valid sort entries", () => {
+    const parsed = parseViewState(
+      JSON.stringify({ sort: [{ columnKey: "a", direction: "ASC" }, { columnKey: "b", direction: "sideways" }, {}] }),
+    );
+    expect(parsed!.sort).toEqual([{ columnKey: "a", direction: "ASC" }]);
+  });
+});

--- a/apps/web/components/workbooks/grid-view-state.ts
+++ b/apps/web/components/workbooks/grid-view-state.ts
@@ -1,0 +1,99 @@
+// Universal Grid & Workbooks — persistent grid view state (EP-GRID-WORKBOOKS Phase 3)
+//
+// Serializes the per-grid view (quick filter, column filters, sort, conditional
+// formatting, provenance toggle, summary config) so it survives reloads. Stored
+// client-side per tableId — works for every grid (custom + platform) with no
+// migration. Parsing is defensive: malformed/old payloads are ignored field by
+// field, never throwing. Pure + unit-testable; the Grid owns the localStorage IO.
+
+import type { ConditionalRule, CfOperator, CfColor } from "./grid-conditional-format";
+import { CF_OPERATORS, CF_COLORS } from "./grid-conditional-format";
+
+export interface SortState {
+  columnKey: string;
+  direction: "ASC" | "DESC";
+}
+
+export interface GridViewState {
+  filterQuery: string;
+  columnFilters: Record<string, string>;
+  sort: SortState[];
+  cfRules: ConditionalRule[];
+  showProvenance: boolean;
+}
+
+export function viewStorageKey(tableId: string): string {
+  return `dpf-workbook-view:${tableId}`;
+}
+
+export function serializeViewState(state: GridViewState): string {
+  return JSON.stringify(state);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function parseSort(raw: unknown): SortState[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SortState[] = [];
+  for (const s of raw) {
+    if (isRecord(s) && typeof s.columnKey === "string" && (s.direction === "ASC" || s.direction === "DESC")) {
+      out.push({ columnKey: s.columnKey, direction: s.direction });
+    }
+  }
+  return out;
+}
+
+function parseColumnFilters(raw: unknown): Record<string, string> {
+  if (!isRecord(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) if (typeof v === "string") out[k] = v;
+  return out;
+}
+
+function parseCfRules(raw: unknown): ConditionalRule[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ConditionalRule[] = [];
+  for (const r of raw) {
+    if (
+      isRecord(r) &&
+      typeof r.id === "string" &&
+      typeof r.columnId === "string" &&
+      typeof r.value === "string" &&
+      CF_OPERATORS.includes(r.operator as CfOperator) &&
+      CF_COLORS.includes(r.color as CfColor)
+    ) {
+      out.push({
+        id: r.id,
+        columnId: r.columnId,
+        operator: r.operator as CfOperator,
+        value: r.value,
+        color: r.color as CfColor,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Defensively parse a stored view payload. Each field is validated independently;
+ * anything malformed is dropped. Returns null only when the JSON itself is bad.
+ */
+export function parseViewState(raw: string | null | undefined): Partial<GridViewState> | null {
+  if (!raw) return null;
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(data)) return null;
+  const out: Partial<GridViewState> = {};
+  if (typeof data.filterQuery === "string") out.filterQuery = data.filterQuery;
+  if (isRecord(data.columnFilters)) out.columnFilters = parseColumnFilters(data.columnFilters);
+  if (Array.isArray(data.sort)) out.sort = parseSort(data.sort);
+  if (Array.isArray(data.cfRules)) out.cfRules = parseCfRules(data.cfRules);
+  if (typeof data.showProvenance === "boolean") out.showProvenance = data.showProvenance;
+  return out;
+}

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -36,6 +36,7 @@ import {
   resolvePlatformReference,
   getReferenceTargetFields,
 } from "@/lib/workbooks/platform-tables";
+import { inferTableFromSheet, type SheetCell } from "@/lib/workbooks/sheet-import";
 import type { CellValue, ColumnDefinition, FieldType, FieldConfig } from "@/lib/workbooks/types";
 
 export type ActionResult<T = void> =
@@ -258,6 +259,54 @@ export async function getReferenceTargetFieldsAction(
   try {
     const user = await requirePlatformUser();
     return { ok: true, data: await getReferenceTargetFields(user, referenceType) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// ── Spreadsheet import (Phase 3) ────────────────────────────────────────────
+// Parse an uploaded .xlsx/.csv server-side and create a workbook table with
+// inferred columns + typed rows, composing the same validated service the manual
+// flow uses (createTable → addColumn → createRow).
+
+export async function importSheetAction(
+  workbookId: string,
+  formData: FormData,
+): Promise<ActionResult<{ tableId: string; columnCount: number; rowCount: number; truncated: boolean }>> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    const file = formData.get("file");
+    if (!(file instanceof File)) throw new WorkbookError("No file uploaded", 400);
+    const buffer = await file.arrayBuffer();
+    const { readSheet } = await import(/* turbopackIgnore: true */ "read-excel-file/browser");
+    const matrix = (await readSheet(buffer)) as SheetCell[][];
+
+    const { columns, rows, truncated } = inferTableFromSheet(matrix);
+    if (columns.length === 0) throw new WorkbookError("The sheet has no columns to import", 400);
+
+    const tableName = file.name.replace(/\.[^.]+$/, "").trim() || "Imported sheet";
+    const table = await svcCreateTable(user, workbookId, { name: tableName });
+
+    const columnIdByName = new Map<string, string>();
+    for (const col of columns) {
+      const created = await svcAddColumn(user, table.tableId, { name: col.name, fieldType: col.fieldType });
+      columnIdByName.set(col.name, created.columnId);
+    }
+
+    for (const row of rows) {
+      const input: Record<string, CellValue> = {};
+      for (const [name, value] of Object.entries(row)) {
+        const columnId = columnIdByName.get(name);
+        if (columnId) input[columnId] = value;
+      }
+      await svcCreateRow(user, table.tableId, input);
+    }
+
+    revalidatePath(`/workbooks/${workbookId}`);
+    return {
+      ok: true,
+      data: { tableId: table.tableId, columnCount: columns.length, rowCount: rows.length, truncated },
+    };
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/workbooks/backlog-adapter.ts
+++ b/apps/web/lib/workbooks/backlog-adapter.ts
@@ -56,7 +56,7 @@ class BacklogItemAdapter implements DataSourceAdapter {
   readonly entityType = BACKLOG_ENTITY_TYPE;
 
   async getColumns(): Promise<ColumnDefinition[]> {
-    return BACKLOG_COLUMNS;
+    return BACKLOG_COLUMNS.map((c) => ({ ...c, provenanceKind: "system" as const }));
   }
 
   async queryRows(

--- a/apps/web/lib/workbooks/custom-table-adapter.ts
+++ b/apps/web/lib/workbooks/custom-table-adapter.ts
@@ -25,6 +25,7 @@ import {
   type PagedRows,
   type GridCapabilities,
   isComputedFieldType,
+  customColumnProvenance,
 } from "./types";
 import {
   validateCell,
@@ -101,6 +102,7 @@ function toColumnDefinition(meta: ColumnMeta, position: number, width: number | 
     config: meta.config,
     editable: !isComputedFieldType(meta.fieldType),
     groupable: meta.fieldType === "select",
+    provenanceKind: customColumnProvenance(meta.fieldType),
   };
 }
 

--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   buildReferenceSearchArgs,
   type GenericTableConfig,
 } from "./generic-read-adapter";
+import { customColumnProvenance } from "./types";
 
 const config: GenericTableConfig = {
   entityType: "epic",
@@ -108,5 +109,20 @@ describe("genericColumnDefs", () => {
     const status = cols.find((c) => c.columnId === "status");
     expect(status?.groupable).toBe(true);
     expect(status?.config?.options?.[0].key).toBe("open");
+  });
+
+  it("marks every generic (platform) column as system provenance", () => {
+    const cols = genericColumnDefs(config);
+    expect(cols.every((c) => c.provenanceKind === "system")).toBe(true);
+  });
+});
+
+describe("customColumnProvenance", () => {
+  it("derives derived for computed types and manual otherwise", () => {
+    expect(customColumnProvenance("formula")).toBe("derived");
+    expect(customColumnProvenance("lookup")).toBe("derived");
+    expect(customColumnProvenance("text")).toBe("manual");
+    expect(customColumnProvenance("reference")).toBe("manual");
+    expect(customColumnProvenance("number")).toBe("manual");
   });
 });

--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -5,6 +5,8 @@ import {
   genericColumnDefs,
   referenceLabelField,
   buildReferenceSearchArgs,
+  genericUpdateData,
+  makeGenericReadAdapter,
   type GenericTableConfig,
 } from "./generic-read-adapter";
 import { customColumnProvenance } from "./types";
@@ -114,6 +116,78 @@ describe("genericColumnDefs", () => {
   it("marks every generic (platform) column as system provenance", () => {
     const cols = genericColumnDefs(config);
     expect(cols.every((c) => c.provenanceKind === "system")).toBe(true);
+  });
+});
+
+const editableConfig: GenericTableConfig = {
+  entityType: "supplier",
+  prismaModel: "supplier",
+  idField: "supplierId",
+  labelField: "name",
+  editableFields: ["name", "status"],
+  columns: [
+    { field: "supplierId", name: "ID", fieldType: "text" },
+    { field: "name", name: "Name", fieldType: "text" },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      options: [
+        { key: "active", label: "Active" },
+        { key: "inactive", label: "Inactive" },
+      ],
+    },
+    { field: "taxId", name: "Tax ID", fieldType: "text" },
+  ],
+};
+
+describe("genericColumnDefs — editability", () => {
+  it("marks only editableFields editable, never the id field", () => {
+    const cols = genericColumnDefs(editableConfig);
+    const byId = Object.fromEntries(cols.map((c) => [c.columnId, c.editable]));
+    expect(byId.name).toBe(true);
+    expect(byId.status).toBe(true);
+    expect(byId.taxId).toBe(false);
+    expect(byId.supplierId).toBe(false);
+  });
+
+  it("read-only config (no editableFields) marks nothing editable", () => {
+    expect(genericColumnDefs(config).every((c) => c.editable === false)).toBe(true);
+  });
+});
+
+describe("genericUpdateData — validated raw-write tier", () => {
+  it("builds a validated data object for allow-listed fields", () => {
+    expect(genericUpdateData(editableConfig, { name: "Acme", status: "active" })).toEqual({
+      name: "Acme",
+      status: "active",
+    });
+  });
+
+  it("rejects editing the id field", () => {
+    expect(() => genericUpdateData(editableConfig, { supplierId: "X" })).toThrow(/cannot be edited/i);
+  });
+
+  it("rejects a non-allow-listed field (fail-closed)", () => {
+    expect(() => genericUpdateData(editableConfig, { taxId: "123" })).toThrow(/not editable/i);
+  });
+
+  it("rejects an invalid select option", () => {
+    expect(() => genericUpdateData(editableConfig, { status: "bogus" })).toThrow(/unknown option/i);
+  });
+
+  it("allows clearing a field to null", () => {
+    expect(genericUpdateData(editableConfig, { name: null })).toEqual({ name: null });
+  });
+});
+
+describe("generic adapter getCapabilities", () => {
+  it("is editable only with canManage AND editableFields", () => {
+    const editable = makeGenericReadAdapter(editableConfig);
+    expect(editable.getCapabilities({ userId: "u", canManage: true }).canEditCell).toBe(true);
+    expect(editable.getCapabilities({ userId: "u", canManage: false }).canEditCell).toBe(false);
+    const readonly = makeGenericReadAdapter(config);
+    expect(readonly.getCapabilities({ userId: "u", canManage: true }).canEditCell).toBe(false);
   });
 });
 

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -1,12 +1,17 @@
-// Universal Grid & Workbooks — generic read-only adapter (EP-GRID-WORKBOOKS, Phase 2)
+// Universal Grid & Workbooks — generic adapter (EP-GRID-WORKBOOKS, Phase 2/3)
 //
 // "Every model is a grid": a config-driven DataSourceAdapter that exposes any
-// Prisma model as a read-only grid/board without a bespoke adapter class. v1 is
-// READ-ONLY by design and config-driven (an explicit field allow-list, not schema
-// introspection) so it can never expose sensitive fields (passwordHash, tokens)
-// and never performs a generic write. Models that need editing keep their
-// bespoke, validated adapters (backlog/invoice/risk). Edit-capable generic
-// adapters + DMMF introspection (with a steward denylist) are a later increment.
+// Prisma model as a grid/board without a bespoke adapter class. Config-driven via
+// an explicit field allow-list (not schema introspection) so it can never expose
+// sensitive fields (passwordHash, tokens).
+//
+// READ is the default. WRITE is opt-in per config via `editableFields` — the
+// "validated raw-write tier" (operator-approved 2026-06-12): for models without a
+// bespoke domain action, the generic adapter writes via Prisma, but only to
+// allow-listed fields and only after the SAME `validateCell` the rest of the
+// platform uses (so a write is still typed + validated, just not routed through a
+// hand-written domain action). Models that have real domain logic keep their
+// bespoke validated adapters (backlog/invoice/risk).
 
 import { prisma } from "@dpf/db";
 import {
@@ -27,6 +32,7 @@ import {
   type PagedRows,
   type GridCapabilities,
 } from "./types";
+import { validateCell, type CellStorage } from "./cell-validation";
 import { applyFilters, applySort, paginate } from "./grid-query";
 
 export interface GenericColumn {
@@ -55,6 +61,12 @@ export interface GenericTableConfig {
    * field, falling back to the id field itself.
    */
   labelField?: string;
+  /**
+   * Opt-in writable fields (validated raw-write tier). A subset of `columns`
+   * field names; the id field and any non-listed field stay read-only. Omit for a
+   * read-only grid. Each write goes through `validateCell` before Prisma.
+   */
+  editableFields?: string[];
 }
 
 const DEFAULT_CAP = 500;
@@ -109,13 +121,15 @@ export function genericRowToGridRow(
 }
 
 export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[] {
+  const editable = new Set(config.editableFields ?? []);
   return config.columns.map((c, i) => ({
     columnId: c.field,
     name: c.name,
     fieldType: c.fieldType,
     position: i,
     required: false,
-    editable: false, // generic v1 is read-only
+    // editable only if opt-in via editableFields (and never the id field)
+    editable: editable.has(c.field) && c.field !== config.idField,
     width: c.width,
     groupable: c.groupable ?? c.fieldType === "select",
     config: c.options ? { options: c.options } : undefined,
@@ -123,9 +137,65 @@ export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[
   }));
 }
 
+/** Pull the validated scalar for a Prisma write from a CellStorage by field type. */
+function prismaValueFromStorage(fieldType: FieldType, storage: CellStorage): unknown {
+  switch (fieldType) {
+    case "text":
+    case "url":
+    case "email":
+      return storage.textValue;
+    case "number":
+      return storage.numberValue;
+    case "date":
+    case "datetime":
+      return storage.dateValue;
+    case "checkbox":
+      return storage.boolValue;
+    case "select":
+      return storage.selectValue;
+    case "multi_select":
+      return storage.multiSelectValue;
+    default:
+      throw new Error(`Field type "${fieldType}" cannot be edited in a generic grid`);
+  }
+}
+
+/**
+ * Build a validated Prisma `data` object for a generic edit. Throws if a change
+ * targets the id field, a non-allow-listed field, an unknown field, or fails
+ * validation — fail-closed, no silent drops. Pure (no DB), so it is unit-testable.
+ */
+export function genericUpdateData(
+  config: GenericTableConfig,
+  changes: Record<string, CellValue>,
+): Record<string, unknown> {
+  const editable = new Set(config.editableFields ?? []);
+  const byField = new Map(config.columns.map((c) => [c.field, c]));
+  const data: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(changes)) {
+    if (field === config.idField) throw new Error(`The id field "${field}" cannot be edited`);
+    if (!editable.has(field)) throw new Error(`Field "${field}" is not editable`);
+    const col = byField.get(field);
+    if (!col) throw new Error(`Unknown field: ${field}`);
+    const result = validateCell(
+      {
+        name: col.name,
+        fieldType: col.fieldType,
+        required: false,
+        config: col.options ? { options: col.options } : undefined,
+      },
+      value,
+    );
+    if (!result.ok) throw new Error(result.error);
+    data[field] = prismaValueFromStorage(col.fieldType, result.storage);
+  }
+  return data;
+}
+
 type ReadDelegate = {
   findMany(args: unknown): Promise<Record<string, unknown>[]>;
   findUnique(args: unknown): Promise<Record<string, unknown> | null>;
+  update(args: unknown): Promise<Record<string, unknown>>;
 };
 
 function delegate(model: string): ReadDelegate {
@@ -210,8 +280,31 @@ class GenericReadAdapter implements DataSourceAdapter {
     return { label: String(r[labelField] ?? r[this.cfg.idField]) };
   }
 
-  getCapabilities(_ctx: AdapterContext): GridCapabilities {
-    return { canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false };
+  async updateCells(
+    entityType: string,
+    rowId: string,
+    changes: Record<string, CellValue>,
+    ctx: AdapterContext,
+  ): Promise<GridRow> {
+    if ((this.cfg.editableFields?.length ?? 0) === 0) {
+      throw new Error("This data source is read-only");
+    }
+    if (!ctx.canManage) {
+      throw new Error("You do not have permission to edit this data");
+    }
+    const data = genericUpdateData(this.cfg, changes); // validates; throws fail-closed
+    await delegate(this.cfg.prismaModel).update({
+      where: { [this.cfg.idField]: rowId },
+      data,
+    });
+    const row = await this.getRow(entityType, rowId);
+    if (!row) throw new Error("Row updated but could not be read back");
+    return row;
+  }
+
+  getCapabilities(ctx: AdapterContext): GridCapabilities {
+    const canEdit = !!ctx.canManage && (this.cfg.editableFields?.length ?? 0) > 0;
+    return { canAddRow: false, canAddColumn: false, canEditCell: canEdit, canDeleteRow: false };
   }
 }
 

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -119,6 +119,7 @@ export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[
     width: c.width,
     groupable: c.groupable ?? c.fieldType === "select",
     config: c.options ? { options: c.options } : undefined,
+    provenanceKind: "system", // a live platform field
   }));
 }
 

--- a/apps/web/lib/workbooks/invoice-adapter.ts
+++ b/apps/web/lib/workbooks/invoice-adapter.ts
@@ -73,7 +73,7 @@ class InvoiceAdapter implements DataSourceAdapter {
   readonly entityType = INVOICE_ENTITY_TYPE;
 
   async getColumns(): Promise<ColumnDefinition[]> {
-    return INVOICE_COLUMNS;
+    return INVOICE_COLUMNS.map((c) => ({ ...c, provenanceKind: "system" as const }));
   }
 
   async queryRows(

--- a/apps/web/lib/workbooks/people-supplier-configs.test.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.test.ts
@@ -61,4 +61,18 @@ describe("people/supplier safe read-only grids", () => {
       expect(present).not.toContain(f);
     }
   });
+
+  it("SUPPLIER editable fields are a safe subset of columns (never id or sensitive)", () => {
+    const cols = new Set(fields(SUPPLIER_TABLE));
+    const editable = SUPPLIER_TABLE.editableFields ?? [];
+    expect(editable.length).toBeGreaterThan(0);
+    for (const f of editable) expect(cols.has(f)).toBe(true);
+    expect(editable).not.toContain(SUPPLIER_TABLE.idField);
+    for (const f of ["taxId", "bankDetails", "address"]) expect(editable).not.toContain(f);
+  });
+
+  it("CUSTOMER and EMPLOYEE grids stay read-only (no manage capability exists)", () => {
+    expect(CUSTOMER_ACCOUNT_TABLE.editableFields).toBeUndefined();
+    expect(EMPLOYEE_PROFILE_TABLE.editableFields).toBeUndefined();
+  });
 });

--- a/apps/web/lib/workbooks/people-supplier-configs.test.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  CUSTOMER_ACCOUNT_TABLE,
+  EMPLOYEE_PROFILE_TABLE,
+  SUPPLIER_TABLE,
+  PEOPLE_SUPPLIER_TABLES,
+} from "./people-supplier-configs";
+
+function fields(t: { columns: { field: string }[] }): string[] {
+  return t.columns.map((c) => c.field);
+}
+
+describe("people/supplier safe read-only grids", () => {
+  it("exposes exactly three tables with unique entity types and label fields", () => {
+    expect(PEOPLE_SUPPLIER_TABLES.map((t) => t.entityType)).toEqual([
+      "customer_account",
+      "employee_profile",
+      "supplier",
+    ]);
+    for (const t of PEOPLE_SUPPLIER_TABLES) {
+      expect(t.labelField).toBeTruthy();
+      // the label + id fields must be in the column allow-list
+      expect(fields(t)).toContain(t.idField);
+      expect(fields(t)).toContain(t.labelField!);
+    }
+  });
+
+  it("EMPLOYEE grid omits all compensation/PII fields (allow-list by omission)", () => {
+    const FORBIDDEN = [
+      "firstName",
+      "middleName",
+      "lastName",
+      "personalEmail",
+      "phoneWork",
+      "phoneMobile",
+      "phoneEmergency",
+      "salary",
+      "compensation",
+      "ssn",
+      "nationalId",
+      "dateOfBirth",
+      "addresses",
+      "bankDetails",
+      "endDate",
+      "userId",
+    ];
+    const present = fields(EMPLOYEE_PROFILE_TABLE);
+    for (const f of FORBIDDEN) expect(present).not.toContain(f);
+    // displayName (not legal name parts) is how an employee is shown
+    expect(present).toContain("displayName");
+  });
+
+  it("SUPPLIER grid omits tax/bank/address fields", () => {
+    const present = fields(SUPPLIER_TABLE);
+    for (const f of ["taxId", "bankDetails", "address"]) expect(present).not.toContain(f);
+  });
+
+  it("CUSTOMER grid omits financial/internal fields", () => {
+    const present = fields(CUSTOMER_ACCOUNT_TABLE);
+    for (const f of ["annualRevenue", "notes", "sourceSystem", "sourceId"]) {
+      expect(present).not.toContain(f);
+    }
+  });
+});

--- a/apps/web/lib/workbooks/people-supplier-configs.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.ts
@@ -1,0 +1,112 @@
+// Universal Grid & Workbooks — read-only generic grids for customers, people, and
+// suppliers (EP-GRID-WORKBOOKS, Phase 2, BI-29E1F452).
+//
+// These are explicit field ALLOW-LISTS: sensitive fields (compensation, legal
+// names beyond display name, personal contact, addresses, tax/bank details) are
+// simply not listed, so they can never surface through the grid OR a reference
+// lookup. Kept in a dedicated module (importing only the GenericTableConfig type)
+// so the allow-lists are unit-testable without the heavy platform-tables chain.
+
+import type { GenericTableConfig } from "./generic-read-adapter";
+
+export const CUSTOMER_ACCOUNT_TABLE: GenericTableConfig = {
+  entityType: "customer_account",
+  prismaModel: "customerAccount",
+  idField: "accountId",
+  labelField: "name",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "accountId", name: "ID", fieldType: "text", width: 140 },
+    { field: "name", name: "Name", fieldType: "text", width: 240 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "prospect", label: "Prospect" },
+        { key: "qualified", label: "Qualified" },
+        { key: "onboarding", label: "Onboarding" },
+        { key: "active", label: "Active" },
+        { key: "at_risk", label: "At risk" },
+        { key: "suspended", label: "Suspended" },
+        { key: "closed", label: "Closed" },
+      ],
+    },
+    { field: "industry", name: "Industry", fieldType: "text", width: 160 },
+    { field: "website", name: "Website", fieldType: "url", width: 200 },
+    { field: "employeeCount", name: "Employees", fieldType: "number", width: 110 },
+    { field: "currency", name: "Currency", fieldType: "text", width: 90 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+export const EMPLOYEE_PROFILE_TABLE: GenericTableConfig = {
+  entityType: "employee_profile",
+  prismaModel: "employeeProfile",
+  idField: "employeeId",
+  labelField: "displayName",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  // Safe org-directory fields ONLY — no legal names beyond display name, no
+  // personal contact, no compensation, no addresses, no termination dates.
+  columns: [
+    { field: "employeeId", name: "ID", fieldType: "text", width: 140 },
+    { field: "displayName", name: "Name", fieldType: "text", width: 200 },
+    { field: "workEmail", name: "Work email", fieldType: "email", width: 220 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "onboarding", label: "Onboarding" },
+        { key: "active", label: "Active" },
+        { key: "on_leave", label: "On leave" },
+        { key: "offboarding", label: "Offboarding" },
+        { key: "terminated", label: "Terminated" },
+      ],
+    },
+    { field: "timezone", name: "Timezone", fieldType: "text", width: 150 },
+    { field: "startDate", name: "Start date", fieldType: "date", width: 130 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+export const SUPPLIER_TABLE: GenericTableConfig = {
+  entityType: "supplier",
+  prismaModel: "supplier",
+  idField: "supplierId",
+  labelField: "name",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  // Excludes taxId, bankDetails, address (sensitive) by omission.
+  columns: [
+    { field: "supplierId", name: "ID", fieldType: "text", width: 140 },
+    { field: "name", name: "Name", fieldType: "text", width: 220 },
+    { field: "contactName", name: "Contact", fieldType: "text", width: 160 },
+    { field: "email", name: "Email", fieldType: "email", width: 200 },
+    { field: "phone", name: "Phone", fieldType: "text", width: 140 },
+    { field: "paymentTerms", name: "Payment terms", fieldType: "text", width: 130 },
+    { field: "defaultCurrency", name: "Currency", fieldType: "text", width: 90 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 120,
+      groupable: true,
+      options: [
+        { key: "active", label: "Active" },
+        { key: "inactive", label: "Inactive" },
+      ],
+    },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+/** All BI-29E1F452 safe read-only grids. */
+export const PEOPLE_SUPPLIER_TABLES: GenericTableConfig[] = [
+  CUSTOMER_ACCOUNT_TABLE,
+  EMPLOYEE_PROFILE_TABLE,
+  SUPPLIER_TABLE,
+];

--- a/apps/web/lib/workbooks/people-supplier-configs.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.ts
@@ -80,6 +80,10 @@ export const SUPPLIER_TABLE: GenericTableConfig = {
   idField: "supplierId",
   labelField: "name",
   orderBy: { field: "updatedAt", dir: "desc" },
+  // Validated raw-write tier (no bespoke Supplier domain action exists). Editable
+  // safe fields only — taxId/bankDetails/address are excluded by omission and so
+  // can never be written here either. Each write still goes through validateCell.
+  editableFields: ["name", "contactName", "email", "phone", "paymentTerms", "defaultCurrency", "status"],
   // Excludes taxId, bankDetails, address (sensitive) by omission.
   columns: [
     { field: "supplierId", name: "ID", fieldType: "text", width: 140 },

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -13,6 +13,7 @@ import "./backlog-adapter"; // self-register the backlog adapter
 import "./invoice-adapter"; // self-register the invoice adapter
 import "./risk-adapter"; // self-register the risk-assessment adapter
 import { registerGenericReadTable, type GenericTableConfig } from "./generic-read-adapter";
+import { PEOPLE_SUPPLIER_TABLES } from "./people-supplier-configs";
 import {
   type ColumnDefinition,
   type GridRow,
@@ -115,6 +116,9 @@ const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {
 
 registerGenericReadTable(EPIC_TABLE);
 registerGenericReadTable(DIGITAL_PRODUCT_TABLE);
+// Customers, people (safe org-directory fields only), suppliers — explicit
+// allow-lists live in people-supplier-configs.ts (unit-tested for safe omission).
+for (const cfg of PEOPLE_SUPPLIER_TABLES) registerGenericReadTable(cfg);
 
 /** The registry of platform datasets available as grids. Add a row per adapter. */
 export const PLATFORM_TABLES: PlatformTableDef[] = [
@@ -157,6 +161,30 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_portfolio",
     manageCapability: "view_portfolio", // read-only grid; adapter performs no writes
     homeSurface: { path: "/portfolio", label: "Portfolio", board: true },
+  },
+  {
+    entityType: "customer_account",
+    label: "Customers",
+    description: "Customer accounts as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_customer",
+    manageCapability: "view_customer", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/customer", label: "Customers", board: true },
+  },
+  {
+    entityType: "employee_profile",
+    label: "People",
+    description: "The team directory as a read-only grid (safe fields only) — board by status.",
+    viewCapability: "view_employee",
+    manageCapability: "view_employee", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/employee", label: "People", board: true },
+  },
+  {
+    entityType: "supplier",
+    label: "Suppliers",
+    description: "Suppliers as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_finance",
+    manageCapability: "view_finance", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/finance", label: "Finance", board: true },
   },
 ];
 

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -181,9 +181,9 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
   {
     entityType: "supplier",
     label: "Suppliers",
-    description: "Suppliers as a read-only grid — sort, filter, and board by status.",
+    description: "Suppliers as an editable spreadsheet — edit safe fields inline; tax/bank details stay out.",
     viewCapability: "view_finance",
-    manageCapability: "view_finance", // read-only grid; adapter performs no writes
+    manageCapability: "manage_finance", // validated raw-write tier (editableFields allow-list)
     homeSurface: { path: "/finance", label: "Finance", board: true },
   },
 ];

--- a/apps/web/lib/workbooks/risk-adapter.ts
+++ b/apps/web/lib/workbooks/risk-adapter.ts
@@ -65,7 +65,7 @@ class RiskAssessmentAdapter implements DataSourceAdapter {
   readonly entityType = RISK_ENTITY_TYPE;
 
   async getColumns(): Promise<ColumnDefinition[]> {
-    return RISK_COLUMNS;
+    return RISK_COLUMNS.map((c) => ({ ...c, provenanceKind: "system" as const }));
   }
 
   async queryRows(

--- a/apps/web/lib/workbooks/sheet-import.test.ts
+++ b/apps/web/lib/workbooks/sheet-import.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  inferFieldType,
+  coerceImportCell,
+  uniqueColumnNames,
+  inferTableFromSheet,
+  type SheetCell,
+} from "./sheet-import";
+
+describe("inferFieldType", () => {
+  it("detects number, checkbox, date, and falls back to text", () => {
+    expect(inferFieldType([1, 2, "3"])).toBe("number");
+    expect(inferFieldType([true, false])).toBe("checkbox");
+    expect(inferFieldType([new Date("2026-01-01"), new Date("2026-02-01")])).toBe("date");
+    expect(inferFieldType(["a", 1])).toBe("text");
+    expect(inferFieldType([null, ""])).toBe("text");
+  });
+});
+
+describe("coerceImportCell", () => {
+  it("coerces by field type and blanks to null", () => {
+    expect(coerceImportCell("number", "12")).toBe(12);
+    expect(coerceImportCell("checkbox", true)).toBe(true);
+    expect(coerceImportCell("date", new Date("2026-01-01T00:00:00.000Z"))).toBe("2026-01-01T00:00:00.000Z");
+    expect(coerceImportCell("text", 5)).toBe("5");
+    expect(coerceImportCell("number", null)).toBeNull();
+  });
+});
+
+describe("uniqueColumnNames", () => {
+  it("fills blanks and de-duplicates", () => {
+    expect(uniqueColumnNames(["Name", "", "Name", null])).toEqual(["Name", "Column 2", "Name 2", "Column 4"]);
+  });
+});
+
+describe("inferTableFromSheet", () => {
+  it("builds columns + typed rows from a matrix, skipping empty rows", () => {
+    const matrix: SheetCell[][] = [
+      ["Name", "Qty", "Active"],
+      ["Widget", 10, true],
+      ["Gadget", "20", false],
+      [null, null, null],
+    ];
+    const { columns, rows, truncated } = inferTableFromSheet(matrix);
+    expect(columns).toEqual([
+      { name: "Name", fieldType: "text" },
+      { name: "Qty", fieldType: "number" },
+      { name: "Active", fieldType: "checkbox" },
+    ]);
+    expect(rows).toEqual([
+      { Name: "Widget", Qty: 10, Active: true },
+      { Name: "Gadget", Qty: 20, Active: false },
+    ]);
+    expect(truncated).toBe(false);
+  });
+
+  it("returns an empty table for an empty matrix", () => {
+    expect(inferTableFromSheet([])).toEqual({ columns: [], rows: [], truncated: false });
+  });
+});

--- a/apps/web/lib/workbooks/sheet-import.ts
+++ b/apps/web/lib/workbooks/sheet-import.ts
@@ -1,0 +1,104 @@
+// Universal Grid & Workbooks — spreadsheet import inference (EP-GRID-WORKBOOKS Phase 3)
+//
+// Pure logic that turns a parsed sheet matrix (first row = headers) into a
+// workbook table definition: deduped column names, an inferred field type per
+// column, and typed cell rows. Kept pure + unit-testable; the server action wires
+// it to the .xlsx parser (read-excel-file) and the workbook service.
+
+import type { CellValue, FieldType } from "./types";
+
+/** What read-excel-file yields per cell. */
+export type SheetCell = string | number | boolean | Date | null;
+
+export interface ImportedColumn {
+  name: string;
+  fieldType: FieldType;
+}
+
+export interface ImportedTable {
+  columns: ImportedColumn[];
+  /** Rows keyed by column name (the action maps names → columnIds after creation). */
+  rows: Record<string, CellValue>[];
+  truncated: boolean;
+}
+
+export const MAX_IMPORT_COLUMNS = 100;
+export const MAX_IMPORT_ROWS = 5000;
+
+function isBlank(v: SheetCell): boolean {
+  return v === null || v === undefined || (typeof v === "string" && v.trim() === "");
+}
+
+/** Infer a column's field type from a sample of its (non-blank) values. */
+export function inferFieldType(values: SheetCell[]): FieldType {
+  const present = values.filter((v) => !isBlank(v));
+  if (present.length === 0) return "text";
+  if (present.every((v) => v instanceof Date)) return "date";
+  if (present.every((v) => typeof v === "boolean")) return "checkbox";
+  if (
+    present.every(
+      (v) => typeof v === "number" || (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))),
+    )
+  ) {
+    return "number";
+  }
+  return "text";
+}
+
+/** Coerce a raw sheet cell to a typed CellValue for the inferred field type. */
+export function coerceImportCell(fieldType: FieldType, value: SheetCell): CellValue {
+  if (isBlank(value)) return null;
+  switch (fieldType) {
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "checkbox":
+      return typeof value === "boolean" ? value : String(value).toLowerCase() === "true";
+    case "date":
+    case "datetime":
+      return value instanceof Date ? value.toISOString() : String(value);
+    default:
+      return String(value);
+  }
+}
+
+/** Make column names unique + non-empty (Excel allows blank/duplicate headers). */
+export function uniqueColumnNames(header: SheetCell[]): string[] {
+  const seen = new Map<string, number>();
+  return header.map((h, i) => {
+    let base = (h === null || h === undefined ? "" : String(h)).trim() || `Column ${i + 1}`;
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    if (count > 0) base = `${base} ${count + 1}`;
+    return base;
+  });
+}
+
+/**
+ * Turn a sheet matrix into an importable table. The first row is the header.
+ * Empty rows are skipped; columns/rows are capped (truncated flag set when hit).
+ */
+export function inferTableFromSheet(matrix: SheetCell[][]): ImportedTable {
+  if (matrix.length === 0) return { columns: [], rows: [], truncated: false };
+  const header = (matrix[0] ?? []).slice(0, MAX_IMPORT_COLUMNS);
+  const names = uniqueColumnNames(header);
+  const colCount = names.length;
+
+  const body = matrix.slice(1).filter((r) => r.some((c) => !isBlank(c)));
+  const truncated = body.length > MAX_IMPORT_ROWS || (matrix[0]?.length ?? 0) > MAX_IMPORT_COLUMNS;
+  const cappedBody = body.slice(0, MAX_IMPORT_ROWS);
+
+  const columns: ImportedColumn[] = names.map((name, i) => ({
+    name,
+    fieldType: inferFieldType(cappedBody.map((r) => r[i] ?? null)),
+  }));
+
+  const rows = cappedBody.map((r) => {
+    const obj: Record<string, CellValue> = {};
+    for (let i = 0; i < colCount; i += 1) {
+      obj[names[i]!] = coerceImportCell(columns[i]!.fieldType, r[i] ?? null);
+    }
+    return obj;
+  });
+
+  return { columns, rows, truncated };
+}

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -72,6 +72,24 @@ export interface FieldConfig {
   lookup?: LookupConfig;
 }
 
+/**
+ * Where a column's values come from — the spec's three-tier provenance, shown as
+ * a progressively-disclosed per-column label (official / live source / calculated
+ * / your note). `system` = a governed platform field; `source` = a live external
+ * feed (Phase 6); `derived` = computed (formula/lookup); `manual` = a free-form
+ * user column.
+ */
+export const PROVENANCE_KINDS = ["system", "source", "derived", "manual"] as const;
+export type ProvenanceKind = (typeof PROVENANCE_KINDS)[number];
+
+/** Human label for a provenance kind (end-user wording — no engineering jargon). */
+export const PROVENANCE_LABELS: Record<ProvenanceKind, string> = {
+  system: "Official",
+  source: "Live source",
+  derived: "Calculated",
+  manual: "Your note",
+};
+
 /** A column as the grid consumes it — derived from a WorkbookColumn or an adapter's getColumns(). */
 export interface ColumnDefinition {
   columnId: string;
@@ -85,6 +103,13 @@ export interface ColumnDefinition {
   editable: boolean;
   /** kanban group-by eligibility (select-like columns) */
   groupable?: boolean;
+  /** value provenance, surfaced via progressive disclosure (defaults to "manual" if absent) */
+  provenanceKind?: ProvenanceKind;
+}
+
+/** Derive provenance from field type for a custom (user-table) column. */
+export function customColumnProvenance(fieldType: FieldType): ProvenanceKind {
+  return isComputedFieldType(fieldType) ? "derived" : "manual";
 }
 
 /** A reference cell value carries both the id and a resolved display label. */

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -106,12 +106,20 @@ columns (fail-closed)** are NOT yet written — tracked for the governance/lifec
 v1 computed columns are local-derivation only, no SoR mutation, so the fail-closed lineage invariant
 (which guards *promotion*) is not yet engaged.
 
-## Slice 3 — `provenanceKind` + progressive disclosure — separate PR (BI-B8549363)
+## Slice 3 — `provenanceKind` + progressive disclosure — SHIPPED (BI-B8549363)
 
-Additive migration: `WorkbookColumn.provenanceKind` (`system|source|derived|manual`). Platform-adapter
-columns report `system`; custom columns default `manual`; slice-2 derived columns are `derived`.
-Progressive disclosure: labels hidden until hover/advanced toggle (Dale review). One migration +
-seed-safe default + adapter `getColumns` populates it + a hover label in the grid header.
+**No migration** — provenance is *derived*, not stored: platform/generic adapters report `system`;
+custom columns are `derived` (formula/lookup) or `manual` (everything else) via
+`customColumnProvenance`. Avoids the deploy-gap entirely and is the correct source of truth (a
+column's tier follows from what it is, not a stored flag that could drift).
+
+- `ColumnDefinition.provenanceKind` + `PROVENANCE_KINDS`/`PROVENANCE_LABELS` (end-user wording:
+  Official / Live source / Calculated / Your note).
+- Every adapter's `getColumns` tags provenance (backlog/invoice/risk/generic = system; custom = derived/manual).
+- **Progressive disclosure (Dale review):** the grid reads as an ordinary spreadsheet; a "Show data
+  sources" toggle reveals a small per-column provenance label in the header. Hidden by default.
+
+`source` (live external feeds) stays unused until Phase 6 integrations land.
 
 ## Slice 4 — Multi-step undo/redo — separate PR (BI-BA57AB71)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -149,11 +149,14 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 
 - **Slice 6 — grid quick filter — SHIPPED.** A client-side, case-insensitive substring filter
   across all columns (pure, unit-tested `grid-filter.ts`; matches reference labels too), with a
-  toolbar search box + "N of M" count. Filters the rows already loaded; server-side/push-down
-  filtering for large datasets is a reporting-phase concern.
-- **Remaining (not built):** per-column filters + AND/OR builder; saved views (persist to the
-  existing `WorkbookView`); conditional formatting (color scales / data bars / icon sets /
-  formula rules); calendar + gallery views; CSV + `.xlsx` import; group-by summary.
+  toolbar search box + "N of M" count.
+- **Slice 7 — per-column filters — SHIPPED.** A toggleable filter panel with one control per column
+  (select → option dropdown, checkbox → checked/unchecked, else text), AND-combined with the quick
+  filter (`applyColumnFilters`, unit-tested), with an active-count badge + Clear. Client-side over
+  loaded rows; precise number/date operators + saved views are follow-ups.
+- **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
+  conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
+  views; CSV + `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -121,11 +121,14 @@ column's tier follows from what it is, not a stored flag that could drift).
 
 `source` (live external feeds) stays unused until Phase 6 integrations land.
 
-## Slice 4 — Multi-step undo/redo — separate PR (BI-BA57AB71)
+## Slice 4 — Multi-step undo/redo — SHIPPED (BI-BA57AB71)
 
-Undo/redo stack in the `<Grid>` contract; each undo replays the inverse edit through the same
-validated dispatch (never raw write); reject + show error + leave cell unchanged when the inverse
-is invalid (parity with #1634 optimistic revert). Cell-value edits in scope; row add/delete deferred.
+Undo/redo for cell edits in the `<Grid>`. Each inverse replays through the **same validated
+dispatch** as a normal edit (never a raw write); a rejected inverse shows the error and leaves the
+cell unchanged (persistCell's optimistic revert, parity with #1634). Ctrl-Z / Ctrl-Y (+ Ctrl-Shift-Z)
+and toolbar Undo/Redo buttons; the keyboard handler yields to a cell editor's own text-undo. Stack
+transitions extracted to a pure, unit-tested `grid-history.ts` (record clears the redo branch;
+commitUndo/commitRedo move entries; LIFO). Cell-value edits in scope; row add/delete deferred.
 
 ## Slice 5 — More read-only generic grids — separate PR (BI-29E1F452)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -130,10 +130,14 @@ and toolbar Undo/Redo buttons; the keyboard handler yields to a cell editor's ow
 transitions extracted to a pure, unit-tested `grid-history.ts` (record clears the redo branch;
 commitUndo/commitRedo move entries; LIFO). Cell-value edits in scope; row add/delete deferred.
 
-## Slice 5 — More read-only generic grids — separate PR (BI-29E1F452)
+## Slice 5 — More read-only generic grids — SHIPPED (BI-29E1F452)
 
-~15-line config rows on the #1722 generic adapter for customers, employees (safe-fields allow-list
-only — no PII/comp), suppliers. Each behind its domain view capability.
+Customers (`customer_account`, view_customer), people (`employee_profile`, view_employee — safe
+org-directory fields only), suppliers (`supplier`, view_finance) as read-only generic grids +
+boards. Allow-lists live in `people-supplier-configs.ts` (a light, type-only-import module) and are
+**unit-tested for safe omission**: the employee grid asserts no legal-name-parts/personal-contact/
+comp/PII/addresses/termination; supplier omits tax/bank/address; customer omits revenue/notes/source.
+They also become reference targets automatically (slice 1). Each behind its domain view capability.
 
 ## Ordering rationale
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -165,9 +165,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   chosen column and shows count + numeric aggregates (sum/avg/min/max) of a chosen value column per
   group. Pure, unit-tested `grid-summary.ts` (`summarize`/`toSummaryNumber`). Over loaded rows; full
   pivots (multi-dimension, subtotals, %) + SQL push-down are later Phase-4 work.
+- **Slice 13 — summary chart — SHIPPED.** A Table/Chart toggle in the Summary panel renders a CSS
+  bar chart of the grouped metric (count, or the value column's sum), scaled to the largest bar.
+  Pure, unit-tested `summaryChartBars`. Richer chart types (pie/line via recharts) are a follow-up.
 - **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import; full pivots + charts/dashboards; metrics/semantic layer;
-  operationalization lifecycle.
+  calendar + gallery views; `.xlsx` import (slice 12, in flight); full pivots + richer charts;
+  metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -168,9 +168,13 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Slice 13 — summary chart — SHIPPED.** A Table/Chart toggle in the Summary panel renders a CSS
   bar chart of the grouped metric (count, or the value column's sum), scaled to the largest bar.
   Pure, unit-tested `summaryChartBars`. Richer chart types (pie/line via recharts) are a follow-up.
-- **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import (slice 12, in flight); full pivots + richer charts;
-  metrics/semantic layer; operationalization lifecycle.
+- **Slice 14 — persistent grid views — SHIPPED.** The per-grid view (quick filter, column filters,
+  sort, conditional-format rules, provenance toggle) is saved per tableId and restored on reload.
+  Client-side localStorage (works for every grid, no migration); pure, unit-tested `grid-view-state.ts`
+  with defensive parsing (malformed/old payloads ignored field-by-field). Named/shareable server-side
+  views (WorkbookView) are a follow-up.
+- **Remaining (not built):** named/shareable views; calendar + gallery views; full pivots + richer
+  charts; metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -173,8 +173,11 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   Client-side localStorage (works for every grid, no migration); pure, unit-tested `grid-view-state.ts`
   with defensive parsing (malformed/old payloads ignored field-by-field). Named/shareable server-side
   views (WorkbookView) are a follow-up.
-- **Remaining (not built):** named/shareable views; calendar + gallery views; full pivots + richer
-  charts; metrics/semantic layer; operationalization lifecycle.
+- **Slice 15 — gallery (card) view — SHIPPED.** A Grid/Gallery toggle on the WorkbookGrid renders
+  rows as cards (one card per row, each column as a label/value pair), honoring the active filters,
+  sort, and conditional-format colour (a left-border accent). No new dependency, like the kanban board.
+- **Remaining (not built):** named/shareable views; calendar view (fullcalendar — needs a date
+  column); full pivots + richer charts; metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -144,3 +144,24 @@ They also become reference targets automatically (slice 1). Each behind its doma
 References (1) are the relational substrate rollups/lookups (2) require. `provenanceKind` (3) is
 cheap and clarifies tiers but does not block 1–2. Undo/redo (4) is independent. Generic grids (5)
 are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
+
+## Phase 3 — Spreadsheet-on-data UX (toward Smartsheet parity)
+
+- **Slice 6 — grid quick filter — SHIPPED.** A client-side, case-insensitive substring filter
+  across all columns (pure, unit-tested `grid-filter.ts`; matches reference labels too), with a
+  toolbar search box + "N of M" count. Filters the rows already loaded; server-side/push-down
+  filtering for large datasets is a reporting-phase concern.
+- **Remaining (not built):** per-column filters + AND/OR builder; saved views (persist to the
+  existing `WorkbookView`); conditional formatting (color scales / data bars / icon sets /
+  formula rules); calendar + gallery views; CSV + `.xlsx` import; group-by summary.
+
+## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
+
+- **Supabase tier:** an *editable* generic adapter (any allow-listed Prisma model writable) — needs
+  a design call (raw validated writes for models without a domain action, as an explicit lower tier,
+  vs. always requiring a bespoke validated action). The biggest remaining Supabase-defining feature.
+- **Reporting (Phase 4):** group-by/pivots, charts/dashboards via report-kit, drill-through,
+  scheduled refresh, RLS pre-aggregation, push-down/materialization, cross-row aggregation functions.
+- **Semantic layer (Phase 4):** `WorkbookMetric` (unique/owned/versioned, lineage-required).
+- **Operationalization lifecycle (Phase 5):** promote column → metric → schema field / page-visual,
+  with gates + blast-radius + governed retirement; derived-column lineage edges (fail-closed).

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -154,9 +154,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   (select → option dropdown, checkbox → checked/unchecked, else text), AND-combined with the quick
   filter (`applyColumnFilters`, unit-tested), with an active-count badge + Clear. Client-side over
   loaded rows; precise number/date operators + saved views are follow-ups.
+- **Slice 9 — CSV export — SHIPPED.** An "Export CSV" toolbar button downloads the current view
+  (filtered + sorted) as RFC-4180-ish CSV (pure, unit-tested `grid-csv.ts`; reuses `cellSearchText`
+  so exported values match what's shown, including reference labels). Works for every grid.
 - **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
   conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
-  views; CSV + `.xlsx` import; group-by summary.
+  views; `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -157,9 +157,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Slice 9 — CSV export — SHIPPED.** An "Export CSV" toolbar button downloads the current view
   (filtered + sorted) as RFC-4180-ish CSV (pure, unit-tested `grid-csv.ts`; reuses `cellSearchText`
   so exported values match what's shown, including reference labels). Works for every grid.
-- **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
-  conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
-  views; `.xlsx` import; group-by summary.
+- **Slice 10 — conditional formatting — SHIPPED.** A "Format" panel of rules (column + operator
+  [equals/contains/gt/lt/empty/…] + value + colour); the first matching rule tints the row.
+  Pure, unit-tested `grid-conditional-format.ts` (`ruleMatches`/`rowColor`); applied via
+  react-data-grid `rowClass`. Session-scoped for now; persisting rules to `WorkbookView` is a follow-up.
+- **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
+  calendar + gallery views; `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -161,8 +161,13 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   [equals/contains/gt/lt/empty/…] + value + colour); the first matching rule tints the row.
   Pure, unit-tested `grid-conditional-format.ts` (`ruleMatches`/`rowColor`); applied via
   react-data-grid `rowClass`. Session-scoped for now; persisting rules to `WorkbookView` is a follow-up.
+- **Slice 11 — group-by summary — SHIPPED.** A "Summary" panel groups the (filtered) rows by a
+  chosen column and shows count + numeric aggregates (sum/avg/min/max) of a chosen value column per
+  group. Pure, unit-tested `grid-summary.ts` (`summarize`/`toSummaryNumber`). Over loaded rows; full
+  pivots (multi-dimension, subtotals, %) + SQL push-down are later Phase-4 work.
 - **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import; group-by summary.
+  calendar + gallery views; `.xlsx` import; full pivots + charts/dashboards; metrics/semantic layer;
+  operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -160,9 +160,14 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 
-- **Supabase tier:** an *editable* generic adapter (any allow-listed Prisma model writable) — needs
-  a design call (raw validated writes for models without a domain action, as an explicit lower tier,
-  vs. always requiring a bespoke validated action). The biggest remaining Supabase-defining feature.
+- **Supabase tier — SHIPPED (slice 8).** Editable generic adapter (validated raw-write tier,
+  operator-approved 2026-06-12): a config opts in via `editableFields` (allow-list); the generic
+  adapter writes via Prisma but only to those fields and only after the same `validateCell` the rest
+  of the platform uses (`genericUpdateData`, pure + unit-tested, fail-closed on id/non-allow-listed/
+  invalid). Capability-gated; the existing `updatePlatformCellsAction` path wires it in with no new
+  UI. Proven on `supplier` (safe fields editable; tax/bank/address excluded by omission so
+  unwritable). Customer/employee stay read-only (no manage_* capability exists yet). Adding more
+  editable models is one `editableFields` line + a real `manageCapability`.
 - **Reporting (Phase 4):** group-by/pivots, charts/dashboards via report-kit, drill-through,
   scheduled refresh, RLS pre-aggregation, push-down/materialization, cross-row aggregation functions.
 - **Semantic layer (Phase 4):** `WorkbookMetric` (unique/owned/versioned, lineage-required).


### PR DESCRIPTION
Consolidated umbrella for the Universal Grid & Workbooks Phase 2-4 work (slices 3-15), as a clean signed linear history onto `main` (slices 1-2 already merged via #1727/#1782).

**Smartsheet-equivalent:** three-tier provenance + progressive disclosure · multi-step undo/redo · read-only grids for customers/people/suppliers · quick filter · per-column filters · conditional formatting · CSV export · .xlsx import · group-by summary + bar chart · persistent grid views · gallery (card) view.

**Supabase-equivalent:** any Prisma model as a live grid · cross-entity references · editable tables (validated raw-write tier) · spreadsheet import.

Each slice shipped with a pure, unit-tested core + `pnpm --filter web typecheck` + production build (143 workbooks tests passing on the consolidated branch). History was rebased onto main to keep it linear + DCO-clean after the stacked-PR merge train introduced unsigned merge commits.

Supersedes the now-closed stacked PRs #1789/#1792/#1793/#1797/#1801/#1802/#1803/#1804/#1805 (folded in here).

Not yet live-verified — the served image predates this; first task after merge + self-upgrade is to drive each feature's happy path on the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)