### PR TITLE
[codex] fix self-upgrade queued run visibility

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -155,6 +155,19 @@ describe("SelfUpgradeClient – enabled", () => {
 // ─── Running ──────────────────────────────────────────────────────────────────
 
 describe("SelfUpgradeClient – running", () => {
+  it("shows queued state as accepted work instead of an idle trigger", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("queued", { startedAt: null, completedAt: null })}
+      />,
+    );
+    expect(html).toContain("Upgrade queued");
+    expect(html).toContain("waiting for the worker");
+    expect(html).toContain('data-run-status="queued"');
+    expect(html).not.toContain('aria-label="Upgrade now"');
+  });
+
   it("shows running badge in the latest run section", () => {
     const html = renderToStaticMarkup(
       <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} />,

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 type LatestRun = {
   runId: string;
@@ -112,6 +113,10 @@ function sourceLabel(source: ImageVersionSource | undefined): string {
   }
 }
 
+function statusLabel(value: string): string {
+  return value.replace(/[_-]/g, " ");
+}
+
 function formatDuration(start: Date | string, end: Date | string): string {
   const ms = new Date(end).getTime() - new Date(start).getTime();
   if (ms <= 0) return "";
@@ -175,13 +180,6 @@ function recoveryPointSummary(run: LatestRun | null): RecoveryPointSummary | nul
   };
 }
 
-const RUN_STATUS_STYLES: Record<string, string> = {
-  running: "bg-[var(--dpf-info)]/20 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
-  succeeded: "bg-[var(--dpf-success)]/20 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
-  failed: "bg-[var(--dpf-destructive)]/20 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/30",
-  skipped: "bg-[var(--dpf-muted)]/20 text-[var(--dpf-muted)] border-[var(--dpf-muted)]/30",
-};
-
 const DEFAULT_STATUS_STYLE =
   "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border-[var(--dpf-border)]";
 
@@ -237,7 +235,8 @@ export default function SelfUpgradeClient({
 
   // True once the worker has actually picked the upgrade up — the run is running
   // or the portal is draining/swapping for the swap.
-  const upgradeInFlight = latestRun?.status === "running" || draining;
+  const queuedRun = latestRun?.status === "queued" || latestRun?.status === "pending";
+  const upgradeInFlight = queuedRun || latestRun?.status === "running" || draining;
 
   // The manual trigger only *queues* an upgrade: the server action returns
   // `{ queued: true }` in well under a second, but the Inngest worker still has
@@ -423,7 +422,9 @@ export default function SelfUpgradeClient({
                   aria-live="polite"
                   data-upgrade-inflight="true"
                 >
-                  Upgrade in progress…
+                  {queuedRun
+                    ? "Upgrade queued — waiting for the worker…"
+                    : "Upgrade in progress…"}
                 </span>
               )
             ) : (
@@ -462,7 +463,7 @@ export default function SelfUpgradeClient({
         )}
       </div>
 
-      {enabled && triggerBusy && latestRun?.status !== "running" && (
+      {enabled && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
         <div
           className="text-xs text-[var(--dpf-muted)]"
           data-upgrade-starting="true"
@@ -731,16 +732,20 @@ export default function SelfUpgradeClient({
         >
           <div className="flex items-center gap-2">
             <span className="text-xs font-medium text-[var(--dpf-text)]">Latest Run</span>
-            <span
-              className={`px-2 py-0.5 rounded-full text-xs border ${
-                RUN_STATUS_STYLES[latestRun.status] ??
-                "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border-[var(--dpf-border)]"
-              }`}
-            >
-              {latestRun.status}
-            </span>
+            <StatusBadge
+              domain="selfUpgradeRun"
+              status={latestRun.status}
+              label={statusLabel(latestRun.status)}
+              variant="soft"
+            />
             <span className="text-xs font-mono text-[var(--dpf-muted)]">{latestRun.runId}</span>
           </div>
+
+          {queuedRun && (
+            <div className="text-xs text-[var(--dpf-muted)]" data-upgrade-queued="true">
+              Upgrade queued — waiting for the worker to accept this run.
+            </div>
+          )}
 
           {latestRun.currentSha && latestRun.targetSha && (
             <div className="text-xs text-[var(--dpf-muted)]">
@@ -872,13 +877,12 @@ export default function SelfUpgradeClient({
                   data-run-id={run.runId}
                 >
                   <td className="px-3 py-2 w-24 shrink-0">
-                    <span
-                      className={`px-2 py-0.5 rounded-full border ${
-                        RUN_STATUS_STYLES[run.status] ?? DEFAULT_STATUS_STYLE
-                      }`}
-                    >
-                      {run.status}
-                    </span>
+                    <StatusBadge
+                      domain="selfUpgradeRun"
+                      status={run.status}
+                      label={statusLabel(run.status)}
+                      variant="soft"
+                    />
                   </td>
                   <td className="px-3 py-2 font-mono text-[var(--dpf-muted)]">{run.runId}</td>
                   <td className="px-3 py-2 text-[var(--dpf-muted)]">

--- a/apps/web/components/ops/SelfUpgradePanel.tsx
+++ b/apps/web/components/ops/SelfUpgradePanel.tsx
@@ -1,6 +1,7 @@
 import type { SelfUpgradeDashboard } from "@/lib/actions/self-upgrade";
 import { requestPortalSelfUpgradeAction } from "@/lib/actions/self-upgrade";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { StatusBadge } from "@/components/ui/report-kit";
 
 function shortSha(value: string | null): string {
   return value ? value.slice(0, 12) : "unknown";
@@ -84,9 +85,12 @@ export function SelfUpgradePanel({ dashboard }: { dashboard: SelfUpgradeDashboar
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="font-mono text-sm font-semibold text-[var(--dpf-text)]">{run.runId}</span>
-                      <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">
-                        {statusLabel(run.status)}
-                      </span>
+                      <StatusBadge
+                        domain="selfUpgradeRun"
+                        status={run.status}
+                        label={statusLabel(run.status)}
+                        variant="soft"
+                      />
                       <span className="text-xs text-[var(--dpf-muted)]">{run.trigger}</span>
                     </div>
                     <div className="mt-2 grid gap-2 text-xs text-[var(--dpf-muted)] sm:grid-cols-3">

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -59,4 +59,12 @@ describe("statusColors", () => {
     expect(resolveIntent("marketing", "approved")).toBe("success");
     expect(resolveIntent("marketing", "rejected")).toBe("danger");
   });
+
+  it("maps self-upgrade run statuses to operational intents", () => {
+    expect(resolveIntent("selfUpgradeRun", "queued")).toBe("info");
+    expect(resolveIntent("selfUpgradeRun", "running")).toBe("accent");
+    expect(resolveIntent("selfUpgradeRun", "succeeded")).toBe("success");
+    expect(resolveIntent("selfUpgradeRun", "failed")).toBe("danger");
+    expect(resolveIntent("selfUpgradeRun", "skipped")).toBe("neutral");
+  });
 });

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -172,6 +172,19 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     failed: "danger",
     blocked: "warning",
   },
+  // Ops self-upgrade lifecycle. Keep these here so the Upgrade Center does not
+  // carry a private run-status color map.
+  selfUpgradeRun: {
+    queued: "info",
+    pending: "info",
+    running: "accent",
+    completing: "accent",
+    succeeded: "success",
+    failed: "danger",
+    skipped: "neutral",
+    cancelled: "neutral",
+    rolled_back: "warning",
+  },
   // Deliberation consensus outcome on the AI Operations Map deliberation lens.
   deliberationConsensus: {
     consensus: "success",

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -19,6 +19,7 @@ vi.mock("@dpf/db", () => ({
       findFirst: vi.fn(),
     },
     selfUpgradeRun: {
+      create: vi.fn(),
       findMany: vi.fn(),
     },
   },
@@ -44,6 +45,8 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 }));
 
 vi.mock("@/lib/self-upgrade/run-store", () => ({
+  createRun: vi.fn(),
+  failRun: vi.fn(),
   getLatestRun: vi.fn(),
 }));
 
@@ -137,7 +140,7 @@ import { prisma } from "@dpf/db";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
-import { getLatestRun } from "@/lib/self-upgrade/run-store";
+import { createRun, getLatestRun } from "@/lib/self-upgrade/run-store";
 import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
@@ -189,6 +192,19 @@ beforeEach(() => {
   vi.mocked(can).mockReturnValue(true);
   vi.mocked(getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
   vi.mocked(getLatestRun).mockResolvedValue(null);
+  vi.mocked(createRun).mockResolvedValue({
+    ...mockRun,
+    runId: "SUR-QUEUED1",
+    status: "queued",
+    trigger: "manual:user-ops-1",
+    currentSha: null,
+    targetSha: null,
+    deployedSha: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date("2026-06-13T21:00:00Z"),
+    updatedAt: new Date("2026-06-13T21:00:00Z"),
+  } as never);
   vi.mocked(getLastCheckedAt).mockResolvedValue(null);
   vi.mocked(nextUpgradeWindowOpen).mockReturnValue(null);
   // Default: treat triggers as in-window so dispatch tests exercise the happy
@@ -644,6 +660,20 @@ describe("triggerSelfUpgrade – access control", () => {
 // ─── triggerSelfUpgrade – dispatch ───────────────────────────────────────────
 
 describe("triggerSelfUpgrade – dispatch", () => {
+  it("creates a durable queued run before sending the worker event", async () => {
+    const result = await triggerSelfUpgrade();
+
+    expect(createRun).toHaveBeenCalledWith({
+      triggeredBy: "manual:user-ops-1",
+    });
+    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ runId: "SUR-QUEUED1" }),
+      }),
+    );
+    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
+  });
+
   it("sends self-upgrade event to inngest", async () => {
     await triggerSelfUpgrade();
 
@@ -676,7 +706,7 @@ describe("triggerSelfUpgrade – dispatch", () => {
 
   it("returns { queued: true }", async () => {
     const result = await triggerSelfUpgrade();
-    expect(result).toEqual({ queued: true });
+    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
   });
 });
 
@@ -690,7 +720,7 @@ describe("triggerSelfUpgrade – manual is not window-gated", () => {
 
     const result = await triggerSelfUpgrade();
 
-    expect(result).toEqual({ queued: true });
+    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
     expect(vi.mocked(inngest.send)).toHaveBeenCalled();
     // It doesn't even consult the window for a manual trigger.
     expect(vi.mocked(isUpgradeWindowOpen)).not.toHaveBeenCalled();
@@ -699,7 +729,7 @@ describe("triggerSelfUpgrade – manual is not window-gated", () => {
   it("emergency override dispatches with force (bypasses the quiescence drain)", async () => {
     const result = await triggerSelfUpgrade({ force: true });
 
-    expect(result).toEqual({ queued: true });
+    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
     expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ force: true }),
@@ -759,6 +789,26 @@ describe("triggerSelfUpgrade – guard: already-running", () => {
     );
     expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
   });
+
+  it("does not dispatch a duplicate event while the latest run is still queued", async () => {
+    vi.mocked(getLatestRun).mockResolvedValue({
+      ...mockRun,
+      runId: "SUR-QUEUED1",
+      status: "queued",
+      startedAt: null,
+      completedAt: null,
+    } as never);
+
+    const result = await triggerSelfUpgrade();
+
+    expect(result).toMatchObject({
+      queued: false,
+      reason: "already-queued",
+      runId: "SUR-QUEUED1",
+    });
+    expect(createRun).not.toHaveBeenCalled();
+    expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
+  });
 });
 
 // ─── triggerSelfUpgrade – guard: invalid-config ───────────────────────────────
@@ -786,7 +836,7 @@ describe("triggerSelfUpgrade – guard: invalid-config", () => {
 
     const result = await triggerSelfUpgrade({ dryRun: true });
 
-    expect(result).toEqual({ queued: true });
+    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
     expect(vi.mocked(inngest.send)).toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -10,7 +10,7 @@ import { generatePromotionId } from "@/lib/version-tracking";
 import { getSelfUpgradeConfig, nextMaintenanceWindowStart } from "@/lib/self-upgrade/config";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
-import { getLatestRun } from "@/lib/self-upgrade/run-store";
+import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
 import {
   isStoreOpen,
   isUpgradeWindowOpen,
@@ -724,6 +724,7 @@ export async function getSelfUpgradeStatus() {
 
 export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: boolean }) {
   const userId = await requireOpsAccess();
+  const triggeredBy = `manual:${userId}`;
 
   if (!opts?.dryRun) {
     const config = await getSelfUpgradeConfig();
@@ -740,16 +741,31 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
   if (latestRun?.status === "running") {
     return { queued: false, reason: "already-running", runId: latestRun.runId } as const;
   }
+  if (latestRun?.status === "queued" || latestRun?.status === "pending") {
+    return { queued: false, reason: "already-queued", runId: latestRun.runId } as const;
+  }
 
-  await inngest.send({
-    name: SELF_UPGRADE_EVENT,
-    data: {
-      triggeredBy: `manual:${userId}`,
-      ...(opts?.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
-      ...(opts?.force ? { force: true } : {}),
-    },
+  const run = await createRun({
+    triggeredBy,
   });
-  return { queued: true } as const;
+
+  try {
+    await inngest.send({
+      name: SELF_UPGRADE_EVENT,
+      data: {
+        runId: run.runId,
+        triggeredBy,
+        ...(opts?.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
+        ...(opts?.force ? { force: true } : {}),
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await failRun(run.runId, `queue-dispatch-failed: ${message}`);
+    return { queued: false, reason: "queue-dispatch-failed", runId: run.runId } as const;
+  }
+
+  return { queued: true, runId: run.runId } as const;
 }
 
 /**

--- a/apps/web/lib/actions/self-upgrade.test.ts
+++ b/apps/web/lib/actions/self-upgrade.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    selfUpgradeRun: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: {
+    send: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/queue/functions/self-upgrade", () => ({
+  SELF_UPGRADE_EVENT: "ops/self-upgrade.run",
+}));
+
+vi.mock("@/lib/self-upgrade/config", () => ({
+  getSelfUpgradeConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/self-upgrade/version", () => ({
+  getUpgradeVersionState: vi.fn(),
+}));
+
+vi.mock("@/lib/self-upgrade/run-store", () => ({
+  createRun: vi.fn(),
+  failRun: vi.fn(),
+  getLatestRun: vi.fn(),
+}));
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { inngest } from "@/lib/queue/inngest-client";
+import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
+import { requestPortalSelfUpgradeAction } from "./self-upgrade";
+
+describe("requestPortalSelfUpgradeAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-ops-1",
+        platformRole: "owner",
+        isSuperuser: true,
+      },
+    } as never);
+    vi.mocked(can).mockReturnValue(true);
+    vi.mocked(getLatestRun).mockResolvedValue(null);
+    vi.mocked(createRun).mockResolvedValue({
+      runId: "SUR-QUEUED1",
+      status: "queued",
+    } as never);
+  });
+
+  it("creates a durable queued run before sending the worker event", async () => {
+    await requestPortalSelfUpgradeAction();
+
+    expect(createRun).toHaveBeenCalledWith({ triggeredBy: "manual:user-ops-1" });
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "ops/self-upgrade.run",
+      data: {
+        runId: "SUR-QUEUED1",
+        triggeredBy: "manual:user-ops-1",
+      },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
+  });
+
+  it.each(["running", "queued", "pending"])(
+    "does not dispatch a duplicate event while the latest run is %s",
+    async (status) => {
+      vi.mocked(getLatestRun).mockResolvedValue({
+        runId: "SUR-ACTIVE1",
+        status,
+      } as never);
+
+      await requestPortalSelfUpgradeAction();
+
+      expect(createRun).not.toHaveBeenCalled();
+      expect(inngest.send).not.toHaveBeenCalled();
+      expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
+    },
+  );
+
+  it("marks the queued run failed when event dispatch fails", async () => {
+    vi.mocked(inngest.send).mockRejectedValueOnce(new Error("inngest offline"));
+
+    await requestPortalSelfUpgradeAction();
+
+    expect(failRun).toHaveBeenCalledWith(
+      "SUR-QUEUED1",
+      "queue-dispatch-failed: inngest offline",
+    );
+    expect(revalidatePath).toHaveBeenCalledWith("/ops/self-upgrade");
+  });
+});

--- a/apps/web/lib/actions/self-upgrade.ts
+++ b/apps/web/lib/actions/self-upgrade.ts
@@ -9,6 +9,7 @@ import { can } from "@/lib/permissions";
 import { inngest } from "@/lib/queue/inngest-client";
 import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
+import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
 import { getUpgradeVersionState, type UpgradeVersionState } from "@/lib/self-upgrade/version";
 
 async function requireSelfUpgradeOperator(
@@ -134,11 +135,34 @@ export async function getSelfUpgradeDashboardAction(): Promise<SelfUpgradeDashbo
 
 export async function requestPortalSelfUpgradeAction(): Promise<void> {
   const { userId } = await requireSelfUpgradeOperator("manage_provider_connections");
-  await inngest.send({
-    name: SELF_UPGRADE_EVENT,
-    data: {
-      triggeredBy: userId ?? "manual",
-    },
+  const triggeredBy = userId ? `manual:${userId}` : "manual";
+  const latestRun = await getLatestRun();
+
+  if (
+    latestRun?.status === "running" ||
+    latestRun?.status === "queued" ||
+    latestRun?.status === "pending"
+  ) {
+    revalidatePath("/ops/self-upgrade");
+    return;
+  }
+
+  const run = await createRun({
+    triggeredBy,
   });
+
+  try {
+    await inngest.send({
+      name: SELF_UPGRADE_EVENT,
+      data: {
+        runId: run.runId,
+        triggeredBy,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await failRun(run.runId, `queue-dispatch-failed: ${message}`);
+  }
+
   revalidatePath("/ops/self-upgrade");
 }

--- a/apps/web/lib/queue/functions/self-upgrade.bundle-boundary.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.bundle-boundary.test.ts
@@ -13,6 +13,7 @@ describe("self-upgrade bundle boundary", () => {
     expect(source).not.toMatch(
       /import\s+\{[^}]*\b(?:runPromoter|isPromoterAvailable)\b[^}]*\}\s+from\s+["']@\/lib\/self-upgrade\/promoter["']/,
     );
-    expect(source).toContain("turbopackIgnore");
+    expect(source).toContain('import("@/lib/self-upgrade/promoter")');
+    expect(source).not.toContain('import(/* turbopackIgnore: true */ "@/lib/self-upgrade/promoter")');
   });
 });

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   startRun: vi.fn(),
   completeRun: vi.fn(),
   failRun: vi.fn(),
+  skipRun: vi.fn(),
+  updateRunPlan: vi.fn(),
   recordRunRecoveryPoint: vi.fn(),
   getLatestRun: vi.fn(),
   getLatestSucceededRun: vi.fn(),
@@ -91,6 +93,8 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   startRun: mocks.startRun,
   completeRun: mocks.completeRun,
   failRun: mocks.failRun,
+  skipRun: mocks.skipRun,
+  updateRunPlan: mocks.updateRunPlan,
   recordRunRecoveryPoint: mocks.recordRunRecoveryPoint,
   getLatestRun: mocks.getLatestRun,
   getLatestSucceededRun: mocks.getLatestSucceededRun,
@@ -315,6 +319,21 @@ describe("success path", () => {
     const result = await runSelfUpgrade({ triggeredBy: "ops" });
     expect(result).toMatchObject({ ok: true, status: "succeeded", runId: "SUR-AAAABBBB" });
     expect(mocks.completeRun).toHaveBeenCalledWith("SUR-AAAABBBB");
+  });
+
+  it("claims a pre-created queued run instead of creating a second run", async () => {
+    mocks.updateRunPlan.mockResolvedValue({ runId: "SUR-QUEUED1" });
+
+    const result = await runSelfUpgrade({ triggeredBy: "ops", runId: "SUR-QUEUED1" });
+
+    expect(mocks.createRun).not.toHaveBeenCalled();
+    expect(mocks.updateRunPlan).toHaveBeenCalledWith("SUR-QUEUED1", {
+      fromVersion: "oldsha1",
+      toVersion: "abc1234deadbeef",
+      expectedDeployedSha: "abc1234deadbeef",
+    });
+    expect(mocks.startRun).toHaveBeenCalledWith("SUR-QUEUED1");
+    expect(result).toMatchObject({ ok: true, status: "succeeded", runId: "SUR-QUEUED1" });
   });
 
   it("creates and records a recovery point after quiescence and before swap starts", async () => {
@@ -931,6 +950,27 @@ describe("skip-before-drain guards", () => {
     expect(mocks.createRun).not.toHaveBeenCalled();
     // A clean no-op sets no cooldown — the next tick re-checks immediately.
     expect(mocks.recordCooldown).not.toHaveBeenCalled();
+  });
+
+  it("marks a pre-created queued run skipped when a pre-drain guard stops the attempt", async () => {
+    mocks.isPromoterAvailable.mockResolvedValue(false);
+
+    const result = await runSelfUpgrade({
+      triggeredBy: "manual:ops",
+      runId: "SUR-QUEUED1",
+    });
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "promoter-unavailable",
+      runId: "SUR-QUEUED1",
+    });
+    expect(mocks.skipRun).toHaveBeenCalledWith(
+      "SUR-QUEUED1",
+      "promoter-unavailable: dpf-promoter",
+    );
+    expect(mocks.recordCheckedAt).not.toHaveBeenCalled();
+    expect(mocks.createRun).not.toHaveBeenCalled();
   });
 
   it("checks promoter availability against the configured image", async () => {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -16,6 +16,8 @@ import {
   startRun,
   completeRun,
   failRun,
+  skipRun,
+  updateRunPlan,
   recordRunRecoveryPoint,
   getLatestRun,
   getLatestSucceededRun,
@@ -50,10 +52,11 @@ type PromoterRuntime = Pick<
 >;
 
 async function loadPromoterRuntime(): Promise<PromoterRuntime> {
-  return await import(/* turbopackIgnore: true */ "@/lib/self-upgrade/promoter");
+  return await import("@/lib/self-upgrade/promoter");
 }
 
 export type SelfUpgradeRunEventData = {
+  runId?: string;
   triggeredBy?: string;
   dryRun?: boolean;
   buildId?: string;
@@ -86,7 +89,21 @@ export async function runSelfUpgrade(
   const now = new Date();
   const cooldownMinutes = config.cooldownMinutes ?? DEFAULT_COOLDOWN_MINUTES;
 
-  if (!config.enabled && !params.dryRun) return { skipped: true, reason: "disabled" };
+  async function skipAttempt(
+    reason: string,
+    persistedReason = reason,
+    extra: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    if (params.runId) await skipRun(params.runId, persistedReason);
+    return {
+      skipped: true,
+      reason,
+      ...(params.runId ? { runId: params.runId } : {}),
+      ...extra,
+    };
+  }
+
+  if (!config.enabled && !params.dryRun) return await skipAttempt("disabled");
 
   // Cooldown backoff. After a deferred or failed drain we set a cooldown so the
   // NEXT attempt — from ANY trigger (scheduled cron, manual `ops/self-upgrade.run`
@@ -97,11 +114,12 @@ export async function runSelfUpgrade(
   if (!params.dryRun && !params.force) {
     const cooldownUntil = await getCooldownUntil();
     if (isInCooldown(cooldownUntil, now)) {
-      return {
-        skipped: true,
-        reason: "cooldown",
-        cooldownUntil: cooldownUntil?.toISOString() ?? null,
-      };
+      const cooldownIso = cooldownUntil?.toISOString() ?? null;
+      return await skipAttempt(
+        "cooldown",
+        cooldownIso ? `cooldown: ${cooldownIso}` : "cooldown",
+        { cooldownUntil: cooldownIso },
+      );
     }
   }
   // The upgrade window ("whenever the storefront is closed", derived from
@@ -117,7 +135,7 @@ export async function runSelfUpgrade(
       schedule,
       timeZone: timezone,
     });
-    if (!allowed) return { skipped: true, reason: "outside-window" };
+    if (!allowed) return await skipAttempt("outside-window");
   }
 
   // checkIntervalHours throttle: only the scheduled cron is rate-limited, so the
@@ -127,12 +145,9 @@ export async function runSelfUpgrade(
   if (params.scheduled && !params.dryRun && !params.force) {
     const lastCheckedAt = await getLastCheckedAt();
     if (!isCheckIntervalElapsed(lastCheckedAt, config.checkIntervalHours, now)) {
-      return { skipped: true, reason: "interval-not-elapsed" };
+      return await skipAttempt("interval-not-elapsed");
     }
   }
-  // A real check is proceeding now — reset the interval clock (scheduled, manual,
-  // or forced; never on dryRun).
-  if (!params.dryRun) await recordCheckedAt(now);
 
   // Promoter-availability precheck — skip BEFORE any drain. A swap is impossible
   // without the promoter image, so if it isn't on the daemon we must NOT drain
@@ -145,11 +160,12 @@ export async function runSelfUpgrade(
     const { isPromoterAvailable } = await loadPromoterRuntime();
     const promoterReady = await isPromoterAvailable(config.promoterImage);
     if (!promoterReady) {
-      return {
-        skipped: true,
-        reason: "promoter-unavailable",
-        promoterImage: config.promoterImage ?? "dpf-promoter",
-      };
+      const promoterImage = config.promoterImage ?? "dpf-promoter";
+      return await skipAttempt(
+        "promoter-unavailable",
+        `promoter-unavailable: ${promoterImage}`,
+        { promoterImage },
+      );
     }
   }
 
@@ -185,13 +201,20 @@ export async function runSelfUpgrade(
       ? snapshot.surfaces
       : snapshot.surfaces.filter((s) => s.kind === "hard");
     if (blocking.length > 0) {
-      return {
-        skipped: true,
-        reason: "activity-in-flight",
-        surfaces: blocking.map((s) => s.surface),
-      };
+      const surfaces = blocking.map((s) => s.surface);
+      return await skipAttempt(
+        "activity-in-flight",
+        `activity-in-flight: ${surfaces.join(", ")}`,
+        { surfaces },
+      );
     }
   }
+
+  // A real target check is proceeding now — reset the interval clock
+  // (scheduled, manual, or forced; never on dryRun). Keep this after local
+  // pre-drain guards so a missing promoter/active work does not delay the next
+  // scheduled poll while producing no useful run history.
+  if (!params.dryRun) await recordCheckedAt(now);
 
   const gitRun = defaultGitRunner;
   const hostSourcePath =
@@ -242,17 +265,25 @@ export async function runSelfUpgrade(
     await gitRun(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
     const head = await gitRun(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
     upstreamSha = head.code === 0 ? head.stdout.trim() : null;
-    if (!upstreamSha) return { skipped: true, reason: "no-target" };
+    if (!upstreamSha) return await skipAttempt("no-target");
 
     const lastOk = await getLatestSucceededRun();
     if (!params.dryRun && !params.force && lastOk?.targetSha === upstreamSha) {
-      return { skipped: true, reason: "up-to-date", upstreamSha };
+      return await skipAttempt("up-to-date", `up-to-date: ${upstreamSha}`, { upstreamSha });
     }
   }
 
   const latestRun = await getLatestRun();
-  if (latestRun?.status === "running") {
-    return { skipped: true, reason: "active-run", runId: latestRun.runId };
+  if (
+    latestRun &&
+    (latestRun.status === "running" ||
+      latestRun.status === "queued" ||
+      latestRun.status === "pending") &&
+    latestRun.runId !== params.runId
+  ) {
+    return await skipAttempt("active-run", `active-run: ${latestRun.runId}`, {
+      activeRunId: latestRun.runId,
+    });
   }
 
   const deployedSha = await getDeployedSha();
@@ -283,11 +314,16 @@ export async function runSelfUpgrade(
       // Conflict / no-target / prep-error: record for audit, do NOT drain or
       // swap. A merge conflict defers (operator resolves in the Upgrade Center);
       // the current build keeps running.
-      const failedRun = await createRun({
-        triggeredBy: params.triggeredBy,
-        fromVersion: deployedSha ?? undefined,
-        toVersion: upstreamSha ?? undefined,
-      });
+      const failedRun = params.runId
+        ? await updateRunPlan(params.runId, {
+            fromVersion: deployedSha ?? undefined,
+            toVersion: upstreamSha ?? undefined,
+          })
+        : await createRun({
+            triggeredBy: params.triggeredBy,
+            fromVersion: deployedSha ?? undefined,
+            toVersion: upstreamSha ?? undefined,
+          });
       const reason =
         prep.reason === "merge-conflict"
           ? `merge-conflict: ${prep.conflictFiles.join(", ")}`
@@ -317,20 +353,26 @@ export async function runSelfUpgrade(
   // the running SHA. A clean no-op: no run row, no QuiescenceRun, no cooldown.
   // force/dryRun bypass (operator asked; dry-run never swaps).
   if (!params.dryRun && !params.force && deployedSha && builtStamp === deployedSha) {
-    return { skipped: true, reason: "up-to-date", builtStamp };
+    return await skipAttempt("up-to-date", `up-to-date: ${builtStamp}`, { builtStamp });
   }
 
-  const run = await createRun({
-    triggeredBy: params.triggeredBy,
-    fromVersion: deployedSha ?? undefined,
-    // targetSha column carries the upstream lineage marker (what the build
-    // contains), falling back to the built stamp in local mode.
-    toVersion: upstreamSha ?? builtStamp,
-    // deployedSha carries the expected runtime identity the rebuilt image will
-    // report after boot. In upstream mode this is the install-branch merge
-    // commit, not the upstream lineage marker above.
-    expectedDeployedSha: builtStamp,
-  });
+  const run = params.runId
+    ? await updateRunPlan(params.runId, {
+        fromVersion: deployedSha ?? undefined,
+        // targetSha column carries the upstream lineage marker (what the build
+        // contains), falling back to the built stamp in local mode.
+        toVersion: upstreamSha ?? builtStamp,
+        // deployedSha carries the expected runtime identity the rebuilt image will
+        // report after boot. In upstream mode this is the install-branch merge
+        // commit, not the upstream lineage marker above.
+        expectedDeployedSha: builtStamp,
+      })
+    : await createRun({
+        triggeredBy: params.triggeredBy,
+        fromVersion: deployedSha ?? undefined,
+        toVersion: upstreamSha ?? builtStamp,
+        expectedDeployedSha: builtStamp,
+      });
   await startRun(run.runId);
   await emitUpgradeEvent({ type: "upgrade.started", runId: run.runId });
 
@@ -536,6 +578,18 @@ export const selfUpgradeManual = inngest.createFunction(
   },
   async ({ event, step }) => {
     const data = event.data as SelfUpgradeRunEventData;
-    return await step.run("run-self-upgrade-manual", () => runSelfUpgrade(data));
+    try {
+      return await step.run("run-self-upgrade-manual", () => runSelfUpgrade(data));
+    } catch (err) {
+      if (data.runId) {
+        const msg = err instanceof Error ? err.message : String(err);
+        try {
+          await failRun(data.runId, `worker-error: ${msg}`);
+        } catch {
+          // Preserve the original Inngest failure; DB recovery failure is secondary.
+        }
+      }
+      throw err;
+    }
   },
 );

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -2,24 +2,47 @@ import { randomUUID } from "node:crypto";
 import { prisma, Prisma } from "@dpf/db";
 
 export type SelfUpgradeRunStatus =
+  | "queued"
   | "pending"
   | "running"
   | "succeeded"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "skipped"
+  | "completing"
+  | "rolled_back";
 
 export async function createRun(params: {
+  runId?: string;
   triggeredBy?: string;
   fromVersion?: string;
   toVersion?: string;
   expectedDeployedSha?: string;
 }) {
-  const runId = `SUR-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+  const runId = params.runId ?? `SUR-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
   return prisma.selfUpgradeRun.create({
     data: {
       runId,
-      status: "pending",
+      status: "queued",
       trigger: params.triggeredBy ?? "unknown",
+      currentSha: params.fromVersion ?? null,
+      targetSha: params.toVersion ?? null,
+      deployedSha: params.expectedDeployedSha ?? null,
+    },
+  });
+}
+
+export async function updateRunPlan(
+  runId: string,
+  params: {
+    fromVersion?: string;
+    toVersion?: string;
+    expectedDeployedSha?: string;
+  },
+) {
+  return prisma.selfUpgradeRun.update({
+    where: { runId },
+    data: {
       currentSha: params.fromVersion ?? null,
       targetSha: params.toVersion ?? null,
       deployedSha: params.expectedDeployedSha ?? null,
@@ -45,6 +68,13 @@ export async function failRun(runId: string, error: string) {
   return prisma.selfUpgradeRun.update({
     where: { runId },
     data: { status: "failed", completedAt: new Date(), failureLog: error },
+  });
+}
+
+export async function skipRun(runId: string, reason: string) {
+  return prisma.selfUpgradeRun.update({
+    where: { runId },
+    data: { status: "skipped", completedAt: new Date(), reason },
   });
 }
 


### PR DESCRIPTION
## Summary
- Persist manual self-upgrade requests as durable `queued` `SelfUpgradeRun` rows before dispatching the worker event.
- Pass the queued `runId` through Inngest so the worker claims, starts, skips, or fails the same row instead of creating invisible work.
- Show queued self-upgrade runs as accepted work in the Ops UI and route run-status badges through report-kit.

## Root Cause
Manual self-upgrade only sent an Inngest event and returned `{ queued: true }`. The worker then crashed before creating a run row because the promoter dynamic import used `turbopackIgnore` with the `@/lib/...` alias, which the built runtime attempted to resolve as a package. After refresh, there was no durable run history for the UI to display.

## Verification
- `pnpm --filter web exec vitest run lib/actions/self-upgrade.test.ts lib/queue/functions/self-upgrade.bundle-boundary.test.ts components/ui/report-kit/statusColors.test.ts components/ops/SelfUpgradeClient.test.tsx lib/actions/promotions.self-upgrade.test.ts lib/queue/functions/self-upgrade.test.ts lib/verify/bundle-boundary.guard.test.ts` — 7 files, 197 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web build` — passed.

## Note
Authenticated browser verification against a host-side worktree preview was attempted but blocked by local preview auth/env mismatch. The main portal was not mutated or rebuilt directly.