### PR TITLE
feat(workbooks): cross-row uniqueness for cardinality-one link columns (slice 4)

### DIFF
--- a/apps/web/lib/workbooks/cell-links.test.ts
+++ b/apps/web/lib/workbooks/cell-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateLinkValue, isReferenceValue } from "./cell-links";
+import { validateLinkValue, isReferenceValue, conflictingLinks } from "./cell-links";
 import type { LinkConfig } from "./types";
 
 const many: LinkConfig = { cardinality: "many", referenceType: "epic" };
@@ -75,5 +75,21 @@ describe("validateLinkValue", () => {
     expect(() => validateLinkValue([{ referenceId: "E1", referenceType: "epic" }], undefined)).toThrow(
       /configuration/i,
     );
+  });
+});
+
+describe("conflictingLinks", () => {
+  it("returns candidates already linked by other rows", () => {
+    const otherRows = new Set(["E2", "E3"]);
+    expect(conflictingLinks(["E1", "E2"], otherRows)).toEqual(["E2"]);
+  });
+
+  it("returns empty when no candidate collides (free to link)", () => {
+    expect(conflictingLinks(["E1"], new Set(["E2"]))).toEqual([]);
+    expect(conflictingLinks(["E1"], new Set())).toEqual([]);
+  });
+
+  it("flags every colliding candidate", () => {
+    expect(conflictingLinks(["E1", "E2"], new Set(["E1", "E2"]))).toEqual(["E1", "E2"]);
   });
 });

--- a/apps/web/lib/workbooks/cell-links.ts
+++ b/apps/web/lib/workbooks/cell-links.ts
@@ -52,3 +52,16 @@ export function validateLinkValue(
   }
   return links;
 }
+
+/**
+ * Cross-row uniqueness check for a `cardinality: "one"` link column (true 1-M/1-1):
+ * given the targets a row wants to link and the set of targets already linked by
+ * *other* rows in the same column, return any that would collide. Pure, so the
+ * adapter can query the "other rows" set and this stays unit-testable.
+ */
+export function conflictingLinks(
+  candidateRefIds: string[],
+  linkedByOtherRows: ReadonlySet<string>,
+): string[] {
+  return candidateRefIds.filter((id) => linkedByOtherRows.has(id));
+}

--- a/apps/web/lib/workbooks/custom-table-adapter.ts
+++ b/apps/web/lib/workbooks/custom-table-adapter.ts
@@ -35,7 +35,7 @@ import {
 import { applyFilters, applySort, paginate } from "./grid-query";
 import { resolveReferenceLabels, referenceKey } from "./reference-resolver";
 import { computeDerivedCells } from "./formula/compute";
-import { validateLinkValue } from "./cell-links";
+import { validateLinkValue, conflictingLinks } from "./cell-links";
 import { genSemanticId } from "./ids";
 
 function asReference(value: unknown): ReferenceValue | null {
@@ -241,6 +241,18 @@ class CustomTableAdapter implements DataSourceAdapter {
       const value = meta.columnId in input ? input[meta.columnId] : null;
       if (meta.fieldType === "link") {
         const links = validateLinkValue(value, meta.config?.link);
+        // cardinality "one": reject targets already linked from any existing row.
+        if (meta.config?.link?.cardinality === "one" && links.length > 0) {
+          const refIds = links.map((l) => l.referenceId);
+          const others = await prisma.workbookCellLink.findMany({
+            where: { columnId: meta.internalId, referenceId: { in: refIds } },
+            select: { referenceId: true },
+          });
+          const clash = conflictingLinks(refIds, new Set(others.map((o) => o.referenceId)));
+          if (clash.length > 0) {
+            throw new Error(`Already linked from another row: ${clash.join(", ")}`);
+          }
+        }
         links.forEach((l, i) =>
           linkInserts.push({
             columnId: meta.internalId,
@@ -307,6 +319,19 @@ class CustomTableAdapter implements DataSourceAdapter {
         if (meta.fieldType === "link") {
           // Replace the cell's link set in WorkbookCellLink (validated, deduped).
           const links = validateLinkValue(value, meta.config?.link);
+          // cardinality "one" → a target may be linked by at most one row (1-M/1-1):
+          // reject targets already linked from a different row (checked in-transaction).
+          if (meta.config?.link?.cardinality === "one" && links.length > 0) {
+            const refIds = links.map((l) => l.referenceId);
+            const others = await tx.workbookCellLink.findMany({
+              where: { columnId: meta.internalId, rowId: { not: row.id }, referenceId: { in: refIds } },
+              select: { referenceId: true },
+            });
+            const clash = conflictingLinks(refIds, new Set(others.map((o) => o.referenceId)));
+            if (clash.length > 0) {
+              throw new Error(`Already linked from another row: ${clash.join(", ")}`);
+            }
+          }
           await tx.workbookCellLink.deleteMany({
             where: { rowId: row.id, columnId: meta.internalId },
           });


### PR DESCRIPTION
## What

**Slice 4 of linked records** — true 1‑M/1‑1 enforcement. Per-cell `cardinality:"one"` (≤1 link per cell — the Airtable "link to a single record" behavior) already shipped in slice 2 (#1849). This adds the stricter **cross-row** guarantee: a target may be linked by **at most one row** in a cardinality-"one" column (referential exclusivity — beyond the default Smartsheet/Airtable behavior, for users who want a real 1‑M/1‑1).

## How

- `conflictingLinks(candidateRefIds, linkedByOtherRows)` — pure, unit-tested helper.
- `custom-table-adapter`: on create/update of a cardinality-"one" link cell, query the targets already linked from **other** rows in that column and reject collisions with a clear error (`Already linked from another row: …`). The update check runs inside the existing write transaction.

## Why write-path, not a DB index

The cardinality lives in `WorkbookColumn.fieldConfig` (not on the link row), so a config-conditional **partial unique index** can't be expressed in Prisma without schema drift (and the repo's schema-regression guard would flag it). A denormalized flag + raw partial index is a possible future hardening; the transactional write-path check is the pragmatic, drift-free enforcement.

## Test plan

`vitest` — `conflictingLinks` (collision / no-collision / all-collide); 141 workbooks tests green. `pnpm --filter web typecheck` green.

With this, linked-records slices 1–5 are done; only **slice 6's** optional *structured* per-column "links to record X" filter remains (the free-text filter + CSV of link labels already work via slice 2's `cellSearchText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
