### PR TITLE
feat(workbooks): CSV export of the current grid view (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -56,6 +56,7 @@ import {
   commitRedo,
 } from "./grid-history";
 import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
+import { rowsToCsv } from "./grid-csv";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -344,6 +345,20 @@ export function WorkbookGrid({
     setBusy(false);
   }, [tableId, selectedRows]);
 
+  const onExportCsv = useCallback(() => {
+    if (typeof document === "undefined") return;
+    const csv = rowsToCsv(columns, sortedRows);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${tableId}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [columns, sortedRows, tableId]);
+
   return (
     <div className="flex h-full flex-col gap-2" onKeyDown={onKeyDown}>
       <div className="flex items-center gap-2">
@@ -404,9 +419,18 @@ export function WorkbookGrid({
         )}
         <button
           type="button"
+          onClick={onExportCsv}
+          disabled={columns.length === 0}
+          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
+          title="Export the current view to CSV"
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
           onClick={() => setShowFilters((v) => !v)}
           aria-pressed={showFilters}
-          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           title="Filter by column"
         >
           {showFilters ? "Hide filters" : "Filters"}

--- a/apps/web/components/workbooks/grid-csv.test.ts
+++ b/apps/web/components/workbooks/grid-csv.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { escapeCsvField, rowsToCsv } from "./grid-csv";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const col = (columnId: string, name: string): ColumnDefinition => ({
+  columnId,
+  name,
+  fieldType: "text",
+  position: 0,
+  required: false,
+  editable: true,
+});
+
+describe("escapeCsvField", () => {
+  it("leaves plain values untouched", () => {
+    expect(escapeCsvField("hello")).toBe("hello");
+  });
+  it("quotes and doubles interior quotes when needed", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+});
+
+describe("rowsToCsv", () => {
+  const columns = [col("name", "Name"), col("status", "Status"), col("epic", "Epic")];
+
+  it("emits a header row then one row per record", () => {
+    const rows: GridRowData[] = [
+      { rowId: "r1", name: "Alpha", status: "open", epic: { referenceId: "EP-1", referenceType: "epic", label: "Launch" } },
+    ];
+    expect(rowsToCsv(columns, rows)).toBe("Name,Status,Epic\r\nAlpha,open,Launch");
+  });
+
+  it("escapes commas and quotes in values, renders empty cells blank", () => {
+    const rows: GridRowData[] = [{ rowId: "r1", name: 'Acme, Inc "HQ"', status: null, epic: null }];
+    expect(rowsToCsv(columns, rows)).toBe('Name,Status,Epic\r\n"Acme, Inc ""HQ""",,');
+  });
+
+  it("emits just the header for no rows", () => {
+    expect(rowsToCsv(columns, [])).toBe("Name,Status,Epic");
+  });
+});

--- a/apps/web/components/workbooks/grid-csv.ts
+++ b/apps/web/components/workbooks/grid-csv.ts
@@ -1,0 +1,24 @@
+// Universal Grid & Workbooks — CSV export (EP-GRID-WORKBOOKS, Phase 3)
+//
+// Serialize the rows currently shown in the grid (already filtered + sorted) to
+// RFC-4180-ish CSV. Pure + unit-testable; the browser download is a thin wrapper
+// in the Grid component. Reuses cellSearchText so exported values match what the
+// user sees (reference labels, joined multi-selects, etc.).
+
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+/** Quote a field if it contains a comma, quote, or newline; double interior quotes. */
+export function escapeCsvField(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Build a CSV document (header row + one row per record) for the given columns. */
+export function rowsToCsv(columns: ColumnDefinition[], rows: GridRowData[]): string {
+  const header = columns.map((c) => escapeCsvField(c.name)).join(",");
+  const body = rows.map((row) =>
+    columns.map((c) => escapeCsvField(cellSearchText(row[c.columnId] ?? null))).join(","),
+  );
+  return [header, ...body].join("\r\n");
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -154,9 +154,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   (select → option dropdown, checkbox → checked/unchecked, else text), AND-combined with the quick
   filter (`applyColumnFilters`, unit-tested), with an active-count badge + Clear. Client-side over
   loaded rows; precise number/date operators + saved views are follow-ups.
+- **Slice 9 — CSV export — SHIPPED.** An "Export CSV" toolbar button downloads the current view
+  (filtered + sorted) as RFC-4180-ish CSV (pure, unit-tested `grid-csv.ts`; reuses `cellSearchText`
+  so exported values match what's shown, including reference labels). Works for every grid.
 - **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
   conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
-  views; CSV + `.xlsx` import; group-by summary.
+  views; `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
An **Export CSV** toolbar button downloads the rows currently shown (after quick filter, per-column filters, and sort) as RFC-4180-ish CSV. Works for every grid (custom + platform).

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

Serialization is a pure, unit-tested `grid-csv.ts` (`escapeCsvField` + `rowsToCsv`) that reuses `cellSearchText`, so exported values match what the user sees — reference labels, joined multi-selects, computed cells — not raw ids. The browser download (Blob + anchor) is a thin, SSR-guarded wrapper in the Grid.

Gate: grid-csv vitest 5 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)