### PR TITLE
feat(build-studio): install pinned OpenCode in sandbox image + tool-registry admission (Phase 2a, BI-01D6A51B)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -37,6 +37,40 @@ RUN curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash \
  && rm -rf /root/.grok \
  && grok --version \
  && su -s /bin/sh node -c "grok --version"
+# OpenCode CLI (sst/opencode): the open-source agent for the Build Studio "opencode"
+# dispatch engine (opencode-dispatch.ts). Runs against the install's OWN local
+# OpenAI-compatible endpoint (Docker Model Runner / Ollama) — no vendor credential.
+#
+# The npm package (`opencode-ai`) postinstall does NOT detect musl (upstream
+# #9571), so on this Alpine/musl base it links the wrong binary. We therefore
+# fetch the dedicated musl release tarball directly (the grok pattern). The
+# `baseline` variant drops the AVX2 requirement so the sandbox runs on arbitrary
+# operator hardware. The tarball is a single `opencode` binary; install it into
+# world-traversable /usr/local/bin and gate the build with `opencode --version`
+# as root AND as the node user (uid 1000, who actually runs dispatch — the same
+# perms trap that bit grok). curl/libstdc++/libgcc are already installed above.
+# Verified live on node:24-alpine: v1.17.4 baseline-musl runs as both users.
+ARG OPENCODE_VERSION=1.17.4
+RUN set -eux; \
+    curl -fsSL -o /tmp/opencode.tar.gz \
+      "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-baseline-musl.tar.gz"; \
+    tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin; \
+    rm /tmp/opencode.tar.gz; \
+    chmod 755 /usr/local/bin/opencode; \
+    cp /usr/local/bin/opencode /opt/dpf-engines/opencode 2>/dev/null || (mkdir -p /opt/dpf-engines && cp /usr/local/bin/opencode /opt/dpf-engines/opencode); \
+    opencode --version; \
+    su -s /bin/sh node -c "opencode --version"
+# Pre-seed the @ai-sdk/openai-compatible provider into OpenCode's per-package
+# cache for the node user. OpenCode resolves provider SDKs into
+# ~/.cache/opencode/packages/<pkg>/node_modules/<pkg> at first run and
+# short-circuits when that path exists — so seeding it keeps a headless build
+# fully air-gapped (no npm fetch on first dispatch).
+RUN set -eux; \
+    PKG_DIR=/home/node/.cache/opencode/packages/@ai-sdk/openai-compatible; \
+    mkdir -p "$PKG_DIR"; \
+    npm install --prefix "$PKG_DIR" @ai-sdk/openai-compatible; \
+    test -d "$PKG_DIR/node_modules/@ai-sdk/openai-compatible"; \
+    chown -R node:node /home/node/.cache
 RUN git config --global user.email "sandbox@dpf.local" \
  && git config --global user.name "DPF Sandbox"
 # Codex CLI defaults: bypass internal sandbox (Docker IS the sandbox),

--- a/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
+++ b/docs/superpowers/plans/2026-06-10-local-llm-build-agent.md
@@ -17,6 +17,8 @@ Phased so each phase lands as one PR with its own gates. Spec holds the rational
 
 Exit: tool registry row merged; exact CLI invocation + env contract documented in the registry entry.
 
+**Status: done** (conditional admission). OpenCode pinned to **1.17.4**; registry row added (status `conditional`, MIT, sandbox-only/local-endpoint-only/version-pinned conditions; formal EP-GOVERN-002 multi-agent run noted to upgrade to `approved`). CLI contract verified live on node:24-alpine: `opencode run` flags `--dir` / `-m provider/model` / `--format json` / `--dangerously-skip-permissions` all present; install + version gate pass as root and the node user.
+
 ## Phase 1 — Runner + config (the core slice)
 
 1. `agent-runner-types.ts`: add `"opencode"` to `BuildAgentId` (id names the agent, not the locality — see spec Decision section).
@@ -38,7 +40,7 @@ Exit: `pnpm --filter web exec vitest run` green on new tests; `pnpm --filter web
 
 ## Phase 2 — Sandbox image + admin UI
 
-1. `Dockerfile.sandbox`: install the **pinned** OpenCode binary. **Research finding (opencode issue #9571):** `npm install -g opencode-ai` does NOT detect musl — on the `node:24-alpine` base it fails or links the wrong binary (the grok failure mode, worse). Do **not** change the base image (blast-radius for codex/claude/grok). Instead install the musl artifact directly — `npm install -g opencode-linux-x64-musl@<pin>` (or download the musl release binary onto PATH) — and, because OpenCode dynamically fetches the `@ai-sdk/openai-compatible` provider package on first run, **pre-install that package into the image** so air-gapped first runs don't fail. Gate the image build loudly with `opencode --version` as root **and** as the `node` user (the grok lesson).
+1. `Dockerfile.sandbox`: install the **pinned** OpenCode binary. **Research finding (opencode issue #9571):** `npm install -g opencode-ai` does NOT detect musl — on the `node:24-alpine` base it fails or links the wrong binary (the grok failure mode, worse). Do **not** change the base image (blast-radius for codex/claude/grok). **Done (Phase 2a, verified live):** fetch the pinned `opencode-linux-x64-baseline-musl.tar.gz` release tarball directly into `/usr/local/bin` (baseline = no AVX2 assumption, for arbitrary operator hardware), gate with `opencode --version` as root **and** the `node` user, and pre-seed `@ai-sdk/openai-compatible` into `/home/node/.cache/opencode/packages/...` (OpenCode's per-package cache short-circuits when that path exists → air-gapped first run). The npm platform package (`opencode-linux-x64-musl`) ships no `bin`, so the tarball is the clean path. A throwaway `docker build` confirmed all three previously-unconfirmed items (asset runs on musl with only libstdc++/libgcc; `--version` exits 0; provider seed lands). The full Build-Studio sandbox image rebuild is part of the governed image pipeline, not this worktree.
 2. Admin Build Studio dispatch config UI: add "Local model (OpenCode)" option with resolved endpoint + model display, an inline endpoint health/context preflight result (config-time, not first at dispatch), preview-tier banner, and a "no credential required" note. Theme tokens per AGENTS.md §12.
 3. Docs: update the Build Studio operator docs' dispatch-provider section (document at ship).
 

--- a/packages/db/data/approved_tools_registry.json
+++ b/packages/db/data/approved_tools_registry.json
@@ -1,5 +1,74 @@
 {
   "version": "1.0.0",
   "generated_at": "2026-03-25",
-  "tools": []
+  "tools": [
+    {
+      "id": "tool-eval-opencode-20260613",
+      "toolName": "opencode (opencode-ai)",
+      "toolType": "npm_package",
+      "version": "1.17.4",
+      "sourceUrl": "https://github.com/anomalyco/opencode",
+      "proposedBy": "BI-01D6A51B (local-LLM Build Studio dispatch)",
+      "proposedAt": "2026-06-13",
+      "status": "conditional",
+      "verdict": {
+        "decision": "conditional",
+        "rationale": "MIT-licensed open-source headless coding agent adopted as the Build Studio 'opencode' dispatch engine. It runs inside the existing sandbox against the install's OWN local OpenAI-compatible endpoint, so it introduces no vendor credential and no network egress beyond the operator's own model server. Install mechanism, runtime, and dispatch flags were verified live on node:24-alpine (musl). Conditional pending the formal EP-GOVERN-002 multi-agent evaluation to upgrade to 'approved'.",
+        "riskLevel": "low",
+        "threatCategories": [],
+        "confidenceScore": 0.6
+      },
+      "conditions": [
+        "version-pinned to 1.17.4 (opencode-linux-x64-baseline-musl release asset)",
+        "sandbox-only — runs inside the Build Studio sandbox container, never on the host or portal",
+        "local-endpoint-only — pointed at the install's local OpenAI-compatible endpoint; no external provider config",
+        "no credential injected — local servers need none; the opencode.json apiKey is a dummy",
+        "capability tier stays 'preview' until Phase 3 eval evidence on a real local model"
+      ],
+      "findings": [
+        {
+          "reviewerAgentId": "claude-code (implementing agent)",
+          "category": "compliance",
+          "severity": "info",
+          "title": "License: MIT",
+          "description": "OpenCode is MIT-licensed (OSI-approved), compatible with the platform. Rejected alternative Crush is FSL-1.1 (not OSI) for this reason.",
+          "evidence": "https://github.com/anomalyco/opencode (LICENSE)",
+          "recommendation": "Compatible — no license condition needed.",
+          "mitigatable": true,
+          "mitigation": null
+        },
+        {
+          "reviewerAgentId": "claude-code (implementing agent)",
+          "category": "supply_chain",
+          "severity": "medium",
+          "title": "npm postinstall does not detect musl (upstream #9571)",
+          "description": "The opencode-ai npm postinstall constructs the glibc binary name and never tries the -musl variant, so `npm install -g opencode-ai` fails/links the wrong binary on the Alpine sandbox base.",
+          "evidence": "https://github.com/anomalyco/opencode/issues/9571",
+          "recommendation": "Bypass npm: fetch the pinned opencode-linux-x64-baseline-musl release tarball directly into the image (the grok pattern). Implemented in Dockerfile.sandbox.",
+          "mitigatable": true,
+          "mitigation": "Direct tarball install + `opencode --version` build gate as root and the node user."
+        },
+        {
+          "reviewerAgentId": "claude-code (implementing agent)",
+          "category": "integration",
+          "severity": "info",
+          "title": "Install + dispatch contract verified live on node:24-alpine",
+          "description": "Probe build confirmed: baseline-musl tarball runs as root and the node user (uid 1000) printing version 1.17.4 exit 0 with only libstdc++/libgcc (no gcompat); the dispatch flags --dir, -m provider/model, --format json, --dangerously-skip-permissions all exist on this pinned version; the @ai-sdk/openai-compatible provider pre-seeds into ~/.cache/opencode/packages/... for air-gapped first run.",
+          "evidence": "docker build .opencode-probe.Dockerfile + opencode run --help (2026-06-13)",
+          "recommendation": "Proceed. Full happy-path (opencode run against a real local model) is the Phase 3 functional gate.",
+          "mitigatable": true,
+          "mitigation": null
+        }
+      ],
+      "reviewers": [
+        { "reviewerId": "claude-code", "role": "implementing-agent", "reviewedAt": "2026-06-13" }
+      ],
+      "approvedBy": null,
+      "approvedAt": null,
+      "reEvaluateAfter": "2026-12-13",
+      "supersedes": null,
+      "createdAt": "2026-06-13",
+      "updatedAt": "2026-06-13"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Phase 2a of the local-LLM Build Studio dispatch option — bakes the **OpenCode CLI (pinned v1.17.4)** into `Dockerfile.sandbox` so the `opencode` dispatch engine (merged in [#1791](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1791)) has its binary, plus the tool-evaluation admission record. Backlog: **BI-01D6A51B** (EP-BUILD-STUDIO).

## Changes

- **`Dockerfile.sandbox`** — fetch the pinned `opencode-linux-x64-baseline-musl.tar.gz` release tarball directly into `/usr/local/bin`. The npm postinstall does **not** detect musl (upstream [#9571](https://github.com/anomalyco/opencode/issues/9571)), so on this Alpine base it links the wrong binary — the direct tarball is the clean path (the grok lesson; **not** a base-image change, which would blast-radius codex/claude/grok). The `baseline` variant drops the AVX2 requirement for arbitrary operator hardware. Build is gated with `opencode --version` as **root and the node user** (uid 1000, who runs dispatch). Pre-seeds `@ai-sdk/openai-compatible` into `/home/node/.cache/opencode/packages/...` so OpenCode's per-package cache short-circuits and the first headless run is **air-gapped**.
- **`approved_tools_registry.json`** — OpenCode admitted `conditional` (MIT; sandbox-only / local-endpoint-only / version-pinned conditions; formal EP-GOVERN-002 multi-agent run noted to upgrade to `approved`) with security/license/integration findings recorded for institutional memory.

## Verification (substrate: throwaway `docker build` on node:24-alpine, host Docker 29.4.3)

A disposable probe image confirmed the three items the docs left unconfirmed:
- the `baseline-musl` asset extracts and runs as **both root and the node user** with only `libstdc++`/`libgcc` already present (no `gcompat` — it's a true musl build);
- `opencode --version` → `1.17.4`, exit 0, no config/network;
- the dispatch flags used by [opencode-dispatch.ts](apps/web/lib/integrate/opencode-dispatch.ts) — `--dir`, `-m provider/model`, `--format json`, `--dangerously-skip-permissions` — **all exist on the pinned 1.17.4 binary**;
- the provider pre-seed lands at the cache path OpenCode's runtime installer short-circuits on.

The governed full Build-Studio sandbox image rebuild is the image pipeline's job, not this worktree (per AGENTS.md §5).

## Next

Phase 2b — the "Local model (OpenCode)" admin UI option with the config-time endpoint preflight. Phase 3 — runtime functional verification (one real `opencode run` against the install's local model) to justify promoting the tier above `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)