### PR TITLE
feat(workbooks): image column type — upload + inline thumbnail

### DIFF
--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -25,6 +25,7 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "formula", label: "Formula" },
   { value: "url", label: "URL" },
   { value: "email", label: "Email" },
+  { value: "image", label: "Image" },
 ];
 
 const RESULT_TYPES: { value: FieldType; label: string }[] = [

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -42,6 +42,8 @@ import {
   makeMultiSelectRenderer,
   renderUrlCell,
   renderEmailCell,
+  renderImageCell,
+  ImageEditor,
   renderDateCell,
   renderReferenceCell,
   renderComputedCell,
@@ -142,6 +144,12 @@ function buildColumn(
         ...base,
         renderCell: renderEmailCell,
         renderEditCell: editable ? renderTextEditor : undefined,
+      };
+    case "image":
+      return {
+        ...base,
+        renderCell: renderImageCell,
+        renderEditCell: editable ? ImageEditor : undefined,
       };
     case "number":
       return { ...base, renderEditCell: editable ? NumberEditor : undefined };

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -148,6 +148,60 @@ export function makeReferenceEditor(referenceType: string) {
   };
 }
 
+/**
+ * Image editor: uploads a chosen file to /api/v1/upload (content-addressed
+ * MediaAsset storage) and commits the returned retrieval URL as the cell value.
+ * The bytes never live in the cell — only the URL string does, so an image
+ * column behaves like a url column with an upload affordance + thumbnail render.
+ */
+export function ImageEditor({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: RenderEditCellProps<GridRowData>): ReactNode {
+  const current = asString(row[column.key]);
+  return (
+    <div className="dpf-grid-editor-image">
+      <input
+        type="file"
+        accept="image/*"
+        autoFocus
+        onChange={async (e) => {
+          const file = e.target.files?.[0];
+          if (!file) {
+            onClose(false);
+            return;
+          }
+          const body = new FormData();
+          body.append("file", file);
+          try {
+            const res = await fetch("/api/v1/upload", { method: "POST", body });
+            const json = (await res.json()) as { data?: { url?: string }; url?: string };
+            const url = json.data?.url ?? json.url ?? null;
+            if (url) {
+              onRowChange({ ...row, [column.key]: url }, true);
+            } else {
+              onClose(false);
+            }
+          } catch {
+            onClose(false);
+          }
+        }}
+      />
+      {current ? (
+        <button
+          type="button"
+          className="dpf-grid-image-clear"
+          onClick={() => onRowChange({ ...row, [column.key]: null }, true)}
+        >
+          Clear
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Display renderers (renderCell)
 // ---------------------------------------------------------------------------
@@ -179,6 +233,13 @@ export function renderUrlCell({ row, column }: RenderCellProps<GridRowData>): Re
       {v}
     </a>
   );
+}
+
+export function renderImageCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {
+  const v = asString(row[column.key]);
+  if (!v) return null;
+  // eslint-disable-next-line @next/next/no-img-element -- content-addressed media URL, arbitrary host; next/image optimizer not applicable
+  return <img className="dpf-grid-thumb" src={v} alt="" />;
 }
 
 export function renderEmailCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -35,6 +35,32 @@
 }
 
 /* Cell renderer helpers */
+.dpf-grid-thumb {
+  block-size: 1.75rem;
+  inline-size: auto;
+  max-inline-size: 4rem;
+  object-fit: cover;
+  border-radius: 0.25rem;
+  border: 1px solid var(--dpf-border);
+  vertical-align: middle;
+}
+
+.dpf-grid-editor-image {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  inline-size: 100%;
+  block-size: 100%;
+  padding-inline: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.dpf-grid-image-clear {
+  color: var(--dpf-muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .dpf-grid-chip {
   display: inline-flex;
   align-items: center;

--- a/apps/web/lib/workbooks/cell-validation.test.ts
+++ b/apps/web/lib/workbooks/cell-validation.test.ts
@@ -75,6 +75,17 @@ describe("validateCell", () => {
     expect(validateCell(col("email"), "nope").ok).toBe(false);
   });
 
+  it("stores an image URL as text and rejects non-strings", () => {
+    const c = col("image");
+    const ok = validateCell(c, "/api/media/abc123");
+    expect(ok.ok && ok.storage.textValue).toBe("/api/media/abc123");
+    expect(validateCell(c, 42 as never).ok).toBe(false);
+    // empty is allowed on a non-required image column
+    expect(validateCell(c, null).ok).toBe(true);
+    // required image column rejects empty
+    expect(validateCell(col("image", { required: true }), null).ok).toBe(false);
+  });
+
   it("requires a referenceId for reference and enforces target type", () => {
     const c = col("reference", { config: { referenceType: "epic" } });
     const ok = validateCell(c, { referenceId: "E1", referenceType: "epic" });
@@ -100,5 +111,10 @@ describe("storageToCellValue", () => {
 
   it("returns empty array for multi_select with no value", () => {
     expect(storageToCellValue("multi_select", null)).toBeNull();
+  });
+
+  it("round-trips an image URL through text storage", () => {
+    const r = validateCell(col("image"), "/api/media/xyz");
+    expect(r.ok && storageToCellValue("image", r.storage)).toBe("/api/media/xyz");
   });
 });

--- a/apps/web/lib/workbooks/cell-validation.ts
+++ b/apps/web/lib/workbooks/cell-validation.ts
@@ -116,6 +116,20 @@ export function validateCell(
       return { ok: true, storage };
     }
 
+    case "image": {
+      // Stores the retrieval URL of an uploaded MediaAsset (e.g. /api/media/<id>)
+      // or an external image URL. The upload editor obtains it from /api/v1/upload;
+      // the bytes live in content-addressed media storage, not in the cell.
+      if (typeof value !== "string") {
+        return { ok: false, error: `Expected an image URL for ${column.name}` };
+      }
+      if (value.length > TEXT_MAX_LENGTH) {
+        return { ok: false, error: `${column.name} exceeds ${TEXT_MAX_LENGTH} characters` };
+      }
+      storage.textValue = value;
+      return { ok: true, storage };
+    }
+
     case "number": {
       const num = typeof value === "number" ? value : Number(value);
       if (typeof value === "boolean" || Number.isNaN(num)) {
@@ -224,6 +238,7 @@ export function storageToCellValue(
     case "text":
     case "url":
     case "email":
+    case "image":
       return cell.textValue ?? null;
     case "number":
       return cell.numberValue ?? null;

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -9,8 +9,8 @@
 
 /**
  * Field types. `formula` and `lookup` (Phase 2) are *computed* — read-only,
- * never user-written, derived on read. `rollup`, attachment, currency remain out
- * of scope.
+ * never user-written, derived on read. `image` stores an uploaded MediaAsset URL
+ * (content-addressed via /api/v1/upload). `rollup`, currency remain out of scope.
  */
 export const FIELD_TYPES = [
   "text",
@@ -23,6 +23,7 @@ export const FIELD_TYPES = [
   "reference",
   "url",
   "email",
+  "image",
   "formula",
   "lookup",
 ] as const;


### PR DESCRIPTION
## What

Adds an **`image`** workbook column type so a column can hold a picture per row — e.g. a product photo in a sell-list. Closes a real Smartsheet/Supabase-parity gap (workbooks previously had no attachment/image type; the type comment even noted attachments were "out of scope").

## How

Reuses the existing **content-addressed media stack** rather than introducing new storage:

- **Upload editor** — an in-cell file picker posts to `/api/v1/upload` (`createMediaAsset`, dedup on content hash) and commits the returned `/api/media/<id>` URL; a **Clear** action empties the cell.
- **Thumbnail renderer** — shows the image inline in the cell.
- **Storage** — the cell holds only the URL string (`textValue`); bytes live in media storage. So an image column behaves like a `url` column with an upload affordance.

Wired through every field-type seam so nothing is half-supported: `FIELD_TYPES`, `validateCell` + `storageToCellValue` (string-only, length-bounded, round-trips via `textValue`), `Grid` `buildColumn` (`renderCell`/`renderEditCell`), and the Add-column type picker. `provenanceKind` stays `manual`.

## Verification

- `vitest` — new cell-validation cases (URL round-trip + non-string rejection + required/empty) green; full workbooks suite green (57 tests).
- `pnpm --filter web typecheck` — green (extends every exhaustive `FieldType` switch; no `never`-guard breakage).
- Live upload smoke-test on the contributor preview is the remaining manual step (file-chooser automation + dev-portal hot-reload made it unreliable to drive headlessly); the upload path itself is the already-shipped `/api/v1/upload` + `createMediaAsset` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
