### PR TITLE
feat(wsid): frontend-engineer + ux-design corpora (wave 5)

### DIFF
--- a/docs/professions/frontend-engineer/wiki/first-rule-of-aria-native-elements.md
+++ b/docs/professions/frontend-engineer/wiki/first-rule-of-aria-native-elements.md
@@ -1,0 +1,40 @@
+---
+title: First rule of ARIA — prefer native elements
+pageKind: principle
+status: published
+abstract: If a native HTML element provides the semantics and behavior you need, use it instead of re-purposing an element with an ARIA role. No ARIA is better than bad ARIA; a role is a promise to implement its interactions.
+principleTier: core
+principleDirection: Don't add an ARIA role where a native element exists; if you do adopt a role, implement all its required keyboard interactions.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "long_term_maintainability": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/using-aria
+  - w3c/aria-apg
+---
+
+## Rule
+
+**First Rule of ARIA:** if a native HTML element with the semantics and behavior you need already exists, use it instead of re-purposing a generic element and adding an ARIA role. ARIA is for the gaps native HTML cannot express, not a default.
+
+## Why
+
+The W3C is blunt: **"No ARIA is better than Bad ARIA."** ARIA changes how assistive technology perceives an element but adds **no behavior** — so when you assign a role, **"a role is a promise"**: you have committed to implementing all of that role's expected keyboard interactions, states, and focus management yourself. A `role="button"` on a `<div>` that doesn't handle Enter/Space and focus is worse than useless — it lies to the screen reader.
+
+## How To Apply
+
+1. **Default to native** per [[professions/frontend-engineer/semantic-html-first]].
+2. **Only add ARIA for genuine gaps** (e.g. a custom widget with no native equivalent).
+3. **Keep the promise.** Adopting a role obligates the full keyboard contract — see [[professions/frontend-engineer/keyboard-navigation-focus-management]].
+4. **Don't clobber needed semantics.** Don't override an element's native role when you still rely on it.
+5. **Test with assistive tech** before shipping ARIA.
+
+## See Also
+
+- [[professions/frontend-engineer/semantic-html-first]]
+- [[professions/frontend-engineer/keyboard-navigation-focus-management]]

--- a/docs/professions/frontend-engineer/wiki/keyboard-navigation-focus-management.md
+++ b/docs/professions/frontend-engineer/wiki/keyboard-navigation-focus-management.md
@@ -1,0 +1,40 @@
+---
+title: Keyboard navigation and focus management
+pageKind: principle
+status: published
+abstract: All interactive controls must be reachable, operable, and visibly focusable using the keyboard alone. Keyboard access is a minimum accessibility requirement; adopting an ARIA widget role obligates its keyboard contract.
+principleTier: core
+principleDirection: Make every interactive control fully operable and visibly focusable by keyboard; implement the keyboard contract for any custom widget.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/wcag22
+  - mdn/accessibility
+  - w3c/aria-apg
+---
+
+## Rule
+
+Every interactive control must be **reachable, operable, and visibly focusable using the keyboard alone** — no action may require a pointer. Focus order must be logical and focus must never be trapped.
+
+## Why
+
+WCAG's **Operable** principle requires that UI components and navigation work without a mouse, and MDN states keyboard accessibility "is part of the minimum accessibility requirements" for interactive widgets. Keyboard-only users, screen-reader users, and many motor-impaired users depend on it. When you build a custom widget with an ARIA role, the WAI APG makes clear you have promised its **keyboard interactions** — arrow-key navigation, Enter/Space activation, Escape, and correct focus movement.
+
+## How To Apply
+
+1. **Tab to everything interactive.** Every control is in the tab order (or programmatically focusable when appropriate); nothing interactive is mouse-only.
+2. **Visible focus.** Never remove focus outlines without an equivalent visible indicator.
+3. **Honor the widget contract.** A custom component's role implies specific keys — implement them per [[professions/frontend-engineer/first-rule-of-aria-native-elements]] (or use a native element that provides them free).
+4. **No focus traps.** Users can always move focus out of a component (modals manage focus deliberately).
+
+## See Also
+
+- [[professions/frontend-engineer/first-rule-of-aria-native-elements]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/performance-budgets-core-web-vitals.md
+++ b/docs/professions/frontend-engineer/wiki/performance-budgets-core-web-vitals.md
@@ -1,0 +1,30 @@
+---
+title: Performance budgets and Core Web Vitals
+pageKind: heuristic
+status: published
+abstract: Hold the page to Core Web Vitals budgets — LCP ≤ 2.5s, INP ≤ 200ms, CLS ≤ 0.1 — measured at the 75th percentile. Budget for the slow path, and trade richness against these thresholds deliberately.
+professionCompetencyLevel: expert
+sources:
+  - webdev/core-web-vitals
+---
+
+## Heuristic
+
+Treat the **Core Web Vitals** as performance budgets the page must stay within, measured at the **75th percentile** across mobile and desktop:
+
+- **LCP (Largest Contentful Paint)** — main content should render within **2.5 seconds** of load start.
+- **INP (Interaction to Next Paint)** — pages should have an INP of **200 milliseconds or less**.
+- **CLS (Cumulative Layout Shift)** — pages should maintain a CLS of **0.1 or less**.
+
+## Why
+
+Core Web Vitals are "the subset of Web Vitals that apply to all web pages" and should be measured by every site owner. They are judged at the **75th percentile** — meaning you must budget for the slow path (older devices, weaker networks), not the median. They are also a search-ranking and real-user-experience signal.
+
+## The Expert Trade-off
+
+This is the expert-tier page because the work is **trade-off management**: a large hero image or heavy client-side framework improves richness but spends LCP/INP budget. Budget explicitly — set per-page byte and timing budgets, defer non-critical JS, reserve layout space (CLS), and measure with real-user data, not just lab runs. Responsiveness ([[professions/frontend-engineer/responsive-design]]) and these budgets are evaluated together.
+
+## See Also
+
+- [[professions/frontend-engineer/responsive-design]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/responsive-design.md
+++ b/docs/professions/frontend-engineer/wiki/responsive-design.md
@@ -1,0 +1,29 @@
+---
+title: Responsive design across devices
+pageKind: heuristic
+status: published
+abstract: Build layouts that adapt to the viewport rather than targeting a fixed width. The web is meant to work for everyone on any device, and Core Web Vitals are judged across both mobile and desktop.
+professionCompetencyLevel: practitioner
+sources:
+  - mdn/accessibility
+  - webdev/core-web-vitals
+---
+
+## Heuristic
+
+Design layouts that **adapt to the viewport** — fluid grids, flexible media, and breakpoints — rather than targeting a single fixed width. The web is "fundamentally designed to work for all people, whatever their hardware, software, language, location, or ability."
+
+## Why
+
+Users arrive on phones, tablets, laptops, and large displays. Core Web Vitals are assessed across **both mobile and desktop** at the 75th percentile, so a layout that only holds on a designer's monitor fails real users. In particular, **CLS ≤ 0.1** means reflow on varying viewports must not cause unexpected layout shifts — reserve space for media and avoid content jumps as the page adapts.
+
+## How To Apply
+
+1. **Fluid first.** Use relative units and flexible layouts; add breakpoints where the content needs them, not at device-specific pixel widths.
+2. **Reserve space** for images/embeds to protect [[professions/frontend-engineer/performance-budgets-core-web-vitals]] (CLS).
+3. **Test small screens** and keyboard/zoom — responsiveness and accessibility reinforce each other ([[professions/frontend-engineer/wcag-four-principles-aa-conformance]]).
+
+## See Also
+
+- [[professions/frontend-engineer/performance-budgets-core-web-vitals]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/semantic-html-first.md
+++ b/docs/professions/frontend-engineer/wiki/semantic-html-first.md
@@ -1,0 +1,40 @@
+---
+title: Use semantic HTML first
+pageKind: principle
+status: published
+abstract: Choose HTML elements for their meaning, not their appearance. Native semantic elements carry built-in behavior and accessibility that assistive technology understands for free — reach for them before generic divs and ARIA.
+principleTier: commandment
+principleDirection: Use the native semantic HTML element for the job before reaching for a div/span plus ARIA or CSS.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.6, "long_term_maintainability": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - mdn/html
+  - w3c/using-aria
+---
+
+## Rule
+
+Choose HTML elements for their **meaning and structure**, not their appearance. HTML "defines the meaning and structure of web content" — meaning belongs to HTML, appearance to CSS, behavior to JavaScript. Reach for `<button>`, `<nav>`, `<header>`, `<article>`, `<label>` before generic `<div>`/`<span>`.
+
+## Why
+
+Native elements carry built-in semantics and behavior that browsers and assistive technologies understand **for free**: focusability, keyboard activation, roles, and states. A `<p>` maps to the accessibility tree identically to `<div role="paragraph">` — so the native element is strictly better (less code, no role to maintain). Re-creating native behavior on a `<div>` means re-implementing focus, keyboard handling, and ARIA correctly, which is where defects enter.
+
+This is the foundation that makes [[professions/frontend-engineer/first-rule-of-aria-native-elements]] possible.
+
+## How To Apply
+
+1. **Pick by purpose.** Interactive control → `<button>`/`<a>`; section landmark → `<nav>`/`<main>`; form field → `<input>` + `<label>`.
+2. **Style with CSS, don't re-tag.** If you need a different look, style the semantic element; don't downgrade to a `<div>`.
+3. **Reserve ARIA for gaps** native HTML cannot express — see the first rule of ARIA.
+
+## See Also
+
+- [[professions/frontend-engineer/first-rule-of-aria-native-elements]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/text-alternative-for-non-text.md
+++ b/docs/professions/frontend-engineer/wiki/text-alternative-for-non-text.md
@@ -1,0 +1,39 @@
+---
+title: Every non-text element needs a text alternative
+pageKind: principle
+status: published
+abstract: Images and other non-text content need a concise text alternative so assistive technology can convey them. The alt attribute is mandatory; use empty alt only for decorative images.
+principleTier: commandment
+principleDirection: Give every meaningful non-text element a concise text alternative; use alt="" only for purely decorative images.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "public_safety": 0.4}
+professionCompetencyLevel: foundational
+sources:
+  - mdn/img
+  - mdn/accessibility
+---
+
+## Rule
+
+Every meaningful non-text element needs a **text alternative**. For images the `alt` attribute is **mandatory** — it is a concise text replacement for the image's content that screen readers read aloud. Video, audio, and other media likewise need proper textual alternatives.
+
+## Why
+
+Assistive technology cannot perceive pixels — it relies on the text alternative to convey what a sighted user sees. MDN is explicit that `alt` is "mandatory and incredibly useful for accessibility." A missing or wrong alt makes the content invisible to non-visual users; this is one of the most common and most easily-avoided WCAG failures.
+
+## How To Apply
+
+1. **Describe the content/function, concisely.** For an action image, describe the action — `alt="next page"`, not `alt="arrow right"` or `alt="image"`.
+2. **Decorative? Empty alt.** Use `alt=""` for purely decorative images and tracking pixels so assistive tech skips them — omitting `alt` entirely is not the same.
+3. **Media needs alternatives too** — captions, transcripts, descriptions.
+4. This satisfies the Perceivable principle of [[professions/frontend-engineer/wcag-four-principles-aa-conformance]].
+
+## See Also
+
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]
+- [[professions/frontend-engineer/semantic-html-first]]

--- a/docs/professions/frontend-engineer/wiki/wcag-four-principles-aa-conformance.md
+++ b/docs/professions/frontend-engineer/wiki/wcag-four-principles-aa-conformance.md
@@ -1,0 +1,33 @@
+---
+title: WCAG 2.2 — four principles and AA conformance
+pageKind: summary
+status: published
+abstract: WCAG 2.2 organizes accessibility under four principles (Perceivable, Operable, Understandable, Robust) and three conformance levels (A, AA, AAA). Level AA is the default target for DPF frontend deliverables.
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+---
+
+## What This Source Is
+
+The **Web Content Accessibility Guidelines (WCAG) 2.2** is the W3C Recommendation (12 December 2024) defining how to make web content accessible. It rests on four principles, captured by the acronym **POUR**:
+
+- **Perceivable** — information and UI components must be presentable to users in ways they can perceive.
+- **Operable** — UI components and navigation must be operable (including by keyboard, not pointer alone).
+- **Understandable** — information and operation must be understandable.
+- **Robust** — content must remain compatible with current and future assistive technologies.
+
+## Conformance Levels
+
+WCAG defines three levels — **A**, **AA**, **AAA**. **AA is the widely recommended target**: it addresses the most common and impactful barriers without the stricter constraints of AAA. **Default standard for every DPF frontend deliverable: meet WCAG 2.2 Level AA.**
+
+## How DPF Coworkers Use It
+
+- Treat AA as the baseline acceptance bar; document any deliberate AAA targets.
+- The principles decompose into concrete practices: [[professions/frontend-engineer/semantic-html-first]], [[professions/frontend-engineer/text-alternative-for-non-text]], [[professions/frontend-engineer/keyboard-navigation-focus-management]].
+
+## See Also
+
+- [[professions/frontend-engineer/semantic-html-first]]
+- [[professions/frontend-engineer/text-alternative-for-non-text]]
+- [[professions/frontend-engineer/keyboard-navigation-focus-management]]

--- a/docs/professions/ux-design/wiki/accessibility-tradeoffs-aaa.md
+++ b/docs/professions/ux-design/wiki/accessibility-tradeoffs-aaa.md
@@ -1,0 +1,43 @@
+---
+title: Accessibility trade-offs and AAA targets
+pageKind: principle
+status: published
+abstract: AAA conformance raises minimums (e.g. 7:1 contrast) but is generally not a blanket requirement — apply it selectively where audience and context warrant. Minimalist aesthetics must never drop below the AA floor.
+principleTier: contextual
+principleDirection: Default to AA; apply AAA selectively by audience/context; never let aesthetics breach the AA minimums.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.7, "human_cognitive_load": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - webaim/contrast
+  - w3c/wcag22
+  - nng/ten-heuristics
+---
+
+## Rule
+
+Treat **AA as the default** and apply **AAA selectively**. AAA raises the bar — for example **7:1** contrast for normal text and **4.5:1** for large — but WCAG itself notes AAA is not recommended as a blanket policy for entire sites; apply it where the audience and context genuinely warrant it (e.g. content for low-vision users).
+
+## The Expert Trade-off
+
+This is the expert-tier page because it is about **balancing competing goods**:
+
+- **Aesthetic/minimalist design vs perceivability** — minimalism (Heuristic 8) must not push text or controls below the AA floor. A beautiful low-contrast palette that fails 4.5:1 is a defect, not a style choice.
+- **Designing complex interactions inclusively** — satisfying POUR simultaneously across keyboard, pointer, and assistive technology, where a richer interaction can conflict with operability.
+- **Selective AAA** — choose where the extra rigor pays off rather than chasing AAA everywhere and exhausting design budget.
+
+## How To Apply
+
+1. **AA is the floor, always.** Never trade it for aesthetics — see [[professions/ux-design/color-contrast-minimums]].
+2. **Target AAA deliberately** for high-need audiences/contexts; document the choice.
+3. **Resolve interaction conflicts** in favor of operability ([[professions/ux-design/target-size-and-operable-interactions]]).
+
+## See Also
+
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/target-size-and-operable-interactions]]
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]

--- a/docs/professions/ux-design/wiki/color-contrast-minimums.md
+++ b/docs/professions/ux-design/wiki/color-contrast-minimums.md
@@ -1,0 +1,45 @@
+---
+title: Color contrast minimums (WCAG 1.4.3)
+pageKind: principle
+status: published
+abstract: Normal text must meet a contrast ratio of at least 4.5:1 against its background; large text may use 3:1 (WCAG 2.2 AA). Enhanced AAA raises these to 7:1 and 4.5:1.
+principleTier: core
+principleDirection: Meet at least 4.5:1 contrast for normal text and 3:1 for large text; never ship text below the AA minimum.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+  - webaim/contrast
+---
+
+## Rule
+
+Text must meet WCAG 2.2 success criterion **1.4.3 (Contrast Minimum, Level AA)**:
+
+- **Normal text:** contrast ratio of **at least 4.5:1** against its background.
+- **Large text:** a reduced minimum of **3:1**. Large is defined as 18pt+ (≈24px) or 14pt+ bold (≈18.67px).
+- **Exempt:** logotypes and inactive/disabled UI components.
+
+For **enhanced (AAA)** conformance the minimums rise to **7:1** for normal text and **4.5:1** for large text.
+
+## Why
+
+Insufficient contrast makes text unreadable for users with low vision, color vision deficiency, or in bright-light/low-quality-display conditions. The ratio is normative in the open WCAG standard; WebAIM's contrast guidance explains and tooling it. Contrast is one of the most frequently failed — and most easily measured — accessibility criteria.
+
+## How To Apply
+
+1. **Measure, don't eyeball.** Use a contrast checker on every text/background pair.
+2. **Bake into design tokens.** Encode AA-passing pairs so the palette can't produce a failing combination.
+3. **Don't sacrifice it for minimalism** — see the trade-off note in [[professions/ux-design/accessibility-tradeoffs-aaa]].
+4. This is part of designing to [[professions/ux-design/design-accessibility-from-the-start-pour]].
+
+## See Also
+
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/target-size-and-operable-interactions]]
+- [[professions/ux-design/accessibility-tradeoffs-aaa]]

--- a/docs/professions/ux-design/wiki/design-accessibility-from-the-start-pour.md
+++ b/docs/professions/ux-design/wiki/design-accessibility-from-the-start-pour.md
@@ -1,0 +1,43 @@
+---
+title: Design for accessibility from the start (POUR)
+pageKind: principle
+status: published
+abstract: Accessibility is built in from project inception, not retrofitted. All UI must satisfy the four POUR principles — Perceivable, Operable, Understandable, Robust — and depends on multiple components working together.
+principleTier: commandment
+principleDirection: Design to POUR from the first wireframe; never defer accessibility to a late retrofit.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+  - w3c/wai-intro
+---
+
+## Rule
+
+Design for accessibility **from the start**. All UI must satisfy the four **POUR** principles:
+
+- **Perceivable** — "information and user interface components must be presentable to users in ways they can perceive."
+- **Operable** — navigation and interface components must be operable, including by keyboard, not pointer alone.
+- **Understandable** — information and operation must be understandable.
+- **Robust** — content must remain compatible with assistive technologies.
+
+## Why
+
+The W3C WAI is explicit that accessibility is **most efficient when incorporated from project inception**, not retrofitted — late fixes are costly and incomplete. Accessibility also depends on **multiple components working together** (the content, browsers, assistive technologies, and authoring tools), so it must be a design constraint, not a final QA pass.
+
+## How To Apply
+
+1. **Start with POUR.** Treat the four principles as design constraints from the first wireframe.
+2. **Bake in the measurables** — contrast ([[professions/ux-design/color-contrast-minimums]]) and target size ([[professions/ux-design/target-size-and-operable-interactions]]).
+3. **Design for assistive tech**, keyboard, and varied abilities — see [[professions/ux-design/what-is-accessibility-wai]].
+
+## See Also
+
+- [[professions/ux-design/what-is-accessibility-wai]]
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/target-size-and-operable-interactions]]

--- a/docs/professions/ux-design/wiki/error-prevention-and-recovery.md
+++ b/docs/professions/ux-design/wiki/error-prevention-and-recovery.md
@@ -1,0 +1,35 @@
+---
+title: Error prevention and recovery
+pageKind: heuristic
+status: published
+abstract: Prevent errors proactively with constraints and confirmations, and when they occur help users recognize, diagnose, and recover with plain-language messages and clear exits. Recovery paths must themselves be accessible.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/ten-heuristics
+  - w3c/wcag22
+---
+
+## Heuristic
+
+Two of Nielsen's heuristics work together around errors:
+
+- **Error prevention (Heuristic 5)** — prevent problems proactively through constraints, good defaults, and confirmations, rather than relying on error messages after the fact.
+- **Help users recognize, diagnose, and recover from errors (Heuristic 9)** — when an error does occur, express it in **plain language**, state the problem precisely, and suggest a constructive solution.
+
+Reinforced by **user control and freedom**: give clear "emergency exits" so users can undo mistakes or cancel unwanted actions.
+
+## Accessibility of Recovery
+
+Prevention and recovery must work for everyone: error messages and exits must be **operable and perceivable** by keyboard and assistive-technology users (WCAG Operable/Perceivable). An error message a screen-reader user never hears is no recovery path at all.
+
+## How To Apply
+
+1. **Prevent first.** Constrain inputs, confirm destructive actions, use sensible defaults.
+2. **Recover gracefully.** Plain-language messages tied to the field, with a concrete fix.
+3. **Always offer an exit** — undo/cancel — and make it accessible.
+4. Surface these issues via [[professions/ux-design/heuristic-evaluation-method]].
+
+## See Also
+
+- [[professions/ux-design/ten-usability-heuristics-summary]]
+- [[professions/ux-design/heuristic-evaluation-method]]

--- a/docs/professions/ux-design/wiki/heuristic-evaluation-method.md
+++ b/docs/professions/ux-design/wiki/heuristic-evaluation-method.md
@@ -1,0 +1,34 @@
+---
+title: Heuristic evaluation method
+pageKind: heuristic
+status: published
+abstract: A heuristic evaluation runs in three phases — prepare, evaluate independently, consolidate — using 3-5 independent evaluators assessing an interface against an established heuristic set. Multiple evaluators are required because one misses most issues.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/heuristic-evaluation
+---
+
+## Method
+
+Heuristic evaluation is a discount usability method that inspects an interface against an established set of heuristics. It runs in **three phases**:
+
+1. **Preparation** — select the heuristic set (Nielsen's 10 are recommended — see [[professions/ux-design/ten-usability-heuristics-summary]]) and narrow the scope to specific flows.
+2. **Independent evaluation** — each evaluator first spends ~1-2 hours familiarizing with the product, then systematically identifies violations on their own.
+3. **Consolidation** — cluster similar findings across evaluators and prioritize recommendations.
+
+## Why Multiple Evaluators
+
+Use **3-5 independent evaluators**. A single evaluator misses a large share of issues; independent passes surface different problems, and consolidation combines their coverage. Evaluating independently *before* comparing avoids anchoring.
+
+> Licensing note: the method is documented by NN/G (copyrighted); this page describes the procedure by reference with short attributed phrasing.
+
+## How DPF Coworkers Use It
+
+- Run it as a fast, low-cost first-pass before usability testing.
+- Score findings against the heuristics and against accessibility criteria ([[professions/ux-design/design-accessibility-from-the-start-pour]]).
+- Error-related findings deepen via [[professions/ux-design/error-prevention-and-recovery]].
+
+## See Also
+
+- [[professions/ux-design/ten-usability-heuristics-summary]]
+- [[professions/ux-design/error-prevention-and-recovery]]

--- a/docs/professions/ux-design/wiki/target-size-and-operable-interactions.md
+++ b/docs/professions/ux-design/wiki/target-size-and-operable-interactions.md
@@ -1,0 +1,43 @@
+---
+title: Target size and operable interactions (WCAG 2.5.8)
+pageKind: principle
+status: published
+abstract: Pointer targets should be at least 24×24 CSS pixels (WCAG 2.2 AA, 2.5.8), with exceptions for adequately-spaced, inline, or user-agent-sized targets. Interactions must be operable beyond the pointer, including by keyboard.
+principleTier: core
+principleDirection: Size pointer targets at least 24x24 CSS px (or space them adequately) and keep all interactions keyboard-operable.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/wcag22
+---
+
+## Rule
+
+Per WCAG 2.2 success criterion **2.5.8 (Target Size — Minimum, Level AA)**, the target for pointer inputs should be **at least 24 by 24 CSS pixels**, with defined exceptions:
+
+- **Spacing** — a smaller target is acceptable when it has adequate spacing around it.
+- **Inline** — targets within a sentence (e.g. links in text) are excluded.
+- **User-agent / essential** — targets sized by the user agent, or where a particular size is essential, are excepted.
+
+More broadly, the **Operable** principle requires interface components and navigation to be operable — including by keyboard, not pointer alone.
+
+## Why
+
+Small, tightly-packed targets are hard to hit for users with motor impairments, tremor, or touch input, causing errors and accidental activation. The 24px floor (plus spacing) gives a reliable hit area; keyboard operability ensures pointer-free use.
+
+## How To Apply
+
+1. **Size or space.** Make interactive targets ≥24×24 CSS px, or guarantee adequate spacing.
+2. **Keyboard parity.** Everything tappable is also keyboard-operable (pairs with [[professions/ux-design/design-accessibility-from-the-start-pour]]).
+3. **Pair with contrast** — a target must be both big enough and visible enough ([[professions/ux-design/color-contrast-minimums]]).
+
+## See Also
+
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/accessibility-tradeoffs-aaa]]

--- a/docs/professions/ux-design/wiki/ten-usability-heuristics-summary.md
+++ b/docs/professions/ux-design/wiki/ten-usability-heuristics-summary.md
@@ -1,0 +1,40 @@
+---
+title: The 10 usability heuristics (Nielsen)
+pageKind: summary
+status: published
+abstract: Nielsen's ten general usability heuristics are broad rules of thumb for interface design — from visibility of system status to error prevention and help users recover from errors. They are a heuristic lens, not a checklist.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/ten-heuristics
+---
+
+## What This Source Is
+
+The **10 Usability Heuristics for User Interface Design** (Jakob Nielsen, Nielsen Norman Group) are broad, general principles — "rules of thumb" — for usable interfaces. They are applied as an evaluative lens, not as specific, prescriptive guidelines.
+
+> Licensing note: NN/G content is copyrighted. This page lists the heuristics by name with short attributed phrases and links to the source; it does not reproduce the article.
+
+## The Ten Heuristics
+
+1. **Visibility of system status** — keep users informed with timely feedback.
+2. **Match between system and the real world** — use users' language and real-world conventions, not internal jargon.
+3. **User control and freedom** — provide clear "emergency exits" (undo/redo, cancel).
+4. **Consistency and standards** — follow platform and product conventions.
+5. **Error prevention** — prevent problems before they occur.
+6. **Recognition rather than recall** — make options visible; minimize memory load.
+7. **Flexibility and efficiency of use** — accelerators for experts, simple for novices.
+8. **Aesthetic and minimalist design** — no irrelevant information competing for attention.
+9. **Help users recognize, diagnose, and recover from errors** — plain-language messages with constructive solutions.
+10. **Help and documentation** — available when needed, task-focused.
+
+## How DPF Coworkers Use It
+
+- Use the heuristics as the lens for a [[professions/ux-design/heuristic-evaluation-method]].
+- Heuristics 5 and 9 are deepened in [[professions/ux-design/error-prevention-and-recovery]].
+- Pair usability with accessibility — see [[professions/ux-design/what-is-accessibility-wai]].
+
+## See Also
+
+- [[professions/ux-design/heuristic-evaluation-method]]
+- [[professions/ux-design/error-prevention-and-recovery]]
+- [[professions/ux-design/what-is-accessibility-wai]]

--- a/docs/professions/ux-design/wiki/what-is-accessibility-wai.md
+++ b/docs/professions/ux-design/wiki/what-is-accessibility-wai.md
@@ -1,0 +1,35 @@
+---
+title: What is accessibility (W3C WAI)
+pageKind: entity
+status: published
+abstract: Web accessibility means websites, tools, and technologies are designed so people with disabilities can use them — perceiving, understanding, navigating, and interacting with the web. It also benefits older adults, mobile users, and people in constrained contexts.
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wai-intro
+---
+
+## Definition
+
+Per the W3C Web Accessibility Initiative: **"Web accessibility means that websites, tools, and technologies are designed and developed so that people with disabilities can use them."** Concretely, it enables people to **perceive, understand, navigate, interact with, and contribute to** the web.
+
+## Who It Serves
+
+Accessibility addresses disabilities spanning **auditory, cognitive, neurological, physical, speech, and visual** domains. It also benefits a far wider population:
+
+- **Older adults** with changing abilities.
+- **Mobile users** and those on small screens or touch.
+- People with **temporary impairments** (a broken arm) or **situational limitations** (bright sunlight, a noisy environment, low bandwidth).
+
+## Evaluation
+
+Effective accessibility evaluation requires **both automated tools and human expertise** — automated checks catch many issues but cannot judge meaning, context, or real assistive-technology behavior.
+
+## How DPF Coworkers Use It
+
+- Frame accessibility as serving a broad population, not a niche — it improves usability for everyone.
+- Operationalize it through [[professions/ux-design/design-accessibility-from-the-start-pour]] and the measurable criteria it links to.
+
+## See Also
+
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/ten-usability-heuristics-summary]]

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -514,6 +514,123 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "with minimum output.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── Frontend-engineer + UX/accessibility families (WSID wave 5) ──
+  // w3c/wcag22 is shared by both families (registered once). W3C docs are open
+  // (W3C Document License); MDN is CC-BY-SA; web.dev is CC-BY-4.0. NN/G and
+  // WebAIM are licensed (no open license) — cited by reference with attribution,
+  // quotes kept short; their structure (heuristic names, contrast ratios that
+  // are also normative in the open WCAG) is used as facts, not reproduced prose.
+  "w3c/wcag22": {
+    sourceType: "standard",
+    title: "Web Content Accessibility Guidelines (WCAG) 2.2",
+    url: "https://www.w3.org/TR/WCAG22/",
+    license: "W3C-Document-License",
+    abstract:
+      "W3C Recommendation defining accessibility under four POUR principles and " +
+      "conformance levels A/AA/AAA, with testable success criteria.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/aria-apg": {
+    sourceType: "standard",
+    title: "ARIA Authoring Practices Guide (APG)",
+    url: "https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/",
+    license: "W3C-Document-License",
+    abstract:
+      'WAI guidance on correct ARIA use: "No ARIA is better than Bad ARIA"; a ' +
+      "role is a promise to implement its interactions.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/using-aria": {
+    sourceType: "standard",
+    title: "Using ARIA",
+    url: "https://www.w3.org/TR/using-aria/",
+    license: "W3C-Document-License",
+    abstract:
+      "Defines the First Rule of ARIA: prefer a native HTML element over " +
+      "re-purposing one with an ARIA role.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/wai-intro": {
+    sourceType: "standard",
+    title: "Introduction to Web Accessibility (W3C WAI)",
+    url: "https://www.w3.org/WAI/fundamentals/accessibility-intro/",
+    license: "W3C-Document-License",
+    abstract:
+      "Defines web accessibility and who benefits; accessibility is most " +
+      "efficient when built in from project inception.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/html": {
+    sourceType: "reference",
+    title: "HTML: HyperText Markup Language (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "HTML defines the meaning and structure of web content; meaning belongs " +
+      "to HTML, appearance to CSS.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/accessibility": {
+    sourceType: "reference",
+    title: "Accessibility (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "Accessibility enables as many people as possible to use sites; covers " +
+      "text alternatives and keyboard access.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/img": {
+    sourceType: "reference",
+    title: "<img>: the Image embed element (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "The alt attribute is mandatory: a concise text replacement for image " +
+      "content; alt=\"\" only for decorative images.",
+    retrievedAt: "2026-06-13",
+  },
+  "webdev/core-web-vitals": {
+    sourceType: "web-article",
+    title: "Web Vitals (web.dev)",
+    url: "https://web.dev/articles/vitals",
+    license: "CC-BY-4.0",
+    abstract:
+      "Core Web Vitals targets: LCP <= 2.5s, INP <= 200ms, CLS <= 0.1, assessed " +
+      "at the 75th percentile across mobile and desktop.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/ten-heuristics": {
+    sourceType: "web-article",
+    title: "10 Usability Heuristics for User Interface Design (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/ten-usability-heuristics/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Nielsen's ten general usability heuristics. Licensed; cited by reference " +
+      "with attribution, not reproduced.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/heuristic-evaluation": {
+    sourceType: "web-article",
+    title: "How to Conduct a Heuristic Evaluation (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Three-phase heuristic-evaluation method using 3-5 independent evaluators. " +
+      "Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
+  "webaim/contrast": {
+    sourceType: "web-article",
+    title: "Contrast and Color Accessibility (WebAIM)",
+    url: "https://webaim.org/articles/contrast/",
+    license: "WebAIM-copyright-cite-by-reference",
+    abstract:
+      "Explains WCAG 2 contrast ratios (4.5:1 normal, 3:1 large, 7:1 AAA) and " +
+      "the definition of large text. Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 5 — frontend-engineer + ux-design corpora on the variant model from [#1808](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1808). All doctrine distilled from **fetched** open-license sources. Both jurisdiction-global; competency tier is the active variant axis.

## Frontend-engineer (7 pages)

WCAG four principles + AA conformance, semantic-HTML-first (commandment), first-rule-of-ARIA, text-alternative-for-non-text (commandment), keyboard navigation & focus management, responsive design, performance budgets / Core Web Vitals (expert).

Sources (all open): W3C WCAG 2.2, Using ARIA, ARIA APG, MDN (HTML / accessibility / img), web.dev Web Vitals.

## UX / accessibility designer (8 pages)

10 usability heuristics, color-contrast minimums (WCAG 1.4.3), design-for-accessibility-from-the-start / POUR (commandment), what-is-accessibility (WAI) entity, heuristic-evaluation method, target size & operable interactions (WCAG 2.5.8), error prevention & recovery, accessibility trade-offs / AAA (expert).

Open sources: W3C WCAG 2.2, W3C WAI. NN/G heuristics + WebAIM contrast are **licensed** — cited by reference with attribution, quotes kept short, contrast ratios anchored on the open WCAG normative text.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards):

- **35 corpus pages on this branch, 0 orphan wiki-links, 0 unknown source citations**
- families on branch: data-architect=4, software-engineer=9, finance=7, frontend-engineer=7, ux-design=8
- competency: `foundational=13, practitioner=16, expert=6`

`w3c/wcag22` shared by both families (registered once); 11 new RawSources.

> Parallel open WSID PRs (independent source keys, no overlap): [#1814](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1814) (security+legal), [#1816](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1816) (qa+pm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)