### PR TITLE
feat(build): ReviewReadinessStrip — evidence-backed review-lens chips (spec §6.2)

### DIFF
--- a/apps/web/components/build/ReviewReadinessStrip.test.tsx
+++ b/apps/web/components/build/ReviewReadinessStrip.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ReviewReadinessStrip } from "@/components/build/ReviewReadinessStrip";
+import type { FeatureBuildRow, ReviewResult } from "@/lib/feature-build-types";
+
+function review(overrides: Partial<ReviewResult> = {}): ReviewResult {
+  return { decision: "pass", issues: [], summary: "", ...overrides };
+}
+
+function build(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    planReview: null,
+    designReview: null,
+    taskResults: null,
+    uxTestResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    ...overrides,
+  } as unknown as FeatureBuildRow;
+}
+
+describe("ReviewReadinessStrip render gate", () => {
+  it("renders nothing outside the review phase", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip build={build({ planReview: review() })} phase="build" />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders the strip during the review phase", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip build={build({ planReview: review() })} phase="review" />,
+    );
+    expect(html).toContain('data-testid="review-readiness-strip"');
+    expect(html).toContain("Review Readiness");
+  });
+});
+
+describe("ReviewReadinessStrip chips", () => {
+  it("always renders the checklist + verification spine for a bare review build", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip build={build()} phase="review" />,
+    );
+    expect(html).toContain('data-lens-key="checklist"');
+    expect(html).toContain('data-lens-key="verification"');
+    // Optional lenses are absent without backing data.
+    expect(html).not.toContain('data-lens-key="code-review"');
+    expect(html).not.toContain('data-lens-key="ux"');
+  });
+
+  it("encodes each lens state in data-state and the aria-label", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip
+        build={build({
+          planReview: review({
+            decision: "fail",
+            issues: [{ severity: "critical", description: "x" }],
+          }),
+        })}
+        phase="review"
+      />,
+    );
+    expect(html).toContain('data-state="fail"');
+    expect(html).toContain('aria-label="Checklist review: fail — 1 critical"');
+  });
+
+  it("shows the cleared / blocking summary in the section header", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip
+        build={build({
+          planReview: review({
+            decision: "fail",
+            issues: [{ severity: "critical", description: "x" }],
+          }),
+          verificationOut: {
+            testsPassed: 1,
+            testsFailed: 0,
+            typecheckPassed: true,
+            fullOutput: "",
+            timestamp: "",
+          },
+        })}
+        phase="review"
+      />,
+    );
+    // checklist=fail, verification=pass → 1/2 cleared · 1 blocking
+    expect(html).toContain("1/2 cleared");
+    expect(html).toContain("1 blocking");
+  });
+
+  it("renders an advisory chip (non-gating) when architecture review ran", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip
+        build={build({
+          planReview: review({
+            architectureAdvisory: { summary: "s", issues: [{ severity: "minor", description: "n" }] },
+          }),
+        })}
+        phase="review"
+      />,
+    );
+    expect(html).toContain('data-lens-key="architecture"');
+    expect(html).toContain('data-state="advisory"');
+    expect(html).toContain('aria-label="Architecture: advisory — 1 note"');
+  });
+
+  it("renders no raw hex literals (DPF token invariant)", () => {
+    const html = renderToStaticMarkup(
+      <ReviewReadinessStrip
+        build={build({
+          planReview: review({ decision: "fail", issues: [{ severity: "critical", description: "x" }] }),
+          taskResults: [
+            { taskIndex: 0, title: "t", testResult: { passed: true, output: "" }, codeReview: review() },
+          ],
+          acceptanceMet: [{ criterion: "a", met: false, evidence: "" }],
+        })}
+        phase="review"
+      />,
+    );
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+  });
+});

--- a/apps/web/components/build/ReviewReadinessStrip.tsx
+++ b/apps/web/components/build/ReviewReadinessStrip.tsx
@@ -1,0 +1,109 @@
+// apps/web/components/build/ReviewReadinessStrip.tsx
+//
+// Review-phase readiness strip: a compact grid of state-coded "lens" chips,
+// each backed by real persisted evidence on the build (checklist review,
+// architecture advisory, code review, UX checks, verification, acceptance).
+//
+// This is the honest realization of spec §6.2. The original sketch drew a
+// roster of named reviewer agents ([EA Architect ✓] [Security ✓] …), but that
+// per-reviewer identity is NOT persisted — the build review system merges its
+// reviewers into a single ReviewResult. So the strip shows review *lenses*
+// derived from stored fields (see lib/build/review-lenses.ts), never invented
+// reviewer names.
+//
+// State is conveyed by colour AND glyph AND text (WCAG 1.4.1), and each chip
+// carries an aria-label summarizing its lens + state + detail.
+"use client";
+
+import type { CSSProperties } from "react";
+import type { BuildPhase, FeatureBuildRow } from "@/lib/feature-build-types";
+import {
+  deriveReviewLenses,
+  type ReviewLens,
+  type ReviewLensState,
+} from "@/lib/build/review-lenses";
+
+type Props = {
+  build: FeatureBuildRow;
+  phase: BuildPhase;
+};
+
+const STATE_CONFIG: Record<ReviewLensState, { colorVar: string; glyph: string; word: string }> = {
+  pass:     { colorVar: "var(--dpf-success)", glyph: "✓", word: "pass" },      // ✓
+  fail:     { colorVar: "var(--dpf-error)",   glyph: "✗", word: "fail" },      // ✗
+  advisory: { colorVar: "var(--dpf-info)",    glyph: "ⓘ", word: "advisory" },  // ⓘ
+  partial:  { colorVar: "var(--dpf-warning)", glyph: "◐", word: "partial" },   // ◐
+  pending:  { colorVar: "var(--dpf-muted)",   glyph: "○", word: "pending" },   // ○
+};
+
+export function ReviewReadinessStrip({ build, phase }: Props) {
+  if (phase !== "review") return null;
+  const lenses = deriveReviewLenses(build);
+  if (lenses.length === 0) return null;
+
+  const cleared = lenses.filter((l) => l.state === "pass").length;
+  const blocking = lenses.filter((l) => l.state === "fail").length;
+
+  return (
+    <div style={{ marginBottom: 16 }} data-testid="review-readiness-strip">
+      <div style={sectionLabelStyle}>
+        Review Readiness
+        <span style={{ color: "var(--dpf-muted)", fontWeight: 600, marginLeft: 6 }}>
+          {cleared}/{lenses.length} cleared
+          {blocking > 0 ? ` · ${blocking} blocking` : ""}
+        </span>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {lenses.map((lens) => (
+          <LensChip key={lens.key} lens={lens} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LensChip({ lens }: { lens: ReviewLens }) {
+  const cfg = STATE_CONFIG[lens.state];
+  return (
+    <div
+      data-testid="review-lens"
+      data-lens-key={lens.key}
+      data-state={lens.state}
+      aria-label={`${lens.label}: ${cfg.word}${lens.detail ? ` — ${lens.detail}` : ""}`}
+      style={{
+        flex: "1 1 144px",
+        minWidth: 144,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        padding: "6px 8px",
+        borderRadius: 6,
+        background: `color-mix(in srgb, ${cfg.colorVar} 12%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${cfg.colorVar} 30%, transparent)`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+        <span aria-hidden="true" style={{ color: cfg.colorVar, fontSize: 11, lineHeight: 1 }}>
+          {cfg.glyph}
+        </span>
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--dpf-text)" }}>
+          {lens.label}
+        </span>
+      </div>
+      {lens.detail && (
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)", paddingLeft: 16 }}>
+          {lens.detail}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const sectionLabelStyle: CSSProperties = {
+  fontSize: 9,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: 0,
+  color: "var(--dpf-muted)",
+  marginBottom: 6,
+};

--- a/apps/web/components/build/WorkflowStageInspector.tsx
+++ b/apps/web/components/build/WorkflowStageInspector.tsx
@@ -16,6 +16,7 @@ import {
   UnifiedEvidenceTimeline,
   type UnifiedEvidenceTimelineEvent,
 } from "./UnifiedEvidenceTimeline";
+import { ReviewReadinessStrip } from "./ReviewReadinessStrip";
 
 type Props = {
   build: FeatureBuildRow;
@@ -349,6 +350,8 @@ export function WorkflowStageInspector({
             <div style={sectionLabelStyle}>What Happened</div>
             <div style={bodyTextStyle}>{getStageSummary(phase, build)}</div>
           </div>
+
+          <ReviewReadinessStrip build={build} phase={phase} />
 
           <div style={{ marginBottom: 16 }}>
             <div style={sectionLabelStyle}>Next Approval</div>

--- a/apps/web/lib/build/review-lenses.test.ts
+++ b/apps/web/lib/build/review-lenses.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+import { deriveReviewLenses } from "@/lib/build/review-lenses";
+import type {
+  FeatureBuildRow,
+  ReviewResult,
+  TaskResult,
+} from "@/lib/feature-build-types";
+
+function review(overrides: Partial<ReviewResult> = {}): ReviewResult {
+  return {
+    decision: "pass",
+    issues: [],
+    summary: "",
+    ...overrides,
+  };
+}
+
+function task(title: string, codeReviewDecision: "pass" | "fail"): TaskResult {
+  return {
+    taskIndex: 0,
+    title,
+    testResult: { passed: true, output: "" },
+    codeReview: review({ decision: codeReviewDecision }),
+  };
+}
+
+function build(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    planReview: null,
+    designReview: null,
+    taskResults: null,
+    uxTestResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    ...overrides,
+  } as unknown as FeatureBuildRow;
+}
+
+function lensByKey(rows: ReturnType<typeof deriveReviewLenses>, key: string) {
+  return rows.find((l) => l.key === key);
+}
+
+describe("deriveReviewLenses — checklist lens", () => {
+  it("is pending with 'not yet reviewed' when no review exists", () => {
+    const l = lensByKey(deriveReviewLenses(build()), "checklist");
+    expect(l).toMatchObject({ state: "pending", detail: "not yet reviewed" });
+  });
+
+  it("is pending with 'review unavailable' on a parse error", () => {
+    const l = lensByKey(
+      deriveReviewLenses(build({ planReview: review({ parseError: true }) })),
+      "checklist",
+    );
+    expect(l).toMatchObject({ state: "pending", detail: "review unavailable" });
+  });
+
+  it("fails with a severity summary when the review decision is fail", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          planReview: review({
+            decision: "fail",
+            issues: [
+              { severity: "critical", description: "x" },
+              { severity: "critical", description: "y" },
+              { severity: "important", description: "z" },
+            ],
+          }),
+        }),
+      ),
+      "checklist",
+    );
+    expect(l).toMatchObject({ state: "fail", detail: "2 critical · 1 important" });
+  });
+
+  it("passes as 'cleared' with no issues", () => {
+    const l = lensByKey(
+      deriveReviewLenses(build({ planReview: review({ decision: "pass" }) })),
+      "checklist",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "cleared" });
+  });
+
+  it("passes as 'cleared · N minor' when minor issues remain on a pass", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          planReview: review({
+            decision: "pass",
+            issues: [{ severity: "minor", description: "nit" }],
+          }),
+        }),
+      ),
+      "checklist",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "cleared · 1 minor" });
+  });
+
+  it("appends a round suffix when the review iterated", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({ planReview: review({ decision: "pass", iteration: { round: 3 } }) }),
+      ),
+      "checklist",
+    );
+    expect(l?.detail).toBe("cleared · round 3");
+  });
+
+  it("marks an oscillating iteration with ↻", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          planReview: review({
+            decision: "fail",
+            issues: [{ severity: "critical", description: "x" }],
+            iteration: { round: 4, oscillating: true },
+          }),
+        }),
+      ),
+      "checklist",
+    );
+    expect(l?.detail).toBe("1 critical · round 4 ↻");
+  });
+
+  it("falls back to designReview when planReview is absent", () => {
+    const l = lensByKey(
+      deriveReviewLenses(build({ designReview: review({ decision: "pass" }) })),
+      "checklist",
+    );
+    expect(l?.state).toBe("pass");
+  });
+});
+
+describe("deriveReviewLenses — architecture advisory lens", () => {
+  it("is omitted when no architecture advisory ran", () => {
+    expect(lensByKey(deriveReviewLenses(build()), "architecture")).toBeUndefined();
+  });
+
+  it("renders as advisory with a note count", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          planReview: review({
+            architectureAdvisory: {
+              summary: "s",
+              issues: [
+                { severity: "important", description: "a" },
+                { severity: "minor", description: "b" },
+              ],
+            },
+          }),
+        }),
+      ),
+      "architecture",
+    );
+    expect(l).toMatchObject({ state: "advisory", detail: "2 notes" });
+  });
+
+  it("renders 'aligned' when the advisory has zero issues", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({ planReview: review({ architectureAdvisory: { summary: "s", issues: [] } }) }),
+      ),
+      "architecture",
+    );
+    expect(l).toMatchObject({ state: "advisory", detail: "aligned" });
+  });
+});
+
+describe("deriveReviewLenses — code review lens", () => {
+  it("is omitted when there are no task results", () => {
+    expect(lensByKey(deriveReviewLenses(build()), "code-review")).toBeUndefined();
+  });
+
+  it("passes as 'N/N clean' when every task's code review passed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({ taskResults: [task("a", "pass"), task("b", "pass")] }),
+      ),
+      "code-review",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "2/2 clean" });
+  });
+
+  it("fails with a flagged count when any task's code review failed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({ taskResults: [task("a", "pass"), task("b", "fail"), task("c", "fail")] }),
+      ),
+      "code-review",
+    );
+    expect(l).toMatchObject({ state: "fail", detail: "2/3 tasks flagged" });
+  });
+});
+
+describe("deriveReviewLenses — UX lens", () => {
+  it("is omitted when no UX checks were recorded", () => {
+    expect(lensByKey(deriveReviewLenses(build()), "ux")).toBeUndefined();
+  });
+
+  it("passes when all recorded checks passed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          uxTestResults: [
+            { step: "a", passed: true, screenshotUrl: null, error: null },
+            { step: "b", passed: true, screenshotUrl: null, error: null },
+          ],
+        }),
+      ),
+      "ux",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "2/2 passed" });
+  });
+
+  it("fails when any check did not pass", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          uxTestResults: [
+            { step: "a", passed: true, screenshotUrl: null, error: null },
+            { step: "b", passed: false, screenshotUrl: null, error: "boom" },
+          ],
+        }),
+      ),
+      "ux",
+    );
+    expect(l).toMatchObject({ state: "fail", detail: "1/2 passed" });
+  });
+});
+
+describe("deriveReviewLenses — verification lens", () => {
+  it("is pending when verification has not run", () => {
+    const l = lensByKey(deriveReviewLenses(build()), "verification");
+    expect(l).toMatchObject({ state: "pending", detail: "not run" });
+  });
+
+  it("passes when typecheck passed and no tests failed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          verificationOut: {
+            testsPassed: 10,
+            testsFailed: 0,
+            typecheckPassed: true,
+            fullOutput: "",
+            timestamp: "",
+          },
+        }),
+      ),
+      "verification",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "typecheck ✓ · tests ✓" });
+  });
+
+  it("fails with 'typecheck ✗' when typecheck failed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          verificationOut: {
+            testsPassed: 0,
+            testsFailed: 0,
+            typecheckPassed: false,
+            fullOutput: "",
+            timestamp: "",
+          },
+        }),
+      ),
+      "verification",
+    );
+    expect(l).toMatchObject({ state: "fail", detail: "typecheck ✗" });
+  });
+
+  it("fails with a failing-test count when typecheck passed but tests failed", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          verificationOut: {
+            testsPassed: 8,
+            testsFailed: 2,
+            typecheckPassed: true,
+            fullOutput: "",
+            timestamp: "",
+          },
+        }),
+      ),
+      "verification",
+    );
+    expect(l).toMatchObject({ state: "fail", detail: "2 tests failing" });
+  });
+});
+
+describe("deriveReviewLenses — acceptance lens", () => {
+  it("is omitted when no acceptance criteria are recorded", () => {
+    expect(lensByKey(deriveReviewLenses(build()), "acceptance")).toBeUndefined();
+  });
+
+  it("passes when all criteria are met", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          acceptanceMet: [
+            { criterion: "a", met: true, evidence: "" },
+            { criterion: "b", met: true, evidence: "" },
+          ],
+        }),
+      ),
+      "acceptance",
+    );
+    expect(l).toMatchObject({ state: "pass", detail: "2/2 met" });
+  });
+
+  it("is partial when some criteria are unmet", () => {
+    const l = lensByKey(
+      deriveReviewLenses(
+        build({
+          acceptanceMet: [
+            { criterion: "a", met: true, evidence: "" },
+            { criterion: "b", met: false, evidence: "" },
+          ],
+        }),
+      ),
+      "acceptance",
+    );
+    expect(l).toMatchObject({ state: "partial", detail: "1/2 met" });
+  });
+});
+
+describe("deriveReviewLenses — composition", () => {
+  it("returns only the always-on spine (checklist + verification) for a bare build", () => {
+    const keys = deriveReviewLenses(build()).map((l) => l.key);
+    expect(keys).toEqual(["checklist", "verification"]);
+  });
+
+  it("orders lenses by review-gate lineage", () => {
+    const keys = deriveReviewLenses(
+      build({
+        planReview: review({
+          decision: "pass",
+          architectureAdvisory: { summary: "s", issues: [] },
+        }),
+        taskResults: [task("a", "pass")],
+        uxTestResults: [{ step: "a", passed: true, screenshotUrl: null, error: null }],
+        verificationOut: {
+          testsPassed: 1,
+          testsFailed: 0,
+          typecheckPassed: true,
+          fullOutput: "",
+          timestamp: "",
+        },
+        acceptanceMet: [{ criterion: "a", met: true, evidence: "" }],
+      }),
+    ).map((l) => l.key);
+    expect(keys).toEqual([
+      "checklist",
+      "architecture",
+      "code-review",
+      "ux",
+      "verification",
+      "acceptance",
+    ]);
+  });
+});

--- a/apps/web/lib/build/review-lenses.ts
+++ b/apps/web/lib/build/review-lenses.ts
@@ -1,0 +1,174 @@
+// apps/web/lib/build/review-lenses.ts
+//
+// Pure derivation: FeatureBuildRow → the review-gate "lenses" that have real,
+// persisted evidence behind them. Drives the ReviewReadinessStrip shown in the
+// Review-phase inspector.
+//
+// Every lens here maps to a field that is actually stored on the row — there is
+// NO synthetic per-reviewer roster (the build review system merges its two
+// reviewers into a single ReviewResult via mergeReviews(), so individual
+// reviewer identity is not persisted). See the §6.2 note in
+// docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md.
+//
+// No DB imports, no side effects — fully unit-testable in the node environment.
+
+import type { FeatureBuildRow, ReviewResult } from "@/lib/feature-build-types";
+
+export type ReviewLensState = "pass" | "fail" | "advisory" | "partial" | "pending";
+
+export type ReviewLens = {
+  /** Stable key for React lists + test targeting. */
+  key: string;
+  /** Operator-facing lens name. */
+  label: string;
+  state: ReviewLensState;
+  /** Short evidence summary, e.g. "2 critical · 1 important" or "12/12 clean". */
+  detail: string;
+};
+
+/** Summarize a ReviewResult's issues by severity into a compact chip detail.
+ *  Returns "" when there are no issues. */
+function summarizeIssues(issues: ReviewResult["issues"]): string {
+  const counts = { critical: 0, important: 0, minor: 0 };
+  for (const issue of issues) counts[issue.severity]++;
+  const parts: string[] = [];
+  if (counts.critical) parts.push(`${counts.critical} critical`);
+  if (counts.important) parts.push(`${counts.important} important`);
+  if (counts.minor) parts.push(`${counts.minor} minor`);
+  return parts.join(" · ");
+}
+
+/** Append a "round N" / oscillating suffix when the review iterated. */
+function roundSuffix(review: ReviewResult): string {
+  const round = review.iteration?.round;
+  if (!round || round <= 1) return "";
+  return review.iteration?.oscillating ? ` · round ${round} ↻` : ` · round ${round}`;
+}
+
+/** The merged checklist review (plan-phase preferred, design-phase fallback). */
+function checklistLens(review: ReviewResult | null): ReviewLens {
+  if (!review || review.parseError) {
+    return {
+      key: "checklist",
+      label: "Checklist review",
+      state: "pending",
+      detail: review?.parseError ? "review unavailable" : "not yet reviewed",
+    };
+  }
+  const issues = summarizeIssues(review.issues);
+  if (review.decision === "fail") {
+    return {
+      key: "checklist",
+      label: "Checklist review",
+      state: "fail",
+      detail: (issues || "blocking issues") + roundSuffix(review),
+    };
+  }
+  return {
+    key: "checklist",
+    label: "Checklist review",
+    state: "pass",
+    detail: (issues ? `cleared · ${issues}` : "cleared") + roundSuffix(review),
+  };
+}
+
+/** Advisory architecture lens — only present when the EA reviewer ran.
+ *  Never gates; always renders as "advisory". */
+function architectureLens(review: ReviewResult | null): ReviewLens | null {
+  const advisory = review?.architectureAdvisory;
+  if (!advisory) return null;
+  const noteCount = advisory.issues.length;
+  return {
+    key: "architecture",
+    label: "Architecture",
+    state: "advisory",
+    detail: noteCount === 0 ? "aligned" : `${noteCount} note${noteCount === 1 ? "" : "s"}`,
+  };
+}
+
+/** Per-task code review rolled up from taskResults[].codeReview. */
+function codeReviewLens(taskResults: FeatureBuildRow["taskResults"]): ReviewLens | null {
+  if (!taskResults || taskResults.length === 0) return null;
+  const total = taskResults.length;
+  const flagged = taskResults.filter((t) => t.codeReview?.decision === "fail").length;
+  if (flagged > 0) {
+    return {
+      key: "code-review",
+      label: "Code review",
+      state: "fail",
+      detail: `${flagged}/${total} task${total === 1 ? "" : "s"} flagged`,
+    };
+  }
+  return {
+    key: "code-review",
+    label: "Code review",
+    state: "pass",
+    detail: `${total}/${total} clean`,
+  };
+}
+
+/** UX checks from the recorded uxTestResults. */
+function uxLens(uxTestResults: FeatureBuildRow["uxTestResults"]): ReviewLens | null {
+  if (!uxTestResults || uxTestResults.length === 0) return null;
+  const total = uxTestResults.length;
+  const passed = uxTestResults.filter((r) => r.passed).length;
+  return {
+    key: "ux",
+    label: "UX checks",
+    state: passed === total ? "pass" : "fail",
+    detail: `${passed}/${total} passed`,
+  };
+}
+
+/** Merged-code verification (typecheck + tests). */
+function verificationLens(verificationOut: FeatureBuildRow["verificationOut"]): ReviewLens {
+  if (!verificationOut) {
+    return { key: "verification", label: "Verification", state: "pending", detail: "not run" };
+  }
+  const { typecheckPassed, testsFailed } = verificationOut;
+  if (typecheckPassed && testsFailed === 0) {
+    return { key: "verification", label: "Verification", state: "pass", detail: "typecheck ✓ · tests ✓" };
+  }
+  if (!typecheckPassed) {
+    return { key: "verification", label: "Verification", state: "fail", detail: "typecheck ✗" };
+  }
+  return {
+    key: "verification",
+    label: "Verification",
+    state: "fail",
+    detail: `${testsFailed} test${testsFailed === 1 ? "" : "s"} failing`,
+  };
+}
+
+/** Acceptance criteria met/total. */
+function acceptanceLens(acceptanceMet: FeatureBuildRow["acceptanceMet"]): ReviewLens | null {
+  if (!acceptanceMet || acceptanceMet.length === 0) return null;
+  const total = acceptanceMet.length;
+  const met = acceptanceMet.filter((c) => c.met).length;
+  return {
+    key: "acceptance",
+    label: "Acceptance",
+    state: met === total ? "pass" : "partial",
+    detail: `${met}/${total} met`,
+  };
+}
+
+/**
+ * Derive the ordered set of review lenses for a build, in review-gate lineage
+ * order. Optional lenses (architecture, code review, UX, acceptance) are omitted
+ * entirely when their backing artifact is absent, so the strip never shows a
+ * chip with no evidence behind it. The checklist + verification lenses always
+ * render (with a "pending" state) because they are the spine of the gate.
+ */
+export function deriveReviewLenses(build: FeatureBuildRow): ReviewLens[] {
+  const checklistReview = build.planReview ?? build.designReview ?? null;
+  const lenses: Array<ReviewLens | null> = [
+    checklistLens(checklistReview),
+    architectureLens(checklistReview),
+    codeReviewLens(build.taskResults),
+    uxLens(build.uxTestResults),
+    verificationLens(build.verificationOut),
+    acceptanceLens(build.acceptanceMet),
+  ];
+  return lenses.filter((lens): lens is ReviewLens => lens !== null);
+}

--- a/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
+++ b/docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md
@@ -147,15 +147,24 @@ Augment each fleet row's `PhaseMiniRail` with a compact completion-density bar t
 
 Data: `FeatureBuildRow.taskResults` (done/failed, deduped by title — last result wins, matching `AgentActivityStrip`'s `resultByTitle` reduction) vs `buildPlan.tasks.length` (denominator, widened to `max(total, done+failed)` so segments never exceed 100%).
 
-#### §6.2 ReviewerStatusGrid
+#### §6.2 ReviewReadinessStrip — **Implemented** (`apps/web/components/build/ReviewReadinessStrip.tsx`)
 
-During `review` phase, replace the reviewer list in `WorkflowStageInspector` with named state-coded cards (same `--dpf-*` visual language, larger granularity since reviewer count is 5–8 and identity matters):
+> **Correction (substrate verification):** the first draft below assumed a roster of named reviewers, each with its own persisted `source` + completion state (`build.reviewIterations[latest].reviews[].source`). **That field does not exist, and that data is not persisted.** The build review system runs two reviewers + an advisory architecture lens and **`mergeReviews()` collapses them into a single `ReviewResult`** ([build-reviewers.ts](../../../apps/web/lib/integrate/build-reviewers.ts)); individual reviewer identity is gone by the time the row is stored. There is also no "reviewer list" in `WorkflowStageInspector` to replace. Rendering named cards would mean **fabricating reviewer names/states in the UI** — a violation of the evidence-is-the-report rule. The original sketch is retained here only as the rejected design:
+>
+> ~~`[EA Architect ✓] [Security ✓] [API Governance ●] [Code Reviewer ✓] [Test Coverage ●] [Accessibility ○]`~~
 
-```
-[EA Architect ✓] [Security ✓] [API Governance ●] [Code Reviewer ✓] [Test Coverage ●] [Accessibility ○]
-```
+**What shipped instead:** a strip of state-coded **review-lens** chips, each backed by a field that is actually stored on the row. Added to `WorkflowStageInspector` between "What Happened" and "Next Approval", gated to `phase === "review"`. Lens derivation is a pure, unit-tested function ([review-lenses.ts](../../../apps/web/lib/build/review-lenses.ts)):
 
-Data: `build.reviewIterations[latest].reviews[].source` (agent display name) + review completion state.
+| Lens | Source field | States |
+|------|-------------|--------|
+| Checklist review | `planReview ?? designReview` → `decision`, `issues[].severity`, `iteration.round`/`oscillating`, `parseError` | pass · fail · pending |
+| Architecture (advisory) | `ReviewResult.architectureAdvisory` (omitted if absent) | advisory |
+| Code review | `taskResults[].codeReview.decision` rolled up (omitted if no tasks) | pass · fail |
+| UX checks | `uxTestResults[]` (omitted if none) | pass · fail |
+| Verification | `verificationOut` (typecheck + tests) | pass · fail · pending |
+| Acceptance | `acceptanceMet[]` (omitted if none) | pass · partial |
+
+Checklist + Verification are the always-on spine (render even when pending); the other four are omitted entirely when their backing artifact is absent, so **no chip ever shows without evidence**. State is conveyed by colour **and** glyph **and** text (WCAG 1.4.1); each chip carries an `aria-label` of `"<lens>: <state> — <detail>"`. The section header shows an `N/M cleared · K blocking` roll-up. DPF token-only, zero new server plumbing.
 
 ### §7. Animation
 
@@ -183,4 +192,6 @@ Applied to running cells via `style={{ animation: "dpf-cell-pulse 1.4s ease-in-o
 
 Follow-on (separate PRs):
 - ~~`FleetDensityBar` in `BuildListItem.tsx`~~ — **done** (§6.1): `FleetDensityBar.tsx` + `FleetDensityBar.test.tsx`, wired into the fleet row.
-- `ReviewerStatusGrid` in `WorkflowStageInspector.tsx`
+- ~~`ReviewerStatusGrid` in `WorkflowStageInspector.tsx`~~ — **done** (§6.2), reshaped to `ReviewReadinessStrip` after substrate verification showed the per-reviewer roster is not persisted: `ReviewReadinessStrip.tsx` + `lib/build/review-lenses.ts`, driven by stored review evidence.
+
+All three follow-on surfaces from §6 are now implemented. The spec is fully realized.


### PR DESCRIPTION
## What

Implements **§6.2** of the [AgentActivityStrip design spec](docs/superpowers/specs/2026-06-13-agent-activity-strip-design.md) — the third and final follow-on surface, completing the multi-agent visibility paradigm. Adds a **Review Readiness** strip to the Review-phase inspector: a row of state-coded *review-lens* chips so the operator can see, at a glance, which review gates have cleared and which are blocking.

```
REVIEW READINESS  4/6 cleared · 1 blocking
[✓ Checklist review]  [ⓘ Architecture]  [✓ Code review]  [✗ UX checks]  [✓ Verification]  [◐ Acceptance]
   cleared · round 2      1 note            12/12 clean       4/6 passed       typecheck ✓        3/4 met
```

## ⚠️ Reshaped after substrate verification (please read)

The spec's first draft drew a roster of **named reviewer cards** (`[EA Architect ✓] [Security ✓] [API Governance ●]…`), claiming the data was *"already on `build.reviewIterations[latest].reviews[].source`."* **Verifying against the codebase, that field does not exist and that data is not persisted:**

- `FeatureBuildRow` has no `reviewIterations` and no per-reviewer array with `source`.
- The review system ([build-reviewers.ts](apps/web/lib/integrate/build-reviewers.ts)) runs two reviewers + an advisory architecture lens, then **`mergeReviews()` collapses them into a single `ReviewResult`** — individual reviewer identity is gone by the time the row is stored.
- `WorkflowStageInspector` has no "reviewer list" to replace.

Rendering named cards would have meant **fabricating reviewer names/states in the UI**. Instead this ships review *lenses* derived only from fields that are actually stored. Spec §6.2 is updated in this PR to record the false assumption and the reshape. (If the richer named-roster grid is wanted, the honest path is a separate BI to persist per-reviewer identity server-side — flagged, not smuggled in here.)

## How

- **[lib/build/review-lenses.ts](apps/web/lib/build/review-lenses.ts)** — pure `deriveReviewLenses(build)` (node-testable, no DOM). Each lens maps to a stored field:

  | Lens | Source | States |
  |---|---|---|
  | Checklist review | `planReview ?? designReview` (decision, severity counts, `iteration.round`/`oscillating`, `parseError`) | pass · fail · pending |
  | Architecture (advisory) | `ReviewResult.architectureAdvisory` — omitted if absent | advisory |
  | Code review | `taskResults[].codeReview.decision` rolled up — omitted if no tasks | pass · fail |
  | UX checks | `uxTestResults[]` — omitted if none | pass · fail |
  | Verification | `verificationOut` (typecheck + tests) | pass · fail · pending |
  | Acceptance | `acceptanceMet[]` — omitted if none | pass · partial |

  Checklist + Verification are the always-on spine; the rest are **omitted when their artifact is absent**, so no chip ever renders without evidence.
- **[ReviewReadinessStrip.tsx](apps/web/components/build/ReviewReadinessStrip.tsx)** — chips dropped into `WorkflowStageInspector` between "What Happened" and "Next Approval", gated to `phase === "review"`. State carried by **colour + glyph + text** (WCAG 1.4.1); each chip `aria-label`led `"<lens>: <state> — <detail>"`; header shows `N/M cleared · K blocking`. DPF token-only, zero new server plumbing.

## Tests

- `review-lenses.test.ts` — every lens (pass/fail/pending/advisory/partial), severity summarization, round/oscillating suffix, `planReview`→`designReview` fallback, optional-lens omission, lineage ordering.
- `ReviewReadinessStrip.test.tsx` — render gate, spine-only render, state encoding in `data-state` + aria-label, cleared/blocking roll-up, advisory chip, DPF-token invariant.
- `WorkflowStageInspector` regression green. **34 tests pass; zero type errors** in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)