### PR TITLE
fix(storefront): seed schedulingDefaults for every archetype with a booking item (#1811)

### DIFF
--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -174,11 +174,33 @@ export async function POST(req: NextRequest) {
     archetypeId,
   });
 
-  // Seed default provider, availability, and booking config from template scheduling defaults
+  // Seed default provider, availability, and booking config from template
+  // scheduling defaults. This block keys on *item-level* ctaType when linking
+  // providers and seeding bookingConfig, so an archetype that has booking items
+  // but no explicit schedulingDefaults (a template config gap) must still get a
+  // working calendar instead of silently shipping an empty one — fall back to a
+  // 09:00–17:00 Mon–Fri provider. Every shipped archetype with a booking item
+  // carries explicit schedulingDefaults (guarded by archetypes.test.ts); this
+  // fallback is defence-in-depth so a future archetype can't regress to the
+  // empty-calendar bug (AUDIT-R3/R4).
   const template = ALL_ARCHETYPES.find((a: { archetypeId: string }) => a.archetypeId === archetypeId);
-  if (template?.schedulingDefaults) {
-    const defaults = template.schedulingDefaults;
-
+  const templateCtaType = template?.ctaType;
+  const templateHasBookingItems =
+    template?.itemTemplates.some(
+      (t: { ctaType?: string }) => (t.ctaType ?? templateCtaType) === "booking",
+    ) ?? false;
+  const FALLBACK_SCHEDULING = {
+    schedulingPattern: "slot" as const,
+    assignmentMode: "next-available" as const,
+    defaultOperatingHours: [1, 2, 3, 4, 5].map((day) => ({ day, start: "09:00", end: "17:00" })),
+    defaultBeforeBuffer: 0,
+    defaultAfterBuffer: 0,
+    minimumNoticeHours: 2,
+    maxAdvanceDays: 60,
+  };
+  const defaults =
+    template?.schedulingDefaults ?? (templateHasBookingItems ? FALLBACK_SCHEDULING : null);
+  if (template && defaults) {
     // 1. Create default ServiceProvider named after the org
     const provider = await prisma.serviceProvider.create({
       data: {

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -49,10 +49,26 @@ describe("archetype catalog", () => {
     }
   });
 
-  it("all booking-type archetypes have schedulingDefaults", () => {
-    const bookingArchetypes = ALL_ARCHETYPES.filter((a) => a.ctaType === "booking");
+  it("every archetype with a booking item has schedulingDefaults", () => {
+    // The setup route (apps/web/app/api/storefront/admin/setup/route.ts) seeds
+    // the ServiceProvider, availability, and per-item bookingConfig only when the
+    // template carries schedulingDefaults, and it keys on *item-level* ctaType.
+    // An archetype whose top-level ctaType is not "booking" but which contains a
+    // booking item (gym, yoga-studio, dance-studio, driving-school,
+    // artisan-goods, the HOA/condo reservations, the municipal pavilion) still
+    // needs schedulingDefaults — without it the booking calendar ships empty
+    // (AUDIT-R3/R4). Guarding on item-level ctaType closes the gap where the old
+    // archetype-level check let these pass while broken.
+    const hasBookingItem = (a: (typeof ALL_ARCHETYPES)[number]) =>
+      a.ctaType === "booking" ||
+      a.itemTemplates.some((t) => (t.ctaType ?? a.ctaType) === "booking");
+    const bookingArchetypes = ALL_ARCHETYPES.filter(hasBookingItem);
+    expect(bookingArchetypes.length).toBeGreaterThan(0);
     for (const a of bookingArchetypes) {
-      expect(a.schedulingDefaults, `${a.archetypeId} missing schedulingDefaults`).toBeDefined();
+      expect(
+        a.schedulingDefaults,
+        `${a.archetypeId} has a booking item but no schedulingDefaults`,
+      ).toBeDefined();
     }
   });
 

--- a/packages/storefront-templates/src/archetypes/education-training.ts
+++ b/packages/storefront-templates/src/archetypes/education-training.ts
@@ -129,5 +129,11 @@ export const educationTrainingArchetypes: ArchetypeDefinition[] = [
       { name: "experience", label: "Driving experience", type: "select" as const, required: true, options: ["Complete beginner", "Some lessons previously", "Returning after a break", "Refresher course"] },
       { name: "transmission", label: "Transmission preference", type: "select" as const, required: false, options: ["Manual", "Automatic", "Either"] },
     ],
+    // Driving lessons are 1:1 slot bookings like tutoring/music-school, so reuse
+    // EDUCATION_SCHEDULING. The archetype's top-level ctaType is "purchase"
+    // (course/package sales), but its lesson items are ctaType:"booking" — without
+    // schedulingDefaults the setup route seeds no provider and the booking
+    // calendar ships empty (AUDIT-R3-DRV-F-001).
+    schedulingDefaults: EDUCATION_SCHEDULING,
   },
 ];

--- a/packages/storefront-templates/src/archetypes/fitness-recreation.ts
+++ b/packages/storefront-templates/src/archetypes/fitness-recreation.ts
@@ -1,4 +1,18 @@
-import type { ArchetypeDefinition } from "../types";
+import type { ArchetypeDefinition, SchedulingDefaults } from "../types";
+
+// Fitness studios run long days, seven days a week, and let the customer pick
+// their slot (PT session, private class, drop-in). Without this the setup route
+// seeds no provider/availability for the booking items and the calendar ships
+// empty (AUDIT-R3/R4). Mirrors the BEAUTY_SCHEDULING shape.
+const FITNESS_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "07:00", end: "21:00" })),
+  defaultBeforeBuffer: 0,
+  defaultAfterBuffer: 10,
+  minimumNoticeHours: 4,
+  maxAdvanceDays: 60,
+};
 
 const CONTACT_FIELDS = [
   { name: "name", label: "Full name", type: "text" as const, required: true },
@@ -34,6 +48,7 @@ export const fitnessRecreationArchetypes: ArchetypeDefinition[] = [
       { name: "membershipType", label: "Membership interest", type: "select" as const, required: false, options: ["Monthly", "Annual", "Day pass", "Student", "Family", "Personal Training"] },
       { name: "fitnessGoal", label: "Primary goal", type: "select" as const, required: false, options: ["Weight loss", "Muscle gain", "General fitness", "Sports performance", "Wellbeing"] },
     ],
+    schedulingDefaults: FITNESS_SCHEDULING,
   },
   {
     archetypeId: "yoga-studio",
@@ -61,6 +76,7 @@ export const fitnessRecreationArchetypes: ArchetypeDefinition[] = [
       { name: "yogaStyle", label: "Style of yoga", type: "select" as const, required: false, options: ["Hatha", "Vinyasa", "Yin", "Restorative", "Ashtanga", "Not sure"] },
       { name: "experienceLevel", label: "Experience level", type: "select" as const, required: false, options: ["Complete beginner", "Some experience", "Regular practitioner", "Advanced"] },
     ],
+    schedulingDefaults: FITNESS_SCHEDULING,
   },
   {
     archetypeId: "dance-studio",
@@ -88,5 +104,6 @@ export const fitnessRecreationArchetypes: ArchetypeDefinition[] = [
       { name: "studentAge", label: "Student age / year group", type: "text" as const, required: false },
       { name: "experienceLevel", label: "Experience level", type: "select" as const, required: false, options: ["Beginner", "Intermediate", "Advanced"] },
     ],
+    schedulingDefaults: FITNESS_SCHEDULING,
   },
 ];

--- a/packages/storefront-templates/src/archetypes/hoa-property-management.ts
+++ b/packages/storefront-templates/src/archetypes/hoa-property-management.ts
@@ -1,4 +1,19 @@
-import type { ArchetypeDefinition } from "../types";
+import type { ArchetypeDefinition, SchedulingDefaults } from "../types";
+
+// Amenity / common-area reservations (clubhouse, pool, party room) are bookable
+// across the week into long daytime-to-evening windows. The archetype's
+// top-level ctaType is "inquiry", but the reservation item is ctaType:"booking"
+// and needs schedulingDefaults or its calendar ships empty (same root cause as
+// AUDIT-R3/R4).
+const AMENITY_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "08:00", end: "22:00" })),
+  defaultBeforeBuffer: 0,
+  defaultAfterBuffer: 30,
+  minimumNoticeHours: 24,
+  maxAdvanceDays: 90,
+};
 
 const CONTACT_FIELDS = [
   { name: "name", label: "Full name", type: "text" as const, required: true },
@@ -33,6 +48,7 @@ export const hoaPropertyManagementArchetypes: ArchetypeDefinition[] = [
       ...CONTACT_FIELDS,
       { name: "requestType", label: "Request type", type: "select" as const, required: true, options: ["Maintenance", "Architectural Review", "Complaint", "General Inquiry", "Amenity Reservation"] },
     ],
+    schedulingDefaults: AMENITY_SCHEDULING,
   },
   {
     archetypeId: "condo-association",
@@ -58,6 +74,7 @@ export const hoaPropertyManagementArchetypes: ArchetypeDefinition[] = [
       ...CONTACT_FIELDS,
       { name: "requestType", label: "Request type", type: "select" as const, required: true, options: ["Maintenance", "Noise Complaint", "Parking", "Move-in / Move-out", "General Inquiry"] },
     ],
+    schedulingDefaults: AMENITY_SCHEDULING,
   },
   {
     archetypeId: "property-management-company",

--- a/packages/storefront-templates/src/archetypes/public-sector.ts
+++ b/packages/storefront-templates/src/archetypes/public-sector.ts
@@ -1,4 +1,18 @@
-import type { ArchetypeDefinition } from "../types";
+import type { ArchetypeDefinition, SchedulingDefaults } from "../types";
+
+// Park pavilion / community-room reservations are booked into daytime slots,
+// every day, well in advance. The archetype's top-level ctaType is "inquiry",
+// but the reservation item is ctaType:"booking" and needs schedulingDefaults or
+// its calendar ships empty (same root cause as AUDIT-R3/R4).
+const CIVIC_FACILITY_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, start: "08:00", end: "20:00" })),
+  defaultBeforeBuffer: 0,
+  defaultAfterBuffer: 30,
+  minimumNoticeHours: 48,
+  maxAdvanceDays: 180,
+};
 
 const RESIDENT_CONTACT_FIELDS = [
   { name: "name", label: "Full name", type: "text" as const, required: true },
@@ -34,6 +48,7 @@ export const publicSectorArchetypes: ArchetypeDefinition[] = [
       { name: "department", label: "Department", type: "select" as const, required: true, options: ["Clerk's Office", "Public Works", "Parks & Recreation", "Planning & Zoning", "Code Enforcement", "Finance / Utility Billing", "Other"] },
       { name: "notes", label: "How can we help?", type: "textarea" as const, required: true },
     ],
+    schedulingDefaults: CIVIC_FACILITY_SCHEDULING,
     activationProfile: {
       profileType: "standard",
       modules: ["service-operations", "projects"],

--- a/packages/storefront-templates/src/archetypes/retail-goods.ts
+++ b/packages/storefront-templates/src/archetypes/retail-goods.ts
@@ -1,4 +1,18 @@
-import type { ArchetypeDefinition } from "../types";
+import type { ArchetypeDefinition, SchedulingDefaults } from "../types";
+
+// Artisan workshops are booked into daytime slots, typically Tue–Sat. The
+// archetype's top-level ctaType is "purchase" (selling goods), but the
+// "Workshop Booking" item is ctaType:"booking" and needs schedulingDefaults or
+// its calendar ships empty (same root cause as AUDIT-R3/R4).
+const WORKSHOP_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [2, 3, 4, 5, 6].map((day) => ({ day, start: "10:00", end: "17:00" })),
+  defaultBeforeBuffer: 0,
+  defaultAfterBuffer: 15,
+  minimumNoticeHours: 48,
+  maxAdvanceDays: 90,
+};
 
 const CONTACT_FIELDS = [
   { name: "name", label: "Full name", type: "text" as const, required: true },
@@ -54,6 +68,7 @@ export const retailGoodsArchetypes: ArchetypeDefinition[] = [
       ...CONTACT_FIELDS,
       { name: "commissionDetails", label: "Commission details", type: "textarea" as const, required: false, placeholder: "Describe what you have in mind" },
     ],
+    schedulingDefaults: WORKSHOP_SCHEDULING,
   },
   {
     archetypeId: "florist",


### PR DESCRIPTION
## Bug 1 — Booking calendar empty on fresh install (AUDIT-R3/R4)

Closes #1811.

### Root cause
`apps/web/app/api/storefront/admin/setup/route.ts` seeds the `ServiceProvider`, availability rows, and per-item `bookingConfig` **only** when the archetype template carries `schedulingDefaults`, and it links providers by **item-level** `ctaType`. Several archetypes have a top-level `ctaType` that is *not* `"booking"` but contain booking items — they had no `schedulingDefaults`, so a fresh install seeded no provider and their booking calendar shipped permanently empty.

The guard test (`archetypes.test.ts`) only asserted `schedulingDefaults` for archetypes whose **top-level** `ctaType === "booking"`, so these passed the test while broken — the exact gap the audit found.

### Affected archetypes
Audit-confirmed: **gym, yoga-studio, dance-studio, driving-school**.
Same root cause, surfaced by the new item-level guard: **artisan-goods** (Workshop Booking), **homeowners-association** (Amenity Reservation), **condo-association** (Common Area Booking), **small-town-municipality** (Park Pavilion Reservation).

### Fix
1. **Add `schedulingDefaults`** to all 8 archetypes:
   - `fitness-recreation.ts` — new `FITNESS_SCHEDULING` (7-day slot booking) on gym/yoga-studio/dance-studio.
   - `education-training.ts` — driving-school reuses the existing `EDUCATION_SCHEDULING` (same 1:1-slot shape as tutoring/music-school).
   - `retail-goods.ts` — `WORKSHOP_SCHEDULING` (Tue–Sat) on artisan-goods.
   - `hoa-property-management.ts` — `AMENITY_SCHEDULING` on both HOA archetypes.
   - `public-sector.ts` — `CIVIC_FACILITY_SCHEDULING` on small-town-municipality.
2. **Item-level guard test** — `archetypes.test.ts` now asserts `schedulingDefaults` for *any* archetype with at least one item whose effective `ctaType === "booking"`, matching how the setup route keys.
3. **Hardened setup route** — when an archetype has booking items but no explicit `schedulingDefaults`, it now falls back to a 09:00–17:00 Mon–Fri provider rather than silently seeding nothing. Defence-in-depth so a future archetype can't regress to the empty-calendar bug.

### Verification
- `packages/storefront-templates` vitest: **89 passed** (8 files), including the new item-level guard.
- `packages/storefront-templates` `tsc --noEmit`: clean.
- apps/web typecheck gated by CI (worktree has no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
