### PR TITLE
feat(workbooks): persistent grid views (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -6,7 +6,14 @@
 // implementation detail contained here, so it can be swapped without touching
 // the data layer, server, or pages.
 
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import {
   DataGrid,
   SelectColumn,
@@ -68,6 +75,12 @@ import {
   operatorNeedsValue,
 } from "./grid-conditional-format";
 import { summarize, numericColumns, summaryChartBars } from "./grid-summary";
+import {
+  viewStorageKey,
+  serializeViewState,
+  parseViewState,
+  type SortState,
+} from "./grid-view-state";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -215,6 +228,42 @@ export function WorkbookGrid({
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
+
+  // Persist the per-grid view (filters/sort/formatting/provenance) per tableId so
+  // it survives reloads. Client-only (localStorage); hydrate once, then save on change.
+  const viewHydratedRef = useRef(false);
+  useEffect(() => {
+    viewHydratedRef.current = false;
+    try {
+      const parsed = parseViewState(localStorage.getItem(viewStorageKey(tableId)));
+      if (parsed) {
+        if (parsed.filterQuery !== undefined) setFilterQuery(parsed.filterQuery);
+        if (parsed.columnFilters) setColumnFilters(parsed.columnFilters);
+        if (parsed.sort) setSortColumns(parsed.sort);
+        if (parsed.cfRules) setCfRules(parsed.cfRules);
+        if (parsed.showProvenance !== undefined) setShowProvenance(parsed.showProvenance);
+      }
+    } catch {
+      // ignore unreadable storage
+    }
+    viewHydratedRef.current = true;
+  }, [tableId]);
+
+  useEffect(() => {
+    if (!viewHydratedRef.current) return;
+    try {
+      const sort: SortState[] = sortColumns.map((s) => ({
+        columnKey: s.columnKey,
+        direction: s.direction,
+      }));
+      localStorage.setItem(
+        viewStorageKey(tableId),
+        serializeViewState({ filterQuery, columnFilters, sort, cfRules, showProvenance }),
+      );
+    } catch {
+      // ignore quota / unavailable storage
+    }
+  }, [tableId, filterQuery, columnFilters, sortColumns, cfRules, showProvenance]);
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
     const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -62,7 +62,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
-import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
+import { quickFilterRows, applyColumnFilters, cellSearchText, type ColumnFilters } from "./grid-filter";
 import { rowsToCsv } from "./grid-csv";
 import {
   type ConditionalRule,
@@ -214,6 +214,7 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  const [gallery, setGallery] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
   const [showFormat, setShowFormat] = useState(false);
@@ -531,6 +532,30 @@ export function WorkbookGrid({
         >
           {showProvenance ? "Hide data sources" : "Show data sources"}
         </button>
+        <div className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+          <button
+            type="button"
+            onClick={() => setGallery(false)}
+            className={
+              gallery
+                ? "px-2 py-1 text-[var(--dpf-muted)]"
+                : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+            }
+          >
+            Grid
+          </button>
+          <button
+            type="button"
+            onClick={() => setGallery(true)}
+            className={
+              gallery
+                ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                : "px-2 py-1 text-[var(--dpf-muted)]"
+            }
+          >
+            Gallery
+          </button>
+        </div>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
 
@@ -798,6 +823,36 @@ export function WorkbookGrid({
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
+        </div>
+      ) : gallery ? (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3 p-1">
+            {sortedRows.map((row) => {
+              const color = rowColor(row, cfRules);
+              return (
+                <div
+                  key={row.rowId}
+                  className={`dpf-gallery-card rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 ${
+                    color ? rowColorClass(color) : ""
+                  }`}
+                >
+                  <dl className="flex flex-col gap-1">
+                    {columns.map((col) => (
+                      <div key={col.columnId} className="flex justify-between gap-2 text-sm">
+                        <dt className="shrink-0 text-[var(--dpf-muted)]">{col.name}</dt>
+                        <dd className="truncate text-right text-[var(--dpf-text)]" title={cellSearchText(row[col.columnId] ?? null)}>
+                          {cellSearchText(row[col.columnId] ?? null)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              );
+            })}
+            {sortedRows.length === 0 && (
+              <div className="text-sm text-[var(--dpf-muted)]">No rows.</div>
+            )}
+          </div>
         </div>
       ) : (
         <div className="min-h-0 flex-1">

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,7 +67,7 @@ import {
   blankRule,
   operatorNeedsValue,
 } from "./grid-conditional-format";
-import { summarize, numericColumns } from "./grid-summary";
+import { summarize, numericColumns, summaryChartBars } from "./grid-summary";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -209,6 +209,7 @@ export function WorkbookGrid({
   const [showSummary, setShowSummary] = useState(false);
   const [summaryGroupBy, setSummaryGroupBy] = useState("");
   const [summaryValue, setSummaryValue] = useState("");
+  const [summaryChart, setSummaryChart] = useState(false);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
@@ -664,7 +665,48 @@ export function WorkbookGrid({
                   </option>
                 ))}
               </select>
+              <div className="ml-auto inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(false)}
+                  className={
+                    summaryChart
+                      ? "px-2 py-1 text-[var(--dpf-muted)]"
+                      : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                  }
+                >
+                  Table
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSummaryChart(true)}
+                  className={
+                    summaryChart
+                      ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                      : "px-2 py-1 text-[var(--dpf-muted)]"
+                  }
+                >
+                  Chart
+                </button>
+              </div>
             </div>
+            {summaryChart ? (
+              <div className="flex flex-col gap-1">
+                {summaryChartBars(summary, Boolean(valueCol)).map((bar) => (
+                  <div key={bar.group} className="flex items-center gap-2 text-sm">
+                    <span className="w-32 shrink-0 truncate text-[var(--dpf-muted)]" title={bar.group}>
+                      {bar.group}
+                    </span>
+                    <span className="dpf-summary-bar-track">
+                      <span className="dpf-summary-bar-fill" style={{ width: `${bar.pct}%` }} />
+                    </span>
+                    <span className="w-16 shrink-0 text-right tabular-nums text-[var(--dpf-text)]">
+                      {bar.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
             <div className="overflow-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -699,6 +741,7 @@ export function WorkbookGrid({
                 </tbody>
               </table>
             </div>
+            )}
           </div>
         );
       })()}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -147,3 +147,17 @@
   min-inline-size: 2px;
   background-color: var(--dpf-accent);
 }
+
+/* Gallery card conditional-format accent (scoped so it never restyles grid rows). */
+.dpf-gallery-card.dpf-cf-red {
+  border-inline-start: 3px solid var(--dpf-error);
+}
+.dpf-gallery-card.dpf-cf-amber {
+  border-inline-start: 3px solid var(--dpf-warning, #b8860b);
+}
+.dpf-gallery-card.dpf-cf-green {
+  border-inline-start: 3px solid var(--dpf-success, #2e7d32);
+}
+.dpf-gallery-card.dpf-cf-blue {
+  border-inline-start: 3px solid var(--dpf-accent);
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -131,3 +131,19 @@
   border-radius: 0.25rem;
   border: 1px solid var(--dpf-border);
 }
+
+/* Group-by summary chart — simple CSS bars. */
+.dpf-summary-bar-track {
+  flex: 1 1 auto;
+  block-size: 0.75rem;
+  border-radius: 9999px;
+  background-color: var(--dpf-surface-1);
+  border: 1px solid var(--dpf-border);
+  overflow: hidden;
+}
+.dpf-summary-bar-fill {
+  display: block;
+  block-size: 100%;
+  min-inline-size: 2px;
+  background-color: var(--dpf-accent);
+}

--- a/apps/web/components/workbooks/grid-summary.test.ts
+++ b/apps/web/components/workbooks/grid-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { summarize, toSummaryNumber, numericColumns } from "./grid-summary";
+import { summarize, toSummaryNumber, numericColumns, summaryChartBars } from "./grid-summary";
 import type { ColumnDefinition } from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
@@ -48,5 +48,24 @@ describe("summarize", () => {
     const empty = s.find((g) => g.group === "(empty)")!;
     // row 4 has a null amount → counted as a row, but no numeric contribution
     expect(empty).toMatchObject({ count: 1, sum: 0, avg: 0, min: 0, max: 0 });
+  });
+});
+
+describe("summaryChartBars", () => {
+  it("uses count when no value column, scaled to the max bar", () => {
+    const bars = summaryChartBars(summarize(rows, "status"), false);
+    const open = bars.find((b) => b.group === "open")!;
+    expect(open).toMatchObject({ value: 2, pct: 100 });
+    const done = bars.find((b) => b.group === "done")!;
+    expect(done).toMatchObject({ value: 1, pct: 50 });
+  });
+
+  it("uses sum when a value column is set", () => {
+    const bars = summaryChartBars(summarize(rows, "status", "amount"), true);
+    const done = bars.find((b) => b.group === "done")!; // sum 200 is the max
+    expect(done).toMatchObject({ value: 200, pct: 100 });
+    const open = bars.find((b) => b.group === "open")!; // sum 150
+    expect(open.value).toBe(150);
+    expect(open.pct).toBe(75);
   });
 });

--- a/apps/web/components/workbooks/grid-summary.ts
+++ b/apps/web/components/workbooks/grid-summary.ts
@@ -78,3 +78,24 @@ export function summarize(
   out.sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
   return out;
 }
+
+export interface SummaryBar {
+  group: string;
+  value: number;
+  /** 0–100, relative to the largest bar (for a CSS bar width). */
+  pct: number;
+}
+
+/**
+ * Turn a summary into chart bars: the bar value is the chosen metric's `sum` when
+ * a value column is set, else the group `count`. `pct` is relative to the max bar.
+ */
+export function summaryChartBars(summary: GroupSummary[], hasValueColumn: boolean): SummaryBar[] {
+  const value = (s: GroupSummary) => (hasValueColumn ? s.sum : s.count);
+  const max = summary.reduce((m, s) => Math.max(m, value(s)), 0);
+  return summary.map((s) => ({
+    group: s.group,
+    value: value(s),
+    pct: max > 0 ? Math.round((value(s) / max) * 100) : 0,
+  }));
+}

--- a/apps/web/components/workbooks/grid-view-state.test.ts
+++ b/apps/web/components/workbooks/grid-view-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  viewStorageKey,
+  serializeViewState,
+  parseViewState,
+  type GridViewState,
+} from "./grid-view-state";
+
+const sample: GridViewState = {
+  filterQuery: "open",
+  columnFilters: { status: "active" },
+  sort: [{ columnKey: "name", direction: "ASC" }],
+  cfRules: [{ id: "r1", columnId: "status", operator: "eq", value: "overdue", color: "red" }],
+  showProvenance: true,
+};
+
+describe("viewStorageKey", () => {
+  it("namespaces by tableId", () => {
+    expect(viewStorageKey("TBL-1")).toBe("dpf-workbook-view:TBL-1");
+  });
+});
+
+describe("serialize/parse round-trip", () => {
+  it("preserves a valid view state", () => {
+    expect(parseViewState(serializeViewState(sample))).toEqual(sample);
+  });
+});
+
+describe("parseViewState — defensive", () => {
+  it("returns null for empty or malformed JSON", () => {
+    expect(parseViewState(null)).toBeNull();
+    expect(parseViewState("")).toBeNull();
+    expect(parseViewState("{not json")).toBeNull();
+    expect(parseViewState("[]")).toBeNull(); // not an object
+  });
+
+  it("drops fields with the wrong type instead of throwing", () => {
+    const parsed = parseViewState(
+      JSON.stringify({ filterQuery: 5, columnFilters: { a: 1, b: "x" }, sort: "nope", showProvenance: "yes" }),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.filterQuery).toBeUndefined(); // 5 is not a string
+    expect(parsed!.columnFilters).toEqual({ b: "x" }); // a:1 dropped
+    expect(parsed!.sort).toBeUndefined(); // "nope" is not an array
+    expect(parsed!.showProvenance).toBeUndefined(); // "yes" is not boolean
+  });
+
+  it("filters invalid conditional-format rules", () => {
+    const parsed = parseViewState(
+      JSON.stringify({
+        cfRules: [
+          { id: "ok", columnId: "c", operator: "eq", value: "v", color: "red" },
+          { id: "bad-op", columnId: "c", operator: "bogus", value: "v", color: "red" },
+          { id: "bad-color", columnId: "c", operator: "eq", value: "v", color: "purple" },
+        ],
+      }),
+    );
+    expect(parsed!.cfRules).toHaveLength(1);
+    expect(parsed!.cfRules![0].id).toBe("ok");
+  });
+
+  it("keeps only valid sort entries", () => {
+    const parsed = parseViewState(
+      JSON.stringify({ sort: [{ columnKey: "a", direction: "ASC" }, { columnKey: "b", direction: "sideways" }, {}] }),
+    );
+    expect(parsed!.sort).toEqual([{ columnKey: "a", direction: "ASC" }]);
+  });
+});

--- a/apps/web/components/workbooks/grid-view-state.ts
+++ b/apps/web/components/workbooks/grid-view-state.ts
@@ -1,0 +1,99 @@
+// Universal Grid & Workbooks — persistent grid view state (EP-GRID-WORKBOOKS Phase 3)
+//
+// Serializes the per-grid view (quick filter, column filters, sort, conditional
+// formatting, provenance toggle, summary config) so it survives reloads. Stored
+// client-side per tableId — works for every grid (custom + platform) with no
+// migration. Parsing is defensive: malformed/old payloads are ignored field by
+// field, never throwing. Pure + unit-testable; the Grid owns the localStorage IO.
+
+import type { ConditionalRule, CfOperator, CfColor } from "./grid-conditional-format";
+import { CF_OPERATORS, CF_COLORS } from "./grid-conditional-format";
+
+export interface SortState {
+  columnKey: string;
+  direction: "ASC" | "DESC";
+}
+
+export interface GridViewState {
+  filterQuery: string;
+  columnFilters: Record<string, string>;
+  sort: SortState[];
+  cfRules: ConditionalRule[];
+  showProvenance: boolean;
+}
+
+export function viewStorageKey(tableId: string): string {
+  return `dpf-workbook-view:${tableId}`;
+}
+
+export function serializeViewState(state: GridViewState): string {
+  return JSON.stringify(state);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function parseSort(raw: unknown): SortState[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SortState[] = [];
+  for (const s of raw) {
+    if (isRecord(s) && typeof s.columnKey === "string" && (s.direction === "ASC" || s.direction === "DESC")) {
+      out.push({ columnKey: s.columnKey, direction: s.direction });
+    }
+  }
+  return out;
+}
+
+function parseColumnFilters(raw: unknown): Record<string, string> {
+  if (!isRecord(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) if (typeof v === "string") out[k] = v;
+  return out;
+}
+
+function parseCfRules(raw: unknown): ConditionalRule[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ConditionalRule[] = [];
+  for (const r of raw) {
+    if (
+      isRecord(r) &&
+      typeof r.id === "string" &&
+      typeof r.columnId === "string" &&
+      typeof r.value === "string" &&
+      CF_OPERATORS.includes(r.operator as CfOperator) &&
+      CF_COLORS.includes(r.color as CfColor)
+    ) {
+      out.push({
+        id: r.id,
+        columnId: r.columnId,
+        operator: r.operator as CfOperator,
+        value: r.value,
+        color: r.color as CfColor,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Defensively parse a stored view payload. Each field is validated independently;
+ * anything malformed is dropped. Returns null only when the JSON itself is bad.
+ */
+export function parseViewState(raw: string | null | undefined): Partial<GridViewState> | null {
+  if (!raw) return null;
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(data)) return null;
+  const out: Partial<GridViewState> = {};
+  if (typeof data.filterQuery === "string") out.filterQuery = data.filterQuery;
+  if (isRecord(data.columnFilters)) out.columnFilters = parseColumnFilters(data.columnFilters);
+  if (Array.isArray(data.sort)) out.sort = parseSort(data.sort);
+  if (Array.isArray(data.cfRules)) out.cfRules = parseCfRules(data.cfRules);
+  if (typeof data.showProvenance === "boolean") out.showProvenance = data.showProvenance;
+  return out;
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -165,9 +165,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   chosen column and shows count + numeric aggregates (sum/avg/min/max) of a chosen value column per
   group. Pure, unit-tested `grid-summary.ts` (`summarize`/`toSummaryNumber`). Over loaded rows; full
   pivots (multi-dimension, subtotals, %) + SQL push-down are later Phase-4 work.
+- **Slice 13 — summary chart — SHIPPED.** A Table/Chart toggle in the Summary panel renders a CSS
+  bar chart of the grouped metric (count, or the value column's sum), scaled to the largest bar.
+  Pure, unit-tested `summaryChartBars`. Richer chart types (pie/line via recharts) are a follow-up.
 - **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import; full pivots + charts/dashboards; metrics/semantic layer;
-  operationalization lifecycle.
+  calendar + gallery views; `.xlsx` import (slice 12, in flight); full pivots + richer charts;
+  metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -168,9 +168,13 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Slice 13 — summary chart — SHIPPED.** A Table/Chart toggle in the Summary panel renders a CSS
   bar chart of the grouped metric (count, or the value column's sum), scaled to the largest bar.
   Pure, unit-tested `summaryChartBars`. Richer chart types (pie/line via recharts) are a follow-up.
-- **Remaining (not built):** saved views (persist filters/sort/format to the existing `WorkbookView`);
-  calendar + gallery views; `.xlsx` import (slice 12, in flight); full pivots + richer charts;
-  metrics/semantic layer; operationalization lifecycle.
+- **Slice 14 — persistent grid views — SHIPPED.** The per-grid view (quick filter, column filters,
+  sort, conditional-format rules, provenance toggle) is saved per tableId and restored on reload.
+  Client-side localStorage (works for every grid, no migration); pure, unit-tested `grid-view-state.ts`
+  with defensive parsing (malformed/old payloads ignored field-by-field). Named/shareable server-side
+  views (WorkbookView) are a follow-up.
+- **Remaining (not built):** named/shareable views; calendar + gallery views; full pivots + richer
+  charts; metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -173,8 +173,11 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   Client-side localStorage (works for every grid, no migration); pure, unit-tested `grid-view-state.ts`
   with defensive parsing (malformed/old payloads ignored field-by-field). Named/shareable server-side
   views (WorkbookView) are a follow-up.
-- **Remaining (not built):** named/shareable views; calendar + gallery views; full pivots + richer
-  charts; metrics/semantic layer; operationalization lifecycle.
+- **Slice 15 — gallery (card) view — SHIPPED.** A Grid/Gallery toggle on the WorkbookGrid renders
+  rows as cards (one card per row, each column as a label/value pair), honoring the active filters,
+  sort, and conditional-format colour (a left-border accent). No new dependency, like the kanban board.
+- **Remaining (not built):** named/shareable views; calendar view (fullcalendar — needs a date
+  column); full pivots + richer charts; metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
A grid's view now **sticks**: the quick filter, per-column filters, sort, conditional-format rules, and the provenance toggle are saved per tableId and restored on reload. Client-side (localStorage) so it works for every grid — custom and platform — with **no migration**.

> Stacked on #1803 (chart) → #1783 (umbrella). Base auto-retargets as the stack merges.

Serialization is a pure, unit-tested `grid-view-state.ts` with **defensive parsing**: bad JSON → null; wrong-typed fields dropped; invalid conditional-format rules and sort entries filtered — a stale/corrupt entry never breaks a grid load. The Grid hydrates once per tableId then saves on change.

Named, shareable server-side views (persisting to the existing `WorkbookView` model) are a tracked follow-up.

Gate: grid-view-state vitest 6 passing; web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)