### PR TITLE
feat(wsid): security + legal-compliance corpora (wave 3)

### DIFF
--- a/docs/professions/legal-compliance/wiki/ccpa-consumer-rights.md
+++ b/docs/professions/legal-compliance/wiki/ccpa-consumer-rights.md
@@ -1,0 +1,51 @@
+---
+title: US (California) — CCPA consumer rights (opt-out model)
+pageKind: principle
+status: published
+abstract: The CCPA (as amended by CPRA) gives California consumers rights to know, delete, correct, opt out of sale/sharing, limit sensitive-data use, and non-discrimination. It is an opt-out model — the structural opposite of GDPR's opt-in consent.
+principleTier: core
+principleDirection: For California consumers, honor the CCPA rights and the opt-out model; do not assume GDPR opt-in consent satisfies US obligations, or vice versa.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "data_privacy": 0.9}
+professionJurisdiction:
+  - us
+professionCompetencyLevel: practitioner
+sources:
+  - ccpa/oag
+  - gdpr/art-6
+  - gdpr/art-7
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** United States (California). The EU counterpart is [[professions/legal-compliance/gdpr-lawful-basis-and-consent]]. **Competency:** practitioner.
+
+## The Structural Contrast (read this first)
+
+The EU and US take opposite default stances, and conflating them is a compliance error:
+
+- **GDPR (EU)** — **opt-in**: a lawful basis is required *before* processing; consent must be affirmatively given (Articles 6 and 7).
+- **CCPA (US/California)** — **opt-out**: a business may collect and even sell/share personal information *unless* the consumer objects via a "Do Not Sell or Share My Personal Information" mechanism.
+
+A GDPR-compliant opt-in flow does not automatically satisfy CCPA's opt-out and disclosure duties, and CCPA compliance does not establish a GDPR lawful basis.
+
+## CCPA Consumer Rights
+
+As amended by the CPRA, the CCPA grants California consumers the rights to:
+
+- **Know** the categories and specific pieces of personal information collected.
+- **Delete** personal information the business collected from them.
+- **Correct** inaccurate personal information (since Jan 1, 2023).
+- **Opt out** of the sale or sharing of their personal information.
+- **Limit** the use of sensitive personal information.
+- **Non-discrimination** for exercising any of these rights.
+
+## See Also
+
+- [[professions/legal-compliance/gdpr-lawful-basis-and-consent]]
+- [[professions/legal-compliance/us-sectoral-privacy]]
+- [[professions/legal-compliance/personal-data-definition]]

--- a/docs/professions/legal-compliance/wiki/eu-ai-act-risk-tiers.md
+++ b/docs/professions/legal-compliance/wiki/eu-ai-act-risk-tiers.md
@@ -1,0 +1,42 @@
+---
+title: EU AI Act — four risk tiers and high-risk obligations
+pageKind: summary
+status: published
+abstract: The EU AI Act classifies AI systems into four risk tiers — unacceptable (banned), high, limited (transparency), and minimal. High-risk providers carry lifecycle obligations for risk management, data governance, oversight, and robustness.
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: expert
+sources:
+  - eu/ai-act
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU. The AI Act applies to AI systems placed on the EU market or affecting people in the EU. **Competency:** expert — classifying a system's tier and discharging high-risk obligations is specialist legal-compliance work.
+
+> Provenance note: the official Official Journal text (CELEX:32024R1689) blocked the research fetcher; this summary is distilled from a fetched open explainer of the Act. Treat tier classification of a specific system as requiring the primary text and qualified review.
+
+## The Four Risk Tiers
+
+1. **Unacceptable risk — prohibited.** Bans subliminal, manipulative, or deceptive techniques and social scoring.
+2. **High risk.** Systems listed in Annex III or that are safety components under Annex I.
+3. **Limited risk — transparency.** Must ensure end-users are aware they are interacting with AI.
+4. **Minimal risk.** No specific obligations.
+
+## High-Risk Provider Obligations
+
+Providers of high-risk systems must, across the lifecycle:
+
+- Establish a **risk-management system** throughout the system's lifecycle.
+- Apply **data governance**: training datasets that are relevant, sufficiently representative, and to the best extent free of errors.
+- Maintain **technical documentation** and **record-keeping**.
+- Ensure **human oversight**, and appropriate **accuracy, robustness, and cybersecurity**.
+
+## How DPF Coworkers Use It
+
+- Classify any AI feature against the four tiers early; high-risk obligations are design-time, not bolt-on.
+- The data-governance obligation pairs with [[professions/legal-compliance/personal-data-definition]] and [[professions/legal-compliance/gdpr-lawful-basis-and-consent]].
+
+## See Also
+
+- [[professions/legal-compliance/gdpr-lawful-basis-and-consent]]

--- a/docs/professions/legal-compliance/wiki/gdpr-data-subject-rights.md
+++ b/docs/professions/legal-compliance/wiki/gdpr-data-subject-rights.md
@@ -1,0 +1,40 @@
+---
+title: EU — GDPR data subject rights (Chapter 3)
+pageKind: summary
+status: published
+abstract: GDPR Chapter 3 grants data subjects the rights of access, rectification, erasure, restriction, portability, objection, and safeguards against solely automated decision-making. These baseline rights are broader than the CCPA's opt-out-centered set.
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - gdpr/chap-3
+  - ccpa/oag
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU/EEA. The narrower US (California) parallel is [[professions/legal-compliance/ccpa-consumer-rights]]. **Competency:** practitioner — fulfilling a rights request is operational work.
+
+## The Rights (GDPR Chapter 3)
+
+- **Right of access** (Art. 15) — obtain confirmation and a copy of the data processed.
+- **Right to rectification** (Art. 16) — correct inaccurate data.
+- **Right to erasure** / "right to be forgotten" (Art. 17).
+- **Right to restriction of processing** (Art. 18).
+- **Right to data portability** (Art. 20) — receive data in a portable format.
+- **Right to object** (Art. 21).
+- **Automated individual decision-making, including profiling** (Art. 22) — safeguards against decisions based solely on automated processing.
+
+## Contrast With CCPA
+
+GDPR rights are a **baseline for all data subjects** regardless of opt-in/opt-out. The CCPA grants a parallel but narrower, opt-out-centered set (know, delete, correct, opt-out of sale/sharing). A rights-handling process built only for CCPA will under-serve GDPR obligations.
+
+## How DPF Coworkers Use It
+
+- Treat a data-subject request as a deadline-bound workflow; identify the right invoked and the lawful basis at stake.
+- Pair with [[professions/legal-compliance/gdpr-lawful-basis-and-consent]] and [[professions/legal-compliance/personal-data-definition]].
+
+## See Also
+
+- [[professions/legal-compliance/ccpa-consumer-rights]]
+- [[professions/legal-compliance/personal-data-definition]]

--- a/docs/professions/legal-compliance/wiki/gdpr-lawful-basis-and-consent.md
+++ b/docs/professions/legal-compliance/wiki/gdpr-lawful-basis-and-consent.md
@@ -1,0 +1,43 @@
+---
+title: EU — every processing activity needs a lawful basis; consent is opt-in
+pageKind: principle
+status: published
+abstract: Under the GDPR, processing personal data requires one of six lawful bases. Where consent is the basis, it must be opt-in, demonstrable, in plain language, and as easy to withdraw as to give.
+principleTier: core
+principleDirection: For EU personal data, establish one of the six lawful bases before processing; if relying on consent, make it opt-in and withdrawable.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "data_privacy": 1.0}
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - gdpr/art-6
+  - gdpr/art-7
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU (and EEA) personal-data processing under the GDPR. The US counterpart follows a different, opt-out model — see [[professions/legal-compliance/ccpa-consumer-rights]]. **Competency:** practitioner — classifying a given activity's lawful basis is day-to-day work; cross-border and high-risk analysis is expert.
+
+## Rule
+
+Before processing personal data of EU data subjects, establish a **lawful basis**. The GDPR provides six (Article 6): **consent**, **contract**, **legal obligation**, **vital interests**, **public task**, and **legitimate interests**. Legitimate interests does not apply to public authorities performing their official duties.
+
+Where **consent** is the basis (Article 7), it is **opt-in**: the controller must be able to demonstrate that the data subject has consented, the request must use clear and plain language, and it must be **as easy to withdraw as to give**. Withdrawal does not affect the lawfulness of processing carried out before it.
+
+## How To Apply
+
+1. **Pick the basis per activity.** Each distinct processing purpose needs its own lawful basis; document it.
+2. **Don't default to consent.** Contract or legitimate interests is often the correct basis; consent carries the withdrawal burden.
+3. **Make consent real.** Opt-in, specific, plain-language, and easily withdrawn — pre-ticked boxes do not qualify.
+4. **Know what counts as personal data** — see [[professions/legal-compliance/personal-data-definition]].
+
+## See Also
+
+- [[professions/legal-compliance/personal-data-definition]]
+- [[professions/legal-compliance/gdpr-data-subject-rights]]
+- [[professions/legal-compliance/ccpa-consumer-rights]]

--- a/docs/professions/legal-compliance/wiki/personal-data-definition.md
+++ b/docs/professions/legal-compliance/wiki/personal-data-definition.md
@@ -1,0 +1,35 @@
+---
+title: Personal data / PII
+pageKind: entity
+status: published
+abstract: Personal data (GDPR) is any information relating to an identified or identifiable natural person. The US uses narrower, sectoral definitions. Identifying personal data is the trigger for every downstream privacy obligation.
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: foundational
+sources:
+  - gdpr/art-4
+  - coppa/govinfo
+  - ccpa/oag
+  - gdpr/art-6
+---
+
+## Definition
+
+Under the GDPR (Article 4), **personal data** is "any information relating to an identified or identifiable natural person." A person is identifiable directly or indirectly — by name, an identification number, location data, an online identifier, or factors specific to their identity.
+
+GDPR also defines **processing** broadly: any operation performed on personal data, whether or not by automated means (collection, storage, use, disclosure, erasure).
+
+## EU vs US Framing
+
+- **EU (GDPR):** a single, broad definition covering any identifiable person — the basis for the [[professions/legal-compliance/gdpr-lawful-basis-and-consent]] requirement.
+- **US:** narrower, sectoral definitions. COPPA defines "personal information" as individually identifiable information about an individual collected online; California's CCPA defines its own scope of personal information for consumer rights.
+
+## Why It Is Foundational
+
+Identifying that data is personal data is the **trigger** for every downstream obligation: an EU lawful basis, CCPA consumer rights, COPPA parental consent. Misclassifying personal data as non-personal is the root of most privacy failures.
+
+## See Also
+
+- [[professions/legal-compliance/gdpr-lawful-basis-and-consent]]
+- [[professions/legal-compliance/ccpa-consumer-rights]]
+- [[professions/legal-compliance/us-sectoral-privacy]]

--- a/docs/professions/legal-compliance/wiki/respect-open-source-license-terms.md
+++ b/docs/professions/legal-compliance/wiki/respect-open-source-license-terms.md
@@ -1,0 +1,40 @@
+---
+title: Always respect open-source license terms
+pageKind: principle
+status: published
+abstract: Every dependency carries a license with obligations. Identify each license by its SPDX identifier, record license and copyright metadata in an SBOM, check compatibility before combining, and preserve attribution.
+principleTier: commandment
+principleDirection: Identify every dependency's license (SPDX), check compatibility before combining, and preserve required attribution and notices.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "blast_radius": 0.6}
+professionJurisdiction:
+  - global
+professionCompetencyLevel: foundational
+sources:
+  - spdx/license-list
+  - spdx/spec
+---
+
+## Rule
+
+Every dependency you consume or ship carries a license with obligations. **Identify** each license by its unambiguous [[professions/legal-compliance/spdx-license-identifier]], **record** license and copyright metadata in machine-readable form (an SBOM, per the SPDX specification), **check compatibility** before combining components, and **preserve attribution** so required notices survive redistribution.
+
+## Why
+
+License obligations are legally binding regardless of intent. Copyleft identifiers (for example `GPL-3.0-only`) impose obligations that permissive licenses (`MIT`, `Apache-2.0`) do not — combining them without checking can create an obligation the project cannot meet. The SPDX specification models attribution precisely (`attributionText`) so notices are not lost when code is redistributed.
+
+## How To Apply
+
+1. **Identify** — resolve every dependency to an SPDX identifier; no free-text guesses.
+2. **Record** — capture license + copyright in the SBOM (this is the same SBOM security uses for [[professions/security/vulnerability-and-supply-chain-auditing]]).
+3. **Check compatibility** before combining — copyleft vs permissive is the first question. *(Full dependency-graph compatibility analysis is expert-level.)*
+4. **Preserve notices** on redistribution.
+
+## See Also
+
+- [[professions/legal-compliance/spdx-license-identifier]]

--- a/docs/professions/legal-compliance/wiki/spdx-license-identifier.md
+++ b/docs/professions/legal-compliance/wiki/spdx-license-identifier.md
@@ -1,0 +1,30 @@
+---
+title: SPDX license identifier
+pageKind: entity
+status: published
+abstract: An SPDX identifier is a standardized short code (e.g. MIT, Apache-2.0, GPL-3.0-only) for an open-source license. The SPDX License List and specification make license and copyright metadata machine-readable.
+professionJurisdiction:
+  - global
+professionCompetencyLevel: foundational
+sources:
+  - spdx/license-list
+  - spdx/spec
+---
+
+## Definition
+
+An **SPDX license identifier** is a standardized short code that unambiguously names an open-source license. The **SPDX License List** (maintained by the Linux Foundation, CC-BY-3.0) enables efficient and reliable identification of licenses and exceptions, providing each identifier alongside its full name, license text, and canonical URL.
+
+Examples: `MIT`, `Apache-2.0`, `GPL-3.0-only`, `BSD-3-Clause`, `CC-BY-4.0`.
+
+## In the SPDX Specification
+
+The License List is an integral part of the **SPDX Specification** (v3.0.1), which carries SBOM data together with license metadata via its licensing modules, and captures attribution through `copyrightText` and `attributionText` properties. This makes "what license is this, and what does it require?" a machine-answerable question across a whole dependency graph.
+
+## Why It Matters
+
+A precise identifier is the prerequisite for license hygiene: you cannot check compatibility or preserve required notices for a dependency whose license you have only recorded as free text. The identifier is the stable key.
+
+## See Also
+
+- [[professions/legal-compliance/respect-open-source-license-terms]]

--- a/docs/professions/legal-compliance/wiki/us-sectoral-privacy.md
+++ b/docs/professions/legal-compliance/wiki/us-sectoral-privacy.md
@@ -1,0 +1,34 @@
+---
+title: US — no single federal privacy law (sectoral + state)
+pageKind: summary
+status: published
+abstract: The US has no omnibus federal privacy law; protection is sectoral (e.g. COPPA for children, HIPAA for health, GLBA for finance) plus state laws like the CCPA. COPPA requires verifiable parental consent for under-13 data.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - coppa/govinfo
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** United States (federal). State-level rights such as California's are in [[professions/legal-compliance/ccpa-consumer-rights]]. **Competency:** foundational — the structural fact that the US is sectoral is something every compliance coworker must hold.
+
+## The Structural Fact
+
+Unlike the EU's single GDPR, the US has **no omnibus federal privacy law**. Privacy protection is **sectoral** — specific statutes for specific domains — layered with **state** laws. A coworker must therefore identify *which* regime applies to a given data type rather than assume one rule covers everything.
+
+## COPPA (the cleanly-sourced example)
+
+The **Children's Online Privacy Protection Act (COPPA)** governs online collection from a **child**, defined as an individual under the age of 13:
+
+- Operators must obtain **verifiable parental consent** for the collection, use, or disclosure of a child's personal information.
+- Operators may not condition a child's participation on disclosing more personal information than is reasonably necessary.
+- The **FTC enforces** violations as unfair or deceptive practices under the FTC Act.
+
+> Scope note: HIPAA (health) and GLBA (financial) are the other major sectoral regimes, but their detail is not authored here because a primary open source was not fetched in research (the FTC business-guidance pages blocked the fetcher). Treat them as known gaps requiring a sourced follow-up, not as covered.
+
+## See Also
+
+- [[professions/legal-compliance/ccpa-consumer-rights]]
+- [[professions/legal-compliance/personal-data-definition]]

--- a/docs/professions/security/wiki/cis-controls-implementation-groups.md
+++ b/docs/professions/security/wiki/cis-controls-implementation-groups.md
@@ -1,0 +1,37 @@
+---
+title: CIS Controls and implementation groups
+pageKind: summary
+status: published
+abstract: The CIS Critical Security Controls are 18 prioritized controls (153 safeguards) organized into three implementation groups — IG1 (essential cyber hygiene) through IG3 — so an organization adopts a defensible baseline matched to its risk.
+professionCompetencyLevel: practitioner
+sources:
+  - cis/controls
+---
+
+## What This Source Is
+
+The **CIS Critical Security Controls** (v8.1) are a prioritized set of **18 controls** comprising **153 safeguards**, published by the Center for Internet Security. They translate high-level risk frameworks into concrete, ordered actions.
+
+> Licensing note: the CIS Controls are free to download (with registration) but the fetched pages carried no explicit open license; this page uses the control structure (counts and group definitions) as facts, not licensed prose.
+
+## Implementation Groups
+
+The safeguards are tiered into three **Implementation Groups (IGs)** so an organization adopts a level matched to its resources and risk:
+
+- **IG1** — the foundational set every enterprise should apply: essential cyber hygiene (56 safeguards).
+- **IG2** — builds on IG1 for more complex environments handling sensitive data or under regulatory obligations.
+- **IG3** — all 153 safeguards, for organizations facing sophisticated threats or heavy regulation.
+
+The controls span asset inventory, data protection, secure configuration, continuous vulnerability management, audit logging, incident response, and penetration testing.
+
+## How DPF Coworkers Use It
+
+- Treat **IG1** as the non-negotiable baseline; escalate to IG2/IG3 by data sensitivity and threat exposure.
+- Continuous Vulnerability Management (Control 7) is operationalized in [[professions/security/cve-cvss-triage]].
+- Service-provider management (Control 15) feeds [[professions/security/vulnerability-and-supply-chain-auditing]].
+- Map controls onto the [[professions/security/nist-csf-2-six-functions]] for executive reporting.
+
+## See Also
+
+- [[professions/security/nist-csf-2-six-functions]]
+- [[professions/security/cve-cvss-triage]]

--- a/docs/professions/security/wiki/cve-cvss-triage.md
+++ b/docs/professions/security/wiki/cve-cvss-triage.md
@@ -1,0 +1,33 @@
+---
+title: CVE and CVSS triage
+pageKind: heuristic
+status: published
+abstract: Vulnerabilities are tracked as CVE identifiers and prioritized by CVSS severity score. Triage continuously, not once, banding by severity and exploitability against the assets actually exposed.
+professionCompetencyLevel: practitioner
+sources:
+  - nist/nvd-cve
+  - cis/controls
+---
+
+## Heuristic
+
+Track known vulnerabilities by their **CVE** identifiers and prioritize remediation by **CVSS** severity — continuously, as part of vulnerability management, not as a one-time scan.
+
+## The Vocabulary
+
+The NIST **National Vulnerability Database (NVD)** is the US-government vulnerability repository that supports automated vulnerability management:
+
+- **CVE** — standardized identifiers cataloging specific vulnerabilities (e.g. `CVE-2026-...`).
+- **CVSS** — the scoring system that rates severity; NVD supports CVSS v4.0, v3.x, and v2.0, each with a calculator.
+
+## Triage Approach
+
+1. **Band by severity.** CVSS bands run Critical → High → Medium → Low; treat Critical/High as time-bound obligations.
+2. **Weight by exposure.** A high score on an internet-facing, exploitable component outranks a higher score on an unreachable one.
+3. **Make it continuous.** CIS Control 7 (Continuous Vulnerability Management) is an IG1 baseline — re-scan and re-triage on a cadence.
+4. **Tie to inventory.** You can only triage what you can enumerate — maintain the SBOM from [[professions/security/sbom-software-bill-of-materials]].
+
+## See Also
+
+- [[professions/security/cis-controls-implementation-groups]]
+- [[professions/security/vulnerability-and-supply-chain-auditing]]

--- a/docs/professions/security/wiki/least-privilege-deny-by-default.md
+++ b/docs/professions/security/wiki/least-privilege-deny-by-default.md
@@ -1,0 +1,42 @@
+---
+title: Least privilege, deny by default
+pageKind: principle
+status: published
+abstract: Every user, service, and credential is granted the minimum access required, and access is denied unless explicitly allowed. Broken access control is the top web application security risk.
+principleTier: commandment
+principleDirection: Grant the minimum access required and deny by default; never provision broad standing access for convenience.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "public_safety": 0.9, "blast_radius": 0.8}
+professionCompetencyLevel: foundational
+sources:
+  - owasp/secrets-management
+  - owasp/top-ten
+---
+
+## Rule
+
+Grant every user, service account, and credential the **minimum access required** to do its job, and **deny access by default** — a request is permitted only when an explicit grant allows it. Scope grants narrowly and revoke them when no longer needed.
+
+## Why
+
+The OWASP Top 10:2025 ranks **Broken Access Control (A01)** as the most critical web application security risk. Over-broad grants are how a single compromised account or service becomes a full breach. The OWASP Secrets Management guidance applies the same rule to secrets: use fine-grained access controls on each object rather than broad grants, so exposure of one credential does not unlock everything.
+
+Least privilege is a containment control — it does not prevent the initial compromise, it bounds the blast radius.
+
+## How To Apply
+
+1. **Default deny.** New principals get no access until a grant is justified.
+2. **Scope to the task.** A service that reads one table gets read on one table, not the database.
+3. **Time-box and review.** Remove standing access; prefer just-in-time elevation with audit.
+4. **Apply to secrets.** Each secret is reachable only by the principals that need it — see [[professions/security/never-hardcode-secrets]].
+
+## See Also
+
+- [[professions/security/never-hardcode-secrets]]
+- [[professions/security/nist-csf-2-six-functions]]
+- [[professions/security/threat-modeling]]

--- a/docs/professions/security/wiki/never-hardcode-secrets.md
+++ b/docs/professions/security/wiki/never-hardcode-secrets.md
@@ -1,0 +1,40 @@
+---
+title: Never hardcode secrets
+pageKind: principle
+status: published
+abstract: Secrets must never live in source code or config files. Centralize them in a managed store, encrypt at rest and in transit, rotate automatically, and detect leaks before commit.
+principleTier: commandment
+principleDirection: Keep secrets out of source and config; centralize, encrypt, rotate, and scan for leaks pre-commit.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 1.0, "governance_compliance": 0.9, "blast_radius": 0.8}
+professionCompetencyLevel: foundational
+sources:
+  - owasp/secrets-management
+  - owasp/top-ten
+---
+
+## Rule
+
+**Eliminate hardcoded secrets** from source code and configuration files. Secrets — API keys, tokens, passwords, private keys — live in a managed secrets store, are injected at runtime, and never enter version control.
+
+## Why
+
+The OWASP Secrets Management guidance is direct: eliminate hardcoding secrets in source and config; centralize and standardize a secrets-management solution; encrypt secrets at rest and in transit, keeping encryption keys separate from the secrets they protect; and automate rotation, because manual maintenance increases the risk of leakage. A leaked secret is a credential compromise that bypasses every other control — related to **Cryptographic Failures (A04:2025)** in the OWASP Top 10.
+
+## How To Apply
+
+1. **Externalize.** Read secrets from a managed store or injected environment, never a literal in code.
+2. **Encrypt and separate.** Encrypt at rest and in transit; store key material apart from the secrets.
+3. **Rotate automatically.** Short-lived, rotated credentials limit the value of any single leak.
+4. **Shift detection left.** Pre-commit hooks and CI scanners catch secrets before they land.
+5. **Scope access** per [[professions/security/least-privilege-deny-by-default]].
+
+## See Also
+
+- [[professions/security/least-privilege-deny-by-default]]
+- [[professions/security/vulnerability-and-supply-chain-auditing]]

--- a/docs/professions/security/wiki/nist-csf-2-six-functions.md
+++ b/docs/professions/security/wiki/nist-csf-2-six-functions.md
@@ -1,0 +1,36 @@
+---
+title: NIST Cybersecurity Framework 2.0 — the six functions
+pageKind: summary
+status: published
+abstract: NIST CSF 2.0 organizes cybersecurity risk management into six functions — Govern, Identify, Protect, Detect, Respond, Recover. Govern is the org-level function added in 2.0 that prioritizes the other five.
+professionCompetencyLevel: expert
+sources:
+  - nist/csf-2
+  - wikipedia/nist-csf
+---
+
+## What This Source Is
+
+The **NIST Cybersecurity Framework (CSF) 2.0** is a voluntary risk-management framework (US-government public domain) that organizes cybersecurity activity into six high-level **Functions**. It is a way to structure and communicate cyber-risk posture, not a control checklist.
+
+> Provenance note: the NIST `cyberframework` landing page confirms the six Functions and the risk-management framing; the primary CSF 2.0 PDF was not text-extractable in research, so the per-function definitions below are taken from a fetched secondary source (Wikipedia, CC BY-SA), with the GOVERN wording matching NIST.
+
+## The Six Functions
+
+1. **Govern** — the organization's cybersecurity risk-management strategy, expectations, and policy are established, communicated, and monitored. (New in 2.0; the org-level function that prioritizes the other five.)
+2. **Identify** — understand the organization's systems, assets, data, suppliers, and the risks to them.
+3. **Protect** — deploy safeguards (access control, data security) to limit or contain the impact of events.
+4. **Detect** — find and analyze possible cybersecurity events.
+5. **Respond** — take action on a detected incident.
+6. **Recover** — restore assets and operations impaired by an incident.
+
+## How DPF Coworkers Use It
+
+- Use the six functions as the frame for posture assessment; **Govern** carries the expert-level org-risk judgment.
+- The control-level operationalization is [[professions/security/cis-controls-implementation-groups]].
+- Protect-function access control is enforced by [[professions/security/least-privilege-deny-by-default]].
+
+## See Also
+
+- [[professions/security/cis-controls-implementation-groups]]
+- [[professions/security/cve-cvss-triage]]

--- a/docs/professions/security/wiki/sbom-software-bill-of-materials.md
+++ b/docs/professions/security/wiki/sbom-software-bill-of-materials.md
@@ -1,0 +1,31 @@
+---
+title: Software Bill of Materials (SBOM)
+pageKind: entity
+status: published
+abstract: An SBOM is a structured, machine-readable inventory of the components and dependencies in a piece of software. CycloneDX is a modular BOM standard (ECMA-424) used to make the supply chain auditable.
+professionCompetencyLevel: expert
+sources:
+  - cyclonedx/spec
+  - owasp/top-ten
+---
+
+## Definition
+
+A **Software Bill of Materials (SBOM)** is a structured inventory of the software components and dependencies that make up an application — the ingredient list that makes the supply chain auditable. Without one, you cannot answer "are we affected by this CVE?" with confidence.
+
+## CycloneDX
+
+**CycloneDX** is a highly modular and extensible framework for representing supply-chain information, governed by the OWASP Foundation with Ecma International and standardized as **ECMA-424** (TC54). Beyond classic SBOMs it can represent related BOM varieties — SaaSBOM, hardware BOM (HBOM), and even cryptographic assets and ML models.
+
+## Why It Matters
+
+The OWASP Top 10:2025 elevates **Software Supply Chain Failures (A03)**. An SBOM is the inventory that makes supply-chain risk tractable: every dependency is enumerable, so a new CVE can be matched against what you actually ship.
+
+## How DPF Coworkers Use It
+
+- Maintain an SBOM so every dependency is enumerable for [[professions/security/cve-cvss-triage]].
+- Use it as the evidence base for [[professions/security/vulnerability-and-supply-chain-auditing]].
+
+## See Also
+
+- [[professions/security/vulnerability-and-supply-chain-auditing]]

--- a/docs/professions/security/wiki/threat-modeling.md
+++ b/docs/professions/security/wiki/threat-modeling.md
@@ -1,0 +1,40 @@
+---
+title: Threat modeling
+pageKind: heuristic
+status: published
+abstract: Threat modeling answers four questions — what are we building, what can go wrong, what will we do about it, did we do a good enough job — and uses STRIDE to enumerate threat categories during design.
+professionCompetencyLevel: expert
+sources:
+  - owasp/threat-modeling
+  - owasp/top-ten
+---
+
+## Heuristic
+
+Model threats during design, not after deployment. The OWASP four-question frame structures the exercise:
+
+1. **What are we working on?** — model the system (data-flow diagrams, trust boundaries).
+2. **What can go wrong?** — enumerate threats, typically with STRIDE.
+3. **What are we going to do about it?** — choose a response for each threat.
+4. **Did we do a good enough job?** — review and validate the model.
+
+## STRIDE
+
+STRIDE enumerates six threat categories, each the violation of a security property:
+
+- **S**poofing (authentication), **T**ampering (integrity), **R**epudiation (accounting), **I**nformation disclosure (confidentiality), **D**enial of service (availability), **E**levation of privilege (authorization).
+
+## Responses
+
+For each identified threat, choose to **mitigate**, **eliminate**, **transfer**, or **accept** it. Threat modeling is the practice that addresses **Insecure Design (A06:2025)** in the OWASP Top 10 — design-time risk that testing alone cannot catch.
+
+## How DPF Coworkers Use It
+
+- Run the four questions on any new design surface; record threats and responses.
+- Authorization threats map to [[professions/security/least-privilege-deny-by-default]].
+- Feed posture into [[professions/security/nist-csf-2-six-functions]].
+
+## See Also
+
+- [[professions/security/least-privilege-deny-by-default]]
+- [[professions/security/nist-csf-2-six-functions]]

--- a/docs/professions/security/wiki/vulnerability-and-supply-chain-auditing.md
+++ b/docs/professions/security/wiki/vulnerability-and-supply-chain-auditing.md
@@ -1,0 +1,47 @@
+---
+title: Vulnerability and supply-chain auditing
+pageKind: principle
+status: published
+abstract: Continuously audit components for known vulnerabilities and maintain an SBOM so every dependency is enumerable. Supply-chain and integrity failures are top OWASP risks; auditing extends to third parties.
+principleTier: core
+principleDirection: Continuously enumerate dependencies (SBOM), track CVEs against them, and extend auditing to third-party providers.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 0.8, "blast_radius": 0.7, "governance_compliance": 0.7}
+professionCompetencyLevel: expert
+sources:
+  - nist/nvd-cve
+  - cyclonedx/spec
+  - owasp/top-ten
+  - cis/controls
+---
+
+## Rule
+
+Continuously audit the software you build and consume: maintain a **Software Bill of Materials** so every dependency is enumerable, track **CVEs** against those components and score them with **CVSS**, and extend the audit to third-party service providers.
+
+## Why
+
+The OWASP Top 10:2025 lists **Software Supply Chain Failures (A03)** and **Software or Data Integrity Failures (A08)** as top risks — a compromised dependency or build step defeats application-level controls. Auditing makes the supply chain observable:
+
+- An **SBOM** (CycloneDX) enumerates every component so a new vulnerability can be matched to what you ship.
+- **CVE/CVSS** tracking against that inventory turns "are we affected?" into a query, not a guess.
+- **CIS Control 15 (Service Provider Management)** extends the discipline to third parties.
+- Secret metadata (created/rotated/accessed, by whom) supports forensic audit.
+
+## How To Apply
+
+1. **Generate and keep an SBOM** — see [[professions/security/sbom-software-bill-of-materials]].
+2. **Triage continuously** — see [[professions/security/cve-cvss-triage]].
+3. **Audit providers**, not just your own code.
+4. **Pair with secret hygiene** — [[professions/security/never-hardcode-secrets]].
+
+## See Also
+
+- [[professions/security/sbom-software-bill-of-materials]]
+- [[professions/security/cve-cvss-triage]]
+- [[professions/security/never-hardcode-secrets]]

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -190,6 +190,170 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "control over financial reporting) and AS 1105 (audit evidence).",
     retrievedAt: "2026-06-13",
   },
+
+  // ── Security family (WSID wave 3) ──
+  "nist/csf-2": {
+    sourceType: "framework",
+    title: "NIST Cybersecurity Framework (CSF) 2.0",
+    url: "https://www.nist.gov/cyberframework",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "NIST CSF 2.0 organizes cybersecurity risk into six Functions: Govern, " +
+      "Identify, Protect, Detect, Respond, Recover.",
+    retrievedAt: "2026-06-13",
+  },
+  "wikipedia/nist-csf": {
+    sourceType: "reference",
+    title: "NIST Cybersecurity Framework (encyclopedia summary)",
+    url: "https://en.wikipedia.org/wiki/NIST_Cybersecurity_Framework",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Secondary open summary of the NIST CSF Function definitions, used where " +
+      "the primary CSF 2.0 PDF was not text-extractable.",
+    retrievedAt: "2026-06-13",
+  },
+  "cis/controls": {
+    sourceType: "framework",
+    title: "CIS Critical Security Controls v8.1",
+    url: "https://www.cisecurity.org/controls",
+    license: "CIS-free-registration",
+    abstract:
+      "18 prioritized security controls and 153 safeguards, grouped into three " +
+      "Implementation Groups (IG1/IG2/IG3). Structure used as facts only.",
+    retrievedAt: "2026-06-13",
+  },
+  "nist/nvd-cve": {
+    sourceType: "reference",
+    title: "NIST National Vulnerability Database (NVD)",
+    url: "https://nvd.nist.gov/",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "US-government vulnerability repository hosting CVE records and CVSS " +
+      "severity scoring (v2/v3.x/v4.0).",
+    retrievedAt: "2026-06-13",
+  },
+  "cyclonedx/spec": {
+    sourceType: "spec",
+    title: "CycloneDX Specification Overview (ECMA-424)",
+    url: "https://cyclonedx.org/specification/overview/",
+    license: "ECMA-424-open",
+    abstract:
+      "Modular bill-of-materials standard (SBOM/SaaSBOM/HBOM) for supply-chain " +
+      "transparency; standardized as ECMA-424.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/threat-modeling": {
+    sourceType: "web-article",
+    title: "OWASP Threat Modeling Cheat Sheet",
+    url: "https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Four-question threat-modeling framework and the STRIDE category set; " +
+      "phases of model, identify, respond, validate.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/secrets-management": {
+    sourceType: "web-article",
+    title: "OWASP Secrets Management Cheat Sheet",
+    url: "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Eliminate hardcoded secrets; centralize, least-privilege, rotate, " +
+      "encrypt, audit, and detect secrets.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── Legal & compliance family (WSID wave 3) ──
+  "gdpr/art-4": {
+    sourceType: "standard",
+    title: "GDPR Article 4 — Definitions",
+    url: "https://gdpr-info.eu/art-4-gdpr/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      'Defines "personal data" and "processing" under the EU General Data ' +
+      "Protection Regulation.",
+    retrievedAt: "2026-06-13",
+  },
+  "gdpr/art-6": {
+    sourceType: "standard",
+    title: "GDPR Article 6 — Lawfulness of processing",
+    url: "https://gdpr-info.eu/art-6-gdpr/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      "The six lawful bases for processing personal data, including consent " +
+      "and legitimate interests.",
+    retrievedAt: "2026-06-13",
+  },
+  "gdpr/art-7": {
+    sourceType: "standard",
+    title: "GDPR Article 7 — Conditions for consent",
+    url: "https://gdpr-info.eu/art-7-gdpr/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      "Consent must be demonstrable, in clear and plain language, and as easy " +
+      "to withdraw as to give.",
+    retrievedAt: "2026-06-13",
+  },
+  "gdpr/chap-3": {
+    sourceType: "standard",
+    title: "GDPR Chapter 3 — Rights of the data subject",
+    url: "https://gdpr-info.eu/chapter-3/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      "Data-subject rights: access, rectification, erasure, restriction, " +
+      "portability, objection, and automated-decision safeguards.",
+    retrievedAt: "2026-06-13",
+  },
+  "eu/ai-act": {
+    sourceType: "standard",
+    title: "EU AI Act — High-level summary",
+    url: "https://artificialintelligenceact.eu/high-level-summary/",
+    license: "open-explainer",
+    abstract:
+      "Summary of the EU AI Act's four risk tiers (unacceptable/high/limited/" +
+      "minimal) and high-risk provider obligations. Secondary explainer.",
+    retrievedAt: "2026-06-13",
+  },
+  "spdx/license-list": {
+    sourceType: "spec",
+    title: "SPDX License List",
+    url: "https://spdx.org/licenses/",
+    license: "CC-BY-3.0",
+    abstract:
+      "Standardized short identifiers (e.g. MIT, Apache-2.0, GPL-3.0-only) for " +
+      "open-source licenses and exceptions.",
+    retrievedAt: "2026-06-13",
+  },
+  "spdx/spec": {
+    sourceType: "spec",
+    title: "SPDX Specification v3.0.1",
+    url: "https://spdx.github.io/spdx-spec/v3.0.1/",
+    license: "CC-BY-3.0",
+    abstract:
+      "Machine-readable SBOM and license/copyright metadata model, including " +
+      "license expressions and attribution text.",
+    retrievedAt: "2026-06-13",
+  },
+  "ccpa/oag": {
+    sourceType: "standard",
+    title: "California Consumer Privacy Act (CCPA), as amended by CPRA",
+    url: "https://oag.ca.gov/privacy/ccpa",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "California consumer privacy rights: know, delete, correct, opt-out of " +
+      "sale/sharing, limit sensitive data, non-discrimination.",
+    retrievedAt: "2026-06-13",
+  },
+  "coppa/govinfo": {
+    sourceType: "standard",
+    title: "COPPA statute — 15 U.S.C. ch. 91",
+    url: "https://www.govinfo.gov/content/pkg/USCODE-2010-title15/html/USCODE-2010-title15-chap91.htm",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "US Children's Online Privacy Protection Act: verifiable parental " +
+      "consent for collecting data from children under 13; FTC-enforced.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 3 — two more profession corpora on the variant model shipped in [#1808](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1808). All doctrine distilled from **fetched** open-license sources (no training-data authoring).

## Security (8 pages, jurisdiction-global)

least-privilege/deny-by-default + never-hardcode-secrets (commandments), NIST CSF 2.0 six functions, CIS Controls implementation groups, CVE/CVSS triage, SBOM entity (CycloneDX), threat modeling (STRIDE), vulnerability/supply-chain auditing.

Sources: OWASP (Top 10, threat-modeling, secrets-management cheat sheets), NIST CSF landing + NVD, CIS Controls, CycloneDX/ECMA-424. NIST CSF function definitions cite a fetched secondary (Wikipedia CC-BY-SA) because the primary CSF 2.0 PDF wasn't text-extractable — noted in-page.

## Legal-compliance (8 pages) — strongest jurisdiction proof

EU vs US split: GDPR lawful-basis/consent + data-subject-rights (eu), EU AI Act risk tiers (eu), **CCPA consumer rights (us) explicitly contrasted opt-in vs opt-out**, US sectoral-privacy grounded on the COPPA statute (us), personal-data entity, SPDX license-identifier entity + respect-open-source-license-terms commandment (global).

Sources: gdpr-info.eu articles, EU AI Act explainer (eur-lex blocked the fetcher; noted), oag.ca.gov CCPA, govinfo COPPA statute, SPDX list + spec. FTC pages 403'd → GLBA/HIPAA left as flagged gaps rather than authored from un-fetched text.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards) across all five families now in the corpus:

- **36 corpus pages, 0 orphan wiki-links, 0 unknown source citations**
- families: data-architect=4, software-engineer=9, finance=7, security=8, legal-compliance=8
- jurisdiction: `global=27, us=4, eu=5, uk=1`
- competency: `foundational=13, practitioner=14, expert=9`

16 new RawSources registered (`owasp/top-ten` reused from wave 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)