### PR TITLE
feat(workbooks): grid quick filter (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -55,6 +55,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
+import { quickFilterRows } from "./grid-filter";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -188,6 +189,7 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
@@ -198,8 +200,9 @@ export function WorkbookGrid({
   }, [columns, capabilities, showProvenance]);
 
   const sortedRows = useMemo<GridRowData[]>(() => {
-    if (sortColumns.length === 0) return rowData;
-    const sorted = [...rowData];
+    const filtered = quickFilterRows(rowData, columns, filterQuery);
+    if (sortColumns.length === 0) return filtered;
+    const sorted = [...filtered];
     sorted.sort((ra, rb) => {
       for (const sc of sortColumns) {
         const cmp = compareValues(ra[sc.columnKey], rb[sc.columnKey]);
@@ -208,7 +211,7 @@ export function WorkbookGrid({
       return 0;
     });
     return sorted;
-  }, [rowData, sortColumns]);
+  }, [rowData, columns, filterQuery, sortColumns]);
 
   const persistCell = useCallback(
     async (
@@ -338,6 +341,19 @@ export function WorkbookGrid({
   return (
     <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
+        <input
+          type="search"
+          value={filterQuery}
+          onChange={(e) => setFilterQuery(e.target.value)}
+          placeholder="Filter…"
+          aria-label="Filter rows"
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+        />
+        {filterQuery.trim() && (
+          <span className="text-xs text-[var(--dpf-muted)]">
+            {sortedRows.length} of {rowData.length}
+          </span>
+        )}
         {capabilities.canAddRow && (
           <button
             type="button"

--- a/apps/web/components/workbooks/grid-filter.test.ts
+++ b/apps/web/components/workbooks/grid-filter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { cellSearchText, quickFilterRows } from "./grid-filter";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const col = (columnId: string): ColumnDefinition => ({
+  columnId,
+  name: columnId,
+  fieldType: "text",
+  position: 0,
+  required: false,
+  editable: true,
+});
+
+describe("cellSearchText", () => {
+  it("stringifies each cell shape for matching", () => {
+    expect(cellSearchText(null)).toBe("");
+    expect(cellSearchText(42)).toBe("42");
+    expect(cellSearchText(true)).toBe("true");
+    expect(cellSearchText(["a", "b"])).toBe("a b");
+    expect(cellSearchText({ referenceId: "EP-1", referenceType: "epic", label: "Grid epic" })).toBe(
+      "Grid epic",
+    );
+    expect(cellSearchText({ referenceId: "EP-2", referenceType: "epic" })).toBe("EP-2");
+  });
+});
+
+describe("quickFilterRows", () => {
+  const columns = [col("name"), col("status"), col("epic")];
+  const rows: GridRowData[] = [
+    { rowId: "r1", name: "Alpha", status: "open", epic: { referenceId: "EP-1", referenceType: "epic", label: "Launch" } },
+    { rowId: "r2", name: "Beta", status: "done", epic: null },
+    { rowId: "r3", name: "Gamma", status: "open", epic: { referenceId: "EP-2", referenceType: "epic", label: "Migrate" } },
+  ];
+
+  it("returns all rows for an empty query", () => {
+    expect(quickFilterRows(rows, columns, "  ")).toHaveLength(3);
+  });
+
+  it("matches case-insensitively across any column", () => {
+    expect(quickFilterRows(rows, columns, "ALPHA").map((r) => r.rowId)).toEqual(["r1"]);
+    expect(quickFilterRows(rows, columns, "open").map((r) => r.rowId)).toEqual(["r1", "r3"]);
+  });
+
+  it("matches against a reference label, not just scalar columns", () => {
+    expect(quickFilterRows(rows, columns, "migrate").map((r) => r.rowId)).toEqual(["r3"]);
+  });
+
+  it("returns no rows when nothing matches", () => {
+    expect(quickFilterRows(rows, columns, "zzz")).toHaveLength(0);
+  });
+});

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -1,0 +1,47 @@
+// Universal Grid & Workbooks — client-side quick filter (EP-GRID-WORKBOOKS, Phase 2)
+//
+// A pure, case-insensitive substring filter across a row's visible cell values —
+// the "type to narrow" affordance every spreadsheet has. Operates over the rows
+// already loaded in the grid (server-side / push-down filtering for large datasets
+// is a reporting-phase concern). Kept pure so it is unit-testable.
+
+import type { CellValue, ColumnDefinition, ReferenceValue } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+/** Render a cell value to the text a user would see, for substring matching. */
+export function cellSearchText(value: CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) return value.join(" ");
+  if (typeof value === "object" && "referenceId" in value) {
+    const ref = value as ReferenceValue;
+    return ref.label ?? ref.referenceId;
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+/** True if any of the row's column values contains the (lowercased) query. */
+export function rowMatchesQuery(
+  row: GridRowData,
+  columns: ColumnDefinition[],
+  loweredQuery: string,
+): boolean {
+  if (!loweredQuery) return true;
+  for (const col of columns) {
+    if (cellSearchText(row[col.columnId] ?? null).toLowerCase().includes(loweredQuery)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Filter rows by a free-text query across all columns. Empty query → all rows. */
+export function quickFilterRows(
+  rows: GridRowData[],
+  columns: ColumnDefinition[],
+  query: string,
+): GridRowData[] {
+  const lowered = query.trim().toLowerCase();
+  if (!lowered) return rows;
+  return rows.filter((r) => rowMatchesQuery(r, columns, lowered));
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -144,3 +144,24 @@ They also become reference targets automatically (slice 1). Each behind its doma
 References (1) are the relational substrate rollups/lookups (2) require. `provenanceKind` (3) is
 cheap and clarifies tiers but does not block 1–2. Undo/redo (4) is independent. Generic grids (5)
 are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
+
+## Phase 3 — Spreadsheet-on-data UX (toward Smartsheet parity)
+
+- **Slice 6 — grid quick filter — SHIPPED.** A client-side, case-insensitive substring filter
+  across all columns (pure, unit-tested `grid-filter.ts`; matches reference labels too), with a
+  toolbar search box + "N of M" count. Filters the rows already loaded; server-side/push-down
+  filtering for large datasets is a reporting-phase concern.
+- **Remaining (not built):** per-column filters + AND/OR builder; saved views (persist to the
+  existing `WorkbookView`); conditional formatting (color scales / data bars / icon sets /
+  formula rules); calendar + gallery views; CSV + `.xlsx` import; group-by summary.
+
+## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
+
+- **Supabase tier:** an *editable* generic adapter (any allow-listed Prisma model writable) — needs
+  a design call (raw validated writes for models without a domain action, as an explicit lower tier,
+  vs. always requiring a bespoke validated action). The biggest remaining Supabase-defining feature.
+- **Reporting (Phase 4):** group-by/pivots, charts/dashboards via report-kit, drill-through,
+  scheduled refresh, RLS pre-aggregation, push-down/materialization, cross-row aggregation functions.
+- **Semantic layer (Phase 4):** `WorkbookMetric` (unique/owned/versioned, lineage-required).
+- **Operationalization lifecycle (Phase 5):** promote column → metric → schema field / page-visual,
+  with gates + blast-radius + governed retirement; derived-column lineage edges (fail-closed).


### PR DESCRIPTION
First Phase-3 (spreadsheet-on-data UX) slice toward Smartsheet parity: a client-side, case-insensitive substring **quick filter** across all columns, with a toolbar search box and an "N of M" match count. Matches reference labels and computed values too — not just scalar columns.

> Stacked on #1783 (provenance + undo + grids). Base auto-retargets to main when #1783 merges.

Filter logic is a pure, unit-tested grid-filter.ts (cellSearchText + quickFilterRows); the Grid applies it ahead of sorting in the sortedRows memo. Filters rows already loaded — server-side/push-down filtering for large datasets is a reporting-phase concern. Per-column filters, AND/OR builder, and saved views (persisting to the existing WorkbookView) are tracked follow-ups.

Gate: workbooks vitest 100 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)