### PR TITLE
fix(test): stop mcp-tools-backlog teardown rpc flake at the source

### DIFF
--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -60,6 +60,18 @@ vi.mock("@/lib/queue/inngest-client", () => ({
   inngest: mockInngest,
 }));
 
+// promote_to_build_studio fires a detached `void (async () => …)()` that
+// dynamically imports this module and dispatches Ideate. With the real module
+// in place that fire-and-forget rejects under the mocked prisma and calls
+// console.error *after* the test has returned — surfacing during worker
+// teardown as the intermittent
+// "Closing rpc while \"onUserConsoleLog\" was pending" EnvironmentTeardownError.
+// Stubbing the dispatch makes the detached promise resolve quietly so nothing
+// logs during teardown.
+vi.mock("@/lib/integrate/ideate-on-approval", () => ({
+  dispatchIdeateForApprovedBuild: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { executeTool } from "./mcp-tools";
 
 describe("backlog MCP tool execution", () => {


### PR DESCRIPTION
## Problem

`apps/web/lib/mcp-tools-backlog.test.ts` intermittently fails CI with a vitest worker-teardown race even though all its tests pass:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "lib/mcp-tools-backlog.test.ts"
```

This surfaces as an "Unhandled Rejection" that makes `vitest run --shard=1/4` exit 1 despite 2599 tests passing — a false CI failure (seen on #1790, cleared on re-run).

## Root cause

`promote_to_build_studio` fires a **detached** `void (async () => …)()` when a promotion is auto-approve-eligible (governed mode + non-empty body — exactly what the `promote_to_build_studio` test exercises). That IIFE dynamically imports `@/lib/integrate/ideate-on-approval` and calls `dispatchIdeateForApprovedBuild`, which **rejects** under the mocked prisma and hits `console.error(…)`.

That `console.error` fires *after* `executeTool` has returned and the test has passed — i.e. during worker teardown. Vitest then tries to send the `onUserConsoleLog` RPC to a closing worker, producing the error. The race against teardown timing is why it was flaky.

#1488 already stubbed `console.log`/`console.info` at the top of the file, but not the `console.error` on this rejection path — so the leak survived.

## Fix

One `vi.mock` stubbing `dispatchIdeateForApprovedBuild` to resolve cleanly, so the detached promise completes quietly with no post-test logging. **No assertions changed** — the existing `promote_to_build_studio` test still asserts the build/backlog mutations exactly as before.

## Verification

Ran the suite by borrowing the root clone's toolchain against this source-only worktree:

- **With the fix:** 10/10 runs — `15 passed (15)`, zero teardown errors.
- **Mock removed (to confirm diagnosis):** the exact error reproduced **3/3** runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
