### PR TITLE
feat(workbooks): rollup columns — reverse-FK aggregation on platform grids

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -200,7 +200,8 @@ function buildColumn(
     }
     case "formula":
     case "lookup":
-      // Phase 2: computed read-only columns (derived server-side).
+    case "rollup":
+      // Computed read-only columns (derived server-side). rollup = reverse-FK aggregate.
       return { ...base, renderCell: renderComputedCell };
     default:
       return base;

--- a/apps/web/lib/workbooks/cell-validation.ts
+++ b/apps/web/lib/workbooks/cell-validation.ts
@@ -250,7 +250,8 @@ export function validateCell(
     }
 
     case "formula":
-    case "lookup": {
+    case "lookup":
+    case "rollup": {
       // Computed columns are derived on read and never user-written.
       return { ok: false, error: `${column.name} is a computed column and cannot be set` };
     }
@@ -305,6 +306,7 @@ export function storageToCellValue(
         : null;
     case "formula":
     case "lookup":
+    case "rollup":
       // Computed on read — no stored value.
       return null;
     default:

--- a/apps/web/lib/workbooks/generic-read-adapter.test.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.test.ts
@@ -7,7 +7,9 @@ import {
   buildReferenceSearchArgs,
   genericUpdateData,
   makeGenericReadAdapter,
+  resolveRollups,
   type GenericTableConfig,
+  type GroupByRunner,
 } from "./generic-read-adapter";
 import { customColumnProvenance } from "./types";
 
@@ -188,6 +190,104 @@ describe("generic adapter getCapabilities", () => {
     expect(editable.getCapabilities({ userId: "u", canManage: false }).canEditCell).toBe(false);
     const readonly = makeGenericReadAdapter(config);
     expect(readonly.getCapabilities({ userId: "u", canManage: true }).canEditCell).toBe(false);
+  });
+});
+
+const rollupConfig: GenericTableConfig = {
+  entityType: "epic",
+  prismaModel: "epic",
+  idField: "epicId",
+  columns: [
+    { field: "epicId", name: "ID", fieldType: "text" },
+    { field: "title", name: "Title", fieldType: "text" },
+  ],
+  rollups: [
+    {
+      field: "itemCount",
+      name: "Backlog items",
+      targetModel: "backlogItem",
+      foreignKeyField: "epicId",
+      anchorField: "id", // FK targets the cuid PK, not the semantic epicId
+      op: "count",
+    },
+    {
+      field: "totalPoints",
+      name: "Total points",
+      targetModel: "backlogItem",
+      foreignKeyField: "epicId",
+      anchorField: "id",
+      op: "sum",
+      valueField: "points",
+    },
+  ],
+};
+
+describe("genericColumnDefs — rollups", () => {
+  it("appends read-only rollup columns with derived provenance", () => {
+    const cols = genericColumnDefs(rollupConfig);
+    expect(cols.map((c) => c.columnId)).toEqual(["epicId", "title", "itemCount", "totalPoints"]);
+    const rollup = cols.find((c) => c.columnId === "itemCount");
+    expect(rollup?.fieldType).toBe("rollup");
+    expect(rollup?.editable).toBe(false);
+    expect(rollup?.provenanceKind).toBe("derived");
+  });
+});
+
+describe("resolveRollups", () => {
+  // Two epics; the records carry the cuid PK (`id`) the FK points at.
+  const records = [
+    { epicId: "EP-1", id: "cuid-1", title: "Alpha" },
+    { epicId: "EP-2", id: "cuid-2", title: "Beta" },
+  ];
+
+  it("counts referencing rows per anchor via a single grouped query, joining on the cuid PK", async () => {
+    const calls: { model: string; args: unknown }[] = [];
+    const runGroupBy: GroupByRunner = async (model, args) => {
+      calls.push({ model, args });
+      return [
+        { epicId: "cuid-1", _count: { _all: 3 } },
+        { epicId: "cuid-2", _count: { _all: 1 } },
+      ];
+    };
+    const maps = await resolveRollups({ ...rollupConfig, rollups: [rollupConfig.rollups![0]] }, records, runGroupBy);
+    expect(maps.get("itemCount")?.get("cuid-1")).toBe(3);
+    expect(maps.get("itemCount")?.get("cuid-2")).toBe(1);
+    // one grouped query, scoped to the anchor cuids (not the semantic epicIds)
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe("backlogItem");
+    expect((calls[0].args as { where: { epicId: { in: string[] } } }).where.epicId.in).toEqual([
+      "cuid-1",
+      "cuid-2",
+    ]);
+  });
+
+  it("sums a value field for a sum rollup", async () => {
+    const runGroupBy: GroupByRunner = async () => [
+      { epicId: "cuid-1", _sum: { points: 13 } },
+      { epicId: "cuid-2", _sum: { points: null } },
+    ];
+    const maps = await resolveRollups({ ...rollupConfig, rollups: [rollupConfig.rollups![1]] }, records, runGroupBy);
+    expect(maps.get("totalPoints")?.get("cuid-1")).toBe(13);
+    expect(maps.get("totalPoints")?.get("cuid-2")).toBe(0);
+  });
+
+  it("skips the query and yields an empty map when there are no rows", async () => {
+    let called = false;
+    const runGroupBy: GroupByRunner = async () => {
+      called = true;
+      return [];
+    };
+    const maps = await resolveRollups(rollupConfig, [], runGroupBy);
+    expect(called).toBe(false);
+    expect(maps.get("itemCount")?.size).toBe(0);
+  });
+
+  it("throws when a sum rollup has no valueField (fail-closed)", async () => {
+    const bad: GenericTableConfig = {
+      ...rollupConfig,
+      rollups: [{ field: "x", name: "X", targetModel: "backlogItem", foreignKeyField: "epicId", op: "sum" }],
+    };
+    await expect(resolveRollups(bad, records, async () => [])).rejects.toThrow(/valueField/i);
   });
 });
 

--- a/apps/web/lib/workbooks/generic-read-adapter.ts
+++ b/apps/web/lib/workbooks/generic-read-adapter.ts
@@ -67,6 +67,37 @@ export interface GenericTableConfig {
    * read-only grid. Each write goes through `validateCell` before Prisma.
    */
   editableFields?: string[];
+  /**
+   * Read-only `rollup` columns: aggregate the records of another model that
+   * reference this row (reporting phase, reverse-FK). Resolved with one grouped
+   * query per rollup, then assigned per row — no N+1.
+   */
+  rollups?: RollupSpec[];
+}
+
+/**
+ * A rollup column: aggregate a related model's rows that point back at this row
+ * via a foreign key. e.g. on an Epic grid, count BacklogItems where epicId = this
+ * epic — note the FK targets the cuid PK (`anchorField: "id"`), NOT the semantic
+ * id used as the grid rowId, so the join uses `anchorField`, not `idField`.
+ */
+export interface RollupSpec {
+  /** grid columnId for this rollup column */
+  field: string;
+  name: string;
+  /** Prisma delegate of the model to aggregate (the "many" side), e.g. "backlogItem" */
+  targetModel: string;
+  /** the FK scalar on the target model pointing back to this model, e.g. "epicId" */
+  foreignKeyField: string;
+  /** field on THIS model the FK references; defaults to the grid idField. For FKs that target a cuid PK, set "id". */
+  anchorField?: string;
+  /** aggregation operation */
+  op: "count" | "sum" | "avg" | "min" | "max";
+  /** numeric field on the target model to aggregate (required for sum/avg/min/max; ignored for count) */
+  valueField?: string;
+  width?: number;
+  /** optional extra Prisma `where` to scope which target rows are counted (e.g. exclude archived) */
+  filter?: Record<string, unknown>;
 }
 
 const DEFAULT_CAP = 500;
@@ -120,9 +151,74 @@ export function genericRowToGridRow(
   return { rowId: String(row[config.idField]), cells };
 }
 
+/** Runs a Prisma `groupBy` for the named model — injected so the resolver is unit-testable without a DB. */
+export type GroupByRunner = (model: string, args: unknown) => Promise<Record<string, unknown>[]>;
+
+/**
+ * Resolve every rollup column to a Map<anchorValue, aggregate> using one grouped
+ * query per rollup (no N+1). Pure but for the injected runner, so it is testable
+ * with a stub. Anchor values are de-duplicated and only the rows actually present
+ * are queried, so the aggregate is correct for the loaded page.
+ */
+export async function resolveRollups(
+  config: GenericTableConfig,
+  records: Record<string, unknown>[],
+  runGroupBy: GroupByRunner,
+): Promise<Map<string, Map<string, number>>> {
+  const out = new Map<string, Map<string, number>>();
+  for (const spec of config.rollups ?? []) {
+    const anchorField = spec.anchorField ?? config.idField;
+    const anchors = [...new Set(records.map((r) => r[anchorField]).filter((v) => v != null))];
+    const valueMap = new Map<string, number>();
+    if (anchors.length > 0) {
+      if (spec.op !== "count" && !spec.valueField) {
+        throw new Error(`Rollup "${spec.field}" with op "${spec.op}" requires a valueField`);
+      }
+      const aggregate =
+        spec.op === "count"
+          ? { _count: { _all: true } }
+          : { [`_${spec.op}`]: { [spec.valueField as string]: true } };
+      const groups = await runGroupBy(spec.targetModel, {
+        by: [spec.foreignKeyField],
+        where: { [spec.foreignKeyField]: { in: anchors }, ...(spec.filter ?? {}) },
+        ...aggregate,
+      });
+      for (const g of groups) {
+        const key = String(g[spec.foreignKeyField]);
+        const value =
+          spec.op === "count"
+            ? Number((g._count as { _all?: number } | undefined)?._all ?? 0)
+            : Number(
+                (g[`_${spec.op}`] as Record<string, unknown> | undefined)?.[spec.valueField as string] ?? 0,
+              );
+        valueMap.set(key, value);
+      }
+    }
+    out.set(spec.field, valueMap);
+  }
+  return out;
+}
+
+/** Build grid rows from raw records, attaching resolved rollup values (count → 0, others → null when absent). */
+function buildGridRows(
+  config: GenericTableConfig,
+  records: Record<string, unknown>[],
+  rollupMaps: Map<string, Map<string, number>>,
+): GridRow[] {
+  return records.map((r) => {
+    const gr = genericRowToGridRow(config, r);
+    for (const spec of config.rollups ?? []) {
+      const anchorField = spec.anchorField ?? config.idField;
+      const v = rollupMaps.get(spec.field)?.get(String(r[anchorField]));
+      gr.cells[spec.field] = v ?? (spec.op === "count" ? 0 : null);
+    }
+    return gr;
+  });
+}
+
 export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[] {
   const editable = new Set(config.editableFields ?? []);
-  return config.columns.map((c, i) => ({
+  const base: ColumnDefinition[] = config.columns.map((c, i) => ({
     columnId: c.field,
     name: c.name,
     fieldType: c.fieldType,
@@ -135,6 +231,18 @@ export function genericColumnDefs(config: GenericTableConfig): ColumnDefinition[
     config: c.options ? { options: c.options } : undefined,
     provenanceKind: "system", // a live platform field
   }));
+  const rollups: ColumnDefinition[] = (config.rollups ?? []).map((spec, i) => ({
+    columnId: spec.field,
+    name: spec.name,
+    fieldType: "rollup",
+    position: config.columns.length + i,
+    required: false,
+    editable: false, // computed, read-only
+    width: spec.width,
+    groupable: false,
+    provenanceKind: "derived", // calculated from related records
+  }));
+  return [...base, ...rollups];
 }
 
 /** Pull the validated scalar for a Prisma write from a CellStorage by field type. */
@@ -196,6 +304,7 @@ type ReadDelegate = {
   findMany(args: unknown): Promise<Record<string, unknown>[]>;
   findUnique(args: unknown): Promise<Record<string, unknown> | null>;
   update(args: unknown): Promise<Record<string, unknown>>;
+  groupBy(args: unknown): Promise<Record<string, unknown>[]>;
 };
 
 function delegate(model: string): ReadDelegate {
@@ -205,6 +314,9 @@ function delegate(model: string): ReadDelegate {
   }
   return d;
 }
+
+/** A GroupByRunner backed by the live Prisma client (the production rollup query path). */
+const prismaGroupBy: GroupByRunner = (model, args) => delegate(model).groupBy(args);
 
 class GenericReadAdapter implements DataSourceAdapter {
   constructor(private readonly cfg: GenericTableConfig) {}
@@ -216,6 +328,8 @@ class GenericReadAdapter implements DataSourceAdapter {
   private select(): Record<string, true> {
     const sel: Record<string, true> = { [this.cfg.idField]: true };
     for (const c of this.cfg.columns) sel[c.field] = true;
+    // Rollups join on the anchor field (often the cuid PK), which may not be a column.
+    for (const r of this.cfg.rollups ?? []) sel[r.anchorField ?? this.cfg.idField] = true;
     return sel;
   }
 
@@ -239,7 +353,8 @@ class GenericReadAdapter implements DataSourceAdapter {
         `[workbooks] generic grid "${this.cfg.entityType}" hit the ${cap}-row cap; older rows omitted (push-down pagination is a Phase-4 follow-up).`,
       );
     }
-    const rows = records.map((r) => genericRowToGridRow(this.cfg, r));
+    const rollupMaps = await resolveRollups(this.cfg, records, prismaGroupBy);
+    const rows = buildGridRows(this.cfg, records, rollupMaps);
     const filtered = applyFilters(rows, opts.filters);
     const sorted = applySort(filtered, opts.sort);
     return paginate(sorted, opts.pagination.cursor, opts.pagination.limit);
@@ -250,7 +365,9 @@ class GenericReadAdapter implements DataSourceAdapter {
       where: { [this.cfg.idField]: rowId },
       select: this.select(),
     });
-    return r ? genericRowToGridRow(this.cfg, r) : null;
+    if (!r) return null;
+    const rollupMaps = await resolveRollups(this.cfg, [r], prismaGroupBy);
+    return buildGridRows(this.cfg, [r], rollupMaps)[0];
   }
 
   async searchReferences(

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -84,6 +84,19 @@ const EPIC_TABLE: GenericTableConfig = {
     { field: "description", name: "Description", fieldType: "text", width: 400 },
     { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
   ],
+  rollups: [
+    {
+      field: "itemCount",
+      name: "Backlog items",
+      targetModel: "backlogItem",
+      // BacklogItem.epic @relation(fields: [epicId], references: [id]) → the FK
+      // targets Epic.id (cuid), NOT the semantic epicId used as the grid rowId.
+      foreignKeyField: "epicId",
+      anchorField: "id",
+      op: "count",
+      width: 120,
+    },
+  ],
 };
 
 const DIGITAL_PRODUCT_TABLE: GenericTableConfig = {

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -8,11 +8,12 @@
 // references it, so it stays swappable.
 
 /**
- * Field types. `formula` and `lookup` (Phase 2) are *computed* — read-only,
- * never user-written, derived on read. `image` stores an uploaded MediaAsset URL;
+ * Field types. `formula`, `lookup`, and `rollup` are *computed* — read-only, never
+ * user-written, derived on read. `image` stores an uploaded MediaAsset URL;
  * `attachment` stores an uploaded file's URL plus its display name/size (any file
- * type) — both content-addressed via /api/v1/upload. `rollup`, currency remain out
- * of scope.
+ * type) — both content-addressed via /api/v1/upload. `rollup` aggregates the
+ * records that reference this row (reverse-FK count/sum/avg/min/max; reporting
+ * phase, platform grids first). `currency` remains out of scope.
  */
 export const FIELD_TYPES = [
   "text",
@@ -29,12 +30,13 @@ export const FIELD_TYPES = [
   "attachment",
   "formula",
   "lookup",
+  "rollup",
 ] as const;
 
 export type FieldType = (typeof FIELD_TYPES)[number];
 
 /** Field types whose value is computed on read, not stored or user-edited. */
-export const COMPUTED_FIELD_TYPES: readonly FieldType[] = ["formula", "lookup"];
+export const COMPUTED_FIELD_TYPES: readonly FieldType[] = ["formula", "lookup", "rollup"];
 
 export function isComputedFieldType(fieldType: FieldType): boolean {
   return COMPUTED_FIELD_TYPES.includes(fieldType);


### PR DESCRIPTION
## What

The **final reporting-phase slice** ([plan](docs/superpowers/plans/2026-06-13-universal-grid-workbooks-reporting-phase.md), [#1838](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1838)): a `rollup` column aggregates the records of another model that point back at this row via a foreign key — the Smartsheet parent-rollup / Supabase aggregate-over-relation gap.

Platform grids first (a row is a real entity with a stable id); custom-table rollups wait for a link-to-many column type, as the plan scoped.

The **Epic grid** ships the first real rollup: **"Backlog items"** = count of `BacklogItem` where `epicId = epic.id`.

## How

- New `rollup` field type — computed/read-only everywhere: added to `COMPUTED_FIELD_TYPES`, `validateCell` rejects writes, `storageToCellValue` → null, Grid renders via `renderComputedCell`, `derived` provenance.
- Config-driven on the generic adapter: `GenericTableConfig.rollups: RollupSpec[]` = `{ targetModel, foreignKeyField, anchorField, op, valueField?, filter? }`.
- `resolveRollups` runs **one grouped query per rollup** (no N+1), de-dupes anchors, scopes the `where` to the loaded rows, and assigns per row. The Prisma `groupBy` is **injected** (`GroupByRunner`) so the resolver is unit-tested without a DB.

## The correctness subtlety (got it right up front)

The FK targets a **cuid PK**, not the semantic grid rowId: `BacklogItem.epic @relation(fields: [epicId], references: [id])`. So `RollupSpec.anchorField` selects the actual join key (`"id"`), and `select()` pulls it even though it isn't a visible column. Joining on the semantic `epicId` would silently count zero — the [documented BacklogItem.epicId pitfall](MEMORY.md). Verified against `schema.prisma`, not assumed.

## Scope / soundness

`count` shipped end to end; `sum/avg/min/max` are supported by the resolver (`valueField` required, fail-closed). Correct for the loaded page — same scope as the generic adapter's existing in-memory filter/sort; full-dataset SQL push-down stays the pre-existing documented Phase-4 follow-on.

## Test plan

`vitest` — `resolveRollups`: count + sum, cuid-anchored join (asserts the grouped `where` uses the cuid anchors, not the semantic ids), empty-rows skips the query, missing-`valueField` fails closed; rollup column defs are read-only + `derived`. 115 workbooks tests green; `pnpm --filter web typecheck` green.

Functional acceptance rides the single path: a `W-ROLLUP` line joins Phase W / RC27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
