### PR TITLE
feat(wsid): qa-engineer + product-manager corpora (wave 4)

### DIFF
--- a/docs/professions/product-manager/wiki/acceptance-criteria.md
+++ b/docs/professions/product-manager/wiki/acceptance-criteria.md
@@ -1,0 +1,29 @@
+---
+title: Acceptance criteria for a user story
+pageKind: entity
+status: published
+abstract: Acceptance criteria are a formal, example-based description of expected product behavior that yields a binary pass/fail. They act as an unambiguous contract between developers and customers.
+professionCompetencyLevel: foundational
+sources:
+  - agile-alliance/acceptance
+---
+
+## Definition
+
+An **acceptance test** is a formal description of the behavior of a software product, generally expressed as an example or a usage scenario, that yields a **binary result — pass or fail**. Acceptance criteria are the conditions a story must satisfy to be accepted; they act as a clear and unambiguous "contract" between developers and customers.
+
+A "story test" is an acceptance test scoped specifically to one user story.
+
+## Why They Matter
+
+Without explicit, binary acceptance criteria, "done" is a matter of opinion. Criteria expressed as concrete examples remove ambiguity about what the story must do, and make the story **Testable** in the [[professions/product-manager/user-story-and-invest]] sense.
+
+## How DPF Coworkers Use It
+
+- Attach acceptance criteria to every story as concrete, checkable examples (Given/When/Then works well).
+- Criteria feed the team's [[professions/product-manager/definition-of-done-and-ready]] — a story is not done until its criteria pass.
+
+## See Also
+
+- [[professions/product-manager/user-story-and-invest]]
+- [[professions/product-manager/definition-of-done-and-ready]]

--- a/docs/professions/product-manager/wiki/agile-values-and-principles.md
+++ b/docs/professions/product-manager/wiki/agile-values-and-principles.md
@@ -1,0 +1,41 @@
+---
+title: Agile values and the twelve principles
+pageKind: summary
+status: published
+abstract: The Agile Manifesto states four values (individuals/interactions, working software, customer collaboration, responding to change) and twelve principles, including early continuous delivery and welcoming change. The left of each pairing is valued more, without discarding the right.
+professionCompetencyLevel: foundational
+sources:
+  - agile/manifesto
+  - agile/principles
+---
+
+## The Four Values
+
+The Agile Manifesto prizes:
+
+- **Individuals and interactions** over processes and tools.
+- **Working software** over comprehensive documentation.
+- **Customer collaboration** over contract negotiation.
+- **Responding to change** over following a plan.
+
+The right-hand items still have value; the left-hand items are valued **more**.
+
+## The Principles (selected)
+
+- Highest priority: satisfy the customer through **early and continuous delivery** of valuable software.
+- **Welcome changing requirements**, even late in development.
+- **Working software is the primary measure of progress.**
+- At regular intervals the team reflects and tunes and adjusts its behavior accordingly.
+- Simplicity — the art of maximizing the amount of work not done — is essential.
+
+## How DPF Coworkers Use It
+
+- Treat these as the value backdrop for every product decision: prefer working increments and changeability over plan adherence.
+- They ground the bias toward [[professions/product-manager/outcome-over-output]] and the ordered, evolving [[professions/product-manager/product-backlog-is-ordered-and-refined]].
+
+> Attribution note: the Agile Manifesto's license permits copying it only in its entirety; this page quotes individual values/principles as short citations rather than reproducing the whole.
+
+## See Also
+
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]
+- [[professions/product-manager/outcome-over-output]]

--- a/docs/professions/product-manager/wiki/definition-of-done-and-ready.md
+++ b/docs/professions/product-manager/wiki/definition-of-done-and-ready.md
@@ -1,0 +1,30 @@
+---
+title: Definition of Done (and Definition of Ready)
+pageKind: entity
+status: published
+abstract: The Definition of Done is the formal quality bar an increment must meet to be releasable; work that does not meet it is not part of the increment. A companion Definition of Ready gates items entering a sprint.
+professionCompetencyLevel: practitioner
+sources:
+  - scrum/guide-2020
+  - agile-alliance/definition-of-done
+---
+
+## Definition
+
+The **Definition of Done (DoD)** is, in the 2020 Scrum Guide, "a formal description of the state of the Increment when it meets the quality measures required for the product." Critically: **work cannot be considered part of an Increment unless it meets the Definition of Done.** The Agile Alliance frames it as a list of criteria that must be met before an increment is considered "done," and notes that an explicit DoD limits the risk of misunderstanding and conflict.
+
+A companion **Definition of Ready** ("READY-ready") describes the criteria an item should meet *before* it is pulled into a sprint.
+
+## Why It Matters
+
+Without a shared DoD, "done" drifts per person and per story, and quality erodes silently. The DoD makes the quality bar explicit and binary, so completion is a fact, not an opinion.
+
+## How DPF Coworkers Use It
+
+- Apply the DoD as the gate on every increment from [[professions/product-manager/product-backlog-is-ordered-and-refined]].
+- DoD complements per-story [[professions/product-manager/acceptance-criteria]]: criteria are story-specific; DoD is the standing quality bar for all work.
+
+## See Also
+
+- [[professions/product-manager/acceptance-criteria]]
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]

--- a/docs/professions/product-manager/wiki/outcome-over-output.md
+++ b/docs/professions/product-manager/wiki/outcome-over-output.md
@@ -1,0 +1,41 @@
+---
+title: Outcome over output
+pageKind: principle
+status: published
+abstract: Prioritize to deliver maximum outcome with minimum output. Remove backlog items that do not contribute to the desired outcome, and judge delivery by outcome achieved, not features shipped.
+principleTier: core
+principleDirection: Optimize for outcomes delivered, not output shipped; cut work that does not move the desired outcome.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.7, "reusability": 0.5, "long_term_maintainability": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - agile-alliance/product-owner
+  - agile/principles
+---
+
+## Rule
+
+Prioritize the backlog to **deliver maximum outcome with minimum output**. Shipping more features is not the goal; achieving the desired result is.
+
+## Why
+
+The Agile Alliance describes the Product Owner's job as prioritizing backlog items to deliver maximum outcome with minimum output, and explicitly empowers the PO to **remove items that do not contribute toward achieving the desired outcome**. Delivery is judged by whether a backlog item was satisfactorily delivered against the outcome — not merely shipped. This is reinforced by the Agile principle of **simplicity — maximizing the amount of work not done**.
+
+Optimizing for output (velocity, feature count) produces motion without progress. Outcome orientation is what separates expert product judgment from feature factories.
+
+## How To Apply
+
+1. **State the outcome** for each initiative before listing features.
+2. **Cut non-contributing work.** If an item does not move the outcome, remove it from [[professions/product-manager/product-backlog-is-ordered-and-refined]].
+3. **Judge by result.** Define success as outcome achieved; pair with explicit [[professions/product-manager/acceptance-criteria]].
+4. **Sequence economically** — high [[professions/product-manager/wsjf-prioritization]] should reflect outcome value.
+
+## See Also
+
+- [[professions/product-manager/agile-values-and-principles]]
+- [[professions/product-manager/wsjf-prioritization]]
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]

--- a/docs/professions/product-manager/wiki/product-backlog-is-ordered-and-refined.md
+++ b/docs/professions/product-manager/wiki/product-backlog-is-ordered-and-refined.md
@@ -1,0 +1,41 @@
+---
+title: The product backlog is ordered and continuously refined
+pageKind: principle
+status: published
+abstract: The product backlog is an emergent, ordered list that is the single source of work, continuously refined with description, order, and size. One accountable Product Owner manages it against a Product Goal.
+principleTier: core
+principleDirection: Keep one ordered, continuously-refined backlog as the single source of work, owned by one accountable Product Owner.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"human_cognitive_load": 0.6, "speed_to_value": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - scrum/guide-2020
+---
+
+## Rule
+
+Maintain a single **ordered** product backlog that is the source of work, and **refine it continuously**. The backlog is owned by one accountable Product Owner and serves a long-term Product Goal.
+
+## Why
+
+The 2020 Scrum Guide defines the Product Backlog as "an emergent, ordered list of what is needed to improve the product" and "the single source of work undertaken by the Scrum Team." Refinement is the ongoing activity of breaking items down and adding a description, order, and size. The Product Owner is accountable for effective Product Backlog management and is "one person, not a committee." The Product Goal is the long-term objective the backlog is ordered to serve.
+
+A backlog that is unordered, or owned by a committee, loses the single-source-of-truth property that makes prioritization meaningful.
+
+## How To Apply
+
+1. **Order, don't just collect.** Every item has a relative position reflecting value and the Product Goal.
+2. **Refine continuously.** Add description, order, and size as an ongoing activity, not a one-time event.
+3. **One owner.** A single Product Owner is accountable — see [[professions/product-manager/product-owner-accountability]].
+4. **Prioritize economically** with [[professions/product-manager/wsjf-prioritization]].
+
+## See Also
+
+- [[professions/product-manager/user-story-and-invest]]
+- [[professions/product-manager/wsjf-prioritization]]
+- [[professions/product-manager/definition-of-done-and-ready]]
+- [[professions/product-manager/product-owner-accountability]]

--- a/docs/professions/product-manager/wiki/product-owner-accountability.md
+++ b/docs/professions/product-manager/wiki/product-owner-accountability.md
@@ -1,0 +1,30 @@
+---
+title: Product Owner accountability
+pageKind: entity
+status: published
+abstract: One Product Owner — a single person, not a committee — is accountable for maximizing the product's value and for effective backlog management, including the Product Goal, item ordering, and transparency.
+professionCompetencyLevel: foundational
+sources:
+  - scrum/guide-2020
+  - agile-alliance/product-owner
+---
+
+## Definition
+
+The **Product Owner (PO)** is accountable for **maximizing the value of the product** resulting from the work of the team. The 2020 Scrum Guide makes the PO accountable for **effective Product Backlog management** — developing the Product Goal, creating and clearly ordering backlog items, and ensuring the backlog is transparent and understood.
+
+A defining constraint: **"The Product Owner is one person, not a committee."** Others may influence the backlog, but accountability rests with one named individual.
+
+## Why It Matters
+
+Diffused ownership ("the committee decides") destroys the single-source-of-truth and clear prioritization that the backlog depends on. A single accountable owner makes value trade-offs decidable and ensures transparency into upcoming work.
+
+## How DPF Coworkers Use It
+
+- Bind one accountable owner to each product's backlog; the PO's ordering is authoritative for [[professions/product-manager/product-backlog-is-ordered-and-refined]].
+- The PO's value mandate is the source of the [[professions/product-manager/outcome-over-output]] bias.
+
+## See Also
+
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]
+- [[professions/product-manager/outcome-over-output]]

--- a/docs/professions/product-manager/wiki/user-story-and-invest.md
+++ b/docs/professions/product-manager/wiki/user-story-and-invest.md
@@ -1,0 +1,34 @@
+---
+title: User story and the INVEST quality checklist
+pageKind: entity
+status: published
+abstract: INVEST is a checklist for user-story quality — Independent, Negotiable, Valuable, Estimable, Small, Testable. A story failing a criterion is a signal to reword or split it.
+professionCompetencyLevel: practitioner
+sources:
+  - agile-alliance/invest
+---
+
+## Definition
+
+**INVEST** is a widely accepted checklist for assessing the quality of a user story. A good story is:
+
+- **I**ndependent — of all other stories, so it can be scheduled and built on its own.
+- **N**egotiable — not a fixed contract of features; the details are a conversation.
+- **V**aluable — delivers value (ideally a vertical slice) to a user or customer.
+- **E**stimable — can be sized to a good approximation.
+- **S**mall — fits within a single iteration.
+- **T**estable — can be verified, at least in principle.
+
+## How To Use It
+
+A story that fails a criterion is a signal to **reword or rewrite** it: a story too large to estimate should be split; one that cannot be tested needs clearer acceptance criteria. INVEST is a diagnostic, not a gate — it tells you *which* quality is missing.
+
+## How DPF Coworkers Use It
+
+- Run INVEST when drafting or refining backlog items in [[professions/product-manager/product-backlog-is-ordered-and-refined]].
+- Pair "Testable" with explicit [[professions/product-manager/acceptance-criteria]].
+
+## See Also
+
+- [[professions/product-manager/acceptance-criteria]]
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]

--- a/docs/professions/product-manager/wiki/wsjf-prioritization.md
+++ b/docs/professions/product-manager/wiki/wsjf-prioritization.md
@@ -1,0 +1,35 @@
+---
+title: WSJF — weighted shortest job first
+pageKind: heuristic
+status: published
+abstract: WSJF prioritizes work as relative cost of delay divided by relative job duration — sequence the shortest jobs with the highest cost of delay first. If you quantify only one thing, quantify cost of delay.
+professionCompetencyLevel: practitioner
+sources:
+  - safe/wsjf
+---
+
+## Heuristic
+
+Prioritize backlog items by **Weighted Shortest Job First (WSJF)**:
+
+```
+WSJF = Cost of Delay / Job Duration   (both relative, not absolute)
+```
+
+Sequence the **shortest jobs with the highest cost of delay first** — this job-sequencing produces the best economic results.
+
+## Cost of Delay
+
+SAFe composes Cost of Delay from three relative factors: **user/business value**, **time criticality**, and **risk reduction / opportunity enablement**. The guiding rule (attributed to Reinertsen): if you only quantify one thing, quantify the Cost of Delay. WSJF also conveniently ignores sunk costs — a Lean-economics property, since only future delay and remaining duration matter.
+
+> Licensing note: WSJF is SAFe content (copyrighted, © Scaled Agile). This page paraphrases the method with attribution and does not reproduce SAFe text.
+
+## How DPF Coworkers Use It
+
+- Use WSJF to order the [[professions/product-manager/product-backlog-is-ordered-and-refined]] when items compete for the same capacity.
+- Pair with [[professions/product-manager/outcome-over-output]]: high WSJF should track real outcome value, not output volume.
+
+## See Also
+
+- [[professions/product-manager/product-backlog-is-ordered-and-refined]]
+- [[professions/product-manager/outcome-over-output]]

--- a/docs/professions/qa-engineer/wiki/defect-needs-reproduction.md
+++ b/docs/professions/qa-engineer/wiki/defect-needs-reproduction.md
@@ -1,0 +1,41 @@
+---
+title: Every defect needs reproduction steps and expected vs actual
+pageKind: principle
+status: published
+abstract: A defect that cannot be reproduced cannot be diagnosed, fixed, or confirmed resolved. Every defect record must capture reproduction steps, expected vs actual behavior, and severity and priority.
+principleTier: commandment
+principleDirection: File no defect without reliable reproduction steps and an explicit expected-vs-actual statement.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.9, "human_cognitive_load": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - wikipedia/software-bug
+  - wikipedia/bug-tracking
+---
+
+## Rule
+
+Every defect record must capture **reliable reproduction steps**, an explicit **expected vs actual** behavior statement, and **severity and priority**. A defect that cannot be reproduced cannot be trusted, triaged, or confirmed fixed.
+
+## Why
+
+"The first step in locating a bug is to reproduce it reliably" — without reproduction a programmer cannot find the cause and therefore cannot fix it. A bug-tracking record exists to convey the erroneous program behavior, and must include details on how to reproduce the bug alongside its severity. State expected vs actual explicitly so the gap is unambiguous.
+
+A bug that cannot be reproduced also cannot be verified as resolved — there is no way to confirm the fix worked.
+
+## How To Apply
+
+1. **Reproduce first.** Establish reliable steps before filing; if it is intermittent, capture frequency and conditions.
+2. **Expected vs actual.** State what should happen and what does happen — the delta is the bug.
+3. **Severity and priority.** Record both per [[professions/qa-engineer/severity-vs-priority]] so triage can manage impact and scheduling.
+4. **Confirm via re-run.** A fix is "done" only when the reproduction no longer triggers the defect — this is validation, see [[professions/qa-engineer/verification-vs-validation]].
+
+## See Also
+
+- [[professions/qa-engineer/severity-vs-priority]]
+- [[professions/qa-engineer/verification-vs-validation]]

--- a/docs/professions/qa-engineer/wiki/iso-25010-quality-model.md
+++ b/docs/professions/qa-engineer/wiki/iso-25010-quality-model.md
@@ -1,0 +1,39 @@
+---
+title: ISO/IEC 25010 product quality model (summary)
+pageKind: summary
+status: published
+abstract: ISO/IEC 25010 defines the product quality characteristics — functional suitability, performance efficiency, compatibility, reliability, interaction capability, security, maintainability, flexibility, safety. Expert QA trades them off rather than maximizing one.
+professionCompetencyLevel: expert
+sources:
+  - iso25000/quality-model
+---
+
+## What This Source Is
+
+**ISO/IEC 25010** defines a product quality model — the set of characteristics by which software quality is judged. Expert QA work is about **trading these off** against each other under constraints, not maximizing any single one.
+
+> Provenance/licensing note: the ISO/IEC 25010 standard itself is a licensed work. This page is distilled from an open summary (iso25000.com) and is checklist-only — use the ISO text for any formal or contractual citation.
+
+## The Quality Characteristics
+
+The model's product-quality characteristics include:
+
+- **Functional Suitability** — provides functions that meet stated and implied needs.
+- **Performance Efficiency** — performs within time and throughput constraints.
+- **Compatibility** — exchanges information with other products/systems.
+- **Reliability** — performs specified functions under specified conditions for a period (faultlessness, availability, fault tolerance, recoverability).
+- **Interaction Capability** (formerly Usability), **Security**, **Maintainability**.
+- **Flexibility** — can be adapted to changes in requirements, contexts, or environment.
+- **Safety** — avoids states endangering human life, health, property, or the environment.
+
+(The 2023 revision renamed Usability → Interaction Capability and Portability → Flexibility, and added Safety.)
+
+## How DPF Coworkers Use It
+
+- Use the characteristics as the vocabulary for non-functional requirements and trade-off discussions.
+- Security maps to [[professions/qa-engineer/security-testing-strategy]]; risk-weighting these attributes feeds [[professions/qa-engineer/risk-based-testing-shift-left]].
+
+## See Also
+
+- [[professions/qa-engineer/security-testing-strategy]]
+- [[professions/qa-engineer/risk-based-testing-shift-left]]

--- a/docs/professions/qa-engineer/wiki/risk-based-testing-shift-left.md
+++ b/docs/professions/qa-engineer/wiki/risk-based-testing-shift-left.md
@@ -1,0 +1,43 @@
+---
+title: Risk-based testing and shift-left
+pageKind: principle
+status: published
+abstract: Allocate test depth by risk — business impact, not uniform coverage — and move quality and security checks earlier in the lifecycle so feedback is fast and defects are caught before they compound.
+principleTier: core
+principleDirection: Prioritize test effort by business impact and run checks as early as possible; do not gate quality only at the end.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.7, "public_safety": 0.6, "speed_to_value": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - wikipedia/software-bug
+  - owasp/wstg
+  - fowler/test-pyramid
+---
+
+## Rule
+
+Allocate testing effort by **risk**, and move quality and security checks **earlier** ("shift left") rather than treating them as a final gate.
+
+## Why
+
+- **Prioritize by impact.** Severity and priority are managed separately, so test prioritization must weigh business impact, not just defect count — see [[professions/qa-engineer/severity-vs-priority]].
+- **Shift security left.** OWASP frames web security testing as a framework of best practices integrated across the lifecycle by testers and organizations — not a one-time pass before release.
+- **Fast feedback.** Structure suites (per the [[professions/qa-engineer/test-automation-pyramid]]) so fast tests run first and reveal breakage immediately.
+- **Reproducibility enables triage.** The first step in locating a bug is to reproduce it reliably — see [[professions/qa-engineer/defect-needs-reproduction]].
+
+## How To Apply
+
+1. **Tier by risk.** Give high-impact, high-exposure areas deeper coverage; do not spread effort uniformly.
+2. **Move checks earlier.** Lint, unit tests, and security scans run in development, not just pre-release.
+3. **Order for speed.** Fast tests gate early in the pipeline; slow end-to-end tests run later.
+
+## See Also
+
+- [[professions/qa-engineer/test-automation-pyramid]]
+- [[professions/qa-engineer/security-testing-strategy]]
+- [[professions/qa-engineer/severity-vs-priority]]

--- a/docs/professions/qa-engineer/wiki/security-testing-strategy.md
+++ b/docs/professions/qa-engineer/wiki/security-testing-strategy.md
@@ -1,0 +1,38 @@
+---
+title: Web security testing strategy (OWASP WSTG)
+pageKind: principle
+status: published
+abstract: Security testing is a structured, repeatable practice spanning many categories, referenced by stable WSTG identifiers — not a single pass. It is integrated across the lifecycle by testers and organizations.
+principleTier: contextual
+principleDirection: Test security across the WSTG categories with stable, repeatable scenarios; integrate it into the lifecycle, not a final gate.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 0.8, "governance_compliance": 0.6}
+professionCompetencyLevel: expert
+sources:
+  - owasp/wstg
+---
+
+## Rule
+
+Treat security testing as a **structured, repeatable practice** that spans many categories and is integrated across the development lifecycle — not an afterthought before release.
+
+## Why
+
+The OWASP Web Security Testing Guide (WSTG) is a framework of best practices used by penetration testers and organizations worldwide. Its scenarios are referenced with stable identifiers (`WSTG-<category>-<number>`), which makes security coverage **consistent and repeatable** across runs and teams. Security testing spans multiple categories (information gathering, application and web-service vulnerability domains) rather than a single sweep.
+
+## How To Apply
+
+1. **Use the categories as a checklist.** Map WSTG categories to your application's surface so coverage is deliberate, not ad hoc.
+2. **Reference by identifier.** Cite `WSTG-<category>-<number>` so a finding maps to a repeatable test.
+3. **Integrate, don't gate.** Fold security tests into the pipeline per [[professions/qa-engineer/risk-based-testing-shift-left]].
+4. **Weight by quality attribute.** Security is one ISO 25010 characteristic among several — see [[professions/qa-engineer/iso-25010-quality-model]].
+
+## See Also
+
+- [[professions/qa-engineer/risk-based-testing-shift-left]]
+- [[professions/qa-engineer/iso-25010-quality-model]]

--- a/docs/professions/qa-engineer/wiki/severity-vs-priority.md
+++ b/docs/professions/qa-engineer/wiki/severity-vs-priority.md
@@ -1,0 +1,34 @@
+---
+title: Severity vs priority
+pageKind: entity
+status: published
+abstract: Severity measures a defect's impact; priority measures the importance of fixing it relative to other work. They are managed separately — a low-severity bug can be high priority and vice versa.
+professionCompetencyLevel: foundational
+sources:
+  - wikipedia/software-bug
+  - wikipedia/bug-tracking
+---
+
+## Definition
+
+Two independent dimensions describe every defect:
+
+- **Severity** measures the bug's **impact** — for example data loss, financial harm, loss of goodwill, or wasted effort.
+- **Priority** measures the **importance of resolving** the bug relative to other bugs and work.
+
+These "may be quantified and managed separately." A low-severity cosmetic bug on the signup page may be high priority; a high-severity crash in a rarely-used admin tool may be low priority.
+
+## Severity Is Not Fix Complexity
+
+A common error is conflating severity with how hard a fix is. The two are unrelated: "the severity of a bug may not be directly related to the complexity of fixing the bug." Estimate effort separately from impact.
+
+## How DPF Coworkers Use It
+
+- Record **both** severity and priority on every defect — they drive different decisions (impact vs scheduling).
+- Use them to feed [[professions/qa-engineer/risk-based-testing-shift-left]]: prioritize by business impact, not raw defect count.
+- A defect is only actionable if it can be reproduced — see [[professions/qa-engineer/defect-needs-reproduction]].
+
+## See Also
+
+- [[professions/qa-engineer/defect-needs-reproduction]]
+- [[professions/qa-engineer/risk-based-testing-shift-left]]

--- a/docs/professions/qa-engineer/wiki/test-automation-pyramid.md
+++ b/docs/professions/qa-engineer/wiki/test-automation-pyramid.md
@@ -1,0 +1,33 @@
+---
+title: The test automation pyramid
+pageKind: heuristic
+status: published
+abstract: Write lots of fast unit tests, fewer coarse-grained service/integration tests, and very few slow end-to-end tests. The shape optimizes for fast feedback because higher-level tests are slower and more fragile.
+professionCompetencyLevel: practitioner
+sources:
+  - fowler/test-pyramid
+---
+
+## Heuristic
+
+Shape the automated suite like a pyramid: **write lots of small and fast unit tests, write some more coarse-grained tests, and write very few high-level (end-to-end) tests.**
+
+- **Base — unit tests:** many, fast, isolated.
+- **Middle — integration/service tests:** fewer; slowed by external dependencies.
+- **Top — UI / end-to-end tests:** very few; slowest and most fragile.
+
+## Why This Shape
+
+Higher-level tests are slower and more fragile — integration tests are slowed by external dependencies and end-to-end tests are the slowest of all. Concentrating coverage in fast unit tests gives **fast feedback**: run the fast tests first so breakage surfaces immediately, and reserve the slow, brittle end-to-end tests for the few flows that truly need full-stack validation.
+
+The layer names come from Mike Cohn's *Succeeding with Agile*; treat them as a heuristic, not a rigid taxonomy — the load-bearing rule is the proportion (many fast, few slow).
+
+## How DPF Coworkers Use It
+
+- When adding tests, default to the lowest [[professions/qa-engineer/test-levels]] that catches the fault.
+- Order the pipeline so fast tests gate early; this is the mechanism behind [[professions/qa-engineer/risk-based-testing-shift-left]].
+
+## See Also
+
+- [[professions/qa-engineer/test-levels]]
+- [[professions/qa-engineer/risk-based-testing-shift-left]]

--- a/docs/professions/qa-engineer/wiki/test-levels.md
+++ b/docs/professions/qa-engineer/wiki/test-levels.md
@@ -1,0 +1,33 @@
+---
+title: Test levels — unit, integration, system, acceptance
+pageKind: entity
+status: published
+abstract: Testing is organized into levels — unit/component, integration, system, and acceptance — each catching a distinct class of fault. Coverage at one level does not substitute for another.
+professionCompetencyLevel: foundational
+sources:
+  - wikipedia/software-testing
+---
+
+## Definition
+
+Software testing is organized into **levels**, each exercising the system at a different scope and catching a different class of fault:
+
+- **Unit / component** — isolated source code is tested to validate expected behavior of the smallest testable parts.
+- **Integration** — multiple components, modules, or services are exercised together to verify they work when combined.
+- **System** — testing conducted on a complete, integrated software system, end to end.
+- **Acceptance** — system-level testing to ensure the software meets customer expectations.
+
+## Why Levels Matter
+
+Each level catches faults the others miss: a unit test cannot find an interface mismatch between two services, and a system test is too coarse to localize a logic error in one function. **Coverage at one level does not substitute for another** — a healthy suite spreads effort across levels, weighted by the [[professions/qa-engineer/test-automation-pyramid]].
+
+## How DPF Coworkers Use It
+
+- Place a new test at the lowest level that can catch the fault it targets.
+- Use the level vocabulary when reasoning about a gap ("this is an integration risk, not a unit risk").
+- Pair with [[professions/qa-engineer/verification-vs-validation]] to ask whether a level is checking "built right" or "right thing."
+
+## See Also
+
+- [[professions/qa-engineer/test-automation-pyramid]]
+- [[professions/qa-engineer/verification-vs-validation]]

--- a/docs/professions/qa-engineer/wiki/verification-vs-validation.md
+++ b/docs/professions/qa-engineer/wiki/verification-vs-validation.md
@@ -1,0 +1,32 @@
+---
+title: Verification vs validation
+pageKind: entity
+status: published
+abstract: Verification asks "are we building the product right?" (mostly static review against spec); validation asks "are we building the right product?" (dynamic execution against intended use). Both are required.
+professionCompetencyLevel: foundational
+sources:
+  - wikipedia/verification-validation
+  - wikipedia/software-testing
+---
+
+## Definition
+
+The classic Boehm framing distinguishes two complementary questions:
+
+- **Verification — "Are we building the product right?"** Predominantly a **static** process: reviews of artifacts and specifications, confirming each phase's output satisfies its input specification.
+- **Validation — "Are we building the right product?"** A **dynamic** process requiring actual software execution, confirming the product satisfies intended use and customer needs.
+
+## Why Both Are Required
+
+Verification without validation can perfectly build the wrong thing — a system that flawlessly meets a specification nobody wanted. Validation without verification ships something roughly right but internally broken. QA owns both: confirm the build matches the spec **and** that the spec serves the user.
+
+## How DPF Coworkers Use It
+
+- Classify each quality activity: a code review or spec check is verification; running the feature against a user scenario is validation.
+- The [[professions/qa-engineer/test-levels]] map onto this — acceptance testing leans validation; unit testing leans verification.
+- Validation depends on reproducible behavior — see [[professions/qa-engineer/defect-needs-reproduction]].
+
+## See Also
+
+- [[professions/qa-engineer/test-levels]]
+- [[professions/qa-engineer/defect-needs-reproduction]]

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -354,6 +354,166 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "consent for collecting data from children under 13; FTC-enforced.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── QA / software-quality family (WSID wave 4) ──
+  // ISTQB glossary blocked the fetcher (403); test terminology is anchored on
+  // fetched CC-BY-SA encyclopedia articles. ISO/IEC 25010 full text is licensed;
+  // the quality-model page uses an open summary and is checklist-only.
+  "owasp/wstg": {
+    sourceType: "web-article",
+    title: "OWASP Web Security Testing Guide",
+    url: "https://owasp.org/www-project-web-security-testing-guide/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Community framework of web-application security testing best practices, " +
+      "addressed by stable WSTG identifiers.",
+    retrievedAt: "2026-06-13",
+  },
+  "fowler/test-pyramid": {
+    sourceType: "web-article",
+    title: "The Practical Test Pyramid (Ham Vocke)",
+    url: "https://martinfowler.com/articles/practical-test-pyramid.html",
+    license: "article-free-to-read",
+    abstract:
+      "The test automation pyramid: many fast unit tests, fewer service tests, " +
+      "very few slow end-to-end tests.",
+    retrievedAt: "2026-06-13",
+  },
+  "iso25000/quality-model": {
+    sourceType: "reference",
+    title: "ISO/IEC 25010 product quality model (open summary)",
+    url: "https://iso25000.com/index.php/en/iso-25000-standards/iso-25010",
+    license: "open-summary-iso-licensed",
+    abstract:
+      "Open summary of the ISO/IEC 25010 product-quality characteristics. The " +
+      "ISO standard itself is licensed (checklist-only).",
+    retrievedAt: "2026-06-13",
+  },
+  "wikipedia/software-testing": {
+    sourceType: "reference",
+    title: "Software testing",
+    url: "https://en.wikipedia.org/wiki/Software_testing",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Test levels (unit, integration, system, acceptance) and the " +
+      "verification/validation framing.",
+    retrievedAt: "2026-06-13",
+  },
+  "wikipedia/verification-validation": {
+    sourceType: "reference",
+    title: "Software verification and validation",
+    url: "https://en.wikipedia.org/wiki/Software_verification_and_validation",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      'The V&V distinction: "building the product right" (static verification) ' +
+      'vs "the right product" (dynamic validation).',
+    retrievedAt: "2026-06-13",
+  },
+  "wikipedia/software-bug": {
+    sourceType: "reference",
+    title: "Software bug",
+    url: "https://en.wikipedia.org/wiki/Software_bug",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Severity vs priority managed separately; reliable reproduction is the " +
+      "first step to fixing a defect.",
+    retrievedAt: "2026-06-13",
+  },
+  "wikipedia/bug-tracking": {
+    sourceType: "reference",
+    title: "Bug tracking system",
+    url: "https://en.wikipedia.org/wiki/Bug_tracking_system",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Defect records capture severity, erroneous behavior, and reproduction " +
+      "steps; severity is not fix complexity.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── Product-management family (WSID wave 4) ──
+  // SVPG/Cagan pages blocked the fetcher (403); outcome-over-output is anchored
+  // on the open Agile Alliance Product Owner page. SAFe WSJF is copyrighted
+  // (paraphrased with attribution, not reproduced).
+  "agile/manifesto": {
+    sourceType: "reference",
+    title: "Manifesto for Agile Software Development",
+    url: "https://agilemanifesto.org/",
+    license: "open-copy-in-entirety",
+    abstract:
+      "The four Agile values (individuals/interactions, working software, " +
+      "customer collaboration, responding to change).",
+    retrievedAt: "2026-06-13",
+  },
+  "agile/principles": {
+    sourceType: "reference",
+    title: "Principles behind the Agile Manifesto",
+    url: "https://agilemanifesto.org/principles.html",
+    license: "open-copy-in-entirety",
+    abstract:
+      "The twelve principles underpinning the Agile values, including early " +
+      "continuous delivery and welcoming change.",
+    retrievedAt: "2026-06-13",
+  },
+  "scrum/guide-2020": {
+    sourceType: "framework",
+    title: "The 2020 Scrum Guide",
+    url: "https://scrumguides.org/scrum-guide.html",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Defines the ordered, refined Product Backlog, Product Owner " +
+      "accountability, Product Goal, Increment, and Definition of Done.",
+    retrievedAt: "2026-06-13",
+  },
+  "safe/wsjf": {
+    sourceType: "framework",
+    title: "WSJF — Weighted Shortest Job First (SAFe)",
+    url: "https://framework.scaledagile.com/wsjf/",
+    license: "Scaled-Agile-copyright",
+    abstract:
+      "WSJF = relative cost of delay divided by relative job duration; sequence " +
+      "shortest high-cost-of-delay jobs first. Paraphrased, attributed.",
+    retrievedAt: "2026-06-13",
+  },
+  "agile-alliance/invest": {
+    sourceType: "reference",
+    title: "INVEST (Agile Alliance glossary)",
+    url: "https://www.agilealliance.org/glossary/invest/",
+    license: "open-attribution",
+    abstract:
+      "Checklist for user-story quality: Independent, Negotiable, Valuable, " +
+      "Estimable, Small, Testable.",
+    retrievedAt: "2026-06-13",
+  },
+  "agile-alliance/acceptance": {
+    sourceType: "reference",
+    title: "Acceptance / Acceptance Testing (Agile Alliance glossary)",
+    url: "https://www.agilealliance.org/glossary/acceptance/",
+    license: "open-attribution",
+    abstract:
+      "An acceptance test is a formal, example-based description of product " +
+      "behavior yielding a binary pass/fail.",
+    retrievedAt: "2026-06-13",
+  },
+  "agile-alliance/definition-of-done": {
+    sourceType: "reference",
+    title: "Definition of Done (Agile Alliance glossary)",
+    url: "https://www.agilealliance.org/glossary/definition-of-done/",
+    license: "open-attribution",
+    abstract:
+      "Criteria an increment must meet to be considered done; references a " +
+      "companion Definition of Ready.",
+    retrievedAt: "2026-06-13",
+  },
+  "agile-alliance/product-owner": {
+    sourceType: "reference",
+    title: "Product Owner (Agile Alliance glossary)",
+    url: "https://www.agilealliance.org/glossary/product-owner/",
+    license: "open-attribution",
+    abstract:
+      "The Product Owner prioritizes the backlog to deliver maximum outcome " +
+      "with minimum output.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 4 — two more profession corpora on the variant model from [#1808](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1808). All doctrine distilled from **fetched** open-license sources (no training-data authoring). Both families are jurisdiction-global; the load-bearing variant here is the competency tier.

## QA / software-quality (8 pages)

test levels, severity vs priority, test automation pyramid, risk-based testing / shift-left, verification vs validation, ISO/IEC 25010 quality model (summary), defect-needs-reproduction (commandment), web security testing strategy (OWASP WSTG).

Sources: OWASP WSTG, Fowler test-pyramid, iso25000.com summary (ISO standard itself licensed → checklist-only), Wikipedia (software-testing, V&V, software-bug, bug-tracking). ISTQB glossary 403'd → terminology anchored on fetched CC-BY-SA articles; noted in-page.

## Product-management (8 pages)

Agile values & principles, ordered/refined product backlog, user story + INVEST, acceptance criteria, WSJF prioritization, outcome over output (expert), Definition of Done/Ready, Product Owner accountability.

Sources: Agile Manifesto, 2020 Scrum Guide (CC BY-SA), Agile Alliance glossary, SAFe (copyrighted → paraphrased with attribution). SVPG/Cagan 403'd → outcome-over-output grounded on the open Agile Alliance Product Owner page; noted.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards):

- **36 corpus pages on this branch, 0 orphan wiki-links, 0 unknown source citations**
- families on branch: data-architect=4, software-engineer=9, finance=7, qa-engineer=8, product-manager=8
- competency: `foundational=15, practitioner=14, expert=7`

15 new RawSources registered.

> Note: security + legal-compliance corpora are in the parallel PR [#1814](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1814) (different source keys; no overlap with this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)