### PR TITLE
feat(wsid): customer-success + strategy-executive corpora (wave 8)

### DIFF
--- a/docs/professions/customer-success/wiki/customer-health-and-escalation-handoff.md
+++ b/docs/professions/customer-success/wiki/customer-health-and-escalation-handoff.md
@@ -1,0 +1,38 @@
+---
+title: Customer health scoring and escalation handoff
+pageKind: heuristic
+status: published
+abstract: A customer health score is a predictive metric of renewal/growth/churn likelihood, blending product usage, engagement, sentiment (NPS), and support signals. Alert on score decay and escalate on early signals — churn is a 30-90 day decay, not a renewal-day surprise.
+professionCompetencyLevel: practitioner
+sources:
+  - gainsight/health-scores
+  - gainsight/cs-guide
+  - wikipedia/nps
+  - bain/net-promoter-system
+---
+
+## Heuristic
+
+Maintain a **customer health score** — "a predictive metric … of the likelihood of renewal, growth, or churn" — and act on its decay before renewal, not at it.
+
+## Building the Score
+
+- **Blend signals:** product usage, engagement/relationship, sentiment (NPS), and support/escalations.
+- **Use a model:** traffic-light (red/yellow/green) or 0-100 banded healthy / at-risk / critical.
+- **Automate alerts:** "set up alerts to notify your team when a health score drops" — make the escalation trigger mechanical, not memory-dependent.
+
+## Escalate Early
+
+Churn is typically a **30-90 day behavioral decay**, so escalate on **early** signals rather than waiting for renewal. NPS feeds the sentiment signal: detractors (scores 0-6) flag churn/defection risk and should be routed to intervention; promoters (9-10) are expansion candidates.
+
+## How DPF Coworkers Use It
+
+- Watch the health score continuously; when it drops, run the intervention playbook and escalate/hand off with full context.
+- NPS specifics are in [[professions/customer-success/net-promoter-score]].
+- Healthy onboarding ([[professions/customer-success/onboarding-and-activation]]) is the first input to health.
+
+## See Also
+
+- [[professions/customer-success/onboarding-and-activation]]
+- [[professions/customer-success/net-promoter-score]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/customer-journey-map.md
+++ b/docs/professions/customer-success/wiki/customer-journey-map.md
@@ -1,0 +1,34 @@
+---
+title: Customer journey map
+pageKind: entity
+status: published
+abstract: A customer journey map combines storytelling and visualization to compile a user's goals, actions, thoughts, emotions, and touchpoints across phases on a timeline. Ground it in real research and keep it a living, shared artifact.
+professionCompetencyLevel: foundational
+sources:
+  - nng/journey-mapping
+---
+
+## Definition
+
+A **customer journey map** "combines storytelling and visualization" to compile a user's goals and actions on a timeline. It makes the customer's experience legible to the whole team.
+
+Core components: a point-of-view **actor**, a **scenario**, **phases**, the user's **actions / thoughts / emotions**, **touchpoints & channels**, **opportunities**, and **ownership**.
+
+> Licensing note: sourced from Nielsen Norman Group (licensed) by reference, with short quotes.
+
+## How To Build One
+
+- **Ground it in research** — journey maps should be "truthful narratives, not fairy tales," built from qualitative evidence, not assumptions.
+- **Establish the business goal first** before mapping; delay aesthetic visualization until after synthesis.
+- **Keep it living and shared** — a journey map is an ongoing alignment tool, not a one-off deliverable that gathers dust.
+
+## How DPF Coworkers Use It
+
+- Use the map to locate where a customer is and what they need next — the basis for [[professions/customer-success/serve-the-customers-actual-goal]].
+- Extend the journey into delivery operations with a [[professions/customer-success/service-blueprint]].
+
+## See Also
+
+- [[professions/customer-success/serve-the-customers-actual-goal]]
+- [[professions/customer-success/service-blueprint]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/net-promoter-score.md
+++ b/docs/professions/customer-success/wiki/net-promoter-score.md
@@ -1,0 +1,35 @@
+---
+title: Net Promoter Score (NPS)
+pageKind: entity
+status: published
+abstract: NPS asks how likely a customer is to recommend, on 0-10. Respondents band into promoters (9-10), passives (7-8), and detractors (0-6); NPS = %promoters minus %detractors. It is used as a loyalty and churn-risk signal.
+professionCompetencyLevel: practitioner
+sources:
+  - wikipedia/nps
+  - bain/net-promoter-system
+---
+
+## Definition
+
+**Net Promoter Score (NPS)** is a loyalty metric based on a single question — how likely the customer is to recommend the product/company — answered on a **0-10** scale. Introduced by Reichheld/Bain (HBR, 2003), it is widely used as a predictor of return business and word of mouth.
+
+## The Bands and Formula
+
+- **Promoters** — score **9-10** (loyal enthusiasts).
+- **Passives** — score **7-8** (satisfied but unenthusiastic).
+- **Detractors** — score **0-6** (at risk of churn or negative word of mouth).
+
+$$\text{NPS} = \%\,\text{Promoters} - \%\,\text{Detractors}$$
+
+> Source note: the score definition and bands are from the open Wikipedia article (CC-BY-SA); the Net Promoter System framing is from Bain (licensed, cited by reference).
+
+## How DPF Coworkers Use It
+
+- Treat NPS as the **sentiment input** to the [[professions/customer-success/customer-health-and-escalation-handoff]] score.
+- Route **detractors** to intervention; engage **promoters** for expansion and referrals.
+- NPS is one signal — combine it with usage and engagement, never read it alone.
+
+## See Also
+
+- [[professions/customer-success/customer-health-and-escalation-handoff]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/onboarding-and-activation.md
+++ b/docs/professions/customer-success/wiki/onboarding-and-activation.md
@@ -1,0 +1,43 @@
+---
+title: Drive onboarding toward activation and first value
+pageKind: principle
+status: published
+abstract: Distinguish the user's "aha" moment (when they discover value) from company-defined activation (when the business sees value). Guide onboarding intentionally toward first value; faster activation and early, consistent usage drive retention.
+principleTier: core
+principleDirection: Design onboarding to reach the user's first-value moment fast; treat activation as a retention signal, not the goal itself.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.6, "human_cognitive_load": 0.4}
+professionCompetencyLevel: practitioner
+sources:
+  - intercom/aha-moments
+  - gainsight/cs-guide
+---
+
+## Rule
+
+Design onboarding to reach **first value** quickly, and keep two concepts distinct:
+
+- **"Aha" moment** — when the **user** discovers value.
+- **Activation** — when the **company** sees value (a business metric).
+
+Treat activation as "a business metric that suggests retention, but is not a reflection of the user's experience." The goal is the user's aha; activation is the signal that it happened.
+
+## Why
+
+The aha moment may occur "before signup, during onboarding, or months later" — so don't assume its timing; guide users intentionally toward it. Faster activation and "early and consistent usage" are core levers for retention, and the CSM owns onboarding, adoption, and value realization across the lifecycle.
+
+## How To Apply
+
+1. **Define the user's first-value moment** explicitly, then design the shortest honest path to it.
+2. **Instrument activation** as a leading retention signal — but optimize the user's experience, not just the metric.
+3. **Hand off to health monitoring** once activated — see [[professions/customer-success/customer-health-and-escalation-handoff]].
+
+## See Also
+
+- [[professions/customer-success/serve-the-customers-actual-goal]]
+- [[professions/customer-success/customer-health-and-escalation-handoff]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/serve-the-customers-actual-goal.md
+++ b/docs/professions/customer-success/wiki/serve-the-customers-actual-goal.md
@@ -1,0 +1,39 @@
+---
+title: Serve the customer's actual goal, not the ticket
+pageKind: principle
+status: published
+abstract: Orient on the customer's measurable outcome, not the surface request. Customer success is proactive — guide customers toward their goal and the value moment that matters to them, even when it differs from internal metrics.
+principleTier: core
+principleDirection: Solve for the customer's underlying goal and value outcome, not just the literal request in front of you.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.5, "human_cognitive_load": 0.4}
+professionCompetencyLevel: foundational
+sources:
+  - gainsight/cs-guide
+  - nng/journey-mapping
+  - intercom/aha-moments
+---
+
+## Rule
+
+Orient every interaction on the customer's **actual goal and measurable outcome**, not the surface request. Customer success is a "proactive, outcome-focused strategy" — it solves for where the customer is trying to get, then uses the request as a clue to that destination.
+
+## Why
+
+A ticket is a symptom; the goal is the cause. CS "guides customers before problems arise" rather than only reacting. Journey mapping grounds this: map the customer's goal and emotions onto their journey before acting, because touchpoints exist to serve those goals. And the value moment that counts is the **user's** "aha" — the moment they discover value — which you must serve even when it differs from an internally-defined metric.
+
+## How To Apply
+
+1. **Ask what outcome the customer wants**, then map the request to it.
+2. **Use the journey** ([[professions/customer-success/customer-journey-map]]) to locate where the customer is and what they need next.
+3. **Drive toward the user's value moment** — see [[professions/customer-success/onboarding-and-activation]].
+
+## See Also
+
+- [[professions/customer-success/customer-journey-map]]
+- [[professions/customer-success/onboarding-and-activation]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/service-blueprint.md
+++ b/docs/professions/customer-success/wiki/service-blueprint.md
@@ -1,0 +1,36 @@
+---
+title: Service blueprint
+pageKind: entity
+status: published
+abstract: A service blueprint visualizes the people, props, and processes behind a service across frontstage, backstage, and support layers, separated by the lines of interaction, visibility, and internal interaction. It is the operational companion to a journey map.
+professionCompetencyLevel: expert
+sources:
+  - nng/service-blueprints
+---
+
+## Definition
+
+A **service blueprint** "visualizes the relationships between different service components — people, props … and processes." Where a journey map shows the customer's experience, a blueprint shows the **delivery system** behind it.
+
+## Layers and Lines
+
+- **Layers:** customer actions, **frontstage** actions (visible to the customer), **backstage** actions (hidden), and **support processes**.
+- **Three separating lines:** the line of **interaction**, the line of **visibility**, and the line of **internal interaction**.
+
+Blueprints "expose the big picture and offer a map of dependencies," which makes them powerful for cross-functional CX design — they reveal where a customer-facing promise depends on a backstage process that might fail.
+
+> Licensing note: sourced from Nielsen Norman Group (licensed) by reference.
+
+## Why It Is Expert Work
+
+A blueprint requires understanding the whole delivery system, not just the customer touchpoints — it is "a companion to customer-journey maps" that extends the journey into operations. Designing one aligns multiple teams around the dependencies that make or break the experience.
+
+## How DPF Coworkers Use It
+
+- Build a blueprint when a customer problem traces to backstage/support failures, not just the frontstage.
+- Pair it with the [[professions/customer-success/customer-journey-map]].
+
+## See Also
+
+- [[professions/customer-success/customer-journey-map]]
+- [[professions/customer-success/what-is-customer-success]]

--- a/docs/professions/customer-success/wiki/what-is-customer-success.md
+++ b/docs/professions/customer-success/wiki/what-is-customer-success.md
@@ -1,0 +1,36 @@
+---
+title: What is customer success
+pageKind: summary
+status: published
+abstract: Customer success is a proactive, outcome-focused practice that helps customers achieve measurable results — distinct from reactive support. Customer-success managers own onboarding, adoption, value realization, renewal, and expansion.
+professionCompetencyLevel: foundational
+sources:
+  - gainsight/cs-guide
+  - wikipedia/nps
+  - bain/net-promoter-system
+---
+
+## What It Is
+
+**Customer success (CS)** is a "proactive, outcome-focused strategy" that helps customers "achieve measurable results." It is distinct from support: CS "guides customers before problems arise," whereas support "reacts to issues." The customer-success manager (CSM) is a strategic partner who guides onboarding, adoption, value realization, renewals, and expansion.
+
+> Licensing note: the CS definition sources here (Gainsight, Bain) are vendor/licensed and cited by reference with short quotes; only the NPS source (Wikipedia) is open-licensed.
+
+## Why It Matters
+
+Loyalty is measurable and economically decisive: NPS is described as a strong predictor of return business and word of mouth, and Bain ties sustained value creation to a Net Promoter Score materially higher than average. Proactively driving customer outcomes — not just closing tickets — is what compounds retention and expansion.
+
+## The CS Mandate (orientation for DPF coworkers)
+
+- **Outcome over output:** serve the customer's actual goal — see [[professions/customer-success/serve-the-customers-actual-goal]].
+- **Drive to first value** in onboarding — see [[professions/customer-success/onboarding-and-activation]].
+- **Watch health, escalate early** — see [[professions/customer-success/customer-health-and-escalation-handoff]].
+- **Map the experience** — [[professions/customer-success/customer-journey-map]] and [[professions/customer-success/service-blueprint]].
+
+## See Also
+
+- [[professions/customer-success/serve-the-customers-actual-goal]]
+- [[professions/customer-success/onboarding-and-activation]]
+- [[professions/customer-success/customer-health-and-escalation-handoff]]
+- [[professions/customer-success/customer-journey-map]]
+- [[professions/customer-success/service-blueprint]]

--- a/docs/professions/external-intelligence/wiki/capability-gap-to-governed-suggestion.md
+++ b/docs/professions/external-intelligence/wiki/capability-gap-to-governed-suggestion.md
@@ -1,0 +1,46 @@
+---
+title: Capability-gap detection to governed backlog suggestion
+pageKind: principle
+status: published
+abstract: A detected capability gap triggers a build-vs-buy judgment, not an automatic adoption. Buy for non-differentiating needs, build where the capability is the edge, weigh total cost over time — and always output a governed backlog suggestion, never a unilateral integration.
+principleTier: core
+principleDirection: Convert a detected gap into a build-vs-buy judgment and a governed backlog suggestion; the scout proposes, governance disposes.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"cost_efficiency": 0.6, "vendor_lock_in": 0.5, "speed_to_value": 0.4}
+professionCompetencyLevel: expert
+sources:
+  - productschool/build-vs-buy
+  - owasp/component-analysis
+---
+
+## Rule
+
+A detected capability gap triggers a **build-vs-buy judgment**, not an automatic adoption — and its output is always a **governed backlog suggestion**, never a unilateral integration. The scout proposes; governance disposes.
+
+## The Build-vs-Buy Judgment
+
+The decision spans cost/TCO, time-to-market, capability fit, in-house expertise, and strategic control:
+
+- **Buy for non-differentiating needs** — "buy for non-core functions and build where learning compounds."
+- **Build where it is the edge** — ask "does this software define your competitive edge?"
+- **Weigh true cost over time** — "smart teams look beyond the first invoice to the total cost of flexibility."
+- **Price in supply-chain cost** — adopting an external tool imports its risk surface, and every new component adds ongoing maintenance cost; factor vetting into the buy side.
+
+## Output: A Governed Suggestion
+
+The scout never integrates unilaterally. The output is a **candidate for review** that enters the governed backlog — consistent with DPF's "governed backlog suggestion" model and the Tool Evaluation Pipeline. Governance, not the scout, decides adoption.
+
+## How To Apply
+
+1. **Frame the gap** as build-vs-buy, not "found a tool, adopt it."
+2. **Require vetting** ([[professions/external-intelligence/vet-before-adopting-external-tools]]) before any buy recommendation.
+3. **File a governed suggestion** with provenance and health evidence from [[professions/external-intelligence/external-tool-catalog-reconnaissance]].
+
+## See Also
+
+- [[professions/external-intelligence/vet-before-adopting-external-tools]]
+- [[professions/external-intelligence/mcp-what-it-is]]

--- a/docs/professions/external-intelligence/wiki/external-tool-catalog-reconnaissance.md
+++ b/docs/professions/external-intelligence/wiki/external-tool-catalog-reconnaissance.md
@@ -1,0 +1,36 @@
+---
+title: External agent/tool catalog reconnaissance
+pageKind: summary
+status: published
+abstract: Scout the external capability landscape through registries — the Smithery MCP-server registry and the public npm registry — capturing machine-readable provenance per candidate. Reconnaissance produces candidates, never adoptions.
+professionCompetencyLevel: practitioner
+sources:
+  - smithery/registry-docs
+  - npm/registry-docs
+---
+
+## What This Covers
+
+The external-intelligence coworker reconnoiters the capability landscape through registries:
+
+- The **Smithery registry** is "a list of MCP servers that are available to use," searchable by name, description, or tags, with "full-text and semantic search" and filters for deployment status, verification, and ownership.
+- The **public npm registry** is "a database of JavaScript packages, each comprised of software and metadata" — the second primary catalog to reconnoiter.
+
+## How To Reconnoiter
+
+1. **Search by capability need**, using full-text and semantic search.
+2. **Distinguish server type** — remote (URL-accessed) vs local (stdio); deployment shape changes the adoption and risk profile.
+3. **Capture provenance per candidate** — namespace, owner, GitHub repo, and the registration timestamp ("ISO 8601 timestamp of when the server was registered").
+4. **Produce candidates, not adoptions.** Recon output is a shortlist; every candidate goes through vetting before any suggestion.
+
+## How DPF Coworkers Use It
+
+- Treat recon as the funnel's top: surface candidates, then hand each to [[professions/external-intelligence/vet-before-adopting-external-tools]].
+- Assess each candidate's health — see [[professions/external-intelligence/server-health-assessment]].
+- A confirmed gap becomes a governed suggestion — see [[professions/external-intelligence/capability-gap-to-governed-suggestion]].
+
+## See Also
+
+- [[professions/external-intelligence/mcp-what-it-is]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/capability-gap-to-governed-suggestion]]

--- a/docs/professions/external-intelligence/wiki/mcp-what-it-is.md
+++ b/docs/professions/external-intelligence/wiki/mcp-what-it-is.md
@@ -1,0 +1,34 @@
+---
+title: Model Context Protocol (MCP) — what it is
+pageKind: entity
+status: published
+abstract: MCP is an open standard for connecting AI applications to external systems via servers that expose tools, resources, and prompts. A scouting target is a tool/resource surface an LLM client can mount, not a UI.
+professionCompetencyLevel: foundational
+sources:
+  - mcp/intro
+  - mcp/architecture
+---
+
+## Definition
+
+The **Model Context Protocol (MCP)** is "an open-source standard for connecting AI applications to external systems" — described as "like a USB-C port for AI applications," one standardized connection interface.
+
+## Architecture
+
+MCP is **client-server**: a host application runs one client per server, and an "MCP Server: A program that provides context to MCP clients." Servers expose three primitives, which clients discover via list methods:
+
+- **Tools** — executable actions.
+- **Resources** — context data.
+- **Prompts** — reusable templates.
+
+Two transports: **stdio** (local process) and **Streamable HTTP** (remote — MCP recommends OAuth for auth tokens).
+
+## Why It Matters for Scouting
+
+For the external-intelligence coworker, a reconnaissance target is therefore **not a UI** but a **tool/resource surface** an LLM client can mount. Understanding the MCP shape (local vs remote, what primitives a server exposes) is the foundation for evaluating an external capability.
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/vet-before-adopting-external-tools]]

--- a/docs/professions/external-intelligence/wiki/server-health-assessment.md
+++ b/docs/professions/external-intelligence/wiki/server-health-assessment.md
@@ -1,0 +1,33 @@
+---
+title: Package / MCP-server health assessment
+pageKind: heuristic
+status: published
+abstract: Assess an external server or package by adoption signals, trust signals, maintenance freshness, semantic-version change risk, and provenance — cross-checked against vulnerability intelligence. Health numbers are only trustworthy once provenance is traced.
+professionCompetencyLevel: practitioner
+sources:
+  - smithery/registry-docs
+  - owasp/component-analysis
+  - npm/semver
+---
+
+## Heuristic
+
+Score a candidate external server or package across five signals before trusting it:
+
+1. **Adoption** — Smithery exposes the "total number of times this server has been connected to"; usage is a (weak) health signal.
+2. **Trust** — the verified-status badge and whether the registry operator maintains the server.
+3. **Maintenance freshness** — keeping components current "reduces remediation time during security incidents"; stale or end-of-life components fail the check.
+4. **Change risk via SemVer** — read the version: major = "changes that break backward compatibility," minor = backward-compatible features, patch = bug fixes.
+5. **Provenance** — owner, GitHub repo, and registration timestamp. **Trace provenance before trusting health numbers** — popularity on an unknown-origin package is not safety.
+
+Cross-check **vulnerability intelligence** from multiple sources beyond the National Vulnerability Database (defect trackers, release notes).
+
+## How DPF Coworkers Use It
+
+- Run this assessment on every candidate from [[professions/external-intelligence/external-tool-catalog-reconnaissance]].
+- Health is necessary but not sufficient — it feeds, but does not replace, [[professions/external-intelligence/vet-before-adopting-external-tools]].
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/mcp-what-it-is]]

--- a/docs/professions/external-intelligence/wiki/vet-before-adopting-external-tools.md
+++ b/docs/professions/external-intelligence/wiki/vet-before-adopting-external-tools.md
@@ -1,0 +1,51 @@
+---
+title: Never adopt an unvetted external tool
+pageKind: principle
+status: published
+abstract: Every external tool, MCP server, or package carries supply-chain risk and must be vetted before adoption. Guard against typosquatting, dependency confusion, and hijacking; reject vulnerable or end-of-life components. A "verified" badge is a signal, not a clearance.
+principleTier: commandment
+principleDirection: Vet every external tool/package for supply-chain risk before adoption; never treat a registry badge as a substitute for independent assessment.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 0.8, "blast_radius": 0.7, "governance_compliance": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - owasp/component-analysis
+  - owasp/dependency-chain-abuse
+  - smithery/registry-docs
+---
+
+## Rule
+
+Never adopt an external tool, MCP server, or package without vetting it for supply-chain risk first. Component analysis exists to identify "potential areas of risk from the use of third-party and open-source software" — vetting is mandatory, not optional.
+
+## Attack Vectors To Guard Against
+
+- **Typosquatting** — "publication of malicious packages with similar names to those of popular packages."
+- **Dependency confusion** and **dependency hijacking** — including "obtaining control of the account of a package maintainer on the public repository."
+- **Brandjacking** and other dependency-chain abuse (OWASP CICD-SEC-3).
+
+## Reject Criteria
+
+- **Known vulnerabilities** and **excessive age** — OWASP advises limiting "acceptable component age to three years maximum" and prohibiting end-of-life components.
+- **Ongoing cost** — "operational and maintenance cost of using open source will increase with the adoption of every new component"; each dependency is a standing liability.
+
+A registry **"verified" badge is a signal, not a clearance** — verification status is one filter, never a substitute for independent risk assessment.
+
+## How To Apply
+
+1. **Vet every candidate** from [[professions/external-intelligence/external-tool-catalog-reconnaissance]] before it can be suggested.
+2. **Run the health assessment** — see [[professions/external-intelligence/server-health-assessment]].
+3. **Factor vetting + maintenance cost** into the build-vs-buy call — see [[professions/external-intelligence/capability-gap-to-governed-suggestion]].
+
+> This aligns with DPF's own Tool Evaluation Pipeline (AGENTS.md §9): external tools must pass security/architecture/compliance/integration review before adoption.
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/capability-gap-to-governed-suggestion]]

--- a/docs/professions/hr-people-ops/wiki/document-people-decisions.md
+++ b/docs/professions/hr-people-ops/wiki/document-people-decisions.md
@@ -1,0 +1,43 @@
+---
+title: Document people decisions
+pageKind: principle
+status: published
+abstract: Record the legitimate, job-related reason for every significant people decision. US law forbids decisions resting on stereotypes; EU law puts the burden of proof on the employer. Contemporaneous documentation is the defense in both.
+principleTier: core
+principleDirection: Record a legitimate, job-related, contemporaneous reason for every hire, pay, discipline, and termination decision.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.8, "evidence_density": 0.7}
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/prohibited-practices
+  - eu/employment-termination
+  - interview/structured
+---
+
+## Rule
+
+For every significant people decision — hiring, pay, discipline, promotion, termination — **record the legitimate, job-related reason**, contemporaneously. Documentation is not bureaucracy; it is the evidence that the decision was lawful and fair.
+
+## Why (both jurisdictions)
+
+- **US:** because adverse actions may not rest on "stereotypes and assumptions," the legitimate, job-related reason must be recorded to show it did not.
+- **EU:** the employer carries the **burden of proof**, so contemporaneous documentation of "legitimate, non-discriminatory reasons" is the defense; dismissals of protected workers require **written justification**, and collective-redundancy "criteria for the selection of staff" must be documented and consistently applied.
+
+In both, the record made *at the time* is worth far more than a reconstruction after a dispute.
+
+## How To Apply
+
+1. **Write the reason down when you decide**, not later.
+2. **Keep it job-related** — tie to performance, role requirements, or conduct, never a protected characteristic.
+3. **Use structured-interview rubrics** as the hiring record — see [[professions/hr-people-ops/structured-competency-based-interviewing]].
+4. **Mind employee-data rules** when storing records — see [[professions/hr-people-ops/gdpr-employee-data-art-88]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]
+- [[professions/hr-people-ops/gdpr-employee-data-art-88]]

--- a/docs/professions/hr-people-ops/wiki/eu-equal-treatment-and-dismissal-protection.md
+++ b/docs/professions/hr-people-ops/wiki/eu-equal-treatment-and-dismissal-protection.md
@@ -1,0 +1,51 @@
+---
+title: EU — equal treatment and dismissal protection
+pageKind: principle
+status: published
+abstract: EU employment law prohibits discriminatory dismissal, gives strong protection to pregnant/parental-leave workers, places the burden of proof on the employer, and requires consultation for collective redundancies. This contrasts sharply with US at-will employment.
+principleTier: core
+principleDirection: For EU employment, require a valid justified ground for dismissal, protect leave/pregnancy, and keep employer-side proof; never assume US at-will applies.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9}
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - eu/employment-termination
+  - atwill/cornell-lii
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU/EEA. The US counterpart is [[professions/hr-people-ops/us-at-will-employment]]. **Competency:** practitioner.
+
+## The Structural Contrast (read first)
+
+The US and EU defaults are opposite, and assuming the wrong one is a serious error:
+
+- **US default — at-will:** employer may terminate "at any time and for almost any reason" (subject to anti-discrimination and narrow exceptions).
+- **EU default — protected:** dismissal requires a **valid, justified ground**; protection is comprehensive, not statute-by-statute.
+
+## EU Rules
+
+- Dismissals may not be based on "sex, racial or ethnic origin, religion or belief, age, disability, sexual orientation."
+- **Pregnant / parental-leave workers** cannot be dismissed "except in exceptional cases" and must be given written justification.
+- When discrimination is alleged, "the burden of proof is primarily on the employer" to show a legitimate reason.
+- **Collective redundancies** require consulting staff representatives and notifying authorities, including the "criteria for the selection of staff to be made redundant."
+- **Business transfers** do not permit dismissal; contracts transfer and the buyer must continue to comply with any collective agreement.
+
+## How To Apply
+
+1. **Establish a valid ground** before any EU dismissal; never assume at-will.
+2. **Document defensibly** — the employer carries the proof burden ([[professions/hr-people-ops/document-people-decisions]]).
+3. **Handle employee data under GDPR** — see [[professions/hr-people-ops/gdpr-employee-data-art-88]].
+
+## See Also
+
+- [[professions/hr-people-ops/us-at-will-employment]]
+- [[professions/hr-people-ops/gdpr-employee-data-art-88]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/gdpr-employee-data-art-88.md
+++ b/docs/professions/hr-people-ops/wiki/gdpr-employee-data-art-88.md
@@ -1,0 +1,45 @@
+---
+title: GDPR employee data — Article 88
+pageKind: principle
+status: published
+abstract: GDPR Article 88 lets EU member states set rules for processing employees' personal data, requiring safeguards for dignity, monitoring transparency, and intra-group transfers. EU employee-data handling is materially stricter than the US baseline.
+principleTier: core
+principleDirection: Handle EU employee data under GDPR Article 88 safeguards — dignity, monitoring transparency, lawful basis — not under a US-style baseline.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.9, "data_privacy": 0.9}
+professionJurisdiction:
+  - eu
+professionCompetencyLevel: practitioner
+sources:
+  - gdpr/art-88
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** EU/EEA. **Competency:** practitioner — applying employee-data safeguards is day-to-day people-ops work.
+
+## Rule
+
+Under **GDPR Article 88**, member states may set rules to protect "the rights and freedoms in respect of the processing of employees' personal data in the employment context." Where you process EU employee data, those rules — and GDPR's safeguards — govern.
+
+Covered purposes include recruitment, contract performance, work management, equality, health and safety, and termination. The rules must include "suitable and specific measures to safeguard the data subject's human dignity, legitimate interests and fundamental rights," with particular emphasis on **transparency of processing, intra-group data transfers, and workplace monitoring**.
+
+## Why It Matters
+
+This sectoral-derogation clause makes EU employee-data handling **materially stricter** than the US baseline. Workplace monitoring, applicant tracking, and HR analytics that might be unremarkable in the US can be unlawful in the EU without the right basis, transparency, and safeguards.
+
+## How To Apply
+
+1. **Establish a lawful basis** for each HR processing purpose (recruitment, monitoring, performance).
+2. **Be transparent** about monitoring; don't deploy covert surveillance.
+3. **Guard intra-group transfers** of employee data.
+4. Document the basis and safeguards — see [[professions/hr-people-ops/document-people-decisions]].
+
+## See Also
+
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/non-discrimination-protected-characteristics-us.md
+++ b/docs/professions/hr-people-ops/wiki/non-discrimination-protected-characteristics-us.md
@@ -1,0 +1,47 @@
+---
+title: US — non-discrimination on protected characteristics (EEOC)
+pageKind: principle
+status: published
+abstract: US federal law prohibits employment decisions based on protected characteristics — race, color, religion, sex, national origin, age 40+, disability, genetic information — across the entire employment lifecycle. Harassment and retaliation are independently illegal.
+principleTier: commandment
+principleDirection: Never base any US employment decision on a protected characteristic; document the legitimate, job-related reason instead.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 1.0, "public_safety": 0.5}
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/prohibited-practices
+  - eeoc/eeo-laws
+  - eeoc/federal-laws-qa
+---
+
+## Jurisdiction & Competency
+
+**Jurisdiction:** United States (federal). The EU equivalent — broader and structured differently — is [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]. **Competency:** foundational — this is non-negotiable for any HR coworker operating in the US.
+
+## Rule
+
+US federal law prohibits employment decisions based on **protected characteristics**: race, color, religion, sex, and national origin (Title VII); age 40 or older (ADEA); disability (ADA / Rehabilitation Act); and genetic information (GINA).
+
+The prohibition spans the **whole employment lifecycle** — job ads, recruitment, hiring, equal pay for equal work, assignments, discipline, and discharge. Decisions may not rest on "stereotypes and assumptions" about a protected group. **Harassment and retaliation** for reporting discrimination are independently illegal.
+
+## Coverage
+
+Statutory thresholds apply (e.g. Title VII / ADA / GINA cover employers with 15+ employees; ADEA 20+). Even where a statute does not apply, basing decisions on protected characteristics is a serious risk and against DPF doctrine.
+
+## How To Apply
+
+1. **Never decide on a protected basis** — see the list in [[professions/hr-people-ops/protected-characteristics]].
+2. **Record the legitimate, job-related reason** for adverse actions — see [[professions/hr-people-ops/document-people-decisions]].
+3. **Use structured, job-analysis-based hiring** — see [[professions/hr-people-ops/structured-competency-based-interviewing]].
+
+## See Also
+
+- [[professions/hr-people-ops/protected-characteristics]]
+- [[professions/hr-people-ops/document-people-decisions]]
+- [[professions/hr-people-ops/structured-competency-based-interviewing]]

--- a/docs/professions/hr-people-ops/wiki/protected-characteristics.md
+++ b/docs/professions/hr-people-ops/wiki/protected-characteristics.md
@@ -1,0 +1,36 @@
+---
+title: Protected characteristics (US)
+pageKind: entity
+status: published
+abstract: US federal protected characteristics are race, color, religion, sex (including pregnancy, sexual orientation, and gender identity), national origin, age 40+, disability, and genetic information. Retaliation for asserting these rights is also protected.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - eeoc/federal-laws-qa
+  - eeoc/prohibited-practices
+---
+
+## The Protected Characteristics (US federal)
+
+- **Race, color, religion, sex, and national origin** (Title VII).
+- **Sex** includes pregnancy, sexual orientation, and gender identity.
+- **Age**, 40 or older (ADEA).
+- **Disability** (ADA / Rehabilitation Act).
+- **Genetic information** (GINA).
+- **Retaliation** for reporting discrimination or asserting these rights is independently prohibited.
+
+## Scope
+
+These are the bases on which a US employment decision may **never** turn. The prohibition runs across the whole lifecycle — ads, hiring, pay, assignments, discipline, discharge — per [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]].
+
+States and localities often add further protected classes (e.g. marital status, sexual orientation where not already federal); treat the federal list as the floor, not the ceiling.
+
+## EU Note
+
+The EU protects overlapping but differently-framed grounds (sex, racial/ethnic origin, religion or belief, age, disability, sexual orientation) under a comprehensive equal-treatment regime — see [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]

--- a/docs/professions/hr-people-ops/wiki/shrm-competency-clusters.md
+++ b/docs/professions/hr-people-ops/wiki/shrm-competency-clusters.md
@@ -1,0 +1,31 @@
+---
+title: SHRM competency clusters (BASK) — checklist only
+pageKind: summary
+status: published
+abstract: The SHRM Body of Applied Skills and Knowledge groups HR competence into three behavioral clusters (Leadership, Interpersonal, Business) plus the HR Expertise technical competency. SHRM content is licensed — used here as a maturity checklist by name only.
+professionCompetencyLevel: expert
+sources:
+  - shrm/bask
+---
+
+## What This Source Is
+
+The **SHRM Body of Applied Skills and Knowledge (BASK)** defines the competencies expected of an HR professional. DPF uses it as an external **maturity checklist** for what a senior HR coworker should cover.
+
+> Licensing note: SHRM BASK is "© SHRM. All Rights Reserved." This page references only the **public competency-cluster and competency names** as facts — it does not ingest or reproduce SHRM text. The actual doctrine lives in the open-sourced pages of this family, not in SHRM content.
+
+## The Structure
+
+- **Three behavioral competency clusters:** Leadership, Interpersonal, Business.
+- **Named behavioral competencies** include: Leadership & Navigation, Ethical Practice, Relationship Management, Communication, Business Acumen, Consultation, Critical Evaluation, Global & Cultural Effectiveness.
+- **One technical competency:** HR Expertise.
+
+## How DPF Coworkers Use It
+
+- Treat the clusters as a **coverage checklist** for expert-level HR capability, not as doctrine to quote.
+- The enforceable doctrine sits in the open pages: non-discrimination, documentation, structured interviewing, and the jurisdiction-specific rules.
+
+## See Also
+
+- [[professions/hr-people-ops/structured-competency-based-interviewing]]
+- [[professions/hr-people-ops/document-people-decisions]]

--- a/docs/professions/hr-people-ops/wiki/structured-competency-based-interviewing.md
+++ b/docs/professions/hr-people-ops/wiki/structured-competency-based-interviewing.md
@@ -1,0 +1,44 @@
+---
+title: Structured, competency-based interviewing
+pageKind: principle
+status: published
+abstract: Ask every candidate the same job-analysis-derived questions in the same order, scored against the same anchored rubric. Structured interviews have higher validity and stronger legal defensibility than unstructured ones, and reduce bias.
+principleTier: core
+principleDirection: Use the same job-analysis-based questions and an anchored rubric for every candidate; score independently before comparing.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"governance_compliance": 0.7, "evidence_density": 0.6}
+professionCompetencyLevel: practitioner
+sources:
+  - interview/structured
+---
+
+## Rule
+
+Interview with **structure**: every candidate answers "the same questions, in the same order, evaluated against the same predetermined scoring criteria." Questions are "developed from job analysis," mapping each answer to a required competency.
+
+## How It Works
+
+- **Question types:** behavioral questions ask candidates to "describe specific past experiences"; situational questions "present hypothetical scenarios."
+- **Anchored rubric:** score against behavioral indicators; interviewers "score independently before comparing notes" to avoid anchoring.
+- **From job analysis:** questions trace to the competencies the role actually requires.
+
+## Why
+
+Structured interviews show **higher validity** (a cited ~.51 vs ~.38 for unstructured) and **reduce bias**. They are also more **legally defensible**, because decisions are "tied to job analysis" rather than subjective impressions — directly supporting non-discrimination obligations ([[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]).
+
+## How To Apply
+
+1. **Derive questions from the role's competencies** (job analysis).
+2. **Standardize** question set, order, and rubric across all candidates.
+3. **Score independently, then calibrate.**
+4. **Keep the scored rubric** as the hiring-decision record — see [[professions/hr-people-ops/document-people-decisions]].
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/document-people-decisions]]
+- [[professions/hr-people-ops/shrm-competency-clusters]]

--- a/docs/professions/hr-people-ops/wiki/us-at-will-employment.md
+++ b/docs/professions/hr-people-ops/wiki/us-at-will-employment.md
@@ -1,0 +1,38 @@
+---
+title: At-will employment (US doctrine)
+pageKind: entity
+status: published
+abstract: US at-will employment lets either party end the relationship at any time for almost any reason, subject to three exceptions (public policy, implied contract, implied covenant) and overriding anti-discrimination law. It contrasts with the EU's protected-dismissal default.
+professionJurisdiction:
+  - us
+professionCompetencyLevel: foundational
+sources:
+  - atwill/cornell-lii
+  - eeoc/prohibited-practices
+---
+
+## Definition
+
+**At-will employment** is the US default: employer and employee may end the relationship "at any time and for almost any reason." There is no general requirement to show cause — distinguishing the US sharply from the EU's [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]].
+
+## The Three Exceptions
+
+At-will is not absolute. Courts recognize:
+
+1. **Public policy** — cannot terminate "in violation of well-established public policy of the state" (e.g. for filing a workers' compensation claim).
+2. **Implied contract** — conduct or an employee handbook may create "a reasonable expectation of a fixed term or even indefinite employment."
+3. **Implied covenant of good faith and fair dealing** — recognized in some states (e.g. California).
+
+## Anti-Discrimination Always Overrides
+
+At-will never permits a termination based on a protected characteristic — statutory anti-discrimination law overrides it. See [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]].
+
+## How DPF Coworkers Use It
+
+- Know the default but never treat at-will as license to act on a protected basis or to skip documentation.
+- For EU staff, at-will does **not** apply — switch to the protected-dismissal rules.
+
+## See Also
+
+- [[professions/hr-people-ops/non-discrimination-protected-characteristics-us]]
+- [[professions/hr-people-ops/eu-equal-treatment-and-dismissal-protection]]

--- a/docs/professions/operations/wiki/blameless-postmortem.md
+++ b/docs/professions/operations/wiki/blameless-postmortem.md
@@ -1,0 +1,33 @@
+---
+title: Run blameless post-incident reviews
+pageKind: heuristic
+status: published
+abstract: A blameless postmortem records an incident's impact, timeline, root causes, and follow-ups, identifying contributing causes without indicting any individual. Fix systems and processes, not people; defined triggers make postmortems routine.
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-postmortem
+---
+
+## Heuristic
+
+After a significant incident, write a **blameless postmortem** — a record of the incident, its impact, the actions taken, the root causes, and the follow-up actions. "Blameless" means "identifying the contributing causes…without indicting any individual or team."
+
+## Why Blameless
+
+Assume everyone "did the right thing with the information they had." The premise: **"You can't 'fix' people, but you can fix systems and processes."** Blame drives information underground — engineers stop reporting near-misses and stop escalating early. Blamelessness builds the escalation confidence that fast incident response depends on.
+
+## Make It Routine
+
+- **Triggers** include user-visible downtime, any data loss, manual on-call intervention, and a monitoring miss; **any stakeholder may request** a postmortem.
+- **No postmortem ships unreviewed** — review is part of the practice.
+- **Reward the practice** so writing one is seen as valuable, not punitive.
+
+## How DPF Coworkers Use It
+
+- Close significant incidents from the [[professions/operations/incident-response-lifecycle]] with a postmortem.
+- Feed root causes into problem management — see [[professions/operations/incident-vs-problem-management]].
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/incident-vs-problem-management]]

--- a/docs/professions/operations/wiki/error-budget-toil-tradeoff.md
+++ b/docs/professions/operations/wiki/error-budget-toil-tradeoff.md
@@ -1,0 +1,39 @@
+---
+title: Trade reliability against innovation via error budgets
+pageKind: principle
+status: published
+abstract: Beyond a point, more reliability costs more than it returns. The error budget makes the reliability-vs-velocity trade-off explicit: spend remaining budget on release speed; when depleted, slow down and harden. Extreme reliability is not free.
+principleTier: contextual
+principleDirection: Use the error budget to govern release velocity vs hardening; do not chase 100% reliability where it is not worth the cost.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.6, "capacity_utilization": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-risk
+---
+
+## Rule
+
+Use the **error budget** to manage the trade-off between reliability and innovation explicitly. Beyond a point, more reliability is "worse for a service…rather than better" — extreme reliability carries real cost (slower delivery, more toil) that may exceed its user value.
+
+## How The Trade-off Works
+
+- While the error budget is **positive**, spend it on **release velocity** — ship features, take measured risk.
+- When the budget is **depleted**, teams self-regulate toward **more testing and slower releases** until reliability recovers.
+
+The budget tensions several levers: software hardening, test intensity, release frequency, and canary size/duration. Making these trade-offs against a shared budget — rather than by argument — is the expert SRE discipline.
+
+## How To Apply
+
+1. **Derive the budget** from the SLOs in [[professions/operations/sli-slo-error-budget]].
+2. **Gate velocity on budget**, not on opinion.
+3. **Pair with postmortems** — recurring budget burn signals systemic issues for [[professions/operations/blameless-postmortem]].
+
+## See Also
+
+- [[professions/operations/sli-slo-error-budget]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/incident-response-lifecycle.md
+++ b/docs/professions/operations/wiki/incident-response-lifecycle.md
@@ -1,0 +1,35 @@
+---
+title: Incident response lifecycle (NIST SP 800-61)
+pageKind: summary
+status: published
+abstract: NIST's incident-response lifecycle has four cyclical phases — preparation; detection & analysis; containment, eradication & recovery; post-incident activity. Lessons feed back into preparation.
+professionCompetencyLevel: practitioner
+sources:
+  - nist/sp-800-61
+  - rapid7/nist-ir-lifecycle
+---
+
+## The Four Phases
+
+NIST SP 800-61 frames incident response as a cyclical lifecycle:
+
+1. **Preparation** — reduce incident probability and ready the response team before anything fires.
+2. **Detection & Analysis** — analyze symptoms and decide whether an event is truly an incident.
+3. **Containment, Eradication & Recovery** — stop the threat, remove it, then restore affected resources, data, and processes.
+4. **Post-Incident Activity** — capture lessons and feed them back into Preparation.
+
+The phases are **cyclical, not linear** — each incident improves the next round of preparation.
+
+> Provenance/currency note: the NIST SP 800-61 primary PDF did not text-extract in research, so phase detail is cited via an open secondary explainer. **Rev. 2 was withdrawn (superseded by Rev. 3)** — re-anchor citations to Rev. 3 when authoring against the current spec. The four-phase shape is durable doctrine.
+
+## How DPF Coworkers Use It
+
+- Run incidents through the four phases; never skip Detection & Analysis straight to action.
+- Classify impact first — see [[professions/operations/incident-severity-classification]] — and execute via [[professions/operations/runbook-driven-resolution]].
+- Close every significant incident with a [[professions/operations/blameless-postmortem]].
+
+## See Also
+
+- [[professions/operations/incident-severity-classification]]
+- [[professions/operations/runbook-driven-resolution]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/incident-severity-classification.md
+++ b/docs/professions/operations/wiki/incident-severity-classification.md
@@ -1,0 +1,42 @@
+---
+title: Classify incident severity before acting
+pageKind: principle
+status: published
+abstract: Classify an incident's severity (SEV1 critical, SEV2 major, SEV3 minor) by business impact before responding, so a pre-defined workflow starts without improvisation. Severity (impact) is distinct from priority (urgency).
+principleTier: core
+principleDirection: Assign a severity by business impact at the start of every incident; tie each level to a predefined response.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"blast_radius": 0.7, "public_safety": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - betterstack/severity-levels
+---
+
+## Rule
+
+At the **start** of an incident, classify its **severity** by business impact. Severity drives which pre-defined response runs, so triage decisions are not improvised under pressure.
+
+## Severity Levels
+
+- **SEV1 (critical)** — service down for all customers, or a major security breach / data loss.
+- **SEV2 (major)** — service down for a subset of customers, or significant loss of core functionality.
+- **SEV3 (minor)** — an inconvenience that does not affect major system functions.
+
+## Severity Is Not Priority
+
+**Severity measures impact; priority measures urgency / what to fix first.** They are distinct: a SEV2 affecting a paying enterprise customer may be worked before a SEV1 on a deprecated system. Record both — the same severity-vs-priority distinction the QA profession draws for defects.
+
+## How To Apply
+
+1. **Classify first.** Assign a SEV level before mobilizing — it determines the response.
+2. **Tie severity to a workflow** so "no improvisation is necessary" — see [[professions/operations/runbook-driven-resolution]].
+3. **Feed the lifecycle** — severity shapes the [[professions/operations/incident-response-lifecycle]].
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/runbook-driven-resolution]]

--- a/docs/professions/operations/wiki/incident-vs-problem-management.md
+++ b/docs/professions/operations/wiki/incident-vs-problem-management.md
@@ -1,0 +1,34 @@
+---
+title: Incident management vs problem management (ITIL)
+pageKind: entity
+status: published
+abstract: Incident management restores normal service as quickly as possible; problem management investigates and eliminates the underlying causes of recurring incidents. They are distinct, complementary practices.
+professionCompetencyLevel: practitioner
+sources:
+  - itsm-tools/incident-vs-problem
+---
+
+## Definition
+
+ITIL distinguishes two complementary service-management practices:
+
+- **Incident management** restores normal service "as quickly as possible, with as little adverse impact as possible." It is first-response: get the user working again.
+- **Problem management** eliminates recurring incidents and minimizes the impact of those it cannot prevent. It is investigative: find and remove the cause.
+
+A **problem** is the cause (or potential cause) of one or more incidents. Incident management asks "how do we restore service now?"; problem management asks "why did this happen, and how do we stop it recurring?"
+
+> Licensing note: ITIL 4 is a proprietary, licensed framework (PeopleCert/Axelos). This page uses an open explainer for the doctrine and does not reproduce ITIL specification text.
+
+## Why The Distinction Matters
+
+Treating every incident as a one-off (restore and move on) lets the same failure recur indefinitely. Treating every incident as a deep investigation paralyzes response. The two practices run in parallel: restore fast (incident), then investigate the cause (problem).
+
+## How DPF Coworkers Use It
+
+- Run incident management through the [[professions/operations/incident-response-lifecycle]].
+- Feed recurring incidents into problem management; the [[professions/operations/blameless-postmortem]] is where cause analysis begins.
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/blameless-postmortem]]

--- a/docs/professions/operations/wiki/observability-three-signals.md
+++ b/docs/professions/operations/wiki/observability-three-signals.md
@@ -1,0 +1,32 @@
+---
+title: Observability — the three signals
+pageKind: summary
+status: published
+abstract: Observability is understanding a system from the outside via its telemetry. The three signals are traces (a request's path), metrics (aggregated numbers over time), and logs (timestamped messages). OpenTelemetry is the vendor-neutral framework for them.
+professionCompetencyLevel: practitioner
+sources:
+  - opentelemetry/observability-primer
+---
+
+## What Observability Is
+
+**Observability** lets you "understand a system from the outside…without knowing its inner workings" — by examining the telemetry it emits. A system you cannot observe, you cannot operate or debug under pressure.
+
+## The Three Signals
+
+- **Traces** record the path of a single request as it propagates through multiple services. A **span** is one unit of work; **distributed tracing** stitches spans across services.
+- **Metrics** are aggregated numeric data over time — error rates, CPU, request volume.
+- **Logs** are timestamped messages emitted by services, usually not tied to a specific request.
+
+**OpenTelemetry** is a vendor-neutral, open-source (CNCF) framework for generating and exporting all three signals, so instrumentation is not locked to one backend.
+
+## How DPF Coworkers Use It
+
+- Instrument for all three signals; rely on traces to localize, metrics to detect, logs to explain.
+- Metrics feed the SLIs behind [[professions/operations/sli-slo-error-budget]].
+- Detection in the [[professions/operations/incident-response-lifecycle]] depends on these signals being present.
+
+## See Also
+
+- [[professions/operations/incident-response-lifecycle]]
+- [[professions/operations/sli-slo-error-budget]]

--- a/docs/professions/operations/wiki/runbook-driven-resolution.md
+++ b/docs/professions/operations/wiki/runbook-driven-resolution.md
@@ -1,0 +1,38 @@
+---
+title: Follow the runbook, then escalate
+pageKind: principle
+status: published
+abstract: Tie each incident severity to a predefined runbook so resolution is repeatable, not improvised. The foundational operations duty is to classify severity, follow the runbook, and escalate when the situation exceeds its scope.
+principleTier: core
+principleDirection: Execute the predefined runbook for the classified severity; escalate promptly when the incident exceeds the runbook's scope.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"blast_radius": 0.6, "human_cognitive_load": 0.5}
+professionCompetencyLevel: foundational
+sources:
+  - betterstack/severity-levels
+  - rapid7/nist-ir-lifecycle
+---
+
+## Rule
+
+Tie each incident severity to a **predefined runbook** so that "no improvisation is necessary." The foundational operations duty is a simple loop: **classify severity → follow the runbook → escalate when out of scope.**
+
+## Why
+
+Under incident pressure, improvisation produces inconsistent, error-prone responses. A runbook captures the containment and recovery steps so restoration is **repeatable**, and frees the responder's attention for judgment the runbook cannot encode. Detection & Analysis (from the [[professions/operations/incident-response-lifecycle]]) decides whether an event is a real incident *before* runbook execution begins.
+
+## How To Apply
+
+1. **Classify first** — see [[professions/operations/incident-severity-classification]].
+2. **Execute the matching runbook** — containment and recovery steps are written down, not recalled.
+3. **Escalate on scope breach.** When the incident exceeds the runbook (novel failure, expanding blast radius), escalate rather than improvise.
+4. **Improve the runbook** from each postmortem.
+
+## See Also
+
+- [[professions/operations/incident-severity-classification]]
+- [[professions/operations/incident-response-lifecycle]]

--- a/docs/professions/operations/wiki/sli-slo-error-budget.md
+++ b/docs/professions/operations/wiki/sli-slo-error-budget.md
@@ -1,0 +1,45 @@
+---
+title: SLIs, SLOs, and error budgets
+pageKind: principle
+status: published
+abstract: An SLI is a quantitative measure of service level; an SLO is a target for it; an SLA adds consequences. The error budget — the gap between the SLO target and 100% — quantifies acceptable unreliability and aligns dev and ops on one incentive.
+principleTier: core
+principleDirection: Define a few representative SLIs, set SLO targets, and manage releases against the resulting error budget.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 0.6, "capacity_utilization": 0.5}
+professionCompetencyLevel: expert
+sources:
+  - google/sre-book-slo
+  - google/sre-book-risk
+---
+
+## Rule
+
+Measure reliability with **SLIs**, target it with **SLOs**, and govern change with the resulting **error budget**.
+
+## The Definitions
+
+- **SLI (Service Level Indicator)** — "a carefully defined quantitative measure of some aspect of the level of service" (e.g. request latency, error rate, availability).
+- **SLO (Service Level Objective)** — a target value or range for an SLI (e.g. latency under 100 ms for 99.9% of requests).
+- **SLA (Service Level Agreement)** — an SLO **plus consequences** for missing it. No consequence means it is an SLO, not an SLA.
+
+Prefer "a handful of representative indicators" and **percentiles over averages** — an average hides the tail that users feel.
+
+## Error Budget
+
+The **error budget** is the gap between the SLO target and 100% — "how much unreliability is remaining." It turns reliability into a currency: while budget remains, teams can spend it on release velocity; when it is exhausted, they self-regulate toward more testing and slower releases. This aligns development and SRE on **one shared incentive** instead of a reliability-vs-features tug of war.
+
+## How To Apply
+
+1. **Pick few, representative SLIs** from your [[professions/operations/observability-three-signals]].
+2. **Set SLO targets** users actually care about; derive the error budget.
+3. **Govern releases** by remaining budget — see [[professions/operations/error-budget-toil-tradeoff]].
+
+## See Also
+
+- [[professions/operations/observability-three-signals]]
+- [[professions/operations/error-budget-toil-tradeoff]]

--- a/docs/professions/strategy-executive/wiki/align-work-to-strategy.md
+++ b/docs/professions/strategy-executive/wiki/align-work-to-strategy.md
@@ -1,0 +1,46 @@
+---
+title: Align work to strategy (strategic alignment)
+pageKind: principle
+status: published
+abstract: Cascade strategy so there is line-of-sight between the work people do and high-level desired results. Objectives become more operational as they cascade from corporate to unit to team, with accountability following the objectives at each level.
+principleTier: core
+principleDirection: Cascade objectives so every team's work has explicit line-of-sight to strategy; never let work float disconnected from desired results.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"speed_to_value": 0.5, "long_term_maintainability": 0.4}
+professionCompetencyLevel: foundational
+sources:
+  - bsi/strategy
+  - bsi/balanced-scorecard
+---
+
+## Rule
+
+Align work to strategy by **cascading** objectives so there is "line-of-sight between the work people do and high level desired results." No team's work should float disconnected from the organization's strategy.
+
+## How Cascading Works
+
+- The corporate scorecard (**Tier 1**) cascades to units/departments (**Tier 2**), then to teams/individuals (**Tier 3**).
+- As strategy cascades, objectives "become more operational and tactical."
+- **Accountability follows** the objectives and measures at each level.
+- Strategic objectives break abstract mission and vision into actionable steps.
+
+> Licensing note: sourced from the Balanced Scorecard Institute, openly readable but copyrighted; cited by reference.
+
+## Why
+
+Strategy that does not cascade is a poster on a wall. Line-of-sight is what turns a high-level objective into the daily decisions of the people who actually move it — and lets leaders see whether work actually serves the strategy.
+
+## How To Apply
+
+1. **Express strategy as measurable objectives** — see [[professions/strategy-executive/measurable-objectives-leading-lagging]].
+2. **Cascade through tiers**, making objectives more operational as they descend.
+3. **Tie team OKRs to the cascade** — see [[professions/strategy-executive/okr-objective-key-results]].
+
+## See Also
+
+- [[professions/strategy-executive/balanced-scorecard-four-perspectives]]
+- [[professions/strategy-executive/okr-objective-key-results]]

--- a/docs/professions/strategy-executive/wiki/balanced-scorecard-four-perspectives.md
+++ b/docs/professions/strategy-executive/wiki/balanced-scorecard-four-perspectives.md
@@ -1,0 +1,38 @@
+---
+title: Balanced Scorecard — the four perspectives
+pageKind: summary
+status: published
+abstract: The Balanced Scorecard is a strategy-management system that translates mission and vision into measures across four perspectives — financial, customer, internal process, and learning & growth — balancing non-financial measures alongside financial ones.
+professionCompetencyLevel: expert
+sources:
+  - bsi/balanced-scorecard
+---
+
+## What It Is
+
+The **Balanced Scorecard (BSC)** is a strategic planning and management system that aligns daily work with strategy and translates abstract mission and vision into concrete measures. "Balanced" means weighing **non-financial** measures alongside financial ones for a fuller view of performance.
+
+## The Four Perspectives
+
+- **Financial (Stewardship):** how effectively the organization uses financial resources.
+- **Customer / Stakeholder:** performance from the viewpoint of those the organization serves.
+- **Internal Process:** the quality and efficiency of operations that deliver products and services.
+- **Organizational Capacity (Learning & Growth):** the people, technology, and culture that enable long-term improvement.
+
+> Licensing note: sourced from the Balanced Scorecard Institute, openly readable but copyrighted; cited by reference with short quotes.
+
+## Why Four Perspectives
+
+Optimizing financials alone hollows out the capabilities (customers, process, people) that produce future financials. The four perspectives force a balanced view and surface leading indicators (learning & growth, process) that drive the lagging financial ones.
+
+## How DPF Coworkers Use It
+
+- Use the four perspectives as the frame for executive performance review and strategy measures.
+- Cascade objectives down the org — see [[professions/strategy-executive/align-work-to-strategy]].
+- Balance leading vs lagging measures — see [[professions/strategy-executive/measurable-objectives-leading-lagging]].
+
+## See Also
+
+- [[professions/strategy-executive/align-work-to-strategy]]
+- [[professions/strategy-executive/measurable-objectives-leading-lagging]]
+- [[professions/strategy-executive/kpi-vs-okr]]

--- a/docs/professions/strategy-executive/wiki/kpi-vs-okr.md
+++ b/docs/professions/strategy-executive/wiki/kpi-vs-okr.md
@@ -1,0 +1,33 @@
+---
+title: KPI vs OKR — distinction and synergy
+pageKind: entity
+status: published
+abstract: KPIs are health metrics that monitor performance and identify problems (often lagging); OKRs are forward-looking goals that drive change and solve problems. They are complementary — a KPI signaling trouble can trigger an OKR.
+professionCompetencyLevel: practitioner
+sources:
+  - mooncamp/okr-vs-kpi
+---
+
+## The Distinction
+
+- **KPIs** are "health metrics" — they measure performance and past results, monitoring health and surfacing problems. Often **lagging** indicators.
+- **OKRs** are forward-looking frameworks designed to "drive change" — they solve problems and drive innovation.
+
+In short: **KPIs monitor; OKRs move.**
+
+## They Are Complementary
+
+KPIs and OKRs are not competing systems — "KPIs and OKRs work perfectly together." A KPI that signals trouble can act as the **trigger** for an OKR: the metric reveals the problem, and the OKR organizes the effort to fix it.
+
+> Licensing note: sourced from Mooncamp, openly readable but copyrighted; cited by reference.
+
+## How DPF Coworkers Use It
+
+- Use KPIs to watch the health of the business and detect problems.
+- Spin up an OKR when a KPI shows a gap worth a focused, change-driving effort.
+- Keep OKR key results as **leading** indicators — see [[professions/strategy-executive/measurable-objectives-leading-lagging]].
+
+## See Also
+
+- [[professions/strategy-executive/okr-objective-key-results]]
+- [[professions/strategy-executive/measurable-objectives-leading-lagging]]

--- a/docs/professions/strategy-executive/wiki/measurable-objectives-leading-lagging.md
+++ b/docs/professions/strategy-executive/wiki/measurable-objectives-leading-lagging.md
@@ -1,0 +1,43 @@
+---
+title: Objectives must be measurable — leading vs lagging indicators
+pageKind: principle
+status: published
+abstract: Objectives must be measurable with no gray area. Distinguish leading indicators (directly measured and influenced, drive change) from lagging indicators (results of past activity). OKR key results should be leading; the two work best as a feedback loop.
+principleTier: core
+principleDirection: Make every objective measurable with no ambiguity; favor leading indicators for key results and pair them with lagging measures.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.7}
+professionCompetencyLevel: expert
+sources:
+  - whatmatters/okr
+  - mooncamp/okr-vs-kpi
+---
+
+## Rule
+
+Every objective must be **measurable with no gray area** — a key result is either met or it is not. Beyond measurability, choose the **right kind** of measure: distinguish leading from lagging indicators.
+
+## Leading vs Lagging
+
+- **Lagging indicators** are the results of previous activity — you can influence them only indirectly (KPIs are typically lagging).
+- **Leading indicators** are directly measured and influenced; OKR key results should be leading.
+- **Why it matters for short cycles:** in a short OKR cycle, lagging indicators are unhelpful — there is no feedback by cycle end.
+- **Use both:** leading and lagging indicators "work best together as a feedback loop."
+
+> Licensing note: sourced from What Matters and Mooncamp, openly readable but copyrighted; cited by reference.
+
+## How To Apply
+
+1. **Make key results binary-measurable** — pass/fail, no ambiguity.
+2. **Prefer leading indicators** so progress is visible within the cycle.
+3. **Keep lagging measures** (e.g. on a [[professions/strategy-executive/balanced-scorecard-four-perspectives]]) to confirm outcomes.
+
+## See Also
+
+- [[professions/strategy-executive/okr-objective-key-results]]
+- [[professions/strategy-executive/kpi-vs-okr]]
+- [[professions/strategy-executive/balanced-scorecard-four-perspectives]]

--- a/docs/professions/strategy-executive/wiki/okr-authoring.md
+++ b/docs/professions/strategy-executive/wiki/okr-authoring.md
@@ -1,0 +1,40 @@
+---
+title: Authoring effective OKRs
+pageKind: heuristic
+status: published
+abstract: Write one concrete, inspirational Objective with 3-5 specific, time-bound, aggressive-yet-realistic Key Results. Validate each key result as binary-measurable, and prefer leading indicators so progress shows within the cycle.
+professionCompetencyLevel: practitioner
+sources:
+  - whatmatters/okr
+  - mooncamp/okr-vs-kpi
+---
+
+## Heuristic
+
+Author OKRs to a tight recipe:
+
+1. **One Objective, 3-5 Key Results** — resist over-loading.
+2. **Objective:** concrete and action-oriented, ideally inspirational.
+3. **Each Key Result:** "specific, time-bound, and aggressive yet realistic."
+4. **Validate measurability:** every key result is binary — pass/fail, no ambiguity.
+5. **Prefer leading indicators** so progress is visible within the cycle (not only at the end).
+6. **Use the template:** "I will (Objective) as measured by (Key Results)."
+
+> Licensing note: sourced from What Matters and Mooncamp, openly readable but copyrighted; cited by reference.
+
+## Common Failure Modes
+
+- **Too many key results** — dilutes focus; cap at five.
+- **Vague objectives** — "improve quality" with no measurable result attached.
+- **Lagging-only key results** — no feedback until the cycle is over (see [[professions/strategy-executive/measurable-objectives-leading-lagging]]).
+- **Sandbagged targets** — key results that are trivially met signal nothing.
+
+## How DPF Coworkers Use It
+
+- Apply this recipe whenever drafting OKRs for a team or initiative.
+- Tie the OKR into the strategy cascade — see [[professions/strategy-executive/okr-objective-key-results]].
+
+## See Also
+
+- [[professions/strategy-executive/okr-objective-key-results]]
+- [[professions/strategy-executive/measurable-objectives-leading-lagging]]

--- a/docs/professions/strategy-executive/wiki/okr-objective-key-results.md
+++ b/docs/professions/strategy-executive/wiki/okr-objective-key-results.md
@@ -1,0 +1,36 @@
+---
+title: OKR — Objective and Key Results
+pageKind: entity
+status: published
+abstract: An OKR pairs one Objective (a significant, concrete, action-oriented goal) with 3-5 measurable Key Results that track progress. Key results are binary-measurable — met or not — expressed as "I will (Objective) as measured by (Key Results)."
+professionCompetencyLevel: practitioner
+sources:
+  - whatmatters/okr
+---
+
+## Definition
+
+An **OKR (Objectives and Key Results)** pairs one **Objective** — *what* to achieve — with measurable **Key Results** that track progress toward it.
+
+- Objectives are "significant, concrete, action oriented, and (ideally) inspirational."
+- Key Results are **measurable**: you either meet the requirement or you don't — no gray area.
+- Standard structure: **one Objective supported by 3-5 Key Results**.
+- The canonical template: **"I will (Objective) as measured by (Key Results)."**
+
+> Licensing note: sourced from What Matters (John Doerr), openly readable but copyrighted; cited by reference with short quotes.
+
+## Why It Works
+
+The Objective gives direction and meaning; the Key Results make success unambiguous. Because Key Results are binary-measurable, an OKR cannot be "mostly done by vibes" — progress is observable, which is what makes the method a forcing function for focus.
+
+## How DPF Coworkers Use It
+
+- Write OKRs per the [[professions/strategy-executive/okr-authoring]] heuristic.
+- Distinguish them from health metrics — see [[professions/strategy-executive/kpi-vs-okr]].
+- Ensure Key Results are the right kind of measure — see [[professions/strategy-executive/measurable-objectives-leading-lagging]].
+
+## See Also
+
+- [[professions/strategy-executive/okr-authoring]]
+- [[professions/strategy-executive/kpi-vs-okr]]
+- [[professions/strategy-executive/measurable-objectives-leading-lagging]]

--- a/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
+++ b/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
@@ -199,3 +199,36 @@ shows real divergence. Competency tiering applies to **every** family.
 5. Omitting both fields yields a jurisdiction-neutral, practitioner-level page
    (backward-compatible with the shipped data-architect corpus, which sets
    neither and therefore tallies as `global` / `practitioner`).
+
+## 9. Coverage disposition for platform-internal families
+
+"Consider variants … for **all** of the AI Coworkers" requires a disposition for
+every registry family, not corpus content for every family. Most families get a
+researched external corpus (data-architect, software-engineer, finance, security,
+legal-compliance, qa-engineer, product-manager, frontend-engineer, ux-design,
+documentation-content, enterprise-architecture, operations, hr-people-ops,
+customer-success, strategy-executive, external-intelligence, plus the wave still
+gated on merges: devops-platform, scrum-master, portfolio-management, marketing,
+release-service-management).
+
+Three registry families are **platform-internal** and are deliberately *not* given
+a parallel external corpus:
+
+- **`build-studio`** and **`admin-operations`** — their professional doctrine is
+  DPF's own platform doctrine, already the single source of truth in the **founder
+  kernel** (`docs/founder-kernel/wiki/principles/`) and `AGENTS.md`. Authoring a
+  `professions/build-studio/*` corpus that re-cited `AGENTS.md` would duplicate the
+  kernel and violate `single-source-of-truth`. Their Phase-1 profession profiles
+  already fall back through the chain to the platform/WWMD kernel (parent spec
+  §4.5), which **is** their body of knowledge. This matches parent spec §4.11:
+  "Platform-internal pipeline agents … are governed by the engineering-flow/WWMD
+  platform doctrine they already have; they map to families only where a real
+  external profession exists."
+- **`external-intelligence`** *does* map to a real external profession (tool/registry
+  scouting, supply-chain vetting) with genuine external sources (MCP, npm, OWASP),
+  so it gets a corpus.
+
+Disposition rule: a family with a real external body of knowledge gets a researched
+corpus; a platform-internal family defers to the founder kernel via the fallback
+chain rather than duplicating it. Both are "covered" — one by corpus, one by
+governed deferral.

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -1083,6 +1083,91 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "indicators, monitor health); the two are complementary.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── External-intelligence / scouting family (WSID wave 9) ──
+  // MCP and npm docs are open developer documentation; OWASP is CC-BY-SA;
+  // Smithery docs page is open (homepage 403'd, not authored from). Product
+  // School build-vs-buy is licensed (cited by reference).
+  "mcp/intro": {
+    sourceType: "spec",
+    title: "Model Context Protocol — Introduction",
+    url: "https://modelcontextprotocol.io/",
+    license: "open-docs",
+    abstract:
+      'MCP is an open standard connecting AI applications to external systems — ' +
+      '"like a USB-C port for AI applications."',
+    retrievedAt: "2026-06-13",
+  },
+  "mcp/architecture": {
+    sourceType: "spec",
+    title: "Model Context Protocol — Architecture",
+    url: "https://modelcontextprotocol.io/docs/concepts/architecture",
+    license: "open-docs",
+    abstract:
+      "MCP client-server architecture; servers expose tools, resources, and " +
+      "prompts discovered by clients via list methods.",
+    retrievedAt: "2026-06-13",
+  },
+  "smithery/registry-docs": {
+    sourceType: "web-article",
+    title: "Smithery Registry — Search Servers (docs)",
+    url: "https://smithery.ai/docs/concepts/registry_search_servers",
+    license: "open-docs",
+    abstract:
+      "Smithery is a searchable registry of MCP servers with full-text/semantic " +
+      "search and usage + verification signals.",
+    retrievedAt: "2026-06-13",
+  },
+  "npm/registry-docs": {
+    sourceType: "web-article",
+    title: "About the public npm registry",
+    url: "https://docs.npmjs.com/about-the-public-npm-registry",
+    license: "open-docs",
+    abstract:
+      "The public npm registry is a database of JavaScript packages, each with " +
+      "software and metadata.",
+    retrievedAt: "2026-06-13",
+  },
+  "npm/semver": {
+    sourceType: "web-article",
+    title: "About semantic versioning (npm)",
+    url: "https://docs.npmjs.com/about-semantic-versioning",
+    license: "open-docs",
+    abstract:
+      "npm semantic versioning: MAJOR.MINOR.PATCH conveys breaking / feature / " +
+      "bug-fix change scope.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/component-analysis": {
+    sourceType: "web-article",
+    title: "OWASP Component Analysis",
+    url: "https://owasp.org/www-community/Component_Analysis",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Process for identifying risk from third-party/open-source components: " +
+      "vulnerability age, component currency, ongoing maintenance cost.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/dependency-chain-abuse": {
+    sourceType: "web-article",
+    title: "OWASP CICD-SEC-3: Dependency Chain Abuse",
+    url: "https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Dependency confusion, hijacking, typosquatting, and brandjacking attack " +
+      "vectors against the software supply chain.",
+    retrievedAt: "2026-06-13",
+  },
+  "productschool/build-vs-buy": {
+    sourceType: "web-article",
+    title: "Build vs Buy: Making Smarter Software Decisions (Product School)",
+    url: "https://productschool.com/blog/leadership/build-vs-buy",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "Build/buy framework across cost/TCO, time-to-market, capability, " +
+      "expertise, and strategic control. Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -789,6 +789,179 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "Licensed; cited by reference.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── IT operations / SRE family (WSID wave 6/7) ──
+  // NIST SP 800-61 Rev.2 was withdrawn 2025-04-03 (superseded by Rev.3); the
+  // IR-lifecycle phases are durable doctrine cited via an open secondary
+  // explainer because the primary PDF did not text-extract. ITIL 4 is licensed
+  // (PeopleCert/Axelos): incident-vs-problem doctrine uses an open explainer,
+  // never ITIL spec text. Google SRE book is CC-BY-NC-ND (cited, not modified).
+  "nist/sp-800-61": {
+    sourceType: "standard",
+    title: "NIST SP 800-61 Computer Security Incident Handling Guide",
+    url: "https://csrc.nist.gov/pubs/sp/800/61/r2/final",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "NIST incident-response lifecycle (preparation; detection & analysis; " +
+      "containment/eradication/recovery; post-incident). Rev.2 withdrawn; see Rev.3.",
+    retrievedAt: "2026-06-13",
+  },
+  "rapid7/nist-ir-lifecycle": {
+    sourceType: "web-article",
+    title: "Introduction to the NIST SP 800-61 Incident Response Life Cycle",
+    url: "https://www.rapid7.com/blog/post/2017/01/11/introduction-to-incident-response-life-cycle-of-nist-sp-800-61/",
+    license: "web-article-public",
+    abstract:
+      "Open secondary explainer of the four NIST SP 800-61 incident-response " +
+      "lifecycle phases.",
+    retrievedAt: "2026-06-13",
+  },
+  "opentelemetry/observability-primer": {
+    sourceType: "spec",
+    title: "OpenTelemetry Observability Primer",
+    url: "https://opentelemetry.io/docs/concepts/observability-primer/",
+    license: "CC-BY-4.0",
+    abstract:
+      "Defines observability and the three signals (traces, metrics, logs), " +
+      "spans, and distributed tracing; vendor-neutral CNCF framework.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-slo": {
+    sourceType: "reference",
+    title: "Google SRE Book — Service Level Objectives",
+    url: "https://sre.google/sre-book/service-level-objectives/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Defines SLI, SLO, and SLA; advocates a handful of representative " +
+      "indicators and percentiles over averages.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-risk": {
+    sourceType: "reference",
+    title: "Google SRE Book — Embracing Risk",
+    url: "https://sre.google/sre-book/embracing-risk/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Error budgets as the gap between target and 100%; the reliability-vs-" +
+      "innovation trade-off.",
+    retrievedAt: "2026-06-13",
+  },
+  "google/sre-book-postmortem": {
+    sourceType: "reference",
+    title: "Google SRE Book — Postmortem Culture",
+    url: "https://sre.google/sre-book/postmortem-culture/",
+    license: "CC-BY-NC-ND-4.0",
+    abstract:
+      "Blameless postmortems: fix systems and processes, not people; defined " +
+      "triggers and mandatory review.",
+    retrievedAt: "2026-06-13",
+  },
+  "betterstack/severity-levels": {
+    sourceType: "web-article",
+    title: "Incident Severity Levels (SEV1-SEV3)",
+    url: "https://betterstack.com/community/guides/incident-management/severity-levels/",
+    license: "CC-BY-NC-SA-4.0",
+    abstract:
+      "Defines incident severity levels SEV1/SEV2/SEV3 and the severity-vs-" +
+      "priority distinction.",
+    retrievedAt: "2026-06-13",
+  },
+  "itsm-tools/incident-vs-problem": {
+    sourceType: "web-article",
+    title: "Incident vs Problem Management (open explainer)",
+    url: "https://itsm.tools/incident-vs-problem-management/",
+    license: "web-article-public",
+    abstract:
+      "Open explainer of the ITIL distinction: incident management restores " +
+      "service; problem management eliminates recurring causes.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── HR / people-ops family (WSID wave 7) — jurisdiction split us vs eu ──
+  // SHRM BASK is licensed (cluster names used as facts, checklist-only). EEOC
+  // and EU Your-Europe are public-domain/open-reuse. US OPM/HHS interview
+  // pages blocked the fetcher; structured-interviewing is anchored on an open
+  // vendor explainer.
+  "eeoc/prohibited-practices": {
+    sourceType: "standard",
+    title: "EEOC — Prohibited Employment Policies/Practices",
+    url: "https://www.eeoc.gov/prohibited-employment-policiespractices",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "US protected bases and prohibited practices across the employment " +
+      "lifecycle (ads, hiring, pay, discipline, harassment).",
+    retrievedAt: "2026-06-13",
+  },
+  "eeoc/eeo-laws": {
+    sourceType: "standard",
+    title: "EEOC — Equal Employment Opportunity Laws",
+    url: "https://www.eeoc.gov/equal-employment-opportunity-laws",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "Overview of the EEOC's role and the federal anti-discrimination statutes " +
+      "it enforces.",
+    retrievedAt: "2026-06-13",
+  },
+  "eeoc/federal-laws-qa": {
+    sourceType: "standard",
+    title: "EEOC — Federal Laws Prohibiting Job Discrimination (Q&A)",
+    url: "https://www.eeoc.gov/fact-sheet/federal-laws-prohibiting-job-discrimination-questions-and-answers",
+    license: "US-Gov-Public-Domain",
+    abstract:
+      "Title VII, EPA, ADEA, ADA, Rehabilitation Act, GINA — protected bases " +
+      "and employer-size coverage thresholds.",
+    retrievedAt: "2026-06-13",
+  },
+  "eu/employment-termination": {
+    sourceType: "standard",
+    title: "Terminating employment contracts in the EU (Your Europe)",
+    url: "https://europa.eu/youreurope/business/human-resources/general-employment-terms-conditions/terminating-employment-contracts/index_en.htm",
+    license: "EC-reuse-attribution",
+    abstract:
+      "EU dismissal protection: non-discrimination, pregnancy/parental " +
+      "protection, employer burden of proof, collective-redundancy consultation.",
+    retrievedAt: "2026-06-13",
+  },
+  "gdpr/art-88": {
+    sourceType: "standard",
+    title: "GDPR Article 88 — Processing in the employment context",
+    url: "https://gdpr-info.eu/art-88-gdpr/",
+    license: "OJ-EU-open-reproduction",
+    abstract:
+      "Member states may set employee-data rules with safeguards for dignity, " +
+      "monitoring transparency, and intra-group transfers.",
+    retrievedAt: "2026-06-13",
+  },
+  "shrm/bask": {
+    sourceType: "framework",
+    title: "SHRM Body of Applied Skills and Knowledge (BASK)",
+    url: "https://www.shrm.org/credentials/certification/exam-preparation/bask",
+    license: "SHRM-copyright-checklist-only",
+    abstract:
+      "SHRM competency clusters (Leadership, Interpersonal, Business) + HR " +
+      "Expertise. Licensed; cluster names used as facts only.",
+    retrievedAt: "2026-06-13",
+  },
+  "atwill/cornell-lii": {
+    sourceType: "reference",
+    title: "Employment-at-will doctrine (Cornell LII Wex)",
+    url: "https://www.law.cornell.edu/wex/employment-at-will_doctrine",
+    license: "Cornell-LII-educational",
+    abstract:
+      "US at-will employment and its exceptions: public policy, implied " +
+      "contract, implied covenant of good faith.",
+    retrievedAt: "2026-06-13",
+  },
+  "interview/structured": {
+    sourceType: "web-article",
+    title: "Structured Interviews — guide",
+    url: "https://www.pin.com/blog/structured-interviews-guide/",
+    license: "web-article-public",
+    abstract:
+      "Same questions/order/rubric for all candidates; behavioral vs " +
+      "situational; higher validity and legal defensibility than unstructured.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -962,6 +962,127 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "situational; higher validity and legal defensibility than unstructured.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── Customer-success family (WSID wave 8) ──
+  // Only wikipedia/nps is open; NN/G, Intercom, Gainsight, Bain are licensed/
+  // vendor and cited by reference (short attributed quotes, facts only). CSA
+  // manifesto blocked the fetcher (403) and is not authored from.
+  "wikipedia/nps": {
+    sourceType: "reference",
+    title: "Net Promoter Score",
+    url: "https://en.wikipedia.org/wiki/Net_promoter_score",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "NPS: the recommend question, promoter/passive/detractor bands, and the " +
+      "%promoters - %detractors formula.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/journey-mapping": {
+    sourceType: "web-article",
+    title: "Customer Journey Mapping (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/customer-journey-mapping/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Journey maps combine storytelling and visualization of user goals, " +
+      "phases, actions, emotions, touchpoints, and opportunities.",
+    retrievedAt: "2026-06-13",
+  },
+  "nng/service-blueprints": {
+    sourceType: "web-article",
+    title: "Service Blueprints: Definition (Nielsen Norman Group)",
+    url: "https://www.nngroup.com/articles/service-blueprints-definition/",
+    license: "NNG-copyright-cite-by-reference",
+    abstract:
+      "Service blueprints map frontstage/backstage/support layers and the " +
+      "interaction, visibility, and internal-interaction lines.",
+    retrievedAt: "2026-06-13",
+  },
+  "intercom/aha-moments": {
+    sourceType: "web-article",
+    title: "Understanding your aha moments (Intercom)",
+    url: "https://www.intercom.com/blog/understanding-your-aha-moments-and-putting-them-to-work/",
+    license: "vendor-copyright-cite-by-reference",
+    abstract:
+      "Distinguishes the user's value-discovery aha moment from company-defined " +
+      "activation in onboarding.",
+    retrievedAt: "2026-06-13",
+  },
+  "bain/net-promoter-system": {
+    sourceType: "web-article",
+    title: "Measuring Your Net Promoter Score (Bain)",
+    url: "https://www.netpromotersystem.com/about/measuring-your-net-promoter-score/",
+    license: "vendor-copyright-cite-by-reference",
+    abstract:
+      "Bain's Net Promoter System: the ultimate question, score bands, and the " +
+      "economics of promoters vs detractors.",
+    retrievedAt: "2026-06-13",
+  },
+  "gainsight/cs-guide": {
+    sourceType: "web-article",
+    title: "The Essential Guide to Customer Success (Gainsight)",
+    url: "https://www.gainsight.com/guides/the-essential-guide-to-customer-success/",
+    license: "vendor-copyright-cite-by-reference",
+    abstract:
+      "Defines customer success as proactive and outcome-focused, contrasted " +
+      "with reactive support; the CSM lifecycle role.",
+    retrievedAt: "2026-06-13",
+  },
+  "gainsight/health-scores": {
+    sourceType: "web-article",
+    title: "Customer Health Scores (Gainsight)",
+    url: "https://www.gainsight.com/blog/customer-health-scores/",
+    license: "vendor-copyright-cite-by-reference",
+    abstract:
+      "Health-score components and models (traffic-light / 0-100) with " +
+      "alert-and-playbook intervention on score decay.",
+    retrievedAt: "2026-06-13",
+  },
+
+  // ── Strategy & executive family (WSID wave 8) ──
+  // No CC/public-domain source exists for these frameworks; all are openly
+  // readable but copyrighted. Cited by reference with short attributed quotes;
+  // doctrine is distilled framework facts (OKR structure, BSC perspectives),
+  // never reproduced prose.
+  "whatmatters/okr": {
+    sourceType: "framework",
+    title: "OKR Meaning, Definition & Example (What Matters)",
+    url: "https://www.whatmatters.com/faqs/okr-meaning-definition-example",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "OKRs pair one Objective with 3-5 measurable Key Results; the " +
+      '"I will (Objective) as measured by (Key Results)" template.',
+    retrievedAt: "2026-06-13",
+  },
+  "bsi/balanced-scorecard": {
+    sourceType: "framework",
+    title: "Balanced Scorecard Basics (Balanced Scorecard Institute)",
+    url: "https://balancedscorecard.org/bsc-basics/",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "The Balanced Scorecard's four perspectives (financial, customer, " +
+      "internal process, learning & growth) translating strategy into measures.",
+    retrievedAt: "2026-06-13",
+  },
+  "bsi/strategy": {
+    sourceType: "framework",
+    title: "Cascading — Creating Alignment (Balanced Scorecard Institute)",
+    url: "https://balancedscorecard.org/cascading-creating-alignment/",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "Cascading scorecards across tiers to create line-of-sight between daily " +
+      "work and high-level strategy.",
+    retrievedAt: "2026-06-13",
+  },
+  "mooncamp/okr-vs-kpi": {
+    sourceType: "web-article",
+    title: "OKR vs KPI: Differences & Synergies (Mooncamp)",
+    url: "https://mooncamp.com/blog/okr-vs-kpi",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "Contrasts OKRs (leading indicators, drive change) with KPIs (lagging " +
+      "indicators, monitor health); the two are complementary.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 8 — customer-success + strategy-executive corpora on the variant model from [#1808](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1808). Both jurisdiction-global; competency tier is the active variant axis.

**Licensing note:** these two families have weak open-license source availability — the authoritative sources are openly readable but copyrighted (NN/G, Gainsight, Bain, Intercom; What Matters, Balanced Scorecard Institute, Mooncamp). They are marked `licensed` and cited **by reference** with short attributed quotes (framework facts, not reproduced prose) — the same treatment applied to SAFe/ISO/ITIL/SHRM in earlier waves. Only `wikipedia/nps` is open-licensed.

## Customer-success (7 pages)

what-is-customer-success, serve-the-customer's-actual-goal (core), onboarding & activation (core), customer journey map, service blueprint (expert), customer health & escalation handoff, NPS entity. CSA manifesto blocked the fetcher (403) → not authored from.

## Strategy-executive (6 pages)

OKR entity, Balanced Scorecard four perspectives (expert), align-work-to-strategy (core), measurable-objectives / leading-vs-lagging (core), KPI-vs-OKR, OKR-authoring heuristic.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards):

- **33 corpus pages on this branch, 0 orphan wiki-links, 0 unknown source citations**
- families on branch: data-architect=4, software-engineer=9, finance=7, customer-success=7, strategy-executive=6
- competency: `foundational=11, practitioner=15, expert=7`

11 new RawSources registered.

> Parallel open WSID PRs: [#1814](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1814), [#1816](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1816), [#1818](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1818), [#1819](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1819), [#1821](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1821).

🤖 Generated with [Claude Code](https://claude.com/claude-code)