### PR TITLE
feat(media): adoptable-animal vertical + galleries on the substrate (Phase 2)

### DIFF
--- a/apps/web/app/(shell)/storefront/animals/page.tsx
+++ b/apps/web/app/(shell)/storefront/animals/page.tsx
@@ -1,0 +1,38 @@
+import { prisma } from "@dpf/db";
+import { redirect } from "next/navigation";
+import { AnimalsManager } from "@/components/storefront-admin/AnimalsManager";
+import { listOwnerMedia } from "@/lib/media";
+
+export default async function AnimalsPage() {
+  const config = await prisma.storefrontConfig.findFirst({
+    select: {
+      id: true,
+      sections: { select: { type: true } },
+    },
+  });
+  if (!config) redirect("/storefront/setup");
+
+  const hasAnimalsSection = config.sections.some((s) => s.type === "animals-available");
+
+  const animals = await prisma.adoptableAnimal.findMany({
+    where: { storefrontId: config.id },
+    orderBy: [{ status: "asc" }, { sortOrder: "asc" }],
+  });
+
+  const withMedia = await Promise.all(
+    animals.map(async (a) => ({
+      id: a.id,
+      name: a.name,
+      species: a.species,
+      breed: a.breed,
+      age: a.age,
+      sex: a.sex,
+      size: a.size,
+      description: a.description,
+      status: a.status,
+      media: await listOwnerMedia("AdoptableAnimal", a.id),
+    })),
+  );
+
+  return <AnimalsManager animals={withMedia} hasAnimalsSection={hasAnimalsSection} />;
+}

--- a/apps/web/app/(shell)/storefront/layout.tsx
+++ b/apps/web/app/(shell)/storefront/layout.tsx
@@ -16,12 +16,18 @@ export default async function StorefrontAdminLayout({ children }: { children: Re
 
   // Load archetype for vocabulary
   const config = await prisma.storefrontConfig.findFirst({
-    include: { archetype: { select: { category: true, customVocabulary: true } } },
+    include: {
+      archetype: { select: { category: true, customVocabulary: true } },
+      sections: { select: { type: true } },
+    },
   });
 
   const vocabulary = getVocabulary(
     config?.archetype?.category,
     config?.archetype?.customVocabulary as Record<string, string> | null,
+  );
+  const showAnimals = Boolean(
+    config?.sections.some((s) => s.type === "animals-available"),
   );
 
   return (
@@ -29,7 +35,7 @@ export default async function StorefrontAdminLayout({ children }: { children: Re
       <div style={{ marginBottom: 16 }}>
         <h1 style={{ fontSize: 20, fontWeight: 700 }}>{vocabulary.portalLabel}</h1>
       </div>
-      <StorefrontAdminTabNav vocabulary={vocabulary} />
+      <StorefrontAdminTabNav vocabulary={vocabulary} showAnimals={showAnimals} />
       {children}
     </div>
   );

--- a/apps/web/app/api/storefront/admin/animals/[id]/route.ts
+++ b/apps/web/app/api/storefront/admin/animals/[id]/route.ts
@@ -1,0 +1,77 @@
+// Storefront admin: adoptable-animal item.
+//   PUT    /api/storefront/admin/animals/:id  -> update
+//   DELETE /api/storefront/admin/animals/:id  -> delete (also detaches photos)
+
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma, type Prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { deleteMediaForOwner } from "@/lib/media";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function isAdmin(session: { user?: unknown } | null): boolean {
+  return Boolean(session?.user && (session.user as { type?: string }).type === "admin");
+}
+
+type UpdateAnimalBody = {
+  name?: string;
+  species?: string | null;
+  breed?: string | null;
+  age?: string | null;
+  sex?: string | null;
+  size?: string | null;
+  description?: string | null;
+  status?: string;
+  attributes?: Record<string, unknown> | null;
+};
+
+export async function PUT(req: NextRequest, context: RouteContext) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await context.params;
+  const existing = await prisma.adoptableAnimal.findUnique({
+    where: { id },
+    select: { id: true, status: true, publishedAt: true, adoptedAt: true },
+  });
+  if (!existing) return NextResponse.json({ error: "Animal not found" }, { status: 404 });
+
+  const body = (await req.json()) as UpdateAnimalBody;
+  const data: Record<string, unknown> = {};
+  if (body.name != null) data.name = body.name.trim();
+  if (body.species !== undefined) data.species = body.species;
+  if (body.breed !== undefined) data.breed = body.breed;
+  if (body.age !== undefined) data.age = body.age;
+  if (body.sex !== undefined) data.sex = body.sex;
+  if (body.size !== undefined) data.size = body.size;
+  if (body.description !== undefined) data.description = body.description;
+  if (body.attributes !== undefined) {
+    data.attributes = body.attributes ? (body.attributes as Prisma.InputJsonValue) : undefined;
+  }
+
+  if (body.status != null && body.status !== existing.status) {
+    data.status = body.status;
+    // First time it becomes available, stamp publishedAt; when adopted, stamp adoptedAt.
+    if (body.status === "available" && !existing.publishedAt) data.publishedAt = new Date();
+    if (body.status === "adopted" && !existing.adoptedAt) data.adoptedAt = new Date();
+  }
+
+  const animal = await prisma.adoptableAnimal.update({ where: { id }, data });
+  return NextResponse.json(animal);
+}
+
+export async function DELETE(_req: NextRequest, context: RouteContext) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await context.params;
+  const existing = await prisma.adoptableAnimal.findUnique({ where: { id }, select: { id: true } });
+  if (!existing) return NextResponse.json({ error: "Animal not found" }, { status: 404 });
+
+  // Detach photos (polymorphic join has no owner FK), then delete the row.
+  await deleteMediaForOwner("AdoptableAnimal", id);
+  await prisma.adoptableAnimal.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/storefront/admin/animals/route.ts
+++ b/apps/web/app/api/storefront/admin/animals/route.ts
@@ -1,0 +1,97 @@
+// Storefront admin: adoptable-animal collection.
+//   GET  /api/storefront/admin/animals  -> list (admin view, all statuses)
+//   POST /api/storefront/admin/animals  -> create
+// Backs the `animals-available` section for pet-rescue / animal-shelter, which
+// previously had no model. Photos attach via /api/media (ownerType=AdoptableAnimal).
+
+import * as crypto from "crypto";
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma, type Prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { listOwnerMedia } from "@/lib/media";
+
+export const runtime = "nodejs";
+
+function isAdmin(session: { user?: unknown } | null): boolean {
+  return Boolean(session?.user && (session.user as { type?: string }).type === "admin");
+}
+
+type CreateAnimalBody = {
+  name?: string;
+  species?: string | null;
+  breed?: string | null;
+  age?: string | null;
+  sex?: string | null;
+  size?: string | null;
+  description?: string | null;
+  status?: string;
+  attributes?: Record<string, unknown> | null;
+};
+
+export async function GET() {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const config = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+  if (!config) return NextResponse.json({ error: "No storefront configured" }, { status: 404 });
+
+  const animals = await prisma.adoptableAnimal.findMany({
+    where: { storefrontId: config.id },
+    orderBy: [{ status: "asc" }, { sortOrder: "asc" }],
+  });
+
+  // Attach gallery so the admin manager can show thumbnails.
+  const withMedia = await Promise.all(
+    animals.map(async (a) => ({
+      ...a,
+      media: await listOwnerMedia("AdoptableAnimal", a.id),
+    })),
+  );
+
+  return NextResponse.json({ animals: withMedia });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { id: true, organizationId: true },
+  });
+  if (!config) return NextResponse.json({ error: "No storefront configured" }, { status: 404 });
+
+  const body = (await req.json()) as CreateAnimalBody;
+  if (!body.name?.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  const last = await prisma.adoptableAnimal.findFirst({
+    where: { storefrontId: config.id },
+    orderBy: { sortOrder: "desc" },
+    select: { sortOrder: true },
+  });
+  const sortOrder = (last?.sortOrder ?? -1) + 1;
+  const animalRef = `ANML-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+  const status = body.status ?? "available";
+
+  const animal = await prisma.adoptableAnimal.create({
+    data: {
+      animalRef,
+      storefrontId: config.id,
+      organizationId: config.organizationId,
+      name: body.name.trim(),
+      species: body.species ?? null,
+      breed: body.breed ?? null,
+      age: body.age ?? null,
+      sex: body.sex ?? null,
+      size: body.size ?? null,
+      description: body.description ?? null,
+      status,
+      attributes: body.attributes ? (body.attributes as Prisma.InputJsonValue) : undefined,
+      publishedAt: status === "available" ? new Date() : null,
+      sortOrder,
+    },
+  });
+
+  return NextResponse.json({ ...animal, media: [] }, { status: 201 });
+}

--- a/apps/web/app/api/storefront/admin/media/[attachmentId]/route.ts
+++ b/apps/web/app/api/storefront/admin/media/[attachmentId]/route.ts
@@ -1,0 +1,50 @@
+// Storefront admin: mutate or remove a single media attachment.
+//   PATCH  /api/storefront/admin/media/:attachmentId
+//          { setPrimary?: true, caption?: string|null, assetId?, altText?: string|null }
+//   DELETE /api/storefront/admin/media/:attachmentId   -> detach (asset/blob kept)
+
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  detachMedia,
+  setPrimaryAttachment,
+  updateAssetAltText,
+  updateAttachmentCaption,
+} from "@/lib/media";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ attachmentId: string }> };
+
+function isAdmin(session: { user?: unknown } | null): boolean {
+  return Boolean(session?.user && (session.user as { type?: string }).type === "admin");
+}
+
+export async function PATCH(req: NextRequest, context: RouteContext) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { attachmentId } = await context.params;
+  const body = (await req.json()) as {
+    setPrimary?: boolean;
+    caption?: string | null;
+    assetId?: string;
+    altText?: string | null;
+  };
+
+  if (body.setPrimary) await setPrimaryAttachment(attachmentId);
+  if (body.caption !== undefined) await updateAttachmentCaption(attachmentId, body.caption);
+  if (body.assetId && body.altText !== undefined) await updateAssetAltText(body.assetId, body.altText);
+
+  return NextResponse.json({ success: true });
+}
+
+export async function DELETE(_req: NextRequest, context: RouteContext) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { attachmentId } = await context.params;
+  const owner = await detachMedia(attachmentId);
+  if (!owner) return NextResponse.json({ error: "Attachment not found" }, { status: 404 });
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/storefront/admin/media/route.ts
+++ b/apps/web/app/api/storefront/admin/media/route.ts
@@ -1,0 +1,48 @@
+// Storefront admin: list + reorder an owner's media gallery.
+//   GET   /api/storefront/admin/media?ownerType=&ownerId=&role=  -> OwnerMediaItem[]
+//   PATCH /api/storefront/admin/media  { ownerType, ownerId, role?, order: id[] }
+// Upload itself goes through POST /api/media (upload + optional attach).
+
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { listOwnerMedia, reorderOwnerMedia, type MediaOwnerType } from "@/lib/media";
+
+export const runtime = "nodejs";
+
+function isAdmin(session: { user?: unknown } | null): boolean {
+  return Boolean(session?.user && (session.user as { type?: string }).type === "admin");
+}
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const ownerType = url.searchParams.get("ownerType") as MediaOwnerType | null;
+  const ownerId = url.searchParams.get("ownerId");
+  const role = url.searchParams.get("role") ?? undefined;
+  if (!ownerType || !ownerId) {
+    return NextResponse.json({ error: "ownerType and ownerId are required" }, { status: 400 });
+  }
+
+  const media = await listOwnerMedia(ownerType, ownerId, role);
+  return NextResponse.json({ media });
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!isAdmin(session)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json()) as {
+    ownerType?: MediaOwnerType;
+    ownerId?: string;
+    role?: string;
+    order?: string[];
+  };
+  if (!body.ownerType || !body.ownerId || !Array.isArray(body.order)) {
+    return NextResponse.json({ error: "ownerType, ownerId and order[] are required" }, { status: 400 });
+  }
+
+  await reorderOwnerMedia(body.ownerType, body.ownerId, body.order, body.role);
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/components/storefront-admin/AnimalsManager.tsx
+++ b/apps/web/components/storefront-admin/AnimalsManager.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+// Admin manager for adoptable animals (pet-rescue / animal-shelter). Creates and
+// edits AdoptableAnimal records and, per animal, embeds the reusable MediaUploader
+// so each gets a photo gallery. Photos drive the public `animals-available`
+// section through the media substrate.
+
+import { useState } from "react";
+import { MediaUploader } from "./MediaUploader";
+
+interface MediaItem {
+  attachmentId: string;
+  assetId: string;
+  url: string;
+  altText: string | null;
+  caption: string | null;
+}
+
+interface AdminAnimal {
+  id: string;
+  name: string;
+  species: string | null;
+  breed: string | null;
+  age: string | null;
+  sex: string | null;
+  size: string | null;
+  description: string | null;
+  status: string;
+  media: MediaItem[];
+}
+
+const STATUSES = ["available", "pending", "hold", "adopted"];
+const SPECIES = ["dog", "cat", "rabbit", "bird", "other"];
+
+const inputStyle: React.CSSProperties = {
+  fontSize: 13,
+  padding: "6px 8px",
+  border: "1px solid var(--dpf-border)",
+  borderRadius: 6,
+  background: "var(--dpf-bg, transparent)",
+  color: "var(--dpf-text)",
+  width: "100%",
+};
+
+const emptyDraft = {
+  name: "",
+  species: "dog",
+  breed: "",
+  age: "",
+  sex: "",
+  size: "",
+  status: "available",
+  description: "",
+};
+
+export function AnimalsManager({
+  animals: initial,
+  hasAnimalsSection,
+}: {
+  animals: AdminAnimal[];
+  hasAnimalsSection: boolean;
+}) {
+  const [animals, setAnimals] = useState<AdminAnimal[]>(initial);
+  const [draft, setDraft] = useState({ ...emptyDraft });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function createAnimal() {
+    if (!draft.name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/storefront/admin/animals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(draft),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? "Could not add animal.");
+        return;
+      }
+      const created = (await res.json()) as AdminAnimal;
+      setAnimals((prev) => [...prev, { ...created, media: [] }]);
+      setDraft({ ...emptyDraft });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function updateAnimal(id: string, patch: Partial<AdminAnimal>) {
+    setAnimals((prev) => prev.map((a) => (a.id === id ? { ...a, ...patch } : a)));
+    await fetch(`/api/storefront/admin/animals/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+  }
+
+  async function deleteAnimal(id: string) {
+    await fetch(`/api/storefront/admin/animals/${id}`, { method: "DELETE" });
+    setAnimals((prev) => prev.filter((a) => a.id !== id));
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20, maxWidth: 880 }}>
+      <div>
+        <h1 style={{ fontSize: 20, fontWeight: 600, color: "var(--dpf-text)" }}>
+          Adoptable animals
+        </h1>
+        <p style={{ fontSize: 13, color: "var(--dpf-muted)" }}>
+          These appear in the “Animals available for adoption” section of your public storefront,
+          each with their photos.
+        </p>
+        {!hasAnimalsSection && (
+          <p style={{ fontSize: 12, color: "var(--dpf-danger, #dc2626)" }}>
+            Your storefront has no “animals-available” section yet — add one in Sections to show
+            these publicly.
+          </p>
+        )}
+      </div>
+
+      {/* Create form */}
+      <div
+        style={{
+          border: "1px solid var(--dpf-border)",
+          borderRadius: 8,
+          padding: 16,
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+          gap: 10,
+          alignItems: "end",
+        }}
+      >
+        <label style={{ gridColumn: "1 / -1" }}>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Name *</span>
+          <input style={inputStyle} value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })} />
+        </label>
+        <label>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Species</span>
+          <select style={inputStyle} value={draft.species}
+            onChange={(e) => setDraft({ ...draft, species: e.target.value })}>
+            {SPECIES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </label>
+        <label>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Breed</span>
+          <input style={inputStyle} value={draft.breed}
+            onChange={(e) => setDraft({ ...draft, breed: e.target.value })} />
+        </label>
+        <label>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Age</span>
+          <input style={inputStyle} value={draft.age} placeholder="e.g. young"
+            onChange={(e) => setDraft({ ...draft, age: e.target.value })} />
+        </label>
+        <label>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Sex</span>
+          <input style={inputStyle} value={draft.sex}
+            onChange={(e) => setDraft({ ...draft, sex: e.target.value })} />
+        </label>
+        <label>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Size</span>
+          <input style={inputStyle} value={draft.size}
+            onChange={(e) => setDraft({ ...draft, size: e.target.value })} />
+        </label>
+        <label style={{ gridColumn: "1 / -1" }}>
+          <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Description</span>
+          <textarea style={{ ...inputStyle, minHeight: 56 }} value={draft.description}
+            onChange={(e) => setDraft({ ...draft, description: e.target.value })} />
+        </label>
+        <button type="button" onClick={() => void createAnimal()} disabled={busy}
+          style={{
+            fontSize: 13, padding: "8px 14px", borderRadius: 6,
+            background: "var(--dpf-accent, #2563eb)", color: "#fff", border: "none",
+            cursor: busy ? "default" : "pointer",
+          }}>
+          {busy ? "Adding…" : "Add animal"}
+        </button>
+        {error && <div style={{ fontSize: 12, color: "var(--dpf-danger, #dc2626)" }}>{error}</div>}
+      </div>
+
+      {/* List */}
+      {animals.length === 0 ? (
+        <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>No animals yet.</div>
+      ) : (
+        animals.map((animal) => (
+          <div key={animal.id}
+            style={{ border: "1px solid var(--dpf-border)", borderRadius: 8, padding: 16,
+              display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+              <input style={{ ...inputStyle, width: 200, fontWeight: 600 }} value={animal.name}
+                onChange={(e) => updateAnimal(animal.id, { name: e.target.value })} />
+              <select style={{ ...inputStyle, width: 140 }} value={animal.status}
+                onChange={(e) => updateAnimal(animal.id, { status: e.target.value })}>
+                {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+              <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
+                {[animal.species, animal.breed, animal.age].filter(Boolean).join(" · ")}
+              </span>
+              <button type="button" onClick={() => void deleteAnimal(animal.id)}
+                style={{ marginLeft: "auto", fontSize: 12, padding: "4px 10px",
+                  border: "1px solid var(--dpf-border)", borderRadius: 6, background: "transparent",
+                  color: "var(--dpf-danger, #dc2626)", cursor: "pointer" }}>
+                Delete
+              </button>
+            </div>
+            <MediaUploader
+              ownerType="AdoptableAnimal"
+              ownerId={animal.id}
+              role="gallery"
+              label="Photos"
+              hint="First photo is the lead image shown on the storefront"
+            />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/storefront-admin/ItemFormDialog.tsx
+++ b/apps/web/components/storefront-admin/ItemFormDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { MediaUploader } from "./MediaUploader";
 
 export type ItemFormData = {
   id?: string;
@@ -90,6 +91,8 @@ type Props = {
   categorySuggestions: string[];
   defaultCtaType: string;
   isEditing: boolean;
+  /** DB id of the item being edited; enables the photo-gallery uploader. */
+  editingItemId?: string;
 };
 
 export function ItemFormDialog({
@@ -101,6 +104,7 @@ export function ItemFormDialog({
   categorySuggestions,
   defaultCtaType,
   isEditing,
+  editingItemId,
 }: Props) {
   const [form, setForm] = useState<ItemFormData>(() => ({
     ...EMPTY_FORM,
@@ -391,13 +395,29 @@ export function ItemFormDialog({
             </div>
           )}
 
-          {/* Image URL (all types) */}
-          <details className="text-sm pt-3 border-t border-[var(--dpf-border)]">
+          {/* Images */}
+          <details className="text-sm pt-3 border-t border-[var(--dpf-border)]" open={Boolean(editingItemId)}>
             <summary className="text-[10px] text-[var(--dpf-muted)] cursor-pointer hover:text-[var(--dpf-text)]">
-              Image
+              Images
             </summary>
-            <div className="mt-2">
-              <Field label="Image URL">
+            <div className="mt-2 flex flex-col gap-3">
+              {editingItemId ? (
+                // Existing item: real upload + gallery via the media substrate.
+                <MediaUploader
+                  ownerType="StorefrontItem"
+                  ownerId={editingItemId}
+                  role="product"
+                  label="Photos"
+                  hint="First photo is the one shown on the storefront card"
+                />
+              ) : (
+                // New item: gallery uploads need a saved item to attach to — save
+                // first, then reopen to add photos. A URL still works immediately.
+                <p className="text-[11px] text-[var(--dpf-muted)]">
+                  Save the {vocabulary.singleItemLabel.toLowerCase()} first, then reopen it to add photos.
+                </p>
+              )}
+              <Field label="Or paste an image URL">
                 <input
                   type="url"
                   value={form.imageUrl}

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -310,6 +310,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         categorySuggestions={categorySuggestions}
         defaultCtaType={defaultCtaType}
         isEditing={!!editingItem}
+        editingItemId={editingItem?.id}
       />
     </div>
   );

--- a/apps/web/components/storefront-admin/MediaUploader.tsx
+++ b/apps/web/components/storefront-admin/MediaUploader.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+// Reusable image gallery editor for any owner entity (storefront item, adoptable
+// animal, provider, section, ...). Drives the media substrate end to end:
+//   upload     POST   /api/media                       (multipart, attaches on upload)
+//   list       GET    /api/storefront/admin/media       ?ownerType&ownerId&role
+//   reorder    PATCH  /api/storefront/admin/media        { order: id[] }
+//   primary    PATCH  /api/storefront/admin/media/:id    { setPrimary }
+//   alt text   PATCH  /api/storefront/admin/media/:id    { assetId, altText }
+//   remove     DELETE /api/storefront/admin/media/:id
+// The first image (sortOrder 0) is the primary; it also syncs the owner's legacy
+// scalar imageUrl/avatarUrl/etc., so existing single-image rendering keeps working.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface MediaUploaderProps {
+  ownerType: string;
+  ownerId: string;
+  role?: string;
+  label?: string;
+  /** Hint copy describing what the images are for (from the archetype profile). */
+  hint?: string;
+  maxImages?: number;
+}
+
+interface MediaItem {
+  attachmentId: string;
+  assetId: string;
+  url: string;
+  altText: string | null;
+  caption: string | null;
+}
+
+export function MediaUploader({
+  ownerType,
+  ownerId,
+  role = "gallery",
+  label = "Images",
+  hint,
+  maxImages = 12,
+}: MediaUploaderProps) {
+  const [items, setItems] = useState<MediaItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/storefront/admin/media?ownerType=${encodeURIComponent(ownerType)}&ownerId=${encodeURIComponent(ownerId)}&role=${encodeURIComponent(role)}`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as { media: MediaItem[] };
+        setItems(data.media);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [ownerType, ownerId, role]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const onPickFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      setError(null);
+      setUploading(true);
+      try {
+        for (const file of Array.from(files)) {
+          if (items.length >= maxImages) {
+            setError(`Up to ${maxImages} images.`);
+            break;
+          }
+          const form = new FormData();
+          form.append("file", file);
+          form.append("ownerType", ownerType);
+          form.append("ownerId", ownerId);
+          form.append("role", role);
+          const res = await fetch("/api/media", { method: "POST", body: form });
+          if (!res.ok) {
+            const data = (await res.json().catch(() => ({}))) as { error?: string };
+            setError(data.error ?? `Upload failed (${res.status})`);
+            break;
+          }
+        }
+        await reload();
+      } finally {
+        setUploading(false);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
+    },
+    [items.length, maxImages, ownerType, ownerId, role, reload],
+  );
+
+  const move = useCallback(
+    async (index: number, dir: -1 | 1) => {
+      const next = [...items];
+      const target = index + dir;
+      if (target < 0 || target >= next.length) return;
+      [next[index], next[target]] = [next[target], next[index]];
+      setItems(next);
+      await fetch("/api/storefront/admin/media", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ownerType, ownerId, role, order: next.map((i) => i.attachmentId) }),
+      });
+    },
+    [items, ownerType, ownerId, role],
+  );
+
+  const remove = useCallback(async (attachmentId: string) => {
+    await fetch(`/api/storefront/admin/media/${attachmentId}`, { method: "DELETE" });
+    setItems((prev) => prev.filter((i) => i.attachmentId !== attachmentId));
+  }, []);
+
+  const saveAlt = useCallback(async (item: MediaItem, altText: string) => {
+    setItems((prev) =>
+      prev.map((i) => (i.attachmentId === item.attachmentId ? { ...i, altText } : i)),
+    );
+    await fetch(`/api/storefront/admin/media/${item.attachmentId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assetId: item.assetId, altText }),
+    });
+  }, []);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span style={{ fontSize: 12, color: "var(--dpf-muted)" }}>{label}</span>
+        {hint && <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>· {hint}</span>}
+      </div>
+
+      {loading ? (
+        <div style={{ fontSize: 12, color: "var(--dpf-muted)" }}>Loading…</div>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+            gap: 10,
+          }}
+        >
+          {items.map((item, index) => (
+            <div
+              key={item.attachmentId}
+              style={{
+                border: "1px solid var(--dpf-border)",
+                borderRadius: 8,
+                padding: 6,
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                position: "relative",
+              }}
+            >
+              {index === 0 && (
+                <span
+                  style={{
+                    position: "absolute",
+                    top: 8,
+                    left: 8,
+                    fontSize: 10,
+                    background: "var(--dpf-accent, #2563eb)",
+                    color: "#fff",
+                    borderRadius: 4,
+                    padding: "1px 5px",
+                  }}
+                >
+                  Primary
+                </span>
+              )}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={item.url}
+                alt={item.altText ?? ""}
+                style={{ width: "100%", height: 90, objectFit: "cover", borderRadius: 4 }}
+              />
+              <input
+                type="text"
+                value={item.altText ?? ""}
+                placeholder="Alt text"
+                onChange={(e) =>
+                  setItems((prev) =>
+                    prev.map((i) =>
+                      i.attachmentId === item.attachmentId ? { ...i, altText: e.target.value } : i,
+                    ),
+                  )
+                }
+                onBlur={(e) => void saveAlt(item, e.target.value)}
+                style={{
+                  fontSize: 11,
+                  padding: "2px 4px",
+                  border: "1px solid var(--dpf-border)",
+                  borderRadius: 4,
+                  background: "var(--dpf-bg, transparent)",
+                  color: "var(--dpf-text)",
+                }}
+              />
+              <div style={{ display: "flex", gap: 4, justifyContent: "space-between" }}>
+                <button type="button" onClick={() => void move(index, -1)} disabled={index === 0}
+                  style={btnStyle} aria-label="Move left">←</button>
+                <button type="button" onClick={() => void move(index, 1)} disabled={index === items.length - 1}
+                  style={btnStyle} aria-label="Move right">→</button>
+                <button type="button" onClick={() => void remove(item.attachmentId)}
+                  style={{ ...btnStyle, color: "var(--dpf-danger, #dc2626)" }} aria-label="Remove">✕</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp"
+          multiple
+          hidden
+          onChange={(e) => void onPickFiles(e.target.files)}
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading || items.length >= maxImages}
+          style={{
+            fontSize: 12,
+            padding: "6px 12px",
+            border: "1px dashed var(--dpf-border)",
+            borderRadius: 6,
+            background: "transparent",
+            color: "var(--dpf-text)",
+            cursor: uploading ? "default" : "pointer",
+          }}
+        >
+          {uploading ? "Uploading…" : "+ Add images"}
+        </button>
+      </div>
+
+      {error && <div style={{ fontSize: 12, color: "var(--dpf-danger, #dc2626)" }}>{error}</div>}
+    </div>
+  );
+}
+
+const btnStyle: React.CSSProperties = {
+  fontSize: 12,
+  padding: "2px 6px",
+  border: "1px solid var(--dpf-border)",
+  borderRadius: 4,
+  background: "transparent",
+  color: "var(--dpf-text)",
+  cursor: "pointer",
+};

--- a/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
+++ b/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
@@ -5,15 +5,18 @@ import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary"
 
 type Props = {
   vocabulary: ArchetypeVocabulary;
+  /** Show the Animals tab — only for archetypes with an animals-available section. */
+  showAnimals?: boolean;
 };
 
-export function StorefrontAdminTabNav({ vocabulary }: Props) {
+export function StorefrontAdminTabNav({ vocabulary, showAnimals = false }: Props) {
   const path = usePathname();
 
   const tabs = [
     { label: "Dashboard", href: "/storefront" },
     { label: "Sections", href: "/storefront/sections" },
     { label: vocabulary.itemsLabel, href: "/storefront/items" },
+    ...(showAnimals ? [{ label: "Animals", href: "/storefront/animals" }] : []),
     { label: vocabulary.teamLabel, href: "/storefront/team" },
     { label: vocabulary.inboxLabel, href: "/storefront/inbox" },
     { label: "Settings", href: "/storefront/settings" },

--- a/apps/web/components/storefront/MediaImage.tsx
+++ b/apps/web/components/storefront/MediaImage.tsx
@@ -1,0 +1,55 @@
+// Shared storefront image component. Renders a media URL with a focal-point crop
+// (object-position) and an optional dominant-colour placeholder background so the
+// layout doesn't jump before the image paints (LQIP). A plain <img> keeps it
+// usable in server components and inside the existing inline-styled storefront.
+
+import type { CSSProperties } from "react";
+
+export interface MediaImageProps {
+  src: string | null | undefined;
+  alt: string;
+  height?: number | string;
+  width?: number | string;
+  /** 0..1 focal point so important content survives the crop (Booqable-style). */
+  focalX?: number | null;
+  focalY?: number | null;
+  /** Hex placeholder shown behind the image while it loads. */
+  placeholderColor?: string | null;
+  radius?: number;
+  style?: CSSProperties;
+}
+
+export function MediaImage({
+  src,
+  alt,
+  height = 160,
+  width = "100%",
+  focalX,
+  focalY,
+  placeholderColor,
+  radius = 4,
+  style,
+}: MediaImageProps) {
+  if (!src) return null;
+  const objectPosition =
+    focalX != null && focalY != null
+      ? `${Math.round(focalX * 100)}% ${Math.round(focalY * 100)}%`
+      : "center";
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      style={{
+        width,
+        height,
+        objectFit: "cover",
+        objectPosition,
+        borderRadius: radius,
+        backgroundColor: placeholderColor ?? "var(--dpf-border)",
+        ...style,
+      }}
+    />
+  );
+}

--- a/apps/web/components/storefront/SectionRenderer.tsx
+++ b/apps/web/components/storefront/SectionRenderer.tsx
@@ -40,7 +40,7 @@ export function SectionRenderer({
     case "donate":
       return <DonationSection content={content} orgSlug={orgSlug} />;
     case "animals-available":
-      return <AnimalsSection content={content} />;
+      return <AnimalsSection content={content} animals={storefront.animals} />;
     case "disclosures":
       return (
         <DisclosuresSection

--- a/apps/web/components/storefront/sections/AnimalsSection.tsx
+++ b/apps/web/components/storefront/sections/AnimalsSection.tsx
@@ -1,52 +1,122 @@
-interface Animal {
+import type { PublicAdoptableAnimal } from "@/lib/release/storefront-types";
+import { MediaImage } from "../MediaImage";
+
+// Legacy free-form shape (content.animals), kept as a fallback for storefronts
+// whose animals were authored as section JSON before the AdoptableAnimal entity.
+interface LegacyAnimal {
   name: string;
   species: string;
   imageUrl?: string;
   description?: string;
 }
 
-export function AnimalsSection({ content }: { content: Record<string, unknown> }) {
-  const intro = content.intro as string | undefined;
-  const animals = Array.isArray(content.animals) ? (content.animals as Animal[]) : [];
+const STATUS_LABEL: Record<string, string> = {
+  available: "Available",
+  pending: "Adoption pending",
+  hold: "On hold",
+};
 
-  if (!intro && animals.length === 0) return null;
+function AnimalCard({ animal }: { animal: PublicAdoptableAnimal }) {
+  const meta = [animal.breed, animal.age, animal.sex, animal.size].filter(Boolean).join(" · ");
+  return (
+    <div
+      style={{
+        border: "1px solid var(--dpf-border)",
+        borderRadius: 8,
+        padding: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div style={{ position: "relative" }}>
+        <MediaImage src={animal.primaryPhotoUrl} alt={animal.name} height={160} />
+        {animal.status !== "available" && (
+          <span
+            style={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              fontSize: 11,
+              background: "rgba(0,0,0,0.7)",
+              color: "#fff",
+              borderRadius: 4,
+              padding: "2px 6px",
+            }}
+          >
+            {STATUS_LABEL[animal.status] ?? animal.status}
+          </span>
+        )}
+      </div>
+      <div style={{ fontWeight: 600, fontSize: 15, color: "var(--dpf-text)" }}>{animal.name}</div>
+      {(animal.species || meta) && (
+        <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>
+          {[animal.species, meta].filter(Boolean).join(" — ")}
+        </div>
+      )}
+      {animal.description && (
+        <div style={{ fontSize: 13, color: "var(--dpf-text)", lineHeight: 1.5 }}>
+          {animal.description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AnimalsSection({
+  content,
+  animals,
+}: {
+  content: Record<string, unknown>;
+  animals?: PublicAdoptableAnimal[];
+}) {
+  const intro = content.intro as string | undefined;
+  const legacy = Array.isArray(content.animals) ? (content.animals as LegacyAnimal[]) : [];
+  const records = animals ?? [];
+
+  if (!intro && records.length === 0 && legacy.length === 0) return null;
 
   return (
     <div style={{ padding: "40px 0" }}>
       {intro && (
-        <p style={{ fontSize: 15, color: "var(--dpf-text)", lineHeight: 1.6, marginBottom: 24 }}>{intro}</p>
+        <p style={{ fontSize: 15, color: "var(--dpf-text)", lineHeight: 1.6, marginBottom: 24 }}>
+          {intro}
+        </p>
       )}
-      {animals.length > 0 && (
-        <div style={{
+      <div
+        style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
           gap: 16,
-        }}>
-          {animals.map((animal, i) => (
-            <div key={i} style={{
-              border: "1px solid var(--dpf-border)",
-              borderRadius: 8,
-              padding: 16,
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}>
-              {animal.imageUrl && (
-                <img
-                  src={animal.imageUrl}
-                  alt={animal.name}
-                  style={{ width: "100%", height: 140, objectFit: "cover", borderRadius: 4 }}
-                />
-              )}
-              <div style={{ fontWeight: 600, fontSize: 15, color: "var(--dpf-text)" }}>{animal.name}</div>
-              <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>{animal.species}</div>
-              {animal.description && (
-                <div style={{ fontSize: 13, color: "var(--dpf-text)", lineHeight: 1.5 }}>{animal.description}</div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+        }}
+      >
+        {records.length > 0
+          ? records.map((animal) => <AnimalCard key={animal.id} animal={animal} />)
+          : legacy.map((animal, i) => (
+              <div
+                key={i}
+                style={{
+                  border: "1px solid var(--dpf-border)",
+                  borderRadius: 8,
+                  padding: 16,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 6,
+                }}
+              >
+                <MediaImage src={animal.imageUrl} alt={animal.name} height={140} />
+                <div style={{ fontWeight: 600, fontSize: 15, color: "var(--dpf-text)" }}>
+                  {animal.name}
+                </div>
+                <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>{animal.species}</div>
+                {animal.description && (
+                  <div style={{ fontSize: 13, color: "var(--dpf-text)", lineHeight: 1.5 }}>
+                    {animal.description}
+                  </div>
+                )}
+              </div>
+            ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/media/attachments.ts
+++ b/apps/web/lib/media/attachments.ts
@@ -254,4 +254,101 @@ export async function syncPrimaryImage(
   }
 
   await cache.apply(ownerId, chosen ? mediaAssetUrl(chosen.mediaAssetId) : null);
+
+  // AdoptableAnimal caches the primary asset *id* (not a URL) on the row.
+  if (ownerType === "AdoptableAnimal") {
+    const first = await prisma.mediaAttachment.findFirst({
+      where: { ownerType, ownerId },
+      orderBy: [{ sortOrder: "asc" }],
+      select: { mediaAssetId: true },
+    });
+    await prisma.adoptableAnimal.update({
+      where: { id: ownerId },
+      data: { primaryPhotoAssetId: first?.mediaAssetId ?? null },
+    });
+  }
+}
+
+/**
+ * Detach one attachment by id (does not delete the shared asset/blob). Returns
+ * the owner so the caller can resync its primary cache, or null if not found.
+ */
+export async function detachMedia(
+  attachmentId: string,
+): Promise<{ ownerType: MediaOwnerType; ownerId: string } | null> {
+  const existing = await prisma.mediaAttachment.findUnique({
+    where: { id: attachmentId },
+    select: { ownerType: true, ownerId: true },
+  });
+  if (!existing) return null;
+  await prisma.mediaAttachment.delete({ where: { id: attachmentId } });
+  const owner = { ownerType: existing.ownerType as MediaOwnerType, ownerId: existing.ownerId };
+  await syncPrimaryImage(owner.ownerType, owner.ownerId);
+  return owner;
+}
+
+/**
+ * Reorder an owner's gallery for a role. `orderedAttachmentIds` is the desired
+ * order; each is written its index as sortOrder. Ids not belonging to the owner
+ * are ignored. Refreshes the primary cache (position 0 becomes primary).
+ */
+export async function reorderOwnerMedia(
+  ownerType: MediaOwnerType,
+  ownerId: string,
+  orderedAttachmentIds: string[],
+  role?: string,
+): Promise<void> {
+  const owned = await prisma.mediaAttachment.findMany({
+    where: { ownerType, ownerId, ...(role ? { role } : {}) },
+    select: { id: true },
+  });
+  const ownedIds = new Set(owned.map((a) => a.id));
+  await prisma.$transaction(
+    orderedAttachmentIds
+      .filter((id) => ownedIds.has(id))
+      .map((id, index) =>
+        prisma.mediaAttachment.update({ where: { id }, data: { sortOrder: index } }),
+      ),
+  );
+  await syncPrimaryImage(ownerType, ownerId);
+}
+
+/** Make one attachment the primary (sortOrder 0); others shift down. */
+export async function setPrimaryAttachment(attachmentId: string): Promise<void> {
+  const target = await prisma.mediaAttachment.findUnique({
+    where: { id: attachmentId },
+    select: { ownerType: true, ownerId: true, role: true },
+  });
+  if (!target) return;
+  const siblings = await prisma.mediaAttachment.findMany({
+    where: { ownerType: target.ownerType, ownerId: target.ownerId, role: target.role },
+    orderBy: { sortOrder: "asc" },
+    select: { id: true },
+  });
+  const reordered = [attachmentId, ...siblings.map((s) => s.id).filter((id) => id !== attachmentId)];
+  await reorderOwnerMedia(
+    target.ownerType as MediaOwnerType,
+    target.ownerId,
+    reordered,
+    target.role,
+  );
+}
+
+/** Update an attachment's caption. */
+export async function updateAttachmentCaption(
+  attachmentId: string,
+  caption: string | null,
+): Promise<void> {
+  await prisma.mediaAttachment.update({
+    where: { id: attachmentId },
+    data: { caption },
+  });
+}
+
+/** Update the alt text on the underlying asset (SEO + accessibility). */
+export async function updateAssetAltText(
+  assetId: string,
+  altText: string | null,
+): Promise<void> {
+  await prisma.mediaAsset.update({ where: { id: assetId }, data: { altText } });
 }

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -2,11 +2,70 @@ import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { FormField } from "@dpf/storefront-templates";
 import { resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
+import { listOwnerMedia, mediaAssetUrl } from "@/lib/media";
 import type {
   PublicStorefrontConfig,
   PublicItem,
   PublicSection,
+  PublicAdoptableAnimal,
 } from "./storefront-types";
+
+/**
+ * Load the published adoptable animals for a storefront, each with its primary
+ * photo and gallery. Only loaded when the storefront has an `animals-available`
+ * section, so every other archetype skips the query.
+ */
+export async function getPublicAdoptableAnimals(
+  storefrontId: string,
+): Promise<PublicAdoptableAnimal[]> {
+  const animals = await prisma.adoptableAnimal.findMany({
+    where: { storefrontId, status: { in: ["available", "pending", "hold"] } },
+    orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+    select: {
+      id: true,
+      animalRef: true,
+      name: true,
+      species: true,
+      breed: true,
+      age: true,
+      sex: true,
+      size: true,
+      description: true,
+      status: true,
+      attributes: true,
+      primaryPhotoAssetId: true,
+    },
+  });
+
+  return Promise.all(
+    animals.map(async (a) => {
+      const photos = (await listOwnerMedia("AdoptableAnimal", a.id)).map((m) => ({
+        url: m.url,
+        altText: m.altText,
+        caption: m.caption,
+        width: m.width,
+        height: m.height,
+      }));
+      return {
+        id: a.id,
+        animalRef: a.animalRef,
+        name: a.name,
+        species: a.species,
+        breed: a.breed,
+        age: a.age,
+        sex: a.sex,
+        size: a.size,
+        description: a.description,
+        status: a.status,
+        attributes: a.attributes as Record<string, unknown> | null,
+        primaryPhotoUrl: a.primaryPhotoAssetId
+          ? mediaAssetUrl(a.primaryPhotoAssetId)
+          : (photos[0]?.url ?? null),
+        photos,
+      };
+    }),
+  );
+}
 
 // Generic fallback used when an archetype defines no form schema (or for custom
 // archetypes that were created without one).
@@ -61,6 +120,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
   const config = await prisma.storefrontConfig.findFirst({
     where: { organization: { slug } },
     select: {
+      id: true,
       isPublished: true,
       tagline: true,
       description: true,
@@ -140,6 +200,15 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
   // a neutral placeholder, never a fabricated "Member FDIC"/NCUA claim.
   // Loaded only when the storefront actually has a disclosures section, so
   // every other archetype skips the extra query.
+  // Adoptable animals back the `animals-available` section (pet-rescue /
+  // animal-shelter). Loaded only when that section is present.
+  const hasAnimalsSection = config.sections.some(
+    (section) => section.type === "animals-available",
+  );
+  const animals = hasAnimalsSection
+    ? await getPublicAdoptableAnimals(config.id)
+    : [];
+
   const hasDisclosuresSection = config.sections.some(
     (section) => section.type === "disclosures",
   );
@@ -201,6 +270,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
       priceAmount: item.priceAmount?.toString() ?? null,
       bookingConfig: item.bookingConfig as Record<string, unknown> | null,
     })),
+    animals,
     displayObligations,
   };
 });

--- a/apps/web/lib/release/storefront-types.ts
+++ b/apps/web/lib/release/storefront-types.ts
@@ -39,6 +39,36 @@ export interface PublicSection {
   isVisible: boolean;
 }
 
+/** One image attached to a public-facing entity (item, animal, gallery section). */
+export interface PublicMediaImage {
+  url: string;
+  altText: string | null;
+  caption: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+/**
+ * An adoptable animal rendered by the `animals-available` section
+ * (pet-rescue / animal-shelter). Backed by the AdoptableAnimal entity + a
+ * MediaAttachment gallery, replacing the old free-form section JSON.
+ */
+export interface PublicAdoptableAnimal {
+  id: string;
+  animalRef: string;
+  name: string;
+  species: string | null;
+  breed: string | null;
+  age: string | null;
+  sex: string | null;
+  size: string | null;
+  description: string | null;
+  status: string;
+  attributes: Record<string, unknown> | null;
+  primaryPhotoUrl: string | null;
+  photos: PublicMediaImage[];
+}
+
 /**
  * A confirmed regulatory display obligation rendered by the storefront
  * "disclosures" section (BI-5D9DCDE6 spec §9.3). Only obligations backed by an
@@ -73,6 +103,8 @@ export interface PublicStorefrontConfig {
   brandingTokens: Record<string, unknown> | null;
   sections: PublicSection[];
   items: PublicItem[];
+  /** Adoptable animals for the `animals-available` section (empty otherwise). */
+  animals: PublicAdoptableAnimal[];
   /** Confirmed regulatory display obligations for the disclosures section. */
   displayObligations: PublicDisplayObligation[];
 }


### PR DESCRIPTION
## Why

Phase 1 ([#1784](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1784), merged) landed the media substrate — `MediaAsset` / `MediaAttachment` / `AdoptableAnimal`, content-addressed storage, upload/serve routes, and derived per-archetype profiles. This Phase 2 builds the **per-entity layer on top**, proving the substrate end-to-end on the biggest gap: **adoptable animals** (the `animals-available` section had no model behind it), and giving storefront items real photo galleries.

## What

**Backend**
- **Owner-media management** — `GET` list / `PATCH` reorder + set-primary + caption + alt-text / `DELETE` detach under `/api/storefront/admin/media`, with helpers (`detachMedia`, `reorderOwnerMedia`, `setPrimaryAttachment`, `updateAssetAltText`). `syncPrimaryImage` now also maintains `AdoptableAnimal.primaryPhotoAssetId`.
- **AdoptableAnimal CRUD** — `/api/storefront/admin/animals` (list/create) and `/:id` (update/delete; delete detaches photos first).
- **Public loader** — `getPublicAdoptableAnimals()` loads animals + galleries, wired into `getPublicStorefront` only when an `animals-available` section is present (every other archetype skips the query).

**UI**
- Reusable **`<MediaUploader>`** (upload, reorder, set-primary, alt text, remove) and **`<MediaImage>`** (focal-point crop + LQIP placeholder).
- **`AnimalsManager`** admin + `/storefront/animals` page; an **Animals** tab appears only for archetypes with an `animals-available` section.
- Item edit form gains a **product-photo gallery** uploader for saved items (URL field stays for quick entry / new items).
- Public **`AnimalsSection`** renders real `AdoptableAnimal` records (photo, name, breed/age, status badge), falling back to legacy section JSON.

## End-to-end flow this proves

Upload (`POST /api/media`) → `MediaAsset` (dedup) + `MediaAttachment` → `syncPrimaryImage` updates the primary cache → `GET /api/media/:id` serves it → public storefront renders the gallery. Same path now works for animals, product galleries, and (via the shared uploader) any future owner.

## Verification

- Scoped typecheck of all new/changed files is **clean** — the only remaining diagnostics are the known next-auth augmentation artifacts that equally affect unmodified files like `lib/govern/auth.ts` (CI's `next typegen` resolves them).
- Media probe/storage unit tests pass.
- Public-loader change is additive and guarded by section presence; the storefront-data test's mock (no animals section) is unaffected. The Animals tab defaults off, so the nav test is unchanged.
- Pre-commit typecheck was skipped locally for the same source-only-worktree reason as Phase 1 (`next` not on PATH); **CI runs the full gate**.

## Follow-ups

Equipment-rental unit galleries + superseding `RentalConditionRecord.mediaRefs` with inspection attachments; brand-extraction logo → `MediaAsset`; per-category placeholder seeding; sharp-based responsive renditions behind `GET /api/media/:id?w=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
