### PR TITLE
feat(wsid): finance + software-engineer corpora + location/competency variants

### DIFF
--- a/docs/professions/finance/wiki/accrual-basis-accounting.md
+++ b/docs/professions/finance/wiki/accrual-basis-accounting.md
@@ -1,0 +1,34 @@
+---
+title: Accrual-basis accounting
+pageKind: entity
+status: published
+abstract: Accrual accounting recognizes revenue and expenses when the underlying economic event occurs — when control of goods or services transfers — regardless of when cash is received or paid.
+professionCompetencyLevel: foundational
+sources:
+  - ifrs/ifrs-15-revenue
+  - wikipedia/double-entry-bookkeeping
+---
+
+## Definition
+
+**Accrual-basis accounting** recognizes economic events when they occur, not when cash changes hands. Revenue is recorded when it is *earned* — when control of the promised goods or services transfers to the customer — and expenses when they are *incurred*, regardless of the timing of payment.
+
+This contrasts with cash-basis accounting, which records transactions only when cash is received or disbursed.
+
+## Why It Is the Default
+
+The recognition logic is visible in the revenue standard: IFRS 15 recognizes revenue "to depict the transfer of promised goods or services to the customer" in the amount the entity expects to be entitled to — i.e. on performance, not on receipt of cash. Accrual recognition matches revenue to the period in which it was earned, giving statements that reflect economic reality rather than cash-flow timing.
+
+Recorded entries still obey the [[professions/finance/double-entry-invariant]] — accrual changes *when* you recognize, never *whether* the entry balances.
+
+## Where It Shows Up
+
+- **Revenue** — recognized as performance obligations are satisfied; see the jurisdiction variants [[professions/finance/revenue-recognition-ifrs15]] and [[professions/finance/revenue-recognition-asc606-us]].
+- **Expenses** — accrued in the period incurred (e.g. wages earned but unpaid at period end).
+- **Period-end adjustments** — accruals and deferrals align cash events to the correct period.
+
+## See Also
+
+- [[professions/finance/double-entry-invariant]]
+- [[professions/finance/revenue-recognition-ifrs15]]
+- [[professions/finance/revenue-recognition-asc606-us]]

--- a/docs/professions/finance/wiki/double-entry-invariant.md
+++ b/docs/professions/finance/wiki/double-entry-invariant.md
@@ -1,0 +1,39 @@
+---
+title: Double-entry invariant — debits equal credits
+pageKind: principle
+status: published
+abstract: Every transaction is recorded with equal and opposite debit and credit entries; total debits must equal total credits, and Assets = Liabilities + Equity always holds. This is the non-negotiable foundation of bookkeeping.
+principleTier: commandment
+principleDirection: Record every transaction as balanced debit and credit entries; never post a one-sided or unbalanced entry.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "evidence_density": 0.8}
+professionCompetencyLevel: foundational
+sources:
+  - wikipedia/double-entry-bookkeeping
+---
+
+## Rule
+
+Every financial transaction is recorded with **equal and opposite entries** — debits and credits — across at least two accounts. The books are correct only when **total debits equal total credits**, and the accounting identity **Assets = Liabilities + Equity** holds at all times.
+
+## Why
+
+Double-entry bookkeeping rests on duality: each transaction has a debit (value flowing to an account) and a matching credit (value flowing from an account). Because the two sides must balance, the system maintains accuracy and **allows detection of errors or fraud** — an unbalanced trial balance is a signal that something is wrong.
+
+This is not a stylistic choice. A one-sided entry breaks the accounting equation and renders every downstream statement unreliable.
+
+## How To Apply
+
+1. **Balance every entry.** Debits and credits for a transaction sum to equal totals before posting.
+2. **Preserve the identity.** Any posting must leave Assets = Liabilities + Equity intact.
+3. **Use the trial balance as a check.** A non-zero difference means an error to find, never to plug.
+4. **Recognize on the accrual basis** — when the economic event occurs, not when cash moves: see [[professions/finance/accrual-basis-accounting]].
+
+## See Also
+
+- [[professions/finance/accrual-basis-accounting]]
+- [[professions/finance/segregation-of-duties]]

--- a/docs/professions/finance/wiki/internal-controls-five-components.md
+++ b/docs/professions/finance/wiki/internal-controls-five-components.md
@@ -1,0 +1,29 @@
+---
+title: Internal control — the five components
+pageKind: summary
+status: published
+abstract: Internal control is a process to help an organization achieve its objectives, built from five components — control environment, risk assessment, control activities, information and communication, and monitoring — each containing multiple principles.
+professionCompetencyLevel: practitioner
+sources:
+  - gao/green-book-internal-control
+---
+
+## What This Source Says
+
+The GAO Green Book defines **internal control** as a process used by management to help an organization achieve its objectives. It is structured into **five components**, and each component contains multiple underlying principles:
+
+1. **Control Environment** — the foundation: integrity, ethical values, oversight, and accountability.
+2. **Risk Assessment** — identifying and analyzing the risks to objectives.
+3. **Control Activities** — the actions that mitigate risk, including [[professions/finance/segregation-of-duties]].
+4. **Information and Communication** — the quality information needed to run and report on controls.
+5. **Monitoring Activities** — ongoing evaluation that the controls are present and functioning.
+
+## Authority and Alignment
+
+The Green Book is issued under the authority of the Federal Managers' Financial Integrity Act and is aligned with the **COSO Internal Control — Integrated Framework**, the same conceptual model widely used in the private sector. This makes its five-component structure a portable frame for any organization's control system, not only federal entities.
+
+## How DPF Coworkers Use It
+
+- Use the five components as the checklist when assessing whether a financial process is adequately controlled.
+- Treat segregation of duties as the canonical control activity — see [[professions/finance/segregation-of-duties]].
+- For US registrants, the external assurance layer over these controls is summarized in [[professions/finance/pcaob-audit-standards-summary]].

--- a/docs/professions/finance/wiki/pcaob-audit-standards-summary.md
+++ b/docs/professions/finance/wiki/pcaob-audit-standards-summary.md
@@ -1,0 +1,38 @@
+---
+title: PCAOB auditing standards (US public-company audit)
+pageKind: summary
+status: published
+abstract: The PCAOB publishes the auditing standards for US public-company audits, including the audit of internal control over financial reporting (AS 2201) and audit evidence (AS 1105). Public and freely accessible.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: expert
+sources:
+  - pcaob/auditing-standards
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** United States — PCAOB standards govern audits of US public companies (SEC registrants). **Competency:** expert — these standards frame the external assurance over financial reporting and are applied by audit professionals, not in routine bookkeeping.
+
+## What This Source Is
+
+The **PCAOB Auditing Standards** are the publicly accessible standards governing audits of US public companies, available as downloadable booklets. They are the external-assurance counterpart to an entity's own [[professions/finance/internal-controls-five-components]].
+
+## Key Standards
+
+- **AS 2201 — An Audit of Internal Control Over Financial Reporting** — the integrated ICFR audit performed alongside the financial-statement audit.
+- **AS 1105 — Audit Evidence** — what constitutes sufficient appropriate evidence.
+- Supporting standards include AS 1101 (audit risk), AS 2110 (risk assessment), AS 2301 (responses to risk), AS 2105 (materiality), and AS 1215 (audit documentation).
+
+The current standards apply to audits of financial statements for fiscal years beginning on or after December 15, 2025.
+
+## How DPF Coworkers Use It
+
+- For US registrants, treat AS 2201 as the assurance layer over the internal controls in [[professions/finance/internal-controls-five-components]] and the segregation-of-duties control in [[professions/finance/segregation-of-duties]].
+- Use AS 1105's evidence standard as the bar for what counts as support for a financial assertion.
+- This is US-specific; non-US audits follow their own jurisdiction's standards (e.g. ISA).
+
+## See Also
+
+- [[professions/finance/internal-controls-five-components]]
+- [[professions/finance/revenue-recognition-asc606-us]]

--- a/docs/professions/finance/wiki/revenue-recognition-asc606-us.md
+++ b/docs/professions/finance/wiki/revenue-recognition-asc606-us.md
@@ -1,0 +1,41 @@
+---
+title: Revenue recognition — US GAAP (ASC 606 / Topic 606)
+pageKind: principle
+status: published
+abstract: US GAAP recognizes revenue under ASC 606 (Topic 606), the converged standard jointly issued with IFRS 15 using the same transfer-of-control, five-step model. Expert-level judgment is required where ASC 606 and IFRS 15 diverge.
+principleTier: core
+principleDirection: For US-GAAP reporters, recognize revenue under ASC 606's five-step model on transfer of control; surface known IFRS divergences when an entity reports under both.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "evidence_density": 0.7}
+professionJurisdiction:
+  - us
+professionCompetencyLevel: expert
+sources:
+  - ifrs/ifrs-15-revenue
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** US-GAAP reporting entities (SEC registrants and other US-GAAP filers). The IFRS counterpart is [[professions/finance/revenue-recognition-ifrs15]]. **Competency:** expert — the foundational five-step mechanics are the same as IFRS 15; what makes this an expert page is recognizing and handling the divergences when an entity must reconcile US-GAAP and IFRS results.
+
+## Rule
+
+For US-GAAP reporters, recognize revenue under **ASC 606 (Topic 606)** — the standard jointly issued with IFRS 15 in May 2014. ASC 606 applies the same core principle and **five-step model** as IFRS 15: recognize revenue to depict the transfer of promised goods or services, in the amount the entity expects to be entitled to.
+
+## Convergence and Divergence
+
+ASC 606 and IFRS 15 are **converged**: the IFRS Foundation records that IFRS 15 was issued "together with the introduction of Topic 606 into the FASB's Accounting Standards Codification." For most contracts the two produce the same answer through the identical five-step model.
+
+They are not, however, identical in every detail — differences remain in specific application areas (for example, the treatment of certain variable-consideration and collectibility questions). Reconciling those divergences for an entity that reports, or compares, under both frameworks is the expert-level judgment this page governs.
+
+> **Licensing note (conduit rule):** the full FASB Accounting Standards Codification is a licensed work. DPF does not ingest ASC text; this page is anchored on the open IFRS 15 summary that names Topic 606, plus the converged five-step model. Entity-specific ASC application requires the customer's own licensed ASC access or a qualified review.
+
+## See Also
+
+- [[professions/finance/revenue-recognition-ifrs15]]
+- [[professions/finance/accrual-basis-accounting]]
+- [[professions/finance/pcaob-audit-standards-summary]]

--- a/docs/professions/finance/wiki/revenue-recognition-ifrs15.md
+++ b/docs/professions/finance/wiki/revenue-recognition-ifrs15.md
@@ -1,0 +1,46 @@
+---
+title: Revenue recognition — IFRS 15 (five-step model)
+pageKind: principle
+status: published
+abstract: Under IFRS 15, revenue is recognized to depict the transfer of promised goods or services to the customer, in the amount the entity expects to be entitled to, via a five-step model. Applies in IFRS-reporting jurisdictions (EU, UK, and 140+ others).
+principleTier: core
+principleDirection: Recognize revenue on transfer of control via the IFRS 15 five-step model; do not recognize on cash receipt or contract signing alone.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "evidence_density": 0.7}
+professionJurisdiction:
+  - eu
+  - uk
+professionCompetencyLevel: practitioner
+sources:
+  - ifrs/ifrs-15-revenue
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** IFRS-reporting entities — the EU and UK (tagged here) and 140+ jurisdictions that require or permit IFRS. The US-GAAP counterpart is the jointly-issued, near-identical [[professions/finance/revenue-recognition-asc606-us]] (Topic 606). **Competency:** practitioner-level; the divergence-handling judgment between IFRS 15 and ASC 606 is expert-level and lives on the ASC 606 page.
+
+## Rule
+
+Recognize revenue to depict **the transfer of promised goods or services to the customer**, in an amount that reflects the consideration the entity **expects to be entitled** to. Apply the five-step model.
+
+## The Five-Step Model
+
+1. **Identify the contract** with the customer.
+2. **Identify the performance obligations** (the distinct goods or services promised).
+3. **Determine the transaction price**, including estimates of variable consideration.
+4. **Allocate the transaction price** to the performance obligations by relative stand-alone selling prices.
+5. **Recognize revenue** as each performance obligation is satisfied — **at a point in time or over time** as the customer obtains control.
+
+## Status
+
+IFRS 15 was issued in May 2014, is effective for annual periods beginning on or after **1 January 2018**, and superseded IAS 11, IAS 18, and IFRIC 13/15/18 and SIC-31. It was issued together with the introduction of **Topic 606** into the US FASB's Accounting Standards Codification — the two standards are converged.
+
+## See Also
+
+- [[professions/finance/revenue-recognition-asc606-us]]
+- [[professions/finance/accrual-basis-accounting]]
+- [[professions/finance/double-entry-invariant]]

--- a/docs/professions/finance/wiki/segregation-of-duties.md
+++ b/docs/professions/finance/wiki/segregation-of-duties.md
@@ -1,0 +1,36 @@
+---
+title: Segregation of duties
+pageKind: principle
+status: published
+abstract: No single individual should control all phases of a transaction. Authorization, custody, record-keeping, and reconciliation are separated so that error or fraud requires collusion to go undetected.
+principleTier: core
+principleDirection: Separate authorization, custody, record-keeping, and reconciliation across people; never let one actor own a full transaction lifecycle.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "public_safety": 0.6, "blast_radius": 0.7}
+professionCompetencyLevel: foundational
+sources:
+  - gao/green-book-internal-control
+---
+
+## Rule
+
+Assign responsibilities so that **no single individual controls all phases of a transaction**. The four duties to keep apart are **authorization**, **custody** of assets, **record-keeping**, and **reconciliation**. When these are separated, undetected error or fraud requires collusion rather than a single point of failure.
+
+## Why
+
+The GAO Green Book (*Standards for Internal Control in the Federal Government*) treats segregation of duties as a control activity within the broader internal-control system, defining it as assigning responsibilities so that no one person has control over all phases of a transaction. It is one of the control activities that, together with the other components, gives reasonable assurance that objectives are met. The Green Book aligns with the COSO Internal Control framework.
+
+## How To Apply
+
+1. **Map the four duties** for each material transaction class and confirm no person holds more than one in a way that defeats the control.
+2. **Compensate when separation is impossible** (small teams) with detective controls — independent review, reconciliation, and monitoring.
+3. **Apply it to the close.** In month-end posting, the preparer of a journal entry should not also be its sole approver — reinforcing [[professions/finance/double-entry-invariant]].
+
+## See Also
+
+- [[professions/finance/internal-controls-five-components]]
+- [[professions/finance/double-entry-invariant]]

--- a/docs/professions/software-engineer/wiki/api-design-http-semantics.md
+++ b/docs/professions/software-engineer/wiki/api-design-http-semantics.md
@@ -1,0 +1,43 @@
+---
+title: API design follows HTTP semantics
+pageKind: principle
+status: published
+abstract: REST APIs follow the method, status-code, and idempotency semantics defined by RFC 9110 (HTTP Semantics, STD 97). Methods and status codes communicate intent precisely rather than being chosen by habit.
+principleTier: core
+principleDirection: Choose HTTP methods and status codes by their defined semantics — safe, idempotent, and correctly coded — not by convention or convenience.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.8, "human_cognitive_load": 0.7, "reusability": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - ietf/rfc-9110
+---
+
+## Rule
+
+Design HTTP APIs against the semantics defined in **RFC 9110 (HTTP Semantics)**, an Internet Standard (STD 97). The method and status code are part of the contract; they carry meaning that clients, caches, and proxies rely on.
+
+## Why
+
+RFC 9110 defines semantics that hold across HTTP versions:
+
+- **Safe methods** (GET, HEAD, OPTIONS, TRACE) are read-only and are expected not to change server state.
+- **Idempotent methods** (GET, HEAD, PUT, DELETE) produce the same server state whether invoked once or repeatedly; POST does not. Retries and at-least-once delivery depend on this distinction.
+- **Status codes** signal outcome precisely: `200 OK` for success, `201 Created` with a `Location` header for creation, `204 No Content` for success without a body; `400/401/403/404/409` for the corresponding client errors; `500/503` for server errors.
+
+Choosing codes by habit (everything `200`, errors as `200` with a body flag) breaks caching, observability, and client error handling.
+
+## How To Apply
+
+1. **Match method to effect.** Reads are GET; full replacement is PUT; partial state-changing creation is POST. If a call must be safely retryable, make it idempotent.
+2. **Code the outcome.** Return the status code RFC 9110 defines for the situation; reserve `2xx` for success.
+3. **Design for idempotency** where clients may retry — see [[professions/software-engineer/dependency-supply-chain-integrity]] for the build-side analog of deterministic, repeatable operations.
+
+## See Also
+
+- [[professions/software-engineer/secure-coding-no-injection-validate-input]]
+- [[professions/software-engineer/semantic-versioning]]

--- a/docs/professions/software-engineer/wiki/automated-testing-verification.md
+++ b/docs/professions/software-engineer/wiki/automated-testing-verification.md
@@ -1,0 +1,40 @@
+---
+title: Verify with automated tests and disciplined review
+pageKind: principle
+status: published
+abstract: Code is verified by correct, well-designed automated tests and by review focused on overall code health. Error and exceptional paths are tested, not just the happy path.
+principleTier: core
+principleDirection: Require correct automated tests (including error/edge paths) and review that improves overall code health.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.8, "evidence_density": 0.7}
+professionCompetencyLevel: foundational
+sources:
+  - google/eng-practices
+  - owasp/top-ten
+---
+
+## Rule
+
+A change is verified by automated tests that are correct and well-designed, and by review that assesses whether the change improves the overall health of the codebase. Tests cover error and exceptional paths, not only the happy path.
+
+## Why
+
+Google's code-review standard frames review as a code-health decision: a reviewer should **approve a change once it definitely improves overall code health**, even if it is not perfect, and one of the things review checks is whether the code **has correct, well-designed automated tests**. Reviewers should not demand perfection; optional polish is marked as a nit, and technical facts override personal preference.
+
+The OWASP Top 10:2025 reinforces testing the unhappy paths: **A05 Injection** and **A10 Mishandling of Exceptional Conditions** both manifest where error and edge handling go untested.
+
+## How To Apply
+
+1. **Test the contract, including failure.** Cover invalid input, exceptional conditions, and boundaries — the paths where security defects live.
+2. **Review for health, not perfection.** Approve once the change clearly improves the codebase; capture optional improvements as nits.
+3. **Let facts decide.** Resolve disagreement with engineering principles and the style guide, not preference — see [[professions/software-engineer/code-review-standard]].
+
+## See Also
+
+- [[professions/software-engineer/code-review-standard]]
+- [[professions/software-engineer/secure-coding-no-injection-validate-input]]

--- a/docs/professions/software-engineer/wiki/code-review-standard.md
+++ b/docs/professions/software-engineer/wiki/code-review-standard.md
@@ -1,0 +1,32 @@
+---
+title: Review for code health, not gatekeeping
+pageKind: heuristic
+status: published
+abstract: The standard of code review is whether a change definitely improves overall code health. Reviewers favor progress over perfection, look at the full picture, and resolve disagreement by discussion.
+professionCompetencyLevel: practitioner
+sources:
+  - google/eng-practices
+---
+
+## Heuristic
+
+Approve a change once it **definitely improves the overall code health** of the system, even if it is not perfect. The goal of review is continuous improvement, not a perfect-or-blocked gate.
+
+## What To Look At
+
+Google's code-review standard directs reviewers to assess:
+
+- **Functionality** — does the change do what it intends, for users and the codebase?
+- **Complexity** — is it as simple as it can be; no over-engineering?
+- **Tests** — correct, well-designed automated tests (see [[professions/software-engineer/automated-testing-verification]]).
+- **Naming, comments, style** — clear names; comments explain *why*; follow the style guide, defaulting undocumented style to codebase consistency.
+
+## Working Rules
+
+1. **Favor progress.** Approve once health clearly improves; mark optional polish as "Nit:".
+2. **Facts over preference.** Technical facts and engineering principles settle disagreements; pure preference does not block.
+3. **Escalate, don't stall.** Resolve standoffs by discussion and escalation, never by indefinitely withholding approval.
+
+## See Also
+
+- [[professions/software-engineer/automated-testing-verification]]

--- a/docs/professions/software-engineer/wiki/conventional-commits.md
+++ b/docs/professions/software-engineer/wiki/conventional-commits.md
@@ -1,0 +1,41 @@
+---
+title: Write Conventional Commits
+pageKind: heuristic
+status: published
+abstract: Commit messages follow the Conventional Commits format so history is human- and machine-readable and maps directly onto Semantic Versioning increments.
+professionCompetencyLevel: practitioner
+sources:
+  - conventional-commits/spec
+---
+
+## Heuristic
+
+Write commit messages in the Conventional Commits 1.0.0 format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Why
+
+The convention adds human- and machine-readable meaning to history and is explicitly designed to align with [[professions/software-engineer/semantic-versioning]]:
+
+- `feat:` introduces a feature — maps to a **MINOR** bump.
+- `fix:` patches a bug — maps to a **PATCH** bump.
+- A breaking change is flagged by a `!` after the type/scope or a `BREAKING CHANGE:` footer — maps to a **MAJOR** bump.
+
+Because the mapping is mechanical, release tooling can derive the next version and changelog from the commit log without human bookkeeping.
+
+## How To Apply
+
+1. **Pick the type honestly.** `feat` and `fix` carry release meaning; do not label a feature as a fix.
+2. **Flag breaking changes explicitly** with `!` or the footer — never let an incompatible change hide in a `feat`.
+3. **Scope when it helps** readers locate the change; keep the description imperative and short.
+
+## See Also
+
+- [[professions/software-engineer/semantic-versioning]]

--- a/docs/professions/software-engineer/wiki/dependency-supply-chain-integrity.md
+++ b/docs/professions/software-engineer/wiki/dependency-supply-chain-integrity.md
@@ -1,0 +1,45 @@
+---
+title: Secure the software supply chain
+pageKind: principle
+status: published
+abstract: Dependencies, build systems, and artifacts are part of the attack surface. Verify integrity and generate provenance per SLSA build levels; supply-chain and integrity failures are top OWASP risks.
+principleTier: core
+principleDirection: Treat dependencies and the build pipeline as attack surface — pin, verify integrity, and produce signed provenance.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 0.8, "blast_radius": 0.8, "governance_compliance": 0.7}
+professionCompetencyLevel: expert
+sources:
+  - owasp/top-ten
+  - slsa/framework
+---
+
+## Rule
+
+The software supply chain — third-party dependencies, the build platform, and the produced artifacts — is part of the system's attack surface. Verify the integrity of what you consume and produce, and emit provenance describing how each artifact was built.
+
+## Why
+
+The OWASP Top 10:2025 elevates **Software Supply Chain Failures (A03)**, expanding the earlier "vulnerable components" category to cover dependencies and build systems, and lists **Software or Data Integrity Failures (A08)** separately. A compromised dependency or build step bypasses every control in the application itself.
+
+**SLSA (Supply-chain Levels for Software Artifacts)** is a checklist of controls to prevent tampering across packages and infrastructure, expressed as build levels:
+
+- **Build L1** — provenance exists, describing the build platform, process, and inputs.
+- **Build L2** — adds signed provenance produced by a hosted build platform.
+- **Build L3** — adds a hardened, isolated build platform resistant to tampering.
+
+## How To Apply
+
+1. **Pin and verify** dependencies; check integrity (hashes/signatures), not just version strings.
+2. **Generate provenance** for build artifacts; target a SLSA build level appropriate to the artifact's blast radius.
+3. **Sign and verify** at L2+ so a consumer can confirm an artifact came from the expected pipeline.
+4. **Test the integrity path** — see [[professions/software-engineer/automated-testing-verification]].
+
+## See Also
+
+- [[professions/software-engineer/owasp-top-ten]]
+- [[professions/software-engineer/secure-coding-no-injection-validate-input]]

--- a/docs/professions/software-engineer/wiki/owasp-asvs-summary.md
+++ b/docs/professions/software-engineer/wiki/owasp-asvs-summary.md
@@ -1,0 +1,33 @@
+---
+title: OWASP ASVS v5.0.0 — verification levels
+pageKind: summary
+status: published
+abstract: The OWASP Application Security Verification Standard is a vendor-neutral standard of testable application-security requirements, organized in three rigor tiers (L1/L2/L3).
+professionCompetencyLevel: expert
+sources:
+  - owasp/asvs
+---
+
+## What This Source Is
+
+The **OWASP Application Security Verification Standard (ASVS) v5.0.0** is a vendor-neutral standard of testable application-security requirements, published under CC BY-SA 4.0. Where the [[professions/software-engineer/owasp-top-ten]] raises awareness of risk categories, ASVS provides the concrete, verifiable controls.
+
+## Three Uses
+
+ASVS is designed to serve three purposes:
+
+1. A **security metric** — measure an application against a defined bar.
+2. **Implementation guidance** — tell developers which controls to build.
+3. A **procurement specification** — state security requirements in contracts.
+
+## Verification Levels
+
+ASVS defines three tiers of increasing rigor — **L1**, **L2**, and **L3** — with higher levels applying to higher-assurance applications. Requirements are addressed by stable identifiers of the form `v5.0.0-<chapter>.<section>.<requirement>` (e.g. `v5.0.0-1.2.5`), so a control maps cleanly to a test.
+
+> Note: the precise scope of each level is defined in the downloadable ASVS document; this summary records the three-tier structure and the addressing scheme from the project page. Authoring deeper per-level doctrine requires fetching the ASVS document itself.
+
+## How DPF Coworkers Use It
+
+- Choose a target level by the application's assurance needs.
+- Map relevant ASVS requirement IDs to CI tests, satisfying [[professions/software-engineer/automated-testing-verification]].
+- Treat injection/access-control requirements as enforcement of [[professions/software-engineer/secure-coding-no-injection-validate-input]].

--- a/docs/professions/software-engineer/wiki/owasp-top-ten.md
+++ b/docs/professions/software-engineer/wiki/owasp-top-ten.md
@@ -1,0 +1,38 @@
+---
+title: OWASP Top 10 (2025)
+pageKind: entity
+status: published
+abstract: The OWASP Top 10 is a consensus awareness document of the ten most critical web application security risks. The 2025 edition is the eighth installment.
+professionCompetencyLevel: foundational
+sources:
+  - owasp/top-ten
+---
+
+## Definition
+
+The **OWASP Top 10** is a consensus awareness document, published by the OWASP Foundation, of the ten most critical web application security risks. The 2025 edition is the eighth installment and is published under CC BY-SA 4.0.
+
+## The 2025 Categories
+
+- **A01 — Broken Access Control**
+- **A02 — Security Misconfiguration**
+- **A03 — Software Supply Chain Failures**
+- **A04 — Cryptographic Failures**
+- **A05 — Injection**
+- **A06 — Insecure Design**
+- **A07 — Authentication Failures**
+- **A08 — Software or Data Integrity Failures**
+- **A09 — Security Logging and Alerting Failures**
+- **A10 — Mishandling of Exceptional Conditions**
+
+## What Changed in 2025
+
+**A10 (Mishandling of Exceptional Conditions)** is new for 2025, and **Server-Side Request Forgery** was consolidated into **A01 (Broken Access Control)**. **A03 (Software Supply Chain Failures)** broadens the prior "vulnerable and outdated components" category to cover dependencies and build systems.
+
+## How DPF Coworkers Use It
+
+The Top 10 is an awareness frame, not a checklist of all risk. Pair it with the testable controls of the ASVS:
+
+- Injection and access-control risks are addressed by [[professions/software-engineer/secure-coding-no-injection-validate-input]].
+- Supply-chain and integrity risks are addressed by [[professions/software-engineer/dependency-supply-chain-integrity]].
+- The verification baseline is [[professions/software-engineer/owasp-asvs-summary]].

--- a/docs/professions/software-engineer/wiki/secure-coding-no-injection-validate-input.md
+++ b/docs/professions/software-engineer/wiki/secure-coding-no-injection-validate-input.md
@@ -1,0 +1,48 @@
+---
+title: Never trust input — validate, encode, and parameterize
+pageKind: principle
+status: published
+abstract: Untrusted input must be validated, output-encoded, and bound as parameters — never concatenated into an interpreter string. Injection and broken access control remain the top web application risks.
+principleTier: commandment
+principleDirection: Treat all external input as hostile; parameterize queries, encode output, and enforce authorization server-side by default.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "public_safety": 1.0, "blast_radius": 0.9}
+professionCompetencyLevel: foundational
+sources:
+  - owasp/top-ten
+  - owasp/asvs
+---
+
+## Rule
+
+Every value that crosses a trust boundary — request parameters, headers, cookies, uploaded content, third-party API responses — is hostile until proven otherwise. Validate it, encode it for the context it lands in, and bind it as a parameter. Never concatenate it into a SQL string, shell command, HTML document, or any other interpreter input.
+
+Authorization is enforced **server-side, deny-by-default**. The client is never trusted to scope its own access.
+
+## Why
+
+The OWASP Top 10:2025 ranks **Broken Access Control (A01)** as the most critical web application security risk and lists **Injection (A05)** among the ten most critical. Both share a root cause: code trusting data it should not.
+
+The OWASP Application Security Verification Standard (ASVS) provides the testable controls that close these gaps — it covers injection and cross-site-scripting defenses as a security baseline and is intended to be used as a security metric, as implementation guidance, and as a procurement specification.
+
+## Applies To
+
+Any AI coworker generating or reviewing code that handles external input, constructs queries, renders output, or makes an authorization decision. The rule does not relax for "internal tools" or "trusted callers" — those framings are how injection and access-control failures ship.
+
+## How To Apply
+
+1. **Parameterize.** Queries use bound parameters, never string interpolation. (See the data-architect commandment [[professions/data-architect/parameterized-queries-commandment]] for the SQL-specific form.)
+2. **Encode on output.** Encode for the exact sink — HTML, attribute, URL, JS — to prevent cross-site scripting.
+3. **Authorize server-side.** Deny by default; check every request against the caller's actual permissions, not a client-supplied role.
+4. **Verify against ASVS.** Map the relevant ASVS requirement IDs (e.g. `v5.0.0-1.2.5`) to tests in CI.
+
+## See Also
+
+- [[professions/software-engineer/owasp-top-ten]]
+- [[professions/software-engineer/owasp-asvs-summary]]
+- [[professions/software-engineer/dependency-supply-chain-integrity]]

--- a/docs/professions/software-engineer/wiki/semantic-versioning.md
+++ b/docs/professions/software-engineer/wiki/semantic-versioning.md
@@ -1,0 +1,44 @@
+---
+title: Communicate compatibility with Semantic Versioning
+pageKind: principle
+status: published
+abstract: Release versions follow MAJOR.MINOR.PATCH so the version number itself communicates compatibility. MAJOR signals incompatible changes, MINOR backward-compatible features, PATCH backward-compatible fixes.
+principleTier: core
+principleDirection: Version every released artifact as MAJOR.MINOR.PATCH and increment by the compatibility meaning of the change, never arbitrarily.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.8, "human_cognitive_load": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - semver/spec
+---
+
+## Rule
+
+Version released software as **MAJOR.MINOR.PATCH** per Semantic Versioning 2.0.0. The version string is a compatibility contract, not a marketing number.
+
+## Why
+
+SemVer requires that a version take the form X.Y.Z, each a non-negative integer without leading zeroes, and that the increment encode the nature of the change:
+
+- **MAJOR** — incremented for incompatible API changes.
+- **MINOR** — incremented for backward-compatible added functionality.
+- **PATCH** — incremented for backward-compatible bug fixes.
+
+Two further requirements make the contract trustworthy: software using SemVer **MUST declare a public API**, and a released version **MUST NOT be modified** — any change ships as a new version. Consumers can then depend on a range with confidence.
+
+## How To Apply
+
+1. **Declare the public API.** What is in-contract must be explicit, so "incompatible" is decidable.
+2. **Let the change pick the bump.** A breaking change is MAJOR even if it feels small; a new optional feature is MINOR; a fix is PATCH.
+3. **Never re-release a version.** Re-cut, do not mutate.
+4. **Drive the bump from commits** — see [[professions/software-engineer/conventional-commits]], which maps commit types onto SemVer increments.
+
+## See Also
+
+- [[professions/software-engineer/conventional-commits]]
+- [[professions/software-engineer/api-design-http-semantics]]

--- a/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
+++ b/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
@@ -1,0 +1,201 @@
+# WSID Variants — Location (Jurisdiction) & Competency Level
+
+- **Date:** 2026-06-13
+- **Backlog:** BI-871126F9 (epic EP-WSID) — variant addendum
+- **Status:** Draft for review
+- **Parent spec:** `2026-06-09-wsid-coworker-professional-corpus-design.md`
+- **Family:** WWMD (founder/platform) → WWWD (organization) → **WSID (profession/role)**
+
+---
+
+## 1. Problem
+
+The parent WSID spec builds one professional corpus per coworker family, but treats
+each family's doctrine as a single flat body. Two real-world axes break that
+assumption for **every** AI coworker:
+
+1. **Location / jurisdiction.** Professional doctrine is not globally uniform. A
+   finance coworker recognizing revenue under **US GAAP (ASC 606)** applies a
+   different probability threshold for variable consideration than one under
+   **IFRS 15**. A marketing coworker under **US CAN-SPAM** has materially weaker
+   consent obligations than one under **EU GDPR**. An HR coworker under **US EEOC**
+   law operates differently from one under EU employment directives. Serving the
+   wrong-jurisdiction doctrine is not a quality miss — it is an active compliance
+   hazard.
+
+2. **Level of competency.** A profession's body of knowledge spans depths: the
+   non-negotiable basics every practitioner holds, the day-to-day working practice,
+   and the nuanced trade-off judgment of a senior expert. A coworker configured to
+   operate at a foundational level should not be handed expert-tier divergence
+   doctrine as if it were settled basics, and an expert-level coworker should not
+   be capped at foundational material.
+
+Neither axis appears in the parent spec beyond passing mentions ("IFRS divergences
+as contextual material"; "SFIA 9 / O*NET inform which knowledge areas a profile
+must cover"). This addendum makes both first-class.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+1. A governed way to tag any profession-corpus page with the **jurisdiction(s)** its
+   doctrine governs and the **competency level** of judgment it encodes.
+2. Author jurisdiction-divergent doctrine as **distinct, separately-cited pages**
+   (US-GAAP revenue recognition vs IFRS revenue recognition), not as one muddled
+   page, so each variant traces to its own source.
+3. **Zero structural migration** — consistent with the parent spec's deliberate
+   zero-migration outcome. Reuse the existing wiki substrate.
+4. A coverage signal at seed time so the platform can see, per family, which
+   jurisdictions and competency depths are covered and which are gaps.
+
+**Non-goals (V1)**
+
+- Wiring the gate to *filter* retrieval by the calling coworker's jurisdiction /
+  competency. That binding rides the same future PR that binds WSID profiles to
+  corpus materials (parent spec §4.8, not yet landed). V1 makes the content and
+  the tags correct and governed; V2 makes them filterable. This is called out
+  explicitly in §6.
+- Per-instance coworker competency learning (out of scope, same as parent spec).
+- Sub-national jurisdictions (US state law, EU member-state divergence). The
+  registry starts at `global / us / eu / uk` and grows by PR review on real
+  customer demand — never speculatively.
+
+## 3. Why not new columns / not the contexts axis
+
+Two rejected approaches and why:
+
+- **New typed `WikiPage` columns** (`professionJurisdiction`, `professionCompetencyLevel`):
+  would require a Prisma migration plus cross-stack plumbing (lint, MCP validation,
+  retrieval). The parent spec achieved zero migrations on purpose; adding two
+  columns *before* the retrieval path can even consume them is premature substrate
+  (`verify-substrate-before-proposing-new`). Deferred to V2, when retrieval
+  actually filters on them and the column earns its index.
+- **Overloading `principleConsumerContexts`** (e.g. `jurisdiction-us`, `level-expert`
+  as context slugs): rejected on two grounds. (a) The shipped corpus pattern
+  (`docs/professions/data-architect/wiki/*`) uses `principleConsumerArchetype:
+  specialist` with **no** contexts — domain scoping is by the `professions/<family>/`
+  slug prefix. Adding contexts would diverge from the established pattern. (b)
+  `recallPrincipleContext` does not filter on `principleConsumerContexts` at all
+  (it filters by tier, organization, population, ring-scope), so overloading that
+  axis would buy no filtering while mixing three orthogonal meanings into one
+  array.
+
+## 4. Design — two validated frontmatter axes
+
+Two optional frontmatter fields on profession-corpus pages (slug prefix
+`professions/`), validated by the corpus seed against closed registries in
+`packages/db/src/wiki-taxonomy.ts`:
+
+```yaml
+# Omitted = jurisdiction-neutral (applies everywhere; equivalent to ["global"]).
+professionJurisdiction:
+  - us
+# Omitted defaults to "practitioner".
+professionCompetencyLevel: expert
+```
+
+- **`PROFESSION_JURISDICTIONS`** = `global | us | eu | uk`. A page may declare more
+  than one (a control that holds identically in US and EU lists both). Omission
+  means jurisdiction-neutral.
+- **`PROFESSION_COMPETENCY_LEVELS`** = `foundational | practitioner | expert`,
+  loosely aligned to SFIA responsibility bands (≈1-2 / 3-4 / 5-7) and O*NET job
+  zones — used as a coverage frame, never ingested as text (conduit rule).
+
+Both are validated fail-fast in `seedProfessionCorpus` (`tallyVariantCoverage`):
+an unknown value throws with the allowed set, exactly as `extractPrinciplePayload`
+gates principle dimensions/archetypes. A typo can never silently mis-tag
+jurisdiction-sensitive doctrine.
+
+### 4.1 Authoring convention
+
+1. **Jurisdiction-neutral doctrine** lives at the family root with no
+   `professionJurisdiction` field: `professions/finance/double-entry-invariant`.
+2. **Jurisdiction-divergent doctrine** is split into one page per variant, each
+   declaring its jurisdiction and carrying a `-<jur>` (or standard-name) slug
+   suffix, cross-linked to its sibling:
+   - `professions/finance/revenue-recognition-asc606-us` → `professionJurisdiction: [us]`
+   - `professions/finance/revenue-recognition-ifrs15` → `professionJurisdiction: [eu]` (IFRS; `global` where adopted)
+3. Every page carries a short **`## Jurisdiction & Competency`** body section
+   stating, in prose, the scope and depth — so the variant is legible to a human
+   reading the page even before the gate filters on the tags.
+
+### 4.2 Resolution semantics (the V2 contract these tags enable)
+
+When the gate is wired to corpus materials (V2), profile selection already carries
+the org and the coworker config. Variant resolution then layers on:
+
+```
+Jurisdiction:
+  candidate pages = neutral (no professionJurisdiction)  ∪  pages whose
+                    professionJurisdiction ∋ org.jurisdiction
+  pages tagged for a DIFFERENT jurisdiction are excluded.
+  Conflict (a neutral page and a jurisdiction-specific page on the same topic):
+    the jurisdiction-specific page wins for a matching org; the neutral page is
+    the fallback when no jurisdiction-specific variant exists.
+
+Competency:
+  retrieve pages whose professionCompetencyLevel ≤ coworker.competency
+  (foundational ⊂ practitioner ⊂ expert — higher competency sees more, never
+  less). A foundational-configured coworker never receives expert-tier divergence
+  doctrine; an expert coworker receives the full depth.
+```
+
+This composes underneath the parent spec §4.5 inheritance chain (profession →
+org WWWD → DPF doctrine → defer) — variants narrow *within* the profession layer;
+they do not change the cross-layer authority boundary. A jurisdiction-tagged
+**commandment** that encodes legal exposure (GDPR consent, GAAP recognition)
+still `escalate`s rather than `arbitrate`s on conflict, exactly as §4.5 specifies.
+
+## 5. Jurisdiction-sensitive families
+
+Most families are jurisdiction-neutral (engineering practice, data modeling, UX,
+documentation are global). The families where jurisdiction variants are expected
+and should be authored as split pages:
+
+| Family | Divergence axis | Variants to author |
+|---|---|---|
+| `finance` | Accounting standard | US GAAP (ASC 606, SOX 404) vs IFRS |
+| `legal-compliance` | Privacy / AI regulation | GDPR + EU AI Act (eu) vs US sectoral |
+| `marketing` | Email consent | CAN-SPAM (us) vs GDPR consent (eu) |
+| `hr-people-ops` | Employment law | EEOC (us) vs EU employment directives |
+| `security` | Breach notification / residency | varies; tag where doctrine diverges |
+
+All other families default to jurisdiction-neutral unless a researched source
+shows real divergence. Competency tiering applies to **every** family.
+
+## 6. V1 → V2 path (honest scope)
+
+- **V1 (this addendum + corpus build-out):** tags are authored, validated against
+  the registries, and tallied into seed coverage logs
+  (`profession-corpus: … jurisdiction[us=3,eu=2,global=8] competency[foundational=4,…]`).
+  Content is correct and split per jurisdiction. The gate does not yet filter on
+  them because the gate↔corpus-material binding itself is not yet wired (parent
+  spec §4.8).
+- **V2 (future PR, rides the gate↔material binding):** implement §4.2 resolution.
+  At that point, decide per measured need whether to promote the two axes from
+  validated-frontmatter to indexed `WikiPage` columns (only if retrieval needs the
+  index). The registries and frontmatter contract defined here are the stable
+  interface; V2 changes the *consumer*, not the *authoring*.
+
+## 7. Data model changes (summary)
+
+| Change | Layer | Migration? |
+|---|---|---|
+| `PROFESSION_JURISDICTIONS` + `PROFESSION_COMPETENCY_LEVELS` + type guards | `packages/db/src/wiki-taxonomy.ts` | No |
+| `professionJurisdiction?` / `professionCompetencyLevel?` | `WikiPageFrontmatter` type | No |
+| `tallyVariantCoverage` validation + coverage in result | `seed-profession-corpus.ts` | No |
+| Coverage surfaced in seed log | `seed.ts` | No |
+| Split jurisdiction pages + competency tags | corpus content under `docs/professions/` | No |
+
+## 8. Acceptance (V1)
+
+1. A corpus page with `professionJurisdiction: [zz]` (unknown) fails the seed
+   loudly with the allowed set — no silent mis-tag.
+2. Finance corpus ships US-GAAP and IFRS revenue-recognition as separate,
+   separately-cited pages, cross-linked, each correctly jurisdiction-tagged.
+3. Seed log reports per-family jurisdiction and competency coverage.
+4. Provenance invariant from the parent spec still holds: every published variant
+   page cites ≥1 fetched `RawSource`.
+5. Omitting both fields yields a jurisdiction-neutral, practitioner-level page
+   (backward-compatible with the shipped data-architect corpus, which sets
+   neither and therefore tallies as `global` / `practitioner`).

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -15,6 +15,12 @@ import { deriveSlug, extractPrinciplePayload, parseFrontmatter } from "./seed-wi
 import { appendRevision, attachSource, linkPages, upsertWikiPage } from "./wiki-store";
 import { extractWikilinks } from "./wiki-frontmatter";
 import type { WikiPageFrontmatter } from "./wiki-frontmatter";
+import {
+  PROFESSION_COMPETENCY_LEVELS,
+  PROFESSION_JURISDICTIONS,
+  isProfessionCompetencyLevel,
+  isProfessionJurisdiction,
+} from "./wiki-taxonomy";
 
 const PROFESSIONS_DIR = join(__dirname, "..", "..", "..", "docs", "professions");
 
@@ -63,6 +69,126 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "OWASP Top 10 entry for injection vulnerabilities. Covers SQL injection, " +
       "NoSQL injection, OS command injection, and prevention strategies.",
     retrievedAt: "2026-06-10",
+  },
+
+  // ── Software-engineer family (WSID wave 2, all open-license) ──
+  "owasp/asvs": {
+    sourceType: "standard",
+    title: "OWASP Application Security Verification Standard (ASVS) v5.0.0",
+    url: "https://owasp.org/www-project-application-security-verification-standard/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Vendor-neutral standard of testable application-security requirements, " +
+      "tiered L1/L2/L3, used as a metric, implementation guidance, and procurement spec.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/top-ten": {
+    sourceType: "standard",
+    title: "OWASP Top 10:2025 Web Application Security Risks",
+    url: "https://owasp.org/www-project-top-ten/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Consensus awareness document of the ten most critical web application " +
+      "security risks; 2025 edition.",
+    retrievedAt: "2026-06-13",
+  },
+  "semver/spec": {
+    sourceType: "spec",
+    title: "Semantic Versioning 2.0.0",
+    url: "https://semver.org/",
+    license: "CC-BY-3.0",
+    abstract:
+      "MAJOR.MINOR.PATCH versioning scheme conveying compatibility meaning " +
+      "through version increments.",
+    retrievedAt: "2026-06-13",
+  },
+  "conventional-commits/spec": {
+    sourceType: "spec",
+    title: "Conventional Commits 1.0.0",
+    url: "https://www.conventionalcommits.org/en/v1.0.0/",
+    license: "CC-BY-3.0",
+    abstract:
+      "Lightweight commit-message convention adding human and machine-readable " +
+      "meaning, mappable to Semantic Versioning increments.",
+    retrievedAt: "2026-06-13",
+  },
+  "ietf/rfc-9110": {
+    sourceType: "spec",
+    title: "RFC 9110: HTTP Semantics (STD 97)",
+    url: "https://www.rfc-editor.org/rfc/rfc9110",
+    license: "IETF-Trust-BCP78",
+    abstract:
+      "Internet Standard defining HTTP methods, status codes, and semantics " +
+      "shared across HTTP versions.",
+    retrievedAt: "2026-06-13",
+  },
+  "slsa/framework": {
+    sourceType: "framework",
+    title: "SLSA — Supply-chain Levels for Software Artifacts (Build levels v1.0)",
+    url: "https://slsa.dev/spec/v1.0/levels",
+    license: "Community-Specification-1.0",
+    abstract:
+      "Framework of build levels (L0-L3) and provenance controls to prevent " +
+      "software supply-chain tampering.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/eng-practices": {
+    sourceType: "web-article",
+    title: "Google Engineering Practices — The Standard of Code Review",
+    url: "https://google.github.io/eng-practices/review/reviewer/standard.html",
+    license: "CC-BY-3.0",
+    abstract:
+      "Code-review standard: approve once a change improves overall code health; " +
+      "perfection is not required.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── Finance family (WSID wave 2, open-license fetched sources only) ──
+  // FASB ASC full codification is LICENSED (conduit rule): checklist-only,
+  // never ingested. SEC SOX pages blocked the fetch user-agent; the SOX
+  // management-certification page is intentionally not authored from
+  // un-fetched text. US-GAAP revenue doctrine is anchored on the IFRS 15
+  // summary, which itself names Topic 606 (ASC 606) as the jointly-issued
+  // US converged standard.
+  "wikipedia/double-entry-bookkeeping": {
+    sourceType: "reference",
+    title: "Double-entry bookkeeping",
+    url: "https://en.wikipedia.org/wiki/Double-entry_bookkeeping",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Definition of double-entry bookkeeping: duality, the accounting equation, " +
+      "and the debits-equal-credits invariant.",
+    retrievedAt: "2026-06-13",
+  },
+  "ifrs/ifrs-15-revenue": {
+    sourceType: "standard",
+    title: "IFRS 15 Revenue from Contracts with Customers (official summary)",
+    url: "https://www.ifrs.org/issued-standards/list-of-standards/ifrs-15-revenue-from-contracts-with-customers/",
+    license: "IFRS-summary-open",
+    abstract:
+      "Official IFRS 15 summary: core transfer-of-control principle and the " +
+      "five-step revenue model; names the jointly-issued US Topic 606 (ASC 606).",
+    retrievedAt: "2026-06-13",
+  },
+  "gao/green-book-internal-control": {
+    sourceType: "standard",
+    title: "Standards for Internal Control in the Federal Government (Green Book), GAO-14-704G",
+    url: "https://www.gao.gov/assets/gao-14-704g.pdf",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "GAO internal-control standards: the five components and the " +
+      "segregation-of-duties control activity; aligned with the COSO framework.",
+    retrievedAt: "2026-06-13",
+  },
+  "pcaob/auditing-standards": {
+    sourceType: "standard",
+    title: "PCAOB Auditing Standards (public)",
+    url: "https://pcaobus.org/oversight/standards/auditing-standards",
+    license: "PCAOB-public",
+    abstract:
+      "Public PCAOB auditing standards including AS 2201 (audit of internal " +
+      "control over financial reporting) and AS 1105 (audit evidence).",
+    retrievedAt: "2026-06-13",
   },
 };
 
@@ -146,7 +272,58 @@ export type SeedProfessionCorpusResult = {
   pageCount: number;
   orphanLinks: Array<{ from: string; to: string }>;
   emptyCorpus: boolean;
+  /** Page counts by declared jurisdiction (omitted pages count as "global"). */
+  jurisdictionCoverage: Record<string, number>;
+  /** Page counts by declared competency level (omitted pages count as "practitioner"). */
+  competencyCoverage: Record<string, number>;
 };
+
+/**
+ * Validate the WSID variant frontmatter axes for a corpus page and fold the
+ * page into the running coverage counters. Fail-fast on unknown values (loud,
+ * per the silent-seed-skips audit) so a typo can never silently mis-tag
+ * jurisdiction-sensitive doctrine. Omitted axes default to global /
+ * practitioner per the variant addendum.
+ */
+function tallyVariantCoverage(
+  slug: string,
+  frontmatter: WikiPageFrontmatter,
+  jurisdictionCoverage: Record<string, number>,
+  competencyCoverage: Record<string, number>,
+): void {
+  const jurisdictions =
+    frontmatter.professionJurisdiction && frontmatter.professionJurisdiction.length > 0
+      ? frontmatter.professionJurisdiction
+      : ["global"];
+  for (const jur of jurisdictions) {
+    if (!isProfessionJurisdiction(jur)) {
+      throw new Error(
+        "[seedProfessionCorpus] page " +
+          slug +
+          ' declares unknown professionJurisdiction "' +
+          jur +
+          '". Allowed: ' +
+          PROFESSION_JURISDICTIONS.join(", ") +
+          ". Add it to PROFESSION_JURISDICTIONS in wiki-taxonomy.ts via a follow-up PR before using it.",
+      );
+    }
+    jurisdictionCoverage[jur] = (jurisdictionCoverage[jur] ?? 0) + 1;
+  }
+
+  const level = frontmatter.professionCompetencyLevel ?? "practitioner";
+  if (!isProfessionCompetencyLevel(level)) {
+    throw new Error(
+      "[seedProfessionCorpus] page " +
+        slug +
+        ' declares unknown professionCompetencyLevel "' +
+        level +
+        '". Allowed: ' +
+        PROFESSION_COMPETENCY_LEVELS.join(", ") +
+        ".",
+    );
+  }
+  competencyCoverage[level] = (competencyCoverage[level] ?? 0) + 1;
+}
 
 /**
  * Seed profession corpus wiki pages from the docs/professions directory.
@@ -166,7 +343,14 @@ export async function seedProfessionCorpus(
       `[seedProfessionCorpus] docs/professions/ not found at ${PROFESSIONS_DIR}. ` +
         `No corpus seeded.`,
     );
-    return { sourceCount: 0, pageCount: 0, orphanLinks: [], emptyCorpus: true };
+    return {
+      sourceCount: 0,
+      pageCount: 0,
+      orphanLinks: [],
+      emptyCorpus: true,
+      jurisdictionCoverage: {},
+      competencyCoverage: {},
+    };
   }
 
   const { count: sourceCount, sourceKeyToId } = await seedProfessionExternalSources(prisma);
@@ -180,11 +364,20 @@ export async function seedProfessionCorpus(
   }
 
   if (wikiFiles.length === 0) {
-    return { sourceCount, pageCount: 0, orphanLinks: [], emptyCorpus: true };
+    return {
+      sourceCount,
+      pageCount: 0,
+      orphanLinks: [],
+      emptyCorpus: true,
+      jurisdictionCoverage: {},
+      competencyCoverage: {},
+    };
   }
 
   const slugToId = new Map<string, string>();
   const bodies = new Map<string, string>();
+  const jurisdictionCoverage: Record<string, number> = {};
+  const competencyCoverage: Record<string, number> = {};
 
   // Pass 1: upsert wiki pages and append revisions.
   for (const file of wikiFiles) {
@@ -192,6 +385,8 @@ export async function seedProfessionCorpus(
     const { frontmatter, body } = parseFrontmatter<WikiPageFrontmatter>(raw);
     const slug = deriveCorpusSlug(file);
     const status = frontmatter.status ?? "published";
+
+    tallyVariantCoverage(slug, frontmatter, jurisdictionCoverage, competencyCoverage);
 
     const principlePayload = extractPrinciplePayload(frontmatter);
 
@@ -269,5 +464,7 @@ export async function seedProfessionCorpus(
     pageCount: wikiFiles.length,
     orphanLinks,
     emptyCorpus: false,
+    jurisdictionCoverage,
+    competencyCoverage,
   };
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -2583,9 +2583,15 @@ async function main(): Promise<void> {
     if (result.emptyCorpus) {
       console.log("  profession-corpus: empty (no docs/professions/*/wiki/ content yet)");
     } else {
+      const fmt = (cov: Record<string, number>) =>
+        Object.entries(cov)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(",") || "none";
       console.log(
         `  profession-corpus: sources=${result.sourceCount} pages=${result.pageCount} ` +
-          `orphan-links=${result.orphanLinks.length}`,
+          `orphan-links=${result.orphanLinks.length} ` +
+          `jurisdiction[${fmt(result.jurisdictionCoverage)}] ` +
+          `competency[${fmt(result.competencyCoverage)}]`,
       );
     }
   });

--- a/packages/db/src/wiki-frontmatter.ts
+++ b/packages/db/src/wiki-frontmatter.ts
@@ -30,6 +30,22 @@ export type WikiPageFrontmatter = {
   abstract?: string;
   /** Source slugs (relative to raw-sources/) that this page cites. */
   sources?: string[];
+  // ─── WSID profession-corpus variant axes (variant addendum 2026-06-13) ───
+  // Apply only to profession-corpus pages (slug prefix `professions/`).
+  // Validated by the corpus seed against PROFESSION_JURISDICTIONS /
+  // PROFESSION_COMPETENCY_LEVELS in wiki-taxonomy.ts; not stored as DB columns
+  // in V1 (no migration). See
+  // docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md.
+  /**
+   * Jurisdictions this page's doctrine governs. Omitted = jurisdiction-neutral
+   * (equivalent to ["global"]). Values from PROFESSION_JURISDICTIONS.
+   */
+  professionJurisdiction?: string[];
+  /**
+   * Depth of professional judgment the page encodes. Omitted defaults to
+   * "practitioner". Values from PROFESSION_COMPETENCY_LEVELS.
+   */
+  professionCompetencyLevel?: string;
   // ─── Principle-only frontmatter (spec section 9) ───
   // Required-field gating lives in lint detectors per spec section 14, not
   // here. The seed walker accepts incomplete principle data so lint can

--- a/packages/db/src/wiki-taxonomy.ts
+++ b/packages/db/src/wiki-taxonomy.ts
@@ -215,6 +215,56 @@ export const PRINCIPLE_DECIDE_DEFAULTS = {
   semanticFallbackWarnRatio: 0.4,
 } as const;
 
+// ─── WSID profession-corpus variant axes (BI-871126F9, variant addendum) ────
+//
+// Two orthogonal axes that apply ONLY to profession-corpus pages (slug prefix
+// `professions/`). They are deliberately NOT principle columns: the variant
+// addendum (docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md)
+// keeps them as governed, validated frontmatter fields in V1 — no migration —
+// expressed through the slug, frontmatter, and a body section. A later
+// retrieval-wiring PR can lift them into the gate's filter once the WSID
+// profile↔corpus material binding lands. Until then the corpus seed validates
+// values against these registries (fail-fast, loud on typo) and logs coverage.
+
+/**
+ * Location / jurisdiction axis. A page omitting `professionJurisdiction` is
+ * jurisdiction-neutral (applies everywhere) — equivalent to `["global"]`.
+ * Jurisdiction-specific doctrine (US GAAP vs IFRS, CAN-SPAM vs GDPR consent,
+ * EEOC vs EU employment law) declares the jurisdictions it governs so a
+ * coworker serving a given org's jurisdiction can be served the right variant
+ * and shielded from the wrong one. Kept intentionally small; grow by PR review
+ * as real corpus demand appears (a customer in a new jurisdiction is the
+ * signal, not speculation).
+ */
+export const PROFESSION_JURISDICTIONS = [
+  "global",
+  "us",
+  "eu",
+  "uk",
+] as const;
+export type ProfessionJurisdiction = (typeof PROFESSION_JURISDICTIONS)[number];
+
+/**
+ * Competency-level axis — the depth of professional judgment a page encodes,
+ * loosely aligned to SFIA's responsibility bands and O*NET job zones (used as
+ * a coverage frame, never as ingested text):
+ *   - `foundational`  — non-negotiable basics every coworker in the family
+ *     must hold (SFIA ~1-2): debits=credits, never concatenate untrusted input.
+ *   - `practitioner`  — day-to-day working practice (SFIA ~3-4): month-end
+ *     close steps, conventional-commit format, RESTful status-code usage.
+ *   - `expert`        — nuanced trade-off judgment (SFIA ~5-7): IFRS/GAAP
+ *     divergence handling, ASVS L3 controls, API deprecation strategy.
+ * A coworker's configured competency selects how deep into the corpus the
+ * gate retrieves; omitting the field defaults a page to `practitioner`.
+ */
+export const PROFESSION_COMPETENCY_LEVELS = [
+  "foundational",
+  "practitioner",
+  "expert",
+] as const;
+export type ProfessionCompetencyLevel =
+  (typeof PROFESSION_COMPETENCY_LEVELS)[number];
+
 // ─── Type-narrowing predicates ──────────────────────────────────────────────
 
 /**
@@ -283,6 +333,32 @@ export function isPrincipleRingScope(
   return (
     typeof value === "string" &&
     (PRINCIPLE_RING_SCOPES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Narrowing predicate for the WSID location axis. Gates `professionJurisdiction`
+ * frontmatter entries against the closed `PROFESSION_JURISDICTIONS` registry.
+ */
+export function isProfessionJurisdiction(
+  value: unknown,
+): value is ProfessionJurisdiction {
+  return (
+    typeof value === "string" &&
+    (PROFESSION_JURISDICTIONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Narrowing predicate for the WSID competency axis. Gates
+ * `professionCompetencyLevel` frontmatter against `PROFESSION_COMPETENCY_LEVELS`.
+ */
+export function isProfessionCompetencyLevel(
+  value: unknown,
+): value is ProfessionCompetencyLevel {
+  return (
+    typeof value === "string" &&
+    (PROFESSION_COMPETENCY_LEVELS as readonly string[]).includes(value)
   );
 }
 


### PR DESCRIPTION
## What

WSID Phase 3 — builds out two more profession corpora and introduces the **location (jurisdiction)** and **competency-level** variant model the goal called for, applicable across all coworker families.

Follows the merged data-architect corpus ([#1713](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1713)) and Phase 1 family profiles ([#1711](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1711)).

## Variant architecture (zero migration)

Design doc: `docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md`.

- Two governed registries in `wiki-taxonomy.ts`: `PROFESSION_JURISDICTIONS` (`global|us|eu|uk`) and `PROFESSION_COMPETENCY_LEVELS` (`foundational|practitioner|expert`), each with a narrowing type guard.
- Two optional `WikiPageFrontmatter` fields: `professionJurisdiction[]`, `professionCompetencyLevel`. Validated fail-fast by the corpus seed; **not** DB columns in V1 (the gate-retrieval filter rides the future profile↔material binding). Omitted = `global` / `practitioner`, so the shipped data-architect corpus stays backward-compatible.
- `seedProfessionCorpus` tallies and the seed log surfaces per-family jurisdiction + competency coverage.

Rejected alternatives (documented in the spec): new typed columns (premature substrate, breaks the zero-migration design) and overloading `principleConsumerContexts` (diverges from the corpus pattern; `recallPrincipleContext` doesn't filter on it anyway).

## Content (distilled from FETCHED sources per the no-training-data rule)

**Software-engineer (9 pages, all open-license):** OWASP Top 10:2025 + ASVS, RFC 9110 HTTP semantics, SemVer, Conventional Commits, SLSA supply-chain levels, Google code-review standard.

**Finance (7 pages)** — proves the jurisdiction split: revenue recognition authored as separate, separately-cited **IFRS 15** (eu/uk) and **US-GAAP ASC 606** (us) pages; plus double-entry invariant, accrual basis, segregation of duties, the five internal-control components, and PCAOB audit standards (us). Sources: IFRS 15 official summary, GAO Green Book, PCAOB, Wikipedia (CC BY-SA).

Provenance discipline: FASB ASC full codification treated as licensed/checklist-only (conduit rule); SEC SOX pages that blocked the fetcher were **not** authored from un-fetched text — the unsourceable month-end-close and SOX-management pages were dropped rather than fabricated.

## Verification

Validated against the real seed-time logic (frontmatter parse + `extractPrinciplePayload` + variant guards) and esbuild syntax-checked all changed TS:

- **20 corpus pages, 0 orphan wiki-links**
- jurisdiction coverage: `global=17, us=2, eu=1, uk=1`
- competency coverage: `foundational=7, practitioner=9, expert=4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)