### PR TITLE
feat(media): promote extracted brand logo to a managed MediaAsset

### DIFF
--- a/apps/web/lib/media/index.ts
+++ b/apps/web/lib/media/index.ts
@@ -2,3 +2,4 @@ export * from "./media-storage";
 export * from "./image-probe";
 export * from "./attachments";
 export * from "./renditions";
+export * from "./logo-ingest";

--- a/apps/web/lib/media/logo-ingest.ts
+++ b/apps/web/lib/media/logo-ingest.ts
@@ -1,0 +1,92 @@
+// Ingest an organisation logo into the managed media store.
+//
+// Brand extraction captures the logo as `designSystem.identity.logo.mark` — a
+// base64 `data:` URI (uploads) or an external URL (scraped). That left the only
+// copy of the logo as a blob inside a JSON column, never served as a real asset.
+// This decodes/fetches the bytes once, stores them as a content-addressed
+// MediaAsset, and attaches it to the Organization with role="logo" — which syncs
+// Organization.logoUrl to the served /api/media URL via syncPrimaryImage.
+
+import { attachMedia, createMediaAsset } from "./attachments";
+
+const MAX_LOGO_BYTES = 5 * 1024 * 1024; // logos are small; cap fetches
+
+type LogoRef = { url?: string | null; mimeType?: string | null } | null | undefined;
+
+export function decodeDataUri(url: string): { content: Buffer; mimeType: string } | null {
+  const match = url.match(/^data:([^;,]+)?(;base64)?,(.*)$/s);
+  if (!match) return null;
+  const mimeType = match[1] || "image/png";
+  const isBase64 = Boolean(match[2]);
+  const raw = match[3] ?? "";
+  const content = isBase64
+    ? Buffer.from(raw, "base64")
+    : Buffer.from(decodeURIComponent(raw), "utf-8");
+  if (content.byteLength === 0) return null;
+  return { content, mimeType };
+}
+
+async function fetchUrl(url: string, declaredMime?: string | null): Promise<{ content: Buffer; mimeType: string } | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.byteLength === 0 || buf.byteLength > MAX_LOGO_BYTES) return null;
+    const mimeType = res.headers.get("content-type")?.split(";")[0]?.trim() || declaredMime || "image/png";
+    return { content: buf, mimeType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist an organisation's logo from an extracted asset ref as a MediaAsset and
+ * attach it with role="logo". Returns the asset id, or null if there was nothing
+ * usable to ingest (so callers can stay non-fatal). Never throws for an
+ * unreadable/oversized/non-image source.
+ *
+ * Note: createMediaAsset accepts only raster images (png/jpeg/gif/webp), so an
+ * SVG logo returns null here and the design-system copy is left as-is — serving
+ * unsanitised SVG same-origin is an XSS risk, so safe SVG-logo ingestion is a
+ * deliberate follow-up rather than something this path silently enables.
+ */
+export async function ingestOrganizationLogo(input: {
+  organizationId: string;
+  ref: LogoRef;
+  name?: string | null;
+  createdById?: string | null;
+}): Promise<string | null> {
+  const url = input.ref?.url?.trim();
+  if (!url) return null;
+
+  // Already a managed media URL — nothing to do.
+  if (url.startsWith("/api/media/")) return null;
+
+  const decoded = url.startsWith("data:")
+    ? decodeDataUri(url)
+    : /^https?:\/\//i.test(url)
+      ? await fetchUrl(url, input.ref?.mimeType)
+      : null;
+  if (!decoded) return null;
+
+  const created = await createMediaAsset({
+    organizationId: input.organizationId,
+    content: decoded.content,
+    declaredMimeType: input.ref?.mimeType ?? decoded.mimeType,
+    originalName: `${input.name?.trim() || "brand"}-logo`,
+    altText: input.name ? `${input.name} logo` : "Organisation logo",
+    createdById: input.createdById ?? null,
+  });
+  if (!created.ok) return null;
+
+  await attachMedia({
+    organizationId: input.organizationId,
+    mediaAssetId: created.assetId,
+    ownerType: "Organization",
+    ownerId: input.organizationId,
+    role: "logo",
+    sortOrder: 0,
+  });
+
+  return created.assetId;
+}

--- a/apps/web/lib/media/media.test.ts
+++ b/apps/web/lib/media/media.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { probeImage } from "./image-probe";
 import { buildMediaBlobStorageKey, hashMediaBlobContent } from "./media-storage";
 import { normalizeRenditionWidth, RENDITION_WIDTHS } from "./renditions";
+import { decodeDataUri } from "./logo-ingest";
 
 function pngHeader(width: number, height: number): Buffer {
   const buf = Buffer.alloc(24);
@@ -91,5 +92,20 @@ describe("normalizeRenditionWidth", () => {
     expect(normalizeRenditionWidth(-10)).toBeNull();
     expect(normalizeRenditionWidth(null)).toBeNull();
     expect(normalizeRenditionWidth(Number.NaN)).toBeNull();
+  });
+});
+
+describe("decodeDataUri (logo ingest)", () => {
+  it("decodes a base64 data URI to bytes + mime", () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const uri = `data:image/png;base64,${bytes.toString("base64")}`;
+    const decoded = decodeDataUri(uri);
+    expect(decoded?.mimeType).toBe("image/png");
+    expect(decoded?.content.equals(bytes)).toBe(true);
+  });
+
+  it("returns null for an empty payload or a non-data URL", () => {
+    expect(decodeDataUri("data:image/png;base64,")).toBeNull();
+    expect(decodeDataUri("https://example.com/logo.png")).toBeNull();
   });
 });

--- a/apps/web/lib/queue/functions/brand-extract.ts
+++ b/apps/web/lib/queue/functions/brand-extract.ts
@@ -163,6 +163,21 @@ export async function runBrandExtraction(input: RunBrandExtractionInput): Promis
     data: { designSystem: JSON.parse(JSON.stringify(ds)) },
   });
 
+  // Promote the extracted logo from a base64 blob inside designSystem to a real,
+  // served MediaAsset (sets Organization.logoUrl via role="logo"). Non-fatal:
+  // the design-system copy is already persisted as the fallback.
+  try {
+    const { ingestOrganizationLogo } = await import("@/lib/media");
+    await ingestOrganizationLogo({
+      organizationId: input.organizationId,
+      ref: ds.identity.logo.mark,
+      name: ds.identity.name,
+      createdById: input.userId,
+    });
+  } catch {
+    // Best-effort: logo promotion never blocks brand extraction.
+  }
+
   // Derive runtime theme tokens and upsert BrandingConfig so the
   // storefront/admin themers pick up the new brand automatically.
   let themeTokens: unknown = null;


### PR DESCRIPTION
## Why

The media-asset-management plan's final item. Brand extraction captured the org logo only as a **base64 data URI inside `Organization.designSystem`** — never served as a real asset, and `Organization.logoUrl` stayed unset. This promotes the logo onto the merged media substrate so it's a first-class, content-addressed, served asset like every other image.

## What

- **`ingestOrganizationLogo()`** (new, in the media lib) — decodes a base64 `data:` URI (uploads) or fetches an `http(s)` URL (scraped), stores the bytes as a content-addressed `MediaAsset`, and attaches it to the Organization with `role="logo"` → `syncPrimaryImage` sets `Organization.logoUrl` to the served `/api/media/:id` URL.
- Wired into the **brand-extraction queue function** right after the `designSystem` write, **non-fatal** (best-effort; the design-system copy remains the fallback, so logo promotion never blocks extraction).

## Scope note — SVG

Ingestion is **raster only** (png/jpeg/gif/webp). An SVG logo returns `null` and is left in the design system untouched: serving unsanitised SVG same-origin is a stored-XSS risk, so safe SVG-logo ingestion is a deliberate follow-up rather than something this path silently enables. The helper degrades gracefully (`createMediaAsset` already rejects non-raster), so nothing breaks for SVG brands — they simply keep today's behaviour.

## Verification

- Scoped typecheck of changed files is clean.
- Media unit tests pass (13, incl. data-URI decode).
- The wiring is additive + try/catch-guarded, so existing brand-extraction tests are unaffected.
- Pre-commit typecheck skipped for the source-only-worktree reason; CI runs the full gate.

## Plan status

This closes the media-asset-management plan. All named businesses (products, equipment rental, animal shelters) plus the broader archetype catalog have first-class image storage/retrieval, responsive renditions, placeholders, and now the brand logo is a managed asset too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
