### PR TITLE
feat(workbooks): gallery (card) view (EP-GRID-WORKBOOKS Phase 3)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -62,7 +62,7 @@ import {
   commitUndo,
   commitRedo,
 } from "./grid-history";
-import { quickFilterRows, applyColumnFilters, type ColumnFilters } from "./grid-filter";
+import { quickFilterRows, applyColumnFilters, cellSearchText, type ColumnFilters } from "./grid-filter";
 import { rowsToCsv } from "./grid-csv";
 import {
   type ConditionalRule,
@@ -214,6 +214,7 @@ export function WorkbookGrid({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showProvenance, setShowProvenance] = useState(false);
+  const [gallery, setGallery] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [showFilters, setShowFilters] = useState(false);
   const [showFormat, setShowFormat] = useState(false);
@@ -531,6 +532,30 @@ export function WorkbookGrid({
         >
           {showProvenance ? "Hide data sources" : "Show data sources"}
         </button>
+        <div className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+          <button
+            type="button"
+            onClick={() => setGallery(false)}
+            className={
+              gallery
+                ? "px-2 py-1 text-[var(--dpf-muted)]"
+                : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+            }
+          >
+            Grid
+          </button>
+          <button
+            type="button"
+            onClick={() => setGallery(true)}
+            className={
+              gallery
+                ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                : "px-2 py-1 text-[var(--dpf-muted)]"
+            }
+          >
+            Gallery
+          </button>
+        </div>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>
 
@@ -798,6 +823,36 @@ export function WorkbookGrid({
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
+        </div>
+      ) : gallery ? (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3 p-1">
+            {sortedRows.map((row) => {
+              const color = rowColor(row, cfRules);
+              return (
+                <div
+                  key={row.rowId}
+                  className={`dpf-gallery-card rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 ${
+                    color ? rowColorClass(color) : ""
+                  }`}
+                >
+                  <dl className="flex flex-col gap-1">
+                    {columns.map((col) => (
+                      <div key={col.columnId} className="flex justify-between gap-2 text-sm">
+                        <dt className="shrink-0 text-[var(--dpf-muted)]">{col.name}</dt>
+                        <dd className="truncate text-right text-[var(--dpf-text)]" title={cellSearchText(row[col.columnId] ?? null)}>
+                          {cellSearchText(row[col.columnId] ?? null)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              );
+            })}
+            {sortedRows.length === 0 && (
+              <div className="text-sm text-[var(--dpf-muted)]">No rows.</div>
+            )}
+          </div>
         </div>
       ) : (
         <div className="min-h-0 flex-1">

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -147,3 +147,17 @@
   min-inline-size: 2px;
   background-color: var(--dpf-accent);
 }
+
+/* Gallery card conditional-format accent (scoped so it never restyles grid rows). */
+.dpf-gallery-card.dpf-cf-red {
+  border-inline-start: 3px solid var(--dpf-error);
+}
+.dpf-gallery-card.dpf-cf-amber {
+  border-inline-start: 3px solid var(--dpf-warning, #b8860b);
+}
+.dpf-gallery-card.dpf-cf-green {
+  border-inline-start: 3px solid var(--dpf-success, #2e7d32);
+}
+.dpf-gallery-card.dpf-cf-blue {
+  border-inline-start: 3px solid var(--dpf-accent);
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -173,8 +173,11 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   Client-side localStorage (works for every grid, no migration); pure, unit-tested `grid-view-state.ts`
   with defensive parsing (malformed/old payloads ignored field-by-field). Named/shareable server-side
   views (WorkbookView) are a follow-up.
-- **Remaining (not built):** named/shareable views; calendar + gallery views; full pivots + richer
-  charts; metrics/semantic layer; operationalization lifecycle.
+- **Slice 15 — gallery (card) view — SHIPPED.** A Grid/Gallery toggle on the WorkbookGrid renders
+  rows as cards (one card per row, each column as a label/value pair), honoring the active filters,
+  sort, and conditional-format colour (a left-border accent). No new dependency, like the kanban board.
+- **Remaining (not built):** named/shareable views; calendar view (fullcalendar — needs a date
+  column); full pivots + richer charts; metrics/semantic layer; operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 


### PR DESCRIPTION
A **Grid/Gallery toggle** on the WorkbookGrid renders rows as cards — one card per row, each column shown as a label/value pair — honoring the active quick filter, per-column filters, sort, and conditional-format colour (a card left-border accent, scoped so it never restyles grid rows). No new dependency, consistent with the kanban board view.

> Stacked on #1804 (persistent views) → #1803 → #1783. Base auto-retargets as the stack merges.

Gate: workbooks vitest 138 passing (regression); web typecheck + production build green. Presentational view — covered by build/typecheck like the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)