### PR TITLE
feat(workbooks): summary chart — bar chart of the group-by (EP-GRID-WORKBOOKS Phase 4)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,7 +67,7 @@ import {
   blankRule,
   operatorNeedsValue,
 } from "./grid-conditional-format";
-import { summarize, numericColumns } from "./grid-summary";
+import { summarize, numericColumns, summaryChartBars } from "./grid-summary";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -209,6 +209,7 @@ export function WorkbookGrid({
   const [showSummary, setShowSummary] = useState(false);
   const [summaryGroupBy, setSummaryGroupBy] = useState("");
   const [summaryValue, setSummaryValue] = useState("");
+  const [summaryChart, setSummaryChart] = useState(false);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -664,7 +665,48 @@ export function WorkbookGrid({
                   </option>
                 ))}
               </select>
+              <div className="ml-auto inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(false)}
+                  className={
+                    summaryChart
+                      ? "px-2 py-1 text-[var(--dpf-muted)]"
+                      : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                  }
+                >
+                  Table
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(true)}
+                  className={
+                    summaryChart
+                      ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                      : "px-2 py-1 text-[var(--dpf-muted)]"
+                  }
+                >
+                  Chart
+                </button>
+              </div>
             </div>
+            {summaryChart ? (
+              <div className="flex flex-col gap-1">
+                {summaryChartBars(summary, Boolean(valueCol)).map((bar) => (
+                  <div key={bar.group} className="flex items-center gap-2 text-sm">
+                    <span className="w-32 shrink-0 truncate text-[var(--dpf-muted)]" title={bar.group}>
+                      {bar.group}
+                    </span>
+                    <span className="dpf-summary-bar-track">
+                      <span className="dpf-summary-bar-fill" style={{ width: `${bar.pct}%` }} />
+                    </span>
+                    <span className="w-16 shrink-0 text-right tabular-nums text-[var(--dpf-text)]">
+                      {bar.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
             <div className="overflow-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -699,6 +741,7 @@ export function WorkbookGrid({
                 </tbody>
               </table>
             </div>
+            )}
           </div>
         );
       })()}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -131,3 +131,19 @@
   border-radius: 0.25rem;
   border: 1px solid var(--dpf-border);
 }
+
+/* Group-by summary chart — simple CSS bars. */
+.dpf-summary-bar-track {
+  flex: 1 1 auto;
+  block-size: 0.75rem;
+  border-radius: 9999px;
+  background-color: var(--dpf-surface-1);
+  border: 1px solid var(--dpf-border);
+  overflow: hidden;
+}
+.dpf-summary-bar-fill {
+  display: block;
+  block-size: 100%;
+  min-inline-size: 2px;
+  background-color: var(--dpf-accent);
+}

--- a/apps/web/components/workbooks/grid-summary.test.ts
+++ b/apps/web/components/workbooks/grid-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { summarize, toSummaryNumber, numericColumns } from "./grid-summary";
+import { summarize, toSummaryNumber, numericColumns, summaryChartBars } from "./grid-summary";
 import type { ColumnDefinition } from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
@@ -48,5 +48,24 @@ describe("summarize", () => {
     const empty = s.find((g) => g.group === "(empty)")!;
     // row 4 has a null amount → counted as a row, but no numeric contribution
     expect(empty).toMatchObject({ count: 1, sum: 0, avg: 0, min: 0, max: 0 });
+  });
+});
+
+describe("summaryChartBars", () => {
+  it("uses count when no value column, scaled to the max bar", () => {
+    const bars = summaryChartBars(summarize(rows, "status"), false);
+    const open = bars.find((b) => b.group === "open")!;
+    expect(open).toMatchObject({ value: 2, pct: 100 });
+    const done = bars.find((b) => b.group === "done")!;
+    expect(done).toMatchObject({ value: 1, pct: 50 });
+  });
+
+  it("uses sum when a value column is set", () => {
+    const bars = summaryChartBars(summarize(rows, "status", "amount"), true);
+    const done = bars.find((b) => b.group === "done")!; // sum 200 is the max
+    expect(done).toMatchObject({ value: 200, pct: 100 });
+    const open = bars.find((b) => b.group === "open")!; // sum 150
+    expect(open.value).toBe(150);
+    expect(open.pct).toBe(75);
   });
 });

--- a/apps/web/components/workbooks/grid-summary.ts
+++ b/apps/web/components/workbooks/grid-summary.ts
@@ -78,3 +78,24 @@ export function summarize(
   out.sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
   return out;
 }
+
+export interface SummaryBar {
+  group: string;
+  value: number;
+  /** 0–100, relative to the largest bar (for a CSS bar width). */
+  pct: number;
+}
+
+/**
+ * Turn a summary into chart bars: the bar value is the chosen metric's `sum` when
+ * a value column is set, else the group `count`. `pct` is relative to the max bar.
+ */
+export function summaryChartBars(summary: GroupSummary[], hasValueColumn: boolean): SummaryBar[] {
+  const value = (s: GroupSummary) => (hasValueColumn ? s.sum : s.count);
+  const max = summary.reduce((m, s) => Math.max(m, value(s)), 0);
+  return summary.map((s) => ({
+    group: s.group,
+    value: value(s),
+    pct: max > 0 ? Math.round((value(s) / max) * 100) : 0,
+  }));
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -165,9 +165,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   chosen column and shows count + numeric aggregates (sum/avg/min/max) of a chosen value column per
   group. Pure, unit-tested `grid-summary.ts` (`summarize`/`toSummaryNumber`). Over loaded rows; full
   pivots (multi-dimension, subtotals, %) + SQL push-down are later Phase-4 work.
+- **Slice 13 — summary chart — SHIPPED.** A Table/Chart toggle in the Summary panel renders a CSS
+  bar chart of the grouped metric (count, or the value column's sum), scaled to the largest bar.
+  Pure, unit-tested `summaryChartBars`. Richer chart types (pie/line via recharts) are a follow-up.
 - **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import; full pivots + charts/dashboards; metrics/semantic layer;
-  operationalization lifecycle.
+  calendar + gallery views; `.xlsx` import (slice 12, in flight); full pivots + richer charts;
+  metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
Adds a **Table/Chart toggle** to the group-by Summary panel: Chart renders a CSS bar chart of the grouped metric (group count, or the chosen value column's sum per group), each bar scaled to the largest. A dependency-free, SSR-safe visualization that rounds out the reporting story (summary table + chart).

> Stacked on #1783 (umbrella). Base auto-retargets to main when #1783 merges.

Bar derivation is a pure, unit-tested `summaryChartBars` (value = sum when a value column is set, else count; pct relative to max). Richer chart types (pie/line via the existing recharts dep) are a follow-up.

Gate: grid-summary vitest 6 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)