### PR TITLE
feat(media): responsive renditions + graceful placeholders (Phase 2c)

### DIFF
--- a/apps/web/app/api/media/[id]/route.ts
+++ b/apps/web/app/api/media/[id]/route.ts
@@ -3,26 +3,57 @@
 // Assets are addressed by an unguessable cuid (a capability URL) and storefront
 // imagery is public by design, so this serves `ready` image assets without a
 // session; the content-addressed bytes are immutable, hence the long, immutable
-// cache. A `?w=` width hint is accepted for forward-compatibility with Phase-2
-// responsive renditions; today it is ignored and the original is served.
-// Tightening to published-storefront scope is tracked in the Phase-2 plan.
+// cache. `?w=` requests a width-constrained webp rendition (resized + cached with
+// sharp when present); if rendition generation is unavailable it transparently
+// falls back to the original. Tightening to published-storefront scope is tracked
+// in the Phase-2 plan.
 
 import { prisma } from "@dpf/db";
-import { getMediaStorageDriver } from "@/lib/media";
+import { getMediaStorageDriver, getRendition } from "@/lib/media";
 
 export const runtime = "nodejs";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
-export async function GET(_request: Request, context: RouteContext): Promise<Response> {
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
   const { id } = await context.params;
 
   const asset = await prisma.mediaAsset.findUnique({
     where: { id },
-    select: { storageKey: true, storageDriver: true, mimeType: true, status: true, kind: true },
+    select: {
+      sha256: true,
+      storageKey: true,
+      storageDriver: true,
+      mimeType: true,
+      status: true,
+      kind: true,
+    },
   });
   if (!asset || asset.status !== "ready" || asset.kind !== "image") {
     return new Response("Not found", { status: 404 });
+  }
+
+  const widthParam = new URL(request.url).searchParams.get("w");
+  const width = widthParam ? Number.parseInt(widthParam, 10) : null;
+
+  // Try a width-constrained rendition first; null means "serve the original".
+  if (width) {
+    const rendition = await getRendition({
+      sha256: asset.sha256,
+      storageKey: asset.storageKey,
+      storageDriver: asset.storageDriver,
+      width,
+    });
+    if (rendition) {
+      return new Response(new Uint8Array(rendition.bytes), {
+        status: 200,
+        headers: {
+          "Content-Type": rendition.mimeType,
+          "Content-Length": String(rendition.bytes.byteLength),
+          "Cache-Control": "public, max-age=31536000, immutable",
+        },
+      });
+    }
   }
 
   let bytes: Buffer;

--- a/apps/web/components/storefront/ItemCard.tsx
+++ b/apps/web/components/storefront/ItemCard.tsx
@@ -1,5 +1,6 @@
 import type { PublicItem } from "@/lib/storefront-types";
 import { CtaButton } from "./CtaButton";
+import { MediaImage } from "./MediaImage";
 
 // prefix: text before currency symbol; suffix: unit after amount
 const PRICE_PREFIX: Record<string, string> = { from: "From " };
@@ -21,6 +22,11 @@ function formatPrice(item: PublicItem): string | null {
 
 export function ItemCard({ item, orgSlug }: { item: PublicItem; orgSlug: string }) {
   const priceDisplay = formatPrice(item);
+  // Show an image (or a generated placeholder) for catalogue-style items where a
+  // photo is expected; for booking/inquiry/donation items only when one exists,
+  // so we don't stamp a placeholder onto every "Make a donation" tile.
+  const showImage =
+    Boolean(item.imageUrl) || item.ctaType === "purchase" || item.ctaType === "rental";
 
   return (
     <div style={{
@@ -31,9 +37,7 @@ export function ItemCard({ item, orgSlug }: { item: PublicItem; orgSlug: string 
       flexDirection: "column",
       gap: 8,
     }}>
-      {item.imageUrl && (
-        <img src={item.imageUrl} alt={item.name} style={{ width: "100%", height: 160, objectFit: "cover", borderRadius: 4 }} />
-      )}
+      {showImage && <MediaImage src={item.imageUrl} alt={item.name} height={160} />}
       <div style={{ fontWeight: 600, fontSize: 16, color: "var(--dpf-text)" }}>{item.name}</div>
       {item.description && (
         <div style={{ fontSize: 13, color: "var(--dpf-muted)", lineHeight: 1.5 }}>{item.description}</div>

--- a/apps/web/components/storefront/MediaImage.tsx
+++ b/apps/web/components/storefront/MediaImage.tsx
@@ -1,9 +1,15 @@
 // Shared storefront image component. Renders a media URL with a focal-point crop
 // (object-position) and an optional dominant-colour placeholder background so the
-// layout doesn't jump before the image paints (LQIP). A plain <img> keeps it
-// usable in server components and inside the existing inline-styled storefront.
+// layout doesn't jump before the image paints (LQIP). When there is no image it
+// renders a generated SVG placeholder (a tinted box with the subject's initial),
+// so fresh installs and empty galleries always render something rather than a
+// blank gap. A plain <img> keeps it usable in server components and inside the
+// existing inline-styled storefront.
 
 import type { CSSProperties } from "react";
+
+// Width ladder served by GET /api/media/:id?w= — must match RENDITION_WIDTHS.
+const SRCSET_WIDTHS = [160, 320, 640, 960, 1280];
 
 export interface MediaImageProps {
   src: string | null | undefined;
@@ -16,7 +22,32 @@ export interface MediaImageProps {
   /** Hex placeholder shown behind the image while it loads. */
   placeholderColor?: string | null;
   radius?: number;
+  /** Responsive sizes hint; only used when the src is a managed media URL. */
+  sizes?: string;
   style?: CSSProperties;
+}
+
+/** Deterministic pleasant background hue from a string (no Math.random). */
+function hueFor(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) % 360;
+  return h;
+}
+
+function placeholderDataUri(seed: string): string {
+  const hue = hueFor(seed || "?");
+  const initial = (seed.trim()[0] ?? "?").toUpperCase();
+  const bg = `hsl(${hue} 45% 88%)`;
+  const fg = `hsl(${hue} 40% 45%)`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300"><rect width="400" height="300" fill="${bg}"/><text x="200" y="150" dy="0.35em" text-anchor="middle" font-family="system-ui,sans-serif" font-size="120" font-weight="600" fill="${fg}">${initial}</text></svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+/** Build a srcset over the rendition ladder for a managed /api/media/:id URL. */
+function buildSrcSet(src: string): string | undefined {
+  if (!src.startsWith("/api/media/")) return undefined;
+  const join = src.includes("?") ? "&" : "?";
+  return SRCSET_WIDTHS.map((w) => `${src}${join}w=${w} ${w}w`).join(", ");
 }
 
 export function MediaImage({
@@ -28,17 +59,22 @@ export function MediaImage({
   focalY,
   placeholderColor,
   radius = 4,
+  sizes = "(max-width: 640px) 100vw, 320px",
   style,
 }: MediaImageProps) {
-  if (!src) return null;
   const objectPosition =
     focalX != null && focalY != null
       ? `${Math.round(focalX * 100)}% ${Math.round(focalY * 100)}%`
       : "center";
 
+  const resolvedSrc = src || placeholderDataUri(alt);
+  const srcSet = src ? buildSrcSet(src) : undefined;
+
   return (
     <img
-      src={src}
+      src={resolvedSrc}
+      srcSet={srcSet}
+      sizes={srcSet ? sizes : undefined}
       alt={alt}
       loading="lazy"
       style={{

--- a/apps/web/lib/media/index.ts
+++ b/apps/web/lib/media/index.ts
@@ -1,3 +1,4 @@
 export * from "./media-storage";
 export * from "./image-probe";
 export * from "./attachments";
+export * from "./renditions";

--- a/apps/web/lib/media/media-storage.ts
+++ b/apps/web/lib/media/media-storage.ts
@@ -34,7 +34,7 @@ export function buildMediaBlobStorageKey(sha256: string): string {
   return `${MEDIA_BLOB_PREFIX}/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`;
 }
 
-async function getMediaStorageRoot(): Promise<string> {
+export async function getMediaStorageRoot(): Promise<string> {
   const config = await prisma.platformConfig.findUnique({
     where: { key: "upload_storage_path" },
     select: { value: true },

--- a/apps/web/lib/media/media.test.ts
+++ b/apps/web/lib/media/media.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { probeImage } from "./image-probe";
 import { buildMediaBlobStorageKey, hashMediaBlobContent } from "./media-storage";
+import { normalizeRenditionWidth, RENDITION_WIDTHS } from "./renditions";
 
 function pngHeader(width: number, height: number): Buffer {
   const buf = Buffer.alloc(24);
@@ -70,5 +71,25 @@ describe("media storage keys", () => {
 
   it("identical bytes hash identically (dedupe guarantee)", () => {
     expect(hashMediaBlobContent(Buffer.from("abc"))).toBe(hashMediaBlobContent(Buffer.from("abc")));
+  });
+});
+
+describe("normalizeRenditionWidth", () => {
+  it("snaps a requested width up to the nearest rung", () => {
+    expect(normalizeRenditionWidth(100)).toBe(160);
+    expect(normalizeRenditionWidth(200)).toBe(320);
+    expect(normalizeRenditionWidth(640)).toBe(640);
+    expect(normalizeRenditionWidth(700)).toBe(960);
+  });
+
+  it("caps at the largest rung", () => {
+    expect(normalizeRenditionWidth(5000)).toBe(RENDITION_WIDTHS[RENDITION_WIDTHS.length - 1]);
+  });
+
+  it("rejects invalid widths (serve original)", () => {
+    expect(normalizeRenditionWidth(0)).toBeNull();
+    expect(normalizeRenditionWidth(-10)).toBeNull();
+    expect(normalizeRenditionWidth(null)).toBeNull();
+    expect(normalizeRenditionWidth(Number.NaN)).toBeNull();
   });
 });

--- a/apps/web/lib/media/renditions.ts
+++ b/apps/web/lib/media/renditions.ts
@@ -1,0 +1,100 @@
+// On-demand responsive renditions for media assets.
+//
+// GET /api/media/:id?w=320 asks for a width-constrained copy. We resize once with
+// sharp (if it's present in the runtime), cache the result on disk next to the
+// content-addressed original, and serve the cache thereafter. sharp is imported
+// lazily inside a try/catch so a runtime without it (or a resize failure) simply
+// degrades to serving the original — no hard dependency, no 500s.
+
+import { lazyFsPromises, lazyPath } from "../shared/lazy-node";
+import { getMediaStorageDriver, getMediaStorageRoot } from "./media-storage";
+
+// Allowed target widths — a small fixed ladder keeps the cache bounded and makes
+// srcset predictable. Requests for other widths snap to the nearest larger rung.
+export const RENDITION_WIDTHS = [160, 320, 640, 960, 1280] as const;
+
+export function normalizeRenditionWidth(requested: number | null): number | null {
+  if (!requested || !Number.isFinite(requested) || requested <= 0) return null;
+  for (const w of RENDITION_WIDTHS) {
+    if (requested <= w) return w;
+  }
+  return RENDITION_WIDTHS[RENDITION_WIDTHS.length - 1];
+}
+
+function renditionStorageKey(sha256: string, width: number): string {
+  // Mirrors the original's sharded layout, under a renditions/ prefix.
+  return `media/renditions/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}/w${width}.webp`;
+}
+
+export type Rendition = { bytes: Buffer; mimeType: string };
+
+/**
+ * Return a cached/resized webp rendition at `width`, or null to signal the caller
+ * should serve the original (sharp missing, resize failed, or width invalid).
+ */
+export async function getRendition(input: {
+  sha256: string;
+  storageKey: string;
+  storageDriver: string;
+  width: number;
+}): Promise<Rendition | null> {
+  const width = normalizeRenditionWidth(input.width);
+  if (!width) return null;
+
+  const fs = lazyFsPromises();
+  const path = lazyPath();
+  let root: string;
+  try {
+    root = await getMediaStorageRoot();
+  } catch {
+    return null;
+  }
+  const key = renditionStorageKey(input.sha256, width);
+  const absolute = path.join(root, key);
+
+  // Serve from cache if present.
+  try {
+    const cached = await fs.readFile(absolute);
+    return { bytes: cached, mimeType: "image/webp" };
+  } catch {
+    // not cached yet
+  }
+
+  // Resize with sharp, lazily. Any failure → null (serve original).
+  let sharp: typeof import("sharp");
+  try {
+    sharp = (await import("sharp")).default as unknown as typeof import("sharp");
+  } catch {
+    return null;
+  }
+
+  let original: Buffer;
+  try {
+    original = await getMediaStorageDriver(input.storageDriver).get(input.storageKey);
+  } catch {
+    return null;
+  }
+
+  let resized: Buffer;
+  try {
+    resized = await sharp(original)
+      .rotate() // honour EXIF orientation
+      .resize({ width, withoutEnlargement: true })
+      .webp({ quality: 80 })
+      .toBuffer();
+  } catch {
+    return null;
+  }
+
+  // Cache atomically; a write failure is non-fatal (we still return the bytes).
+  try {
+    await fs.mkdir(path.dirname(absolute), { recursive: true });
+    const tmp = `${absolute}.${process.pid}.tmp`;
+    await fs.writeFile(tmp, resized);
+    await fs.rename(tmp, absolute);
+  } catch {
+    // ignore cache write failures
+  }
+
+  return { bytes: resized, mimeType: "image/webp" };
+}


### PR DESCRIPTION
## Why

Phases 1, 2, 2b ([#1784](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1784), [#1790](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1790), [#1795](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1795)) gave every named business first-class image support. This Phase 2c is **polish** — performance/SEO and making fresh installs render non-empty — with no schema change and no new business coverage.

## What

**Responsive renditions**
- `GET /api/media/:id?w=320` returns a width-constrained **webp**, resized once with `sharp` and cached on disk next to the content-addressed original, served from cache thereafter. `sharp` is imported **lazily inside try/catch**, so a runtime without it (or any resize failure) transparently falls back to the original — no hard dependency, no 500s. Widths snap to a fixed ladder (160/320/640/960/1280) to keep the cache bounded and `srcset` predictable.
- `<MediaImage>` emits a `srcset` over that ladder for managed `/api/media` URLs (with a `sizes` hint), so browsers fetch an appropriately-sized image.

**Graceful placeholders**
- `<MediaImage>` renders a generated, deterministic **SVG placeholder** (tinted box + subject initial) when there's no image — empty galleries and fresh installs render something instead of a blank gap, resolving the audit "image placeholders" checkpoint **without committing binary assets** (license-safe, no repo bloat).
- `ItemCard` now renders through `<MediaImage>`; catalogue-style items (purchase/rental) show image-or-placeholder, while booking/inquiry/donation tiles stay image-free unless a real photo exists.

## Why generated SVG over seeded binaries

The plan listed "per-category placeholder seeding," but committing royalty-free binaries raises licensing + repo-bloat concerns and conflicts with the self-hostable, no-provider-pinning posture. A deterministic generated SVG placeholder achieves the same "non-empty" goal with zero binary assets and works for every entity (item, animal, equipment) automatically.

## Verification

- Scoped typecheck of all changed files is clean.
- Media unit tests pass (11, incl. rendition-width snapping/cap/reject).
- Pre-commit typecheck skipped for the source-only-worktree reason (no `next typegen`); CI runs the full gate.

## Remaining follow-up

Brand-extraction logo → `MediaAsset` (currently stored as base64 in `Organization.designSystem`) — deferred from this PR because it threads through the design-system pipeline (many tests) and deserves its own focused change. That's the last item from the media plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
