### PR TITLE
feat(workbooks): editable generic adapter — validated raw-write tier (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -5,6 +5,8 @@ import {
   genericColumnDefs,
   referenceLabelField,
   buildReferenceSearchArgs,
+  genericUpdateData,
+  makeGenericReadAdapter,
   type GenericTableConfig,
 } from "./generic-read-adapter";
 import { customColumnProvenance } from "./types";
@@ -114,6 +116,78 @@ describe("genericColumnDefs", () => {
   it("marks every generic (platform) column as system provenance", () => {
     const cols = genericColumnDefs(config);
     expect(cols.every((c) => c.provenanceKind === "system")).toBe(true);
+  });
+});
+
+const editableConfig: GenericTableConfig = {
+  entityType: "supplier",
+  prismaModel: "supplier",
+  idField: "supplierId",
+  labelField: "name",
+  editableFields: ["name", "status"],
+  columns: [
+    { field: "supplierId", name: "ID", fieldType: "text" },
+    { field: "name", name: "Name", fieldType: "text" },
+    {
+      field: "status",
+      name: "Status",
+      fieldType: "select",
+      options: [
+        { key: "active", label: "Active" },
+        { key: "inactive", label: "Inactive" },
+      ],
+    },
+    { field: "taxId", name: "Tax ID", fieldType: "text" },
+  ],
+};
+
+describe("genericColumnDefs — editability", () => {
+  it("marks only editableFields editable, never the id field", () => {
+    const cols = genericColumnDefs(editableConfig);
+    const byId = Object.fromEntries(cols.map((c) => [c.columnId, c.editable]));
+    expect(byId.name).toBe(true);
+    expect(byId.status).toBe(true);
+    expect(byId.taxId).toBe(false);
+    expect(byId.supplierId).toBe(false);
+  });
+
+  it("read-only config (no editableFields) marks nothing editable", () => {
+    expect(genericColumnDefs(config).every((c) => c.editable === false)).toBe(true);
+  });
+});
+
+describe("genericUpdateData — validated raw-write tier", () => {
+  it("builds a validated data object for allow-listed fields", () => {
+    expect(genericUpdateData(editableConfig, { name: "Acme", status: "active" })).toEqual({
+      name: "Acme",
+      status: "active",
+    });
+  });
+
+  it("rejects editing the id field", () => {
+    expect(() => genericUpdateData(editableConfig, { supplierId: "X" })).toThrow(/cannot be edited/i);
+  });
+
+  it("rejects a non-allow-listed field (fail-closed)", () => {
+    expect(() => genericUpdateData(editableConfig, { taxId: "123" })).toThrow(/not editable/i);
+  });
+
+  it("rejects an invalid select option", () => {
+    expect(() => genericUpdateData(editableConfig, { status: "bogus" })).toThrow(/unknown option/i);
+  });
+
+  it("allows clearing a field to null", () => {
+    expect(genericUpdateData(editableConfig, { name: null })).toEqual({ name: null });
+  });
+});
+
+describe("generic adapter getCapabilities", () => {
+  it("is editable only with canManage AND editableFields", () => {
+    const editable = makeGenericReadAdapter(editableConfig);
+    expect(editable.getCapabilities({ userId: "u", canManage: true }).canEditCell).toBe(true);
+    expect(editable.getCapabilities({ userId: "u", canManage: false }).canEditCell).toBe(false);
+    const readonly = makeGenericReadAdapter(config);
+    expect(readonly.getCapabilities({ userId: "u", canManage: true }).canEditCell).toBe(false);
   });
 });
 

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -1,12 +1,17 @@
-// Universal Grid & Workbooks — generic read-only adapter (EP-GRID-WORKBOOKS, Phase 2)
+// Universal Grid & Workbooks — generic adapter (EP-GRID-WORKBOOKS, Phase 2/3)
 //
 // "Every model is a grid": a config-driven DataSourceAdapter that exposes any
-// Prisma model as a read-only grid/board without a bespoke adapter class. v1 is
-// READ-ONLY by design and config-driven (an explicit field allow-list, not schema
-// introspection) so it can never expose sensitive fields (passwordHash, tokens)
-// and never performs a generic write. Models that need editing keep their
-// bespoke, validated adapters (backlog/invoice/risk). Edit-capable generic
-// adapters + DMMF introspection (with a steward denylist) are a later increment.
+// Prisma model as a grid/board without a bespoke adapter class. Config-driven via
+// an explicit field allow-list (not schema introspection) so it can never expose
+// sensitive fields (passwordHash, tokens).
+//
+// READ is the default. WRITE is opt-in per config via `editableFields` — the
+// "validated raw-write tier" (operator-approved 2026-06-12): for models without a
+// bespoke domain action, the generic adapter writes via Prisma, but only to
+// allow-listed fields and only after the SAME `validateCell` the rest of the
+// platform uses (so a write is still typed + validated, just not routed through a
+// hand-written domain action). Models that have real domain logic keep their
+// bespoke validated adapters (backlog/invoice/risk).
 
 import { prisma } from "@dpf/db";
 import {
@@ -27,6 +32,7 @@ import {
   type PagedRows,
   type GridCapabilities,
 } from "./types";
+import { validateCell, type CellStorage } from "./cell-validation";
 import { applyFilters, applySort, paginate } from "./grid-query";
 
 export interface GenericColumn {
@@ -55,6 +61,12 @@ export interface GenericTableConfig {
    * field, falling back to the id field itself.
    */
   labelField?: string;
+  /**
+   * Opt-in writable fields (validated raw-write tier). A subset of `columns`
+   * field names; the id field and any non-listed field stay read-only. Omit for a
+   * read-only grid. Each write goes through `validateCell` before Prisma.
+   */
+  editableFields?: string[];
 }
 
 const DEFAULT_CAP = 500;
@@ -109,13 +121,15 @@ export function genericRowToGridRow(
 }
 
 export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[] {
+  const editable = new Set(config.editableFields ?? []);
   return config.columns.map((c, i) => ({
     columnId: c.field,
     name: c.name,
     fieldType: c.fieldType,
     position: i,
     required: false,
-    editable: false, // generic v1 is read-only
+    // editable only if opt-in via editableFields (and never the id field)
+    editable: editable.has(c.field) && c.field !== config.idField,
     width: c.width,
     groupable: c.groupable ?? c.fieldType === "select",
     config: c.options ? { options: c.options } : undefined,
@@ -123,9 +137,65 @@ export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[
   }));
 }
 
+/** Pull the validated scalar for a Prisma write from a CellStorage by field type. */
+function prismaValueFromStorage(fieldType: FieldType, storage: CellStorage): unknown {
+  switch (fieldType) {
+    case "text":
+    case "url":
+    case "email":
+      return storage.textValue;
+    case "number":
+      return storage.numberValue;
+    case "date":
+    case "datetime":
+      return storage.dateValue;
+    case "checkbox":
+      return storage.boolValue;
+    case "select":
+      return storage.selectValue;
+    case "multi_select":
+      return storage.multiSelectValue;
+    default:
+      throw new Error(`Field type "${fieldType}" cannot be edited in a generic grid`);
+  }
+}
+
+/**
+ * Build a validated Prisma `data` object for a generic edit. Throws if a change
+ * targets the id field, a non-allow-listed field, an unknown field, or fails
+ * validation — fail-closed, no silent drops. Pure (no DB), so it is unit-testable.
+ */
+export function genericUpdateData(
+  config: GenericTableConfig,
+  changes: Record<string, CellValue>,
+): Record<string, unknown> {
+  const editable = new Set(config.editableFields ?? []);
+  const byField = new Map(config.columns.map((c) => [c.field, c]));
+  const data: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(changes)) {
+    if (field === config.idField) throw new Error(`The id field "${field}" cannot be edited`);
+    if (!editable.has(field)) throw new Error(`Field "${field}" is not editable`);
+    const col = byField.get(field);
+    if (!col) throw new Error(`Unknown field: ${field}`);
+    const result = validateCell(
+      {
+        name: col.name,
+        fieldType: col.fieldType,
+        required: false,
+        config: col.options ? { options: col.options } : undefined,
+      },
+      value,
+    );
+    if (!result.ok) throw new Error(result.error);
+    data[field] = prismaValueFromStorage(col.fieldType, result.storage);
+  }
+  return data;
+}
+
 type ReadDelegate = {
   findMany(args: unknown): Promise<Record<string, unknown>[]>;
   findUnique(args: unknown): Promise<Record<string, unknown> | null>;
+  update(args: unknown): Promise<Record<string, unknown>>;
 };
 
 function delegate(model: string): ReadDelegate {
@@ -210,8 +280,31 @@ class GenericReadAdapter implements DataSourceAdapter {
     return { label: String(r[labelField] ?? r[this.cfg.idField]) };
   }
 
-  getCapabilities(_ctx: AdapterContext): GridCapabilities {
-    return { canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false };
+  async updateCells(
+    entityType: string,
+    rowId: string,
+    changes: Record<string, CellValue>,
+    ctx: AdapterContext,
+  ): Promise<GridRow> {
+    if ((this.cfg.editableFields?.length ?? 0) === 0) {
+      throw new Error("This data source is read-only");
+    }
+    if (!ctx.canManage) {
+      throw new Error("You do not have permission to edit this data");
+    }
+    const data = genericUpdateData(this.cfg, changes); // validates; throws fail-closed
+    await delegate(this.cfg.prismaModel).update({
+      where: { [this.cfg.idField]: rowId },
+      data,
+    });
+    const row = await this.getRow(entityType, rowId);
+    if (!row) throw new Error("Row updated but could not be read back");
+    return row;
+  }
+
+  getCapabilities(ctx: AdapterContext): GridCapabilities {
+    const canEdit = !!ctx.canManage && (this.cfg.editableFields?.length ?? 0) > 0;
+    return { canAddRow: false, canAddColumn: false, canEditCell: canEdit, canDeleteRow: false };
   }
 }
 

--- a/apps/web/lib/workbooks/people-supplier-configs.test.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.test.ts
@@ -61,4 +61,18 @@ describe("people/supplier safe read-only grids", () => {
       expect(present).not.toContain(f);
     }
   });
+
+  it("SUPPLIER editable fields are a safe subset of columns (never id or sensitive)", () => {
+    const cols = new Set(fields(SUPPLIER_TABLE));
+    const editable = SUPPLIER_TABLE.editableFields ?? [];
+    expect(editable.length).toBeGreaterThan(0);
+    for (const f of editable) expect(cols.has(f)).toBe(true);
+    expect(editable).not.toContain(SUPPLIER_TABLE.idField);
+    for (const f of ["taxId", "bankDetails", "address"]) expect(editable).not.toContain(f);
+  });
+
+  it("CUSTOMER and EMPLOYEE grids stay read-only (no manage capability exists)", () => {
+    expect(CUSTOMER_ACCOUNT_TABLE.editableFields).toBeUndefined();
+    expect(EMPLOYEE_PROFILE_TABLE.editableFields).toBeUndefined();
+  });
 });

--- a/apps/web/lib/workbooks/people-supplier-configs.ts
+++ b/apps/web/lib/workbooks/people-supplier-configs.ts
@@ -80,6 +80,10 @@ export const SUPPLIER_TABLE: GenericTableConfig = {
   idField: "supplierId",
   labelField: "name",
   orderBy: { field: "updatedAt", dir: "desc" },
+  // Validated raw-write tier (no bespoke Supplier domain action exists). Editable
+  // safe fields only — taxId/bankDetails/address are excluded by omission and so
+  // can never be written here either. Each write still goes through validateCell.
+  editableFields: ["name", "contactName", "email", "phone", "paymentTerms", "defaultCurrency", "status"],
   // Excludes taxId, bankDetails, address (sensitive) by omission.
   columns: [
     { field: "supplierId", name: "ID", fieldType: "text", width: 140 },

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -181,9 +181,9 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
   {
     entityType: "supplier",
     label: "Suppliers",
-    description: "Suppliers as a read-only grid — sort, filter, and board by status.",
+    description: "Suppliers as an editable spreadsheet — edit safe fields inline; tax/bank details stay out.",
     viewCapability: "view_finance",
-    manageCapability: "view_finance", // read-only grid; adapter performs no writes
+    manageCapability: "manage_finance", // validated raw-write tier (editableFields allow-list)
     homeSurface: { path: "/finance", label: "Finance", board: true },
   },
 ];

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -160,9 +160,14 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 
-- **Supabase tier:** an *editable* generic adapter (any allow-listed Prisma model writable) — needs
-  a design call (raw validated writes for models without a domain action, as an explicit lower tier,
-  vs. always requiring a bespoke validated action). The biggest remaining Supabase-defining feature.
+- **Supabase tier — SHIPPED (slice 8).** Editable generic adapter (validated raw-write tier,
+  operator-approved 2026-06-12): a config opts in via `editableFields` (allow-list); the generic
+  adapter writes via Prisma but only to those fields and only after the same `validateCell` the rest
+  of the platform uses (`genericUpdateData`, pure + unit-tested, fail-closed on id/non-allow-listed/
+  invalid). Capability-gated; the existing `updatePlatformCellsAction` path wires it in with no new
+  UI. Proven on `supplier` (safe fields editable; tax/bank/address excluded by omission so
+  unwritable). Customer/employee stay read-only (no manage_* capability exists yet). Adding more
+  editable models is one `editableFields` line + a real `manageCapability`.
 - **Reporting (Phase 4):** group-by/pivots, charts/dashboards via report-kit, drill-through,
   scheduled refresh, RLS pre-aggregation, push-down/materialization, cross-row aggregation functions.
 - **Semantic layer (Phase 4):** `WorkbookMetric` (unique/owned/versioned, lineage-required).


### PR DESCRIPTION
The Supabase-defining "edit any table" capability, as the **operator-approved validated raw-write tier**. A Prisma model with no bespoke domain action becomes editable by opting in via `editableFields` on its config; the generic adapter then writes via Prisma — but **only to allow-listed fields and only after the same `validateCell`** the rest of the platform uses. A write is still typed + validated; it just isn't routed through a hand-written domain action.

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

**Guardrails (fail-closed, all unit-tested):**
- `genericUpdateData` rejects edits to the id field, any non-allow-listed field, unknown fields, and values that fail validation — no silent drops.
- `getCapabilities` reports `canEditCell` only when `ctx.canManage` AND `editableFields` is non-empty; read-only configs stay read-only even for a manager.
- Fields omitted from `columns` (supplier taxId/bankDetails/address) can be neither read nor written.

Wires into the existing platform-grid edit path (`updatePlatformCellsAction` → `adapter.updateCells`) with **no new UI**. Proven on `supplier` (safe fields editable, manageCapability=manage_finance); customer/employee stay read-only (no manage_* capability exists yet). Adding another editable model = one `editableFields` line + a real manageCapability.

Gate: workbooks vitest 100 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)