### PR TITLE
feat: P0 — operational value-stream architecture derived at setup, rendered on /ea

### DIFF
--- a/apps/web/app/(shell)/ea/value-streams/page.tsx
+++ b/apps/web/app/(shell)/ea/value-streams/page.tsx
@@ -1,30 +1,19 @@
 // apps/web/app/(shell)/ea/value-streams/page.tsx
 import Link from "next/link";
-import { prisma } from "@dpf/db";
 import { EaTabNav } from "@/components/ea/EaTabNav";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { isOperationalValueStreamScope, listValueStreamViews } from "@/lib/ea/value-stream-views";
 
 export default async function EaValueStreamsPage() {
-  const views = await prisma.eaView.findMany({
-    where: { scopeType: "reference_model_projection" },
-    orderBy: [{ createdAt: "desc" }],
-    select: {
-      id: true,
-      name: true,
-      description: true,
-      scopeRef: true,
-      createdAt: true,
-      notation: { select: { name: true } },
-      _count: { select: { viewElements: true } },
-    },
-  });
+  const views = await listValueStreamViews();
 
   return (
     <div>
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Enterprise Architecture</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Value Streams — reference-model value-stream architecture projected onto the EA canvas.
+          Value Streams — your business&rsquo;s operational value stream alongside reference-model
+          value-stream projections, on the EA canvas.
         </p>
       </div>
 
@@ -36,7 +25,8 @@ export default async function EaValueStreamsPage() {
             <Link key={v.id} href={`/ea/views/${v.id}`} style={{ textDecoration: "none" }}>
               <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]">
                 <p className="mb-1 font-mono text-[9px] text-[var(--dpf-muted)]">
-                  {v.notation.name} · Value stream view
+                  {v.notation.name} ·{" "}
+                  {isOperationalValueStreamScope(v.scopeType) ? "Operational — your business" : "Reference model"}
                 </p>
                 <p className="mb-1 text-sm font-semibold leading-tight text-[var(--dpf-text)]">{v.name}</p>
                 {v.description != null && (
@@ -59,8 +49,9 @@ export default async function EaValueStreamsPage() {
             No value-stream view generated yet.
           </p>
           <p className="mb-4 text-xs text-[var(--dpf-muted)]">
-            Value-stream views are projected from a reference model (e.g. IT4IT). Open a reference model and use
-            &ldquo;Load value stream view&rdquo; to materialize it onto the EA canvas.
+            Two kinds of value stream appear here: your business&rsquo;s operational value stream, generated when
+            you complete storefront setup, and reference-model projections (e.g. IT4IT) loaded from a reference
+            model onto the EA canvas.
           </p>
           <Link
             href="/ea/models"

--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -10,6 +10,7 @@ import {
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
 import { setCapabilityChoice } from "@/lib/storefront/capability-activation";
+import { projectOperationalValueStreamForArchetype } from "@/lib/storefront/project-operational-value-stream";
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -163,6 +164,14 @@ export async function POST(req: NextRequest) {
   await applyBusinessCapabilityPerspective(prisma, {
     archetypeId,
     category: archetype.category,
+  });
+
+  // P0 "Capture": derive and persist the org's operational value-stream
+  // architecture so it renders on /ea and seeds the WWWD business-context
+  // perspective. Fatal: setup has not met the architecture contract without it.
+  await projectOperationalValueStreamForArchetype({
+    organizationId: org.id,
+    archetypeId,
   });
 
   // Seed default provider, availability, and booking config from template scheduling defaults

--- a/apps/web/lib/ea/value-stream-views.test.ts
+++ b/apps/web/lib/ea/value-stream-views.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindMany } = vi.hoisted(() => ({ mockFindMany: vi.fn() }));
+vi.mock("@dpf/db", () => ({ prisma: { eaView: { findMany: mockFindMany } } }));
+
+import {
+  isOperationalValueStreamScope,
+  listValueStreamViews,
+  VALUE_STREAM_VIEW_SCOPES,
+} from "./value-stream-views";
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+  mockFindMany.mockResolvedValue([]);
+});
+
+describe("listValueStreamViews", () => {
+  it("queries both reference-model and operational value-stream scopes", async () => {
+    await listValueStreamViews();
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { scopeType: { in: ["reference_model_projection", "archetype_value_stream"] } },
+      }),
+    );
+    // scopeType must be selected so cards can label operational vs reference.
+    const arg = mockFindMany.mock.calls[0]![0] as { select: { scopeType?: boolean } };
+    expect(arg.select.scopeType).toBe(true);
+  });
+});
+
+describe("isOperationalValueStreamScope", () => {
+  it("recognises the org operational scope and nothing else", () => {
+    expect(isOperationalValueStreamScope("archetype_value_stream")).toBe(true);
+    expect(isOperationalValueStreamScope("reference_model_projection")).toBe(false);
+    expect(isOperationalValueStreamScope(null)).toBe(false);
+    expect(VALUE_STREAM_VIEW_SCOPES).toContain("archetype_value_stream");
+  });
+});

--- a/apps/web/lib/ea/value-stream-views.ts
+++ b/apps/web/lib/ea/value-stream-views.ts
@@ -17,7 +17,25 @@ export function isOperationalValueStreamScope(scopeType: string | null | undefin
   return scopeType === "archetype_value_stream";
 }
 
-export async function listValueStreamViews() {
+/**
+ * Explicit return shape (not the inferred Prisma `findMany` type). The inferred
+ * type for a query with `select` + `_count` is large, and letting it propagate
+ * across the module boundary into the page server component pushed the apps/web
+ * `tsc` heap over its ceiling (OOM, PR #1798 CI). A plain interface keeps the
+ * boundary cheap; the Prisma result is structurally assignable to it.
+ */
+export interface ValueStreamViewListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  scopeType: string;
+  scopeRef: string | null;
+  createdAt: Date;
+  notation: { name: string };
+  _count: { viewElements: number };
+}
+
+export async function listValueStreamViews(): Promise<ValueStreamViewListItem[]> {
   return prisma.eaView.findMany({
     where: { scopeType: { in: [...VALUE_STREAM_VIEW_SCOPES] } },
     orderBy: [{ createdAt: "desc" }],

--- a/apps/web/lib/ea/value-stream-views.ts
+++ b/apps/web/lib/ea/value-stream-views.ts
@@ -1,0 +1,35 @@
+import { prisma } from "@dpf/db";
+
+/**
+ * EA view scopes that render on the `/ea/value-streams` surface:
+ * - `reference_model_projection` — value streams projected from a reference
+ *   model (IT4IT, BIAN, …).
+ * - `archetype_value_stream` — the org's own derived operational value stream
+ *   (P0 Capture). One list, two sources; see
+ *   docs/superpowers/specs/2026-06-12-value-stream-architecture-platform-design.md.
+ */
+export const VALUE_STREAM_VIEW_SCOPES = [
+  "reference_model_projection",
+  "archetype_value_stream",
+] as const;
+
+export function isOperationalValueStreamScope(scopeType: string | null | undefined): boolean {
+  return scopeType === "archetype_value_stream";
+}
+
+export async function listValueStreamViews() {
+  return prisma.eaView.findMany({
+    where: { scopeType: { in: [...VALUE_STREAM_VIEW_SCOPES] } },
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      scopeType: true,
+      scopeRef: true,
+      createdAt: true,
+      notation: { select: { name: true } },
+      _count: { select: { viewElements: true } },
+    },
+  });
+}

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -18,6 +18,13 @@ vi.mock("nanoid", () => ({
   nanoid: mockNanoid,
 }));
 
+// The OVSM projection is covered by its own tests; mock it here so the reset
+// test does not load the Prisma-client chain, and assert reset invokes it.
+const { mockProjectOvs } = vi.hoisted(() => ({ mockProjectOvs: vi.fn() }));
+vi.mock("./project-operational-value-stream", () => ({
+  projectOperationalValueStreamForArchetype: mockProjectOvs,
+}));
+
 import { resetStorefrontArchetype } from "./archetype-reset";
 
 function businessCapabilityProjectionStore() {
@@ -35,6 +42,8 @@ describe("resetStorefrontArchetype", () => {
   beforeEach(() => {
     mockNanoid.mockReset();
     mockPrisma.$transaction.mockReset();
+    mockProjectOvs.mockReset();
+    mockProjectOvs.mockResolvedValue({ viewId: "view-ovs" });
     mockNanoid.mockReturnValue("abcd1234");
   });
 
@@ -94,6 +103,12 @@ describe("resetStorefrontArchetype", () => {
     expect(tx.businessContext.updateMany).toHaveBeenCalledWith({
       where: { organizationId: "org_1" },
       data: { industry: "software-platform", ctaType: "inquiry" },
+    });
+    // Reset regenerates the operational value stream inside the transaction.
+    expect(mockProjectOvs).toHaveBeenCalledWith({
+      db: tx,
+      organizationId: "org_1",
+      archetypeId: "software-platform",
     });
   });
 

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@dpf/db";
 import { applyBusinessCapabilityPerspective } from "@dpf/db/business-capability-perspectives";
 import { nanoid } from "nanoid";
+import { projectOperationalValueStreamForArchetype } from "./project-operational-value-stream";
 
 type ResetMode = "replace-seeded-content";
 
@@ -67,6 +68,15 @@ export async function resetStorefrontArchetype(input: {
     await applyBusinessCapabilityPerspective(tx, {
       archetypeId: targetArchetype.archetypeId,
       category: targetArchetype.category,
+    });
+
+    // P0 "Capture": regenerate the org's operational value-stream architecture
+    // inside the reset transaction (idempotent; prunes stages the new archetype
+    // does not have, e.g. rental → non-rental drops Return & Inspect).
+    await projectOperationalValueStreamForArchetype({
+      db: tx,
+      organizationId,
+      archetypeId: targetArchetype.archetypeId,
     });
 
     let sectionsCreated = 0;

--- a/apps/web/lib/storefront/project-operational-value-stream.test.ts
+++ b/apps/web/lib/storefront/project-operational-value-stream.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// This helper is pure orchestration glue (find template → derive → project).
+// Mock both heavy dependencies and assert the wiring; the derivation itself is
+// covered by packages/storefront-templates/operational-value-stream.test.ts and
+// the projection by packages/db/archetype-value-stream-projection.test.ts.
+const { mockDerive, mockProject } = vi.hoisted(() => ({
+  mockDerive: vi.fn(),
+  mockProject: vi.fn(),
+}));
+
+vi.mock("@dpf/storefront-templates", () => ({
+  ALL_ARCHETYPES: [
+    { archetypeId: "hair-salon", name: "Hair Salon", category: "beauty-personal-care" },
+    { archetypeId: "veterinary-clinic", name: "Veterinary Clinic", category: "healthcare-wellness" },
+  ],
+  deriveOperationalValueStream: mockDerive,
+}));
+
+vi.mock("@dpf/db/archetype-value-stream-projection", () => ({
+  projectArchetypeValueStream: mockProject,
+}));
+
+import { projectOperationalValueStreamForArchetype } from "./project-operational-value-stream";
+
+beforeEach(() => {
+  mockDerive.mockReset();
+  mockProject.mockReset();
+  mockDerive.mockImplementation((a: { archetypeId: string; name: string }) => ({
+    archetypeId: a.archetypeId,
+    archetypeName: a.name,
+    stages: [{ key: "capture" }],
+  }));
+  mockProject.mockResolvedValue({ viewId: "view-1" });
+});
+
+describe("projectOperationalValueStreamForArchetype", () => {
+  it("finds the template, derives its OVSM, and projects it", async () => {
+    const result = await projectOperationalValueStreamForArchetype({
+      organizationId: "org-1",
+      archetypeId: "hair-salon",
+    });
+
+    expect(result).toEqual({ viewId: "view-1" });
+    expect(mockDerive).toHaveBeenCalledWith(
+      expect.objectContaining({ archetypeId: "hair-salon" }),
+    );
+    expect(mockProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: "org-1",
+        ovsm: expect.objectContaining({ archetypeId: "hair-salon" }),
+      }),
+    );
+  });
+
+  it("threads an injected db (the reset transaction) to the projector", async () => {
+    const tx = { marker: "tx" };
+    await projectOperationalValueStreamForArchetype({
+      db: tx as unknown as Parameters<typeof projectOperationalValueStreamForArchetype>[0]["db"],
+      organizationId: "org-2",
+      archetypeId: "veterinary-clinic",
+    });
+    expect((mockProject.mock.calls[0]![0] as { db: unknown }).db).toBe(tx);
+  });
+
+  it("throws when the archetype template is missing and projects nothing", async () => {
+    await expect(
+      projectOperationalValueStreamForArchetype({ organizationId: "org-1", archetypeId: "does-not-exist" }),
+    ).rejects.toThrow("not found in ALL_ARCHETYPES");
+    expect(mockDerive).not.toHaveBeenCalled();
+    expect(mockProject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/storefront/project-operational-value-stream.ts
+++ b/apps/web/lib/storefront/project-operational-value-stream.ts
@@ -1,0 +1,27 @@
+import { ALL_ARCHETYPES, deriveOperationalValueStream } from "@dpf/storefront-templates";
+import {
+  projectArchetypeValueStream,
+  type ProjectArchetypeValueStreamInput,
+} from "@dpf/db/archetype-value-stream-projection";
+
+type Db = ProjectArchetypeValueStreamInput["db"];
+
+/**
+ * App-layer orchestration for P0 "Capture": resolve the template archetype,
+ * derive its Operational Value Stream Model, and project it into the EA
+ * substrate. Called from storefront setup (with the package Prisma client) and
+ * from archetype-reset (with the reset transaction, so the projection commits or
+ * rolls back atomically with the rest of the reset).
+ */
+export async function projectOperationalValueStreamForArchetype(input: {
+  db?: Db;
+  organizationId: string;
+  archetypeId: string;
+}) {
+  const template = ALL_ARCHETYPES.find((a) => a.archetypeId === input.archetypeId);
+  if (!template) {
+    throw new Error(`Template archetype ${input.archetypeId} not found in ALL_ARCHETYPES`);
+  }
+  const ovsm = deriveOperationalValueStream(template);
+  return projectArchetypeValueStream({ db: input.db, orgId: input.organizationId, ovsm });
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
     "./ea-validation": "./src/ea-validation.ts",
     "./neo4j-sync": "./src/neo4j-sync.ts",
     "./reference-model-projection": "./src/reference-model-projection.ts",
+    "./archetype-value-stream-projection": "./src/archetype-value-stream-projection.ts",
     "./discovery-attribution": "./src/discovery-attribution.ts",
     "./discovery-triage": "./src/discovery-triage.ts",
     "./discovery-triage-enums": "./src/discovery-triage-enums.ts",

--- a/packages/db/src/archetype-value-stream-projection.test.ts
+++ b/packages/db/src/archetype-value-stream-projection.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationalValueStream } from "@dpf/storefront-templates";
+
+// The service imports the package Prisma singleton at module load; stub it so
+// the test never touches the generated client (we always inject a mock `db`).
+vi.mock("./client.js", () => ({ prisma: {} }));
+
+import {
+  projectArchetypeValueStream,
+  type ProjectArchetypeValueStreamInput,
+} from "./archetype-value-stream-projection.js";
+
+// A small, explicit OVSM (3 primary stages) keeps mock wiring focused on the
+// projection behaviour rather than the full 8-stage backbone.
+const OVSM: OperationalValueStream = {
+  archetypeId: "hair-salon",
+  archetypeName: "Hair Salon",
+  category: "beauty-personal-care",
+  capacityUnit: "slot-hours",
+  demandSignature: "weekly",
+  trustGates: [],
+  it4itStageBinding: ["request-to-fulfill"],
+  loadBearingStageKeys: ["qualify"],
+  stages: [
+    { key: "capture", label: "Capture Demand", order: 20, loadBearing: false, capabilityBindings: [], metricBindings: ["inbox-submissions"], trustGateKeys: [] },
+    { key: "qualify", label: "Qualify & Schedule", order: 30, loadBearing: true, capabilityBindings: ["service-operations"], metricBindings: ["utilization"], trustGateKeys: [] },
+    { key: "settle", label: "Settle & Account", order: 50, loadBearing: false, capabilityBindings: ["billing-readiness"], metricBindings: ["invoice"], trustGateKeys: [] },
+  ],
+};
+
+function makeDb() {
+  return {
+    eaNotation: { findUnique: vi.fn().mockResolvedValue({ id: "notation-1" }) },
+    viewpointDefinition: { findUnique: vi.fn().mockResolvedValue({ id: "viewpoint-1" }) },
+    eaElementType: {
+      findUnique: vi.fn(async (args: { where: { notationId_slug: { slug: string } } }) => ({
+        id: `type-${args.where.notationId_slug.slug}`,
+      })),
+    },
+    eaRelationshipType: { findUnique: vi.fn().mockResolvedValue({ id: "reltype-flow" }) },
+    eaView: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    eaElement: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), findMany: vi.fn(), deleteMany: vi.fn() },
+    eaViewElement: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), deleteMany: vi.fn() },
+    eaRelationship: { findFirst: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
+  };
+}
+
+type MockDb = ReturnType<typeof makeDb>;
+
+function run(db: MockDb, orgId = "org-1") {
+  return projectArchetypeValueStream({
+    db: db as unknown as ProjectArchetypeValueStreamInput["db"],
+    orgId,
+    ovsm: OVSM,
+  });
+}
+
+describe("projectArchetypeValueStream", () => {
+  let db: MockDb;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  it("creates the org operational value-stream view, band, stages, and flows", async () => {
+    db.eaView.findFirst.mockResolvedValue(null);
+    db.eaView.create.mockResolvedValue({ id: "view-1" });
+    db.eaElement.findMany.mockResolvedValue([]); // no prior projection
+    db.eaElement.findFirst.mockResolvedValue(null);
+    db.eaElement.create
+      .mockResolvedValueOnce({ id: "ea-band" })
+      .mockResolvedValueOnce({ id: "ea-capture" })
+      .mockResolvedValueOnce({ id: "ea-qualify" })
+      .mockResolvedValueOnce({ id: "ea-settle" });
+    db.eaViewElement.findUnique.mockResolvedValue(null);
+    db.eaViewElement.create
+      .mockResolvedValueOnce({ id: "ve-band" })
+      .mockResolvedValueOnce({ id: "ve-capture" })
+      .mockResolvedValueOnce({ id: "ve-qualify" })
+      .mockResolvedValueOnce({ id: "ve-settle" });
+    db.eaRelationship.findFirst.mockResolvedValue(null);
+    db.eaRelationship.create.mockResolvedValue({ id: "rel" });
+
+    const result = await run(db);
+
+    expect(result).toMatchObject({
+      viewId: "view-1",
+      createdView: true,
+      createdElements: 4, // 1 band + 3 stages
+      createdViewElements: 4,
+      removedElements: 0,
+    });
+
+    // View carries the org-scoped operational scope.
+    expect(db.eaView.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          scopeType: "archetype_value_stream",
+          scopeRef: "org-1:operational",
+          layoutType: "graph",
+        }),
+      }),
+    );
+
+    // Band element is a stream_band.
+    expect(db.eaElement.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          properties: expect.objectContaining({
+            projection: expect.objectContaining({ layoutRole: "stream_band", source: "archetype-ovsm", orgId: "org-1" }),
+          }),
+        }),
+      }),
+    );
+
+    // First stage element is a stream_stage carrying OVSM metadata.
+    const stageCall = db.eaElement.create.mock.calls[1]![0] as { data: { properties: { projection: Record<string, unknown>; operationalValueStream: Record<string, unknown> } } };
+    expect(stageCall.data.properties.projection.layoutRole).toBe("stream_stage");
+    expect(stageCall.data.properties.projection.stageKey).toBe("capture");
+    expect(stageCall.data.properties.operationalValueStream.capacityUnit).toBe("slot-hours");
+
+    // The load-bearing stage (qualify) is flagged.
+    const qualifyCall = db.eaElement.create.mock.calls[2]![0] as { data: { properties: { operationalValueStream: { loadBearing: boolean; stageKey: string } } } };
+    expect(qualifyCall.data.properties.operationalValueStream.stageKey).toBe("qualify");
+    expect(qualifyCall.data.properties.operationalValueStream.loadBearing).toBe(true);
+
+    // Stage view elements hang off the band, in order.
+    expect(db.eaViewElement.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ data: expect.objectContaining({ parentViewElementId: "ve-band", orderIndex: 0 }) }),
+    );
+
+    // Two flows: capture → qualify → settle.
+    expect(db.eaRelationship.create).toHaveBeenCalledTimes(2);
+    expect(db.eaElement.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an existing projection in place without creating duplicates", async () => {
+    db.eaView.findFirst.mockResolvedValue({ id: "view-1" });
+    db.eaView.update.mockResolvedValue({ id: "view-1" });
+    db.eaElement.findMany.mockResolvedValue([
+      { id: "ea-band" },
+      { id: "ea-capture" },
+      { id: "ea-qualify" },
+      { id: "ea-settle" },
+    ]);
+    db.eaElement.findFirst
+      .mockResolvedValueOnce({ id: "ea-band" })
+      .mockResolvedValueOnce({ id: "ea-capture" })
+      .mockResolvedValueOnce({ id: "ea-qualify" })
+      .mockResolvedValueOnce({ id: "ea-settle" });
+    db.eaElement.update.mockImplementation(async (args: { where: { id: string } }) => ({ id: args.where.id }));
+    db.eaViewElement.findUnique
+      .mockResolvedValueOnce({ id: "ve-band" })
+      .mockResolvedValueOnce({ id: "ve-capture" })
+      .mockResolvedValueOnce({ id: "ve-qualify" })
+      .mockResolvedValueOnce({ id: "ve-settle" });
+    db.eaViewElement.update.mockImplementation(async (args: { where: { id: string } }) => ({ id: args.where.id }));
+    db.eaRelationship.findFirst.mockResolvedValue({ id: "rel" });
+
+    const result = await run(db);
+
+    expect(result).toMatchObject({
+      viewId: "view-1",
+      createdView: false,
+      createdElements: 0,
+      updatedElements: 4,
+      createdViewElements: 0,
+      updatedViewElements: 4,
+      removedElements: 0,
+    });
+    expect(db.eaView.create).not.toHaveBeenCalled();
+    expect(db.eaElement.create).not.toHaveBeenCalled();
+    expect(db.eaViewElement.create).not.toHaveBeenCalled();
+    expect(db.eaRelationship.create).not.toHaveBeenCalled();
+  });
+
+  it("prunes orphan stages left by an archetype change (e.g. dropped Return & Inspect)", async () => {
+    db.eaView.findFirst.mockResolvedValue({ id: "view-1" });
+    db.eaView.update.mockResolvedValue({ id: "view-1" });
+    // A prior rental projection left an extra return-inspect element.
+    db.eaElement.findMany.mockResolvedValue([
+      { id: "ea-band" },
+      { id: "ea-capture" },
+      { id: "ea-qualify" },
+      { id: "ea-settle" },
+      { id: "ea-return-inspect" }, // orphan: not in the current OVSM
+    ]);
+    db.eaElement.findFirst
+      .mockResolvedValueOnce({ id: "ea-band" })
+      .mockResolvedValueOnce({ id: "ea-capture" })
+      .mockResolvedValueOnce({ id: "ea-qualify" })
+      .mockResolvedValueOnce({ id: "ea-settle" });
+    db.eaElement.update.mockImplementation(async (args: { where: { id: string } }) => ({ id: args.where.id }));
+    db.eaViewElement.findUnique
+      .mockResolvedValueOnce({ id: "ve-band" })
+      .mockResolvedValueOnce({ id: "ve-capture" })
+      .mockResolvedValueOnce({ id: "ve-qualify" })
+      .mockResolvedValueOnce({ id: "ve-settle" });
+    db.eaViewElement.update.mockImplementation(async (args: { where: { id: string } }) => ({ id: args.where.id }));
+    db.eaRelationship.findFirst.mockResolvedValue({ id: "rel" });
+    db.eaRelationship.deleteMany.mockResolvedValue({ count: 0 });
+    db.eaViewElement.deleteMany.mockResolvedValue({ count: 1 });
+    db.eaElement.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await run(db);
+
+    expect(result.removedElements).toBe(1);
+    expect(db.eaElement.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: { in: ["ea-return-inspect"] } }) }),
+    );
+    expect(db.eaRelationship.deleteMany).toHaveBeenCalled();
+  });
+
+  it("throws clearly when ArchiMate notation is not seeded", async () => {
+    db.eaNotation.findUnique.mockResolvedValue(null);
+    await expect(run(db)).rejects.toThrow("ArchiMate 4 notation is not seeded");
+  });
+});

--- a/packages/db/src/archetype-value-stream-projection.ts
+++ b/packages/db/src/archetype-value-stream-projection.ts
@@ -1,0 +1,363 @@
+import type { Prisma, PrismaClient } from "../generated/client/client";
+import { prisma } from "./client";
+import type { OperationalValueStream } from "@dpf/storefront-templates";
+
+/**
+ * Persist an org's derived Operational Value Stream Model (OVSM) into the
+ * existing EA substrate (EaElement / EaView / EaViewElement / EaRelationship) so
+ * it renders on the same `/ea/value-streams` canvas as reference-model
+ * projections and exports through the same ArchiMate path. Mirrors
+ * `reference-model-projection.ts`, with two differences:
+ *   1. an injectable `db` (setup calls with the package client; archetype-reset
+ *      calls inside its `prisma.$transaction`);
+ *   2. the source is a derived OVSM, not a seeded reference model, so idempotency
+ *      keys on (source, orgId, stageKey) and a prune keeps the org's single
+ *      operational view clean across archetype changes (e.g. rental→non-rental
+ *      drops the Return & Inspect stage).
+ *
+ * No new Prisma table — this is a projection into EA elements/views.
+ */
+
+type Db = Prisma.TransactionClient | PrismaClient;
+
+const ARCHETYPE_OVSM_SOURCE = "archetype-ovsm";
+/** Sentinel stageKey for the band element that holds the whole stream. */
+const BAND_STAGE_KEY = "__stream__";
+/** Cross-cuts are rendered as stages but are not part of the linear flow. */
+const FLOW_EXCLUDED_KEYS = new Set(["trust-compliance", "operate-improve"]);
+
+export interface ProjectArchetypeValueStreamInput {
+  db?: Db;
+  orgId: string;
+  ovsm: OperationalValueStream;
+}
+
+export interface ProjectArchetypeValueStreamResult {
+  viewId: string;
+  createdView: boolean;
+  createdElements: number;
+  updatedElements: number;
+  createdViewElements: number;
+  updatedViewElements: number;
+  removedElements: number;
+}
+
+function buildScopeRef(orgId: string): string {
+  return `${orgId}:operational`;
+}
+
+function bandMetadata(orgId: string, ovsm: OperationalValueStream): Prisma.InputJsonValue {
+  return {
+    projection: {
+      layoutRole: "stream_band",
+      source: ARCHETYPE_OVSM_SOURCE,
+      orgId,
+      archetypeId: ovsm.archetypeId,
+      stageKey: BAND_STAGE_KEY,
+    },
+    operationalValueStream: {
+      orgId,
+      archetypeId: ovsm.archetypeId,
+      category: ovsm.category,
+      loadBearingStageKeys: ovsm.loadBearingStageKeys,
+      capacityUnit: ovsm.capacityUnit,
+      demandSignature: ovsm.demandSignature,
+      trustGates: ovsm.trustGates,
+      // EaElement.itValueStream uses the EA notation's value-stream slugs
+      // (evaluate/explore/…), a different taxonomy from the storefront IT4IT
+      // stages, so the binding is stored here rather than mapped onto that field.
+      it4itStageBinding: ovsm.it4itStageBinding,
+    },
+  } satisfies Prisma.InputJsonValue;
+}
+
+function stageMetadata(
+  orgId: string,
+  ovsm: OperationalValueStream,
+  stage: OperationalValueStream["stages"][number],
+): Prisma.InputJsonValue {
+  return {
+    projection: {
+      layoutRole: "stream_stage",
+      source: ARCHETYPE_OVSM_SOURCE,
+      orgId,
+      archetypeId: ovsm.archetypeId,
+      stageKey: stage.key,
+    },
+    operationalValueStream: {
+      orgId,
+      stageKey: stage.key,
+      loadBearing: stage.loadBearing,
+      capabilityBindings: stage.capabilityBindings,
+      metricBindings: stage.metricBindings,
+      trustGateKeys: stage.trustGateKeys,
+      // OVSM-level facts denormalized onto each stage for cheap reads.
+      capacityUnit: ovsm.capacityUnit,
+      demandSignature: ovsm.demandSignature,
+      trustGates: ovsm.trustGates,
+      it4itStageBinding: ovsm.it4itStageBinding,
+    },
+  } satisfies Prisma.InputJsonValue;
+}
+
+async function resolveElement(
+  db: Db,
+  input: {
+    orgId: string;
+    stageKey: string;
+    elementTypeId: string;
+    name: string;
+    description: string;
+    properties: Prisma.InputJsonValue;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const existing = await db.eaElement.findFirst({
+    where: {
+      elementTypeId: input.elementTypeId,
+      AND: [
+        { properties: { path: ["projection", "source"], equals: ARCHETYPE_OVSM_SOURCE } },
+        { properties: { path: ["projection", "orgId"], equals: input.orgId } },
+        { properties: { path: ["projection", "stageKey"], equals: input.stageKey } },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    const updated = await db.eaElement.update({
+      where: { id: existing.id },
+      data: {
+        name: input.name,
+        description: input.description,
+        properties: input.properties,
+        lifecycleStage: "design",
+        lifecycleStatus: "draft",
+      },
+      select: { id: true },
+    });
+    return { id: updated.id, created: false };
+  }
+
+  const created = await db.eaElement.create({
+    data: {
+      elementTypeId: input.elementTypeId,
+      name: input.name,
+      description: input.description,
+      properties: input.properties,
+      lifecycleStage: "design",
+      lifecycleStatus: "draft",
+    },
+    select: { id: true },
+  });
+  return { id: created.id, created: true };
+}
+
+async function resolveViewElement(
+  db: Db,
+  input: { viewId: string; elementId: string; parentViewElementId: string | null; orderIndex: number | null },
+): Promise<{ id: string; created: boolean }> {
+  const existing = await db.eaViewElement.findUnique({
+    where: { viewId_elementId: { viewId: input.viewId, elementId: input.elementId } },
+    select: { id: true },
+  });
+
+  if (existing) {
+    const updated = await db.eaViewElement.update({
+      where: { id: existing.id },
+      data: {
+        parentViewElementId: input.parentViewElementId,
+        orderIndex: input.orderIndex,
+        mode: "reference",
+      },
+      select: { id: true },
+    });
+    return { id: updated.id, created: false };
+  }
+
+  const created = await db.eaViewElement.create({
+    data: {
+      viewId: input.viewId,
+      elementId: input.elementId,
+      parentViewElementId: input.parentViewElementId,
+      orderIndex: input.orderIndex,
+      mode: "reference",
+    },
+    select: { id: true },
+  });
+  return { id: created.id, created: true };
+}
+
+export async function projectArchetypeValueStream(
+  input: ProjectArchetypeValueStreamInput,
+): Promise<ProjectArchetypeValueStreamResult> {
+  const db: Db = input.db ?? prisma;
+  const { orgId, ovsm } = input;
+
+  const notation = await db.eaNotation.findUnique({
+    where: { slug: "archimate4" },
+    select: { id: true },
+  });
+  if (!notation) throw new Error("ArchiMate 4 notation is not seeded");
+
+  const viewpoint = await db.viewpointDefinition.findUnique({
+    where: { name: "Business Architecture" },
+    select: { id: true },
+  });
+
+  const [valueStreamType, valueStreamStageType, flowRelationshipType] = await Promise.all([
+    db.eaElementType.findUnique({
+      where: { notationId_slug: { notationId: notation.id, slug: "value_stream" } },
+      select: { id: true },
+    }),
+    db.eaElementType.findUnique({
+      where: { notationId_slug: { notationId: notation.id, slug: "value_stream_stage" } },
+      select: { id: true },
+    }),
+    db.eaRelationshipType.findUnique({
+      where: { notationId_slug: { notationId: notation.id, slug: "flows_to" } },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!valueStreamType || !valueStreamStageType) {
+    throw new Error("Required ArchiMate value stream types are not seeded");
+  }
+
+  // Resolve the org's single operational value-stream view (idempotent by scope).
+  const scopeRef = buildScopeRef(orgId);
+  const viewName = `${ovsm.archetypeName} — Operational Value Stream`;
+  const existingView = await db.eaView.findFirst({
+    where: { scopeType: "archetype_value_stream", scopeRef },
+    select: { id: true },
+  });
+  const viewData = {
+    notationId: notation.id,
+    name: viewName,
+    description: `Operational value stream for ${ovsm.archetypeName} (${ovsm.archetypeId})`,
+    layoutType: "graph",
+    scopeType: "archetype_value_stream",
+    scopeRef,
+    viewpointId: viewpoint?.id ?? null,
+    status: "draft",
+  };
+  const view = existingView
+    ? { id: (await db.eaView.update({ where: { id: existingView.id }, data: viewData, select: { id: true } })).id, created: false }
+    : { id: (await db.eaView.create({ data: viewData, select: { id: true } })).id, created: true };
+
+  // Snapshot existing projected elements for this org so we can prune orphans
+  // (e.g. the Return & Inspect stage when resetting rental → non-rental).
+  const existingElements = await db.eaElement.findMany({
+    where: {
+      AND: [
+        { properties: { path: ["projection", "source"], equals: ARCHETYPE_OVSM_SOURCE } },
+        { properties: { path: ["projection", "orgId"], equals: orgId } },
+      ],
+    },
+    select: { id: true },
+  });
+
+  let createdElements = 0;
+  let updatedElements = 0;
+  let createdViewElements = 0;
+  let updatedViewElements = 0;
+  const currentElementIds = new Set<string>();
+  const elementIdByStageKey = new Map<string, string>();
+
+  // Band element + view element.
+  const band = await resolveElement(db, {
+    orgId,
+    stageKey: BAND_STAGE_KEY,
+    elementTypeId: valueStreamType.id,
+    name: viewName,
+    description: `How ${ovsm.archetypeName} creates and delivers value`,
+    properties: bandMetadata(orgId, ovsm),
+  });
+  band.created ? (createdElements += 1) : (updatedElements += 1);
+  currentElementIds.add(band.id);
+
+  const bandViewElement = await resolveViewElement(db, {
+    viewId: view.id,
+    elementId: band.id,
+    parentViewElementId: null,
+    orderIndex: null,
+  });
+  bandViewElement.created ? (createdViewElements += 1) : (updatedViewElements += 1);
+
+  // Stage elements, ordered.
+  const orderedStages = [...ovsm.stages].sort((a, b) => a.order - b.order);
+  orderedStages.forEach((_, index) => index);
+  for (let index = 0; index < orderedStages.length; index += 1) {
+    const stage = orderedStages[index]!;
+    const element = await resolveElement(db, {
+      orgId,
+      stageKey: stage.key,
+      elementTypeId: valueStreamStageType.id,
+      name: stage.label,
+      description: `${stage.label} — ${ovsm.archetypeName}`,
+      properties: stageMetadata(orgId, ovsm, stage),
+    });
+    element.created ? (createdElements += 1) : (updatedElements += 1);
+    currentElementIds.add(element.id);
+    elementIdByStageKey.set(stage.key, element.id);
+
+    const stageViewElement = await resolveViewElement(db, {
+      viewId: view.id,
+      elementId: element.id,
+      parentViewElementId: bandViewElement.id,
+      orderIndex: index,
+    });
+    stageViewElement.created ? (createdViewElements += 1) : (updatedViewElements += 1);
+  }
+
+  // Prune orphans no longer in the current stage set.
+  const orphanIds = existingElements
+    .map((e: { id: string }) => e.id)
+    .filter((id: string) => !currentElementIds.has(id));
+  let removedElements = 0;
+  if (orphanIds.length > 0) {
+    await db.eaRelationship.deleteMany({
+      where: { OR: [{ fromElementId: { in: orphanIds } }, { toElementId: { in: orphanIds } }] },
+    });
+    await db.eaViewElement.deleteMany({ where: { elementId: { in: orphanIds } } });
+    const removed = await db.eaElement.deleteMany({ where: { id: { in: orphanIds } } });
+    removedElements = removed.count;
+  }
+
+  // Linear flow between sequential primary stages (cross-cuts excluded).
+  if (flowRelationshipType) {
+    const flowStages = orderedStages.filter((s) => !FLOW_EXCLUDED_KEYS.has(s.key));
+    for (let index = 0; index < flowStages.length - 1; index += 1) {
+      const fromId = elementIdByStageKey.get(flowStages[index]!.key);
+      const toId = elementIdByStageKey.get(flowStages[index + 1]!.key);
+      if (!fromId || !toId) continue;
+      const existingRel = await db.eaRelationship.findFirst({
+        where: { fromElementId: fromId, toElementId: toId, relationshipTypeId: flowRelationshipType.id },
+        select: { id: true },
+      });
+      if (!existingRel) {
+        await db.eaRelationship.create({
+          data: {
+            fromElementId: fromId,
+            toElementId: toId,
+            relationshipTypeId: flowRelationshipType.id,
+            notationSlug: "archimate4",
+            properties: {
+              projection: { source: ARCHETYPE_OVSM_SOURCE, orgId },
+            } satisfies Prisma.InputJsonValue,
+          },
+          select: { id: true },
+        });
+      }
+    }
+  }
+
+  return {
+    viewId: view.id,
+    createdView: view.created,
+    createdElements,
+    updatedElements,
+    createdViewElements,
+    updatedViewElements,
+    removedElements,
+  };
+}

--- a/packages/db/src/archetype-value-stream-projection.ts
+++ b/packages/db/src/archetype-value-stream-projection.ts
@@ -18,13 +18,45 @@ import type { OperationalValueStream } from "@dpf/storefront-templates";
  * No new Prisma table — this is a projection into EA elements/views.
  */
 
-// A single Prisma client type, not a union: `PrismaClient` is assignable to
-// `Prisma.TransactionClient` (it has a superset of the delegates), so both the
-// setup caller (package client) and the reset caller (transaction client) fit.
-// Using the union here forced the type checker to resolve every delegate across
-// two enormous client types at each call site, which blew the build/typecheck
-// heap (OOM) — see PR #1798 CI.
-type Db = Prisma.TransactionClient;
+// Minimal structural DB interface — deliberately type-safety-light.
+// Typing `db` as the full Prisma client (or `Prisma.TransactionClient`, an Omit
+// mapped type) and calling ~20 delegate methods with recursive JSON-path `where`
+// filters forced the type checker to instantiate Prisma's giant generic delegate
+// types at every call site, which exhausted the typecheck / Next-build heap
+// (OOM, PR #1798 CI). This narrow interface keeps the queries cheap to check; the
+// real PrismaClient and a `$transaction` client both satisfy it at runtime, so we
+// cast at the single boundary in projectArchetypeValueStream(). Query shapes are
+// covered by the unit tests rather than the Prisma types.
+type IdRow = { id: string };
+interface OvsmDb {
+  eaNotation: { findUnique(args: unknown): Promise<IdRow | null> };
+  viewpointDefinition: { findUnique(args: unknown): Promise<IdRow | null> };
+  eaElementType: { findUnique(args: unknown): Promise<IdRow | null> };
+  eaRelationshipType: { findUnique(args: unknown): Promise<IdRow | null> };
+  eaView: {
+    findFirst(args: unknown): Promise<IdRow | null>;
+    create(args: unknown): Promise<IdRow>;
+    update(args: unknown): Promise<IdRow>;
+  };
+  eaElement: {
+    findFirst(args: unknown): Promise<IdRow | null>;
+    findMany(args: unknown): Promise<IdRow[]>;
+    create(args: unknown): Promise<IdRow>;
+    update(args: unknown): Promise<IdRow>;
+    deleteMany(args: unknown): Promise<{ count: number }>;
+  };
+  eaViewElement: {
+    findUnique(args: unknown): Promise<IdRow | null>;
+    create(args: unknown): Promise<IdRow>;
+    update(args: unknown): Promise<IdRow>;
+    deleteMany(args: unknown): Promise<{ count: number }>;
+  };
+  eaRelationship: {
+    findFirst(args: unknown): Promise<IdRow | null>;
+    create(args: unknown): Promise<IdRow>;
+    deleteMany(args: unknown): Promise<{ count: number }>;
+  };
+}
 
 const ARCHETYPE_OVSM_SOURCE = "archetype-ovsm";
 /** Sentinel stageKey for the band element that holds the whole stream. */
@@ -33,7 +65,8 @@ const BAND_STAGE_KEY = "__stream__";
 const FLOW_EXCLUDED_KEYS = new Set(["trust-compliance", "operate-improve"]);
 
 export interface ProjectArchetypeValueStreamInput {
-  db?: Db;
+  /** A PrismaClient or a `$transaction` client; cast to the narrow OvsmDb inside. */
+  db?: Prisma.TransactionClient;
   orgId: string;
   ovsm: OperationalValueStream;
 }
@@ -52,7 +85,7 @@ function buildScopeRef(orgId: string): string {
   return `${orgId}:operational`;
 }
 
-function bandMetadata(orgId: string, ovsm: OperationalValueStream): Prisma.InputJsonValue {
+function bandMetadata(orgId: string, ovsm: OperationalValueStream): Record<string, unknown> {
   return {
     projection: {
       layoutRole: "stream_band",
@@ -74,14 +107,14 @@ function bandMetadata(orgId: string, ovsm: OperationalValueStream): Prisma.Input
       // stages, so the binding is stored here rather than mapped onto that field.
       it4itStageBinding: ovsm.it4itStageBinding,
     },
-  } satisfies Prisma.InputJsonValue;
+  };
 }
 
 function stageMetadata(
   orgId: string,
   ovsm: OperationalValueStream,
   stage: OperationalValueStream["stages"][number],
-): Prisma.InputJsonValue {
+): Record<string, unknown> {
   return {
     projection: {
       layoutRole: "stream_stage",
@@ -103,18 +136,18 @@ function stageMetadata(
       trustGates: ovsm.trustGates,
       it4itStageBinding: ovsm.it4itStageBinding,
     },
-  } satisfies Prisma.InputJsonValue;
+  };
 }
 
 async function resolveElement(
-  db: Db,
+  db: OvsmDb,
   input: {
     orgId: string;
     stageKey: string;
     elementTypeId: string;
     name: string;
     description: string;
-    properties: Prisma.InputJsonValue;
+    properties: Record<string, unknown>;
   },
 ): Promise<{ id: string; created: boolean }> {
   const existing = await db.eaElement.findFirst({
@@ -159,7 +192,7 @@ async function resolveElement(
 }
 
 async function resolveViewElement(
-  db: Db,
+  db: OvsmDb,
   input: { viewId: string; elementId: string; parentViewElementId: string | null; orderIndex: number | null },
 ): Promise<{ id: string; created: boolean }> {
   const existing = await db.eaViewElement.findUnique({
@@ -196,7 +229,9 @@ async function resolveViewElement(
 export async function projectArchetypeValueStream(
   input: ProjectArchetypeValueStreamInput,
 ): Promise<ProjectArchetypeValueStreamResult> {
-  const db: Db = input.db ?? prisma;
+  // Single boundary cast: the real PrismaClient / transaction client satisfies
+  // OvsmDb structurally at runtime (see the OvsmDb note above).
+  const db = (input.db ?? prisma) as unknown as OvsmDb;
   const { orgId, ovsm } = input;
 
   const notation = await db.eaNotation.findUnique({
@@ -349,7 +384,7 @@ export async function projectArchetypeValueStream(
             notationSlug: "archimate4",
             properties: {
               projection: { source: ARCHETYPE_OVSM_SOURCE, orgId },
-            } satisfies Prisma.InputJsonValue,
+            },
           },
           select: { id: true },
         });

--- a/packages/db/src/archetype-value-stream-projection.ts
+++ b/packages/db/src/archetype-value-stream-projection.ts
@@ -1,4 +1,3 @@
-import type { Prisma } from "../generated/client/client";
 import { prisma } from "./client";
 import type { OperationalValueStream } from "@dpf/storefront-templates";
 
@@ -65,8 +64,14 @@ const BAND_STAGE_KEY = "__stream__";
 const FLOW_EXCLUDED_KEYS = new Set(["trust-compliance", "operate-improve"]);
 
 export interface ProjectArchetypeValueStreamInput {
-  /** A PrismaClient or a `$transaction` client; cast to the narrow OvsmDb inside. */
-  db?: Prisma.TransactionClient;
+  /**
+   * A PrismaClient or a `$transaction` client. Typed `unknown` on purpose: naming
+   * the Prisma client type here forced every importer (incl. apps/web) to compute
+   * Prisma's `Omit<PrismaClient, …>` mapped type, which blew the typecheck heap
+   * (OOM, PR #1798 CI). It is cast to the narrow OvsmDb at the single boundary in
+   * projectArchetypeValueStream(); callers pass `prisma` or a transaction client.
+   */
+  db?: unknown;
   orgId: string;
   ovsm: OperationalValueStream;
 }

--- a/packages/db/src/archetype-value-stream-projection.ts
+++ b/packages/db/src/archetype-value-stream-projection.ts
@@ -1,4 +1,4 @@
-import type { Prisma, PrismaClient } from "../generated/client/client";
+import type { Prisma } from "../generated/client/client";
 import { prisma } from "./client";
 import type { OperationalValueStream } from "@dpf/storefront-templates";
 
@@ -18,7 +18,13 @@ import type { OperationalValueStream } from "@dpf/storefront-templates";
  * No new Prisma table — this is a projection into EA elements/views.
  */
 
-type Db = Prisma.TransactionClient | PrismaClient;
+// A single Prisma client type, not a union: `PrismaClient` is assignable to
+// `Prisma.TransactionClient` (it has a superset of the delegates), so both the
+// setup caller (package client) and the reset caller (transaction client) fit.
+// Using the union here forced the type checker to resolve every delegate across
+// two enormous client types at each call site, which blew the build/typecheck
+// heap (OOM) — see PR #1798 CI.
+type Db = Prisma.TransactionClient;
 
 const ARCHETYPE_OVSM_SOURCE = "archetype-ovsm";
 /** Sentinel stageKey for the band element that holds the whole stream. */

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -5,4 +5,5 @@ export * from "./activation-profile";
 export * from "./capability-activation";
 export * from "./archetypes/index";
 export * from "./media-profile";
+export * from "./operational-value-stream";
 export * from "./sections/schemas";

--- a/packages/storefront-templates/src/operational-value-stream.test.ts
+++ b/packages/storefront-templates/src/operational-value-stream.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import {
+  deriveOperationalValueStream,
+  type OperationalValueStream,
+} from "./operational-value-stream";
+
+function ovsmFor(archetypeId: string): OperationalValueStream {
+  const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!archetype) throw new Error(`test archetype not found: ${archetypeId}`);
+  return deriveOperationalValueStream(archetype);
+}
+
+describe("deriveOperationalValueStream — invariants across all archetypes", () => {
+  it("produces a well-formed OVSM for every seeded archetype", () => {
+    expect(ALL_ARCHETYPES.length).toBeGreaterThanOrEqual(56);
+    for (const archetype of ALL_ARCHETYPES) {
+      const ovs = deriveOperationalValueStream(archetype);
+      // The six primary stages + two cross-cuts are always present.
+      const keys = ovs.stages.map((s) => s.key);
+      for (const required of [
+        "attract",
+        "capture",
+        "qualify",
+        "deliver",
+        "settle",
+        "retain",
+        "trust-compliance",
+        "operate-improve",
+      ]) {
+        expect(keys).toContain(required);
+      }
+      // Stages are ordered.
+      const orders = ovs.stages.map((s) => s.order);
+      expect([...orders]).toEqual([...orders].sort((a, b) => a - b));
+      // Core derived facts are always present.
+      expect(ovs.loadBearingStageKeys.length).toBeGreaterThan(0);
+      expect(ovs.capacityUnit).toBeTruthy();
+      expect(ovs.demandSignature).toBeTruthy();
+      expect(ovs.it4itStageBinding.length).toBeGreaterThan(0);
+      // Exactly the load-bearing stages are flagged.
+      const flagged = ovs.stages.filter((s) => s.loadBearing).map((s) => s.key).sort();
+      expect(flagged).toEqual([...ovs.loadBearingStageKeys].sort());
+      // Trust gates live on the trust-compliance stage.
+      const trustStage = ovs.stages.find((s) => s.key === "trust-compliance");
+      expect(trustStage?.trustGateKeys).toEqual(ovs.trustGates);
+    }
+  });
+
+  it("adds the return-inspect stage only for reservation-and-return archetypes", () => {
+    const rentalIds = ["equipment-rental", "self-storage", "agricultural-cooperative"];
+    for (const id of rentalIds) {
+      expect(ovsmFor(id).stages.map((s) => s.key)).toContain("return-inspect");
+    }
+    // Non-rental archetypes never grow the stage.
+    for (const archetype of ALL_ARCHETYPES) {
+      if (rentalIds.includes(archetype.archetypeId)) continue;
+      const ovs = deriveOperationalValueStream(archetype);
+      expect(ovs.stages.map((s) => s.key)).not.toContain("return-inspect");
+    }
+  });
+});
+
+describe("deriveOperationalValueStream — representative archetypes", () => {
+  it("hair-salon: appointment-checkout, load-bearing qualify, slot-hours", () => {
+    const ovs = ovsmFor("hair-salon");
+    expect(ovs.loadBearingStageKeys).toContain("qualify");
+    expect(ovs.capacityUnit).toBe("slot-hours");
+  });
+
+  it("veterinary-clinic: encounter-based, load-bearing deliver, clinical trust gate", () => {
+    const ovs = ovsmFor("veterinary-clinic");
+    expect(ovs.loadBearingStageKeys).toContain("deliver");
+    expect(ovs.trustGates).toContain("clinical-adjacent-no-advice");
+  });
+
+  it("bakery: point-of-sale, load-bearing capture, perishable/durable stock", () => {
+    const ovs = ovsmFor("bakery");
+    expect(ovs.loadBearingStageKeys).toContain("capture");
+    expect(["perishable-stock", "durable-stock"]).toContain(ovs.capacityUnit);
+  });
+
+  it("gym: subscription, load-bearing retain, physical hard cap", () => {
+    const ovs = ovsmFor("gym");
+    expect(ovs.loadBearingStageKeys).toContain("retain");
+    expect(ovs.capacityUnit).toBe("physical-hard-cap");
+  });
+
+  it("it-managed-services: recurring-agreement, load-bearing deliver, strict estate gate", () => {
+    const ovs = ovsmFor("it-managed-services");
+    expect(ovs.loadBearingStageKeys).toContain("deliver");
+    expect(ovs.trustGates).toContain("strict-estate-separation");
+  });
+
+  it("community-bank: account-based-fees, trust gate precedes qualify, KYC signal", () => {
+    const ovs = ovsmFor("community-bank");
+    expect(ovs.loadBearingStageKeys).toContain("trust-compliance");
+    expect(ovs.trustGates).toContain("kyc-and-disclosure");
+  });
+
+  it("small-town-municipality: statutory, universal-service obligation", () => {
+    const ovs = ovsmFor("small-town-municipality");
+    expect(ovs.trustGates).toContain("universal-service-obligation");
+  });
+
+  it("charity: donation, load-bearing capture, donation receipt (no invoice)", () => {
+    const ovs = ovsmFor("charity");
+    expect(ovs.loadBearingStageKeys).toContain("capture");
+    const settle = ovs.stages.find((s) => s.key === "settle");
+    expect(settle?.metricBindings).toContain("donation-receipt");
+    expect(settle?.metricBindings).not.toContain("invoice");
+  });
+
+  it("equipment-rental: reusable pooled asset, synchronized contention, return-inspect", () => {
+    const ovs = ovsmFor("equipment-rental");
+    expect(ovs.capacityUnit).toBe("reusable-pooled-asset");
+    expect(ovs.demandSignature).toBe("synchronized-contention");
+    expect(ovs.stages.map((s) => s.key)).toContain("return-inspect");
+  });
+
+  it("self-storage: reusable pooled asset", () => {
+    expect(ovsmFor("self-storage").capacityUnit).toBe("reusable-pooled-asset");
+  });
+
+  it("agricultural-cooperative: member-owned equitable allocation + return-inspect", () => {
+    const ovs = ovsmFor("agricultural-cooperative");
+    expect(ovs.trustGates).toContain("member-equitable-allocation");
+    expect(ovs.stages.map((s) => s.key)).toContain("return-inspect");
+  });
+});

--- a/packages/storefront-templates/src/operational-value-stream.ts
+++ b/packages/storefront-templates/src/operational-value-stream.ts
@@ -1,0 +1,329 @@
+import type {
+  ArchetypeCategory,
+  ArchetypeDefinition,
+  ArchetypeModule,
+  CommercialModel,
+  It4ItStage,
+} from "./types";
+
+/**
+ * Operational Value Stream Model (OVSM) — a pure projection of an archetype's
+ * existing substrate (axes / activation profile / scheduling / billing) into the
+ * six-stage operational value stream described in
+ * `docs/architecture/archetype-business-value-streams.md` (§3 load-bearing,
+ * §5 capability binding, §7 demand–capacity). This is the P0 "Capture" contract:
+ * derive, never author — no new fields on ArchetypeDefinition, no prose parsing.
+ */
+
+export type OperationalValueStreamStageKey =
+  | "attract"
+  | "capture"
+  | "qualify"
+  | "deliver"
+  | "settle"
+  | "retain"
+  | "trust-compliance"
+  | "operate-improve"
+  /** Rental/shared-asset only: the asset returns to the pool and is inspected. */
+  | "return-inspect";
+
+export type CapacityUnitType =
+  | "slot-hours"
+  | "service-throughput"
+  | "durable-stock"
+  | "perishable-stock"
+  | "physical-hard-cap"
+  | "billable-hours"
+  | "volunteer-or-bed-capacity"
+  | "loan-processing-throughput"
+  | "statutory-throughput"
+  | "reusable-pooled-asset"
+  | "governance-cycle";
+
+export type DemandSignature =
+  | "steady"
+  | "seasonal"
+  | "weekly"
+  | "event-driven"
+  | "fiscal-calendar"
+  | "rate-sensitive"
+  | "emergency-reactive"
+  | "synchronized-contention";
+
+export interface OperationalValueStreamStage {
+  key: OperationalValueStreamStageKey;
+  label: string;
+  order: number;
+  loadBearing: boolean;
+  capabilityBindings: ArchetypeModule[];
+  metricBindings: string[];
+  trustGateKeys: string[];
+}
+
+export interface OperationalValueStream {
+  archetypeId: string;
+  archetypeName: string;
+  category: string;
+  stages: OperationalValueStreamStage[];
+  loadBearingStageKeys: OperationalValueStreamStageKey[];
+  capacityUnit: CapacityUnitType;
+  demandSignature: DemandSignature;
+  trustGates: string[];
+  it4itStageBinding: It4ItStage[];
+}
+
+// ── Stage backbone ───────────────────────────────────────────────────────────
+
+interface StageSpec {
+  key: OperationalValueStreamStageKey;
+  label: string;
+  order: number;
+}
+
+const PRIMARY_STAGE_SPECS: StageSpec[] = [
+  { key: "attract", label: "Attract & Discover", order: 10 },
+  { key: "capture", label: "Capture Demand", order: 20 },
+  { key: "qualify", label: "Qualify & Schedule", order: 30 },
+  { key: "deliver", label: "Deliver the Value", order: 40 },
+  { key: "settle", label: "Settle & Account", order: 50 },
+  { key: "retain", label: "Retain & Grow", order: 60 },
+];
+
+const RETURN_INSPECT_SPEC: StageSpec = {
+  key: "return-inspect",
+  label: "Return & Inspect",
+  order: 45, // between deliver (40) and settle (50)
+};
+
+const CROSS_CUT_SPECS: StageSpec[] = [
+  { key: "trust-compliance", label: "Trust & Compliance", order: 70 },
+  { key: "operate-improve", label: "Operate & Improve", order: 80 },
+];
+
+// Stage → enabling capability modules (artefact §5). Intersected with the
+// archetype's actual active modules when an activation profile is present so we
+// never claim a capability the archetype did not activate.
+const STAGE_CAPABILITY_MAP: Record<OperationalValueStreamStageKey, ArchetypeModule[]> = {
+  attract: [],
+  capture: [],
+  qualify: ["service-operations"],
+  deliver: ["customer-estate", "service-operations", "projects"],
+  settle: ["billing-readiness"],
+  retain: ["service-agreements", "lifecycle-signals"],
+  "trust-compliance": [],
+  "operate-improve": ["integrations"],
+  "return-inspect": ["rental-fleet", "rental-agreements"],
+};
+
+const STAGE_METRIC_MAP: Record<OperationalValueStreamStageKey, string[]> = {
+  attract: ["storefront-published"],
+  capture: ["inbox-submissions", "capture-conversion"],
+  qualify: ["utilization", "no-show-rate", "lead-time"],
+  deliver: ["estate-completeness", "fulfilment"],
+  settle: ["invoice", "profit-loss"],
+  retain: ["repeat-rate", "renewals"],
+  "trust-compliance": ["obligations-status"],
+  "operate-improve": ["backlog-throughput"],
+  "return-inspect": ["asset-utilization", "turnaround", "overdue-returns"],
+};
+
+// ── Category defaults (used only when axes do not set a commercial model) ─────
+
+const CATEGORY_DEFAULT_COMMERCIAL_MODEL: Partial<Record<ArchetypeCategory, CommercialModel>> = {
+  "healthcare-wellness": "encounter-based",
+  "beauty-personal-care": "appointment-checkout",
+  "pet-services": "appointment-checkout",
+  "trades-maintenance": "transactional",
+  "professional-services": "recurring-agreement",
+  "software-platform": "subscription",
+  "fitness-recreation": "subscription",
+  "retail-goods": "point-of-sale",
+  "hoa-property-management": "statutory-fees-and-levies",
+  "public-sector": "statutory-fees-and-levies",
+  "banking-financial-services": "account-based-fees",
+};
+
+function resolveCommercialModel(a: ArchetypeDefinition): CommercialModel {
+  const fromAxes = a.activationProfile?.axes?.commercialModel;
+  if (fromAxes) return fromAxes;
+  // food-hospitality and education-training are mixed — key on the CTA.
+  if (a.category === "food-hospitality" || a.category === "education-training") {
+    if (a.ctaType === "purchase") return "point-of-sale";
+    if (a.ctaType === "booking") return "appointment-checkout";
+    return "transactional";
+  }
+  return CATEGORY_DEFAULT_COMMERCIAL_MODEL[a.category] ?? "transactional";
+}
+
+const CATEGORY_DEFAULT_DEMAND: Partial<Record<ArchetypeCategory, DemandSignature>> = {
+  "beauty-personal-care": "weekly",
+  "food-hospitality": "weekly",
+  "healthcare-wellness": "seasonal",
+  "pet-services": "seasonal",
+  "retail-goods": "seasonal",
+  "fitness-recreation": "seasonal",
+  "public-sector": "seasonal",
+  "hoa-property-management": "seasonal",
+  "trades-maintenance": "emergency-reactive",
+  "education-training": "fiscal-calendar",
+  "professional-services": "fiscal-calendar",
+  "nonprofit-community": "fiscal-calendar",
+  "banking-financial-services": "rate-sensitive",
+  "software-platform": "steady",
+};
+
+const CATEGORY_DEFAULT_CAPACITY: Partial<Record<ArchetypeCategory, CapacityUnitType>> = {
+  "beauty-personal-care": "slot-hours",
+  "healthcare-wellness": "slot-hours",
+  "pet-services": "slot-hours",
+  "education-training": "slot-hours",
+  "trades-maintenance": "slot-hours",
+  "fitness-recreation": "physical-hard-cap",
+  "retail-goods": "durable-stock",
+  "professional-services": "billable-hours",
+  "public-sector": "statutory-throughput",
+  "nonprofit-community": "volunteer-or-bed-capacity",
+  "software-platform": "service-throughput",
+  "hoa-property-management": "service-throughput",
+};
+
+// ── Derivation ───────────────────────────────────────────────────────────────
+
+function resolveCapacityUnit(a: ArchetypeDefinition, isRental: boolean, cm: CommercialModel): CapacityUnitType {
+  if (isRental) return "reusable-pooled-asset";
+  if (a.category === "food-hospitality") return a.ctaType === "purchase" ? "perishable-stock" : "slot-hours";
+  if (a.category === "banking-financial-services") {
+    return a.archetypeId === "mortgage-lending" ? "loan-processing-throughput" : "service-throughput";
+  }
+  if (a.category === "professional-services" && a.activationProfile?.profileType === "managed-service-provider") {
+    return "service-throughput";
+  }
+  if (a.archetypeId === "cooperative") return "governance-cycle";
+  const byCategory = CATEGORY_DEFAULT_CAPACITY[a.category];
+  if (byCategory) return byCategory;
+  // Commercial-model fallback for categories without a default.
+  if (cm === "subscription") return "physical-hard-cap";
+  return "service-throughput";
+}
+
+function resolveLoadBearingStages(
+  cm: CommercialModel,
+  isRental: boolean,
+  isDonation: boolean,
+): OperationalValueStreamStageKey[] {
+  if (isRental) return ["qualify"]; // reserve the right asset against a finite pool
+  if (isDonation) return ["capture"]; // capture the gift; no purchase artefact downstream
+  switch (cm) {
+    case "appointment-checkout":
+      return ["qualify"];
+    case "encounter-based":
+      return ["deliver"];
+    case "recurring-agreement":
+      return ["deliver"];
+    case "subscription":
+      return ["retain"];
+    case "transactional":
+    case "point-of-sale":
+      return ["capture"];
+    case "account-based-fees":
+      return ["trust-compliance", "qualify"]; // the gate precedes scheduling
+    case "statutory-fees-and-levies":
+      return ["trust-compliance"];
+    case "usage-based":
+      return ["qualify"];
+    default:
+      return ["capture"];
+  }
+}
+
+function resolveTrustGates(a: ArchetypeDefinition, isRental: boolean): string[] {
+  const gates: string[] = [];
+  const governance = a.activationProfile?.axes?.governance ?? "investor-owned";
+
+  if (a.category === "healthcare-wellness") gates.push("clinical-adjacent-no-advice");
+  if (a.archetypeId === "counselling") gates.push("crisis-routing");
+  if (a.archetypeId === "optician") gates.push("clinical-adjacent-no-advice");
+  if (a.category === "banking-financial-services") gates.push("kyc-and-disclosure");
+  if (a.archetypeId === "legal-services" || a.archetypeId === "accounting") gates.push("regulated-no-advice");
+
+  if (governance === "public-body") gates.push("universal-service-obligation");
+  if (a.archetypeId === "law-enforcement-agency") gates.push("no-cji-access");
+
+  if (a.activationProfile?.estateSeparation === "strict") gates.push("strict-estate-separation");
+
+  if (governance === "member-owned") {
+    gates.push(isRental ? "member-equitable-allocation" : "member-governance");
+  }
+
+  return Array.from(new Set(gates));
+}
+
+function resolveIt4itBinding(a: ArchetypeDefinition): It4ItStage[] {
+  const portfolios = a.activationProfile?.portfolios;
+  if (portfolios) {
+    const stages = new Set<It4ItStage>();
+    for (const profile of Object.values(portfolios)) {
+      for (const stage of profile?.it4itStages ?? []) stages.add(stage);
+    }
+    if (stages.size > 0) return Array.from(stages);
+  }
+  return ["request-to-fulfill"];
+}
+
+/**
+ * Pure derivation: archetype definition → operational value stream model.
+ * Deterministic and side-effect-free; safe to call at setup, archetype-reset,
+ * or in tests across every archetype in `ALL_ARCHETYPES`.
+ */
+export function deriveOperationalValueStream(archetype: ArchetypeDefinition): OperationalValueStream {
+  const commercialModel = resolveCommercialModel(archetype);
+  const provisioning = archetype.activationProfile?.axes?.provisioning;
+  const isRental = provisioning === "reservation-and-return";
+  const isDonation = archetype.ctaType === "donation";
+
+  const loadBearingStageKeys = resolveLoadBearingStages(commercialModel, isRental, isDonation);
+  const trustGates = resolveTrustGates(archetype, isRental);
+  const capacityUnit = resolveCapacityUnit(archetype, isRental, commercialModel);
+  const demandSignature = isRental
+    ? "synchronized-contention"
+    : (CATEGORY_DEFAULT_DEMAND[archetype.category] ?? "steady");
+  const it4itStageBinding = resolveIt4itBinding(archetype);
+
+  const activeModules = archetype.activationProfile?.modules;
+
+  const specs: StageSpec[] = [
+    ...PRIMARY_STAGE_SPECS,
+    ...(isRental ? [RETURN_INSPECT_SPEC] : []),
+    ...CROSS_CUT_SPECS,
+  ].sort((x, y) => x.order - y.order);
+
+  const stages: OperationalValueStreamStage[] = specs.map((spec) => {
+    const mapped = STAGE_CAPABILITY_MAP[spec.key];
+    const capabilityBindings = activeModules
+      ? mapped.filter((m) => activeModules.includes(m))
+      : mapped;
+    const metricBindings =
+      spec.key === "settle" && isDonation ? ["donation-receipt"] : STAGE_METRIC_MAP[spec.key];
+    return {
+      key: spec.key,
+      label: spec.label,
+      order: spec.order,
+      loadBearing: loadBearingStageKeys.includes(spec.key),
+      capabilityBindings,
+      metricBindings,
+      trustGateKeys: spec.key === "trust-compliance" ? trustGates : [],
+    };
+  });
+
+  return {
+    archetypeId: archetype.archetypeId,
+    archetypeName: archetype.name,
+    category: archetype.category,
+    stages,
+    loadBearingStageKeys,
+    capacityUnit,
+    demandSignature,
+    trustGates,
+    it4itStageBinding,
+  };
+}


### PR DESCRIPTION
## P0 "Capture" — operational value-stream architecture, derived at setup and rendered on `/ea`

Implements Phase P0 of the [value-stream platform design](docs/superpowers/specs/2026-06-12-value-stream-architecture-platform-design.md), per the [P0 plan](docs/superpowers/plans/2026-06-12-value-stream-p0-capture-implementation-plan.md). Anchor: #1724. Epic: `EP-ARCH-8D4F2A`.

Each org's operational value stream (six-stage backbone + load-bearing stage + capacity unit + demand signature + trust gates, plus the rental-only Return & Inspect stage) is **derived from existing archetype substrate** and **persisted as EA elements/view** — so it renders on the EA canvas you already have and exports through the existing ArchiMate path.

### Chunks
1. **Derive** — `deriveOperationalValueStream()` in `@dpf/storefront-templates`: a pure function over each archetype's axes/activation-profile/scheduling/billing. No new fields on `ArchetypeDefinition`; handles archetypes with and without explicit axes.
2. **Project** — `projectArchetypeValueStream()` in `@dpf/db`: persists the OVSM as `EaElement`/`EaView`/`EaViewElement`/`EaRelationship` (scopeType `archetype_value_stream`), mirroring `reference-model-projection.ts`. Injectable Prisma client (for the reset transaction), idempotent on `(source, orgId, stageKey)`, prunes orphan stages on archetype change.
3. **Wire** — `projectOperationalValueStreamForArchetype()` orchestration, called from the storefront setup route and inside the archetype-reset transaction.
4. **Surface** — `/ea/value-streams` widened (via a tested `listValueStreamViews()` helper) to list the org's operational stream alongside reference-model projections, labelled distinctly. Rendering (swimlane) and ArchiMate export are reused as-is.

### Guarantees
- **No new Prisma table** — the OVSM is a projection into existing EA substrate.
- **No new route** — one widened list filter is the only UI surface change; rendering/export reused.

### Verification
- **Source-local (run via the root toolchain against this worktree): 30 tests pass** + typecheck clean —
  - `@dpf/storefront-templates`: 13 (all 56 archetypes + representative cases); `tsc -p` exit 0.
  - `@dpf/db`: 8 (4 new projection + 4 existing `reference-model-projection`, unaffected).
  - `apps/web`: 9 (orchestration helper 3, archetype-reset 4 incl. new assertion, ea-list helper 2).
- **CI** is the canonical substrate for the production build, full test suite, and typecheck (db/web typecheck need the generated Prisma client / workspace links absent in this source-only worktree).
- **Pending manual gate: live-install UX verification** — drive setup for a representative archetype, confirm one operational view on `/ea/value-streams`, swimlane render on `/ea/views/[id]`, ArchiMate export, and idempotent regeneration on archetype-reset. Could not be run from this environment (no portal runtime / `dpf` MCP offline); to be completed on the running install.

### Notes
- Docs (design spec + P0 plan) already merged in #1777.
- P1 (measure), P2 (coworker facilitation + WWWD profile), P3 (proactivity) follow per the design's phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
