### PR TITLE
fix(workbooks): persist reference-cell selection (commitOnOutsideClick)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -176,6 +176,10 @@ function buildColumn(
         renderCell: renderReferenceCell,
         renderEditCell:
           editable && referenceType ? makeReferenceEditor(referenceType) : undefined,
+        // The typeahead's result list is a floating element; without this,
+        // react-data-grid treats a click on it as an outside-click and commits
+        // the (empty) draft before onSelect runs, so the picked reference is lost.
+        editorOptions: { commitOnOutsideClick: false },
       };
     }
     case "formula":


### PR DESCRIPTION
**Found via live testing on the merged code** (:3001 contributor preview): picking a value in a reference cell's typeahead did **not persist** — the cell saved with an empty referenceId.

## Root cause
A react-data-grid behaviour: the typeahead's result list is a floating element, and RDG treats a click on it as an **outside click**, committing the cell's still-empty draft *before* the option's onSelect fires. The chosen ReferenceValue is lost.

## Fix
Set editorOptions.commitOnOutsideClick=false on reference columns, so the only commit path is the typeahead's onSelect → onRowChange(value, true), which carries the picked reference.

## Why unit tests missed it
The suites cover the **pure** helpers (searchReferences/resolveReference, label hydration, cell-validation's reference branch) but not the RDG editor→onRowsChange→persist integration, which needs a component/browser harness. Verified here by reasoning + the live repro.

## Verification status
- Live repro confirmed the bug on merged code; the search/typeahead half works (returns real platform entities).
- Full **post-fix** live re-verification is pending a **stable install** — during testing the dev install was being continuously reseeded by the archetype-audit harness (the org name changed every page load and created workbooks 404'd within minutes), so I could not get a clean post-fix read.

Gate: web typecheck + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)