### PR TITLE
feat(wsid): external-intelligence corpus + platform-internal coverage disposition (wave 9)

### DIFF
--- a/docs/professions/external-intelligence/wiki/capability-gap-to-governed-suggestion.md
+++ b/docs/professions/external-intelligence/wiki/capability-gap-to-governed-suggestion.md
@@ -1,0 +1,46 @@
+---
+title: Capability-gap detection to governed backlog suggestion
+pageKind: principle
+status: published
+abstract: A detected capability gap triggers a build-vs-buy judgment, not an automatic adoption. Buy for non-differentiating needs, build where the capability is the edge, weigh total cost over time — and always output a governed backlog suggestion, never a unilateral integration.
+principleTier: core
+principleDirection: Convert a detected gap into a build-vs-buy judgment and a governed backlog suggestion; the scout proposes, governance disposes.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"cost_efficiency": 0.6, "vendor_lock_in": 0.5, "speed_to_value": 0.4}
+professionCompetencyLevel: expert
+sources:
+  - productschool/build-vs-buy
+  - owasp/component-analysis
+---
+
+## Rule
+
+A detected capability gap triggers a **build-vs-buy judgment**, not an automatic adoption — and its output is always a **governed backlog suggestion**, never a unilateral integration. The scout proposes; governance disposes.
+
+## The Build-vs-Buy Judgment
+
+The decision spans cost/TCO, time-to-market, capability fit, in-house expertise, and strategic control:
+
+- **Buy for non-differentiating needs** — "buy for non-core functions and build where learning compounds."
+- **Build where it is the edge** — ask "does this software define your competitive edge?"
+- **Weigh true cost over time** — "smart teams look beyond the first invoice to the total cost of flexibility."
+- **Price in supply-chain cost** — adopting an external tool imports its risk surface, and every new component adds ongoing maintenance cost; factor vetting into the buy side.
+
+## Output: A Governed Suggestion
+
+The scout never integrates unilaterally. The output is a **candidate for review** that enters the governed backlog — consistent with DPF's "governed backlog suggestion" model and the Tool Evaluation Pipeline. Governance, not the scout, decides adoption.
+
+## How To Apply
+
+1. **Frame the gap** as build-vs-buy, not "found a tool, adopt it."
+2. **Require vetting** ([[professions/external-intelligence/vet-before-adopting-external-tools]]) before any buy recommendation.
+3. **File a governed suggestion** with provenance and health evidence from [[professions/external-intelligence/external-tool-catalog-reconnaissance]].
+
+## See Also
+
+- [[professions/external-intelligence/vet-before-adopting-external-tools]]
+- [[professions/external-intelligence/mcp-what-it-is]]

--- a/docs/professions/external-intelligence/wiki/external-tool-catalog-reconnaissance.md
+++ b/docs/professions/external-intelligence/wiki/external-tool-catalog-reconnaissance.md
@@ -1,0 +1,36 @@
+---
+title: External agent/tool catalog reconnaissance
+pageKind: summary
+status: published
+abstract: Scout the external capability landscape through registries — the Smithery MCP-server registry and the public npm registry — capturing machine-readable provenance per candidate. Reconnaissance produces candidates, never adoptions.
+professionCompetencyLevel: practitioner
+sources:
+  - smithery/registry-docs
+  - npm/registry-docs
+---
+
+## What This Covers
+
+The external-intelligence coworker reconnoiters the capability landscape through registries:
+
+- The **Smithery registry** is "a list of MCP servers that are available to use," searchable by name, description, or tags, with "full-text and semantic search" and filters for deployment status, verification, and ownership.
+- The **public npm registry** is "a database of JavaScript packages, each comprised of software and metadata" — the second primary catalog to reconnoiter.
+
+## How To Reconnoiter
+
+1. **Search by capability need**, using full-text and semantic search.
+2. **Distinguish server type** — remote (URL-accessed) vs local (stdio); deployment shape changes the adoption and risk profile.
+3. **Capture provenance per candidate** — namespace, owner, GitHub repo, and the registration timestamp ("ISO 8601 timestamp of when the server was registered").
+4. **Produce candidates, not adoptions.** Recon output is a shortlist; every candidate goes through vetting before any suggestion.
+
+## How DPF Coworkers Use It
+
+- Treat recon as the funnel's top: surface candidates, then hand each to [[professions/external-intelligence/vet-before-adopting-external-tools]].
+- Assess each candidate's health — see [[professions/external-intelligence/server-health-assessment]].
+- A confirmed gap becomes a governed suggestion — see [[professions/external-intelligence/capability-gap-to-governed-suggestion]].
+
+## See Also
+
+- [[professions/external-intelligence/mcp-what-it-is]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/capability-gap-to-governed-suggestion]]

--- a/docs/professions/external-intelligence/wiki/mcp-what-it-is.md
+++ b/docs/professions/external-intelligence/wiki/mcp-what-it-is.md
@@ -1,0 +1,34 @@
+---
+title: Model Context Protocol (MCP) — what it is
+pageKind: entity
+status: published
+abstract: MCP is an open standard for connecting AI applications to external systems via servers that expose tools, resources, and prompts. A scouting target is a tool/resource surface an LLM client can mount, not a UI.
+professionCompetencyLevel: foundational
+sources:
+  - mcp/intro
+  - mcp/architecture
+---
+
+## Definition
+
+The **Model Context Protocol (MCP)** is "an open-source standard for connecting AI applications to external systems" — described as "like a USB-C port for AI applications," one standardized connection interface.
+
+## Architecture
+
+MCP is **client-server**: a host application runs one client per server, and an "MCP Server: A program that provides context to MCP clients." Servers expose three primitives, which clients discover via list methods:
+
+- **Tools** — executable actions.
+- **Resources** — context data.
+- **Prompts** — reusable templates.
+
+Two transports: **stdio** (local process) and **Streamable HTTP** (remote — MCP recommends OAuth for auth tokens).
+
+## Why It Matters for Scouting
+
+For the external-intelligence coworker, a reconnaissance target is therefore **not a UI** but a **tool/resource surface** an LLM client can mount. Understanding the MCP shape (local vs remote, what primitives a server exposes) is the foundation for evaluating an external capability.
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/vet-before-adopting-external-tools]]

--- a/docs/professions/external-intelligence/wiki/server-health-assessment.md
+++ b/docs/professions/external-intelligence/wiki/server-health-assessment.md
@@ -1,0 +1,33 @@
+---
+title: Package / MCP-server health assessment
+pageKind: heuristic
+status: published
+abstract: Assess an external server or package by adoption signals, trust signals, maintenance freshness, semantic-version change risk, and provenance — cross-checked against vulnerability intelligence. Health numbers are only trustworthy once provenance is traced.
+professionCompetencyLevel: practitioner
+sources:
+  - smithery/registry-docs
+  - owasp/component-analysis
+  - npm/semver
+---
+
+## Heuristic
+
+Score a candidate external server or package across five signals before trusting it:
+
+1. **Adoption** — Smithery exposes the "total number of times this server has been connected to"; usage is a (weak) health signal.
+2. **Trust** — the verified-status badge and whether the registry operator maintains the server.
+3. **Maintenance freshness** — keeping components current "reduces remediation time during security incidents"; stale or end-of-life components fail the check.
+4. **Change risk via SemVer** — read the version: major = "changes that break backward compatibility," minor = backward-compatible features, patch = bug fixes.
+5. **Provenance** — owner, GitHub repo, and registration timestamp. **Trace provenance before trusting health numbers** — popularity on an unknown-origin package is not safety.
+
+Cross-check **vulnerability intelligence** from multiple sources beyond the National Vulnerability Database (defect trackers, release notes).
+
+## How DPF Coworkers Use It
+
+- Run this assessment on every candidate from [[professions/external-intelligence/external-tool-catalog-reconnaissance]].
+- Health is necessary but not sufficient — it feeds, but does not replace, [[professions/external-intelligence/vet-before-adopting-external-tools]].
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/mcp-what-it-is]]

--- a/docs/professions/external-intelligence/wiki/vet-before-adopting-external-tools.md
+++ b/docs/professions/external-intelligence/wiki/vet-before-adopting-external-tools.md
@@ -1,0 +1,51 @@
+---
+title: Never adopt an unvetted external tool
+pageKind: principle
+status: published
+abstract: Every external tool, MCP server, or package carries supply-chain risk and must be vetted before adoption. Guard against typosquatting, dependency confusion, and hijacking; reject vulnerable or end-of-life components. A "verified" badge is a signal, not a clearance.
+principleTier: commandment
+principleDirection: Vet every external tool/package for supply-chain risk before adoption; never treat a registry badge as a substitute for independent assessment.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"public_safety": 0.8, "blast_radius": 0.7, "governance_compliance": 0.6}
+professionCompetencyLevel: foundational
+sources:
+  - owasp/component-analysis
+  - owasp/dependency-chain-abuse
+  - smithery/registry-docs
+---
+
+## Rule
+
+Never adopt an external tool, MCP server, or package without vetting it for supply-chain risk first. Component analysis exists to identify "potential areas of risk from the use of third-party and open-source software" — vetting is mandatory, not optional.
+
+## Attack Vectors To Guard Against
+
+- **Typosquatting** — "publication of malicious packages with similar names to those of popular packages."
+- **Dependency confusion** and **dependency hijacking** — including "obtaining control of the account of a package maintainer on the public repository."
+- **Brandjacking** and other dependency-chain abuse (OWASP CICD-SEC-3).
+
+## Reject Criteria
+
+- **Known vulnerabilities** and **excessive age** — OWASP advises limiting "acceptable component age to three years maximum" and prohibiting end-of-life components.
+- **Ongoing cost** — "operational and maintenance cost of using open source will increase with the adoption of every new component"; each dependency is a standing liability.
+
+A registry **"verified" badge is a signal, not a clearance** — verification status is one filter, never a substitute for independent risk assessment.
+
+## How To Apply
+
+1. **Vet every candidate** from [[professions/external-intelligence/external-tool-catalog-reconnaissance]] before it can be suggested.
+2. **Run the health assessment** — see [[professions/external-intelligence/server-health-assessment]].
+3. **Factor vetting + maintenance cost** into the build-vs-buy call — see [[professions/external-intelligence/capability-gap-to-governed-suggestion]].
+
+> This aligns with DPF's own Tool Evaluation Pipeline (AGENTS.md §9): external tools must pass security/architecture/compliance/integration review before adoption.
+
+## See Also
+
+- [[professions/external-intelligence/external-tool-catalog-reconnaissance]]
+- [[professions/external-intelligence/server-health-assessment]]
+- [[professions/external-intelligence/capability-gap-to-governed-suggestion]]

--- a/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
+++ b/docs/superpowers/specs/2026-06-13-wsid-location-competency-variants-design.md
@@ -199,3 +199,36 @@ shows real divergence. Competency tiering applies to **every** family.
 5. Omitting both fields yields a jurisdiction-neutral, practitioner-level page
    (backward-compatible with the shipped data-architect corpus, which sets
    neither and therefore tallies as `global` / `practitioner`).
+
+## 9. Coverage disposition for platform-internal families
+
+"Consider variants … for **all** of the AI Coworkers" requires a disposition for
+every registry family, not corpus content for every family. Most families get a
+researched external corpus (data-architect, software-engineer, finance, security,
+legal-compliance, qa-engineer, product-manager, frontend-engineer, ux-design,
+documentation-content, enterprise-architecture, operations, hr-people-ops,
+customer-success, strategy-executive, external-intelligence, plus the wave still
+gated on merges: devops-platform, scrum-master, portfolio-management, marketing,
+release-service-management).
+
+Three registry families are **platform-internal** and are deliberately *not* given
+a parallel external corpus:
+
+- **`build-studio`** and **`admin-operations`** — their professional doctrine is
+  DPF's own platform doctrine, already the single source of truth in the **founder
+  kernel** (`docs/founder-kernel/wiki/principles/`) and `AGENTS.md`. Authoring a
+  `professions/build-studio/*` corpus that re-cited `AGENTS.md` would duplicate the
+  kernel and violate `single-source-of-truth`. Their Phase-1 profession profiles
+  already fall back through the chain to the platform/WWMD kernel (parent spec
+  §4.5), which **is** their body of knowledge. This matches parent spec §4.11:
+  "Platform-internal pipeline agents … are governed by the engineering-flow/WWMD
+  platform doctrine they already have; they map to families only where a real
+  external profession exists."
+- **`external-intelligence`** *does* map to a real external profession (tool/registry
+  scouting, supply-chain vetting) with genuine external sources (MCP, npm, OWASP),
+  so it gets a corpus.
+
+Disposition rule: a family with a real external body of knowledge gets a researched
+corpus; a platform-internal family defers to the founder kernel via the fallback
+chain rather than duplicating it. Both are "covered" — one by corpus, one by
+governed deferral.

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -1083,6 +1083,91 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
       "indicators, monitor health); the two are complementary.",
     retrievedAt: "2026-06-13",
   },
+
+  // ── External-intelligence / scouting family (WSID wave 9) ──
+  // MCP and npm docs are open developer documentation; OWASP is CC-BY-SA;
+  // Smithery docs page is open (homepage 403'd, not authored from). Product
+  // School build-vs-buy is licensed (cited by reference).
+  "mcp/intro": {
+    sourceType: "spec",
+    title: "Model Context Protocol — Introduction",
+    url: "https://modelcontextprotocol.io/",
+    license: "open-docs",
+    abstract:
+      'MCP is an open standard connecting AI applications to external systems — ' +
+      '"like a USB-C port for AI applications."',
+    retrievedAt: "2026-06-13",
+  },
+  "mcp/architecture": {
+    sourceType: "spec",
+    title: "Model Context Protocol — Architecture",
+    url: "https://modelcontextprotocol.io/docs/concepts/architecture",
+    license: "open-docs",
+    abstract:
+      "MCP client-server architecture; servers expose tools, resources, and " +
+      "prompts discovered by clients via list methods.",
+    retrievedAt: "2026-06-13",
+  },
+  "smithery/registry-docs": {
+    sourceType: "web-article",
+    title: "Smithery Registry — Search Servers (docs)",
+    url: "https://smithery.ai/docs/concepts/registry_search_servers",
+    license: "open-docs",
+    abstract:
+      "Smithery is a searchable registry of MCP servers with full-text/semantic " +
+      "search and usage + verification signals.",
+    retrievedAt: "2026-06-13",
+  },
+  "npm/registry-docs": {
+    sourceType: "web-article",
+    title: "About the public npm registry",
+    url: "https://docs.npmjs.com/about-the-public-npm-registry",
+    license: "open-docs",
+    abstract:
+      "The public npm registry is a database of JavaScript packages, each with " +
+      "software and metadata.",
+    retrievedAt: "2026-06-13",
+  },
+  "npm/semver": {
+    sourceType: "web-article",
+    title: "About semantic versioning (npm)",
+    url: "https://docs.npmjs.com/about-semantic-versioning",
+    license: "open-docs",
+    abstract:
+      "npm semantic versioning: MAJOR.MINOR.PATCH conveys breaking / feature / " +
+      "bug-fix change scope.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/component-analysis": {
+    sourceType: "web-article",
+    title: "OWASP Component Analysis",
+    url: "https://owasp.org/www-community/Component_Analysis",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Process for identifying risk from third-party/open-source components: " +
+      "vulnerability age, component currency, ongoing maintenance cost.",
+    retrievedAt: "2026-06-13",
+  },
+  "owasp/dependency-chain-abuse": {
+    sourceType: "web-article",
+    title: "OWASP CICD-SEC-3: Dependency Chain Abuse",
+    url: "https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse",
+    license: "CC-BY-SA-4.0",
+    abstract:
+      "Dependency confusion, hijacking, typosquatting, and brandjacking attack " +
+      "vectors against the software supply chain.",
+    retrievedAt: "2026-06-13",
+  },
+  "productschool/build-vs-buy": {
+    sourceType: "web-article",
+    title: "Build vs Buy: Making Smarter Software Decisions (Product School)",
+    url: "https://productschool.com/blog/leadership/build-vs-buy",
+    license: "copyright-cite-by-reference",
+    abstract:
+      "Build/buy framework across cost/TCO, time-to-market, capability, " +
+      "expertise, and strategic control. Licensed; cited by reference.",
+    retrievedAt: "2026-06-13",
+  },
 };
 
 // ─── Source seeding ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

WSID corpus build-out wave 9 — the external-intelligence corpus, plus an explicit **coverage disposition** for platform-internal families so "consider variants for all coworkers" is grounded for the whole roster.

## External-intelligence / scouting (5 pages, jurisdiction-global)

MCP (what it is), external tool/registry reconnaissance (Smithery + npm), **never-adopt-an-unvetted-tool** (commandment — OWASP component analysis + dependency-chain abuse), capability-gap → governed-suggestion (expert — build-vs-buy), package/server health assessment.

Sources: MCP docs, npm docs (open); OWASP (CC-BY-SA); Smithery docs (open). Product School build-vs-buy is licensed → cited by reference. Smithery homepage 403'd → not authored from.

## Coverage disposition (variant spec addendum §9)

Reading AGENTS.md surfaced that **build-studio** and **admin-operations** are platform-internal roles whose doctrine already lives — single-source-of-truth — in the **founder kernel** (`docs/founder-kernel/wiki/principles/`) and AGENTS.md. Authoring a parallel `professions/*` corpus that re-cited AGENTS.md would duplicate the kernel. Their Phase-1 profiles already fall back to the platform/WWMD kernel (their real body of knowledge), matching parent spec §4.11. So they are **covered by governed deferral, not by a duplicate corpus**. external-intelligence maps to a real external profession, so it gets a corpus. The addendum documents this disposition rule for the whole roster.

## Verification

Validated against the real seed-time logic (parse + `extractPrinciplePayload` + variant guards):

- **25 corpus pages on this branch, 0 orphan wiki-links, 0 unknown source citations**
- families on branch: data-architect=4, software-engineer=9, finance=7, external-intelligence=5

8 new RawSources registered.

## Roster status (16 of ~25 families with corpus; 3 kernel-deferred; 5 merge-gated)

Built/in-flight: data-architect, software-engineer, finance, security, legal-compliance, qa-engineer, product-manager, frontend-engineer, ux-design, documentation-content, enterprise-architecture, operations, hr-people-ops, customer-success, strategy-executive, **external-intelligence**. Kernel-deferred: build-studio, admin-operations. Remaining (gated on the open PRs merging, to avoid source-key collisions): devops-platform, scrum-master, portfolio-management, marketing, release-service-management.

> Parallel open WSID PRs: [#1814](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1814), [#1816](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1816), [#1818](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1818), [#1819](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1819), [#1821](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1821), [#1822](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1822).

🤖 Generated with [Claude Code](https://claude.com/claude-code)