### PR TITLE
feat(workbooks): per-column filters (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -55,7 +55,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
-import { quickFilterRows } from "./grid-filter";
+import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -190,6 +190,9 @@ export function WorkbookGrid({
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [showFilters, setShowFilters] = useState(false);
+  const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
+  const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
@@ -200,7 +203,10 @@ export function WorkbookGrid({
   }, [columns, capabilities, showProvenance]);
 
   const sortedRows = useMemo<GridRowData[]>(() => {
-    const filtered = quickFilterRows(rowData, columns, filterQuery);
+    const filtered = applyColumnFilters(
+      quickFilterRows(rowData, columns, filterQuery),
+      columnFilters,
+    );
     if (sortColumns.length === 0) return filtered;
     const sorted = [...filtered];
     sorted.sort((ra, rb) => {
@@ -211,7 +217,7 @@ export function WorkbookGrid({
       return 0;
     });
     return sorted;
-  }, [rowData, columns, filterQuery, sortColumns]);
+  }, [rowData, columns, filterQuery, columnFilters, sortColumns]);
 
   const persistCell = useCallback(
     async (
@@ -398,15 +404,89 @@ export function WorkbookGrid({
         )}
         <button
           type="button"
+          onClick={() => setShowFilters((v) => !v)}
+          aria-pressed={showFilters}
+          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Filter by column"
+        >
+          {showFilters ? "Hide filters" : "Filters"}
+          {activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
-          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           title="Show where each column's values come from"
         >
           {showProvenance ? "Hide data sources" : "Show data sources"}
         </button>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
+
+      {showFilters && columns.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+          {columns.map((col) => {
+            const value = columnFilters[col.columnId] ?? "";
+            const set = (v: string) =>
+              setColumnFilters((f) => ({ ...f, [col.columnId]: v }));
+            const ctrlClass =
+              "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+            if (col.fieldType === "select") {
+              return (
+                <select
+                  key={col.columnId}
+                  value={value}
+                  onChange={(e) => set(e.target.value)}
+                  aria-label={`Filter ${col.name}`}
+                  className={ctrlClass}
+                >
+                  <option value="">{col.name}: any</option>
+                  {(col.config?.options ?? []).map((o) => (
+                    <option key={o.key} value={o.key}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              );
+            }
+            if (col.fieldType === "checkbox") {
+              return (
+                <select
+                  key={col.columnId}
+                  value={value}
+                  onChange={(e) => set(e.target.value)}
+                  aria-label={`Filter ${col.name}`}
+                  className={ctrlClass}
+                >
+                  <option value="">{col.name}: any</option>
+                  <option value="true">Checked</option>
+                  <option value="false">Unchecked</option>
+                </select>
+              );
+            }
+            return (
+              <input
+                key={col.columnId}
+                value={value}
+                onChange={(e) => set(e.target.value)}
+                placeholder={col.name}
+                aria-label={`Filter ${col.name}`}
+                className={ctrlClass}
+              />
+            );
+          })}
+          {activeFilterCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setColumnFilters({})}
+              className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
 
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">

--- a/apps/web/components/workbooks/grid-filter.test.ts
+++ b/apps/web/components/workbooks/grid-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { cellSearchText, quickFilterRows } from "./grid-filter";
+import {
+  cellSearchText,
+  quickFilterRows,
+  applyColumnFilters,
+  activeColumnFilters,
+} from "./grid-filter";
 import type { ColumnDefinition } from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
@@ -48,5 +53,34 @@ describe("quickFilterRows", () => {
 
   it("returns no rows when nothing matches", () => {
     expect(quickFilterRows(rows, columns, "zzz")).toHaveLength(0);
+  });
+});
+
+describe("activeColumnFilters", () => {
+  it("keeps only non-empty filters, lowercased", () => {
+    expect(activeColumnFilters({ a: "  Open ", b: "", c: "X" })).toEqual([
+      ["a", "open"],
+      ["c", "x"],
+    ]);
+  });
+});
+
+describe("applyColumnFilters", () => {
+  const rows: GridRowData[] = [
+    { rowId: "r1", name: "Alpha", status: "open" },
+    { rowId: "r2", name: "Beta", status: "done" },
+    { rowId: "r3", name: "Alpine", status: "open" },
+  ];
+
+  it("returns all rows when no filters are active", () => {
+    expect(applyColumnFilters(rows, { name: "", status: "" })).toHaveLength(3);
+  });
+
+  it("AND-combines per-column substring filters", () => {
+    expect(applyColumnFilters(rows, { name: "alp", status: "open" }).map((r) => r.rowId)).toEqual([
+      "r1",
+      "r3",
+    ]);
+    expect(applyColumnFilters(rows, { name: "alp", status: "done" })).toHaveLength(0);
   });
 });

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -45,3 +45,27 @@ export function quickFilterRows(
   if (!lowered) return rows;
   return rows.filter((r) => rowMatchesQuery(r, columns, lowered));
 }
+
+/** Per-column filters: columnId → substring the column's value must contain. */
+export type ColumnFilters = Record<string, string>;
+
+/** Keep only the non-empty filters (lowercased), as [columnId, needle] pairs. */
+export function activeColumnFilters(filters: ColumnFilters): [string, string][] {
+  return Object.entries(filters)
+    .map(([k, v]) => [k, v.trim().toLowerCase()] as [string, string])
+    .filter(([, v]) => v.length > 0);
+}
+
+/** AND-combine per-column substring filters. No active filters → all rows. */
+export function applyColumnFilters(
+  rows: GridRowData[],
+  filters: ColumnFilters,
+): GridRowData[] {
+  const active = activeColumnFilters(filters);
+  if (active.length === 0) return rows;
+  return rows.filter((row) =>
+    active.every(([columnId, needle]) =>
+      cellSearchText(row[columnId] ?? null).toLowerCase().includes(needle),
+    ),
+  );
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -149,11 +149,14 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 
 - **Slice 6 — grid quick filter — SHIPPED.** A client-side, case-insensitive substring filter
   across all columns (pure, unit-tested `grid-filter.ts`; matches reference labels too), with a
-  toolbar search box + "N of M" count. Filters the rows already loaded; server-side/push-down
-  filtering for large datasets is a reporting-phase concern.
-- **Remaining (not built):** per-column filters + AND/OR builder; saved views (persist to the
-  existing `WorkbookView`); conditional formatting (color scales / data bars / icon sets /
-  formula rules); calendar + gallery views; CSV + `.xlsx` import; group-by summary.
+  toolbar search box + "N of M" count.
+- **Slice 7 — per-column filters — SHIPPED.** A toggleable filter panel with one control per column
+  (select → option dropdown, checkbox → checked/unchecked, else text), AND-combined with the quick
+  filter (`applyColumnFilters`, unit-tested), with an active-count badge + Clear. Client-side over
+  loaded rows; precise number/date operators + saved views are follow-ups.
+- **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
+  conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
+  views; CSV + `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
Builds on the quick filter: a toggleable **per-column filter panel** — one control per column (select → option dropdown, checkbox → checked/unchecked, otherwise text) — AND-combined with each other and the global quick filter, with a "Filters (N)" active-count badge and Clear.

> Stacked on #1783 (provenance/undo/grids/quick-filter umbrella). Base auto-retargets to main when #1783 merges.

Matching is uniform substring on each column's display text (`applyColumnFilters`/`activeColumnFilters`, pure + unit-tested) — works across scalars, selects, checkboxes, and reference labels. Client-side over loaded rows; precise number/date operators and saved views (persisting to the existing `WorkbookView`) are tracked follow-ups.

Gate: grid-filter vitest 8 passing (added column-filter cases); web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)