### PR TITLE
feat(workbooks): group-by summary — pivot-lite reporting (EP-GRID-WORKBOOKS Phase 4)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,6 +67,7 @@ import {
   blankRule,
   operatorNeedsValue,
 } from "./grid-conditional-format";
+import { summarize, numericColumns } from "./grid-summary";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -205,6 +206,9 @@ export function WorkbookGrid({
   const [showFormat, setShowFormat] = useState(false);
   const [cfRules, setCfRules] = useState<ConditionalRule[]>([]);
   const cfIdRef = useRef(0);
+  const [showSummary, setShowSummary] = useState(false);
+  const [summaryGroupBy, setSummaryGroupBy] = useState("");
+  const [summaryValue, setSummaryValue] = useState("");
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -461,6 +465,15 @@ export function WorkbookGrid({
         </button>
         <button
           type="button"
+          onClick={() => setShowSummary((v) => !v)}
+          aria-pressed={showSummary}
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Group rows and summarize"
+        >
+          {showSummary ? "Hide summary" : "Summary"}
+        </button>
+        <button
+          type="button"
           onClick={() => setShowProvenance((v) => !v)}
           aria-pressed={showProvenance}
           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -613,6 +626,82 @@ export function WorkbookGrid({
           </button>
         </div>
       )}
+
+      {showSummary && columns.length > 0 && (() => {
+        const groupBy = summaryGroupBy || columns[0]!.columnId;
+        const valueCol = summaryValue || undefined;
+        const numCols = numericColumns(columns);
+        const summary = summarize(sortedRows, groupBy, valueCol);
+        const ctrlClass =
+          "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+        return (
+          <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
+              <select
+                value={groupBy}
+                onChange={(e) => setSummaryGroupBy(e.target.value)}
+                aria-label="Group by column"
+                className={ctrlClass}
+              >
+                {columns.map((c) => (
+                  <option key={c.columnId} value={c.columnId}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-[var(--dpf-muted)]">summarize</span>
+              <select
+                value={summaryValue}
+                onChange={(e) => setSummaryValue(e.target.value)}
+                aria-label="Value column"
+                className={ctrlClass}
+              >
+                <option value="">count only</option>
+                {numCols.map((c) => (
+                  <option key={c.columnId} value={c.columnId}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-[var(--dpf-muted)]">
+                    <th className="px-2 py-1">Group</th>
+                    <th className="px-2 py-1">Count</th>
+                    {valueCol && (
+                      <>
+                        <th className="px-2 py-1">Sum</th>
+                        <th className="px-2 py-1">Avg</th>
+                        <th className="px-2 py-1">Min</th>
+                        <th className="px-2 py-1">Max</th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.map((s) => (
+                    <tr key={s.group} className="border-t border-[var(--dpf-border)]">
+                      <td className="px-2 py-1">{s.group}</td>
+                      <td className="px-2 py-1">{s.count}</td>
+                      {valueCol && (
+                        <>
+                          <td className="px-2 py-1">{s.sum}</td>
+                          <td className="px-2 py-1">{s.avg}</td>
+                          <td className="px-2 py-1">{s.min}</td>
+                          <td className="px-2 py-1">{s.max}</td>
+                        </>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })()}
 
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">

--- a/apps/web/components/workbooks/grid-summary.test.ts
+++ b/apps/web/components/workbooks/grid-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { summarize, toSummaryNumber, numericColumns } from "./grid-summary";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const rows: GridRowData[] = [
+  { rowId: "1", status: "open", amount: 100 },
+  { rowId: "2", status: "open", amount: 50 },
+  { rowId: "3", status: "done", amount: 200 },
+  { rowId: "4", status: "", amount: null },
+];
+
+describe("toSummaryNumber", () => {
+  it("coerces numerics and rejects non-numbers", () => {
+    expect(toSummaryNumber(5)).toBe(5);
+    expect(toSummaryNumber("12")).toBe(12);
+    expect(toSummaryNumber(true)).toBe(1);
+    expect(toSummaryNumber("abc")).toBeNull();
+    expect(toSummaryNumber(null)).toBeNull();
+    expect(toSummaryNumber("")).toBeNull();
+  });
+});
+
+describe("numericColumns", () => {
+  it("keeps only number columns", () => {
+    const cols: ColumnDefinition[] = [
+      { columnId: "a", name: "A", fieldType: "number", position: 0, required: false, editable: true },
+      { columnId: "b", name: "B", fieldType: "text", position: 1, required: false, editable: true },
+    ];
+    expect(numericColumns(cols).map((c) => c.columnId)).toEqual(["a"]);
+  });
+});
+
+describe("summarize", () => {
+  it("counts rows per group (empty group labelled), sorted by count desc", () => {
+    const s = summarize(rows, "status");
+    expect(s.map((g) => [g.group, g.count])).toEqual([
+      ["open", 2],
+      ["(empty)", 1],
+      ["done", 1],
+    ]);
+  });
+
+  it("aggregates a numeric value column per group", () => {
+    const s = summarize(rows, "status", "amount");
+    const open = s.find((g) => g.group === "open")!;
+    expect(open).toMatchObject({ count: 2, sum: 150, avg: 75, min: 50, max: 100 });
+    const empty = s.find((g) => g.group === "(empty)")!;
+    // row 4 has a null amount → counted as a row, but no numeric contribution
+    expect(empty).toMatchObject({ count: 1, sum: 0, avg: 0, min: 0, max: 0 });
+  });
+});

--- a/apps/web/components/workbooks/grid-summary.ts
+++ b/apps/web/components/workbooks/grid-summary.ts
@@ -1,0 +1,80 @@
+// Universal Grid & Workbooks — group-by summary (EP-GRID-WORKBOOKS Phase 4)
+//
+// The "pivot-lite" affordance: group the rows by one column and show count plus
+// numeric aggregates (sum/avg/min/max) of another column per group. Pure +
+// unit-testable; operates over the rows already loaded in the grid (full pivots
+// and SQL push-down are later Phase-4 work).
+
+import type { CellValue, ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+export interface GroupSummary {
+  group: string;
+  count: number;
+  sum: number;
+  avg: number;
+  min: number;
+  max: number;
+}
+
+const EMPTY_GROUP = "(empty)";
+
+/** Coerce a cell to a finite number, or null if it isn't numeric. */
+export function toSummaryNumber(value: CellValue): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  const n = typeof value === "number" ? value : Number(cellSearchText(value));
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Columns whose values are meaningfully summable (numeric). */
+export function numericColumns(columns: ColumnDefinition[]): ColumnDefinition[] {
+  return columns.filter((c) => c.fieldType === "number");
+}
+
+/** Round to 2dp without floating-point noise. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Group rows by `groupByColumnId` and aggregate `valueColumnId` (optional) per
+ * group. Groups are returned sorted by descending count, then group label.
+ */
+export function summarize(
+  rows: GridRowData[],
+  groupByColumnId: string,
+  valueColumnId?: string,
+): GroupSummary[] {
+  const counts = new Map<string, number>();
+  const values = new Map<string, number[]>();
+  for (const row of rows) {
+    const key = cellSearchText(row[groupByColumnId] ?? null) || EMPTY_GROUP;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (valueColumnId) {
+      const n = toSummaryNumber(row[valueColumnId] ?? null);
+      if (n !== null) {
+        const bucket = values.get(key) ?? [];
+        bucket.push(n);
+        values.set(key, bucket);
+      }
+    }
+  }
+
+  const out: GroupSummary[] = [];
+  for (const [group, count] of counts) {
+    const nums = values.get(group) ?? [];
+    const sum = nums.reduce((s, v) => s + v, 0);
+    out.push({
+      group,
+      count,
+      sum: round2(sum),
+      avg: nums.length ? round2(sum / nums.length) : 0,
+      min: nums.length ? round2(Math.min(...nums)) : 0,
+      max: nums.length ? round2(Math.max(...nums)) : 0,
+    });
+  }
+  out.sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
+  return out;
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -161,8 +161,13 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   [equals/contains/gt/lt/empty/…] + value + colour); the first matching rule tints the row.
   Pure, unit-tested `grid-conditional-format.ts` (`ruleMatches`/`rowColor`); applied via
   react-data-grid `rowClass`. Session-scoped for now; persisting rules to `WorkbookView` is a follow-up.
+- **Slice 11 — group-by summary — SHIPPED.** A "Summary" panel groups the (filtered) rows by a
+  chosen column and shows count + numeric aggregates (sum/avg/min/max) of a chosen value column per
+  group. Pure, unit-tested `grid-summary.ts` (`summarize`/`toSummaryNumber`). Over loaded rows; full
+  pivots (multi-dimension, subtotals, %) + SQL push-down are later Phase-4 work.
 - **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import; group-by summary.
+  calendar + gallery views; `.xlsx` import; full pivots + charts/dashboards; metrics/semantic layer;
+  operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
First Phase-4 (reporting) slice: a **Summary** panel groups the current (filtered) rows by a chosen column and shows **count + numeric aggregates (sum/avg/min/max)** of a chosen value column per group — the Excel/Smartsheet pivot-lite.

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

Aggregation is a pure, unit-tested `grid-summary.ts`: empty group values are labelled "(empty)" and still counted; non-numeric values are excluded from numeric aggregates; results sort by count desc. Operates over loaded rows; full pivots (multi-dimension, subtotals/%, calculated fields) and SQL push-down are later Phase-4 work.

Gate: grid-summary vitest 4 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)