### PR TITLE
feat(workbooks): read-only grids for customers, people, suppliers (EP-GRID-WORKBOOKS Phase 2)

### DIFF
--- a/apps/web/lib/workbooks/people-supplier-configs.test.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  CUSTOMER_ACCOUNT_TABLE,
+  EMPLOYEE_PROFILE_TABLE,
+  SUPPLIER_TABLE,
+  PEOPLE_SUPPLIER_TABLES,
+} from "./people-supplier-configs";
+
+function fields(t: { columns: { field: string }[] }): string[] {
+  return t.columns.map((c) => c.field);
+}
+
+describe("people/supplier safe read-only grids", () => {
+  it("exposes exactly three tables with unique entity types and label fields", () => {
+    expect(PEOPLE_SUPPLIER_TABLES.map((t) => t.entityType)).toEqual([
+      "customer_account",
+      "employee_profile",
+      "supplier",
+    ]);
+    for (const t of PEOPLE_SUPPLIER_TABLES) {
+      expect(t.labelField).toBeTruthy();
+      // the label + id fields must be in the column allow-list
+      expect(fields(t)).toContain(t.idField);
+      expect(fields(t)).toContain(t.labelField!);
+    }
+  });
+
+  it("EMPLOYEE grid omits all compensation/PII fields (allow-list by omission)", () => {
+    const FORBIDDEN = [
+      "firstName",
+      "middleName",
+      "lastName",
+      "personalEmail",
+      "phoneWork",
+      "phoneMobile",
+      "phoneEmergency",
+      "salary",
+      "compensation",
+      "ssn",
+      "nationalId",
+      "dateOfBirth",
+      "addresses",
+      "bankDetails",
+      "endDate",
+      "userId",
+    ];
+    const present = fields(EMPLOYEE_PROFILE_TABLE);
+    for (const f of FORBIDDEN) expect(present).not.toContain(f);
+    // displayName (not legal name parts) is how an employee is shown
+    expect(present).toContain("displayName");
+  });
+
+  it("SUPPLIER grid omits tax/bank/address fields", () => {
+    const present = fields(SUPPLIER_TABLE);
+    for (const f of ["taxId", "bankDetails", "address"]) expect(present).not.toContain(f);
+  });
+
+  it("CUSTOMER grid omits financial/internal fields", () => {
+    const present = fields(CUSTOMER_ACCOUNT_TABLE);
+    for (const f of ["annualRevenue", "notes", "sourceSystem", "sourceId"]) {
+      expect(present).not.toContain(f);
+    }
+  });
+});

--- a/apps/web/lib/workbooks/people-supplier-configs.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.ts
@@ -1,0 +1,112 @@
+// Universal Grid & Workbooks — read-only generic grids for customers, people, and
+// suppliers (EP-GRID-WORKBOOKS, Phase 2, BI-29E1F452).
+//
+// These are explicit field ALLOW-LISTS: sensitive fields (compensation, legal
+// names beyond display name, personal contact, addresses, tax/bank details) are
+// simply not listed, so they can never surface through the grid OR a reference
+// lookup. Kept in a dedicated module (importing only the GenericTableConfig type)
+// so the allow-lists are unit-testable without the heavy platform-tables chain.
+
+import type { GenericTableConfig } from "./generic-read-adapter";
+
+export const CUSTOMER_ACCOUNT_TABLE: GenericTableConfig = {
+  entityType: "customer_account",
+  prismaModel: "customerAccount",
+  idField: "accountId",
+  labelField: "name",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  columns: [
+    { field: "accountId", name: "ID", fieldType: "text", width: 140 },
+    { field: "name", name: "Name", fieldType: "text", width: 240 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "prospect", label: "Prospect" },
+        { key: "qualified", label: "Qualified" },
+        { key: "onboarding", label: "Onboarding" },
+        { key: "active", label: "Active" },
+        { key: "at_risk", label: "At risk" },
+        { key: "suspended", label: "Suspended" },
+        { key: "closed", label: "Closed" },
+      ],
+    },
+    { field: "industry", name: "Industry", fieldType: "text", width: 160 },
+    { field: "website", name: "Website", fieldType: "url", width: 200 },
+    { field: "employeeCount", name: "Employees", fieldType: "number", width: 110 },
+    { field: "currency", name: "Currency", fieldType: "text", width: 90 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+export const EMPLOYEE_PROFILE_TABLE: GenericTableConfig = {
+  entityType: "employee_profile",
+  prismaModel: "employeeProfile",
+  idField: "employeeId",
+  labelField: "displayName",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  // Safe org-directory fields ONLY — no legal names beyond display name, no
+  // personal contact, no compensation, no addresses, no termination dates.
+  columns: [
+    { field: "employeeId", name: "ID", fieldType: "text", width: 140 },
+    { field: "displayName", name: "Name", fieldType: "text", width: 200 },
+    { field: "workEmail", name: "Work email", fieldType: "email", width: 220 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 130,
+      groupable: true,
+      options: [
+        { key: "onboarding", label: "Onboarding" },
+        { key: "active", label: "Active" },
+        { key: "on_leave", label: "On leave" },
+        { key: "offboarding", label: "Offboarding" },
+        { key: "terminated", label: "Terminated" },
+      ],
+    },
+    { field: "timezone", name: "Timezone", fieldType: "text", width: 150 },
+    { field: "startDate", name: "Start date", fieldType: "date", width: 130 },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+export const SUPPLIER_TABLE: GenericTableConfig = {
+  entityType: "supplier",
+  prismaModel: "supplier",
+  idField: "supplierId",
+  labelField: "name",
+  orderBy: { field: "updatedAt", dir: "desc" },
+  // Excludes taxId, bankDetails, address (sensitive) by omission.
+  columns: [
+    { field: "supplierId", name: "ID", fieldType: "text", width: 140 },
+    { field: "name", name: "Name", fieldType: "text", width: 220 },
+    { field: "contactName", name: "Contact", fieldType: "text", width: 160 },
+    { field: "email", name: "Email", fieldType: "email", width: 200 },
+    { field: "phone", name: "Phone", fieldType: "text", width: 140 },
+    { field: "paymentTerms", name: "Payment terms", fieldType: "text", width: 130 },
+    { field: "defaultCurrency", name: "Currency", fieldType: "text", width: 90 },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      width: 120,
+      groupable: true,
+      options: [
+        { key: "active", label: "Active" },
+        { key: "inactive", label: "Inactive" },
+      ],
+    },
+    { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
+  ],
+};
+
+/** All BI-29E1F452 safe read-only grids. */
+export const PEOPLE_SUPPLIER_TABLES: GenericTableConfig[] = [
+  CUSTOMER_ACCOUNT_TABLE,
+  EMPLOYEE_PROFILE_TABLE,
+  SUPPLIER_TABLE,
+];

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -13,6 +13,7 @@ import "./backlog-adapter"; // self-register the backlog adapter
 import "./invoice-adapter"; // self-register the invoice adapter
 import "./risk-adapter"; // self-register the risk-assessment adapter
 import { registerGenericReadTable, type GenericTableConfig } from "./generic-read-adapter";
+import { PEOPLE_SUPPLIER_TABLES } from "./people-supplier-configs";
 import {
   type ColumnDefinition,
   type GridRow,
@@ -115,6 +116,9 @@ const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {
 
 registerGenericReadTable(EPIC_TABLE);
 registerGenericReadTable(DIGITAL_PRODUCT_TABLE);
+// Customers, people (safe org-directory fields only), suppliers — explicit
+// allow-lists live in people-supplier-configs.ts (unit-tested for safe omission).
+for (const cfg of PEOPLE_SUPPLIER_TABLES) registerGenericReadTable(cfg);
 
 /** The registry of platform datasets available as grids. Add a row per adapter. */
 export const PLATFORM_TABLES: PlatformTableDef[] = [
@@ -157,6 +161,30 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_portfolio",
     manageCapability: "view_portfolio", // read-only grid; adapter performs no writes
     homeSurface: { path: "/portfolio", label: "Portfolio", board: true },
+  },
+  {
+    entityType: "customer_account",
+    label: "Customers",
+    description: "Customer accounts as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_customer",
+    manageCapability: "view_customer", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/customer", label: "Customers", board: true },
+  },
+  {
+    entityType: "employee_profile",
+    label: "People",
+    description: "The team directory as a read-only grid (safe fields only) — board by status.",
+    viewCapability: "view_employee",
+    manageCapability: "view_employee", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/employee", label: "People", board: true },
+  },
+  {
+    entityType: "supplier",
+    label: "Suppliers",
+    description: "Suppliers as a read-only grid — sort, filter, and board by status.",
+    viewCapability: "view_finance",
+    manageCapability: "view_finance", // read-only grid; adapter performs no writes
+    homeSurface: { path: "/finance", label: "Finance", board: true },
   },
 ];
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -130,10 +130,14 @@ and toolbar Undo/Redo buttons; the keyboard handler yields to a cell editor's ow
 transitions extracted to a pure, unit-tested `grid-history.ts` (record clears the redo branch;
 commitUndo/commitRedo move entries; LIFO). Cell-value edits in scope; row add/delete deferred.
 
-## Slice 5 — More read-only generic grids — separate PR (BI-29E1F452)
+## Slice 5 — More read-only generic grids — SHIPPED (BI-29E1F452)
 
-~15-line config rows on the #1722 generic adapter for customers, employees (safe-fields allow-list
-only — no PII/comp), suppliers. Each behind its domain view capability.
+Customers (`customer_account`, view_customer), people (`employee_profile`, view_employee — safe
+org-directory fields only), suppliers (`supplier`, view_finance) as read-only generic grids +
+boards. Allow-lists live in `people-supplier-configs.ts` (a light, type-only-import module) and are
+**unit-tested for safe omission**: the employee grid asserts no legal-name-parts/personal-contact/
+comp/PII/addresses/termination; supplier omits tax/bank/address; customer omits revenue/notes/source.
+They also become reference targets automatically (slice 1). Each behind its domain view capability.
 
 ## Ordering rationale
 


### PR DESCRIPTION
Slice 5 of Universal Grid & Workbooks Phase 2 (EP-GRID-WORKBOOKS, BI-29E1F452). Customers (view_customer), people (view_employee — safe org-directory fields only), suppliers (view_finance) as read-only generic grids + boards via the #1722 pattern. Stacked on #1783 (provenance + undo); base auto-retargets to main when #1783 merges.

Safety: allow-lists live in people-supplier-configs.ts (type-only import, unit-testable). Sensitive fields excluded by omission; the generic adapter only selects allow-listed fields. A safety suite enforces it — employee grid: no legal-name parts/personal contact/comp/PII/addresses/termination; supplier: no taxId/bankDetails/address; customer: no annualRevenue/notes/source. These entities also become reference targets automatically, still capability-gated.

Gate: workbooks vitest 90 passing; web typecheck + production build green. Live verification pending next self-upgrade deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)