### PR TITLE
feat(workbooks): conditional formatting — highlight rows by rule (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,7 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -57,6 +57,16 @@ import {
 } from "./grid-history";
 import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
 import { rowsToCsv } from "./grid-csv";
+import {
+  type ConditionalRule,
+  CF_OPERATORS,
+  CF_OPERATOR_LABELS,
+  CF_COLORS,
+  rowColor,
+  rowColorClass,
+  blankRule,
+  operatorNeedsValue,
+} from "./grid-conditional-format";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -192,6 +202,9 @@ export function WorkbookGrid({
   const [showProvenance, setShowProvenance] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
+  const [showFormat, setShowFormat] = useState(false);
+  const [cfRules, setCfRules] = useState<ConditionalRule[]>([]);
+  const cfIdRef = useRef(0);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -438,6 +451,16 @@ export function WorkbookGrid({
         </button>
         <button
           type="button"
+          onClick={() => setShowFormat((v) => !v)}
+          aria-pressed={showFormat}
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Highlight rows by a condition"
+        >
+          {showFormat ? "Hide formatting" : "Format"}
+          {cfRules.length > 0 ? ` (${cfRules.length})` : ""}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -512,6 +535,85 @@ export function WorkbookGrid({
         </div>
       )}
 
+      {showFormat && columns.length > 0 && (
+        <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+          {cfRules.map((rule) => {
+            const update = (patch: Partial<ConditionalRule>) =>
+              setCfRules((rs) => rs.map((r) => (r.id === rule.id ? { ...r, ...patch } : r)));
+            const ctrlClass =
+              "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+            return (
+              <div key={rule.id} className="flex flex-wrap items-center gap-2">
+                <span className="text-sm text-[var(--dpf-muted)]">Highlight when</span>
+                <select
+                  value={rule.columnId}
+                  onChange={(e) => update({ columnId: e.target.value })}
+                  aria-label="Column"
+                  className={ctrlClass}
+                >
+                  {columns.map((c) => (
+                    <option key={c.columnId} value={c.columnId}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={rule.operator}
+                  onChange={(e) => update({ operator: e.target.value as ConditionalRule["operator"] })}
+                  aria-label="Operator"
+                  className={ctrlClass}
+                >
+                  {CF_OPERATORS.map((op) => (
+                    <option key={op} value={op}>
+                      {CF_OPERATOR_LABELS[op]}
+                    </option>
+                  ))}
+                </select>
+                {operatorNeedsValue(rule.operator) && (
+                  <input
+                    value={rule.value}
+                    onChange={(e) => update({ value: e.target.value })}
+                    placeholder="value"
+                    aria-label="Value"
+                    className={ctrlClass}
+                  />
+                )}
+                <select
+                  value={rule.color}
+                  onChange={(e) => update({ color: e.target.value as ConditionalRule["color"] })}
+                  aria-label="Color"
+                  className={ctrlClass}
+                >
+                  {CF_COLORS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                <span className={`dpf-cf-swatch ${rowColorClass(rule.color)}`} aria-hidden="true" />
+                <button
+                  type="button"
+                  onClick={() => setCfRules((rs) => rs.filter((r) => r.id !== rule.id))}
+                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                  aria-label="Remove rule"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() =>
+              setCfRules((rs) => [...rs, blankRule(`cf-${(cfIdRef.current += 1)}`, columns)])
+            }
+            className="w-fit rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)]"
+          >
+            + Add formatting rule
+          </button>
+        </div>
+      )}
+
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
@@ -528,6 +630,10 @@ export function WorkbookGrid({
             onSortColumnsChange={setSortColumns}
             selectedRows={selectedRows}
             onSelectedRowsChange={setSelectedRows}
+            rowClass={(row) => {
+              const color = rowColor(row, cfRules);
+              return color ? rowColorClass(color) : undefined;
+            }}
             defaultColumnOptions={{ resizable: true, sortable: true }}
           />
         </div>

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -110,3 +110,24 @@
   outline: 2px solid var(--dpf-accent);
   outline-offset: -2px;
 }
+
+/* Conditional formatting — row tints (subtle, theme-token based). */
+.dpf-cf-red .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-error) 16%, transparent);
+}
+.dpf-cf-amber .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-warning, #b8860b) 18%, transparent);
+}
+.dpf-cf-green .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-success, #2e7d32) 16%, transparent);
+}
+.dpf-cf-blue .rdg-cell {
+  background-color: color-mix(in srgb, var(--dpf-accent) 16%, transparent);
+}
+.dpf-cf-swatch {
+  display: inline-block;
+  inline-size: 1rem;
+  block-size: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--dpf-border);
+}

--- a/apps/web/components/workbooks/grid-conditional-format.test.ts
+++ b/apps/web/components/workbooks/grid-conditional-format.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  ruleMatches,
+  rowColor,
+  rowColorClass,
+  operatorNeedsValue,
+  type ConditionalRule,
+} from "./grid-conditional-format";
+import type { GridRowData } from "./cell-editors";
+
+const rule = (over: Partial<ConditionalRule>): ConditionalRule => ({
+  id: "r",
+  columnId: "status",
+  operator: "eq",
+  value: "",
+  color: "amber",
+  ...over,
+});
+
+const row: GridRowData = { rowId: "r1", status: "overdue", amount: 120, note: "" };
+
+describe("ruleMatches", () => {
+  it("eq / neq are case-insensitive on display text", () => {
+    expect(ruleMatches(rule({ operator: "eq", value: "OVERDUE" }), row)).toBe(true);
+    expect(ruleMatches(rule({ operator: "neq", value: "open" }), row)).toBe(true);
+  });
+  it("contains needs a non-empty needle", () => {
+    expect(ruleMatches(rule({ operator: "contains", value: "due" }), row)).toBe(true);
+    expect(ruleMatches(rule({ operator: "contains", value: "" }), row)).toBe(false);
+  });
+  it("empty / notEmpty test the raw value", () => {
+    expect(ruleMatches(rule({ columnId: "note", operator: "empty" }), row)).toBe(true);
+    expect(ruleMatches(rule({ columnId: "status", operator: "notEmpty" }), row)).toBe(true);
+  });
+  it("gt / lt coerce numerically and fail closed on non-numbers", () => {
+    expect(ruleMatches(rule({ columnId: "amount", operator: "gt", value: "100" }), row)).toBe(true);
+    expect(ruleMatches(rule({ columnId: "amount", operator: "lt", value: "100" }), row)).toBe(false);
+    expect(ruleMatches(rule({ columnId: "status", operator: "gt", value: "1" }), row)).toBe(false);
+  });
+});
+
+describe("rowColor", () => {
+  it("returns the first matching rule's color", () => {
+    const rules = [
+      rule({ id: "a", columnId: "amount", operator: "lt", value: "100", color: "green" }),
+      rule({ id: "b", columnId: "status", operator: "eq", value: "overdue", color: "red" }),
+    ];
+    expect(rowColor(row, rules)).toBe("red");
+  });
+  it("returns undefined when nothing matches", () => {
+    expect(rowColor(row, [rule({ value: "paid" })])).toBeUndefined();
+  });
+});
+
+describe("helpers", () => {
+  it("rowColorClass maps to a css class", () => {
+    expect(rowColorClass("blue")).toBe("dpf-cf-blue");
+  });
+  it("operatorNeedsValue is false only for empty/notEmpty", () => {
+    expect(operatorNeedsValue("eq")).toBe(true);
+    expect(operatorNeedsValue("empty")).toBe(false);
+    expect(operatorNeedsValue("notEmpty")).toBe(false);
+  });
+});

--- a/apps/web/components/workbooks/grid-conditional-format.ts
+++ b/apps/web/components/workbooks/grid-conditional-format.ts
@@ -1,0 +1,91 @@
+// Universal Grid & Workbooks — conditional formatting (EP-GRID-WORKBOOKS Phase 3)
+//
+// Pure rule evaluation for highlighting rows that match a condition (the Smartsheet
+// "color rows where status = overdue" affordance). The first matching rule wins.
+// Kept pure + unit-testable; the Grid owns the (session) rule list and applies the
+// resulting class via react-data-grid's rowClass.
+
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+export const CF_OPERATORS = ["eq", "neq", "contains", "gt", "lt", "empty", "notEmpty"] as const;
+export type CfOperator = (typeof CF_OPERATORS)[number];
+
+export const CF_OPERATOR_LABELS: Record<CfOperator, string> = {
+  eq: "equals",
+  neq: "not equals",
+  contains: "contains",
+  gt: "greater than",
+  lt: "less than",
+  empty: "is empty",
+  notEmpty: "is not empty",
+};
+
+export const CF_COLORS = ["red", "amber", "green", "blue"] as const;
+export type CfColor = (typeof CF_COLORS)[number];
+
+export interface ConditionalRule {
+  id: string;
+  columnId: string;
+  operator: CfOperator;
+  value: string;
+  color: CfColor;
+}
+
+/** Does a single rule match a row? Numeric ops coerce; text ops are case-insensitive. */
+export function ruleMatches(rule: ConditionalRule, row: GridRowData): boolean {
+  const raw = cellSearchText(row[rule.columnId] ?? null);
+  const text = raw.toLowerCase();
+  const target = rule.value.trim().toLowerCase();
+  switch (rule.operator) {
+    case "eq":
+      return text === target;
+    case "neq":
+      return text !== target;
+    case "contains":
+      return target.length > 0 && text.includes(target);
+    case "empty":
+      return raw === "";
+    case "notEmpty":
+      return raw !== "";
+    case "gt":
+    case "lt": {
+      const n = Number(raw);
+      const t = Number(rule.value);
+      if (Number.isNaN(n) || Number.isNaN(t)) return false;
+      return rule.operator === "gt" ? n > t : n < t;
+    }
+    default:
+      return false;
+  }
+}
+
+/** The color of the first matching rule for a row, or undefined. */
+export function rowColor(row: GridRowData, rules: ConditionalRule[]): CfColor | undefined {
+  for (const rule of rules) {
+    if (ruleMatches(rule, row)) return rule.color;
+  }
+  return undefined;
+}
+
+/** The CSS class that paints a row a given conditional-format color. */
+export function rowColorClass(color: CfColor): string {
+  return `dpf-cf-${color}`;
+}
+
+/** Operators that don't need a value input. */
+export function operatorNeedsValue(op: CfOperator): boolean {
+  return op !== "empty" && op !== "notEmpty";
+}
+
+/** A blank rule seeded to the first column (for the rule builder). */
+export function blankRule(id: string, columns: ColumnDefinition[]): ConditionalRule {
+  return {
+    id,
+    columnId: columns[0]?.columnId ?? "",
+    operator: "eq",
+    value: "",
+    color: "amber",
+  };
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -157,9 +157,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Slice 9 — CSV export — SHIPPED.** An "Export CSV" toolbar button downloads the current view
   (filtered + sorted) as RFC-4180-ish CSV (pure, unit-tested `grid-csv.ts`; reuses `cellSearchText`
   so exported values match what's shown, including reference labels). Works for every grid.
-- **Remaining (not built):** saved views (persist filters/sort to the existing `WorkbookView`);
-  conditional formatting (color scales / data bars / icon sets / formula rules); calendar + gallery
-  views; `.xlsx` import; group-by summary.
+- **Slice 10 — conditional formatting — SHIPPED.** A "Format" panel of rules (column + operator
+  [equals/contains/gt/lt/empty/…] + value + colour); the first matching rule tints the row.
+  Pure, unit-tested `grid-conditional-format.ts` (`ruleMatches`/`rowColor`); applied via
+  react-data-grid `rowClass`. Session-scoped for now; persisting rules to `WorkbookView` is a follow-up.
+- **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
+  calendar + gallery views; `.xlsx` import; group-by summary.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
A defining Smartsheet capability: a **Format** panel lets a user add rules — column + operator (equals / not equals / contains / greater-than / less-than / is-empty / is-not-empty) + value + colour (red/amber/green/blue) — and the **first matching rule tints each row**.

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

Rule evaluation is a pure, unit-tested `grid-conditional-format.ts` (`ruleMatches`, `rowColor`): text ops are case-insensitive on display text; numeric ops coerce and fail closed on non-numbers; reuses `cellSearchText` so it works across scalars, selects, references, and computed cells. Applied via react-data-grid `rowClass` with theme-token row tints (color-mix on `--dpf-error/warning/success/accent`). Rules are session-scoped for now; persisting to `WorkbookView` is a tracked follow-up.

Gate: grid-conditional-format vitest 8 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)