### PR TITLE
feat(workbooks): linked records (M-M / 1-M) — substrate + storage + editor (slices 1-3)

### DIFF
--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -27,6 +27,7 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "email", label: "Email" },
   { value: "image", label: "Image" },
   { value: "attachment", label: "Attachment" },
+  { value: "link", label: "Link to records" },
 ];
 
 const RESULT_TYPES: { value: FieldType; label: string }[] = [
@@ -69,6 +70,7 @@ export function AddColumnButton({
   const [optionsRaw, setOptionsRaw] = useState("");
   const [referenceType, setReferenceType] = useState("");
   const [referenceTargets, setReferenceTargets] = useState<ReferenceTarget[]>([]);
+  const [linkCardinality, setLinkCardinality] = useState<"one" | "many">("many");
   const [formula, setFormula] = useState("");
   const [resultType, setResultType] = useState<FieldType>("text");
   const [lookupRefColumnId, setLookupRefColumnId] = useState("");
@@ -116,6 +118,7 @@ export function AddColumnButton({
     setFieldType("text");
     setOptionsRaw("");
     setReferenceType("");
+    setLinkCardinality("many");
     setFormula("");
     setResultType("text");
     setLookupRefColumnId("");
@@ -128,6 +131,7 @@ export function AddColumnButton({
   function buildConfig(): FieldConfig | undefined {
     if (fieldType === "select") return { options: parseOptions(optionsRaw) };
     if (fieldType === "reference") return { referenceType };
+    if (fieldType === "link") return { link: { cardinality: linkCardinality, referenceType } };
     if (fieldType === "formula") return { formula, resultType };
     if (fieldType === "lookup") {
       return { lookup: { referenceColumnId: lookupRefColumnId, targetField: lookupTargetField } };
@@ -135,10 +139,10 @@ export function AddColumnButton({
     return undefined;
   }
 
-  const missingReferenceTarget = fieldType === "reference" && !referenceType;
+  const missingTarget = (fieldType === "reference" || fieldType === "link") && !referenceType;
   const missingFormula = fieldType === "formula" && !formula.trim();
   const missingLookup = fieldType === "lookup" && (!lookupRefColumnId || !lookupTargetField);
-  const invalidConfig = missingReferenceTarget || missingFormula || missingLookup;
+  const invalidConfig = missingTarget || missingFormula || missingLookup;
 
   function submit() {
     setError(null);
@@ -198,20 +202,40 @@ export function AddColumnButton({
           className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
         />
       )}
-      {fieldType === "reference" && (
+      {(fieldType === "reference" || fieldType === "link") && (
         <select
           value={referenceType}
           onChange={(e) => setReferenceType(e.target.value)}
           className={selectClass}
+          aria-label="Link target"
         >
           <option value="" className={optionClass}>
-            {referenceTargets.length === 0 ? "No reference targets available" : "Select what to reference…"}
+            {referenceTargets.length === 0
+              ? "No targets available"
+              : fieldType === "link"
+                ? "Select what to link to…"
+                : "Select what to reference…"}
           </option>
           {referenceTargets.map((t) => (
             <option key={t.entityType} value={t.entityType} className={optionClass}>
               {t.label}
             </option>
           ))}
+        </select>
+      )}
+      {fieldType === "link" && (
+        <select
+          value={linkCardinality}
+          onChange={(e) => setLinkCardinality(e.target.value as "one" | "many")}
+          className={selectClass}
+          aria-label="How many"
+        >
+          <option value="many" className={optionClass}>
+            Link to many (M-M)
+          </option>
+          <option value="one" className={optionClass}>
+            Link to one (1-1 / 1-M)
+          </option>
         </select>
       )}
       {fieldType === "formula" && (

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -52,6 +52,7 @@ import {
   renderComputedCell,
   renderLinkCell,
   makeReferenceEditor,
+  makeLinkEditor,
 } from "./cell-editors";
 import {
   createRowAction,
@@ -205,9 +206,16 @@ function buildColumn(
     case "rollup":
       // Computed read-only columns (derived server-side). rollup = reverse-FK aggregate.
       return { ...base, renderCell: renderComputedCell };
-    case "link":
-      // Link-to-many: chips per linked record. Multi-select editor lands in slice 3.
-      return { ...base, renderCell: renderLinkCell };
+    case "link": {
+      // Link-to-many: chips per linked record + multi-select typeahead editor.
+      const linkConfig = col.config?.link;
+      return {
+        ...base,
+        renderCell: renderLinkCell,
+        renderEditCell: editable && linkConfig ? makeLinkEditor(linkConfig) : undefined,
+        editorOptions: { commitOnOutsideClick: false },
+      };
+    }
     default:
       return base;
   }

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -28,6 +28,7 @@ import {
   type ColumnDefinition,
   type GridRow,
   type CellValue,
+  type ReferenceValue,
   type GridCapabilities,
   type ProvenanceKind,
   PROVENANCE_LABELS,
@@ -49,6 +50,7 @@ import {
   renderDateCell,
   renderReferenceCell,
   renderComputedCell,
+  renderLinkCell,
   makeReferenceEditor,
 } from "./cell-editors";
 import {
@@ -203,6 +205,9 @@ function buildColumn(
     case "rollup":
       // Computed read-only columns (derived server-side). rollup = reverse-FK aggregate.
       return { ...base, renderCell: renderComputedCell };
+    case "link":
+      // Link-to-many: chips per linked record. Multi-select editor lands in slice 3.
+      return { ...base, renderCell: renderLinkCell };
     default:
       return base;
   }
@@ -211,7 +216,13 @@ function buildColumn(
 function compareValues(a: CellValue, b: CellValue): number {
   const norm = (v: CellValue): string | number => {
     if (v === null || v === undefined) return "";
-    if (Array.isArray(v)) return v.join(",");
+    if (Array.isArray(v)) {
+      // link cell = array of references; sort by their labels/ids
+      if (v.length > 0 && typeof v[0] === "object" && v[0] !== null && "referenceId" in v[0]) {
+        return v.map((it) => (it as ReferenceValue).label ?? (it as ReferenceValue).referenceId).join(", ");
+      }
+      return v.join(",");
+    }
     if (typeof v === "object") {
       if ("referenceId" in v) return v.referenceId ?? "";
       if ("url" in v) return v.name ?? v.url;

--- a/apps/web/components/workbooks/KanbanBoard.tsx
+++ b/apps/web/components/workbooks/KanbanBoard.tsx
@@ -52,6 +52,13 @@ function formatValue(col: ColumnDefinition | undefined, value: CellValue): strin
       return typeof value === "object" && value && !Array.isArray(value) && "url" in value
         ? value.name ?? value.url
         : String(value);
+    case "link":
+      return Array.isArray(value)
+        ? value
+            .filter((it) => it && typeof it === "object" && "referenceId" in it)
+            .map((it) => (it as { label?: string; referenceId: string }).label ?? (it as { referenceId: string }).referenceId)
+            .join(", ")
+        : String(value);
     default:
       return String(value);
   }

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -352,7 +352,7 @@ export function makeMultiSelectRenderer(options: SelectOption[]) {
   const byKey = new Map(options.map((o) => [o.key, o]));
   return function MultiSelectCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {
     const v = row[column.key];
-    const keys = Array.isArray(v) ? v : [];
+    const keys: string[] = Array.isArray(v) ? v.filter((it): it is string => typeof it === "string") : [];
     if (keys.length === 0) return null;
     return (
       <>
@@ -383,6 +383,23 @@ export function renderReferenceCell({ row, column }: RenderCellProps<GridRowData
     return <span className="dpf-grid-chip">{ref.label ?? ref.referenceId}</span>;
   }
   return null;
+}
+
+/** Read-only renderer for `link` cells — a chip per linked record. */
+export function renderLinkCell({ row, column }: RenderCellProps<GridRowData>): ReactNode {
+  const v = row[column.key];
+  if (!Array.isArray(v) || v.length === 0) return null;
+  const refs = v.filter((it): it is ReferenceValue => !!it && typeof it === "object" && "referenceId" in it);
+  if (refs.length === 0) return null;
+  return (
+    <span className="dpf-grid-chips">
+      {refs.map((ref) => (
+        <span key={ref.referenceId} className="dpf-grid-chip">
+          {ref.label ?? ref.referenceId}
+        </span>
+      ))}
+    </span>
+  );
 }
 
 /** Read-only renderer for computed (formula/lookup) cells. */

--- a/apps/web/components/workbooks/cell-editors.tsx
+++ b/apps/web/components/workbooks/cell-editors.tsx
@@ -164,6 +164,67 @@ export function makeReferenceEditor(referenceType: string) {
 }
 
 /**
+ * Link editor: multi-select typeahead over a live target entity for a `link`
+ * column. Each pick/remove commits the updated link set (a ReferenceValue[]) and
+ * closes — re-open the cell to add another. `cardinality: "one"` replaces rather
+ * than appends. The dropdown lives in the editor's subtree and the column sets
+ * commitOnOutsideClick:false, so a result click never cancels the edit.
+ */
+export function makeLinkEditor(config: { cardinality: "one" | "many"; referenceType: string }) {
+  return function LinkEditor({
+    row,
+    column,
+    onRowChange,
+  }: RenderEditCellProps<GridRowData>): ReactNode {
+    const raw = row[column.key];
+    const current: ReferenceValue[] = Array.isArray(raw)
+      ? raw.filter((it): it is ReferenceValue => !!it && typeof it === "object" && "referenceId" in it)
+      : [];
+    const commit = (next: ReferenceValue[]) => onRowChange({ ...row, [column.key]: next }, true);
+    const add = (item: { id: string; label: string }) => {
+      const ref: ReferenceValue = { referenceId: item.id, referenceType: config.referenceType, label: item.label };
+      if (config.cardinality === "one") return commit([ref]);
+      if (current.some((r) => r.referenceId === item.id)) return commit(current);
+      return commit([...current, ref]);
+    };
+    return (
+      <div className="dpf-grid-editor-reference">
+        {current.length > 0 ? (
+          <div className="dpf-grid-chips">
+            {current.map((r) => (
+              <span key={r.referenceId} className="dpf-grid-chip">
+                {r.label ?? r.referenceId}
+                <button
+                  type="button"
+                  className="dpf-grid-chip-x"
+                  aria-label={`Remove ${r.label ?? r.referenceId}`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    commit(current.filter((x) => x.referenceId !== r.referenceId));
+                  }}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <ReferenceTypeahead
+          autoFocus
+          placeholder="Search…"
+          value={null}
+          onSearch={async (q) => {
+            const res = await searchReferencesAction(config.referenceType, q);
+            return res.ok ? res.data : [];
+          }}
+          onSelect={add}
+        />
+      </div>
+    );
+  };
+}
+
+/**
  * Image editor: uploads a chosen file to /api/v1/upload (content-addressed
  * MediaAsset storage) and commits the returned retrieval URL as the cell value.
  * The bytes never live in the cell — only the URL string does, so an image

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -103,6 +103,20 @@
   align-items: center;
 }
 
+/* remove (×) button inside a link chip in the editor */
+.dpf-grid-chip-x {
+  margin-inline-start: 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--dpf-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+.dpf-grid-chip-x:hover {
+  color: var(--dpf-text);
+}
+
 .dpf-grid-link {
   color: var(--dpf-accent);
   text-decoration: underline;

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -95,6 +95,14 @@
   border: 1px solid var(--dpf-border);
 }
 
+/* link cell: a flex row of chips that wraps within the cell */
+.dpf-grid-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+  align-items: center;
+}
+
 .dpf-grid-link {
   color: var(--dpf-accent);
   text-decoration: underline;

--- a/apps/web/components/workbooks/grid-filter.ts
+++ b/apps/web/components/workbooks/grid-filter.ts
@@ -16,7 +16,13 @@ import type { GridRowData } from "./cell-editors";
 /** Render a cell value to the text a user would see, for substring matching. */
 export function cellSearchText(value: CellValue): string {
   if (value === null || value === undefined) return "";
-  if (Array.isArray(value)) return value.join(" ");
+  if (Array.isArray(value)) {
+    // link cell = array of references → search/export by their labels
+    if (value.length > 0 && typeof value[0] === "object" && value[0] !== null && "referenceId" in value[0]) {
+      return (value as ReferenceValue[]).map((r) => r.label ?? r.referenceId).join(" ");
+    }
+    return value.join(" ");
+  }
   if (typeof value === "object" && "referenceId" in value) {
     const ref = value as ReferenceValue;
     return ref.label ?? ref.referenceId;

--- a/apps/web/components/workbooks/link-editor.test.tsx
+++ b/apps/web/components/workbooks/link-editor.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+//
+// Component test for the link-cell multi-select editor — drives the typeahead
+// (search → pick) and asserts it commits the chosen record as a ReferenceValue[]
+// via onRowChange(value, /* commitChanges */ true), and that cardinality "one"
+// replaces rather than appends.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("@/lib/actions/workbooks", () => ({
+  searchReferencesAction: vi.fn(async () => ({
+    ok: true,
+    data: [{ id: "E1", label: "Epic One" }],
+  })),
+}));
+
+import { makeLinkEditor } from "./cell-editors";
+
+afterEach(() => cleanup());
+
+describe("link cell editor", () => {
+  it("appends a picked record as a ReferenceValue[] and commits", async () => {
+    const Editor = makeLinkEditor({ cardinality: "many", referenceType: "epic" });
+    const onRowChange = vi.fn();
+    const row = { rowId: "r1", c1: [] };
+    const column = { key: "c1" } as never;
+
+    render(<Editor row={row} column={column} onRowChange={onRowChange} onClose={vi.fn()} rowIdx={0} /> as never);
+
+    fireEvent.change(screen.getByPlaceholderText("Search…"), { target: { value: "epic" } });
+    fireEvent.click(await screen.findByText("Epic One"));
+
+    await waitFor(() => expect(onRowChange).toHaveBeenCalled());
+    expect(onRowChange).toHaveBeenCalledWith(
+      { rowId: "r1", c1: [{ referenceId: "E1", referenceType: "epic", label: "Epic One" }] },
+      true,
+    );
+  });
+
+  it("replaces the existing link when cardinality is 'one'", async () => {
+    const Editor = makeLinkEditor({ cardinality: "one", referenceType: "epic" });
+    const onRowChange = vi.fn();
+    const row = { rowId: "r1", c1: [{ referenceId: "E0", referenceType: "epic", label: "Old" }] };
+    const column = { key: "c1" } as never;
+
+    render(<Editor row={row} column={column} onRowChange={onRowChange} onClose={vi.fn()} rowIdx={0} /> as never);
+
+    fireEvent.change(screen.getByPlaceholderText("Search…"), { target: { value: "epic" } });
+    fireEvent.click(await screen.findByText("Epic One"));
+
+    await waitFor(() => expect(onRowChange).toHaveBeenCalled());
+    expect(onRowChange).toHaveBeenCalledWith(
+      { rowId: "r1", c1: [{ referenceId: "E1", referenceType: "epic", label: "Epic One" }] },
+      true,
+    );
+  });
+});

--- a/apps/web/lib/workbooks/cell-links.test.ts
+++ b/apps/web/lib/workbooks/cell-links.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { validateLinkValue, isReferenceValue } from "./cell-links";
+import type { LinkConfig } from "./types";
+
+const many: LinkConfig = { cardinality: "many", referenceType: "epic" };
+const one: LinkConfig = { cardinality: "one", referenceType: "epic" };
+
+describe("isReferenceValue", () => {
+  it("accepts a reference object, rejects arrays/strings/null", () => {
+    expect(isReferenceValue({ referenceId: "E1", referenceType: "epic" })).toBe(true);
+    expect(isReferenceValue([{ referenceId: "E1" }])).toBe(false);
+    expect(isReferenceValue("E1")).toBe(false);
+    expect(isReferenceValue(null)).toBe(false);
+  });
+});
+
+describe("validateLinkValue", () => {
+  it("normalizes a list of references and fills referenceType from config", () => {
+    const out = validateLinkValue(
+      [{ referenceId: "E1", referenceType: "epic" }, { referenceId: "E2" } as never],
+      many,
+    );
+    expect(out).toEqual([
+      { referenceId: "E1", referenceType: "epic" },
+      { referenceId: "E2", referenceType: "epic" },
+    ]);
+  });
+
+  it("treats null/empty as no links", () => {
+    expect(validateLinkValue(null, many)).toEqual([]);
+    expect(validateLinkValue([], many)).toEqual([]);
+  });
+
+  it("de-duplicates repeated targets within a cell", () => {
+    const out = validateLinkValue(
+      [
+        { referenceId: "E1", referenceType: "epic" },
+        { referenceId: "E1", referenceType: "epic" },
+      ],
+      many,
+    );
+    expect(out).toEqual([{ referenceId: "E1", referenceType: "epic" }]);
+  });
+
+  it("rejects a wrong target type (fail-closed)", () => {
+    expect(() =>
+      validateLinkValue([{ referenceId: "C1", referenceType: "customer_account" }], many),
+    ).toThrow(/links to epic/i);
+  });
+
+  it("rejects a non-list value", () => {
+    expect(() => validateLinkValue("E1" as never, many)).toThrow(/list of records/i);
+  });
+
+  it("rejects a malformed item", () => {
+    expect(() => validateLinkValue([{ foo: "bar" } as never], many)).toThrow(/referenceId/i);
+  });
+
+  it("enforces cardinality 'one' (at most a single link)", () => {
+    expect(
+      validateLinkValue([{ referenceId: "E1", referenceType: "epic" }], one),
+    ).toHaveLength(1);
+    expect(() =>
+      validateLinkValue(
+        [
+          { referenceId: "E1", referenceType: "epic" },
+          { referenceId: "E2", referenceType: "epic" },
+        ],
+        one,
+      ),
+    ).toThrow(/only one/i);
+  });
+
+  it("throws when config is missing", () => {
+    expect(() => validateLinkValue([{ referenceId: "E1", referenceType: "epic" }], undefined)).toThrow(
+      /configuration/i,
+    );
+  });
+});

--- a/apps/web/lib/workbooks/cell-links.ts
+++ b/apps/web/lib/workbooks/cell-links.ts
@@ -1,0 +1,54 @@
+// Universal Grid & Workbooks — link cell helpers (EP-GRID-WORKBOOKS)
+//
+// A `link` column points a cell at many target records, stored as rows in
+// WorkbookCellLink (not in WorkbookCell scalar columns). This module is the pure,
+// DB-free validation/normalization shared by the write path; Prisma persistence
+// lives in the adapter. Cardinality "one" caps a cell at a single link; the
+// cross-row 1-M/1-1 uniqueness (a target linked by at most one row) is a write-path
+// + DB concern handled in a later slice.
+
+import type { CellValue, ReferenceValue, LinkConfig } from "./types";
+
+/** A value is a single reference object ({referenceId, referenceType}). */
+export function isReferenceValue(v: unknown): v is ReferenceValue {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    "referenceId" in v &&
+    typeof (v as ReferenceValue).referenceId === "string"
+  );
+}
+
+/**
+ * Validate + normalize a link cell value to a clean, de-duplicated
+ * ReferenceValue[] for a `link` column. Throws (fail-closed) on a bad shape, a
+ * wrong target type, or a cardinality violation. `null`/empty → no links.
+ */
+export function validateLinkValue(
+  value: CellValue,
+  config: LinkConfig | undefined,
+): ReferenceValue[] {
+  if (!config) throw new Error("Link column is missing its target configuration");
+  if (value === null || value === undefined || value === "") return [];
+  if (!Array.isArray(value)) throw new Error("A link value must be a list of records");
+
+  const links: ReferenceValue[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!isReferenceValue(item)) {
+      throw new Error("Each link must be a {referenceId, referenceType}");
+    }
+    const referenceType = item.referenceType ?? config.referenceType;
+    if (referenceType !== config.referenceType) {
+      throw new Error(`This column links to ${config.referenceType}`);
+    }
+    if (seen.has(item.referenceId)) continue; // dedup within the cell
+    seen.add(item.referenceId);
+    links.push({ referenceId: item.referenceId, referenceType });
+  }
+  if (config.cardinality === "one" && links.length > 1) {
+    throw new Error("This column allows only one linked record");
+  }
+  return links;
+}

--- a/apps/web/lib/workbooks/cell-validation.ts
+++ b/apps/web/lib/workbooks/cell-validation.ts
@@ -217,15 +217,16 @@ export function validateCell(
           error: `Expected an array of select keys for ${column.name}`,
         };
       }
+      const keys = value as string[]; // guarded above: every element is a string
       const options = column.config?.options ?? [];
       if (options.length > 0) {
         const valid = new Set(options.map((o) => o.key));
-        const bad = value.find((v) => !valid.has(v));
+        const bad = keys.find((v) => !valid.has(v));
         if (bad !== undefined) {
           return { ok: false, error: `Unknown option "${bad}" for ${column.name}` };
         }
       }
-      storage.multiSelectValue = value;
+      storage.multiSelectValue = keys;
       return { ok: true, storage };
     }
 
@@ -254,6 +255,12 @@ export function validateCell(
     case "rollup": {
       // Computed columns are derived on read and never user-written.
       return { ok: false, error: `${column.name} is a computed column and cannot be set` };
+    }
+
+    case "link": {
+      // Links live in WorkbookCellLink, not in CellStorage — the adapter routes
+      // link columns to the join table (validateLinkValue), never through here.
+      return { ok: false, error: `${column.name} links are stored separately` };
     }
 
     default: {
@@ -308,6 +315,9 @@ export function storageToCellValue(
     case "lookup":
     case "rollup":
       // Computed on read — no stored value.
+      return null;
+    case "link":
+      // Loaded from WorkbookCellLink, not CellStorage.
       return null;
     default:
       return null;

--- a/apps/web/lib/workbooks/custom-table-adapter.ts
+++ b/apps/web/lib/workbooks/custom-table-adapter.ts
@@ -35,34 +35,50 @@ import {
 import { applyFilters, applySort, paginate } from "./grid-query";
 import { resolveReferenceLabels, referenceKey } from "./reference-resolver";
 import { computeDerivedCells } from "./formula/compute";
+import { validateLinkValue } from "./cell-links";
 import { genSemanticId } from "./ids";
 
-function asReference(value: CellValue): ReferenceValue | null {
+function asReference(value: unknown): ReferenceValue | null {
   if (value && typeof value === "object" && !Array.isArray(value) && "referenceId" in value) {
     return value as ReferenceValue;
   }
   return null;
 }
 
-/** Hydrate live display labels for every reference cell (labels are not persisted). */
+/**
+ * Hydrate live display labels for every reference cell — single `reference` cells
+ * and `link` cells (arrays of references). Labels are not persisted.
+ */
 async function hydrateReferenceLabels(rows: GridRow[]): Promise<void> {
   const refs: { referenceType: string; referenceId: string }[] = [];
+  const collect = (ref: ReferenceValue | null) => {
+    if (ref?.referenceId && ref.referenceType) {
+      refs.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
+    }
+  };
   for (const row of rows) {
     for (const value of Object.values(row.cells)) {
-      const ref = asReference(value);
-      if (ref?.referenceId && ref.referenceType) {
-        refs.push({ referenceType: ref.referenceType, referenceId: ref.referenceId });
-      }
+      if (Array.isArray(value)) value.forEach((it) => collect(asReference(it)));
+      else collect(asReference(value));
     }
   }
   if (refs.length === 0) return;
   const labels = await resolveReferenceLabels(refs);
+  const withLabel = (ref: ReferenceValue): ReferenceValue => {
+    const label = labels.get(referenceKey(ref.referenceType, ref.referenceId));
+    return label ? { ...ref, label } : ref;
+  };
   for (const row of rows) {
     for (const [colId, value] of Object.entries(row.cells)) {
-      const ref = asReference(value);
-      if (!ref?.referenceId || !ref.referenceType) continue;
-      const label = labels.get(referenceKey(ref.referenceType, ref.referenceId));
-      if (label) row.cells[colId] = { ...ref, label };
+      if (Array.isArray(value)) {
+        // link cell = array of references; multi_select = array of strings (skipped)
+        if (value.length > 0 && asReference(value[0])) {
+          row.cells[colId] = value.map((it) => withLabel(it as ReferenceValue));
+        }
+      } else {
+        const ref = asReference(value);
+        if (ref?.referenceId && ref.referenceType) row.cells[colId] = withLabel(ref);
+      }
     }
   }
 }
@@ -154,8 +170,10 @@ class CustomTableAdapter implements DataSourceAdapter {
     });
     const gridRows = rows.map((row) => {
       const cells: Record<string, CellValue> = {};
-      // default every column to null so the grid renders empty cells
-      for (const m of metas) cells[m.columnId] = m.fieldType === "multi_select" ? [] : null;
+      // default every column to null (multi_select / link render as empty arrays)
+      for (const m of metas) {
+        cells[m.columnId] = m.fieldType === "multi_select" || m.fieldType === "link" ? [] : null;
+      }
       for (const cell of row.cells) {
         const meta = byInternal.get(cell.columnId);
         if (!meta) continue;
@@ -163,6 +181,25 @@ class CustomTableAdapter implements DataSourceAdapter {
       }
       return { rowId: row.rowId, cells };
     });
+
+    // Link columns: pull targets from WorkbookCellLink and attach as ReferenceValue[].
+    if (metas.some((m) => m.fieldType === "link")) {
+      const gridByInternal = new Map(rows.map((r, i) => [r.id, gridRows[i]]));
+      const internalColToSemantic = new Map(metas.map((m) => [m.internalId, m.columnId]));
+      const links = await prisma.workbookCellLink.findMany({
+        where: { row: { tableId: internalTableId } },
+        orderBy: { position: "asc" },
+      });
+      for (const link of links) {
+        const gr = gridByInternal.get(link.rowId);
+        const semanticCol = internalColToSemantic.get(link.columnId);
+        if (!gr || !semanticCol) continue;
+        const arr = (gr.cells[semanticCol] as ReferenceValue[] | undefined) ?? [];
+        arr.push({ referenceId: link.referenceId, referenceType: link.referenceType });
+        gr.cells[semanticCol] = arr;
+      }
+    }
+
     await hydrateReferenceLabels(gridRows);
     await computeDerivedCells(metas, gridRows);
     return gridRows;
@@ -191,11 +228,29 @@ class CustomTableAdapter implements DataSourceAdapter {
     const metas = await loadColumnMeta(internalTableId);
 
     // Validate every column (required checks included, even if absent from input).
-    // Computed columns (formula/lookup) are derived on read — never stored.
+    // Computed columns are derived on read; link columns persist to WorkbookCellLink.
     const writes: { internalColumnId: string; storage: CellStorage }[] = [];
+    const linkInserts: {
+      columnId: string;
+      referenceId: string;
+      referenceType: string;
+      position: number;
+    }[] = [];
     for (const meta of metas) {
       if (isComputedFieldType(meta.fieldType)) continue;
       const value = meta.columnId in input ? input[meta.columnId] : null;
+      if (meta.fieldType === "link") {
+        const links = validateLinkValue(value, meta.config?.link);
+        links.forEach((l, i) =>
+          linkInserts.push({
+            columnId: meta.internalId,
+            referenceId: l.referenceId,
+            referenceType: l.referenceType,
+            position: i,
+          }),
+        );
+        continue;
+      }
       const result = validateCell(meta, value);
       if (!result.ok) throw new Error(result.error);
       writes.push({ internalColumnId: meta.internalId, storage: result.storage });
@@ -218,6 +273,9 @@ class CustomTableAdapter implements DataSourceAdapter {
             ...storagePayload(w.storage),
           })),
         },
+        ...(linkInserts.length > 0
+          ? { cellLinks: { create: linkInserts } }
+          : {}),
       },
     });
 
@@ -245,6 +303,25 @@ class CustomTableAdapter implements DataSourceAdapter {
         if (!meta) throw new Error(`Unknown column: ${semanticColId}`);
         if (isComputedFieldType(meta.fieldType)) {
           throw new Error(`${meta.name} is a computed column and cannot be edited`);
+        }
+        if (meta.fieldType === "link") {
+          // Replace the cell's link set in WorkbookCellLink (validated, deduped).
+          const links = validateLinkValue(value, meta.config?.link);
+          await tx.workbookCellLink.deleteMany({
+            where: { rowId: row.id, columnId: meta.internalId },
+          });
+          if (links.length > 0) {
+            await tx.workbookCellLink.createMany({
+              data: links.map((l, i) => ({
+                rowId: row.id,
+                columnId: meta.internalId,
+                referenceId: l.referenceId,
+                referenceType: l.referenceType,
+                position: i,
+              })),
+            });
+          }
+          continue;
         }
         const result = validateCell(meta, value);
         if (!result.ok) throw new Error(result.error);

--- a/apps/web/lib/workbooks/kanban-grouping.ts
+++ b/apps/web/lib/workbooks/kanban-grouping.ts
@@ -3,7 +3,7 @@
 // column. No React/DOM here so it is unit-testable; the board component renders
 // the result and wires drag-and-drop.
 
-import type { ColumnDefinition, GridRow, CellValue } from "./types";
+import type { ColumnDefinition, GridRow, CellValue, ReferenceValue } from "./types";
 
 export interface KanbanLane {
   key: string; // the group-by value ("" for unset)
@@ -16,7 +16,15 @@ const UNSET_LABEL = "(unset)";
 
 function cellKey(value: CellValue): string {
   if (value === null || value === undefined) return UNSET_KEY;
-  if (Array.isArray(value)) return value[0] ?? UNSET_KEY;
+  if (Array.isArray(value)) {
+    const first = value[0];
+    if (first === undefined) return UNSET_KEY;
+    // link cell = array of references (links aren't groupable, but stay type-safe)
+    if (typeof first === "object" && first !== null && "referenceId" in first) {
+      return (first as ReferenceValue).referenceId ?? UNSET_KEY;
+    }
+    return String(first);
+  }
   if (typeof value === "object") {
     if ("referenceId" in value) return value.referenceId ?? UNSET_KEY;
     if ("url" in value) return value.url ?? UNSET_KEY;

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -31,6 +31,7 @@ export const FIELD_TYPES = [
   "formula",
   "lookup",
   "rollup",
+  "link",
 ] as const;
 
 export type FieldType = (typeof FIELD_TYPES)[number];
@@ -60,6 +61,17 @@ export interface LookupConfig {
   targetFieldType?: FieldType;
 }
 
+/**
+ * Configuration for a `link` column: link to many target records of one kind.
+ * `cardinality: "one"` = single / enforced-unique (1-1, 1-M); `"many"` = M-M.
+ * `referenceType` is the target kind — a platform entity type ("epic", …) or a
+ * workbook table id (table↔table links). Targets are stored in WorkbookCellLink.
+ */
+export interface LinkConfig {
+  cardinality: "one" | "many";
+  referenceType: string;
+}
+
 /** Column-level configuration, persisted as WorkbookColumn.fieldConfig (JSON). */
 export interface FieldConfig {
   /** select / multi_select options */
@@ -76,6 +88,8 @@ export interface FieldConfig {
   resultType?: FieldType;
   /** lookup columns: where to pull the value from */
   lookup?: LookupConfig;
+  /** link columns: target kind + cardinality (links stored in WorkbookCellLink) */
+  link?: LinkConfig;
 }
 
 /**
@@ -136,6 +150,9 @@ export interface AttachmentValue {
   size?: number;
 }
 
+/** A link cell value: the ordered set of records a `link` column points at (persisted in WorkbookCellLink). */
+export type LinkValue = ReferenceValue[];
+
 /** The union of values a single cell can hold, keyed by field type at runtime. */
 export type CellValue =
   | string
@@ -144,6 +161,7 @@ export type CellValue =
   | string[]
   | ReferenceValue
   | AttachmentValue
+  | LinkValue
   | null;
 
 /** One row as the grid consumes it: a map of columnId -> value, plus the row id. */

--- a/packages/db/prisma/migrations/20260613000000_add_workbook_cell_link/migration.sql
+++ b/packages/db/prisma/migrations/20260613000000_add_workbook_cell_link/migration.sql
@@ -1,0 +1,33 @@
+-- Universal Grid & Workbooks — link-to-many (linked records) substrate.
+-- See docs/superpowers/plans/2026-06-13-universal-grid-workbooks-link-to-many.md.
+-- Additive only: a first-class join table so a (row, column) cell can link to many
+-- target records (1-M / M-M). The single-valued `reference` columns on
+-- WorkbookCell are untouched.
+
+-- CreateTable
+CREATE TABLE "WorkbookCellLink" (
+    "id" TEXT NOT NULL,
+    "rowId" TEXT NOT NULL,
+    "columnId" TEXT NOT NULL,
+    "referenceId" TEXT NOT NULL,
+    "referenceType" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WorkbookCellLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WorkbookCellLink_columnId_referenceId_idx" ON "WorkbookCellLink"("columnId", "referenceId");
+
+-- CreateIndex
+CREATE INDEX "WorkbookCellLink_rowId_columnId_idx" ON "WorkbookCellLink"("rowId", "columnId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkbookCellLink_rowId_columnId_referenceId_key" ON "WorkbookCellLink"("rowId", "columnId", "referenceId");
+
+-- AddForeignKey
+ALTER TABLE "WorkbookCellLink" ADD CONSTRAINT "WorkbookCellLink_rowId_fkey" FOREIGN KEY ("rowId") REFERENCES "WorkbookRow"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkbookCellLink" ADD CONSTRAINT "WorkbookCellLink_columnId_fkey" FOREIGN KEY ("columnId") REFERENCES "WorkbookColumn"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10461,6 +10461,7 @@ model WorkbookColumn {
   defaultValue String?
   width        Int? // pixel width for grid rendering
   cells        WorkbookCell[]
+  cellLinks    WorkbookCellLink[]
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
 
@@ -10476,6 +10477,7 @@ model WorkbookRow {
   createdById String?
   createdBy   User?          @relation("WorkbookRowCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
   cells       WorkbookCell[]
+  cellLinks   WorkbookCellLink[]
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @updatedAt
 
@@ -10504,6 +10506,28 @@ model WorkbookCell {
   @@index([columnId, textValue])
   @@index([columnId, numberValue])
   @@index([columnId, dateValue])
+}
+
+// A single link from a (row, column) cell to one target record — the "link-to-many"
+// substrate (EP-GRID-WORKBOOKS). Many rows per cell model 1-M / M-M; a `reference`
+// column stays single-valued on WorkbookCell. The target is a platform entity
+// (referenceType = "epic", … + referenceId) or another workbook row (referenceType
+// = a workbook table id + referenceId = WorkbookRow.rowId). First-class rows so
+// rollups can group/aggregate over links in SQL.
+model WorkbookCellLink {
+  id            String         @id @default(cuid())
+  rowId         String
+  row           WorkbookRow    @relation(fields: [rowId], references: [id], onDelete: Cascade)
+  columnId      String
+  column        WorkbookColumn @relation(fields: [columnId], references: [id], onDelete: Cascade)
+  referenceId   String // target record id (platform entity id or WorkbookRow.rowId)
+  referenceType String // target kind: "epic", "customer_account", … or a workbook table id
+  position      Int            @default(0)
+  createdAt     DateTime       @default(now())
+
+  @@unique([rowId, columnId, referenceId]) // no duplicate link within a cell
+  @@index([columnId, referenceId]) // reverse lookup + rollup groupBy
+  @@index([rowId, columnId]) // read a cell's links in one scan
 }
 
 model WorkbookView {


### PR DESCRIPTION
## What

The substrate + storage for **linked records** (Option B, approved in [#1842](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1842)) — slices 1 & 2 together, because the storage path can't compile without the table (a schema-only PR would be dead code).

A `link` column points a cell at **many** target records (1‑M / M‑M), persisted as rows in a join table. The single-valued `reference` column is untouched.

## Slice 1 — `WorkbookCellLink` join table

```
WorkbookCellLink { id, rowId, columnId, referenceId, referenceType, position, createdAt }
```
- Cascade FKs to `WorkbookRow` / `WorkbookColumn`.
- `@@index([columnId, referenceId])` (reverse lookup + rollup groupBy), `@@index([rowId, columnId])` (read a cell's links), `@@unique([rowId, columnId, referenceId])` (dedup within a cell).
- Hand-authored additive migration; `prisma validate` + `generate` clean.

## Slice 2 — `link` field type + storage

- **types:** `link` FieldType (editable); `LinkConfig { cardinality: "one"|"many"; referenceType }`; `LinkValue = ReferenceValue[]` in `CellValue`.
- **cell-links.ts:** pure `validateLinkValue` — deduped `ReferenceValue[]`, fail-closed on bad shape / wrong target type / cardinality "one" overflow.
- **custom-table-adapter:** link columns route to `WorkbookCellLink`, not `WorkbookCell` — `materializeRows` loads ordered links → `ReferenceValue[]`; `createRow` inserts; `updateCells` replaces the link set in-transaction; label hydration covers link arrays.
- **cell-validation:** `link` rejected on the scalar path + `storageToCellValue` → null (adapter owns persistence).
- **display:** read-only chips per linked record; **multi-select editor is slice 3.** Object-aware seams updated so links never render/sort/search as `[object Object]` (compareValues, cellSearchText for filter + CSV, kanban formatValue/cellKey).

## Cardinality

One `link` field type; `cardinality: "one"` caps a cell at a single link (1‑1 / 1‑M), `"many"` = M‑M. The cross-row 1‑M/1‑1 *uniqueness* (a target linked by at most one row) is enforced in slice 4.

## Test plan

`vitest` — `cell-links` (normalize/dedup/cardinality/fail-closed/wrong-type); full workbooks suite **179 passed**. `prisma validate` + `generate` ✓; `pnpm --filter web typecheck` ✓. Functional `W-LINK` acceptance rides the single archetype-rebuild path.

Remaining slices: 3 multi-select editor · 4 cardinality enforcement (unique index) · 5 custom-table rollups over links · 6 link filters + CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
