### PR TITLE
feat(workbooks): multi-step undo/redo for cell edits (EP-GRID-WORKBOOKS Phase 2)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,7 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -46,6 +46,15 @@ import {
   deleteRowAction,
 } from "@/lib/actions/workbooks";
 import { updatePlatformCellsAction } from "@/lib/actions/platform-grid";
+import {
+  type GridHistory,
+  EMPTY_HISTORY,
+  recordEdit,
+  peekUndo,
+  peekRedo,
+  commitUndo,
+  commitRedo,
+} from "./grid-history";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -179,6 +188,9 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  // Multi-step undo/redo of cell edits (distinct from the audit history). Each
+  // entry's inverse replays through the same validated dispatch as a normal edit.
+  const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
     const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));
@@ -199,7 +211,12 @@ export function WorkbookGrid({
   }, [rowData, sortColumns]);
 
   const persistCell = useCallback(
-    async (rowId: string, columnId: string, value: CellValue, prevValue: CellValue) => {
+    async (
+      rowId: string,
+      columnId: string,
+      value: CellValue,
+      prevValue: CellValue,
+    ): Promise<boolean> => {
       setError(null);
       const res =
         source === "platform"
@@ -211,7 +228,9 @@ export function WorkbookGrid({
         setRowData((prev) =>
           prev.map((r) => (r.rowId === rowId ? { ...r, [columnId]: prevValue } : r)),
         );
+        return false;
       }
+      return true;
     },
     [tableId, source],
   );
@@ -226,11 +245,62 @@ export function WorkbookGrid({
         if (!changed) continue;
         const prevRow = rowData.find((r) => r.rowId === changed.rowId);
         const prevValue: CellValue = prevRow ? prevRow[columnId] ?? null : null;
-        void persistCell(changed.rowId, columnId, changed[columnId] ?? null, prevValue);
+        const nextValue: CellValue = changed[columnId] ?? null;
+        void persistCell(changed.rowId, columnId, nextValue, prevValue).then((ok) => {
+          // Only a committed edit is undoable; a rejected one is already reverted.
+          if (ok) {
+            setHistory((h) => recordEdit(h, { rowId: changed.rowId, columnId, prevValue, nextValue }));
+          }
+        });
       }
       setRowData((prev) => prev.map((r) => byId.get(r.rowId) ?? r));
     },
     [persistCell, rowData],
+  );
+
+  // Replay a cell to a target value through the validated dispatch; on success
+  // commit the stack transition. A failed persist leaves history unchanged
+  // (persistCell already reverted the optimistic cell).
+  const undo = useCallback(() => {
+    const entry = peekUndo(history);
+    if (!entry) return;
+    setRowData((prev) =>
+      prev.map((r) => (r.rowId === entry.rowId ? { ...r, [entry.columnId]: entry.prevValue } : r)),
+    );
+    void persistCell(entry.rowId, entry.columnId, entry.prevValue, entry.nextValue).then((ok) => {
+      if (ok) setHistory((h) => commitUndo(h));
+    });
+  }, [history, persistCell]);
+
+  const redo = useCallback(() => {
+    const entry = peekRedo(history);
+    if (!entry) return;
+    setRowData((prev) =>
+      prev.map((r) => (r.rowId === entry.rowId ? { ...r, [entry.columnId]: entry.nextValue } : r)),
+    );
+    void persistCell(entry.rowId, entry.columnId, entry.nextValue, entry.prevValue).then((ok) => {
+      if (ok) setHistory((h) => commitRedo(h));
+    });
+  }, [history, persistCell]);
+
+  const onKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!capabilities.canEditCell) return;
+      // Don't hijack a cell editor's own text undo while editing.
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+      const key = e.key.toLowerCase();
+      if (key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      } else if (key === "y" || (key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        redo();
+      }
+    },
+    [capabilities.canEditCell, undo, redo],
   );
 
   const onAddRow = useCallback(async () => {
@@ -266,7 +336,7 @@ export function WorkbookGrid({
   }, [tableId, selectedRows]);
 
   return (
-    <div className="flex h-full flex-col gap-2">
+    <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
         {capabilities.canAddRow && (
           <button
@@ -287,6 +357,28 @@ export function WorkbookGrid({
           >
             Delete {selectedRows.size} selected
           </button>
+        )}
+        {capabilities.canEditCell && (
+          <>
+            <button
+              type="button"
+              onClick={undo}
+              disabled={history.undo.length === 0}
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-40"
+              title="Undo (Ctrl+Z)"
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={redo}
+              disabled={history.redo.length === 0}
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-40"
+              title="Redo (Ctrl+Y)"
+            >
+              Redo
+            </button>
+          </>
         )}
         <button
           type="button"

--- a/apps/web/components/workbooks/grid-history.test.ts
+++ b/apps/web/components/workbooks/grid-history.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_HISTORY,
+  recordEdit,
+  peekUndo,
+  peekRedo,
+  commitUndo,
+  commitRedo,
+  type CellEdit,
+} from "./grid-history";
+
+const edit = (rowId: string, prev: string, next: string): CellEdit => ({
+  rowId,
+  columnId: "c1",
+  prevValue: prev,
+  nextValue: next,
+});
+
+describe("grid-history", () => {
+  it("records an edit onto undo and clears the redo branch", () => {
+    let h = recordEdit(EMPTY_HISTORY, edit("r1", "a", "b"));
+    h = commitUndo(h); // r1 now on redo
+    expect(h.redo).toHaveLength(1);
+    // a new edit must clear the redo branch (no longer reachable)
+    h = recordEdit(h, edit("r2", "x", "y"));
+    expect(h.redo).toHaveLength(0);
+    expect(h.undo).toHaveLength(1);
+  });
+
+  it("peeks the most recent undo/redo entry", () => {
+    const h = recordEdit(recordEdit(EMPTY_HISTORY, edit("r1", "a", "b")), edit("r2", "c", "d"));
+    expect(peekUndo(h)?.rowId).toBe("r2");
+    expect(peekRedo(h)).toBeUndefined();
+  });
+
+  it("moves entries undo → redo on commitUndo and back on commitRedo", () => {
+    let h = recordEdit(EMPTY_HISTORY, edit("r1", "a", "b"));
+    h = commitUndo(h);
+    expect(h.undo).toHaveLength(0);
+    expect(peekRedo(h)?.rowId).toBe("r1");
+    h = commitRedo(h);
+    expect(peekUndo(h)?.rowId).toBe("r1");
+    expect(h.redo).toHaveLength(0);
+  });
+
+  it("round-trips a multi-edit stack in LIFO order", () => {
+    let h = EMPTY_HISTORY;
+    h = recordEdit(h, edit("r1", "1", "2"));
+    h = recordEdit(h, edit("r2", "3", "4"));
+    expect(peekUndo(h)?.rowId).toBe("r2");
+    h = commitUndo(h); // undo r2
+    expect(peekUndo(h)?.rowId).toBe("r1");
+    expect(peekRedo(h)?.rowId).toBe("r2");
+    h = commitUndo(h); // undo r1
+    expect(h.undo).toHaveLength(0);
+    expect(h.redo.map((e) => e.rowId)).toEqual(["r2", "r1"]);
+  });
+
+  it("is a no-op when committing past the end of a stack", () => {
+    expect(commitUndo(EMPTY_HISTORY)).toBe(EMPTY_HISTORY);
+    expect(commitRedo(EMPTY_HISTORY)).toBe(EMPTY_HISTORY);
+  });
+});

--- a/apps/web/components/workbooks/grid-history.ts
+++ b/apps/web/components/workbooks/grid-history.ts
@@ -1,0 +1,50 @@
+// Universal Grid & Workbooks — undo/redo stack transitions (EP-GRID-WORKBOOKS, Phase 2)
+//
+// Pure list transitions for multi-step cell-edit undo/redo, kept out of the
+// component so the invariants are unit-testable. The component owns the async
+// replay (persisting the inverse edit through the validated dispatch) and only
+// commits a transition here once the persist succeeds.
+
+import type { CellValue } from "@/lib/workbooks/types";
+
+/** One undoable cell edit. */
+export interface CellEdit {
+  rowId: string;
+  columnId: string;
+  prevValue: CellValue;
+  nextValue: CellValue;
+}
+
+export interface GridHistory {
+  undo: CellEdit[];
+  redo: CellEdit[];
+}
+
+export const EMPTY_HISTORY: GridHistory = { undo: [], redo: [] };
+
+/** Record a fresh edit: push onto undo and clear the redo branch. */
+export function recordEdit(h: GridHistory, edit: CellEdit): GridHistory {
+  return { undo: [...h.undo, edit], redo: [] };
+}
+
+export function peekUndo(h: GridHistory): CellEdit | undefined {
+  return h.undo[h.undo.length - 1];
+}
+
+export function peekRedo(h: GridHistory): CellEdit | undefined {
+  return h.redo[h.redo.length - 1];
+}
+
+/** After a successful undo of the top entry: move it from undo → redo. */
+export function commitUndo(h: GridHistory): GridHistory {
+  const entry = peekUndo(h);
+  if (!entry) return h;
+  return { undo: h.undo.slice(0, -1), redo: [...h.redo, entry] };
+}
+
+/** After a successful redo of the top entry: move it from redo → undo. */
+export function commitRedo(h: GridHistory): GridHistory {
+  const entry = peekRedo(h);
+  if (!entry) return h;
+  return { undo: [...h.undo, entry], redo: h.redo.slice(0, -1) };
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -121,11 +121,14 @@ column's tier follows from what it is, not a stored flag that could drift).
 
 `source` (live external feeds) stays unused until Phase 6 integrations land.
 
-## Slice 4 — Multi-step undo/redo — separate PR (BI-BA57AB71)
+## Slice 4 — Multi-step undo/redo — SHIPPED (BI-BA57AB71)
 
-Undo/redo stack in the `<Grid>` contract; each undo replays the inverse edit through the same
-validated dispatch (never raw write); reject + show error + leave cell unchanged when the inverse
-is invalid (parity with #1634 optimistic revert). Cell-value edits in scope; row add/delete deferred.
+Undo/redo for cell edits in the `<Grid>`. Each inverse replays through the **same validated
+dispatch** as a normal edit (never a raw write); a rejected inverse shows the error and leaves the
+cell unchanged (persistCell's optimistic revert, parity with #1634). Ctrl-Z / Ctrl-Y (+ Ctrl-Shift-Z)
+and toolbar Undo/Redo buttons; the keyboard handler yields to a cell editor's own text-undo. Stack
+transitions extracted to a pure, unit-tested `grid-history.ts` (record clears the redo branch;
+commitUndo/commitRedo move entries; LIFO). Cell-value edits in scope; row add/delete deferred.
 
 ## Slice 5 — More read-only generic grids — separate PR (BI-29E1F452)
 


### PR DESCRIPTION
## What

Slice 4 of **Universal Grid & Workbooks Phase 2** (EP-GRID-WORKBOOKS, BI-BA57AB71) — the spec's "everything is undoable" safety promise. Multi-step **Ctrl-Z / Ctrl-Y** (+ Ctrl-Shift-Z) and toolbar Undo/Redo buttons in the `<Grid>`, for both custom and platform grids.

> Stacked on [#1783](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1783) (provenance) → [#1782](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1782) (computed columns). Base auto-retargets as the stack merges.

## How

- Each undo/redo **replays the inverse edit through the same validated dispatch** as a normal edit (`updatePlatformCellsAction` / `updateCellsAction`) — never a raw write. A rejected inverse surfaces the error and leaves the cell unchanged (persistCell optimistic revert, parity with #1634).
- Only **committed** edits are undoable (a rejected edit is already reverted and never recorded).
- The keyboard handler **yields to a cell editor's own text-undo** (skips INPUT/TEXTAREA/SELECT targets).
- Stack transitions live in a **pure, unit-tested** `grid-history.ts` (`recordEdit` clears the redo branch; `commitUndo`/`commitRedo` move the top entry; LIFO), so the component only owns the async replay.
- Cell-value edits in scope; row add/delete undo deferred (documented).

## Test / build gate

- workbooks vitest: **91 passing** (added `grid-history` suite — record/clear-redo, peek, commit transitions, LIFO round-trip, no-op past end).
- `pnpm --filter web typecheck`: green.
- `pnpm --filter web build`: green (EXIT 0).

## Verification status

Interactive undo/redo is inherently UX behavior — build + unit-verified here; will drive Ctrl-Z/redo on the live install once deployed (structural ≠ functional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)