### PR TITLE
feat(workbooks): attachment column type — upload any file + download chip

### DIFF
--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -26,6 +26,7 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "url", label: "URL" },
   { value: "email", label: "Email" },
   { value: "image", label: "Image" },
+  { value: "attachment", label: "Attachment" },
 ];
 
 const RESULT_TYPES: { value: FieldType; label: string }[] = [

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -44,6 +44,8 @@ import {
   renderEmailCell,
   renderImageCell,
   ImageEditor,
+  renderAttachmentCell,
+  AttachmentEditor,
   renderDateCell,
   renderReferenceCell,
   renderComputedCell,
@@ -151,6 +153,12 @@ function buildColumn(
         renderCell: renderImageCell,
         renderEditCell: editable ? ImageEditor : undefined,
       };
+    case "attachment":
+      return {
+        ...base,
+        renderCell: renderAttachmentCell,
+        renderEditCell: editable ? AttachmentEditor : undefined,
+      };
     case "number":
       return { ...base, renderEditCell: editable ? NumberEditor : undefined };
     case "date":
@@ -203,7 +211,11 @@ function compareValues(a: CellValue, b: CellValue): number {
   const norm = (v: CellValue): string | number => {
     if (v === null || v === undefined) return "";
     if (Array.isArray(v)) return v.join(",");
-    if (typeof v === "object") return v.referenceId ?? "";
+    if (typeof v === "object") {
+      if ("referenceId" in v) return v.referenceId ?? "";
+      if ("url" in v) return v.name ?? v.url;
+      return "";
+    }
     if (typeof v === "boolean") return v ? 1 : 0;
     return v;
   };

--- a/apps/web/components/workbooks/KanbanBoard.tsx
+++ b/apps/web/components/workbooks/KanbanBoard.tsx
@@ -44,8 +44,13 @@ function formatValue(col: ColumnDefinition | undefined, value: CellValue): strin
     case "datetime":
       return typeof value === "string" ? new Date(value).toLocaleString() : String(value);
     case "reference":
-      return typeof value === "object" && value && !Array.isArray(value)
+      return typeof value === "object" && value && !Array.isArray(value) && "referenceId" in value
         ? value.label ?? value.referenceId
+        : String(value);
+    case "image":
+    case "attachment":
+      return typeof value === "object" && value && !Array.isArray(value) && "url" in value
+        ? value.name ?? value.url
         : String(value);
     default:
       return String(value);

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -6,7 +6,7 @@
 
 import type { ReactNode } from "react";
 import type { RenderEditCellProps, RenderCellProps } from "react-data-grid";
-import type { CellValue, SelectOption, ReferenceValue } from "@/lib/workbooks/types";
+import type { CellValue, SelectOption, ReferenceValue, AttachmentValue } from "@/lib/workbooks/types";
 import { ReferenceTypeahead } from "@/components/ui/ReferenceTypeahead";
 import { searchReferencesAction } from "@/lib/actions/workbooks";
 
@@ -15,6 +15,21 @@ export type GridRowData = { rowId: string } & Record<string, CellValue>;
 
 function asString(v: CellValue): string {
   return typeof v === "string" ? v : "";
+}
+
+function asAttachment(v: CellValue): AttachmentValue | null {
+  return v && typeof v === "object" && "url" in v && typeof v.url === "string"
+    ? (v as AttachmentValue)
+    : null;
+}
+
+/** Human-readable byte size, e.g. 2.4 MB / 812 KB / 96 B. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb < 10 ? kb.toFixed(1) : Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)} MB`;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +217,63 @@ export function ImageEditor({
   );
 }
 
+/**
+ * Attachment editor: uploads any file type to /api/v1/upload (content-addressed
+ * MediaAsset storage) and commits an {url, name, size} value. Unlike the image
+ * editor it accepts any file and preserves the original filename + size for a
+ * download chip (the upload endpoint echoes only the URL, so name/size are
+ * captured client-side from the chosen File).
+ */
+export function AttachmentEditor({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: RenderEditCellProps<GridRowData>): ReactNode {
+  const current = asAttachment(row[column.key]);
+  return (
+    <div className="dpf-grid-editor-image">
+      <input
+        type="file"
+        autoFocus
+        onChange={async (e) => {
+          const file = e.target.files?.[0];
+          if (!file) {
+            onClose(false);
+            return;
+          }
+          const body = new FormData();
+          body.append("file", file);
+          try {
+            const res = await fetch("/api/v1/upload", { method: "POST", body });
+            const json = (await res.json()) as { data?: { url?: string }; url?: string };
+            const url = json.data?.url ?? json.url ?? null;
+            if (url) {
+              onRowChange(
+                { ...row, [column.key]: { url, name: file.name, size: file.size } },
+                true,
+              );
+            } else {
+              onClose(false);
+            }
+          } catch {
+            onClose(false);
+          }
+        }}
+      />
+      {current ? (
+        <button
+          type="button"
+          className="dpf-grid-image-clear"
+          onClick={() => onRowChange({ ...row, [column.key]: null }, true)}
+        >
+          Clear
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Display renderers (renderCell)
 // ---------------------------------------------------------------------------
@@ -240,6 +312,20 @@ export function renderImageCell({ row, column }: RenderCellProps<GridRowData>): 
   if (!v) return null;
   // eslint-disable-next-line @next/next/no-img-element -- content-addressed media URL, arbitrary host; next/image optimizer not applicable
   return <img className="dpf-grid-thumb" src={v} alt="" />;
+}
+
+export function renderAttachmentCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {
+  const att = asAttachment(row[column.key]);
+  if (!att) return null;
+  const label = att.name ?? att.url.split("/").pop() ?? "file";
+  return (
+    <a className="dpf-grid-attachment" href={att.url} target="_blank" rel="noreferrer" download={att.name}>
+      <span className="dpf-grid-attachment-name">{label}</span>
+      {typeof att.size === "number" ? (
+        <span className="dpf-grid-attachment-size">{formatBytes(att.size)}</span>
+      ) : null}
+    </a>
+  );
 }
 
 export function renderEmailCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -61,6 +61,27 @@
   cursor: pointer;
 }
 
+.dpf-grid-attachment {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  max-inline-size: 100%;
+  color: var(--dpf-text);
+}
+
+.dpf-grid-attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-decoration: underline;
+}
+
+.dpf-grid-attachment-size {
+  flex: none;
+  color: var(--dpf-muted);
+  font-size: 0.7rem;
+}
+
 .dpf-grid-chip {
   display: inline-flex;
   align-items: center;

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -5,7 +5,12 @@
 // already loaded in the grid (server-side / push-down filtering for large datasets
 // is a reporting-phase concern). Kept pure so it is unit-testable.
 
-import type { CellValue, ColumnDefinition, ReferenceValue } from "@/lib/workbooks/types";
+import type {
+  CellValue,
+  ColumnDefinition,
+  ReferenceValue,
+  AttachmentValue,
+} from "@/lib/workbooks/types";
 import type { GridRowData } from "./cell-editors";
 
 /** Render a cell value to the text a user would see, for substring matching. */
@@ -15,6 +20,10 @@ export function cellSearchText(value: CellValue): string {
   if (typeof value === "object" && "referenceId" in value) {
     const ref = value as ReferenceValue;
     return ref.label ?? ref.referenceId;
+  }
+  if (typeof value === "object" && "url" in value) {
+    const att = value as AttachmentValue;
+    return att.name ?? att.url;
   }
   if (typeof value === "boolean") return value ? "true" : "false";
   return String(value);

--- a/apps/web/lib/workbooks/cell-validation.test.ts
+++ b/apps/web/lib/workbooks/cell-validation.test.ts
@@ -86,6 +86,26 @@ describe("validateCell", () => {
     expect(validateCell(col("image", { required: true }), null).ok).toBe(false);
   });
 
+  it("serializes an attachment {url,name,size} and rejects missing url", () => {
+    const c = col("attachment");
+    const ok = validateCell(c, { url: "/api/media/file1", name: "report.pdf", size: 2048 });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(JSON.parse(ok.storage.textValue ?? "{}")).toEqual({
+        url: "/api/media/file1",
+        name: "report.pdf",
+        size: 2048,
+      });
+    }
+    // a bare URL string is accepted (external link / resilience)
+    expect(validateCell(c, "/api/media/bare").ok).toBe(true);
+    // an object without a url is rejected
+    expect(validateCell(c, { name: "x" } as never).ok).toBe(false);
+    // empty allowed when optional, rejected when required
+    expect(validateCell(c, null).ok).toBe(true);
+    expect(validateCell(col("attachment", { required: true }), null).ok).toBe(false);
+  });
+
   it("requires a referenceId for reference and enforces target type", () => {
     const c = col("reference", { config: { referenceType: "epic" } });
     const ok = validateCell(c, { referenceId: "E1", referenceType: "epic" });
@@ -116,5 +136,20 @@ describe("storageToCellValue", () => {
   it("round-trips an image URL through text storage", () => {
     const r = validateCell(col("image"), "/api/media/xyz");
     expect(r.ok && storageToCellValue("image", r.storage)).toBe("/api/media/xyz");
+  });
+
+  it("round-trips an attachment value through JSON text storage", () => {
+    const r = validateCell(col("attachment"), { url: "/api/media/doc", name: "spec.docx", size: 5120 });
+    expect(r.ok && storageToCellValue("attachment", r.storage)).toEqual({
+      url: "/api/media/doc",
+      name: "spec.docx",
+      size: 5120,
+    });
+  });
+
+  it("treats a legacy plain-url attachment text as {url}", () => {
+    expect(storageToCellValue("attachment", { textValue: "/api/media/legacy" })).toEqual({
+      url: "/api/media/legacy",
+    });
   });
 });

--- a/apps/web/lib/workbooks/cell-validation.ts
+++ b/apps/web/lib/workbooks/cell-validation.ts
@@ -11,6 +11,7 @@ import {
   type FieldType,
   type FieldConfig,
   type ReferenceValue,
+  type AttachmentValue,
   TEXT_MAX_LENGTH,
 } from "./types";
 
@@ -67,6 +68,15 @@ function isReferenceValue(value: unknown): value is ReferenceValue {
     value !== null &&
     "referenceId" in value &&
     typeof (value as ReferenceValue).referenceId === "string"
+  );
+}
+
+function isAttachmentValue(value: unknown): value is AttachmentValue {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "url" in value &&
+    typeof (value as AttachmentValue).url === "string"
   );
 }
 
@@ -127,6 +137,31 @@ export function validateCell(
         return { ok: false, error: `${column.name} exceeds ${TEXT_MAX_LENGTH} characters` };
       }
       storage.textValue = value;
+      return { ok: true, storage };
+    }
+
+    case "attachment": {
+      // Stores an uploaded file's retrieval URL plus its display name/size,
+      // serialized as JSON in textValue. The bytes live in content-addressed
+      // media storage (/api/v1/upload), not in the cell. A bare URL string is
+      // accepted too (treated as {url}) for resilience / external links.
+      const att = isAttachmentValue(value)
+        ? value
+        : typeof value === "string"
+          ? { url: value }
+          : null;
+      if (!att || typeof att.url !== "string" || att.url.length === 0) {
+        return { ok: false, error: `Expected an uploaded file for ${column.name}` };
+      }
+      const serialized = JSON.stringify({
+        url: att.url,
+        ...(att.name ? { name: att.name } : {}),
+        ...(typeof att.size === "number" ? { size: att.size } : {}),
+      });
+      if (serialized.length > TEXT_MAX_LENGTH) {
+        return { ok: false, error: `${column.name} exceeds ${TEXT_MAX_LENGTH} characters` };
+      }
+      storage.textValue = serialized;
       return { ok: true, storage };
     }
 
@@ -240,6 +275,16 @@ export function storageToCellValue(
     case "email":
     case "image":
       return cell.textValue ?? null;
+    case "attachment": {
+      if (!cell.textValue) return null;
+      try {
+        const parsed = JSON.parse(cell.textValue) as AttachmentValue;
+        return parsed && typeof parsed.url === "string" ? parsed : null;
+      } catch {
+        // legacy/plain url stored as text
+        return { url: cell.textValue };
+      }
+    }
     case "number":
       return cell.numberValue ?? null;
     case "date":

--- a/apps/web/lib/workbooks/kanban-grouping.ts
+++ b/apps/web/lib/workbooks/kanban-grouping.ts
@@ -17,7 +17,11 @@ const UNSET_LABEL = "(unset)";
 function cellKey(value: CellValue): string {
   if (value === null || value === undefined) return UNSET_KEY;
   if (Array.isArray(value)) return value[0] ?? UNSET_KEY;
-  if (typeof value === "object") return value.referenceId ?? UNSET_KEY;
+  if (typeof value === "object") {
+    if ("referenceId" in value) return value.referenceId ?? UNSET_KEY;
+    if ("url" in value) return value.url ?? UNSET_KEY;
+    return UNSET_KEY;
+  }
   return String(value);
 }
 

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -9,8 +9,10 @@
 
 /**
  * Field types. `formula` and `lookup` (Phase 2) are *computed* — read-only,
- * never user-written, derived on read. `image` stores an uploaded MediaAsset URL
- * (content-addressed via /api/v1/upload). `rollup`, currency remain out of scope.
+ * never user-written, derived on read. `image` stores an uploaded MediaAsset URL;
+ * `attachment` stores an uploaded file's URL plus its display name/size (any file
+ * type) — both content-addressed via /api/v1/upload. `rollup`, currency remain out
+ * of scope.
  */
 export const FIELD_TYPES = [
   "text",
@@ -24,6 +26,7 @@ export const FIELD_TYPES = [
   "url",
   "email",
   "image",
+  "attachment",
   "formula",
   "lookup",
 ] as const;
@@ -120,6 +123,17 @@ export interface ReferenceValue {
   label?: string;
 }
 
+/**
+ * An attachment cell value: an uploaded file's retrieval URL plus display
+ * metadata. The bytes live in content-addressed media storage (/api/v1/upload);
+ * the cell only carries the URL and the original filename/size for display.
+ */
+export interface AttachmentValue {
+  url: string;
+  name?: string;
+  size?: number;
+}
+
 /** The union of values a single cell can hold, keyed by field type at runtime. */
 export type CellValue =
   | string
@@ -127,6 +141,7 @@ export type CellValue =
   | boolean
   | string[]
   | ReferenceValue
+  | AttachmentValue
   | null;
 
 /** One row as the grid consumes it: a map of columnId -> value, plus the row id. */


### PR DESCRIPTION
## What

Adds an **`attachment`** field type to Universal Grid & Workbooks (EP-GRID-WORKBOOKS): a column that holds an arbitrary file per row (PDF, doc, zip, …). This is the Smartsheet *attach-to-row* / Supabase storage parity follow-on to the image column ([#1832](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1832)).

## How

Reuses the existing content-addressed media stack (`/api/v1/upload` → `MediaAsset`); only the cell payload differs from `image`:

| | `image` | `attachment` |
|---|---|---|
| accepts | `image/*` | any file |
| cell value | bare URL string | `{ url, name, size }` |
| render | inline thumbnail | download chip (filename + size) |

The upload endpoint echoes only the URL, so `name`/`size` are captured client-side from the chosen `File`.

Wired through every field-type seam:
- **types** — `FIELD_TYPES` + `AttachmentValue` added to the `CellValue` union.
- **cell-validation** — `validateCell` serializes `{url,name,size}` JSON (a bare URL string is also accepted, for resilience / external links) with length bound + required check; `storageToCellValue` parses it back and treats legacy plain-url text as `{url}`.
- **Grid** — `buildColumn` wires `renderAttachmentCell` / `AttachmentEditor`; Add-column picker offers "Attachment".
- **object-aware seams** — places that previously assumed any object cell value was a `ReferenceValue` now narrow reference-vs-attachment: `compareValues` (sort), kanban `cellKey` + `formatValue`, and `cellSearchText` (which powers **both** quick-filter and **CSV export** → exports the filename, not `[object Object]`).

`provenanceKind` stays `manual` (user-entered).

## Test plan

- `vitest` — new cell-validation cases (serialize `{url,name,size}`, accept bare URL, reject missing url, required/optional empty, JSON round-trip, legacy plain-url → `{url}`) + full workbooks suite: **151 passed**.
- `pnpm --filter web typecheck` — green (incl. the union-narrowing fixes).

Functional verification (upload → chip → reload-persist → CSV) is covered by a new line in the Phase W audit checklist and runs on the canonical per-archetype rebuild path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
