### PR TITLE
feat(workbooks): custom-table rollups over links — count (slice 5)

### DIFF
--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -28,6 +28,7 @@ const OFFERED_TYPES: { value: FieldType; label: string }[] = [
   { value: "image", label: "Image" },
   { value: "attachment", label: "Attachment" },
   { value: "link", label: "Link to records" },
+  { value: "rollup", label: "Rollup (count links)" },
 ];
 
 const RESULT_TYPES: { value: FieldType; label: string }[] = [
@@ -71,6 +72,7 @@ export function AddColumnButton({
   const [referenceType, setReferenceType] = useState("");
   const [referenceTargets, setReferenceTargets] = useState<ReferenceTarget[]>([]);
   const [linkCardinality, setLinkCardinality] = useState<"one" | "many">("many");
+  const [rollupLinkColumnId, setRollupLinkColumnId] = useState("");
   const [formula, setFormula] = useState("");
   const [resultType, setResultType] = useState<FieldType>("text");
   const [lookupRefColumnId, setLookupRefColumnId] = useState("");
@@ -82,6 +84,8 @@ export function AddColumnButton({
 
   // Reference columns on this table are the only valid lookup sources.
   const referenceColumns = columns.filter((c) => c.fieldType === "reference");
+  // Link columns on this table are the rollup-over-links sources.
+  const linkColumns = columns.filter((c) => c.fieldType === "link");
   const selectedRefColumn = referenceColumns.find((c) => c.columnId === lookupRefColumnId);
 
   // Load the available reference targets once the picker is opened.
@@ -119,6 +123,7 @@ export function AddColumnButton({
     setOptionsRaw("");
     setReferenceType("");
     setLinkCardinality("many");
+    setRollupLinkColumnId("");
     setFormula("");
     setResultType("text");
     setLookupRefColumnId("");
@@ -132,6 +137,7 @@ export function AddColumnButton({
     if (fieldType === "select") return { options: parseOptions(optionsRaw) };
     if (fieldType === "reference") return { referenceType };
     if (fieldType === "link") return { link: { cardinality: linkCardinality, referenceType } };
+    if (fieldType === "rollup") return { rollup: { linkColumnId: rollupLinkColumnId, op: "count" } };
     if (fieldType === "formula") return { formula, resultType };
     if (fieldType === "lookup") {
       return { lookup: { referenceColumnId: lookupRefColumnId, targetField: lookupTargetField } };
@@ -142,7 +148,8 @@ export function AddColumnButton({
   const missingTarget = (fieldType === "reference" || fieldType === "link") && !referenceType;
   const missingFormula = fieldType === "formula" && !formula.trim();
   const missingLookup = fieldType === "lookup" && (!lookupRefColumnId || !lookupTargetField);
-  const invalidConfig = missingTarget || missingFormula || missingLookup;
+  const missingRollup = fieldType === "rollup" && !rollupLinkColumnId;
+  const invalidConfig = missingTarget || missingFormula || missingLookup || missingRollup;
 
   function submit() {
     setError(null);
@@ -236,6 +243,23 @@ export function AddColumnButton({
           <option value="one" className={optionClass}>
             Link to one (1-1 / 1-M)
           </option>
+        </select>
+      )}
+      {fieldType === "rollup" && (
+        <select
+          value={rollupLinkColumnId}
+          onChange={(e) => setRollupLinkColumnId(e.target.value)}
+          className={selectClass}
+          aria-label="Link column to count"
+        >
+          <option value="" className={optionClass}>
+            {linkColumns.length === 0 ? "Add a link column first" : "Count links in…"}
+          </option>
+          {linkColumns.map((c) => (
+            <option key={c.columnId} value={c.columnId} className={optionClass}>
+              {c.name}
+            </option>
+          ))}
         </select>
       )}
       {fieldType === "formula" && (

--- a/apps/web/lib/workbooks/formula/compute.test.ts
+++ b/apps/web/lib/workbooks/formula/compute.test.ts
@@ -42,6 +42,43 @@ describe("computeDerivedCells — formulas", () => {
     expect(String(rows[0].cells.c_x)).toMatch(/^#ERROR/);
   });
 
+  it("counts a link column's targets into a rollup column", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_links", name: "Tasks", fieldType: "link", config: { link: { cardinality: "many", referenceType: "epic" } } },
+      { columnId: "c_count", name: "Task count", fieldType: "rollup", config: { rollup: { linkColumnId: "c_links", op: "count" } } },
+    ];
+    const rows: GridRow[] = [
+      {
+        rowId: "r1",
+        cells: {
+          c_links: [
+            { referenceId: "E1", referenceType: "epic" },
+            { referenceId: "E2", referenceType: "epic" },
+          ],
+          c_count: null,
+        },
+      },
+      { rowId: "r2", cells: { c_links: [], c_count: null } },
+    ];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_count).toBe(2);
+    expect(rows[1].cells.c_count).toBe(0);
+  });
+
+  it("lets a formula reference a link-rollup count", async () => {
+    const columns: DerivableColumn[] = [
+      { columnId: "c_links", name: "Tasks", fieldType: "link", config: { link: { cardinality: "many", referenceType: "epic" } } },
+      { columnId: "c_count", name: "Task count", fieldType: "rollup", config: { rollup: { linkColumnId: "c_links", op: "count" } } },
+      { columnId: "c_busy", name: "Busy", fieldType: "formula", config: { formula: '=IF([Task count]>1,"yes","no")' } },
+    ];
+    const rows: GridRow[] = [
+      { rowId: "r1", cells: { c_links: [{ referenceId: "E1", referenceType: "epic" }, { referenceId: "E2", referenceType: "epic" }], c_count: null, c_busy: null } },
+    ];
+    await computeDerivedCells(columns, rows);
+    expect(rows[0].cells.c_count).toBe(2);
+    expect(rows[0].cells.c_busy).toBe("yes");
+  });
+
   it("is a no-op when there are no computed columns", async () => {
     const columns: DerivableColumn[] = [{ columnId: "c_a", name: "A", fieldType: "number" }];
     const rows: GridRow[] = [{ rowId: "r1", cells: { c_a: 1 } }];

--- a/apps/web/lib/workbooks/formula/compute.ts
+++ b/apps/web/lib/workbooks/formula/compute.ts
@@ -62,6 +62,21 @@ export async function computeDerivedCells(
 ): Promise<void> {
   const lookupCols = columns.filter((c) => c.fieldType === "lookup" && c.config?.lookup);
   const formulaCols = columns.filter((c) => c.fieldType === "formula");
+  const rollupCols = columns.filter((c) => c.fieldType === "rollup" && c.config?.rollup);
+  if (lookupCols.length === 0 && formulaCols.length === 0 && rollupCols.length === 0) return;
+
+  // 0) Rollup columns (custom tables): aggregate over a `link` column's targets.
+  //    v1 = count of linked records (the links are already loaded into the cell as
+  //    a ReferenceValue[] by the adapter). Computed before formulas so a formula
+  //    can reference a rollup's value. No DB round-trip.
+  if (rollupCols.length > 0) {
+    for (const row of rows) {
+      for (const rc of rollupCols) {
+        const links = row.cells[rc.config!.rollup!.linkColumnId];
+        row.cells[rc.columnId] = Array.isArray(links) ? links.length : 0;
+      }
+    }
+  }
   if (lookupCols.length === 0 && formulaCols.length === 0) return;
 
   // A formula may resolve a reference inline via REF()/LOOKUP(); if any does, we

--- a/apps/web/lib/workbooks/types.ts
+++ b/apps/web/lib/workbooks/types.ts
@@ -90,6 +90,13 @@ export interface FieldConfig {
   lookup?: LookupConfig;
   /** link columns: target kind + cardinality (links stored in WorkbookCellLink) */
   link?: LinkConfig;
+  /** rollup columns (custom tables): aggregate over a `link` column's targets */
+  rollup?: {
+    /** columnId of a `link` column on the same table */
+    linkColumnId: string;
+    /** aggregation — v1 supports count of linked records */
+    op: "count";
+  };
 }
 
 /**


### PR DESCRIPTION
## What

**Slice 5 of linked records** (slices 1–3 merged in [#1849](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/1849)): a custom-table **rollup over a `link` column** — closes the reporting-phase gap that was deferred because custom tables had no one-to-many to aggregate. Now a custom table's `link` column *is* that one-to-many, so a rollup can count its targets.

## How

- `FieldConfig.rollup = { linkColumnId, op: "count" }` for custom-table rollup columns (distinct from the platform generic-adapter `RollupSpec`, which rides real FKs in #1841).
- `computeDerivedCells` resolves rollup columns **in-memory** from the already-loaded link cell (no DB round-trip), *before* the formula pass — so a formula can reference a rollup count, e.g. `=IF([Task count]>1,"busy","ok")`.
- `AddColumnButton` offers "Rollup (count links)" with a link-column picker.

Reuses the existing `rollup` field type (read-only, `derived`) and `renderComputedCell` — no Grid/validation changes.

## Scope

v1 is **count**; `sum/avg/min/max` over a *linked target's field* (needs fetching the target records) is the natural follow-on.

## Test plan

`vitest` — count over links + a formula referencing a rollup count; full formula suite (35) green. `pnpm --filter web typecheck` green.

After this, the only remaining linked-records slices are **4** (cross-row 1‑M/1‑1 uniqueness enforcement) and **6** ("links to X" filter + CSV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
