### PR TITLE
feat(build): AgentActivityStrip — ambient task-level progress grid

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -117,3 +117,9 @@ body {
   to   { opacity: 1; transform: translateY(0); }
 }
 .dpf-slide-up { animation: dpf-slide-up 320ms ease-out; }
+
+/* AgentActivityStrip — running-cell glow pulse */
+@keyframes dpf-cell-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--dpf-accent) 50%, transparent); }
+  55%       { opacity: 0.65; box-shadow: 0 0 0 3px color-mix(in srgb, var(--dpf-accent) 0%, transparent); }
+}

--- a/apps/web/components/build/AgentActivityStrip.test.tsx
+++ b/apps/web/components/build/AgentActivityStrip.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // apps/web/components/build/AgentActivityStrip.test.tsx
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";

--- a/apps/web/components/build/AgentActivityStrip.test.tsx
+++ b/apps/web/components/build/AgentActivityStrip.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 // apps/web/components/build/AgentActivityStrip.test.tsx
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});
 import { AgentActivityStrip } from "./AgentActivityStrip";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 

--- a/apps/web/components/build/AgentActivityStrip.test.tsx
+++ b/apps/web/components/build/AgentActivityStrip.test.tsx
@@ -1,0 +1,168 @@
+// apps/web/components/build/AgentActivityStrip.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { AgentActivityStrip } from "./AgentActivityStrip";
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+
+// Minimal FeatureBuildRow fixture for the strip's needs
+function makeRow(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    buildId: "build-test-01",
+    phase: "build",
+    buildPlan: {
+      fileStructure: [
+        { path: "packages/db/prisma/schema.prisma", action: "modify", purpose: "add table" },
+        { path: "apps/web/components/ui/Card.tsx", action: "create", purpose: "new component" },
+        { path: "apps/web/components/ui/Card.test.tsx", action: "create", purpose: "unit test" },
+        { path: "apps/web/lib/utils.ts", action: "create", purpose: "helper" },
+        { path: "apps/web/app/page.tsx", action: "modify", purpose: "route" },
+      ],
+      tasks: [
+        { title: "Extend schema", testFirst: "", implement: "", verify: "" },
+        { title: "Create Card component", testFirst: "", implement: "", verify: "" },
+        { title: "Wire route", testFirst: "", implement: "", verify: "" },
+        { title: "Add utils helper", testFirst: "", implement: "", verify: "" },
+        { title: "Write Card test", testFirst: "", implement: "", verify: "" },
+      ],
+    },
+    taskResults: null,
+    // satisfy remaining required fields with minimal values
+    backlogItemId: null,
+    orgId: "org-1",
+    status: "active",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ideateOutput: null,
+    planOutput: null,
+    reviewOutput: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    planReview: null,
+    buildExecState: null,
+    reviewIterations: null,
+    ...overrides,
+  } as unknown as FeatureBuildRow;
+}
+
+describe("AgentActivityStrip render gate", () => {
+  it("renders nothing when phase is not build", () => {
+    const { container } = render(<AgentActivityStrip build={makeRow({ phase: "plan" })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when buildPlan is null", () => {
+    const { container } = render(<AgentActivityStrip build={makeRow({ buildPlan: null })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when fewer than 5 tasks", () => {
+    const row = makeRow();
+    const shortPlan = { ...row.buildPlan!, tasks: row.buildPlan!.tasks.slice(0, 3) };
+    const { container } = render(<AgentActivityStrip build={makeRow({ buildPlan: shortPlan })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the strip when phase is build and has enough tasks", () => {
+    render(<AgentActivityStrip build={makeRow()} />);
+    expect(screen.getByTestId("agent-activity-strip")).toBeTruthy();
+  });
+});
+
+describe("AgentActivityStrip cell state priority", () => {
+  it("marks tasks with a passing taskResult as done", () => {
+    const row = makeRow({
+      taskResults: [
+        { taskIndex: 0, title: "Extend schema", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as any },
+      ],
+    });
+    render(<AgentActivityStrip build={row} />);
+    // The aria-label on each cell encodes state
+    const cell = screen.getByRole("img", { name: /Extend schema: done/i });
+    expect(cell).toBeTruthy();
+  });
+
+  it("marks tasks with a failing taskResult as failed", () => {
+    const row = makeRow({
+      taskResults: [
+        { taskIndex: 1, title: "Create Card component", testResult: { passed: false, output: "fail" }, codeReview: { issues: [] } as any },
+      ],
+    });
+    render(<AgentActivityStrip build={row} />);
+    expect(screen.getByRole("img", { name: /Create Card component: failed/i })).toBeTruthy();
+  });
+
+  it("marks tasks with no result as queued initially", () => {
+    render(<AgentActivityStrip build={makeRow()} />);
+    // All 5 tasks have no results and no active events — all should be queued
+    const cells = screen.getAllByRole("img", { name: /: queued/i });
+    expect(cells.length).toBe(5);
+  });
+
+  it("transitions task to running on orchestrator:task_dispatched event", async () => {
+    render(<AgentActivityStrip build={makeRow()} />);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("build-progress-update", {
+          detail: {
+            type: "orchestrator:task_dispatched",
+            buildId: "build-test-01",
+            taskTitle: "Extend schema",
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByRole("img", { name: /Extend schema: running/i })).toBeTruthy();
+  });
+
+  it("ignores events for different builds", async () => {
+    render(<AgentActivityStrip build={makeRow()} />);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("build-progress-update", {
+          detail: {
+            type: "orchestrator:task_dispatched",
+            buildId: "other-build",
+            taskTitle: "Extend schema",
+          },
+        }),
+      );
+    });
+
+    // Should still be queued, not running
+    expect(screen.getByRole("img", { name: /Extend schema: queued/i })).toBeTruthy();
+  });
+
+  it("transitions running task back to done when taskResult arrives on re-render", () => {
+    const { rerender } = render(<AgentActivityStrip build={makeRow()} />);
+
+    const withResult = makeRow({
+      taskResults: [
+        { taskIndex: 0, title: "Extend schema", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as any },
+      ],
+    });
+    rerender(<AgentActivityStrip build={withResult} />);
+
+    expect(screen.getByRole("img", { name: /Extend schema: done/i })).toBeTruthy();
+  });
+});
+
+describe("AgentActivityStrip meta label", () => {
+  it("shows task count summary", () => {
+    render(<AgentActivityStrip build={makeRow()} />);
+    expect(screen.getByText(/0 \/ 5 tasks/)).toBeTruthy();
+  });
+
+  it("updates summary after tasks complete", () => {
+    const row = makeRow({
+      taskResults: [
+        { taskIndex: 0, title: "Extend schema", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as any },
+        { taskIndex: 1, title: "Create Card component", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as any },
+      ],
+    });
+    render(<AgentActivityStrip build={row} />);
+    expect(screen.getByText(/2 \/ 5 tasks/)).toBeTruthy();
+  });
+});

--- a/apps/web/components/build/AgentActivityStrip.tsx
+++ b/apps/web/components/build/AgentActivityStrip.tsx
@@ -1,0 +1,260 @@
+// apps/web/components/build/AgentActivityStrip.tsx
+//
+// Ambient task-level progress strip shown during the Build phase.
+// Renders every task as a 9×9px cell (done/running/queued/failed),
+// grouped by dependency wave from buildDependencyGraph().
+//
+// Data sources:
+//   - Initial done/failed state: build.taskResults
+//   - Live running state: build-progress-update CustomEvent (orchestrator:task_dispatched / task_complete)
+//
+// Spec: docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
+"use client";
+
+import { useEffect, useMemo, useState, useRef } from "react";
+import { buildDependencyGraph } from "@/lib/integrate/task-dependency-graph";
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type CellState = "done" | "running" | "queued" | "failed";
+
+type TaskCell = {
+  title: string;
+  taskIndex: number;
+  state: CellState;
+};
+
+type WaveGroup = {
+  waveIndex: number;
+  label: string;
+  tasks: TaskCell[];
+};
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SPECIALIST_LABELS: Record<string, string> = {
+  "data-architect": "Foundation",
+  "software-engineer": "Core Logic",
+  "frontend-engineer": "UI Components",
+  "qa-engineer": "Testing",
+};
+
+const MIN_TASKS_TO_SHOW = 5;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+type Props = {
+  build: FeatureBuildRow;
+};
+
+export function AgentActivityStrip({ build }: Props) {
+  // ── Live running-task state via CustomEvents ────────────────────────────
+  const [activeTaskTitles, setActiveTaskTitles] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleUpdate = (e: Event) => {
+      const data = (e as CustomEvent<{ type: string; buildId?: string; taskTitle?: string }>).detail;
+      // Ignore events for other builds
+      if (data?.buildId && data.buildId !== build.buildId) return;
+
+      if (data?.type === "orchestrator:task_dispatched" && data.taskTitle) {
+        setActiveTaskTitles((prev) => new Set(prev).add(data.taskTitle!));
+      } else if (data?.type === "orchestrator:task_complete" && data.taskTitle) {
+        setActiveTaskTitles((prev) => {
+          const next = new Set(prev);
+          next.delete(data.taskTitle!);
+          return next;
+        });
+      } else if (data?.type === "done") {
+        setActiveTaskTitles(new Set());
+      }
+    };
+
+    window.addEventListener("build-progress-update", handleUpdate);
+    return () => window.removeEventListener("build-progress-update", handleUpdate);
+  }, [build.buildId]);
+
+  // Reset active titles when build changes
+  useEffect(() => {
+    setActiveTaskTitles(new Set());
+  }, [build.buildId]);
+
+  // ── Elapsed timer ───────────────────────────────────────────────────────
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    startRef.current = Date.now();
+    setElapsed(0);
+    const iv = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(iv);
+  }, [build.buildId]);
+
+  // ── Wave groups from dependency graph ───────────────────────────────────
+  const waves = useMemo((): WaveGroup[] => {
+    if (!build.buildPlan?.tasks?.length) return [];
+
+    const execPhases = buildDependencyGraph(
+      build.buildPlan.fileStructure,
+      build.buildPlan.tasks,
+    );
+
+    // Build lookup of completed task results: title → passed
+    const resultByTitle = new Map<string, boolean>();
+    (build.taskResults ?? []).forEach((r) => {
+      resultByTitle.set(r.title, r.testResult?.passed ?? true);
+    });
+
+    return execPhases.map((phase) => {
+      const dominantSpec = phase.tasks[0]?.specialist ?? "software-engineer";
+      return {
+        waveIndex: phase.phaseIndex,
+        label: SPECIALIST_LABELS[dominantSpec] ?? dominantSpec,
+        tasks: phase.tasks.map((t) => {
+          let state: CellState;
+          if (resultByTitle.has(t.title)) {
+            state = resultByTitle.get(t.title) ? "done" : "failed";
+          } else if (activeTaskTitles.has(t.title)) {
+            state = "running";
+          } else {
+            state = "queued";
+          }
+          return { title: t.title, taskIndex: t.taskIndex, state };
+        }),
+      };
+    });
+  }, [build.buildPlan, build.taskResults, activeTaskTitles]);
+
+  // ── Render gate ─────────────────────────────────────────────────────────
+  const totalTasks = waves.reduce((s, w) => s + w.tasks.length, 0);
+  if (build.phase !== "build" || totalTasks < MIN_TASKS_TO_SHOW) return null;
+
+  const doneTasks = waves.reduce((s, w) => s + w.tasks.filter((t) => t.state === "done").length, 0);
+  const runningTasks = waves.reduce((s, w) => s + w.tasks.filter((t) => t.state === "running").length, 0);
+
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+  const elapsedLabel = mins > 0 ? `${mins}m ${String(secs).padStart(2, "0")}s` : `${secs}s`;
+
+  return (
+    <div
+      className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+      data-testid="agent-activity-strip"
+      aria-label={`Agent activity: ${doneTasks} of ${totalTasks} tasks complete, ${runningTasks} running`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2 bg-[var(--dpf-surface-2)] border-b border-[var(--dpf-border)]">
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+          Agent Activity
+        </span>
+        <span className="text-xs font-medium text-[var(--dpf-text)] tabular-nums">
+          {doneTasks} / {totalTasks} tasks
+          {runningTasks > 0 && ` · ${runningTasks} running`}
+          {elapsed > 0 && ` · ${elapsedLabel}`}
+        </span>
+        <span className="ml-auto rounded px-1.5 py-0.5 text-[10px] font-semibold bg-[var(--dpf-accent)] text-white">
+          Build Phase
+        </span>
+      </div>
+
+      {/* Wave grid */}
+      <div className="flex items-start px-4 py-3">
+        {waves.map((wave, wi) => (
+          <div key={wave.waveIndex} className="flex items-start">
+            <div className="flex flex-col gap-1.5">
+              <WaveLabel wave={wave} />
+              <div className="flex flex-wrap gap-0.5">
+                {wave.tasks.map((task) => (
+                  <Cell key={task.taskIndex} task={task} />
+                ))}
+              </div>
+            </div>
+            {wi < waves.length - 1 && (
+              <div
+                className="mx-2 self-stretch mt-5 w-px bg-[var(--dpf-border)]"
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-3 px-4 pb-2.5">
+        <LegendItem state="done" label="Done" />
+        <LegendItem state="running" label="Running" />
+        <LegendItem state="queued" label="Queued" />
+        <LegendItem state="failed" label="Failed" />
+        <span className="ml-auto text-[10px] text-[var(--dpf-muted)]">
+          Hover for task name
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Wave label ──────────────────────────────────────────────────────────────
+
+function WaveLabel({ wave }: { wave: WaveGroup }) {
+  const done = wave.tasks.filter((t) => t.state === "done").length;
+  const running = wave.tasks.filter((t) => t.state === "running").length;
+  const total = wave.tasks.length;
+  const meta =
+    running > 0 ? `${done} done · ${running} running` : `${done}/${total}`;
+
+  return (
+    <div className="text-[10px] text-[var(--dpf-muted)] font-medium whitespace-nowrap">
+      {wave.label}{" "}
+      <span className="opacity-55">· {meta}</span>
+    </div>
+  );
+}
+
+// ─── Individual task cell ────────────────────────────────────────────────────
+
+const CELL_BG: Record<CellState, string> = {
+  done:    "var(--dpf-success)",
+  running: "var(--dpf-accent)",
+  failed:  "var(--dpf-error)",
+  queued:  "transparent",
+};
+
+function Cell({ task }: { task: TaskCell }) {
+  const isRunning = task.state === "running";
+  const isQueued = task.state === "queued";
+
+  return (
+    <div
+      role="img"
+      aria-label={`${task.title}: ${task.state}`}
+      title={task.title}
+      className="w-[9px] h-[9px] rounded-[1.5px] cursor-default transition-transform hover:scale-150 hover:z-10 relative shrink-0"
+      style={{
+        background: CELL_BG[task.state],
+        border: isQueued ? "1px solid var(--dpf-border)" : "none",
+        animation: isRunning ? "dpf-cell-pulse 1.4s ease-in-out infinite" : "none",
+      }}
+    />
+  );
+}
+
+// ─── Legend item ─────────────────────────────────────────────────────────────
+
+function LegendItem({ state, label }: { state: CellState; label: string }) {
+  const isQueued = state === "queued";
+  return (
+    <div className="flex items-center gap-1">
+      <div
+        className="w-2 h-2 rounded-[1.5px] shrink-0"
+        style={{
+          background: isQueued ? "transparent" : CELL_BG[state],
+          border: isQueued ? "1px solid var(--dpf-muted)" : "none",
+        }}
+      />
+      <span className="text-[10px] text-[var(--dpf-muted)]">{label}</span>
+    </div>
+  );
+}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -53,6 +53,7 @@ import {
   getBuildStudioSidebarClassName,
   shouldOpenBuildStudioSidebarByDefault,
 } from "./build-studio-layout";
+import { AgentActivityStrip } from "./AgentActivityStrip";
 
 type Props = {
   builds: FeatureBuildRow[];
@@ -756,6 +757,7 @@ export function BuildStudio({
                     bomSummary={bomSummary}
                     findings={assuranceFindings}
                   />
+                  <AgentActivityStrip build={activeBuild} />
                   <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
                     Select any stage or task to inspect — or open Details on the right for progress, brief, review, sandbox, and BS Queue evidence.
                   </div>

--- a/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
+++ b/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
@@ -1,0 +1,182 @@
+# Build Studio: AgentActivityStrip — Ambient Task-Level Progress Visibility
+
+**Status:** Approved  
+**Date:** 2026-06-13  
+**Epic:** EP-BUILD-001 (Build Studio)  
+**Scope:** New `AgentActivityStrip` component surfacing real-time agent-level task progress during the Build phase; fleet density bar augmentation; follow-on `ReviewerStatusGrid` shape.  
+**Dependencies:** EP-BUILD-001 (Build Studio — implemented), `buildDependencyGraph` (`apps/web/lib/integrate/task-dependency-graph.ts`), `build-progress-update` CustomEvent (emitted by `AgentCoworkerPanel`), `FeatureBuildRow.taskResults` + `buildPlan`
+
+---
+
+## Problem Statement
+
+Build Studio already exposes two visibility layers during an active build:
+
+1. **Phase bar** (StepTracker / PhaseIndicator) — coarse: which of 5 phases.
+2. **ProcessGraph** (ReactFlow DAG) — fine: every task node, but requires active navigation (pan, zoom, click).
+
+The gap is an **ambient middle layer**: something readable at a glance without navigation that answers "how many things are running right now, are they making progress, and is anything stuck?"
+
+During the Build phase the orchestrator dispatches 20–50 parallel tasks in dependency waves. Today the operator sees a progress ring (X/Y tasks) and a quiet-agent warning that fires only after a 5-minute stall. There is no compact real-time signal that distinguishes "8 agents pulsing, fast progress" from "0 agents running, stall in progress."
+
+---
+
+## Goals
+
+1. Show every build-phase task as a compact colored cell — done/running/queued/failed — organized by dependency wave.
+2. Running cells animate (pulse glow) so motion = momentum; absence of motion = stall.
+3. Wave grouping exposes dependency order without requiring the operator to read the ProcessGraph.
+4. Zero new server-side plumbing: the component consumes the existing `build-progress-update` CustomEvent and `FeatureBuildRow.taskResults`.
+5. Each cell is hoverable (task title tooltip) and click-delegates into the existing task inspector.
+6. Renders only when `build.phase === "build"` and `buildPlan.tasks.length >= 5`; hidden otherwise.
+
+## Non-Goals
+
+- Replacing ProcessGraph — the full DAG remains accessible via click-through.
+- Showing tasks for phases other than Build (plan tasks, review iterations, ship steps).
+- Persistent server-side event recording (CustomEvents are ephemeral; taskResults is the durable signal).
+- Fleet density bar and ReviewerStatusGrid (shaped in §6; follow-on slices after this lands).
+
+---
+
+## Research & Benchmarking
+
+**Claude Code Workflow UI** (reference screenshot, 2026-06-13): Compact header chip showing "WorkflowName · N Agents · elapsed" plus a flat grid of 6–8px colored squares. Color distribution (blue vs grey) reads as a health ratio without active focus. This is the direct analogue for the Build phase strip.
+
+**GitHub Actions job matrix**: Grid of job cells per run, colored by status. Established pattern for "many parallel things, one glance."
+
+**Linear cycle boards**: Compact swimlane with per-assignee dot clusters. Closer to the reviewer card pattern (§6.2) than the anonymous grid.
+
+**Adopted from Claude Code UI**: flat grid, square cells, pulsing-color for active, wave/group dividers for structure.  
+**Adapted for DPF**: wave labels from `buildDependencyGraph` specialist assignment; hover tooltip with task title; click-delegates into existing `TaskInspector`; respects `--dpf-*` tokens for theme/branding.  
+**Rejected**: labelled swim-lanes per specialist (too wide for the space); sparkline timeline (adds temporal axis complexity not needed here).
+
+---
+
+## Design
+
+### §1. Component: `AgentActivityStrip`
+
+**File:** `apps/web/components/build/AgentActivityStrip.tsx`
+
+```
+┌─ Agent Activity ─────────────── 23 / 47 tasks · 5 running · 3m 22s ─ [Build Phase] ─┐
+│  Wave 1 · Foundation     │  Wave 2 · Components              │  Wave 3 · Testing      │
+│  ████████████  (12/12)   │  ████████●●●●●░░░░░░░  (8d 5r 7q) │  ░░░░░░░░░░░░░  (0/15) │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+  ■ Done  ● Running  ○ Queued  ✕ Failed            Hover for task name · click to inspect
+```
+
+Cells: 9×9px, 2px gap, `border-radius: 1.5px`.  
+Wave separator: 1px vertical rule `var(--dpf-border)`, 8px margin.  
+Header: surface-2 bg, `border-b var(--dpf-border)`.  
+Footer: legend + right-aligned hint.
+
+### §2. Cell State Rules
+
+| Priority | Condition | State |
+|----------|-----------|-------|
+| 1 | `taskResults` has entry for this title AND `testResult.passed === false` | `failed` |
+| 2 | `taskResults` has entry for this title (any pass value) | `done` |
+| 3 | `activeTaskTitles` Set contains this title | `running` |
+| 4 | (none of the above) | `queued` |
+
+`activeTaskTitles` is a local React state populated by:
+- `orchestrator:task_dispatched` → add to set
+- `orchestrator:task_complete` → remove from set
+- `done` → clear set
+
+Filter by `detail.buildId === build.buildId` to prevent cross-build contamination.
+
+### §3. Wave Derivation
+
+```ts
+const execPhases = buildDependencyGraph(
+  build.buildPlan?.fileStructure,
+  build.buildPlan?.tasks ?? [],
+);
+// Each ExecutionPhase → one WaveGroup
+// wave label from specialist of first task in phase:
+//   data-architect → "Foundation"
+//   software-engineer → "Core Logic"
+//   frontend-engineer → "UI Components"
+//   qa-engineer → "Testing"
+```
+
+`buildDependencyGraph` always appends a QA phase; the strip shows all phases including it.
+
+### §4. Render Gate
+
+```tsx
+if (
+  build.phase !== "build" ||
+  !build.buildPlan?.tasks?.length ||
+  build.buildPlan.tasks.length < 5
+) return null;
+```
+
+### §5. Integration Point in `BuildStudio.tsx`
+
+Insert **after `<AssuranceRow … />` (line 751)** and **before the instruction text div (line 759)**:
+
+```tsx
+import { AgentActivityStrip } from "./AgentActivityStrip";
+
+// inside the JSX, after AssuranceRow:
+<AgentActivityStrip build={activeBuild} />
+```
+
+No other props needed — the component derives everything from `build` and the CustomEvent stream.
+
+### §6. Follow-on Surfaces (shaped here, implemented as separate slices)
+
+#### §6.1 Fleet Density Bar
+
+Augment each fleet row's `PhaseMiniRail` with a mini density bar (5×5px cells) to the right:
+
+```tsx
+// In BuildListItem.tsx, next to the existing PhaseMiniRail:
+{build.phase === "build" && build.taskResults && (
+  <FleetDensityBar taskResults={build.taskResults} buildPlan={build.buildPlan} />
+)}
+```
+
+Data: `FeatureBuildRow.taskResults` (done count) vs `buildPlan.tasks.length` (total). No CustomEvent subscription needed — fleet rows poll on refetch cycle.
+
+#### §6.2 ReviewerStatusGrid
+
+During `review` phase, replace the reviewer list in `WorkflowStageInspector` with named state-coded cards (same `--dpf-*` visual language, larger granularity since reviewer count is 5–8 and identity matters):
+
+```
+[EA Architect ✓] [Security ✓] [API Governance ●] [Code Reviewer ✓] [Test Coverage ●] [Accessibility ○]
+```
+
+Data: `build.reviewIterations[latest].reviews[].source` (agent display name) + review completion state.
+
+### §7. Animation
+
+Add to `apps/web/app/globals.css`:
+
+```css
+@keyframes dpf-cell-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--dpf-accent) 50%, transparent); }
+  55%       { opacity: 0.65; box-shadow: 0 0 0 3px color-mix(in srgb, var(--dpf-accent) 0%, transparent); }
+}
+```
+
+Applied to running cells via `style={{ animation: "dpf-cell-pulse 1.4s ease-in-out infinite" }}`.
+
+---
+
+## Implementation Plan
+
+| # | File | Action |
+|---|------|--------|
+| 1 | `apps/web/components/build/AgentActivityStrip.tsx` | Create — full component |
+| 2 | `apps/web/app/globals.css` | Add `@keyframes dpf-cell-pulse` |
+| 3 | `apps/web/components/build/BuildStudio.tsx` | Import + render `<AgentActivityStrip build={activeBuild} />` after AssuranceRow |
+| 4 | `apps/web/components/build/AgentActivityStrip.test.tsx` | Unit tests: wave derivation, cell state priority, render gate |
+
+Follow-on (separate PRs):
+- `FleetDensityBar` in `BuildListItem.tsx`
+- `ReviewerStatusGrid` in `WorkflowStageInspector.tsx`


### PR DESCRIPTION
## Summary

- Adds `AgentActivityStrip` below the AssuranceRow during the Build phase — a compact 9px-cell density grid showing every task as done/running/queued/failed, grouped by dependency wave
- Running cells animate with `dpf-cell-pulse` glow so motion = momentum and no-motion = stall, filling the ambient visibility gap between the phase bar and the ProcessGraph DAG
- Zero new server plumbing: subscribes to the existing `build-progress-update` CustomEvent stream and reads `FeatureBuildRow.taskResults`
- Includes spec, unit tests, and `@keyframes dpf-cell-pulse` in globals.css

## Test plan

- [ ] Open an active Build phase build in Build Studio — AgentActivityStrip should appear between AssuranceRow and the instruction text
- [ ] Verify strip is hidden for builds in `plan`, `review`, `ship`, `complete` phases
- [ ] Verify strip is hidden when `buildPlan.tasks` has < 5 tasks
- [ ] Trigger a build and observe running cells pulsing as `orchestrator:task_dispatched` events fire
- [ ] Observe cells transition to done (green) as `orchestrator:task_complete` fires
- [ ] Hover a cell to confirm task title tooltip
- [ ] `pnpm --filter web vitest run AgentActivityStrip` — all tests pass

## Follow-on (separate PRs)

- `FleetDensityBar` — mini density strip in fleet list rows alongside `PhaseMiniRail`
- `ReviewerStatusGrid` — named reviewer cards for the Review phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)