### PR TITLE
feat(build): FleetDensityBar — per-row task completion density on fleet rows (spec §6.1)

### DIFF
--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -327,6 +327,65 @@ describe("BuildListItem fleet density", () => {
     expect(html).toContain("group-hover:flex");
   });
 
+  it("renders the FleetDensityBar during the build phase when a plan is attached", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild({
+          phase: "build",
+          buildPlan: {
+            fileStructure: [],
+            tasks: [
+              { title: "T1", testFirst: "", implement: "", verify: "" },
+              { title: "T2", testFirst: "", implement: "", verify: "" },
+              { title: "T3", testFirst: "", implement: "", verify: "" },
+              { title: "T4", testFirst: "", implement: "", verify: "" },
+            ],
+          },
+          taskResults: [
+            { taskIndex: 0, title: "T1", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as never },
+          ],
+        })}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain('data-testid="fleet-density-bar"');
+    expect(html).toContain('aria-label="Tasks: 1 of 4 done"');
+  });
+
+  it("does NOT render the FleetDensityBar outside the build phase", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild({
+          phase: "review",
+          buildPlan: {
+            fileStructure: [],
+            tasks: [
+              { title: "T1", testFirst: "", implement: "", verify: "" },
+              { title: "T2", testFirst: "", implement: "", verify: "" },
+            ],
+          },
+          taskResults: [
+            { taskIndex: 0, title: "T1", testResult: { passed: true, output: "" }, codeReview: { issues: [] } as never },
+          ],
+        })}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).not.toContain('data-testid="fleet-density-bar"');
+  });
+
   it("renders no hex literals at fleet density (DPF variable invariant)", () => {
     const html = renderToStaticMarkup(
       <BuildListItem

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -5,6 +5,7 @@ import {
   BUILD_STUDIO_TEST_IDS,
   FLEET_ROW_HEIGHT_CLASS,
 } from "./build-studio-layout";
+import { FleetDensityBar } from "./FleetDensityBar";
 import { PhaseMiniRail, type PhaseRailPhase } from "./PhaseMiniRail";
 import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
 
@@ -212,6 +213,9 @@ function FleetDensityRow({
           {build.buildId}
         </span>
         <PhaseMiniRail currentPhase={railPhase} />
+        {build.phase === "build" && (
+          <FleetDensityBar taskResults={build.taskResults} buildPlan={build.buildPlan} />
+        )}
         {build.claimStatus === "claimed" && build.claimedByAgentId && (
           <span
             className="inline-flex h-3.5 items-center justify-center rounded-full bg-[var(--dpf-accent-soft)] px-1.5 text-[9px] font-semibold uppercase text-[var(--dpf-accent)]"

--- a/apps/web/components/build/FleetDensityBar.test.tsx
+++ b/apps/web/components/build/FleetDensityBar.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FleetDensityBar } from "@/components/build/FleetDensityBar";
+import type { BuildPlanDoc, TaskResult } from "@/lib/feature-build-types";
+
+function plan(taskCount: number): BuildPlanDoc {
+  return {
+    fileStructure: [],
+    tasks: Array.from({ length: taskCount }, (_, i) => ({
+      title: `Task ${i + 1}`,
+      testFirst: "",
+      implement: "",
+      verify: "",
+    })),
+  };
+}
+
+function result(title: string, passed: boolean): TaskResult {
+  return {
+    taskIndex: 0,
+    title,
+    testResult: { passed, output: "" },
+    codeReview: { issues: [] } as unknown as TaskResult["codeReview"],
+  };
+}
+
+describe("FleetDensityBar render gate", () => {
+  it("renders nothing when buildPlan is null", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar taskResults={null} buildPlan={null} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders nothing when the plan has zero tasks", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar taskResults={null} buildPlan={plan(0)} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders the bar (0 done) even when taskResults is null — a started build with no results yet", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar taskResults={null} buildPlan={plan(8)} />,
+    );
+    expect(html).toContain('data-testid="fleet-density-bar"');
+    expect(html).toContain('aria-label="Tasks: 0 of 8 done"');
+    expect(html).toContain('data-done="0"');
+    expect(html).toContain('data-total="8"');
+  });
+});
+
+describe("FleetDensityBar counts", () => {
+  it("counts passing results as done and sizes the fill proportionally", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[result("Task 1", true)]}
+        buildPlan={plan(4)}
+      />,
+    );
+    expect(html).toContain('aria-label="Tasks: 1 of 4 done"');
+    // 1/4 → 25% done fill, no failed segment.
+    expect(html).toContain("width:25%");
+    expect(html).toContain("var(--dpf-success)");
+    expect(html).not.toContain("var(--dpf-error)");
+  });
+
+  it("counts failing results separately and adds them to the label", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[result("Task 1", true), result("Task 2", false)]}
+        buildPlan={plan(4)}
+      />,
+    );
+    expect(html).toContain('aria-label="Tasks: 1 of 4 done, 1 failed"');
+    expect(html).toContain('data-done="1"');
+    expect(html).toContain('data-failed="1"');
+    // Both a success and an error segment render.
+    expect(html).toContain("var(--dpf-success)");
+    expect(html).toContain("var(--dpf-error)");
+  });
+
+  it("dedupes a retried task by title — last result wins (fail → pass counts as done)", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[result("Task 1", false), result("Task 1", true)]}
+        buildPlan={plan(4)}
+      />,
+    );
+    // Only one entry for Task 1, and the later pass wins: 1 done, 0 failed.
+    expect(html).toContain('data-done="1"');
+    expect(html).toContain('data-failed="0"');
+    expect(html).toContain('aria-label="Tasks: 1 of 4 done"');
+  });
+
+  it("widens the denominator when results exceed the plan length (segments never exceed 100%)", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[
+          result("Task 1", true),
+          result("Task 2", true),
+          result("Task 3", true),
+        ]}
+        buildPlan={plan(2)}
+      />,
+    );
+    // denom = max(2, 3) = 3 → 100% done; label still reports the plan total.
+    expect(html).toContain('aria-label="Tasks: 3 of 2 done"');
+    expect(html).toContain("width:100%");
+  });
+
+  it("renders a full bar when every task passes", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[result("Task 1", true), result("Task 2", true)]}
+        buildPlan={plan(2)}
+      />,
+    );
+    expect(html).toContain('aria-label="Tasks: 2 of 2 done"');
+    expect(html).toContain("width:100%");
+  });
+});
+
+describe("FleetDensityBar DPF token invariant", () => {
+  it("renders no raw hex literals (uses only --dpf-* tokens)", () => {
+    const html = renderToStaticMarkup(
+      <FleetDensityBar
+        taskResults={[result("Task 1", true), result("Task 2", false)]}
+        buildPlan={plan(4)}
+      />,
+    );
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+  });
+});

--- a/apps/web/components/build/FleetDensityBar.tsx
+++ b/apps/web/components/build/FleetDensityBar.tsx
@@ -1,0 +1,83 @@
+// apps/web/components/build/FleetDensityBar.tsx
+//
+// Compact completion-density bar for a fleet row, shown only during the Build
+// phase. A glanceable proportional fill (done / failed / remaining) that lets
+// the operator compare progress across many builds at once — the fleet-list
+// analogue of the per-task AgentActivityStrip grid.
+//
+// Divergence from spec §6.1's "5×5px cells": a literal per-task cell grid
+// (20–50 cells) overflows the ≤32px fleet row. A fixed-width proportional bar
+// stays bounded regardless of task count while preserving the
+// density-at-a-glance signal; exact counts live in the tooltip + aria-label.
+//
+// Data: FeatureBuildRow.taskResults (done / failed) vs buildPlan.tasks.length
+// (denominator). No CustomEvent subscription — fleet rows refresh on the list
+// refetch cycle, so "running" is not distinguished (folded into "remaining").
+//
+// Spec: docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md §6.1
+"use client";
+
+import type { BuildPlanDoc, TaskResult } from "@/lib/feature-build-types";
+
+type Props = {
+  taskResults: TaskResult[] | null;
+  buildPlan: BuildPlanDoc | null;
+};
+
+export function FleetDensityBar({ taskResults, buildPlan }: Props) {
+  const total = buildPlan?.tasks?.length ?? 0;
+  if (total === 0) return null;
+
+  // Dedupe by title — a retried task can appear twice; last result wins.
+  // Mirrors AgentActivityStrip's resultByTitle reduction so both surfaces
+  // count completion the same way.
+  const byTitle = new Map<string, boolean>();
+  for (const r of taskResults ?? []) {
+    byTitle.set(r.title, r.testResult?.passed ?? true);
+  }
+  let done = 0;
+  let failed = 0;
+  for (const passed of byTitle.values()) {
+    if (passed) done++;
+    else failed++;
+  }
+
+  // taskResults can exceed the plan length if the plan shrank between runs;
+  // widen the denominator so the segments never sum past 100%.
+  const denom = Math.max(total, done + failed);
+  const donePct = (done / denom) * 100;
+  const failedPct = (failed / denom) * 100;
+
+  const label =
+    failed > 0
+      ? `Tasks: ${done} of ${total} done, ${failed} failed`
+      : `Tasks: ${done} of ${total} done`;
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      data-testid="fleet-density-bar"
+      data-done={done}
+      data-failed={failed}
+      data-total={total}
+      className="box-border inline-flex h-1.5 w-11 shrink-0 overflow-hidden rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-3)]"
+    >
+      {donePct > 0 && (
+        <span
+          aria-hidden="true"
+          className="h-full bg-[var(--dpf-success)]"
+          style={{ width: `${donePct}%` }}
+        />
+      )}
+      {failedPct > 0 && (
+        <span
+          aria-hidden="true"
+          className="h-full bg-[var(--dpf-error)]"
+          style={{ width: `${failedPct}%` }}
+        />
+      )}
+    </span>
+  );
+}

--- a/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
+++ b/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
@@ -130,18 +130,22 @@ No other props needed — the component derives everything from `build` and the 
 
 ### §6. Follow-on Surfaces (shaped here, implemented as separate slices)
 
-#### §6.1 Fleet Density Bar
+#### §6.1 Fleet Density Bar — **Implemented** (`apps/web/components/build/FleetDensityBar.tsx`)
 
-Augment each fleet row's `PhaseMiniRail` with a mini density bar (5×5px cells) to the right:
+Augment each fleet row's `PhaseMiniRail` with a compact completion-density bar to the right:
 
 ```tsx
-// In BuildListItem.tsx, next to the existing PhaseMiniRail:
-{build.phase === "build" && build.taskResults && (
+// In BuildListItem.tsx, immediately after <PhaseMiniRail … />:
+{build.phase === "build" && (
   <FleetDensityBar taskResults={build.taskResults} buildPlan={build.buildPlan} />
 )}
 ```
 
-Data: `FeatureBuildRow.taskResults` (done count) vs `buildPlan.tasks.length` (total). No CustomEvent subscription needed — fleet rows poll on refetch cycle.
+**Divergence from the first draft ("5×5px cells"):** a literal per-task cell grid (20–50 cells) overflows the ≤32px fleet row. The implemented form is a fixed-width (44px) proportional bar that stays bounded regardless of task count while preserving the density-at-a-glance signal. Exact counts live in the tooltip + `aria-label` (`"Tasks: 12 of 47 done, 1 failed"`). The full per-task grid remains available in the main panel via `AgentActivityStrip`.
+
+**Segments:** done (`--dpf-success`) / failed (`--dpf-error`) / remaining (muted track). Fleet rows refresh on the list refetch cycle and do **not** subscribe to `build-progress-update` (subscribing every row would be wasteful), so "running" is not distinguished — it folds into "remaining". The component returns `null` unless `buildPlan.tasks.length > 0`, so the outer `phase === "build"` gate is the only call-site condition.
+
+Data: `FeatureBuildRow.taskResults` (done/failed, deduped by title — last result wins, matching `AgentActivityStrip`'s `resultByTitle` reduction) vs `buildPlan.tasks.length` (denominator, widened to `max(total, done+failed)` so segments never exceed 100%).
 
 #### §6.2 ReviewerStatusGrid
 
@@ -178,5 +182,5 @@ Applied to running cells via `style={{ animation: "dpf-cell-pulse 1.4s ease-in-o
 | 4 | `apps/web/components/build/AgentActivityStrip.test.tsx` | Unit tests: wave derivation, cell state priority, render gate |
 
 Follow-on (separate PRs):
-- `FleetDensityBar` in `BuildListItem.tsx`
+- ~~`FleetDensityBar` in `BuildListItem.tsx`~~ — **done** (§6.1): `FleetDensityBar.tsx` + `FleetDensityBar.test.tsx`, wired into the fleet row.
 - `ReviewerStatusGrid` in `WorkflowStageInspector.tsx`


### PR DESCRIPTION
## What

Implements **§6.1** of the [AgentActivityStrip design spec](docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md) — the fleet-list follow-on to [#1835](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1835) (merged).

Adds a compact **44px proportional density bar** to each fleet row during the Build phase, showing **done / failed / remaining** task density. It's the fleet-list analogue of the per-task `AgentActivityStrip` grid that now lives in the main panel: where the strip answers *"what's happening in this build right now,"* the density bar lets the operator compare progress **across many builds at a glance** — which is furthest along, which is stalled at 0.

```
[FB-9B19] [●●●○○]  [▓▓▓▓░░░░░░░]  …title…   ← done fill vs muted remaining
```

## Why this shape (divergence from the spec's first draft)

The spec originally sketched "5×5px cells" per task. A literal per-task grid (20–50 cells) **overflows the ≤32px fleet row**, so the implemented form is a fixed-width proportional bar that stays bounded regardless of task count. Exact counts live in the tooltip + `aria-label` (`"Tasks: 12 of 47 done, 1 failed"`). The full per-task grid remains available in the main panel via `AgentActivityStrip`. Spec §6.1 is updated in this PR to record the divergence and rationale.

## How

- **Data:** `FeatureBuildRow.taskResults` (done/failed, deduped by title — last result wins, matching `AgentActivityStrip`'s `resultByTitle` reduction) vs `buildPlan.tasks.length` (denominator, widened to `max(total, done+failed)` so segments never exceed 100%).
- **No CustomEvent subscription** — fleet rows refresh on the list refetch cycle (subscribing every row would be wasteful), so "running" folds into "remaining".
- **DPF token-only** (`--dpf-success` / `--dpf-error` / `--dpf-surface-3` / `--dpf-border`); no hex literals (asserted by test). Returns `null` unless `phase === "build"` with a non-empty plan, so non-build rows are unchanged.

## Tests

- `FleetDensityBar.test.tsx` — render gate, done/failed counts, proportional widths, title-dedupe (fail→pass), denominator clamp, DPF-token invariant.
- 2 new `BuildListItem.test.tsx` integration tests — bar present during build with a plan, absent otherwise.
- All 26 build-component tests green locally; **zero type errors** in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)