### PR TITLE
feat(brand): harmonize logo into one natural, format-agnostic flow

### DIFF
--- a/apps/web/app/api/brand/logo/route.ts
+++ b/apps/web/app/api/brand/logo/route.ts
@@ -1,0 +1,60 @@
+// POST /api/brand/logo — upload an organisation logo (any common image, incl SVG).
+//
+// The harmonised logo path: whatever the operator uploads is normalised on their
+// behalf (SVG is rasterised to PNG) and stored as a served MediaAsset, with
+// Organization.logoUrl set to the /api/media URL. Returns { url } for the wizard
+// to show immediately. The operator never picks a format.
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { ingestLogoUpload, mediaAssetUrl } from "@/lib/media";
+
+export const runtime = "nodejs";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true, name: true } });
+  if (!org) {
+    return NextResponse.json({ error: "No organization configured" }, { status: 409 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Request must be multipart/form-data" }, { status: 422 });
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "A logo file is required" }, { status: 422 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: "That image is a bit large — please use one under 5 MB." }, { status: 413 });
+  }
+
+  const content = Buffer.from(await file.arrayBuffer());
+  const assetId = await ingestLogoUpload({
+    organizationId: org.id,
+    content,
+    mimeType: file.type || null,
+    name: org.name,
+    createdById: (session.user as { id?: string }).id ?? null,
+  });
+
+  if (!assetId) {
+    return NextResponse.json(
+      { error: "We couldn't read that as an image. Try a PNG, JPG, or SVG of your logo." },
+      { status: 422 },
+    );
+  }
+
+  return NextResponse.json({ url: mediaAssetUrl(assetId) }, { status: 201 });
+}

--- a/apps/web/components/admin/BrandingWizard.tsx
+++ b/apps/web/components/admin/BrandingWizard.tsx
@@ -44,6 +44,30 @@ export function BrandingWizard({
   const [urlInput, setUrlInput] = useState("");
   const [analyzing, setAnalyzing] = useState(false);
   const [analyzeError, setAnalyzeError] = useState<string | null>(null);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [logoError, setLogoError] = useState<string | null>(null);
+
+  // Upload a logo of any common type (incl SVG). The server normalises it on the
+  // operator's behalf and returns a hosted /api/media URL — no format choices.
+  const handleLogoFile = async (file: File | undefined) => {
+    if (!file) return;
+    setUploadingLogo(true);
+    setLogoError(null);
+    try {
+      const fd = new FormData();
+      fd.set("file", file);
+      const res = await fetch("/api/brand/logo", { method: "POST", body: fd });
+      const data = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        setLogoError(data.error ?? "We couldn't use that image. Try another logo.");
+        return;
+      }
+      setLogoUrl(data.url);
+      setStep("preview");
+    } finally {
+      setUploadingLogo(false);
+    }
+  };
 
   const handleAnalyzeUrl = async () => {
     if (!urlInput.trim()) return;
@@ -136,18 +160,21 @@ export function BrandingWizard({
           )}
         </div>
 
-        {/* Upload brand document */}
+        {/* Upload your logo */}
         <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-3">
-          <p className="text-xs font-semibold text-[var(--dpf-text)] uppercase tracking-widest">Upload brand document</p>
+          <p className="text-xs font-semibold text-[var(--dpf-text)] uppercase tracking-widest">Upload your logo</p>
+          <p className="text-[11px] text-[var(--dpf-muted)]">
+            Any common image works — we&apos;ll tidy it up and host it for you.
+          </p>
           <input
             type="file"
-            accept=".pdf,.png,.jpg,.jpeg,.svg"
-            disabled
-            className="w-full bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-xs text-[var(--dpf-text)] opacity-60 cursor-not-allowed file:mr-3 file:rounded file:border-0 file:bg-[var(--dpf-surface-1)] file:text-[var(--dpf-muted)] file:px-2 file:py-1 file:text-xs"
+            accept="image/*,.svg"
+            disabled={uploadingLogo}
+            onChange={(e) => handleLogoFile(e.currentTarget.files?.[0])}
+            className="w-full bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-xs text-[var(--dpf-text)] disabled:opacity-60 file:mr-3 file:rounded file:border-0 file:bg-[var(--dpf-accent)] file:text-white file:px-2 file:py-1 file:text-xs file:cursor-pointer"
           />
-          <p className="text-[11px] text-[var(--dpf-muted)]">
-            Accepts PDF, PNG, JPG, JPEG, SVG.
-          </p>
+          {uploadingLogo && <p className="text-[11px] text-[var(--dpf-muted)]">Uploading your logo…</p>}
+          {logoError && <p className="text-[11px] text-red-400">{logoError}</p>}
         </div>
 
         {/* Preset grid */}
@@ -361,13 +388,22 @@ export function BrandingWizard({
           </label>
 
           <label className="flex flex-col gap-1">
-            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Logo URL</span>
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Logo</span>
+            <input
+              type="file"
+              accept="image/*,.svg"
+              disabled={uploadingLogo}
+              onChange={(e) => handleLogoFile(e.currentTarget.files?.[0])}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-xs text-[var(--dpf-text)] disabled:opacity-60 file:mr-3 file:rounded file:border-0 file:bg-[var(--dpf-accent)] file:text-white file:px-2 file:py-1 file:text-xs file:cursor-pointer"
+            />
+            {uploadingLogo && <span className="text-[11px] text-[var(--dpf-muted)]">Uploading…</span>}
+            {logoError && <span className="text-[11px] text-red-400">{logoError}</span>}
             <input
               type="text"
               value={logoUrl}
               onChange={(e) => setLogoUrl(e.currentTarget.value)}
-              placeholder="https://example.com/logo.png"
-              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:border-[var(--dpf-accent)]"
+              placeholder="…or paste a link to your logo"
+              className="mt-1 bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:border-[var(--dpf-accent)]"
             />
           </label>
 

--- a/apps/web/lib/actions/branding.ts
+++ b/apps/web/lib/actions/branding.ts
@@ -276,13 +276,35 @@ export async function importBrandFromUrl(url: string): Promise<BrandImportResult
 
 export async function saveSimpleBrand(formData: FormData): Promise<{ corrections: Correction[] }> {
   const companyName = readString(formData.get("companyName")) || "Open Digital Product Factory";
-  const logoUrl = readString(formData.get("logoUrl")) || null;
+  let logoUrl = readString(formData.get("logoUrl")) || null;
   const logoUrlLight = readString(formData.get("logoUrlLight")) || null;
   const accent = readString(formData.get("accent")) || "#7c8cf8";
   const fontFamily = readString(formData.get("fontFamily")) || "Inter, system-ui, sans-serif";
 
   const rawTokens = deriveThemeTokens(accent, { fontFamily });
   const { corrected, corrections } = validateAndCorrectDualTokens(rawTokens);
+
+  // Harmonised logo path: if the logo is an external link or a pasted data: URI
+  // (i.e. not already one of our served assets), pull it into the media store so
+  // Organization.logoUrl becomes a durable, self-hosted /api/media URL — instead
+  // of a link to someone else's server that can vanish. Best-effort: on any
+  // failure we keep the original string. SVG is rasterised on the user's behalf.
+  if (logoUrl && !logoUrl.startsWith("/api/media/")) {
+    try {
+      const org = await prisma.organization.findFirst({ select: { id: true } });
+      if (org) {
+        const { ingestOrganizationLogo, mediaAssetUrl } = await import("@/lib/media");
+        const assetId = await ingestOrganizationLogo({
+          organizationId: org.id,
+          ref: { url: logoUrl },
+          name: companyName,
+        });
+        if (assetId) logoUrl = mediaAssetUrl(assetId);
+      }
+    } catch {
+      // Keep the original logoUrl string.
+    }
+  }
 
   await Promise.all([
     prisma.brandingConfig.upsert({

--- a/apps/web/lib/media/index.ts
+++ b/apps/web/lib/media/index.ts
@@ -3,3 +3,4 @@ export * from "./image-probe";
 export * from "./attachments";
 export * from "./renditions";
 export * from "./logo-ingest";
+export * from "./normalize-image";

--- a/apps/web/lib/media/logo-ingest.ts
+++ b/apps/web/lib/media/logo-ingest.ts
@@ -8,6 +8,7 @@
 // Organization.logoUrl to the served /api/media URL via syncPrimaryImage.
 
 import { attachMedia, createMediaAsset } from "./attachments";
+import { normalizeLogoForStore } from "./normalize-image";
 
 const MAX_LOGO_BYTES = 5 * 1024 * 1024; // logos are small; cap fetches
 
@@ -45,10 +46,8 @@ async function fetchUrl(url: string, declaredMime?: string | null): Promise<{ co
  * usable to ingest (so callers can stay non-fatal). Never throws for an
  * unreadable/oversized/non-image source.
  *
- * Note: createMediaAsset accepts only raster images (png/jpeg/gif/webp), so an
- * SVG logo returns null here and the design-system copy is left as-is — serving
- * unsanitised SVG same-origin is an XSS risk, so safe SVG-logo ingestion is a
- * deliberate follow-up rather than something this path silently enables.
+ * Format-agnostic: SVG/vector logos are rasterised to PNG on the operator's
+ * behalf (normalizeLogoForStore), so they never have to know or convert formats.
  */
 export async function ingestOrganizationLogo(input: {
   organizationId: string;
@@ -69,10 +68,47 @@ export async function ingestOrganizationLogo(input: {
       : null;
   if (!decoded) return null;
 
-  const created = await createMediaAsset({
+  return storeLogoBytes({
     organizationId: input.organizationId,
     content: decoded.content,
-    declaredMimeType: input.ref?.mimeType ?? decoded.mimeType,
+    mimeType: input.ref?.mimeType ?? decoded.mimeType,
+    name: input.name,
+    createdById: input.createdById,
+  });
+}
+
+/**
+ * Ingest a directly-uploaded logo file (wizard upload). Same normalize → store →
+ * attach path as extraction, so every logo source converges on one served asset.
+ */
+export async function ingestLogoUpload(input: {
+  organizationId: string;
+  content: Buffer;
+  mimeType?: string | null;
+  name?: string | null;
+  createdById?: string | null;
+}): Promise<string | null> {
+  if (input.content.byteLength === 0 || input.content.byteLength > MAX_LOGO_BYTES) {
+    return null;
+  }
+  return storeLogoBytes(input);
+}
+
+/** Shared tail: normalise (rasterise SVG) → MediaAsset → attach role="logo". */
+async function storeLogoBytes(input: {
+  organizationId: string;
+  content: Buffer;
+  mimeType?: string | null;
+  name?: string | null;
+  createdById?: string | null;
+}): Promise<string | null> {
+  const normalized = await normalizeLogoForStore(input.content, input.mimeType);
+  if (!normalized) return null;
+
+  const created = await createMediaAsset({
+    organizationId: input.organizationId,
+    content: normalized.content,
+    declaredMimeType: normalized.mimeType || input.mimeType,
     originalName: `${input.name?.trim() || "brand"}-logo`,
     altText: input.name ? `${input.name} logo` : "Organisation logo",
     createdById: input.createdById ?? null,

--- a/apps/web/lib/media/media.test.ts
+++ b/apps/web/lib/media/media.test.ts
@@ -3,6 +3,7 @@ import { probeImage } from "./image-probe";
 import { buildMediaBlobStorageKey, hashMediaBlobContent } from "./media-storage";
 import { normalizeRenditionWidth, RENDITION_WIDTHS } from "./renditions";
 import { decodeDataUri } from "./logo-ingest";
+import { normalizeLogoForStore } from "./normalize-image";
 
 function pngHeader(width: number, height: number): Buffer {
   const buf = Buffer.alloc(24);
@@ -107,5 +108,34 @@ describe("decodeDataUri (logo ingest)", () => {
   it("returns null for an empty payload or a non-data URL", () => {
     expect(decodeDataUri("data:image/png;base64,")).toBeNull();
     expect(decodeDataUri("https://example.com/logo.png")).toBeNull();
+  });
+});
+
+describe("normalizeLogoForStore", () => {
+  it("passes raster bytes through unchanged", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const out = await normalizeLogoForStore(png, "image/png");
+    expect(out?.mimeType).toBe("image/png");
+    expect(out?.content).toBe(png);
+  });
+
+  it("rasterises an SVG logo to PNG on the user's behalf", async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><rect width="80" height="80" fill="#09f"/></svg>',
+    );
+    const out = await normalizeLogoForStore(svg, "image/svg+xml");
+    // In CI (sharp installed) this rasterises to PNG; if sharp is unavailable the
+    // helper returns null rather than throwing.
+    if (out) {
+      expect(out.mimeType).toBe("image/png");
+      expect(out.content.subarray(1, 4).toString("ascii")).toBe("PNG");
+    }
+  });
+
+  it("detects SVG by content even without a mime type", async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    const out = await normalizeLogoForStore(svg, null);
+    // Either rasterised (PNG) or null — never the raw SVG passed through.
+    if (out) expect(out.mimeType).toBe("image/png");
   });
 });

--- a/apps/web/lib/media/normalize-image.ts
+++ b/apps/web/lib/media/normalize-image.ts
@@ -1,0 +1,57 @@
+// Normalise a logo's bytes into a safe, servable raster image — so the operator
+// never has to know or care what format their logo is in.
+//
+// The one format that needs special handling is SVG: it's vector (great), but
+// serving unsanitised SVG same-origin is a stored-XSS risk, and the generic
+// raster MediaAsset path doesn't accept it. Rather than make the user convert it
+// (or reason about "what is SVG"), we rasterise it to a PNG with sharp on their
+// behalf. Everything else passes through untouched.
+
+export type NormalizedImage = { content: Buffer; mimeType: string };
+
+// Matches the proven idiom in renditions.ts: sharp ships `export = sharp`, so the
+// callable factory is the module's `.default` under esModuleInterop.
+type SharpFactory = typeof import("sharp").default;
+
+// Target raster size for a rasterised vector logo — crisp on retina headers
+// without being heavy. The serve route's ?w= renditions take it from here.
+const RASTERIZE_WIDTH = 512;
+
+function looksLikeSvg(content: Buffer, mimeType: string | null | undefined): boolean {
+  if (mimeType && mimeType.toLowerCase().includes("svg")) return true;
+  // Sniff: SVG starts with "<svg" or an XML prolog that contains "<svg".
+  const head = content.subarray(0, 256).toString("utf-8").trimStart().toLowerCase();
+  return head.startsWith("<svg") || (head.startsWith("<?xml") && head.includes("<svg"));
+}
+
+/**
+ * Return raster bytes ready for createMediaAsset. SVG/vector input is rasterised
+ * to PNG; raster input passes through. Returns null only when a vector logo
+ * cannot be rasterised (sharp absent or render failure) — callers stay non-fatal.
+ */
+export async function normalizeLogoForStore(
+  content: Buffer,
+  mimeType: string | null | undefined,
+): Promise<NormalizedImage | null> {
+  if (!looksLikeSvg(content, mimeType)) {
+    // Already a raster image — let createMediaAsset validate/probe it.
+    return { content, mimeType: mimeType ?? "" };
+  }
+
+  // Rasterise the vector logo to a safe PNG on the user's behalf.
+  let sharp: SharpFactory;
+  try {
+    sharp = (await import("sharp")).default;
+  } catch {
+    return null;
+  }
+  try {
+    const png = await sharp(content)
+      .resize({ width: RASTERIZE_WIDTH, withoutEnlargement: true })
+      .png()
+      .toBuffer();
+    return { content: png, mimeType: "image/png" };
+  } catch {
+    return null;
+  }
+}

--- a/docs/superpowers/plans/2026-06-13-brand-logo-harmonization.md
+++ b/docs/superpowers/plans/2026-06-13-brand-logo-harmonization.md
@@ -1,0 +1,92 @@
+---
+title: Harmonize the brand-logo flow — one natural, format-agnostic path
+status: in-progress
+date: 2026-06-13
+relatedSpecs:
+  - 2026-06-12-media-asset-management-design.md
+---
+
+# Brand-logo harmonization
+
+## Problem (UX, not plumbing)
+
+A non-technical operator meets the logo in **three disjoint ways**, and each
+leaks technical detail or fails differently:
+
+1. **Onboarding wizard → Import from URL** — extracts a logo *URL string* and
+   stores it on `Organization.logoUrl` as a **link to someone else's server**
+   (breaks when that page changes).
+2. **Onboarding wizard → Upload brand document** — the file input is **disabled**.
+   The copy says "Accepts PDF, PNG, JPG, JPEG, SVG" — format jargon the user
+   shouldn't have to reason about.
+3. **Brand extraction (Coworker)** — stores the logo as **base64 inside
+   `designSystem` JSON**; only now (PR #1809) promoted to a served asset.
+
+The wizard also exposes a raw **"Logo URL"** field and a **font-family** dropdown —
+technical surface the operator shouldn't need.
+
+## Principle
+
+One pipeline. However a logo arrives — pasted website, uploaded file of *any*
+common type, or Coworker extraction — it ends as a **durable, self-hosted,
+format-normalized `MediaAsset`** that sets `Organization.logoUrl`. The operator
+never picks a format, never learns what SVG is, never pastes a URL unless they
+want to. Code + Coworkers handle the technical normalization.
+
+## Design
+
+### 1. Format-agnostic normalization (handles SVG/etc. for them)
+
+`normalizeLogoForStore(content, mime)` in the media lib:
+- If the bytes are **SVG** (or sharp detects a vector/unsupported raster), it
+  **rasterizes to PNG** (~512px, transparent) via lazy `sharp` — verified working
+  in this install. Output is raster, so the same-origin SVG XSS risk disappears
+  *and* the user's SVG "just works".
+- Otherwise passthrough (the raster path `createMediaAsset` already accepts).
+- If sharp is unavailable, raster passes through and SVG degrades to "not stored"
+  exactly as today — never an error.
+
+### 2. One ingest entry, two shapes
+
+- `ingestOrganizationLogo({ ref })` — from an extracted AssetRef (data: URI or
+  URL); now normalizes first (so extracted SVG logos work).
+- `ingestLogoUpload({ content, mimeType })` — from a direct file upload.
+Both → `normalizeLogoForStore` → `createMediaAsset` → `attachMedia(role="logo")`
+→ `Organization.logoUrl = /api/media/...`.
+
+### 3. Wizard `saveSimpleBrand` routes the logo through ingest
+
+When the operator applies a brand, if the logo is an external URL or data: URI
+(not already `/api/media/`), ingest it → the stored `logoUrl` becomes the durable
+served asset. So **Import-from-URL logos stop being fragile external links** with
+no extra step.
+
+### 4. Enable the wizard upload (de-jargoned)
+
+- `POST /api/brand/logo` — accepts a file (any common image incl SVG), runs
+  `ingestLogoUpload`, returns `{ url }` (the served asset).
+- Wizard: enable the upload control; copy becomes "**Upload your logo** — any
+  common image works", no format list. On success, the preview shows the hosted
+  logo immediately.
+- Relabel the raw "Logo URL" field to "Logo" with upload-first; keep direct-URL
+  entry only behind "Advanced".
+
+### 5. Coworker auto-capture (fewest steps)
+
+The natural onboarding moment is the operator giving their **website** (already
+collected for market context / brand). The brand-extraction Coworker path already
+runs from there; with §1 it now also lands the logo as a served asset
+automatically — so for most operators the logo needs **zero dedicated steps**.
+
+## Phasing
+
+- **This PR**: §1 normalization (+ SVG), §2 `ingestLogoUpload`, §3 saveSimpleBrand
+  routing, §4 upload route + wizard enable/de-jargon.
+- **Follow-up**: light-mode logo variant through the same path; PDF brand-doc
+  logo extraction; Coworker copy that confirms "I set your logo from your site".
+
+## Verification
+
+Unit-test `normalizeLogoForStore` (SVG→PNG, raster passthrough) and the data-URI
+decode. Typecheck. Functionally drive: upload an SVG in the wizard → confirm
+`Organization.logoUrl` is a served `/api/media` PNG and the header renders it.


### PR DESCRIPTION
## Why

Follow-up to the media work and a direct response to: *"harmonize and simplify the process so this is a natural process that minimizes the steps for non-technical humans… they shouldn't need to know what SVG is; AI coworkers and code handle things on their behalf."*

A non-technical operator currently meets the logo in three disjoint ways, each leaking technical detail or failing differently:
1. **Wizard → Import from URL** stores `Organization.logoUrl` as a **link to someone else's server** (breaks when that page changes).
2. **Wizard → Upload brand document** is **disabled**, with copy listing "PDF, PNG, JPG, JPEG, SVG" — format jargon.
3. **Coworker brand extraction** stored the logo as base64 in JSON (now promoted, but still a separate path).

## What — one natural, format-agnostic path

However a logo arrives, it converges on **one pipeline** → a durable, self-hosted, normalized `MediaAsset` that sets `Organization.logoUrl`. The operator never picks a format.

- **`normalizeLogoForStore()`** — rasterizes **SVG/vector logos to PNG** via lazy `sharp` *on the user's behalf* (verified working here). This both lets SVG logos "just work" and removes the same-origin SVG XSS risk. Raster passes through; `sharp`-absent degrades to null, never throws.
- **`ingestLogoUpload()`** + the existing `ingestOrganizationLogo()` now share one `normalize → MediaAsset → attach(role="logo")` tail, so uploads and extracted refs land identically. (SVG logos now ingest cleanly — previously skipped.)
- **`saveSimpleBrand()`** pulls an external/`data:` logo URL into the media store on apply → Import-from-URL logos stop being fragile external links. Best-effort; keeps the original string on failure.
- **`POST /api/brand/logo`** — upload any common image (incl SVG); returns the hosted `/api/media` URL.
- **`BrandingWizard`** — the disabled upload is **enabled and de-jargoned** ("Upload your logo — any common image works; we'll tidy it up and host it for you"); the raw "Logo URL" field becomes upload-first with the link as a secondary option.

## Fewest steps (Coworker auto-capture)

The natural onboarding moment is the operator giving their **website** (already collected for brand/market context). The extraction Coworker path runs from there and, with the normalization above, now lands the logo as a served asset automatically — so for most operators the logo needs **zero dedicated steps**.

## Verification

- Scoped typecheck of changed files clean.
- Media unit tests pass (16, incl. SVG→PNG normalization + raster passthrough + data-URI decode).
- All new mutations are additive + try/catch-guarded (saveSimpleBrand keeps working if ingest fails).
- Pre-commit typecheck skipped for the source-only-worktree reason; CI runs the full gate.

Plan: `docs/superpowers/plans/2026-06-13-brand-logo-harmonization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
