### PR TITLE
feat(wsid): documentation-content + enterprise-architecture corpora (wave 6)

### DIFF
--- a/docs/professions/documentation-content/wiki/choose-the-right-documentation-mode.md
+++ b/docs/professions/documentation-content/wiki/choose-the-right-documentation-mode.md
@@ -1,0 +1,46 @@
+---
+title: Choose the right documentation mode — don't mix them
+pageKind: principle
+status: published
+abstract: Before writing, decide which user need a page serves and commit to that Diataxis mode. Reference describes only; how-to guides give action only; explanation stays apart from practice. Mixing modes is the root of many documentation failures.
+principleTier: core
+principleDirection: Write each page in exactly one Diataxis mode for one user need; never blend tutorial, how-to, reference, and explanation in one page.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"human_cognitive_load": 0.7, "long_term_maintainability": 0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - diataxis/framework
+  - diataxis/reference
+  - diataxis/how-to-guides
+  - diataxis/explanation
+---
+
+## Rule
+
+The four Diataxis modes serve **different user needs**. Before writing, decide which need the page serves and **commit to that mode** — do not blend learning, task, information, and understanding material in one page.
+
+## Why
+
+Each mode has a discipline, and mixing them serves none of the needs well:
+
+- **Reference** should "describe and only describe" — keep instruction and explanation out of it.
+- **How-to guides** should give "action and only action" — not teach mechanics a competent user already has.
+- **Explanation** belongs apart from active practice — the material you might read away from the keyboard.
+
+Conflating tutorials with how-to guides is, per Diataxis, "at the root of many difficulties that afflict documentation." A page trying to teach, instruct, list facts, and explain at once overwhelms the reader and is hard to maintain.
+
+## How To Apply
+
+1. **Name the need first.** Is the reader learning, doing, looking up, or understanding?
+2. **Pick one mode** ([[professions/documentation-content/diataxis-four-modes]]) and hold its discipline.
+3. **Split, don't blend.** If you need two modes, write two pages and link them.
+
+## See Also
+
+- [[professions/documentation-content/diataxis-four-modes]]
+- [[professions/documentation-content/tutorials-vs-how-to-guides]]

--- a/docs/professions/documentation-content/wiki/diagram-as-code-mermaid.md
+++ b/docs/professions/documentation-content/wiki/diagram-as-code-mermaid.md
@@ -1,0 +1,39 @@
+---
+title: Diagram as code with Mermaid
+pageKind: heuristic
+status: published
+abstract: Author diagrams as version-controllable text with Mermaid rather than in GUI tools, so diagrams live beside the docs and update with the source. Choose the diagram type to match the message.
+professionCompetencyLevel: practitioner
+sources:
+  - mermaid/intro
+---
+
+## Heuristic
+
+Author diagrams **as code**. Mermaid is "a JavaScript based diagramming and charting tool that renders Markdown-inspired text definitions" — so a diagram is plain text that lives in the repository next to the documentation and updates with the source.
+
+## Why Diagram-as-Code
+
+- **Version-controlled.** Diffs, reviews, and history apply to diagrams like any other source.
+- **Co-located.** The diagram lives beside the doc it illustrates and cannot drift into a stale exported image.
+- **No GUI round-trip.** Edits are text edits, reviewable in a PR.
+
+## Pick the Type to the Message
+
+Mermaid supports a broad set — flowchart, sequence, class, state, ER, Gantt, C4, mindmap, timeline. Match the type to what you are communicating:
+
+- **Flowchart** — a process or decision flow.
+- **Sequence** — interactions/messages over time.
+- **ER** — data model relationships.
+- **Class / state** — structure and lifecycle.
+
+## How DPF Coworkers Use It
+
+- Default to Mermaid for architecture and flow diagrams in docs; reserve images for what text cannot express.
+- Keep diagrams in the right Diataxis page — see [[professions/documentation-content/documentation-set-structure-ia]].
+- Apply [[professions/documentation-content/write-for-the-reader-clarity]] to labels.
+
+## See Also
+
+- [[professions/documentation-content/documentation-set-structure-ia]]
+- [[professions/documentation-content/write-for-the-reader-clarity]]

--- a/docs/professions/documentation-content/wiki/diataxis-four-modes.md
+++ b/docs/professions/documentation-content/wiki/diataxis-four-modes.md
@@ -1,0 +1,44 @@
+---
+title: The four Diataxis documentation modes
+pageKind: summary
+status: published
+abstract: Diataxis identifies four distinct documentation needs — tutorials (learning), how-to guides (tasks), reference (information), explanation (understanding) — organized around the structure of user needs across content, style, and architecture.
+professionCompetencyLevel: foundational
+sources:
+  - diataxis/framework
+---
+
+## What This Source Is
+
+**Diataxis** is a systematic approach to technical documentation that identifies **four distinct documentation needs**, each with its own form. Documentation fails when these are conflated; it succeeds when each page serves one clear need.
+
+## The Four Modes
+
+| Mode | User orientation | Serves |
+|------|------------------|--------|
+| **Tutorials** | Learning | A beginner acquiring skill through guided doing |
+| **How-to guides** | Tasks | A competent user achieving a specific goal |
+| **Reference** | Information | A user looking up precise technical facts |
+| **Explanation** | Understanding | A user seeking context, reasons, connections |
+
+## Three Dimensions
+
+The framework spans three dimensions, not just "what to write":
+
+- **Content** — what to write.
+- **Style** — how to write it.
+- **Architecture** — how to organize it.
+
+The four modes sit in a systematic relationship organized around the **structure of user needs**, not author convenience.
+
+## How DPF Coworkers Use It
+
+- Before writing, identify which need the page serves — see [[professions/documentation-content/choose-the-right-documentation-mode]].
+- The most consequential distinction is [[professions/documentation-content/tutorials-vs-how-to-guides]].
+- The architecture dimension governs the whole set — see [[professions/documentation-content/documentation-set-structure-ia]].
+
+## See Also
+
+- [[professions/documentation-content/choose-the-right-documentation-mode]]
+- [[professions/documentation-content/tutorials-vs-how-to-guides]]
+- [[professions/documentation-content/documentation-set-structure-ia]]

--- a/docs/professions/documentation-content/wiki/documentation-set-structure-ia.md
+++ b/docs/professions/documentation-content/wiki/documentation-set-structure-ia.md
@@ -1,0 +1,44 @@
+---
+title: Structure the whole documentation set (information architecture)
+pageKind: principle
+status: published
+abstract: Architecture is a first-class Diataxis dimension — organize the documentation set around the structure of user needs, keep the four modes in a systematic relationship, and make reference mirror the product's structure.
+principleTier: core
+principleDirection: Organize the whole documentation set around user needs and the four modes; make reference mirror the product structure.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.7, "human_cognitive_load": 0.6}
+professionCompetencyLevel: expert
+sources:
+  - diataxis/framework
+  - diataxis/reference
+  - diataxis/explanation
+---
+
+## Rule
+
+Treat **architecture** — how the documentation set is organized — as a first-class concern, not an afterthought to content. Organize the whole set around the **structure of user needs**, keeping the four Diataxis modes in a systematic relationship.
+
+## Why This Is Expert Work
+
+Individual pages can be good while the set as a whole is unusable. Expert documentation work is **information architecture**:
+
+- Diataxis names architecture as one of its three dimensions ("how to organize it") — co-equal with content and style.
+- For **reference**, "the structure of the documentation should mirror the structure of the product," so users navigate both at once. Reference must be wholly authoritative — "no doubt or ambiguity" — to give readers a firm platform.
+- **Explanation** maintains "distance from the active concerns of the practitioner," linking topics and giving the bigger picture across the corpus.
+
+## How To Apply
+
+1. **Organize by need**, not by author org chart — group around tutorials/how-to/reference/explanation.
+2. **Mirror the product** in reference structure so lookup is predictable.
+3. **Maintain cross-reference integrity** — links between modes should be deliberate and unbroken.
+4. Each page still obeys [[professions/documentation-content/choose-the-right-documentation-mode]].
+
+## See Also
+
+- [[professions/documentation-content/diataxis-four-modes]]
+- [[professions/documentation-content/choose-the-right-documentation-mode]]
+- [[professions/documentation-content/diagram-as-code-mermaid]]

--- a/docs/professions/documentation-content/wiki/tutorials-vs-how-to-guides.md
+++ b/docs/professions/documentation-content/wiki/tutorials-vs-how-to-guides.md
@@ -1,0 +1,38 @@
+---
+title: Tutorials vs how-to guides (learning vs task)
+pageKind: entity
+status: published
+abstract: A tutorial is learning-oriented — it helps a beginner acquire skill, with responsibility on the teacher. A how-to guide is task-oriented — directions for a competent user pursuing a goal. Conflating them is a root cause of bad documentation.
+professionCompetencyLevel: practitioner
+sources:
+  - diataxis/tutorials
+  - diataxis/how-to-guides
+---
+
+## The Distinction
+
+These two action-shaped modes look similar and are constantly confused, but serve opposite readers:
+
+| | Tutorial | How-to guide |
+|---|----------|--------------|
+| Orientation | **Learning** | **Tasks** |
+| Reader | A beginner, from scratch | A competent user who knows the goal |
+| Purpose | Help them **learn** | Help them **get something done** |
+| Responsibility | On the **teacher** to design success | On the reader to apply the directions |
+
+## Tutorials (learning-oriented)
+
+A tutorial's purpose "is not to help the user get something done, but to help them learn." In a tutorial "nearly all the responsibility falls upon the teacher." Tutorial craft: deliver visible results early, **ruthlessly minimise explanation**, and aspire to perfect reliability so the learner never gets stuck.
+
+## How-to Guides (task-oriented)
+
+A how-to guide is goal-oriented — "directions that guide the reader through a problem or towards a result." It addresses a **competent user** who already knows what they want to achieve and needs the steps, not the teaching.
+
+## Why It Matters
+
+Conflating the two is, per Diataxis, "at the root of many difficulties that afflict documentation." Deciding which one you are writing is the first step of [[professions/documentation-content/choose-the-right-documentation-mode]].
+
+## See Also
+
+- [[professions/documentation-content/choose-the-right-documentation-mode]]
+- [[professions/documentation-content/diataxis-four-modes]]

--- a/docs/professions/documentation-content/wiki/write-for-the-reader-clarity.md
+++ b/docs/professions/documentation-content/wiki/write-for-the-reader-clarity.md
@@ -1,0 +1,48 @@
+---
+title: Write for the reader — clarity first
+pageKind: principle
+status: published
+abstract: Documentation is written for the reader, not to impress. Be conversational, write for a global audience, use second person and active voice, and put conditions before instructions. Prioritize clarity and consistency even over any single guideline.
+principleTier: commandment
+principleDirection: Write clearly for the reader — second person, active voice, conditions before instructions, global audience — never to impress.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"human_cognitive_load": 0.8}
+professionCompetencyLevel: foundational
+sources:
+  - google/dev-style
+---
+
+## Rule
+
+Write for the **reader**, not to impress. Clarity is the goal of every documentation page.
+
+## The Practices
+
+From the Google developer documentation style guide:
+
+- **Be conversational and friendly** without being frivolous.
+- **Write for a global audience** — assume diverse readers, languages, and abilities; write accessibly.
+- **Use second person** ("you," not "we") and **active voice** so it is clear who performs each action.
+- **Put conditions before instructions, not after** — readers must know whether a step applies *before* they act.
+- **Prioritize clarity and consistency** for your readers even when it means deviating from a specific guideline.
+
+## Why
+
+Documentation exists to transfer understanding with minimum reader effort. Passive voice, jargon, and conditions-after-the-fact all increase cognitive load and cause errors (a reader completes a step that did not apply to them). Writing for a global audience also widens reach and supports accessibility.
+
+## How To Apply
+
+1. **Second person, active voice** by default.
+2. **Condition first:** "If you use X, do Y" — not "Do Y, if you use X."
+3. **Cut to impress nobody** — remove words that add length but not clarity.
+4. Combine with the right mode — see [[professions/documentation-content/choose-the-right-documentation-mode]].
+
+## See Also
+
+- [[professions/documentation-content/choose-the-right-documentation-mode]]
+- [[professions/documentation-content/diataxis-four-modes]]

--- a/docs/professions/enterprise-architecture/wiki/archimate-three-layers.md
+++ b/docs/professions/enterprise-architecture/wiki/archimate-three-layers.md
@@ -1,0 +1,35 @@
+---
+title: ArchiMate — the three core layers
+pageKind: summary
+status: published
+abstract: ArchiMate is an open enterprise-architecture modeling language that relates three core layers — Business, Application, Technology — through service-orientation, plus motivation, strategy, and implementation elements.
+professionCompetencyLevel: foundational
+sources:
+  - opengroup/archimate-3-2
+---
+
+## What This Source Is
+
+**ArchiMate** is an open, tool-independent enterprise-architecture modeling language for describing, analyzing, and visualizing relationships across business domains. Its defining structure is a set of layers related by **service-orientation**.
+
+> Provenance/licensing note: the full ArchiMate 3.2 specification is OAuth-gated (The Open Group). This page records only the well-established layer structure from the public overview; element-level modeling guidance requires the licensed specification.
+
+## The Three Core Layers
+
+- **Business layer** — business services, processes, actors, and roles.
+- **Application layer** — application services and components that support the business.
+- **Technology layer** — infrastructure services, nodes, and platforms that run the applications.
+
+Service-orientation and **realization** relationships link concrete elements to the more abstract services they provide, so each layer's services support the layer above. ArchiMate also spans Motivation, Strategy, and Implementation & Migration elements, plus stakeholders, viewpoints, and views.
+
+## How DPF Coworkers Use It
+
+- Before placing an element, decide **which layer** it belongs to — the most common modeling error is mixing layers.
+- Map architecture work to the value streams of [[professions/enterprise-architecture/it4it-value-streams]] and the phases of [[professions/enterprise-architecture/togaf-adm-phases]].
+- Capture significant modeling choices as [[professions/enterprise-architecture/record-decisions-as-adrs]].
+
+## See Also
+
+- [[professions/enterprise-architecture/togaf-adm-phases]]
+- [[professions/enterprise-architecture/it4it-value-streams]]
+- [[professions/enterprise-architecture/record-decisions-as-adrs]]

--- a/docs/professions/enterprise-architecture/wiki/architecture-decision-record.md
+++ b/docs/professions/enterprise-architecture/wiki/architecture-decision-record.md
@@ -1,0 +1,36 @@
+---
+title: Architecture Decision Record (ADR)
+pageKind: entity
+status: published
+abstract: An ADR captures one architectural decision and its rationale using Nygard's five parts — Title, Status, Context, Decision, Consequences. Context is value-neutral; a superseded decision changes status rather than being deleted.
+professionCompetencyLevel: practitioner
+sources:
+  - nygard/adr
+  - adr/github
+---
+
+## Definition
+
+An **Architecture Decision Record (ADR)** captures a single architectural decision and its rationale, including its trade-offs and consequences. ADRs accumulate into a project's decision log.
+
+## Nygard's Five-Part Structure
+
+1. **Title** — a short noun phrase naming the decision.
+2. **Status** — proposed / accepted / deprecated / superseded.
+3. **Context** — the forces at play (technological, political, social, project-local), written in **value-neutral language** describing the forces, not the preferred answer.
+4. **Decision** — stated in active voice: "We will …".
+5. **Consequences** — the resulting context after applying the decision: positive, negative, and neutral.
+
+## Working Rules
+
+- **Context is neutral.** Describe the forces honestly, not as justification for a foregone conclusion.
+- **Supersede, don't delete.** When a decision is reversed, change its status to *superseded* (linking the new ADR) so the historical record survives.
+- **Freely reusable.** Nygard's original article is CC0/public-domain, so its template can be adopted directly in DPF.
+
+## How DPF Coworkers Use It
+
+- Use this structure whenever [[professions/enterprise-architecture/record-decisions-as-adrs]] is triggered.
+
+## See Also
+
+- [[professions/enterprise-architecture/record-decisions-as-adrs]]

--- a/docs/professions/enterprise-architecture/wiki/conways-law.md
+++ b/docs/professions/enterprise-architecture/wiki/conways-law.md
@@ -1,0 +1,45 @@
+---
+title: Conway's Law
+pageKind: principle
+status: published
+abstract: A system's design tends to mirror the communication structure of the organization that builds it. Architecture and org design must be reasoned about together; a target architecture that fights the org structure is a trade-off to surface explicitly.
+principleTier: core
+principleDirection: Design architecture and team/communication structure together; when they conflict, surface the mismatch as an explicit decision.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.6, "blast_radius": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - conway/law
+  - nygard/adr
+---
+
+## The Law
+
+Conway's Law: "Any organization that designs a system … will produce a design whose structure is a copy of the organization's communication structure." It originates in Conway's 1968 paper *"How Do Committees Invent?"* (Datamation, April 1968).
+
+## Why It Matters for EA
+
+System and module boundaries tend to **mirror team and communication boundaries**. This is not a curiosity — it is a design force:
+
+- If you design an architecture whose boundaries cut across how teams actually communicate, the implementation will drift back toward the org structure.
+- Therefore **architecture and organization design must be reasoned about together**, not in isolation.
+
+## The Expert Move
+
+When a target architecture conflicts with the current organization's communication structure, the expert response is to **surface the mismatch as an explicit trade-off** — either adapt the architecture, or deliberately reshape teams to fit the desired architecture ("inverse Conway maneuver"). Either way it is an architecturally significant decision.
+
+## How To Apply
+
+1. **Read the org chart as an architecture constraint.**
+2. **Name the conflict.** Don't silently fight Conway's Law — record the tension.
+3. **Decide explicitly** and capture it via [[professions/enterprise-architecture/record-decisions-as-adrs]].
+4. Factor it into [[professions/enterprise-architecture/togaf-adm-phases]] (especially Vision and Business Architecture).
+
+## See Also
+
+- [[professions/enterprise-architecture/record-decisions-as-adrs]]
+- [[professions/enterprise-architecture/togaf-adm-phases]]

--- a/docs/professions/enterprise-architecture/wiki/it4it-value-streams.md
+++ b/docs/professions/enterprise-architecture/wiki/it4it-value-streams.md
@@ -1,0 +1,34 @@
+---
+title: IT4IT value streams (S2P, R2D, R2F, D2C)
+pageKind: summary
+status: published
+abstract: IT4IT is a value-stream-based reference architecture for managing digital/IT delivery. Its four value streams — Strategy to Portfolio, Requirement to Deploy, Request to Fulfill, Detect to Correct — frame the IT lifecycle. IT4IT is a stated DPF foundation.
+professionCompetencyLevel: practitioner
+sources:
+  - opengroup/it4it
+  - techtarget/it4it
+---
+
+## What This Source Is
+
+**IT4IT** is a flexible, value-stream-based reference architecture for managing IT and digital delivery across organizations of any size. It is a **stated DPF foundation** — DPF features and decisions are framed against its value streams.
+
+> Licensing note: the full IT4IT standard (3.0 snapshot) is OAuth-gated (The Open Group). Value-stream names and approach come from the public overview; per-stream detail from a secondary explainer, cited by reference.
+
+## The Four Value Streams
+
+- **Strategy to Portfolio (S2P)** — balance and broker IT activity via service-portfolio and project management, aligning IT to business strategy.
+- **Requirement to Deploy (R2D)** — set requirements, build, and deploy services for high-quality, predictable, cost-effective results.
+- **Request to Fulfill (R2F)** — streamline the process to fulfill requests, optimizing service consumption and fulfillment via the catalog.
+- **Detect to Correct (D2C)** — detect issues before they hurt the user, integrating event, incident, problem, change, and configuration management.
+
+## How DPF Coworkers Use It
+
+- **Map every feature and decision to the relevant value stream** — this is the DPF alignment practice.
+- S2P aligns with portfolio work; R2D with engineering delivery; R2F with the service catalog/customer-success; D2C with operations/SRE.
+- Architecture work spans the streams via [[professions/enterprise-architecture/togaf-adm-phases]] and is modeled with [[professions/enterprise-architecture/archimate-three-layers]].
+
+## See Also
+
+- [[professions/enterprise-architecture/togaf-adm-phases]]
+- [[professions/enterprise-architecture/archimate-three-layers]]

--- a/docs/professions/enterprise-architecture/wiki/record-decisions-as-adrs.md
+++ b/docs/professions/enterprise-architecture/wiki/record-decisions-as-adrs.md
@@ -1,0 +1,39 @@
+---
+title: Record architecturally significant decisions as ADRs
+pageKind: principle
+status: published
+abstract: When a design choice is architecturally significant, record it as an Architecture Decision Record capturing its rationale — not just the outcome — so future contributors can judge whether it still holds. The accumulated ADRs form the decision log.
+principleTier: core
+principleDirection: Emit an ADR with rationale for every architecturally significant decision; never leave such decisions undocumented.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.8, "long_term_maintainability": 0.7}
+professionCompetencyLevel: foundational
+sources:
+  - nygard/adr
+  - adr/github
+---
+
+## Rule
+
+When a design choice is **architecturally significant**, record it as an **Architecture Decision Record (ADR)** — capturing the **rationale**, not just the outcome. The accumulated ADRs form the project's **decision log**.
+
+## Why
+
+As Nygard put it, one of the hardest things to track over a project's life is the **motivation** behind decisions. A new contributor who cannot see why a choice was made will either preserve it blindly or overturn it ignorantly. An Architectural Decision is "a justified design choice that addresses a functional or non-functional requirement that is architecturally significant" — recording the forces and trade-offs lets future readers judge whether the decision still holds.
+
+## How To Apply
+
+1. **Trigger on significance.** If a choice is hard to reverse, affects structure, or constrains future options, write an ADR.
+2. **Record the why.** Context and consequences matter more than the decision sentence — use the [[professions/enterprise-architecture/architecture-decision-record]] structure.
+3. **Never delete; supersede.** A reversed decision changes status, preserving history.
+4. Org/communication-structure decisions are significant too — see [[professions/enterprise-architecture/conways-law]].
+
+## See Also
+
+- [[professions/enterprise-architecture/architecture-decision-record]]
+- [[professions/enterprise-architecture/conways-law]]

--- a/docs/professions/enterprise-architecture/wiki/togaf-adm-phases.md
+++ b/docs/professions/enterprise-architecture/wiki/togaf-adm-phases.md
@@ -1,0 +1,44 @@
+---
+title: TOGAF ADM phases
+pageKind: summary
+status: published
+abstract: TOGAF's Architecture Development Method (ADM) is an iterative cycle — Preliminary then phases A through H — with Requirements Management at the center. It is the core method of the TOGAF enterprise-architecture framework.
+professionCompetencyLevel: expert
+sources:
+  - opengroup/togaf
+  - conexiam/togaf-adm
+---
+
+## What This Source Is
+
+**TOGAF** is a proven enterprise-architecture methodology and framework; its core is the **Architecture Development Method (ADM)** — an iterative cycle for developing and governing an enterprise architecture.
+
+> Licensing note: the full TOGAF Standard is purchase-licensed (The Open Group). This page records the ADM phase structure from the public overview and an open secondary explainer; deeper governance guidance requires the licensed standard.
+
+## The ADM Phases
+
+- **Preliminary** — establish the architecture framework, principles, and governance.
+- **A — Architecture Vision** — scope, stakeholders, and the high-level vision.
+- **B — Business Architecture.**
+- **C — Information Systems Architecture** (data and application).
+- **D — Technology Architecture.**
+- **E — Opportunities & Solutions** — identify delivery vehicles.
+- **F — Migration Planning.**
+- **G — Implementation Governance.**
+- **H — Architecture Change Management.**
+
+**Requirements Management** runs continuously at the center, feeding and validating requirements into every phase.
+
+The ADM is **iterative and adaptable** — phases are revisited as requirements change, not run strictly once.
+
+## How DPF Coworkers Use It
+
+- Use the phases as the lifecycle frame for an architecture effort; map deliverables to phases.
+- Layer models from [[professions/enterprise-architecture/archimate-three-layers]] populate phases B–D; align to [[professions/enterprise-architecture/it4it-value-streams]].
+- Capture phase decisions as [[professions/enterprise-architecture/record-decisions-as-adrs]].
+
+## See Also
+
+- [[professions/enterprise-architecture/archimate-three-layers]]
+- [[professions/enterprise-architecture/it4it-value-streams]]
+- [[professions/enterprise-architecture/record-decisions-as-adrs]]

--- a/docs/professions/frontend-engineer/wiki/first-rule-of-aria-native-elements.md
+++ b/docs/professions/frontend-engineer/wiki/first-rule-of-aria-native-elements.md
@@ -1,0 +1,40 @@
+---
+title: First rule of ARIA — prefer native elements
+pageKind: principle
+status: published
+abstract: If a native HTML element provides the semantics and behavior you need, use it instead of re-purposing an element with an ARIA role. No ARIA is better than bad ARIA; a role is a promise to implement its interactions.
+principleTier: core
+principleDirection: Don't add an ARIA role where a native element exists; if you do adopt a role, implement all its required keyboard interactions.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "long_term_maintainability": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/using-aria
+  - w3c/aria-apg
+---
+
+## Rule
+
+**First Rule of ARIA:** if a native HTML element with the semantics and behavior you need already exists, use it instead of re-purposing a generic element and adding an ARIA role. ARIA is for the gaps native HTML cannot express, not a default.
+
+## Why
+
+The W3C is blunt: **"No ARIA is better than Bad ARIA."** ARIA changes how assistive technology perceives an element but adds **no behavior** — so when you assign a role, **"a role is a promise"**: you have committed to implementing all of that role's expected keyboard interactions, states, and focus management yourself. A `role="button"` on a `<div>` that doesn't handle Enter/Space and focus is worse than useless — it lies to the screen reader.
+
+## How To Apply
+
+1. **Default to native** per [[professions/frontend-engineer/semantic-html-first]].
+2. **Only add ARIA for genuine gaps** (e.g. a custom widget with no native equivalent).
+3. **Keep the promise.** Adopting a role obligates the full keyboard contract — see [[professions/frontend-engineer/keyboard-navigation-focus-management]].
+4. **Don't clobber needed semantics.** Don't override an element's native role when you still rely on it.
+5. **Test with assistive tech** before shipping ARIA.
+
+## See Also
+
+- [[professions/frontend-engineer/semantic-html-first]]
+- [[professions/frontend-engineer/keyboard-navigation-focus-management]]

--- a/docs/professions/frontend-engineer/wiki/keyboard-navigation-focus-management.md
+++ b/docs/professions/frontend-engineer/wiki/keyboard-navigation-focus-management.md
@@ -1,0 +1,40 @@
+---
+title: Keyboard navigation and focus management
+pageKind: principle
+status: published
+abstract: All interactive controls must be reachable, operable, and visibly focusable using the keyboard alone. Keyboard access is a minimum accessibility requirement; adopting an ARIA widget role obligates its keyboard contract.
+principleTier: core
+principleDirection: Make every interactive control fully operable and visibly focusable by keyboard; implement the keyboard contract for any custom widget.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/wcag22
+  - mdn/accessibility
+  - w3c/aria-apg
+---
+
+## Rule
+
+Every interactive control must be **reachable, operable, and visibly focusable using the keyboard alone** — no action may require a pointer. Focus order must be logical and focus must never be trapped.
+
+## Why
+
+WCAG's **Operable** principle requires that UI components and navigation work without a mouse, and MDN states keyboard accessibility "is part of the minimum accessibility requirements" for interactive widgets. Keyboard-only users, screen-reader users, and many motor-impaired users depend on it. When you build a custom widget with an ARIA role, the WAI APG makes clear you have promised its **keyboard interactions** — arrow-key navigation, Enter/Space activation, Escape, and correct focus movement.
+
+## How To Apply
+
+1. **Tab to everything interactive.** Every control is in the tab order (or programmatically focusable when appropriate); nothing interactive is mouse-only.
+2. **Visible focus.** Never remove focus outlines without an equivalent visible indicator.
+3. **Honor the widget contract.** A custom component's role implies specific keys — implement them per [[professions/frontend-engineer/first-rule-of-aria-native-elements]] (or use a native element that provides them free).
+4. **No focus traps.** Users can always move focus out of a component (modals manage focus deliberately).
+
+## See Also
+
+- [[professions/frontend-engineer/first-rule-of-aria-native-elements]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/performance-budgets-core-web-vitals.md
+++ b/docs/professions/frontend-engineer/wiki/performance-budgets-core-web-vitals.md
@@ -1,0 +1,30 @@
+---
+title: Performance budgets and Core Web Vitals
+pageKind: heuristic
+status: published
+abstract: Hold the page to Core Web Vitals budgets — LCP ≤ 2.5s, INP ≤ 200ms, CLS ≤ 0.1 — measured at the 75th percentile. Budget for the slow path, and trade richness against these thresholds deliberately.
+professionCompetencyLevel: expert
+sources:
+  - webdev/core-web-vitals
+---
+
+## Heuristic
+
+Treat the **Core Web Vitals** as performance budgets the page must stay within, measured at the **75th percentile** across mobile and desktop:
+
+- **LCP (Largest Contentful Paint)** — main content should render within **2.5 seconds** of load start.
+- **INP (Interaction to Next Paint)** — pages should have an INP of **200 milliseconds or less**.
+- **CLS (Cumulative Layout Shift)** — pages should maintain a CLS of **0.1 or less**.
+
+## Why
+
+Core Web Vitals are "the subset of Web Vitals that apply to all web pages" and should be measured by every site owner. They are judged at the **75th percentile** — meaning you must budget for the slow path (older devices, weaker networks), not the median. They are also a search-ranking and real-user-experience signal.
+
+## The Expert Trade-off
+
+This is the expert-tier page because the work is **trade-off management**: a large hero image or heavy client-side framework improves richness but spends LCP/INP budget. Budget explicitly — set per-page byte and timing budgets, defer non-critical JS, reserve layout space (CLS), and measure with real-user data, not just lab runs. Responsiveness ([[professions/frontend-engineer/responsive-design]]) and these budgets are evaluated together.
+
+## See Also
+
+- [[professions/frontend-engineer/responsive-design]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/responsive-design.md
+++ b/docs/professions/frontend-engineer/wiki/responsive-design.md
@@ -1,0 +1,29 @@
+---
+title: Responsive design across devices
+pageKind: heuristic
+status: published
+abstract: Build layouts that adapt to the viewport rather than targeting a fixed width. The web is meant to work for everyone on any device, and Core Web Vitals are judged across both mobile and desktop.
+professionCompetencyLevel: practitioner
+sources:
+  - mdn/accessibility
+  - webdev/core-web-vitals
+---
+
+## Heuristic
+
+Design layouts that **adapt to the viewport** — fluid grids, flexible media, and breakpoints — rather than targeting a single fixed width. The web is "fundamentally designed to work for all people, whatever their hardware, software, language, location, or ability."
+
+## Why
+
+Users arrive on phones, tablets, laptops, and large displays. Core Web Vitals are assessed across **both mobile and desktop** at the 75th percentile, so a layout that only holds on a designer's monitor fails real users. In particular, **CLS ≤ 0.1** means reflow on varying viewports must not cause unexpected layout shifts — reserve space for media and avoid content jumps as the page adapts.
+
+## How To Apply
+
+1. **Fluid first.** Use relative units and flexible layouts; add breakpoints where the content needs them, not at device-specific pixel widths.
+2. **Reserve space** for images/embeds to protect [[professions/frontend-engineer/performance-budgets-core-web-vitals]] (CLS).
+3. **Test small screens** and keyboard/zoom — responsiveness and accessibility reinforce each other ([[professions/frontend-engineer/wcag-four-principles-aa-conformance]]).
+
+## See Also
+
+- [[professions/frontend-engineer/performance-budgets-core-web-vitals]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/semantic-html-first.md
+++ b/docs/professions/frontend-engineer/wiki/semantic-html-first.md
@@ -1,0 +1,40 @@
+---
+title: Use semantic HTML first
+pageKind: principle
+status: published
+abstract: Choose HTML elements for their meaning, not their appearance. Native semantic elements carry built-in behavior and accessibility that assistive technology understands for free — reach for them before generic divs and ARIA.
+principleTier: commandment
+principleDirection: Use the native semantic HTML element for the job before reaching for a div/span plus ARIA or CSS.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.6, "long_term_maintainability": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - mdn/html
+  - w3c/using-aria
+---
+
+## Rule
+
+Choose HTML elements for their **meaning and structure**, not their appearance. HTML "defines the meaning and structure of web content" — meaning belongs to HTML, appearance to CSS, behavior to JavaScript. Reach for `<button>`, `<nav>`, `<header>`, `<article>`, `<label>` before generic `<div>`/`<span>`.
+
+## Why
+
+Native elements carry built-in semantics and behavior that browsers and assistive technologies understand **for free**: focusability, keyboard activation, roles, and states. A `<p>` maps to the accessibility tree identically to `<div role="paragraph">` — so the native element is strictly better (less code, no role to maintain). Re-creating native behavior on a `<div>` means re-implementing focus, keyboard handling, and ARIA correctly, which is where defects enter.
+
+This is the foundation that makes [[professions/frontend-engineer/first-rule-of-aria-native-elements]] possible.
+
+## How To Apply
+
+1. **Pick by purpose.** Interactive control → `<button>`/`<a>`; section landmark → `<nav>`/`<main>`; form field → `<input>` + `<label>`.
+2. **Style with CSS, don't re-tag.** If you need a different look, style the semantic element; don't downgrade to a `<div>`.
+3. **Reserve ARIA for gaps** native HTML cannot express — see the first rule of ARIA.
+
+## See Also
+
+- [[professions/frontend-engineer/first-rule-of-aria-native-elements]]
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]

--- a/docs/professions/frontend-engineer/wiki/text-alternative-for-non-text.md
+++ b/docs/professions/frontend-engineer/wiki/text-alternative-for-non-text.md
@@ -1,0 +1,39 @@
+---
+title: Every non-text element needs a text alternative
+pageKind: principle
+status: published
+abstract: Images and other non-text content need a concise text alternative so assistive technology can convey them. The alt attribute is mandatory; use empty alt only for decorative images.
+principleTier: commandment
+principleDirection: Give every meaningful non-text element a concise text alternative; use alt="" only for purely decorative images.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "public_safety": 0.4}
+professionCompetencyLevel: foundational
+sources:
+  - mdn/img
+  - mdn/accessibility
+---
+
+## Rule
+
+Every meaningful non-text element needs a **text alternative**. For images the `alt` attribute is **mandatory** — it is a concise text replacement for the image's content that screen readers read aloud. Video, audio, and other media likewise need proper textual alternatives.
+
+## Why
+
+Assistive technology cannot perceive pixels — it relies on the text alternative to convey what a sighted user sees. MDN is explicit that `alt` is "mandatory and incredibly useful for accessibility." A missing or wrong alt makes the content invisible to non-visual users; this is one of the most common and most easily-avoided WCAG failures.
+
+## How To Apply
+
+1. **Describe the content/function, concisely.** For an action image, describe the action — `alt="next page"`, not `alt="arrow right"` or `alt="image"`.
+2. **Decorative? Empty alt.** Use `alt=""` for purely decorative images and tracking pixels so assistive tech skips them — omitting `alt` entirely is not the same.
+3. **Media needs alternatives too** — captions, transcripts, descriptions.
+4. This satisfies the Perceivable principle of [[professions/frontend-engineer/wcag-four-principles-aa-conformance]].
+
+## See Also
+
+- [[professions/frontend-engineer/wcag-four-principles-aa-conformance]]
+- [[professions/frontend-engineer/semantic-html-first]]

--- a/docs/professions/frontend-engineer/wiki/wcag-four-principles-aa-conformance.md
+++ b/docs/professions/frontend-engineer/wiki/wcag-four-principles-aa-conformance.md
@@ -1,0 +1,33 @@
+---
+title: WCAG 2.2 — four principles and AA conformance
+pageKind: summary
+status: published
+abstract: WCAG 2.2 organizes accessibility under four principles (Perceivable, Operable, Understandable, Robust) and three conformance levels (A, AA, AAA). Level AA is the default target for DPF frontend deliverables.
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+---
+
+## What This Source Is
+
+The **Web Content Accessibility Guidelines (WCAG) 2.2** is the W3C Recommendation (12 December 2024) defining how to make web content accessible. It rests on four principles, captured by the acronym **POUR**:
+
+- **Perceivable** — information and UI components must be presentable to users in ways they can perceive.
+- **Operable** — UI components and navigation must be operable (including by keyboard, not pointer alone).
+- **Understandable** — information and operation must be understandable.
+- **Robust** — content must remain compatible with current and future assistive technologies.
+
+## Conformance Levels
+
+WCAG defines three levels — **A**, **AA**, **AAA**. **AA is the widely recommended target**: it addresses the most common and impactful barriers without the stricter constraints of AAA. **Default standard for every DPF frontend deliverable: meet WCAG 2.2 Level AA.**
+
+## How DPF Coworkers Use It
+
+- Treat AA as the baseline acceptance bar; document any deliberate AAA targets.
+- The principles decompose into concrete practices: [[professions/frontend-engineer/semantic-html-first]], [[professions/frontend-engineer/text-alternative-for-non-text]], [[professions/frontend-engineer/keyboard-navigation-focus-management]].
+
+## See Also
+
+- [[professions/frontend-engineer/semantic-html-first]]
+- [[professions/frontend-engineer/text-alternative-for-non-text]]
+- [[professions/frontend-engineer/keyboard-navigation-focus-management]]

--- a/docs/professions/hr-people-ops/wiki/document-people-decisions.md
+++ b/docs/professions/hr-people-ops/wiki/document-people-decisions.md
@@ -1,0 +1,43 @@
+---
+title: Document people decisions
+pageKind: principle
+status: published
+abstract: Record the legitimate, job-related reason for every significant people decision. US law forbids decisions resting on stereotypes; EU law puts the burden of proof on the employer. Contemporaneous documentation is the defense in both.
+principleTier: core
+principleDirection: Record a legitimate, job-related, contemporaneous reason for every hire, pay, discipline, and termination decision.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "evidence_density": 0.7}
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/prohibited-practices
+  - eu/employment-termination
+  - interview/structured
+---
+
+## Rule
+
+For every significant people decision — hiring, pay, discipline, promotion, termination — **record the legitimate, job-related reason**, contemporaneously. Documentation is not bureaucracy; it is the evidence that the decision was lawful and fair.
+
+## Why (both jurisdictions)
+
+- **US:** because adverse actions may not rest on "stereotypes and assumptions," the legitimate, job-related reason must be recorded to show it did not.
+- **EU:** the employer carries the **burden of proof**, so contemporaneous documentation of "legitimate, non-discriminatory reasons" is the defense; dismissals of protected workers require **written justification**, and collective-redundancy "criteria for the selection of staff" must be documented and consistently applied.
+
+In both, the record made *at the time* is worth far more than a reconstruction after a dispute.
+
+## How To Apply
+
+1. **Write the reason down when you decide**, not later.
+2. **Keep it job-related** — tie to performance, role requirements, or conduct, never a protected characteristic.
+3. **Use structured-interview rubrics** as the hiring record — see [[professions/hr-people-ops/structured-competency-based-interviewing]].
+4. **Mind employee-data rules** when storing records — see [[professions/hr-people-ops/gdpr-employee-data-art-88]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]
+- [[professions/hr-people-ops/gdpr-employee-data-art-88]]

--- a/docs/professions/hr-people-ops/wiki/eu-equal-treatment-and-dismissal-protection.md
+++ b/docs/professions/hr-people-ops/wiki/eu-equal-treatment-and-dismissal-protection.md
@@ -1,0 +1,51 @@
+---
+title: EU — equal treatment and dismissal protection
+pageKind: principle
+status: published
+abstract: EU employment law prohibits discriminatory dismissal, gives strong protection to pregnant/parental-leave workers, places the burden of proof on the employer, and requires consultation for collective redundancies. This contrasts sharply with US at-will employment.
+principleTier: core
+principleDirection: For EU employment, require a valid justified ground for dismissal, protect leave/pregnancy, and keep employer-side proof; never assume US at-will applies.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9}
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - eu/employment-termination
+  - atwill/cornell-lii
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU/EEA. The US counterpart is [[professions/hr-people-ops/us-at-will-employment]]. **Competency:** practitioner.
+
+## The Structural Contrast (read first)
+
+The US and EU defaults are opposite, and assuming the wrong one is a serious error:
+
+- **US default — at-will:** employer may terminate "at any time and for almost any reason" (subject to anti-discrimination and narrow exceptions).
+- **EU default — protected:** dismissal requires a **valid, justified ground**; protection is comprehensive, not statute-by-statute.
+
+## EU Rules
+
+- Dismissals may not be based on "sex, racial or ethnic origin, religion or belief, age, disability, sexual orientation."
+- **Pregnant / parental-leave workers** cannot be dismissed "except in exceptional cases" and must be given written justification.
+- When discrimination is alleged, "the burden of proof is primarily on the employer" to show a legitimate reason.
+- **Collective redundancies** require consulting staff representatives and notifying authorities, including the "criteria for the selection of staff to be made redundant."
+- **Business transfers** do not permit dismissal; contracts transfer and the buyer must continue to comply with any collective agreement.
+
+## How To Apply
+
+1. **Establish a valid ground** before any EU dismissal; never assume at-will.
+2. **Document defensibly** — the employer carries the proof burden ([[professions/hr-people-ops/document-people-decisions]]).
+3. **Handle employee data under GDPR** — see [[professions/hr-people-ops/gdpr-employee-data-art-88]].
+
+## See Also
+
+- [[professions/hr-people-ops/us-at-will-employment]]
+- [[professions/hr-people-ops/gdpr-employee-data-art-88]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/gdpr-employee-data-art-88.md
+++ b/docs/professions/hr-people-ops/wiki/gdpr-employee-data-art-88.md
@@ -1,0 +1,45 @@
+---
+title: GDPR employee data — Article 88
+pageKind: principle
+status: published
+abstract: GDPR Article 88 lets EU member states set rules for processing employees' personal data, requiring safeguards for dignity, monitoring transparency, and intra-group transfers. EU employee-data handling is materially stricter than the US baseline.
+principleTier: core
+principleDirection: Handle EU employee data under GDPR Article 88 safeguards — dignity, monitoring transparency, lawful basis — not under a US-style baseline.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "data_privacy": 0.9}
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - gdpr/art-88
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU/EEA. **Competency:** practitioner — applying employee-data safeguards is day-to-day people-ops work.
+
+## Rule
+
+Under **GDPR Article 88**, member states may set rules to protect "the rights and freedoms in respect of the processing of employees' personal data in the employment context." Where you process EU employee data, those rules — and GDPR's safeguards — govern.
+
+Covered purposes include recruitment, contract performance, work management, equality, health and safety, and termination. The rules must include "suitable and specific measures to safeguard the data subject's human dignity, legitimate interests and fundamental rights," with particular emphasis on **transparency of processing, intra-group data transfers, and workplace monitoring**.
+
+## Why It Matters
+
+This sectoral-derogation clause makes EU employee-data handling **materially stricter** than the US baseline. Workplace monitoring, applicant tracking, and HR analytics that might be unremarkable in the US can be unlawful in the EU without the right basis, transparency, and safeguards.
+
+## How To Apply
+
+1. **Establish a lawful basis** for each HR processing purpose (recruitment, monitoring, performance).
+2. **Be transparent** about monitoring; don't deploy covert surveillance.
+3. **Guard intra-group transfers** of employee data.
+4. Document the basis and safeguards — see [[professions/hr-people-ops/document-people-decisions]].
+
+## See Also
+
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/non-discrimination-protected-characteristics-us.md
+++ b/docs/professions/hr-people-ops/wiki/non-discrimination-protected-characteristics-us.md
@@ -1,0 +1,47 @@
+---
+title: US — non-discrimination on protected characteristics (EEOC)
+pageKind: principle
+status: published
+abstract: US federal law prohibits employment decisions based on protected characteristics — race, color, religion, sex, national origin, age 40+, disability, genetic information — across the entire employment lifecycle. Harassment and retaliation are independently illegal.
+principleTier: commandment
+principleDirection: Never base any US employment decision on a protected characteristic; document the legitimate, job-related reason instead.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "public_safety": 0.5}
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/prohibited-practices
+  - eeoc/eeo-laws
+  - eeoc/federal-laws-qa
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** United States (federal). The EU equivalent — broader and structured differently — is [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]. **Competency:** foundational — this is non-negotiable for any HR coworker operating in the US.
+
+## Rule
+
+US federal law prohibits employment decisions based on **protected characteristics**: race, color, religion, sex, and national origin (Title VII); age 40 or older (ADEA); disability (ADA / Rehabilitation Act); and genetic information (GINA).
+
+The prohibition spans the **whole employment lifecycle** — job ads, recruitment, hiring, equal pay for equal work, assignments, discipline, and discharge. Decisions may not rest on "stereotypes and assumptions" about a protected group. **Harassment and retaliation** for reporting discrimination are independently illegal.
+
+## Coverage
+
+Statutory thresholds apply (e.g. Title VII / ADA / GINA cover employers with 15+ employees; ADEA 20+). Even where a statute does not apply, basing decisions on protected characteristics is a serious risk and against DPF doctrine.
+
+## How To Apply
+
+1. **Never decide on a protected basis** — see the list in [[professions/hr-people-ops/protected-characteristics]].
+2. **Record the legitimate, job-related reason** for adverse actions — see [[professions/hr-people-ops/document-people-decisions]].
+3. **Use structured, job-analysis-based hiring** — see [[professions/hr-people-ops/structured-competency-based-interviewing]].
+
+## See Also
+
+- [[professions/hr-people-ops/protected-characteristics]]
+- [[professions/hr-people-ops/document-people-decisions]]
+- [[professions/hr-people-ops/structured-competency-based-interviewing]]

--- a/docs/professions/hr-people-ops/wiki/protected-characteristics.md
+++ b/docs/professions/hr-people-ops/wiki/protected-characteristics.md
@@ -1,0 +1,36 @@
+---
+title: Protected characteristics (US)
+pageKind: entity
+status: published
+abstract: US federal protected characteristics are race, color, religion, sex (including pregnancy, sexual orientation, and gender identity), national origin, age 40+, disability, and genetic information. Retaliation for asserting these rights is also protected.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/federal-laws-qa
+  - eeoc/prohibited-practices
+---
+
+## The Protected Characteristics (US federal)
+
+- **Race, color, religion, sex, and national origin** (Title VII).
+- **Sex** includes pregnancy, sexual orientation, and gender identity.
+- **Age**, 40 or older (ADEA).
+- **Disability** (ADA / Rehabilitation Act).
+- **Genetic information** (GINA).
+- **Retaliation** for reporting discrimination or asserting these rights is independently prohibited.
+
+## Scope
+
+These are the bases on which a US employment decision may **never** turn. The prohibition runs across the whole lifecycle — ads, hiring, pay, assignments, discipline, discharge — per [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]].
+
+States and localities often add further protected classes (e.g. marital status, sexual orientation where not already federal); treat the federal list as the floor, not the ceiling.
+
+## EU Note
+
+The EU protects overlapping but differently-framed grounds (sex, racial/ethnic origin, religion or belief, age, disability, sexual orientation) under a comprehensive equal-treatment regime — see [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]

--- a/docs/professions/hr-people-ops/wiki/shrm-competency-clusters.md
+++ b/docs/professions/hr-people-ops/wiki/shrm-competency-clusters.md
@@ -1,0 +1,31 @@
+---
+title: SHRM competency clusters (BASK) — checklist only
+pageKind: summary
+status: published
+abstract: The SHRM Body of Applied Skills and Knowledge groups HR competence into three behavioral clusters (Leadership, Interpersonal, Business) plus the HR Expertise technical competency. SHRM content is licensed — used here as a maturity checklist by name only.
+professionCompetencyLevel: expert
+sources:
+  - shrm/bask
+---
+
+## What This Source Is
+
+The **SHRM Body of Applied Skills and Knowledge (BASK)** defines the competencies expected of an HR professional. DPF uses it as an external **maturity checklist** for what a senior HR coworker should cover.
+
+> Licensing note: SHRM BASK is "© SHRM. All Rights Reserved." This page references only the **public competency-cluster and competency names** as facts — it does not ingest or reproduce SHRM text. The actual doctrine lives in the open-sourced pages of this family, not in SHRM content.
+
+## The Structure
+
+- **Three behavioral competency clusters:** Leadership, Interpersonal, Business.
+- **Named behavioral competencies** include: Leadership & Navigation, Ethical Practice, Relationship Management, Communication, Business Acumen, Consultation, Critical Evaluation, Global & Cultural Effectiveness.
+- **One technical competency:** HR Expertise.
+
+## How DPF Coworkers Use It
+
+- Treat the clusters as a **coverage checklist** for expert-level HR capability, not as doctrine to quote.
+- The enforceable doctrine sits in the open pages: non-discrimination, documentation, structured interviewing, and the jurisdiction-specific rules.
+
+## See Also
+
+- [[professions/hr-people-ops/structured-competency-based-interviewing]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/structured-competency-based-interviewing.md
+++ b/docs/professions/hr-people-ops/wiki/structured-competency-based-interviewing.md
@@ -1,0 +1,44 @@
+---
+title: Structured, competency-based interviewing
+pageKind: principle
+status: published
+abstract: Ask every candidate the same job-analysis-derived questions in the same order, scored against the same anchored rubric. Structured interviews have higher validity and stronger legal defensibility than unstructured ones, and reduce bias.
+principleTier: core
+principleDirection: Use the same job-analysis-based questions and an anchored rubric for every candidate; score independently before comparing.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.7, "evidence_density": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - interview/structured
+---
+
+## Rule
+
+Interview with **structure**: every candidate answers "the same questions, in the same order, evaluated against the same predetermined scoring criteria." Questions are "developed from job analysis," mapping each answer to a required competency.
+
+## How It Works
+
+- **Question types:** behavioral questions ask candidates to "describe specific past experiences"; situational questions "present hypothetical scenarios."
+- **Anchored rubric:** score against behavioral indicators; interviewers "score independently before comparing notes" to avoid anchoring.
+- **From job analysis:** questions trace to the competencies the role actually requires.
+
+## Why
+
+Structured interviews show **higher validity** (a cited ~.51 vs ~.38 for unstructured) and **reduce bias**. They are also more **legally defensible**, because decisions are "tied to job analysis" rather than subjective impressions — directly supporting non-discrimination obligations ([[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]).
+
+## How To Apply
+
+1. **Derive questions from the role's competencies** (job analysis).
+2. **Standardize** question set, order, and rubric across all candidates.
+3. **Score independently, then calibrate.**
+4. **Keep the scored rubric** as the hiring-decision record — see [[professions/hr-people-ops/document-people-decisions]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/document-people-decisions]]
+- [[professions/hr-people-ops/shrm-competency-clusters]]

--- a/docs/professions/hr-people-ops/wiki/us-at-will-employment.md
+++ b/docs/professions/hr-people-ops/wiki/us-at-will-employment.md
@@ -1,0 +1,38 @@
+---
+title: At-will employment (US doctrine)
+pageKind: entity
+status: published
+abstract: US at-will employment lets either party end the relationship at any time for almost any reason, subject to three exceptions (public policy, implied contract, implied covenant) and overriding anti-discrimination law. It contrasts with the EU's protected-dismissal default.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - atwill/cornell-lii
+  - eeoc/prohibited-practices
+---
+
+## Definition
+
+**At-will employment** is the US default: employer and employee may end the relationship "at any time and for almost any reason." There is no general requirement to show cause — distinguishing the US sharply from the EU's [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]].
+
+## The Three Exceptions
+
+At-will is not absolute. Courts recognize:
+
+1. **Public policy** — cannot terminate "in violation of well-established public policy of the state" (e.g. for filing a workers' compensation claim).
+2. **Implied contract** — conduct or an employee handbook may create "a reasonable expectation of a fixed term or even indefinite employment."
+3. **Implied covenant of good faith and fair dealing** — recognized in some states (e.g. California).
+
+## Anti-Discrimination Always Overrides
+
+At-will never permits a termination based on a protected characteristic — statutory anti-discrimination law overrides it. See [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]].
+
+## How DPF Coworkers Use It
+
+- Know the default but never treat at-will as license to act on a protected basis or to skip documentation.
+- For EU staff, at-will does **not** apply — switch to the protected-dismissal rules.
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]

--- a/docs/professions/operations/wiki/blameless-postmortem.md
+++ b/docs/professions/operations/wiki/blameless-postmortem.md
@@ -1,0 +1,33 @@
+---
+title: Run blameless post-incident reviews
+pageKind: heuristic
+status: published
+abstract: A blameless postmortem records an incident's impact, timeline, root causes, and follow-ups, identifying contributing causes without indicting any individual. Fix systems and processes, not people; defined triggers make postmortems routine.
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-postmortem
+---
+
+## Heuristic
+
+After a significant incident, write a **blameless postmortem** — a record of the incident, its impact, the actions taken, the root causes, and the follow-up actions. "Blameless" means "identifying the contributing causes…without indicting any individual or team."
+
+## Why Blameless
+
+Assume everyone "did the right thing with the information they had." The premise: **"You can't 'fix' people, but you can fix systems and processes."** Blame drives information underground — engineers stop reporting near-misses and stop escalating early. Blamelessness builds the escalation confidence that fast incident response depends on.
+
+## Make It Routine
+
+- **Triggers** include user-visible downtime, any data loss, manual on-call intervention, and a monitoring miss; **any stakeholder may request** a postmortem.
+- **No postmortem ships unreviewed** — review is part of the practice.
+- **Reward the practice** so writing one is seen as valuable, not punitive.
+
+## How DPF Coworkers Use It
+
+- Close significant incidents from the [[professions/operations/incident-response-lifecycle]] with a postmortem.
+- Feed root causes into problem management — see [[professions/operations/incident-vs-problem-management]].
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/incident-vs-problem-management]]

--- a/docs/professions/operations/wiki/error-budget-toil-tradeoff.md
+++ b/docs/professions/operations/wiki/error-budget-toil-tradeoff.md
@@ -1,0 +1,39 @@
+---
+title: Trade reliability against innovation via error budgets
+pageKind: principle
+status: published
+abstract: Beyond a point, more reliability costs more than it returns. The error budget makes the reliability-vs-velocity trade-off explicit: spend remaining budget on release speed; when depleted, slow down and harden. Extreme reliability is not free.
+principleTier: contextual
+principleDirection: Use the error budget to govern release velocity vs hardening; do not chase 100% reliability where it is not worth the cost.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.6, "capacity_utilization": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-risk
+---
+
+## Rule
+
+Use the **error budget** to manage the trade-off between reliability and innovation explicitly. Beyond a point, more reliability is "worse for a service…rather than better" — extreme reliability carries real cost (slower delivery, more toil) that may exceed its user value.
+
+## How The Trade-off Works
+
+- While the error budget is **positive**, spend it on **release velocity** — ship features, take measured risk.
+- When the budget is **depleted**, teams self-regulate toward **more testing and slower releases** until reliability recovers.
+
+The budget tensions several levers: software hardening, test intensity, release frequency, and canary size/duration. Making these trade-offs against a shared budget — rather than by argument — is the expert SRE discipline.
+
+## How To Apply
+
+1. **Derive the budget** from the SLOs in [[professions/operations/sli-slo-error-budget]].
+2. **Gate velocity on budget**, not on opinion.
+3. **Pair with postmortems** — recurring budget burn signals systemic issues for [[professions/operations/blameless-postmortem]].
+
+## See Also
+
+- [[professions/operations/sli-slo-error-budget]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/incident-response-lifecycle.md
+++ b/docs/professions/operations/wiki/incident-response-lifecycle.md
@@ -1,0 +1,35 @@
+---
+title: Incident response lifecycle (NIST SP 800-61)
+pageKind: summary
+status: published
+abstract: NIST's incident-response lifecycle has four cyclical phases — preparation; detection & analysis; containment, eradication & recovery; post-incident activity. Lessons feed back into preparation.
+professionCompetencyLevel: practitioner
+sources:
+  - nist/sp-800-61
+  - rapid7/nist-ir-lifecycle
+---
+
+## The Four Phases
+
+NIST SP 800-61 frames incident response as a cyclical lifecycle:
+
+1. **Preparation** — reduce incident probability and ready the response team before anything fires.
+2. **Detection & Analysis** — analyze symptoms and decide whether an event is truly an incident.
+3. **Containment, Eradication & Recovery** — stop the threat, remove it, then restore affected resources, data, and processes.
+4. **Post-Incident Activity** — capture lessons and feed them back into Preparation.
+
+The phases are **cyclical, not linear** — each incident improves the next round of preparation.
+
+> Provenance/currency note: the NIST SP 800-61 primary PDF did not text-extract in research, so phase detail is cited via an open secondary explainer. **Rev. 2 was withdrawn (superseded by Rev. 3)** — re-anchor citations to Rev. 3 when authoring against the current spec. The four-phase shape is durable doctrine.
+
+## How DPF Coworkers Use It
+
+- Run incidents through the four phases; never skip Detection & Analysis straight to action.
+- Classify impact first — see [[professions/operations/incident-severity-classification]] — and execute via [[professions/operations/runbook-driven-resolution]].
+- Close every significant incident with a [[professions/operations/blameless-postmortem]].
+
+## See Also
+
+- [[professions/operations/incident-severity-classification]]
+- [[professions/operations/runbook-driven-resolution]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/incident-severity-classification.md
+++ b/docs/professions/operations/wiki/incident-severity-classification.md
@@ -1,0 +1,42 @@
+---
+title: Classify incident severity before acting
+pageKind: principle
+status: published
+abstract: Classify an incident's severity (SEV1 critical, SEV2 major, SEV3 minor) by business impact before responding, so a pre-defined workflow starts without improvisation. Severity (impact) is distinct from priority (urgency).
+principleTier: core
+principleDirection: Assign a severity by business impact at the start of every incident; tie each level to a predefined response.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"blast_radius": 0.7, "public_safety": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - betterstack/severity-levels
+---
+
+## Rule
+
+At the **start** of an incident, classify its **severity** by business impact. Severity drives which pre-defined response runs, so triage decisions are not improvised under pressure.
+
+## Severity Levels
+
+- **SEV1 (critical)** — service down for all customers, or a major security breach / data loss.
+- **SEV2 (major)** — service down for a subset of customers, or significant loss of core functionality.
+- **SEV3 (minor)** — an inconvenience that does not affect major system functions.
+
+## Severity Is Not Priority
+
+**Severity measures impact; priority measures urgency / what to fix first.** They are distinct: a SEV2 affecting a paying enterprise customer may be worked before a SEV1 on a deprecated system. Record both — the same severity-vs-priority distinction the QA profession draws for defects.
+
+## How To Apply
+
+1. **Classify first.** Assign a SEV level before mobilizing — it determines the response.
+2. **Tie severity to a workflow** so "no improvisation is necessary" — see [[professions/operations/runbook-driven-resolution]].
+3. **Feed the lifecycle** — severity shapes the [[professions/operations/incident-response-lifecycle]].
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/runbook-driven-resolution]]

--- a/docs/professions/operations/wiki/incident-vs-problem-management.md
+++ b/docs/professions/operations/wiki/incident-vs-problem-management.md
@@ -1,0 +1,34 @@
+---
+title: Incident management vs problem management (ITIL)
+pageKind: entity
+status: published
+abstract: Incident management restores normal service as quickly as possible; problem management investigates and eliminates the underlying causes of recurring incidents. They are distinct, complementary practices.
+professionCompetencyLevel: practitioner
+sources:
+  - itsm-tools/incident-vs-problem
+---
+
+## Definition
+
+ITIL distinguishes two complementary service-management practices:
+
+- **Incident management** restores normal service "as quickly as possible, with as little adverse impact as possible." It is first-response: get the user working again.
+- **Problem management** eliminates recurring incidents and minimizes the impact of those it cannot prevent. It is investigative: find and remove the cause.
+
+A **problem** is the cause (or potential cause) of one or more incidents. Incident management asks "how do we restore service now?"; problem management asks "why did this happen, and how do we stop it recurring?"
+
+> Licensing note: ITIL 4 is a proprietary, licensed framework (PeopleCert/Axelos). This page uses an open explainer for the doctrine and does not reproduce ITIL specification text.
+
+## Why The Distinction Matters
+
+Treating every incident as a one-off (restore and move on) lets the same failure recur indefinitely. Treating every incident as a deep investigation paralyzes response. The two practices run in parallel: restore fast (incident), then investigate the cause (problem).
+
+## How DPF Coworkers Use It
+
+- Run incident management through the [[professions/operations/incident-response-lifecycle]].
+- Feed recurring incidents into problem management; the [[professions/operations/blameless-postmortem]] is where cause analysis begins.
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/observability-three-signals.md
+++ b/docs/professions/operations/wiki/observability-three-signals.md
@@ -1,0 +1,32 @@
+---
+title: Observability — the three signals
+pageKind: summary
+status: published
+abstract: Observability is understanding a system from the outside via its telemetry. The three signals are traces (a request's path), metrics (aggregated numbers over time), and logs (timestamped messages). OpenTelemetry is the vendor-neutral framework for them.
+professionCompetencyLevel: practitioner
+sources:
+  - opentelemetry/observability-primer
+---
+
+## What Observability Is
+
+**Observability** lets you "understand a system from the outside…without knowing its inner workings" — by examining the telemetry it emits. A system you cannot observe, you cannot operate or debug under pressure.
+
+## The Three Signals
+
+- **Traces** record the path of a single request as it propagates through multiple services. A **span** is one unit of work; **distributed tracing** stitches spans across services.
+- **Metrics** are aggregated numeric data over time — error rates, CPU, request volume.
+- **Logs** are timestamped messages emitted by services, usually not tied to a specific request.
+
+**OpenTelemetry** is a vendor-neutral, open-source (CNCF) framework for generating and exporting all three signals, so instrumentation is not locked to one backend.
+
+## How DPF Coworkers Use It
+
+- Instrument for all three signals; rely on traces to localize, metrics to detect, logs to explain.
+- Metrics feed the SLIs behind [[professions/operations/sli-slo-error-budget]].
+- Detection in the [[professions/operations/incident-response-lifecycle]] depends on these signals being present.
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/sli-slo-error-budget]]

--- a/docs/professions/operations/wiki/runbook-driven-resolution.md
+++ b/docs/professions/operations/wiki/runbook-driven-resolution.md
@@ -1,0 +1,38 @@
+---
+title: Follow the runbook, then escalate
+pageKind: principle
+status: published
+abstract: Tie each incident severity to a predefined runbook so resolution is repeatable, not improvised. The foundational operations duty is to classify severity, follow the runbook, and escalate when the situation exceeds its scope.
+principleTier: core
+principleDirection: Execute the predefined runbook for the classified severity; escalate promptly when the incident exceeds the runbook's scope.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"blast_radius": 0.6, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - betterstack/severity-levels
+  - rapid7/nist-ir-lifecycle
+---
+
+## Rule
+
+Tie each incident severity to a **predefined runbook** so that "no improvisation is necessary." The foundational operations duty is a simple loop: **classify severity → follow the runbook → escalate when out of scope.**
+
+## Why
+
+Under incident pressure, improvisation produces inconsistent, error-prone responses. A runbook captures the containment and recovery steps so restoration is **repeatable**, and frees the responder's attention for judgment the runbook cannot encode. Detection & Analysis (from the [[professions/operations/incident-response-lifecycle]]) decides whether an event is a real incident *before* runbook execution begins.
+
+## How To Apply
+
+1. **Classify first** — see [[professions/operations/incident-severity-classification]].
+2. **Execute the matching runbook** — containment and recovery steps are written down, not recalled.
+3. **Escalate on scope breach.** When the incident exceeds the runbook (novel failure, expanding blast radius), escalate rather than improvise.
+4. **Improve the runbook** from each postmortem.
+
+## See Also
+
+- [[professions/operations/incident-severity-classification]]
+- [[professions/operations/incident-response-lifecycle]]

--- a/docs/professions/operations/wiki/sli-slo-error-budget.md
+++ b/docs/professions/operations/wiki/sli-slo-error-budget.md
@@ -1,0 +1,45 @@
+---
+title: SLIs, SLOs, and error budgets
+pageKind: principle
+status: published
+abstract: An SLI is a quantitative measure of service level; an SLO is a target for it; an SLA adds consequences. The error budget — the gap between the SLO target and 100% — quantifies acceptable unreliability and aligns dev and ops on one incentive.
+principleTier: core
+principleDirection: Define a few representative SLIs, set SLO targets, and manage releases against the resulting error budget.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.6, "capacity_utilization": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-slo
+  - google/sre-book-risk
+---
+
+## Rule
+
+Measure reliability with **SLIs**, target it with **SLOs**, and govern change with the resulting **error budget**.
+
+## The Definitions
+
+- **SLI (Service Level Indicator)** — "a carefully defined quantitative measure of some aspect of the level of service" (e.g. request latency, error rate, availability).
+- **SLO (Service Level Objective)** — a target value or range for an SLI (e.g. latency under 100 ms for 99.9% of requests).
+- **SLA (Service Level Agreement)** — an SLO **plus consequences** for missing it. No consequence means it is an SLO, not an SLA.
+
+Prefer "a handful of representative indicators" and **percentiles over averages** — an average hides the tail that users feel.
+
+## Error Budget
+
+The **error budget** is the gap between the SLO target and 100% — "how much unreliability is remaining." It turns reliability into a currency: while budget remains, teams can spend it on release velocity; when it is exhausted, they self-regulate toward more testing and slower releases. This aligns development and SRE on **one shared incentive** instead of a reliability-vs-features tug of war.
+
+## How To Apply
+
+1. **Pick few, representative SLIs** from your [[professions/operations/observability-three-signals]].
+2. **Set SLO targets** users actually care about; derive the error budget.
+3. **Govern releases** by remaining budget — see [[professions/operations/error-budget-toil-tradeoff]].
+
+## See Also
+
+- [[professions/operations/observability-three-signals]]
+- [[professions/operations/error-budget-toil-tradeoff]]

--- a/docs/professions/ux-design/wiki/accessibility-tradeoffs-aaa.md
+++ b/docs/professions/ux-design/wiki/accessibility-tradeoffs-aaa.md
@@ -1,0 +1,43 @@
+---
+title: Accessibility trade-offs and AAA targets
+pageKind: principle
+status: published
+abstract: AAA conformance raises minimums (e.g. 7:1 contrast) but is generally not a blanket requirement — apply it selectively where audience and context warrant. Minimalist aesthetics must never drop below the AA floor.
+principleTier: contextual
+principleDirection: Default to AA; apply AAA selectively by audience/context; never let aesthetics breach the AA minimums.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.7, "human_cognitive_load": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - webaim/contrast
+  - w3c/wcag22
+  - nng/ten-heuristics
+---
+
+## Rule
+
+Treat **AA as the default** and apply **AAA selectively**. AAA raises the bar — for example **7:1** contrast for normal text and **4.5:1** for large — but WCAG itself notes AAA is not recommended as a blanket policy for entire sites; apply it where the audience and context genuinely warrant it (e.g. content for low-vision users).
+
+## The Expert Trade-off
+
+This is the expert-tier page because it is about **balancing competing goods**:
+
+- **Aesthetic/minimalist design vs perceivability** — minimalism (Heuristic 8) must not push text or controls below the AA floor. A beautiful low-contrast palette that fails 4.5:1 is a defect, not a style choice.
+- **Designing complex interactions inclusively** — satisfying POUR simultaneously across keyboard, pointer, and assistive technology, where a richer interaction can conflict with operability.
+- **Selective AAA** — choose where the extra rigor pays off rather than chasing AAA everywhere and exhausting design budget.
+
+## How To Apply
+
+1. **AA is the floor, always.** Never trade it for aesthetics — see [[professions/ux-design/color-contrast-minimums]].
+2. **Target AAA deliberately** for high-need audiences/contexts; document the choice.
+3. **Resolve interaction conflicts** in favor of operability ([[professions/ux-design/target-size-and-operable-interactions]]).
+
+## See Also
+
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/target-size-and-operable-interactions]]
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]

--- a/docs/professions/ux-design/wiki/color-contrast-minimums.md
+++ b/docs/professions/ux-design/wiki/color-contrast-minimums.md
@@ -1,0 +1,45 @@
+---
+title: Color contrast minimums (WCAG 1.4.3)
+pageKind: principle
+status: published
+abstract: Normal text must meet a contrast ratio of at least 4.5:1 against its background; large text may use 3:1 (WCAG 2.2 AA). Enhanced AAA raises these to 7:1 and 4.5:1.
+principleTier: core
+principleDirection: Meet at least 4.5:1 contrast for normal text and 3:1 for large text; never ship text below the AA minimum.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+  - webaim/contrast
+---
+
+## Rule
+
+Text must meet WCAG 2.2 success criterion **1.4.3 (Contrast Minimum, Level AA)**:
+
+- **Normal text:** contrast ratio of **at least 4.5:1** against its background.
+- **Large text:** a reduced minimum of **3:1**. Large is defined as 18pt+ (≈24px) or 14pt+ bold (≈18.67px).
+- **Exempt:** logotypes and inactive/disabled UI components.
+
+For **enhanced (AAA)** conformance the minimums rise to **7:1** for normal text and **4.5:1** for large text.
+
+## Why
+
+Insufficient contrast makes text unreadable for users with low vision, color vision deficiency, or in bright-light/low-quality-display conditions. The ratio is normative in the open WCAG standard; WebAIM's contrast guidance explains and tooling it. Contrast is one of the most frequently failed — and most easily measured — accessibility criteria.
+
+## How To Apply
+
+1. **Measure, don't eyeball.** Use a contrast checker on every text/background pair.
+2. **Bake into design tokens.** Encode AA-passing pairs so the palette can't produce a failing combination.
+3. **Don't sacrifice it for minimalism** — see the trade-off note in [[professions/ux-design/accessibility-tradeoffs-aaa]].
+4. This is part of designing to [[professions/ux-design/design-accessibility-from-the-start-pour]].
+
+## See Also
+
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/target-size-and-operable-interactions]]
+- [[professions/ux-design/accessibility-tradeoffs-aaa]]

--- a/docs/professions/ux-design/wiki/design-accessibility-from-the-start-pour.md
+++ b/docs/professions/ux-design/wiki/design-accessibility-from-the-start-pour.md
@@ -1,0 +1,43 @@
+---
+title: Design for accessibility from the start (POUR)
+pageKind: principle
+status: published
+abstract: Accessibility is built in from project inception, not retrofitted. All UI must satisfy the four POUR principles — Perceivable, Operable, Understandable, Robust — and depends on multiple components working together.
+principleTier: commandment
+principleDirection: Design to POUR from the first wireframe; never defer accessibility to a late retrofit.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wcag22
+  - w3c/wai-intro
+---
+
+## Rule
+
+Design for accessibility **from the start**. All UI must satisfy the four **POUR** principles:
+
+- **Perceivable** — "information and user interface components must be presentable to users in ways they can perceive."
+- **Operable** — navigation and interface components must be operable, including by keyboard, not pointer alone.
+- **Understandable** — information and operation must be understandable.
+- **Robust** — content must remain compatible with assistive technologies.
+
+## Why
+
+The W3C WAI is explicit that accessibility is **most efficient when incorporated from project inception**, not retrofitted — late fixes are costly and incomplete. Accessibility also depends on **multiple components working together** (the content, browsers, assistive technologies, and authoring tools), so it must be a design constraint, not a final QA pass.
+
+## How To Apply
+
+1. **Start with POUR.** Treat the four principles as design constraints from the first wireframe.
+2. **Bake in the measurables** — contrast ([[professions/ux-design/color-contrast-minimums]]) and target size ([[professions/ux-design/target-size-and-operable-interactions]]).
+3. **Design for assistive tech**, keyboard, and varied abilities — see [[professions/ux-design/what-is-accessibility-wai]].
+
+## See Also
+
+- [[professions/ux-design/what-is-accessibility-wai]]
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/target-size-and-operable-interactions]]

--- a/docs/professions/ux-design/wiki/error-prevention-and-recovery.md
+++ b/docs/professions/ux-design/wiki/error-prevention-and-recovery.md
@@ -1,0 +1,35 @@
+---
+title: Error prevention and recovery
+pageKind: heuristic
+status: published
+abstract: Prevent errors proactively with constraints and confirmations, and when they occur help users recognize, diagnose, and recover with plain-language messages and clear exits. Recovery paths must themselves be accessible.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/ten-heuristics
+  - w3c/wcag22
+---
+
+## Heuristic
+
+Two of Nielsen's heuristics work together around errors:
+
+- **Error prevention (Heuristic 5)** — prevent problems proactively through constraints, good defaults, and confirmations, rather than relying on error messages after the fact.
+- **Help users recognize, diagnose, and recover from errors (Heuristic 9)** — when an error does occur, express it in **plain language**, state the problem precisely, and suggest a constructive solution.
+
+Reinforced by **user control and freedom**: give clear "emergency exits" so users can undo mistakes or cancel unwanted actions.
+
+## Accessibility of Recovery
+
+Prevention and recovery must work for everyone: error messages and exits must be **operable and perceivable** by keyboard and assistive-technology users (WCAG Operable/Perceivable). An error message a screen-reader user never hears is no recovery path at all.
+
+## How To Apply
+
+1. **Prevent first.** Constrain inputs, confirm destructive actions, use sensible defaults.
+2. **Recover gracefully.** Plain-language messages tied to the field, with a concrete fix.
+3. **Always offer an exit** — undo/cancel — and make it accessible.
+4. Surface these issues via [[professions/ux-design/heuristic-evaluation-method]].
+
+## See Also
+
+- [[professions/ux-design/ten-usability-heuristics-summary]]
+- [[professions/ux-design/heuristic-evaluation-method]]

--- a/docs/professions/ux-design/wiki/heuristic-evaluation-method.md
+++ b/docs/professions/ux-design/wiki/heuristic-evaluation-method.md
@@ -1,0 +1,34 @@
+---
+title: Heuristic evaluation method
+pageKind: heuristic
+status: published
+abstract: A heuristic evaluation runs in three phases — prepare, evaluate independently, consolidate — using 3-5 independent evaluators assessing an interface against an established heuristic set. Multiple evaluators are required because one misses most issues.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/heuristic-evaluation
+---
+
+## Method
+
+Heuristic evaluation is a discount usability method that inspects an interface against an established set of heuristics. It runs in **three phases**:
+
+1. **Preparation** — select the heuristic set (Nielsen's 10 are recommended — see [[professions/ux-design/ten-usability-heuristics-summary]]) and narrow the scope to specific flows.
+2. **Independent evaluation** — each evaluator first spends ~1-2 hours familiarizing with the product, then systematically identifies violations on their own.
+3. **Consolidation** — cluster similar findings across evaluators and prioritize recommendations.
+
+## Why Multiple Evaluators
+
+Use **3-5 independent evaluators**. A single evaluator misses a large share of issues; independent passes surface different problems, and consolidation combines their coverage. Evaluating independently *before* comparing avoids anchoring.
+
+> Licensing note: the method is documented by NN/G (copyrighted); this page describes the procedure by reference with short attributed phrasing.
+
+## How DPF Coworkers Use It
+
+- Run it as a fast, low-cost first-pass before usability testing.
+- Score findings against the heuristics and against accessibility criteria ([[professions/ux-design/design-accessibility-from-the-start-pour]]).
+- Error-related findings deepen via [[professions/ux-design/error-prevention-and-recovery]].
+
+## See Also
+
+- [[professions/ux-design/ten-usability-heuristics-summary]]
+- [[professions/ux-design/error-prevention-and-recovery]]

--- a/docs/professions/ux-design/wiki/target-size-and-operable-interactions.md
+++ b/docs/professions/ux-design/wiki/target-size-and-operable-interactions.md
@@ -1,0 +1,43 @@
+---
+title: Target size and operable interactions (WCAG 2.5.8)
+pageKind: principle
+status: published
+abstract: Pointer targets should be at least 24×24 CSS pixels (WCAG 2.2 AA, 2.5.8), with exceptions for adequately-spaced, inline, or user-agent-sized targets. Interactions must be operable beyond the pointer, including by keyboard.
+principleTier: core
+principleDirection: Size pointer targets at least 24x24 CSS px (or space them adequately) and keep all interactions keyboard-operable.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "human_cognitive_load": 0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - w3c/wcag22
+---
+
+## Rule
+
+Per WCAG 2.2 success criterion **2.5.8 (Target Size — Minimum, Level AA)**, the target for pointer inputs should be **at least 24 by 24 CSS pixels**, with defined exceptions:
+
+- **Spacing** — a smaller target is acceptable when it has adequate spacing around it.
+- **Inline** — targets within a sentence (e.g. links in text) are excluded.
+- **User-agent / essential** — targets sized by the user agent, or where a particular size is essential, are excepted.
+
+More broadly, the **Operable** principle requires interface components and navigation to be operable — including by keyboard, not pointer alone.
+
+## Why
+
+Small, tightly-packed targets are hard to hit for users with motor impairments, tremor, or touch input, causing errors and accidental activation. The 24px floor (plus spacing) gives a reliable hit area; keyboard operability ensures pointer-free use.
+
+## How To Apply
+
+1. **Size or space.** Make interactive targets ≥24×24 CSS px, or guarantee adequate spacing.
+2. **Keyboard parity.** Everything tappable is also keyboard-operable (pairs with [[professions/ux-design/design-accessibility-from-the-start-pour]]).
+3. **Pair with contrast** — a target must be both big enough and visible enough ([[professions/ux-design/color-contrast-minimums]]).
+
+## See Also
+
+- [[professions/ux-design/color-contrast-minimums]]
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/accessibility-tradeoffs-aaa]]

--- a/docs/professions/ux-design/wiki/ten-usability-heuristics-summary.md
+++ b/docs/professions/ux-design/wiki/ten-usability-heuristics-summary.md
@@ -1,0 +1,40 @@
+---
+title: The 10 usability heuristics (Nielsen)
+pageKind: summary
+status: published
+abstract: Nielsen's ten general usability heuristics are broad rules of thumb for interface design — from visibility of system status to error prevention and help users recover from errors. They are a heuristic lens, not a checklist.
+professionCompetencyLevel: practitioner
+sources:
+  - nng/ten-heuristics
+---
+
+## What This Source Is
+
+The **10 Usability Heuristics for User Interface Design** (Jakob Nielsen, Nielsen Norman Group) are broad, general principles — "rules of thumb" — for usable interfaces. They are applied as an evaluative lens, not as specific, prescriptive guidelines.
+
+> Licensing note: NN/G content is copyrighted. This page lists the heuristics by name with short attributed phrases and links to the source; it does not reproduce the article.
+
+## The Ten Heuristics
+
+1. **Visibility of system status** — keep users informed with timely feedback.
+2. **Match between system and the real world** — use users' language and real-world conventions, not internal jargon.
+3. **User control and freedom** — provide clear "emergency exits" (undo/redo, cancel).
+4. **Consistency and standards** — follow platform and product conventions.
+5. **Error prevention** — prevent problems before they occur.
+6. **Recognition rather than recall** — make options visible; minimize memory load.
+7. **Flexibility and efficiency of use** — accelerators for experts, simple for novices.
+8. **Aesthetic and minimalist design** — no irrelevant information competing for attention.
+9. **Help users recognize, diagnose, and recover from errors** — plain-language messages with constructive solutions.
+10. **Help and documentation** — available when needed, task-focused.
+
+## How DPF Coworkers Use It
+
+- Use the heuristics as the lens for a [[professions/ux-design/heuristic-evaluation-method]].
+- Heuristics 5 and 9 are deepened in [[professions/ux-design/error-prevention-and-recovery]].
+- Pair usability with accessibility — see [[professions/ux-design/what-is-accessibility-wai]].
+
+## See Also
+
+- [[professions/ux-design/heuristic-evaluation-method]]
+- [[professions/ux-design/error-prevention-and-recovery]]
+- [[professions/ux-design/what-is-accessibility-wai]]

--- a/docs/professions/ux-design/wiki/what-is-accessibility-wai.md
+++ b/docs/professions/ux-design/wiki/what-is-accessibility-wai.md
@@ -1,0 +1,35 @@
+---
+title: What is accessibility (W3C WAI)
+pageKind: entity
+status: published
+abstract: Web accessibility means websites, tools, and technologies are designed so people with disabilities can use them — perceiving, understanding, navigating, and interacting with the web. It also benefits older adults, mobile users, and people in constrained contexts.
+professionCompetencyLevel: foundational
+sources:
+  - w3c/wai-intro
+---
+
+## Definition
+
+Per the W3C Web Accessibility Initiative: **"Web accessibility means that websites, tools, and technologies are designed and developed so that people with disabilities can use them."** Concretely, it enables people to **perceive, understand, navigate, interact with, and contribute to** the web.
+
+## Who It Serves
+
+Accessibility addresses disabilities spanning **auditory, cognitive, neurological, physical, speech, and visual** domains. It also benefits a far wider population:
+
+- **Older adults** with changing abilities.
+- **Mobile users** and those on small screens or touch.
+- People with **temporary impairments** (a broken arm) or **situational limitations** (bright sunlight, a noisy environment, low bandwidth).
+
+## Evaluation
+
+Effective accessibility evaluation requires **both automated tools and human expertise** — automated checks catch many issues but cannot judge meaning, context, or real assistive-technology behavior.
+
+## How DPF Coworkers Use It
+
+- Frame accessibility as serving a broad population, not a niche — it improves usability for everyone.
+- Operationalize it through [[professions/ux-design/design-accessibility-from-the-start-pour]] and the measurable criteria it links to.
+
+## See Also
+
+- [[professions/ux-design/design-accessibility-from-the-start-pour]]
+- [[professions/ux-design/ten-usability-heuristics-summary]]

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -631,6 +631,164 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "the definition of large text. Licensed; cited by reference.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── Documentation & content family (WSID wave 6, open-license) ──
+  "diataxis/framework": {
+    sourceType: "framework",
+    title: "Diataxis — A systematic approach to technical documentation",
+    url: "https://diataxis.fr/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Documentation framework defining four modes (tutorials, how-to guides, " +
+      "reference, explanation) across content, style, and architecture.",
+    retrievedAt: "2026-06-13",
+  },
+  "diataxis/tutorials": {
+    sourceType: "framework",
+    title: "Tutorials — Diataxis",
+    url: "https://diataxis.fr/tutorials/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Learning-oriented documentation: the teacher takes responsibility for the " +
+      "learner's success through guided doing.",
+    retrievedAt: "2026-06-13",
+  },
+  "diataxis/how-to-guides": {
+    sourceType: "framework",
+    title: "How-to guides — Diataxis",
+    url: "https://diataxis.fr/how-to-guides/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Task-oriented directions guiding a competent user toward a real-world goal; " +
+      "action, not teaching.",
+    retrievedAt: "2026-06-13",
+  },
+  "diataxis/reference": {
+    sourceType: "framework",
+    title: "Reference — Diataxis",
+    url: "https://diataxis.fr/reference/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Information-oriented, austere technical description whose structure mirrors " +
+      "the product; describe and only describe.",
+    retrievedAt: "2026-06-13",
+  },
+  "diataxis/explanation": {
+    sourceType: "framework",
+    title: "Explanation — Diataxis",
+    url: "https://diataxis.fr/explanation/",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Understanding-oriented, discursive documentation giving context, reasons, " +
+      "and connections, distinct from active practice.",
+    retrievedAt: "2026-06-13",
+  },
+  "mermaid/intro": {
+    sourceType: "web-article",
+    title: "Mermaid — Overview / Introduction",
+    url: "https://mermaid.js.org/intro/",
+    license: "MIT",
+    abstract:
+      "JavaScript diagramming tool rendering Markdown-inspired text into diagrams " +
+      "(diagram-as-code); many diagram types.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/dev-style": {
+    sourceType: "web-article",
+    title: "Google developer documentation style guide",
+    url: "https://developers.google.com/style",
+    license: "CC-BY-4.0",
+    abstract:
+      "Technical-writing voice/clarity guide: conversational, global audience, " +
+      "second person, active voice, conditions before instructions.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── Enterprise-architecture family (WSID wave 6) ──
+  // The Open Group full specs (ArchiMate 3.2, TOGAF Standard, IT4IT 3.0 snapshot)
+  // are OAuth-gated / purchase-licensed: structure (layer names, ADM phases,
+  // value-stream names) is used as facts from the public overviews; element-level
+  // detail requires the licensed copy. ADR (Nygard) is CC0/public-domain.
+  "opengroup/archimate-3-2": {
+    sourceType: "standard",
+    title: "ArchiMate 3.2 Specification (public overview)",
+    url: "https://pubs.opengroup.org/architecture/archimate3-doc/",
+    license: "OpenGroup-licensed",
+    abstract:
+      "Open EA modeling language relating Business, Application, and Technology " +
+      "layers via service-orientation. Full spec OAuth-gated.",
+    retrievedAt: "2026-06-13",
+  },
+  "opengroup/togaf": {
+    sourceType: "framework",
+    title: "TOGAF Standard — Overview",
+    url: "https://www.opengroup.org/togaf",
+    license: "OpenGroup-licensed",
+    abstract:
+      "EA methodology whose core is the Architecture Development Method (ADM). " +
+      "Full standard is purchase-licensed.",
+    retrievedAt: "2026-06-13",
+  },
+  "opengroup/it4it": {
+    sourceType: "framework",
+    title: "IT4IT Reference Architecture — Overview",
+    url: "https://www.opengroup.org/it4it",
+    license: "OpenGroup-licensed",
+    abstract:
+      "Value-stream-based reference architecture for digital/IT management; four " +
+      "value streams S2P, R2D, R2F, D2C.",
+    retrievedAt: "2026-06-13",
+  },
+  "conexiam/togaf-adm": {
+    sourceType: "web-article",
+    title: "TOGAF ADM Phases Explained (Conexiam)",
+    url: "https://conexiam.com/togaf-adm-phases-explained/",
+    license: "web-article-public",
+    abstract:
+      "Per-phase purpose of the TOGAF ADM: Preliminary plus phases A through H, " +
+      "with central Requirements Management.",
+    retrievedAt: "2026-06-13",
+  },
+  "adr/github": {
+    sourceType: "web-article",
+    title: "Architectural Decision Records (ADR)",
+    url: "https://adr.github.io/",
+    license: "open-community",
+    abstract:
+      "Community home for ADRs: an architectural decision is a justified, " +
+      "architecturally-significant design choice; ADRs form a decision log.",
+    retrievedAt: "2026-06-13",
+  },
+  "nygard/adr": {
+    sourceType: "web-article",
+    title: "Documenting Architecture Decisions (Michael Nygard)",
+    url: "https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions",
+    license: "CC0-public-domain",
+    abstract:
+      "The original ADR format: Title, Status, Context, Decision, Consequences; " +
+      "record the rationale, not just the outcome.",
+    retrievedAt: "2026-06-13",
+  },
+  "conway/law": {
+    sourceType: "reference",
+    title: "Conway's Law (author's page)",
+    url: "https://www.melconway.com/Home/Conways_Law.html",
+    license: "author-site-open",
+    abstract:
+      "Canonical statement of Conway's Law from \"How Do Committees Invent?\" " +
+      "(Datamation, April 1968).",
+    retrievedAt: "2026-06-13",
+  },
+  "techtarget/it4it": {
+    sourceType: "web-article",
+    title: "What is IT4IT? (TechTarget)",
+    url: "https://www.techtarget.com/whatis/definition/IT4IT",
+    license: "TechTarget-copyright-cite-by-reference",
+    abstract:
+      "Secondary explainer of the four IT4IT value streams (S2P, R2D, R2F, D2C). " +
+      "Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -789,6 +789,179 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "Licensed; cited by reference.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── IT operations / SRE family (WSID wave 6/7) ──
+  // NIST SP 800-61 Rev.2 was withdrawn 2025-04-03 (superseded by Rev.3); the
+  // IR-lifecycle phases are durable doctrine cited via an open secondary
+  // explainer because the primary PDF did not text-extract. ITIL 4 is licensed
+  // (PeopleCert/Axelos): incident-vs-problem doctrine uses an open explainer,
+  // never ITIL spec text. Google SRE book is CC-BY-NC-ND (cited, not modified).
+  "nist/sp-800-61": {
+    sourceType: "standard",
+    title: "NIST SP 800-61 Computer Security Incident Handling Guide",
+    url: "https://csrc.nist.gov/pubs/sp/800/61/r2/final",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "NIST incident-response lifecycle (preparation; detection & analysis; " +
+      "containment/eradication/recovery; post-incident). Rev.2 withdrawn; see Rev.3.",
+    retrievedAt: "2026-06-13",
+  },
+  "rapid7/nist-ir-lifecycle": {
+    sourceType: "web-article",
+    title: "Introduction to the NIST SP 800-61 Incident Response Life Cycle",
+    url: "https://www.rapid7.com/blog/post/2017/01/11/introduction-to-incident-response-life-cycle-of-nist-sp-800-61/",
+    license: "web-article-public",
+    abstract:
+      "Open secondary explainer of the four NIST SP 800-61 incident-response " +
+      "lifecycle phases.",
+    retrievedAt: "2026-06-13",
+  },
+  "opentelemetry/observability-primer": {
+    sourceType: "spec",
+    title: "OpenTelemetry Observability Primer",
+    url: "https://opentelemetry.io/docs/concepts/observability-primer/",
+    license: "CC-BY-4.0",
+    abstract:
+      "Defines observability and the three signals (traces, metrics, logs), " +
+      "spans, and distributed tracing; vendor-neutral CNCF framework.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-slo": {
+    sourceType: "reference",
+    title: "Google SRE Book — Service Level Objectives",
+    url: "https://sre.google/sre-book/service-level-objectives/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Defines SLI, SLO, and SLA; advocates a handful of representative " +
+      "indicators and percentiles over averages.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-risk": {
+    sourceType: "reference",
+    title: "Google SRE Book — Embracing Risk",
+    url: "https://sre.google/sre-book/embracing-risk/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Error budgets as the gap between target and 100%; the reliability-vs-" +
+      "innovation trade-off.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-postmortem": {
+    sourceType: "reference",
+    title: "Google SRE Book — Postmortem Culture",
+    url: "https://sre.google/sre-book/postmortem-culture/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Blameless postmortems: fix systems and processes, not people; defined " +
+      "triggers and mandatory review.",
+    retrievedAt: "2026-06-13",
+  },
+  "betterstack/severity-levels": {
+    sourceType: "web-article",
+    title: "Incident Severity Levels (SEV1-SEV3)",
+    url: "https://betterstack.com/community/guides/incident-management/severity-levels/",
+    license: "CC-BY-NC-SA-4.0",
+    abstract:
+      "Defines incident severity levels SEV1/SEV2/SEV3 and the severity-vs-" +
+      "priority distinction.",
+    retrievedAt: "2026-06-13",
+  },
+  "itsm-tools/incident-vs-problem": {
+    sourceType: "web-article",
+    title: "Incident vs Problem Management (open explainer)",
+    url: "https://itsm.tools/incident-vs-problem-management/",
+    license: "web-article-public",
+    abstract:
+      "Open explainer of the ITIL distinction: incident management restores " +
+      "service; problem management eliminates recurring causes.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── HR / people-ops family (WSID wave 7) — jurisdiction split us vs eu ──
+  // SHRM BASK is licensed (cluster names used as facts, checklist-only). EEOC
+  // and EU Your-Europe are public-domain/open-reuse. US OPM/HHS interview
+  // pages blocked the fetcher; structured-interviewing is anchored on an open
+  // vendor explainer.
+  "eeoc/prohibited-practices": {
+    sourceType: "standard",
+    title: "EEOC — Prohibited Employment Policies/Practices",
+    url: "https://www.eeoc.gov/prohibited-employment-policiespractices",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "US protected bases and prohibited practices across the employment " +
+      "lifecycle (ads, hiring, pay, discipline, harassment).",
+    retrievedAt: "2026-06-13",
+  },
+  "eeoc/eeo-laws": {
+    sourceType: "standard",
+    title: "EEOC — Equal Employment Opportunity Laws",
+    url: "https://www.eeoc.gov/equal-employment-opportunity-laws",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "Overview of the EEOC's role and the federal anti-discrimination statutes " +
+      "it enforces.",
+    retrievedAt: "2026-06-13",
+  },
+  "eeoc/federal-laws-qa": {
+    sourceType: "standard",
+    title: "EEOC — Federal Laws Prohibiting Job Discrimination (Q&A)",
+    url: "https://www.eeoc.gov/fact-sheet/federal-laws-prohibiting-job-discrimination-questions-and-answers",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "Title VII, EPA, ADEA, ADA, Rehabilitation Act, GINA — protected bases " +
+      "and employer-size coverage thresholds.",
+    retrievedAt: "2026-06-13",
+  },
+  "eu/employment-termination": {
+    sourceType: "standard",
+    title: "Terminating employment contracts in the EU (Your Europe)",
+    url: "https://europa.eu/youreurope/business/human-resources/general-employment-terms-conditions/terminating-employment-contracts/index_en.htm",
+    license: "EC-reuse-attribution",
+    abstract:
+      "EU dismissal protection: non-discrimination, pregnancy/parental " +
+      "protection, employer burden of proof, collective-redundancy consultation.",
+    retrievedAt: "2026-06-13",
+  },
+  "gdpr/art-88": {
+    sourceType: "standard",
+    title: "GDPR Article 88 — Processing in the employment context",
+    url: "https://gdpr-info.eu/art-88-gdpr/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      "Member states may set employee-data rules with safeguards for dignity, " +
+      "monitoring transparency, and intra-group transfers.",
+    retrievedAt: "2026-06-13",
+  },
+  "shrm/bask": {
+    sourceType: "framework",
+    title: "SHRM Body of Applied Skills and Knowledge (BASK)",
+    url: "https://www.shrm.org/credentials/certification/exam-preparation/bask",
+    license: "SHRM-copyright-checklist-only",
+    abstract:
+      "SHRM competency clusters (Leadership, Interpersonal, Business) + HR " +
+      "Expertise. Licensed; cluster names used as facts only.",
+    retrievedAt: "2026-06-13",
+  },
+  "atwill/cornell-lii": {
+    sourceType: "reference",
+    title: "Employment-at-will doctrine (Cornell LII Wex)",
+    url: "https://www.law.cornell.edu/wex/employment-at-will_doctrine",
+    license: "Cornell-LII-educational",
+    abstract:
+      "US at-will employment and its exceptions: public policy, implied " +
+      "contract, implied covenant of good faith.",
+    retrievedAt: "2026-06-13",
+  },
+  "interview/structured": {
+    sourceType: "web-article",
+    title: "Structured Interviews — guide",
+    url: "https://www.pin.com/blog/structured-interviews-guide/",
+    license: "web-article-public",
+    abstract:
+      "Same questions/order/rubric for all candidates; behavioral vs " +
+      "situational; higher validity and legal defensibility than unstructured.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -514,6 +514,123 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "with minimum output.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── Frontend-engineer + UX/accessibility families (WSID wave 5) ──
+  // w3c/wcag22 is shared by both families (registered once). W3C docs are open
+  // (W3C Document License); MDN is CC-BY-SA; web.dev is CC-BY-4.0. NN/G and
+  // WebAIM are licensed (no open license) — cited by reference with attribution,
+  // quotes kept short; their structure (heuristic names, contrast ratios that
+  // are also normative in the open WCAG) is used as facts, not reproduced prose.
+  "w3c/wcag22": {
+    sourceType: "standard",
+    title: "Web Content Accessibility Guidelines (WCAG) 2.2",
+    url: "https://www.w3.org/TR/WCAG22/",
+    license: "W3C-Document-License",
+    abstract:
+      "W3C Recommendation defining accessibility under four POUR principles and " +
+      "conformance levels A/AA/AAA, with testable success criteria.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/aria-apg": {
+    sourceType: "standard",
+    title: "ARIA Authoring Practices Guide (APG)",
+    url: "https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/",
+    license: "W3C-Document-License",
+    abstract:
+      'WAI guidance on correct ARIA use: "No ARIA is better than Bad ARIA"; a ' +
+      "role is a promise to implement its interactions.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/using-aria": {
+    sourceType: "standard",
+    title: "Using ARIA",
+    url: "https://www.w3.org/TR/using-aria/",
+    license: "W3C-Document-License",
+    abstract:
+      "Defines the First Rule of ARIA: prefer a native HTML element over " +
+      "re-purposing one with an ARIA role.",
+    retrievedAt: "2026-06-13",
+  },
+  "w3c/wai-intro": {
+    sourceType: "standard",
+    title: "Introduction to Web Accessibility (W3C WAI)",
+    url: "https://www.w3.org/WAI/fundamentals/accessibility-intro/",
+    license: "W3C-Document-License",
+    abstract:
+      "Defines web accessibility and who benefits; accessibility is most " +
+      "efficient when built in from project inception.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/html": {
+    sourceType: "reference",
+    title: "HTML: HyperText Markup Language (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "HTML defines the meaning and structure of web content; meaning belongs " +
+      "to HTML, appearance to CSS.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/accessibility": {
+    sourceType: "reference",
+    title: "Accessibility (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "Accessibility enables as many people as possible to use sites; covers " +
+      "text alternatives and keyboard access.",
+    retrievedAt: "2026-06-13",
+  },
+  "mdn/img": {
+    sourceType: "reference",
+    title: "<img>: the Image embed element (MDN)",
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img",
+    license: "CC-BY-SA-2.5",
+    abstract:
+      "The alt attribute is mandatory: a concise text replacement for image " +
+      "content; alt=\"\" only for decorative images.",
+    retrievedAt: "2026-06-13",
+  },
+  "webdev/core-web-vitals": {
+    sourceType: "web-article",
+    title: "Web Vitals (web.dev)",
+    url: "https://web.dev/articles/vitals",
+    license: "CC-BY-4.0",
+    abstract:
+      "Core Web Vitals targets: LCP <= 2.5s, INP <= 200ms, CLS <= 0.1, assessed " +
+      "at the 75th percentile across mobile and desktop.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/ten-heuristics": {
+    sourceType: "web-article",
+    title: "10 Usability Heuristics for User Interface Design (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/ten-usability-heuristics/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Nielsen's ten general usability heuristics. Licensed; cited by reference " +
+      "with attribution, not reproduced.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/heuristic-evaluation": {
+    sourceType: "web-article",
+    title: "How to Conduct a Heuristic Evaluation (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Three-phase heuristic-evaluation method using 3-5 independent evaluators. " +
+      "Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
+  "webaim/contrast": {
+    sourceType: "web-article",
+    title: "Contrast and Color Accessibility (WebAIM)",
+    url: "https://webaim.org/articles/contrast/",
+    license: "WebAIM-copyright-cite-by-reference",
+    abstract:
+      "Explains WCAG 2 contrast ratios (4.5:1 normal, 3:1 large, 7:1 AAA) and " +
+      "the definition of large text. Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 6 — documentation-content + enterprise-architecture corpora on the variant model from [#1808](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1808). All doctrine distilled from **fetched** open-license sources. Both jurisdiction-global; competency tier is the active variant axis.

## Documentation & content (6 pages)

The four Diataxis modes, choose-the-right-mode (don't blend), tutorials-vs-how-to-guides, write-for-the-reader/clarity (commandment), diagram-as-code with Mermaid, documentation-set IA (expert).

Sources (all open): Diataxis (CC-BY-SA), Mermaid (MIT), Google developer documentation style guide (CC-BY-4.0).

## Enterprise-architecture (6 pages)

ArchiMate three layers, record-decisions-as-ADRs (core), the ADR entity (Nygard's 5-part structure), TOGAF ADM phases (expert), Conway's Law (expert), IT4IT value streams (a stated DPF foundation).

The Open Group full specs (ArchiMate 3.2 / TOGAF / IT4IT 3.0) are OAuth-gated/purchase-licensed — structure (layer names, ADM phases, value-stream names) is used as facts from the public overviews and flagged in-page; ADR doctrine is anchored on Nygard (CC0/public-domain) + adr.github.io, and Conway's Law on the author's own site.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards):

- **32 corpus pages on this branch, 0 orphan wiki-links, 0 unknown source citations**
- families on branch: data-architect=4, software-engineer=9, finance=7, documentation-content=6, enterprise-architecture=6
- competency: `foundational=11, practitioner=14, expert=7`

15 new RawSources registered.

> Parallel open WSID PRs (independent source keys): [#1814](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1814), [#1816](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1816), [#1818](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)