### PR TITLE
feat(workbooks): reporting-phase formula extensions — cross-row aggregation + inline REF/LOOKUP

### DIFF
--- a/apps/web/lib/workbooks/formula/compute.test.ts
+++ b/apps/web/lib/workbooks/formula/compute.test.ts
@@ -107,6 +107,41 @@ describe("computeDerivedCells — lookups", () => {
     expect(rows[1].cells.c_epicstatus).toBeNull();
   });
 
+  it("resolves LOOKUP() inside a formula via the referenced record", async () => {
+    const adapter = {
+      entityType: "fake_formula_acct",
+      getColumns: async () => [],
+      queryRows: async () => ({ data: [], nextCursor: null }),
+      getRow: async (_t: string, id: string) =>
+        id === "A-1" ? { rowId: "A-1", cells: { tier: "gold", mrr: 1200 } } : null,
+      getCapabilities: () => ({ canAddRow: false, canAddColumn: false, canEditCell: false, canDeleteRow: false }),
+    } as unknown as DataSourceAdapter;
+    gridRegistry.register(adapter);
+
+    const columns: DerivableColumn[] = [
+      { columnId: "c_acct", name: "Account", fieldType: "reference", config: { referenceType: "fake_formula_acct" } },
+      {
+        columnId: "c_arr",
+        name: "ARR",
+        fieldType: "formula",
+        config: { formula: '=LOOKUP([Account],"mrr") * 12', resultType: "number" },
+      },
+    ];
+    const rows: GridRow[] = [
+      {
+        rowId: "r1",
+        cells: {
+          c_acct: { referenceId: "A-1", referenceType: "fake_formula_acct", label: "Acme" },
+          c_arr: null,
+        },
+      },
+      { rowId: "r2", cells: { c_acct: null, c_arr: null } },
+    ];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_arr).toBe(14400);
+    expect(rows[1].cells.c_arr).toBe(0); // empty reference → LOOKUP null → 0 * 12
+  });
+
   it("makes a lookup value available to a downstream formula", async () => {
     const adapter = {
       entityType: "fake_lookup_prod",

--- a/apps/web/lib/workbooks/formula/compute.test.ts
+++ b/apps/web/lib/workbooks/formula/compute.test.ts
@@ -48,6 +48,27 @@ describe("computeDerivedCells — formulas", () => {
     await computeDerivedCells(columns, rows);
     expect(rows[0].cells.c_a).toBe(1);
   });
+
+  it("resolves a cross-row SUMIF over the whole table on every row", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_status", name: "Status", fieldType: "select" },
+      { columnId: "c_hours", name: "Hours", fieldType: "number" },
+      {
+        columnId: "c_done",
+        name: "DoneHours",
+        fieldType: "formula",
+        config: { formula: '=SUMIF([Status],"done",[Hours])', resultType: "number" },
+      },
+    ];
+    const rows: GridRow[] = [
+      { rowId: "r1", cells: { c_status: "done", c_hours: 3, c_done: null } },
+      { rowId: "r2", cells: { c_status: "open", c_hours: 5, c_done: null } },
+      { rowId: "r3", cells: { c_status: "done", c_hours: 2, c_done: null } },
+    ];
+    await computeDerivedCells(columns, rows);
+    // Same dataset-wide total on every row (3 + 2 = 5).
+    expect(rows.map((r) => r.cells.c_done)).toEqual([5, 5, 5]);
+  });
 });
 
 describe("computeDerivedCells — lookups", () => {

--- a/apps/web/lib/workbooks/formula/compute.ts
+++ b/apps/web/lib/workbooks/formula/compute.ts
@@ -76,8 +76,9 @@ export async function computeDerivedCells(
   }
   const records = refsNeeded.length > 0 ? await fetchReferenceRecords(refsNeeded) : new Map();
 
+  // 2) Lookups: pull the target field from the referenced record (all rows first,
+  //    so the column arrays built next include resolved lookup values).
   for (const row of rows) {
-    // 2) Lookups: pull the target field from the referenced record.
     for (const lc of lookupCols) {
       const { referenceColumnId, targetField } = lc.config!.lookup!;
       const ref = asReference(row.cells[referenceColumnId]);
@@ -88,21 +89,37 @@ export async function computeDerivedCells(
       }
       row.cells[lc.columnId] = value;
     }
+  }
 
-    // 3) Formulas: evaluate in position order, each seeing earlier columns.
-    if (formulaCols.length > 0) {
-      const scope = new Map<string, FormulaValue>();
-      for (const c of columns) {
-        if (c.fieldType === "formula") continue;
-        scope.set(normalizeName(c.name), toFormulaValue(row.cells[c.columnId] ?? null));
-      }
-      for (const fc of formulaCols) {
-        const res = evaluateFormula(fc.config?.formula ?? "", scope);
-        row.cells[fc.columnId] = res.ok
-          ? coerceResult(res.value, fc.config?.resultType)
-          : `#ERROR: ${res.error ?? "formula"}`;
-        scope.set(normalizeName(fc.name), res.ok ? res.value : null);
-      }
+  if (formulaCols.length === 0) return;
+
+  // 3) Build the column dataset for cross-row functions (COUNTIF/SUMIF/AVERAGEIF):
+  //    every non-formula column's values across all rows, in row order. Formula
+  //    columns are intentionally excluded — aggregating over a derived column is a
+  //    later slice — so a cross-row range over one yields "unknown column".
+  const columnArrays = new Map<string, FormulaValue[]>();
+  for (const c of columns) {
+    if (c.fieldType === "formula") continue;
+    columnArrays.set(
+      normalizeName(c.name),
+      rows.map((r) => toFormulaValue(r.cells[c.columnId] ?? null)),
+    );
+  }
+
+  // 4) Formulas: evaluate in position order, each seeing earlier columns (per-row
+  //    scope) and the whole dataset (column arrays).
+  for (const row of rows) {
+    const scope = new Map<string, FormulaValue>();
+    for (const c of columns) {
+      if (c.fieldType === "formula") continue;
+      scope.set(normalizeName(c.name), toFormulaValue(row.cells[c.columnId] ?? null));
+    }
+    for (const fc of formulaCols) {
+      const res = evaluateFormula(fc.config?.formula ?? "", scope, columnArrays);
+      row.cells[fc.columnId] = res.ok
+        ? coerceResult(res.value, fc.config?.resultType)
+        : `#ERROR: ${res.error ?? "formula"}`;
+      scope.set(normalizeName(fc.name), res.ok ? res.value : null);
     }
   }
 }

--- a/apps/web/lib/workbooks/formula/compute.ts
+++ b/apps/web/lib/workbooks/formula/compute.ts
@@ -64,13 +64,29 @@ export async function computeDerivedCells(
   const formulaCols = columns.filter((c) => c.fieldType === "formula");
   if (lookupCols.length === 0 && formulaCols.length === 0) return;
 
-  // 1) Batch-fetch every referenced record needed by lookup columns.
+  // A formula may resolve a reference inline via REF()/LOOKUP(); if any does, we
+  // must fetch the records for every reference column too (not just lookup columns).
+  const referenceCols = columns.filter((c) => c.fieldType === "reference");
+  const formulaUsesRef =
+    referenceCols.length > 0 &&
+    formulaCols.some((fc) => /\b(ref|lookup)\s*\(/i.test(fc.config?.formula ?? ""));
+
+  // 1) Batch-fetch every referenced record needed by lookup columns (+ all
+  //    reference columns when a formula resolves references inline).
   const refsNeeded: { referenceType: string; referenceId: string }[] = [];
   for (const row of rows) {
     for (const lc of lookupCols) {
       const ref = asReference(row.cells[lc.config!.lookup!.referenceColumnId]);
       if (ref?.referenceId && ref.referenceType) {
         refsNeeded.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
+      }
+    }
+    if (formulaUsesRef) {
+      for (const rc of referenceCols) {
+        const ref = asReference(row.cells[rc.columnId]);
+        if (ref?.referenceId && ref.referenceType) {
+          refsNeeded.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
+        }
       }
     }
   }
@@ -106,16 +122,32 @@ export async function computeDerivedCells(
     );
   }
 
+  // Map a reference column's normalized name -> its columnId, for inline REF()/LOOKUP().
+  const refColIdByName = new Map(referenceCols.map((c) => [normalizeName(c.name), c.columnId]));
+
   // 4) Formulas: evaluate in position order, each seeing earlier columns (per-row
-  //    scope) and the whole dataset (column arrays).
+  //    scope), the whole dataset (column arrays), and a per-row reference resolver.
   for (const row of rows) {
     const scope = new Map<string, FormulaValue>();
     for (const c of columns) {
       if (c.fieldType === "formula") continue;
       scope.set(normalizeName(c.name), toFormulaValue(row.cells[c.columnId] ?? null));
     }
+
+    const resolveRef = formulaUsesRef
+      ? (columnName: string, field?: string): FormulaValue => {
+          const colId = refColIdByName.get(columnName);
+          if (!colId) return null;
+          const ref = asReference(row.cells[colId]);
+          if (!ref?.referenceId || !ref.referenceType) return null;
+          if (field === undefined) return ref.label ?? ref.referenceId; // REF → display
+          const rec = records.get(referenceKey(ref.referenceType, ref.referenceId));
+          return rec ? toFormulaValue(rec.cells[field] ?? null) : null; // LOOKUP → field
+        }
+      : undefined;
+
     for (const fc of formulaCols) {
-      const res = evaluateFormula(fc.config?.formula ?? "", scope, columnArrays);
+      const res = evaluateFormula(fc.config?.formula ?? "", scope, columnArrays, resolveRef);
       row.cells[fc.columnId] = res.ok
         ? coerceResult(res.value, fc.config?.resultType)
         : `#ERROR: ${res.error ?? "formula"}`;

--- a/apps/web/lib/workbooks/formula/evaluate.test.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.test.ts
@@ -103,6 +103,47 @@ describe("evaluateFormula — cross-row aggregation (COUNTIF/SUMIF/AVERAGEIF)", 
   });
 });
 
+describe("evaluateFormula — REF/LOOKUP inside a formula", () => {
+  const resolveRef = (col: string, field?: string): FormulaValue => {
+    if (col !== "account") return null;
+    if (field === undefined) return "Acme Corp"; // REF → label
+    const fields: Record<string, FormulaValue> = { tier: "gold", mrr: 1200 };
+    return field in fields ? fields[field] : null;
+  };
+
+  it("REF returns the reference display label", () => {
+    expect(evaluateFormula("=REF([Account])", scope({}), undefined, resolveRef)).toEqual({
+      ok: true,
+      value: "Acme Corp",
+    });
+  });
+  it("LOOKUP pulls a field from the referenced record and composes with operators", () => {
+    expect(evaluateFormula('=LOOKUP([Account],"tier") & " tier"', scope({}), undefined, resolveRef)).toEqual({
+      ok: true,
+      value: "gold tier",
+    });
+    expect(evaluateFormula('=LOOKUP([Account],"mrr") * 12', scope({}), undefined, resolveRef)).toEqual({
+      ok: true,
+      value: 14400,
+    });
+  });
+  it("LOOKUP requires a field-name second argument", () => {
+    const r = evaluateFormula("=LOOKUP([Account])", scope({}), undefined, resolveRef);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/field name/i);
+  });
+  it("the first argument must be a reference column", () => {
+    const r = evaluateFormula('=LOOKUP("x","tier")', scope({}), undefined, resolveRef);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/reference column/i);
+  });
+  it("errors when used without a resolver (per-row context only)", () => {
+    const r = evaluateFormula("=REF([Account])", scope({}));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/table context/i);
+  });
+});
+
 describe("evaluateFormula — error handling (never throws)", () => {
   it("reports division by zero", () => {
     const r = evaluateFormula("=a/b", scope({ a: 1, b: 0 }));

--- a/apps/web/lib/workbooks/formula/evaluate.test.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.test.ts
@@ -54,6 +54,55 @@ describe("evaluateFormula — functions", () => {
   });
 });
 
+describe("evaluateFormula — cross-row aggregation (COUNTIF/SUMIF/AVERAGEIF)", () => {
+  function cols(obj: Record<string, FormulaValue[]>): Map<string, FormulaValue[]> {
+    const m = new Map<string, FormulaValue[]>();
+    for (const [k, v] of Object.entries(obj)) m.set(normalizeName(k), v);
+    return m;
+  }
+  // A small 4-row dataset: status + hours columns.
+  const dataset = cols({
+    Status: ["done", "open", "done", "blocked"],
+    Hours: [3, 5, 2, 8],
+  });
+
+  it("COUNTIF counts rows matching an exact criterion", () => {
+    expect(evaluateFormula('=COUNTIF([Status], "done")', scope({}), dataset)).toEqual({ ok: true, value: 2 });
+  });
+  it("COUNTIF supports operator-prefixed numeric criteria", () => {
+    expect(evaluateFormula('=COUNTIF([Hours], ">3")', scope({}), dataset)).toEqual({ ok: true, value: 2 });
+    expect(evaluateFormula('=COUNTIF([Hours], "<>5")', scope({}), dataset)).toEqual({ ok: true, value: 3 });
+  });
+  it("SUMIF sums a separate value column over matching rows", () => {
+    expect(evaluateFormula('=SUMIF([Status], "done", [Hours])', scope({}), dataset)).toEqual({
+      ok: true,
+      value: 5,
+    });
+  });
+  it("AVERAGEIF averages the value column over matching rows", () => {
+    expect(evaluateFormula('=AVERAGEIF([Status], "done", [Hours])', scope({}), dataset)).toEqual({
+      ok: true,
+      value: 2.5,
+    });
+  });
+  it("a cross-row aggregate can feed an ordinary per-row expression", () => {
+    // % of total hours contributed by 'done' rows, for the current row.
+    const r = evaluateFormula('=SUMIF([Status],"done",[Hours]) / SUM([Hours])', scope({ hours: 18 }), dataset);
+    // SUM here is the per-row SUM of the single scalar 18 → 18; 5/18.
+    expect(r.ok && Math.round((r.value as number) * 100) / 100).toBe(0.28);
+  });
+  it("errors when a cross-row range is not a column reference", () => {
+    const r = evaluateFormula('=COUNTIF(1+1, "x")', scope({}), dataset);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/range must be a column/i);
+  });
+  it("errors when used without a dataset (per-row context only)", () => {
+    const r = evaluateFormula('=COUNTIF([Status], "done")', scope({}));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/table context/i);
+  });
+});
+
 describe("evaluateFormula — error handling (never throws)", () => {
   it("reports division by zero", () => {
     const r = evaluateFormula("=a/b", scope({ a: 1, b: 0 }));

--- a/apps/web/lib/workbooks/formula/evaluate.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.ts
@@ -11,6 +11,9 @@ import jsep from "jsep";
 import {
   FORMULA_FUNCTIONS,
   FormulaError,
+  CROSS_ROW_FUNCTIONS,
+  matchCriterion,
+  numOrZero,
   toNumber,
   toStr,
   toBool,
@@ -34,15 +37,55 @@ const CONSTANTS: Record<string, FormulaValue> = {
   no: false,
 };
 
-/** Excel → jsep-friendly normalization: drop leading `=`, `<>`→`!=`, `=`→`==`, `[Name]`→name. */
+/**
+ * Excel → jsep-friendly normalization: drop leading `=`, `<>`→`!=`, `=`→`==`,
+ * `[Name]`→name. Transforms are applied only OUTSIDE string literals, so an
+ * operator inside a quoted criterion (e.g. COUNTIF([H], "<>5") or "=done") is
+ * preserved verbatim rather than being rewritten into the comparison operator.
+ */
 export function normalizeFormulaSource(src: string): string {
   let s = src.trim();
   if (s.startsWith("=")) s = s.slice(1);
-  s = s.replace(/\[([^\]]+)\]/g, (_m, inner: string) => normalizeName(inner));
-  s = s.replace(/<>/g, "!=");
-  // single `=` (not part of <=, >=, ==, !=) → `==`
-  s = s.replace(/(?<![<>=!])=(?!=)/g, "==");
-  return s;
+
+  let out = "";
+  let quote: string | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+
+    if (quote) {
+      out += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+
+    // [Column Name] → normalized identifier
+    if (ch === "[") {
+      const end = s.indexOf("]", i);
+      if (end > i) {
+        out += normalizeName(s.slice(i + 1, end));
+        i = end;
+        continue;
+      }
+    }
+    // <> → !=
+    if (ch === "<" && s[i + 1] === ">") {
+      out += "!=";
+      i++;
+      continue;
+    }
+    // single = (not part of <=, >=, ==, !=) → ==
+    if (ch === "=" && s[i + 1] !== "=" && !["<", ">", "=", "!"].includes(s[i - 1])) {
+      out += "==";
+      continue;
+    }
+    out += ch;
+  }
+  return out;
 }
 
 type Node = {
@@ -96,20 +139,67 @@ function applyBinary(op: string, l: FormulaValue, r: FormulaValue): FormulaValue
   }
 }
 
-function evalNode(node: Node, scope: Map<string, FormulaValue>): FormulaValue {
+/** Evaluation context: the current row's values, plus (for cross-row functions) every column's full array. */
+export interface EvalContext {
+  /** normalized column name -> the current row's value */
+  scope: Map<string, FormulaValue>;
+  /** normalized column name -> all rows' values, in row order (only set on the dataset path) */
+  columns?: Map<string, FormulaValue[]>;
+}
+
+/** Resolve a cross-row function's range argument (must be a bare column reference) to its full column array. */
+function columnArray(fnName: string, argNode: Node | undefined, ctx: EvalContext): FormulaValue[] {
+  if (!argNode || argNode.type !== "Identifier" || !argNode.name) {
+    throw new FormulaError(`${fnName} range must be a column reference`);
+  }
+  const key = normalizeName(argNode.name);
+  const arr = ctx.columns?.get(key);
+  if (!arr) throw new FormulaError(`${fnName} range refers to an unknown column: ${argNode.name}`);
+  return arr;
+}
+
+/** Evaluate COUNTIF / SUMIF / AVERAGEIF over the dataset's column arrays. */
+function evalCrossRow(fnName: string, args: Node[], ctx: EvalContext): FormulaValue {
+  if (!ctx.columns) {
+    throw new FormulaError(`${fnName} can only be used in a table context`);
+  }
+  const range = columnArray(fnName, args[0], ctx);
+  const criterion = args[1] ? evalNode(args[1], ctx) : null;
+  const matches = (i: number) => matchCriterion(range[i] ?? null, criterion);
+
+  if (fnName === "COUNTIF") {
+    let n = 0;
+    for (let i = 0; i < range.length; i++) if (matches(i)) n++;
+    return n;
+  }
+
+  // SUMIF / AVERAGEIF: optional third arg is the column to sum/average (defaults to the range column).
+  const valueArr = args[2] ? columnArray(fnName, args[2], ctx) : range;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < range.length; i++) {
+    if (!matches(i)) continue;
+    sum += numOrZero(valueArr[i] ?? null);
+    count++;
+  }
+  if (fnName === "SUMIF") return sum;
+  return count === 0 ? 0 : sum / count; // AVERAGEIF — empty match averages to 0 (never #DIV/0!)
+}
+
+function evalNode(node: Node, ctx: EvalContext): FormulaValue {
   switch (node.type) {
     case "Literal":
       return (node.value ?? null) as FormulaValue;
 
     case "Identifier": {
       const key = normalizeName(node.name ?? "");
-      if (scope.has(key)) return scope.get(key) ?? null;
+      if (ctx.scope.has(key)) return ctx.scope.get(key) ?? null;
       if (key in CONSTANTS) return CONSTANTS[key];
       throw new FormulaError(`Unknown field or name: ${node.name}`);
     }
 
     case "UnaryExpression": {
-      const v = evalNode(node.argument as Node, scope);
+      const v = evalNode(node.argument as Node, ctx);
       if (node.operator === "-") return -toNumber(v);
       if (node.operator === "+") return toNumber(v);
       if (node.operator === "!") return !toBool(v);
@@ -119,30 +209,34 @@ function evalNode(node: Node, scope: Map<string, FormulaValue>): FormulaValue {
     case "BinaryExpression":
       return applyBinary(
         node.operator as string,
-        evalNode(node.left as Node, scope),
-        evalNode(node.right as Node, scope),
+        evalNode(node.left as Node, ctx),
+        evalNode(node.right as Node, ctx),
       );
 
     case "LogicalExpression": {
-      const left = evalNode(node.left as Node, scope);
-      if (node.operator === "&&") return toBool(left) ? evalNode(node.right as Node, scope) : false;
-      if (node.operator === "||") return toBool(left) ? true : evalNode(node.right as Node, scope);
+      const left = evalNode(node.left as Node, ctx);
+      if (node.operator === "&&") return toBool(left) ? evalNode(node.right as Node, ctx) : false;
+      if (node.operator === "||") return toBool(left) ? true : evalNode(node.right as Node, ctx);
       throw new FormulaError(`Unsupported logical operator: ${node.operator}`);
     }
 
     case "ConditionalExpression":
-      return toBool(evalNode(node.test as Node, scope))
-        ? evalNode(node.consequent as Node, scope)
-        : evalNode(node.alternate as Node, scope);
+      return toBool(evalNode(node.test as Node, ctx))
+        ? evalNode(node.consequent as Node, ctx)
+        : evalNode(node.alternate as Node, ctx);
 
     case "CallExpression": {
       const callee = node.callee as Node;
       if (callee.type !== "Identifier" || !callee.name) {
         throw new FormulaError("Only named function calls are allowed");
       }
-      const fn = FORMULA_FUNCTIONS[callee.name.toUpperCase()];
+      const fnName = callee.name.toUpperCase();
+      if (CROSS_ROW_FUNCTIONS.has(fnName)) {
+        return evalCrossRow(fnName, node.arguments ?? [], ctx);
+      }
+      const fn = FORMULA_FUNCTIONS[fnName];
       if (!fn) throw new FormulaError(`Unknown function: ${callee.name}`);
-      const args = (node.arguments ?? []).map((a) => evalNode(a, scope));
+      const args = (node.arguments ?? []).map((a) => evalNode(a, ctx));
       return fn(args);
     }
 
@@ -169,18 +263,21 @@ export interface FormulaResult {
 
 /**
  * Evaluate a formula against a scope of column values (keyed by normalized name).
+ * Pass `columns` (normalized name -> all rows' values) to enable cross-row
+ * functions (COUNTIF/SUMIF/AVERAGEIF); omit it for pure per-row evaluation.
  * Returns a structured result — a bad formula yields { ok:false } with the message,
  * never throws, so one broken cell can't crash a grid load.
  */
 export function evaluateFormula(
   formula: string,
   scope: Map<string, FormulaValue>,
+  columns?: Map<string, FormulaValue[]>,
 ): FormulaResult {
   try {
     const normalized = normalizeFormulaSource(formula);
     if (!normalized) return { ok: true, value: null };
     const ast = jsep(normalized) as unknown as Node;
-    return { ok: true, value: evalNode(ast, scope) };
+    return { ok: true, value: evalNode(ast, { scope, columns }) };
   } catch (e) {
     return { ok: false, value: null, error: e instanceof Error ? e.message : "Formula error" };
   }

--- a/apps/web/lib/workbooks/formula/evaluate.ts
+++ b/apps/web/lib/workbooks/formula/evaluate.ts
@@ -145,6 +145,13 @@ export interface EvalContext {
   scope: Map<string, FormulaValue>;
   /** normalized column name -> all rows' values, in row order (only set on the dataset path) */
   columns?: Map<string, FormulaValue[]>;
+  /**
+   * Resolve REF([col]) / LOOKUP([col], field) for the current row against a
+   * `reference` column: `field` omitted → the reference's display label (REF);
+   * `field` given → that field of the referenced record (LOOKUP). Set only when
+   * referenced records have been fetched.
+   */
+  resolveRef?: (columnName: string, field?: string) => FormulaValue;
 }
 
 /** Resolve a cross-row function's range argument (must be a bare column reference) to its full column array. */
@@ -184,6 +191,22 @@ function evalCrossRow(fnName: string, args: Node[], ctx: EvalContext): FormulaVa
   }
   if (fnName === "SUMIF") return sum;
   return count === 0 ? 0 : sum / count; // AVERAGEIF — empty match averages to 0 (never #DIV/0!)
+}
+
+/** Evaluate REF([col]) / LOOKUP([col], "field") against the current row's reference columns. */
+function evalRefLookup(fnName: string, args: Node[], ctx: EvalContext): FormulaValue {
+  if (!ctx.resolveRef) {
+    throw new FormulaError(`${fnName} can only be used in a table context`);
+  }
+  const colNode = args[0];
+  if (!colNode || colNode.type !== "Identifier" || !colNode.name) {
+    throw new FormulaError(`${fnName} first argument must be a reference column`);
+  }
+  const colName = normalizeName(colNode.name);
+  if (fnName === "REF") return ctx.resolveRef(colName);
+  if (!args[1]) throw new FormulaError("LOOKUP requires a field name as the second argument");
+  const field = toStr(evalNode(args[1], ctx));
+  return ctx.resolveRef(colName, field);
 }
 
 function evalNode(node: Node, ctx: EvalContext): FormulaValue {
@@ -234,6 +257,9 @@ function evalNode(node: Node, ctx: EvalContext): FormulaValue {
       if (CROSS_ROW_FUNCTIONS.has(fnName)) {
         return evalCrossRow(fnName, node.arguments ?? [], ctx);
       }
+      if (fnName === "REF" || fnName === "LOOKUP") {
+        return evalRefLookup(fnName, node.arguments ?? [], ctx);
+      }
       const fn = FORMULA_FUNCTIONS[fnName];
       if (!fn) throw new FormulaError(`Unknown function: ${callee.name}`);
       const args = (node.arguments ?? []).map((a) => evalNode(a, ctx));
@@ -272,12 +298,13 @@ export function evaluateFormula(
   formula: string,
   scope: Map<string, FormulaValue>,
   columns?: Map<string, FormulaValue[]>,
+  resolveRef?: EvalContext["resolveRef"],
 ): FormulaResult {
   try {
     const normalized = normalizeFormulaSource(formula);
     if (!normalized) return { ok: true, value: null };
     const ast = jsep(normalized) as unknown as Node;
-    return { ok: true, value: evalNode(ast, { scope, columns }) };
+    return { ok: true, value: evalNode(ast, { scope, columns, resolveRef }) };
   } catch (e) {
     return { ok: false, value: null, error: e instanceof Error ? e.message : "Formula error" };
   }

--- a/apps/web/lib/workbooks/formula/functions.ts
+++ b/apps/web/lib/workbooks/formula/functions.ts
@@ -132,3 +132,63 @@ export const FORMULA_FUNCTIONS: Record<string, FormulaFn> = {
 export function isFormulaFunction(name: string): boolean {
   return Object.prototype.hasOwnProperty.call(FORMULA_FUNCTIONS, name.toUpperCase());
 }
+
+// ── cross-row aggregation (reporting phase) ──────────────────────────────────
+//
+// COUNTIF/SUMIF/AVERAGEIF operate over a whole column (all rows), not the row's
+// own scalar, so they are handled specially by the evaluator (which has the
+// column arrays) rather than living in FORMULA_FUNCTIONS. The criterion-matching
+// and safe-numeric helpers are factored here so they are unit-testable on their own.
+
+/** Function names whose first (and optional third) argument is a column range, not a scalar. */
+export const CROSS_ROW_FUNCTIONS = new Set(["COUNTIF", "SUMIF", "AVERAGEIF"]);
+
+/** Coerce to a number, treating non-numeric / empty as 0 (Excel SUMIF ignores text). */
+export function numOrZero(v: FormulaValue): number {
+  if (v === null || v === "" || v === undefined) return 0;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/** Whether two values are equal, numerically when both parse as numbers, else case-insensitive text. */
+function criterionEquals(value: FormulaValue, target: string): boolean {
+  if (value === null || value === undefined || value === "") return target === "";
+  const a = typeof value === "boolean" ? toStr(value) : String(value);
+  const an = Number(a);
+  const bn = Number(target);
+  if (a !== "" && target !== "" && !Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
+  return a.toLowerCase() === target.toLowerCase();
+}
+
+/**
+ * Excel-style criterion match: a bare value compares by equality; a string
+ * prefixed with a comparison operator (`>`, `>=`, `<`, `<=`, `<>`, `=`) compares
+ * accordingly (numeric operators require both sides to be numeric).
+ */
+export function matchCriterion(value: FormulaValue, criterion: FormulaValue): boolean {
+  if (typeof criterion === "string") {
+    const m = criterion.match(/^(<=|>=|<>|=|<|>)\s*(.*)$/);
+    if (m) {
+      const op = m[1];
+      const rhs = m[2].trim();
+      if (op === "=") return criterionEquals(value, rhs);
+      if (op === "<>") return !criterionEquals(value, rhs);
+      const lhsNum = typeof value === "number" ? value : Number(value);
+      const rhsNum = Number(rhs);
+      const numeric =
+        value !== null && value !== "" && !Number.isNaN(lhsNum) && !Number.isNaN(rhsNum);
+      if (!numeric) return false;
+      switch (op) {
+        case ">":
+          return lhsNum > rhsNum;
+        case ">=":
+          return lhsNum >= rhsNum;
+        case "<":
+          return lhsNum < rhsNum;
+        case "<=":
+          return lhsNum <= rhsNum;
+      }
+    }
+  }
+  return criterionEquals(value, typeof criterion === "boolean" ? toStr(criterion) : String(criterion ?? ""));
+}


### PR DESCRIPTION
## What

The reporting phase's **formula-engine extensions** ([plan](docs/superpowers/plans/2026-06-13-universal-grid-workbooks-reporting-phase.md), [#1838](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1838)) — the two ways a formula can now reach beyond its own row, the Smartsheet/Supabase parity gap for computed columns. Both fit the existing substrate (no reverse-references), so they're built directly.

**Cross-row aggregation** (plan slice 3):
- `COUNTIF([Range], criterion)`, `SUMIF([Range], criterion, [SumRange])`, `AVERAGEIF([Range], criterion, [AvgRange])`
- Criterion: exact match or operator-prefixed (`">3"`, `"<>done"`, `">=10"`); numeric ops need numeric operands; non-numeric value cells count as 0; AVERAGEIF of zero matches → 0 (never `#DIV/0!`).

**Inline reference resolution** (plan slice 4):
- `REF([RefColumn])` → the reference's display label.
- `LOOKUP([RefColumn], "field")` → that field of the referenced record, composable in any expression: `=LOOKUP([Account],"mrr") * 12`, `=LOOKUP([Account],"tier") & " tier"`.

## Why it's sound on the current substrate

The custom-table adapter **materializes all rows before pagination** and runs `computeDerivedCells` over the full set — so cross-row aggregates are dataset-correct today (same scope as the existing in-memory filter/sort/summary; SQL push-down for very large tables is the pre-existing documented follow-on). For REF/LOOKUP, compute batch-fetches the referenced records (extending the lookup-column fetch path).

## How

- The evaluator threads an `EvalContext { scope, columns?, resolveRef? }`. A cross-row function's range arg (a bare `[Column]` ref) resolves to the whole column array; `REF`/`LOOKUP` resolve via a per-row `resolveRef(column, field?)` closure. Every other reference stays per-row.
- Pure per-row formulas are unchanged — when `columns`/`resolveRef` are absent, the new functions error with "can only be used in a table context."
- `computeDerivedCells`: lookups → build column dataset → (detect inline REF/LOOKUP, fetch reference records) → evaluate formulas with both contexts. Aggregating over a *formula* column is intentionally out of v1 scope.

## Bug fixed along the way

`normalizeFormulaSource` rewrote operators (`<>`→`!=`, `=`→`==`) **inside string literals**, corrupting any quoted criterion (and any formula with an operator inside a string). Now the transforms skip quoted regions; existing `normalizeFormulaSource` tests still pass.

## Test plan

`vitest` formula suite (33 tests): COUNTIF/SUMIF/AVERAGEIF (exact + operator criteria, separate value range, aggregate feeding a per-row expression, non-column-range + no-dataset errors); REF/LOOKUP (label, field pulled + composed with operators, missing-field + non-column + no-resolver errors); compute-level tests proving the dataset total resolves on every row and LOOKUP resolves through a registered adapter. Full workbooks suite green; `pnpm --filter web typecheck` green.

Verification rides the single path: a `W-AGG`/`W-REFFN` line will join the Phase W / RC27 checklist with the next reporting-phase PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
