### PR TITLE
feat(build-studio): Local model (OpenCode) admin option + endpoint preflight (Phase 2b, BI-01D6A51B)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/build-studio/page.tsx
@@ -78,6 +78,9 @@ export default async function BuildStudioPage() {
   const grokProviders = allProviders.filter(p =>
     (p.provider as Record<string, unknown>).cliEngine === "grok",
   );
+  const opencodeProviders = allProviders.filter(p =>
+    (p.provider as Record<string, unknown>).cliEngine === "opencode",
+  );
 
   return (
     <div>
@@ -115,6 +118,13 @@ export default async function BuildStudioPage() {
           costNotes: p.provider.costPerformanceNotes,
         }))}
         grokProviders={grokProviders.map(p => ({
+          providerId: p.provider.providerId,
+          name: p.provider.name,
+          status: p.credential?.status ?? "unconfigured",
+          billingLabel: p.provider.billingLabel,
+          costNotes: p.provider.costPerformanceNotes,
+        }))}
+        opencodeProviders={opencodeProviders.map(p => ({
           providerId: p.provider.providerId,
           name: p.provider.name,
           status: p.credential?.status ?? "unconfigured",

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { saveBuildStudioConfig } from "@/lib/actions/build-studio";
+import { saveBuildStudioConfig, checkLocalEndpoint } from "@/lib/actions/build-studio";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
+import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 import { engineReadinessBadgeContent, ENGINE_READINESS_TONE_COLOR } from "./engine-readiness-badge";
@@ -29,6 +30,7 @@ type Props = {
   claudeProviders: ProviderOption[];
   codexProviders: ProviderOption[];
   grokProviders: ProviderOption[];
+  opencodeProviders: ProviderOption[];
   contributorMcpReadiness: ContributorMcpReadiness;
   /** Per-engine sandbox readiness (engineId → last probe), keyed "claude"|"codex"|"grok". */
   engineReadiness?: Record<string, EngineReadinessBadge>;
@@ -75,6 +77,7 @@ export function BuildStudioConfigForm({
   claudeProviders,
   codexProviders,
   grokProviders,
+  opencodeProviders,
   contributorMcpReadiness,
   engineReadiness,
   baseUrl,
@@ -87,10 +90,15 @@ export function BuildStudioConfigForm({
   const [claudeModel, setClaudeModel] = useState(config.claudeModel);
   const [codexModel, setCodexModel] = useState(config.codexModel);
   const [grokModel, setGrokModel] = useState(config.grokModel);
-  // opencode (local model) fields are carried through here; the dedicated
-  // "Local model (OpenCode)" UI surface lands in Phase 2 of the local-LLM plan.
-  const [opencodeProviderId] = useState(config.opencodeProviderId);
-  const [opencodeModel] = useState(config.opencodeModel);
+  // opencode = local model via the install's own OpenAI-compatible endpoint.
+  // No credential to pick; the operator chooses which local provider (usually
+  // one) and optionally a model, then preflights the endpoint here.
+  const [opencodeProviderId, setOpencodeProviderId] = useState(
+    config.opencodeProviderId || opencodeProviders[0]?.providerId || "",
+  );
+  const [opencodeModel, setOpencodeModel] = useState(config.opencodeModel);
+  const [endpointCheck, setEndpointCheck] = useState<LocalEndpointPreflight | null>(null);
+  const [checkingEndpoint, setCheckingEndpoint] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -98,6 +106,21 @@ export function BuildStudioConfigForm({
   const hasClaudeCreds = claudeProviders.some(p => isConfigured(p.status));
   const hasCodexCreds = codexProviders.some(p => isConfigured(p.status));
   const hasGrokCreds = grokProviders.some(p => isConfigured(p.status));
+  const hasOpencodeProvider = opencodeProviders.length > 0;
+
+  function runEndpointCheck() {
+    setCheckingEndpoint(true);
+    setEndpointCheck(null);
+    startTransition(async () => {
+      try {
+        setEndpointCheck(await checkLocalEndpoint(opencodeModel));
+      } catch (err) {
+        setEndpointCheck({ ok: false, resolvedModel: null, models: [], contextOk: false, reason: (err as Error).message });
+      } finally {
+        setCheckingEndpoint(false);
+      }
+    });
+  }
 
   function handleSave() {
     setSaved(false);
@@ -210,6 +233,18 @@ export function BuildStudioConfigForm({
             desc="xAI models · headless grok -p"
             unconfiguredMsg={!hasGrokCreds ? "No xAI credentials found." : undefined}
             readiness={engineReadiness?.grok}
+            canProvision={canWrite}
+          />
+          <ProviderRadio
+            name="provider"
+            value="opencode"
+            checked={provider === "opencode"}
+            onChange={() => setProvider("opencode")}
+            disabled={!canWrite || !hasOpencodeProvider}
+            label="Local model (OpenCode) (Preview)"
+            desc="Your own local LLM · no credential, runs offline"
+            unconfiguredMsg={!hasOpencodeProvider ? "No local model provider found." : undefined}
+            readiness={engineReadiness?.opencode}
             canProvision={canWrite}
           />
           <ProviderRadio
@@ -382,6 +417,82 @@ export function BuildStudioConfigForm({
                   }}
                 />
               </label>
+            </div>
+          )}
+
+          {provider === "opencode" && (
+            <div>
+              <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginBottom: 6 }}>
+                Runs the open-source OpenCode agent against your install&apos;s own local model
+                endpoint — no API key, nothing leaves your machine. Preview tier until eval
+                evidence on a real local model promotes it.
+              </p>
+              <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--dpf-text)", marginBottom: 8 }}>
+                Model:
+                <input
+                  type="text"
+                  value={opencodeModel}
+                  onChange={e => setOpencodeModel(e.target.value)}
+                  disabled={!canWrite}
+                  placeholder="auto (first served model)"
+                  style={{
+                    width: 200,
+                    fontSize: 11,
+                    padding: "2px 6px",
+                    border: "1px solid var(--dpf-border)",
+                    borderRadius: 4,
+                    background: "var(--dpf-bg)",
+                    color: "var(--dpf-text)",
+                  }}
+                />
+              </label>
+              <p style={{ fontSize: 10, color: "var(--dpf-muted)", marginBottom: 8 }}>
+                Leave blank to use the first model your local endpoint serves. A coding model
+                with ≥22k context (e.g. a qwen3-coder build) is recommended.
+              </p>
+              {canWrite && (
+                <button
+                  type="button"
+                  onClick={runEndpointCheck}
+                  disabled={checkingEndpoint}
+                  style={{
+                    padding: "4px 12px",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    background: "var(--dpf-surface-2)",
+                    color: "var(--dpf-text)",
+                    border: "1px solid var(--dpf-border)",
+                    borderRadius: 6,
+                    cursor: checkingEndpoint ? "wait" : "pointer",
+                  }}
+                >
+                  {checkingEndpoint ? "Checking…" : "Test local endpoint"}
+                </button>
+              )}
+              {endpointCheck && (
+                <div
+                  role="status"
+                  style={{
+                    marginTop: 8,
+                    fontSize: 11,
+                    color: endpointCheck.ok ? "var(--dpf-success)" : "var(--dpf-error)",
+                  }}
+                >
+                  {endpointCheck.ok ? (
+                    <>
+                      ✓ Endpoint reachable — will dispatch to{" "}
+                      <strong>{endpointCheck.resolvedModel}</strong>.
+                      {endpointCheck.models.length > 0 && (
+                        <span style={{ color: "var(--dpf-muted)" }}>
+                          {" "}Models served: {endpointCheck.models.join(", ")}.
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>⚠ {endpointCheck.reason}</>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </section>

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -4,6 +4,8 @@ import { prisma, type Prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
+import { getOllamaBaseUrl } from "@/lib/inference/ollama-url";
+import { preflightLocalEndpoint, type LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 
 async function requireManageProviders(): Promise<string> {
   const session = await auth();
@@ -14,7 +16,7 @@ async function requireManageProviders(): Promise<string> {
   return user.id;
 }
 
-const VALID_ENGINES = new Set(["claude", "codex", "grok", "agentic"]);
+const VALID_ENGINES = new Set(["claude", "codex", "grok", "opencode", "agentic"]);
 const VALID_CLAUDE_MODELS = new Set(["haiku", "sonnet", "opus"]);
 
 export async function saveBuildStudioConfig(
@@ -51,6 +53,14 @@ export async function saveBuildStudioConfig(
       throw new Error(`Provider ${config.grokProviderId} is not a Grok-compatible provider`);
     }
   }
+  if (config.opencodeProviderId) {
+    const opencodeProvider = await prisma.modelProvider.findFirst({
+      where: { providerId: config.opencodeProviderId, cliEngine: "opencode" },
+    });
+    if (!opencodeProvider) {
+      throw new Error(`Provider ${config.opencodeProviderId} is not an OpenCode-compatible (local) provider`);
+    }
+  }
 
   if (config.claudeModel && !VALID_CLAUDE_MODELS.has(config.claudeModel)) {
     throw new Error(`Invalid Claude model: ${config.claudeModel}`);
@@ -63,4 +73,18 @@ export async function saveBuildStudioConfig(
   });
 
   return { ok: true };
+}
+
+/**
+ * Config-time preflight of the local model endpoint behind the opencode engine.
+ * Surfaces, at configuration time rather than first at dispatch, whether the
+ * install's local OpenAI-compatible endpoint is reachable and serving the
+ * desired model. Read-only; gated on the same manage-providers capability.
+ */
+export async function checkLocalEndpoint(
+  model: string,
+): Promise<LocalEndpointPreflight> {
+  await requireManageProviders();
+  const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
+  return preflightLocalEndpoint(portalBaseUrl, model ?? "");
 }


### PR DESCRIPTION
## Summary

Phase 2b of the local-LLM Build Studio dispatch option — makes the `opencode` engine **selectable and configurable** in **Admin > AI > Build Studio**, and fixes a Phase 1 save-path gap. Backlog: **BI-01D6A51B** (EP-BUILD-STUDIO). Builds on [#1791](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1791) (engine) and [#1796](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1796) (sandbox image).

## Changes

- **`build-studio.ts`** — **bug fix:** `opencode` was missing from `VALID_ENGINES`, so saving the engine threw "Invalid provider engine" (a Phase 1 gap). Added it, plus `opencodeProviderId` validation against `cliEngine: "opencode"`. New **`checkLocalEndpoint()`** server action (gated on `manage_provider_connections`) runs the portal-side `preflightLocalEndpoint` so the operator sees endpoint reachability + the served model **at config time, not first at dispatch**.
- **`page.tsx`** — groups + passes the local (`cliEngine: "opencode"`) providers to the form.
- **`BuildStudioConfigForm`** — a **"Local model (OpenCode) (Preview)"** radio (enabled when a local provider exists, framed "no credential, runs offline"), an editable model field (blank = first served model, with the ≥22k-context guidance), and a **"Test local endpoint"** button that surfaces the preflight result inline (reachable + resolved model + models served, or the BLOCKED reason).

## Verification (substrate: source-only worktree via root-clone toolchain)

- **Pre-commit scoped typecheck gate passed** (real gate, not skipped) — `pnpm --filter web typecheck` clean.
- `opencode-dispatch` + `build-studio-config` suites green (28 tests). No new logic added that isn't already covered by the preflight unit tests; `checkLocalEndpoint` is a thin auth-gated wrapper over the tested `preflightLocalEndpoint`.
- Full UX exercise (clicking through the option against a live local endpoint) is part of the Phase 3 functional gate on the canonical install.

## Theme compliance

New UI uses `var(--dpf-*)` tokens throughout (AGENTS.md §12); the inline styles match the existing form's established pattern.

## Next

Phase 3 — runtime functional verification: one real `opencode run` end-to-end against the install's local model, which is what would justify promoting the capability tier above `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)