### PR TITLE
feat(workbooks): .xlsx import — create a table from a spreadsheet (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
+++ b/apps/web/app/(shell)/workbooks/[workbookId]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { WorkbookGrid } from "@/components/workbooks/Grid";
 import { CreateTableButton } from "@/components/workbooks/CreateTableButton";
 import { AddColumnButton } from "@/components/workbooks/AddColumnButton";
+import { ImportSheetButton } from "@/components/workbooks/ImportSheetButton";
 
 export const dynamic = "force-dynamic";
 
@@ -89,6 +90,7 @@ export default async function WorkbookDetailPage({ params, searchParams }: Props
           );
         })}
         {canManage && <CreateTableButton workbookId={workbookId} />}
+        {canManage && <ImportSheetButton workbookId={workbookId} />}
       </div>
 
       {!grid ? (

--- a/apps/web/components/workbooks/ImportSheetButton.tsx
+++ b/apps/web/components/workbooks/ImportSheetButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { importSheetAction } from "@/lib/actions/workbooks";
+
+/** Upload an .xlsx and create a new workbook table from it (columns + rows inferred). */
+export function ImportSheetButton({ workbookId }: { workbookId: string }) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [isError, setIsError] = useState(false);
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setMessage(null);
+    setIsError(false);
+    const fd = new FormData();
+    fd.append("file", file);
+    startTransition(async () => {
+      const res = await importSheetAction(workbookId, fd);
+      if (inputRef.current) inputRef.current.value = "";
+      if (!res.ok) {
+        setIsError(true);
+        setMessage(res.error);
+        return;
+      }
+      setMessage(
+        `Imported ${res.data.rowCount} rows, ${res.data.columnCount} columns` +
+          (res.data.truncated ? " (truncated to the import limit)" : ""),
+      );
+      router.refresh();
+    });
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => inputRef.current?.click()}
+        className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] disabled:opacity-50"
+      >
+        {pending ? "Importing…" : "Import .xlsx"}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        className="hidden"
+        onChange={onFile}
+      />
+      {message && (
+        <span className={`text-sm ${isError ? "text-[var(--dpf-error)]" : "text-[var(--dpf-muted)]"}`}>
+          {message}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -36,6 +36,7 @@ import {
   resolvePlatformReference,
   getReferenceTargetFields,
 } from "@/lib/workbooks/platform-tables";
+import { inferTableFromSheet, type SheetCell } from "@/lib/workbooks/sheet-import";
 import type { CellValue, ColumnDefinition, FieldType, FieldConfig } from "@/lib/workbooks/types";
 
 export type ActionResult<T = void> =
@@ -258,6 +259,54 @@ export async function getReferenceTargetFieldsAction(
   try {
     const user = await requirePlatformUser();
     return { ok: true, data: await getReferenceTargetFields(user, referenceType) };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// ── Spreadsheet import (Phase 3) ────────────────────────────────────────────
+// Parse an uploaded .xlsx/.csv server-side and create a workbook table with
+// inferred columns + typed rows, composing the same validated service the manual
+// flow uses (createTable → addColumn → createRow).
+
+export async function importSheetAction(
+  workbookId: string,
+  formData: FormData,
+): Promise<ActionResult<{ tableId: string; columnCount: number; rowCount: number; truncated: boolean }>> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    const file = formData.get("file");
+    if (!(file instanceof File)) throw new WorkbookError("No file uploaded", 400);
+    const buffer = await file.arrayBuffer();
+    const { readSheet } = await import(/* turbopackIgnore: true */ "read-excel-file/browser");
+    const matrix = (await readSheet(buffer)) as SheetCell[][];
+
+    const { columns, rows, truncated } = inferTableFromSheet(matrix);
+    if (columns.length === 0) throw new WorkbookError("The sheet has no columns to import", 400);
+
+    const tableName = file.name.replace(/\.[^.]+$/, "").trim() || "Imported sheet";
+    const table = await svcCreateTable(user, workbookId, { name: tableName });
+
+    const columnIdByName = new Map<string, string>();
+    for (const col of columns) {
+      const created = await svcAddColumn(user, table.tableId, { name: col.name, fieldType: col.fieldType });
+      columnIdByName.set(col.name, created.columnId);
+    }
+
+    for (const row of rows) {
+      const input: Record<string, CellValue> = {};
+      for (const [name, value] of Object.entries(row)) {
+        const columnId = columnIdByName.get(name);
+        if (columnId) input[columnId] = value;
+      }
+      await svcCreateRow(user, table.tableId, input);
+    }
+
+    revalidatePath(`/workbooks/${workbookId}`);
+    return {
+      ok: true,
+      data: { tableId: table.tableId, columnCount: columns.length, rowCount: rows.length, truncated },
+    };
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/workbooks/sheet-import.test.ts
+++ b/apps/web/lib/workbooks/sheet-import.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  inferFieldType,
+  coerceImportCell,
+  uniqueColumnNames,
+  inferTableFromSheet,
+  type SheetCell,
+} from "./sheet-import";
+
+describe("inferFieldType", () => {
+  it("detects number, checkbox, date, and falls back to text", () => {
+    expect(inferFieldType([1, 2, "3"])).toBe("number");
+    expect(inferFieldType([true, false])).toBe("checkbox");
+    expect(inferFieldType([new Date("2026-01-01"), new Date("2026-02-01")])).toBe("date");
+    expect(inferFieldType(["a", 1])).toBe("text");
+    expect(inferFieldType([null, ""])).toBe("text");
+  });
+});
+
+describe("coerceImportCell", () => {
+  it("coerces by field type and blanks to null", () => {
+    expect(coerceImportCell("number", "12")).toBe(12);
+    expect(coerceImportCell("checkbox", true)).toBe(true);
+    expect(coerceImportCell("date", new Date("2026-01-01T00:00:00.000Z"))).toBe("2026-01-01T00:00:00.000Z");
+    expect(coerceImportCell("text", 5)).toBe("5");
+    expect(coerceImportCell("number", null)).toBeNull();
+  });
+});
+
+describe("uniqueColumnNames", () => {
+  it("fills blanks and de-duplicates", () => {
+    expect(uniqueColumnNames(["Name", "", "Name", null])).toEqual(["Name", "Column 2", "Name 2", "Column 4"]);
+  });
+});
+
+describe("inferTableFromSheet", () => {
+  it("builds columns + typed rows from a matrix, skipping empty rows", () => {
+    const matrix: SheetCell[][] = [
+      ["Name", "Qty", "Active"],
+      ["Widget", 10, true],
+      ["Gadget", "20", false],
+      [null, null, null],
+    ];
+    const { columns, rows, truncated } = inferTableFromSheet(matrix);
+    expect(columns).toEqual([
+      { name: "Name", fieldType: "text" },
+      { name: "Qty", fieldType: "number" },
+      { name: "Active", fieldType: "checkbox" },
+    ]);
+    expect(rows).toEqual([
+      { Name: "Widget", Qty: 10, Active: true },
+      { Name: "Gadget", Qty: 20, Active: false },
+    ]);
+    expect(truncated).toBe(false);
+  });
+
+  it("returns an empty table for an empty matrix", () => {
+    expect(inferTableFromSheet([])).toEqual({ columns: [], rows: [], truncated: false });
+  });
+});

--- a/apps/web/lib/workbooks/sheet-import.ts
+++ b/apps/web/lib/workbooks/sheet-import.ts
@@ -1,0 +1,104 @@
+// Universal Grid & Workbooks — spreadsheet import inference (EP-GRID-WORKBOOKS Phase 3)
+//
+// Pure logic that turns a parsed sheet matrix (first row = headers) into a
+// workbook table definition: deduped column names, an inferred field type per
+// column, and typed cell rows. Kept pure + unit-testable; the server action wires
+// it to the .xlsx parser (read-excel-file) and the workbook service.
+
+import type { CellValue, FieldType } from "./types";
+
+/** What read-excel-file yields per cell. */
+export type SheetCell = string | number | boolean | Date | null;
+
+export interface ImportedColumn {
+  name: string;
+  fieldType: FieldType;
+}
+
+export interface ImportedTable {
+  columns: ImportedColumn[];
+  /** Rows keyed by column name (the action maps names → columnIds after creation). */
+  rows: Record<string, CellValue>[];
+  truncated: boolean;
+}
+
+export const MAX_IMPORT_COLUMNS = 100;
+export const MAX_IMPORT_ROWS = 5000;
+
+function isBlank(v: SheetCell): boolean {
+  return v === null || v === undefined || (typeof v === "string" && v.trim() === "");
+}
+
+/** Infer a column's field type from a sample of its (non-blank) values. */
+export function inferFieldType(values: SheetCell[]): FieldType {
+  const present = values.filter((v) => !isBlank(v));
+  if (present.length === 0) return "text";
+  if (present.every((v) => v instanceof Date)) return "date";
+  if (present.every((v) => typeof v === "boolean")) return "checkbox";
+  if (
+    present.every(
+      (v) => typeof v === "number" || (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))),
+    )
+  ) {
+    return "number";
+  }
+  return "text";
+}
+
+/** Coerce a raw sheet cell to a typed CellValue for the inferred field type. */
+export function coerceImportCell(fieldType: FieldType, value: SheetCell): CellValue {
+  if (isBlank(value)) return null;
+  switch (fieldType) {
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "checkbox":
+      return typeof value === "boolean" ? value : String(value).toLowerCase() === "true";
+    case "date":
+    case "datetime":
+      return value instanceof Date ? value.toISOString() : String(value);
+    default:
+      return String(value);
+  }
+}
+
+/** Make column names unique + non-empty (Excel allows blank/duplicate headers). */
+export function uniqueColumnNames(header: SheetCell[]): string[] {
+  const seen = new Map<string, number>();
+  return header.map((h, i) => {
+    let base = (h === null || h === undefined ? "" : String(h)).trim() || `Column ${i + 1}`;
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    if (count > 0) base = `${base} ${count + 1}`;
+    return base;
+  });
+}
+
+/**
+ * Turn a sheet matrix into an importable table. The first row is the header.
+ * Empty rows are skipped; columns/rows are capped (truncated flag set when hit).
+ */
+export function inferTableFromSheet(matrix: SheetCell[][]): ImportedTable {
+  if (matrix.length === 0) return { columns: [], rows: [], truncated: false };
+  const header = (matrix[0] ?? []).slice(0, MAX_IMPORT_COLUMNS);
+  const names = uniqueColumnNames(header);
+  const colCount = names.length;
+
+  const body = matrix.slice(1).filter((r) => r.some((c) => !isBlank(c)));
+  const truncated = body.length > MAX_IMPORT_ROWS || (matrix[0]?.length ?? 0) > MAX_IMPORT_COLUMNS;
+  const cappedBody = body.slice(0, MAX_IMPORT_ROWS);
+
+  const columns: ImportedColumn[] = names.map((name, i) => ({
+    name,
+    fieldType: inferFieldType(cappedBody.map((r) => r[i] ?? null)),
+  }));
+
+  const rows = cappedBody.map((r) => {
+    const obj: Record<string, CellValue> = {};
+    for (let i = 0; i < colCount; i += 1) {
+      obj[names[i]!] = coerceImportCell(columns[i]!.fieldType, r[i] ?? null);
+    }
+    return obj;
+  });
+
+  return { columns, rows, truncated };
+}


### PR DESCRIPTION
The **data-in** complement to CSV export: an **Import .xlsx** button on the workbook page uploads a sheet; a server action parses it (read-excel-file, server-side), infers a field type per column, and creates a new workbook table — composing the **same validated service** the manual flow uses (createTable → addColumn → createRow), so imported data is typed + validated, not raw-inserted.

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

Type inference is a pure, unit-tested `sheet-import.ts`: `inferFieldType` (number/checkbox/date/text), `coerceImportCell`, `uniqueColumnNames` (fills blank + de-dupes Excel headers), `inferTableFromSheet` (header row, skips empty rows, caps columns/rows with a `truncated` flag — no silent truncation; the UI reports it).

Gate: sheet-import vitest 5 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)