### PR TITLE
feat(archetypes): Phase 2 — provenance schema, service-line actions, admin panel (EP-ARCH-8D4F2A)

### DIFF
--- a/apps/web/app/(shell)/storefront/page.tsx
+++ b/apps/web/app/(shell)/storefront/page.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { StorefrontDashboard } from "@/components/storefront-admin/StorefrontDashboard";
+import { ServiceLinesPanel } from "@/components/storefront-admin/ServiceLinesPanel";
 import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
 import { resolveVocabularyKey } from "@/lib/storefront/resolve-vocabulary";
+import { loadCompositionViewData } from "@/lib/storefront/service-line-actions";
+import { deriveStorefrontCompositionView } from "@/lib/storefront/composition-view";
 
 function getSetupSteps(portalLabel: string, stakeholderLabel: string) {
   return [
@@ -47,28 +50,56 @@ export default async function StorefrontPage() {
   });
 
   if (config) {
-    const [inquiryCount, bookingCount, orderCount, donationCount] = await Promise.all([
-      prisma.storefrontInquiry.count({ where: { storefrontId: config.id } }),
-      prisma.storefrontBooking.count({ where: { storefrontId: config.id } }),
-      prisma.storefrontOrder.count({ where: { storefrontId: config.id } }),
-      prisma.storefrontDonation.count({ where: { storefrontId: config.id } }),
+    const [inquiryCount, bookingCount, orderCount, donationCount, compositionData, allArchetypes] =
+      await Promise.all([
+        prisma.storefrontInquiry.count({ where: { storefrontId: config.id } }),
+        prisma.storefrontBooking.count({ where: { storefrontId: config.id } }),
+        prisma.storefrontOrder.count({ where: { storefrontId: config.id } }),
+        prisma.storefrontDonation.count({ where: { storefrontId: config.id } }),
+        loadCompositionViewData(config.id),
+        prisma.storefrontArchetype.findMany({
+          select: { archetypeId: true, name: true, category: true },
+          orderBy: { name: "asc" },
+        }),
+      ]);
+
+    const compositionView = compositionData
+      ? deriveStorefrontCompositionView(compositionData)
+      : null;
+
+    // Archetypes not already active in the composition
+    const activeSlugSet = new Set([
+      compositionData?.primary.archetypeSlug,
+      ...(compositionData?.secondaries.map((s) => s.archetypeSlug) ?? []),
     ]);
+    const availableArchetypes = allArchetypes
+      .filter((a) => !activeSlugSet.has(a.archetypeId))
+      .map((a) => ({ archetypeSlug: a.archetypeId, name: a.name, category: a.category }));
 
     return (
-      <StorefrontDashboard
-        config={{
-          id: config.id,
-          isPublished: config.isPublished,
-          tagline: config.tagline,
-          orgSlug: config.organization.slug,
-          orgName: config.organization.name,
-          archetypeId: config.archetype?.archetypeId ?? "",
-          ctaType: config.archetype?.ctaType ?? "inquiry",
-          sectionCount: config._count.sections,
-          itemCount: config._count.items,
-        }}
-        counts={{ inquiries: inquiryCount, bookings: bookingCount, orders: orderCount, donations: donationCount }}
-      />
+      <>
+        <StorefrontDashboard
+          config={{
+            id: config.id,
+            isPublished: config.isPublished,
+            tagline: config.tagline,
+            orgSlug: config.organization.slug,
+            orgName: config.organization.name,
+            archetypeId: config.archetype?.archetypeId ?? "",
+            ctaType: config.archetype?.ctaType ?? "inquiry",
+            sectionCount: config._count.sections,
+            itemCount: config._count.items,
+          }}
+          counts={{ inquiries: inquiryCount, bookings: bookingCount, orders: orderCount, donations: donationCount }}
+        />
+        {compositionView && (
+          <ServiceLinesPanel
+            storefrontId={config.id}
+            view={compositionView}
+            availableArchetypes={availableArchetypes}
+          />
+        )}
+      </>
     );
   }
 

--- a/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
+++ b/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  addStorefrontServiceLine,
+  removeStorefrontServiceLine,
+} from "@/lib/storefront/service-line-actions";
+import type { StorefrontCompositionView, StorefrontServiceLineView } from "@/lib/storefront/composition-view";
+import { intentStyle } from "@/components/ui/report-kit/statusColors";
+
+interface AvailableArchetype {
+  archetypeSlug: string;
+  name: string;
+  category: string;
+}
+
+interface Props {
+  storefrontId: string;
+  view: StorefrontCompositionView;
+  availableArchetypes: AvailableArchetype[];
+}
+
+export function ServiceLinesPanel({ storefrontId, view, availableArchetypes }: Props) {
+  const [selectedSlug, setSelectedSlug] = useState(availableArchetypes[0]?.archetypeSlug ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleAdd() {
+    if (!selectedSlug) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await addStorefrontServiceLine(storefrontId, selectedSlug);
+      if ("error" in result) setError(result.error);
+    });
+  }
+
+  function handleRemove(compositionId: string) {
+    setError(null);
+    startTransition(async () => {
+      const result = await removeStorefrontServiceLine(storefrontId, compositionId);
+      if ("error" in result) setError(result.error);
+    });
+  }
+
+  const hasSummaryWarning =
+    view.compatibilitySummary.status !== "good" &&
+    view.compatibilitySummary.status !== "unknown";
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--dpf-border)",
+        borderRadius: 10,
+        overflow: "hidden",
+        marginTop: 24,
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 20px",
+          borderBottom: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 700, color: "var(--dpf-text)" }}>
+            Active service lines
+          </div>
+          <div style={{ fontSize: 12, color: "var(--dpf-muted)", marginTop: 2 }}>
+            Add secondary lines to serve customers across multiple business models.
+          </div>
+        </div>
+        {hasSummaryWarning && (
+          <CompatibilityChip
+            status={view.compatibilitySummary.status}
+            label={view.compatibilitySummary.label}
+          />
+        )}
+      </div>
+
+      {/* Lines list */}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <ServiceLineRow line={view.primary} onRemove={undefined} isPending={isPending} />
+        {view.secondaries.map((line) => (
+          <ServiceLineRow
+            key={line.compositionId}
+            line={line}
+            onRemove={() => handleRemove(line.compositionId)}
+            isPending={isPending}
+          />
+        ))}
+      </div>
+
+      {/* Compatibility reasons */}
+      {view.compatibilitySummary.reasons.length > 0 && (
+        <div
+          style={{
+            padding: "10px 20px",
+            borderTop: "1px solid var(--dpf-border)",
+            background: "color-mix(in srgb, var(--dpf-warning) 8%, transparent)",
+          }}
+        >
+          {view.compatibilitySummary.reasons.map((reason, i) => (
+            <div key={i} style={{ fontSize: 12, color: "var(--dpf-text)", marginBottom: i < view.compatibilitySummary.reasons.length - 1 ? 4 : 0 }}>
+              {reason}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add service line row */}
+      {availableArchetypes.length > 0 && (
+        <div
+          style={{
+            padding: "12px 20px",
+            borderTop: "1px solid var(--dpf-border)",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
+            background: "var(--dpf-surface-1)",
+          }}
+        >
+          <select
+            value={selectedSlug}
+            onChange={(e) => setSelectedSlug(e.target.value)}
+            disabled={isPending}
+            style={{
+              flex: 1,
+              minWidth: 180,
+              padding: "7px 10px",
+              border: "1px solid var(--dpf-border)",
+              borderRadius: 6,
+              fontSize: 13,
+              background: "var(--dpf-surface-1)",
+              color: "var(--dpf-text)",
+            }}
+          >
+            {availableArchetypes.map((a) => (
+              <option key={a.archetypeSlug} value={a.archetypeSlug}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleAdd}
+            disabled={isPending || !selectedSlug}
+            style={{
+              padding: "7px 16px",
+              borderRadius: 6,
+              border: "none",
+              background: "var(--dpf-accent)",
+              color: "white",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: isPending || !selectedSlug ? "not-allowed" : "pointer",
+              opacity: isPending || !selectedSlug ? 0.6 : 1,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {isPending ? "Adding…" : "Add service line"}
+          </button>
+          {error && (
+            <div style={{ width: "100%", fontSize: 12, color: "var(--dpf-error)", marginTop: 4 }}>
+              {error}
+            </div>
+          )}
+        </div>
+      )}
+
+      {availableArchetypes.length === 0 && view.secondaries.length >= 2 && (
+        <div
+          style={{
+            padding: "10px 20px",
+            borderTop: "1px solid var(--dpf-border)",
+            fontSize: 12,
+            color: "var(--dpf-muted)",
+            background: "var(--dpf-surface-1)",
+          }}
+        >
+          Maximum of 2 secondary service lines reached.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ServiceLineRow({
+  line,
+  onRemove,
+  isPending,
+}: {
+  line: StorefrontServiceLineView;
+  onRemove?: () => void;
+  isPending: boolean;
+}) {
+  const chip = intentStyle(line.statusIntent);
+  const isSecondary = line.role === "secondary";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "12px 20px",
+        borderBottom: "1px solid var(--dpf-border)",
+      }}
+    >
+      {/* Role pill */}
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          padding: "2px 6px",
+          borderRadius: 4,
+          background: isSecondary
+            ? "color-mix(in srgb, var(--dpf-accent) 15%, transparent)"
+            : "color-mix(in srgb, var(--dpf-success) 15%, transparent)",
+          color: isSecondary ? "var(--dpf-accent)" : "var(--dpf-success)",
+          whiteSpace: "nowrap",
+          flexShrink: 0,
+        }}
+      >
+        {isSecondary ? "Secondary" : "Primary"}
+      </div>
+
+      {/* Name + category */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            color: "var(--dpf-text)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {line.operatorLabel}
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--dpf-muted)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {line.category}
+        </div>
+      </div>
+
+      {/* Modules count */}
+      {line.contributedModules.length > 0 && (
+        <div style={{ fontSize: 12, color: "var(--dpf-muted)", whiteSpace: "nowrap", flexShrink: 0 }}>
+          {line.contributedModules.length} module{line.contributedModules.length !== 1 ? "s" : ""}
+        </div>
+      )}
+
+      {/* Compatibility badge (secondaries only) */}
+      {isSecondary && (
+        <CompatibilityChip status={line.status} label={line.statusLabel} />
+      )}
+
+      {/* Remove button (secondaries only) */}
+      {isSecondary && onRemove && (
+        <button
+          onClick={onRemove}
+          disabled={isPending}
+          aria-label={`Remove ${line.operatorLabel}`}
+          style={{
+            padding: "4px 10px",
+            borderRadius: 5,
+            border: "1px solid var(--dpf-error)",
+            background: "transparent",
+            color: "var(--dpf-error)",
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: isPending ? "not-allowed" : "pointer",
+            opacity: isPending ? 0.5 : 1,
+            whiteSpace: "nowrap",
+            flexShrink: 0,
+          }}
+        >
+          Remove
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CompatibilityChip({
+  status,
+  label,
+}: {
+  status: StorefrontServiceLineView["status"];
+  label: string;
+}) {
+  const style = intentStyle(
+    status === "good"
+      ? "success"
+      : status === "concern"
+        ? "warning"
+        : status === "acute"
+          ? "danger"
+          : status === "in-motion"
+            ? "accent"
+            : "neutral",
+  );
+
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "3px 8px",
+        borderRadius: 20,
+        fontSize: 11,
+        fontWeight: 600,
+        background: style.softBg,
+        color: style.fg,
+        border: `1px solid ${style.border}`,
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -227,6 +227,17 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     high: "warning",
     critical: "danger",
   },
+  // Multi-archetype composition compatibility (EP-ARCH-8D4F2A §4.3).
+  // good = same-category or low-conflict; concern = cross-category differences;
+  // acute = trust/compliance/identity block; in-motion = seeding in progress;
+  // unknown = metadata missing (never green).
+  compositionCompatibility: {
+    good: "success",
+    concern: "warning",
+    acute: "danger",
+    "in-motion": "accent",
+    unknown: "neutral",
+  },
 };
 
 /**

--- a/apps/web/lib/storefront/composition-view.test.ts
+++ b/apps/web/lib/storefront/composition-view.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import { deriveStorefrontCompositionView } from "./composition-view";
+import type { StorefrontCompositionTemplateRef } from "./composition-view";
+import type { ActivationProfile } from "@dpf/storefront-templates";
+
+function makeProfile(
+  modules: string[],
+  serviceCategories: string[] = [],
+): ActivationProfile {
+  return {
+    profileType: "standard",
+    modules: modules as ActivationProfile["modules"],
+    seededServiceCategories: serviceCategories,
+    billingReadinessMode: "off",
+    customerGraph: "simple",
+    seededConfigurationItemTypes: [],
+  };
+}
+
+function makeRef(
+  overrides: Partial<StorefrontCompositionTemplateRef> & Pick<StorefrontCompositionTemplateRef, "compositionId" | "archetypeSlug" | "category">,
+): StorefrontCompositionTemplateRef {
+  return {
+    name: overrides.archetypeSlug,
+    activationProfile: makeProfile(["crm"]),
+    ...overrides,
+  };
+}
+
+const PRIMARY = makeRef({
+  compositionId: "comp-1",
+  archetypeSlug: "hoa",
+  category: "hoa-property-management",
+  name: "HOA Management",
+  activationProfile: makeProfile(["crm", "payments"]),
+});
+
+describe("deriveStorefrontCompositionView", () => {
+  it("returns single-line view for no secondaries", () => {
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [],
+    });
+    expect(view.primary.role).toBe("primary");
+    expect(view.primary.status).toBe("good");
+    expect(view.secondaries).toHaveLength(0);
+    expect(view.compatibilitySummary.label).toBe("Single service line");
+    expect(view.compatibilitySummary.status).toBe("good");
+  });
+
+  it("same-category secondary → good status", () => {
+    const secondary = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "hoa-2",
+      category: "hoa-property-management",
+      name: "HOA Commercial",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [secondary],
+    });
+    expect(view.secondaries[0].status).toBe("good");
+    expect(view.compatibilitySummary.status).toBe("good");
+    expect(view.compatibilitySummary.reasons).toHaveLength(0);
+  });
+
+  it("cross-category secondary → concern status", () => {
+    const secondary = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "trades",
+      category: "trades-maintenance",
+      name: "Trades",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [secondary],
+    });
+    expect(view.secondaries[0].status).toBe("concern");
+    expect(view.compatibilitySummary.status).toBe("concern");
+    expect(view.compatibilitySummary.reasons).toHaveLength(1);
+  });
+
+  it("banking + healthcare → acute status", () => {
+    const bankingPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "bank",
+      category: "banking-financial-services",
+      name: "Bank",
+    });
+    const healthcareSecondary = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "health",
+      category: "healthcare-wellness",
+      name: "Health",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: bankingPrimary,
+      secondaries: [healthcareSecondary],
+    });
+    expect(view.secondaries[0].status).toBe("acute");
+    expect(view.compatibilitySummary.status).toBe("acute");
+  });
+
+  it("public-sector cross-category → acute status", () => {
+    const pubPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "gov",
+      category: "public-sector",
+      name: "Government",
+    });
+    const retailSecondary = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "retail",
+      category: "retail-goods",
+      name: "Retail",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: pubPrimary,
+      secondaries: [retailSecondary],
+    });
+    expect(view.secondaries[0].status).toBe("acute");
+  });
+
+  it("worst-case status bubbles to summary with two secondaries", () => {
+    const concern = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "trades",
+      category: "trades-maintenance",
+      name: "Trades",
+    });
+    const acute = makeRef({
+      compositionId: "comp-3",
+      archetypeSlug: "health",
+      category: "healthcare-wellness",
+      name: "Health",
+    });
+    const bankPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "bank",
+      category: "banking-financial-services",
+      name: "Bank",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: bankPrimary,
+      secondaries: [concern, acute],
+    });
+    expect(view.compatibilitySummary.status).toBe("acute");
+    expect(view.compatibilitySummary.reasons).toHaveLength(2);
+  });
+
+  it("missing activationProfile → unknown status, no crash", () => {
+    const noProfile = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "unknown-arch",
+      category: "some-category",
+      name: "Unknown",
+      activationProfile: null,
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [noProfile],
+    });
+    expect(view.secondaries[0].status).toBe("unknown");
+    expect(view.secondaries[0].warnings).toContain(
+      "Archetype metadata is incomplete — compatibility cannot be assessed.",
+    );
+  });
+
+  it("seededCounts are surfaced on rows", () => {
+    const secondary = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "trades",
+      category: "trades-maintenance",
+      name: "Trades",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [secondary],
+      seededCountsByCompositionId: {
+        "comp-1": { items: 4, sections: 3 },
+        "comp-2": { items: 6, sections: 2 },
+      },
+    });
+    expect(view.primary.contributedItemCount).toBe(4);
+    expect(view.primary.contributedSectionCount).toBe(3);
+    expect(view.secondaries[0].contributedItemCount).toBe(6);
+    expect(view.secondaries[0].contributedSectionCount).toBe(2);
+  });
+
+  it("visual pattern: banking → trust-gate-board", () => {
+    const bankPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "bank",
+      category: "banking-financial-services",
+      name: "Bank",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: bankPrimary,
+      secondaries: [],
+    });
+    expect(view.primary.visualPattern).toBe("trust-gate-board");
+  });
+
+  it("visual pattern: fitness → slot-board", () => {
+    const fitnessPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "fitness",
+      category: "fitness-recreation",
+      name: "Fitness",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: fitnessPrimary,
+      secondaries: [],
+    });
+    expect(view.primary.visualPattern).toBe("slot-board");
+  });
+
+  it("visual pattern: trades with service-operations → map-dispatch", () => {
+    const tradesPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "trades",
+      category: "trades-maintenance",
+      name: "Trades",
+      activationProfile: makeProfile(["crm", "service-operations"]),
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: tradesPrimary,
+      secondaries: [],
+    });
+    expect(view.primary.visualPattern).toBe("map-dispatch");
+  });
+
+  it("primary.operatorLabel equals archetype name", () => {
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: PRIMARY,
+      secondaries: [],
+    });
+    expect(view.primary.operatorLabel).toBe("HOA Management");
+  });
+
+  it("statusIntent maps correctly: good→success, concern→warning, acute→danger", () => {
+    const bankPrimary = makeRef({
+      compositionId: "comp-1",
+      archetypeSlug: "bank",
+      category: "banking-financial-services",
+      name: "Bank",
+    });
+    const secondaryConcern = makeRef({
+      compositionId: "comp-2",
+      archetypeSlug: "trades",
+      category: "trades-maintenance",
+      name: "Trades",
+    });
+    const secondaryAcute = makeRef({
+      compositionId: "comp-3",
+      archetypeSlug: "health",
+      category: "healthcare-wellness",
+      name: "Health",
+    });
+    const view = deriveStorefrontCompositionView({
+      storefrontId: "sf-1",
+      primary: bankPrimary,
+      secondaries: [secondaryConcern, secondaryAcute],
+    });
+    expect(view.secondaries[0].statusIntent).toBe("warning");
+    expect(view.secondaries[1].statusIntent).toBe("danger");
+  });
+});

--- a/apps/web/lib/storefront/composition-view.test.ts
+++ b/apps/web/lib/storefront/composition-view.test.ts
@@ -13,6 +13,7 @@ function makeProfile(
     seededServiceCategories: serviceCategories,
     billingReadinessMode: "none",
     customerGraph: "none",
+    estateSeparation: "shared",
     seededConfigurationItemTypes: [],
   };
 }

--- a/apps/web/lib/storefront/composition-view.test.ts
+++ b/apps/web/lib/storefront/composition-view.test.ts
@@ -11,8 +11,8 @@ function makeProfile(
     profileType: "standard",
     modules: modules as ActivationProfile["modules"],
     seededServiceCategories: serviceCategories,
-    billingReadinessMode: "off",
-    customerGraph: "simple",
+    billingReadinessMode: "none",
+    customerGraph: "none",
     seededConfigurationItemTypes: [],
   };
 }

--- a/apps/web/lib/storefront/composition-view.ts
+++ b/apps/web/lib/storefront/composition-view.ts
@@ -1,0 +1,252 @@
+// Pure helper: derive a human-readable composition view from archetype template
+// data. No Prisma imports — callers load data and pass it in.
+
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type { ActivationProfile, ArchetypeModule } from "@dpf/storefront-templates";
+
+export type CompositionCompatibilityStatus =
+  | "good"
+  | "concern"
+  | "acute"
+  | "in-motion"
+  | "unknown";
+
+export type VisualPattern =
+  | "standard-flow"
+  | "slot-board"
+  | "map-dispatch"
+  | "asset-pool-board"
+  | "stock-reorder-board"
+  | "case-queue"
+  | "trust-gate-board";
+
+export interface StorefrontCompositionTemplateRef {
+  compositionId: string;
+  archetypeSlug: string;
+  name: string;
+  category: string;
+  activationProfile: ActivationProfile | null;
+}
+
+export interface StorefrontServiceLineView {
+  compositionId: string;
+  role: "primary" | "secondary";
+  archetypeSlug: string;
+  name: string;
+  category: string;
+  operatorLabel: string;
+  visualPattern: VisualPattern;
+  status: CompositionCompatibilityStatus;
+  statusLabel: string;
+  statusIntent: Intent;
+  statusIconName: string;
+  contributedModules: ArchetypeModule[];
+  contributedServiceCategories: string[];
+  contributedItemCount: number;
+  contributedSectionCount: number;
+  warnings: string[];
+}
+
+export interface StorefrontCompositionView {
+  storefrontId: string;
+  primary: StorefrontServiceLineView;
+  secondaries: StorefrontServiceLineView[];
+  compatibilitySummary: {
+    status: CompositionCompatibilityStatus;
+    label: string;
+    reasons: string[];
+  };
+}
+
+// ─── Visual pattern ───────────────────────────────────────────────────────────
+
+function resolveVisualPattern(
+  category: string,
+  modules: ArchetypeModule[],
+): VisualPattern {
+  if (category === "banking-financial-services" || category === "public-sector") {
+    return "trust-gate-board";
+  }
+  if (category === "asset-rental") return "asset-pool-board";
+  if (category === "retail-goods") return "stock-reorder-board";
+  if (
+    category === "hoa-property-management" ||
+    (category === "professional-services" && !modules.includes("projects"))
+  ) {
+    return "case-queue";
+  }
+  if (
+    modules.includes("service-operations") &&
+    (category === "trades-maintenance" || category === "facilities-maintenance")
+  ) {
+    return "map-dispatch";
+  }
+  if (
+    category === "fitness-recreation" ||
+    category === "beauty-personal-care" ||
+    (category === "healthcare-wellness" && !modules.includes("customer-estate"))
+  ) {
+    return "slot-board";
+  }
+  return "standard-flow";
+}
+
+// ─── Compatibility ────────────────────────────────────────────────────────────
+
+// Trust/compliance blocks: combinations where identity, regulatory model, or
+// customer-data governance would be misleading without an explicit design.
+const ACUTE_PAIRS = new Set<string>([
+  "banking-financial-services|healthcare-wellness",
+  "healthcare-wellness|banking-financial-services",
+  "public-sector|banking-financial-services",
+  "banking-financial-services|public-sector",
+  "public-sector|retail-goods",
+  "public-sector|fitness-recreation",
+  "public-sector|beauty-personal-care",
+  "public-sector|food-hospitality",
+  "public-sector|professional-services",
+]);
+
+function resolveCompatibility(
+  primaryCategory: string,
+  secondaryCategory: string,
+): { status: CompositionCompatibilityStatus; reason: string } {
+  if (primaryCategory === secondaryCategory) {
+    return { status: "good", reason: "Same service category — no capability conflicts." };
+  }
+  const pair = `${primaryCategory}|${secondaryCategory}`;
+  if (ACUTE_PAIRS.has(pair)) {
+    return {
+      status: "acute",
+      reason: `${primaryCategory} and ${secondaryCategory} carry different trust, compliance, or identity models. Confirm your operating design before enabling.`,
+    };
+  }
+  return {
+    status: "concern",
+    reason: `Cross-category addition: ${secondaryCategory} introduces different capability requirements, vocabulary, and operating axes. Review before confirming.`,
+  };
+}
+
+// ─── Operator label ───────────────────────────────────────────────────────────
+
+const STATUS_LABELS: Record<CompositionCompatibilityStatus, string> = {
+  good: "Compatible",
+  concern: "Review recommended",
+  acute: "Confirm design first",
+  "in-motion": "Applying…",
+  unknown: "Metadata missing",
+};
+
+const STATUS_ICONS: Record<CompositionCompatibilityStatus, string> = {
+  good: "check-circle",
+  concern: "alert-triangle",
+  acute: "shield-alert",
+  "in-motion": "loader",
+  unknown: "help-circle",
+};
+
+const STATUS_INTENTS: Record<CompositionCompatibilityStatus, Intent> = {
+  good: "success",
+  concern: "warning",
+  acute: "danger",
+  "in-motion": "accent",
+  unknown: "neutral",
+};
+
+// ─── Main derive function ─────────────────────────────────────────────────────
+
+export function deriveStorefrontCompositionView(input: {
+  storefrontId: string;
+  primary: StorefrontCompositionTemplateRef;
+  secondaries: StorefrontCompositionTemplateRef[];
+  seededCountsByCompositionId?: Record<string, { items: number; sections: number }>;
+}): StorefrontCompositionView {
+  const { storefrontId, primary, secondaries, seededCountsByCompositionId = {} } = input;
+
+  function buildLineView(
+    ref: StorefrontCompositionTemplateRef,
+    role: "primary" | "secondary",
+    secondaryStatus?: CompositionCompatibilityStatus,
+    secondaryWarnings?: string[],
+  ): StorefrontServiceLineView {
+    if (!ref.activationProfile) {
+      const counts = seededCountsByCompositionId[ref.compositionId] ?? { items: 0, sections: 0 };
+      return {
+        compositionId: ref.compositionId,
+        role,
+        archetypeSlug: ref.archetypeSlug,
+        name: ref.name,
+        category: ref.category,
+        operatorLabel: ref.name,
+        visualPattern: "standard-flow",
+        status: "unknown",
+        statusLabel: STATUS_LABELS.unknown,
+        statusIntent: STATUS_INTENTS.unknown,
+        statusIconName: STATUS_ICONS.unknown,
+        contributedModules: [],
+        contributedServiceCategories: [],
+        contributedItemCount: counts.items,
+        contributedSectionCount: counts.sections,
+        warnings: ["Archetype metadata is incomplete — compatibility cannot be assessed."],
+      };
+    }
+
+    const profile = ref.activationProfile;
+    const counts = seededCountsByCompositionId[ref.compositionId] ?? { items: 0, sections: 0 };
+    const status = secondaryStatus ?? "good";
+
+    return {
+      compositionId: ref.compositionId,
+      role,
+      archetypeSlug: ref.archetypeSlug,
+      name: ref.name,
+      category: ref.category,
+      operatorLabel: ref.name,
+      visualPattern: resolveVisualPattern(ref.category, profile.modules),
+      status,
+      statusLabel: STATUS_LABELS[status],
+      statusIntent: STATUS_INTENTS[status],
+      statusIconName: STATUS_ICONS[status],
+      contributedModules: profile.modules,
+      contributedServiceCategories: profile.seededServiceCategories ?? [],
+      contributedItemCount: counts.items,
+      contributedSectionCount: counts.sections,
+      warnings: secondaryWarnings ?? [],
+    };
+  }
+
+  const primaryView = buildLineView(primary, "primary");
+
+  const secondaryViews: StorefrontServiceLineView[] = secondaries.map((sec) => {
+    const { status, reason } = resolveCompatibility(primary.category, sec.category);
+    const warnings = status !== "good" ? [reason] : [];
+    return buildLineView(sec, "secondary", status, warnings);
+  });
+
+  const worstStatus = secondaryViews.reduce<CompositionCompatibilityStatus>(
+    (worst, v) => {
+      const rank: Record<CompositionCompatibilityStatus, number> = {
+        unknown: 1, "in-motion": 1, good: 2, concern: 3, acute: 4,
+      };
+      return rank[v.status] > rank[worst] ? v.status : worst;
+    },
+    "good",
+  );
+
+  const summaryReasons = secondaryViews.flatMap((v) => v.warnings);
+  const summaryLabel =
+    secondaryViews.length === 0
+      ? "Single service line"
+      : STATUS_LABELS[worstStatus];
+
+  return {
+    storefrontId,
+    primary: primaryView,
+    secondaries: secondaryViews,
+    compatibilitySummary: {
+      status: worstStatus,
+      label: summaryLabel,
+      reasons: summaryReasons,
+    },
+  };
+}

--- a/apps/web/lib/storefront/service-line-actions.ts
+++ b/apps/web/lib/storefront/service-line-actions.ts
@@ -1,0 +1,265 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+import { nanoid } from "nanoid";
+import { readActivationProfile, mergeActivationProfiles } from "@dpf/storefront-templates";
+
+const MAX_SECONDARY_LINES = 2;
+
+type ActionResult = { success: true } | { error: string };
+
+async function requireAdmin(): Promise<{ organizationId: string } | { error: string }> {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return { error: "Unauthorized" };
+  }
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) return { error: "Organization not found" };
+  return { organizationId: org.id };
+}
+
+/**
+ * Add a secondary archetype service line to the storefront.
+ * Seeds the secondary's item and section templates with sourceCompositionId
+ * provenance so removeStorefrontServiceLine can scope cleanup precisely.
+ */
+export async function addStorefrontServiceLine(
+  storefrontId: string,
+  secondaryArchetypeSlug: string,
+): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth;
+
+  const storefront = await prisma.storefrontConfig.findFirst({
+    where: { id: storefrontId, organizationId: auth.organizationId },
+    select: { id: true, archetypeId: true },
+  });
+  if (!storefront) return { error: "Storefront not found" };
+
+  const secondaryArchetype = await prisma.storefrontArchetype.findUnique({
+    where: { archetypeId: secondaryArchetypeSlug },
+  });
+  if (!secondaryArchetype) return { error: "Archetype not found" };
+
+  // Guard: cannot add the primary as a secondary
+  if (secondaryArchetype.id === storefront.archetypeId) {
+    return { error: "Primary archetype cannot be added as a secondary" };
+  }
+
+  // Guard: max service lines
+  const activeSecondaries = await prisma.storefrontArchetypeComposition.count({
+    where: { storefrontId, role: "secondary", removedAt: null },
+  });
+  if (activeSecondaries >= MAX_SECONDARY_LINES) {
+    return { error: `Maximum ${MAX_SECONDARY_LINES} secondary service lines allowed` };
+  }
+
+  // Guard: already added and active
+  const existing = await prisma.storefrontArchetypeComposition.findUnique({
+    where: { storefrontId_archetypeId: { storefrontId, archetypeId: secondaryArchetype.id } },
+  });
+  if (existing && !existing.removedAt) {
+    return { error: "This service line is already active" };
+  }
+
+  // Get highest existing sortOrder
+  const lastComposition = await prisma.storefrontArchetypeComposition.findFirst({
+    where: { storefrontId },
+    orderBy: { sortOrder: "desc" },
+    select: { sortOrder: true },
+  });
+  const nextSortOrder = (lastComposition?.sortOrder ?? 0) + 1;
+
+  // Write (or reactivate) the composition row
+  const composition = existing
+    ? await prisma.storefrontArchetypeComposition.update({
+        where: { id: existing.id },
+        data: { removedAt: null, sortOrder: nextSortOrder, updatedAt: new Date() },
+      })
+    : await prisma.storefrontArchetypeComposition.create({
+        data: {
+          storefrontId,
+          archetypeId: secondaryArchetype.id,
+          role: "secondary",
+          sortOrder: nextSortOrder,
+        },
+      });
+
+  // Seed item templates from the secondary archetype
+  const itemTemplates = secondaryArchetype.itemTemplates as Array<{
+    name: string;
+    description?: string;
+    priceType: string;
+    ctaType?: string;
+    ctaLabel?: string;
+    priceAmount?: number | null;
+  }>;
+
+  if (itemTemplates.length > 0) {
+    await prisma.storefrontItem.createMany({
+      data: itemTemplates.map((t, i) => ({
+        itemId: `itm-${nanoid(8)}`,
+        storefrontId,
+        name: t.name,
+        description: t.description ?? null,
+        priceType: t.priceType,
+        ctaType: t.ctaType ?? secondaryArchetype.ctaType,
+        ctaLabel: t.ctaLabel ?? null,
+        priceAmount: t.priceAmount ?? null,
+        sortOrder: 1000 + i,
+        isActive: true,
+        priceCurrency: "GBP",
+        sourceCompositionId: composition.id,
+      })),
+    });
+  }
+
+  // Seed section templates from the secondary — hidden by default so operator reveals them
+  const sectionTemplates = secondaryArchetype.sectionTemplates as Array<{
+    type: string;
+    title: string;
+    sortOrder: number;
+  }>;
+
+  const lastSection = await prisma.storefrontSection.findFirst({
+    where: { storefrontId },
+    orderBy: { sortOrder: "desc" },
+    select: { sortOrder: true },
+  });
+  const sectionBase = (lastSection?.sortOrder ?? 0) + 1;
+
+  if (sectionTemplates.length > 0) {
+    await prisma.storefrontSection.createMany({
+      data: sectionTemplates.map((s, i) => ({
+        storefrontId,
+        type: s.type,
+        title: s.title,
+        sortOrder: sectionBase + i,
+        content: {},
+        isVisible: false,
+        sourceCompositionId: composition.id,
+      })),
+    });
+  }
+
+  revalidatePath("/storefront");
+  return { success: true };
+}
+
+/**
+ * Remove a secondary service line by soft-deleting its composition row and
+ * deactivating/hiding all items and sections seeded from it.
+ * Primary service lines cannot be removed.
+ */
+export async function removeStorefrontServiceLine(
+  storefrontId: string,
+  compositionId: string,
+): Promise<ActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth;
+
+  const composition = await prisma.storefrontArchetypeComposition.findFirst({
+    where: {
+      id: compositionId,
+      storefrontId,
+      storefront: { organizationId: auth.organizationId },
+      removedAt: null,
+    },
+  });
+  if (!composition) return { error: "Service line not found" };
+  if (composition.role === "primary") return { error: "Primary service line cannot be removed" };
+
+  // Deactivate seeded items and hide seeded sections
+  await Promise.all([
+    prisma.storefrontItem.updateMany({
+      where: { sourceCompositionId: compositionId },
+      data: { isActive: false },
+    }),
+    prisma.storefrontSection.updateMany({
+      where: { sourceCompositionId: compositionId },
+      data: { isVisible: false },
+    }),
+    prisma.storefrontArchetypeComposition.update({
+      where: { id: compositionId },
+      data: { removedAt: new Date() },
+    }),
+  ]);
+
+  revalidatePath("/storefront");
+  return { success: true };
+}
+
+/**
+ * Load the full composition view data for a storefront, ready to pass to
+ * deriveStorefrontCompositionView. Returns null if the storefront has no
+ * composition rows (pre-migration or incomplete setup).
+ */
+export async function loadCompositionViewData(storefrontId: string) {
+  const rows = await prisma.storefrontArchetypeComposition.findMany({
+    where: { storefrontId, removedAt: null },
+    orderBy: [{ sortOrder: "asc" }],
+    include: {
+      archetype: {
+        select: {
+          archetypeId: true,
+          name: true,
+          category: true,
+          activationProfile: true,
+        },
+      },
+      _count: { select: { seededItems: true, seededSections: true } },
+    },
+  });
+
+  if (rows.length === 0) return null;
+
+  const seededCountsByCompositionId: Record<string, { items: number; sections: number }> = {};
+  for (const row of rows) {
+    seededCountsByCompositionId[row.id] = {
+      items: row._count.seededItems,
+      sections: row._count.seededSections,
+    };
+  }
+
+  const primary = rows.find((r) => r.role === "primary");
+  const secondaries = rows.filter((r) => r.role === "secondary");
+
+  if (!primary) return null;
+
+  return {
+    storefrontId,
+    primary: {
+      compositionId: primary.id,
+      archetypeSlug: primary.archetype.archetypeId,
+      name: primary.archetype.name,
+      category: primary.archetype.category,
+      activationProfile: readActivationProfile(primary.archetype.activationProfile),
+    },
+    secondaries: secondaries.map((s) => ({
+      compositionId: s.id,
+      archetypeSlug: s.archetype.archetypeId,
+      name: s.archetype.name,
+      category: s.archetype.category,
+      activationProfile: readActivationProfile(s.archetype.activationProfile),
+    })),
+    seededCountsByCompositionId,
+  };
+}
+
+/**
+ * Get the current merged activation profile for a storefront from its
+ * active composition rows. Falls back to null for pre-migration storefronts.
+ */
+export async function getCompositeActivationProfileForStorefront(storefrontId: string) {
+  const data = await loadCompositionViewData(storefrontId);
+  if (!data) return null;
+
+  const allProfiles = [data.primary, ...data.secondaries]
+    .map((r) => r.activationProfile)
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+
+  if (allProfiles.length === 0) return null;
+  return mergeActivationProfiles(allProfiles);
+}

--- a/apps/web/lib/tak/marketing-playbooks.test.ts
+++ b/apps/web/lib/tak/marketing-playbooks.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPlaybook,
+  getPlaybookForCategory,
+  getCompositePlaybook,
+} from "./marketing-playbooks";
+
+describe("getPlaybook", () => {
+  it("returns category playbook when category is known", () => {
+    const pb = getPlaybook("hoa-property-management", "inquiry");
+    expect(pb.primaryGoal).toContain("Homeowner");
+  });
+
+  it("falls back to CTA type when category is unknown", () => {
+    const pb = getPlaybook("unknown-category", "booking");
+    expect(pb.primaryGoal).toContain("appointment");
+  });
+
+  it("falls back to inquiry when both are unknown", () => {
+    const pb = getPlaybook(null, null);
+    expect(pb.ctaLanguage).toContain("Get a quote");
+  });
+});
+
+describe("getCompositePlaybook", () => {
+  it("returns primary unchanged when no secondaries", () => {
+    const composite = getCompositePlaybook("fitness-recreation", []);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    expect(composite).toBe(primary);
+  });
+
+  it("primary identity fields are unchanged", () => {
+    const composite = getCompositePlaybook("fitness-recreation", ["retail-goods"]);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    expect(composite.primaryGoal).toBe(primary.primaryGoal);
+    expect(composite.stakeholders).toBe(primary.stakeholders);
+    expect(composite.contentTone).toBe(primary.contentTone);
+    expect(composite.keyMetrics).toBe(primary.keyMetrics);
+    expect(composite.ctaLanguage).toBe(primary.ctaLanguage);
+  });
+
+  it("secondary contributes unique campaign types", () => {
+    const composite = getCompositePlaybook("fitness-recreation", ["retail-goods"]);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    const secondary = getPlaybookForCategory("retail-goods");
+    expect(composite.campaignTypes.length).toBeGreaterThan(primary.campaignTypes.length);
+    // At least one retail campaign type should appear
+    const retailCampaigns = secondary.campaignTypes;
+    const addedCount = composite.campaignTypes.filter((c) => retailCampaigns.includes(c)).length;
+    expect(addedCount).toBeGreaterThan(0);
+  });
+
+  it("secondary contributes unique agent skills", () => {
+    const composite = getCompositePlaybook("fitness-recreation", ["retail-goods"]);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    expect(composite.agentSkills.length).toBeGreaterThanOrEqual(primary.agentSkills.length);
+  });
+
+  it("duplicate campaign types are not added", () => {
+    // Same category — all campaigns are already in primary
+    const composite = getCompositePlaybook("fitness-recreation", ["fitness-recreation"]);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    expect(composite.campaignTypes.length).toBe(primary.campaignTypes.length);
+  });
+
+  it("returns primary unchanged when secondary adds nothing new", () => {
+    const composite = getCompositePlaybook("fitness-recreation", ["fitness-recreation"]);
+    const primary = getPlaybookForCategory("fitness-recreation");
+    expect(composite).toBe(primary);
+  });
+
+  it("handles null secondary categories gracefully", () => {
+    const composite = getCompositePlaybook("hoa-property-management", [null, undefined]);
+    const primary = getPlaybookForCategory("hoa-property-management");
+    // Null/undefined resolve to the inquiry fallback — adds its unique skills
+    expect(composite.agentSkills.length).toBeGreaterThanOrEqual(primary.agentSkills.length);
+  });
+
+  it("multiple secondaries union their unique contributions", () => {
+    const composite = getCompositePlaybook("professional-services", [
+      "retail-goods",
+      "fitness-recreation",
+    ]);
+    const primary = getPlaybookForCategory("professional-services");
+    expect(composite.campaignTypes.length).toBeGreaterThan(primary.campaignTypes.length);
+    expect(composite.agentSkills.length).toBeGreaterThan(primary.agentSkills.length);
+  });
+
+  it("primary goal is taken from primary even for same-category secondary", () => {
+    const composite = getCompositePlaybook("trades-maintenance", ["trades-maintenance"]);
+    expect(composite.primaryGoal).toContain("first call");
+  });
+});

--- a/apps/web/lib/tak/marketing-playbooks.ts
+++ b/apps/web/lib/tak/marketing-playbooks.ts
@@ -454,3 +454,52 @@ export function getPlaybookForCtaType(ctaType: string | null | undefined): Marke
 export function getPlaybook(category: string | null | undefined, ctaType: string | null | undefined): MarketingPlaybook {
   return CATEGORY_PLAYBOOKS[category ?? ""] ?? CTA_FALLBACKS[ctaType ?? "inquiry"] ?? CTA_FALLBACKS["inquiry"]!;
 }
+
+/**
+ * Composite playbook for multi-archetype storefronts.
+ *
+ * Primary drives identity (primaryGoal, stakeholders, contentTone,
+ * keyMetrics, ctaLanguage). Secondary categories contribute unique
+ * campaignTypes and agentSkills as supplemental context — so the AI
+ * coworker can suggest service-line-specific campaigns without losing the
+ * primary business's voice.
+ */
+export function getCompositePlaybook(
+  primaryCategory: string | null | undefined,
+  secondaryCategories: Array<string | null | undefined>,
+  primaryCtaType?: string | null,
+): MarketingPlaybook {
+  const primary = getPlaybook(primaryCategory, primaryCtaType);
+
+  if (secondaryCategories.length === 0) return primary;
+
+  const seenCampaigns = new Set(primary.campaignTypes);
+  const seenSkills = new Set(primary.agentSkills);
+
+  const addedCampaigns: string[] = [];
+  const addedSkills: string[] = [];
+
+  for (const cat of secondaryCategories) {
+    const secondary = getPlaybookForCategory(cat);
+    for (const c of secondary.campaignTypes) {
+      if (!seenCampaigns.has(c)) {
+        seenCampaigns.add(c);
+        addedCampaigns.push(c);
+      }
+    }
+    for (const s of secondary.agentSkills) {
+      if (!seenSkills.has(s)) {
+        seenSkills.add(s);
+        addedSkills.push(s);
+      }
+    }
+  }
+
+  if (addedCampaigns.length === 0 && addedSkills.length === 0) return primary;
+
+  return {
+    ...primary,
+    campaignTypes: [...primary.campaignTypes, ...addedCampaigns],
+    agentSkills: [...primary.agentSkills, ...addedSkills],
+  };
+}

--- a/docs/superpowers/specs/2026-06-13-multi-archetype-composition-design.md
+++ b/docs/superpowers/specs/2026-06-13-multi-archetype-composition-design.md
@@ -1,7 +1,7 @@
 # Multi-Archetype Composition Design
 
 **Date:** 2026-06-13
-**Status:** Draft - pending operator review
+**Status:** Phase 1 merged (#1847) · Phase 2 in PR (#1851) · Phase 3 advisory (schedule on operator feedback)
 **Author:** Claude with user direction (Mark Bodman)
 **Related docs:**
 - `packages/storefront-templates/src/types.ts` — `ArchetypeDefinition`, `ActivationProfile`, `ArchetypeModule`, `OperatingModelAxes`

--- a/packages/db/prisma/migrations/20260613140000_add_composition_provenance/migration.sql
+++ b/packages/db/prisma/migrations/20260613140000_add_composition_provenance/migration.sql
@@ -1,0 +1,25 @@
+-- Phase 2 composition provenance (EP-ARCH-8D4F2A)
+-- Adds sourceCompositionId to StorefrontItem and StorefrontSection so
+-- removeStorefrontServiceLine can scope cleanup to a specific secondary's
+-- seeded rows without relying on labels or category matching.
+-- Adds removedAt to StorefrontArchetypeComposition for soft-delete lifecycle.
+
+-- StorefrontArchetypeComposition: soft-delete field
+ALTER TABLE "StorefrontArchetypeComposition" ADD COLUMN "removedAt" TIMESTAMP(3);
+CREATE INDEX "StorefrontArchetypeComposition_removedAt_idx" ON "StorefrontArchetypeComposition"("removedAt");
+
+-- StorefrontItem: provenance FK
+ALTER TABLE "StorefrontItem" ADD COLUMN "sourceCompositionId" TEXT;
+ALTER TABLE "StorefrontItem" ADD CONSTRAINT "StorefrontItem_sourceCompositionId_fkey"
+  FOREIGN KEY ("sourceCompositionId")
+  REFERENCES "StorefrontArchetypeComposition"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "StorefrontItem_sourceCompositionId_idx" ON "StorefrontItem"("sourceCompositionId");
+
+-- StorefrontSection: provenance FK
+ALTER TABLE "StorefrontSection" ADD COLUMN "sourceCompositionId" TEXT;
+ALTER TABLE "StorefrontSection" ADD CONSTRAINT "StorefrontSection_sourceCompositionId_fkey"
+  FOREIGN KEY ("sourceCompositionId")
+  REFERENCES "StorefrontArchetypeComposition"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "StorefrontSection_sourceCompositionId_idx" ON "StorefrontSection"("sourceCompositionId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7033,20 +7033,28 @@ model StorefrontConfig {
 // (role=primary) written at setup completion; secondaries are added post-setup
 // via the "Add service line" admin action.
 model StorefrontArchetypeComposition {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   storefrontId String
   archetypeId  String
   /// "primary" | "secondary"
   role         String
-  sortOrder    Int      @default(0)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  sortOrder    Int       @default(0)
+  /// Soft-delete: set when operator removes a service line. Seeded items/sections
+  /// are deactivated/hidden first; this marks the composition row as inactive while
+  /// preserving the audit trail. sourceCompositionId FKs use onDelete:SetNull so
+  /// historical item rows survive a hard delete if ever needed.
+  removedAt    DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
-  storefront StorefrontConfig    @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
-  archetype  StorefrontArchetype @relation(fields: [archetypeId], references: [id])
+  storefront     StorefrontConfig    @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  archetype      StorefrontArchetype @relation(fields: [archetypeId], references: [id])
+  seededItems    StorefrontItem[]
+  seededSections StorefrontSection[]
 
   @@unique([storefrontId, archetypeId])
   @@index([storefrontId, role])
+  @@index([removedAt])
 }
 
 model MarketingStrategy {
@@ -7386,45 +7394,54 @@ model OutboundAutopilotPolicy {
 }
 
 model StorefrontSection {
-  id           String           @id @default(cuid())
-  storefrontId String
-  type         String
-  title        String?
-  content      Json
-  sortOrder    Int              @default(0)
-  isVisible    Boolean          @default(true)
-  createdAt    DateTime         @default(now())
-  updatedAt    DateTime         @updatedAt
-  storefront   StorefrontConfig @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  id                  String                          @id @default(cuid())
+  storefrontId        String
+  type                String
+  title               String?
+  content             Json
+  sortOrder           Int                             @default(0)
+  isVisible           Boolean                         @default(true)
+  /// Provenance: set when this section was seeded by a secondary add-line action.
+  sourceCompositionId String?
+  createdAt           DateTime                        @default(now())
+  updatedAt           DateTime                        @updatedAt
+  storefront          StorefrontConfig                @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  sourceComposition   StorefrontArchetypeComposition? @relation(fields: [sourceCompositionId], references: [id], onDelete: SetNull)
 
   @@index([storefrontId, sortOrder])
+  @@index([sourceCompositionId])
 }
 
 model StorefrontItem {
-  id               String            @id @default(cuid())
-  itemId           String            @unique
-  storefrontId     String
-  name             String
-  description      String?
-  category         String?
-  priceAmount      Decimal?
-  priceCurrency    String            @default("GBP")
-  priceType        String?
-  imageUrl         String?
-  ctaType          String
-  ctaLabel         String?
-  bookingConfig    Json?
-  isActive         Boolean           @default(true)
-  sortOrder        Int               @default(0)
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
-  storefront       StorefrontConfig  @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
-  providerServices ProviderService[]
-  bookingHolds     BookingHold[]
-  rentableUnits    RentableUnit[]
-  rentalAgreements RentalAgreement[]
+  id                  String                          @id @default(cuid())
+  itemId              String                          @unique
+  storefrontId        String
+  name                String
+  description         String?
+  category            String?
+  priceAmount         Decimal?
+  priceCurrency       String                          @default("GBP")
+  priceType           String?
+  imageUrl            String?
+  ctaType             String
+  ctaLabel            String?
+  bookingConfig       Json?
+  isActive            Boolean                         @default(true)
+  sortOrder           Int                             @default(0)
+  /// Provenance: set when this item was seeded by a secondary add-line action.
+  /// Used by removeStorefrontServiceLine to scope cleanup to the right items.
+  sourceCompositionId String?
+  createdAt           DateTime                        @default(now())
+  updatedAt           DateTime                        @updatedAt
+  storefront          StorefrontConfig                @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
+  sourceComposition   StorefrontArchetypeComposition? @relation(fields: [sourceCompositionId], references: [id], onDelete: SetNull)
+  providerServices    ProviderService[]
+  bookingHolds        BookingHold[]
+  rentableUnits       RentableUnit[]
+  rentalAgreements    RentalAgreement[]
 
   @@index([storefrontId, isActive, sortOrder])
+  @@index([sourceCompositionId])
 }
 
 model StorefrontBooking {


### PR DESCRIPTION
## Summary

Phase 2 of multi-archetype composition (EP-ARCH-8D4F2A). Phase 1 (schema + pure logic) already merged in #1847.

- **Provenance migration** (`20260613140000`): `removedAt` on `StorefrontArchetypeComposition` (soft-delete lifecycle); `sourceCompositionId` FK on `StorefrontItem` and `StorefrontSection` with `onDelete: SetNull` — enables precise cleanup when a secondary line is removed without relying on labels or category matching
- **`composition-view.ts`**: pure `deriveStorefrontCompositionView` helper — visual-pattern resolution (7 patterns: standard-flow, slot-board, map-dispatch, asset-pool-board, stock-reorder-board, case-queue, trust-gate-board), same-category / cross-category / acute-pair compatibility rules, `StorefrontServiceLineView` / `StorefrontCompositionView` types
- **`service-line-actions.ts`**: `"use server"` actions — `addStorefrontServiceLine` (seeds items + sections with provenance FK, reactivates soft-deleted rows, max-2 guard), `removeStorefrontServiceLine` (soft-delete + deactivate/hide seeded rows), `loadCompositionViewData`, `getCompositeActivationProfileForStorefront`
- **`ServiceLinesPanel.tsx`**: client component — primary/secondary rows with role pills, compatibility chips (report-kit intent tokens), remove button per secondary, "Add service line" picker with available archetypes; optimistic via `useTransition`
- **`storefront/page.tsx`**: loads composition + available archetypes server-side; renders `ServiceLinesPanel` below existing `StorefrontDashboard` when composition rows exist; backwards-compatible (single-archetype installs unchanged)
- **`statusColors.ts`**: adds `compositionCompatibility` domain
- **13 new unit tests** for `composition-view.ts` covering all compatibility paths, visual patterns, null profiles, seeded counts, statusIntent mapping — all passing

## Compatibility

- Existing single-archetype storefronts render identically (panel only shows when composition rows exist)
- `StorefrontArchetypeComposition` primary row was backfilled in Phase 1 migration for all existing storefronts

## Test plan

- [x] `composition-view.test.ts` — 13/13 passing
- [x] `composition.test.ts` (Phase 1) — 16/16 still passing
- [ ] CI typecheck + production build
- [ ] Functional verification: add a secondary service line → items/sections seeded with provenance FK → remove → items deactivated, sections hidden, composition soft-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)