### PR TITLE
feat(calendar): surface workbook date columns on the workspace calendar

### DIFF
--- a/apps/web/components/workspace/WorkspaceCalendar.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.tsx
@@ -36,6 +36,7 @@ const SOURCE_FILTER_CONFIG: Record<string, { label: string; matchFn: (e: { sourc
   "op-hours":      { label: "Hours",          matchFn: (e) => e.eventType === "operating-hours" },
   providers:       { label: "Providers",      matchFn: (e) => e.eventType === "provider-schedule" },
   "agent-tasks":   { label: "AI tasks",       matchFn: (e) => e.eventType === "agent-task" },
+  workbooks:       { label: "Workbooks",      matchFn: (e) => e.eventType === "workbook" },
 };
 
 /** Archetype categories where certain source filters are hidden by default. */

--- a/apps/web/lib/workforce/calendar-data.ts
+++ b/apps/web/lib/workforce/calendar-data.ts
@@ -4,6 +4,7 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { WeeklySchedule, DaySchedule } from "@/lib/operating-hours-types";
+import { buildWorkbookEvents, type WorkbookEventInput } from "./workbook-calendar-events";
 
 // ─── Unified Event Type ─────────────────────────────────────────────────────
 
@@ -974,6 +975,88 @@ async function projectScheduledJobEvents(rangeStart: Date, rangeEnd: Date): Prom
   return events;
 }
 
+// ─── Workbook projections (EP-GRID-WORKBOOKS integration) ───────────────────
+
+/**
+ * Project rows of user workbooks that carry a date/datetime column onto the
+ * calendar — e.g. a "Due date" column on a custom grid becomes an event. Uses
+ * the first date column per table as the event date and the first other column
+ * as the row label. Only custom (EAV) tables have rows/cells.
+ */
+async function projectWorkbookEvents(rangeStart: Date, rangeEnd: Date): Promise<CalendarEventView[]> {
+  const dateColumns = await prisma.workbookColumn.findMany({
+    where: { fieldType: { in: ["date", "datetime"] }, table: { dataSource: "custom" } },
+    select: { id: true, tableId: true, fieldType: true, position: true },
+    orderBy: { position: "asc" },
+  });
+  if (dateColumns.length === 0) return [];
+
+  // First date column per table (lowest position).
+  const dateColByTable = new Map<string, { id: string; withTime: boolean }>();
+  for (const c of dateColumns) {
+    if (!dateColByTable.has(c.tableId)) {
+      dateColByTable.set(c.tableId, { id: c.id, withTime: c.fieldType === "datetime" });
+    }
+  }
+  const tableIds = [...dateColByTable.keys()];
+  const dateColInternalIds = [...dateColByTable.values()].map((c) => c.id);
+
+  // First non-date column per table = the row label.
+  const allColumns = await prisma.workbookColumn.findMany({
+    where: { tableId: { in: tableIds } },
+    select: { id: true, tableId: true },
+    orderBy: { position: "asc" },
+  });
+  const titleColByTable = new Map<string, string>();
+  for (const c of allColumns) {
+    if (dateColByTable.get(c.tableId)?.id === c.id) continue; // skip the date column
+    if (!titleColByTable.has(c.tableId)) titleColByTable.set(c.tableId, c.id);
+  }
+
+  const tables = await prisma.workbookTable.findMany({
+    where: { id: { in: tableIds } },
+    select: { id: true, name: true },
+  });
+  const tableNameById = new Map(tables.map((t) => [t.id, t.name]));
+
+  // Date cells in range.
+  const dateCells = await prisma.workbookCell.findMany({
+    where: { columnId: { in: dateColInternalIds }, dateValue: { gte: rangeStart, lte: rangeEnd } },
+    select: { dateValue: true, row: { select: { id: true, rowId: true, tableId: true } } },
+  });
+  if (dateCells.length === 0) return [];
+
+  // Title cells for those rows.
+  const titleColInternalIds = [...titleColByTable.values()];
+  const rowInternalIds = dateCells.map((c) => c.row.id);
+  const titleByRow = new Map<string, string>();
+  if (titleColInternalIds.length > 0) {
+    const titleCells = await prisma.workbookCell.findMany({
+      where: { rowId: { in: rowInternalIds }, columnId: { in: titleColInternalIds } },
+      select: { rowId: true, textValue: true, selectValue: true },
+    });
+    for (const t of titleCells) {
+      const label = t.textValue ?? t.selectValue;
+      if (label) titleByRow.set(t.rowId, label);
+    }
+  }
+
+  const inputs: WorkbookEventInput[] = [];
+  for (const cell of dateCells) {
+    if (!cell.dateValue) continue;
+    const tableName = tableNameById.get(cell.row.tableId);
+    if (!tableName) continue;
+    inputs.push({
+      tableName,
+      rowId: cell.row.rowId,
+      dateISO: cell.dateValue.toISOString(),
+      title: titleByRow.get(cell.row.id) ?? null,
+      withTime: dateColByTable.get(cell.row.tableId)?.withTime ?? false,
+    });
+  }
+  return buildWorkbookEvents(inputs);
+}
+
 // ─── Main Query ─────────────────────────────────────────────────────────────
 
 export const getCalendarEvents = cache(async (
@@ -1013,7 +1096,7 @@ export const getCalendarEvents = cache(async (
     leaves, reviews, timesheets, onboarding, lifecycle, maintenance,
     compliance, finance, changeMgmt, deployWindows,
     bookings, crmActivities, pipeline, operatingHours, providerAvail,
-    agentTasks,
+    agentTasks, workbookEvents,
   ] = await Promise.all([
     projectLeaveEvents(rangeStart, rangeEnd),
     projectReviewEvents(rangeStart, rangeEnd),
@@ -1031,12 +1114,13 @@ export const getCalendarEvents = cache(async (
     projectOperatingHoursEvents(rangeStart, rangeEnd),
     projectProviderAvailabilityEvents(rangeStart, rangeEnd),
     projectScheduledAgentTasks(rangeStart, rangeEnd),
+    projectWorkbookEvents(rangeStart, rangeEnd),
   ]);
 
   return [
     ...native, ...leaves, ...reviews, ...timesheets, ...onboarding, ...lifecycle,
     ...maintenance, ...compliance, ...finance, ...changeMgmt, ...deployWindows,
     ...bookings, ...crmActivities, ...pipeline, ...operatingHours, ...providerAvail,
-    ...agentTasks,
+    ...agentTasks, ...workbookEvents,
   ].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
 });

--- a/apps/web/lib/workforce/workbook-calendar-events.test.ts
+++ b/apps/web/lib/workforce/workbook-calendar-events.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { buildWorkbookEvents, type WorkbookEventInput } from "./workbook-calendar-events";
+
+describe("buildWorkbookEvents", () => {
+  it("projects a date-column row as an all-day event titled table: label", () => {
+    const inputs: WorkbookEventInput[] = [
+      { tableName: "Site Visits", rowId: "ROW-1", dateISO: "2026-07-01T00:00:00.000Z", title: "North Depot", withTime: false },
+    ];
+    expect(buildWorkbookEvents(inputs)).toEqual([
+      {
+        id: "workbook-ROW-1",
+        title: "Site Visits: North Depot",
+        start: "2026-07-01T00:00:00.000Z",
+        end: null,
+        allDay: true,
+        category: "business",
+        eventType: "workbook",
+        color: "#14b8a6",
+        editable: false,
+        sourceType: "projected",
+        sourceId: "ROW-1",
+      },
+    ]);
+  });
+
+  it("uses a timed event for datetime columns and (untitled) when no label", () => {
+    const [ev] = buildWorkbookEvents([
+      { tableName: "Tasks", rowId: "ROW-2", dateISO: "2026-07-02T14:30:00.000Z", title: null, withTime: true },
+    ]);
+    expect(ev.allDay).toBe(false);
+    expect(ev.title).toBe("Tasks: (untitled)");
+  });
+
+  it("trims blank titles to (untitled)", () => {
+    const [ev] = buildWorkbookEvents([
+      { tableName: "T", rowId: "ROW-3", dateISO: "2026-07-03T00:00:00.000Z", title: "   ", withTime: false },
+    ]);
+    expect(ev.title).toBe("T: (untitled)");
+  });
+});

--- a/apps/web/lib/workforce/workbook-calendar-events.ts
+++ b/apps/web/lib/workforce/workbook-calendar-events.ts
@@ -1,0 +1,40 @@
+// Workbook → calendar projection (EP-GRID-WORKBOOKS × calendar integration)
+//
+// Pure builder that turns workbook rows carrying a date/datetime column into
+// calendar events, so a user's grid with a "Due date" (or any date) column shows
+// up on the workspace calendar. Kept pure + unit-testable; the server projection
+// in calendar-data.ts does the (EAV) querying and calls this.
+
+import type { CalendarEventView } from "./calendar-data";
+
+export interface WorkbookEventInput {
+  /** Owning table's display name (event title prefix). */
+  tableName: string;
+  /** Semantic row id (ROW-*), used as the stable event id + sourceId. */
+  rowId: string;
+  /** ISO date string from the row's date/datetime cell. */
+  dateISO: string;
+  /** A human label for the row (its title column), if any. */
+  title: string | null;
+  /** datetime column → timed event; date column → all-day. */
+  withTime: boolean;
+}
+
+const WORKBOOK_EVENT_COLOR = "#14b8a6"; // business category
+
+/** Build calendar events from workbook date-column rows. */
+export function buildWorkbookEvents(inputs: WorkbookEventInput[]): CalendarEventView[] {
+  return inputs.map((i) => ({
+    id: `workbook-${i.rowId}`,
+    title: `${i.tableName}: ${i.title?.trim() || "(untitled)"}`,
+    start: i.dateISO,
+    end: null,
+    allDay: !i.withTime,
+    category: "business",
+    eventType: "workbook",
+    color: WORKBOOK_EVENT_COLOR,
+    editable: false,
+    sourceType: "projected",
+    sourceId: i.rowId,
+  }));
+}


### PR DESCRIPTION
Makes the existing workspace calendar **more integrated** (per request — enhances it, doesn't reinvent it): any custom **workbook** table with a date/datetime column now projects its rows as calendar events, so a grid with a "Due date" column shows up alongside the finance/compliance/HR/CRM events the calendar already surfaces.

## How
- New `projectWorkbookEvents()` in `calendar-data.ts` joins `WorkbookColumn` (date/datetime columns on custom tables) → `WorkbookCell` (date values in the visible range) → first-other-column row label, all **batched** (no N+1). The first date column per table is the event date (datetime → timed, date → all-day); events are titled "<Table>: <label>".
- Feeds a pure, unit-tested `buildWorkbookEvents` builder.
- Registered in `getCalendarEvents` alongside the existing 16 projections.
- `WorkspaceCalendar` gains a **"Workbooks"** source filter so users can toggle it on/off (URL-persisted like the others).

Depends only on the Phase-1 workbook schema (already on `main`), so it's independent of the Phase 2-4 grid stack (#1783).

## Gate
`workbook-calendar-events` vitest 3 passing; `pnpm --filter web typecheck` (validates the Prisma projection against the generated client) + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)