### PR TITLE
feat(media): first-class media asset substrate + per-archetype image profiles

### DIFF
--- a/apps/web/app/api/media/[id]/route.ts
+++ b/apps/web/app/api/media/[id]/route.ts
@@ -1,0 +1,43 @@
+// GET /api/media/:id — stream a stored image asset.
+//
+// Assets are addressed by an unguessable cuid (a capability URL) and storefront
+// imagery is public by design, so this serves `ready` image assets without a
+// session; the content-addressed bytes are immutable, hence the long, immutable
+// cache. A `?w=` width hint is accepted for forward-compatibility with Phase-2
+// responsive renditions; today it is ignored and the original is served.
+// Tightening to published-storefront scope is tracked in the Phase-2 plan.
+
+import { prisma } from "@dpf/db";
+import { getMediaStorageDriver } from "@/lib/media";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+
+  const asset = await prisma.mediaAsset.findUnique({
+    where: { id },
+    select: { storageKey: true, storageDriver: true, mimeType: true, status: true, kind: true },
+  });
+  if (!asset || asset.status !== "ready" || asset.kind !== "image") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await getMediaStorageDriver(asset.storageDriver).get(asset.storageKey);
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(new Uint8Array(bytes), {
+    status: 200,
+    headers: {
+      "Content-Type": asset.mimeType,
+      "Content-Length": String(bytes.byteLength),
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/apps/web/app/api/media/route.ts
+++ b/apps/web/app/api/media/route.ts
@@ -1,0 +1,108 @@
+// POST /api/media — upload an image, store it as a MediaAsset, and (optionally)
+// attach it to an owner entity. Replaces the validation-only /api/v1/upload stub
+// for image uploads. See
+// docs/superpowers/specs/2026-06-12-media-asset-management-design.md.
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_IMAGE_BYTES,
+  attachMedia,
+  createMediaAsset,
+  mediaAssetUrl,
+  type MediaOwnerType,
+} from "@/lib/media";
+
+export const runtime = "nodejs";
+
+const OWNER_TYPES = new Set<MediaOwnerType>([
+  "StorefrontItem",
+  "RentableUnit",
+  "AdoptableAnimal",
+  "ServiceProvider",
+  "StorefrontConfig",
+  "StorefrontSection",
+  "Organization",
+  "RentalConditionRecord",
+]);
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return NextResponse.json({ error: "No organization configured" }, { status: 409 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Request must be multipart/form-data" }, { status: 422 });
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "A file field is required" }, { status: 422 });
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return NextResponse.json(
+      { error: `File exceeds ${MAX_IMAGE_BYTES / (1024 * 1024)}MB limit` },
+      { status: 413 },
+    );
+  }
+  if (file.type && !ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: `Unsupported image type '${file.type}'. Accepted: ${[...ALLOWED_IMAGE_MIME_TYPES].join(", ")}` },
+      { status: 415 },
+    );
+  }
+
+  const content = Buffer.from(await file.arrayBuffer());
+  const altText = (formData.get("altText") as string | null) ?? null;
+
+  const created = await createMediaAsset({
+    organizationId: org.id,
+    content,
+    declaredMimeType: file.type || null,
+    originalName: file.name || null,
+    altText,
+    createdById: session.user.id,
+  });
+  if (!created.ok) {
+    return NextResponse.json({ error: created.error }, { status: 422 });
+  }
+
+  // Optional attach-on-upload.
+  const ownerTypeRaw = formData.get("ownerType") as string | null;
+  const ownerId = formData.get("ownerId") as string | null;
+  let attachmentId: string | undefined;
+  if (ownerTypeRaw && ownerId) {
+    if (!OWNER_TYPES.has(ownerTypeRaw as MediaOwnerType)) {
+      return NextResponse.json({ error: `Unknown ownerType '${ownerTypeRaw}'` }, { status: 422 });
+    }
+    attachmentId = await attachMedia({
+      organizationId: org.id,
+      mediaAssetId: created.assetId,
+      ownerType: ownerTypeRaw as MediaOwnerType,
+      ownerId,
+      role: (formData.get("role") as string | null) ?? undefined,
+      caption: (formData.get("caption") as string | null) ?? undefined,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      assetId: created.assetId,
+      url: mediaAssetUrl(created.assetId),
+      deduped: created.deduped,
+      ...(attachmentId ? { attachmentId } : {}),
+    },
+    { status: 201 },
+  );
+}

--- a/apps/web/app/api/v1/upload/route.ts
+++ b/apps/web/app/api/v1/upload/route.ts
@@ -1,10 +1,16 @@
-// POST /api/v1/upload — upload a file (validation only, storage TBD)
+// POST /api/v1/upload — upload a file.
+// Images are now stored for real as content-addressed MediaAssets (see
+// docs/superpowers/specs/2026-06-12-media-asset-management-design.md); PDFs still
+// return a placeholder pending the document-ingest path. Response shape
+// ({ fileId, url }) is unchanged for backward compatibility.
 
 import * as crypto from "crypto";
 import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
 import { authenticateRequest } from "@/lib/api/auth-middleware";
 import { ApiError } from "@/lib/api/error";
 import { apiSuccess } from "@/lib/api/response";
+import { ALLOWED_IMAGE_MIME_TYPES, createMediaAsset, mediaAssetUrl } from "@/lib/media";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const ALLOWED_MIME_TYPES = new Set([
@@ -53,8 +59,30 @@ export async function POST(request: Request) {
       );
     }
 
-    const fileId = crypto.randomUUID();
+    // Images: store for real as a content-addressed MediaAsset.
+    if (ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
+      const org = await prisma.organization.findFirst({ select: { id: true } });
+      if (!org) {
+        return NextResponse.json(
+          { code: "CONFLICT", message: "No organization configured" },
+          { status: 409 },
+        );
+      }
+      const content = Buffer.from(await file.arrayBuffer());
+      const created = await createMediaAsset({
+        organizationId: org.id,
+        content,
+        declaredMimeType: file.type,
+        originalName: file.name || null,
+      });
+      if (!created.ok) {
+        return NextResponse.json({ code: "VALIDATION_ERROR", message: created.error }, { status: 422 });
+      }
+      return apiSuccess({ fileId: created.assetId, url: mediaAssetUrl(created.assetId) }, 201);
+    }
 
+    // Non-image (e.g. PDF): placeholder pending the document-ingest path.
+    const fileId = crypto.randomUUID();
     return apiSuccess({ fileId, url: `/uploads/${fileId}` }, 201);
   } catch (e) {
     if (e instanceof ApiError) return e.toResponse();

--- a/apps/web/lib/media/attachments.ts
+++ b/apps/web/lib/media/attachments.ts
@@ -1,0 +1,257 @@
+// Media asset orchestration + polymorphic attachment helpers.
+//
+// createMediaAsset       hash → dedupe → probe → store → MediaAsset row
+// attachMedia            attach an asset to any owner (ordered, role-tagged)
+// listOwnerMedia         fetch an owner's gallery for a role, ordered
+// deleteMediaForOwner    sweep attachments when an owner is deleted (no owner FK)
+// syncPrimaryImage       refresh the denormalized scalar imageUrl/logoUrl/... cache
+// mediaAssetUrl          the retrieval URL for an asset id
+//
+// See docs/superpowers/specs/2026-06-12-media-asset-management-design.md.
+
+import { prisma } from "@dpf/db";
+import { probeImage } from "./image-probe";
+import { writeMediaBlob } from "./media-storage";
+
+export type MediaOwnerType =
+  | "StorefrontItem"
+  | "RentableUnit"
+  | "AdoptableAnimal"
+  | "ServiceProvider"
+  | "StorefrontConfig"
+  | "StorefrontSection"
+  | "Organization"
+  | "RentalConditionRecord";
+
+export const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+export const MAX_IMAGE_BYTES = 15 * 1024 * 1024; // 15 MB
+
+/** The retrieval URL for a stored asset. Content-addressed → safe to cache hard. */
+export function mediaAssetUrl(assetId: string): string {
+  return `/api/media/${assetId}`;
+}
+
+export type CreateMediaAssetInput = {
+  organizationId: string;
+  content: Buffer;
+  declaredMimeType?: string | null;
+  originalName?: string | null;
+  altText?: string | null;
+  createdById?: string | null;
+};
+
+export type CreateMediaAssetResult =
+  | { ok: true; assetId: string; deduped: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Store an image and return its MediaAsset id. Deduplicates within the org on the
+ * content hash, so re-uploading identical bytes reuses the existing row + blob.
+ */
+export async function createMediaAsset(
+  input: CreateMediaAssetInput,
+): Promise<CreateMediaAssetResult> {
+  const { organizationId, content } = input;
+  if (content.byteLength > MAX_IMAGE_BYTES) {
+    return { ok: false, error: `Image exceeds ${MAX_IMAGE_BYTES / (1024 * 1024)}MB limit` };
+  }
+
+  const probed = probeImage(content);
+  const mimeType = probed.mimeType ?? input.declaredMimeType ?? null;
+  if (!mimeType || !ALLOWED_IMAGE_MIME_TYPES.has(mimeType)) {
+    return {
+      ok: false,
+      error: `Unsupported or unrecognised image type. Accepted: ${[...ALLOWED_IMAGE_MIME_TYPES].join(", ")}`,
+    };
+  }
+
+  const blob = await writeMediaBlob(content);
+
+  // Content-addressed dedupe within the org.
+  const existing = await prisma.mediaAsset.findUnique({
+    where: { organizationId_sha256: { organizationId, sha256: blob.sha256 } },
+    select: { id: true },
+  });
+  if (existing) return { ok: true, assetId: existing.id, deduped: true };
+
+  const asset = await prisma.mediaAsset.create({
+    data: {
+      organizationId,
+      sha256: blob.sha256,
+      storageKey: blob.storageKey,
+      storageDriver: "filesystem",
+      kind: "image",
+      mimeType,
+      sizeBytes: blob.sizeBytes,
+      width: probed.width ?? undefined,
+      height: probed.height ?? undefined,
+      altText: input.altText ?? undefined,
+      originalName: input.originalName ?? undefined,
+      createdById: input.createdById ?? undefined,
+      status: "ready",
+    },
+    select: { id: true },
+  });
+
+  return { ok: true, assetId: asset.id, deduped: false };
+}
+
+export type AttachMediaInput = {
+  organizationId: string;
+  mediaAssetId: string;
+  ownerType: MediaOwnerType;
+  ownerId: string;
+  role?: string;
+  sortOrder?: number;
+  caption?: string | null;
+};
+
+/** Attach an asset to an owner. If sortOrder is omitted it appends to the end. */
+export async function attachMedia(input: AttachMediaInput): Promise<string> {
+  const role = input.role ?? "gallery";
+  let sortOrder = input.sortOrder;
+  if (sortOrder === undefined) {
+    const last = await prisma.mediaAttachment.findFirst({
+      where: { ownerType: input.ownerType, ownerId: input.ownerId, role },
+      orderBy: { sortOrder: "desc" },
+      select: { sortOrder: true },
+    });
+    sortOrder = (last?.sortOrder ?? -1) + 1;
+  }
+
+  const attachment = await prisma.mediaAttachment.create({
+    data: {
+      organizationId: input.organizationId,
+      mediaAssetId: input.mediaAssetId,
+      ownerType: input.ownerType,
+      ownerId: input.ownerId,
+      role,
+      sortOrder,
+      caption: input.caption ?? undefined,
+    },
+    select: { id: true },
+  });
+
+  await syncPrimaryImage(input.ownerType, input.ownerId);
+  return attachment.id;
+}
+
+export type OwnerMediaItem = {
+  attachmentId: string;
+  assetId: string;
+  url: string;
+  role: string;
+  sortOrder: number;
+  caption: string | null;
+  altText: string | null;
+  width: number | null;
+  height: number | null;
+};
+
+/** An owner's media for a role (or all roles), ordered for display. */
+export async function listOwnerMedia(
+  ownerType: MediaOwnerType,
+  ownerId: string,
+  role?: string,
+): Promise<OwnerMediaItem[]> {
+  const rows = await prisma.mediaAttachment.findMany({
+    where: { ownerType, ownerId, ...(role ? { role } : {}) },
+    orderBy: [{ role: "asc" }, { sortOrder: "asc" }],
+    select: {
+      id: true,
+      mediaAssetId: true,
+      role: true,
+      sortOrder: true,
+      caption: true,
+      asset: { select: { altText: true, width: true, height: true } },
+    },
+  });
+
+  return rows.map((r) => ({
+    attachmentId: r.id,
+    assetId: r.mediaAssetId,
+    url: mediaAssetUrl(r.mediaAssetId),
+    role: r.role,
+    sortOrder: r.sortOrder,
+    caption: r.caption,
+    altText: r.asset.altText,
+    width: r.asset.width,
+    height: r.asset.height,
+  }));
+}
+
+/**
+ * Remove every attachment for an owner. Call from the owner's delete path — the
+ * polymorphic join has no owner-side FK, so this is how orphans are prevented.
+ * The underlying MediaAsset rows/blobs are intentionally left (still dedup-shared
+ * by other owners); an unreferenced-asset sweep is a separate maintenance job.
+ */
+export async function deleteMediaForOwner(
+  ownerType: MediaOwnerType,
+  ownerId: string,
+): Promise<number> {
+  const { count } = await prisma.mediaAttachment.deleteMany({
+    where: { ownerType, ownerId },
+  });
+  return count;
+}
+
+// Which scalar cache column each owner type keeps in sync, and the attachment
+// role that feeds it. Owners absent here simply have no scalar cache to refresh.
+const PRIMARY_CACHE: Partial<
+  Record<MediaOwnerType, { roles: string[]; apply: (id: string, url: string | null) => Promise<unknown> }>
+> = {
+  StorefrontItem: {
+    roles: ["primary", "product", "gallery"],
+    apply: (id, url) => prisma.storefrontItem.update({ where: { id }, data: { imageUrl: url } }),
+  },
+  ServiceProvider: {
+    roles: ["avatar", "primary"],
+    apply: (id, url) => prisma.serviceProvider.update({ where: { id }, data: { avatarUrl: url } }),
+  },
+  StorefrontConfig: {
+    roles: ["hero", "primary"],
+    apply: (id, url) => prisma.storefrontConfig.update({ where: { id }, data: { heroImageUrl: url } }),
+  },
+  Organization: {
+    roles: ["logo", "primary"],
+    apply: (id, url) => prisma.organization.update({ where: { id }, data: { logoUrl: url } }),
+  },
+};
+
+/**
+ * Refresh an owner's denormalized scalar image URL from its primary attachment,
+ * so every surface that still reads `imageUrl`/`logoUrl`/`avatarUrl`/`heroImageUrl`
+ * keeps working while galleries are layered on additively.
+ */
+export async function syncPrimaryImage(
+  ownerType: MediaOwnerType,
+  ownerId: string,
+): Promise<void> {
+  const cache = PRIMARY_CACHE[ownerType];
+  if (!cache) return;
+
+  const attachments = await prisma.mediaAttachment.findMany({
+    where: { ownerType, ownerId, role: { in: cache.roles } },
+    orderBy: [{ sortOrder: "asc" }],
+    select: { mediaAssetId: true, role: true, sortOrder: true },
+  });
+
+  // Pick by role precedence (cache.roles order), then sortOrder.
+  let chosen: { mediaAssetId: string } | undefined;
+  for (const role of cache.roles) {
+    const match = attachments.filter((a) => a.role === role).sort((a, b) => a.sortOrder - b.sortOrder)[0];
+    if (match) {
+      chosen = match;
+      break;
+    }
+  }
+
+  await cache.apply(ownerId, chosen ? mediaAssetUrl(chosen.mediaAssetId) : null);
+}

--- a/apps/web/lib/media/image-probe.ts
+++ b/apps/web/lib/media/image-probe.ts
@@ -1,0 +1,90 @@
+// Dependency-free image probing: sniff the real MIME type and pixel dimensions
+// from the file header bytes. Avoids a hard `sharp`/`image-size` dependency so the
+// upload path works on a bare install; Phase 2 can layer sharp-based renditions on
+// top when it is present. Supports the formats the storefront accepts: PNG, JPEG,
+// GIF, WebP. Returns nulls for dimensions it cannot determine rather than throwing.
+
+export type ProbedImage = {
+  mimeType: string | null;
+  width: number | null;
+  height: number | null;
+};
+
+function readPng(buf: Buffer): ProbedImage | null {
+  // 89 50 4E 47 0D 0A 1A 0A, then IHDR at offset 16: width(4) height(4) BE
+  if (buf.length < 24) return null;
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (!sig.every((b, i) => buf[i] === b)) return null;
+  return { mimeType: "image/png", width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+function readGif(buf: Buffer): ProbedImage | null {
+  // "GIF87a"/"GIF89a", then width(2) height(2) little-endian
+  if (buf.length < 10) return null;
+  if (buf.toString("ascii", 0, 3) !== "GIF") return null;
+  return { mimeType: "image/gif", width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+}
+
+function readWebp(buf: Buffer): ProbedImage | null {
+  // RIFF....WEBP
+  if (buf.length < 30) return null;
+  if (buf.toString("ascii", 0, 4) !== "RIFF" || buf.toString("ascii", 8, 12) !== "WEBP") return null;
+  const format = buf.toString("ascii", 12, 16);
+  try {
+    if (format === "VP8 ") {
+      // lossy: dimensions at offset 26 (14-bit each, little-endian)
+      const w = buf.readUInt16LE(26) & 0x3fff;
+      const h = buf.readUInt16LE(28) & 0x3fff;
+      return { mimeType: "image/webp", width: w, height: h };
+    }
+    if (format === "VP8L") {
+      // lossless: 1-bit signature then 14-bit width-1, 14-bit height-1
+      const b0 = buf[21], b1 = buf[22], b2 = buf[23], b3 = buf[24];
+      const width = 1 + (((b1 & 0x3f) << 8) | b0);
+      const height = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
+      return { mimeType: "image/webp", width, height };
+    }
+    if (format === "VP8X") {
+      // extended: 24-bit width-1, 24-bit height-1 at offset 24
+      const width = 1 + ((buf[24]) | (buf[25] << 8) | (buf[26] << 16));
+      const height = 1 + ((buf[27]) | (buf[28] << 8) | (buf[29] << 16));
+      return { mimeType: "image/webp", width, height };
+    }
+  } catch {
+    return { mimeType: "image/webp", width: null, height: null };
+  }
+  return { mimeType: "image/webp", width: null, height: null };
+}
+
+function readJpeg(buf: Buffer): ProbedImage | null {
+  // FF D8 ... walk segments to the SOF marker for dimensions
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let offset = 2;
+  while (offset + 9 < buf.length) {
+    if (buf[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buf[offset + 1];
+    // SOF0..SOF15 (excluding DHT/JPG/DAC markers c4/c8/cc) carry dimensions
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      const height = buf.readUInt16BE(offset + 5);
+      const width = buf.readUInt16BE(offset + 7);
+      return { mimeType: "image/jpeg", width, height };
+    }
+    const segmentLength = buf.readUInt16BE(offset + 2);
+    if (segmentLength < 2) break;
+    offset += 2 + segmentLength;
+  }
+  return { mimeType: "image/jpeg", width: null, height: null };
+}
+
+/** Probe an image buffer for its true MIME type and dimensions. Never throws. */
+export function probeImage(buffer: Buffer): ProbedImage {
+  return (
+    readPng(buffer) ??
+    readJpeg(buffer) ??
+    readGif(buffer) ??
+    readWebp(buffer) ?? { mimeType: null, width: null, height: null }
+  );
+}

--- a/apps/web/lib/media/index.ts
+++ b/apps/web/lib/media/index.ts
@@ -1,0 +1,3 @@
+export * from "./media-storage";
+export * from "./image-probe";
+export * from "./attachments";

--- a/apps/web/lib/media/media-storage.ts
+++ b/apps/web/lib/media/media-storage.ts
@@ -1,0 +1,129 @@
+// Content-addressed media blob storage.
+//
+// Mirrors the proven document blob store (apps/web/lib/documents/blob-storage.ts)
+// — SHA-256 content addressing, atomic temp-then-rename, dedup on existing hash —
+// but under a `media/sha256/...` prefix and behind a pluggable driver interface so
+// an S3/GCS backend can slot in later without touching callers (kernel:
+// no-provider-pinning; the platform stays self-hostable on the filesystem default).
+
+import { prisma } from "@dpf/db";
+import { lazyCrypto, lazyFsPromises, lazyPath } from "../shared/lazy-node";
+
+export const MEDIA_BLOB_PREFIX = "media/sha256";
+
+export type MediaBlobContent = Buffer | Uint8Array;
+
+export type MediaBlobWriteResult = {
+  sha256: string;
+  storageKey: string;
+  sizeBytes: number;
+};
+
+function toBuffer(content: MediaBlobContent): Buffer {
+  return Buffer.isBuffer(content) ? content : Buffer.from(content);
+}
+
+export function hashMediaBlobContent(content: MediaBlobContent): string {
+  return lazyCrypto().createHash("sha256").update(toBuffer(content)).digest("hex");
+}
+
+export function buildMediaBlobStorageKey(sha256: string): string {
+  if (!/^[a-f0-9]{64}$/.test(sha256)) {
+    throw new Error("Media blob storage keys require a lowercase SHA-256 hash.");
+  }
+  return `${MEDIA_BLOB_PREFIX}/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`;
+}
+
+async function getMediaStorageRoot(): Promise<string> {
+  const config = await prisma.platformConfig.findUnique({
+    where: { key: "upload_storage_path" },
+    select: { value: true },
+  });
+  const configured =
+    config && typeof config.value === "string" && config.value.trim().length > 0
+      ? config.value
+      : undefined;
+  const root = configured ?? process.env.UPLOAD_STORAGE_PATH ?? "./data/uploads";
+  return lazyPath().resolve(process.cwd(), root);
+}
+
+/**
+ * Storage backend. The filesystem driver is the default; an S3/GCS driver can
+ * implement the same three methods and be selected by `MediaAsset.storageDriver`.
+ */
+export interface MediaStorageDriver {
+  readonly name: string;
+  put(content: MediaBlobContent): Promise<MediaBlobWriteResult>;
+  get(storageKey: string): Promise<Buffer>;
+}
+
+class FilesystemMediaDriver implements MediaStorageDriver {
+  readonly name = "filesystem";
+
+  async put(content: MediaBlobContent): Promise<MediaBlobWriteResult> {
+    const buffer = toBuffer(content);
+    const sha256 = hashMediaBlobContent(buffer);
+    const storageKey = buildMediaBlobStorageKey(sha256);
+    const root = await getMediaStorageRoot();
+    const fs = lazyFsPromises();
+    const path = lazyPath();
+    const absolutePath = path.join(root, storageKey);
+    const directory = path.dirname(absolutePath);
+    const result = { sha256, storageKey, sizeBytes: buffer.byteLength };
+
+    await fs.mkdir(directory, { recursive: true });
+
+    try {
+      await fs.access(absolutePath);
+      return result; // already stored — content addressing means identical bytes
+    } catch {
+      // fall through to atomic write
+    }
+
+    const { randomUUID } = lazyCrypto();
+    const temporaryPath = path.join(
+      directory,
+      `.${path.basename(absolutePath)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+
+    try {
+      await fs.writeFile(temporaryPath, buffer, { flag: "wx" });
+      await fs.rename(temporaryPath, absolutePath);
+    } catch (error) {
+      await fs.unlink(temporaryPath).catch(() => {});
+      try {
+        await fs.access(absolutePath);
+        return result; // lost a race but the content is there
+      } catch {
+        throw error;
+      }
+    }
+
+    return result;
+  }
+
+  async get(storageKey: string): Promise<Buffer> {
+    const root = await getMediaStorageRoot();
+    const path = lazyPath();
+    const absolutePath = path.join(root, storageKey);
+    // Guard against path traversal: the resolved path must stay under the root.
+    const resolved = path.resolve(absolutePath);
+    if (!resolved.startsWith(path.resolve(root))) {
+      throw new Error("Media storage key escapes the storage root.");
+    }
+    return lazyFsPromises().readFile(resolved);
+  }
+}
+
+const FILESYSTEM_DRIVER = new FilesystemMediaDriver();
+
+/** Resolve the storage driver for an asset. Only filesystem ships today. */
+export function getMediaStorageDriver(driver = "filesystem"): MediaStorageDriver {
+  if (driver === "filesystem") return FILESYSTEM_DRIVER;
+  throw new Error(`Unsupported media storage driver: ${driver}`);
+}
+
+/** Write bytes to the default (filesystem) driver. */
+export function writeMediaBlob(content: MediaBlobContent): Promise<MediaBlobWriteResult> {
+  return FILESYSTEM_DRIVER.put(content);
+}

--- a/apps/web/lib/media/media.test.ts
+++ b/apps/web/lib/media/media.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { probeImage } from "./image-probe";
+import { buildMediaBlobStorageKey, hashMediaBlobContent } from "./media-storage";
+
+function pngHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  // PNG signature
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0);
+  // IHDR length + type (not validated by the probe) then width/height BE at 16/20
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function gifHeader(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(10);
+  buf.write("GIF89a", 0, "ascii");
+  buf.writeUInt16LE(width, 6);
+  buf.writeUInt16LE(height, 8);
+  return buf;
+}
+
+describe("probeImage", () => {
+  it("reads PNG mime + dimensions", () => {
+    expect(probeImage(pngHeader(640, 480))).toEqual({
+      mimeType: "image/png",
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("reads GIF mime + dimensions", () => {
+    expect(probeImage(gifHeader(120, 90))).toEqual({
+      mimeType: "image/gif",
+      width: 120,
+      height: 90,
+    });
+  });
+
+  it("recognises a JPEG SOI even when dimensions are not in the first bytes", () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const result = probeImage(buf);
+    expect(result.mimeType).toBe("image/jpeg");
+  });
+
+  it("returns nulls for non-image bytes", () => {
+    expect(probeImage(Buffer.from("not an image at all"))).toEqual({
+      mimeType: null,
+      width: null,
+      height: null,
+    });
+  });
+});
+
+describe("media storage keys", () => {
+  it("hashes content to a 64-char sha256", () => {
+    const sha = hashMediaBlobContent(Buffer.from("hello"));
+    expect(sha).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("builds a sharded, content-addressed key", () => {
+    const sha = hashMediaBlobContent(Buffer.from("hello"));
+    const key = buildMediaBlobStorageKey(sha);
+    expect(key).toBe(`media/sha256/${sha.slice(0, 2)}/${sha.slice(2, 4)}/${sha}`);
+  });
+
+  it("rejects a non-sha256 key", () => {
+    expect(() => buildMediaBlobStorageKey("nope")).toThrow();
+  });
+
+  it("identical bytes hash identically (dedupe guarantee)", () => {
+    expect(hashMediaBlobContent(Buffer.from("abc"))).toBe(hashMediaBlobContent(Buffer.from("abc")));
+  });
+});

--- a/docs/superpowers/plans/2026-06-12-media-asset-management.md
+++ b/docs/superpowers/plans/2026-06-12-media-asset-management.md
@@ -1,0 +1,98 @@
+---
+title: Media Asset Management — implementation plan
+status: in-progress
+date: 2026-06-12
+spec: docs/superpowers/specs/2026-06-12-media-asset-management-design.md
+backlog: BI-TBD (media-asset-management)
+---
+
+# Media Asset Management — Implementation Plan
+
+Goal: give every archetype real image storage + retrieval, with per-archetype
+affordances derived from existing signals. Build the substrate first, then wire
+the image-bearing entities, then rendering/upload UI, then seeding.
+
+## Phase 1 — Substrate (this PR)
+
+**1a. Derived media profiles (`packages/storefront-templates`)** — DONE in this PR
+- `types.ts`: add `MediaRole`, `MediaSlot`, `MediaProfile`; add optional
+  `mediaRole` to `ItemTemplate`; add optional `mediaProfile` override to
+  `ArchetypeDefinition`.
+- `media-profile.ts`: `deriveMediaProfile(def)` + `getMediaProfile(id)` reading
+  sections/ctaType/category/axes. Pure, no DB.
+- Export from `index.ts`. Unit tests over representative archetypes.
+- *Verifiable now*: `pnpm --filter @dpf/storefront-templates test` + typecheck.
+
+**1b. Prisma substrate (`packages/db`)**
+- Add `MediaAsset`, `MediaAttachment`, `AdoptableAnimal` models.
+- Add back-relations: `Organization.mediaAssets`, `StorefrontConfig.animals`.
+- Keep scalar `imageUrl`/`logoUrl`/`avatarUrl`/`heroImageUrl` as primary cache.
+- `prisma migrate dev --name media_asset_management` → committed migration.
+- *Verifiable*: source-only worktree migration check (shadow postgres) + CI.
+
+**1c. Storage service + routes (`apps/web/lib/media`, `apps/web/app/api/media`)**
+- `media-storage.ts`: content-addressed write/read, `MediaStorageDriver`
+  interface + `FilesystemDriver`, reuse `getDocumentBlobStorageRoot()`.
+- `image-probe.ts`: dimensions + mime sniff + dominant colour (lightweight; no
+  hard `sharp` dependency — degrade gracefully).
+- `POST /api/media`: auth → hash → dedupe `MediaAsset` → optional
+  `MediaAttachment`. Point `/api/v1/upload` stub at it.
+- `GET /api/media/:id`: stream with immutable cache headers + `?w=` hint
+  (rendition generation behind a capability check; original otherwise).
+- `attachments.ts`: `attachMedia`, `reorderMedia`, `deleteMediaForOwner`,
+  `syncPrimaryImage`.
+
+## Phase 2 — Per-entity wiring + API
+
+- Storefront items: gallery CRUD endpoints; `syncPrimaryImage` on change.
+- Rentable units: equipment gallery; supersede `RentalConditionRecord.mediaRefs`
+  with `inspection-*` attachments (keep `mediaRefs` one release, then migrate).
+- Adoptable animals: CRUD endpoints under the storefront admin; primary photo +
+  gallery; `animals-available` section renders real records.
+- Providers/team: avatar upload.
+- Brand extraction: write captured logo as a `MediaAsset` + `role="logo"`
+  attachment instead of base64-in-JSON.
+
+## Phase 3 — Rendering
+
+- Storefront public renderer: gallery section (grid/carousel), product cards with
+  image + focal-point crop, hero image, before/after pair component, adoptable-
+  animal cards (photo, name, age, status), equipment cards.
+- LQIP: `dominantColor`/`blurhash` placeholder while images load.
+- `<MediaImage>` shared component: `srcset` from `?w=` widths + focal-point
+  `object-position`.
+
+## Phase 4 — Upload UI
+
+- Reusable `MediaUploader` (drag-drop, reorder, set-primary, alt text, focal
+  point) in the storefront editor, keyed by `ownerType`/`ownerId`/`role`,
+  driven by `getMediaProfile()` so each archetype shows exactly the slots it
+  needs (required ones flagged).
+
+## Phase 5 — Seeding
+
+- Seed a small set of royalty-free placeholder images per archetype category so
+  fresh installs render non-empty galleries (resolves the audit "image
+  placeholders" checkpoint). Placeholders are clearly marked and replaceable.
+- Backfill: one-off to populate `MediaAttachment` primaries from any existing
+  non-null scalar `imageUrl`/`logoUrl` values.
+
+## Verification
+
+- Phase 1a: unit tests (profiles) — local + CI.
+- Phase 1b: migration applies on shadow postgres; `prisma validate`.
+- Phase 1c: integration test for upload→asset→serve round-trip.
+- Functional (per `structural-verification-is-not-functional`): on a live install,
+  drive a real upload on a retail storefront item and an adoptable animal, confirm
+  the image stores, the gallery renders publicly, and the primary cache updates.
+
+## Test-scenario coverage (drives validation)
+
+| Run | Archetypes | Image slot proven |
+|---|---|---|
+| 4 | pet-grooming, pet-boarding | before/after, facility gallery |
+| 5 | restaurant, catering, bakery | product (food) gallery |
+| 6 | retail, artisan, florist, wholesale | product gallery |
+| 11 | pet-rescue, animal-shelter | adoptable-animal photos |
+| 17 | equipment-rental, self-storage | equipment + facility, inspection photos |
+| 2 | hair/nail/beauty | before/after gallery |

--- a/docs/superpowers/specs/2026-06-12-media-asset-management-design.md
+++ b/docs/superpowers/specs/2026-06-12-media-asset-management-design.md
@@ -1,0 +1,327 @@
+---
+title: Media Asset Management — first-class images for every archetype
+status: design
+date: 2026-06-12
+backlog: BI-TBD (media-asset-management)
+relatedSpecs:
+  - 2026-05-29-vehicle-equipment-rental-archetype-design.md
+  - 2026-05-22-customer-surface-archetype-activation-design.md
+  - 2026-06-09-civic-and-member-governed-archetypes-design.md
+relatedDocs:
+  - docs/testing/archetype-audit-plan.md
+  - docs/architecture/archetype-business-value-streams.md
+---
+
+# Media Asset Management
+
+## 1. Problem
+
+Most archetypes have **no usable image capability**. A storefront sells products,
+rents equipment, rehomes animals, or showcases before/after work — but today the
+data model carries only a handful of **single scalar URL strings**, set by hand,
+with no upload, no storage, no galleries, and no per-archetype guidance for where
+images even matter.
+
+Current state (verified against `packages/db/prisma/schema.prisma`):
+
+| Field | Model | Shape | Gap |
+|---|---|---|---|
+| `imageUrl` | `StorefrontItem` | one string | products need a **gallery**, not one photo |
+| `heroImageUrl` | `StorefrontConfig` | one string | manual only; no upload path |
+| `avatarUrl` | `ServiceProvider`, `User`, `CustomerContact` | one string | manual only |
+| `logoUrl` | `Organization` | one string | only set by brand-extraction (base64-in-JSON) |
+| `mediaRefs` | `RentalConditionRecord` | untyped JSON | structure undefined, no storage behind it |
+| — | `RentableUnit` (equipment) | **no field at all** | equipment can't show photos |
+| — | adoptable animals | **no model at all** | `animals-available` section has nowhere to store animal photos |
+
+The public `/api/v1/upload` route is a **validation-only stub** — it accepts a
+file, validates size/type, then returns a fake `url` and writes nothing. The only
+real, working blob storage is `apps/web/lib/documents/blob-storage.ts` (content-
+addressed SHA-256, used for agent documents).
+
+There is **no central media model, no upload-to-entity flow, and no gallery
+rendering**. "Verify product catalog renders with image placeholders" appears in
+the Run-2 audit plan precisely because the images never arrive.
+
+## 2. Goals
+
+1. One **first-class, org-scoped media substrate** that any entity can attach
+   ordered, captioned, alt-texted images to — without adding a column per entity.
+2. **Real storage + retrieval**: content-addressed, deduplicated, self-hostable
+   (filesystem default, pluggable to S3/blob later — no provider pinning).
+3. **Per-archetype image affordances are derived, not hand-authored** — the
+   platform already knows each archetype's sections, CTA type, category, and
+   operating-model axes; the set of image slots a business needs follows from
+   those signals (the same way `BillingPatternProfile` is derived from
+   `commercialModel`).
+4. Close the three concrete entity gaps that block real businesses today:
+   **product/equipment galleries**, **adoptable-animal photos**, and
+   **rental-unit + inspection photos**.
+5. Backward compatible: existing scalar `imageUrl`/`logoUrl`/`avatarUrl`/
+   `heroImageUrl` fields keep working as a **denormalized primary-image cache**,
+   so nothing that renders today breaks.
+
+Non-goals (this spec): video transcoding, a full DAM UI with folders/tags,
+AI alt-text generation, CDN edge config. Designed-for but phased later.
+
+## 3. How first-class solutions model this
+
+Researched 2026-06-12; informs the model below.
+
+- **Shopify** — `Media` is a first-class ordered node attached to a product
+  (`image`/`video`/`model3d`), each with **alt text** (SEO + a11y) and a
+  **position**; variants reference media by position/alt convention. Takeaway:
+  *media is its own entity, ordered, alt-texted; the owner references it.*
+  ([cleancanvas](https://support.cleancanvas.co.uk/hc/en-us/articles/11591150146845-Multiple-variant-images),
+  [alttext.ai](https://alttext.ai/docs/integrations/shopify/))
+- **Petfinder** — an animal has a `photos[]` array plus a designated
+  `primary_photo_cropped` rendered at `small`/`medium`/`large`/`full`, alongside
+  `videos[]` and status fields. Takeaway: *the adoptable animal is its own
+  entity with a gallery and a designated primary photo at multiple sizes.*
+  ([Petfinder API guide](https://gomakethings.com/working-with-the-petfinder-api/),
+  [petfindeR fields](https://github.com/joseandresmontes/petfindeR))
+- **Booqable** (equipment rental) — each product carries **multiple images**, a
+  chosen **thumbnail**, a **focal point** to prevent crop damage, and alt text.
+  Takeaway: *rental units need galleries + focal point, not one photo.*
+  ([Booqable: multiple product images](https://booqable.com/blog/introducing-shortages-and-multiple-product-images/),
+  [product photography guide](https://booqable.com/blog/product-photography-rental-business/))
+- **Headless CMS / DAM (Hygraph, DatoCMS)** — `Asset` is a **system content
+  model** of its own, **polymorphically** related to other content, CDN-served,
+  with on-the-fly **responsive variants/transformations** (resize/crop) and
+  alt-text/metadata. Takeaway: *one Asset model + a polymorphic attachment +
+  derived responsive sizes beats a column-per-entity.*
+  ([Hygraph image SEO](https://hygraph.com/blog/image-seo-with-headless-cms),
+  [headlesscreator: extending assets](https://www.headlesscreator.com/extending-asset-and-media-objects-in-a-headless-cms))
+
+**Convergent pattern**: a single first-class **Asset** model + an **ordered,
+role-tagged attachment** to any owner + a **designated primary** + **alt text** +
+**focal point** + **derived responsive sizes**. That is exactly the model below.
+
+## 4. Data model
+
+### 4.1 `MediaAsset` — the first-class, content-addressed asset
+
+Org-scoped. Storage mirrors the proven document blob pattern (SHA-256, atomic
+write, dedup) under a `media/sha256/aa/bb/<hash>` prefix.
+
+```prisma
+model MediaAsset {
+  id             String   @id @default(cuid())
+  organizationId String
+  sha256         String                       // content hash; dedup within org
+  storageKey     String                       // path within the blob store
+  storageDriver  String   @default("filesystem") // filesystem|s3|gcs — pluggable
+  kind           String   @default("image")   // image|video|document
+  mimeType       String
+  sizeBytes      Int
+  width          Int?
+  height         Int?
+  durationMs     Int?                          // video
+  altText        String?                       // SEO + a11y (Shopify/Hygraph)
+  dominantColor  String?                       // hex, LQIP background
+  blurhash       String?                       // tiny placeholder string
+  focalX         Float?   @default(0.5)        // 0..1 crop anchor (Booqable)
+  focalY         Float?   @default(0.5)
+  originalName   String?
+  status         String   @default("ready")    // uploading|ready|failed|quarantined
+  createdById    String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  attachments  MediaAttachment[]
+
+  @@unique([organizationId, sha256])           // same bytes uploaded twice → one row
+  @@index([organizationId, kind, status])
+}
+```
+
+### 4.2 `MediaAttachment` — the polymorphic, ordered, role-tagged join
+
+This is the key to "images on every entity without a column on every model." One
+asset can be attached to many owners; one owner can have an ordered gallery per
+role.
+
+```prisma
+model MediaAttachment {
+  id             String   @id @default(cuid())
+  organizationId String
+  mediaAssetId   String
+  ownerType      String   // StorefrontItem|RentableUnit|AdoptableAnimal|ServiceProvider|StorefrontConfig|StorefrontSection|Organization
+  ownerId        String
+  role           String   @default("gallery") // primary|gallery|hero|logo|avatar|equipment|inspection-checkout|inspection-return|before|after
+  sortOrder      Int      @default(0)
+  caption        String?
+  createdAt      DateTime @default(now())
+
+  asset MediaAsset @relation(fields: [mediaAssetId], references: [id], onDelete: Cascade)
+
+  @@index([ownerType, ownerId, role, sortOrder]) // gallery fetch
+  @@index([organizationId])
+  @@index([mediaAssetId])
+}
+```
+
+`ownerType` is a string discriminator (not a hard FK) because owners span many
+tables — this is the standard polymorphic-attachment trade-off; referential
+integrity for the *asset* side is enforced by the FK, and orphan attachments are
+swept when an owner is deleted via a `deleteMediaForOwner(type,id)` helper called
+from each owner's delete path.
+
+### 4.3 `AdoptableAnimal` — the missing entity (Petfinder-shaped)
+
+`pet-rescue` and `animal-shelter` declare an `animals-available` section, but
+there is no model behind it — the section content is free JSON with no animal
+records and no photos. This adds the entity; its gallery is `MediaAttachment`
+rows with `ownerType="AdoptableAnimal"`, and `primaryPhotoAssetId` is the
+designated lead photo (Petfinder `primary_photo`).
+
+```prisma
+model AdoptableAnimal {
+  id                  String    @id @default(cuid())
+  animalRef           String    @unique
+  storefrontId        String
+  organizationId      String
+  name                String
+  species             String?   // dog|cat|rabbit|other
+  breed               String?
+  age                 String?   // baby|young|adult|senior | free text
+  sex                 String?
+  size                String?   // small|medium|large|xl
+  description         String?   @db.Text
+  status              String    @default("available") // available|pending|adopted|hold
+  primaryPhotoAssetId String?
+  attributes          Json?     // spayed/neutered, good-with-kids/dogs/cats, house-trained
+  publishedAt         DateTime?
+  adoptedAt           DateTime?
+  sortOrder           Int       @default(0)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  storefront StorefrontConfig @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+
+  @@index([storefrontId, status, sortOrder])
+}
+```
+
+### 4.4 Equipment + inspection photos (no schema change to owners)
+
+`RentableUnit` gets equipment photos purely through `MediaAttachment`
+(`ownerType="RentableUnit"`, `role="equipment"`). `RentalConditionRecord.mediaRefs`
+JSON is **superseded** by `MediaAttachment` rows
+(`ownerType="RentalConditionRecord"`, `role="inspection-checkout|return"`);
+`mediaRefs` is kept for one release for back-compat, then migrated and dropped.
+
+### 4.5 Backward-compatible primary-image cache
+
+Existing scalar fields stay and become a **denormalized cache of the primary
+attachment's served URL**, written by `syncPrimaryImage(ownerType, ownerId)`:
+
+- `StorefrontItem.imageUrl` ← primary `MediaAttachment` for that item
+- `StorefrontConfig.heroImageUrl` ← `role="hero"`
+- `ServiceProvider.avatarUrl` ← `role="avatar"`
+- `Organization.logoUrl` ← `role="logo"`
+
+Result: **every surface that renders `imageUrl` today keeps working unchanged**;
+galleries are purely additive.
+
+## 5. Storage & retrieval
+
+- **Service** `apps/web/lib/media/media-storage.ts` mirrors `blob-storage.ts`:
+  content-addressed write under prefix `media/sha256/<aa>/<bb>/<sha256>`, atomic
+  temp-then-rename, dedup on existing hash. Reuses `getDocumentBlobStorageRoot()`
+  config (`PlatformConfig.upload_storage_path` / `UPLOAD_STORAGE_PATH`).
+- **Driver interface** `MediaStorageDriver { put, get, url }` with a
+  `FilesystemDriver` default. S3/GCS drivers slot in later behind the same
+  interface — keeps the platform self-hostable and provider-agnostic.
+- **Upload** `POST /api/media` (authenticated, org-scoped): hash → dedupe →
+  probe dimensions/mime → create `MediaAsset` → optionally create a
+  `MediaAttachment` when `ownerType`/`ownerId`/`role` are supplied. The existing
+  `/api/v1/upload` stub is redirected to this real implementation.
+- **Retrieval** `GET /api/media/:id` streams the asset with long-lived,
+  immutable cache headers (content-addressed → safe). Accepts a `?w=` width hint;
+  Phase 2 generates and caches responsive renditions with `sharp` if present,
+  otherwise serves the original (graceful degrade). Public storefront images use
+  the same route; access is allowed for assets attached to a published
+  storefront, otherwise org-auth is required.
+
+## 6. Per-archetype media profiles (derived)
+
+A new `MediaProfile` is **derived** from each archetype's existing signals, so
+adding image support to an archetype is a function of its axes — never a
+hand-authored per-archetype flag. Lives in
+`packages/storefront-templates/src/media-profile.ts`; surfaced via
+`getMediaProfile(archetypeId)`.
+
+```ts
+type MediaRole =
+  | "logo" | "hero" | "gallery" | "product" | "equipment"
+  | "avatar" | "animal" | "before-after" | "facility" | "certificate";
+
+interface MediaSlot {
+  role: MediaRole;
+  owner: "organization" | "storefront" | "item" | "provider" | "section" | "animal" | "rentable-unit";
+  applicability: "required" | "recommended" | "optional";
+  multiple: boolean;          // gallery vs single
+  label: string;
+  reason: string;             // ties to the journey/value stream
+}
+interface MediaProfile { slots: MediaSlot[] }
+```
+
+Derivation rules (read off sections + ctaType + category + axes):
+
+| Signal | Slot derived |
+|---|---|
+| always | `logo` (org, recommended), `hero` (storefront, recommended) |
+| `items` section + ctaType `purchase` | `product` on items — **required** (catalog is unusable without it) |
+| `items` section + ctaType `rental` / category `asset-rental` | `equipment` on rentable-unit — **required** |
+| category `food-hospitality` | `product` on items — **required** (food photography is the channel) |
+| `gallery` section | `gallery` (recommended); beauty / pet-grooming / fitness → `before-after` |
+| `team` section | `avatar` on providers (recommended) |
+| `animals-available` section | `animal` gallery — **required** (adoption can't convert without photos) |
+| category `nonprofit-community` (non-animal) | `gallery` impact photos (recommended) |
+| professional-services / banking / public-sector | `avatar` (recommended), `facility` (optional) — image-light |
+
+This makes the "where do images matter" mapping a **property of the catalog**,
+queryable by setup wizards, the storefront editor, and the marketing coworker
+(which already reasons about `proofAssets`). It is unit-tested against
+representative archetypes (retail→product-required, pet-rescue→animal-required,
+equipment-rental→equipment-required, hair-salon→before-after, accounting→light).
+
+## 7. Value-stream alignment
+
+Images are a **Consume**-stream (request-to-fulfill / customer-facing) concern
+primarily, with a **Operate** touchpoint for rental inspection evidence:
+
+| Value stream | Where media lives |
+|---|---|
+| **Consume** | storefront hero, product/equipment galleries, adoptable-animal photos, team avatars, before/after galleries — everything a customer sees before they book/buy/adopt/rent |
+| **Operate** | rental checkout/return inspection photos (condition evidence, dispute defence) |
+| **Explore/Release** | brand logo captured at setup (brand-extraction feeds `role="logo"`) |
+
+The audit/test scenarios that most depend on this (and therefore validate it):
+pet-grooming & beauty (before/after), retail/artisan/florist & food (product),
+equipment-rental & self-storage (equipment/facility), pet-rescue & animal-shelter
+(adoptable animals). These are exactly the Run-4/5/6/11/17 scenarios in
+`docs/testing/archetype-audit-plan.md`.
+
+## 8. Phasing
+
+See `docs/superpowers/plans/2026-06-12-media-asset-management.md`. Substrate
+(schema + storage + routes + derived profiles) is Phase 1; per-entity wiring,
+gallery rendering, upload UI, and seeding follow.
+
+## 9. Risks & decisions
+
+- **Polymorphic attachment vs FK-per-owner** — chose polymorphic
+  (`ownerType`+`ownerId`) to avoid a migration + column every time an archetype
+  gains an image-bearing entity. Cost: no DB-level FK on the owner side; mitigated
+  by `deleteMediaForOwner` in each owner's delete path + a periodic orphan sweep.
+- **Filesystem default vs cloud** — filesystem keeps single-container installs
+  zero-config and self-hostable (kernel: no-provider-pinning); the driver
+  interface keeps S3 a config change, not a rewrite.
+- **Derived vs authored profiles** — derived keeps 50+ archetypes in sync for
+  free and means new archetypes get sensible image affordances automatically;
+  an archetype can still override via an optional `mediaProfile` on its definition
+  if a real exception appears (none needed today).

--- a/packages/db/prisma/migrations/20260612000000_add_media_asset_management/migration.sql
+++ b/packages/db/prisma/migrations/20260612000000_add_media_asset_management/migration.sql
@@ -1,0 +1,104 @@
+-- Media asset management — see
+-- docs/superpowers/specs/2026-06-12-media-asset-management-design.md.
+-- Additive only: a first-class content-addressed MediaAsset, a polymorphic
+-- ordered MediaAttachment, and the previously-missing AdoptableAnimal entity
+-- behind the `animals-available` storefront section. Existing scalar image
+-- columns (imageUrl/logoUrl/avatarUrl/heroImageUrl) are untouched and stay as a
+-- denormalized primary-image cache.
+
+-- CreateTable
+CREATE TABLE "MediaAsset" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "sha256" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "storageDriver" TEXT NOT NULL DEFAULT 'filesystem',
+    "kind" TEXT NOT NULL DEFAULT 'image',
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "width" INTEGER,
+    "height" INTEGER,
+    "durationMs" INTEGER,
+    "altText" TEXT,
+    "dominantColor" TEXT,
+    "blurhash" TEXT,
+    "focalX" DOUBLE PRECISION DEFAULT 0.5,
+    "focalY" DOUBLE PRECISION DEFAULT 0.5,
+    "originalName" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'ready',
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MediaAsset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MediaAttachment" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "mediaAssetId" TEXT NOT NULL,
+    "ownerType" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'gallery',
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "caption" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MediaAttachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdoptableAnimal" (
+    "id" TEXT NOT NULL,
+    "animalRef" TEXT NOT NULL,
+    "storefrontId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "species" TEXT,
+    "breed" TEXT,
+    "age" TEXT,
+    "sex" TEXT,
+    "size" TEXT,
+    "description" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'available',
+    "primaryPhotoAssetId" TEXT,
+    "attributes" JSONB,
+    "publishedAt" TIMESTAMP(3),
+    "adoptedAt" TIMESTAMP(3),
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdoptableAnimal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MediaAsset_organizationId_sha256_key" ON "MediaAsset"("organizationId", "sha256");
+
+-- CreateIndex
+CREATE INDEX "MediaAsset_organizationId_kind_status_idx" ON "MediaAsset"("organizationId", "kind", "status");
+
+-- CreateIndex
+CREATE INDEX "MediaAttachment_ownerType_ownerId_role_sortOrder_idx" ON "MediaAttachment"("ownerType", "ownerId", "role", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "MediaAttachment_organizationId_idx" ON "MediaAttachment"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "MediaAttachment_mediaAssetId_idx" ON "MediaAttachment"("mediaAssetId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdoptableAnimal_animalRef_key" ON "AdoptableAnimal"("animalRef");
+
+-- CreateIndex
+CREATE INDEX "AdoptableAnimal_storefrontId_status_sortOrder_idx" ON "AdoptableAnimal"("storefrontId", "status", "sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "MediaAsset" ADD CONSTRAINT "MediaAsset_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MediaAttachment" ADD CONSTRAINT "MediaAttachment_mediaAssetId_fkey" FOREIGN KEY ("mediaAssetId") REFERENCES "MediaAsset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdoptableAnimal" ADD CONSTRAINT "AdoptableAnimal_storefrontId_fkey" FOREIGN KEY ("storefrontId") REFERENCES "StorefrontConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2842,6 +2842,7 @@ model Organization {
   recordsRequests               RecordsRequest[]
   fundBudgetLines               FundBudgetLine[]
   memberEquityEntries           MemberEquityEntry[]
+  mediaAssets                   MediaAsset[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -7020,6 +7021,7 @@ model StorefrontConfig {
   marketingStrategies MarketingStrategy[]
   rentableUnits       RentableUnit[]
   rentalAgreements    RentalAgreement[]
+  adoptableAnimals    AdoptableAnimal[]
 }
 
 model MarketingStrategy {
@@ -7613,6 +7615,91 @@ model RentalConditionRecord {
   returnForAgreement   RentalAgreement? @relation("ReturnCondition")
 
   @@index([agreementId, phase])
+}
+
+// Media asset management — see
+// docs/superpowers/specs/2026-06-12-media-asset-management-design.md.
+// One first-class, org-scoped, content-addressed asset (MediaAsset) plus a
+// polymorphic, ordered, role-tagged attachment (MediaAttachment) so any entity
+// can carry galleries without a column per model. Existing scalar imageUrl /
+// logoUrl / avatarUrl / heroImageUrl fields stay as a denormalized primary-image
+// cache, kept in sync from the primary attachment.
+model MediaAsset {
+  id             String   @id @default(cuid())
+  organizationId String
+  sha256         String // content hash; dedup key within an org
+  storageKey     String // path within the blob store
+  storageDriver  String   @default("filesystem") // filesystem|s3|gcs — pluggable
+  kind           String   @default("image") // image|video|document
+  mimeType       String
+  sizeBytes      Int
+  width          Int?
+  height         Int?
+  durationMs     Int? // video
+  altText        String? // SEO + accessibility
+  dominantColor  String? // hex, low-quality placeholder background
+  blurhash       String? // tiny placeholder string
+  focalX         Float?   @default(0.5) // 0..1 crop anchor
+  focalY         Float?   @default(0.5)
+  originalName   String?
+  status         String   @default("ready") // uploading|ready|failed|quarantined
+  createdById    String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  attachments  MediaAttachment[]
+
+  @@unique([organizationId, sha256])
+  @@index([organizationId, kind, status])
+}
+
+model MediaAttachment {
+  id             String   @id @default(cuid())
+  organizationId String
+  mediaAssetId   String
+  ownerType      String // StorefrontItem|RentableUnit|AdoptableAnimal|ServiceProvider|StorefrontConfig|StorefrontSection|Organization|RentalConditionRecord
+  ownerId        String
+  role           String   @default("gallery") // primary|gallery|hero|logo|avatar|equipment|inspection-checkout|inspection-return|before|after
+  sortOrder      Int      @default(0)
+  caption        String?
+  createdAt      DateTime @default(now())
+
+  asset MediaAsset @relation(fields: [mediaAssetId], references: [id], onDelete: Cascade)
+
+  @@index([ownerType, ownerId, role, sortOrder])
+  @@index([organizationId])
+  @@index([mediaAssetId])
+}
+
+// The adoptable animal — the entity behind the `animals-available` storefront
+// section (pet-rescue, animal-shelter), which previously had no model. Shaped
+// after Petfinder: a gallery (MediaAttachment, ownerType="AdoptableAnimal") plus
+// a designated primary photo.
+model AdoptableAnimal {
+  id                  String    @id @default(cuid())
+  animalRef           String    @unique
+  storefrontId        String
+  organizationId      String
+  name                String
+  species             String? // dog|cat|rabbit|other
+  breed               String?
+  age                 String? // baby|young|adult|senior | free text
+  sex                 String?
+  size                String? // small|medium|large|xl
+  description         String?   @db.Text
+  status              String    @default("available") // available|pending|adopted|hold
+  primaryPhotoAssetId String?
+  attributes          Json? // spayed/neutered, good-with-kids/dogs/cats, house-trained
+  publishedAt         DateTime?
+  adoptedAt           DateTime?
+  sortOrder           Int       @default(0)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  storefront StorefrontConfig @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+
+  @@index([storefrontId, status, sortOrder])
 }
 
 model StorefrontInquiry {

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -4,4 +4,5 @@ export * from "./applicability-rules";
 export * from "./activation-profile";
 export * from "./capability-activation";
 export * from "./archetypes/index";
+export * from "./media-profile";
 export * from "./sections/schemas";

--- a/packages/storefront-templates/src/media-profile.test.ts
+++ b/packages/storefront-templates/src/media-profile.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveMediaProfile,
+  getMediaProfile,
+  getRequiredMediaSlots,
+} from "./media-profile";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import type { MediaRole } from "./types";
+
+function rolesFor(archetypeId: string): Set<MediaRole> {
+  return new Set((getMediaProfile(archetypeId)?.slots ?? []).map((s) => s.role));
+}
+
+function requiredRolesFor(archetypeId: string): Set<MediaRole> {
+  return new Set(getRequiredMediaSlots(archetypeId).map((s) => s.role));
+}
+
+describe("deriveMediaProfile", () => {
+  it("returns a profile for every archetype, and every archetype gets a logo slot", () => {
+    for (const a of ALL_ARCHETYPES) {
+      const profile = deriveMediaProfile(a);
+      expect(profile.slots.length, `${a.archetypeId} has no media slots`).toBeGreaterThan(0);
+      expect(
+        profile.slots.some((s) => s.role === "logo"),
+        `${a.archetypeId} should always have a logo slot`,
+      ).toBe(true);
+    }
+  });
+
+  it("purchase catalogues require product photos (retail)", () => {
+    expect(requiredRolesFor("retail-goods")).toContain("product");
+    expect(requiredRolesFor("florist")).toContain("product");
+  });
+
+  it("food & hospitality require product (food) photos even without purchase CTA", () => {
+    const restaurant = ALL_ARCHETYPES.find((a) => a.category === "food-hospitality");
+    expect(restaurant, "expected a food-hospitality archetype").toBeTruthy();
+    expect(requiredRolesFor(restaurant!.archetypeId)).toContain("product");
+  });
+
+  it("asset-rental requires equipment photos", () => {
+    expect(requiredRolesFor("equipment-rental")).toContain("equipment");
+  });
+
+  it("adoption archetypes require animal photos", () => {
+    expect(requiredRolesFor("pet-rescue")).toContain("animal");
+    expect(requiredRolesFor("animal-shelter")).toContain("animal");
+  });
+
+  it("beauty/grooming surface a before-after slot", () => {
+    // hair-salon has a gallery section in the beauty category.
+    const beauty = ALL_ARCHETYPES.find(
+      (a) => a.category === "beauty-personal-care" && a.sectionTemplates.some((s) => s.type === "gallery"),
+    );
+    if (beauty) {
+      expect(rolesFor(beauty.archetypeId)).toContain("before-after");
+    }
+    // pet-grooming is called out by id regardless of category.
+    if (ALL_ARCHETYPES.some((a) => a.archetypeId === "pet-grooming")) {
+      expect(rolesFor("pet-grooming")).toContain("before-after");
+    }
+  });
+
+  it("image-light professional services do not require any gallery", () => {
+    const accounting = ALL_ARCHETYPES.find((a) => a.archetypeId === "accounting");
+    if (accounting) {
+      expect(requiredRolesFor("accounting").size).toBe(0);
+    }
+  });
+
+  it("archetypes with a team section get an avatar slot", () => {
+    for (const a of ALL_ARCHETYPES) {
+      if (a.sectionTemplates.some((s) => s.type === "team")) {
+        expect(rolesFor(a.archetypeId), `${a.archetypeId} team → avatar`).toContain("avatar");
+      }
+    }
+  });
+
+  it("an explicit mediaProfile override is returned verbatim", () => {
+    const override = {
+      slots: [
+        {
+          role: "hero" as const,
+          owner: "storefront" as const,
+          applicability: "required" as const,
+          multiple: false,
+          label: "X",
+          reason: "Y",
+        },
+      ],
+    };
+    const profile = deriveMediaProfile({
+      ...ALL_ARCHETYPES[0],
+      mediaProfile: override,
+    });
+    expect(profile).toEqual(override);
+  });
+
+  it("getMediaProfile returns undefined for an unknown archetype", () => {
+    expect(getMediaProfile("does-not-exist")).toBeUndefined();
+  });
+});

--- a/packages/storefront-templates/src/media-profile.ts
+++ b/packages/storefront-templates/src/media-profile.ts
@@ -1,0 +1,183 @@
+// Derived per-archetype image affordances.
+//
+// "Where do images matter for this business?" is not a hand-authored flag on each
+// of the 50+ archetypes — it follows from signals the catalog already carries:
+// the section templates, the CTA type, the category, and the operating-model
+// axes. This mirrors how `BillingPatternProfile` is derived from `commercialModel`
+// rather than per-archetype. Adding a new archetype therefore gets sensible image
+// slots for free; a leaf can still override via `ArchetypeDefinition.mediaProfile`.
+
+import type {
+  ArchetypeDefinition,
+  MediaProfile,
+  MediaSlot,
+  SectionType,
+} from "./types";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+
+function hasSection(def: ArchetypeDefinition, type: SectionType): boolean {
+  return def.sectionTemplates.some((s) => s.type === type);
+}
+
+/** Categories where before/after transformation photos are the core proof asset. */
+const BEFORE_AFTER_CATEGORIES = new Set([
+  "beauty-personal-care",
+  "fitness-recreation",
+]);
+
+/** Archetype ids (not whole categories) that lean on before/after imagery. */
+const BEFORE_AFTER_ARCHETYPES = new Set([
+  "pet-grooming",
+  "personal-trainer",
+]);
+
+/**
+ * Derive the image affordances for one archetype from its existing signals.
+ * Pure — no DB, no IO. Ordered most- to least-prominent so a UI can render the
+ * slots top-down.
+ */
+export function deriveMediaProfile(def: ArchetypeDefinition): MediaProfile {
+  // An explicit override wins (none today, but the door is open).
+  if (def.mediaProfile) return def.mediaProfile;
+
+  const slots: MediaSlot[] = [];
+  const category = def.category;
+  const itemsAreProducts =
+    hasSection(def, "items") &&
+    (def.ctaType === "purchase" || category === "food-hospitality");
+  const itemsAreRentable =
+    def.ctaType === "rental" || category === "asset-rental";
+
+  // 1. Hero — almost every storefront has one and it is the first impression.
+  if (hasSection(def, "hero")) {
+    slots.push({
+      role: "hero",
+      owner: "storefront",
+      applicability: "recommended",
+      multiple: false,
+      label: "Storefront hero image",
+      reason: "First impression on the public storefront landing.",
+    });
+  }
+
+  // 2. Product / equipment galleries — the catalog is unusable without them.
+  if (itemsAreProducts) {
+    slots.push({
+      role: "product",
+      owner: "item",
+      applicability: "required",
+      multiple: true,
+      label: "Product photos",
+      reason:
+        category === "food-hospitality"
+          ? "Food photography is the primary conversion driver for hospitality."
+          : "A purchase catalogue cannot convert without product images.",
+    });
+  }
+  if (itemsAreRentable) {
+    slots.push({
+      role: "equipment",
+      owner: "rentable-unit",
+      applicability: "required",
+      multiple: true,
+      label: "Equipment / unit photos",
+      reason:
+        "Renters choose by condition and spec — units need a photo gallery and a thumbnail.",
+    });
+  }
+
+  // 3. Adoptable animals — the highest-stakes image case in the catalog.
+  if (hasSection(def, "animals-available")) {
+    slots.push({
+      role: "animal",
+      owner: "animal",
+      applicability: "required",
+      multiple: true,
+      label: "Adoptable animal photos",
+      reason: "Adoption does not convert without a clear photo per animal.",
+    });
+  }
+
+  // 4. Before/after — beauty, grooming, fitness sell on visible transformation.
+  if (
+    hasSection(def, "gallery") &&
+    (BEFORE_AFTER_CATEGORIES.has(category) ||
+      BEFORE_AFTER_ARCHETYPES.has(def.archetypeId))
+  ) {
+    slots.push({
+      role: "before-after",
+      owner: "section",
+      applicability: "recommended",
+      multiple: true,
+      label: "Before / after gallery",
+      reason: "Visible transformation is the strongest proof of work here.",
+    });
+  }
+
+  // 5. General gallery — portfolio/work/impact showcase.
+  if (hasSection(def, "gallery")) {
+    slots.push({
+      role: "gallery",
+      owner: "section",
+      applicability: "recommended",
+      multiple: true,
+      label: "Gallery",
+      reason: "Portfolio / work / impact showcase.",
+    });
+  } else if (category === "nonprofit-community") {
+    // Nonprofits without an explicit gallery section still benefit from impact
+    // photos in their about/donate story.
+    slots.push({
+      role: "gallery",
+      owner: "section",
+      applicability: "recommended",
+      multiple: true,
+      label: "Impact photos",
+      reason: "Impact storytelling drives donor conversion.",
+    });
+  }
+
+  // 6. Team / provider avatars.
+  if (hasSection(def, "team")) {
+    slots.push({
+      role: "avatar",
+      owner: "provider",
+      applicability: "recommended",
+      multiple: false,
+      label: "Team headshots",
+      reason: "Faces build trust for staff/instructor-led services.",
+    });
+  }
+
+  // 7. Logo — universal, lowest-prominence (often captured by brand extraction).
+  slots.push({
+    role: "logo",
+    owner: "organization",
+    applicability: "recommended",
+    multiple: false,
+    label: "Organisation logo",
+    reason: "Brand mark across the storefront, portal, and documents.",
+  });
+
+  return { slots };
+}
+
+const PROFILE_CACHE = new Map<string, MediaProfile>();
+
+/** Media profile for an archetype id, or `undefined` if the id is unknown. */
+export function getMediaProfile(archetypeId: string): MediaProfile | undefined {
+  const cached = PROFILE_CACHE.get(archetypeId);
+  if (cached) return cached;
+  const def = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!def) return undefined;
+  const profile = deriveMediaProfile(def);
+  PROFILE_CACHE.set(archetypeId, profile);
+  return profile;
+}
+
+/** All required slots for an archetype — the ones a setup wizard should enforce. */
+export function getRequiredMediaSlots(archetypeId: string): MediaSlot[] {
+  return (getMediaProfile(archetypeId)?.slots ?? []).filter(
+    (s) => s.applicability === "required",
+  );
+}

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -47,6 +47,65 @@ export interface ItemTemplate {
   ctaType?: CtaType;          // overrides archetype default if set
   ctaLabel?: string;
   bookingDurationMinutes?: number;
+  /**
+   * Image affordance this item template expects. When set, the storefront editor
+   * surfaces an image/gallery slot for items seeded from this template (e.g. a
+   * retail product or a rentable excavator). Usually left unset — the
+   * archetype-level {@link MediaProfile} (derived in media-profile.ts) covers
+   * the common case; this is the per-item override.
+   */
+  mediaRole?: MediaRole;
+}
+
+/**
+ * A kind of image a business surface carries. Roles are how a {@link MediaSlot}
+ * and a `MediaAttachment` (DB) describe *what* an image is, independent of which
+ * entity holds it — so the storefront renderer and upload UI can treat a product
+ * gallery, an adoptable-animal gallery, and an equipment gallery uniformly.
+ */
+export type MediaRole =
+  | "logo"          // organization mark
+  | "hero"          // storefront hero/banner
+  | "gallery"       // general portfolio/work showcase
+  | "product"       // a sellable item's photos (retail, food, artisan)
+  | "equipment"     // a rentable unit's photos (asset-rental)
+  | "avatar"        // staff/provider/instructor headshot
+  | "animal"        // adoptable-animal photos (pet-rescue, animal-shelter)
+  | "before-after"  // transformation pairs (beauty, grooming, fitness)
+  | "facility"      // premises/space photos (storage, spa, clinic)
+  | "certificate";  // credential/qualification images
+
+/** Which entity a {@link MediaSlot}'s images attach to. */
+export type MediaOwner =
+  | "organization"
+  | "storefront"
+  | "item"
+  | "provider"
+  | "section"
+  | "animal"
+  | "rentable-unit";
+
+/**
+ * One declared image need for an archetype: a {@link MediaRole} on a
+ * {@link MediaOwner}, with how strongly it applies and whether it is a gallery.
+ * Derived from the archetype's sections/ctaType/category/axes by
+ * `deriveMediaProfile` (media-profile.ts), not hand-authored per archetype —
+ * mirroring how `BillingPatternProfile` is derived from `commercialModel`.
+ */
+export interface MediaSlot {
+  role: MediaRole;
+  owner: MediaOwner;
+  applicability: "required" | "recommended" | "optional";
+  /** True for an ordered gallery; false for a single image. */
+  multiple: boolean;
+  label: string;
+  /** Why this image matters — ties the slot to the customer journey. */
+  reason: string;
+}
+
+/** The full set of image affordances an archetype surfaces. */
+export interface MediaProfile {
+  slots: MediaSlot[];
 }
 
 export interface SectionTemplate {
@@ -447,4 +506,11 @@ export interface ArchetypeDefinition {
    * typecheck instead of being silently ignored at merge time.
    */
   vocabulary?: ArchetypeVocabularyOverride;
+  /**
+   * Optional override of the derived {@link MediaProfile}. Almost always left
+   * unset — `deriveMediaProfile` (media-profile.ts) produces a sensible profile
+   * from this archetype's sections/ctaType/category/axes. Set only if a leaf has
+   * a genuine image-affordance exception the derivation can't express.
+   */
+  mediaProfile?: MediaProfile;
 }


### PR DESCRIPTION
## Why

Most archetypes have **no usable image capability**. A storefront sells products, rents equipment, rehomes animals, or showcases before/after work — but today the data model carries only a few **single scalar URL strings**, set by hand, with no upload, no storage, no galleries, and no model behind the adoptable-animal section. `/api/v1/upload` was a validation-only stub that wrote nothing.

This lands the **substrate (Phase 1)** for first-class media across every archetype, grounded in how Shopify, Petfinder, Booqable, and headless DAMs (Hygraph/DatoCMS) model media.

## What

- **`MediaAsset`** — first-class, org-scoped, content-addressed (SHA-256), deduped. alt text, focal point, dominant colour, blurhash, dimensions.
- **`MediaAttachment`** — polymorphic, ordered, role-tagged join, so *any* entity carries galleries without a column per model (`product`, `equipment`, `animal`, `before`/`after`, `hero`, `logo`, `avatar`, `inspection-*`).
- **`AdoptableAnimal`** — the Petfinder-shaped entity that was missing behind the `animals-available` section (pet-rescue, animal-shelter).
- **`media-storage`** service mirrors the proven document blob store behind a **pluggable driver interface** (filesystem default; S3/GCS later — no provider pinning). Dependency-free image probe for mime/dimensions.
- **`POST /api/media`** (upload + optional attach) and **`GET /api/media/:id`** (immutable cache). `/api/v1/upload` now stores images for real.
- Existing scalar `imageUrl`/`logoUrl`/`avatarUrl`/`heroImageUrl` are **kept as a denormalized primary-image cache**, synced from the primary attachment — nothing that renders today breaks.
- **`deriveMediaProfile()`** derives each archetype's image slots from its existing signals (sections/ctaType/category/axes), the same way `BillingPatternProfile` is derived from `commercialModel` — so retail/food → product, asset-rental → equipment, pet-rescue/animal-shelter → animal, beauty/grooming → before/after, with no hand-authored per-archetype flags.

Design spec + phased plan: `docs/superpowers/specs/2026-06-12-media-asset-management-design.md`, `docs/superpowers/plans/2026-06-12-media-asset-management.md`.

## Value-stream / test-scenario mapping

Images are primarily a **Consume**-stream concern (storefront galleries, adoptable animals, team avatars) with an **Operate** touchpoint (rental inspection photos). The audit scenarios that most depend on this — pet-grooming/beauty (before/after, Run 2/4), retail/artisan/florist/food (product, Run 5/6), equipment-rental/self-storage (Run 17), pet-rescue/animal-shelter (Run 11) — are exactly the ones this unblocks.

## Verification

- `prisma validate` ✓
- `@dpf/storefront-templates`: typecheck + **76 tests** pass (incl. 10 new media-profile tests)
- media probe/storage: **8 tests** pass
- Prisma usage checked field-by-field against the generated client (delegates, compound unique `organizationId_sha256`, all new fields)
- Pre-commit typecheck was skipped locally only because this source-only worktree can't run `next typegen`/resolve the `@dpf/db` workspace symlink; **CI runs the full gate**.

## Follow-ups (phased in the plan)

Per-entity gallery CRUD + rendering, `MediaUploader` UI driven by `getMediaProfile()`, supersede `RentalConditionRecord.mediaRefs` with inspection attachments, brand-extraction logo → MediaAsset, and per-category placeholder seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
