### PR TITLE
feat(archetypes): add real-estate-construction category — new-home-builder + custom-home-builder

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -58,6 +58,7 @@ describe("resolveBusinessProfile", () => {
       "nonprofit-community",
       "public-sector",
       "asset-rental",
+      "real-estate-construction",
     ];
 
     it("populates a non-empty supplyChain on every industry profile", () => {

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -110,6 +110,18 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
     supplyChain:
       "Our physical supply chain is intentionally light — most of what we consume is software, research databases, and professional subscriptions. The discipline is in vendor selection and renewal review: a stale tool can cost more than its licence.",
   },
+  "real-estate-construction": {
+    missionTheme:
+      "build homes and communities our buyers are proud to live in",
+    businessModel:
+      "Home sales driven by display-home visits and purchase agreements; revenue arrives at settlement with milestone draws during construction. Subcontractors deliver the trade work; the builder's value is design, project management, and quality assurance.",
+    whoWeServe:
+      "We serve home buyers — first-timers, families upsizing, downsizers, and investors — who trust us with the largest purchase of their lives. Every home we hand over is a reflection of that trust and our reputation.",
+    howWeDecide:
+      "We decide for build quality, delivery on time, and the buyer's confidence at handover. A defect caught before settlement is never optional to fix, and a warranty call is an opportunity to demonstrate we stand behind our work. We hold completion integrity above schedule shortcuts.",
+    supplyChain:
+      "Our build supply chain is almost entirely subcontracted — framers, concreters, plumbers, electricians, plasterers, tilers, and painters all work under our project management umbrella. The discipline is in subcontractor qualification, schedule coordination, and quality inspection at every stage. Material supply (structural timber, windows, bricks, roof tiles) typically runs through builders' merchants and volume trade accounts; lead times and material price volatility are operational risks that need to be hedged in contract pricing.",
+  },
   "asset-rental": {
     missionTheme:
       "keep a well-maintained pool of equipment available and turning so customers get what they need, when they need it",
@@ -228,6 +240,22 @@ const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
       "Online transactional sales with repeat custom; product quality, fast fulfilment, and easy support turn first orders into loyal customers.",
     supplyChain:
       "Inventory comes from wholesalers, brand suppliers, or via dropship; some SKUs we hold, some ship direct. We manage against turn rate, lead times, and fulfilment-partner reliability — what is on the website needs to be in stock or shippable, not aspirational.",
+  },
+  "new-home-builder": {
+    missionTheme:
+      "build quality homes and thriving communities that buyers are proud to call home",
+    businessModel:
+      "Volume production of homes across planned communities; display homes serve as the showroom, and most buyer contact begins with a guided tour. Subcontractors complete most trade work under the builder's project management; revenue arrives at settlement.",
+    supplyChain:
+      "Volume builders run centralised supply chains with preferred suppliers and trade partnerships across structural, building envelope, joinery, services (MEP), and finishes categories. Trade-pack pricing and volume commitments buffer against spot-price volatility; site supervisors manage the subcontractor schedule and stage inspections.",
+  },
+  "custom-home-builder": {
+    missionTheme:
+      "design and build the home each client has been imagining, on the lot they have chosen",
+    businessModel:
+      "Project-based: one contract per home, structured around a build programme with milestone payments. Each project is unique; the builder manages the design-to-handover journey including permits, subcontractor coordination, and quality sign-off.",
+    supplyChain:
+      "Custom builders procure on a project-by-project basis, working with trusted local subcontractors and trade suppliers who match the quality standard the brief demands. Supplier relationships are long-term but quantities are project-specific, with provisional sums built into contracts for items such as stone, joinery, and fixtures where selection drives price. Site lead times for premium materials require early ordering.",
   },
   nonprofit: {
     missionTheme:

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -109,6 +109,15 @@ const VOCABULARY: Record<string, ArchetypeVocabulary> = {
     portalLabel: "Rental Portal", stakeholderLabel: "Renters",
     teamLabel: "Team", inboxLabel: "Reservations", agentName: "Rental Desk",
   },
+  // Residential construction — production builders (communities + display homes) and
+  // custom builders (BYOL/BOYL). Per-leaf override for custom-home-builder ("Clients",
+  // "Build Team") ships with that archetype via customVocabulary.
+  "real-estate-construction": {
+    itemsLabel: "Homes & Communities", singleItemLabel: "Home", addButtonLabel: "Add home",
+    categoryLabel: "Community", priceLabel: "From",
+    portalLabel: "Buyer Portal", stakeholderLabel: "Home Buyers",
+    teamLabel: "Sales Team", inboxLabel: "Appointments", agentName: "New Homes Advisor",
+  },
 };
 
 const DEFAULT_VOCABULARY: ArchetypeVocabulary = {
@@ -226,6 +235,10 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
   // Rental & shared assets
   "equipment-rental": ["Earthmoving", "Access & Lifting", "Power & Site", "Cleaning", "Events"],
   "self-storage": ["Small Units", "Medium Units", "Large Units", "Climate-Controlled"],
+
+  // Real estate & construction
+  "new-home-builder": ["Single Storey", "Double Storey", "Townhouses & Duplexes", "Acreage Designs", "Granny Flats"],
+  "custom-home-builder": ["New Home Build", "Knockdown & Rebuild", "Renovation & Extension", "Dual Occupancy", "Acreage Builds"],
 };
 
 export function getCategorySuggestions(archetypeId: string | null | undefined): string[] {

--- a/apps/web/lib/storefront/industries.test.ts
+++ b/apps/web/lib/storefront/industries.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from "vitest";
 import { INDUSTRY_OPTIONS, INDUSTRY_SLUGS, isIndustrySlug, industryLabel } from "./industries";
 
 describe("industries", () => {
-  it("exposes exactly the 15 canonical industries", () => {
-    expect(INDUSTRY_OPTIONS).toHaveLength(15);
+  it("exposes exactly the 16 canonical industries", () => {
+    expect(INDUSTRY_OPTIONS).toHaveLength(16);
     expect(INDUSTRY_SLUGS).toContain("healthcare-wellness");
     expect(INDUSTRY_SLUGS).toContain("hoa-property-management");
     expect(INDUSTRY_SLUGS).toContain("software-platform");
     expect(INDUSTRY_SLUGS).toContain("banking-financial-services");
     expect(INDUSTRY_SLUGS).toContain("public-sector");
     expect(INDUSTRY_SLUGS).toContain("asset-rental");
+    expect(INDUSTRY_SLUGS).toContain("real-estate-construction");
   });
 
   it("slugs are kebab-case, never underscore", () => {

--- a/apps/web/lib/storefront/industries.ts
+++ b/apps/web/lib/storefront/industries.ts
@@ -14,6 +14,7 @@ export const INDUSTRY_OPTIONS = [
   { value: "banking-financial-services", label: "Banking & Financial Services" },
   { value: "public-sector", label: "Public Sector & Local Government" },
   { value: "asset-rental", label: "Rental & Shared Assets" },
+  { value: "real-estate-construction", label: "Home Building & Construction" },
 ] as const;
 
 export type IndustrySlug = (typeof INDUSTRY_OPTIONS)[number]["value"];

--- a/apps/web/lib/tak/marketing-playbooks.ts
+++ b/apps/web/lib/tak/marketing-playbooks.ts
@@ -331,6 +331,39 @@ const CATEGORY_PLAYBOOKS: Record<string, MarketingPlaybook> = {
     agentSkills: ["Holiday boarding campaign", "Puppy programme launch", "Rebooking reminders", "Seasonal grooming promotion"],
   },
 
+  "real-estate-construction": {
+    primaryGoal: "Generate qualified buyer enquiries and display-home appointments that convert to purchase agreements",
+    stakeholders: "Home buyers (first-time, upsizing, downsizing, investing), real estate agents, mortgage brokers, subcontractors",
+    campaignTypes: [
+      "Community and stage release announcements",
+      "Display home open-weekend promotions",
+      "Design centre event invitations (colour palette reveals, upgrade showcases)",
+      "First-home buyer education content (the build journey explained)",
+      "Construction milestone updates for under-contract buyers",
+      "Post-handover warranty follow-up sequences (30 / 60 / 90 days)",
+      "Before-and-after project showcases for custom builds",
+      "Referral programmes for settled buyers",
+      "Build timeline and progress updates for custom clients",
+    ],
+    contentTone: "Aspirational, milestone-driven, trustworthy — homes are the largest purchase buyers will make; tone must project permanence and quality",
+    keyMetrics: [
+      "Display home appointments booked",
+      "Enquiry-to-appointment conversion rate",
+      "Purchase agreements signed",
+      "Days from first enquiry to contract",
+      "Buyer referral rate",
+      "Warranty call rate at 90 days post-handover",
+    ],
+    ctaLanguage: [
+      "Schedule a tour", "Book a display home visit", "Enquire now",
+      "View floor plans", "Register your interest", "Download the community guide",
+    ],
+    agentSkills: [
+      "Community release announcement", "Display home open-day promotion",
+      "Buyer journey explainer", "Construction milestone update template",
+    ],
+  },
+
   "retail-goods": {
     primaryGoal: "Increase order frequency and average order value",
     stakeholders: "Customers, wholesale/trade buyers, event organisers",

--- a/packages/db/src/seed-storefront-archetypes.ts
+++ b/packages/db/src/seed-storefront-archetypes.ts
@@ -55,6 +55,20 @@ const MARKETING_SKILL_RULES: Record<string, Record<string, unknown>> = {
       reframe: "Focus on impact storytelling, donor stewardship, volunteer appreciation, and fundraising event promotion. Tone is mission-focused and gratitude-first.",
     },
   },
+  "real-estate-construction": {
+    "seo-content-optimizer": {
+      label: "Community & Home Search Visibility",
+      reframe: "Focus on community name visibility, suburb-level search terms (new homes near [suburb], custom builders in [region]), and floor-plan content that ranks for home-search queries. Include structured data for property listings where applicable.",
+    },
+    "competitive-analysis": {
+      label: "Market & Community Positioning",
+      reframe: "Focus on community differentiators, build quality, included features versus the market, and delivery track record. Avoid unverifiable price-per-sqft claims; any public price comparisons must reflect current listed prices.",
+    },
+    "email-campaign-builder": {
+      label: "Buyer Journey Communication Builder",
+      reframe: "Focus on community launch announcements, construction milestone updates for under-contract buyers, design centre appointment reminders, and post-handover warranty follow-ups. Tone is professional, milestone-driven, and celebratory at key moments (slab down, frame up, handover).",
+    },
+  },
   "banking-financial-services": {
     "competitive-analysis": {
       label: "Local Institution Positioning",

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -200,4 +200,53 @@ describe("archetype catalog", () => {
     expect(salonProfile?.partnerProgram.portalMode).toBe("none");
     expect(getCapabilityApplicability(salonProfile, "partner-program")).toBe("not-applicable");
   });
+
+  it("ships home builder archetypes with booking items, scheduling defaults, and correct operating model (EP-GRID-BUILDER)", () => {
+    const builders = ALL_ARCHETYPES.filter((a) => a.category === "real-estate-construction");
+    expect(builders.map((a) => a.archetypeId).sort()).toEqual([
+      "custom-home-builder",
+      "new-home-builder",
+    ]);
+
+    for (const b of builders) {
+      // Both have a booking item — model home tour or design consultation.
+      const hasBookingItem =
+        b.ctaType === "booking" ||
+        b.itemTemplates.some((t) => (t.ctaType ?? b.ctaType) === "booking");
+      expect(hasBookingItem, `${b.archetypeId} should have a booking item`).toBe(true);
+      // Scheduling defaults are required when a booking item exists (AUDIT-R3/R4 rule).
+      expect(b.schedulingDefaults, `${b.archetypeId} needs schedulingDefaults`).toBeDefined();
+      // Builders sell physical goods to households.
+      expect(b.activationProfile?.axes?.form, `${b.archetypeId} form`).toBe("goods");
+      expect(b.activationProfile?.axes?.primaryConsumer, `${b.archetypeId} primaryConsumer`).toBe("household");
+      expect(b.activationProfile?.axes?.delivery, `${b.archetypeId} delivery`).toBe("physical");
+      // Milestone payments require billing-readiness prepared-not-prescribed.
+      expect(b.activationProfile?.modules, `${b.archetypeId} modules`).toContain("billing-readiness");
+      expect(b.activationProfile?.modules, `${b.archetypeId} modules`).toContain("projects");
+      expect(b.activationProfile?.billingReadinessMode, `${b.archetypeId} billing`).toBe("prepared-not-prescribed");
+    }
+
+    // Model homes are open 7 days — production builder must have Sunday hours.
+    const nhb = builders.find((b) => b.archetypeId === "new-home-builder");
+    const nhbSunday = nhb?.schedulingDefaults?.defaultOperatingHours.find((h) => h.day === 0);
+    expect(nhbSunday, "new-home-builder model homes open on Sundays").toBeDefined();
+
+    // Custom builder runs business-hours only — no weekend hours.
+    const chb = builders.find((b) => b.archetypeId === "custom-home-builder");
+    const chbSunday = chb?.schedulingDefaults?.defaultOperatingHours.find((h) => h.day === 0);
+    expect(chbSunday, "custom-home-builder should not have Sunday hours").toBeUndefined();
+    const chbSaturday = chb?.schedulingDefaults?.defaultOperatingHours.find((h) => h.day === 6);
+    expect(chbSaturday, "custom-home-builder should not have Saturday hours").toBeUndefined();
+
+    // Custom builder carries a leaf-level vocabulary override (Clients, Build Team).
+    expect(chb?.vocabulary?.stakeholderLabel).toBe("Clients");
+    expect(chb?.vocabulary?.teamLabel).toBe("Build Team");
+    expect(chb?.vocabulary?.agentName).toBe("Build Consultant");
+
+    // Production builder has no leaf vocabulary override — category default applies.
+    expect(nhb?.vocabulary).toBeUndefined();
+
+    // Custom builder includes service-operations for active subcontractor coordination.
+    expect(chb?.activationProfile?.modules).toContain("service-operations");
+  });
 });

--- a/packages/storefront-templates/src/archetypes/index.ts
+++ b/packages/storefront-templates/src/archetypes/index.ts
@@ -13,6 +13,7 @@ import { hoaPropertyManagementArchetypes } from "./hoa-property-management";
 import { bankingFinancialServicesArchetypes } from "./banking-financial-services";
 import { publicSectorArchetypes } from "./public-sector";
 import { assetRentalArchetypes } from "./asset-rental";
+import { realEstateConstructionArchetypes } from "./real-estate-construction";
 
 export const ALL_ARCHETYPES = [
   ...healthcareWellnessArchetypes,
@@ -30,4 +31,5 @@ export const ALL_ARCHETYPES = [
   ...bankingFinancialServicesArchetypes,
   ...publicSectorArchetypes,
   ...assetRentalArchetypes,
+  ...realEstateConstructionArchetypes,
 ];

--- a/packages/storefront-templates/src/archetypes/real-estate-construction.ts
+++ b/packages/storefront-templates/src/archetypes/real-estate-construction.ts
@@ -1,0 +1,343 @@
+import type { ArchetypeDefinition, SchedulingDefaults } from "../types";
+
+// Model home tours and design centre appointments run 7 days a week —
+// model homes are the builder's "store" and keep retail hours including weekends.
+const MODEL_HOME_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [
+    { day: 0, start: "12:00", end: "17:00" }, // Sunday
+    { day: 1, start: "10:00", end: "18:00" }, // Monday
+    { day: 2, start: "10:00", end: "18:00" }, // Tuesday
+    { day: 3, start: "10:00", end: "18:00" }, // Wednesday
+    { day: 4, start: "10:00", end: "18:00" }, // Thursday
+    { day: 5, start: "10:00", end: "18:00" }, // Friday
+    { day: 6, start: "10:00", end: "17:00" }, // Saturday
+  ],
+  defaultBeforeBuffer: 15,
+  defaultAfterBuffer: 15,
+  minimumNoticeHours: 2,
+  maxAdvanceDays: 30,
+};
+
+// Custom builder design consultations are substantive, project-scoped meetings —
+// business hours only, with sufficient buffer for site briefing and questions.
+const CONSULTATION_SCHEDULING: SchedulingDefaults = {
+  schedulingPattern: "slot",
+  assignmentMode: "customer-choice",
+  defaultOperatingHours: [
+    { day: 1, start: "09:00", end: "17:00" }, // Monday
+    { day: 2, start: "09:00", end: "17:00" }, // Tuesday
+    { day: 3, start: "09:00", end: "17:00" }, // Wednesday
+    { day: 4, start: "09:00", end: "17:00" }, // Thursday
+    { day: 5, start: "09:00", end: "17:00" }, // Friday
+  ],
+  defaultBeforeBuffer: 30,
+  defaultAfterBuffer: 30,
+  minimumNoticeHours: 24,
+  maxAdvanceDays: 60,
+};
+
+const BUYER_CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: true },
+];
+
+export const realEstateConstructionArchetypes: ArchetypeDefinition[] = [
+  {
+    archetypeId: "new-home-builder",
+    name: "New Home Builder",
+    category: "real-estate-construction",
+    ctaType: "inquiry",
+    tags: [
+      "new homes", "home builder", "property", "residential",
+      "development", "community", "house and land", "construction",
+      "display homes", "master planned community",
+    ],
+    itemTemplates: [
+      {
+        name: "Model Home Tour",
+        description: "Walk through our display homes with a sales consultant — book your appointment",
+        priceType: "free",
+        ctaType: "booking",
+        bookingDurationMinutes: 60,
+        mediaRole: "facility",
+      },
+      {
+        name: "Design Centre Appointment",
+        description: "Choose your colour palette, fixtures, flooring, and upgrade options with our design consultant",
+        priceType: "free",
+        ctaType: "booking",
+        bookingDurationMinutes: 60,
+        mediaRole: "facility",
+      },
+      {
+        name: "3-Bedroom Home Plans",
+        description: "Enquire about availability, lots, and pricing for our 3-bedroom designs",
+        priceType: "from",
+        ctaType: "inquiry",
+        mediaRole: "product",
+      },
+      {
+        name: "4-Bedroom Home Plans",
+        description: "Enquire about availability, lots, and pricing for our 4-bedroom designs",
+        priceType: "from",
+        ctaType: "inquiry",
+        mediaRole: "product",
+      },
+      {
+        name: "Community Information Pack",
+        description: "Receive detailed information about our communities, amenities, stages, and pricing",
+        priceType: "free",
+        ctaType: "inquiry",
+      },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "gallery", title: "Display Homes & Communities", sortOrder: 1 },
+      { type: "items", title: "Communities & Homes", sortOrder: 2 },
+      { type: "team", title: "Sales Team", sortOrder: 3 },
+      { type: "testimonials", title: "Buyer Stories", sortOrder: 4 },
+      { type: "about", title: "About Us", sortOrder: 5 },
+      { type: "contact", title: "Schedule a Visit", sortOrder: 6 },
+    ],
+    formSchema: [
+      ...BUYER_CONTACT_FIELDS,
+      {
+        name: "communityOfInterest",
+        label: "Community or area of interest",
+        type: "text" as const,
+        required: false,
+        placeholder: "e.g. Riverside Estate, or any community near [suburb]",
+      },
+      {
+        name: "bedroomsRequired",
+        label: "Bedrooms needed",
+        type: "select" as const,
+        required: true,
+        options: ["2 bedrooms", "3 bedrooms", "4 bedrooms", "5+ bedrooms"],
+      },
+      {
+        name: "targetBudget",
+        label: "Budget range",
+        type: "select" as const,
+        required: false,
+        options: ["Under $400k", "$400k–$550k", "$550k–$750k", "$750k–$1M", "Over $1M", "Not sure yet"],
+      },
+      {
+        name: "purchaseTimeline",
+        label: "When are you looking to buy?",
+        type: "select" as const,
+        required: true,
+        options: ["Within 3 months", "3–6 months", "6–12 months", "12+ months"],
+      },
+      {
+        name: "buyingStatus",
+        label: "Buying situation",
+        type: "select" as const,
+        required: false,
+        options: ["First-time buyer", "Upsizing", "Downsizing", "Relocating", "Investment"],
+      },
+      {
+        name: "notes",
+        label: "Anything else you would like us to know?",
+        type: "textarea" as const,
+        required: false,
+      },
+    ],
+    schedulingDefaults: MODEL_HOME_SCHEDULING,
+    activationProfile: {
+      profileType: "standard",
+      modules: ["customer-estate", "projects", "billing-readiness", "lifecycle-signals"],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "separate-customer-projection",
+      estateSeparation: "shared",
+      axes: {
+        form: "goods",
+        delivery: "physical",
+        primaryConsumer: "household",
+        consumptionChannel: "sales-assisted",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: {
+          scope: "primary",
+          it4itStages: ["requirement-to-deploy", "request-to-fulfill"],
+          offerings: ["new-home-communities", "design-centre-packages", "house-and-land"],
+        },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "land-and-community-development",
+        "home-design-and-floor-plans",
+        "permitting-and-approvals",
+        "site-preparation",
+        "construction",
+        "design-centre-selections",
+        "sales-and-contracts",
+        "quality-inspections",
+        "settlement-and-handover",
+        "warranty-and-aftercare",
+      ],
+    },
+  },
+  {
+    archetypeId: "custom-home-builder",
+    name: "Custom Home Builder",
+    category: "real-estate-construction",
+    ctaType: "inquiry",
+    tags: [
+      "custom home", "home builder", "build on your lot", "BYOL", "BOYL",
+      "construction", "bespoke", "residential", "knockdown rebuild",
+      "architect builder", "project home",
+    ],
+    itemTemplates: [
+      {
+        name: "Initial Design Consultation",
+        description: "Meet our team to discuss your vision, site, and build options — obligation-free",
+        priceType: "free",
+        ctaType: "booking",
+        bookingDurationMinutes: 60,
+      },
+      {
+        name: "Custom Home Design",
+        description: "Fully bespoke architectural design and floor plan drawn to your brief",
+        priceType: "quote",
+        ctaType: "inquiry",
+        mediaRole: "product",
+      },
+      {
+        name: "Full Build Contract",
+        description: "Design, permits, and end-to-end construction of your custom home on your lot",
+        priceType: "quote",
+        ctaType: "inquiry",
+      },
+      {
+        name: "Knockdown & Rebuild",
+        description: "Remove an existing dwelling and build your new home on the same lot",
+        priceType: "quote",
+        ctaType: "inquiry",
+      },
+      {
+        name: "Renovation & Extension",
+        description: "Major renovation, addition, or extension — quoted after a site assessment",
+        priceType: "quote",
+        ctaType: "inquiry",
+      },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "gallery", title: "Portfolio", sortOrder: 1 },
+      { type: "items", title: "Services", sortOrder: 2 },
+      { type: "team", title: "Build Team", sortOrder: 3 },
+      { type: "testimonials", title: "Client Stories", sortOrder: 4 },
+      { type: "about", title: "Our Craftsmanship", sortOrder: 5 },
+      { type: "contact", title: "Start Your Build", sortOrder: 6 },
+    ],
+    formSchema: [
+      ...BUYER_CONTACT_FIELDS,
+      {
+        name: "lotAddress",
+        label: "Do you have a lot or site? If so, where is it located?",
+        type: "text" as const,
+        required: false,
+        placeholder: "e.g. 42 Smith Street, Suburb — or 'Not yet'",
+      },
+      {
+        name: "serviceType",
+        label: "What are you looking to do?",
+        type: "select" as const,
+        required: true,
+        options: ["Build on my own lot", "Knockdown & rebuild", "Major renovation or extension", "Not sure yet"],
+      },
+      {
+        name: "bedroomsRequired",
+        label: "Bedrooms required",
+        type: "select" as const,
+        required: true,
+        options: ["2 bedrooms", "3 bedrooms", "4 bedrooms", "5 bedrooms", "6+ bedrooms"],
+      },
+      {
+        name: "targetBudget",
+        label: "Build budget (excluding land)",
+        type: "select" as const,
+        required: false,
+        options: ["Under $500k", "$500k–$750k", "$750k–$1M", "$1M–$1.5M", "$1.5M–$2.5M", "Over $2.5M", "Not sure yet"],
+      },
+      {
+        name: "buildTimeline",
+        label: "When are you hoping to start building?",
+        type: "select" as const,
+        required: false,
+        options: ["As soon as possible", "Within 6 months", "6–12 months", "12+ months"],
+      },
+      {
+        name: "notes",
+        label: "Tell us about your dream home",
+        type: "textarea" as const,
+        required: false,
+      },
+    ],
+    schedulingDefaults: CONSULTATION_SCHEDULING,
+    activationProfile: {
+      profileType: "standard",
+      modules: [
+        "customer-estate",
+        "projects",
+        "billing-readiness",
+        "service-operations",
+        "lifecycle-signals",
+      ],
+      billingReadinessMode: "prepared-not-prescribed",
+      customerGraph: "separate-customer-projection",
+      estateSeparation: "shared",
+      axes: {
+        form: "goods",
+        delivery: "physical",
+        primaryConsumer: "household",
+        consumptionChannel: "sales-assisted",
+        commercialModel: "transactional",
+        provisioning: "account-with-billing",
+        platform: "no",
+      },
+      portfolios: {
+        foundational: { scope: "minimal" },
+        manufactureAndDeliver: {
+          scope: "primary",
+          it4itStages: ["requirement-to-deploy", "request-to-fulfill"],
+          offerings: ["custom-home-design", "full-build-contracts", "knockdown-rebuild"],
+        },
+        forEmployees: { scope: "standard" },
+        productsAndServicesSold: { scope: "primary" },
+      },
+      seededServiceCategories: [
+        "design-and-planning",
+        "permitting-and-approvals",
+        "site-preparation",
+        "foundation",
+        "framing-and-structure",
+        "mechanical-electrical-plumbing",
+        "insulation-and-drywall",
+        "interior-finishes",
+        "exterior-finishes",
+        "quality-inspections-and-handover",
+        "warranty-and-aftercare",
+      ],
+    },
+    vocabulary: {
+      stakeholderLabel: "Clients",
+      teamLabel: "Build Team",
+      agentName: "Build Consultant",
+      inboxLabel: "Project Enquiries",
+      itemsLabel: "Services",
+      singleItemLabel: "Service",
+      addButtonLabel: "Add service",
+      portalLabel: "Client Portal",
+    },
+  },
+];

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -29,7 +29,12 @@ export type ArchetypeCategory =
    *  re-pool (the S4b Return & Inspect stage); see
    *  docs/architecture/archetype-business-value-streams.md §10.1 and
    *  docs/superpowers/specs/2026-05-29-vehicle-equipment-rental-archetype-design.md. */
-  | "asset-rental";
+  | "asset-rental"
+  /** Residential construction: production builders (communities and display homes)
+   *  and custom builders (build-on-your-lot / BYOL). The defining value stream is
+   *  design → permit → build → inspect → handover; subcontractors deliver most
+   *  trade work under the builder's project management umbrella. */
+  | "real-estate-construction";
 
 export interface FormField {
   name: string;


### PR DESCRIPTION
## Summary

Adds a new `real-estate-construction` archetype category with two leaf archetypes covering the residential construction industry.

### `new-home-builder` — Production / volume builder
- Display home communities are the store; sales are appointment-driven (model home tours, design centre visits)
- 7-day scheduling (Mon–Fri 10–18, Sat 10–17, Sun 12–17)
- Items: Model Home Tour (booking), Design Centre Appointment (booking), 3-bed & 4-bed Floor Plans (inquiry), Community Information Pack
- Activation: goods / physical / household / sales-assisted / transactional / account-with-billing
- Modules: customer-estate, projects, billing-readiness (prepared-not-prescribed), lifecycle-signals
- Service categories seeded: land-and-community-development through warranty-and-aftercare (10 stages)

### `custom-home-builder` — Build-on-your-lot / BYOL
- Business-hours only (Mon–Fri 09–17); substantive design consultation model
- Items: Initial Design Consultation (booking), Custom Home Design, Full Build Contract, Knockdown & Rebuild, Renovation & Extension (all quote)
- Adds `service-operations` module (subcontractor coordination, active build management)
- Leaf vocabulary override: Clients / Build Team / Build Consultant / Client Portal / Project Enquiries

### Cross-cutting surface changes
- `types.ts` — `ArchetypeCategory` union: new `"real-estate-construction"` value with JSDoc
- `archetype-vocabulary.ts` — category vocabulary + category suggestions (`new-home-builder`, `custom-home-builder`)
- `industries.ts` + test — 16th canonical industry (`real-estate-construction` → "Home Building & Construction"); test updated from 15 → 16
- `archetype-business-context.ts` + test — industry profile (mission, businessModel, whoWeServe, howWeDecide, supplyChain) + archetype-level overrides for both leaves
- `marketing-playbooks.ts` — `real-estate-construction` campaign playbook (9 campaign types, buyer journey CTA language)
- `seed-storefront-archetypes.ts` — marketing skill rules: SEO relabelled "Community & Home Search Visibility", competitive analysis relabelled "Market & Community Positioning", email relabelled "Buyer Journey Communication Builder"
- `archetypes.test.ts` — new `EP-GRID-BUILDER` guard: asserts both archetypes exist, booking items present, scheduling defaults set, correct axes (goods/physical/household), billing-readiness+projects modules, Sunday/no-weekend hours split, vocabulary override on custom only, service-operations on custom only

## Test plan

- [ ] `packages/storefront-templates` vitest — 13/13 pass (archetype catalog suite including new builder guard)
- [ ] `apps/web/lib/storefront/industries.test.ts` — 4/4 pass (16 canonical industries)
- [ ] `apps/web/lib/onboarding/archetype-business-context.test.ts` — 11/11 pass (real-estate-construction supplyChain coverage included)
- [ ] CI typecheck — local worktree has no node_modules; gate runs on CI
- [ ] Portal archetype end-to-end validation — separate thread per Mark's instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)